### PR TITLE
fixes typo in tutorial where expose was missing "--port"

### DIFF
--- a/docs/content/getting-started/install-cli.md
+++ b/docs/content/getting-started/install-cli.md
@@ -102,7 +102,9 @@ wget -q "https://radiuspublic.blob.core.windows.net/tools/rad/install.sh" | /bin
    Available Commands:
      application Manage applications
      bicep       Manage bicep compiler
+     component   Manage components
      deploy      Deploy a RAD application
+     deployment  Manage deployments
      env         Manage environments
      expose      Expose local port
      help        Help about any command
@@ -110,6 +112,7 @@ wget -q "https://radiuspublic.blob.core.windows.net/tools/rad/install.sh" | /bin
    Flags:
          --config string   config file (default is $HOME/.rad/config.yaml)
      -h, --help            help for rad
+     -v, --version         version for rad
    
    Use "rad [command] --help" for more information about a command.
    ```

--- a/docs/content/getting-started/tutorial/dapr-microservices/index.md
+++ b/docs/content/getting-started/tutorial/dapr-microservices/index.md
@@ -500,7 +500,7 @@ Now you are ready to deploy.
 1. To test out the state store, open a local tunnel on port 3000 again:
 
    ```sh
-   rad expose dapr-hello nodeapp 3000
+   rad expose dapr-hello nodeapp --port 3000
    ```
 
 1. Visit the the URL `http://localhost:3000/order` in your browser. You should see a message like:
@@ -572,7 +572,7 @@ Now you are ready to deploy.
 1. To test out the pythonapp microservice, open a local tunnel on port 3000 again:
 
    ```sh
-   rad expose dapr-hello nodeapp 3000
+   rad expose dapr-hello nodeapp --port 3000
    ```
 
 1. Visit the URL `http://localhost:3000/order` in your browser.

--- a/docs/content/getting-started/tutorial/webapp/index.md
+++ b/docs/content/getting-started/tutorial/webapp/index.md
@@ -302,7 +302,7 @@ Now you are ready to deploy the application for the first time.
 1. To test out your `webapp` application, open a local tunnel to your application:
 
    ```sh
-   rad expose webapp todoapp 3000
+   rad expose webapp todoapp --port 3000
    ```
 
    {{% alert title="💡 rad expose" color="primary" %}}
@@ -460,7 +460,7 @@ Now you are ready to deploy.
 1. To test out the database, open a local tunnel on port 3000 again:
 
    ```sh
-   rad expose webapp todoapp 3000
+   rad expose webapp todoapp --port 3000
    ```
 
 1. Visit the URL `http://localhost:3000` in your browser. You should see a page like:


### PR DESCRIPTION
fixes: #255

also updates `rad` output example on install CLI page. 