### PR TITLE
Add automation environment creation

### DIFF
--- a/.github/workflows/radius-bot.yaml
+++ b/.github/workflows/radius-bot.yaml
@@ -40,9 +40,8 @@ jobs:
           }
           console.log("Analysis done: " + JSON.stringify(result));
           return result
-    - name: Analyze context
+    - name: Run create-environment
       uses: actions/github-script@v4
-      id: analyze
       if: success() && steps.analyze.outputs.result.command == 'create-environment' && steps.analyze.outputs.result.isPullRequest == true
       with:
         github-token: ${{secrets.RADIUS_BOT_TOKEN}}
@@ -67,9 +66,8 @@ jobs:
                   
           console.log(`Triggering environment creation for ${JSON.stringify(payload)}`);
 
-    - name: Analyze context
+    - name: Run e2e-tests
       uses: actions/github-script@v4
-      id: analyze
       if: success() && steps.analyze.outputs.result.command == 'run-e2e-tests' && steps.analyze.outputs.result.isPullRequest == true
       with:
         github-token: ${{secrets.RADIUS_BOT_TOKEN}}


### PR DESCRIPTION
This change adds a workflow that will create a radius environment on
demand and add it to the test environment list.

This workflow can only be manually trigger via a comment or from other
workflows. It also will create an issue when it fails.