### PR TITLE
OpenAPI mutability Experiment

### DIFF
--- a/pkg/radclient/zz_generated_application.go
+++ b/pkg/radclient/zz_generated_application.go
@@ -29,7 +29,7 @@ func NewApplicationClient(con *armcore.Connection, subscriptionID string) *Appli
 }
 
 // CreateOrUpdate - Creates or updates an application.
-func (client *ApplicationClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, applicationName string, parameters ApplicationCreateParameters, options *ApplicationCreateOrUpdateOptions) (ApplicationResourceResponse, error) {
+func (client *ApplicationClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, applicationName string, parameters ApplicationResource, options *ApplicationCreateOrUpdateOptions) (ApplicationResourceResponse, error) {
 	req, err := client.createOrUpdateCreateRequest(ctx, resourceGroupName, applicationName, parameters, options)
 	if err != nil {
 		return ApplicationResourceResponse{}, err
@@ -45,7 +45,7 @@ func (client *ApplicationClient) CreateOrUpdate(ctx context.Context, resourceGro
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ApplicationClient) createOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, applicationName string, parameters ApplicationCreateParameters, options *ApplicationCreateOrUpdateOptions) (*azcore.Request, error) {
+func (client *ApplicationClient) createOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, applicationName string, parameters ApplicationResource, options *ApplicationCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/{applicationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/pkg/radclient/zz_generated_models.go
+++ b/pkg/radclient/zz_generated_models.go
@@ -17,12 +17,6 @@ type ApplicationCreateOrUpdateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// Parameters used to create an application.
-type ApplicationCreateParameters struct {
-	// Any object
-	Properties interface{} `json:"properties,omitempty"`
-}
-
 // ApplicationDeleteOptions contains the optional parameters for the Application.Delete method.
 type ApplicationDeleteOptions struct {
 	// placeholder for future optional parameters
@@ -53,11 +47,17 @@ type ApplicationListResponse struct {
 	RawResponse *http.Response
 }
 
+// Properties of an application.
+type ApplicationProperties struct {
+	Ferb *string `json:"ferb,omitempty"`
+	Kerb *string `json:"kerb,omitempty"`
+}
+
 // Application resource.
 type ApplicationResource struct {
 	TrackedResource
 	// Properties of the application.
-	Properties interface{} `json:"properties,omitempty"`
+	Properties *ApplicationProperties `json:"properties,omitempty"`
 }
 
 // ApplicationResourceResponse is the response envelope for operations that return a ApplicationResource type.

--- a/schemas/rest-api-specs/radius.json
+++ b/schemas/rest-api-specs/radius.json
@@ -120,7 +120,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/ApplicationCreateParameters"
+              "$ref": "#/definitions/ApplicationResource"
             },
             "description": "Parameters supplied to the Create Application operation."
           },
@@ -223,25 +223,22 @@
     "ApplicationProperties": {
       "description": "Properties of an application.",
       "type": "object",
+      "x-ms-azure-resource": true,
       "properties": {
-      }
-    },
-    "ApplicationCreateParameters": {
-      "description": "Parameters used to create an application.",
-      "type": "object",
-      "required": [
-        "properties"
-      ],
-      "properties": {
-        "properties": {
-          "type": "object",
-          "$ref": "#/definitions/ApplicationCreateProperties"
+        "ferb": {
+          "type": "string",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "kerb": {
+          "type": "string",
+          "x-ms-mutability": [
+            "read"
+          ]
         }
       }
-    },
-    "ApplicationCreateProperties": {
-      "description": "Properties used to create an application.",
-      "type": "object"
     }
   },
   "parameters": {


### PR DESCRIPTION
This is me following up on the discussion today about `x-ms-mutability`. 

This doesn't look like it has a big impact on what the generated code does :-/. It feels like the pattern that's there now (a separate type for parameters) results in a clearer API in go.

I don't think this is a big decision for us either way, but I was curious about it and wanted to share the results.