### PR TITLE
Fix invoke of az CLI on windows

### DIFF
--- a/pkg/rad/azcli/azcli.go
+++ b/pkg/rad/azcli/azcli.go
@@ -1,0 +1,34 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package azcli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// RunCLICommand runs an az CLI command with stdout and stderr forwarded to this process's output.
+func RunCLICommand(args ...string) error {
+	var executableName string
+	var executableArgs []string
+	if runtime.GOOS == "windows" {
+		// Use shell on windows since az is a script not an executable
+		executableName = fmt.Sprintf("%s\\system32\\cmd.exe", os.Getenv("windir"))
+		executableArgs = append(executableArgs, "/c", "az")
+	} else {
+		executableName = "az"
+	}
+
+	executableArgs = append(executableArgs, args...)
+
+	c := exec.Command(executableName, executableArgs...)
+	c.Stderr = os.Stderr
+	c.Stdout = os.Stdout
+	err := c.Run()
+	return err
+}


### PR DESCRIPTION
Fixes: #126

Using the shell on windows since the az CLI is actually a cmd script
(not an executable).