### PR TITLE
Fix failing e2e scheduled job

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -7,7 +7,7 @@ name: e2e-tests
 
 on:
   schedule:
-    - cron: '0 */2 * * *'
+    - cron: '0 */24 * * *'
   repository_dispatch:
     types: [e2e-tests]
   workflow_dispatch:
@@ -41,7 +41,7 @@ jobs:
         if: github.event_name != 'repository_dispatch'
         run: |
           echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
-          echo "CHECKOUT_REF=refs/heads/master" >> $GITHUB_ENV
+          echo "CHECKOUT_REF=refs/heads/main" >> $GITHUB_ENV
       - name: Parse test payload
         if: github.event_name == 'repository_dispatch'
         uses: actions/github-script@0.3.0


### PR DESCRIPTION
This is using the wrong branch name - so it always fails when it's
running the scheduled job.

This is also running a lot more frequently than we need. Once a day is
plenty.