### PR TITLE
Adds `rad application switch` and updates all CLI commands

### DIFF
--- a/.github/workflows/create-environment.yaml
+++ b/.github/workflows/create-environment.yaml
@@ -76,7 +76,7 @@ jobs:
         run: |
           go run cmd/cli/main.go \
             env init azure \
-            --name ${{ steps.generate-resource-group-name.outputs.result }} \
+            -e ${{ steps.generate-resource-group-name.outputs.result }} \
             --subscription-id ${{ env.INTEGRATION_TEST_SUBSCRIPTION_ID }} \
             --resource-group ${{ steps.generate-resource-group-name.outputs.result }} \
             --location "${{ steps.select-location.outputs.result }}"

--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -98,7 +98,7 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("Application '%s' has been deleted\n", applicationName)
 
-	updateApplicationConfig(cmd, env, applicationName, ac)
+	err = updateApplicationConfig(cmd, env, applicationName, ac)
 	return err
 }
 

--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -39,12 +39,12 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	env, err := requireEnvironment(cmd)
+	env, err := rad.RequireEnvironment(cmd)
 	if err != nil {
 		return err
 	}
 
-	applicationName, err := requireApplicationArgs(cmd, args, env)
+	applicationName, err := rad.RequireApplicationArgs(cmd, args, env)
 	if err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func updateApplicationConfig(cmd *cobra.Command,
 
 		fmt.Printf("Removing default application '%v' from environment '%v'\n", applicationName, azureEnv.Name)
 
-		env.Items[azureEnv.Name]["defaultapplication"] = ""
+		env.Items[azureEnv.Name][azureEnv.DefaultApplication] = ""
 
 		rad.UpdateEnvironmentSection(v, env)
 

--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -30,7 +30,7 @@ var appDeleteCmd = &cobra.Command{
 func init() {
 	applicationCmd.AddCommand(appDeleteCmd)
 
-	appDeleteCmd.Flags().BoolP("yes", "y", false, "Confirms deletion of application")
+	envDeleteCmd.Flags().BoolP("yes", "y", false, "Use this flag to prevent prompt for confirmation")
 }
 
 func deleteApplication(cmd *cobra.Command, args []string) error {
@@ -38,24 +38,15 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	applicationName, err := cmd.Flags().GetString("application")
+
+	env, err := requireEnvironment(cmd)
 	if err != nil {
 		return err
 	}
 
-	env, err := validateDefaultEnvironment()
+	applicationName, err := requireApplicationName(cmd, args, env)
 	if err != nil {
 		return err
-	}
-
-	if applicationName == "" {
-		// Get the default application name if not passed in
-		applicationName = env.GetDefaultApplication()
-
-		if applicationName == "" {
-			return fmt.Errorf("No application name provided and no default application set. " +
-				"Either pass in an application name or set a default application by calling `rad appplication switch`.")
-		}
 	}
 
 	// Prompt user to confirm deletion
@@ -71,7 +62,7 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 
 	azcred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
-		return fmt.Errorf("Failed to obtain Azure credential: %w", err)
+		return fmt.Errorf("failed to obtain Azure credential: %w", err)
 	}
 
 	con := armcore.NewDefaultConnection(azcred, nil)

--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -31,15 +31,22 @@ func init() {
 	applicationCmd.AddCommand(appDeleteCmd)
 
 	appDeleteCmd.Flags().StringP("name", "n", "", "The application name")
-	if err := appDeleteCmd.MarkFlagRequired("name"); err != nil {
-		fmt.Printf("Failed to mark the name flag required: %v", err)
-	}
 }
 
 func deleteApplication(cmd *cobra.Command, args []string) error {
 	applicationName, err := cmd.Flags().GetString("name")
 	if err != nil {
 		return err
+	}
+
+	if applicationName == "" {
+		// Get the default application name
+		v := viper.GetViper()
+
+		applicationName, err = rad.GetDefaultApplicationName(v)
+		if err != nil {
+			return err
+		}
 	}
 
 	env, err := validateDefaultEnvironment()

--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -44,7 +44,7 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	applicationName, err := requireApplicationName(cmd, args, env)
+	applicationName, err := requireApplicationArgs(cmd, args, env)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -30,7 +30,6 @@ var appDeleteCmd = &cobra.Command{
 func init() {
 	applicationCmd.AddCommand(appDeleteCmd)
 
-	appDeleteCmd.Flags().StringP("name", "n", "", "The application name")
 	appDeleteCmd.Flags().BoolP("yes", "y", false, "Confirms deletion of application")
 }
 
@@ -39,7 +38,7 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	applicationName, err := cmd.Flags().GetString("name")
+	applicationName, err := cmd.Flags().GetString("application")
 	if err != nil {
 		return err
 	}
@@ -54,7 +53,8 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 		applicationName = env.GetDefaultApplication()
 
 		if applicationName == "" {
-			return fmt.Errorf("No application name provided and no default application set.")
+			return fmt.Errorf("No application name provided and no default application set. " +
+				"Either pass in an application name or set a default application by calling `rad appplication switch`.")
 		}
 	}
 

--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -30,7 +30,7 @@ var appDeleteCmd = &cobra.Command{
 func init() {
 	applicationCmd.AddCommand(appDeleteCmd)
 
-	envDeleteCmd.Flags().BoolP("yes", "y", false, "Use this flag to prevent prompt for confirmation")
+	appDeleteCmd.Flags().BoolP("yes", "y", false, "Use this flag to prevent prompt for confirmation")
 }
 
 func deleteApplication(cmd *cobra.Command, args []string) error {

--- a/cmd/cli/cmd/appList.go
+++ b/cmd/cli/cmd/appList.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/radius/cmd/cli/utils"
+	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
 )
@@ -30,7 +31,7 @@ func init() {
 }
 
 func listApplications(cmd *cobra.Command, args []string) error {
-	env, err := requireEnvironment(cmd)
+	env, err := rad.RequireEnvironment(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/appList.go
+++ b/cmd/cli/cmd/appList.go
@@ -30,7 +30,7 @@ func init() {
 }
 
 func listApplications(cmd *cobra.Command, args []string) error {
-	env, err := validateDefaultEnvironment()
+	env, err := requireEnvironment(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/appShow.go
+++ b/cmd/cli/cmd/appShow.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/radius/cmd/cli/utils"
+	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
 )
@@ -29,12 +30,12 @@ func init() {
 }
 
 func showApplication(cmd *cobra.Command, args []string) error {
-	env, err := requireEnvironment(cmd)
+	env, err := rad.RequireEnvironment(cmd)
 	if err != nil {
 		return err
 	}
 
-	applicationName, err := requireApplicationArgs(cmd, args, env)
+	applicationName, err := rad.RequireApplicationArgs(cmd, args, env)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/appShow.go
+++ b/cmd/cli/cmd/appShow.go
@@ -12,31 +12,40 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/radius/cmd/cli/utils"
+	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
-// appGetCmd command to get properties of an application
-var appGetCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Get RAD application details",
-	Long:  "Get RAD application details",
-	RunE:  getApplication,
+// appShowCmd command to show properties of an application
+var appShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show RAD application details",
+	Long:  "Show RAD application details",
+	RunE:  showApplication,
 }
 
 func init() {
-	applicationCmd.AddCommand(appGetCmd)
+	applicationCmd.AddCommand(appShowCmd)
 
-	appGetCmd.Flags().StringP("name", "n", "", "The application name")
-	if err := appGetCmd.MarkFlagRequired("name"); err != nil {
-		fmt.Printf("Failed to mark the name flag required: %v", err)
-	}
+	appShowCmd.Flags().StringP("name", "n", "", "The application name")
 }
 
-func getApplication(cmd *cobra.Command, args []string) error {
+func showApplication(cmd *cobra.Command, args []string) error {
 	applicationName, err := cmd.Flags().GetString("name")
 	if err != nil {
 		return err
+	}
+
+	if applicationName == "" {
+		// Get the default application name
+		v := viper.GetViper()
+
+		applicationName, err = rad.GetDefaultApplicationName(v)
+		if err != nil {
+			return err
+		}
 	}
 
 	env, err := validateDefaultEnvironment()

--- a/cmd/cli/cmd/appShow.go
+++ b/cmd/cli/cmd/appShow.go
@@ -29,23 +29,14 @@ func init() {
 }
 
 func showApplication(cmd *cobra.Command, args []string) error {
-	applicationName, err := cmd.Flags().GetString("application")
+	env, err := requireEnvironment(cmd)
 	if err != nil {
 		return err
 	}
 
-	env, err := validateDefaultEnvironment()
+	applicationName, err := requireApplicationName(cmd, args, env)
 	if err != nil {
 		return err
-	}
-
-	if applicationName == "" {
-		// Get the default application name if not passed in
-		applicationName = env.GetDefaultApplication()
-		if applicationName == "" {
-			return fmt.Errorf("No application name provided and no default application set. " +
-				"Either pass in an application name or set a default application by calling `rad appplication switch`.")
-		}
 	}
 
 	azcred, err := azidentity.NewDefaultAzureCredential(nil)

--- a/cmd/cli/cmd/appShow.go
+++ b/cmd/cli/cmd/appShow.go
@@ -34,7 +34,7 @@ func showApplication(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	applicationName, err := requireApplicationName(cmd, args, env)
+	applicationName, err := requireApplicationArgs(cmd, args, env)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/appShow.go
+++ b/cmd/cli/cmd/appShow.go
@@ -12,10 +12,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/radius/cmd/cli/utils"
-	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // appShowCmd command to show properties of an application
@@ -38,19 +36,18 @@ func showApplication(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if applicationName == "" {
-		// Get the default application name
-		v := viper.GetViper()
-
-		applicationName, err = rad.GetDefaultApplicationName(v)
-		if err != nil {
-			return err
-		}
-	}
-
 	env, err := validateDefaultEnvironment()
 	if err != nil {
 		return err
+	}
+
+	if applicationName == "" {
+		// Get the default application name if not passed in
+		applicationName = env.GetDefaultApplication()
+		if applicationName == "" {
+			return fmt.Errorf("No application name provided and no default application set. " +
+				"Either pass in an application name or set a default application by calling `rad appplication switch`.")
+		}
 	}
 
 	azcred, err := azidentity.NewDefaultAzureCredential(nil)

--- a/cmd/cli/cmd/appShow.go
+++ b/cmd/cli/cmd/appShow.go
@@ -26,12 +26,10 @@ var appShowCmd = &cobra.Command{
 
 func init() {
 	applicationCmd.AddCommand(appShowCmd)
-
-	appShowCmd.Flags().StringP("name", "n", "", "The application name")
 }
 
 func showApplication(cmd *cobra.Command, args []string) error {
-	applicationName, err := cmd.Flags().GetString("name")
+	applicationName, err := cmd.Flags().GetString("application")
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/appSwitch.go
+++ b/cmd/cli/cmd/appSwitch.go
@@ -1,0 +1,71 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/radius/cmd/cli/utils"
+	"github.com/Azure/radius/pkg/rad"
+	"github.com/Azure/radius/pkg/rad/logger"
+	"github.com/Azure/radius/pkg/radclient"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// appSwitchCmd command to switch applications
+var appSwitchCmd = &cobra.Command{
+	Use:   "switch",
+	Short: "Switch the default RAD application",
+	Long:  "Switches the default RAD application",
+	RunE:  switchApplications,
+}
+
+func init() {
+	applicationCmd.AddCommand(appSwitchCmd)
+}
+
+func switchApplications(cmd *cobra.Command, args []string) error {
+	env, err := validateDefaultEnvironment()
+	if len(args) < 1 {
+		return errors.New("application name is required")
+	}
+	applicationName := args[0]
+
+	v := viper.GetViper()
+	as, err := rad.ReadApplicationSection(v)
+
+	if as.Default == applicationName {
+		logger.LogInfo("Default application is already set to %v", applicationName)
+		return nil
+	}
+
+	azcred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return fmt.Errorf("Failed to obtain Azure credentials: %w", err)
+	}
+	con := armcore.NewDefaultConnection(azcred, nil)
+	ac := radclient.NewApplicationClient(con, env.SubscriptionID)
+
+	// Need to validate that application exists prior to switching
+	_, err = ac.Get(cmd.Context(), env.ResourceGroup, applicationName, nil)
+	if err != nil {
+		return utils.UnwrapErrorFromRawResponse(err)
+	}
+
+	logger.LogInfo("Switching default application from %v to %v", as.Default, applicationName)
+	as.Default = applicationName
+
+	rad.UpdateApplicationSection(v, as)
+	err = saveConfig()
+	if err != nil {
+		return err
+	}
+	return err
+}

--- a/cmd/cli/cmd/appSwitch.go
+++ b/cmd/cli/cmd/appSwitch.go
@@ -9,13 +9,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/Azure/radius/pkg/rad/logger"
-	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -77,19 +73,6 @@ func switchApplications(cmd *cobra.Command, args []string) error {
 	azureEnv, err := environments.RequireAzureCloud(e)
 	if err != nil {
 		return err
-	}
-
-	azcred, err := azidentity.NewDefaultAzureCredential(nil)
-	if err != nil {
-		return fmt.Errorf("failed to obtain Azure credentials: %w", err)
-	}
-	con := armcore.NewDefaultConnection(azcred, nil)
-	ac := radclient.NewApplicationClient(con, azureEnv.SubscriptionID)
-
-	// Need to validate that application exists prior to switching
-	_, err = ac.Get(cmd.Context(), azureEnv.ResourceGroup, applicationName, nil)
-	if err != nil {
-		return fmt.Errorf("could not find application '%v' in environment '%v': %w", applicationName, azureEnv.Name, utils.UnwrapErrorFromRawResponse(err))
 	}
 
 	if azureEnv.DefaultApplication != "" {

--- a/cmd/cli/cmd/appSwitch.go
+++ b/cmd/cli/cmd/appSwitch.go
@@ -44,12 +44,10 @@ func switchApplications(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) > 0 {
-		if args[0] != "" {
-			if applicationName != "" {
-				return fmt.Errorf("cannot specify application name via both arguments and `-a`")
-			}
-			applicationName = args[0]
+		if applicationName != "" {
+			return fmt.Errorf("cannot specify application name via both arguments and `-a`")
 		}
+		applicationName = args[0]
 	}
 
 	if applicationName == "" {

--- a/cmd/cli/cmd/appSwitch.go
+++ b/cmd/cli/cmd/appSwitch.go
@@ -81,7 +81,7 @@ func switchApplications(cmd *cobra.Command, args []string) error {
 
 	azcred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
-		return fmt.Errorf("Failed to obtain Azure credentials: %w", err)
+		return fmt.Errorf("failed to obtain Azure credentials: %w", err)
 	}
 	con := armcore.NewDefaultConnection(azcred, nil)
 	ac := radclient.NewApplicationClient(con, azureEnv.SubscriptionID)
@@ -98,7 +98,7 @@ func switchApplications(cmd *cobra.Command, args []string) error {
 		logger.LogInfo("Switching default application to %v", applicationName)
 	}
 
-	env.Items[azureEnv.Name]["defaultapplication"] = applicationName
+	env.Items[azureEnv.Name][azureEnv.DefaultApplication] = applicationName
 
 	rad.UpdateEnvironmentSection(v, env)
 	err = saveConfig()

--- a/cmd/cli/cmd/appSwitch.go
+++ b/cmd/cli/cmd/appSwitch.go
@@ -40,6 +40,9 @@ func switchApplications(cmd *cobra.Command, args []string) error {
 
 	v := viper.GetViper()
 	as, err := rad.ReadApplicationSection(v)
+	if err != nil {
+		return err
+	}
 
 	if as.Default == applicationName {
 		logger.LogInfo("Default application is already set to %v", applicationName)

--- a/cmd/cli/cmd/appSwitch.go
+++ b/cmd/cli/cmd/appSwitch.go
@@ -33,6 +33,10 @@ func init() {
 
 func switchApplications(cmd *cobra.Command, args []string) error {
 	env, err := validateDefaultEnvironment()
+	if err != nil {
+		return err
+	}
+
 	if len(args) < 1 {
 		return errors.New("application name is required")
 	}
@@ -40,6 +44,7 @@ func switchApplications(cmd *cobra.Command, args []string) error {
 
 	v := viper.GetViper()
 	as, err := rad.ReadApplicationSection(v)
+
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/application.go
+++ b/cmd/cli/cmd/application.go
@@ -20,6 +20,8 @@ var applicationCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(applicationCmd)
+	applicationCmd.PersistentFlags().StringP("application", "a", "", "The application name")
+	applicationCmd.PersistentFlags().StringP("environment", "e", "", "The environment name")
 }
 
 func requireApplicationArgs(cmd *cobra.Command, args []string, env *environments.AzureCloudEnvironment) (string, error) {
@@ -41,7 +43,7 @@ func requireApplicationArgs(cmd *cobra.Command, args []string, env *environments
 		applicationName = env.GetDefaultApplication()
 		if applicationName == "" {
 			return "", fmt.Errorf("no application name provided and no default application set, " +
-				"either pass in an application name or set a default application by calling `rad appplication switch`")
+				"either pass in an application name or set a default application by using `rad appplication switch`")
 		}
 	}
 

--- a/cmd/cli/cmd/application.go
+++ b/cmd/cli/cmd/application.go
@@ -6,6 +6,9 @@
 package cmd
 
 import (
+	"fmt"
+
+	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
 )
 
@@ -17,4 +20,34 @@ var applicationCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(applicationCmd)
+}
+
+func requireApplicationArgs(cmd *cobra.Command, args []string, env *environments.AzureCloudEnvironment) (string, error) {
+	applicationName, err := cmd.Flags().GetString("application")
+	if err != nil {
+		return "", err
+	}
+
+	if len(args) > 0 {
+		if args[0] != "" {
+			if applicationName != "" {
+				return "", fmt.Errorf("cannot specify application name via both arguments and `-a`")
+			}
+			applicationName = args[0]
+		}
+	}
+
+	if applicationName == "" {
+		applicationName = env.GetDefaultApplication()
+		if applicationName == "" {
+			return "", fmt.Errorf("no application name provided and no default application set, " +
+				"either pass in an application name or set a default application by calling `rad appplication switch`")
+		}
+	}
+
+	return applicationName, nil
+}
+
+func requireApplication(cmd *cobra.Command, env *environments.AzureCloudEnvironment) (string, error) {
+	return requireApplicationArgs(cmd, []string{}, env)
 }

--- a/cmd/cli/cmd/application.go
+++ b/cmd/cli/cmd/application.go
@@ -6,9 +6,6 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
 )
 
@@ -22,34 +19,4 @@ func init() {
 	RootCmd.AddCommand(applicationCmd)
 	applicationCmd.PersistentFlags().StringP("application", "a", "", "The application name")
 	applicationCmd.PersistentFlags().StringP("environment", "e", "", "The environment name")
-}
-
-func requireApplicationArgs(cmd *cobra.Command, args []string, env *environments.AzureCloudEnvironment) (string, error) {
-	applicationName, err := cmd.Flags().GetString("application")
-	if err != nil {
-		return "", err
-	}
-
-	if len(args) > 0 {
-		if args[0] != "" {
-			if applicationName != "" {
-				return "", fmt.Errorf("cannot specify application name via both arguments and `-a`")
-			}
-			applicationName = args[0]
-		}
-	}
-
-	if applicationName == "" {
-		applicationName = env.GetDefaultApplication()
-		if applicationName == "" {
-			return "", fmt.Errorf("no application name provided and no default application set, " +
-				"either pass in an application name or set a default application by using `rad appplication switch`")
-		}
-	}
-
-	return applicationName, nil
-}
-
-func requireApplication(cmd *cobra.Command, env *environments.AzureCloudEnvironment) (string, error) {
-	return requireApplicationArgs(cmd, []string{}, env)
 }

--- a/cmd/cli/cmd/bicepDelete.go
+++ b/cmd/cli/cmd/bicepDelete.go
@@ -11,9 +11,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var bicepCleanCmd = &cobra.Command{
-	Use:   "clean",
-	Short: "Clean installed bicep compiler",
+var bicepDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete installed bicep compiler",
 	Long:  `Removes the local copy of the bicep compiler`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		logger.LogInfo("removing local copy of bicep...")
@@ -27,11 +27,11 @@ var bicepCleanCmd = &cobra.Command{
 			return err
 		}
 
-		err = bicep.CleanBicep()
+		err = bicep.DeleteBicep()
 		return err
 	},
 }
 
 func init() {
-	bicepCmd.AddCommand(bicepCleanCmd)
+	bicepCmd.AddCommand(bicepDeleteCmd)
 }

--- a/cmd/cli/cmd/component.go
+++ b/cmd/cli/cmd/component.go
@@ -17,6 +17,9 @@ var componentCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(componentCmd)
+	componentCmd.PersistentFlags().StringP("application", "a", "", "The application name")
+	componentCmd.PersistentFlags().StringP("environment", "e", "", "The environment name")
+	componentCmd.PersistentFlags().StringP("component", "c", "", "The component name")
 }
 
 func requireComponent(cmd *cobra.Command, args []string) (string, error) {

--- a/cmd/cli/cmd/component.go
+++ b/cmd/cli/cmd/component.go
@@ -21,7 +21,3 @@ func init() {
 	componentCmd.PersistentFlags().StringP("environment", "e", "", "The environment name")
 	componentCmd.PersistentFlags().StringP("component", "c", "", "The component name")
 }
-
-func requireComponent(cmd *cobra.Command, args []string) (string, error) {
-	return require(cmd, args, "component")
-}

--- a/cmd/cli/cmd/component.go
+++ b/cmd/cli/cmd/component.go
@@ -18,3 +18,7 @@ var componentCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(componentCmd)
 }
+
+func requireComponent(cmd *cobra.Command, args []string) (string, error) {
+	return require(cmd, args, "component")
+}

--- a/cmd/cli/cmd/componentExpose.go
+++ b/cmd/cli/cmd/componentExpose.go
@@ -15,6 +15,7 @@ import (
 	"os/signal"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
+	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/azure"
 	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/Azure/radius/pkg/workloads"
@@ -40,17 +41,17 @@ Press CTRL+C to exit the command and terminate the tunnel.`,
 # on local port 5000
 rad component expose --application icecream-store orders --port 5000 --remote-port 80`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		env, err := requireEnvironment(cmd)
+		env, err := rad.RequireEnvironment(cmd)
 		if err != nil {
 			return err
 		}
 
-		application, err := requireApplication(cmd, env)
+		application, err := rad.RequireApplication(cmd, env)
 		if err != nil {
 			return err
 		}
 
-		component, err := requireComponent(cmd, args)
+		component, err := rad.RequireComponent(cmd, args)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/cmd/componentList.go
+++ b/cmd/cli/cmd/componentList.go
@@ -26,20 +26,15 @@ var componentListCmd = &cobra.Command{
 
 func init() {
 	componentCmd.AddCommand(componentListCmd)
-
-	componentListCmd.Flags().StringP("name", "n", "", "Application name")
-	if err := componentListCmd.MarkFlagRequired("name"); err != nil {
-		fmt.Printf("Failed to mark the name flag required: %v", err)
-	}
 }
 
 func listComponents(cmd *cobra.Command, args []string) error {
-	applicationName, err := cmd.Flags().GetString("name")
+	env, err := requireEnvironment(cmd)
 	if err != nil {
 		return err
 	}
 
-	env, err := validateDefaultEnvironment()
+	applicationName, err := requireApplicationName(cmd, args, env)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/componentList.go
+++ b/cmd/cli/cmd/componentList.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/radius/cmd/cli/utils"
+	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
 )
@@ -29,12 +30,12 @@ func init() {
 }
 
 func listComponents(cmd *cobra.Command, args []string) error {
-	env, err := requireEnvironment(cmd)
+	env, err := rad.RequireEnvironment(cmd)
 	if err != nil {
 		return err
 	}
 
-	applicationName, err := requireApplicationArgs(cmd, args, env)
+	applicationName, err := rad.RequireApplicationArgs(cmd, args, env)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/componentList.go
+++ b/cmd/cli/cmd/componentList.go
@@ -34,7 +34,7 @@ func listComponents(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	applicationName, err := requireApplicationName(cmd, args, env)
+	applicationName, err := requireApplicationArgs(cmd, args, env)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/componentLogs.go
+++ b/cmd/cli/cmd/componentLogs.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/workloads"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -39,17 +40,17 @@ rad component logs --application icecream-store orders --follow
 # read logs from the 'daprd' sidecare container of the 'orders' component of the 'icecream-store' application
 rad component logs --application icecream-store orders --container daprd`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		env, err := requireEnvironment(cmd)
+		env, err := rad.RequireEnvironment(cmd)
 		if err != nil {
 			return err
 		}
 
-		application, err := requireApplication(cmd, env)
+		application, err := rad.RequireApplication(cmd, env)
 		if err != nil {
 			return err
 		}
 
-		component, err := requireComponent(cmd, args)
+		component, err := rad.RequireComponent(cmd, args)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/cmd/componentLogs.go
+++ b/cmd/cli/cmd/componentLogs.go
@@ -25,23 +25,34 @@ var logsCmd = &cobra.Command{
 	Long: `Reads logs from a running component. Currently only supports the kind 'radius.dev/Container'.
 This command allows you to access logs of a deployed application and output those logs to the local console.
 
-'rad logs' will output logs from the component's primary container. In scenarios like Dapr where multiple containers are in use, the '--continer <name>' option can specify the desired container.
+'rad component logs' will output logs from the component's primary container. In scenarios like Dapr where multiple containers are in use, the '--continer <name>' option can specify the desired container.
 
-'rad logs' will output all currently available logs for the component and then exit.
+'rad component logs' will output all currently available logs for the component and then exit.
 
 Specify the '--follow' option to stream additional logs as they are emitted by the component. When following, press CTRL+C to exit the command and terminate the stream.`,
 	Example: `# read logs from the 'orders' component of the 'icecream-store' application
-rad logs icecream-store orders
+rad component logs --application icecream-store orders
 
 # stream logs from the 'orders' component of the 'icecream-store' application
-rad logs icecream-store orders --follow
+rad component logs --application icecream-store orders --follow
 
 # read logs from the 'daprd' sidecare container of the 'orders' component of the 'icecream-store' application
-rad logs icecream-store orders --container daprd`,
-	Args: NamedPositionalArgs([]string{"application", "component"}),
+rad component logs --application icecream-store orders --container daprd`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		application := args[0]
-		component := args[1]
+		env, err := requireEnvironment(cmd)
+		if err != nil {
+			return err
+		}
+
+		application, err := requireApplication(cmd, env)
+		if err != nil {
+			return err
+		}
+
+		component, err := requireComponent(cmd, args)
+		if err != nil {
+			return err
+		}
 
 		follow, err := cmd.Flags().GetBool("follow")
 		if err != nil {
@@ -49,11 +60,6 @@ rad logs icecream-store orders --container daprd`,
 		}
 
 		container, err := cmd.Flags().GetString("container")
-		if err != nil {
-			return err
-		}
-
-		env, err := validateDefaultEnvironment()
 		if err != nil {
 			return err
 		}
@@ -130,7 +136,7 @@ rad logs icecream-store orders --container daprd`,
 }
 
 func init() {
-	RootCmd.AddCommand(logsCmd)
+	componentCmd.AddCommand(logsCmd)
 
 	logsCmd.Flags().StringP("container", "c", "", "specify the container from which logs should be streamed")
 	logsCmd.Flags().BoolP("follow", "f", false, "specify that logs should be stream until the command is canceled")

--- a/cmd/cli/cmd/componentLogs.go
+++ b/cmd/cli/cmd/componentLogs.go
@@ -138,7 +138,7 @@ rad component logs --application icecream-store orders --container daprd`,
 func init() {
 	componentCmd.AddCommand(logsCmd)
 
-	logsCmd.Flags().StringP("container", "c", "", "specify the container from which logs should be streamed")
+	logsCmd.Flags().String("container", "", "specify the container from which logs should be streamed")
 	logsCmd.Flags().BoolP("follow", "f", false, "specify that logs should be stream until the command is canceled")
 }
 

--- a/cmd/cli/cmd/componentShow.go
+++ b/cmd/cli/cmd/componentShow.go
@@ -16,40 +16,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// componentGetCmd command to get details of a component
-var componentGetCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Get RAD component details",
-	Long:  "Get details of the specified Radius component",
-	RunE:  getComponent,
+// componentShowCmd command to show details of a component
+var componentShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show RAD component details",
+	Long:  "Show details of the specified Radius component",
+	RunE:  showComponent,
 }
 
 func init() {
-	componentCmd.AddCommand(componentGetCmd)
-
-	componentGetCmd.Flags().StringP("name", "n", "", "Component name")
-	if err := componentGetCmd.MarkFlagRequired("name"); err != nil {
-		fmt.Printf("Failed to mark the name flag required: %v", err)
-	}
-
-	componentGetCmd.Flags().StringP("application-name", "a", "", "Application name for the component")
-	if err := componentGetCmd.MarkFlagRequired("application-name"); err != nil {
-		fmt.Printf("Failed to mark the application-name flag required: %v", err)
-	}
+	componentCmd.AddCommand(componentShowCmd)
 }
 
-func getComponent(cmd *cobra.Command, args []string) error {
-	applicationName, err := cmd.Flags().GetString("application-name")
+func showComponent(cmd *cobra.Command, args []string) error {
+	env, err := requireEnvironment(cmd)
 	if err != nil {
 		return err
 	}
 
-	componentName, err := cmd.Flags().GetString("name")
+	applicationName, err := requireApplicationNameNoArgs(cmd, env)
 	if err != nil {
 		return err
 	}
 
-	env, err := validateDefaultEnvironment()
+	componentName, err := requireComponent(cmd, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/componentShow.go
+++ b/cmd/cli/cmd/componentShow.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/radius/cmd/cli/utils"
+	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
 )
@@ -29,17 +30,17 @@ func init() {
 }
 
 func showComponent(cmd *cobra.Command, args []string) error {
-	env, err := requireEnvironment(cmd)
+	env, err := rad.RequireEnvironment(cmd)
 	if err != nil {
 		return err
 	}
 
-	applicationName, err := requireApplication(cmd, env)
+	applicationName, err := rad.RequireApplication(cmd, env)
 	if err != nil {
 		return err
 	}
 
-	componentName, err := requireComponent(cmd, args)
+	componentName, err := rad.RequireComponent(cmd, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/componentShow.go
+++ b/cmd/cli/cmd/componentShow.go
@@ -34,7 +34,7 @@ func showComponent(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	applicationName, err := requireApplicationNameNoArgs(cmd, env)
+	applicationName, err := requireApplication(cmd, env)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -47,7 +47,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	env, err := validateDefaultEnvironment()
+	env, err := requireEnvironment(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -111,6 +111,8 @@ func deploy(cmd *cobra.Command, args []string) error {
 		}
 
 		as.Default = applicationName
+
+		logger.LogInfo("Setting default application to %v", applicationName)
 		rad.UpdateApplicationSection(v, as)
 		err = saveConfig()
 		if err != nil {

--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -34,6 +34,7 @@ var deployCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(deployCmd)
+	deployCmd.PersistentFlags().StringP("environment", "e", "", "The environment name")
 }
 
 func deploy(cmd *cobra.Command, args []string) error {

--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -15,13 +15,19 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
+	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/radius/cmd/cli/utils"
+	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/azure"
 	"github.com/Azure/radius/pkg/rad/bicep"
 	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/Azure/radius/pkg/rad/logger"
+	"github.com/Azure/radius/pkg/radclient"
 	"github.com/Azure/radius/pkg/version"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // deployCmd represents the deploy command
@@ -87,6 +93,28 @@ func deploy(cmd *cobra.Command, args []string) error {
 	logger.CompleteStep(step)
 
 	logger.LogInfo("Deployment Complete")
+
+	// Set default application if one isn't set prior.
+
+	v := viper.GetViper()
+	as, err := rad.ReadApplicationSection(v)
+
+	if as.Default == "" {
+		// no default application name set, add one.
+		applicationName, err := getApplicationName(cmd, env)
+
+		if err != nil {
+			return err
+		}
+
+		as.Default = applicationName
+		rad.UpdateApplicationSection(v, as)
+		err = saveConfig()
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -156,4 +184,25 @@ func createDeploymentClient(env *environments.AzureCloudEnvironment) (resources.
 	dc.PollingDuration = 0
 
 	return dc, nil
+}
+
+func getApplicationName(cmd *cobra.Command, env *environments.AzureCloudEnvironment) (string, error) {
+	azcred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		return "", fmt.Errorf("Failed to obtain Azure credentials: %w", err)
+	}
+	con := armcore.NewDefaultConnection(azcred, nil)
+	ac := radclient.NewApplicationClient(con, env.SubscriptionID)
+	response, err := ac.ListByResourceGroup(cmd.Context(), env.ResourceGroup, nil)
+	if err != nil {
+		return "", utils.UnwrapErrorFromRawResponse(err)
+	}
+
+	applicationsList := *response.ApplicationList
+	appList := *applicationsList.Value
+	if len(appList) < 1 {
+		return "", fmt.Errorf("No applications present after deployment")
+	}
+	resource := appList[0]
+	return *resource.Name, nil
 }

--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -98,6 +98,9 @@ func deploy(cmd *cobra.Command, args []string) error {
 
 	v := viper.GetViper()
 	as, err := rad.ReadApplicationSection(v)
+	if err != nil {
+		return err
+	}
 
 	if as.Default == "" {
 		// no default application name set, add one.

--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
+	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/azure"
 	"github.com/Azure/radius/pkg/rad/bicep"
 	"github.com/Azure/radius/pkg/rad/environments"
@@ -48,7 +49,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	env, err := requireEnvironment(cmd)
+	env, err := rad.RequireEnvironment(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
-	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/rad/azure"
 	"github.com/Azure/radius/pkg/rad/bicep"
 	"github.com/Azure/radius/pkg/rad/environments"

--- a/cmd/cli/cmd/deployment.go
+++ b/cmd/cli/cmd/deployment.go
@@ -18,7 +18,3 @@ var deploymentCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(deploymentCmd)
 }
-
-func requireDeployment(cmd *cobra.Command, args []string) (string, error) {
-	return require(cmd, args, "deployment")
-}

--- a/cmd/cli/cmd/deployment.go
+++ b/cmd/cli/cmd/deployment.go
@@ -18,3 +18,7 @@ var deploymentCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(deploymentCmd)
 }
+
+func requireDeployment(cmd *cobra.Command, args []string) (string, error) {
+	return require(cmd, args, "deployment")
+}

--- a/cmd/cli/cmd/deploymentDelete.go
+++ b/cmd/cli/cmd/deploymentDelete.go
@@ -26,7 +26,7 @@ var deploymentDeleteCmd = &cobra.Command{
 
 func init() {
 	deploymentCmd.AddCommand(deploymentDeleteCmd)
-	envDeleteCmd.Flags().BoolP("yes", "y", false, "Use this flag to prevent prompt for confirmation")
+	deploymentDeleteCmd.Flags().BoolP("yes", "y", false, "Use this flag to prevent prompt for confirmation")
 }
 
 func deleteDeployment(cmd *cobra.Command, args []string) error {

--- a/cmd/cli/cmd/deploymentDelete.go
+++ b/cmd/cli/cmd/deploymentDelete.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/radius/cmd/cli/utils"
+	"github.com/Azure/radius/pkg/rad/prompt"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
 )
@@ -25,32 +26,39 @@ var deploymentDeleteCmd = &cobra.Command{
 
 func init() {
 	deploymentCmd.AddCommand(deploymentDeleteCmd)
-
-	deploymentDeleteCmd.Flags().StringP("name", "n", "", "Deployment name")
-	if err := deploymentDeleteCmd.MarkFlagRequired("name"); err != nil {
-		fmt.Printf("Failed to mark the name flag required: %v", err)
-	}
-
-	deploymentDeleteCmd.Flags().StringP("application-name", "a", "", "Application name for the deployment")
-	if err := deploymentDeleteCmd.MarkFlagRequired("application-name"); err != nil {
-		fmt.Printf("Failed to mark the application-name flag required: %v", err)
-	}
+	envDeleteCmd.Flags().BoolP("yes", "y", false, "Use this flag to prevent prompt for confirmation")
 }
 
 func deleteDeployment(cmd *cobra.Command, args []string) error {
-	applicationName, err := cmd.Flags().GetString("application-name")
+	yes, err := cmd.Flags().GetBool("yes")
 	if err != nil {
 		return err
 	}
 
-	depName, err := cmd.Flags().GetString("name")
+	env, err := requireEnvironment(cmd)
 	if err != nil {
 		return err
 	}
 
-	env, err := validateDefaultEnvironment()
+	applicationName, err := requireApplicationNameNoArgs(cmd, env)
 	if err != nil {
 		return err
+	}
+
+	depName, err := requireDeployment(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	// Prompt user to confirm deletion
+	if !yes {
+		confirmed, err := prompt.Confirm(fmt.Sprintf("Are you sure you want to delete '%v' from '%v' [y/n]?", depName, env.Name))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return nil
+		}
 	}
 
 	azcred, err := azidentity.NewDefaultAzureCredential(nil)

--- a/cmd/cli/cmd/deploymentDelete.go
+++ b/cmd/cli/cmd/deploymentDelete.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/radius/cmd/cli/utils"
+	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/prompt"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
@@ -35,17 +36,17 @@ func deleteDeployment(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	env, err := requireEnvironment(cmd)
+	env, err := rad.RequireEnvironment(cmd)
 	if err != nil {
 		return err
 	}
 
-	applicationName, err := requireApplication(cmd, env)
+	applicationName, err := rad.RequireApplication(cmd, env)
 	if err != nil {
 		return err
 	}
 
-	depName, err := requireDeployment(cmd, args)
+	depName, err := rad.RequireDeployment(cmd, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/deploymentDelete.go
+++ b/cmd/cli/cmd/deploymentDelete.go
@@ -40,7 +40,7 @@ func deleteDeployment(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	applicationName, err := requireApplicationNameNoArgs(cmd, env)
+	applicationName, err := requireApplication(cmd, env)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/deploymentList.go
+++ b/cmd/cli/cmd/deploymentList.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/radius/cmd/cli/utils"
+	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
 )
@@ -32,12 +33,12 @@ func init() {
 }
 
 func listDeployments(cmd *cobra.Command, args []string) error {
-	env, err := requireEnvironment(cmd)
+	env, err := rad.RequireEnvironment(cmd)
 	if err != nil {
 		return err
 	}
 
-	applicationName, err := requireApplication(cmd, env)
+	applicationName, err := rad.RequireApplication(cmd, env)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/deploymentList.go
+++ b/cmd/cli/cmd/deploymentList.go
@@ -29,20 +29,15 @@ var deploymentListCmd = &cobra.Command{
 
 func init() {
 	deploymentCmd.AddCommand(deploymentListCmd)
-
-	deploymentListCmd.Flags().StringP("application-name", "a", "", "Application name")
-	if err := deploymentListCmd.MarkFlagRequired("application-name"); err != nil {
-		fmt.Printf("Failed to mark the application-name flag required: %v", err)
-	}
 }
 
 func listDeployments(cmd *cobra.Command, args []string) error {
-	applicationName, err := cmd.Flags().GetString("application-name")
+	env, err := requireEnvironment(cmd)
 	if err != nil {
 		return err
 	}
 
-	env, err := validateDefaultEnvironment()
+	applicationName, err := requireApplicationNameNoArgs(cmd, env)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/deploymentList.go
+++ b/cmd/cli/cmd/deploymentList.go
@@ -37,7 +37,7 @@ func listDeployments(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	applicationName, err := requireApplicationNameNoArgs(cmd, env)
+	applicationName, err := requireApplication(cmd, env)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/deploymentShow.go
+++ b/cmd/cli/cmd/deploymentShow.go
@@ -20,40 +20,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// deploymentGetCmd command to get details of a deployment
-var deploymentGetCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Get Radius deployment details",
-	Long:  "Get details of the specified Radius deployment deployed in the default environment",
-	RunE:  getDeployment,
+// deploymentShowCmd command to show details of a deployment
+var deploymentShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show Radius deployment details",
+	Long:  "Show details of the specified Radius deployment deployed in the default environment",
+	RunE:  showDeployment,
 }
 
 func init() {
-	deploymentCmd.AddCommand(deploymentGetCmd)
-
-	deploymentGetCmd.Flags().StringP("name", "n", "", "Deployment name")
-	if err := deploymentGetCmd.MarkFlagRequired("name"); err != nil {
-		fmt.Printf("Failed to mark the name flag required: %v", err)
-	}
-
-	deploymentGetCmd.Flags().StringP("application-name", "a", "", "Application name for the deployment")
-	if err := deploymentGetCmd.MarkFlagRequired("application-name"); err != nil {
-		fmt.Printf("Failed to mark the application-name flag required: %v", err)
-	}
+	deploymentCmd.AddCommand(deploymentShowCmd)
 }
 
-func getDeployment(cmd *cobra.Command, args []string) error {
-	applicationName, err := cmd.Flags().GetString("application-name")
+func showDeployment(cmd *cobra.Command, args []string) error {
+	env, err := requireEnvironment(cmd)
 	if err != nil {
 		return err
 	}
 
-	depName, err := cmd.Flags().GetString("name")
+	applicationName, err := requireApplicationNameNoArgs(cmd, env)
 	if err != nil {
 		return err
 	}
 
-	env, err := validateDefaultEnvironment()
+	depName, err := requireDeployment(cmd, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/deploymentShow.go
+++ b/cmd/cli/cmd/deploymentShow.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 
 	"github.com/Azure/radius/cmd/cli/utils"
+	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
 )
@@ -33,17 +34,17 @@ func init() {
 }
 
 func showDeployment(cmd *cobra.Command, args []string) error {
-	env, err := requireEnvironment(cmd)
+	env, err := rad.RequireEnvironment(cmd)
 	if err != nil {
 		return err
 	}
 
-	applicationName, err := requireApplication(cmd, env)
+	applicationName, err := rad.RequireApplication(cmd, env)
 	if err != nil {
 		return err
 	}
 
-	depName, err := requireDeployment(cmd, args)
+	depName, err := rad.RequireDeployment(cmd, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/deploymentShow.go
+++ b/cmd/cli/cmd/deploymentShow.go
@@ -38,7 +38,7 @@ func showDeployment(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	applicationName, err := requireApplicationNameNoArgs(cmd, env)
+	applicationName, err := requireApplication(cmd, env)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/env.go
+++ b/cmd/cli/cmd/env.go
@@ -6,12 +6,7 @@
 package cmd
 
 import (
-	"fmt"
-
-	"github.com/Azure/radius/pkg/rad"
-	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var envCmd = &cobra.Command{
@@ -23,56 +18,4 @@ var envCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(envCmd)
 	envCmd.PersistentFlags().StringP("environment", "e", "", "The environment name")
-}
-
-// Used by commands that require a named environment to be an azure cloud environment.
-func validateNamedEnvironment(name string) (*environments.AzureCloudEnvironment, error) {
-	v := viper.GetViper()
-	env, err := rad.ReadEnvironmentSection(v)
-	if err != nil {
-		return nil, err
-	}
-
-	e, err := env.GetEnvironment(name)
-	if err != nil {
-		return nil, err
-	}
-
-	return environments.RequireAzureCloud(e)
-}
-
-func requireEnvironment(cmd *cobra.Command) (*environments.AzureCloudEnvironment, error) {
-	environmentName, err := cmd.Flags().GetString("environment")
-	if err != nil {
-		return nil, err
-	}
-
-	env, err := validateNamedEnvironment(environmentName)
-	return env, err
-}
-
-func requireEnvironmentArgs(cmd *cobra.Command, args []string) (*environments.AzureCloudEnvironment, error) {
-	environmentName, err := requireEnvironmentNameArgs(cmd, args)
-	if err != nil {
-		return nil, err
-	}
-
-	env, err := validateNamedEnvironment(environmentName)
-	return env, err
-}
-
-func requireEnvironmentNameArgs(cmd *cobra.Command, args []string) (string, error) {
-	environmentName, err := cmd.Flags().GetString("environment")
-	if err != nil {
-		return "", err
-	}
-
-	if len(args) > 0 {
-		if environmentName != "" {
-			return "", fmt.Errorf("cannot specify environment name via both arguments and `-e`")
-		}
-		environmentName = args[0]
-	}
-
-	return environmentName, err
 }

--- a/cmd/cli/cmd/env.go
+++ b/cmd/cli/cmd/env.go
@@ -22,6 +22,7 @@ var envCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(envCmd)
+	envCmd.PersistentFlags().StringP("environment", "e", "", "The environment name")
 }
 
 // Used by commands that require a named environment to be an azure cloud environment.

--- a/cmd/cli/cmd/env.go
+++ b/cmd/cli/cmd/env.go
@@ -53,6 +53,9 @@ func requireEnvironment(cmd *cobra.Command) (*environments.AzureCloudEnvironment
 
 func requireEnvironmentArgs(cmd *cobra.Command, args []string) (*environments.AzureCloudEnvironment, error) {
 	environmentName, err := requireEnvironmentNameArgs(cmd, args)
+	if err != nil {
+		return nil, err
+	}
 
 	env, err := validateNamedEnvironment(environmentName)
 	return env, err

--- a/cmd/cli/cmd/env.go
+++ b/cmd/cli/cmd/env.go
@@ -6,7 +6,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/Azure/radius/pkg/rad"
@@ -23,26 +22,6 @@ var envCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(envCmd)
-}
-
-// Used by commands that require the current environment to be an azure cloud environment.
-func validateDefaultEnvironment() (*environments.AzureCloudEnvironment, error) {
-	v := viper.GetViper()
-	env, err := rad.ReadEnvironmentSection(v)
-	if err != nil {
-		return nil, err
-	}
-
-	if env.Default == "" {
-		return nil, errors.New("no environment set, run 'rad env switch'")
-	}
-
-	e, err := env.GetEnvironment("") // default environment
-	if err != nil {
-		return nil, err
-	}
-
-	return environments.RequireAzureCloud(e)
 }
 
 // Used by commands that require a named environment to be an azure cloud environment.

--- a/cmd/cli/cmd/env.go
+++ b/cmd/cli/cmd/env.go
@@ -51,6 +51,13 @@ func requireEnvironment(cmd *cobra.Command) (*environments.AzureCloudEnvironment
 	return env, err
 }
 
+func requireEnvironmentArgs(cmd *cobra.Command, args []string) (*environments.AzureCloudEnvironment, error) {
+	environmentName, err := requireEnvironmentNameArgs(cmd, args)
+
+	env, err := validateNamedEnvironment(environmentName)
+	return env, err
+}
+
 func requireEnvironmentNameArgs(cmd *cobra.Command, args []string) (string, error) {
 	environmentName, err := cmd.Flags().GetString("environment")
 	if err != nil {
@@ -58,12 +65,10 @@ func requireEnvironmentNameArgs(cmd *cobra.Command, args []string) (string, erro
 	}
 
 	if len(args) > 0 {
-		if args[0] != "" {
-			if environmentName != "" {
-				return "", fmt.Errorf("cannot specify environment name via both arguments and `-e`")
-			}
-			environmentName = args[0]
+		if environmentName != "" {
+			return "", fmt.Errorf("cannot specify environment name via both arguments and `-e`")
 		}
+		environmentName = args[0]
 	}
 
 	return environmentName, err

--- a/cmd/cli/cmd/env.go
+++ b/cmd/cli/cmd/env.go
@@ -7,6 +7,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/environments"
@@ -58,4 +59,32 @@ func validateNamedEnvironment(name string) (*environments.AzureCloudEnvironment,
 	}
 
 	return environments.RequireAzureCloud(e)
+}
+
+func requireEnvironment(cmd *cobra.Command) (*environments.AzureCloudEnvironment, error) {
+	environmentName, err := cmd.Flags().GetString("environment")
+	if err != nil {
+		return nil, err
+	}
+
+	env, err := validateNamedEnvironment(environmentName)
+	return env, err
+}
+
+func requireEnvironmentNameArgs(cmd *cobra.Command, args []string) (string, error) {
+	environmentName, err := cmd.Flags().GetString("environment")
+	if err != nil {
+		return "", err
+	}
+
+	if len(args) > 0 {
+		if args[0] != "" {
+			if environmentName != "" {
+				return "", fmt.Errorf("cannot specify environment name via both arguments and `-e`")
+			}
+			environmentName = args[0]
+		}
+	}
+
+	return environmentName, err
 }

--- a/cmd/cli/cmd/envDelete.go
+++ b/cmd/cli/cmd/envDelete.go
@@ -39,7 +39,7 @@ func deleteEnv(cmd *cobra.Command, args []string) error {
 	}
 
 	// Validate environment exists, retrieve associated resource group and subscription id
-	env, err := requireEnvironmentArgs(cmd, args)
+	env, err := rad.RequireEnvironmentArgs(cmd, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/envDelete.go
+++ b/cmd/cli/cmd/envDelete.go
@@ -29,11 +29,6 @@ var envDeleteCmd = &cobra.Command{
 func init() {
 	envCmd.AddCommand(envDeleteCmd)
 
-	envDeleteCmd.Flags().StringP("name", "n", "", "The environment name")
-	if err := envDeleteCmd.MarkFlagRequired("name"); err != nil {
-		panic(err)
-	}
-
 	envDeleteCmd.Flags().BoolP("yes", "y", false, "Use this flag to prevent prompt for confirmation")
 }
 
@@ -44,7 +39,7 @@ func deleteEnv(cmd *cobra.Command, args []string) error {
 	}
 
 	// Validate environment exists, retrieve associated resource group and subscription id
-	env, err := requireEnvironment(cmd)
+	env, err := requireEnvironmentArgs(cmd, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/envDelete.go
+++ b/cmd/cli/cmd/envDelete.go
@@ -38,24 +38,19 @@ func init() {
 }
 
 func deleteEnv(cmd *cobra.Command, args []string) error {
-	envName, err := cmd.Flags().GetString("name")
-	if err != nil {
-		return err
-	}
-
-	noPrompt, err := cmd.Flags().GetBool("yes")
+	yes, err := cmd.Flags().GetBool("yes")
 	if err != nil {
 		return err
 	}
 
 	// Validate environment exists, retrieve associated resource group and subscription id
-	az, err := validateNamedEnvironment(envName)
+	env, err := requireEnvironment(cmd)
 	if err != nil {
 		return err
 	}
 
-	if !noPrompt {
-		confirmed, err := prompt.Confirm(fmt.Sprintf("Resource group %s with all its resources will be deleted. Continue deleting? [y/n]?", az.ResourceGroup))
+	if !yes {
+		confirmed, err := prompt.Confirm(fmt.Sprintf("Resource group %s with all its resources will be deleted. Continue deleting? [y/n]?", env.ResourceGroup))
 		if err != nil {
 			return err
 		}
@@ -72,12 +67,12 @@ func deleteEnv(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err = deleteResourceGroup(cmd.Context(), authorizer, az.ResourceGroup, az.SubscriptionID); err != nil {
+	if err = deleteResourceGroup(cmd.Context(), authorizer, env.ResourceGroup, env.SubscriptionID); err != nil {
 		return err
 	}
 
 	// Delete env from the config, update default env if needed
-	if err = deleteEnvFromConfig(envName); err != nil {
+	if err = deleteEnvFromConfig(env.Name); err != nil {
 		return err
 	}
 

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -96,7 +96,6 @@ rad env init azure --name myenv --subscription-id SUB-ID-GUID --resource-group R
 func init() {
 	envInitCmd.AddCommand(envInitAzureCmd)
 
-	envInitAzureCmd.Flags().StringP("name", "n", "", "The environment name")
 	envInitAzureCmd.Flags().StringP("subscription-id", "s", "", "The subscription ID to use for the environment")
 	envInitAzureCmd.Flags().StringP("resource-group", "g", "", "The resource group to use for the environment")
 	envInitAzureCmd.Flags().StringP("location", "l", "", "The Azure location to use for the environment")
@@ -121,7 +120,7 @@ func validate(cmd *cobra.Command, args []string) (arguments, error) {
 		return arguments{}, err
 	}
 
-	name, err := cmd.Flags().GetString("name")
+	name, err := cmd.Flags().GetString("environment")
 	if err != nil {
 		return arguments{}, err
 	}

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -65,7 +65,7 @@ rad env init azure -i
 # Create a Radius environment using flags
 ## If an environment of the same name, resource group, and subscription
 ## already exists Radius will connect to it instead of deploying a new one.
-rad env init azure --name myenv --subscription-id SUB-ID-GUID --resource-group RG-NAME --location westus2
+rad env init azure -e myenv --subscription-id SUB-ID-GUID --resource-group RG-NAME --location westus2
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		a, err := validate(cmd, args)

--- a/cmd/cli/cmd/envMergeCredentials.go
+++ b/cmd/cli/cmd/envMergeCredentials.go
@@ -20,16 +20,7 @@ var envMergeCredentialsCmd = &cobra.Command{
 	Short: "Merge Kubernetes credentials",
 	Long:  "Merge Kubernetes credentials into your local user store. Currently only supports Azure environments",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		name, err := cmd.Flags().GetString("name")
-		if err != nil {
-			return err
-		}
-
-		// name can be empty if it wasn't provided, then we use the default environment
-		az, err := validateNamedEnvironment(name)
-		if err != nil {
-			return err
-		}
+		env, err := requireEnvironment(cmd)
 
 		isServicePrincipalConfigured, err := azure.IsServicePrincipalConfigured()
 		if err != nil {
@@ -48,7 +39,7 @@ var envMergeCredentialsCmd = &cobra.Command{
 			}
 		}
 
-		err = azcli.RunCLICommand("aks", "get-credentials", "--subscription", az.SubscriptionID, "--resource-group", az.ResourceGroup, "--name", az.ClusterName)
+		err = azcli.RunCLICommand("aks", "get-credentials", "--subscription", env.SubscriptionID, "--resource-group", env.ResourceGroup, "--name", env.ClusterName)
 		return err
 
 	},

--- a/cmd/cli/cmd/envMergeCredentials.go
+++ b/cmd/cli/cmd/envMergeCredentials.go
@@ -21,6 +21,9 @@ var envMergeCredentialsCmd = &cobra.Command{
 	Long:  "Merge Kubernetes credentials into your local user store. Currently only supports Azure environments",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		env, err := requireEnvironment(cmd)
+		if err != nil {
+			return err
+		}
 
 		isServicePrincipalConfigured, err := azure.IsServicePrincipalConfigured()
 		if err != nil {

--- a/cmd/cli/cmd/envMergeCredentials.go
+++ b/cmd/cli/cmd/envMergeCredentials.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/azcli"
 	"github.com/Azure/radius/pkg/rad/azure"
 	"github.com/spf13/cobra"
@@ -20,7 +21,7 @@ var envMergeCredentialsCmd = &cobra.Command{
 	Short: "Merge Kubernetes credentials",
 	Long:  "Merge Kubernetes credentials into your local user store. Currently only supports Azure environments",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		env, err := requireEnvironment(cmd)
+		env, err := rad.RequireEnvironment(cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/cmd/envShow.go
+++ b/cmd/cli/cmd/envShow.go
@@ -24,13 +24,10 @@ var envShowCmd = &cobra.Command{
 
 func init() {
 	envCmd.AddCommand(envShowCmd)
-
-	envShowCmd.Flags().StringP("env", "e", "", "The environment name")
 }
 
 func showEnvironment(cmd *cobra.Command, args []string) error {
-
-	envName, err := cmd.Flags().GetString("env")
+	envName, err := cmd.Flags().GetString("environment")
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/envSwitch.go
+++ b/cmd/cli/cmd/envSwitch.go
@@ -6,7 +6,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/Azure/radius/pkg/rad"
@@ -28,10 +27,6 @@ func init() {
 }
 
 func switchEnv(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return errors.New("environment name is required")
-	}
-
 	v := viper.GetViper()
 	env, err := rad.ReadEnvironmentSection(v)
 	if err != nil {
@@ -43,15 +38,15 @@ func switchEnv(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	name := args[0]
-	_, ok := env.Items[name]
+	envName, err := requireEnvironmentNameArgs(cmd, args)
+	_, ok := env.Items[envName]
 	if !ok {
-		fmt.Printf("Could not find environment %v\n", name)
+		fmt.Printf("Could not find environment %v\n", envName)
 		return nil
 	}
 
 	// Retrieve associated resource group and subscription id
-	az, err := validateNamedEnvironment(name)
+	az, err := validateNamedEnvironment(envName)
 	if err != nil {
 		return err
 	}
@@ -62,9 +57,9 @@ func switchEnv(cmd *cobra.Command, args []string) error {
 	}
 
 	logger.LogInfo("Default environment is now: %v\n\n"+
-		"%v environment is available at:\n%v\n", name, name, envUrl)
+		"%v environment is available at:\n%v\n", envName, envName, envUrl)
 
-	env.Default = name
+	env.Default = envName
 	rad.UpdateEnvironmentSection(v, env)
 	err = saveConfig()
 	if err != nil {

--- a/cmd/cli/cmd/envSwitch.go
+++ b/cmd/cli/cmd/envSwitch.go
@@ -39,6 +39,10 @@ func switchEnv(cmd *cobra.Command, args []string) error {
 	}
 
 	envName, err := requireEnvironmentNameArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
 	_, ok := env.Items[envName]
 	if !ok {
 		fmt.Printf("Could not find environment %v\n", envName)

--- a/cmd/cli/cmd/envSwitch.go
+++ b/cmd/cli/cmd/envSwitch.go
@@ -38,7 +38,7 @@ func switchEnv(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	envName, err := requireEnvironmentNameArgs(cmd, args)
+	envName, err := rad.RequireEnvironmentNameArgs(cmd, args)
 	if err != nil {
 		return err
 	}
@@ -50,7 +50,7 @@ func switchEnv(cmd *cobra.Command, args []string) error {
 	}
 
 	// Retrieve associated resource group and subscription id
-	az, err := validateNamedEnvironment(envName)
+	az, err := rad.ValidateNamedEnvironment(envName)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -46,10 +46,6 @@ func init() {
 	RootCmd.SetVersionTemplate(template)
 
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.rad/config.yaml)")
-	RootCmd.PersistentFlags().StringP("application", "a", "", "The application name")
-	RootCmd.PersistentFlags().StringP("environment", "e", "", "The environment name")
-	RootCmd.PersistentFlags().StringP("component", "c", "", "The component name")
-	RootCmd.PersistentFlags().StringP("deployment", "d", "", "The deployment name")
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -109,12 +105,10 @@ func require(cmd *cobra.Command, args []string, name string) (string, error) {
 	}
 
 	if len(args) > 0 {
-		if args[0] != "" {
-			if value != "" {
-				return "", fmt.Errorf("cannot specify %v name via both arguments and `-d`", name)
-			}
-			value = args[0]
+		if value != "" {
+			return "", fmt.Errorf("cannot specify %v name via both arguments and switch", name)
 		}
+		value = args[0]
 	}
 
 	if value == "" {

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -97,23 +97,3 @@ func saveConfig() error {
 	fmt.Printf("Successfully wrote configuration to %v\n", cfgFile)
 	return nil
 }
-
-func require(cmd *cobra.Command, args []string, name string) (string, error) {
-	value, err := cmd.Flags().GetString(name)
-	if err != nil {
-		return "", err
-	}
-
-	if len(args) > 0 {
-		if value != "" {
-			return "", fmt.Errorf("cannot specify %v name via both arguments and switch", name)
-		}
-		value = args[0]
-	}
-
-	if value == "" {
-		return "", fmt.Errorf("no %v name provided", name)
-	}
-
-	return value, nil
-}

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -46,6 +46,8 @@ func init() {
 	RootCmd.SetVersionTemplate(template)
 
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.rad/config.yaml)")
+	RootCmd.PersistentFlags().StringP("application", "a", "", "The application name")
+	RootCmd.PersistentFlags().StringP("environment", "e", "", "The environment name")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/docs/content/contributing/code/tests/running-integration-tests.md
+++ b/docs/content/contributing/code/tests/running-integration-tests.md
@@ -51,7 +51,7 @@ The tests use our product functionality (the Radius config file) to configure th
 ## Running the tests locally
 
 1. Create an environment (`rad env init azure -i`)
-2. Merge your AKS credentials to your kubeconfig (`rad env merge-credentials --name azure`)
+2. Merge your AKS credentials to your kubeconfig (`rad env merge-credentials -e azure`)
 3. Place `rad` on your path
 4. Run:
 

--- a/docs/content/environments/azure-environments/index.md
+++ b/docs/content/environments/azure-environments/index.md
@@ -89,7 +89,7 @@ If you wish to attach to an existing environment instead of deploying a new one,
 1. Use the rad CLI to delete the environment:
 
    ```bash
-   rad env delete --name azure --yes
+   rad env delete -e azure --yes
    ```
 
 ## Related links

--- a/docs/content/getting-started/tutorial/dapr-microservices/dapr-microservices-add-dapr/index.md
+++ b/docs/content/getting-started/tutorial/dapr-microservices/dapr-microservices-add-dapr/index.md
@@ -163,7 +163,7 @@ resource app 'radius.dev/Applications@v1alpha1' = {
 1. You can confirm that the new `statestore` component was deployed by running:
 
    ```sh
-   rad deployment list --application-name dapr-hello
+   rad deployment list --application dapr-hello
    ```
 
    You should see both `nodeapp` and `statestore` components in your `dapr-hello` application. Example output: 
@@ -194,7 +194,7 @@ resource app 'radius.dev/Applications@v1alpha1' = {
 1. To test out the state store, open a local tunnel on port 3000 again:
 
    ```sh
-   rad expose dapr-hello nodeapp --port 3000
+   rad component expose nodeapp --application dapr-hello --port 3000
    ```
 
 1. Visit the the URL [http://localhost:3000/order](http://localhost:3000/order) in your browser. You should see the following message:

--- a/docs/content/getting-started/tutorial/dapr-microservices/dapr-microservices-add-pythonapp/index.md
+++ b/docs/content/getting-started/tutorial/dapr-microservices/dapr-microservices-add-pythonapp/index.md
@@ -146,7 +146,7 @@ resource app 'radius.dev/Applications@v1alpha1' = {
 1. To test out the pythonapp microservice, open a local tunnel on port 3000 once more:
 
    ```sh
-   rad expose dapr-hello nodeapp --port 3000
+   rad component expose nodeapp --application dapr-hello --port 3000
    ```
 
 1. Visit [http://localhost:3000/order](http://localhost:3000/order) in your browser.

--- a/docs/content/getting-started/tutorial/dapr-microservices/dapr-microservices-initial-deployment/index.md
+++ b/docs/content/getting-started/tutorial/dapr-microservices/dapr-microservices-initial-deployment/index.md
@@ -97,7 +97,7 @@ Now you are ready to deploy the application for the first time.
 1. To test your `dapr-hello` application, open a local tunnel to your application:
 
    ```sh
-   rad expose dapr-hello nodeapp --port 3000
+   rad component expose nodeapp --application dapr-hello --port 3000
    ```
 
    {{% alert title="💡 rad expose" color="primary" %}}

--- a/docs/content/getting-started/tutorial/webapp/webapp-add-database/index.md
+++ b/docs/content/getting-started/tutorial/webapp/webapp-add-database/index.md
@@ -123,7 +123,7 @@ resource app 'radius.dev/Applications@v1alpha1' = {
 1. You can confirm that the new `db` component was deployed by running:
 
    ```sh
-   rad deployment list --application-name webapp
+   rad deployment list --application webapp
    ```
 
    You should see both `db` and `todoapp` components in your `webapp` application. Example output: 
@@ -154,7 +154,7 @@ resource app 'radius.dev/Applications@v1alpha1' = {
 1. To test the database, open a local tunnel on port 3000 again:
 
    ```sh
-   rad expose webapp todoapp --port 3000
+   rad component expose todoapp --application webapp --port 3000
    ```
 
 1. Visit the URL [http://localhost:3000](http://localhost:3000) in your browser. You should see a page like:

--- a/docs/content/getting-started/tutorial/webapp/webapp-initial-deployment/index.md
+++ b/docs/content/getting-started/tutorial/webapp/webapp-initial-deployment/index.md
@@ -99,7 +99,7 @@ Now you are ready to deploy the application for the first time.
 1. To test your `webapp` application, open a local tunnel to your application:
 
    ```sh
-   rad expose webapp todoapp --port 3000
+   rad component expose todoapp --application webapp --port 3000
    ```
 
    {{% alert title="💡 rad expose" color="primary" %}}

--- a/docs/content/reference/cli/_index.md
+++ b/docs/content/reference/cli/_index.md
@@ -13,9 +13,11 @@ Usage:
   rad [command]
 
 Available Commands:
+  application Manage applications
+  component   Manage components
   deploy      Deploy a RAD application
+  deployments Manage deployments
   env         Manage environments
-  expose      Expose local port
   help        Help about any command
 
 Flags:

--- a/examples/azure-examples/azure-keyvault/index.md
+++ b/examples/azure-examples/azure-keyvault/index.md
@@ -121,7 +121,7 @@ When you are ready to clean up and delete the resources you can delete your envi
 - The application you just deployed
 
 ```sh
-rad env delete --name azure --yes
+rad env delete -e azure --yes
 ```
 
 

--- a/examples/azure-examples/azure-servicebus/dapr-integrations/pubsub-azure-servicebus.md
+++ b/examples/azure-examples/azure-servicebus/dapr-integrations/pubsub-azure-servicebus.md
@@ -190,5 +190,5 @@ When you are ready to clean up and delete the resources you can delete your envi
 - The application you just deployed
 
 ```sh
-rad env delete --name azure --yes
+rad env delete -e azure --yes
 ```

--- a/examples/azure-examples/azure-servicebus/index.md
+++ b/examples/azure-examples/azure-servicebus/index.md
@@ -180,7 +180,7 @@ When you are ready to clean up and delete the resources you can delete your envi
 - The application you just deployed
 
 ```sh
-rad env delete --name azure --yes
+rad env delete -e azure --yes
 ```
 
 

--- a/pkg/rad/bicep/bicep.go
+++ b/pkg/rad/bicep/bicep.go
@@ -39,8 +39,8 @@ func IsBicepInstalled() (bool, error) {
 	return true, nil
 }
 
-// CleanBicep cleans our local copy of bicep
-func CleanBicep() error {
+// DeleteBicep cleans our local copy of bicep
+func DeleteBicep() error {
 	filepath, err := GetLocalBicepFilepath()
 	if err != nil {
 		return err

--- a/pkg/rad/clivalidation.go
+++ b/pkg/rad/clivalidation.go
@@ -1,0 +1,119 @@
+package rad
+
+import (
+	"fmt"
+
+	"github.com/Azure/radius/pkg/rad/environments"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// Used by commands that require a named environment to be an azure cloud environment.
+func ValidateNamedEnvironment(name string) (*environments.AzureCloudEnvironment, error) {
+	v := viper.GetViper()
+	env, err := ReadEnvironmentSection(v)
+	if err != nil {
+		return nil, err
+	}
+
+	e, err := env.GetEnvironment(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return environments.RequireAzureCloud(e)
+}
+
+func RequireEnvironment(cmd *cobra.Command) (*environments.AzureCloudEnvironment, error) {
+	environmentName, err := cmd.Flags().GetString("environment")
+	if err != nil {
+		return nil, err
+	}
+
+	env, err := ValidateNamedEnvironment(environmentName)
+	return env, err
+}
+
+func RequireEnvironmentArgs(cmd *cobra.Command, args []string) (*environments.AzureCloudEnvironment, error) {
+	environmentName, err := RequireEnvironmentNameArgs(cmd, args)
+	if err != nil {
+		return nil, err
+	}
+
+	env, err := ValidateNamedEnvironment(environmentName)
+	return env, err
+}
+
+func RequireEnvironmentNameArgs(cmd *cobra.Command, args []string) (string, error) {
+	environmentName, err := cmd.Flags().GetString("environment")
+	if err != nil {
+		return "", err
+	}
+
+	if len(args) > 0 {
+		if environmentName != "" {
+			return "", fmt.Errorf("cannot specify environment name via both arguments and `-e`")
+		}
+		environmentName = args[0]
+	}
+
+	return environmentName, err
+}
+
+func RequireApplicationArgs(cmd *cobra.Command, args []string, env *environments.AzureCloudEnvironment) (string, error) {
+	applicationName, err := cmd.Flags().GetString("application")
+	if err != nil {
+		return "", err
+	}
+
+	if len(args) > 0 {
+		if args[0] != "" {
+			if applicationName != "" {
+				return "", fmt.Errorf("cannot specify application name via both arguments and `-a`")
+			}
+			applicationName = args[0]
+		}
+	}
+
+	if applicationName == "" {
+		applicationName = env.GetDefaultApplication()
+		if applicationName == "" {
+			return "", fmt.Errorf("no application name provided and no default application set, " +
+				"either pass in an application name or set a default application by using `rad appplication switch`")
+		}
+	}
+
+	return applicationName, nil
+}
+
+func RequireApplication(cmd *cobra.Command, env *environments.AzureCloudEnvironment) (string, error) {
+	return RequireApplicationArgs(cmd, []string{}, env)
+}
+
+func RequireDeployment(cmd *cobra.Command, args []string) (string, error) {
+	return required(cmd, args, "deployment")
+}
+
+func RequireComponent(cmd *cobra.Command, args []string) (string, error) {
+	return required(cmd, args, "component")
+}
+
+func required(cmd *cobra.Command, args []string, name string) (string, error) {
+	value, err := cmd.Flags().GetString(name)
+	if err != nil {
+		return "", err
+	}
+
+	if len(args) > 0 {
+		if value != "" {
+			return "", fmt.Errorf("cannot specify %v name via both arguments and switch", name)
+		}
+		value = args[0]
+	}
+
+	if value == "" {
+		return "", fmt.Errorf("no %v name provided", name)
+	}
+
+	return value, nil
+}

--- a/pkg/rad/config.go
+++ b/pkg/rad/config.go
@@ -21,12 +21,19 @@ import (
 )
 
 // EnvironmentKey is the key used for the environment section
-const EnvironmentKey string = "environment"
+const (
+	EnvironmentKey string = "environment"
+	ApplicationKey string = "application"
+)
 
 // EnvironmentSection is the representation of the environment section of radius config.
 type EnvironmentSection struct {
 	Default string                            `mapstructure:"default" yaml:"default"`
 	Items   map[string]map[string]interface{} `mapstructure:"items" yaml:"items"`
+}
+
+type ApplicationSection struct {
+	Default string `mapstructure:"default" yaml:"default"`
 }
 
 // ReadEnvironmentSection reads the EnvironmentSection from radius config.
@@ -68,6 +75,27 @@ func (env EnvironmentSection) GetEnvironment(name string) (environments.Environm
 	}
 
 	return env.decodeEnvironmentSection(name)
+}
+
+// ReadApplictionSection reads the ApplicationSection from radius config.
+func ReadApplicationSection(v *viper.Viper) (ApplicationSection, error) {
+	s := v.Sub(ApplicationKey)
+	if s == nil {
+		return ApplicationSection{}, nil
+	}
+
+	section := ApplicationSection{}
+	err := s.UnmarshalExact(&section)
+	if err != nil {
+		return ApplicationSection{}, nil
+	}
+
+	return section, nil
+}
+
+// UpdateApplicationSection updates the ApplicationSection in radius config.
+func UpdateApplicationSection(v *viper.Viper, as ApplicationSection) {
+	v.Set(ApplicationKey, as)
 }
 
 func (env EnvironmentSection) decodeEnvironmentSection(name string) (environments.Environment, error) {

--- a/pkg/rad/config.go
+++ b/pkg/rad/config.go
@@ -93,6 +93,16 @@ func ReadApplicationSection(v *viper.Viper) (ApplicationSection, error) {
 	return section, nil
 }
 
+func GetDefaultApplicationName(v *viper.Viper) (string, error) {
+	// Get the default name
+	as, err := ReadApplicationSection(v)
+	if err != nil {
+		return "", err
+	}
+
+	return as.Default, nil
+}
+
 // UpdateApplicationSection updates the ApplicationSection in radius config.
 func UpdateApplicationSection(v *viper.Viper, as ApplicationSection) {
 	v.Set(ApplicationKey, as)

--- a/pkg/rad/config.go
+++ b/pkg/rad/config.go
@@ -77,37 +77,6 @@ func (env EnvironmentSection) GetEnvironment(name string) (environments.Environm
 	return env.decodeEnvironmentSection(name)
 }
 
-// ReadApplicationSection reads the ApplicationSection from radius config.
-func ReadApplicationSection(v *viper.Viper) (ApplicationSection, error) {
-	s := v.Sub(ApplicationKey)
-	if s == nil {
-		return ApplicationSection{}, nil
-	}
-
-	section := ApplicationSection{}
-	err := s.UnmarshalExact(&section)
-	if err != nil {
-		return ApplicationSection{}, nil
-	}
-
-	return section, nil
-}
-
-func GetDefaultApplicationName(v *viper.Viper) (string, error) {
-	// Get the default name
-	as, err := ReadApplicationSection(v)
-	if err != nil {
-		return "", err
-	}
-
-	return as.Default, nil
-}
-
-// UpdateApplicationSection updates the ApplicationSection in radius config.
-func UpdateApplicationSection(v *viper.Viper, as ApplicationSection) {
-	v.Set(ApplicationKey, as)
-}
-
 func (env EnvironmentSection) decodeEnvironmentSection(name string) (environments.Environment, error) {
 	raw, ok := env.Items[cases.Fold().String(name)]
 	if !ok {

--- a/pkg/rad/config.go
+++ b/pkg/rad/config.go
@@ -77,7 +77,7 @@ func (env EnvironmentSection) GetEnvironment(name string) (environments.Environm
 	return env.decodeEnvironmentSection(name)
 }
 
-// ReadApplictionSection reads the ApplicationSection from radius config.
+// ReadApplicationSection reads the ApplicationSection from radius config.
 func ReadApplicationSection(v *viper.Viper) (ApplicationSection, error) {
 	s := v.Sub(ApplicationKey)
 	if s == nil {

--- a/pkg/rad/config_test.go
+++ b/pkg/rad/config_test.go
@@ -178,6 +178,38 @@ environment:
 	require.Equal(t, map[string]interface{}{"extra": "testextra"}, aenv.Properties)
 }
 
+func Test_ReadApplicationSection_NoContent(t *testing.T) {
+	var yaml = ``
+
+	v, err := makeConfig(yaml)
+	require.NoError(t, err)
+
+	as, err := ReadApplicationSection(v)
+	require.NoError(t, err)
+	require.Empty(t, as.Default)
+}
+
+func Test_ReadApplicationSection_SomeItems(t *testing.T) {
+	var yaml = `
+application:
+  default: appName
+environment:
+  default: test
+  items:
+    test:
+      kind: testing
+    test2:
+      kind: testing
+`
+
+	v, err := makeConfig(yaml)
+	require.NoError(t, err)
+
+	as, err := ReadApplicationSection(v)
+	require.NoError(t, err)
+	require.Equal(t, as.Default, "appName")
+}
+
 func makeConfig(yaml string) (*viper.Viper, error) {
 	v := viper.New()
 	v.SetConfigType("YAML")

--- a/pkg/rad/config_test.go
+++ b/pkg/rad/config_test.go
@@ -178,38 +178,6 @@ environment:
 	require.Equal(t, map[string]interface{}{"extra": "testextra"}, aenv.Properties)
 }
 
-func Test_ReadApplicationSection_NoContent(t *testing.T) {
-	var yaml = ``
-
-	v, err := makeConfig(yaml)
-	require.NoError(t, err)
-
-	as, err := ReadApplicationSection(v)
-	require.NoError(t, err)
-	require.Empty(t, as.Default)
-}
-
-func Test_ReadApplicationSection_SomeItems(t *testing.T) {
-	var yaml = `
-application:
-  default: appName
-environment:
-  default: test
-  items:
-    test:
-      kind: testing
-    test2:
-      kind: testing
-`
-
-	v, err := makeConfig(yaml)
-	require.NoError(t, err)
-
-	as, err := ReadApplicationSection(v)
-	require.NoError(t, err)
-	require.Equal(t, as.Default, "appName")
-}
-
 func makeConfig(yaml string) (*viper.Viper, error) {
 	v := viper.New()
 	v.SetConfigType("YAML")

--- a/pkg/rad/environments/types.go
+++ b/pkg/rad/environments/types.go
@@ -14,15 +14,17 @@ const KindAzureCloud = "azure"
 type Environment interface {
 	GetName() string
 	GetKind() string
+	GetDefaultApplication() string
 }
 
 // AzureCloudEnvironment represents an Azure Cloud Radius environment.
 type AzureCloudEnvironment struct {
-	Name           string `mapstructure:"name" validate:"required"`
-	Kind           string `mapstructure:"kind" validate:"required"`
-	SubscriptionID string `mapstructure:"subscriptionid" validate:"required"`
-	ResourceGroup  string `mapstructure:"resourcegroup" validate:"required"`
-	ClusterName    string `mapstructure:"clustername" validate:"required"`
+	Name               string `mapstructure:"name" validate:"required"`
+	Kind               string `mapstructure:"kind" validate:"required"`
+	SubscriptionID     string `mapstructure:"subscriptionid" validate:"required"`
+	ResourceGroup      string `mapstructure:"resourcegroup" validate:"required"`
+	ClusterName        string `mapstructure:"clustername" validate:"required"`
+	DefaultApplication string `mapstructure:"defaultapplication"`
 
 	// We tolerate and allow extra fields - this helps with forwards compat.
 	Properties map[string]interface{} `mapstructure:",remain"`
@@ -36,10 +38,15 @@ func (e *AzureCloudEnvironment) GetKind() string {
 	return e.Kind
 }
 
+func (e *AzureCloudEnvironment) GetDefaultApplication() string {
+	return e.DefaultApplication
+}
+
 // GenericEnvironment represents an *unknown* kind of environment.
 type GenericEnvironment struct {
-	Name string `mapstructure:"name" validate:"required"`
-	Kind string `mapstructure:"kind" validate:"required"`
+	Name               string `mapstructure:"name" validate:"required"`
+	Kind               string `mapstructure:"kind" validate:"required"`
+	DefaultApplication string `mapstructure:"defaultapplication"`
 
 	// Capture arbitrary other properties
 	Properties map[string]interface{} `mapstructure:",remain"`
@@ -51,6 +58,10 @@ func (e *GenericEnvironment) GetName() string {
 
 func (e *GenericEnvironment) GetKind() string {
 	return e.Kind
+}
+
+func (e *GenericEnvironment) GetDefaultApplication() string {
+	return e.DefaultApplication
 }
 
 func RequireAzureCloud(e Environment) (*AzureCloudEnvironment, error) {

--- a/pkg/rad/environments/types.go
+++ b/pkg/rad/environments/types.go
@@ -9,7 +9,10 @@ import (
 	"fmt"
 )
 
-const KindAzureCloud = "azure"
+const (
+	KindAzureCloud     = "azure"
+	DefaultApplication = "defaultapplication"
+)
 
 type Environment interface {
 	GetName() string

--- a/test/utils/rad_helpers.go
+++ b/test/utils/rad_helpers.go
@@ -46,13 +46,13 @@ func RunRadApplicationDeleteCommand(applicationName, configFilePath string, time
 	// Create the command with our context
 	var cmd *exec.Cmd
 	if configFilePath == "" {
-		cmd = exec.CommandContext(ctx, "rad", "application", "delete", "-a", applicationName)
+		cmd = exec.CommandContext(ctx, "rad", "application", "delete", "--yes", "-a", applicationName)
 	} else {
 		if _, err := os.Stat(configFilePath); err != nil {
 			return fmt.Errorf("error deploying template using configfile: %s - %w", configFilePath, err)
 		}
 
-		cmd = exec.CommandContext(ctx, "rad", "application", "delete", "-a", applicationName, "--config", configFilePath)
+		cmd = exec.CommandContext(ctx, "rad", "application", "delete", "--yes", "-a", applicationName, "--config", configFilePath)
 	}
 
 	err := RunCommand(ctx, cmd)

--- a/test/utils/rad_helpers.go
+++ b/test/utils/rad_helpers.go
@@ -46,13 +46,13 @@ func RunRadApplicationDeleteCommand(applicationName, configFilePath string, time
 	// Create the command with our context
 	var cmd *exec.Cmd
 	if configFilePath == "" {
-		cmd = exec.CommandContext(ctx, "rad", "application", "delete", "--name", applicationName)
+		cmd = exec.CommandContext(ctx, "rad", "application", "delete", "-a", applicationName)
 	} else {
 		if _, err := os.Stat(configFilePath); err != nil {
 			return fmt.Errorf("error deploying template using configfile: %s - %w", configFilePath, err)
 		}
 
-		cmd = exec.CommandContext(ctx, "rad", "application", "delete", "--name", applicationName, "--config", configFilePath)
+		cmd = exec.CommandContext(ctx, "rad", "application", "delete", "-a", applicationName, "--config", configFilePath)
 	}
 
 	err := RunCommand(ctx, cmd)


### PR DESCRIPTION
Fixes https://github.com/Azure/radius/issues/348.
Fixes https://github.com/Azure/radius/issues/349.

I haven't added "add a prompt to user: "Are you sure you want to delete $application from $env?" (Y/N)" for `rad application delete` as I wanted to make sure we are okay prompting for user input without the `-i` flag. At the very least, we should add a way to bypass this without requiring user input for scripting scenarios.

I'm currently logging a message for switching like:
```
Switching default application from webapp to dapr-hello
```

Finally, is there any documentation I need to add for the new command and changes or will everything be autogenerated?