### PR TITLE
Prefer curl for downloads over wget

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -74,7 +74,7 @@ runAsRoot() {
 
 checkHttpRequestCLI() {
     if type "curl" > /dev/null; then
-        RADIUS_HTTP_REQUEST_CLI=wget
+        RADIUS_HTTP_REQUEST_CLI=curl
     elif type "wget" > /dev/null; then
         RADIUS_HTTP_REQUEST_CLI=wget
     else


### PR DESCRIPTION
Fixes: #241

Fixing a bug where our installer script uses wget even when curl is
available. This is likely the root cause of #241 based on:

- wget is always used
- macos has an old version of most *nix userspace
- old wget doesn't support TLS 1.2
- TLS 1.2 is required by our assets