### PR TITLE
change base codeowners rule from blank to * (all files)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 # All of the people (and only those people) from the matching rule will be notified
 
 # Default rule: anything that doesn't match a more specific rule goes here
-@kachawla @rynowak @vinayada1
+* @kachawla @rynowak @vinayada1
 
 # Docs rule: any PR that touches docs goes here
 /docs/ @AaronCrawfis @kachawla @rynowak @vinayada1 @emily-potyraj


### PR DESCRIPTION
I'm not sure why codeowners was working previously, but from github documentation and a bunch of examples they have, it looks like the base rule for owners of all files should be "*". 

I tried making this change in my sandbox repo. before, when the rule was just `@emily-potyraj`, I didn't show up as an owner on all files (the little shield icon). Now that the rule is `* @emily-potyraj`, github shows that I'm an owner for all files in my sandbox repo. 

https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax