### PR TITLE
Update version of deploymentScript resource

### DIFF
--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -274,7 +274,7 @@
         },
         {
             "type": "Microsoft.Resources/deploymentScripts",
-            "apiVersion": "2019-10-01-preview",
+            "apiVersion": "2020-10-01",
             "name": "deploy-radius-runtime",
             "location": "[resourceGroup().location]",
             "dependsOn": [


### PR DESCRIPTION
Fixes: #25

The issue here is actually a bug with the version of deploymentScript
that we were using. The newer version has an updated permissions model
and avoids the need for manual RP registration on a fresh subscription.