### PR TITLE
add new CLI commands to webapp tutorial

### DIFF
--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -69,7 +69,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 	}
 	logger.CompleteStep(step)
 
-	logger.LogInfo("Deployment complete")
+	logger.LogInfo("Deployment Complete")
 	return nil
 }
 

--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -55,21 +55,21 @@ func deploy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	step := logger.BeginStep("building application...")
+	step := logger.BeginStep("Building Application...")
 	template, err := bicepBuild(filePath)
 	if err != nil {
 		return err
 	}
 	logger.CompleteStep(step)
 
-	step = logger.BeginStep("deploying application...")
+	step = logger.BeginStep("Deploying Application...")
 	err = deployApplication(cmd.Context(), template, env)
 	if err != nil {
 		return err
 	}
 	logger.CompleteStep(step)
 
-	logger.LogInfo("deployment complete")
+	logger.LogInfo("Deployment Complete")
 	return nil
 }
 
@@ -93,7 +93,7 @@ func bicepBuild(filePath string) (string, error) {
 	}
 
 	if !ok {
-		logger.LogInfo("downloading bicep...")
+		logger.LogInfo("Downloading Bicep...")
 		err = bicep.DownloadBicep()
 		if err != nil {
 			return "", fmt.Errorf("failed to download rad-bicep: %w", err)

--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -69,7 +69,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 	}
 	logger.CompleteStep(step)
 
-	logger.LogInfo("Deployment Complete")
+	logger.LogInfo("Deployment complete")
 	return nil
 }
 

--- a/docs/content/getting-started/tutorial/dapr-microservices/dapr-microservices.bicep
+++ b/docs/content/getting-started/tutorial/dapr-microservices/dapr-microservices.bicep
@@ -1,7 +1,7 @@
 resource app 'radius.dev/Applications@v1alpha1' = {
   name: 'dapr-hello'
 
-  resource nodeapp 'Components' = {
+  resource nodeapplication 'Components' = {
     name: 'nodeapp'
     kind: 'radius.dev/Container@v1alpha1'
     properties: {
@@ -35,7 +35,7 @@ resource app 'radius.dev/Applications@v1alpha1' = {
     }
   }
 
-  resource pythonapp 'Components' = {
+  resource pythonapplication 'Components' = {
     name: 'pythonapp'
     kind: 'radius.dev/Container@v1alpha1'
     properties: {

--- a/docs/content/getting-started/tutorial/dapr-microservices/index.md
+++ b/docs/content/getting-started/tutorial/dapr-microservices/index.md
@@ -469,8 +469,6 @@ Refresh the page multiple times, and you should see a message like before, but t
 
 If your message matches, then it means that pythonapp is able to communicate with nodeapp. When you are done testing press CTRL+C to terminate the port-forward.
 
-You have completed this tutorial!
-
 ## Step 3: Cleanup
 
 If you'd like to try another tutorial with your existing environment, go back to the [Radius tutorials]({{< ref tutorial >}}). 
@@ -487,6 +485,8 @@ Deleting an environment will delete:
 ```sh
 rad env delete azure --yes
 ```
+
+You have completed this tutorial!
 
 ## Related links
 

--- a/docs/content/getting-started/tutorial/dapr-microservices/index.md
+++ b/docs/content/getting-started/tutorial/dapr-microservices/index.md
@@ -8,10 +8,10 @@ weight: 200
 
 ## Before you begin
 
-This tutorial will teach you how to use Radius to deploy a microservices application from first principles. You will learn  
+This tutorial will teach you how to use Radius to deploy a microservices application from first principles. You will learn:  
 
-- the concepts of the Radius application model 
-- the basic syntax of the Bicep language 
+- The concepts of the Radius application model 
+- The basic syntax of the Bicep language 
 
 The Radius application in this tutorial uses [Dapr](https://dapr.io). No prior knowledge of Dapr, Radius, or [Bicep](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/bicep-overview) is needed.
 
@@ -140,7 +140,7 @@ A component can be:
 - A resource that works with data (eg. a message queue or database)
 - A configuration resource (eg. configuration for an API gateway)
 
-#### Component settings
+#### Kind
 
 The component *kind* specifies the type of resource to deploy. In this case, the kind is `radius.dev/Container@v1alpha1`, which represents a generic container.
 

--- a/docs/content/getting-started/tutorial/dapr-microservices/index.md
+++ b/docs/content/getting-started/tutorial/dapr-microservices/index.md
@@ -6,83 +6,79 @@ description: "Learn Project Radius by authoring templates and deploying a workin
 weight: 200
 ---
 
-## Prerequisites
-
-To begin this tutorial you should have already completed the following steps:
-
-- [Install Radius CLI]({{< ref install-cli.md >}})
-- [Create an environment]({{< ref create-environment.md >}})
-- [(Recommended) Install Visual Studio Code](https://code.visualstudio.com/)
-
-No prior knowledge of Radius is needed, this tutorial will walk you through authoring the deployment template and deploying a microservices application from first principles.
-
-Using [Visual Studio Code](https://code.visualstudio.com/) as your editor for this tutorial is highly recommended. The [installation guide]({{< ref install-cli.md >}}) includes instructions for installing the Project Radius extension which provides syntax highlighting, completion, and linting.
-
-You can also complete this tutorial with any basic text editor.
-
 ## Before you begin
 
-This is a tutorial that will teach you how to use Radius to deploy a microservices application from first principles. As part of this tutorial you will learn the basic syntax of the Bicep language as well as the concepts of the Radius application model.
+This tutorial will teach you how to use Radius to deploy a microservices application from first principles. You will learn  
 
-The application in this tutorial uses [Dapr](https://dapr.io). You do not need experience with Dapr to complete the tutorial.
+- the concepts of the Radius application model 
+- the basic syntax of the Bicep language 
 
-## Understanding the application
+The Radius application in this tutorial uses [Dapr](https://dapr.io). No prior knowledge of Dapr, Radius, or [Bicep](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/bicep-overview) is needed.
 
-The application you will be deploying is a microservices order processing application. There are three components:
+## Prerequisites
 
-- An order processing service written in Node.JS
-- An order generating service written in Python
-- A Dapr state store used to store the orders
+- [Install Radius CLI]({{< ref install-cli.md >}})
+- [Create a Radius environment]({{< ref create-environment.md >}})
+- [(recommended) Install Visual Studio Code](https://code.visualstudio.com/)
+   - The [Radius VSCode extension]({{< ref "install-cli.md#2-install-custom-vscode-extension" >}}) provides syntax highlighting, completion, and linting.
+   - You can also complete this tutorial with any basic text editor.
 
-You can find the source code for the application [here](https://github.com/dapr/quickstarts/tree/v1.0.0/hello-world) as well as additional information and tutorials for Dapr. You will not need to build the application from source or have Dapr installed to complete this tutorial.
+## Overview of the tutorial application
 
-Here is a diagram of the complete application:
+You will be deploying a microservices order processing application. It will have three Radius *components*:
+
+- An containerized order processing microservice written in Node.JS ("nodeapp")
+- A Dapr state store used to store the orders ("statestore")
+- An order generating microservice ("pythonapp")
 
 <img src="https://raw.githubusercontent.com/dapr/quickstarts/v1.0.0/hello-world/img/Architecture_Diagram_B.png" alt="The complete application" width=800>
 
-### Order processing service
+### Order processing microservice
 
-The order processing service (nodeapp) accepts HTTP requests to create or display orders. Here is a diagram focused on the order processing service:
+The order processing microservice (`nodeapp`) accepts HTTP requests to create or display orders. Here is a diagram focused on the order processing service:
 
 <img src="https://raw.githubusercontent.com/dapr/quickstarts/v1.0.0/hello-world/img/Architecture_Diagram.png" alt="The nodeapp order processing service" width=700>
 
-You can see that the nodeapp accepts HTTP requests on two endpoints: `GET /order` and `POST /neworder`.
+The nodeapp accepts HTTP requests on two endpoints: `GET /order` and `POST /neworder`.
 
-The nodeapp also uses a [Dapr state store](https://docs.dapr.io/developing-applications/building-blocks/state-management/state-management-overview/) to store information about orders.
+### Dapr state store
+The state store (`statestore`) stores information about orders. It could be any compatible [Dapr state store](https://docs.dapr.io/developing-applications/building-blocks/state-management/state-management-overview/). In this tutorial we will use Azure Table Storage.
 
 ### Order generating service
 
-The order generting service (pythonapp) does not accept any incoming traffic, and uses [Dapr service invocation](https://docs.dapr.io/developing-applications/building-blocks/service-invocation/service-invocation-overview/) to send requests to nodeapp. 
-
-### Dapr state store
-The state store could be any compatible Dapr state store. In this tutorial we will use Azure Table Storage.
+The order generting service (`pythonapp`) uses [Dapr service invocation](https://docs.dapr.io/developing-applications/building-blocks/service-invocation/service-invocation-overview/) to send requests to nodeapp. It does not accept any incoming traffic. 
 
 ## The Radius mindset
 
-To get into the right mindset for Radius, you should think about the application in *logical* terms. The diagrams shown so far document the communication flows of the application, but there are some details that are missing. 
+The diagrams shown so far document the communication flows, but a Radius application also describes additional details. 
 
-A Radius template includes all of the logical relationships of an application but also the operational details associated with those relationships. Here is an updated diagram that shows what the Radius template needs to capture:
+A Radius template includes 
+
+- the logical relationships of an application 
+- the operational details associated with those relationships 
+
+Here is an updated diagram that shows what the Radius template needs to capture:
 
 <img src="https://user-images.githubusercontent.com/1430011/111005089-04b3c280-833f-11eb-9ce1-bdd12beef78b.png" alt="The application logical diagram" width=800>
 
-The diagram reflects important details of the Radius model that are different from other deployment technologies you may have used:
+This diagram reflects important details of the Radius model that are different from other deployment technologies you may have used:
 
-- The data components (statestore) are part of the application
+- The data component (`statestore` here) is part of the application
 - Relationships between components are fully specified with protocols and other strongly-typed information
 
-In addition to this high level information, you will also need typical details like:
+In addition to this high level information, the Radius model also uses typical details like:
 
-- container images
-- listening ports
-- programmatic identifiers and configuration like a Dapr app-id.
+- Container images
+- Listening ports
+- Configuration like connection strings
 
-Keep the diagram in mind as you proceed through the following steps. Creating a Radius deployment template is similar to process of understanding a diagram like this one.
+Keep the diagram in mind as you proceed through the following steps. Your Radius deployment template will aim to match it. 
 
 ## Step 1: Creating the application definition
 
-Radius uses the Bicep langauge as its file-format and structure. Create a new filed called `template.bicep` with the following content:
+Radius uses the Bicep langauge as its file-format and structure. Create a new `template.bicep` file with the following content:
 
-```txt
+```bash
 resource app 'radius.dev/Applications@v1alpha1' = {
   name: 'dapr-hello'
 
@@ -94,7 +90,7 @@ This defines the basic structure of an application. This declaration:
 - Defines an application resource with the variable name of `app`. 
 - Assigns the name `dapr-hello` to the application resource that will be created.
 
-Declarations in Bicep start with `resource`. They also declare a variable, and assign a resource type, and then are followed by an equals-sign `=` and then an object. 
+Declarations in Bicep start with `resource`. They also declare a variable, assign a resource type, and then are followed by an equals-sign `=` and then an object. 
 
 {{% alert title="💡 Declarations" color="primary" %}}
 Declarations in Bicep have symbolic (variable) names associated with them. The variable name `app` could be used in this file to reference the application in other declarations. The value of the `name` property (`dapr-hello`) is what will be used to identify the application during management operations.
@@ -106,21 +102,21 @@ Objects in Bicep don't need quotes around property names like in JSON. Propertie
 While Bicep uses newlines to separate properties and other syntax, it is not sensitive to indention like YAML is. By convention Bicep uses 2 spaces for indentation, but it is just a convention and not required.
 {{% /alert %}}
 
-At this point you could deploy the application but it doesn't contain any components and so it won't do anything interesting. In the next step, we will begin to fill in components.
+At this point you could deploy the application but it doesn't contain any components and so it won't do anything interesting. 
 
 ## Step 2: Deploying a single container
 
 Now that you've defined the shell for an application, you can add components to it.
 
-### Add a component
+### Add a container component
 We will first add a component representing a container.  
-Inside your application definition, add the `nodeapp` component shown below.
+Inside your application definition, add the `nodeapp` component shown below:
 
-```txt
+```bash
 resource app 'radius.dev/Applications@v1alpha1' = {
   name: 'dapr-hello'
 
-  resource nodeapp 'Components' = {
+  resource nodeapplication 'Components' = {
     name: 'nodeapp'
     kind: 'radius.dev/Container@v1alpha1'
     properties: {
@@ -144,28 +140,30 @@ A component can be:
 - A resource that works with data (eg. a message queue or database)
 - A configuration resource (eg. configuration for an API gateway)
 
-The *kind* specifies the kind of resource to create. The set of properties and settings available inside the body of the component depends on the kind. The `run` section is used to specify how the component runs. In this case `run` specifies a container image to run. 
+#### Component settings
+
+The component *kind* specifies the type of resource to deploy. In this case, the kind is `radius.dev/Container@v1alpha1`, which represents a generic container.
+
+The set of properties and settings available inside the body of the component depends on the kind. The `run` section is used to specify how the component runs. In this case `run` specifies the container image to run. 
 
 {{% alert title="💡 Naming" color="primary" %}}
-Like the application declaration, components also declare a variable name. The variable name `nodeapp` could be used in this file to reference the component in other declarations. The value of the `name` property (also `nodeapp`) is what will be used to identify the component during management operations.
+Like the application declaration, components also declare a variable name. The variable name `nodeapplication` could be used in this file to reference the component in other declarations. The value of the `name` property (`nodeapp`) is what will be used to identify the component during management operations.
 {{% /alert %}}
 
 {{% alert title="💡 Run" color="primary" %}}
 The `run` section is one of several top level sections in a *component*. In general components that run your code will have a `run` section.
 {{% /alert %}}
 
-### Add HTTP
-You could deploy this now and it will run the `radiusteam/nodeapp` image, however you would have no way to interact with the running application.
+### Add an HTTP service
+You could deploy this now and it will run the `radiusteam/nodeapp` image but you would have no way to interact with the running application.
 
-You can add the ability to listen for HTTP traffic as depicted in the diagram above.
+Add the ability to listen for HTTP traffic as depicted in the diagram above. Expand your `nodeapp` as shown below so that it includes a web service definition via a `provides` section:
 
-Expand your `nodeapp` as shown below so that it includes a web service definition via a `provides` section.
-
-```txt
+```bash
 resource app 'radius.dev/Applications@v1alpha1' = {
   name: 'dapr-hello'
 
-  resource nodeapp 'Components' = {
+  resource nodeapplication 'Components' = {
     name: 'nodeapp'
     kind: 'radius.dev/Container@v1alpha1'
     properties: {
@@ -186,7 +184,11 @@ resource app 'radius.dev/Applications@v1alpha1' = {
 }
 ```
 
-What you've added here defines a *service* called `web` and with the kind `http`. Services in Radius are logical connection-points. It's a way that one component can expose functionality for components of the application to bind to. In this case you've defined an HTTP service that others can use to find the URL of `nodeapp` and sent it HTTP traffic. There is nothing special about the name `web`, it is just an identifier used for the name of the service.
+#### Service
+
+What you've added here defines a *service* called `web` and with the kind `http`. Services in Radius are logical connection-points. It's a way that one component can expose functionality for components of the application to bind to. In this case you've defined an HTTP service that others can use to find the URL of `nodeapp` and sent it HTTP traffic. 
+
+There is nothing special about the name `web`, it is just an identifier used for the name of the service.
 
 {{% alert title="💡 HTTP services" color="primary" %}}
 HTTP services in Radius are *internal*, meaning that they are not exposed to internet traffic by default.
@@ -196,57 +198,136 @@ HTTP services in Radius are *internal*, meaning that they are not exposed to int
 
 Now you are ready to deploy the application for the first time. 
 
-First, double-check that you are logged-in to Azure. Switch to your commandline and run the following command:
+1. First, double-check that you are logged-in to Azure. Switch to your commandline and run the following command:
 
-```sh
-az account show
-```
+   ```sh
+   az login
+   ```
 
-If necessary, log into Azure via
+1. Then after that completes, run:
 
-```sh
-az login
-```
+   ```sh
+   rad deploy template.bicep
+   ```
 
-Then after that completes, run:
+   This will deploy the application and launch the container.
 
-```sh
-rad deploy template.bicep
-```
+1. Confirm that your container was deployed
 
-This will deploy the application and launch the container.
+   View deployed applications:
 
-To test it out, you can use the following command from the commandline:
+   ```sh
+   rad application list
+   ```
+   
+   Example output with the `dapr-hello` Radius application: 
+   ```sh
+   {
+     "value": [
+       {
+         "id": "/subscriptions/{SUB-ID}/resourceGroups/{RESOURCE-GROUP}/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/dapr-hello",
+         "name": "radius/dapr-hello",
+         "type": "Microsoft.CustomProviders/resourceProviders/Applications"
+       }
+     ]
+   }
+   ```
 
-```sh
-rad expose dapr-hello nodeapp --port 3000
-```
+   View deployments for a specific app: 
 
-This will open a local tunnel on port 3000 to port 3000 inside the container. Then you can visit the URL `http://localhost:3000/order` in the browser. For now you should see a message like:
+   ```sh
+   rad deployment list --application-name dapr-hello
+   ```
 
-```txt
-{"message":"The container is running, but Dapr has not been configured."}
-```
+   Your `nodeapp` component has been created into a `default` deployment of the `dapr-hello` application. 
+   You should see something like this:
 
-If your message matches, then it means that the container is running. When you are done testing press CTRL+C to terminate the port-forward, and you are ready to move on to the next step.
+   ```sh
+   {
+     "value": [
+       {
+         "id": "/subscriptions/{SUB-ID}/resourceGroups/{RESOURCE-GROUP}/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/dapr-hello/Deployments/default",
+         "name": "radius/dapr-hello/default",
+         "type": "Microsoft.CustomProviders/resourceProviders/Applications/Deployments",
+         "properties": {
+           "components": [
+             {
+               "componentName": "nodeapp"
+             }
+           ]
+         }
+       }
+     ]
+   }
+   ```
 
-{{% alert title="💡 rad expose" color="primary" %}}
-The `rad expose` command provides the application name, followed by the component name, followed by a port. If you changed any of these names when deploying, update your command to match.
-{{% /alert %}}
+1. View the properties of the deployed `nodeapp` component 
+
+   ```sh
+   rad component get --application-name dapr-hello --name nodeapp
+   ```
+ 
+   The details of the `nodeapp` component should match its definition from your template.bicep file. Example output:
+
+   ```sh
+   Using config file: /Users/{USER}/.rad/config.yaml
+   {
+     "id": "/subscriptions/{SUB-ID}/resourceGroups/{RESOURCE-GROUP}/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/dapr-hello/Components/nodeapp",
+     "name": "radius/dapr-hello/nodeapp",
+     "type": "Microsoft.CustomProviders/resourceProviders/Applications/Components",
+     "kind": "radius.dev/Container@v1alpha1",
+     "properties": {
+       "provides": [
+         {
+           "containerPort": 3000,
+           "kind": "http",
+           "name": "web"
+         }
+       ],
+       "revision": "623b7888a3b779c6579e82ee2f7215a6396dfcef",
+       "run": {
+         "container": {
+           "image": "radiusteam/tutorial-nodeapp"
+         }
+       }
+     }
+   }
+   ```
+
+1. To test out your `dapr-hello` application, open a local tunnel to your application:
+
+   ```sh
+   rad expose dapr-hello nodeapp --port 3000
+   ```
+
+   {{% alert title="💡 rad expose" color="primary" %}}
+   The `rad expose` command provides the application name, followed by the component name, followed by a port. If you changed any of these names when deploying, update your command to match.
+   {{% /alert %}}
+
+1. Visit the URL `http://localhost:3000/order` in your browser. For now you should see a message like:
+
+   ```txt
+   {"message":"The container is running, but Dapr has not been configured."}
+   ```
+
+   If the message matches, then it means that the container is running as expected.
+
+1. When you are done testing press CTRL+C to terminate the port-forward, and you are ready to move on to the next step.
 
 ## Step 3: Adding Dapr and the state store
 
 As the message from the previous step stated, you haven't yet added Dapr. You also haven't configured the Azure Table Storage state store. This step will add both of these things.
 
-### Add trait
+### Add a Dapr trait to the nodeapp component
 We will first add a *trait* that describes the Dapr configuration. 
+
 Expand your `nodeapp` as shown below so that it includes a `traits` section.
 
-```txt
+```bash
 resource app 'radius.dev/Applications@v1alpha1' = {
   name: 'dapr-hello'
 
-  resource nodeapp 'Components' = {
+  resource nodeapplication 'Components' = {
     name: 'nodeapp'
     kind: 'radius.dev/Container@v1alpha1'
     properties: {
@@ -283,11 +364,11 @@ The `traits` section is one of several top level sections in a *component*. Trai
 {{% /alert %}}
 
 ### Add statestore component
-Now the nodeapp is hooked up to Dapr, but we still need to address the topic of the state store.
+Now the nodeapp is hooked up to Dapr, but we still need to define a state store to save information about orders.
 
-Type the new component declaration from the following text inside your application definition. Leave your existing declaration for nodeapp unchanged.
+Add a new component declaration (`statestore`) to your application definition as shown below. Leave your existing declaration for `nodeapp` unchanged.
 
-```txt
+```bash
 resource app 'radius.dev/Applications@v1alpha1' = {
   name: 'dapr-hello'
 
@@ -306,30 +387,30 @@ resource app 'radius.dev/Applications@v1alpha1' = {
 }
 ```
 
-This declaration adds the state store as a component of kind `dapr.io/StateStore@v1alpha1`. You've seen component declarations before, so you can notice some differences with this one. The `statestore` component has a "config" section, while the previous `noneapp` compnent had "run" and "provides" (services) sections.
+This declaration adds the state store as a component of kind `dapr.io/StateStore@v1alpha1`. You've seen component declarations before, so you can notice some differences with this one. `statestore` has a `config` section instead of `run` and `provides` (services) sections.
 
 {{% alert title="💡 Config" color="primary" %}}
-The `config` section is one of several top level sections in a *component*. In general component that represent a data store will have a `config` section
+The `config` section is one of several top level sections in a *component*. In general components that represent a data store will have a `config` section
 {{% /alert %}}
 
-Inside the `config` section you specified a `kind` of `state.azure.tablestorage`. This corresponds to the kind of Dapr state store used for [Azure Table Storage](https://docs.dapr.io/operations/components/setup-state-store/supported-state-stores/setup-azure-tablestorage/).
+Inside the `config` section, you specified a `kind` of `state.azure.tablestorage`. This corresponds to the kind of Dapr state store used for [Azure Table Storage](https://docs.dapr.io/operations/components/setup-state-store/supported-state-stores/setup-azure-tablestorage/).
 
-Inside the `config` section you specified `managed: true`. This flag tells Radius to manage the lifetime of the Azure Storage account for you. The Azure Storage account will be deleted when you delete the application.
+You also specified `managed: true`. This flag tells Radius to manage the lifetime of the Azure Storage account for you. The Azure Storage account will be deleted when you delete the application.
 
 {{% alert title="💡 Resource creation" color="primary" %}}
-If you have used Dapr before, you may notice that you neither had to create the Azure Storage resource itself, nor configure Dapr with details like connection strings. Radius does this for you.
+If you have used Dapr before, you may notice that your Radius template neither created the Azure Storage resource itself nor configured Dapr with details like connection strings. Radius does this for you.
 {{% /alert %}}
 
-### Reference statestore from application
-Now that you've created the state store as an component, you can reference it from nodeapp to connect them.
+### Reference statestore from nodeapp
+Now that you've created the state store as a component, you can connect them by referecing the `statestore` component from the `nodeapp` component. 
 
-Type the additional content from the following text inside your application definition. What's new this time is the `dependsOn` section.
+Type or paste the additional content from the following text inside your application definition. What's new is the `dependsOn` section.
 
-```txt
+```bash
 resource app 'radius.dev/Applications@v1alpha1' = {
   name: 'dapr-hello'
 
-  resource nodeapp 'Components' = {
+  resource nodeapplication 'Components' = {
     name: 'nodeapp'
     kind: 'radius.dev/Container@v1alpha1'
     properties: {
@@ -375,42 +456,75 @@ Radius captures the relationships and intentions behind an application so that t
 
 ### Deploy application with Dapr
 
-Now you are ready to deploy. Switch to the command-line and run the following command.
+Now you are ready to deploy. 
 
-```sh
-rad deploy template.bicep
-```
+1. Switch to the command-line and run the following command.
 
-This will deploy the application, including the Azure Storage account. This may take a few minutes because of the extra time required to create the Storage Account.
+   ```sh
+   rad deploy template.bicep
+   ```
 
-To test it out, you can use the following command from the commandline:
+   This will deploy the application, including the Azure Storage account. This may take a few minutes because of the extra time required to create the Storage Account.
 
-```sh
-rad expose dapr-hello nodeapp 3000
-```
+1. Confirm that the state store was deployed.
 
-This will open a local tunnel on port 3000. Then you can visit the URL `http://localhost:3000/order` in the browser. For now you should see a message like:
+   ```sh
+   rad deployment list --application-name dapr-hello
+   ```
 
-```txt
-{"message":"no orders yet"}
-```
+   Now you should see both `nodeapp` and `statestore` components in your `dapr-hello` application, similar to:
 
-If your message matches, then it means that the container is able to communicate with the state store. When you are done testing press CTRL+C to terminate the port-forward, and you are ready to move on to the next step.
+   ```sh
+   Using config file: /Users/{USER}/.rad/config.yaml
+   {
+     "value": [
+       {
+         "id": "/subscriptions/{SUB-ID}/resourceGroups/{RESOURCE-GROUP}/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/dapr-hello/Deployments/default",
+         "name": "radius/dapr-hello/default",
+         "type": "Microsoft.CustomProviders/resourceProviders/Applications/Deployments",
+         "properties": {
+           "components": [
+             {
+               "componentName": "nodeapp"
+             },
+             {
+               "componentName": "statestore"
+             }
+           ]
+         }
+       }
+     ]
+   }
+   ```
+
+1. To test out the state store, open a local tunnel on port 3000 again:
+
+   ```sh
+   rad expose dapr-hello nodeapp 3000
+   ```
+
+1. Visit the the URL `http://localhost:3000/order` in your browser. You should see a message like:
+
+   ```txt
+   {"message":"no orders yet"}
+   ```
+
+   If your message matches, then it means that the container is able to communicate with the state store. When you are done testing press CTRL+C to terminate the port-forward, and you are ready to move on to the next step.
 
 ## Step 4: Adding pythonapp
 
-To complete the application, you need to add another component for the pythonapp.
+To complete the application, you need to add another component for the order generating microservice (`pythonapp`).
 
 ### Add pythonapp component
 Type the new component declaration from the following text inside your application definition. Leave your existing declarations for nodeapp and statestore unchanged.
 
-```txt
+```bash
 resource app 'radius.dev/Applications@v1alpha1' = {
   name: 'dapr-hello'
 
   ...
 
-  resource pythonapp 'Components' = {
+  resource pythonapplication 'Components' = {
     name: 'pythonapp'
     kind: 'radius.dev/Container@v1alpha1'
     properties: {
@@ -438,43 +552,46 @@ resource app 'radius.dev/Applications@v1alpha1' = {
 }
 ```
 
-The definition for pythonapp is simpler than what you have done so far for node app. There are few key points that you should notice:
+The definition for `pythonapp` is simpler than what you have done previously for `nodeapp`. There are few key points that you should notice:
 
-- pythonapp doesn't listen for HTTP traffic, so it neither configures a Dapr app-port nor a service for HTTP
-- pythonapp needs to communicate with nodeapp using the Dapr service invocation protocol
+- `pythonapp` doesn't listen for HTTP traffic, so it configures neither a Dapr app-port nor a service for HTTP.
+- `pythonapp` needs to communicate with `nodeapp` using the Dapr service invocation protocol.
 
 ### Deploy application with pythonapp
 
-Now you are ready to deploy. Switch to the command-line and run the following command.
+Now you are ready to deploy. 
 
-```sh
-rad deploy template.bicep
-```
+1. Switch to the command-line and run the following command.
 
-This will deploy the complete application, including both containers and the Azure Storage account.
+   ```sh
+   rad deploy template.bicep
+   ```
 
-To test it out, you can use the following command from the commandline:
+   This will deploy the complete application, including both containers and the Azure Storage account.
 
-```sh
-rad expose dapr-hello nodeapp 3000
-```
+1. To test out the pythonapp microservice, open a local tunnel on port 3000 again:
 
-This will open a local tunnel on port 3000. Then you can visit the URL `http://localhost:3000/order` in the browser.
+   ```sh
+   rad expose dapr-hello nodeapp 3000
+   ```
 
-Refresh the page multiple times, and you should see a message like before, but the order number is steadily increasing.
+1. Visit the URL `http://localhost:3000/order` in your browser.
 
-```txt
-{"orderId":28}
-```
+   Refresh the page multiple times and you should see a message like before. The order number is steadily increasing after refresh. 
 
-If your message matches, then it means that pythonapp is able to communicate with nodeapp. When you are done testing press CTRL+C to terminate the port-forward.
+   ```txt
+   {"orderId":7}
+   ```
 
-## Step 3: Cleanup
+   If your message matches, then it means that `pythonapp` is able to communicate with `nodeapp`. 
 
-If you'd like to try another tutorial with your existing environment, go back to the [Radius tutorials]({{< ref tutorial >}}). 
+1. When you are done testing press CTRL+C to terminate the port-forward. 
+
+## Step 5: Cleanup
+
+If you'd like to try another tutorial with your existing environment, go back to the [Radius tutorials]({{< ref tutorial >}}) page. 
 
 If you're done with testing, clean up your environment to **prevent additional charges in your subscription**. 
-
 
 Deleting an environment will delete:
 
@@ -490,5 +607,6 @@ You have completed this tutorial!
 
 ## Related links
 
+- View the full template.bicep for this tutorial [here](https://github.com/Azure/radius/blob/main/docs/content/getting-started/tutorial/dapr-microservices/dapr-microservices.bicep)
 - [Dapr documentation](https://docs.dapr.io/)
-- [Dapr Hello World](https://github.com/dapr/quickstarts/tree/v1.0.0/hello-world)
+- You can find the source code for this application [here](https://github.com/dapr/quickstarts/tree/v1.0.0/hello-world) as well as additional information and tutorials for Dapr.

--- a/docs/content/getting-started/tutorial/webapp/index.md
+++ b/docs/content/getting-started/tutorial/webapp/index.md
@@ -8,31 +8,34 @@ weight: 100
 
 ## Before you begin
 
-This is a tutorial that will teach you how to use Radius to deploy a web application from first principles. As part of this tutorial you will learn the basic syntax of the Bicep language as well as the concepts of the Radius application model. No prior knowledge of Radius is needed, this tutorial will cover the basics.
+This tutorial will teach you how to use Radius to deploy a web application from first principles. You will learn  
+
+- the concepts of the Radius application model 
+- the basic syntax of the Bicep language 
+
+No prior knowledge of Radius or [Bicep](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/bicep-overview) is needed.
 
 ## Prerequisites
-
-To begin this tutorial you should have already completed the following steps:
 
 - [Install Radius CLI]({{< ref install-cli.md >}})
 - [Create a Radius environment]({{< ref create-environment.md >}})
 - [(recommended) Install Visual Studio Code](https://code.visualstudio.com/)
    - The [Radius VSCode extension]({{< ref "install-cli.md#2-install-custom-vscode-extension" >}}) provides syntax highlighting, completion, and linting.
+   - You can also complete this tutorial with any basic text editor.
 
-## Understanding the application
+## Overview of the tutorial application
 
-The application you will be deploying is a web application with a database. There are two components:
+You will be deploying a *To-Do List* web application. It will have two Radius *components*:
 
-- A *To-Do List* containerized web application written in Node.JS
-- An Azure CosmosDB database
+- A containerized web application written in Node.JS ("webapp")
+- An Azure CosmosDB database ("db")
 
-Here is a diagram of the complete application:
 
 <img src="./todoapp-diagram.png" width=400 alt="Simple app diagram">
 
-### Web appliation
+### Web application
 
-The web application (`todoapp`) is a single-page-application (SPA) with a Node.JS backend. The SPA sends requests HTTP requests to the Node.JS backend to read and store a lost of *todo* items.
+The example web application (`todoapp`) is a single-page-application (SPA) with a Node.JS backend. The SPA sends requests HTTP requests to the Node.JS backend to read and store *todo* items.
 
 The web application listens on port 3000 for HTTP requests. 
 
@@ -44,30 +47,33 @@ The database (`db`) is an Azure Cosmos MongoDB database.
 
 ## The Radius mindset
 
-To get into the right mindset for Radius, you should think about the application in *logical* terms. The diagrams shown so far document the communication flows of the application, but there are some details that are missing. 
+The diagrams shown so far document the communication flows, but a Radius application also describes additional details. 
 
-A Radius template includes all of the logical relationships of an application but also the operational details associated with those relationships. Here is an updated diagram that shows what the Radius template needs to capture:
+A Radius template includes 
+
+- the logical relationships of an application 
+- the operational details associated with those relationships 
+
+Here is an updated diagram that shows what the Radius template needs to capture:
 
 <img src="./todoapp-appdiagram.png" width=600 alt="App diagram with descriptions of all the details and relationships."><br />
 
 This diagram reflects important details of the Radius model that are different from other deployment technologies you may have used:
 
-- The data component (`db`) are part of the application
+- The data component (`db` here) is part of the application
 - Relationships between components are fully specified with protocols and other strongly-typed information
 
-In addition to this high level information, you will also need typical details like:
+In addition to this high level information, the Radius model also uses typical details like:
 
 - Container images
 - Listening ports
 - Configuration like connection strings
 
-Keep the diagram in mind as you proceed through the following steps. Creating a Radius deployment template is similar to process of understanding a diagram like this one.
+Keep the diagram in mind as you proceed through the following steps. Your Radius deployment template will aim to match it. 
 
 ## Step 1: Creating the application definition
 
-You can start by creating a new `template.bicep` file.
-
-Inside `template.bicep`, type or paste in the following content:
+Radius uses the Bicep langauge as its file-format and structure. Create a new `template.bicep` file with the following content:
 
 ```bash
 resource app 'radius.dev/Applications@v1alpha1' = {
@@ -78,10 +84,10 @@ resource app 'radius.dev/Applications@v1alpha1' = {
 
 This defines the basic structure of an application. This declaration:
 
-- Defines an application resource with the variable name of `app`
-- Assigns the name `webapp` to the application resource that will be created
+- Defines an application resource with the variable name of `app`.
+- Assigns the name `webapp` to the application resource that will be created.
 
-Declarations in Bicep start with `resource`. They also declare a variable, and assign a resource type, and then are followed by an equals-sign `=` and then an object. 
+Declarations in Bicep start with `resource`. They also declare a variable, assign a resource type, and then are followed by an equals-sign `=` and then an object. 
 
 {{% alert title="💡 Declarations" color="primary" %}}
 Declarations in Bicep have symbolic (variable) names associated with them. The variable name `app` could be used in this file to reference the application in other declarations. The value of the `name` property (`webapp`) is what will be used to identify the application during management operations.
@@ -93,21 +99,21 @@ Objects in Bicep don't need quotes around property names like in JSON. Propertie
 While Bicep uses newlines to separate properties and other syntax, it is not sensitive to indention like YAML is. By convention Bicep uses 2 spaces for indentation, but it is just a convention and not required.
 {{% /alert %}}
 
-At this point you could deploy the application but it doesn't contain any components and so it won't do anything interesting. Move on to the next step where we will begin to fill in components.
+At this point you could deploy the application but it doesn't contain any components and so it won't do anything interesting. 
 
 ## Step 2: Deploying a single container
 
-Now that you've defined the shell for an application, you can add components inside.
+Now that you've defined the shell for an application, you can add components to it.
 
 ### Add a container component
 
-Type or paste the additional content from the following text inside your application definition. What's new is the `todoapp` component.
+Inside your application definition, add the `todoapp` component shown below:
 
 ```bash
 resource app 'radius.dev/Applications@v1alpha1' = {
   name: 'webapp'
 
-  resource todoapp 'Components' = {
+  resource todoapplication 'Components' = {
     name: 'todoapp'
     kind: 'radius.dev/Container@v1alpha1'
     properties: {
@@ -121,41 +127,39 @@ resource app 'radius.dev/Applications@v1alpha1' = {
 }
 ```
 
-The content you added declares a *component*. If you visualize the structure of an application *as a graph*, then *components* represent the nodes and things to deploy.
+The content you added declares a *component*. If you visualize the structure of an application as a graph, then components represent the nodes and things to deploy.
 
 A component can be:
 
-- A resource that runs your code *(eg. a container)*
-- A resource that works with data *(eg. a message queue or database)*
-- A configuration resource *(eg. configuration for an API gateway)*
+- A resource that runs your code (eg. a container)
+- A resource that works with data (eg. a message queue or database)
+- A configuration resource (eg. configuration for an API gateway)
 
-#### Kind
+#### Component settings
 
-The specific type of resource to deploy is specified by the component *kind*. In this case the kind is `radius.dev/Container@v1alpha1`, which represents a generic container.
+The component *kind* specifies the type of resource to deploy. In this case, the kind is `radius.dev/Container@v1alpha1`, which represents a generic container.
 
 The set of properties and settings available inside the body of the component depends on the kind. The `run` section is used to specify how the component runs. In this case `run` specifies the container image to run. 
 
 {{% alert title="💡 Naming" color="primary" %}}
-Like the application declaration, components also declare a variable name. The variable name `todoapp` could be used in this file to reference the component in other declarations. The value of the `name` property (also `todoapp`) is what will be used to identify the component during management operations.
+Like the application declaration, components also declare a variable name. The variable name `todoapplication` could be used in this file to reference the component in other declarations. The value of the `name` property (`todoapp`) is what will be used to identify the component during management operations.
 {{% /alert %}}
 
 {{% alert title="💡 Run" color="primary" %}}
-The `run` section is one of several top level sections in a *component*. In general components that run your code will have a `run` section.
+The `run` section is one of several top level sections in a *component*. In general, components that run your code will have a `run` section.
 {{% /alert %}}
 
-### Add HTTP
+### Add an HTTP service
 
-If you were to deploy this application now it will run the `radiusteam/todoapp` image. However, you would have no way to interact with the running application.
+If you were to deploy the application now, it would run the `radiusteam/tutorial-todoapp` image but you would have no way to interact with the running application.
 
-You now need to add the ability to listen for HTTP traffic as depicted in the diagram above.
-
-Type or paste the additional content from the following text inside your application definition. What's new this time is the `provides` section of `todoapp`:
+Add the ability to listen for HTTP traffic as depicted in the diagram above. Expand your `todoapp` as shown below so that it includes a web service definition via a `provides` section:
 
 ```bash
 resource app 'radius.dev/Applications@v1alpha1' = {
   name: 'webapp'
 
-  resource todoapp 'Components' = {
+  resource todoapplication 'Components' = {
     name: 'todoapp'
     kind: 'radius.dev/Container@v1alpha1'
     properties: {
@@ -196,7 +200,7 @@ Now you are ready to deploy the application for the first time.
    az login
    ```
 
-2. Then after that completes, run:
+1. Then after that completes, run:
 
    ```sh
    rad deploy template.bicep
@@ -204,36 +208,128 @@ Now you are ready to deploy the application for the first time.
 
    This will deploy the application and launch the container.
 
-3. Open a local tunnel to your application:
+1. Confirm that your web application was deployed
+
+   View deployed applications:
+
+   ```sh
+   rad application list
+   ```
+   
+   Example output with the `webapp` Radius application: 
+   ```sh
+   {
+     "value": [
+       {
+         "id": "/subscriptions/{SUB-ID}/resourceGroups/{RESOURCE-GROUP}/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/webapp",
+         "name": "radius/webapp",
+         "type": "Microsoft.CustomProviders/resourceProviders/Applications"
+       }
+     ]
+   }
+   ```
+
+   View deployments for a specific app: 
+
+   ```sh
+   rad deployment list --application-name webapp
+   ```
+
+   Your `todoapp` component has been created into a `default` deployment of the `webapp` application. 
+   You should see something like this:
+
+   ```sh
+   {
+     "value": [
+       {
+         "id": "/subscriptions/{SUB-ID}/resourceGroups/{RESOURCE-GROUP}/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/webapp/Deployments/default",
+         "name": "radius/webapp/default",
+         "type": "Microsoft.CustomProviders/resourceProviders/Applications/Deployments",
+         "properties": {
+           "components": [
+             {
+               "componentName": "todoapp"
+             }
+           ]
+         }
+       }
+     ]
+   }
+   ```
+
+1. View the properties of the deployed `todoapp` component 
+
+   ```sh
+   rad component get --application-name webapp --name todoapp
+   ```
+ 
+   The details of the `todoapp` component should match its definition from your template.bicep file. Example output:
+
+   ```sh
+   Using config file: /Users/{USER}/.rad/config.yaml
+   {
+     "id": "/subscriptions/{SUB-ID}/resourceGroups/{RESOURCE-GROUP}/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/webapp/Components/todoapp",
+     "name": "radius/webapp/todoapp",
+     "type": "Microsoft.CustomProviders/resourceProviders/Applications/Components",
+     "kind": "radius.dev/Container@v1alpha1",
+     "properties": {
+       "dependsOn": [
+         {
+           "kind": "mongodb.com/Mongo",
+           "name": "db",
+           "setEnv": {
+             "DB_CONNECTION": "connectionString"
+           }
+         }
+       ],
+       "provides": [
+         {
+           "containerPort": 3000,
+           "kind": "http",
+           "name": "web"
+         }
+       ],
+       "revision": "89622fa78bc845079129b8722a20452156f1f80f",
+       "run": {
+         "container": {
+           "image": "radiusteam/tutorial-todoapp"
+         }
+       }
+     }
+   }
+   ```
+
+1. To test out your `webapp` application, open a local tunnel to your application:
 
    ```sh
    rad expose webapp todoapp 3000
    ```
+
    {{% alert title="💡 rad expose" color="primary" %}}
    The `rad expose` command provides the application name, followed by the component name, followed by a port. If you changed any of these names when deploying, update your command to match.
    {{% /alert %}}
 
-4. Visit the URL `http://localhost:3000` in the browser. For now you should see a page like:
+1. Visit the URL `http://localhost:3000` in your browser. For now you should see a page like:
 
    <img src="todoapp-nodb.png" width="400" alt="screenshot of the todo application with no database">
 
-   If the page you are seeing matches the screenshot hat means that the container is running. As the message indicates no database has been configured yet.
+   If the page you are seeing matches the screenshot hat means that the container is running as expected. 
 
    You can play around with the application's features features:
    - Add a todo item
    - Mark a todo item as complete
    - Delete a todo item
 
-5. When you are done testing press CTRL+C to terminate the port-forward, and you are ready to move on to the next step.
+1. When you are done testing press CTRL+C to terminate the port-forward, and you are ready to move on to the next step.
 
 ## Step 3: Adding a database
 
-As the message from the previous step stated, you have not yet added a database. This means that the todo items you enter will be stored in memory inside the application. If the web application restarts then all of your data will be lost!
+As the message from the previous step stated, you have not yet configured a database, so the todo items you enter will be stored in memory inside the application. If the web application restarts then all of your data will be lost!
 
 In this step you will learn how to add a database and connect to it from the application.
 
 ### Add db component
-Type or paste the new component declaration (`db`) from the following text inside your application definition. Leave your existing declaration for todoapp unchanged.
+Add a new component declaration (`db`) to your application definition as shown below. Leave your existing declaration for `todoapp` unchanged.
 
 ```bash
 resource app 'radius.dev/Applications@v1alpha1' = {
@@ -256,21 +352,22 @@ resource app 'radius.dev/Applications@v1alpha1' = {
 This declaration adds the database as a component of kind `azure.com/CosmosDocumentDb@v1alpha1`. You've seen component declarations before, so you can notice some differences with this one. `db` has a `config` section instead of a `run` section.
 
 {{% alert title="💡 Config" color="primary" %}}
-The `config` section is one of several top level sections in a *component*. In general component that represent a data store will have a `config` section
+The `config` section is one of several top level sections in a *component*. In general components that represent a data store will have a `config` section
 {{% /alert %}}
 
-Inside the `config` section you specified `managed: true`. This flag tells Radius to manage the lifetime of the database for you. The database will be deleted when you delete the application.
+Inside the `config` section, you specified `managed: true`. This flag tells Radius to manage the lifetime of the database for you. The database will be deleted when you delete the application.
 
 ### Reference db from todoapp
 
-Now that you've created the database as an component, you can reference it from todoapp to connect them.
+Now that you've created the database as a component, you can connect them by referencing the `db` component from the `todoapp` component.
 
-Type or paste the additional content from the following text inside your application definition. What's new this time is the `dependsOn` section:
+Type or paste the additional content from the following text inside your application definition. What's new is the `dependsOn` section:
+
 ```bash
 resource app 'radius.dev/Applications@v1alpha1' = {
   name: 'webapp'
 
-  resource todoapp 'Components' = {
+  resource todoapplication 'Components' = {
     name: 'todoapp'
     kind: 'radius.dev/Container@v1alpha1'
     properties: {
@@ -311,10 +408,10 @@ Relations in Radius are based on protocols and services as a form of *loose-coup
 {{% /alert %}}
 
 
-The `setEnv` section declares operations to perform *based on* the relationship. In this case the `connectionString` value will be retrieved from the database and set as an environment variable on the component. As a result of this, `todoapp` will be able to use the `DB_CONNECTION` environment variable to access to the database connection string.
+The `setEnv` section declares operations to perform *based on* the relationship. In this case the `connectionString` value will be retrieved from the database and set as an environment variable on the component. As a result, `todoapp` will be able to use the `DB_CONNECTION` environment variable to access to the database connection string.
 
 {{% alert title="💡 Relationships" color="primary" %}}
-Radius captures the relationships and intentions behind an application so that they can simplify deployment. Examples of this include wiring up connection strings, or granting permissions, or restarting components when a dependency changes.
+Radius captures the relationships and intentions behind an application so that they can simplify deployment. Examples of this include: wiring up connection strings, granting permissions, or restarting components when a dependency changes.
 {{% /alert %}}
 
 ### Deploy application with database
@@ -329,19 +426,48 @@ Now you are ready to deploy.
 
    This will deploy the application, including the Azure CosmosDB database. This may take a few minutes because of the extra time required to create the database.
 
-1. To test it out, you can use the following command from the commandline:
+1. Confirm that the database was deployed.
+
+   ```sh
+   rad deployment list --application-name webapp
+   ```
+
+   Now you should see both `db` and `todoapp` components in your `webapp` application, similar to:
+
+   ```sh
+   Using config file: /Users/{USER}/.rad/config.yaml
+   {
+     "value": [
+       {
+         "id": "/subscriptions/{SUB-ID}/resourceGroups/{RESOURCE-GROUP}/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/webapp/Deployments/default",
+         "name": "radius/webapp/default",
+         "type": "Microsoft.CustomProviders/resourceProviders/Applications/Deployments",
+         "properties": {
+           "components": [
+             {
+               "componentName": "db"
+             },
+             {
+               "componentName": "todoapp"
+             }
+           ]
+         }
+       }
+     ]
+   }
+   ```
+
+1. To test out the database, open a local tunnel on port 3000 again:
 
    ```sh
    rad expose webapp todoapp 3000
    ```
 
-   This will open a local tunnel on port 3000.
-
-1. Visit the URL `http://localhost:3000` in the browser. For now you should see a page like:
+1. Visit the URL `http://localhost:3000` in your browser. You should see a page like:
 
    <img src="todoapp-withdb.png" width="400" alt="screenshot of the todo application with a database">
 
-   If your page matches, then it means that the container is able to communicate with the database. Just like before you can test the features of the todo app. Now your data is being stored in an actual database. Add a task or two. 
+   If your page matches, then it means that the container is able to communicate with the database. Just like before, you can test the features of the todo app. Add a task or two. Now your data is being stored in an actual database. 
 
 1. Now that the app is using a database, we can confirm that the task items persist across application restarts. 
    1. Press CTRL+C to terminate the port-forward
@@ -349,94 +475,13 @@ Now you are ready to deploy.
    1. Restart port-forwarding via `rad expose webapp todoapp 3000`. 
    1. Visit the URL `http://localhost:3000` in the browser again to see the tasks you previously created. 
 
-1. When you are done testing press CTRL+C to terminate the port-forward. You have completed this tutorial!
+1. When you are done testing press CTRL+C to terminate the port-forward. 
 
+## Step 4: Cleanup
 
-## Step 4: Inspect application
-
-### Review application's deployment 
-Now that the "webapp" application deployment is complete, you can inspect it by listing deployments. 
-
-```sh
-rad deployment list --application-name webapp
-```
-
-Your "db" and "todoapp" components have been created into a "default" deployment of the "webapp" application. 
-You should see something like this:
-
-```sh
-Using config file: /Users/tutorial-user/.rad/config.yaml
-{
-  "value": [
-    {
-      "id": "/subscriptions/76d1209e-1382-45d3-99bb-650e6bf63fc1/resourceGroups/tutorial-resource-group/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/webapp/Deployments/default",
-      "name": "radius/webapp/default",
-      "type": "Microsoft.CustomProviders/resourceProviders/Applications/Deployments",
-      "properties": {
-        "components": [
-          {
-            "componentName": "db"
-          },
-          {
-            "componentName": "todoapp"
-          }
-        ]
-      }
-    }
-  ]
-}
-```
-
-### Inspect a specific component's details 
-
-View properties of a specific component: 
-
-```sh
-rad component get --application-name webapp --name todoapp
-```
-
-The details of the deployed component should match that component's definition from your template.bicep file. Example output:
-
-```sh
-Using config file: /Users/tutorial-user/.rad/config.yaml
-{
-  "id": "/subscriptions/76d1209e-1382-45d3-99bb-650e6bf63fc1/resourceGroups/tutorial-resource-group/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/webapp/Components/todoapp",
-  "name": "radius/webapp/todoapp",
-  "type": "Microsoft.CustomProviders/resourceProviders/Applications/Components",
-  "kind": "radius.dev/Container@v1alpha1",
-  "properties": {
-    "dependsOn": [
-      {
-        "kind": "mongodb.com/Mongo",
-        "name": "db",
-        "setEnv": {
-          "DB_CONNECTION": "connectionString"
-        }
-      }
-    ],
-    "provides": [
-      {
-        "containerPort": 3000,
-        "kind": "http",
-        "name": "web"
-      }
-    ],
-    "revision": "89622fa78bc845079129b8722a20452156f1f80f",
-    "run": {
-      "container": {
-        "image": "radiusteam/tutorial-todoapp"
-      }
-    }
-  }
-}
-```
-
-## Step 5: Cleanup
-
-If you'd like to try another tutorial with your existing environment, go back to the [Radius tutorials]({{< ref tutorial >}}). 
+If you'd like to try another tutorial with your existing environment, go back to the [Radius tutorials]({{< ref tutorial >}}) page. 
 
 If you're done with testing, clean up your environment to **prevent additional charges in your subscription**. 
-
 
 Deleting an environment will delete:
 
@@ -449,3 +494,7 @@ rad env delete azure --yes
 ```
 
 You have completed this tutorial!
+
+## Related links
+
+- View the full template.bicep for this tutorial [here](https://github.com/Azure/radius/blob/main/docs/content/getting-started/tutorial/webapp/template.bicep)

--- a/docs/content/getting-started/tutorial/webapp/index.md
+++ b/docs/content/getting-started/tutorial/webapp/index.md
@@ -8,10 +8,10 @@ weight: 100
 
 ## Before you begin
 
-This tutorial will teach you how to use Radius to deploy a web application from first principles. You will learn  
+This tutorial will teach you how to use Radius to deploy a web application from first principles. You will learn:  
 
-- the concepts of the Radius application model 
-- the basic syntax of the Bicep language 
+- The concepts of the Radius application model 
+- The basic syntax of the Bicep language 
 
 No prior knowledge of Radius or [Bicep](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/bicep-overview) is needed.
 
@@ -135,7 +135,7 @@ A component can be:
 - A resource that works with data (eg. a message queue or database)
 - A configuration resource (eg. configuration for an API gateway)
 
-#### Component settings
+#### Kind
 
 The component *kind* specifies the type of resource to deploy. In this case, the kind is `radius.dev/Container@v1alpha1`, which represents a generic container.
 
@@ -468,12 +468,6 @@ Now you are ready to deploy.
    <img src="todoapp-withdb.png" width="400" alt="screenshot of the todo application with a database">
 
    If your page matches, then it means that the container is able to communicate with the database. Just like before, you can test the features of the todo app. Add a task or two. Now your data is being stored in an actual database. 
-
-1. Now that the app is using a database, we can confirm that the task items persist across application restarts. 
-   1. Press CTRL+C to terminate the port-forward
-   1. Redeploy the application via `rad deploy template.bicep`
-   1. Restart port-forwarding via `rad expose webapp todoapp 3000`. 
-   1. Visit the URL `http://localhost:3000` in the browser again to see the tasks you previously created. 
 
 1. When you are done testing press CTRL+C to terminate the port-forward. 
 

--- a/docs/content/getting-started/tutorial/webapp/index.md
+++ b/docs/content/getting-started/tutorial/webapp/index.md
@@ -351,7 +351,87 @@ Now you are ready to deploy.
 
 1. When you are done testing press CTRL+C to terminate the port-forward. You have completed this tutorial!
 
-## Step 4: Cleanup
+
+## Step 4: Inspect application
+
+### Review application's deployment 
+Now that the "webapp" application deployment is complete, you can inspect it by listing deployments. 
+
+```sh
+rad deployment list --application-name webapp
+```
+
+Your "db" and "todoapp" components have been created into a "default" deployment of the "webapp" application. 
+You should see something like this:
+
+```sh
+Using config file: /Users/tutorial-user/.rad/config.yaml
+{
+  "value": [
+    {
+      "id": "/subscriptions/76d1209e-1382-45d3-99bb-650e6bf63fc1/resourceGroups/tutorial-resource-group/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/webapp/Deployments/default",
+      "name": "radius/webapp/default",
+      "type": "Microsoft.CustomProviders/resourceProviders/Applications/Deployments",
+      "properties": {
+        "components": [
+          {
+            "componentName": "db"
+          },
+          {
+            "componentName": "todoapp"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+### Inspect a specific component's details 
+
+View properties of a specific component: 
+
+```sh
+rad component get --application-name webapp --name todoapp
+```
+
+The details of the deployed component should match that component's definition from your template.bicep file. Example output:
+
+```sh
+Using config file: /Users/tutorial-user/.rad/config.yaml
+{
+  "id": "/subscriptions/76d1209e-1382-45d3-99bb-650e6bf63fc1/resourceGroups/tutorial-resource-group/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/webapp/Components/todoapp",
+  "name": "radius/webapp/todoapp",
+  "type": "Microsoft.CustomProviders/resourceProviders/Applications/Components",
+  "kind": "radius.dev/Container@v1alpha1",
+  "properties": {
+    "dependsOn": [
+      {
+        "kind": "mongodb.com/Mongo",
+        "name": "db",
+        "setEnv": {
+          "DB_CONNECTION": "connectionString"
+        }
+      }
+    ],
+    "provides": [
+      {
+        "containerPort": 3000,
+        "kind": "http",
+        "name": "web"
+      }
+    ],
+    "revision": "89622fa78bc845079129b8722a20452156f1f80f",
+    "run": {
+      "container": {
+        "image": "radiusteam/tutorial-todoapp"
+      }
+    }
+  }
+}
+```
+
+## Step 5: Cleanup
 
 If you'd like to try another tutorial with your existing environment, go back to the [Radius tutorials]({{< ref tutorial >}}). 
 
@@ -367,3 +447,5 @@ Deleting an environment will delete:
 ```sh
 rad env delete azure --yes
 ```
+
+You have completed this tutorial!

--- a/docs/content/getting-started/tutorial/webapp/template.bicep
+++ b/docs/content/getting-started/tutorial/webapp/template.bicep
@@ -1,7 +1,7 @@
 resource app 'radius.dev/Applications@v1alpha1' = {
   name: 'webapp'
 
-  resource todoapp 'Components' = {
+  resource todoapplication 'Components' = {
     name: 'todoapp'
     kind: 'radius.dev/Container@v1alpha1'
     properties: {


### PR DESCRIPTION
- adds "Inspect application" section to Webapp tutorial (but not Dapr microservices tutorial)
  - rad deployment list --application-name webapp
  - rad component get --application-name webapp --name todoapp
- updates log messages in `rad deploy` to match capitalized log messages in `rad env init`
- minor flow change to microservices tutorial: move "tour completed" text to the end 