### PR TITLE
Add version to CLI and RP image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ GIT_COMMIT  = $(shell git rev-list -1 HEAD)
 GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty)
 CGO			?= 0
 
-
 WEBAPP_BINARY  = radius-rp
 CLI_BINARY = rad
 
@@ -71,7 +70,8 @@ endif
 OUT_DIR := ./dist
 
 BINS_OUT_DIR := $(OUT_DIR)/$(GOOS)_$(GOARCH)/$(BUILDTYPE_DIR)
-LDFLAGS := "-s -w -X main.version=$(REL_VERSION)"
+BASE_PACKAGE_NAME := github.com/Azure/radius
+LDFLAGS := "-s -w -X $(BASE_PACKAGE_NAME)/pkg/version.release=$(REL_VERSION) -X $(BASE_PACKAGE_NAME)/pkg/version.commit=$(GIT_COMMIT) -X $(BASE_PACKAGE_NAME)/pkg/version.version=$(GIT_VERSION)"
 GOPATH := $(shell go env GOPATH)
 
 ifeq (,$(shell go env GOBIN))
@@ -79,6 +79,7 @@ GOBIN=$(shell go env GOPATH)/bin
 else
 GOBIN=$(shell go env GOBIN)
 endif
+
 
 ################################################################################
 # Docker build details                                                         #
@@ -211,7 +212,12 @@ clean:
 .PHONY: docker
 docker:
 	$(info $(H) Building image as '$(DOCKER_IMAGE)')
-	docker build . -f ./deploy/rp/Dockerfile -t $(DOCKER_IMAGE)
+	docker build . \
+		-f ./deploy/rp/Dockerfile \
+		-t $(DOCKER_IMAGE) \
+		--build-arg LDFLAGS=$(LDFLAGS) \
+		--label org.opencontainers.image.version="$(REL_VERSION)" \
+		--label org.opencontainers.image.revision="$(GIT_COMMIT)"
 
 ################################################################################
 # Target: dockerpush                                                           #

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/Azure/radius/pkg/version"
 	"github.com/spf13/cobra"
 
 	homedir "github.com/mitchellh/go-homedir"
@@ -38,6 +39,11 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+
+	// Initialize support for --version
+	RootCmd.Version = version.Release()
+	template := fmt.Sprintf("Release: %s \nVersion: %s\nCommit: %s\n", version.Release(), version.Version(), version.Commit())
+	RootCmd.SetVersionTemplate(template)
 
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.rad/config.yaml)")
 }

--- a/deploy/rp/Dockerfile
+++ b/deploy/rp/Dockerfile
@@ -1,3 +1,5 @@
+ARG LDFLAGS="-w -s"
+
 FROM golang:alpine AS build-env
 RUN apk --no-cache add build-base git gcc
 WORKDIR /src
@@ -5,9 +7,9 @@ COPY go.mod ./
 COPY go.sum ./
 RUN go mod download
 COPY . ./
-RUN go build -o radius-rp -ldflags "-w -s" cmd/rp/main.go
+RUN go build -o radius-rp -ldflags "$LD_FLAGS" cmd/rp/main.go
 
-FROM alpine 
+FROM alpine
 RUN apk --no-cache add ca-certificates
 COPY --from=build-env /src/radius-rp ./radius-rp
 EXPOSE 5000

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,28 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package version
+
+// Values for these are injected by the build.
+var (
+	release = "edge"
+	version = "edge"
+	commit  = "unknown"
+)
+
+// Commit returns the full git SHA of the build.
+func Commit() string {
+	return commit
+}
+
+// Release returns the semver release version of the build.
+func Release() string {
+	return release
+}
+
+// Version returns the 'git describe' output of the build.
+func Version() string {
+	return version
+}


### PR DESCRIPTION
Fixes: #37

Part of: #231

This change adds version info to our binary builds and our RP image.