### PR TITLE
Add completions to rad cli via `rad completion`

### DIFF
--- a/cmd/cli/cmd/completion.go
+++ b/cmd/cli/cmd/completion.go
@@ -56,32 +56,32 @@ var completionCommand = &cobra.Command{
 	Use:     "completion",
 	Short:   "Generates shell completion scripts",
 	Example: completionExample,
-	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
 	},
 }
 
 var completionZshCommand = &cobra.Command{
 	Use:   "zsh",
 	Short: "Generates zsh completion scripts",
-	Run: func(cmd *cobra.Command, args []string) {
-		RootCmd.GenZshCompletion(os.Stdout)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return RootCmd.GenZshCompletion(os.Stdout)
 	},
 }
 
 var completionBashCommand = &cobra.Command{
 	Use:   "bash",
 	Short: "Generates bash completion scripts",
-	Run: func(cmd *cobra.Command, args []string) {
-		RootCmd.GenBashCompletion(os.Stdout)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return RootCmd.GenBashCompletion(os.Stdout)
 	},
 }
 
 var completionPowershellCommand = &cobra.Command{
 	Use:   "powershell",
 	Short: "Generates powershell completion scripts",
-	Run: func(cmd *cobra.Command, args []string) {
-		RootCmd.GenPowerShellCompletion(os.Stdout)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return RootCmd.GenPowerShellCompletion(os.Stdout)
 	},
 }
 

--- a/cmd/cli/cmd/completion.go
+++ b/cmd/cli/cmd/completion.go
@@ -1,0 +1,93 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionExample = `
+	# Installing bash completion on macOS using homebrew
+	## If running Bash 3.2 included with macOS
+	brew install bash-completion
+	## or, if running Bash 4.1+
+	brew install bash-completion@2
+	## Add the completion to your completion directory
+	rad completion bash > $(brew --prefix)/etc/bash_completion.d/rad
+	source ~/.bash_profile
+	# Installing bash completion on Linux
+	## If bash-completion is not installed on Linux, please install the 'bash-completion' package
+	## via your distribution's package manager.
+	## Load the rad completion code for bash into the current shell
+	source <(rad completion bash)
+	## Write bash completion code to a file and source if from .bash_profile
+	rad completion bash > ~/.rad/completion.bash.inc
+	printf "
+	## rad shell completion
+	source '$HOME/.rad/completion.bash.inc'
+	" >> $HOME/.bash_profile
+	source $HOME/.bash_profile
+	# Installing zsh completion on macOS using homebrew
+	## If zsh-completion is not installed on macOS, please install the 'zsh-completion' package
+	brew install zsh-completions
+	## Set the rad completion code for zsh[1] to autoload on startup
+	rad completion zsh > "${fpath[1]}/_rad"
+	source ~/.zshrc
+	# Installing zsh completion on Linux
+	## If zsh-completion is not installed on Linux, please install the 'zsh-completion' package
+	## via your distribution's package manager.
+	## Load the rad completion code for zsh into the current shell
+	source <(rad completion zsh)
+	# Set the rad completion code for zsh[1] to autoload on startup
+	rad completion zsh > "${fpath[1]}/_rad"
+	# Installing powershell completion on Windows
+	## Create $PROFILE if it not exists
+	if (!(Test-Path -Path $PROFILE )){ New-Item -Type File -Path $PROFILE -Force }
+	## Add the completion to your profile
+	rad completion powershell >> $PROFILE
+`
+
+var completionCommand = &cobra.Command{
+	Use:     "completion",
+	Short:   "Generates shell completion scripts",
+	Example: completionExample,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+var completionZshCommand = &cobra.Command{
+	Use:   "zsh",
+	Short: "Generates zsh completion scripts",
+	Run: func(cmd *cobra.Command, args []string) {
+		RootCmd.GenZshCompletion(os.Stdout)
+	},
+}
+
+var completionBashCommand = &cobra.Command{
+	Use:   "bash",
+	Short: "Generates bash completion scripts",
+	Run: func(cmd *cobra.Command, args []string) {
+		RootCmd.GenBashCompletion(os.Stdout)
+	},
+}
+
+var completionPowershellCommand = &cobra.Command{
+	Use:   "powershell",
+	Short: "Generates powershell completion scripts",
+	Run: func(cmd *cobra.Command, args []string) {
+		RootCmd.GenPowerShellCompletion(os.Stdout)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(completionCommand)
+	completionCommand.AddCommand(completionZshCommand)
+	completionCommand.AddCommand(completionBashCommand)
+	completionCommand.AddCommand(completionPowershellCommand)
+}

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -31,6 +31,7 @@ var RootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(1)

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -31,7 +31,6 @@ var RootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(1)


### PR DESCRIPTION
Fixes https://github.com/Azure/radius/issues/256

The design I went with follows what `dapr` does today and has a top level command for completions.

![image](https://user-images.githubusercontent.com/8302101/120550482-c5c76300-c3a9-11eb-8369-ecd9f2c94fa5.png)

We could consider adding this to the installation script for radius as well.
