### PR TITLE
Return root cause of failure from async operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	golang.org/x/net v0.0.0-20210326220855-61e056675ecf // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20210326220804-49726bf1d181 // indirect
-	golang.org/x/text v0.3.5 // indirect
+	golang.org/x/text v0.3.5
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/pkg/curp/armerrors/errors.go
+++ b/pkg/curp/armerrors/errors.go
@@ -5,6 +5,17 @@
 
 package armerrors
 
+// See: https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/common-deployment-errors
+//
+// We get to define our own codes and document them, these are just examples, but consistency doesn't hurt.
+const (
+	// Used for generic validation errors.
+	CodeInvalid = "BadRequest"
+
+	// Used for internal/unclassified failures.
+	CodeInternal = "Internal"
+)
+
 // see : https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/common-api-details.md#error-response-content
 
 // ErrorResponse represents an error HTTP response as defined by the ARM API.

--- a/pkg/curp/converter.go
+++ b/pkg/curp/converter.go
@@ -174,6 +174,10 @@ func newDBDeploymentFromREST(original *rest.Deployment) *db.Deployment {
 }
 
 func newRESTDeploymentFromDB(original *db.Deployment) *rest.Deployment {
+	// NOTE: Deployment has some additional state that we don't include in REST responses
+	//
+	// We track things here like the resources associated with the application as well as
+	// any errors that occur during deployment.
 	d := &rest.Deployment{
 		ResourceBase: newRESTResourceBaseFromDB(original.ResourceBase),
 		Properties: rest.DeploymentProperties{

--- a/pkg/curp/db/types.go
+++ b/pkg/curp/db/types.go
@@ -123,6 +123,7 @@ type Scope struct {
 type Deployment struct {
 	ResourceBase `bson:",inline"`
 	Status       DeploymentStatus     `bson:"status"`
+	Error        string               `bson:"error"`
 	Properties   DeploymentProperties `bson:"properties"`
 }
 

--- a/pkg/curp/rest/results.go
+++ b/pkg/curp/rest/results.go
@@ -202,6 +202,12 @@ func NewBadRequestResponse(message string) Response {
 	}
 }
 
+func NewBadRequestARMResponse(body armerrors.ErrorResponse) Response {
+	return &BadRequestResponse{
+		Body: body,
+	}
+}
+
 func (r *BadRequestResponse) Apply(w http.ResponseWriter, req *http.Request) error {
 	bytes, err := json.MarshalIndent(r.Body, "", "  ")
 	if err != nil {
@@ -318,6 +324,32 @@ func (r *ConflictResponse) Apply(w http.ResponseWriter, req *http.Request) error
 
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(409)
+	_, err = w.Write(bytes)
+	if err != nil {
+		return fmt.Errorf("error writing marshaled %T bytes to output: %s", r.Body, err)
+	}
+
+	return nil
+}
+
+type InternalServerErrorResponse struct {
+	Body armerrors.ErrorResponse
+}
+
+func NewInternalServerErrorARMResponse(body armerrors.ErrorResponse) Response {
+	return &InternalServerErrorResponse{
+		Body: body,
+	}
+}
+
+func (r *InternalServerErrorResponse) Apply(w http.ResponseWriter, req *http.Request) error {
+	bytes, err := json.MarshalIndent(r.Body, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshaling %T: %w", r.Body, err)
+	}
+
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(500)
 	_, err = w.Write(bytes)
 	if err != nil {
 		return fmt.Errorf("error writing marshaled %T bytes to output: %s", r.Body, err)


### PR DESCRIPTION
Fixes: #312

This change uses the operation response to return the root cause of a
failure when it occurs during an asynchronous operation. The semantics
of the operation response:

- If the operation is ongoing -> return 202 and location header +
  current resource snapshot as body
- If the operation is complete and successful -> return 200 or 204
  depending on whether it was a delete or a PUT
- If the operation has failed -> return an ARM error

This addresses a regression, when we implemented async operations we
lost the ability to report root causes for errors.