### PR TITLE
Add support for private container registry at init

### DIFF
--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -58,6 +58,20 @@
                 "description": "The name of the Managed Cluster resource."
             }
         },
+        "registryId": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The resource id of the ACR container registry"
+            }
+        },
+        "registryName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The name of the ACR container registry"
+            }
+        },
         "sku": {
             "type": "string",
             "allowedValues": [
@@ -144,9 +158,12 @@
     "variables": {
         "clusteridentityroledefinitionid": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('managedIdentityOperatorRole'))]",
         "clusteridentityroledefinitionname": "[guid(parameters('clusterName'), subscription().subscriptionId)]",
+        "registrypullroledefinitionid": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('acrPullRole'))]",
+        "registrypullroledefinitionname": "[guid(parameters('registryName'), subscription().subscriptionId)]",
         "contributorRole": "b24988ac-6180-42a0-ab88-20f7382dd24c",
         "hostingPlanName": "[concat('radius-rp-plan-', resourceGroup().name)]",
         "managedIdentityOperatorRole": "f1a07417-d97a-45cb-824c-7a7467783830",
+        "acrPullRole": "7f951dda-4ed3-4680-a7ca-43fe172d538d",
         "ownerRole": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
         "rpRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('ownerRole'))]",
         "rpRoleDefinitionName": "[guid(parameters('siteName'), subscription().subscriptionId)]",
@@ -273,6 +290,21 @@
             "roleDefinitionId": "[variables('clusterIdentityRoleDefinitionId')]",
             "scope": "[resourceGroup().id]"
           }
+        },
+        {
+            "condition": "[not(equals(parameters('registryId'), ''))]",
+            "type": "Microsoft.ContainerRegistry/registries/providers/roleAssignments",
+            "apiVersion": "2019-04-01-preview",
+            "name": "[concat(parameters('registryName'), '/Microsoft.Authorization/', variables('registrypullroledefinitionname'))]",
+            "tags": "[parameters('resourceTags')]",
+            "dependsOn": [
+                "[concat('Microsoft.ContainerService/managedClusters/', parameters('clusterName'))]"
+            ],
+            "properties": {
+                "principalId": "[reference(parameters('clusterName'), '2020-11-01').identityProfile.kubeletidentity.objectId]",
+                "principalType": "ServicePrincipal",
+                "roleDefinitionId": "[variables('registrypullroledefinitionid')]"
+            }
         },
         {
             "type": "Microsoft.Resources/deploymentScripts",

--- a/docs/content/environments/azure-environments/index.md
+++ b/docs/content/environments/azure-environments/index.md
@@ -43,6 +43,7 @@ These steps will walk through how to deploy, manage, and delete environments in 
 - [Azure subscription](https://signup.azure.com)
 - [az CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 - [rad CLI]({{< ref install-cli.md >}})
+- (optional) [create a an Azure Container Registry](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-get-started-azure-cli) to use as a private container registry
 
 ### Deploy an environment
 
@@ -65,7 +66,16 @@ While Radius environments are optimized for cost, any costs incurred by the depl
 
    This step may take up to 10 minutes to deploy.
 
-1. Verify deployment
+   {{% alert title="💡 using a private container registry" color="success" %}}
+   To use a private container registry, you can specify the registry name as part of the `rad env init azure` command. The registry must be part of the same subscription as the environment being created.
+
+   ```bash
+   rad env init azure -i --container-registry myregistry
+   ```
+
+   {{% /alert %}}
+
+2. Verify deployment
 
    To verify the environment deployment succeeded, navigate to your subscription at https://portal.azure.com. You should see a new Resource Group with the name you entered during the previous step: 
 
@@ -74,6 +84,8 @@ While Radius environments are optimized for cost, any costs incurred by the depl
    Inside you will see the [environment resources](#azure-environments) created for the environment:
 
    <img src="./azure-resources.png" width=500 alt="New resource group that was created">
+
+#### 
 
 ## Connect to an existing environment
 


### PR DESCRIPTION
This change adds support for initializing an environment with an ACR
registry as part of `rad env init azure`. This is a stopgap for 0.2 to
make ACR registries easy to use. We'll do a more thorough design pass on
this in the future and produce a more flexible and declarative approach.