### PR TITLE
add v0.2 to the dropdown menu for Releases on our docs site

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -61,10 +61,6 @@ version_menu = "Releases"
   url = "https://edge.radapp.dev"
 
 [[params.versions]]
-  version = "v0.1 (latest)"
-  url = "https://v01.radapp.dev"
-
-[[params.versions]]
   version = "v0.2 (latest)"
   url = "https://radapp.dev"
 

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -62,6 +62,10 @@ version_menu = "Releases"
 
 [[params.versions]]
   version = "v0.1 (latest)"
+  url = "https://v01.radapp.dev"
+
+[[params.versions]]
+  version = "v0.2 (latest)"
   url = "https://radapp.dev"
 
 # Markdown Engine - Allow inline html


### PR DESCRIPTION
We need to perform this step whenever we want there to be another option in the dropdown menu. 

This change basically reroutes https://radapp.dev from the v0.1 line to the v0.2 line. 