### PR TITLE
Support port-forwarding without Kubernetes CLI

### DIFF
--- a/cmd/cli/cmd/expose.go
+++ b/cmd/cli/cmd/expose.go
@@ -6,92 +6,200 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
+	"os/signal"
 
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
+	"github.com/Azure/radius/cmd/cli/utils"
+	"github.com/Azure/radius/pkg/rad/environments"
+	"github.com/Azure/radius/pkg/workloads"
 	"github.com/spf13/cobra"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
 )
 
 var exposeCmd = &cobra.Command{
-	Use:   "expose component on local port",
-	Short: "Expose local port",
-	Long:  `Expose local port`,
-	Args:  cobra.ExactArgs(3),
+	Use:   "expose application component",
+	Short: "Exposes a component for network traffic",
+	Long: `Exposes a port inside a component for network traffic using a local port.
+This command is useful for testing components that accept network traffic but are not exposed to the public internet. Exposing a port for testing allows you to send TCP traffic from your local machine to the component.
+
+Press CTRL+C to exit the command and terminate the tunnel.`,
+	Example: `# expose port 80 on the 'orders' component of the 'icecream-store' application
+# on local port 5000
+rad expose icecream-store orders --port 5000 --remote-port 80`,
+	Args: NamedPositionalArgs([]string{"application", "component"}),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		config, err := createClient()
+
+		application := args[0]
+		component := args[1]
+		localPort, err := cmd.Flags().GetInt("port")
 		if err != nil {
 			return err
 		}
 
-		client, err := client.New(config, client.Options{Scheme: scheme.Scheme})
+		remotePort, err := cmd.Flags().GetInt("remote-port")
 		if err != nil {
 			return err
 		}
 
-		service := v1.Service{}
-		err = client.Get(cmd.Context(), types.NamespacedName{Namespace: args[0], Name: args[1]}, &service)
+		if remotePort == -1 {
+			remotePort = localPort
+		}
+
+		env, err := validateDefaultEnvironment()
 		if err != nil {
 			return err
 		}
 
-		var remotePort *int32
-		for _, p := range service.Spec.Ports {
-			remotePort = &p.Port
-			break
+		config, err := getMonitoringCredentials(cmd.Context(), *env)
+		if err != nil {
+			return err
 		}
 
-		if remotePort == nil {
-			return errors.New("could not find service port")
+		client, err := k8s.NewForConfig(config)
+		if err != nil {
+			return err
 		}
 
-		var executableName string
-		if runtime.GOOS == "windows" {
-			executableName = "kubectl.exe"
-		} else {
-			executableName = "kubectl"
+		replica, err := getRunningReplica(cmd.Context(), client, application, component)
+		if err != nil {
+			return err
 		}
 
-		c := exec.Command(executableName, "port-forward", "-n", args[0], fmt.Sprintf("svc/%v", args[1]), fmt.Sprintf("%v:%v", args[2], *remotePort))
-		c.Stderr = os.Stderr
-		c.Stdout = os.Stdout
-		err = c.Run()
-		return err
+		signals := make(chan os.Signal, 1)
+		signal.Notify(signals, os.Interrupt)
+		defer signal.Stop(signals)
+
+		failed := make(chan error)
+		ready := make(chan struct{})
+		stop := make(chan struct{}, 1)
+		go func() {
+			err := runPortforward(config, client, replica, ready, stop, localPort, remotePort)
+			failed <- err
+		}()
+
+		for {
+			select {
+			case <-signals:
+				// shutting down... wait for socket to close
+				close(stop)
+				continue
+			case err := <-failed:
+				if err != nil {
+					return fmt.Errorf("failed to port-forward: %w", err)
+				}
+
+				return nil
+			}
+		}
 	},
 }
 
 func init() {
 	RootCmd.AddCommand(exposeCmd)
-}
 
-func createClient() (*rest.Config, error) {
-	var kubeConfig string
-	if home := homeDir(); home != "" {
-		kubeConfig = filepath.Join(home, ".kube", "config")
-	} else {
-		return nil, errors.New("no HOME directory, cannot find kubeconfig")
+	exposeCmd.Flags().IntP("port", "p", -1, "specify the local port")
+	err := exposeCmd.MarkFlagRequired("port")
+	if err != nil {
+		panic(err)
 	}
 
-	config, err := clientcmd.BuildConfigFromFlags("", kubeConfig)
+	exposeCmd.Flags().IntP("remote-port", "r", -1, "specify the remote port")
+}
+
+func getMonitoringCredentials(ctx context.Context, env environments.AzureCloudEnvironment) (*rest.Config, error) {
+	armauth, err := utils.GetResourceManagerEndpointAuthorizer()
 	if err != nil {
 		return nil, err
 	}
 
-	return config, nil
+	// Currently we go to AKS every time to ask for credentials, we don't
+	// cache them locally. This could be done in the future, but skipping it for now
+	// since it's non-obvious that we'd store credentials in your ~/.rad directory
+	mcc := containerservice.NewManagedClustersClient(env.SubscriptionID)
+	mcc.Authorizer = armauth
+
+	results, err := mcc.ListClusterMonitoringUserCredentials(ctx, env.ResourceGroup, env.ClusterName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list AKS cluster credentials: %w", err)
+	}
+
+	if results.Kubeconfigs == nil || len(*results.Kubeconfigs) == 0 {
+		return nil, errors.New("failed to list AKS cluster credentials: response did not contain credentials")
+	}
+
+	kc := (*results.Kubeconfigs)[0]
+	c, err := clientcmd.NewClientConfigFromBytes(*kc.Value)
+	if err != nil {
+		return nil, fmt.Errorf("kubeconfig was invalid: %w", err)
+	}
+
+	restconfig, err := c.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("kubeconfig did not contain client credentials: %w", err)
+	}
+
+	return restconfig, nil
 }
 
-func homeDir() string {
-	if h := os.Getenv("HOME"); h != "" {
-		return h
+func getRunningReplica(ctx context.Context, client *k8s.Clientset, application string, component string) (*corev1.Pod, error) {
+	// Right now this connects to a pod related to a component. We can find the pods with the labels
+	// and then choose one that's in the running state.
+	pods, err := client.CoreV1().Pods(application).List(ctx, v1.ListOptions{
+		LabelSelector: labels.FormatLabels(map[string]string{workloads.LabelRadiusComponent: component}),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list running replicas for component %v: %w", component, err)
 	}
-	return os.Getenv("USERPROFILE") // windows
+
+	for _, p := range pods.Items {
+		if p.Status.Phase == corev1.PodRunning {
+			return &p, nil
+		}
+	}
+
+	return nil, fmt.Errorf("failed to find a running replica for component %v", component)
+}
+
+func runPortforward(restconfig *rest.Config, client *k8s.Clientset, replica *corev1.Pod, ready chan struct{}, stop <-chan struct{}, localPort int, remotePort int) error {
+	// Build URL so we can open a port-forward via SPDY
+	url := client.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace(replica.Namespace).
+		Name(replica.Name).
+		SubResource("portforward").URL()
+
+	transport, upgrader, err := spdy.RoundTripperFor(restconfig)
+	if err != nil {
+		return err
+	}
+
+	out := ioutil.Discard
+	errOut := ioutil.Discard
+	if true {
+		out = os.Stdout
+		errOut = os.Stderr
+	}
+
+	ports := []string{fmt.Sprintf("%d:%d", localPort, remotePort)}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", url)
+
+	fw, err := portforward.NewOnAddresses(dialer, []string{"localhost"}, ports, stop, ready, out, errOut)
+	if err != nil {
+		return err
+	}
+
+	return fw.ForwardPorts()
 }

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -92,3 +92,17 @@ func saveConfig() error {
 	fmt.Printf("Successfully wrote configuration to %v\n", cfgFile)
 	return nil
 }
+
+// NamedPositionalArgs creates a positional argument validator for our commands.
+func NamedPositionalArgs(names []string) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) == len(names) {
+			return nil
+		} else if len(args) > len(names) {
+			return fmt.Errorf("unexpected value '%v', expected %v arguments", args[len(names)], len(names))
+		} else {
+			name := names[len(args)]
+			return fmt.Errorf("%v is required", name)
+		}
+	}
+}

--- a/docs/content/getting-started/tutorial/dapr-microservices/index.md
+++ b/docs/content/getting-started/tutorial/dapr-microservices/index.md
@@ -12,7 +12,6 @@ To begin this tutorial you should have already completed the following steps:
 
 - [Install Radius CLI]({{< ref install-cli.md >}})
 - [Create an environment]({{< ref create-environment.md >}})
-- [Install Kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [(Recommended) Install Visual Studio Code](https://code.visualstudio.com/)
 
 No prior knowledge of Radius is needed, this tutorial will walk you through authoring the deployment template and deploying a microservices application from first principles.
@@ -217,22 +216,13 @@ rad deploy template.bicep
 
 This will deploy the application and launch the container.
 
-{{% alert title="⚠️ Temporary" color="warning" %}}
-Run this command at the commandline, which is temporary pending additions to the rad CLI:
-
-```sh
-rad env merge-credentials --name azure 
-```
-
-{{% /alert %}}
-
 To test it out, you can use the following command from the commandline:
 
 ```sh
-rad expose dapr-hello nodeapp 3000
+rad expose dapr-hello nodeapp --port 3000
 ```
 
-This will open a local tunnel on port 3000. Then you can visit the URL `http://localhost:3000/order` in the browser. For now you should see a message like:
+This will open a local tunnel on port 3000 to port 3000 inside the container. Then you can visit the URL `http://localhost:3000/order` in the browser. For now you should see a message like:
 
 ```txt
 {"message":"The container is running, but Dapr has not been configured."}

--- a/docs/content/getting-started/tutorial/webapp/index.md
+++ b/docs/content/getting-started/tutorial/webapp/index.md
@@ -16,7 +16,6 @@ To begin this tutorial you should have already completed the following steps:
 
 - [Install Radius CLI]({{< ref install-cli.md >}})
 - [Create a Radius environment]({{< ref create-environment.md >}})
-- [Install Kubectl](https://kubernetes.io/docs/tasks/tools/)
 - [(recommended) Install Visual Studio Code](https://code.visualstudio.com/)
    - The [Radius VSCode extension]({{< ref "install-cli.md#2-install-custom-vscode-extension" >}}) provides syntax highlighting, completion, and linting.
 
@@ -197,7 +196,7 @@ Now you are ready to deploy the application for the first time.
    az login
    ```
 
-1. Then after that completes, run:
+2. Then after that completes, run:
 
    ```sh
    rad deploy template.bicep
@@ -205,17 +204,7 @@ Now you are ready to deploy the application for the first time.
 
    This will deploy the application and launch the container.
 
-3. Merge credentials
-   
-   {{% alert title="⚠️ Temporary" color="warning" %}}
-   Run this command at the commandline to gain access to the underlying AKS cluster in your Radius environment. This is temporary pending additions to the rad CLI:
-
-   ```sh
-   rad env merge-credentials --name azure 
-   ```
-   {{% /alert %}}
-
-1. Open a local tunnel to your application:
+3. Open a local tunnel to your application:
 
    ```sh
    rad expose webapp todoapp 3000
@@ -224,7 +213,7 @@ Now you are ready to deploy the application for the first time.
    The `rad expose` command provides the application name, followed by the component name, followed by a port. If you changed any of these names when deploying, update your command to match.
    {{% /alert %}}
 
-1. Visit the URL `http://localhost:3000` in the browser. For now you should see a page like:
+4. Visit the URL `http://localhost:3000` in the browser. For now you should see a page like:
 
    <img src="todoapp-nodb.png" width="400" alt="screenshot of the todo application with no database">
 
@@ -235,7 +224,7 @@ Now you are ready to deploy the application for the first time.
    - Mark a todo item as complete
    - Delete a todo item
 
-1. When you are done testing press CTRL+C to terminate the port-forward, and you are ready to move on to the next step.
+5. When you are done testing press CTRL+C to terminate the port-forward, and you are ready to move on to the next step.
 
 ## Step 3: Adding a database
 

--- a/go.sum
+++ b/go.sum
@@ -124,10 +124,12 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
+github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=


### PR DESCRIPTION
Fixes: #173

This change updates the `rad expose` command to work without:

- Local Kubernetes CLI
- Local Kubernetes credentials

We use the AKS Azure SDK to retrieve 'monitoring' credentials for the
environment. Then we can use the Kubernetes port-forward support as a
library.

I also reworked the command to make it clearer what you're specifying
when you work with it. You also have the ability to specify the remote
port on the container, this wasn't supported before, it had to be
something you exposed as a service. This is much more flexible and
probably easier to understand as well.