### PR TITLE
 Add unmanaged-resource support for servicebus

### DIFF
--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
-	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/rad/azure"
 	"github.com/Azure/radius/pkg/rad/bicep"
 	"github.com/Azure/radius/pkg/rad/environments"
@@ -142,7 +141,7 @@ func deployApplication(ctx context.Context, content string, env *environments.Az
 }
 
 func createDeploymentClient(env *environments.AzureCloudEnvironment) (resources.DeploymentsClient, error) {
-	armauth, err := utils.GetResourceManagerEndpointAuthorizer()
+	armauth, err := azure.GetResourceManagerEndpointAuthorizer()
 	if err != nil {
 		return resources.DeploymentsClient{}, err
 	}

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -24,7 +24,6 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/Azure/radius/cmd/cli/utils"
 	radresources "github.com/Azure/radius/pkg/curp/resources"
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/azure"
@@ -293,7 +292,7 @@ func selectResourceGroup(ctx context.Context, authorizer autorest.Authorizer, su
 }
 
 func connect(ctx context.Context, name string, subscriptionID string, resourceGroup, location string, deploymentTemplate string) error {
-	armauth, err := utils.GetResourceManagerEndpointAuthorizer()
+	armauth, err := azure.GetResourceManagerEndpointAuthorizer()
 	if err != nil {
 		return err
 	}
@@ -441,7 +440,7 @@ func registerSubscription(ctx context.Context, authorizer autorest.Authorizer, s
 
 func createResourceGroup(ctx context.Context, subscriptionID, resourceGroupName, location string) error {
 	groupsClient := resources.NewGroupsClient(subscriptionID)
-	a, err := utils.GetResourceManagerEndpointAuthorizer()
+	a, err := azure.GetResourceManagerEndpointAuthorizer()
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/envMergeCredentials.go
+++ b/cmd/cli/cmd/envMergeCredentials.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 
 	"github.com/Azure/go-autorest/autorest/azure/auth"
-	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/rad/azcli"
+	"github.com/Azure/radius/pkg/rad/azure"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +31,7 @@ var envMergeCredentialsCmd = &cobra.Command{
 			return err
 		}
 
-		isServicePrincipalConfigured, err := utils.IsServicePrincipalConfigured()
+		isServicePrincipalConfigured, err := azure.IsServicePrincipalConfigured()
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/cmd/expose.go
+++ b/cmd/cli/cmd/expose.go
@@ -15,7 +15,7 @@ import (
 	"os/signal"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
-	"github.com/Azure/radius/cmd/cli/utils"
+	"github.com/Azure/radius/pkg/rad/azure"
 	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/Azure/radius/pkg/workloads"
 	"github.com/spf13/cobra"
@@ -120,7 +120,7 @@ func init() {
 }
 
 func getMonitoringCredentials(ctx context.Context, env environments.AzureCloudEnvironment) (*rest.Config, error) {
-	armauth, err := utils.GetResourceManagerEndpointAuthorizer()
+	armauth, err := azure.GetResourceManagerEndpointAuthorizer()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cli/utils/utils.go
+++ b/cmd/cli/utils/utils.go
@@ -12,66 +12,8 @@ import (
 	"io/ioutil"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/radius/pkg/radclient"
 )
-
-// GetResourceManagerEndpointAuthorizer returns the authorizer for the ResourceManager endpoint
-func GetResourceManagerEndpointAuthorizer() (autorest.Authorizer, error) {
-	settings, err := auth.GetSettingsFromEnvironment()
-	if err != nil {
-		return nil, err
-	}
-
-	return getArmAuthorizer(settings.Environment.ResourceManagerEndpoint)
-}
-
-// GetGraphEndpointAuthorizer returns the authorizer for the ResourceManager endpoint
-func GetGraphEndpointAuthorizer() (autorest.Authorizer, error) {
-	settings, err := auth.GetSettingsFromEnvironment()
-	if err != nil {
-		return nil, err
-	}
-
-	return getArmAuthorizer(settings.Environment.GraphEndpoint)
-}
-
-func getArmAuthorizer(endpoint string) (autorest.Authorizer, error) {
-
-	var authorizer autorest.Authorizer
-
-	useServicePrincipal, err := IsServicePrincipalConfigured()
-	if err != nil {
-		return nil, err
-	}
-
-	if useServicePrincipal {
-		// Use the service principal specified
-		authorizer, err = auth.NewAuthorizerFromEnvironment()
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		authorizer, err = auth.NewAuthorizerFromCLIWithResource(endpoint)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return authorizer, nil
-}
-
-// IsServicePrincipalConfigured determines whether a service principal is specifed
-func IsServicePrincipalConfigured() (bool, error) {
-	settings, err := auth.GetSettingsFromEnvironment()
-	if err != nil {
-		return false, err
-	}
-
-	spSpecified := settings.Values[auth.ClientID] != "" && settings.Values[auth.ClientSecret] != ""
-	return spSpecified, nil
-}
 
 // UnwrapErrorFromRawResponse raw http response into ErrorResponse format and builds
 // an error message with error code, message and details.
@@ -132,22 +74,22 @@ func GenerateErrorMessage(e radclient.ErrorResponse) string {
 
 // GenerateEnvUrl Returns the URL string for an environment based on its subscriptionID and resourceGroup.
 // Uses environment kind to determine how which kind-specific function should build the URL string.
-func GenerateEnvUrl(kind, subscriptionID string, resourceGroup string) (string) { 	
+func GenerateEnvUrl(kind, subscriptionID string, resourceGroup string) string {
 	envUrl := ""
-	if kind == "azure" { 
+	if kind == "azure" {
 		envUrl = generateEnvUrlAzure(subscriptionID, resourceGroup)
 	} else {
-		envUrl = "Env URL unknown." 
+		envUrl = "Env URL unknown."
 	}
 
 	return envUrl
 }
 
 // generateEnvUrlAzure Returns Returns the URL string for an Azure environment.
-func generateEnvUrlAzure(subscriptionID string, resourceGroup string) (string) {
-	
-	envUrl := "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/" + 
-	          subscriptionID + "/resourceGroups/" + resourceGroup + "/overview"
+func generateEnvUrlAzure(subscriptionID string, resourceGroup string) string {
+
+	envUrl := "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/" +
+		subscriptionID + "/resourceGroups/" + resourceGroup + "/overview"
 
 	return envUrl
 }

--- a/examples/dapr-examples/dapr-pubsub-azure/index.md
+++ b/examples/dapr-examples/dapr-pubsub-azure/index.md
@@ -6,10 +6,16 @@ description: "Sample application running with Dapr PubSub on Azure ServiceBus"
 weight: 50
 ---
 
-## Deploying to "local" RP
+## Using a Radius-managed ServiceBus topic
 
-You'll need to set `ARM_SUBSCRIPTION_ID` and `ARM_RESOURCE_GROUP` - this example uses Azure resources.
+This example sets the property `managed: true` for the Dapr PubSub Component. When `managed` is set to true, Radius will manage the lifecycle of the underlying ServiceBus namespace and topic.
 
-## Bicep file
+{{< rad file="managed.bicep">}}
 
-{{< rad file="template.bicep">}}
+## Using a user-managed ServiceBus topic
+
+This example sets the `resource` property to a ServiceBus topic for the Dapr PubSub Component. Setting `managed: false` or using the default value allows you to explicitly specify a link to an Azure resource that you managed. When you supply your own `resource` value, Radius will not change or delete the resource you provide. 
+
+In this example the ServiceBus resources are configured as part of the same `.bicep` template.
+
+{{< rad file="unmanaged.bicep">}}

--- a/examples/dapr-examples/dapr-pubsub-azure/managed.bicep
+++ b/examples/dapr-examples/dapr-pubsub-azure/managed.bicep
@@ -1,5 +1,5 @@
 resource app 'radius.dev/Applications@v1alpha1' = {
-  name: 'dapr-pubsub'
+  name: 'dapr-pubsub-managed'
 
   resource nodesubscriber 'Components' = {
     name: 'nodesubscriber'

--- a/examples/dapr-examples/dapr-pubsub-azure/unmanaged.bicep
+++ b/examples/dapr-examples/dapr-pubsub-azure/unmanaged.bicep
@@ -1,0 +1,87 @@
+resource app 'radius.dev/Applications@v1alpha1' = {
+  name: 'dapr-pubsub-unmanaged'
+
+  resource nodesubscriber 'Components' = {
+    name: 'nodesubscriber'
+    kind: 'radius.dev/Container@v1alpha1'
+    properties: {
+      run: {
+        container: {
+          image: 'radiusteam/dapr-pubsub-nodesubscriber:latest'
+        }
+      }
+      dependsOn: [
+        {
+          name: 'pubsub'
+          kind: 'dapr.io/PubSubTopic'
+          setEnv: {
+            SB_PUBSUBNAME: 'pubsubName'
+            SB_TOPIC: 'topic'
+          }
+        }
+      ]
+      traits: [
+        {
+          kind: 'dapr.io/App@v1alpha1'
+          properties: {
+            appId: 'nodesubscriber'
+            appPort: 50051
+          }
+        }
+      ]
+    }
+  }
+  
+  resource pythonpublisher 'Components' = {
+    name: 'pythonpublisher'
+    kind: 'radius.dev/Container@v1alpha1'
+    properties: {
+      run: {
+        container: {
+          image: 'radiusteam/dapr-pubsub-pythonpublisher:latest'
+        }
+      }
+      dependsOn: [
+        {
+          name: 'pubsub'
+          kind: 'dapr.io/PubSubTopic'
+          setEnv: {
+            SB_PUBSUBNAME: 'pubsubName'
+            SB_TOPIC: 'topic'
+          }
+        }
+      ]
+      traits: [
+        {
+          kind: 'dapr.io/App@v1alpha1'
+          properties: {
+            appId: 'pythonpublisher'
+          }
+        }
+      ]
+    }
+  }
+  
+  resource pubsub 'Components' = {
+    name: 'pubsub'
+    kind: 'dapr.io/PubSubTopic@v1alpha1'
+    properties: {
+      config: {
+        kind: 'pubsub.azure.servicebus'
+        resource: namespace::topic.id
+      }
+    }
+  }
+}
+
+resource namespace 'Microsoft.ServiceBus/namespaces@2017-04-01' = {
+  name: 'ns-${guid(resourceGroup().name)}'
+  location: resourceGroup().location
+  tags: {
+    radiustest: 'true'
+  }
+
+  resource topic 'topics' = {
+    name: 'TOPIC_A'
+  }
+}

--- a/pkg/curp/handlers/azure_servicebus.go
+++ b/pkg/curp/handlers/azure_servicebus.go
@@ -7,9 +7,10 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
+	azresources "github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/servicebus/mgmt/servicebus"
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 	"github.com/Azure/radius/pkg/curp/armauth"
@@ -18,94 +19,45 @@ import (
 )
 
 func NewAzureServiceBusQueueHandler(arm armauth.ArmConfig) ResourceHandler {
-	return &azureServiceBusQueueHandler{arm: arm}
+	return &azureServiceBusQueueHandler{
+		azureServiceBusBaseHandler: azureServiceBusBaseHandler{arm: arm},
+	}
+}
+
+type azureServiceBusBaseHandler struct {
+	arm armauth.ArmConfig
 }
 
 type azureServiceBusQueueHandler struct {
-	arm armauth.ArmConfig
+	azureServiceBusBaseHandler
 }
 
 func (sbh *azureServiceBusQueueHandler) Put(ctx context.Context, options PutOptions) (map[string]string, error) {
 	properties := mergeProperties(options.Resource, options.Existing)
 
-	sbc := servicebus.NewNamespacesClient(sbh.arm.SubscriptionID)
-	sbc.Authorizer = sbh.arm.Auth
-
-	// Check if a service bus namespace exists in the resource group
-	sbItr, err := sbc.ListByResourceGroupComplete(ctx, sbh.arm.ResourceGroup)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to list service bus namespaces: %w", err)
-	}
-
-	var sbNamespace servicebus.SBNamespace
-	if sbItr.NotDone() &&
-		radresources.HasRadiusApplicationTag(sbItr.Value().Tags, options.Application) {
-		// A service bus namespace already exists
-		sbNamespace = sbItr.Value()
-	} else {
-		// Generate a random namespace name
-		namespaceName := namegenerator.GenerateName("radius-ns")
-
-		// TODO: for now we just use the resource-groups location. This would be a place where we'd plug
-		// in something to do with data locality.
-		rgc := resources.NewGroupsClient(sbh.arm.SubscriptionID)
-		rgc.Authorizer = sbh.arm.Auth
-
-		g, err := rgc.Get(ctx, sbh.arm.ResourceGroup)
-		if err != nil {
-			return nil, fmt.Errorf("failed to PUT service bus: %w", err)
-		}
-
-		sbNamespaceFuture, err := sbc.CreateOrUpdate(ctx, sbh.arm.ResourceGroup, namespaceName, servicebus.SBNamespace{
-			Sku: &servicebus.SBSku{
-				Name:     servicebus.Basic,
-				Tier:     servicebus.SkuTierBasic,
-				Capacity: to.Int32Ptr(1),
-			},
-			Location: g.Location,
-			Tags: map[string]*string{
-				radresources.TagRadiusApplication: &options.Application,
-			},
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to PUT service bus: %w", err)
-		}
-
-		err = sbNamespaceFuture.WaitForCompletionRef(ctx, sbc.Client)
-		if err != nil {
-			return nil, fmt.Errorf("failed to PUT service bus: %w", err)
-		}
-
-		sbNamespace, err = sbNamespaceFuture.Result(sbc)
-		if err != nil {
-			return nil, fmt.Errorf("failed to PUT service bus: %w", err)
-		}
-	}
-
-	// store account so we can delete later
-	properties["servicebusnamespace"] = *sbNamespace.Name
-	properties["servicebusid"] = *sbNamespace.ID
-
+	// 'servicebusqueue' is a name that must be specified by the user
 	queueName, ok := properties["servicebusqueue"]
 	if !ok {
-		return nil, fmt.Errorf("failed to PUT service bus: %w", err)
+		return nil, errors.New("missing required property 'servicebusqueue'")
 	}
-	qc := servicebus.NewQueuesClient(sbh.arm.SubscriptionID)
-	qc.Authorizer = sbh.arm.Auth
 
-	sbq, err := qc.CreateOrUpdate(ctx, sbh.arm.ResourceGroup, *sbNamespace.Name, queueName, servicebus.SBQueue{
-		Name: to.StringPtr(queueName),
-		SBQueueProperties: &servicebus.SBQueueProperties{
-			MaxSizeInMegabytes: to.Int32Ptr(1024),
-		},
-	})
-
+	namespace, err := sbh.GetExistingNamespaceFromResourceGroup(ctx, options.Application)
 	if err != nil {
-		return nil, fmt.Errorf("failed to PUT servicebus queue: %w", err)
+		return nil, err
 	}
 
-	// store db so we can delete later
-	properties["queueName"] = *sbq.Name
+	if namespace == nil {
+		namespace, err = sbh.CreateNamespace(ctx, options.Application)
+	}
+
+	properties["servicebusnamespace"] = *namespace.Name
+	properties["servicebusid"] = *namespace.ID
+
+	_, err = sbh.CreateQueue(ctx, *namespace.Name, queueName)
+	if err != nil {
+		return nil, err
+	}
+
 	return properties, nil
 }
 
@@ -152,4 +104,198 @@ func (sbh *azureServiceBusQueueHandler) Delete(ctx context.Context, options Dele
 	}
 
 	return nil
+}
+
+func (handler *azureServiceBusBaseHandler) CreateNamespace(ctx context.Context, application string) (*servicebus.SBNamespace, error) {
+	rgc := azresources.NewGroupsClient(handler.arm.SubscriptionID)
+	rgc.Authorizer = handler.arm.Auth
+
+	sbc := servicebus.NewNamespacesClient(handler.arm.SubscriptionID)
+	sbc.Authorizer = handler.arm.Auth
+
+	// TODO: for now we just use the resource-groups location. This would be a place where we'd plug
+	// in something to do with data locality.
+	g, err := rgc.Get(ctx, handler.arm.ResourceGroup)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get resource group: %w", err)
+	}
+
+	// Generate a random namespace name
+	namespaceName := namegenerator.GenerateName("radius-ns")
+
+	future, err := sbc.CreateOrUpdate(ctx, handler.arm.ResourceGroup, namespaceName, servicebus.SBNamespace{
+		Sku: &servicebus.SBSku{
+			Name:     servicebus.Standard,
+			Tier:     servicebus.SkuTierStandard,
+			Capacity: to.Int32Ptr(1),
+		},
+		Location: g.Location,
+		Tags: map[string]*string{
+			radresources.TagRadiusApplication: &application,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create servicebus namespace: %w", err)
+	}
+
+	err = future.WaitForCompletionRef(ctx, sbc.Client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create servicebus namespace: %w", err)
+	}
+
+	namespace, err := future.Result(sbc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create servicebus namespace: %w", err)
+	}
+
+	return &namespace, err
+}
+
+func (handler *azureServiceBusBaseHandler) CreateTopic(ctx context.Context, namespaceName string, topicName string) (*servicebus.SBTopic, error) {
+	tc := servicebus.NewTopicsClient(handler.arm.SubscriptionID)
+	tc.Authorizer = handler.arm.Auth
+
+	topic, err := tc.CreateOrUpdate(ctx, handler.arm.ResourceGroup, namespaceName, topicName, servicebus.SBTopic{
+		Name: to.StringPtr(topicName),
+		SBTopicProperties: &servicebus.SBTopicProperties{
+			MaxSizeInMegabytes: to.Int32Ptr(1024),
+		},
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create servicebus topic: %w", err)
+	}
+
+	return &topic, nil
+}
+
+func (handler *azureServiceBusBaseHandler) CreateQueue(ctx context.Context, namespaceName string, queueName string) (*servicebus.SBQueue, error) {
+	qc := servicebus.NewQueuesClient(handler.arm.SubscriptionID)
+	qc.Authorizer = handler.arm.Auth
+
+	queue, err := qc.CreateOrUpdate(ctx, handler.arm.ResourceGroup, namespaceName, queueName, servicebus.SBQueue{
+		Name: to.StringPtr(queueName),
+		SBQueueProperties: &servicebus.SBQueueProperties{
+			MaxSizeInMegabytes: to.Int32Ptr(1024),
+		},
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create servicebus queue: %w", err)
+	}
+
+	return &queue, nil
+}
+
+func (handler *azureServiceBusBaseHandler) GetConnectionString(ctx context.Context, namespaceName string) (*string, error) {
+	sbc := servicebus.NewNamespacesClient(handler.arm.SubscriptionID)
+	sbc.Authorizer = handler.arm.Auth
+
+	accessKeys, err := sbc.ListKeys(ctx, handler.arm.ResourceGroup, namespaceName, "RootManageSharedAccessKey")
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve connection strings: %w", err)
+	}
+
+	if accessKeys.PrimaryConnectionString == nil {
+		return nil, fmt.Errorf("failed to retrieve connection strings")
+	}
+
+	return accessKeys.PrimaryConnectionString, nil
+}
+
+func (handler *azureServiceBusBaseHandler) DeleteNamespace(ctx context.Context, namespaceName string) error {
+	// The last queue in the service bus namespace was deleted. Now delete the namespace as well
+	sbc := servicebus.NewNamespacesClient(handler.arm.SubscriptionID)
+	sbc.Authorizer = handler.arm.Auth
+
+	sbNamespaceFuture, err := sbc.Delete(ctx, handler.arm.ResourceGroup, namespaceName)
+	if err != nil && sbNamespaceFuture.Response().StatusCode != 404 {
+		return fmt.Errorf("failed to delete servicebus namespace: %w", err)
+	}
+
+	err = sbNamespaceFuture.WaitForCompletionRef(ctx, sbc.Client)
+	if err != nil {
+		return fmt.Errorf("failed to delete servicebus namespace: %w", err)
+	}
+
+	response, err := sbNamespaceFuture.Result(sbc)
+	if err != nil && response.StatusCode != 404 {
+		return fmt.Errorf("failed to delete servicebus namespace: %w", err)
+	}
+
+	return nil
+}
+
+// Returns true if the namespace can be deleted
+func (handler *azureServiceBusBaseHandler) DeleteTopic(ctx context.Context, namespaceName string, topicName string) (bool, error) {
+	tc := servicebus.NewTopicsClient(handler.arm.SubscriptionID)
+	tc.Authorizer = handler.arm.Auth
+
+	// We might see a 404 here due the namespace already being deleted. This is benign and could occur on retry
+	// of a failed deletion. Either way if the namespace is gone then the topic is gone.
+	result, err := tc.Delete(ctx, handler.arm.ResourceGroup, namespaceName, topicName)
+	if err != nil && result.StatusCode != 404 {
+		return false, fmt.Errorf("failed to DELETE servicebus topic: %w", err)
+	}
+
+	tItr, err := tc.ListByNamespaceComplete(ctx, handler.arm.ResourceGroup, namespaceName, nil, nil)
+	if err != nil && tItr.Response().StatusCode != 404 {
+		return false, fmt.Errorf("failed to DELETE servicebus topic: %w", err)
+	}
+
+	// Delete service bus topic only marks the topic for deletion but does not actually delete it. Hence the additional check...
+	// https://docs.microsoft.com/en-us/rest/api/servicebus/delete-topic
+	if tItr.NotDone() && tItr.Value().Name != &topicName {
+		// There are other topics in the same service bus namespace. Do not remove the namespace as a part of this delete deployment
+		return false, nil
+	}
+
+	// Namespace is empty, it can be deleted if it is unused
+	return true, nil
+}
+
+// Returns true if the namespace can be deleted
+func (handler *azureServiceBusBaseHandler) DeleteQueue(ctx context.Context, namespaceName, queueName string) (bool, error) {
+	qc := servicebus.NewQueuesClient(handler.arm.SubscriptionID)
+	qc.Authorizer = handler.arm.Auth
+
+	result, err := qc.Delete(ctx, handler.arm.ResourceGroup, namespaceName, queueName)
+	if err != nil && result.StatusCode != 404 {
+		return false, fmt.Errorf("failed to delete servicebus queue: %w", err)
+	}
+
+	qItr, err := qc.ListByNamespaceComplete(ctx, handler.arm.ResourceGroup, namespaceName, nil, nil)
+	if err != nil && qItr.Response().StatusCode != 404 {
+		return false, fmt.Errorf("failed to delete servicebus queue: %w", err)
+	}
+
+	if qItr.NotDone() {
+		// There are other queues in the same service bus namespace. Do not remove the namespace as a part of this delete deployment
+		return false, nil
+	}
+
+	// Namespace is empty, it can be deleted if it is unused
+	return true, nil
+}
+
+func (handler *azureServiceBusBaseHandler) GetExistingNamespaceFromResourceGroup(ctx context.Context, application string) (*servicebus.SBNamespace, error) {
+	sbc := servicebus.NewNamespacesClient(handler.arm.SubscriptionID)
+	sbc.Authorizer = handler.arm.Auth
+
+	// Check if a service bus namespace exists in the resource group for this application
+	list, err := sbc.ListByResourceGroupComplete(ctx, handler.arm.ResourceGroup)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to list service bus namespaces: %w", err)
+	}
+
+	// Azure Service Bus needs StandardTier or higher SKU to support topics
+	if list.NotDone() &&
+		list.Value().Sku.Tier != servicebus.SkuTierBasic &&
+		radresources.HasRadiusApplicationTag(list.Value().Tags, application) {
+		// A service bus namespace already exists
+		namespace := list.Value()
+		return &namespace, nil
+	}
+
+	return nil, nil
 }

--- a/pkg/curp/handlers/common_keys.go
+++ b/pkg/curp/handlers/common_keys.go
@@ -1,0 +1,15 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package handlers
+
+const (
+	ManagedKey = "managed"
+
+	KubernetesAPIVersionKey = "apiVersion"
+	KubernetesKindKey       = "kind"
+	KubernetesNamespaceKey  = "namespace"
+	KubernetesNameKey       = "name"
+)

--- a/pkg/curp/handlers/dapr_pubsub_servicebus.go
+++ b/pkg/curp/handlers/dapr_pubsub_servicebus.go
@@ -7,123 +7,91 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	azresources "github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/servicebus/mgmt/servicebus"
-	"github.com/Azure/azure-sdk-for-go/sdk/to"
 	"github.com/Azure/radius/pkg/curp/armauth"
-	radresources "github.com/Azure/radius/pkg/curp/resources"
-	"github.com/Azure/radius/pkg/rad/namegenerator"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func NewDaprPubSubServiceBusHandler(arm armauth.ArmConfig, k8s client.Client) ResourceHandler {
-	return &daprPubSubServiceBusHandler{arm: arm, k8s: k8s}
+	return &daprPubSubServiceBusHandler{
+		azureServiceBusBaseHandler: azureServiceBusBaseHandler{arm: arm},
+		k8s:                        k8s,
+	}
 }
 
 type daprPubSubServiceBusHandler struct {
-	arm armauth.ArmConfig
+	azureServiceBusBaseHandler
 	k8s client.Client
 }
 
 func (pssb *daprPubSubServiceBusHandler) Put(ctx context.Context, options PutOptions) (map[string]string, error) {
 	properties := mergeProperties(options.Resource, options.Existing)
 
-	sbc := servicebus.NewNamespacesClient(pssb.arm.SubscriptionID)
-	sbc.Authorizer = pssb.arm.Auth
-
-	// Check if a service bus namespace exists in the resource group for this application
-	sbItr, err := sbc.ListByResourceGroupComplete(ctx, pssb.arm.ResourceGroup)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to list service bus namespaces: %w", err)
-	}
-
-	var sbNamespace servicebus.SBNamespace
-
-	// Azure Service Bus needs StandardTier or higher SKU to support topics
-	if sbItr.NotDone() &&
-		sbItr.Value().Sku.Tier != servicebus.SkuTierBasic &&
-		radresources.HasRadiusApplicationTag(sbItr.Value().Tags, options.Application) {
-		// A service bus namespace already exists
-		sbNamespace = sbItr.Value()
-	} else {
-		// Generate a random namespace name
-		namespaceName := namegenerator.GenerateName("radius-ns")
-
-		// TODO: for now we just use the resource-groups location. This would be a place where we'd plug
-		// in something to do with data locality.
-		rgc := azresources.NewGroupsClient(pssb.arm.SubscriptionID)
-		rgc.Authorizer = pssb.arm.Auth
-
-		g, err := rgc.Get(ctx, pssb.arm.ResourceGroup)
-		if err != nil {
-			return nil, fmt.Errorf("failed to PUT service bus pubsub: %w", err)
-		}
-
-		sbNamespaceFuture, err := sbc.CreateOrUpdate(ctx, pssb.arm.ResourceGroup, namespaceName, servicebus.SBNamespace{
-			Sku: &servicebus.SBSku{
-				Name:     servicebus.Standard,
-				Tier:     servicebus.SkuTierStandard,
-				Capacity: to.Int32Ptr(1),
-			},
-			Location: g.Location,
-			Tags: map[string]*string{
-				radresources.TagRadiusApplication: &options.Application,
-			},
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to PUT service bus pubsub: %w", err)
-		}
-
-		err = sbNamespaceFuture.WaitForCompletionRef(ctx, sbc.Client)
-		if err != nil {
-			return nil, fmt.Errorf("failed to PUT service bus pubsub: %w", err)
-		}
-
-		sbNamespace, err = sbNamespaceFuture.Result(sbc)
-		if err != nil {
-			return nil, fmt.Errorf("failed to PUT service bus pubsub: %w", err)
-		}
-	}
-
-	properties["servicebusnamespace"] = *sbNamespace.Name
-	properties["servicebusid"] = *sbNamespace.ID
-
+	// 'servicbustopic' is a name that must be specified by the user
 	topicName, ok := properties["servicebustopic"]
 	if !ok {
-		return nil, fmt.Errorf("failed to PUT service bus pubsub: %w", err)
+		return nil, errors.New("missing required property 'servicebustopic'")
 	}
-	tc := servicebus.NewTopicsClient(pssb.arm.SubscriptionID)
-	tc.Authorizer = pssb.arm.Auth
 
-	sbTopic, err := tc.CreateOrUpdate(ctx, pssb.arm.ResourceGroup, *sbNamespace.Name, topicName, servicebus.SBTopic{
-		Name: to.StringPtr(topicName),
-		SBTopicProperties: &servicebus.SBTopicProperties{
-			MaxSizeInMegabytes: to.Int32Ptr(1024),
-		},
-	})
-
+	namespace, err := pssb.GetExistingNamespaceFromResourceGroup(ctx, options.Application)
 	if err != nil {
-		return nil, fmt.Errorf("failed to PUT servicebus topic: %w", err)
+		return nil, err
 	}
 
-	// store db so we can delete later
-	properties["topicName"] = *sbTopic.Name
+	if namespace == nil {
+		namespace, err = pssb.CreateNamespace(ctx, options.Application)
+	}
 
-	accessKeys, err := sbc.ListKeys(ctx, pssb.arm.ResourceGroup, *sbNamespace.Name, "RootManageSharedAccessKey")
+	properties["servicebusnamespace"] = *namespace.Name
+	properties["servicebusid"] = *namespace.ID
 
+	_, err = pssb.CreateTopic(ctx, *namespace.Name, topicName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve connection strings: %w", err)
+		return nil, err
 	}
 
-	if accessKeys.PrimaryConnectionString == nil && accessKeys.SecondaryConnectionString == nil {
-		return nil, fmt.Errorf("failed to retrieve connection strings")
+	cs, err := pssb.GetConnectionString(ctx, *namespace.Name)
+	if err != nil {
+		return nil, err
 	}
 
-	cs := accessKeys.PrimaryConnectionString
+	err = pssb.PatchDaprPubSub(ctx, properties, *cs)
+	if err != nil {
+		return nil, err
+	}
 
+	return properties, nil
+}
+
+func (pssb *daprPubSubServiceBusHandler) Delete(ctx context.Context, options DeleteOptions) error {
+	properties := options.Existing.Properties
+	namespaceName := properties["servicebusnamespace"]
+	topicName := properties["servicebustopic"]
+
+	err := pssb.DeleteDaprPubSub(ctx, properties)
+	if err != nil {
+		return err
+	}
+
+	deleteNamespace, err := pssb.DeleteTopic(ctx, namespaceName, topicName)
+	if err != nil {
+		return err
+	}
+
+	if deleteNamespace {
+		err = pssb.DeleteNamespace(ctx, namespaceName)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (handler *daprPubSubServiceBusHandler) PatchDaprPubSub(ctx context.Context, properties map[string]string, cs string) error {
 	item := unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": properties["apiVersion"],
@@ -145,16 +113,15 @@ func (pssb *daprPubSubServiceBusHandler) Put(ctx context.Context, options PutOpt
 		},
 	}
 
-	err = pssb.k8s.Patch(ctx, &item, client.Apply, &client.PatchOptions{FieldManager: "radius-rp"})
+	err := handler.k8s.Patch(ctx, &item, client.Apply, &client.PatchOptions{FieldManager: "radius-rp"})
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("failed to patch Dapr PubSub: %w", err)
 	}
 
-	return properties, nil
+	return nil
 }
 
-func (pssb *daprPubSubServiceBusHandler) Delete(ctx context.Context, options DeleteOptions) error {
-	properties := options.Existing.Properties
+func (handler *daprPubSubServiceBusHandler) DeleteDaprPubSub(ctx context.Context, properties map[string]string) error {
 	item := unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": properties["apiVersion"],
@@ -166,51 +133,9 @@ func (pssb *daprPubSubServiceBusHandler) Delete(ctx context.Context, options Del
 		},
 	}
 
-	err := client.IgnoreNotFound(pssb.k8s.Delete(ctx, &item))
+	err := client.IgnoreNotFound(handler.k8s.Delete(ctx, &item))
 	if err != nil {
-		return err
-	}
-
-	namespaceName := properties["servicebusnamespace"]
-	topicName := properties["servicebustopic"]
-
-	tc := servicebus.NewTopicsClient(pssb.arm.SubscriptionID)
-	tc.Authorizer = pssb.arm.Auth
-
-	result, err := tc.Delete(ctx, pssb.arm.ResourceGroup, namespaceName, topicName)
-	if err != nil && result.StatusCode != 404 {
-		return fmt.Errorf("failed to DELETE servicebus topic: %w", err)
-	}
-
-	tItr, err := tc.ListByNamespaceComplete(ctx, pssb.arm.ResourceGroup, namespaceName, nil, nil)
-	if err != nil && tItr.Response().StatusCode != 404 {
-		return fmt.Errorf("failed to DELETE servicebus topic: %w", err)
-	}
-
-	// Delete service bus topic only marks the topic for deletion but does not actually delete it. Hence the additional check...
-	// https://docs.microsoft.com/en-us/rest/api/servicebus/delete-topic
-	if tItr.NotDone() && tItr.Value().Name != &topicName {
-		// There are other topics in the same service bus namespace. Do not remove the namespace as a part of this delete deployment
-		return nil
-	}
-
-	// The last queue in the service bus namespace was deleted. Now delete the namespace as well
-	sbc := servicebus.NewNamespacesClient(pssb.arm.SubscriptionID)
-	sbc.Authorizer = pssb.arm.Auth
-
-	sbNamespaceFuture, err := sbc.Delete(ctx, pssb.arm.ResourceGroup, namespaceName)
-	if err != nil && sbNamespaceFuture.Response().StatusCode != 404 {
-		return fmt.Errorf("failed to DELETE servicebus: %w", err)
-	}
-
-	err = sbNamespaceFuture.WaitForCompletionRef(ctx, sbc.Client)
-	if err != nil {
-		return fmt.Errorf("failed to DELETE servicebus: %w", err)
-	}
-
-	response, err := sbNamespaceFuture.Result(sbc)
-	if err != nil && response.StatusCode != 404 {
-		return fmt.Errorf("failed to DELETE servicebus: %w", err)
+		return fmt.Errorf("failed to delete Dapr PubSub: %w", err)
 	}
 
 	return nil

--- a/pkg/curp/handlers/dapr_statestore_storage.go
+++ b/pkg/curp/handlers/dapr_statestore_storage.go
@@ -71,8 +71,6 @@ func (sssh *daprStateStoreAzureStorageHandler) Put(ctx context.Context, options 
 		return nil, fmt.Errorf("failed to find a storage name")
 	}
 
-	// TODO: for now we just use the resource-groups location. This would be a place where we'd plug
-	// in something to do with data locality.
 	rgc := resources.NewGroupsClient(sssh.arm.SubscriptionID)
 	rgc.Authorizer = sssh.arm.Auth
 
@@ -135,11 +133,11 @@ func (sssh *daprStateStoreAzureStorageHandler) Put(ctx context.Context, options 
 
 	item := unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": properties["apiVersion"],
-			"kind":       properties["kind"],
+			"apiVersion": properties[KubernetesAPIVersionKey],
+			"kind":       properties[KubernetesKindKey],
 			"metadata": map[string]interface{}{
-				"namespace": properties["namespace"],
-				"name":      properties["name"],
+				"namespace": properties[KubernetesNamespaceKey],
+				"name":      properties[KubernetesNameKey],
 			},
 			"spec": map[string]interface{}{
 				"type":    "state.azure.tablestorage",
@@ -174,11 +172,11 @@ func (sssh *daprStateStoreAzureStorageHandler) Delete(ctx context.Context, optio
 	properties := options.Existing.Properties
 	item := unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": properties["apiVersion"],
-			"kind":       properties["kind"],
+			"apiVersion": properties[KubernetesAPIVersionKey],
+			"kind":       properties[KubernetesKindKey],
 			"metadata": map[string]interface{}{
-				"namespace": properties["namespace"],
-				"name":      properties["name"],
+				"namespace": properties[KubernetesNamespaceKey],
+				"name":      properties[KubernetesNameKey],
 			},
 		},
 	}

--- a/pkg/curp/handlers/kubernetes.go
+++ b/pkg/curp/handlers/kubernetes.go
@@ -32,10 +32,10 @@ func (kh *kubernetesHandler) Put(ctx context.Context, options PutOptions) (map[s
 
 	// For a Kubernetes resource we only need to store the ObjectMeta and TypeMeta data
 	p := map[string]string{
-		"kind":       item.GetKind(),
-		"apiVersion": item.GetAPIVersion(),
-		"namespace":  item.GetNamespace(),
-		"name":       item.GetName(),
+		KubernetesKindKey:       item.GetKind(),
+		KubernetesAPIVersionKey: item.GetAPIVersion(),
+		KubernetesNamespaceKey:  item.GetNamespace(),
+		KubernetesNameKey:       item.GetName(),
 	}
 
 	err = kh.k8s.Patch(ctx, &item, client.Apply, &client.PatchOptions{FieldManager: "radius-rp"})
@@ -50,11 +50,11 @@ func (kh *kubernetesHandler) Delete(ctx context.Context, options DeleteOptions) 
 	properties := options.Existing.Properties
 	item := unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": properties["apiVersion"],
-			"kind":       properties["kind"],
+			"apiVersion": properties[KubernetesAPIVersionKey],
+			"kind":       properties[KubernetesKindKey],
 			"metadata": map[string]interface{}{
-				"namespace": properties["namespace"],
-				"name":      properties["name"],
+				"namespace": properties[KubernetesNamespaceKey],
+				"name":      properties[KubernetesNameKey],
 			},
 		},
 	}

--- a/pkg/curp/resources/id.go
+++ b/pkg/curp/resources/id.go
@@ -25,13 +25,13 @@ type ResourceType struct {
 }
 
 type KnownType struct {
-	types []ResourceType
+	Types []ResourceType
 }
 
 // Type prints the fully-qualified resource type of a KnownType.
 func (t KnownType) Type() string {
-	types := make([]string, len(t.types))
-	for i, t := range t.types {
+	types := make([]string, len(t.Types))
+	for i, t := range t.Types {
 		types[i] = t.Type
 	}
 	return strings.Join(types, "/")
@@ -75,11 +75,11 @@ func (ri ResourceID) Format(f fmt.State, c rune) {
 // ValidateResourceType validates that the resource ID matches the expected type.
 func (ri ResourceID) ValidateResourceType(t KnownType) error {
 
-	if len(ri.Types) != len(t.types) {
+	if len(ri.Types) != len(t.Types) {
 		return invalidType(ri.ID)
 	}
 
-	for i, rt := range t.types {
+	for i, rt := range t.Types {
 		// Mismatched type
 		if !strings.EqualFold(rt.Type, ri.Types[i].Type) {
 			return invalidType(ri.ID)
@@ -217,13 +217,13 @@ func MakeCollectionURITemplate(t KnownType) string {
 		"providers",
 	}
 
-	if len(t.types) == 0 {
+	if len(t.Types) == 0 {
 		return "/" + strings.Join(segments, "/")
 	}
 
-	segments = append(segments, t.types[0].Type)
+	segments = append(segments, t.Types[0].Type)
 
-	for i, rt := range t.types[1:] {
+	for i, rt := range t.Types[1:] {
 		segments = append(segments, fmt.Sprintf("{resourceName%d}", i))
 		segments = append(segments, rt.Type)
 	}
@@ -241,14 +241,14 @@ func MakeResourceURITemplate(t KnownType) string {
 		"providers",
 	}
 
-	if len(t.types) == 0 {
+	if len(t.Types) == 0 {
 		return "/" + strings.Join(segments, "/")
 	}
 
-	segments = append(segments, t.types[0].Type)
+	segments = append(segments, t.Types[0].Type)
 	segments = append(segments, "{resourceName0}")
 
-	for i, rt := range t.types[1:] {
+	for i, rt := range t.Types[1:] {
 		segments = append(segments, rt.Type)
 		segments = append(segments, fmt.Sprintf("{resourceName%d}", i+1))
 	}

--- a/pkg/curp/resources/id_test.go
+++ b/pkg/curp/resources/id_test.go
@@ -204,15 +204,15 @@ func Test_MakeCollectionURITemplate(t *testing.T) {
 		expected string
 	}{
 		{
-			types:    KnownType{types: []ResourceType{{Name: "*", Type: baseResourceType}}},
+			types:    KnownType{Types: []ResourceType{{Name: "*", Type: baseResourceType}}},
 			expected: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.CustomProviders/resourceProviders",
 		},
 		{
-			types:    KnownType{types: []ResourceType{{Name: "*", Type: baseResourceType}, {Name: "*", Type: "foo"}}},
+			types:    KnownType{Types: []ResourceType{{Name: "*", Type: baseResourceType}, {Name: "*", Type: "foo"}}},
 			expected: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.CustomProviders/resourceProviders/{resourceName0}/foo",
 		},
 		{
-			types:    KnownType{types: []ResourceType{{Name: "*", Type: baseResourceType}, {Name: "*", Type: "foo"}, {Name: "*", Type: "bar"}}},
+			types:    KnownType{Types: []ResourceType{{Name: "*", Type: baseResourceType}, {Name: "*", Type: "foo"}, {Name: "*", Type: "bar"}}},
 			expected: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.CustomProviders/resourceProviders/{resourceName0}/foo/{resourceName1}/bar",
 		},
 	}
@@ -231,15 +231,15 @@ func Test_MakeResourceURITemplate(t *testing.T) {
 		expected string
 	}{
 		{
-			types:    KnownType{types: []ResourceType{{Name: "*", Type: baseResourceType}}},
+			types:    KnownType{Types: []ResourceType{{Name: "*", Type: baseResourceType}}},
 			expected: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.CustomProviders/resourceProviders/{resourceName0}",
 		},
 		{
-			types:    KnownType{types: []ResourceType{{Name: "*", Type: baseResourceType}, {Name: "*", Type: "foo"}}},
+			types:    KnownType{Types: []ResourceType{{Name: "*", Type: baseResourceType}, {Name: "*", Type: "foo"}}},
 			expected: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.CustomProviders/resourceProviders/{resourceName0}/foo/{resourceName1}",
 		},
 		{
-			types:    KnownType{types: []ResourceType{{Name: "*", Type: baseResourceType}, {Name: "*", Type: "foo"}, {Name: "*", Type: "bar"}}},
+			types:    KnownType{Types: []ResourceType{{Name: "*", Type: baseResourceType}, {Name: "*", Type: "foo"}, {Name: "*", Type: "bar"}}},
 			expected: "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.CustomProviders/resourceProviders/{resourceName0}/foo/{resourceName1}/bar/{resourceName2}",
 		},
 	}

--- a/pkg/rad/azure/auth.go
+++ b/pkg/rad/azure/auth.go
@@ -1,0 +1,57 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package azure
+
+import (
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+)
+
+// GetResourceManagerEndpointAuthorizer returns the authorizer for the ResourceManager endpoint
+func GetResourceManagerEndpointAuthorizer() (autorest.Authorizer, error) {
+	settings, err := auth.GetSettingsFromEnvironment()
+	if err != nil {
+		return nil, err
+	}
+
+	return getArmAuthorizer(settings.Environment.ResourceManagerEndpoint)
+}
+
+// IsServicePrincipalConfigured determines whether a service principal is specifed
+func IsServicePrincipalConfigured() (bool, error) {
+	settings, err := auth.GetSettingsFromEnvironment()
+	if err != nil {
+		return false, err
+	}
+
+	spSpecified := settings.Values[auth.ClientID] != "" && settings.Values[auth.ClientSecret] != ""
+	return spSpecified, nil
+}
+
+func getArmAuthorizer(endpoint string) (autorest.Authorizer, error) {
+
+	var authorizer autorest.Authorizer
+
+	useServicePrincipal, err := IsServicePrincipalConfigured()
+	if err != nil {
+		return nil, err
+	}
+
+	if useServicePrincipal {
+		// Use the service principal specified
+		authorizer, err = auth.NewAuthorizerFromEnvironment()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		authorizer, err = auth.NewAuthorizerFromCLIWithResource(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return authorizer, nil
+}

--- a/pkg/workloads/daprpubsubv1alpha1/render.go
+++ b/pkg/workloads/daprpubsubv1alpha1/render.go
@@ -10,13 +10,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Azure/radius/pkg/curp/armauth"
 	"github.com/Azure/radius/pkg/workloads"
 )
 
 // Renderer is the WorkloadRenderer implementation for the dapr pubsub workload.
 type Renderer struct {
-	Arm armauth.ArmConfig
 }
 
 // Allocate is the WorkloadRenderer implementation for dapr pubsub workload.
@@ -31,7 +29,7 @@ func (r Renderer) Allocate(ctx context.Context, w workloads.InstantiatedWorkload
 
 	properties := wrp[0].Properties
 	namespaceName := properties["servicebusnamespace"]
-	pubsubName := properties["servicebuspubsubname"]
+	pubsubName := properties["servicebusname"]
 	topicName := properties["servicebustopic"]
 
 	values := map[string]interface{}{
@@ -55,17 +53,21 @@ func (r Renderer) Render(ctx context.Context, w workloads.InstantiatedWorkload) 
 		return []workloads.WorkloadResource{}, errors.New("only 'managed=true' is supported right now")
 	}
 
+	if component.Config.Managed && component.Config.Topic == "" {
+		return []workloads.WorkloadResource{}, errors.New("the 'topic' field is require when 'managed=true'")
+	}
+
 	// generate data we can use to manage a servicebus instance
 
 	resource := workloads.WorkloadResource{
 		Type: workloads.ResourceKindDaprPubSubTopicAzureServiceBus,
 		Resource: map[string]string{
-			"name":                 w.Workload.Name,
-			"namespace":            w.Application,
-			"apiVersion":           "dapr.io/v1alpha1",
-			"kind":                 "Component",
-			"servicebuspubsubname": component.Config.Name,
-			"servicebustopic":      component.Config.Topic,
+			"name":            w.Workload.Name,
+			"namespace":       w.Application,
+			"apiVersion":      "dapr.io/v1alpha1",
+			"kind":            "Component",
+			"servicebusname":  component.Config.Name,
+			"servicebustopic": component.Config.Topic,
 		},
 	}
 

--- a/pkg/workloads/daprpubsubv1alpha1/render.go
+++ b/pkg/workloads/daprpubsubv1alpha1/render.go
@@ -10,6 +10,9 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/Azure/radius/pkg/curp/handlers"
+	"github.com/Azure/radius/pkg/curp/resources"
+	radresources "github.com/Azure/radius/pkg/curp/resources"
 	"github.com/Azure/radius/pkg/workloads"
 )
 
@@ -28,9 +31,9 @@ func (r Renderer) Allocate(ctx context.Context, w workloads.InstantiatedWorkload
 	}
 
 	properties := wrp[0].Properties
-	namespaceName := properties["servicebusnamespace"]
-	pubsubName := properties["servicebusname"]
-	topicName := properties["servicebustopic"]
+	namespaceName := properties[handlers.ServiceBusNamespaceNameKey]
+	pubsubName := properties[handlers.KubernetesNameKey]
+	topicName := properties[handlers.ServiceBusTopicNameKey]
 
 	values := map[string]interface{}{
 		"namespace":  namespaceName,
@@ -49,28 +52,70 @@ func (r Renderer) Render(ctx context.Context, w workloads.InstantiatedWorkload) 
 		return []workloads.WorkloadResource{}, err
 	}
 
-	if !component.Config.Managed {
-		return []workloads.WorkloadResource{}, errors.New("only 'managed=true' is supported right now")
+	// The Dapr pubsub name can default to the component name.
+	if component.Config.Name == "" {
+		component.Config.Name = component.Name
 	}
 
-	if component.Config.Managed && component.Config.Topic == "" {
-		return []workloads.WorkloadResource{}, errors.New("the 'topic' field is require when 'managed=true'")
+	if component.Config.Managed {
+		if component.Config.Topic == "" {
+			return []workloads.WorkloadResource{}, errors.New("the 'topic' field is required when 'managed=true'")
+		}
+
+		if component.Config.Resource != "" {
+			return nil, errors.New("the 'resource' field cannot be specified when 'managed=true'")
+		}
+
+		// generate data we can use to manage a servicebus topic
+		resource := workloads.WorkloadResource{
+			Type: workloads.ResourceKindDaprPubSubTopicAzureServiceBus,
+			Resource: map[string]string{
+				handlers.ManagedKey:              "true",
+				handlers.KubernetesNameKey:       component.Config.Name,
+				handlers.KubernetesNamespaceKey:  w.Application,
+				handlers.KubernetesAPIVersionKey: "dapr.io/v1alpha1",
+				handlers.KubernetesKindKey:       "Component",
+				handlers.ServiceBusTopicNameKey:  component.Config.Topic,
+			},
+		}
+
+		return []workloads.WorkloadResource{resource}, nil
+	} else {
+		if component.Config.Topic != "" {
+			return nil, errors.New("the 'topic' cannot be specified when 'managed' is not specified")
+		}
+
+		if component.Config.Resource == "" {
+			return nil, errors.New("the 'resource' field is required when 'managed' is not specified")
+		}
+
+		topicID, err := radresources.Parse(component.Config.Resource)
+		if err != nil {
+			return nil, errors.New("the 'resource' field must be a valid resource id.")
+		}
+
+		err = topicID.ValidateResourceType(TopicResourceType)
+		if err != nil {
+			return nil, fmt.Errorf("the 'resource' field must refer to a ServiceBus Topic")
+		}
+
+		// generate data we can use to connect to a servicebus topic
+		resource := workloads.WorkloadResource{
+			Type: workloads.ResourceKindDaprPubSubTopicAzureServiceBus,
+			Resource: map[string]string{
+				handlers.ManagedKey:              "false",
+				handlers.KubernetesNameKey:       component.Config.Name,
+				handlers.KubernetesNamespaceKey:  w.Application,
+				handlers.KubernetesAPIVersionKey: "dapr.io/v1alpha1",
+				handlers.KubernetesKindKey:       "Component",
+
+				// Truncate the topic part of the ID to make an ID for the namespace
+				handlers.ServiceBusNamespaceIDKey:   resources.MakeID(topicID.SubscriptionID, topicID.ResourceGroup, topicID.Types[0]),
+				handlers.ServiceBusTopicIDKey:       topicID.ID,
+				handlers.ServiceBusNamespaceNameKey: topicID.Types[0].Name,
+				handlers.ServiceBusTopicNameKey:     topicID.Types[1].Name,
+			},
+		}
+		return []workloads.WorkloadResource{resource}, nil
 	}
-
-	// generate data we can use to manage a servicebus instance
-
-	resource := workloads.WorkloadResource{
-		Type: workloads.ResourceKindDaprPubSubTopicAzureServiceBus,
-		Resource: map[string]string{
-			"name":            w.Workload.Name,
-			"namespace":       w.Application,
-			"apiVersion":      "dapr.io/v1alpha1",
-			"kind":            "Component",
-			"servicebusname":  component.Config.Name,
-			"servicebustopic": component.Config.Topic,
-		},
-	}
-
-	// It's already in the correct format
-	return []workloads.WorkloadResource{resource}, nil
 }

--- a/pkg/workloads/daprpubsubv1alpha1/render_test.go
+++ b/pkg/workloads/daprpubsubv1alpha1/render_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Azure/radius/pkg/curp/components"
+	"github.com/Azure/radius/pkg/curp/handlers"
 	"github.com/Azure/radius/pkg/workloads"
 	"github.com/stretchr/testify/require"
 )
@@ -34,9 +35,47 @@ func Test_Render_Unanaged_Failure(t *testing.T) {
 
 	_, err := renderer.Render(context.Background(), workload)
 	require.Error(t, err)
+	require.Equal(t, "the 'topic' field is required when 'managed=true'", err.Error())
 }
 
-func Test_Render_Managed_Success(t *testing.T) {
+func Test_Render_Managed_Success_DefaultName(t *testing.T) {
+	renderer := Renderer{}
+
+	workload := workloads.InstantiatedWorkload{
+		Application: "test-app",
+		Name:        "test-component",
+		Workload: components.GenericComponent{
+			Kind: Kind,
+			Name: "test-component",
+			Config: map[string]interface{}{
+				"managed": true,
+				"topic":   "cool-topic",
+			},
+		},
+		ServiceValues: map[string]map[string]interface{}{},
+	}
+
+	resources, err := renderer.Render(context.Background(), workload)
+	require.NoError(t, err)
+
+	require.Len(t, resources, 1)
+	resource := resources[0]
+
+	require.Equal(t, "", resource.LocalID)
+	require.Equal(t, workloads.ResourceKindDaprPubSubTopicAzureServiceBus, resource.Type)
+
+	expected := map[string]string{
+		handlers.ManagedKey:              "true",
+		handlers.KubernetesNameKey:       "test-component",
+		handlers.KubernetesNamespaceKey:  "test-app",
+		handlers.KubernetesAPIVersionKey: "dapr.io/v1alpha1",
+		handlers.KubernetesKindKey:       "Component",
+		handlers.ServiceBusTopicNameKey:  "cool-topic",
+	}
+	require.Equal(t, expected, resource.Resource)
+}
+
+func Test_Render_Managed_Success_SpecifyName(t *testing.T) {
 	renderer := Renderer{}
 
 	workload := workloads.InstantiatedWorkload{
@@ -64,12 +103,95 @@ func Test_Render_Managed_Success(t *testing.T) {
 	require.Equal(t, workloads.ResourceKindDaprPubSubTopicAzureServiceBus, resource.Type)
 
 	expected := map[string]string{
-		"name":                 "test-component",
-		"namespace":            "test-app",
-		"apiVersion":           "dapr.io/v1alpha1",
-		"kind":                 "Component",
-		"servicebuspubsubname": "cool-servicebus",
-		"servicebustopic":      "cool-topic",
+		handlers.ManagedKey:              "true",
+		handlers.KubernetesNameKey:       "cool-servicebus",
+		handlers.KubernetesNamespaceKey:  "test-app",
+		handlers.KubernetesAPIVersionKey: "dapr.io/v1alpha1",
+		handlers.KubernetesKindKey:       "Component",
+		handlers.ServiceBusTopicNameKey:  "cool-topic",
 	}
 	require.Equal(t, expected, resource.Resource)
+}
+
+func Test_Render_Unmanaged_Success(t *testing.T) {
+	renderer := Renderer{}
+
+	workload := workloads.InstantiatedWorkload{
+		Application: "test-app",
+		Name:        "test-component",
+		Workload: components.GenericComponent{
+			Kind: Kind,
+			Name: "test-component",
+			Config: map[string]interface{}{
+				"name":     "cool-servicebus",
+				"resource": "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.ServiceBus/namespaces/test-namespace/topics/test-topic",
+			},
+		},
+		ServiceValues: map[string]map[string]interface{}{},
+	}
+
+	resources, err := renderer.Render(context.Background(), workload)
+	require.NoError(t, err)
+
+	require.Len(t, resources, 1)
+	resource := resources[0]
+
+	require.Equal(t, "", resource.LocalID)
+	require.Equal(t, workloads.ResourceKindDaprPubSubTopicAzureServiceBus, resource.Type)
+
+	expected := map[string]string{
+		handlers.ManagedKey:                 "false",
+		handlers.KubernetesNameKey:          "cool-servicebus",
+		handlers.KubernetesNamespaceKey:     "test-app",
+		handlers.KubernetesAPIVersionKey:    "dapr.io/v1alpha1",
+		handlers.KubernetesKindKey:          "Component",
+		handlers.ServiceBusNamespaceIDKey:   "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.ServiceBus/namespaces/test-namespace",
+		handlers.ServiceBusNamespaceNameKey: "test-namespace",
+		handlers.ServiceBusTopicIDKey:       "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.ServiceBus/namespaces/test-namespace/topics/test-topic",
+		handlers.ServiceBusTopicNameKey:     "test-topic",
+	}
+	require.Equal(t, expected, resource.Resource)
+}
+
+func Test_Render_Unmanaged_InvalidResourceType(t *testing.T) {
+	renderer := Renderer{}
+
+	workload := workloads.InstantiatedWorkload{
+		Application: "test-app",
+		Name:        "test-component",
+		Workload: components.GenericComponent{
+			Kind: Kind,
+			Name: "test-component",
+			Config: map[string]interface{}{
+				"resource": "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.SomethingElse/test-namespace/topics/test-topic",
+			},
+		},
+		ServiceValues: map[string]map[string]interface{}{},
+	}
+
+	_, err := renderer.Render(context.Background(), workload)
+	require.Error(t, err)
+	require.Equal(t, "the 'resource' field must refer to a ServiceBus Topic", err.Error())
+}
+
+func Test_Render_Unmanaged_SpecifiesTopicWithResource(t *testing.T) {
+	renderer := Renderer{}
+
+	workload := workloads.InstantiatedWorkload{
+		Application: "test-app",
+		Name:        "test-component",
+		Workload: components.GenericComponent{
+			Kind: Kind,
+			Name: "test-component",
+			Config: map[string]interface{}{
+				"topic":    "not-allowed",
+				"resource": "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.SomethingElse/test-namespace/topics/test-topic",
+			},
+		},
+		ServiceValues: map[string]map[string]interface{}{},
+	}
+
+	_, err := renderer.Render(context.Background(), workload)
+	require.Error(t, err)
+	require.Equal(t, "the 'topic' cannot be specified when 'managed' is not specified", err.Error())
 }

--- a/pkg/workloads/daprpubsubv1alpha1/render_test.go
+++ b/pkg/workloads/daprpubsubv1alpha1/render_test.go
@@ -1,0 +1,75 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package daprpubsubv1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/radius/pkg/curp/components"
+	"github.com/Azure/radius/pkg/workloads"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Render_Unanaged_Failure(t *testing.T) {
+	renderer := Renderer{}
+
+	workload := workloads.InstantiatedWorkload{
+		Application: "test-app",
+		Name:        "test-component",
+		Workload: components.GenericComponent{
+			Kind: Kind,
+			Name: "test-component",
+			Config: map[string]interface{}{
+				"managed": true,
+				"name":    "cool-servicebus",
+				// Topic is required
+			},
+		},
+		ServiceValues: map[string]map[string]interface{}{},
+	}
+
+	_, err := renderer.Render(context.Background(), workload)
+	require.Error(t, err)
+}
+
+func Test_Render_Managed_Success(t *testing.T) {
+	renderer := Renderer{}
+
+	workload := workloads.InstantiatedWorkload{
+		Application: "test-app",
+		Name:        "test-component",
+		Workload: components.GenericComponent{
+			Kind: Kind,
+			Name: "test-component",
+			Config: map[string]interface{}{
+				"managed": true,
+				"name":    "cool-servicebus",
+				"topic":   "cool-topic",
+			},
+		},
+		ServiceValues: map[string]map[string]interface{}{},
+	}
+
+	resources, err := renderer.Render(context.Background(), workload)
+	require.NoError(t, err)
+
+	require.Len(t, resources, 1)
+	resource := resources[0]
+
+	require.Equal(t, "", resource.LocalID)
+	require.Equal(t, workloads.ResourceKindDaprPubSubTopicAzureServiceBus, resource.Type)
+
+	expected := map[string]string{
+		"name":                 "test-component",
+		"namespace":            "test-app",
+		"apiVersion":           "dapr.io/v1alpha1",
+		"kind":                 "Component",
+		"servicebuspubsubname": "cool-servicebus",
+		"servicebustopic":      "cool-topic",
+	}
+	require.Equal(t, expected, resource.Resource)
+}

--- a/pkg/workloads/daprpubsubv1alpha1/types.go
+++ b/pkg/workloads/daprpubsubv1alpha1/types.go
@@ -20,8 +20,9 @@ type DaprPubSubComponent struct {
 
 // DaprPubSubConfig is the defintion of the config section
 type DaprPubSubConfig struct {
-	Kind    string `json:"kind"`
-	Managed bool   `json:"managed"`
-	Name    string `json:"name"`
-	Topic   string `json:"topic"`
+	Kind     string `json:"kind"`
+	Managed  bool   `json:"managed"`
+	Resource string `json:"resource"`
+	Name     string `json:"name"`
+	Topic    string `json:"topic"`
 }

--- a/pkg/workloads/daprpubsubv1alpha1/types.go
+++ b/pkg/workloads/daprpubsubv1alpha1/types.go
@@ -5,7 +5,22 @@
 
 package daprpubsubv1alpha1
 
+import "github.com/Azure/radius/pkg/curp/resources"
+
 const Kind = "dapr.io/PubSubTopic@v1alpha1"
+
+var TopicResourceType = resources.KnownType{
+	Types: []resources.ResourceType{
+		{
+			Type: "Microsoft.ServiceBus/namespaces",
+			Name: "*",
+		},
+		{
+			Type: "topics",
+			Name: "*",
+		},
+	},
+}
 
 // DaprPubSubComponent is the definition of the container component
 type DaprPubSubComponent struct {
@@ -20,9 +35,10 @@ type DaprPubSubComponent struct {
 
 // DaprPubSubConfig is the defintion of the config section
 type DaprPubSubConfig struct {
-	Kind     string `json:"kind"`
-	Managed  bool   `json:"managed"`
-	Resource string `json:"resource"`
+	Kind    string `json:"kind"`
+	Managed bool   `json:"managed"`
+	// The name of the Dapr pubsub Component
 	Name     string `json:"name"`
+	Resource string `json:"resource"`
 	Topic    string `json:"topic"`
 }

--- a/pkg/workloads/daprstatestorev1alpha1/render.go
+++ b/pkg/workloads/daprstatestorev1alpha1/render.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/Azure/radius/pkg/curp/handlers"
 	"github.com/Azure/radius/pkg/workloads"
 )
 
@@ -47,10 +48,10 @@ func (r Renderer) Render(ctx context.Context, w workloads.InstantiatedWorkload) 
 	resource := workloads.WorkloadResource{
 		Type: workloads.ResourceKindDaprStateStoreAzureStorage,
 		Resource: map[string]string{
-			"name":       w.Name,
-			"namespace":  w.Application,
-			"apiVersion": "dapr.io/v1alpha1",
-			"kind":       "Component",
+			handlers.KubernetesNameKey:       w.Name,
+			handlers.KubernetesNamespaceKey:  w.Application,
+			handlers.KubernetesAPIVersionKey: "dapr.io/v1alpha1",
+			handlers.KubernetesKindKey:       "Component",
 		},
 	}
 

--- a/pkg/workloads/servicebusqueuev1alpha1/render.go
+++ b/pkg/workloads/servicebusqueuev1alpha1/render.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/servicebus/mgmt/servicebus"
 	"github.com/Azure/radius/pkg/curp/armauth"
+	"github.com/Azure/radius/pkg/curp/handlers"
+	"github.com/Azure/radius/pkg/curp/resources"
 	"github.com/Azure/radius/pkg/workloads"
 )
 
@@ -31,8 +33,8 @@ func (r Renderer) Allocate(ctx context.Context, w workloads.InstantiatedWorkload
 	}
 
 	properties := wrp[0].Properties
-	namespaceName := properties["servicebusnamespace"]
-	queueName := properties["servicebusqueue"]
+	namespaceName := properties[handlers.ServiceBusNamespaceNameKey]
+	queueName := properties[handlers.ServiceBusQueueNameKey]
 
 	sbClient := servicebus.NewNamespacesClient(r.Arm.SubscriptionID)
 	sbClient.Authorizer = r.Arm.Auth
@@ -62,27 +64,60 @@ func (r Renderer) Render(ctx context.Context, w workloads.InstantiatedWorkload) 
 	component := ServiceBusQueueComponent{}
 	err := w.Workload.AsRequired(Kind, &component)
 	if err != nil {
-		return []workloads.WorkloadResource{}, err
+		return nil, err
 	}
 
-	if !component.Config.Managed {
-		return []workloads.WorkloadResource{}, errors.New("only 'managed=true' is supported right now")
+	if component.Config.Managed {
+		if component.Config.Queue == "" {
+			return nil, errors.New("the 'topic' field is required when 'managed=true'")
+		}
+
+		if component.Config.Resource != "" {
+			return nil, errors.New("the 'resource' field cannot be specified when 'managed=true'")
+		}
+
+		// generate data we can use to manage a servicebus queue
+
+		resource := workloads.WorkloadResource{
+			Type: workloads.ResourceKindAzureServiceBusQueue,
+			Resource: map[string]string{
+				handlers.ManagedKey:             "true",
+				handlers.ServiceBusQueueNameKey: component.Config.Queue,
+			},
+		}
+
+		// It's already in the correct format
+		return []workloads.WorkloadResource{resource}, nil
+	} else {
+		if component.Config.Resource == "" {
+			return nil, errors.New("the 'resource' field is required when 'managed' is not specified")
+		}
+
+		queueID, err := resources.Parse(component.Config.Resource)
+		if err != nil {
+			return nil, errors.New("the 'resource' field must be a valid resource id.")
+		}
+
+		err = queueID.ValidateResourceType(QueueResourceType)
+		if err != nil {
+			return nil, fmt.Errorf("the 'resource' field must refer to a ServiceBus Queue")
+		}
+
+		// generate data we can use to connect to a servicebus queue
+		resource := workloads.WorkloadResource{
+			Type: workloads.ResourceKindAzureServiceBusQueue,
+			Resource: map[string]string{
+				handlers.ManagedKey: "false",
+
+				// Truncate the queue part of the ID to make an ID for the namespace
+				handlers.ServiceBusNamespaceIDKey:   resources.MakeID(queueID.SubscriptionID, queueID.ResourceGroup, queueID.Types[0]),
+				handlers.ServiceBusQueueIDKey:       queueID.ID,
+				handlers.ServiceBusNamespaceNameKey: queueID.Types[0].Name,
+				handlers.ServiceBusQueueNameKey:     queueID.Types[1].Name,
+			},
+		}
+
+		// It's already in the correct format
+		return []workloads.WorkloadResource{resource}, nil
 	}
-
-	if component.Config.Managed && component.Config.Queue == "" {
-		return []workloads.WorkloadResource{}, errors.New("the 'topic' field is require when 'managed=true'")
-	}
-
-	// generate data we can use to manage a servicebus instance
-
-	resource := workloads.WorkloadResource{
-		Type: workloads.ResourceKindAzureServiceBusQueue,
-		Resource: map[string]string{
-			"servicebusname":  w.Workload.Name,
-			"servicebusqueue": component.Config.Queue,
-		},
-	}
-
-	// It's already in the correct format
-	return []workloads.WorkloadResource{resource}, nil
 }

--- a/pkg/workloads/servicebusqueuev1alpha1/render.go
+++ b/pkg/workloads/servicebusqueuev1alpha1/render.go
@@ -69,12 +69,16 @@ func (r Renderer) Render(ctx context.Context, w workloads.InstantiatedWorkload) 
 		return []workloads.WorkloadResource{}, errors.New("only 'managed=true' is supported right now")
 	}
 
+	if component.Config.Managed && component.Config.Queue == "" {
+		return []workloads.WorkloadResource{}, errors.New("the 'topic' field is require when 'managed=true'")
+	}
+
 	// generate data we can use to manage a servicebus instance
 
 	resource := workloads.WorkloadResource{
 		Type: workloads.ResourceKindAzureServiceBusQueue,
 		Resource: map[string]string{
-			"name":            w.Workload.Name,
+			"servicebusname":  w.Workload.Name,
 			"servicebusqueue": component.Config.Queue,
 		},
 	}

--- a/pkg/workloads/servicebusqueuev1alpha1/render_test.go
+++ b/pkg/workloads/servicebusqueuev1alpha1/render_test.go
@@ -1,0 +1,70 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package servicebusqueuev1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/radius/pkg/curp/components"
+	"github.com/Azure/radius/pkg/workloads"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Render_Unanaged_Failure(t *testing.T) {
+	renderer := Renderer{}
+
+	workload := workloads.InstantiatedWorkload{
+		Application: "test-app",
+		Name:        "test-component",
+		Workload: components.GenericComponent{
+			Kind: Kind,
+			Name: "test-component",
+			Config: map[string]interface{}{
+				"managed": true,
+				"name":    "cool-servicebus",
+				// Queue is required
+			},
+		},
+		ServiceValues: map[string]map[string]interface{}{},
+	}
+
+	_, err := renderer.Render(context.Background(), workload)
+	require.Error(t, err)
+}
+
+func Test_Render_Managed_Success(t *testing.T) {
+	renderer := Renderer{}
+
+	workload := workloads.InstantiatedWorkload{
+		Application: "test-app",
+		Name:        "test-component",
+		Workload: components.GenericComponent{
+			Kind: Kind,
+			Name: "test-component",
+			Config: map[string]interface{}{
+				"managed": true,
+				"queue":   "cool-queue",
+			},
+		},
+		ServiceValues: map[string]map[string]interface{}{},
+	}
+
+	resources, err := renderer.Render(context.Background(), workload)
+	require.NoError(t, err)
+
+	require.Len(t, resources, 1)
+	resource := resources[0]
+
+	require.Equal(t, "", resource.LocalID)
+	require.Equal(t, workloads.ResourceKindAzureServiceBusQueue, resource.Type)
+
+	expected := map[string]string{
+		"servicebusname":  "test-component",
+		"servicebusqueue": "cool-queue",
+	}
+	require.Equal(t, expected, resource.Resource)
+}

--- a/pkg/workloads/servicebusqueuev1alpha1/types.go
+++ b/pkg/workloads/servicebusqueuev1alpha1/types.go
@@ -5,7 +5,22 @@
 
 package servicebusqueuev1alpha1
 
+import "github.com/Azure/radius/pkg/curp/resources"
+
 const Kind = "azure.com/ServiceBusQueue@v1alpha1"
+
+var QueueResourceType = resources.KnownType{
+	Types: []resources.ResourceType{
+		{
+			Type: "Microsoft.ServiceBus/namespaces",
+			Name: "*",
+		},
+		{
+			Type: "queues",
+			Name: "*",
+		},
+	},
+}
 
 // ServiceBusQueueComponent is the definition of the service bus queue component
 type ServiceBusQueueComponent struct {
@@ -20,6 +35,7 @@ type ServiceBusQueueComponent struct {
 
 // ServiceBusQueueConfig is the defintion of the config section
 type ServiceBusQueueConfig struct {
-	Managed bool   `json:"managed"`
-	Queue   string `json:"queue"`
+	Managed  bool   `json:"managed"`
+	Queue    string `json:"queue"`
+	Resource string `json:"resource"`
 }

--- a/test/integrationtests/deploy_test.go
+++ b/test/integrationtests/deploy_test.go
@@ -13,9 +13,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/servicebus/mgmt/servicebus"
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/go-autorest/autorest"
 	cliutils "github.com/Azure/radius/cmd/cli/utils"
+	"github.com/Azure/radius/pkg/rad/azure"
 	"github.com/Azure/radius/pkg/rad/bicep"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/Azure/radius/pkg/workloads"
@@ -52,6 +55,10 @@ func TestDeployment(t *testing.T) {
 	require.NoErrorf(t, err, "Failed to obtain Azure credentials")
 	con := armcore.NewDefaultConnection(azcred, nil)
 
+	// Access Azure credentials
+	armauth, err := azure.GetResourceManagerEndpointAuthorizer()
+	require.NoErrorf(t, err, "Failed to obtain Azure credentials")
+
 	// Ensure rad-bicep has been downloaded before we go parallel
 	installed, err := bicep.IsBicepInstalled()
 	require.NoErrorf(t, err, "Failed to local rad-bicep")
@@ -64,6 +71,7 @@ func TestDeployment(t *testing.T) {
 		Environment:   env,
 		ARMConnection: con,
 		K8s:           k8s,
+		Authorizer:    armauth,
 	}
 
 	table := []Row{
@@ -79,7 +87,7 @@ func TestDeployment(t *testing.T) {
 					},
 				},
 			},
-			Verify: func(t *testing.T, at ApplicationTest) {
+			PostDeployVerify: func(t *testing.T, at ApplicationTest) {
 				appclient := radclient.NewApplicationClient(at.Options.ARMConnection, at.Options.Environment.SubscriptionID)
 
 				// get application and verify name
@@ -100,7 +108,7 @@ func TestDeployment(t *testing.T) {
 					},
 				},
 			},
-			Verify: func(t *testing.T, at ApplicationTest) {
+			PostDeployVerify: func(t *testing.T, at ApplicationTest) {
 				// Verify that we've created an ingress resource. We don't verify reachability because allocating
 				// a public IP can take a few minutes.
 				labelset := map[string]string{
@@ -128,16 +136,64 @@ func TestDeployment(t *testing.T) {
 			},
 		},
 		{
-			Application: "dapr-pubsub",
-			Description: "dapr-pubsub (Azure)",
-			Template:    "../../examples/dapr-examples/dapr-pubsub-azure/template.bicep",
+			Application: "dapr-pubsub-managed",
+			Description: "dapr-pubsub (Azure + Radius-managed)",
+			Template:    "../../examples/dapr-examples/dapr-pubsub-azure/managed.bicep",
 			Pods: validation.PodSet{
 				Namespaces: map[string][]validation.Pod{
-					"dapr-pubsub": {
-						validation.NewPodForComponent("dapr-pubsub", "nodesubscriber"),
-						validation.NewPodForComponent("dapr-pubsub", "pythonpublisher"),
+					"dapr-pubsub-managed": {
+						validation.NewPodForComponent("dapr-pubsub-managed", "nodesubscriber"),
+						validation.NewPodForComponent("dapr-pubsub-managed", "pythonpublisher"),
 					},
 				},
+			},
+		},
+		{
+			Application: "dapr-pubsub-unmanaged",
+			Description: "dapr-pubsub (Azure + user-managed)",
+			Template:    "../../examples/dapr-examples/dapr-pubsub-azure/unmanaged.bicep",
+			Pods: validation.PodSet{
+				Namespaces: map[string][]validation.Pod{
+					"dapr-pubsub-unmanaged": {
+						validation.NewPodForComponent("dapr-pubsub-unmanaged", "nodesubscriber"),
+						validation.NewPodForComponent("dapr-pubsub-unmanaged", "pythonpublisher"),
+					},
+				},
+			},
+			// This test has additional 'unmanaged' resources that are deployed in the same template but not managed
+			// by Radius.
+			//
+			// We don't need to delete these, they will be deleted as part of the resource group cleanup.
+			PostDeleteVerify: func(t *testing.T, at ApplicationTest) {
+				// Verify that the servicebus resources were not deleted
+				nsc := servicebus.NewNamespacesClient(at.Options.Environment.SubscriptionID)
+				nsc.Authorizer = at.Options.Authorizer
+
+				// We have to use a generated name due to uniqueness requirements, so lookup based on tags
+				var ns *servicebus.SBNamespace
+				list, err := nsc.ListByResourceGroup(context.Background(), at.Options.Environment.ResourceGroup)
+				require.NoErrorf(t, err, "failed to list servicebus namespaces")
+
+			outer:
+				for ; list.NotDone(); err = list.Next() {
+					require.NoErrorf(t, err, "failed to list servicebus namespaces")
+
+					for _, value := range list.Values() {
+						if value.Tags["radiustest"] != nil {
+							temp := value
+							ns = &temp
+							break outer
+						}
+					}
+				}
+
+				require.NotNilf(t, ns, "failed to find servicebus namespace with 'radiustest' tag")
+
+				tc := servicebus.NewTopicsClient(at.Options.Environment.SubscriptionID)
+				tc.Authorizer = at.Options.Authorizer
+
+				_, err = tc.Get(context.Background(), at.Options.Environment.ResourceGroup, *ns.Name, "TOPIC_A")
+				require.NoErrorf(t, err, "failed to find servicebus topic")
 			},
 		},
 		{
@@ -174,17 +230,19 @@ func TestDeployment(t *testing.T) {
 }
 
 type Row struct {
-	Application string
-	Description string
-	Template    string
-	Pods        validation.PodSet
-	Verify      func(*testing.T, ApplicationTest)
+	Application      string
+	Description      string
+	Template         string
+	Pods             validation.PodSet
+	PostDeployVerify func(*testing.T, ApplicationTest)
+	PostDeleteVerify func(*testing.T, ApplicationTest)
 }
 
 type Options struct {
 	Environment   *environment.TestEnvironment
 	K8s           *kubernetes.Clientset
 	ARMConnection *armcore.Connection
+	Authorizer    autorest.Authorizer
 }
 
 type ApplicationTest struct {
@@ -221,8 +279,8 @@ func (at ApplicationTest) Test(t *testing.T) {
 		validation.ValidatePodsRunning(t, at.Options.K8s, at.Row.Pods)
 
 		// Custom verification is expected to use `t` to trigger its own assertions
-		if at.Row.Verify != nil {
-			at.Row.Verify(t, at)
+		if at.Row.PostDeployVerify != nil {
+			at.Row.PostDeployVerify(t, at)
 		}
 	})
 
@@ -234,5 +292,10 @@ func (at ApplicationTest) Test(t *testing.T) {
 
 	for ns := range at.Row.Pods.Namespaces {
 		validation.ValidateNoPodsInNamespace(t, at.Options.K8s, ns)
+	}
+
+	// Custom verification is expected to use `t` to trigger its own assertions
+	if at.Row.PostDeleteVerify != nil {
+		at.Row.PostDeleteVerify(t, at)
 	}
 }


### PR DESCRIPTION
Part of: #414

This change implements support for 'unmanaged' resources in Radius,
starting with ServiceBus and Dapr.

The principle here is that when a user specifies a resource id, we can
handle this during the 'rendering' phase and break it down into parts.
This way the 'handler' has a relatively simple job, and we do the
validation up front.