### PR TITLE
Remove AKS version selection

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -97,10 +97,10 @@ getLatestRelease() {
     local releaseUrl="https://radiuspublic.blob.core.windows.net/version/stable.txt"
     local latest_release=""
 
-    if [ "$DAPR_HTTP_REQUEST_CLI" == "curl" ]; then
-        latest_release=$(curl -s $daprReleaseUrl)
+    if [ "$RADIUS_HTTP_REQUEST_CLI" == "curl" ]; then
+        latest_release=$(curl -s $releaseUrl)
     else
-        latest_release=$(wget -q -O - $daprReleaseUrl)
+        latest_release=$(wget -q -O - $releaseUrl)
     fi
 
     ret_val=$latest_release


### PR DESCRIPTION
Based on the code/documentation if a version is not specified, the default version is picked up by default, so given that we are selecting default it shouldn't be needed at all.

Ran env init to test, here's the cluster that was created https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourceGroups/testing-env/providers/Microsoft.ContainerService/managedClusters/radius-aks-jdjkyqdqybubc/overview

```
% radius env init azure -i -n kachawla-test-aks
Using config file: /Users/karishmachawla/.rad/config.yaml
Use Subscription 'Radius Dev' [y/n]? y
Enter a Resource Group name: test-version
Validating Subscription...
Deploying Environment...
Updating Config...
Successfully wrote configuration to /Users/karishmachawla/.rad/config.yaml
```