### PR TITLE
Fix config update when items is empty

### DIFF
--- a/pkg/rad/config.go
+++ b/pkg/rad/config.go
@@ -18,17 +18,22 @@ type EnvironmentSection struct {
 
 // ReadEnvironmentSection reads the EnvironmentSection from elbow config.
 func ReadEnvironmentSection(v *viper.Viper) (EnvironmentSection, error) {
-	section := EnvironmentSection{}
-
 	s := v.Sub(EnvironmentKey)
 	if s == nil {
-		section.Items = map[string]map[string]interface{}{}
-		return section, nil
+		return EnvironmentSection{
+			Items: map[string]map[string]interface{}{},
+		}, nil
 	}
 
+	section := EnvironmentSection{}
 	err := s.UnmarshalExact(&section)
 	if err != nil {
 		return EnvironmentSection{}, nil
+	}
+
+	// if items is not present it will be nil
+	if section.Items == nil {
+		section.Items = map[string]map[string]interface{}{}
 	}
 
 	return section, nil


### PR DESCRIPTION
Items will be nil if the `items` property in the config file is empty.