### PR TITLE
remove dependency on build tests for publishing Rad CLI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -224,7 +224,7 @@ jobs:
 
   publish:
     name: Publish rad CLI binaries
-    needs: [ 'build', 'deploy_tests' ]
+    needs: [ 'build' ] # may want to add needs 'deploy_tests' as well in the future
     runs-on: ubuntu-latest
     if: (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') # upload on push to main or tag
     steps:


### PR DESCRIPTION
The CLI binaries are currently not being published since that push currently depends on often-failing build actions. 

Temporarily removing dependency on deploy_tests. 