### PR TITLE
Fix rad env merge-credentials

### DIFF
--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -7,14 +7,17 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/authorization/mgmt/authorization"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/subscription/mgmt/subscription"
-	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-02-01/containerservice"
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/Azure/azure-sdk-for-go/services/preview/customproviders/mgmt/2018-09-01-preview/customproviders"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
@@ -53,7 +56,7 @@ var envInitAzureCmd = &cobra.Command{
 			}
 		}
 
-		err = connect(cmd.Context(), a.Name, a.SubscriptionID, a.ResourceGroup)
+		err = connect(cmd.Context(), a.Name, a.SubscriptionID, a.ResourceGroup, a.DeploymentTemplate)
 		if err != nil {
 			return err
 		}
@@ -69,13 +72,17 @@ func init() {
 	envInitAzureCmd.Flags().String("subscription-id", "", "The subscription ID to use for the environment")
 	envInitAzureCmd.Flags().String("resource-group", "", "The resource group to use for the environment")
 	envInitAzureCmd.Flags().BoolP("interactive", "i", false, "Specify interactive to choose subscription and resource group interactively")
+
+	// development support
+	envInitAzureCmd.Flags().String("deployment-template", "", "The file path to the deployment template - this can be used to override a custom build of the environment deployment ARM template for testing")
 }
 
 type arguments struct {
-	Name           string
-	Interactive    bool
-	SubscriptionID string
-	ResourceGroup  string
+	Name               string
+	Interactive        bool
+	SubscriptionID     string
+	ResourceGroup      string
+	DeploymentTemplate string
 }
 
 func validate(cmd *cobra.Command, args []string) (arguments, error) {
@@ -107,11 +114,24 @@ func validate(cmd *cobra.Command, args []string) (arguments, error) {
 		return arguments{}, errors.New("subscription id and resource group must be specified")
 	}
 
+	deploymentTemplate, err := cmd.Flags().GetString("deployment-template")
+	if err != nil {
+		return arguments{}, err
+	}
+
+	if deploymentTemplate != "" {
+		_, err := os.Stat(deploymentTemplate)
+		if err != nil {
+			return arguments{}, fmt.Errorf("could not read deployment-template: %w", err)
+		}
+	}
+
 	return arguments{
-		Name:           name,
-		Interactive:    interactive,
-		SubscriptionID: subscriptionID,
-		ResourceGroup:  resourceGroup,
+		Name:               name,
+		Interactive:        interactive,
+		SubscriptionID:     subscriptionID,
+		ResourceGroup:      resourceGroup,
+		DeploymentTemplate: deploymentTemplate,
 	}, nil
 }
 
@@ -222,7 +242,7 @@ func selectResourceGroup(ctx context.Context, authorizer autorest.Authorizer, su
 	return name, nil
 }
 
-func connect(ctx context.Context, name string, subscriptionID string, resourceGroup string) error {
+func connect(ctx context.Context, name string, subscriptionID string, resourceGroup string, deploymentTemplate string) error {
 	settings, err := auth.GetSettingsFromEnvironment()
 	if err != nil {
 		return err
@@ -240,7 +260,7 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 
 	// Check for an existing RP in the target resource group. This way we
 	// can use a single command to bind to an existing environment
-	exists, err := lookForExisting(ctx, armauth, subscriptionID, resourceGroup)
+	exists, clusterName, err := findExistingEnvironment(ctx, armauth, subscriptionID, resourceGroup)
 	if err != nil {
 		return err
 	}
@@ -248,7 +268,7 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 	if exists {
 		// We already have a provider in this resource group
 		logger.LogInfo("Found existing environment...")
-		err = storeEnvironment(ctx, armauth, name, subscriptionID, resourceGroup)
+		err = storeEnvironment(ctx, armauth, name, subscriptionID, resourceGroup, clusterName)
 		if err != nil {
 			return err
 		}
@@ -271,12 +291,17 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 		return err
 	}
 
-	_, err = deployEnvironment(ctx, armauth, sp, subscriptionID, resourceGroup)
+	deployment, err := deployEnvironment(ctx, armauth, sp, subscriptionID, resourceGroup, deploymentTemplate)
 	if err != nil {
 		return err
 	}
 
-	err = storeEnvironment(ctx, armauth, name, subscriptionID, resourceGroup)
+	clusterName, err = findClusterInDeployment(ctx, deployment)
+	if err != nil {
+		return err
+	}
+
+	err = storeEnvironment(ctx, armauth, name, subscriptionID, resourceGroup, clusterName)
 	if err != nil {
 		return err
 	}
@@ -284,20 +309,53 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 	return nil
 }
 
-func lookForExisting(ctx context.Context, authorizer autorest.Authorizer, subscriptionID string, resourceGroup string) (bool, error) {
+func findExistingEnvironment(ctx context.Context, authorizer autorest.Authorizer, subscriptionID string, resourceGroup string) (bool, string, error) {
 	cpc := customproviders.NewCustomResourceProviderClient(subscriptionID)
 	cpc.Authorizer = authorizer
 
 	_, err := cpc.Get(ctx, resourceGroup, "radius")
 	if detail, ok := util.ExtractDetailedError(err); ok && detail.StatusCode == 404 {
 		// not found - will need to be created
-		return false, nil
+		return false, "", nil
 	} else if err != nil {
-		return false, err
-	} else {
-		// already exists
-		return true, nil
+		return false, "", err
 	}
+
+	// Custom Provider already exists, find the cluster...
+	mcc := containerservice.NewManagedClustersClient(subscriptionID)
+	mcc.Authorizer = authorizer
+
+	iter, err := mcc.ListByResourceGroupComplete(ctx, resourceGroup)
+	if err != nil {
+		return false, "", err
+	}
+
+	var cluster *containerservice.ManagedCluster
+	for {
+		tag, ok := iter.Value().Tags["rad-environment"]
+
+		// For SOME REASON the value 'true' in a tag gets normalized to 'True'
+		if ok && strings.EqualFold(*tag, "true") {
+			temp := iter.Value()
+			cluster = &temp
+			break
+		}
+
+		if !iter.NotDone() {
+			break
+		}
+
+		err := iter.NextWithContext(ctx)
+		if err != nil {
+			return false, "", fmt.Errorf("cannot read AKS clusters: %w", err)
+		}
+	}
+
+	if cluster == nil {
+		return false, "", fmt.Errorf("could not find an AKS instance in resource group '%v'", resourceGroup)
+	}
+
+	return true, *cluster.Name, nil
 }
 
 func validateSubscription(ctx context.Context, authorizer autorest.Authorizer, subscriptionID string, resourceGroup string) (string, error) {
@@ -429,10 +487,16 @@ func configurePermissions(ctx context.Context, authorizer autorest.Authorizer, s
 	return errors.New("timed out waiting for service principal to show up")
 }
 
-func deployEnvironment(ctx context.Context, authorizer autorest.Authorizer, sp servicePrincipal, subscriptionID string, resourceGroup string) (resources.DeploymentExtended, error) {
+func deployEnvironment(ctx context.Context, authorizer autorest.Authorizer, sp servicePrincipal, subscriptionID string, resourceGroup string, deploymentTemplate string) (resources.DeploymentExtended, error) {
 	step := logger.BeginStep("Deploying Environment...")
 	dc := resources.NewDeploymentsClient(subscriptionID)
 	dc.Authorizer = authorizer
+
+	// Don't set a timeout, the user can cancel the command if they want a timeout.
+	dc.PollingDuration = 0
+
+	// Poll faster for completion when possible. The default is 60 seconds which is a long time to wait.
+	dc.PollingDelay = time.Second * 15
 
 	key, err := ssh.GenerateKey(ssh.DefaultSize)
 	if err != nil {
@@ -456,18 +520,37 @@ func deployEnvironment(ctx context.Context, authorizer autorest.Authorizer, sp s
 		},
 	}
 
+	deploymentProperties := &resources.DeploymentProperties{
+		Parameters: parameters,
+		Mode:       resources.Incremental,
+	}
+
+	if deploymentTemplate == "" {
+		deploymentProperties.TemplateLink = &resources.TemplateLink{
+			URI: to.StringPtr(armTemplateURI),
+		}
+	} else {
+		logger.LogInfo("overriding deployment template: %v", deploymentTemplate)
+		templateContent, err := ioutil.ReadFile(deploymentTemplate)
+		if err != nil {
+			return resources.DeploymentExtended{}, fmt.Errorf("could not read deployment template: %w", err)
+		}
+
+		data := map[string]interface{}{}
+		err = json.Unmarshal(templateContent, &data)
+		if err != nil {
+			return resources.DeploymentExtended{}, fmt.Errorf("could not read deployment template as JSON: %w", err)
+		}
+
+		deploymentProperties.Template = data
+	}
+
 	// See https://github.com/Azure/AKS/issues/1206 - propagation of service principals can cause issues during
-	// validation.
+	// validation. We need retries to work around that.
 	name := fmt.Sprintf("rad-create-environment-%v", uuid.New().String())
 	for i := 0; i < 30; i++ {
 		op, err := dc.CreateOrUpdate(ctx, resourceGroup, name, resources.Deployment{
-			Properties: &resources.DeploymentProperties{
-				TemplateLink: &resources.TemplateLink{
-					URI: to.StringPtr(armTemplateURI),
-				},
-				Parameters: parameters,
-				Mode:       resources.Incremental,
-			},
+			Properties: deploymentProperties,
 		})
 		if detailed, ok := util.ExtractDetailedError(err); ok && detailed.StatusCode == 400 {
 			if service, ok := util.ExtractServiceError(err); ok {
@@ -507,39 +590,38 @@ func deployEnvironment(ctx context.Context, authorizer autorest.Authorizer, sp s
 	return resources.DeploymentExtended{}, errors.New("timed out waiting for creation to succeeed")
 }
 
-func storeEnvironment(ctx context.Context, authorizer autorest.Authorizer, name string, subscriptionID string, resourceGroup string) error {
+func findClusterInDeployment(ctx context.Context, deployment resources.DeploymentExtended) (string, error) {
+	obj := deployment.Properties.Outputs
+	outputs, ok := obj.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("deployment outputs has unexpected type: %T", obj)
+	}
+
+	obj, ok = outputs["clusterName"]
+	if !ok {
+		return "", fmt.Errorf("deployment outputs does not contain cluster name: %v", outputs)
+	}
+
+	clusterNameOutput, ok := obj.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("cluster name was of unexpected type: %T", obj)
+	}
+
+	obj, ok = clusterNameOutput["value"]
+	if !ok {
+		return "", fmt.Errorf("cluster name output does not contain value: %v", outputs)
+	}
+
+	clusterName, ok := obj.(string)
+	if !ok {
+		return "", fmt.Errorf("cluster name was of unexpected type: %T", obj)
+	}
+
+	return clusterName, nil
+}
+
+func storeEnvironment(ctx context.Context, authorizer autorest.Authorizer, name string, subscriptionID string, resourceGroup string, clusterName string) error {
 	step := logger.BeginStep("Updating Config...")
-
-	mcc := containerservice.NewManagedClustersClient(subscriptionID)
-	mcc.Authorizer = authorizer
-
-	iter, err := mcc.ListByResourceGroupComplete(ctx, resourceGroup)
-	if err != nil {
-		return err
-	}
-
-	var cluster *containerservice.ManagedCluster
-	for {
-		tag, ok := iter.Value().Tags["rad-environment"]
-		if ok && *tag == "true" {
-			temp := iter.Value()
-			cluster = &temp
-			break
-		}
-
-		if !iter.NotDone() {
-			break
-		}
-
-		err := iter.NextWithContext(ctx)
-		if err != nil {
-			return fmt.Errorf("cannot read AKS clusters: %w", err)
-		}
-	}
-
-	if cluster == nil {
-		return fmt.Errorf("could not find an AKS instance in resource group '%v'", resourceGroup)
-	}
 
 	v := viper.GetViper()
 	env, err := rad.ReadEnvironmentSection(v)
@@ -551,6 +633,7 @@ func storeEnvironment(ctx context.Context, authorizer autorest.Authorizer, name 
 		"kind":           "azure",
 		"subscriptionId": subscriptionID,
 		"resourceGroup":  resourceGroup,
+		"clusterName":    clusterName,
 	}
 	if len(env.Items) == 1 {
 		env.Default = name

--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -157,6 +157,15 @@
             "metadata": {
                 "description": "The identity name to use for the deployment script."
             }
+        },
+        "resourceTags": {
+            "type": "object",
+            "defaultValue": {
+                "rad-environment": true
+            },
+            "metadata": {
+                "description": "The tags to apply to each resource"
+            }
         }
     },
     "variables": {
@@ -169,12 +178,14 @@
             "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
             "name": "[parameters('identityName')]",
             "apiVersion": "2018-11-30",
-            "location": "[resourceGroup().location]"
+            "location": "[resourceGroup().location]",
+            "tags": "[parameters('resourceTags')]"
         },
         {
             "type": "Microsoft.Authorization/roleAssignments",
             "apiVersion": "2019-04-01-preview",
             "name": "[variables('roleDefinitionName')]",
+            "tags": "[parameters('resourceTags')]",
             "dependsOn": [
                 "[parameters('identityName')]"
             ],
@@ -190,6 +201,7 @@
             "name": "[parameters('accountName')]",
             "apiVersion": "2020-03-01",
             "location": "[parameters('location')]",
+            "tags": "[parameters('resourceTags')]",
             "kind": "MongoDB",
             "properties": {
                 "locations": [
@@ -209,6 +221,7 @@
             "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases",
             "name": "[concat(parameters('accountName'), '/', parameters('databaseName'))]",
             "apiVersion": "2020-03-01",
+            "tags": "[parameters('resourceTags')]",
             "dependsOn": [ "[resourceId('Microsoft.DocumentDB/databaseAccounts/', parameters('accountName'))]" ],
             "properties": {
                 "resource": {
@@ -221,6 +234,7 @@
             "type": "Microsoft.DocumentDb/databaseAccounts/mongodbDatabases/collections",
             "name": "[concat(parameters('accountName'), '/', parameters('databaseName'), '/', 'applications')]",
             "apiVersion": "2020-03-01",
+            "tags": "[parameters('resourceTags')]",
             "dependsOn": [ "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('accountName'), parameters('databaseName'))]" ],
             "properties": {
                 "resource": {
@@ -239,9 +253,7 @@
             "type": "Microsoft.ContainerService/managedClusters",
             "location": "[parameters('location')]",
             "name": "[parameters('clusterName')]",
-            "tags": {
-                "rad-environment": "true"
-            },
+            "tags": "[parameters('resourceTags')]",
             "properties": {
                 "kubernetesVersion": "[parameters('kubernetesVersion')]",
                 "dnsPrefix": "[parameters('clusterName')]",
@@ -277,6 +289,7 @@
             "apiVersion": "2020-10-01",
             "name": "deploy-radius-runtime",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('resourceTags')]",
             "dependsOn": [
                 "[resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName'))]",
                 "[resourceId('Microsoft.Authorization/roleAssignments', variables('roleDefinitionName'))]"
@@ -304,6 +317,7 @@
             "apiVersion": "2018-02-01",
             "name": "[variables('hostingPlanName')]",
             "location": "[parameters('location')]",
+            "tags": "[parameters('resourceTags')]",
             "sku": {
                 "name": "[parameters('sku')]",
                 "capacity": "[parameters('workerSize')]"
@@ -319,6 +333,7 @@
             "apiVersion": "2020-06-01",
             "name": "[parameters('siteName')]",
             "location": "[parameters('location')]",
+            "tags": "[parameters('resourceTags')]",
             "identity": {
                 "type": "None"
             },
@@ -377,6 +392,7 @@
             "type": "Microsoft.CustomProviders/resourceProviders",
             "name": "radius",
             "location": "[parameters('location')]",
+            "tags": "[parameters('resourceTags')]",
             "dependsOn": [
                 "[concat('Microsoft.Web/sites/', parameters('siteName'))]"
             ],
@@ -405,5 +421,11 @@
                 ]
             }
         }
-    ]
+    ],
+    "outputs": {
+        "clusterName": {
+            "type": "string",
+            "value": "[parameters('clusterName')]"
+        }
+    }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,10 @@
 
 [Running rad CLI](development/running-rad-cli.md)
 
+[Debugging Go with VSCode](development/debugging-go-with-vscode.md)
+
+[Testing environment setup](development/testing-environment-setup.md)
+
 [Running locally](development/running-locally.md)
 
 [Testing locally](development/testing-locally.md)

--- a/docs/development/debugging-go-with-vscode.md
+++ b/docs/development/debugging-go-with-vscode.md
@@ -1,0 +1,97 @@
+# Debugging Go with VSCode
+
+VSCode has good support for debugging VSCode, it's just a little unintuitive to set up.
+
+VSCode's configuration for the debugger lives in `.vscode/launch.json` in the repo. We don't check this file in, and so everyone can maintain their own set of profiles/aliases.
+
+## Debugging tests
+
+Debugging unit tests is easy. Codelens on the test function will offer you a run or debug option, and you just click. No setup needed.
+
+## Basic debugging
+
+The most basic configuration for Go looks like this:
+
+```json
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch file",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${file}"
+        },
+    ]
+}
+```
+
+This example will allow you to launch the debugger with whatever file open in the editor as the entry point.
+
+To use this open a file like `cmd/cli/main.go` and press the green triangle button.
+
+## Building aliases
+
+While that option is flexible, it's not super convenient because it depends on the focus of the editor.
+
+You can create your own aliases as well, and select them from the drop down.
+
+```json
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        ...
+
+        {
+            "name": "Launch RP",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd/rp/main.go",
+            "env": [ ... environment variables here ...]
+            "args": [ ... args here ...]
+        },
+    ]
+}
+```
+
+## Debugging interactive commands
+
+Interactive commands like `rad env init azure -i` don't work with Go debugging. This is a limitation of the underlying debugging infrastucture, it just doesn't support user input.
+
+For this case you will need to create an alias and pass in the values you want. For this reason it's important that we create scriptable version of everything we do interactively. We can't easily debug the interactive version!
+
+Here's an example:
+
+```json
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        ...
+
+        {
+            "name": "Launch rad env init azure",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd/cli/main.go",
+            "args": [
+                "env", "init", "azure", 
+                "--subscription-id", "...", 
+                "--resource-group", "...", 
+                "--deployment-template", "${workspaceFolder}/deploy/rp-full.json"
+            ]
+        }
+    ]
+}
+```

--- a/docs/development/running-rad-cli.md
+++ b/docs/development/running-rad-cli.md
@@ -11,7 +11,7 @@ Create the following script and place it on your path with a name like `dev-rad`
 ```sh
 #!/bin/sh
 set -eu
-go run ~/github.com/Azure/radius/cmd/cli/main.go -- $@%
+go run ~/github.com/Azure/radius/cmd/cli/main.go $@
 ```
 
 Replace `~/github.com/Azure/radius` with the path to your repository root.

--- a/docs/development/testing-environment-setup.md
+++ b/docs/development/testing-environment-setup.md
@@ -1,0 +1,9 @@
+# Testing environment setup
+
+The `rad` CLI usually gets the deployment template from an online location. This isn't handy for developing the deployment template so we also support an override to pass in a file at the command line.
+
+Example:
+
+```sh
+rad env init azure -i --deployment-template "./deploy/rp-full.json"
+```


### PR DESCRIPTION
Fixes: #19

The fix here includes a variety of small enhancements:

- Apply tags consistenly for environment resources
- Use deployment outputs for AKS
- Always store the cluster name (root cause)
- Fix tag-based lookup of cluster, this was broken by a casing
  difference

Also fixed a minor bug in the dev docs, and improved docs for
troubleshooting environment creation.