### PR TITLE
Update our SDK references to latest

### DIFF
--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -17,7 +17,7 @@ import (
 	"path"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
 	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/bicep"

--- a/cmd/cli/cmd/envDelete.go
+++ b/cmd/cli/cmd/envDelete.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/radius/pkg/rad"

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -17,10 +17,10 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
+	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/customproviders/mgmt/customproviders"
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/subscription/mgmt/subscription"
 	containerserviceclient "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2018-03-31/containerservice"
-	"github.com/Azure/azure-sdk-for-go/services/preview/customproviders/mgmt/2018-09-01-preview/customproviders"
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"

--- a/test/config/config.go
+++ b/test/config/config.go
@@ -9,8 +9,8 @@ import (
 	"bytes"
 	"os"
 
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
-	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2015-06-15/storage"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/storage/mgmt/storage"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/marstr/randname"
 )

--- a/test/deploy-tests/deploytest_helpers.go
+++ b/test/deploy-tests/deploytest_helpers.go
@@ -23,7 +23,7 @@ var (
 func findTestCluster(ctx context.Context) (string, error) {
 	file, err := os.Open("deploy-tests-clusters.txt")
 	if err != nil {
-		return "", fmt.Errorf("cannot read test cluster manifest: %v", err)
+		return "", fmt.Errorf("cannot read test cluster manifest: %w", err)
 	}
 	defer file.Close()
 
@@ -33,7 +33,7 @@ func findTestCluster(ctx context.Context) (string, error) {
 		// Check if cluster is in use
 		err = utils.AcquireStorageContainerLease(ctx, accountName, accountGroupName, testClusterName)
 		if err != nil {
-			fmt.Printf("Test cluster: %s not available.", testClusterName)
+			fmt.Printf("Test cluster: %s not available. err: %v\n", testClusterName, err)
 			continue
 		}
 


### PR DESCRIPTION
This came up in PR feedback - it's better for us to float along on
recent API versions than to pin to a specific version (which might be
old). In general the API import paths for the azure SDK should not
contain dates for us (unless we have a good reason).