### PR TITLE
print env URL during some CLI commands. stop printing "Using config file: __" 

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,21 +1,7 @@
-<<<<<<< HEAD
-=======
-# TODO: The maintainer of this repo has not yet edited this file
-
-**REPO OWNER**: Do you want Customer Service & Support (CSS) support for this product/project?
-
-- **No CSS support:** Fill out this template with information about how to file issues and get help.
-- **Yes CSS support:** Fill out an intake form at [aka.ms/spot](https://aka.ms/spot). CSS will work with/help you to determine next steps. More details also available at [aka.ms/onboardsupport](https://aka.ms/onboardsupport).
-- **Not sure?** Fill out a SPOT intake as though the answer were "Yes". CSS will help you decide.
-
-*Then remove this first heading from this SUPPORT.MD file before publishing your repo.*
-
->>>>>>> nuisance EOL issue for SUPPORT.md preventing me from rebasing.
 # Support
 
 ## How to file issues and get help  
 
-<<<<<<< HEAD
 This project uses GitHub Issues to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates.  For new issues, file your bug or feature request as a new Issue.
 
 For help and questions about using this project, please email radiusct@microsoft.com
@@ -23,16 +9,3 @@ For help and questions about using this project, please email radiusct@microsoft
 ## Microsoft Support Policy  
 
 Support for this project is limited to the resources listed above.
-=======
-This project uses GitHub Issues to track bugs and feature requests. Please search the existing 
-issues before filing new issues to avoid duplicates.  For new issues, file your bug or 
-feature request as a new Issue.
-
-For help and questions about using this project, please **REPO MAINTAINER: INSERT INSTRUCTIONS HERE 
-FOR HOW TO ENGAGE REPO OWNERS OR COMMUNITY FOR HELP. COULD BE A STACK OVERFLOW TAG OR OTHER
-CHANNEL. WHERE WILL YOU HELP PEOPLE?**.
-
-## Microsoft Support Policy  
-
-Support for this **PROJECT or PRODUCT** is limited to the resources listed above.
->>>>>>> nuisance EOL issue for SUPPORT.md preventing me from rebasing.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,7 +1,21 @@
+<<<<<<< HEAD
+=======
+# TODO: The maintainer of this repo has not yet edited this file
+
+**REPO OWNER**: Do you want Customer Service & Support (CSS) support for this product/project?
+
+- **No CSS support:** Fill out this template with information about how to file issues and get help.
+- **Yes CSS support:** Fill out an intake form at [aka.ms/spot](https://aka.ms/spot). CSS will work with/help you to determine next steps. More details also available at [aka.ms/onboardsupport](https://aka.ms/onboardsupport).
+- **Not sure?** Fill out a SPOT intake as though the answer were "Yes". CSS will help you decide.
+
+*Then remove this first heading from this SUPPORT.MD file before publishing your repo.*
+
+>>>>>>> nuisance EOL issue for SUPPORT.md preventing me from rebasing.
 # Support
 
 ## How to file issues and get help  
 
+<<<<<<< HEAD
 This project uses GitHub Issues to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates.  For new issues, file your bug or feature request as a new Issue.
 
 For help and questions about using this project, please email radiusct@microsoft.com
@@ -9,3 +23,16 @@ For help and questions about using this project, please email radiusct@microsoft
 ## Microsoft Support Policy  
 
 Support for this project is limited to the resources listed above.
+=======
+This project uses GitHub Issues to track bugs and feature requests. Please search the existing 
+issues before filing new issues to avoid duplicates.  For new issues, file your bug or 
+feature request as a new Issue.
+
+For help and questions about using this project, please **REPO MAINTAINER: INSERT INSTRUCTIONS HERE 
+FOR HOW TO ENGAGE REPO OWNERS OR COMMUNITY FOR HELP. COULD BE A STACK OVERFLOW TAG OR OTHER
+CHANNEL. WHERE WILL YOU HELP PEOPLE?**.
+
+## Microsoft Support Policy  
+
+Support for this **PROJECT or PRODUCT** is limited to the resources listed above.
+>>>>>>> nuisance EOL issue for SUPPORT.md preventing me from rebasing.

--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -72,11 +72,11 @@ func deploy(cmd *cobra.Command, args []string) error {
 	}
 	logger.CompleteStep(step)
 
-	rgUrl := utils.GenerateResourceGroupUrl(env.SubscriptionID, env.ResourceGroup)
+	envUrl := utils.GenerateEnvUrl(env.Kind, env.SubscriptionID, env.ResourceGroup)
 
-	step = logger.BeginStep("Deploying Application...\n" + 
-							"\nMeanwhile, you can view the Resource Group '%v' in the Azure portal:\n%v\n" +
-							"Deployment In Progress...", env.ResourceGroup, rgUrl)
+	step = logger.BeginStep("Deploying Application into environment '%v'...\n\n" + 
+							"Meanwhile, you can view the environment '%v' at:\n%v\n\n" +
+							"Deployment In Progress...", env.Name, env.Name, envUrl)
 	err = deployApplication(cmd.Context(), template, env)
 	if err != nil {
 		return err

--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -78,9 +78,9 @@ func deploy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	step = logger.BeginStep("Deploying Application into environment '%v'...\n\n" + 
-							"Meanwhile, you can view the environment '%v' at:\n%v\n\n" +
-							"Deployment In Progress...", env.Name, env.Name, envUrl)
+	step = logger.BeginStep("Deploying Application into environment '%v'...\n\n"+
+		"Meanwhile, you can view the environment '%v' at:\n%v\n\n"+
+		"Deployment In Progress...", env.Name, env.Name, envUrl)
 	err = deployApplication(cmd.Context(), template, env)
 	if err != nil {
 		return err

--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -72,7 +72,11 @@ func deploy(cmd *cobra.Command, args []string) error {
 	}
 	logger.CompleteStep(step)
 
-	step = logger.BeginStep("Deploying Application...")
+	rgUrl := utils.GenerateResourceGroupUrl(env.SubscriptionID, env.ResourceGroup)
+
+	step = logger.BeginStep("Deploying Application...\n" + 
+							"\nMeanwhile, you can view the Resource Group '%v' in the Azure portal:\n%v\n" +
+							"Deployment In Progress...", env.ResourceGroup, rgUrl)
 	err = deployApplication(cmd.Context(), template, env)
 	if err != nil {
 		return err

--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
 	"github.com/Azure/radius/cmd/cli/utils"
+	"github.com/Azure/radius/pkg/rad/azure"
 	"github.com/Azure/radius/pkg/rad/bicep"
 	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/Azure/radius/pkg/rad/logger"
@@ -72,7 +73,10 @@ func deploy(cmd *cobra.Command, args []string) error {
 	}
 	logger.CompleteStep(step)
 
-	envUrl := utils.GenerateEnvUrl(env.Kind, env.SubscriptionID, env.ResourceGroup)
+	envUrl, err := azure.GenerateAzureEnvUrl(env.SubscriptionID, env.ResourceGroup)
+	if err != nil {
+		return err
+	}
 
 	step = logger.BeginStep("Deploying Application into environment '%v'...\n\n" + 
 							"Meanwhile, you can view the environment '%v' at:\n%v\n\n" +

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -300,9 +300,12 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 		return err
 	}
 
+	rgUrl := utils.GenerateResourceGroupUrl(subscriptionID, resourceGroup)
+
 	if exists {
 		// We already have a provider in this resource group
-		logger.LogInfo("Found existing environment...")
+		logger.LogInfo("Found existing environment...\n" +
+					   "Environment '%v' available at:\n%v", name, rgUrl)
 		err = storeEnvironment(ctx, armauth, name, subscriptionID, resourceGroup, clusterName)
 		if err != nil {
 			return err
@@ -327,6 +330,7 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 		err := createResourceGroup(ctx, subscriptionID, resourceGroup, location)
 		if err != nil {
 			return err
+		logger.LogInfo("New Environment '%v' with Resource Group '%v' available at:\n%v", name, resourceGroup, rgUrl)
 		}
 	} else if !isSupportedLocation(*group.Location) {
 		return fmt.Errorf("the location '%s' of resource group '%s' is not supported. choose from: %s", *group.Location, *group.Name, strings.Join(supportedLocations[:], ", "))

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -307,8 +307,8 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 
 	if exists {
 		// We already have a provider in this resource group
-		logger.LogInfo("Found existing environment...\n\n" +
-					   "Environment '%v' available at:\n%v\n", name, envUrl)
+		logger.LogInfo("Found existing environment...\n\n"+
+			"Environment '%v' available at:\n%v\n", name, envUrl)
 		err = storeEnvironment(ctx, armauth, name, subscriptionID, resourceGroup, clusterName)
 		if err != nil {
 			return err
@@ -333,8 +333,9 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 		err := createResourceGroup(ctx, subscriptionID, resourceGroup, location)
 		if err != nil {
 			return err
-		logger.LogInfo("New Environment '%v' with Resource Group '%v' available at:\n%v", name, resourceGroup, envUrl)
 		}
+
+		logger.LogInfo("New Environment '%v' with Resource Group '%v' available at:\n%v", name, resourceGroup, envUrl)
 	} else if !isSupportedLocation(*group.Location) {
 		return fmt.Errorf("the location '%s' of resource group '%s' is not supported. choose from: %s", *group.Location, *group.Name, strings.Join(supportedLocations[:], ", "))
 	}
@@ -460,15 +461,15 @@ func createResourceGroup(ctx context.Context, subscriptionID, resourceGroupName,
 }
 
 func deployEnvironment(ctx context.Context, authorizer autorest.Authorizer, subscriptionID string, resourceGroup string, params deploymentParameters) (resources.DeploymentExtended, error) {
-	
+
 	envUrl, err := azure.GenerateAzureEnvUrl(subscriptionID, resourceGroup)
 	if err != nil {
 		return resources.DeploymentExtended{}, err
 	}
 
-	step := logger.BeginStep(fmt.Sprintf("Deploying Environment from channel %s...\n\n" +
-										 "New Environment with Resource Group '%v' will be available at:\n%v\n\n" +
-										 "Deployment In Progress...", version.Channel(), resourceGroup, envUrl))
+	step := logger.BeginStep(fmt.Sprintf("Deploying Environment from channel %s...\n\n"+
+		"New Environment with Resource Group '%v' will be available at:\n%v\n\n"+
+		"Deployment In Progress...", version.Channel(), resourceGroup, envUrl))
 	dc := resources.NewDeploymentsClient(subscriptionID)
 	dc.Authorizer = authorizer
 

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -300,10 +300,13 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 		return err
 	}
 
+	envUrl, err := azure.GenerateAzureEnvUrl(subscriptionID, resourceGroup)
+	if err != nil {
+		return err
+	}
+
 	if exists {
 		// We already have a provider in this resource group
-		envUrl := utils.GenerateEnvUrl("azure", subscriptionID, resourceGroup)
-
 		logger.LogInfo("Found existing environment...\n\n" +
 					   "Environment '%v' available at:\n%v\n", name, envUrl)
 		err = storeEnvironment(ctx, armauth, name, subscriptionID, resourceGroup, clusterName)
@@ -330,7 +333,7 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 		err := createResourceGroup(ctx, subscriptionID, resourceGroup, location)
 		if err != nil {
 			return err
-		logger.LogInfo("New Environment '%v' with Resource Group '%v' available at:\n%v", name, resourceGroup, rgUrl)
+		logger.LogInfo("New Environment '%v' with Resource Group '%v' available at:\n%v", name, resourceGroup, envUrl)
 		}
 	} else if !isSupportedLocation(*group.Location) {
 		return fmt.Errorf("the location '%s' of resource group '%s' is not supported. choose from: %s", *group.Location, *group.Name, strings.Join(supportedLocations[:], ", "))
@@ -458,7 +461,10 @@ func createResourceGroup(ctx context.Context, subscriptionID, resourceGroupName,
 
 func deployEnvironment(ctx context.Context, authorizer autorest.Authorizer, subscriptionID string, resourceGroup string, params deploymentParameters) (resources.DeploymentExtended, error) {
 	
-	envUrl := utils.GenerateEnvUrl("azure", subscriptionID, resourceGroup)
+	envUrl, err := azure.GenerateAzureEnvUrl(subscriptionID, resourceGroup)
+	if err != nil {
+		return resources.DeploymentExtended{}, err
+	}
 
 	step := logger.BeginStep(fmt.Sprintf("Deploying Environment from channel %s...\n\n" +
 										 "New Environment with Resource Group '%v' will be available at:\n%v\n\n" +

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -300,12 +300,12 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 		return err
 	}
 
-	rgUrl := utils.GenerateResourceGroupUrl(subscriptionID, resourceGroup)
-
 	if exists {
 		// We already have a provider in this resource group
-		logger.LogInfo("Found existing environment...\n" +
-					   "Environment '%v' available at:\n%v", name, rgUrl)
+		envUrl := utils.GenerateEnvUrl("azure", subscriptionID, resourceGroup)
+
+		logger.LogInfo("Found existing environment...\n\n" +
+					   "Environment '%v' available at:\n%v\n", name, envUrl)
 		err = storeEnvironment(ctx, armauth, name, subscriptionID, resourceGroup, clusterName)
 		if err != nil {
 			return err
@@ -457,7 +457,12 @@ func createResourceGroup(ctx context.Context, subscriptionID, resourceGroupName,
 }
 
 func deployEnvironment(ctx context.Context, authorizer autorest.Authorizer, subscriptionID string, resourceGroup string, params deploymentParameters) (resources.DeploymentExtended, error) {
-	step := logger.BeginStep(fmt.Sprintf("Deploying Environment from channel %s...", version.Channel()))
+	
+	envUrl := utils.GenerateEnvUrl("azure", subscriptionID, resourceGroup)
+
+	step := logger.BeginStep(fmt.Sprintf("Deploying Environment from channel %s...\n\n" +
+										 "New Environment with Resource Group '%v' will be available at:\n%v\n\n" +
+										 "Deployment In Progress...", version.Channel(), resourceGroup, envUrl))
 	dc := resources.NewDeploymentsClient(subscriptionID)
 	dc.Authorizer = authorizer
 

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -461,7 +461,6 @@ func createResourceGroup(ctx context.Context, subscriptionID, resourceGroupName,
 }
 
 func deployEnvironment(ctx context.Context, authorizer autorest.Authorizer, subscriptionID string, resourceGroup string, params deploymentParameters) (resources.DeploymentExtended, error) {
-
 	envUrl, err := azure.GenerateAzureEnvUrl(subscriptionID, resourceGroup)
 	if err != nil {
 		return resources.DeploymentExtended{}, err

--- a/cmd/cli/cmd/envSwitch.go
+++ b/cmd/cli/cmd/envSwitch.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/logger"
 	"github.com/spf13/cobra"
@@ -48,7 +49,10 @@ func switchEnv(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	logger.LogInfo("using environment %v", args[0])
+	envUrl := utils.GenerateEnvUrl(env.Items[args[0]]["kind"].(string), env.Items[args[0]]["subscriptionid"].(string), env.Items[args[0]]["resourcegroup"].(string)) 
+	
+	logger.LogInfo("Default environment is now: %v\n\n" +
+				   "%v environment is available at:\n%v\n", args[0], args[0], envUrl)		   
 
 	env.Default = args[0]
 	rad.UpdateEnvironmentSection(v, env)

--- a/cmd/cli/cmd/envSwitch.go
+++ b/cmd/cli/cmd/envSwitch.go
@@ -56,13 +56,13 @@ func switchEnv(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	envUrl, err := azure.GenerateAzureEnvUrl(az.SubscriptionID, az.ResourceGroup) 
+	envUrl, err := azure.GenerateAzureEnvUrl(az.SubscriptionID, az.ResourceGroup)
 	if err != nil {
 		return err
 	}
-	
-	logger.LogInfo("Default environment is now: %v\n\n" +
-				   "%v environment is available at:\n%v\n", name, name, envUrl)		   
+
+	logger.LogInfo("Default environment is now: %v\n\n"+
+		"%v environment is available at:\n%v\n", name, name, envUrl)
 
 	env.Default = name
 	rad.UpdateEnvironmentSection(v, env)

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -78,7 +78,6 @@ func initConfig() {
 		// Set the default config file so we can write to it if desired
 		cfgFile = path.Join(home, ".rad", "config.yaml")
 	} else if err == nil {
-		fmt.Println("Using config file:", viper.ConfigFileUsed())
 		cfgFile = viper.ConfigFileUsed()
 	}
 }

--- a/cmd/cli/utils/utils.go
+++ b/cmd/cli/utils/utils.go
@@ -129,25 +129,3 @@ func GenerateErrorMessage(e radclient.ErrorResponse) string {
 	}
 	return msg
 }
-
-// GenerateEnvUrl Returns the URL string for an environment based on its subscriptionID and resourceGroup.
-// Uses environment kind to determine how which kind-specific function should build the URL string.
-func GenerateEnvUrl(kind, subscriptionID string, resourceGroup string) (string) { 	
-	envUrl := ""
-	if kind == "azure" { 
-		envUrl = generateEnvUrlAzure(subscriptionID, resourceGroup)
-	} else {
-		envUrl = "Env URL unknown." 
-	}
-
-	return envUrl
-}
-
-// generateEnvUrlAzure Returns Returns the URL string for an Azure environment.
-func generateEnvUrlAzure(subscriptionID string, resourceGroup string) (string) {
-	
-	envUrl := "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/" + 
-	          subscriptionID + "/resourceGroups/" + resourceGroup + "/overview"
-
-	return envUrl
-}

--- a/cmd/cli/utils/utils.go
+++ b/cmd/cli/utils/utils.go
@@ -130,10 +130,24 @@ func GenerateErrorMessage(e radclient.ErrorResponse) string {
 	return msg
 }
 
-func GenerateResourceGroupUrl(subscriptionID string, resourceGroup string) (string) {
-	
-	rgUrl := "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/" + subscriptionID + 
-		"/resourceGroups/" + resourceGroup + "/overview"
-	return rgUrl
+// GenerateEnvUrl Returns the URL string for an environment based on its subscriptionID and resourceGroup.
+// Uses environment kind to determine how which kind-specific function should build the URL string.
+func GenerateEnvUrl(kind, subscriptionID string, resourceGroup string) (string) { 	
+	envUrl := ""
+	if kind == "azure" { 
+		envUrl = generateEnvUrlAzure(subscriptionID, resourceGroup)
+	} else {
+		envUrl = "Env URL unknown." 
+	}
 
+	return envUrl
+}
+
+// generateEnvUrlAzure Returns Returns the URL string for an Azure environment.
+func generateEnvUrlAzure(subscriptionID string, resourceGroup string) (string) {
+	
+	envUrl := "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/" + 
+	          subscriptionID + "/resourceGroups/" + resourceGroup + "/overview"
+
+	return envUrl
 }

--- a/cmd/cli/utils/utils.go
+++ b/cmd/cli/utils/utils.go
@@ -129,3 +129,11 @@ func GenerateErrorMessage(e radclient.ErrorResponse) string {
 	}
 	return msg
 }
+
+func GenerateResourceGroupUrl(subscriptionID string, resourceGroup string) (string) {
+	
+	rgUrl := "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/" + subscriptionID + 
+		"/resourceGroups/" + resourceGroup + "/overview"
+	return rgUrl
+
+}

--- a/pkg/rad/azure/env_url.go
+++ b/pkg/rad/azure/env_url.go
@@ -28,7 +28,7 @@ func GenerateAzureEnvUrl(subscriptionID string, resourceGroup string) (string, e
 		return "Unable to find tenant ID for this subscription.", nil
 	}
 	
-	envUrl := fmt.Sprintf("https://ms.portal.azure.com/#@%s/resource/subscriptions/%s/resourceGroups/%s/overview", 
+	envUrl := fmt.Sprintf("https://portal.azure.com/#@%s/resource/subscriptions/%s/resourceGroups/%s/overview", 
 						tenantId, subscriptionID, resourceGroup)
 
 	return envUrl, nil

--- a/pkg/rad/azure/env_url.go
+++ b/pkg/rad/azure/env_url.go
@@ -1,0 +1,35 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package azure
+
+import (
+	"fmt"
+)
+
+
+// GenerateAzureEnvUrl Returns the URL string for an Azure environment based on its subscriptionID and resourceGroup.
+// Currently only supports kind=azure. We may generalize this function in the future as necessary. 
+func GenerateAzureEnvUrl(subscriptionID string, resourceGroup string) (string, error) { 	
+	tenantId := ""
+	
+	subs, err := LoadSubscriptionsFromProfile() 
+	if err != nil {
+		return "", err 
+	}	
+	for _, s := range subs.Subscriptions {
+		if s.SubscriptionID == subscriptionID {
+			tenantId = s.TenantID
+		}
+	}
+	if tenantId == "" {
+		return "Unable to find tenant ID for this subscription.", nil
+	}
+	
+	envUrl := fmt.Sprintf("https://ms.portal.azure.com/#@%s/resource/subscriptions/%s/resourceGroups/%s/overview", 
+						tenantId, subscriptionID, resourceGroup)
+
+	return envUrl, nil
+}


### PR DESCRIPTION
1. Print info about accessing env URL during the following commands:  
- rad env init azure
- rad env switch
- rad deploy
2. Stop printing `Using config file: __` every time we read the config file via initConfig. Closes: radius-project/radius#254, radius-project/core-team#796
3. During `rad deploy`, print which env is being used. 


Not sure whether we prefer to add error handling inside GenerateEnvUrl (in utils.go) or in the other files where GenerateEnvUrl is called - or both. 
_____

Sorry for any confusion about SUPPORT.md being in this PR. Until that EOL change gets merged, git makes it a mandatory change for me. 