### PR TITLE
Test linter in a separate workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,11 +62,6 @@ jobs:
         run: python ./.github/scripts/get_release_version.py
       - name: Make
         run: make
-      - name: Run linter
-        if: matrix.target_arch != 'arm' && matrix.target_os == 'linux'
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: 'latest'
       - name: Run make test
         if: matrix.target_arch != 'arm'
         run: make test

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,44 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+name: lint
+
+on:
+  push:
+    branches:
+      - main
+      - release/*
+    tags:
+      - v*
+    paths-ignore:
+    - 'docs/**'
+  pull_request:
+    branches:
+      - main
+      - release/*
+    paths-ignore:
+    - 'docs/**'
+jobs:
+  build:
+    name: Lint
+    runs-on: ubuntu-latest
+    env:
+      GOVER: '^1.16.0'
+      GOPROXY: https://proxy.golang.org
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+      - name: Set up Go ${{ env.GOVER }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GOVER }}
+      - name: Parse release version and set REL_VERSION
+        run: python ./.github/scripts/get_release_version.py
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: 'latest'
+          skip-go-installation: true
+          args: --timeout=10m


### PR DESCRIPTION
According to some resources I found there are caching and concurrency
issues with the linter running in parallel jobs with things like tests.
The linter has its own expectations around ownership of the cache.