### PR TITLE
Fix Kubernetes version discovery

### DIFF
--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -428,7 +428,7 @@ func findKubernetesVersion(ctx context.Context, authorizer autorest.Authorizer, 
 	k8sc := containerserviceclient.NewContainerServicesClient(subscriptionID)
 	k8sc.Authorizer = authorizer
 
-	result, err := k8sc.ListOrchestrators(ctx, *group.Location, "")
+	result, err := k8sc.ListOrchestrators(ctx, *group.Location, "managedClusters")
 	if err != nil {
 		return "", fmt.Errorf("cannot get AKS version: %w", err)
 	}


### PR DESCRIPTION
We were missing a parameter here that filters this endpoint to return
AKS info. Without this endpoint we no longer get info about the
'default' K8s version.