### PR TITLE
add new CLI command: rad env show

### DIFF
--- a/cmd/cli/cmd/envShow.go
+++ b/cmd/cli/cmd/envShow.go
@@ -18,7 +18,7 @@ import (
 var envShowCmd = &cobra.Command{
 	Use:   "show",
 	Short: "Show RAD environment details",
-	Long:  "Show RAD environment details. Uses current default env by default.",
+	Long:  "Show Radius environment details. Uses the current user's default environment by default.",
 	RunE:  showEnvironment,
 }
 

--- a/cmd/cli/cmd/envShow.go
+++ b/cmd/cli/cmd/envShow.go
@@ -1,0 +1,59 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/Azure/radius/pkg/rad"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+// envShowCmd command returns properties of an environment
+var envShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show RAD environment details",
+	Long:  "Show RAD environment details. Uses current default env by default.",
+	RunE:  showEnvironment,
+}
+
+func init() {
+	envCmd.AddCommand(envShowCmd)
+
+	envShowCmd.Flags().StringP("env", "e", "", "The environment name")
+}
+
+func showEnvironment(cmd *cobra.Command, args []string) error {
+
+	envName, err := cmd.Flags().GetString("env")
+	if err != nil {
+		return err
+	}
+
+	v := viper.GetViper()
+	env, err := rad.ReadEnvironmentSection(v)
+	if err != nil {
+		return err
+	}
+
+	e, err := env.GetEnvironment(envName)
+	if err != nil {
+		return err
+	}
+
+	b, err := yaml.Marshal(&e)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Println(string(b))
+	fmt.Println()
+	return nil
+
+}

--- a/docs/content/contributing/code/first-commit/first-commit-02-building.md
+++ b/docs/content/contributing/code/first-commit/first-commit-02-building.md
@@ -13,7 +13,7 @@ If you have not already done so, clone the repository and navigate there in your
 You can build the main outputs using `make`:
 
 ```sh
-$ make
+make
 ```
 
 You should see output similar to the following:
@@ -43,7 +43,7 @@ CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 \
 You should be able to run the binary that was just produced for the CLI. Copy the path from the previous output and run it at the command line.
 
 ```sh
-$ ./dist/darwin_amd64/release/rad
+./dist/darwin_amd64/release/rad
 ```
 
 You should see the basic help text of the CLI. At the time of this writing it looks like:

--- a/docs/content/contributing/code/first-commit/first-commit-05-running-tests/index.md
+++ b/docs/content/contributing/code/first-commit/first-commit-05-running-tests/index.md
@@ -11,7 +11,7 @@ weight: 100
 To run the all unit tests for the project from the command line:
 
 ```sh
-$ make test
+make test
 ```
 
 After tests run, you should see a big list of all of the project's packages:

--- a/docs/content/contributing/code/first-commit/first-commit-06-creating-a-pr/index.md
+++ b/docs/content/contributing/code/first-commit/first-commit-06-creating-a-pr/index.md
@@ -20,10 +20,10 @@ Now you've got something to work on. Once you've developed and tested your chang
 
 ## One last check
 
-Before proceeding, make sure your changes pass all the unit tests as well as golint.
+Before proceeding, make sure your changes pass all the unit tests as well as [golint](https://golangci-lint.run/usage/install/#local-installation).
 
 ```sh
-$ make lint && make test
+make lint && make test
 ```
 
 It is best if you can resolve problems identified here before submitting.


### PR DESCRIPTION
This PR also makes minor updates to the Contributing Code section of our docs: removes "$" char from code blocks now that our docs have "Copy" button. 
_______

### rad env show
```
% rad env show --help
Show RAD environment details

Usage:
  rad env show [flags]

Flags:
  -e, --env string   The environment name
  -h, --help         help for show

Global Flags:
      --config string   config file (default is $HOME/.rad/config.yaml)
```

Default behavior with no env specified by user is to return info for the current default env: 
```
% rad env show         
Using config file: /Users/emilypotyraj/.rad/config.yaml

name: azure
kind: azure
subscriptionid: 66d1209e-1382-45d3-99bb-650e6bf63fc0
resourcegroup: em-0512-v1
clustername: radius-aks-pbw4gi2t3stss
```

Users can also use the `-e` (`-env`) flag to specify an env from their config file 
```
% rad env show --config $HOME/.rad/config.yaml -e local
Using config file: /Users/emilypotyraj/.rad/config.yaml

name: local
kind: local
```
_________

Btw, output format of `rad env show` is intended to match that of `rad env list`:
```
% rad env list --config $HOME/.rad/config.yaml
Using config file: /Users/emilypotyraj/.rad/config.yaml

default: azure
items:
    azure:
        clustername: radius-aks-pbw4gi2t3stss
        kind: azure
        resourcegroup: em-0512-v1
        subscriptionid: 66d1209e-1382-45d3-99bb-650e6bf63fc0
    local:
        kind: local
```