### PR TITLE
Add cross-platform gitattibutes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# text files use OS defaults on checkout, LF on checkin
+* text eol=auto
+
+# shell scripts always use LF
+*.sh text eol=lf


### PR DESCRIPTION
Now that we have some folks working from windows we should have a
`.gitattributes`. These settings will enable everyone to work together
without conflict.