### PR TITLE
Add integration test to validate resource name is stored instead of fully qualified path

### DIFF
--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -63,7 +63,7 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 	deploymentResources := *response.DeploymentList
 	for _, deploymentResource := range *deploymentResources.Value {
 		// This is needed until server side implementation is fixed https://github.com/Azure/radius/issues/159
-		deploymentName := utils.GetResourceNameFromFullyQualifiedPath(*deploymentResource.Name)
+		deploymentName := *deploymentResource.Name
 
 		poller, err := dc.BeginDelete(cmd.Context(), env.ResourceGroup, applicationName, deploymentName, nil)
 		if err != nil {

--- a/cmd/cli/utils/utils.go
+++ b/cmd/cli/utils/utils.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/go-autorest/autorest"
@@ -72,18 +71,6 @@ func IsServicePrincipalConfigured() (bool, error) {
 
 	spSpecified := settings.Values[auth.ClientID] != "" && settings.Values[auth.ClientSecret] != ""
 	return spSpecified, nil
-}
-
-// GetResourceNameFromFullyQualifiedPath Returns the resource name from full path of the resource.
-// For example returns 'default' for 'radius/frontend-backend/default'
-func GetResourceNameFromFullyQualifiedPath(fullyQualifiedPath string) string {
-	name := fullyQualifiedPath
-	if strings.Contains(fullyQualifiedPath, "/") {
-		split := strings.Split(fullyQualifiedPath, "/")
-		name = split[len(split)-1]
-	}
-
-	return name
 }
 
 // UnwrapErrorFromRawResponse raw http response into ErrorResponse format and builds


### PR DESCRIPTION
Add integration test to validate resource name is stored instead of fully qualified path. Related to this change in control plane: https://github.com/Azure/radius/pull/323

Removed CLI workaround that was added temporarily handle this bug.

### Validation
* Verified the test integration test for frontend-backend section passes locally.
* Manually verified cli application delete/list/get.
