### PR TITLE
Disable northeurope region in tests

### DIFF
--- a/.github/workflows/create-environment.yaml
+++ b/.github/workflows/create-environment.yaml
@@ -49,7 +49,8 @@ jobs:
           script: |
             const locations = [
               "eastus",
-              "northeurope",
+              // northeurope has been causing capacity problems for us and has been unrelable. 
+              //"northeurope",
               "westeurope",
               "westus2",
             ];


### PR DESCRIPTION
Fixes: radius-project/core-team#963

This change removes northeurope as supported region for tests. Capacity
limits have been causing provisioning failures for us.