### PR TITLE
Keep bicep output in memory

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     runs-on: ${{ matrix.os }}
     env:
-      GOVER: '^1.15.0'
+      GOVER: '^1.16.0'
       GOLANGCILINT_VER: 1.26.0
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries and run e2e tests
     runs-on: ${{ matrix.os }}
     env:
-      GOVER: '^1.15.0'
+      GOVER: '^1.16.0'
       GOLANGCILINT_VER: 1.26.0
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/radius
 
-go 1.15
+go 1.16
 
 require (
 	github.com/Azure/azure-sdk-for-go v52.3.1+incompatible


### PR DESCRIPTION
Fixes: #20

This change updates our handling the rad-bicep CLI to capture output
from stdout rather than using a file on disk. These files were sticking
around and it was messy.

Also increased our polling frequency and removed the timeout from
deployment.