### PR TITLE
Add `rad version` to docs

### DIFF
--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -45,6 +45,7 @@ func init() {
 	template := fmt.Sprintf("Release: %s \nVersion: %s\nCommit: %s\n", version.Release(), version.Version(), version.Commit())
 	RootCmd.SetVersionTemplate(template)
 
+	RootCmd.Flags().BoolP("version", "v", false, "version for radius")
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.rad/config.yaml)")
 }
 

--- a/docs/content/reference/cli/_index.md
+++ b/docs/content/reference/cli/_index.md
@@ -23,6 +23,7 @@ Available Commands:
 Flags:
       --config string   config file (default is $HOME/.rad/config.yaml)
   -h, --help            help for rad
+  -v, --version         version for radius
 
 Use "rad [command] --help" for more information about a command.
 ```


### PR DESCRIPTION
Fixes https://github.com/Azure/radius/issues/319

For some reason, the version isn't generated in docs without explicitly adding it.