### PR TITLE
Remove kubernetes version from template

### DIFF
--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -427,9 +427,6 @@ func deployEnvironment(ctx context.Context, authorizer autorest.Authorizer, subs
 		"channel": map[string]interface{}{
 			"value": version.Channel(),
 		},
-		"kubernetesVersion": map[string]interface{}{
-			"value": params.KubernetesVersion,
-		},
 	}
 
 	deploymentProperties := &resources.DeploymentProperties{
@@ -539,5 +536,4 @@ func storeEnvironment(ctx context.Context, authorizer autorest.Authorizer, name 
 
 type deploymentParameters struct {
 	DeploymentTemplate string
-	KubernetesVersion  string
 }

--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -89,13 +89,6 @@
                 "description": "The instance size of the hosting plan (small, medium, or large)."
             }
         },
-        "kubernetesVersion": {
-            "type": "string",
-            "defaultValue": "1.18.14",
-            "metadata": {
-                "description": "The version of Kubernetes to use."
-            }
-        },
         "osDiskSizeGB": {
             "type": "int",
             "defaultValue": 0,
@@ -241,7 +234,6 @@
                 "type": "SystemAssigned"
             },
             "properties": {
-                "kubernetesVersion": "[parameters('kubernetesVersion')]",
                 "dnsPrefix": "[parameters('clusterName')]",
                 "agentPoolProfiles": [
                     {


### PR DESCRIPTION
We're no longer setting this, and we can rely on the AKS default.