### PR TITLE
Finish versioning story

### DIFF
--- a/docs/content/contributing/code/release-process.md
+++ b/docs/content/contributing/code/release-process.md
@@ -3,7 +3,7 @@ type: docs
 title: "Release process"
 linkTitle: "Release process"
 description: "How we create Radius releases"
-weight: 50
+weight: 80
 ---
 
 ## Release process

--- a/docs/content/contributing/code/release-process.md
+++ b/docs/content/contributing/code/release-process.md
@@ -23,7 +23,7 @@ Currently performing a release involves our custom Bicep compiler - which is in 
 
 1. In the Bicep fork:
 
-```
+```bash
 # replace v0.1.0 with the release version
 git tag v0.1.0
 git push --tags

--- a/docs/content/contributing/code/release-process.md
+++ b/docs/content/contributing/code/release-process.md
@@ -6,7 +6,6 @@ description: "How we create Radius releases"
 weight: 80
 ---
 
-## Release process
 
 Our release process for Project Radius is based on git tags. Pushing a new tag with the format: `v.<major>.<minor>.<patch>` will trigger a release build.
 

--- a/docs/content/contributing/code/release-process.md
+++ b/docs/content/contributing/code/release-process.md
@@ -1,0 +1,70 @@
+---
+type: docs
+title: "Release process"
+linkTitle: "Release process"
+description: "How we create Radius releases"
+weight: 50
+---
+
+## Release process
+
+Our release process for Project Radius is based on git tags. Pushing a new tag with the format: `v.<major>.<minor>.<patch>` will trigger a release build.
+
+{{% alert title="🚌🚌🚌 Busfactor Warning 🚌🚌🚌" color="warning" %}}
+Currently performing a release involves our custom Bicep compiler - which is in a private fork. We'll update these instructions in the future when this moves to a shared repository.
+{{% /alert %}}
+
+Before you begin:
+
+- Find the storage account on Azure. It is called `radiuspublic`
+- Determine the release version. This is in the form `v.<major>.<minor>.<patch>`
+- Determine the release channel This is in the form `<major>.<minor>`
+
+Steps for performing a release:
+
+1. In the Bicep fork:
+
+```
+# replace v0.1.0 with the release version
+git tag v0.1.0
+git push --tags
+```
+
+Verify that GitHub actions triggers a build in response to the tag, and that the build completes.
+
+Next, check the timestamps in the `tools` container of the storage account. There should be new builds of `rad-bicep` and the VS Code extension that correspond to the channel. Look at the paths `tools/bicep/<channel>/<architecture>/` and `tools/vscode/<channel>`. These should reflect the new build.
+
+2. In the azure/radius repo:
+
+```
+# replace v0.1.0 with the release version
+git tag v0.1.0
+git push --tags
+```
+
+Verify that GitHub actions triggers a build in response to the tag, and that the build completes.
+
+Next, check the timestamps in the `environment` container of the storage account. There should be new copies of our environment setup assets that correspond to the channel.  Look at the path `environment/<channel>/`. These should reflect the new build.
+
+3. Check the stable version marker
+
+If this is a patch release - you can stop here, you are done.
+
+If this is a new minor release - check the stable version marker.
+
+The file https://radiuspublic.blob.core.windows.net/version/stable.txt should contain (in plain text) the channel you just created.
+
+You can find this file in the storage account under `version/stable.txt`.
+
+## How releases work
+
+Each release belongs to a *channel* named like `<major>.<minor>`. Releases will only interact with assets from their channel. For example, the `0.1` `rad` CLI will:
+
+- Download `rad-bicep` from the `0.1` channel
+- Create an environment using the `0.1` version of the RP and environment setup script
+
+{{% alert title="⚠️ Compatibility ⚠️" color="warning" %}}
+At this time we do not guarantee compatibility across releases or provide a migration path. For example, the behavior of a `0.1` `rad` CLI talking to a `0.2` control plane is unspecifed. We expect the project to change too frequently to provide compatibility guarantees at this time.
+{{% /alert %}}
+
+Conceptually we scope channels to a major+minor pair because this allows us to freely patch assets as needed without needing to change the intermediate pieces. For example pushing a `v0.1.1` tag will update the assets in the `v0.1` channel. This works as long as it is a *true* patch release and maintains compatibility.

--- a/docs/content/contributing/code/release-process.md
+++ b/docs/content/contributing/code/release-process.md
@@ -1,6 +1,6 @@
 ---
 type: docs
-title: "Release process"
+title: "How to create and publish a Project Radius release"
 linkTitle: "Release process"
 description: "How we create Radius releases"
 weight: 80

--- a/docs/content/contributing/code/release-process.md
+++ b/docs/content/contributing/code/release-process.md
@@ -35,6 +35,7 @@ Currently performing a release involves our custom Bicep compiler - which is in 
 
    ```bash
    az storage blob directory list -c tools -d bicep --account-name radiuspublic --output table
+   az storage blob directory list -c tools -d vscode --account-name radiuspublic --output table
    ```
 
 2. In the azure/radius repo:

--- a/docs/content/contributing/code/release-process.md
+++ b/docs/content/contributing/code/release-process.md
@@ -14,7 +14,7 @@ Our release process for Project Radius is based on git tags. Pushing a new tag w
 Currently performing a release involves our custom Bicep compiler - which is in a private fork. We'll update these instructions in the future when this moves to a shared repository.
 {{% /alert %}}
 
-Before you begin:
+## Pre-requisites
 
 - Find the storage account on Azure. It is called `radiuspublic`
 - Determine the release version. This is in the form `v.<major>.<minor>.<patch>`

--- a/docs/content/contributing/code/release-process.md
+++ b/docs/content/contributing/code/release-process.md
@@ -23,27 +23,35 @@ Currently performing a release involves our custom Bicep compiler - which is in 
 
 1. In the Bicep fork:
 
-```bash
-# replace v0.1.0 with the release version
-git tag v0.1.0
-git push --tags
-```
+   ```bash
+   # replace v0.1.0 with the release version
+   git tag v0.1.0
+   git push --tags
+   ```
 
-Verify that GitHub actions triggers a build in response to the tag, and that the build completes.
+   Verify that GitHub actions triggers a build in response to the tag, and that the build completes.
 
-Next, check the timestamps in the `tools` container of the storage account. There should be new builds of `rad-bicep` and the VS Code extension that correspond to the channel. Look at the paths `tools/bicep/<channel>/<architecture>/` and `tools/vscode/<channel>`. These should reflect the new build.
+   Next, check the timestamps in the `tools` container of the storage account. There should be new builds of `rad-bicep` and the VS Code extension that correspond to the channel. Look at the paths `tools/bicep/<channel>/<architecture>/` and `tools/vscode/<channel>`. These should reflect the new build.
+
+   ```bash
+   az storage blob directory list -c tools -d bicep --account-name radiuspublic --output table
+   ```
 
 2. In the azure/radius repo:
 
-```bash
-# replace v0.1.0 with the release version
-git tag v0.1.0
-git push --tags
-```
+   ```bash
+   # replace v0.1.0 with the release version
+   git tag v0.1.0
+   git push --tags
+   ```
 
-Verify that GitHub actions triggers a build in response to the tag, and that the build completes.
+   Verify that GitHub actions triggers a build in response to the tag, and that the build completes.
 
-Next, check the timestamps in the `environment` container of the storage account. There should be new copies of our environment setup assets that correspond to the channel.  Look at the path `environment/<channel>/`. These should reflect the new build.
+   Next, check the timestamps in the `environment` container of the storage account. There should be new copies of our environment setup assets that correspond to the channel.  Look at the path `environment/<channel>/`. These should reflect the new build.
+
+   ```bash
+   az storage blob directory list -c tools -d vscode --account-name radiuspublic --account-key <access_key> --output table
+   ```
 
 3. Check the stable version marker
 
@@ -54,6 +62,10 @@ Next, check the timestamps in the `environment` container of the storage account
    The file https://radiuspublic.blob.core.windows.net/version/stable.txt should contain (in plain text) the channel you just created.
    
    You can find this file in the storage account under `version/stable.txt`.
+
+4. Update docs for latest stable binaries
+   
+   Our getting started instructions refer to a hardcoded version number for the manual download section. If this is a new minor release, update this version and check it it.
 
 ## How releases work
 

--- a/docs/content/contributing/code/release-process.md
+++ b/docs/content/contributing/code/release-process.md
@@ -47,13 +47,13 @@ Next, check the timestamps in the `environment` container of the storage account
 
 3. Check the stable version marker
 
-If this is a patch release - you can stop here, you are done.
-
-If this is a new minor release - check the stable version marker.
-
-The file https://radiuspublic.blob.core.windows.net/version/stable.txt should contain (in plain text) the channel you just created.
-
-You can find this file in the storage account under `version/stable.txt`.
+   If this is a patch release - you can stop here, you are done.
+   
+   If this is a new minor release - check the stable version marker.
+   
+   The file https://radiuspublic.blob.core.windows.net/version/stable.txt should contain (in plain text) the channel you just created.
+   
+   You can find this file in the storage account under `version/stable.txt`.
 
 ## How releases work
 

--- a/docs/content/contributing/code/release-process.md
+++ b/docs/content/contributing/code/release-process.md
@@ -15,7 +15,7 @@ Currently performing a release involves our custom Bicep compiler - which is in 
 
 ## Pre-requisites
 
-- Find the storage account on Azure. It is called `radiuspublic`
+- Find the storage account on Azure under 'Radius Dev' subscription. It is called `radiuspublic`
 - Determine the release version. This is in the form `v.<major>.<minor>.<patch>`
 - Determine the release channel This is in the form `<major>.<minor>`
 

--- a/docs/content/contributing/code/release-process.md
+++ b/docs/content/contributing/code/release-process.md
@@ -35,7 +35,7 @@ Next, check the timestamps in the `tools` container of the storage account. Ther
 
 2. In the azure/radius repo:
 
-```
+```bash
 # replace v0.1.0 with the release version
 git tag v0.1.0
 git push --tags

--- a/docs/content/contributing/code/release-process.md
+++ b/docs/content/contributing/code/release-process.md
@@ -66,7 +66,7 @@ Currently performing a release involves our custom Bicep compiler - which is in 
 
 4. Update docs for latest stable binaries
    
-   Our getting started instructions refer to a hardcoded version number for the manual download section. If this is a new minor release, update this version and check it it.
+   Our getting started instructions refer to a hardcoded version number for the manual download section. If this is a new minor release, update this version and check it in.
 
 ## How releases work
 

--- a/docs/content/contributing/code/release-process.md
+++ b/docs/content/contributing/code/release-process.md
@@ -51,7 +51,7 @@ Currently performing a release involves our custom Bicep compiler - which is in 
    Next, check the timestamps in the `environment` container of the storage account. There should be new copies of our environment setup assets that correspond to the channel.  Look at the path `environment/<channel>/`. These should reflect the new build.
 
    ```bash
-   az storage blob directory list -c tools -d vscode --account-name radiuspublic --account-key <access_key> --output table
+   az storage blob directory list -c environment -d <channel> --account-name radiuspublic --output table
    ```
 
 3. Check the stable version marker

--- a/docs/content/contributing/code/release-process.md
+++ b/docs/content/contributing/code/release-process.md
@@ -19,7 +19,7 @@ Currently performing a release involves our custom Bicep compiler - which is in 
 - Determine the release version. This is in the form `v.<major>.<minor>.<patch>`
 - Determine the release channel This is in the form `<major>.<minor>`
 
-Steps for performing a release:
+## Performing a release
 
 1. In the Bicep fork:
 

--- a/docs/content/getting-started/install-cli.md
+++ b/docs/content/getting-started/install-cli.md
@@ -71,7 +71,7 @@ wget -q "https://radiuspublic.blob.core.windows.net/tools/rad/install.sh" -O - |
 ### Install the latest unstable version
 
 ```bash
-wget -q "https://radiuspublic.blob.core.windows.net/tools/rad/install.sh" | /bin/bash -s edge
+wget -q "https://radiuspublic.blob.core.windows.net/tools/rad/install.sh" -O - | /bin/bash -s edge
 ```
 
 ### Install a specific version
@@ -83,6 +83,16 @@ wget -q "https://radiuspublic.blob.core.windows.net/tools/rad/install.sh" -O - |
 {{% /codetab %}}
 
 {{% codetab %}}
+
+### Install the latest stable version
+
+1. Download the `rad` CLI from one of these URLs:
+
+   - MacOS: https://radiuspublic.blob.core.windows.net/tools/rad/0.1/macos-x64/rad
+   - Linux: https://radiuspublic.blob.core.windows.net/tools/rad/0.1/linux-x64/rad
+   - Windows: https://radiuspublic.blob.core.windows.net/tools/rad/0.1/windows-x64/rad.exe
+
+1. Ensure the user has permission to execute the binary and place it somewhere on your PATH so it can be invoked easily.
 
 ### Install the latest unstable version
 

--- a/docs/content/getting-started/install-cli.md
+++ b/docs/content/getting-started/install-cli.md
@@ -24,6 +24,13 @@ These steps will setup the required tools and extensions to get you up and runni
 powershell -Command "iwr -useb https://radiuspublic.blob.core.windows.net/tools/rad/install.ps1 | iex"
 ```
 
+### Install the latest unstable version
+
+```powershell
+powershell -Command "$script=iwr -useb  https://radiuspublic.blob.core.windows.net/tools/rad/install.ps1; $block=[ScriptBlock]::Create($script); invoke-command -ScriptBlock $block -ArgumentList edge"
+```
+
+
 ### Install a specific version
 
 ```powershell
@@ -37,6 +44,12 @@ powershell -Command "$script=iwr -useb  https://radiuspublic.blob.core.windows.n
 
 ```bash
 curl -fsSL "https://radiuspublic.blob.core.windows.net/tools/rad/install.sh" | /bin/bash
+```
+
+### Install the latest unstable version
+
+```bash
+curl -fsSL "https://radiuspublic.blob.core.windows.net/tools/rad/install.sh" | /bin/bash -s edge
 ```
 
 ### Install a specific version
@@ -55,6 +68,12 @@ curl -fsSL "https://radiuspublic.blob.core.windows.net/tools/rad/install.sh" | /
 wget -q "https://radiuspublic.blob.core.windows.net/tools/rad/install.sh" -O - | /bin/bash
 ```
 
+### Install the latest unstable version
+
+```bash
+wget -q "https://radiuspublic.blob.core.windows.net/tools/rad/install.sh" | /bin/bash -s edge
+```
+
 ### Install a specific version
 
 ```bash
@@ -65,7 +84,7 @@ wget -q "https://radiuspublic.blob.core.windows.net/tools/rad/install.sh" -O - |
 
 {{% codetab %}}
 
-### Install the latest stable version
+### Install the latest unstable version
 
 1. Download the `rad` CLI from one of these URLs:
 

--- a/docs/content/getting-started/setup-vscode/index.md
+++ b/docs/content/getting-started/setup-vscode/index.md
@@ -17,7 +17,7 @@ Radius can be used with any text editor, but Radius-specific optimizations are a
 
 ## Install Radius extension
 
-1. Download the [custom VSCode extension file](https://radiuspublic.blob.core.windows.net/tools/vscode/edge/rad-vscode-bicep.vsix)
+1. Download the stable version of the [custom VSCode extension file](https://radiuspublic.blob.core.windows.net/tools/vscode/stable/rad-vscode-bicep.vsix)
 
 1. Install the `.vsix` file
    - In VSCode, manually install the extension using the *Install from VSIX* command in the Extensions view command drop-down.
@@ -31,5 +31,11 @@ Radius can be used with any text editor, but Radius-specific optimizations are a
 
 1. Disable the official Bicep extension if you have it installed. (Do NOT install the Bicep extension if you haven't already.)
    - Our custom extension needs to be responsible for handling `.bicep` files and you cannot have both extensions enabled at once.
+
+## Install other Radius extension versions
+
+You can access other versions of the Radius extension from the following URLs:
+
+- [Latest unstable](https://radiuspublic.blob.core.windows.net/tools/vscode/edge/rad-vscode-bicep.vsix)
 
 <br /><a class="btn btn-primary" href="{{< ref create-environment.md >}}" role="button">Next: Create environment</a>

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -19,15 +19,7 @@ $RadiusCliFileName = "rad.exe"
 $RadiusCliFilePath = "${RadiusRoot}\${RadiusCliFileName}"
 $OsArch = "windows-x64"
 $BaseDownloadUrl = "https://radiuspublic.blob.core.windows.net/tools/rad"
-
-# Set Github request authentication for basic authentication.
-if ($Env:GITHUB_USER) {
-    $basicAuth = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($Env:GITHUB_USER + ":" + $Env:GITHUB_TOKEN));
-    $githubHeader = @{"Authorization" = "Basic $basicAuth" }
-}
-else {
-    $githubHeader = @{}
-}
+$StableVersionUrl = "https://radiuspublic.blob.core.windows.net/version/stable.txt"
 
 if ((Get-ExecutionPolicy) -gt 'RemoteSigned' -or (Get-ExecutionPolicy) -eq 'ByPass') {
     Write-Output "PowerShell requires an execution policy of 'RemoteSigned'."
@@ -56,10 +48,9 @@ if (!(Test-Path $RadiusRoot -PathType Container)) {
     throw "Cannot create $RadiusRoot"
 }
 
-# TODO Get the list of release from GitHub and get the latest version
 if($Version -eq "")
 {
-    $Version = "edge"
+    $Version = Invoke-WebRequest $StableVersionUrl
 }
 $urlParts = @(
     $BaseDownloadUrl,

--- a/install/install.sh
+++ b/install/install.sh
@@ -94,10 +94,14 @@ checkExistingRadius() {
 }
 
 getLatestRelease() {
-    local current_osarch="${OS}-${ARCH}"
-    local latest_release="edge"
-    
-    # TODO Add code to check the release versions and get the latest release
+    local releaseUrl="https://radiuspublic.blob.core.windows.net/version/stable.txt"
+    local latest_release=""
+
+    if [ "$DAPR_HTTP_REQUEST_CLI" == "curl" ]; then
+        latest_release=$(curl -s $daprReleaseUrl)
+    else
+        latest_release=$(wget -q -O - $daprReleaseUrl)
+    fi
 
     ret_val=$latest_release
 }


### PR DESCRIPTION
Fixes: #231

This part of the change updates our installers and our docs to refer to
'stable' builds. We should merge this when we're ready to cut a release
because prior to that these URLs will 404.