### PR TITLE
Adding get and list operations for radius applications

### DIFF
--- a/cmd/cli/cmd/appGet.go
+++ b/cmd/cli/cmd/appGet.go
@@ -26,7 +26,9 @@ func init() {
 	applicationCmd.AddCommand(getCmd)
 
 	getCmd.Flags().String("name", "", "The application name")
-	getCmd.MarkFlagRequired("name")
+	if err := getCmd.MarkFlagRequired("name"); err != nil {
+		fmt.Printf("Failed to mark the name flag required: %v", err)
+	}
 }
 
 func getApplication(cmd *cobra.Command, args []string) error {
@@ -48,6 +50,10 @@ func getApplication(cmd *cobra.Command, args []string) error {
 	radc := radclient.NewClient(env.SubscriptionID)
 	radc.Authorizer = authorizer
 	app, err := radc.GetApplication(cmd.Context(), env.ResourceGroup, applicationName)
+	if err != nil {
+		return fmt.Errorf("Error getting the application information: '%w'", err)
+	}
+
 	var applicationDetails []byte
 	applicationDetails, err = json.MarshalIndent(app, "", "\t")
 	if err != nil {

--- a/cmd/cli/cmd/appGet.go
+++ b/cmd/cli/cmd/appGet.go
@@ -1,0 +1,64 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/Azure/radius/pkg/radclient"
+	"github.com/spf13/cobra"
+)
+
+// getCmd command to get properties of an application
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get RAD application details",
+	Long:  "Get RAD application details",
+	RunE:  getApplication,
+}
+
+func init() {
+	applicationCmd.AddCommand(getCmd)
+
+	getCmd.Flags().String("name", "", "The application name")
+	getCmd.MarkFlagRequired("name")
+}
+
+func getApplication(cmd *cobra.Command, args []string) error {
+	applicationName, err := cmd.Flags().GetString("name")
+	if err != nil {
+		return err
+	}
+
+	env, err := validateEnvironment()
+	if err != nil {
+		return err
+	}
+
+	authorizer, err := auth.NewAuthorizerFromCLI()
+	if err != nil {
+		return err
+	}
+
+	radc := radclient.NewClient(env.SubscriptionID)
+	radc.Authorizer = authorizer
+	app, err := radc.GetApplication(cmd.Context(), env.ResourceGroup, applicationName)
+	// fmt.Println("name:", app.Name)
+	// fmt.Println("id:", app.ID)
+	// fmt.Printf("%+v\n", app)
+	var applicationDetails []byte
+	applicationDetails, err = json.MarshalIndent(app, "", "\t")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", applicationDetails)
+
+	// az rest --method "GET" --url "/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourceGroups/kachawla-radius/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/?api-version=2018-09-01-preview"
+
+	return err
+}

--- a/cmd/cli/cmd/appGet.go
+++ b/cmd/cli/cmd/appGet.go
@@ -48,17 +48,12 @@ func getApplication(cmd *cobra.Command, args []string) error {
 	radc := radclient.NewClient(env.SubscriptionID)
 	radc.Authorizer = authorizer
 	app, err := radc.GetApplication(cmd.Context(), env.ResourceGroup, applicationName)
-	// fmt.Println("name:", app.Name)
-	// fmt.Println("id:", app.ID)
-	// fmt.Printf("%+v\n", app)
 	var applicationDetails []byte
 	applicationDetails, err = json.MarshalIndent(app, "", "\t")
 	if err != nil {
 		return err
 	}
 	fmt.Printf("%s\n", applicationDetails)
-
-	// az rest --method "GET" --url "/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourceGroups/kachawla-radius/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/?api-version=2018-09-01-preview"
 
 	return err
 }

--- a/cmd/cli/cmd/appList.go
+++ b/cmd/cli/cmd/appList.go
@@ -50,6 +50,7 @@ func listApplications(cmd *cobra.Command, args []string) error {
 	}
 	if applications == nil {
 		fmt.Println("No applications found")
+		return nil
 	}
 	for _, app := range applications {
 		var applicationDetails []byte

--- a/cmd/cli/cmd/appList.go
+++ b/cmd/cli/cmd/appList.go
@@ -1,0 +1,64 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/Azure/radius/pkg/radclient"
+	"github.com/spf13/cobra"
+)
+
+// listCmd command to list applications deployed in the resource group
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Lists RAD applications",
+	Long:  "Lists RAD applications deployed in all the environments in the resource group",
+	Args:  cobra.ExactArgs(0),
+	RunE:  listApplications,
+}
+
+const resourceType = "Applications"
+
+func init() {
+	applicationCmd.AddCommand(listCmd)
+}
+
+func listApplications(cmd *cobra.Command, args []string) error {
+	env, err := validateEnvironment()
+	if err != nil {
+		return err
+	}
+
+	authorizer, err := auth.NewAuthorizerFromCLI()
+	if err != nil {
+		return err
+	}
+
+	radc := radclient.NewClient(env.SubscriptionID)
+	radc.Authorizer = authorizer
+
+	var applications []radclient.Application
+	applications, err = radc.ListRadiusResources(cmd.Context(), env.ResourceGroup, resourceType)
+	if err != nil {
+		return fmt.Errorf("Error listing the applications: '%w'", err)
+	}
+	if applications == nil {
+		fmt.Println("No applications found")
+	}
+	for _, app := range applications {
+		var applicationDetails []byte
+		applicationDetails, err = json.MarshalIndent(app, "", "\t")
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s\n", applicationDetails)
+	}
+
+	return err
+}

--- a/cmd/cli/cmd/appList.go
+++ b/cmd/cli/cmd/appList.go
@@ -48,18 +48,13 @@ func listApplications(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("Error listing the applications: '%w'", err)
 	}
-	if applications == nil {
-		fmt.Println("No applications found")
+	if len(applications) == 0 {
+		fmt.Println(applications)
 		return nil
 	}
-	for _, app := range applications {
-		var applicationDetails []byte
-		applicationDetails, err = json.MarshalIndent(app, "", "\t")
-		if err != nil {
-			return err
-		}
-		fmt.Printf("%s\n", applicationDetails)
-	}
+
+	applicationDetails, err := json.MarshalIndent(applications, "", "\t")
+	fmt.Printf("%s\n", applicationDetails)
 
 	return err
 }

--- a/cmd/cli/cmd/application.go
+++ b/cmd/cli/cmd/application.go
@@ -1,0 +1,20 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var applicationCmd = &cobra.Command{
+	Use:   "application",
+	Short: "Manage applications",
+	Long:  `Manage applications`,
+}
+
+func init() {
+	rootCmd.AddCommand(applicationCmd)
+}

--- a/cmd/cli/cmd/envDelete.go
+++ b/cmd/cli/cmd/envDelete.go
@@ -85,12 +85,12 @@ func validateEnvironmentExists(envName string) (string, string, error) {
 	}
 
 	if len(env.Items) == 0 {
-		return "", "", errors.New("No environments found.")
+		return "", "", errors.New("no environments found")
 	}
 
 	envConfig, exists := env.Items[envName]
 	if !exists {
-		return "", "", fmt.Errorf("Could not find the environment %s. Use 'rad env list' to list all environments.", envName)
+		return "", "", fmt.Errorf("could not find the environment %s. Use 'rad env list' to list all environments", envName)
 	}
 
 	return envConfig["resourcegroup"].(string), envConfig["subscriptionid"].(string), nil

--- a/pkg/radclient/client.go
+++ b/pkg/radclient/client.go
@@ -1,0 +1,221 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package radclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+)
+
+const apiVersion = "2018-09-01-preview"
+const resourceProviderNamespace = "Microsoft.CustomProviders"
+const parentResourcePath = "resourceProviders/radius"
+
+// Client wrapper around resources.Client to extend operations on custom resource types.
+type Client struct {
+	resources.Client
+}
+
+// Application Any new customer facing property (tag etc) if added to the radius application, should be added here.
+type Application struct {
+	Name string
+	ID   string
+}
+
+// NewClient creates an instance of the radclient Client.
+func NewClient(subscriptionID string) Client {
+	return NewClientWithBaseURI(resources.DefaultBaseURI, subscriptionID)
+}
+
+// NewClientWithBaseURI creates an instance of the radclient Client using a custom endpoint.  Use this when interacting
+// with an Azure cloud that uses a non-standard base URI (sovereign clouds, Azure stack).
+func NewClientWithBaseURI(baseURI string, subscriptionID string) Client {
+	return Client{resources.NewClientWithBaseURI(baseURI, subscriptionID)}
+}
+
+// GetApplication get radius application details. Currently supports name and id.
+func (client Client) GetApplication(ctx context.Context, resourceGroupName string, applicationName string) (Application, error) {
+	id := fmt.Sprintf("/subscriptions/%v/resourceGroups/%v/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/%v", client.SubscriptionID, resourceGroupName, applicationName)
+	result, err := client.Client.GetByID(ctx, id, apiVersion)
+	if err != nil {
+		return Application{}, err
+	}
+
+	app := Application{
+		Name: *result.Name,
+		ID:   *result.ID,
+	}
+
+	return app, err
+}
+
+// ListRadiusResources lists all radius resources of the specified resource type in the resource group.
+// Most of the code here is replicated from resources.Get https://github.com/Azure/azure-sdk-for-go/blob/master/services/resources/mgmt/2020-10-01/resources/resources.go#L643
+// TODO Currently it only supports Application return type, extend it to support all radius resource types.
+func (client Client) ListRadiusResources(ctx context.Context, resourceGroupName string, resourceType string) (resources []Application, err error) {
+	if !isAValidRadiusResourceType(resourceType) {
+		return resources, fmt.Errorf("%s is not a supported radius resource type", resourceType)
+	}
+
+	// TODO Add tracing support
+
+	if err := validation.Validate([]validation.Validation{
+		{TargetValue: resourceGroupName,
+			Constraints: []validation.Constraint{{Target: "resourceGroupName", Name: validation.MaxLength, Rule: 90, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.MinLength, Rule: 1, Chain: nil},
+				{Target: "resourceGroupName", Name: validation.Pattern, Rule: `^[-\p{L}\._\(\)\w]+$`, Chain: nil}}}}); err != nil {
+		return resources, validation.NewError("resources.Client", "Get", err.Error())
+	}
+
+	req, err := client.getResourcesPreparer(ctx, resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, apiVersion)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "resources.Client", "Get", nil, "Failure preparing request")
+		return resources, err
+	}
+
+	resp, err := client.GetSender(req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "resources.Client", "Get", resp, "Failure sending request")
+		return resources, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return resources, wrapHTTPResponseInAzureError(resp)
+	}
+
+	// TODO this can be improved by unmarshalling directly into the struct, or rather override resources.GetResponder with support for list of resources
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return resources, fmt.Errorf("failed to read the response: %w", err)
+	}
+	var parsedResponse map[string]interface{}
+	err = json.Unmarshal(respBytes, &parsedResponse)
+	if err != nil {
+		return resources, err
+	}
+	if parsedResponse["value"] == nil {
+		return resources, err
+	}
+	applications := parsedResponse["value"].([]interface{})
+
+	for _, value := range applications {
+		app := Application{
+			Name: value.(map[string]interface{})["name"].(string),
+			ID:   value.(map[string]interface{})["id"].(string),
+		}
+		resources = append(resources, app)
+	}
+
+	return resources, err
+}
+
+// Prepares the ListRadiusResources request.
+// Taken from resources.GetPreparer with added support for custom resource types. https://github.com/Azure/azure-sdk-for-go/blob/master/services/resources/mgmt/2020-10-01/resources/resources.go#L685
+func (client Client) getResourcesPreparer(ctx context.Context, resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, APIVersion string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"parentResourcePath":        parentResourcePath,
+		"resourceGroupName":         autorest.Encode("path", resourceGroupName),
+		"resourceProviderNamespace": autorest.Encode("path", resourceProviderNamespace),
+		"resourceType":              resourceType,
+		"subscriptionId":            autorest.Encode("path", client.SubscriptionID),
+	}
+
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+func isAValidRadiusResourceType(rt string) bool {
+	var supportedResourceTypes = []string{"Applications"}
+	for _, st := range supportedResourceTypes {
+		if st == rt {
+			return true
+		}
+	}
+	return false
+}
+
+// Wraps the response into an error. This code is mostly taken from azure.WithErrorUnlessStatusCode
+func wrapHTTPResponseInAzureError(resp *http.Response) (err error) {
+	var e azure.RequestError
+
+	encodedAs := autorest.EncodedAsJSON
+	if strings.Contains(resp.Header.Get("Content-Type"), "xml") {
+		encodedAs = autorest.EncodedAsXML
+	}
+
+	// Copy and replace the Body in case it does not contain an error object.
+	// This will leave the Body available to the caller.
+	b, decodeErr := autorest.CopyAndDecode(encodedAs, resp.Body, &e)
+	resp.Body = ioutil.NopCloser(&b)
+	if decodeErr != nil {
+		return fmt.Errorf("error response cannot be parsed: %q error: %v", b.String(), decodeErr)
+	}
+	if e.ServiceError == nil {
+		// Check if error is unwrapped ServiceError
+		decoder := autorest.NewDecoder(encodedAs, bytes.NewReader(b.Bytes()))
+		if err := decoder.Decode(&e.ServiceError); err != nil {
+			return fmt.Errorf("error response cannot be parsed: %q error: %v", b.String(), err)
+		}
+
+		// should the API return the literal value `null` as the response
+		if e.ServiceError == nil {
+			e.ServiceError = &azure.ServiceError{
+				Code:    "Unknown",
+				Message: "Unknown service error",
+				Details: []map[string]interface{}{
+					{
+						"HttpResponse.Body": b.String(),
+					},
+				},
+			}
+		}
+	}
+
+	if e.ServiceError != nil && e.ServiceError.Message == "" {
+		// if we're here it means the returned error wasn't OData v4 compliant.
+		// try to unmarshal the body in hopes of getting something.
+		rawBody := map[string]interface{}{}
+		decoder := autorest.NewDecoder(encodedAs, bytes.NewReader(b.Bytes()))
+		if err := decoder.Decode(&rawBody); err != nil {
+			return fmt.Errorf("Error response cannot be parsed: %q error: %v", b.String(), err)
+		}
+
+		e.ServiceError = &azure.ServiceError{
+			Code:    "Unknown",
+			Message: "Unknown service error",
+		}
+		if len(rawBody) > 0 {
+			e.ServiceError.Details = []map[string]interface{}{rawBody}
+		}
+	}
+
+	e.Response = resp
+	e.RequestID = azure.ExtractRequestID(resp)
+	if e.StatusCode == nil {
+		e.StatusCode = resp.StatusCode
+	}
+	err = &e
+
+	return err
+}

--- a/pkg/radclient/client.go
+++ b/pkg/radclient/client.go
@@ -107,7 +107,7 @@ func (client Client) ListRadiusResources(ctx context.Context, resourceGroupName 
 		return resources, err
 	}
 	if parsedResponse["value"] == nil {
-		return resources, err
+		return []Application{}, err
 	}
 	applications := parsedResponse["value"].([]interface{})
 

--- a/pkg/radclient/client.go
+++ b/pkg/radclient/client.go
@@ -80,7 +80,7 @@ func (client Client) ListRadiusResources(ctx context.Context, resourceGroupName 
 		return resources, validation.NewError("resources.Client", "Get", err.Error())
 	}
 
-	req, err := client.getResourcesPreparer(ctx, resourceGroupName, resourceProviderNamespace, parentResourcePath, resourceType, apiVersion)
+	req, err := client.getResourcesPreparer(ctx, resourceGroupName, resourceType)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "resources.Client", "Get", nil, "Failure preparing request")
 		return resources, err
@@ -89,7 +89,7 @@ func (client Client) ListRadiusResources(ctx context.Context, resourceGroupName 
 	resp, err := client.GetSender(req)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "resources.Client", "Get", resp, "Failure sending request")
-		return resources, err
+		return []Application{}, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
@@ -124,7 +124,7 @@ func (client Client) ListRadiusResources(ctx context.Context, resourceGroupName 
 
 // Prepares the ListRadiusResources request.
 // Taken from resources.GetPreparer with added support for custom resource types. https://github.com/Azure/azure-sdk-for-go/blob/master/services/resources/mgmt/2020-10-01/resources/resources.go#L685
-func (client Client) getResourcesPreparer(ctx context.Context, resourceGroupName string, resourceProviderNamespace string, parentResourcePath string, resourceType string, APIVersion string) (*http.Request, error) {
+func (client Client) getResourcesPreparer(ctx context.Context, resourceGroupName string, resourceType string) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
 		"parentResourcePath":        parentResourcePath,
 		"resourceGroupName":         autorest.Encode("path", resourceGroupName),
@@ -134,7 +134,7 @@ func (client Client) getResourcesPreparer(ctx context.Context, resourceGroupName
 	}
 
 	queryParameters := map[string]interface{}{
-		"api-version": APIVersion,
+		"api-version": apiVersion,
 	}
 
 	preparer := autorest.CreatePreparer(


### PR DESCRIPTION
Related issue: https://github.com/Azure/radius/issues/17

**Testing:**
Tested locally for 200 and 404. Copying the sample output below.

**_List:_**
```% radius application list
[
	{
		"Name": "kachawla-dapr-test",
		"ID": "/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourceGroups/kachawla-radius/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/kachawla-dapr-test"
	},
	{
		"Name": "frontend-backend",
		"ID": "/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourceGroups/kachawla-radius/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/frontend-backend"
	}
]
```

**_Empty list_**
```% radius application list
[]
```

**_404 on list:_**
```% radius application list
Error listing the applications: 'autorest/azure: Service returned an error. Status=404 Code="OperationNotFound" Message="The resource provider 'radius' did not find a valid route definition for 'Application'. Please ensure the route exists and is correctly configured."'
```

**_Get:_**
```% radius application get --name frontend-backend
{
	"Name": "frontend-backend",
	"ID": "/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourceGroups/kachawla-radius/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/frontend-backend"
}
```