### PR TITLE
Add install script

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -229,3 +229,10 @@ jobs:
           connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
           sync: true
           extra_args: '--destination-path rad/${{ env.REL_VERSION }}/windows-x64/ --pattern rad.exe'
+      - uses: bacongobbler/azure-blob-storage-upload@v1.1.1
+        with:
+          source_dir: install
+          container_name: 'tools'
+          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
+          sync: true
+          extra_args: '--destination-path rad/ --pattern install.*'

--- a/docs/content/getting-started/install-cli.md
+++ b/docs/content/getting-started/install-cli.md
@@ -57,7 +57,7 @@ wget -q "https://raw.githubusercontent.com/azure/radius/main/install/install.sh"
 
 ### Install a specific version
 
-```
+```bash
 wget -q "https://raw.githubusercontent.com/azure/radius/main/install/install.sh" | /bin/bash -s <Version>
 ```
 

--- a/docs/content/getting-started/install-cli.md
+++ b/docs/content/getting-started/install-cli.md
@@ -35,7 +35,7 @@ powershell -Command "$script=iwr -useb  https://raw.githubusercontent.com/azure/
 
 ### Install the latest stable version
 
-```
+```bash
 curl -fsSL "https://raw.githubusercontent.com/azure/radius/main/install/install.sh" | /bin/bash
 ```
 

--- a/docs/content/getting-started/install-cli.md
+++ b/docs/content/getting-started/install-cli.md
@@ -20,7 +20,7 @@ These steps will setup the required tools and extensions to get you up and runni
 
 ### Install the latest stable version
 
-```
+```powershell
 powershell -Command "iwr -useb https://raw.githubusercontent.com/azure/radius/main/install/install.ps1 | iex"
 ```
 

--- a/docs/content/getting-started/install-cli.md
+++ b/docs/content/getting-started/install-cli.md
@@ -26,7 +26,7 @@ powershell -Command "iwr -useb https://raw.githubusercontent.com/azure/radius/ma
 
 ### Install a specific version
 
-```
+```powershell
 powershell -Command "$script=iwr -useb  https://raw.githubusercontent.com/azure/radius/main/install/install.ps1; $block=[ScriptBlock]::Create($script); invoke-command -ScriptBlock $block -ArgumentList <Version>"
 ```
 

--- a/docs/content/getting-started/install-cli.md
+++ b/docs/content/getting-started/install-cli.md
@@ -61,7 +61,7 @@ wget -q "https://raw.githubusercontent.com/azure/radius/main/install/install.sh"
 wget -q "https://raw.githubusercontent.com/azure/radius/main/install/install.sh" | /bin/bash -s <Version>
 ```
 
-{{% codetab %}}
+{{% /codetab %}}
 
 {{% codetab %}}
 

--- a/docs/content/getting-started/install-cli.md
+++ b/docs/content/getting-started/install-cli.md
@@ -12,15 +12,81 @@ These steps will setup the required tools and extensions to get you up and runni
 
 - [Az CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 
-## Install rad CLI
+## Install CLI
 
-1. Download the `rad` CLI from one of these links:
+{{< tabs Windows MacOS Linux Binaries >}}
 
-   - [MacOS](https://radiuspublic.blob.core.windows.net/tools/rad/edge/macos-x64/rad)
-   - [Linux](https://radiuspublic.blob.core.windows.net/tools/rad/edge/linux-x64/rad)
-   - [Windows](https://radiuspublic.blob.core.windows.net/tools/rad/edge/windows-x64/rad.exe)
+{{% codetab %}}
+
+### Install the latest stable version
+
+```
+powershell -Command "iwr -useb https://raw.githubusercontent.com/azure/radius/main/install/install.ps1 | iex"
+```
+
+### Install a specific version
+
+```
+powershell -Command "$script=iwr -useb  https://raw.githubusercontent.com/azure/radius/main/install/install.ps1; $block=[ScriptBlock]::Create($script); invoke-command -ScriptBlock $block -ArgumentList <Version>"
+```
+
+{{% /codetab %}}
+{{% codetab %}}
+
+### Install the latest stable version
+
+```
+curl -fsSL "https://raw.githubusercontent.com/azure/radius/main/install/install.sh" | /bin/bash
+```
+
+### Install a specific version
+
+```
+curl -fsSL "https://raw.githubusercontent.com/azure/radius/main/install/install.sh" | /bin/bash -s <Version>
+```
+
+{{% /codetab %}}
+
+{{% codetab %}}
+
+### Install the latest stable version
+
+```
+wget -q "https://raw.githubusercontent.com/azure/radius/main/install/install.sh" | /bin/bash
+```
+
+### Install a specific version
+
+```
+wget -q "https://raw.githubusercontent.com/azure/radius/main/install/install.sh" | /bin/bash -s <Version>
+```
+
+{{% codetab %}}
+
+{{% codetab %}}
+
+### Install the latest stable version
+
+1. Download the `rad` CLI from one of these URLs:
+
+   - MacOS: https://radiuspublic.blob.core.windows.net/tools/rad/edge/macos-x64/rad
+   - Linux: https://radiuspublic.blob.core.windows.net/tools/rad/edge/linux-x64/rad
+   - Windows: https://radiuspublic.blob.core.windows.net/tools/rad/edge/windows-x64/rad.exe
 
 1. Ensure the user has permission to execute the binary and place it somewhere on your PATH so it can be invoked easily.
+
+### Install a specific version
+
+1. Download the `rad` CLI from one of these URLs (replace `<version>` with your desired version):
+
+   - MacOS: https://radiuspublic.blob.core.windows.net/tools/rad/<version>/macos-x64/rad
+   - Linux: https://radiuspublic.blob.core.windows.net/tools/rad/edge/linux-x64/rad
+   - Windows: https://radiuspublic.blob.core.windows.net/tools/rad/edge/windows-x64/rad.exe
+
+2. Ensure the user has permission to execute the binary and place it somewhere on your PATH so it can be invoked easily.
+
+
+## Test it out
 
 1. Verify the rad CLI is installed correctly:
 

--- a/docs/content/getting-started/install-cli.md
+++ b/docs/content/getting-started/install-cli.md
@@ -41,7 +41,7 @@ curl -fsSL "https://raw.githubusercontent.com/azure/radius/main/install/install.
 
 ### Install a specific version
 
-```
+```bash
 curl -fsSL "https://raw.githubusercontent.com/azure/radius/main/install/install.sh" | /bin/bash -s <Version>
 ```
 

--- a/docs/content/getting-started/install-cli.md
+++ b/docs/content/getting-started/install-cli.md
@@ -85,6 +85,9 @@ wget -q "https://raw.githubusercontent.com/azure/radius/main/install/install.sh"
 
 2. Ensure the user has permission to execute the binary and place it somewhere on your PATH so it can be invoked easily.
 
+{{% /codetab %}}
+
+{{< /tabs >}}
 
 ## Test it out
 

--- a/docs/content/getting-started/install-cli.md
+++ b/docs/content/getting-started/install-cli.md
@@ -80,8 +80,8 @@ wget -q "https://raw.githubusercontent.com/azure/radius/main/install/install.sh"
 1. Download the `rad` CLI from one of these URLs (replace `<version>` with your desired version):
 
    - MacOS: https://radiuspublic.blob.core.windows.net/tools/rad/<version>/macos-x64/rad
-   - Linux: https://radiuspublic.blob.core.windows.net/tools/rad/edge/linux-x64/rad
-   - Windows: https://radiuspublic.blob.core.windows.net/tools/rad/edge/windows-x64/rad.exe
+   - Linux: https://radiuspublic.blob.core.windows.net/tools/rad/<version>/linux-x64/rad
+   - Windows: https://radiuspublic.blob.core.windows.net/tools/rad/<version>/windows-x64/rad.exe
 
 2. Ensure the user has permission to execute the binary and place it somewhere on your PATH so it can be invoked easily.
 

--- a/docs/content/getting-started/install-cli.md
+++ b/docs/content/getting-started/install-cli.md
@@ -79,9 +79,9 @@ wget -q "https://raw.githubusercontent.com/azure/radius/main/install/install.sh"
 
 1. Download the `rad` CLI from one of these URLs (replace `<version>` with your desired version):
 
-   - MacOS: https://radiuspublic.blob.core.windows.net/tools/rad/<version>/macos-x64/rad
-   - Linux: https://radiuspublic.blob.core.windows.net/tools/rad/<version>/linux-x64/rad
-   - Windows: https://radiuspublic.blob.core.windows.net/tools/rad/<version>/windows-x64/rad.exe
+   - MacOS: https://radiuspublic.blob.core.windows.net/tools/rad/<version\>/macos-x64/rad
+   - Linux: https://radiuspublic.blob.core.windows.net/tools/rad/<version\>/linux-x64/rad
+   - Windows: https://radiuspublic.blob.core.windows.net/tools/rad/<version\>/windows-x64/rad.exe
 
 2. Ensure the user has permission to execute the binary and place it somewhere on your PATH so it can be invoked easily.
 

--- a/docs/content/getting-started/install-cli.md
+++ b/docs/content/getting-started/install-cli.md
@@ -51,7 +51,7 @@ curl -fsSL "https://raw.githubusercontent.com/azure/radius/main/install/install.
 
 ### Install the latest stable version
 
-```
+```bash
 wget -q "https://raw.githubusercontent.com/azure/radius/main/install/install.sh" | /bin/bash
 ```
 

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -1,0 +1,104 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+param (
+    [string]$Version,
+    [string]$RadiusRoot = "c:\radius"
+)
+
+Write-Output ""
+$ErrorActionPreference = 'stop'
+
+#Escape space of RadiusRoot path
+$RadiusRoot = $RadiusRoot -replace ' ', '` '
+
+# Constants
+$RadiusCliFileName = "rad.exe"
+$RadiusCliFilePath = "${RadiusRoot}\${RadiusCliFileName}"
+$OsArch = "windows-x64"
+$BaseDownloadUrl = "https://radiuspublic.blob.core.windows.net/tools/rad"
+
+# Set Github request authentication for basic authentication.
+if ($Env:GITHUB_USER) {
+    $basicAuth = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($Env:GITHUB_USER + ":" + $Env:GITHUB_TOKEN));
+    $githubHeader = @{"Authorization" = "Basic $basicAuth" }
+}
+else {
+    $githubHeader = @{}
+}
+
+if ((Get-ExecutionPolicy) -gt 'RemoteSigned' -or (Get-ExecutionPolicy) -eq 'ByPass') {
+    Write-Output "PowerShell requires an execution policy of 'RemoteSigned'."
+    Write-Output "To make this change please run:"
+    Write-Output "'Set-ExecutionPolicy RemoteSigned -scope CurrentUser'"
+    break
+}
+
+# Change security protocol to support TLS 1.2 / 1.1 / 1.0 - old powershell uses TLS 1.0 as a default protocol
+[Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
+
+# Check if Radius CLI is installed.
+if (Test-Path $RadiusCliFilePath -PathType Leaf) {
+    Write-Warning "Radius is detected - $RadiusCliFilePath"
+    #TODO Invoke-Expression "$RadiusCliFilePath --version"
+    Write-Output "Reinstalling Radius..."
+}
+else {
+    Write-Output "Installing Radius..."
+}
+
+# Create Radius Directory
+Write-Output "Creating $RadiusRoot directory"
+New-Item -ErrorAction Ignore -Path $RadiusRoot -ItemType "directory"
+if (!(Test-Path $RadiusRoot -PathType Container)) {
+    throw "Cannot create $RadiusRoot"
+}
+
+# TODO Get the list of release from GitHub and get the latest version
+if($Version -eq "")
+{
+    $Version = "edge"
+}
+$urlParts = @(
+    $BaseDownloadUrl,
+    $Version,
+    $OsArch,
+    $RadiusCliFileName
+)
+$binaryUrl =  $urlParts -join "/"
+
+$binaryFilePath = $RadiusRoot + "\" + $RadiusCliFileName
+Write-Output "Downloading $binaryUrl ..."
+
+$githubHeader.Accept = "application/octet-stream"
+$uri = [uri]$binaryUrl
+try
+{
+    Invoke-WebRequest -Headers $githubHeader -Uri $binaryUrl -OutFile $binaryFilePath
+    if (!(Test-Path $binaryFilePath -PathType Leaf)) {
+        throw "Failed to download Radius Cli binary - $binaryFilePath"
+    }
+}
+catch [Net.WebException]
+{
+    throw "ERROR: The specified release version: $Version does not exist."
+}
+
+# TODO Check the Radius CLI version: Invoke-Expression "$RadiusCliFilePath --version"
+
+# Add RadiusRoot directory to User Path environment variable
+Write-Output "Try to add $RadiusRoot to User Path Environment variable..."
+$UserPathEnvironmentVar = [Environment]::GetEnvironmentVariable("PATH", "User")
+if ($UserPathEnvironmentVar -like '*radius*') {
+    Write-Output "Skipping to add $RadiusRoot to User Path - $UserPathEnvironmentVar"
+}
+else {
+    [System.Environment]::SetEnvironmentVariable("PATH", $UserPathEnvironmentVar + ";$RadiusRoot", "User")
+    $UserPathEnvironmentVar = [Environment]::GetEnvironmentVariable("PATH", "User")
+    Write-Output "Added $RadiusRoot to User Path - $UserPathEnvironmentVar"
+}
+
+Write-Output "`r`nRadius CLI is installed successfully."
+Write-Output "To get started with Radius, please visit https://docs.radapp.dev/getting-started/."

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+# Radius CLI location
+: ${RADIUS_INSTALL_DIR:="/usr/local/bin"}
+
+# sudo is required to copy binary to RADIUS_INSTALL_DIR for linux
+: ${USE_SUDO:="false"}
+
+# Http request CLI
+RADIUS_HTTP_REQUEST_CLI=curl
+
+# Radius CLI filename
+RADIUS_CLI_FILENAME=rad
+
+RADIUS_CLI_FILE="${RADIUS_INSTALL_DIR}/${RADIUS_CLI_FILENAME}"
+
+getSystemInfo() {
+    ARCH=$(uname -m)
+    case $ARCH in
+        armv7*) ARCH="arm";;
+        aarch64) ARCH="arm64";;
+        x86_64) ARCH="x64";;
+    esac
+
+    OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
+
+    if [ "$OS" == "darwin" ]; then
+        OS="macos"
+    fi
+
+    # Most linux distro needs root permission to copy the file to /usr/local/bin
+    if [ "$OS" == "linux" ] && [ "$RADIUS_INSTALL_DIR" == "/usr/local/bin" ]; then
+        USE_SUDO="true"
+    fi
+}
+
+verifySupported() {
+    local supported=(macos-x64 linux-x64 linux-arm linux-arm64)
+    local current_osarch="${OS}-${ARCH}"
+
+    for osarch in "${supported[@]}"; do
+        if [ "$osarch" == "$current_osarch" ]; then
+            echo "Your system is ${OS}_${ARCH}"
+            return
+        fi
+    done
+
+    if [ "$current_osarch" == "macos-arm64" ]; then
+        echo "The macos-arm64 arch has no native binary, however you can use the x64 version so long as you have rosetta installed"
+        echo "Use 'softwareupdate --install-rosetta' to install rosetta if you don't already have it"
+        ARCH="x64"
+        return
+    fi
+
+
+    echo "No prebuilt binary for ${current_osarch}"
+    exit 1
+}
+
+runAsRoot() {
+    local CMD="$*"
+
+    if [ $EUID -ne 0 -a $USE_SUDO = "true" ]; then
+        CMD="sudo $CMD"
+    fi
+
+    $CMD
+}
+
+checkHttpRequestCLI() {
+    if type "curl" > /dev/null; then
+        RADIUS_HTTP_REQUEST_CLI=wget
+    elif type "wget" > /dev/null; then
+        RADIUS_HTTP_REQUEST_CLI=wget
+    else
+        echo "Either curl or wget is required"
+        exit 1
+    fi
+}
+
+checkExistingRadius() {
+    if [ -f "$RADIUS_CLI_FILE" ]; then
+        echo -e "\nRadius CLI is detected:"
+        #TODO $RADIUS_CLI_FILE --version
+        echo -e "Reinstalling Radius CLI - ${RADIUS_CLI_FILE}...\n"
+    else
+        echo -e "Installing Radius CLI...\n"
+    fi
+}
+
+getLatestRelease() {
+    local current_osarch="${OS}-${ARCH}"
+    local latest_release="edge"
+    
+    # TODO Add code to check the release versions and get the latest release
+
+    ret_val=$latest_release
+}
+
+downloadFile() {
+    LATEST_RELEASE_TAG=$1
+
+    OS_ARCH="${OS}-${ARCH}"
+    RADIUS_CLI_ARTIFACT="rad"
+    DOWNLOAD_BASE="https://radiuspublic.blob.core.windows.net/tools/rad"
+    DOWNLOAD_URL="${DOWNLOAD_BASE}/${LATEST_RELEASE_TAG}/${OS_ARCH}/${RADIUS_CLI_ARTIFACT}"
+
+    # Create the temp directory
+    RADIUS_TMP_ROOT=$(mktemp -dt Radius-install-XXXXXX)
+    ARTIFACT_TMP_FILE="$RADIUS_TMP_ROOT/$RADIUS_CLI_ARTIFACT"
+
+    if [ "$RADIUS_HTTP_REQUEST_CLI" == "curl" ]; then
+        if ! curl --output /dev/null --silent --head --fail "$DOWNLOAD_URL"; then
+            echo "ERROR: The specified release version: $LATEST_RELEASE_TAG does not exist."
+            exit 1
+        fi
+    else
+        if ! wget --spider "$DOWNLOAD_URL" 2>/dev/null; then
+            echo "ERROR: The specified release version: $LATEST_RELEASE_TAG does not exist."
+            exit 1
+        fi
+    fi
+
+
+    echo "Downloading $DOWNLOAD_URL ..."
+    if [ "$RADIUS_HTTP_REQUEST_CLI" == "curl" ]; then
+        curl -SsL "$DOWNLOAD_URL" -o "$ARTIFACT_TMP_FILE"
+    else
+        wget -q -O "$ARTIFACT_TMP_FILE" "$DOWNLOAD_URL"
+    fi
+
+    if [ ! -f "$ARTIFACT_TMP_FILE" ]; then
+        echo "failed to download $DOWNLOAD_URL ..."
+        exit 1
+    fi
+}
+
+installFile() {
+    local tmp_root_Radius_cli="$RADIUS_TMP_ROOT/$RADIUS_CLI_FILENAME"
+
+    if [ ! -f "$tmp_root_Radius_cli" ]; then
+        echo "Failed to download Radius CLI executable."
+        exit 1
+    fi
+
+    chmod a+x $tmp_root_Radius_cli
+    runAsRoot cp "$tmp_root_Radius_cli" "$RADIUS_INSTALL_DIR"
+
+    if [ -f "$RADIUS_CLI_FILE" ]; then
+        echo "$RADIUS_CLI_FILENAME installed into $RADIUS_INSTALL_DIR successfully."
+
+        # TODO: $RADIUS_CLI_FILE --version
+    else 
+        echo "Failed to install $RADIUS_CLI_FILENAME"
+        exit 1
+    fi
+}
+
+fail_trap() {
+    result=$?
+    if [ "$result" != "0" ]; then
+        echo "Failed to install Radius CLI"
+        echo "For support, go to https://github.com/Azure/radius"
+    fi
+    cleanup
+    exit $result
+}
+
+cleanup() {
+    if [[ -d "${RADIUS_TMP_ROOT:-}" ]]; then
+        rm -rf "$RADIUS_TMP_ROOT"
+    fi
+}
+
+installCompleted() {
+    echo -e "\nTo get started with Radius, please visit https://docs.radapp.dev/getting-started/"
+}
+
+# -----------------------------------------------------------------------------
+# main
+# -----------------------------------------------------------------------------
+trap "fail_trap" EXIT
+
+getSystemInfo
+verifySupported
+checkExistingRadius
+checkHttpRequestCLI
+
+
+if [ -z "$1" ]; then
+    echo "Getting the latest Radius CLI..."
+    getLatestRelease
+else
+    ret_val=$1
+    echo "Getting the Radius CLI release version: $1..."
+fi
+
+echo "Installing $ret_val Radius CLI..."
+
+downloadFile $ret_val
+installFile
+cleanup
+
+installCompleted


### PR DESCRIPTION
Fixes: #35

Hosting the install script on GitHub rather than our storage account
because GitHub allows downlevel versions of TLS.