### PR TITLE
Skip deployment tests unless its a PR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -135,10 +135,13 @@ jobs:
           DOCKER_REGISTRY: ${{ matrix.registry }}
           DOCKER_TAG_VERSION: ${{ env.REL_VERSION }}
 
+  # We run the deploy tests on PRs only - this way an unreliable deploy test
+  # won't block publishing of binaries.
   deploy_tests: 
     name: Run deployment tests
     needs: [ 'build', 'images' ]
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/pull/')
     env:
       GOVER: '^1.16.0'
     steps:
@@ -224,7 +227,7 @@ jobs:
 
   publish:
     name: Publish rad CLI binaries
-    needs: [ 'build', 'deploy_tests' ]
+    needs: [ 'build' ]
     runs-on: ubuntu-latest
     if: (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') # upload on push to main or tag
     steps:


### PR DESCRIPTION
This change will make it so deployment tests only apply to PRs.

This solves an issue where a PR might pass and and push/tag might fail,
and thus fail to publish binaries.