### PR TITLE
Ignore docs updates on build workflows

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -11,6 +11,8 @@ on:
       - main
     tags:
       - v*
+    paths-ignore:
+    - 'docs/**'
 jobs:
   publish:
     name: Assets

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,10 +12,14 @@ on:
       - release/*
     tags:
       - v*
+    paths-ignore:
+    - 'docs/**'
   pull_request:
     branches:
       - main
       - release/*
+    paths-ignore:
+    - 'docs/**'
 jobs:
   build:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,10 +17,14 @@ on:
       - release/*
     tags:
       - v*
+    paths-ignore:
+    - 'docs/**'
   pull_request:
     branches:
       - main
       - release/*
+    paths-ignore:
+    - 'docs/**'
 jobs:
   build:
     name: Docker build


### PR DESCRIPTION
Add paths-ignore for docs so build pipeline doesn't run just for a docs update