### PR TITLE
Use resource group name for env name default

### DIFF
--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -82,6 +82,7 @@ rad env init azure --name myenv --subscription-id SUB-ID-GUID --resource-group R
 		}
 
 		if a.Name == "" {
+			logger.LogInfo("updating name to %v", a.ResourceGroup)
 			a.Name = a.ResourceGroup
 		}
 
@@ -297,6 +298,7 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 	if err != nil {
 		return err
 	}
+	logger.LogInfo("%v", name)
 
 	// Check for an existing RP in the target resource group. This way we
 	// can use a single command to bind to an existing environment
@@ -471,7 +473,7 @@ func deployEnvironment(ctx context.Context, authorizer autorest.Authorizer, name
 
 	step := logger.BeginStep(fmt.Sprintf("Deploying Environment from channel %s...\n\n"+
 		"New Environment '%v' with Resource Group '%v' will be available at:\n%v\n\n"+
-		"Deployment In Progress...", name, version.Channel(), resourceGroup, envUrl))
+		"Deployment In Progress...", version.Channel(), name, resourceGroup, envUrl))
 	dc := resources.NewDeploymentsClient(subscriptionID)
 	dc.Authorizer = authorizer
 

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -82,7 +82,6 @@ rad env init azure --name myenv --subscription-id SUB-ID-GUID --resource-group R
 		}
 
 		if a.Name == "" {
-			logger.LogInfo("updating name to %v", a.ResourceGroup)
 			a.Name = a.ResourceGroup
 		}
 
@@ -298,7 +297,6 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 	if err != nil {
 		return err
 	}
-	logger.LogInfo("%v", name)
 
 	// Check for an existing RP in the target resource group. This way we
 	// can use a single command to bind to an existing environment
@@ -334,8 +332,6 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 	if err != nil {
 		return err
 	}
-
-	logger.LogInfo("%v", group == nil)
 
 	if group == nil {
 		// Resource group specified was not found. Create it

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -81,6 +81,10 @@ rad env init azure --name myenv --subscription-id SUB-ID-GUID --resource-group R
 			}
 		}
 
+		if a.Name == "" {
+			a.Name = a.ResourceGroup
+		}
+
 		err = connect(cmd.Context(), a.Name, a.SubscriptionID, a.ResourceGroup, a.Location, a.DeploymentTemplate)
 		if err != nil {
 			return err
@@ -93,7 +97,7 @@ rad env init azure --name myenv --subscription-id SUB-ID-GUID --resource-group R
 func init() {
 	envInitCmd.AddCommand(envInitAzureCmd)
 
-	envInitAzureCmd.Flags().StringP("name", "n", "azure", "The environment name")
+	envInitAzureCmd.Flags().StringP("name", "n", "", "The environment name")
 	envInitAzureCmd.Flags().StringP("subscription-id", "s", "", "The subscription ID to use for the environment")
 	envInitAzureCmd.Flags().StringP("resource-group", "g", "", "The resource group to use for the environment")
 	envInitAzureCmd.Flags().StringP("location", "l", "", "The Azure location to use for the environment")

--- a/docs/content/getting-started/create-environment.md
+++ b/docs/content/getting-started/create-environment.md
@@ -38,7 +38,7 @@ While Radius environments are optimized for cost, any costs incurred by the depl
 
 1. Create a Radius environment:
 
-   Initialize the private resource provider (environment) in your Azure subscription using the [`rad` CLI]({{< ref rad_env_init_azure >}}). The following command creates an environment in interactive mode and will prompt you for input like the name of a new Resource Group and location. 
+   Initialize the private resource provider (environment) in your Azure subscription using the [`rad` CLI]({{< ref rad_env_init_azure >}}). The following command creates an environment in interactive mode and will prompt you for input like the name of a new Resource Group and location. If no environment name is specified, it will default to the Resource Group name.
 
    ```sh
    rad env init azure -i


### PR DESCRIPTION
Fixes https://github.com/Azure/radius/issues/294

Updates name after acquiring the resource name.