### PR TITLE
 Add "channel" concept to our asset publishing

### DIFF
--- a/.github/scripts/get_release_version.py
+++ b/.github/scripts/get_release_version.py
@@ -6,47 +6,95 @@
 # This script parses release version from Git tag and set the parsed version to
 # environment variable, REL_VERSION.
 
+# We set the environment variable REL_CHANNEL based on the kind of release. REL_CHANNEL is:
+# 'edge': for most builds
+# 'pr-<pr number>': for PR builds
+# '1.0.0-rc1' (the full version): for a tagged prerelease
+# '1.0' (major.minor): for a tagged release
+
+# We set the environment variable UPDATE_RELEASE if it's a full release (tagged and not prerelease)
+
+# REL_VERSION is used to stamp versions into binaries
+# REL_CHANNEL is used to upload assets to different paths
+
+# This way a 1.0 user can download 1.0.1, etc.
+
 import os
 import re
 import sys
 
 gitRef = os.getenv("GITHUB_REF")
-tagRefRegex = r"refs/tags/v(.*)"
-pullRefRegex = r"refs/pull/(.*)/(.*)"
+
+# From https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+# Group 'version' returns the whole version
+# other named groups return the components
+tagRefRegex = r"^refs/tags/v(?P<version>0|(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$"
+pullRefRegex = r"^refs/pull/(.*)/(.*)$"
 
 with open(os.getenv("GITHUB_ENV"), "a") as githubEnv:
     if gitRef is None:
         print("This is not running in github, GITHUB_REF is null. Assuming a local build...")
+
         version = "REL_VERSION=edge"
         print("Setting: {}".format(version))
         githubEnv.write(version + "\n")
+
+        channel = "REL_CHANNEL=edge"
+        print("Setting: {}".format(channel))
+        githubEnv.write(channel + "\n")
+
         sys.exit(0)
 
     match = re.search(pullRefRegex, gitRef)
     if match is not None:
         print("This is pull request {}...".format(match.group(1)))
+
         version = "REL_VERSION=pr-{}".format(match.group(1))
         print("Setting: {}".format(version))
         githubEnv.write(version + "\n")
+
+        channel = "REL_CHANNEL=pr-{}".format(match.group(1))
+        print("Setting: {}".format(channel))
+        githubEnv.write(channel + "\n")
+
         sys.exit(0)
 
     match = re.search(tagRefRegex, gitRef)
     if match is not None:
-        print("This is tagged as {}...".format(match.group(1)))
-        version = "REL_VERSION={}".format(match.group(1))
-        print("Setting: {}".format(version))
-        githubEnv.write(version + "\n")
+        print("This is tagged as {}...".format(match.group("version")))
 
-        if version.find("-rc") > 0:
-            print("Release Candidate build from {}...".format(version))
+        if match.group("prerelease") is None:
+            print("This is a full release...")
+
+            version = "REL_VERSION={}".format(match.group("version"))
+            print("Setting: {}".format(version))
+            githubEnv.write(version + "\n")
+
+            channel = "REL_CHANNEL={}.{}".format(match.group("major"), match.group("minor"))
+            print("Setting: {}".format(channel))
+            githubEnv.write(channel + "\n")
+
+            print("Setting: UPDATE_RELEASE=true")
+            githubEnv.write("UPDATE_RELEASE=true" + "\n")
+            sys.exit(0)
+
         else:
-            print("Release build from {}...".format(version))
-            githubEnv.write("LATEST_RELEASE=true\n")
-        sys.exit(0)
+            print("This is a prerelease...")
+        
+            version = "REL_VERSION={}".format(match.group("version"))
+            print("Setting: {}".format(version))
+            githubEnv.write(version + "\n")
 
-    githubEnv.write("\n")
-    print("This is daily build from {}...".format(gitRef))
+            channel = "REL_CHANNEL={}".format(match.group("version"))
+            print("Setting: {}".format(channel))
+            githubEnv.write(channel + "\n")
+            sys.exit(0)
+
+    print("This is a normal build")
     version = "REL_VERSION=edge"
     print("Setting: {}".format(version))
     githubEnv.write(version + "\n")
-    sys.exit(0)
+
+    channel = "REL_CHANNEL=edge"
+    print("Setting: {}".format(channel))
+    githubEnv.write(channel + "\n")

--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -20,19 +20,59 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Parse release version and set REL_VERSION
+      - name: Parse release version and set enviroment variables
         run: python ./.github/scripts/get_release_version.py
-      - uses: bacongobbler/azure-blob-storage-upload@v1.1.1
+      - name: Upload deployment template
+        uses: bacongobbler/azure-blob-storage-upload@v1.1.1
         with:
           source_dir: 'deploy'
           container_name: 'environment'
           connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
           sync: true
-          extra_args: '--destination-path ${{ env.REL_VERSION }} --pattern rp-full.json'
-      - uses: bacongobbler/azure-blob-storage-upload@v1.1.1
+          extra_args: '--destination-path ${{ env.REL_CHANNEL }} --pattern rp-full.json'
+      - name: Upload deployment script
+        uses: bacongobbler/azure-blob-storage-upload@v1.1.1
         with:
           source_dir: 'deploy'
           container_name: 'environment'
           connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
           sync: true
-          extra_args: '--destination-path ${{ env.REL_VERSION }} --pattern initialize-cluster.sh'
+          extra_args: '--destination-path ${{ env.REL_CHANNEL }} --pattern initialize-cluster.sh'
+      
+      # Logic: If this is a real release (tagged, non-rc) then compare to our existing full
+      # release and see if it's newer. This prevents a patch release of an older vintage from overwriting
+      # a newer release
+      - name: Download version marker file
+        run: |
+          curl https://radiuspublic.blob.core.windows.net/version/stable.txt -o current-stable.txt
+        if: ${{ success() && env.UPDATE_RELEASE == 'true' }}
+      - name: Get version
+        id: setcurrentversion
+        if: ${{ success() && env.UPDATE_RELEASE == 'true' }}
+        run: echo ::set-output name=version::$(cat current-stable.txt)
+      - name: Compare versions
+        uses: madhead/semver-utils@latest
+        if: ${{ success() && env.UPDATE_RELEASE == 'true' }}
+        id: compare
+        with:
+          version: ${{ env.REL_CHANNEL }}.0
+          compare-to: ${{ steps.setcurrentversion.outputs.version }}.0
+      - name: Print info (for sanity)
+        if: ${{ success() && env.UPDATE_RELEASE == 'true' }}
+        run: |
+          echo "current stable channel: ${{ steps.setcurrentversion.outputs.version }}"
+          echo "this build channel: ${{ env.REL_CHANNEL }}"
+          echo "comparison: ${{ steps.compare.outputs.comparison-result }}"
+      - name: Write stable.txt
+        if: ${{ success() && steps.compare.outputs.comparison-result == '>' }}
+        run: |
+          echo $REL_CHANNEL > stable.txt
+      - name: 'Update latest version marker'
+        uses: bacongobbler/azure-blob-storage-upload@v1.1.1
+        if: ${{ success() && steps.compare.outputs.comparison-result == '>' }}
+        with:
+          container_name: 'version'
+          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
+          sync: true
+          source_dir: .
+          extra_args: '--pattern stable.txt' 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GOVER }}
-      - name: Parse release version and set REL_VERSION
+      - name: Parse release version and set environment variables
         run: python ./.github/scripts/get_release_version.py
       - name: Make
         run: make
@@ -92,7 +92,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Parse release version and set REL_VERSION
+      - name: Parse release version and set environment variables
         run: python ./.github/scripts/get_release_version.py
       - name: make docker
         run: make docker
@@ -104,13 +104,13 @@ jobs:
         if: startsWith(github.ref, 'refs/pull/')
         env:
           DOCKER_REGISTRY: ${{ matrix.registry }}
-          DOCKER_TAG_VERSION: ${{ env.REL_VERSION }}
+          DOCKER_TAG_VERSION: ${{ env.REL_CHANNEL }}
       - name: make docker (release)
         run: make docker
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           DOCKER_REGISTRY: ${{ matrix.registry }}
-          DOCKER_TAG_VERSION: ${{ env.REL_VERSION }}
+          DOCKER_TAG_VERSION: ${{ env.REL_CHANNEL }}
       - uses: azure/docker-login@v1
         with:
           login-server: ${{ matrix.login_server }}
@@ -127,13 +127,13 @@ jobs:
         if: startsWith(github.ref, 'refs/pull/') # push image on pr
         env:
           DOCKER_REGISTRY: ${{ matrix.registry }}
-          DOCKER_TAG_VERSION: ${{ env.REL_VERSION }}
+          DOCKER_TAG_VERSION: ${{ env.REL_CHANNEL }}
       - name: make dockerpush (release)
         run: make dockerpush
         if: startsWith(github.ref, 'refs/tags/v') # push image on tag
         env:
           DOCKER_REGISTRY: ${{ matrix.registry }}
-          DOCKER_TAG_VERSION: ${{ env.REL_VERSION }}
+          DOCKER_TAG_VERSION: ${{ env.REL_CHANNEL }}
 
   deploy_tests: 
     name: Run deployment tests
@@ -148,7 +148,7 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVER }}
-    - name: Parse release version and set REL_VERSION
+    - name: Parse release version and set environment variables
       run: python ./.github/scripts/get_release_version.py
     - name: Download release artifacts
       uses: actions/download-artifact@v2
@@ -201,7 +201,7 @@ jobs:
         go run cmd/testenv/main.go \
           update-rp \
           --configpath ~/.rad/config.yaml \
-          --image radiusteam/radius-rp:${{ env.REL_VERSION }}
+          --image radiusteam/radius-rp:${{ env.REL_CHANNEL }}
     - name: Run deploy tests
       run: |
         export PATH=$GITHUB_WORKSPACE/dist:$PATH
@@ -230,7 +230,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Parse release version and set REL_VERSION
+      - name: Parse release version and set environment variables
         run: python ./.github/scripts/get_release_version.py
       - name: Download release artifacts
         uses: actions/download-artifact@v2
@@ -253,21 +253,21 @@ jobs:
           container_name: 'tools'
           connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
           sync: true
-          extra_args: '--destination-path rad/${{ env.REL_VERSION }}/macos-x64/ --pattern rad'
+          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/macos-x64/ --pattern rad'
       - uses: bacongobbler/azure-blob-storage-upload@v1.1.1
         with:
           source_dir: rad_cli_linux_amd64
           container_name: 'tools'
           connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
           sync: true
-          extra_args: '--destination-path rad/${{ env.REL_VERSION }}/linux-x64/ --pattern rad'
+          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-x64/ --pattern rad'
       - uses: bacongobbler/azure-blob-storage-upload@v1.1.1
         with:
           source_dir: rad_cli_windows_amd64
           container_name: 'tools'
           connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
           sync: true
-          extra_args: '--destination-path rad/${{ env.REL_VERSION }}/windows-x64/ --pattern rad.exe'
+          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/windows-x64/ --pattern rad.exe'
       - uses: bacongobbler/azure-blob-storage-upload@v1.1.1
         with:
           source_dir: install


### PR DESCRIPTION
Part of: #231

This change makes our version publishing logic more sophisticated. After
this change we produce two version from each tagged release:

- The release version (full version)
- The channel (excludes patch)

Things that get a version number baked in are stamped with the release
version. That way a `rad --version` output will include the full build
info including the patch level.

Things that are downloaded by the user are uploaded based on a
"channel". This allows us to patch things and for users to see the
update. For instance we can patch the RP by uploading a new build with
the same tag. Users can restart their RP and pick up the update.

There's also built-in support for updating a version marker to point to
the latest channel. This way we can push a `v0.2` tag and then `0.2`
becomes the stable channel. Our install scripts and other assets will
refer to this channel through the file.