### PR TITLE
Refactor and clean makefiles

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Parse release version and set environment variables
         run: python ./.github/scripts/get_release_version.py
       - name: Make
-        run: make
+        run: make build
       - name: Run make test (unit tests)
         if: matrix.target_arch != 'arm'
         run: make test
@@ -90,19 +90,19 @@ jobs:
         uses: actions/checkout@v2
       - name: Parse release version and set environment variables
         run: python ./.github/scripts/get_release_version.py
-      - name: make docker
-        run: make docker
+      - name: make docker-build
+        run: make docker-build
         env:
           DOCKER_REGISTRY: ${{ matrix.registry }}
           DOCKER_TAG_VERSION: latest
-      - name: make docker (PR)
-        run: make docker
+      - name: make docker-build (PR)
+        run: make docker-build
         if: startsWith(github.ref, 'refs/pull/')
         env:
           DOCKER_REGISTRY: ${{ matrix.registry }}
           DOCKER_TAG_VERSION: ${{ env.REL_VERSION }} # includes PR number
-      - name: make docker (release)
-        run: make docker
+      - name: make docker-build (release)
+        run: make docker-build
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           DOCKER_REGISTRY: ${{ matrix.registry }}
@@ -112,20 +112,20 @@ jobs:
           login-server: ${{ matrix.login_server }}
           username: '${{ secrets[matrix.username_secret] }}'
           password: '${{ secrets[matrix.password_secret] }}'
-      - name: make dockerpush (latest)
-        run: make dockerpush
+      - name: make docker-push (latest)
+        run: make docker-push
         if: (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') # push image on push to main or tag
         env:
           DOCKER_REGISTRY: ${{ matrix.registry }}
           DOCKER_TAG_VERSION: latest
-      - name: make dockerpush (PR)
-        run: make dockerpush
+      - name: make docker-push (PR)
+        run: make docker-push
         if: startsWith(github.ref, 'refs/pull/') # push image on pr
         env:
           DOCKER_REGISTRY: ${{ matrix.registry }}
           DOCKER_TAG_VERSION: ${{ env.REL_VERSION }} # includes PR number
-      - name: make dockerpush (release)
-        run: make dockerpush
+      - name: make docker-push (release)
+        run: make docker-push
         if: startsWith(github.ref, 'refs/tags/v') # push image on tag
         env:
           DOCKER_REGISTRY: ${{ matrix.registry }}
@@ -224,7 +224,7 @@ jobs:
           update-rp \
           --configpath ~/.rad/config.yaml \
           --image radiusteam/radius-rp:${{ env.REL_VERSION }}
-    - name: Run deploy tests
+    - name: Run integration tests
       run: |
         export PATH=$GITHUB_WORKSPACE/dist:$PATH
         export AZURE_TENANT_ID=${{ secrets.INTEGRATION_TEST_TENANT_ID }}
@@ -233,7 +233,7 @@ jobs:
         cd $GITHUB_WORKSPACE
         echo "PATH is $PATH"
         which rad || { echo "cannot find rad"; exit 1; }
-        make deploy-tests
+        make test-integration
 
     # Now we'll delete the test environment we used. This prevents PRs from
     # dirtying state in a preserved environment

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ docs/content/reference/cli/rad*
 # Build Output 
 dist/
 radius-rp
+!radius-rp/
 radius-rp.exe
 rad
 !rad/

--- a/build/build.mk
+++ b/build/build.mk
@@ -1,0 +1,98 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+BASE_PACKAGE_NAME := github.com/Azure/radius
+OUT_DIR := ./dist
+
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+GOPATH := $(shell go env GOPATH)
+
+ifeq (,$(shell go env GOBIN))
+	GOBIN=$(shell go env GOPATH)/bin
+else
+	GOBIN=$(shell go env GOBIN)
+endif
+
+ifeq ($(GOOS),windows)
+   BINARY_EXT = .exe
+   GOLANGCI_LINT:=golangci-lint.exe
+else
+   GOLANGCI_LINT:=golangci-lint
+endif
+
+ifeq ($(origin DEBUG), undefined)
+  BUILDTYPE_DIR:=release
+  GCFLAGS:=""
+else ifeq ($(DEBUG),0)
+  BUILDTYPE_DIR:=release
+  GCFLAGS:=""
+else
+  BUILDTYPE_DIR:=debug
+  GCFLAGS:="all=-N -l"
+endif
+
+BINS_OUT_DIR := $(OUT_DIR)/$(GOOS)_$(GOARCH)/$(BUILDTYPE_DIR)
+
+LDFLAGS := "-s -w -X $(BASE_PACKAGE_NAME)/pkg/version.channel=$(REL_CHANNEL) -X $(BASE_PACKAGE_NAME)/pkg/version.release=$(REL_VERSION) -X $(BASE_PACKAGE_NAME)/pkg/version.commit=$(GIT_COMMIT) -X $(BASE_PACKAGE_NAME)/pkg/version.version=$(GIT_VERSION)"
+GOARGS := -v -gcflags $(GCFLAGS) -ldflags $(LDFLAGS)
+
+export GO111MODULE ?= on
+export GOPROXY ?= https://proxy.golang.org
+export GOSUMDB ?= sum.golang.org
+export CGO_ENABLED=0
+
+##@ Build
+
+.PHONY: build
+build: build-packages build-binaries ## Build all go targets.
+
+.PHONY: build-packages
+build-packages: ## Builds all go packages.
+	@echo "$(ARROW) Building all packages"
+	go build \
+		-v \
+		-gcflags $(GCFLAGS) \
+		-ldflags=$(LDFLAGS) \
+		./...
+
+# Generate a target for each binary we define
+# Params:
+# $(1): the binary name for the target
+# $(2): the binary main directory
+define generateBuildTarget
+.PHONY: build-$(1)
+build-$(1):
+	@echo "$(ARROW) Building $(1) to $(BINS_OUT_DIR)/$(1)$(BINARY_EXT)"
+	go build \
+		-v \
+		-gcflags $(GCFLAGS) \
+		-ldflags=$(LDFLAGS) \
+		-o $(BINS_OUT_DIR)/$(1)$(BINARY_EXT) \
+		$(2)/
+endef
+
+# defines a target for each binary
+BINARIES := docgen radtest rp testenv
+$(foreach ITEM,$(BINARIES),$(eval $(call generateBuildTarget,$(ITEM),./cmd/$(ITEM))))
+
+# 'rad' deviates from our convention
+$(eval $(call generateBuildTarget,rad,./cmd/cli))
+
+# list of 'outputs' to build for all binaries
+BINARY_TARGETS:=$(foreach ITEM,$(BINARIES),build-$(ITEM)) build-rad
+
+.PHONY: build-binaries
+build-binaries: $(BINARY_TARGETS) ## Builds all go binaries.
+
+.PHONY: clean
+clean: ## Cleans output directory.
+	@echo "$(ARROW) Cleaning all $(OUT_DIR)"
+	rm -rf $(OUT_DIR)
+
+# Due to https://github.com/golangci/golangci-lint/issues/580, we need to add --fix for windows
+.PHONY: lint
+lint: ## Runs golangci-lint
+	$(GOLANGCI_LINT) run --fix

--- a/build/docker.mk
+++ b/build/docker.mk
@@ -1,0 +1,46 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+DOCKER_REGISTRY?=$(shell whoami)
+DOCKER_TAG_VERSION?=latest
+
+##@ Docker Images
+
+# Generate a target for each image we define
+# Params:
+# $(1): the image name for the target
+# $(2): the Dockerfile path
+define generateDockerTargets
+.PHONY: docker-build-$(1)
+docker-build-$(1):
+	@echo "$(ARROW) Building image $(DOCKER_REGISTRY)/$(1)\:$(DOCKER_TAG_VERSION) from $(2)"
+	docker build . \
+		-f $(2) \
+		-t $(DOCKER_REGISTRY)/$(1)\:$(DOCKER_TAG_VERSION) \
+		--build-arg LDFLAGS=$(LDFLAGS) \
+		--label org.opencontainers.image.version="$(REL_VERSION)" \
+		--label org.opencontainers.image.revision="$(GIT_COMMIT)"
+
+.PHONY: docker-push-$(1)
+docker-push-$(1):
+	@echo "$(ARROW) Pushing image $(DOCKER_REGISTRY)/$(1)\:$(DOCKER_TAG_VERSION)"
+	docker push $(DOCKER_REGISTRY)/$(1)\:$(DOCKER_TAG_VERSION)
+endef
+
+# defines a target for each image
+DOCKER_IMAGES := radius-rp
+$(foreach IMAGE,$(DOCKER_IMAGES),$(eval $(call generateDockerTargets,$(IMAGE),./deploy/images/$(IMAGE)/Dockerfile)))
+
+# list of 'outputs' to build all images
+DOCKER_BUILD_TARGETS:=$(foreach IMAGE,$(DOCKER_IMAGES),docker-build-$(IMAGE))
+
+# list of 'outputs' to push all images
+DOCKER_PUSH_TARGETS:=$(foreach IMAGE,$(DOCKER_IMAGES),docker-push-$(IMAGE))
+
+.PHONY: docker-build
+docker-build: $(DOCKER_BUILD_TARGETS) ## Builds all Docker images.
+
+.PHONY: docker-push
+docker-push: $(DOCKER_PUSH_TARGETS) ## Pushes all Docker images (without building).

--- a/build/generate.mk
+++ b/build/generate.mk
@@ -1,0 +1,46 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+##@ Generate (Code and Schema Generation)
+
+.PHONY: generate
+generate: generate-radclient generate-go ## Generates all targets.
+
+.PHONY: generate-node-installed
+generate-node-installed:
+	@echo "$(ARROW) Detecting node..."
+	@which node > /dev/null || { echo "node is a required dependency"; exit 1; }
+	@echo "$(ARROW) OK"
+
+.PHONY: generate-autorest-installed
+generate-autorest-installed:
+	@echo "$(ARROW) Detecting autorest..."
+	@which autorest > /dev/null || { echo "run 'npm install -g autorest' to install autorest"; exit 1; }
+	@echo "$(ARROW) OK"
+
+.PHONY: generate-radclient
+generate-radclient: generate-node-installed generate-autorest-installed ## Generates the radclient SDK (Autorest).
+	autorest --use=@autorest/go@4.0.0-preview.14 \
+		schemas/rest-api-specs/readme.md \
+		--tag=package-2018-09-01-preview \
+		--go  \
+		--gomod-root=. \
+		--output-folder=./pkg/radclient \
+		--modelerfour.lenient-model-deduplication \
+		--license-header=MICROSOFT_MIT_NO_VERSION \
+		--file-prefix=zz_generated_ \
+		--azure-arm \
+		--verbose
+
+.PHONY: generate-mockgen-installed
+generate-mockgen-installed:
+	@echo "$(ARROW) Detecting mockgen..."
+	@which mockgen > /dev/null || { echo "run 'go install github.com/golang/mock/mockgen@v1.5.0' to install mockgen"; exit 1; }
+	@echo "$(ARROW) OK"
+
+.PHONY: generate-go
+generate-go: generate-mockgen-installed ## Generates go with 'go generate' (Mocks).
+	@echo "$(ARROW) Running go generate..."
+	go generate -v ./... 

--- a/build/help.mk
+++ b/build/help.mk
@@ -1,0 +1,21 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+##@ General
+
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk commands is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# http://linuxcommand.org/lc3_adv_awk.php
+
+.DEFAULT_GOAL: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/build/test.mk
+++ b/build/test.mk
@@ -3,7 +3,12 @@
 # Licensed under the MIT License.
 # ------------------------------------------------------------
 
-ARROW := \033[34;1m=>\033[0m
+##@ Test
 
-# order matters for these
-include build/help.mk build/version.mk build/build.mk build/generate.mk build/test.mk build/docker.mk
+.PHONY: test
+test: ## Runs unit tests.
+	go test ./pkg/...
+
+.PHONY: test-integration
+test-integration: ## Runs integration tests
+	go test ./test/integrationtests/... -timeout 1800s

--- a/build/version.mk
+++ b/build/version.mk
@@ -1,0 +1,12 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+# Commit and release info is used by multiple categories of commands
+
+GIT_COMMIT  = $(shell git rev-list -1 HEAD)
+GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty)
+
+REL_VERSION ?= edge
+REL_CHANNEL ?= edge

--- a/deploy/deployment-script/Dockerfile
+++ b/deploy/deployment-script/Dockerfile
@@ -1,2 +1,0 @@
-FROM mcr.microsoft.com/azure-cli:latest 
-COPY initialize-cluster.sh ./initialize-cluster.sh

--- a/deploy/images/radius-rp/Dockerfile
+++ b/deploy/images/radius-rp/Dockerfile
@@ -1,5 +1,3 @@
-ARG LDFLAGS="-w -s"
-
 FROM golang:alpine AS build-env
 RUN apk --no-cache add build-base git gcc
 WORKDIR /src
@@ -7,7 +5,10 @@ COPY go.mod ./
 COPY go.sum ./
 RUN go mod download
 COPY . ./
-RUN go build -o radius-rp -ldflags "$LD_FLAGS" cmd/rp/main.go
+
+# ARG needs to come after FROM
+ARG LDFLAGS="-w -s"
+RUN CGO_ENABLED=0 go build -v -o radius-rp -ldflags "$LD_FLAGS" cmd/rp/main.go
 
 FROM alpine
 RUN apk --no-cache add ca-certificates

--- a/docs/content/contributing/code/first-commit/first-commit-02-building.md
+++ b/docs/content/contributing/code/first-commit/first-commit-02-building.md
@@ -13,13 +13,13 @@ If you have not already done so, clone the repository and navigate there in your
 You can build the main outputs using `make`:
 
 ```sh
-make
+make build
 ```
 
 You should see output similar to the following:
 
 ```txt
-➜ make
+➜ make build
 => Building RP from 'cmd/rp/main.go'
 => Built RP in './dist/darwin_amd64/release/radius-rp'
 CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 \
@@ -37,6 +37,8 @@ CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 \
 	-o ./dist/darwin_amd64/release/rad \
 	./cmd/cli/main.go;
 ```
+
+Our makefile also has a built-in help command. Run `make` or `make help` to see the list of targets.
 
 ## Test it out
 


### PR DESCRIPTION
This change does some surgery on our Makefiles to make them more
organized and maintainable.

I made a bunch of improvments to the Makefiles as part of my recent
Kubernetes prototyping. Getting these changes done up front will help
porting those changes.

---

In the Kubernetes work I was confronted with a bunch of new Makefile constructs that I didn't know super well. It's always bothered me how we're using `make` but I don't really understand it. So I took some time to dig in and grok what's happening in a much better way.

I also made some significant simplications. The current setup is something I've been using for like a year, and it got copy-pasted from elsewhere. 

Here's a big notable improvement. Help!

![image](https://user-images.githubusercontent.com/1430011/119213876-3f408680-ba77-11eb-90c3-495367fa515c.png)
