### PR TITLE
Use type `Proxy` instead of `Proxy,Cache`

### DIFF
--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -369,22 +369,22 @@
                 "resourceTypes": [
                     {
                         "name": "Applications",
-                        "routingType": "Proxy,Cache",
+                        "routingType": "Proxy",
                         "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
                     },
                     {
                         "name": "Applications/Components",
-                        "routingType": "Proxy,Cache",
+                        "routingType": "Proxy",
                         "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
                     },
                     {
                         "name": "Applications/Scopes",
-                        "routingType": "Proxy,Cache",
+                        "routingType": "Proxy",
                         "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
                     },
                     {
                         "name": "Applications/Deployments",
-                        "routingType": "Proxy,Cache",
+                        "routingType": "Proxy",
                         "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
                     }
                 ]

--- a/deploy/rp-only.json
+++ b/deploy/rp-only.json
@@ -27,22 +27,22 @@
                 "resourceTypes": [
                     {
                         "name": "Applications",
-                        "routingType": "Proxy,Cache",
+                        "routingType": "Proxy",
                         "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
                     },
                     {
                         "name": "Applications/Components",
-                        "routingType": "Proxy,Cache",
+                        "routingType": "Proxy",
                         "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
                     },
                     {
                         "name": "Applications/Scopes",
-                        "routingType": "Proxy,Cache",
+                        "routingType": "Proxy",
                         "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
                     },
                     {
                         "name": "Applications/Deployments",
-                        "routingType": "Proxy,Cache",
+                        "routingType": "Proxy",
                         "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
                     }
                 ]


### PR DESCRIPTION
This changes how we're registering our resource types with ARM. What
this means that GET requests (GET/LIST) will be sent through to our RP
rather than being handled by ARM's cache on our behalf.

The reason for this change is that `Proxy,Cache` is resulting in our
top-level `kind` property being omitted. We return this property from
our RP, but it's not in the final response :-/.

We're following up with the ARM team on this behavior.