### PR TITLE
Unwrap http response into error

### DIFF
--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -56,7 +56,7 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 	// Retrieve all the deployments in the application
 	response, err := dc.ListByApplication(cmd.Context(), env.ResourceGroup, applicationName, nil)
 	if err != nil {
-		return err
+		return utils.UnwrapErrorFromRawResponse(err)
 	}
 
 	// Delete the deployments
@@ -67,7 +67,7 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 
 		_, err := dc.Delete(cmd.Context(), env.ResourceGroup, applicationName, deploymentName, nil)
 		if err != nil {
-			return fmt.Errorf("Failed to delete the deployment %s, %w", deploymentName, err)
+			return utils.UnwrapErrorFromRawResponse(err)
 		}
 		fmt.Printf("Deleted deployment '%s'\n", deploymentName)
 	}
@@ -77,7 +77,7 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 
 	_, err = ac.Delete(cmd.Context(), env.ResourceGroup, applicationName, nil)
 	if err != nil {
-		return fmt.Errorf("Failed to delete the application %w", err)
+		return utils.UnwrapErrorFromRawResponse(err)
 	}
 	fmt.Printf("Application '%s' has been deleted\n", applicationName)
 

--- a/cmd/cli/cmd/appGet.go
+++ b/cmd/cli/cmd/appGet.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
 )
@@ -51,7 +52,7 @@ func getApplication(cmd *cobra.Command, args []string) error {
 	ac := radclient.NewApplicationClient(con, env.SubscriptionID)
 	response, err := ac.Get(cmd.Context(), env.ResourceGroup, applicationName, nil)
 	if err != nil {
-		return fmt.Errorf("Failed to get the application %s, %w", applicationName, err)
+		return utils.UnwrapErrorFromRawResponse(err)
 	}
 
 	applicationResource := *response.ApplicationResource

--- a/cmd/cli/cmd/appList.go
+++ b/cmd/cli/cmd/appList.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
 )
@@ -42,7 +43,7 @@ func listApplications(cmd *cobra.Command, args []string) error {
 	ac := radclient.NewApplicationClient(con, env.SubscriptionID)
 	response, err := ac.ListByResourceGroup(cmd.Context(), env.ResourceGroup, nil)
 	if err != nil {
-		return fmt.Errorf("Failed to list applications in the resource group %s, %w", env.ResourceGroup, err)
+		return utils.UnwrapErrorFromRawResponse(err)
 	}
 
 	applicationsList := *response.ApplicationList

--- a/cmd/cli/cmd/componentGet.go
+++ b/cmd/cli/cmd/componentGet.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
 )
@@ -62,7 +63,7 @@ func getComponent(cmd *cobra.Command, args []string) error {
 
 	response, err := componentClient.Get(cmd.Context(), env.ResourceGroup, applicationName, componentName, nil)
 	if err != nil {
-		return fmt.Errorf("Failed to get the component %s, %w", componentName, err)
+		return utils.UnwrapErrorFromRawResponse(err)
 	}
 
 	componentResource := *response.ComponentResource

--- a/cmd/cli/cmd/componentList.go
+++ b/cmd/cli/cmd/componentList.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
 )
@@ -53,7 +54,7 @@ func listComponents(cmd *cobra.Command, args []string) error {
 
 	response, err := componentClient.ListByApplication(cmd.Context(), env.ResourceGroup, applicationName, nil)
 	if err != nil {
-		return fmt.Errorf("Failed to list components in the application %s, %w", applicationName, err)
+		return utils.UnwrapErrorFromRawResponse(err)
 	}
 
 	componentsList := *response.ComponentList

--- a/cmd/cli/cmd/deploymentDelete.go
+++ b/cmd/cli/cmd/deploymentDelete.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
 )
@@ -62,7 +63,7 @@ func deleteDeployment(cmd *cobra.Command, args []string) error {
 	dc := radclient.NewDeploymentClient(con, env.SubscriptionID)
 	_, err = dc.Delete(cmd.Context(), env.ResourceGroup, applicationName, depName, nil)
 	if err != nil {
-		return fmt.Errorf("Failed to delete the deployment %s, %w", depName, err)
+		return utils.UnwrapErrorFromRawResponse(err)
 	}
 	fmt.Printf("Deployment '%s' deleted.\n", depName)
 

--- a/cmd/cli/cmd/deploymentGet.go
+++ b/cmd/cli/cmd/deploymentGet.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 
+	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
 )
@@ -72,7 +73,7 @@ func getDeployment(cmd *cobra.Command, args []string) error {
 			return radclient.NewRadiusError("ResourceNotFound", errorMessage)
 		}
 
-		return fmt.Errorf("Failed to get the deployment %s, %w", depName, err)
+		return utils.UnwrapErrorFromRawResponse(err)
 	}
 
 	deploymentResource := *response.DeploymentResource

--- a/cmd/cli/cmd/deploymentList.go
+++ b/cmd/cli/cmd/deploymentList.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
 )
@@ -61,7 +62,7 @@ func listDeployments(cmd *cobra.Command, args []string) error {
 			return radclient.NewRadiusError("ResourceNotFound", errorMessage)
 		}
 
-		return fmt.Errorf("Failed to list deployments in the application %s, %w", applicationName, err)
+		return utils.UnwrapErrorFromRawResponse(err)
 	}
 
 	deploymentsList := *response.DeploymentList

--- a/cmd/cli/utils/utils.go
+++ b/cmd/cli/utils/utils.go
@@ -6,10 +6,16 @@
 package utils
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/Azure/radius/pkg/radclient"
 )
 
 // GetResourceManagerEndpointAuthorizer returns the authorizer for the ResourceManager endpoint
@@ -78,4 +84,61 @@ func GetResourceNameFromFullyQualifiedPath(fullyQualifiedPath string) string {
 	}
 
 	return name
+}
+
+// UnwrapErrorFromRawResponse raw http response into ErrorResponse format and builds
+// an error message with error code, message and details.
+// This is a temporary fix until we fix this through a combination of changes on server side error implementation
+// and SDK Error interface implementation. https://github.com/Azure/radius/issues/243
+func UnwrapErrorFromRawResponse(err error) error {
+	var httpResp azcore.HTTPResponse
+	ok := errors.As(err, &httpResp)
+	if ok {
+		respBytes, err := ioutil.ReadAll(httpResp.RawResponse().Body)
+		if err != nil {
+			return fmt.Errorf("failed to parse the response: %w", err)
+		}
+
+		var unwrappedError radclient.ErrorResponse
+		err = json.Unmarshal(respBytes, &unwrappedError)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshall the response %w", err)
+		}
+
+		return errors.New(GenerateErrorMessage(unwrappedError))
+	}
+
+	return err
+}
+
+// GenerateErrorMessage generates error message from InnerError
+// Mostly replicated from Error interface implementation of generated model.
+func GenerateErrorMessage(e radclient.ErrorResponse) string {
+	msg := ""
+	if e.InnerError != nil {
+		msg += "Error: \n"
+		if e.InnerError.Code != nil {
+			msg += fmt.Sprintf("\tCode: %v\n", *e.InnerError.Code)
+		}
+		if e.InnerError.Message != nil {
+			msg += fmt.Sprintf("\tMessage: %v\n", *e.InnerError.Message)
+		}
+		if e.InnerError.Target != nil {
+			msg += fmt.Sprintf("\tTarget: %v\n", *e.InnerError.Target)
+		}
+		if e.InnerError.Details != nil {
+			for _, value := range *e.InnerError.Details {
+				if value.Message != nil {
+					msg += fmt.Sprintf("\tDetails: %v\n", *value.Message)
+				}
+			}
+		}
+		if e.InnerError.AdditionalInfo != nil {
+			msg += fmt.Sprintf("\tAdditionalInfo: %v\n", *e.InnerError.AdditionalInfo)
+		}
+	}
+	if msg == "" {
+		msg = "missing error info"
+	}
+	return msg
 }


### PR DESCRIPTION
More details about the issue: https://github.com/Azure/radius/issues/243

This fix is hacky way to achieve what we are trying to get, and is temporary until we handle it on server side and fix SDK autogenerated Error interface implementation. This will for now unblock us from getting more visibility into errors. Sample output for before and after this change.

**_Error returned on delete application for webapp tutorial before this change is deployed:_**
```
% radius application delete -n webapp
Using config file: /Users/karishmachawla/.rad/config.yaml
InnerError: 
	Code: DownstreamEndpointError
	Message: The resource provider 'radius' received a non-success response 'BadRequest' from the downstream endpoint for the request 'DELETE' on 'Applications/webapp/Deployments/default'. Please refer to additional info for details.
	Details: [{<nil> 0xc000965cc0 <nil> 0xc000965cd0 <nil>}]

exit status 1
```

**_Error returned after this change:_**
```
% radius application delete -n webapp
Using config file: /Users/karishmachawla/.rad/config.yaml
Error: 
	Code: DownstreamEndpointError
	Message: The resource provider 'radius' received a non-success response 'BadRequest' from the downstream endpoint for the request 'DELETE' on 'Applications/webapp/Deployments/default'. Please refer to additional info for details.
	Details: {"error":{"code":"","message":"failed deleting resource azure.cosmos.documentdb of workload database: failed to DELETE cosmosdb database: documentdb.MongoDBResourcesClient#DeleteMongoDBDatabase: Failure sending request: StatusCode=0 -- Original Error: Code=\"ResourceNotFound\" Message=\"The Resource 'Microsoft.DocumentDB/databaseAccounts/database-2260cd7e6c3e4fa' under resource group 'kachawla-webapp' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix\"","target":""}}

exit status 1
```