### PR TITLE
Adding missing dependency in tooling installation

### DIFF
--- a/docs/content/getting-started/install-cli.md
+++ b/docs/content/getting-started/install-cli.md
@@ -49,7 +49,7 @@ Use "rad [command] --help" for more information about a command.
 
 Radius can be used with any text editor, but Radius-specific optimizations are available for [Visual Studio Code](https://code.visualstudio.com/). The Project Radius VSCode extension provides syntax highlighting, completion, and linting.
 
-Install the VSCode extension from `.vsix` file:
+Make sure you have [.Net 5.0](https://dotnet.microsoft.com/download/dotnet/5.0) installed. Then install the VSCode extension from `.vsix` file:
 
 - [Download](https://radiuspublic.blob.core.windows.net/tools/vscode/edge/rad-vscode-bicep.vsix)
 - In VSCode, manually install the extension using the *Install from VSIX* command in the Extensions view command drop-down.


### PR DESCRIPTION
The Radius VS Code extension is taking .Net 5.0 as dependency.