### PR TITLE
Refactor: Remove component revision tracking

### DIFF
--- a/mocks/mock_db.go
+++ b/mocks/mock_db.go
@@ -8,7 +8,6 @@ import (
 	context "context"
 	db "github.com/Azure/radius/pkg/curp/db"
 	resources "github.com/Azure/radius/pkg/curp/resources"
-	revision "github.com/Azure/radius/pkg/curp/revision"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
@@ -122,18 +121,18 @@ func (mr *MockCurpDBMockRecorder) GetApplicationByID(arg0, arg1 interface{}) *go
 }
 
 // GetComponentByApplicationID mocks base method
-func (m *MockCurpDB) GetComponentByApplicationID(arg0 context.Context, arg1 resources.ApplicationID, arg2 string, arg3 revision.Revision) (*db.Component, error) {
+func (m *MockCurpDB) GetComponentByApplicationID(arg0 context.Context, arg1 resources.ApplicationID, arg2 string) (*db.Component, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetComponentByApplicationID", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetComponentByApplicationID", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*db.Component)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetComponentByApplicationID indicates an expected call of GetComponentByApplicationID
-func (mr *MockCurpDBMockRecorder) GetComponentByApplicationID(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockCurpDBMockRecorder) GetComponentByApplicationID(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetComponentByApplicationID", reflect.TypeOf((*MockCurpDB)(nil).GetComponentByApplicationID), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetComponentByApplicationID", reflect.TypeOf((*MockCurpDB)(nil).GetComponentByApplicationID), arg0, arg1, arg2)
 }
 
 // GetDeploymentByApplicationID mocks base method
@@ -257,18 +256,18 @@ func (mr *MockCurpDBMockRecorder) PatchApplication(arg0, arg1 interface{}) *gomo
 }
 
 // PatchComponentByApplicationID mocks base method
-func (m *MockCurpDB) PatchComponentByApplicationID(arg0 context.Context, arg1 resources.ApplicationID, arg2 string, arg3 *db.Component, arg4 revision.Revision) (bool, error) {
+func (m *MockCurpDB) PatchComponentByApplicationID(arg0 context.Context, arg1 resources.ApplicationID, arg2 string, arg3 *db.Component) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PatchComponentByApplicationID", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "PatchComponentByApplicationID", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PatchComponentByApplicationID indicates an expected call of PatchComponentByApplicationID
-func (mr *MockCurpDBMockRecorder) PatchComponentByApplicationID(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockCurpDBMockRecorder) PatchComponentByApplicationID(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchComponentByApplicationID", reflect.TypeOf((*MockCurpDB)(nil).PatchComponentByApplicationID), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchComponentByApplicationID", reflect.TypeOf((*MockCurpDB)(nil).PatchComponentByApplicationID), arg0, arg1, arg2, arg3)
 }
 
 // PatchDeploymentByApplicationID mocks base method

--- a/pkg/curp/converter.go
+++ b/pkg/curp/converter.go
@@ -164,7 +164,8 @@ func newDBDeploymentFromREST(original *rest.Deployment) *db.Deployment {
 		cc := &db.DeploymentComponent{
 			ID:            c.ID,
 			ComponentName: c.ComponentName,
-			Revision:      c.Revision,
+
+			// We don't allow a REST deployment to specify the revision - it's readonly.
 		}
 
 		d.Properties.Components = append(d.Properties.Components, cc)

--- a/pkg/curp/db/db.go
+++ b/pkg/curp/db/db.go
@@ -175,7 +175,7 @@ func (d curpDB) GetComponentByApplicationID(ctx context.Context, id resources.Ap
 
 	item, ok := application.Components[name]
 	if !ok {
-		log.Printf("Failed to find Component with Application id, name, and revision: %s, %s", id, name)
+		log.Printf("Failed to find Component with Application id and name: %s, %s", id, name)
 		return nil, ErrNotFound
 	}
 

--- a/pkg/curp/db/types.go
+++ b/pkg/curp/db/types.go
@@ -6,6 +6,7 @@
 package db
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/Azure/radius/pkg/curp/armerrors"
@@ -44,30 +45,16 @@ type ResourceBase struct {
 // Application represents an Radius Application with its nested resources.
 type Application struct {
 	ResourceBase `bson:",inline"`
-	Properties   map[string]interface{}      `bson:"properties,omitempty"`
-	Components   map[string]ComponentHistory `bson:"components,omitempty"`
-	Scopes       map[string]Scope            `bson:"scopes,omitempty"`
-	Deployments  map[string]Deployment       `bson:"deployments,omitempty"`
+	Properties   map[string]interface{} `bson:"properties,omitempty"`
+	Components   map[string]Component   `bson:"components,omitempty"`
+	Scopes       map[string]Scope       `bson:"scopes,omitempty"`
+	Deployments  map[string]Deployment  `bson:"deployments,omitempty"`
 }
 
 // ApplicationPatch represents an Radius application without its nested resources.
 type ApplicationPatch struct {
 	ResourceBase `bson:",inline"`
 	Properties   map[string]interface{} `bson:"properties,omitempty"`
-}
-
-// ComponentHistory represents the whole history of a component.
-type ComponentHistory struct {
-	ResourceBase    `bson:",inline"`
-	Revision        revision.Revision   `bson:"revision"`
-	RevisionHistory []ComponentRevision `bson:"revisionHistory,omitempty"`
-}
-
-// ComponentRevision represents an individual revision of a component.
-type ComponentRevision struct {
-	Kind       string              `bson:"kind"`
-	Revision   revision.Revision   `bson:"revision,omitempty"`
-	Properties ComponentProperties `bson:"properties,omitempty"`
 }
 
 // Component represents an Radius Component.
@@ -202,7 +189,7 @@ func (d *Deployment) Marshal() interface{} {
 func NewApplication() *Application {
 	return &Application{
 		Properties:  map[string]interface{}{},
-		Components:  map[string]ComponentHistory{},
+		Components:  map[string]Component{},
 		Scopes:      map[string]Scope{},
 		Deployments: map[string]Deployment{},
 	}
@@ -228,22 +215,6 @@ func (app ApplicationPatch) FriendlyName() string {
 	}
 
 	return app.Name
-}
-
-// LookupComponentRevision looks up the component revision by name and revision.
-func (app Application) LookupComponentRevision(name string, revision revision.Revision) (*ComponentRevision, bool) {
-	ch, ok := app.Components[name]
-	if !ok {
-		return nil, false
-	}
-
-	for _, cr := range ch.RevisionHistory {
-		if cr.Revision == revision {
-			return &cr, true
-		}
-	}
-
-	return nil, false
 }
 
 // NewComponentProperties returns a new instance of ComponentProperties.
@@ -292,4 +263,37 @@ func (dc DeploymentComponent) FriendlyName() string {
 	}
 
 	return name
+}
+
+// AssignRevisions stamps the latest version of component into the deployment unless otherwise specified - also
+// grab the 'active' version of each component
+func (d Deployment) AssignRevisions(app *Application) (map[string]revision.Revision, error) {
+	revisions := map[string]revision.Revision{}
+
+	for _, dc := range d.Properties.Components {
+		name := dc.FriendlyName()
+		component, ok := app.Components[name]
+		if !ok {
+			return nil, fmt.Errorf("component %s does not exist", name)
+		}
+
+		// Use the latest
+		dc.Revision = component.Revision
+		revisions[name] = component.Revision
+	}
+
+	return revisions, nil
+}
+
+// GetRevisions gets the deployed revision for each component that is part of the deployment. This should
+// only be called on a deployment that's been deployed already.
+func (d Deployment) GetRevisions() map[string]revision.Revision {
+	revisions := map[string]revision.Revision{}
+
+	for _, dc := range d.Properties.Components {
+		name := dc.FriendlyName()
+		revisions[name] = dc.Revision
+	}
+
+	return revisions
 }

--- a/pkg/curp/deployment/deployment_processor.go
+++ b/pkg/curp/deployment/deployment_processor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/radius/pkg/curp/components"
 	"github.com/Azure/radius/pkg/curp/db"
 	"github.com/Azure/radius/pkg/curp/handlers"
+	"github.com/Azure/radius/pkg/curp/revision"
 	"github.com/Azure/radius/pkg/workloads"
 	"github.com/Azure/radius/pkg/workloads/containerv1alpha1"
 	"github.com/Azure/radius/pkg/workloads/cosmosdocumentdbv1alpha1"
@@ -51,15 +52,16 @@ type ComponentAction struct {
 	ApplicationName string
 	ComponentName   string
 	Operation       DeploymentOperation
-	Definition      *db.ComponentRevision
-	Instantiation   *db.DeploymentComponent
+
 	Provides        map[string]ComponentService
 	ServiceBindings map[string]ServiceBinding
+	NewRevision     revision.Revision
+	OldRevision     revision.Revision
 
 	// Will be `nil` for a delete
-	Component             *components.GenericComponent
-	PreviousDefinition    *db.ComponentRevision
-	PreviousInstanitation *db.DeploymentComponent
+	Definition *db.Component
+	// Will be `nil` for a delete
+	Component *components.GenericComponent
 }
 
 // ComponentService represents a service provided by this component

--- a/pkg/curp/handler_test.go
+++ b/pkg/curp/handler_test.go
@@ -161,7 +161,7 @@ func (test *test) DBCreateComponent(applicationName string, componentName string
 	}
 
 	previous := revision.Revision("")
-	old, err := test.db.GetComponentByApplicationID(context.TODO(), applicationID, componentName, revision.Revision(""))
+	old, err := test.db.GetComponentByApplicationID(context.TODO(), applicationID, componentName)
 	if err == db.ErrNotFound {
 		// this is fine - we don't have a previous version to compare against
 	} else if err != nil {
@@ -175,7 +175,7 @@ func (test *test) DBCreateComponent(applicationName string, componentName string
 
 	component.Revision = rev
 
-	_, err = test.db.PatchComponentByApplicationID(context.TODO(), applicationID, componentName, component, previous)
+	_, err = test.db.PatchComponentByApplicationID(context.TODO(), applicationID, componentName, component)
 	require.NoError(test.t, err)
 
 	return rev


### PR DESCRIPTION
Part of AppModel v2 work

I found more vestigial features when working through the AppModel v2
changes. Previously we supported a Deployment object explicitly
specifying a revision of a component. This would allow you to target any
version of a component's lineage and deploy the version specifically.

This is holdover from a previous era of the AppModel where a component
was a defintion and a Deployment was an application. The idea was that
you could define a component once and deploy it multiple times with
different parameters. Note that we no longer have the idea of parameters
:). This is truly unused.

The actual requirement here is that we can easily compare the content of
a component to the deployed version so we can tell if it is the same -
this is much simpler than what was here.

----

So removing this old/unused feature simplifies the database code for
components as well as all of the code that accesses the database layer
of the system.

I thought it make sense to work through this as a self-contained change
(mostly deletions) separately from the actual AppModel v2 change.