### PR TITLE
Fix issue# 309 for tests to work

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,6 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOVER: '^1.16.0'
+      DEPLOY_TEST_SUBSCRIPTION_ID: "85716382-7362-45c3-ae03-2126e459a123"
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -166,6 +167,7 @@ jobs:
           --username ${{ secrets.INTEGRATION_TEST_SP_APP_ID }} \
           --password ${{ secrets.INTEGRATION_TEST_SP_PASSWORD }} \
           --tenant ${{ secrets.INTEGRATION_TEST_TENANT_ID }}
+        az account set -s ${{ env.DEPLOY_TEST_SUBSCRIPTION_ID }}
       # We select a test environment here and load it into the default 
       # radius config so that it will be used by tests
     - name: Reserve test environment

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,7 +138,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOVER: '^1.16.0'
-      DEPLOY_TEST_SUBSCRIPTION_ID: "85716382-7362-45c3-ae03-2126e459a123"
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -167,7 +166,6 @@ jobs:
           --username ${{ secrets.INTEGRATION_TEST_SP_APP_ID }} \
           --password ${{ secrets.INTEGRATION_TEST_SP_PASSWORD }} \
           --tenant ${{ secrets.INTEGRATION_TEST_TENANT_ID }}
-        az account set -s ${{ env.DEPLOY_TEST_SUBSCRIPTION_ID }}
       # We select a test environment here and load it into the default 
       # radius config so that it will be used by tests
     - name: Reserve test environment

--- a/cmd/testenv/cmd/updaterp.go
+++ b/cmd/testenv/cmd/updaterp.go
@@ -108,6 +108,7 @@ func updateRP(ctx context.Context, auth autorest.Authorizer, env environments.Az
 	args := []string{
 		"webapp", "config", "container", "set",
 		"--resource-group", env.ResourceGroup,
+		"--subscription", env.SubscriptionID,
 		"--name", website,
 		"--docker-custom-image-name", image,
 	}

--- a/cmd/testenv/cmd/updaterp.go
+++ b/cmd/testenv/cmd/updaterp.go
@@ -122,6 +122,7 @@ func updateRP(ctx context.Context, auth autorest.Authorizer, env environments.Az
 	args = []string{
 		"webapp", "restart",
 		"--resource-group", env.ResourceGroup,
+		"--subscription", env.SubscriptionID,
 		"--name", website,
 	}
 

--- a/pkg/rad/config.go
+++ b/pkg/rad/config.go
@@ -17,6 +17,7 @@ import (
 	en_translations "github.com/go-playground/validator/v10/translations/en"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
+	"golang.org/x/text/cases"
 )
 
 // EnvironmentKey is the key used for the environment section
@@ -70,7 +71,7 @@ func (env EnvironmentSection) GetEnvironment(name string) (environments.Environm
 }
 
 func (env EnvironmentSection) decodeEnvironmentSection(name string) (environments.Environment, error) {
-	raw, ok := env.Items[name]
+	raw, ok := env.Items[cases.Fold().String(name)]
 	if !ok {
 		return nil, fmt.Errorf("the environment '%v' could not be found in the list of environments. use `rad env list` to list environments", name)
 	}


### PR DESCRIPTION
1. Resource groups with upper case names cannot be found while merging env credentials
2. In the deploy tests, after logging in with the service principal, the default sub is chosen. After changing the test subscription to a different one, need to set the subscription