### PR TITLE
Use a fixed list of locations for environment setup

### DIFF
--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -140,8 +140,7 @@ func validate(cmd *cobra.Command, args []string) (arguments, error) {
 		}
 	}
 
-	if location != "" {
-		if !isSupportedLocation(location) {
+	if location != "" && !isSupportedLocation(location) {
 			return arguments{}, fmt.Errorf("the location '%s' is not supported. choose from: %s", location, strings.Join(supportedLocations[:], ", "))
 		}
 	}

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -141,8 +141,7 @@ func validate(cmd *cobra.Command, args []string) (arguments, error) {
 	}
 
 	if location != "" && !isSupportedLocation(location) {
-			return arguments{}, fmt.Errorf("the location '%s' is not supported. choose from: %s", location, strings.Join(supportedLocations[:], ", "))
-		}
+		return arguments{}, fmt.Errorf("the location '%s' is not supported. choose from: %s", location, strings.Join(supportedLocations[:], ", "))
 	}
 
 	return arguments{


### PR DESCRIPTION
Fixes: #239

Note, this pr also adds validation to existing resource groups and
locations passed in at the command line. We weren't validating this
previously.