### PR TITLE
Add more logging where use az cli in CI

### DIFF
--- a/.github/workflows/create-environment.yaml
+++ b/.github/workflows/create-environment.yaml
@@ -108,5 +108,6 @@ jobs:
           az group delete \
             --subscription ${{ env.INTEGRATION_TEST_SUBSCRIPTION_ID }} \
             --resource-group ${{ steps.generate-resource-group-name.outputs.result }} \
-            --yes
+            --yes \
+            --verbose
           

--- a/.github/workflows/delete-environment.yaml
+++ b/.github/workflows/delete-environment.yaml
@@ -59,7 +59,8 @@ jobs:
           az group delete \
             --subscription ${{ env.INTEGRATION_TEST_SUBSCRIPTION_ID }} \
             --resource-group ${{ github.event.client_payload.environment}} \
-            --yes
+            --yes \
+            --verbose
       - name: Create issue on failure
         uses: JasonEtco/create-an-issue@v2
         if: failure()


### PR DESCRIPTION
Fixes: #457

We've encountered failures in environment create/delete that don't give
enough information to investigate. There's likely more error info
available in these cases that we can't see just from the CLI. Adding
`--debug` means the CLI will log request/response payloads.