### PR TITLE
Remove comments from JSON in readme

### DIFF
--- a/docs/content/developing/debugging-go-with-vscode.md
+++ b/docs/content/developing/debugging-go-with-vscode.md
@@ -20,9 +20,6 @@ The most basic configuration for Go looks like this:
 
 ```json
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {
@@ -48,9 +45,6 @@ You can create your own aliases as well, and select them from the drop down.
 
 ```json
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         ...
@@ -78,9 +72,6 @@ Here's an example:
 
 ```json
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         ...


### PR DESCRIPTION
This shows up in all red in the syntax highlighting. It looks bad 😆