### PR TITLE
 Refactor CLI to separate business logic from clients

### DIFF
--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -8,15 +8,10 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/Azure/radius/pkg/rad/prompt"
-	"github.com/Azure/radius/pkg/radclient"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // appDeleteCmd command to delete an application
@@ -60,78 +55,10 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	azcred, err := azidentity.NewDefaultAzureCredential(nil)
+	client, err := environments.CreateManagementClient(env)
 	if err != nil {
-		return fmt.Errorf("failed to obtain Azure credential: %w", err)
+		return err
 	}
 
-	con := armcore.NewDefaultConnection(azcred, nil)
-
-	// Delete deployments: An application can have multiple deployments in it that should be deleted before the application can be deleted.
-	dc := radclient.NewDeploymentClient(con, env.SubscriptionID)
-
-	// Retrieve all the deployments in the application
-	response, err := dc.ListByApplication(cmd.Context(), env.ResourceGroup, applicationName, nil)
-	if err != nil {
-		return utils.UnwrapErrorFromRawResponse(err)
-	}
-
-	// Delete the deployments
-	deploymentResources := *response.DeploymentList
-	for _, deploymentResource := range *deploymentResources.Value {
-		// This is needed until server side implementation is fixed https://github.com/Azure/radius/issues/159
-		deploymentName := *deploymentResource.Name
-
-		poller, err := dc.BeginDelete(cmd.Context(), env.ResourceGroup, applicationName, deploymentName, nil)
-		if err != nil {
-			return utils.UnwrapErrorFromRawResponse(err)
-		}
-
-		_, err = poller.PollUntilDone(cmd.Context(), radclient.PollInterval)
-		if err != nil {
-			return utils.UnwrapErrorFromRawResponse(err)
-		}
-
-		fmt.Printf("Deleted deployment '%s'\n", deploymentName)
-	}
-
-	// Delete application
-	ac := radclient.NewApplicationClient(con, env.SubscriptionID)
-
-	_, err = ac.Delete(cmd.Context(), env.ResourceGroup, applicationName, nil)
-	if err != nil {
-		return utils.UnwrapErrorFromRawResponse(err)
-	}
-	fmt.Printf("Application '%s' has been deleted\n", applicationName)
-
-	err = updateApplicationConfig(cmd, env, applicationName, ac)
-	return err
-}
-
-func updateApplicationConfig(cmd *cobra.Command,
-	azureEnv *environments.AzureCloudEnvironment,
-	applicationName string,
-	ac *radclient.ApplicationClient) error {
-
-	// If the application we are deleting is the default application, remove it
-	if azureEnv.DefaultApplication == applicationName {
-		v := viper.GetViper()
-		env, err := rad.ReadEnvironmentSection(v)
-		if err != nil {
-			return err
-		}
-
-		fmt.Printf("Removing default application '%v' from environment '%v'\n", applicationName, azureEnv.Name)
-
-		env.Items[azureEnv.Name][environments.EnvironmentKeyDefaultApplication] = ""
-
-		rad.UpdateEnvironmentSection(v, env)
-
-		err = saveConfig()
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return client.DeleteApplication(cmd.Context(), applicationName)
 }

--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -60,5 +60,10 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return client.DeleteApplication(cmd.Context(), applicationName)
+	err = client.DeleteApplication(cmd.Context(), applicationName)
+	if err != nil {
+		return err
+	}
+
+	return rad.UpdateApplicationConfig(env, applicationName)
 }

--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -51,7 +51,7 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 
 	// Prompt user to confirm deletion
 	if !yes {
-		confirmed, err := prompt.Confirm(fmt.Sprintf("Are you sure you want to delete '%v' from '%v' [y/n]?", applicationName, env.Name))
+		confirmed, err := prompt.Confirm(fmt.Sprintf("Are you sure you want to delete '%v' from '%v' [y/n]?", applicationName, env.GetName()))
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -61,14 +61,10 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	response, err := client.DeleteApplication(cmd.Context(), applicationName)
-	if err != nil {
-		return err
-	}
+	deploymentList, err := client.ListDeployments(cmd.Context(), applicationName)
 
 	// Delete the deployments
-	deploymentResources := *response.DeploymentList
-	for _, deploymentResource := range *deploymentResources.Value {
+	for _, deploymentResource := range *deploymentList.Value {
 		// This is needed until server side implementation is fixed https://github.com/Azure/radius/issues/159
 		deploymentName := *deploymentResource.Name
 		err = client.DeleteDeployment(cmd.Context(), deploymentName, applicationName)
@@ -76,6 +72,11 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		fmt.Printf("Deployment '%s' deleted.\n", deploymentName)
+	}
+
+	err = client.DeleteApplication(cmd.Context(), applicationName)
+	if err != nil {
+		return err
 	}
 
 	err = updateApplicationConfig(env, applicationName)

--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -62,6 +62,9 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 	}
 
 	deploymentList, err := client.ListDeployments(cmd.Context(), applicationName)
+	if err != nil {
+		return err
+	}
 
 	// Delete the deployments
 	for _, deploymentResource := range *deploymentList.Value {

--- a/cmd/cli/cmd/appList.go
+++ b/cmd/cli/cmd/appList.go
@@ -6,6 +6,9 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
@@ -34,5 +37,17 @@ func listApplications(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return client.ListApplications(cmd.Context())
+
+	applicationList, err := client.ListApplications(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	applications, err := json.MarshalIndent(applicationList, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal application response as JSON %w", err)
+	}
+	fmt.Println(string(applications))
+
+	return nil
 }

--- a/cmd/cli/cmd/appList.go
+++ b/cmd/cli/cmd/appList.go
@@ -6,14 +6,8 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/rad"
-	"github.com/Azure/radius/pkg/radclient"
+	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
 )
 
@@ -36,23 +30,9 @@ func listApplications(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	azcred, err := azidentity.NewDefaultAzureCredential(nil)
+	client, err := environments.CreateManagementClient(env)
 	if err != nil {
-		return fmt.Errorf("failed to obtain Azure credentials: %w", err)
+		return err
 	}
-	con := armcore.NewDefaultConnection(azcred, nil)
-	ac := radclient.NewApplicationClient(con, env.SubscriptionID)
-	response, err := ac.ListByResourceGroup(cmd.Context(), env.ResourceGroup, nil)
-	if err != nil {
-		return utils.UnwrapErrorFromRawResponse(err)
-	}
-
-	applicationsList := *response.ApplicationList
-	applications, err := json.MarshalIndent(applicationsList, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal application response as JSON %w", err)
-	}
-	fmt.Println(string(applications))
-
-	return err
+	return client.ListApplications(cmd.Context())
 }

--- a/cmd/cli/cmd/appShow.go
+++ b/cmd/cli/cmd/appShow.go
@@ -6,6 +6,9 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
@@ -38,5 +41,16 @@ func showApplication(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return client.ShowApplication(cmd.Context(), applicationName)
+
+	applicationResource, err := client.ShowApplication(cmd.Context(), applicationName)
+	if err != nil {
+		return err
+	}
+	applicationDetails, err := json.MarshalIndent(applicationResource, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal application response as JSON %w", err)
+	}
+	fmt.Println(string(applicationDetails))
+
+	return err
 }

--- a/cmd/cli/cmd/appShow.go
+++ b/cmd/cli/cmd/appShow.go
@@ -6,14 +6,8 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/rad"
-	"github.com/Azure/radius/pkg/radclient"
+	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
 )
 
@@ -40,23 +34,9 @@ func showApplication(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	azcred, err := azidentity.NewDefaultAzureCredential(nil)
+	client, err := environments.CreateManagementClient(env)
 	if err != nil {
-		return fmt.Errorf("failed to obtain Azure credentials: %w", err)
+		return err
 	}
-	con := armcore.NewDefaultConnection(azcred, nil)
-	ac := radclient.NewApplicationClient(con, env.SubscriptionID)
-	response, err := ac.Get(cmd.Context(), env.ResourceGroup, applicationName, nil)
-	if err != nil {
-		return utils.UnwrapErrorFromRawResponse(err)
-	}
-
-	applicationResource := *response.ApplicationResource
-	applicationDetails, err := json.MarshalIndent(applicationResource, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal application response as JSON %w", err)
-	}
-	fmt.Println(string(applicationDetails))
-
-	return err
+	return client.ShowApplication(cmd.Context(), applicationName)
 }

--- a/cmd/cli/cmd/appSwitch.go
+++ b/cmd/cli/cmd/appSwitch.go
@@ -84,6 +84,6 @@ func switchApplications(cmd *cobra.Command, args []string) error {
 	env.Items[azureEnv.Name][environments.EnvironmentKeyDefaultApplication] = applicationName
 
 	rad.UpdateEnvironmentSection(v, env)
-	err = saveConfig()
+	err = rad.SaveConfig()
 	return err
 }

--- a/cmd/cli/cmd/componentExpose.go
+++ b/cmd/cli/cmd/componentExpose.go
@@ -6,28 +6,10 @@
 package cmd
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-	"os"
-	"os/signal"
-
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
 	"github.com/Azure/radius/pkg/rad"
-	"github.com/Azure/radius/pkg/rad/azure"
+	"github.com/Azure/radius/pkg/rad/clients"
 	"github.com/Azure/radius/pkg/rad/environments"
-	"github.com/Azure/radius/pkg/workloads"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	k8s "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/portforward"
-	"k8s.io/client-go/transport/spdy"
 )
 
 var exposeCmd = &cobra.Command{
@@ -70,47 +52,17 @@ rad component expose --application icecream-store orders --port 5000 --remote-po
 			remotePort = localPort
 		}
 
-		config, err := getMonitoringCredentials(cmd.Context(), *env)
+		client, err := environments.CreateDiagnosticsClient(env)
+
 		if err != nil {
 			return err
 		}
 
-		client, err := k8s.NewForConfig(config)
-		if err != nil {
-			return err
-		}
-
-		replica, err := getRunningReplica(cmd.Context(), client, application, component)
-		if err != nil {
-			return err
-		}
-
-		signals := make(chan os.Signal, 1)
-		signal.Notify(signals, os.Interrupt)
-		defer signal.Stop(signals)
-
-		failed := make(chan error)
-		ready := make(chan struct{})
-		stop := make(chan struct{}, 1)
-		go func() {
-			err := runPortforward(config, client, replica, ready, stop, localPort, remotePort)
-			failed <- err
-		}()
-
-		for {
-			select {
-			case <-signals:
-				// shutting down... wait for socket to close
-				close(stop)
-				continue
-			case err := <-failed:
-				if err != nil {
-					return fmt.Errorf("failed to port-forward: %w", err)
-				}
-
-				return nil
-			}
-		}
+		return client.Expose(cmd.Context(), clients.ExposeOptions{
+			Application: application,
+			Component:   component,
+			Port:        localPort,
+			RemotePort:  remotePort})
 	},
 }
 
@@ -124,89 +76,4 @@ func init() {
 	}
 
 	exposeCmd.Flags().IntP("remote-port", "r", -1, "specify the remote port")
-}
-
-func getMonitoringCredentials(ctx context.Context, env environments.AzureCloudEnvironment) (*rest.Config, error) {
-	armauth, err := azure.GetResourceManagerEndpointAuthorizer()
-	if err != nil {
-		return nil, err
-	}
-
-	// Currently we go to AKS every time to ask for credentials, we don't
-	// cache them locally. This could be done in the future, but skipping it for now
-	// since it's non-obvious that we'd store credentials in your ~/.rad directory
-	mcc := containerservice.NewManagedClustersClient(env.SubscriptionID)
-	mcc.Authorizer = armauth
-
-	results, err := mcc.ListClusterMonitoringUserCredentials(ctx, env.ResourceGroup, env.ClusterName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list AKS cluster credentials: %w", err)
-	}
-
-	if results.Kubeconfigs == nil || len(*results.Kubeconfigs) == 0 {
-		return nil, errors.New("failed to list AKS cluster credentials: response did not contain credentials")
-	}
-
-	kc := (*results.Kubeconfigs)[0]
-	c, err := clientcmd.NewClientConfigFromBytes(*kc.Value)
-	if err != nil {
-		return nil, fmt.Errorf("kubeconfig was invalid: %w", err)
-	}
-
-	restconfig, err := c.ClientConfig()
-	if err != nil {
-		return nil, fmt.Errorf("kubeconfig did not contain client credentials: %w", err)
-	}
-
-	return restconfig, nil
-}
-
-func getRunningReplica(ctx context.Context, client *k8s.Clientset, application string, component string) (*corev1.Pod, error) {
-	// Right now this connects to a pod related to a component. We can find the pods with the labels
-	// and then choose one that's in the running state.
-	pods, err := client.CoreV1().Pods(application).List(ctx, v1.ListOptions{
-		LabelSelector: labels.FormatLabels(map[string]string{workloads.LabelRadiusComponent: component}),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list running replicas for component %v: %w", component, err)
-	}
-
-	for _, p := range pods.Items {
-		if p.Status.Phase == corev1.PodRunning {
-			return &p, nil
-		}
-	}
-
-	return nil, fmt.Errorf("failed to find a running replica for component %v", component)
-}
-
-func runPortforward(restconfig *rest.Config, client *k8s.Clientset, replica *corev1.Pod, ready chan struct{}, stop <-chan struct{}, localPort int, remotePort int) error {
-	// Build URL so we can open a port-forward via SPDY
-	url := client.CoreV1().RESTClient().Post().
-		Resource("pods").
-		Namespace(replica.Namespace).
-		Name(replica.Name).
-		SubResource("portforward").URL()
-
-	transport, upgrader, err := spdy.RoundTripperFor(restconfig)
-	if err != nil {
-		return err
-	}
-
-	out := ioutil.Discard
-	errOut := ioutil.Discard
-	if true {
-		out = os.Stdout
-		errOut = os.Stderr
-	}
-
-	ports := []string{fmt.Sprintf("%d:%d", localPort, remotePort)}
-	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", url)
-
-	fw, err := portforward.NewOnAddresses(dialer, []string{"localhost"}, ports, stop, ready, out, errOut)
-	if err != nil {
-		return err
-	}
-
-	return fw.ForwardPorts()
 }

--- a/cmd/cli/cmd/componentList.go
+++ b/cmd/cli/cmd/componentList.go
@@ -6,6 +6,9 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
@@ -39,5 +42,15 @@ func listComponents(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return client.ListComponents(cmd.Context(), applicationName)
+	componentList, err := client.ListComponents(cmd.Context(), applicationName)
+	if err != nil {
+		return err
+	}
+	components, err := json.MarshalIndent(componentList, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal component response as JSON %w", err)
+	}
+
+	fmt.Println(string(components))
+	return nil
 }

--- a/cmd/cli/cmd/componentList.go
+++ b/cmd/cli/cmd/componentList.go
@@ -6,14 +6,8 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/rad"
-	"github.com/Azure/radius/pkg/radclient"
+	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
 )
 
@@ -40,25 +34,10 @@ func listComponents(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	azcred, err := azidentity.NewDefaultAzureCredential(nil)
+	client, err := environments.CreateManagementClient(env)
 	if err != nil {
-		return fmt.Errorf("failed to obtain a Azure credentials: %w", err)
-	}
-	con := armcore.NewDefaultConnection(azcred, nil)
-
-	componentClient := radclient.NewComponentClient(con, env.SubscriptionID)
-
-	response, err := componentClient.ListByApplication(cmd.Context(), env.ResourceGroup, applicationName, nil)
-	if err != nil {
-		return utils.UnwrapErrorFromRawResponse(err)
+		return err
 	}
 
-	componentsList := *response.ComponentList
-	components, err := json.MarshalIndent(componentsList, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal component response as JSON %w", err)
-	}
-	fmt.Println(string(components))
-
-	return err
+	return client.ListComponents(cmd.Context(), applicationName)
 }

--- a/cmd/cli/cmd/componentLogs.go
+++ b/cmd/cli/cmd/componentLogs.go
@@ -6,18 +6,10 @@
 package cmd
 
 import (
-	"bufio"
-	"context"
-	"fmt"
-	"io"
-	"os"
-
 	"github.com/Azure/radius/pkg/rad"
-	"github.com/Azure/radius/pkg/workloads"
+	"github.com/Azure/radius/pkg/rad/clients"
+	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
-	k8s "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 var logsCmd = &cobra.Command{
@@ -65,74 +57,16 @@ rad component logs --application icecream-store orders --container daprd`,
 			return err
 		}
 
-		config, err := getMonitoringCredentials(cmd.Context(), *env)
+		client, err := environments.CreateDiagnosticsClient(env)
 		if err != nil {
 			return err
 		}
 
-		client, err := k8s.NewForConfig(config)
-		if err != nil {
-			return err
-		}
-
-		replica, err := getRunningReplica(cmd.Context(), client, application, component)
-		if err != nil {
-			return err
-		}
-
-		if container == "" {
-			// We don't really expect this to fail, but let's do something reasonable if it does...
-			container = getAppContainerName(replica)
-			if container == "" {
-				return fmt.Errorf("failed to find the default container for component '%s'. use '--container <name>' to specify the name", component)
-			}
-		}
-
-		stream, err := streamLogs(cmd.Context(), config, client, replica, container, follow)
-		if err != nil {
-			return fmt.Errorf("failed to open log stream to %s: %w", component, err)
-		}
-		defer stream.Close()
-
-		// We can keep reading this until cancellation occurs.
-		if follow {
-			// Sending to stderr so it doesn't interfere with parsing
-			fmt.Fprintf(os.Stderr, "Streaming logs from component %s. Press CTRL+C to exit...\n", component)
-		}
-
-		hasLogs := false
-		reader := bufio.NewReader(stream)
-		for {
-			line, prefix, err := reader.ReadLine()
-			if err == context.Canceled {
-				// CTRL+C => done
-				return nil
-			} else if err == io.EOF {
-				// End of stream
-				//
-				// Output a status message to stderr if there were no logs for non-streaming
-				// so an interactive user gets *some* feedback.
-				if !follow && !hasLogs {
-					fmt.Fprintln(os.Stderr, "Component's log is currently empty.")
-				}
-
-				return nil
-			} else if err != nil {
-				return fmt.Errorf("failed to read log stream %T: %w", err, err)
-			}
-
-			hasLogs = true
-
-			// Handle the case where a partial line is returned
-			if prefix {
-				fmt.Print(string(line))
-				continue
-			}
-
-			fmt.Println(string(line))
-		}
-
-		// Unreachable
+		return client.Logs(cmd.Context(), clients.LogsOptions{
+			Application: application,
+			Component:   component,
+			Follow:      follow,
+			Container:   container})
 	},
 }
 
@@ -141,20 +75,4 @@ func init() {
 
 	logsCmd.Flags().String("container", "", "specify the container from which logs should be streamed")
 	logsCmd.Flags().BoolP("follow", "f", false, "specify that logs should be stream until the command is canceled")
-}
-
-func getAppContainerName(replica *corev1.Pod) string {
-	// The container name will be the component name
-	component := replica.Labels[workloads.LabelRadiusComponent]
-	return component
-}
-
-func streamLogs(ctx context.Context, config *rest.Config, client *k8s.Clientset, replica *corev1.Pod, container string, follow bool) (io.ReadCloser, error) {
-	options := &corev1.PodLogOptions{
-		Container: container,
-		Follow:    follow,
-	}
-
-	request := client.CoreV1().Pods(replica.Namespace).GetLogs(replica.Name, options)
-	return request.Stream(ctx)
 }

--- a/cmd/cli/cmd/componentShow.go
+++ b/cmd/cli/cmd/componentShow.go
@@ -6,6 +6,9 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
@@ -44,5 +47,16 @@ func showComponent(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return client.ShowComponent(cmd.Context(), applicationName, componentName)
+	componentResource, err := client.ShowComponent(cmd.Context(), applicationName, componentName)
+	if err != nil {
+		return err
+	}
+
+	componentDetails, err := json.MarshalIndent(componentResource, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal component response as JSON %w", err)
+	}
+	fmt.Println(string(componentDetails))
+
+	return nil
 }

--- a/cmd/cli/cmd/componentShow.go
+++ b/cmd/cli/cmd/componentShow.go
@@ -6,14 +6,8 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/rad"
-	"github.com/Azure/radius/pkg/radclient"
+	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
 )
 
@@ -45,24 +39,10 @@ func showComponent(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	azcred, err := azidentity.NewDefaultAzureCredential(nil)
+	client, err := environments.CreateManagementClient(env)
 	if err != nil {
-		return fmt.Errorf("failed to obtain a Azure credentials: %w", err)
-	}
-	con := armcore.NewDefaultConnection(azcred, nil)
-	componentClient := radclient.NewComponentClient(con, env.SubscriptionID)
-
-	response, err := componentClient.Get(cmd.Context(), env.ResourceGroup, applicationName, componentName, nil)
-	if err != nil {
-		return utils.UnwrapErrorFromRawResponse(err)
+		return err
 	}
 
-	componentResource := *response.ComponentResource
-	componentDetails, err := json.MarshalIndent(componentResource, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal component response as JSON %w", err)
-	}
-	fmt.Println(string(componentDetails))
-
-	return err
+	return client.ShowComponent(cmd.Context(), applicationName, componentName)
 }

--- a/cmd/cli/cmd/deploymentList.go
+++ b/cmd/cli/cmd/deploymentList.go
@@ -6,17 +6,8 @@
 package cmd
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"net/http"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/rad"
-	"github.com/Azure/radius/pkg/radclient"
+	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
 )
 
@@ -43,31 +34,10 @@ func listDeployments(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	azcred, err := azidentity.NewDefaultAzureCredential(nil)
+	client, err := environments.CreateManagementClient(env)
 	if err != nil {
-		return fmt.Errorf("failed to obtain Azure credentials: %w", err)
-	}
-	con := armcore.NewDefaultConnection(azcred, nil)
-	dc := radclient.NewDeploymentClient(con, env.SubscriptionID)
-
-	response, err := dc.ListByApplication(cmd.Context(), env.ResourceGroup, applicationName, nil)
-	if err != nil {
-		var httpresp azcore.HTTPResponse
-		if ok := errors.As(err, &httpresp); ok && httpresp.RawResponse().StatusCode == http.StatusNotFound {
-			errorMessage := fmt.Sprintf("application '%s' was not found in the resource group '%s'", applicationName, env.ResourceGroup)
-			return radclient.NewRadiusError("ResourceNotFound", errorMessage)
-		}
-
-		return utils.UnwrapErrorFromRawResponse(err)
+		return err
 	}
 
-	deploymentsList := *response.DeploymentList
-	deployments, err := json.MarshalIndent(deploymentsList, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal deployment response as JSON %w", err)
-	}
-
-	fmt.Println(string(deployments))
-
-	return err
+	return client.ListDeployments(cmd.Context(), applicationName)
 }

--- a/cmd/cli/cmd/deploymentList.go
+++ b/cmd/cli/cmd/deploymentList.go
@@ -6,6 +6,9 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
@@ -39,5 +42,17 @@ func listDeployments(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return client.ListDeployments(cmd.Context(), applicationName)
+	deploymentList, err := client.ListDeployments(cmd.Context(), applicationName)
+	if err != nil {
+		return err
+	}
+
+	deployments, err := json.MarshalIndent(deploymentList, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal deployment response as JSON %w", err)
+	}
+
+	fmt.Println(string(deployments))
+
+	return nil
 }

--- a/cmd/cli/cmd/deploymentShow.go
+++ b/cmd/cli/cmd/deploymentShow.go
@@ -6,18 +6,8 @@
 package cmd
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"net/http"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-
-	"github.com/Azure/radius/cmd/cli/utils"
 	"github.com/Azure/radius/pkg/rad"
-	"github.com/Azure/radius/pkg/radclient"
+	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
 )
 
@@ -44,36 +34,15 @@ func showDeployment(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	depName, err := rad.RequireDeployment(cmd, args)
+	deploymentName, err := rad.RequireDeployment(cmd, args)
 	if err != nil {
 		return err
 	}
 
-	azcred, err := azidentity.NewDefaultAzureCredential(nil)
+	client, err := environments.CreateManagementClient(env)
 	if err != nil {
-		return fmt.Errorf("failed to obtain Azure credentials: %w", err)
-	}
-	con := armcore.NewDefaultConnection(azcred, nil)
-	dc := radclient.NewDeploymentClient(con, env.SubscriptionID)
-
-	response, err := dc.Get(cmd.Context(), env.ResourceGroup, applicationName, depName, nil)
-	if err != nil {
-		var httpresp azcore.HTTPResponse
-		if ok := errors.As(err, &httpresp); ok && httpresp.RawResponse().StatusCode == http.StatusNotFound {
-			errorMessage := fmt.Sprintf("deployment '%s' for application '%s' and resource group '%s' was not found", depName, applicationName, env.ResourceGroup)
-			return radclient.NewRadiusError("ResourceNotFound", errorMessage)
-		}
-
-		return utils.UnwrapErrorFromRawResponse(err)
+		return err
 	}
 
-	deploymentResource := *response.DeploymentResource
-	deploymentDetails, err := json.MarshalIndent(deploymentResource, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal deployment response as JSON %w", err)
-	}
-
-	fmt.Println(string(deploymentDetails))
-
-	return err
+	return client.ShowDeployment(cmd.Context(), deploymentName, applicationName)
 }

--- a/cmd/cli/cmd/deploymentShow.go
+++ b/cmd/cli/cmd/deploymentShow.go
@@ -6,6 +6,9 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
@@ -44,5 +47,16 @@ func showDeployment(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return client.ShowDeployment(cmd.Context(), deploymentName, applicationName)
+	deploymentResource, err := client.ShowDeployment(cmd.Context(), deploymentName, applicationName)
+	if err != nil {
+		return err
+	}
+
+	deploymentDetails, err := json.MarshalIndent(deploymentResource, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal deployment response as JSON %w", err)
+	}
+
+	fmt.Println(string(deploymentDetails))
+	return nil
 }

--- a/cmd/cli/cmd/envDelete.go
+++ b/cmd/cli/cmd/envDelete.go
@@ -127,7 +127,7 @@ func deleteEnvFromConfig(envName string) error {
 		}
 	}
 	rad.UpdateEnvironmentSection(v, env)
-	if err = saveConfig(); err != nil {
+	if err = rad.SaveConfig(); err != nil {
 		return err
 	}
 

--- a/cmd/cli/cmd/envDelete.go
+++ b/cmd/cli/cmd/envDelete.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/radius/pkg/rad"
+	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/Azure/radius/pkg/rad/logger"
 	"github.com/Azure/radius/pkg/rad/prompt"
 	"github.com/spf13/cobra"
@@ -44,8 +45,13 @@ func deleteEnv(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	az, err := environments.RequireAzureCloud(env)
+	if err != nil {
+		return err
+	}
+
 	if !yes {
-		confirmed, err := prompt.Confirm(fmt.Sprintf("Resource group %s with all its resources will be deleted. Continue deleting? [y/n]?", env.ResourceGroup))
+		confirmed, err := prompt.Confirm(fmt.Sprintf("Resource group %s with all its resources will be deleted. Continue deleting? [y/n]?", az.ResourceGroup))
 		if err != nil {
 			return err
 		}
@@ -62,12 +68,12 @@ func deleteEnv(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err = deleteResourceGroup(cmd.Context(), authorizer, env.ResourceGroup, env.SubscriptionID); err != nil {
+	if err = deleteResourceGroup(cmd.Context(), authorizer, az.ResourceGroup, az.SubscriptionID); err != nil {
 		return err
 	}
 
 	// Delete env from the config, update default env if needed
-	if err = deleteEnvFromConfig(env.Name); err != nil {
+	if err = deleteEnvFromConfig(az.Name); err != nil {
 		return err
 	}
 

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -627,7 +627,7 @@ func storeEnvironment(ctx context.Context, authorizer autorest.Authorizer, name 
 	}
 	rad.UpdateEnvironmentSection(v, env)
 
-	err = saveConfig()
+	err = rad.SaveConfig()
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/envInitLocal.go
+++ b/cmd/cli/cmd/envInitLocal.go
@@ -30,7 +30,7 @@ var envInitLocalCmd = &cobra.Command{
 		}
 		rad.UpdateEnvironmentSection(v, env)
 
-		err = saveConfig()
+		err = rad.SaveConfig()
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/cmd/envMergeCredentials.go
+++ b/cmd/cli/cmd/envMergeCredentials.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/azcli"
 	"github.com/Azure/radius/pkg/rad/azure"
+	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
 )
 
@@ -43,7 +44,12 @@ var envMergeCredentialsCmd = &cobra.Command{
 			}
 		}
 
-		err = azcli.RunCLICommand("aks", "get-credentials", "--subscription", env.SubscriptionID, "--resource-group", env.ResourceGroup, "--name", env.ClusterName)
+		az, err := environments.RequireAzureCloud(env)
+		if err != nil {
+			return err
+		}
+
+		err = azcli.RunCLICommand("aks", "get-credentials", "--subscription", az.SubscriptionID, "--resource-group", az.ResourceGroup, "--name", az.ClusterName)
 		return err
 
 	},

--- a/cmd/cli/cmd/envSwitch.go
+++ b/cmd/cli/cmd/envSwitch.go
@@ -67,7 +67,7 @@ func switchEnv(cmd *cobra.Command, args []string) error {
 
 	section.Default = envName
 	rad.UpdateEnvironmentSection(v, section)
-	err = saveConfig()
+	err = rad.SaveConfig()
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/envSwitch.go
+++ b/cmd/cli/cmd/envSwitch.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/Azure/radius/pkg/rad"
-	"github.com/Azure/radius/pkg/rad/azure"
 	"github.com/Azure/radius/pkg/rad/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -28,12 +27,12 @@ func init() {
 
 func switchEnv(cmd *cobra.Command, args []string) error {
 	v := viper.GetViper()
-	env, err := rad.ReadEnvironmentSection(v)
+	section, err := rad.ReadEnvironmentSection(v)
 	if err != nil {
 		return err
 	}
 
-	if len(env.Items) == 0 {
+	if len(section.Items) == 0 {
 		fmt.Println("No environments found. Use 'rad env init' to initialize.")
 		return nil
 	}
@@ -43,28 +42,31 @@ func switchEnv(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	_, ok := env.Items[envName]
+	_, ok := section.Items[envName]
 	if !ok {
 		fmt.Printf("Could not find environment %v\n", envName)
 		return nil
 	}
 
 	// Retrieve associated resource group and subscription id
-	az, err := rad.ValidateNamedEnvironment(envName)
+	env, err := rad.ValidateNamedEnvironment(envName)
 	if err != nil {
 		return err
 	}
 
-	envUrl, err := azure.GenerateAzureEnvUrl(az.SubscriptionID, az.ResourceGroup)
-	if err != nil {
-		return err
+	status := env.GetStatusLink()
+	var text string
+	if status == "" {
+		text = fmt.Sprintf("Default environment is now: %v\n", envName)
+	} else {
+		text = fmt.Sprintf("Default environment is now: %v\n\n"+
+			"%v environment is available at:\n%v\n", envName, envName, status)
 	}
 
-	logger.LogInfo("Default environment is now: %v\n\n"+
-		"%v environment is available at:\n%v\n", envName, envName, envUrl)
+	logger.LogInfo(text)
 
-	env.Default = envName
-	rad.UpdateEnvironmentSection(v, env)
+	section.Default = envName
+	rad.UpdateEnvironmentSection(v, section)
 	err = saveConfig()
 	if err != nil {
 		return err

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -33,7 +33,7 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
+	cobra.OnInitialize(rad.InitConfig)
 
 	// Initialize support for --version
 	RootCmd.Version = version.Release()
@@ -42,8 +42,4 @@ func init() {
 
 	RootCmd.Flags().BoolP("version", "v", false, "version for radius")
 	RootCmd.PersistentFlags().StringVar(&rad.CfgFile, "config", "", "config file (default is $HOME/.rad/config.yaml)")
-}
-
-func initConfig() {
-	rad.InitConfig()
 }

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -8,16 +8,11 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path"
 
+	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/version"
 	"github.com/spf13/cobra"
-
-	homedir "github.com/mitchellh/go-homedir"
-	"github.com/spf13/viper"
 )
-
-var cfgFile string
 
 // RootCmd is the root command of the rad CLI. This is exported so we can generate docs for it.
 var RootCmd = &cobra.Command{
@@ -46,55 +41,9 @@ func init() {
 	RootCmd.SetVersionTemplate(template)
 
 	RootCmd.Flags().BoolP("version", "v", false, "version for radius")
-	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.rad/config.yaml)")
+	RootCmd.PersistentFlags().StringVar(&rad.CfgFile, "config", "", "config file (default is $HOME/.rad/config.yaml)")
 }
 
-// initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// Find home directory.
-		home, err := homedir.Dir()
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
-		rad := path.Join(home, ".rad")
-		viper.AddConfigPath(rad)
-		viper.SetConfigName("config")
-	}
-
-	// If a config file is found, read it in.
-	err := viper.ReadInConfig()
-	if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-		home, err := homedir.Dir()
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
-		// Set the default config file so we can write to it if desired
-		cfgFile = path.Join(home, ".rad", "config.yaml")
-	} else if err == nil {
-		cfgFile = viper.ConfigFileUsed()
-	}
-}
-
-func saveConfig() error {
-	dir := path.Dir(cfgFile)
-	_, err := os.Stat(dir)
-	if os.IsNotExist(err) {
-		_ = os.MkdirAll(dir, os.ModeDir|0755)
-	}
-
-	err = viper.WriteConfigAs(cfgFile)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("Successfully wrote configuration to %v\n", cfgFile)
-	return nil
+	rad.InitConfig()
 }

--- a/pkg/rad/azure/deployment.go
+++ b/pkg/rad/azure/deployment.go
@@ -1,0 +1,56 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package azure
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
+	"github.com/Azure/radius/pkg/rad/clients"
+	"github.com/google/uuid"
+)
+
+type ARMDeploymentClient struct {
+	ResourceGroup  string
+	SubscriptionID string
+	Client         resources.DeploymentsClient
+}
+
+var _ clients.DeploymentClient = (*ARMDeploymentClient)(nil)
+
+func (dc *ARMDeploymentClient) Deploy(ctx context.Context, content string) error {
+	template := map[string]interface{}{}
+	err := json.Unmarshal([]byte(content), &template)
+	if err != nil {
+		return err
+	}
+
+	name := fmt.Sprintf("rad-deploy-%v", uuid.New().String())
+	op, err := dc.Client.CreateOrUpdate(ctx, dc.ResourceGroup, name, resources.Deployment{
+		Properties: &resources.DeploymentProperties{
+			Template:   template,
+			Parameters: map[string]interface{}{},
+			Mode:       resources.Incremental,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	err = op.WaitForCompletionRef(ctx, dc.Client.Client)
+	if err != nil {
+		return err
+	}
+
+	_, err = op.Result(dc.Client)
+	if err != nil {
+		return err
+	}
+
+	return err
+}

--- a/pkg/rad/azure/diagnostics.go
+++ b/pkg/rad/azure/diagnostics.go
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package azure
+
+import (
+	"context"
+
+	"github.com/Azure/radius/pkg/rad/clients"
+)
+
+type ARMDiagnosticsClient struct {
+}
+
+var _ clients.DiagnosticsClient = (*ARMDiagnosticsClient)(nil)
+
+func (dc *ARMDiagnosticsClient) Expose(ctx context.Context, options clients.ExposeOptions) error {
+	return nil
+}
+
+func (dc *ARMDiagnosticsClient) Logs(ctx context.Context, options clients.LogsOptions) error {
+	return nil
+}

--- a/pkg/rad/azure/diagnostics.go
+++ b/pkg/rad/azure/diagnostics.go
@@ -6,20 +6,195 @@
 package azure
 
 import (
+	"bufio"
 	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/signal"
 
 	"github.com/Azure/radius/pkg/rad/clients"
+	"github.com/Azure/radius/pkg/workloads"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
 )
 
 type ARMDiagnosticsClient struct {
+	Client     *k8s.Clientset
+	RestConfig *rest.Config
 }
 
 var _ clients.DiagnosticsClient = (*ARMDiagnosticsClient)(nil)
 
 func (dc *ARMDiagnosticsClient) Expose(ctx context.Context, options clients.ExposeOptions) error {
-	return nil
+	replica, err := getRunningReplica(ctx, dc.Client, options.Application, options.Component)
+	if err != nil {
+		return err
+	}
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt)
+	defer signal.Stop(signals)
+
+	failed := make(chan error)
+	ready := make(chan struct{})
+	stop := make(chan struct{}, 1)
+	go func() {
+		err := runPortforward(dc.RestConfig, dc.Client, replica, ready, stop, options.Port, options.RemotePort)
+		failed <- err
+	}()
+
+	for {
+		select {
+		case <-signals:
+			// shutting down... wait for socket to close
+			close(stop)
+			continue
+		case err := <-failed:
+			if err != nil {
+				return fmt.Errorf("failed to port-forward: %w", err)
+			}
+
+			return nil
+		}
+	}
 }
 
 func (dc *ARMDiagnosticsClient) Logs(ctx context.Context, options clients.LogsOptions) error {
-	return nil
+	component := options.Component
+
+	replica, err := getRunningReplica(ctx, dc.Client, options.Application, component)
+
+	if err != nil {
+		return err
+	}
+
+	follow := options.Follow
+	container := options.Container
+	if container == "" {
+		// We don't really expect this to fail, but let's do something reasonable if it does...
+		container = getAppContainerName(replica)
+		if container == "" {
+			return fmt.Errorf("failed to find the default container for component '%s'. use '--container <name>' to specify the name", component)
+		}
+	}
+
+	stream, err := streamLogs(ctx, dc.RestConfig, dc.Client, replica, container, follow)
+	if err != nil {
+		return fmt.Errorf("failed to open log stream to %s: %w", component, err)
+	}
+	defer stream.Close()
+
+	// We can keep reading this until cancellation occurs.
+	if follow {
+		// Sending to stderr so it doesn't interfere with parsing
+		fmt.Fprintf(os.Stderr, "Streaming logs from component %s. Press CTRL+C to exit...\n", component)
+	}
+
+	hasLogs := false
+	reader := bufio.NewReader(stream)
+	for {
+		line, prefix, err := reader.ReadLine()
+		if err == context.Canceled {
+			// CTRL+C => done
+			return nil
+		} else if err == io.EOF {
+			// End of stream
+			//
+			// Output a status message to stderr if there were no logs for non-streaming
+			// so an interactive user gets *some* feedback.
+			if !follow && !hasLogs {
+				fmt.Fprintln(os.Stderr, "Component's log is currently empty.")
+			}
+
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("failed to read log stream %T: %w", err, err)
+		}
+
+		hasLogs = true
+
+		// Handle the case where a partial line is returned
+		if prefix {
+			fmt.Print(string(line))
+			continue
+		}
+
+		fmt.Println(string(line))
+	}
+
+	// Unreachable
+}
+
+func getRunningReplica(ctx context.Context, client *k8s.Clientset, application string, component string) (*corev1.Pod, error) {
+	// Right now this connects to a pod related to a component. We can find the pods with the labels
+	// and then choose one that's in the running state.
+	pods, err := client.CoreV1().Pods(application).List(ctx, v1.ListOptions{
+		LabelSelector: labels.FormatLabels(map[string]string{workloads.LabelRadiusComponent: component}),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list running replicas for component %v: %w", component, err)
+	}
+
+	for _, p := range pods.Items {
+		if p.Status.Phase == corev1.PodRunning {
+			return &p, nil
+		}
+	}
+
+	return nil, fmt.Errorf("failed to find a running replica for component %v", component)
+}
+
+func runPortforward(restconfig *rest.Config, client *k8s.Clientset, replica *corev1.Pod, ready chan struct{}, stop <-chan struct{}, localPort int, remotePort int) error {
+	// Build URL so we can open a port-forward via SPDY
+	url := client.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace(replica.Namespace).
+		Name(replica.Name).
+		SubResource("portforward").URL()
+
+	transport, upgrader, err := spdy.RoundTripperFor(restconfig)
+	if err != nil {
+		return err
+	}
+
+	out := ioutil.Discard
+	errOut := ioutil.Discard
+	if true {
+		out = os.Stdout
+		errOut = os.Stderr
+	}
+
+	ports := []string{fmt.Sprintf("%d:%d", localPort, remotePort)}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", url)
+
+	fw, err := portforward.NewOnAddresses(dialer, []string{"localhost"}, ports, stop, ready, out, errOut)
+	if err != nil {
+		return err
+	}
+
+	return fw.ForwardPorts()
+}
+
+func getAppContainerName(replica *corev1.Pod) string {
+	// The container name will be the component name
+	component := replica.Labels[workloads.LabelRadiusComponent]
+	return component
+}
+
+func streamLogs(ctx context.Context, config *rest.Config, client *k8s.Clientset, replica *corev1.Pod, container string, follow bool) (io.ReadCloser, error) {
+	options := &corev1.PodLogOptions{
+		Container: container,
+		Follow:    follow,
+	}
+
+	request := client.CoreV1().Pods(replica.Namespace).GetLogs(replica.Name, options)
+	return request.Stream(ctx)
 }

--- a/pkg/rad/azure/management.go
+++ b/pkg/rad/azure/management.go
@@ -7,7 +7,6 @@ package azure
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -29,41 +28,27 @@ type ARMManagementClient struct {
 
 var _ clients.ManagementClient = (*ARMManagementClient)(nil)
 
-func (dm *ARMManagementClient) ListApplications(ctx context.Context) error {
+func (dm *ARMManagementClient) ListApplications(ctx context.Context) (*radclient.ApplicationList, error) {
 	ac := radclient.NewApplicationClient(dm.Connection, dm.SubscriptionID)
 	response, err := ac.ListByResourceGroup(ctx, dm.ResourceGroup, nil)
 	if err != nil {
-		return utils.UnwrapErrorFromRawResponse(err)
+		return nil, utils.UnwrapErrorFromRawResponse(err)
 	}
 
-	applicationsList := *response.ApplicationList
-	applications, err := json.MarshalIndent(applicationsList, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal application response as JSON %w", err)
-	}
-	fmt.Println(string(applications))
-
-	return nil
+	return response.ApplicationList, nil
 }
 
-func (dm *ARMManagementClient) ShowApplication(ctx context.Context, applicationName string) error {
+func (dm *ARMManagementClient) ShowApplication(ctx context.Context, applicationName string) (*radclient.ApplicationResource, error) {
 	ac := radclient.NewApplicationClient(dm.Connection, dm.SubscriptionID)
 	response, err := ac.Get(ctx, dm.ResourceGroup, applicationName, nil)
 	if err != nil {
-		return utils.UnwrapErrorFromRawResponse(err)
+		return nil, utils.UnwrapErrorFromRawResponse(err)
 	}
 
-	applicationResource := *response.ApplicationResource
-	applicationDetails, err := json.MarshalIndent(applicationResource, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal application response as JSON %w", err)
-	}
-	fmt.Println(string(applicationDetails))
-
-	return nil
+	return response.ApplicationResource, err
 }
 
-func (dm *ARMManagementClient) DeleteApplication(ctx context.Context, applicationName string) error {
+func (dm *ARMManagementClient) DeleteApplication(ctx context.Context, applicationName string) (*radclient.DeploymentListResponse, error) {
 
 	// Delete deployments: An application can have multiple deployments in it that should be deleted before the application can be deleted.
 	dc := radclient.NewDeploymentClient(dm.Connection, dm.SubscriptionID)
@@ -71,26 +56,7 @@ func (dm *ARMManagementClient) DeleteApplication(ctx context.Context, applicatio
 	// Retrieve all the deployments in the application
 	response, err := dc.ListByApplication(ctx, dm.ResourceGroup, applicationName, nil)
 	if err != nil {
-		return utils.UnwrapErrorFromRawResponse(err)
-	}
-
-	// Delete the deployments
-	deploymentResources := *response.DeploymentList
-	for _, deploymentResource := range *deploymentResources.Value {
-		// This is needed until server side implementation is fixed https://github.com/Azure/radius/issues/159
-		deploymentName := *deploymentResource.Name
-
-		poller, err := dc.BeginDelete(ctx, dm.ResourceGroup, applicationName, deploymentName, nil)
-		if err != nil {
-			return utils.UnwrapErrorFromRawResponse(err)
-		}
-
-		_, err = poller.PollUntilDone(ctx, radclient.PollInterval)
-		if err != nil {
-			return utils.UnwrapErrorFromRawResponse(err)
-		}
-
-		fmt.Printf("Deleted deployment '%s'\n", deploymentName)
+		return nil, utils.UnwrapErrorFromRawResponse(err)
 	}
 
 	// Delete application
@@ -98,46 +64,31 @@ func (dm *ARMManagementClient) DeleteApplication(ctx context.Context, applicatio
 
 	_, err = ac.Delete(ctx, dm.ResourceGroup, applicationName, nil)
 	if err != nil {
-		return utils.UnwrapErrorFromRawResponse(err)
+		return nil, utils.UnwrapErrorFromRawResponse(err)
 	}
-	fmt.Printf("Application '%s' has been deleted\n", applicationName)
-	return err
+
+	return &response, err
 }
 
-func (dm *ARMManagementClient) ListComponents(ctx context.Context, applicationName string) error {
+func (dm *ARMManagementClient) ListComponents(ctx context.Context, applicationName string) (*radclient.ComponentList, error) {
 	componentClient := radclient.NewComponentClient(dm.Connection, dm.SubscriptionID)
 
 	response, err := componentClient.ListByApplication(ctx, dm.ResourceGroup, applicationName, nil)
 	if err != nil {
-		return utils.UnwrapErrorFromRawResponse(err)
+		return nil, utils.UnwrapErrorFromRawResponse(err)
 	}
-
-	componentsList := *response.ComponentList
-	components, err := json.MarshalIndent(componentsList, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal component response as JSON %w", err)
-	}
-	fmt.Println(string(components))
-
-	return err
+	return response.ComponentList, err
 }
 
-func (dm *ARMManagementClient) ShowComponent(ctx context.Context, applicationName string, componentName string) error {
+func (dm *ARMManagementClient) ShowComponent(ctx context.Context, applicationName string, componentName string) (*radclient.ComponentResource, error) {
 	componentClient := radclient.NewComponentClient(dm.Connection, dm.SubscriptionID)
 
 	response, err := componentClient.Get(ctx, dm.ResourceGroup, applicationName, componentName, nil)
 	if err != nil {
-		return utils.UnwrapErrorFromRawResponse(err)
+		return nil, utils.UnwrapErrorFromRawResponse(err)
 	}
 
-	componentResource := *response.ComponentResource
-	componentDetails, err := json.MarshalIndent(componentResource, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal component response as JSON %w", err)
-	}
-	fmt.Println(string(componentDetails))
-
-	return err
+	return response.ComponentResource, err
 }
 
 func (dm *ARMManagementClient) DeleteDeployment(ctx context.Context, deploymentName string, applicationName string) error {
@@ -151,12 +102,10 @@ func (dm *ARMManagementClient) DeleteDeployment(ctx context.Context, deploymentN
 	if err != nil {
 		return utils.UnwrapErrorFromRawResponse(err)
 	}
-
-	fmt.Printf("Deployment '%s' deleted.\n", deploymentName)
 	return err
 }
 
-func (dm *ARMManagementClient) ListDeployments(ctx context.Context, applicationName string) error {
+func (dm *ARMManagementClient) ListDeployments(ctx context.Context, applicationName string) (*radclient.DeploymentList, error) {
 
 	dc := radclient.NewDeploymentClient(dm.Connection, dm.SubscriptionID)
 
@@ -165,24 +114,16 @@ func (dm *ARMManagementClient) ListDeployments(ctx context.Context, applicationN
 		var httpresp azcore.HTTPResponse
 		if ok := errors.As(err, &httpresp); ok && httpresp.RawResponse().StatusCode == http.StatusNotFound {
 			errorMessage := fmt.Sprintf("application '%s' was not found in the resource group '%s'", applicationName, dm.ResourceGroup)
-			return radclient.NewRadiusError("ResourceNotFound", errorMessage)
+			return nil, radclient.NewRadiusError("ResourceNotFound", errorMessage)
 		}
 
-		return utils.UnwrapErrorFromRawResponse(err)
+		return nil, utils.UnwrapErrorFromRawResponse(err)
 	}
 
-	deploymentsList := *response.DeploymentList
-	deployments, err := json.MarshalIndent(deploymentsList, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal deployment response as JSON %w", err)
-	}
-
-	fmt.Println(string(deployments))
-
-	return err
+	return response.DeploymentList, err
 }
 
-func (dm *ARMManagementClient) ShowDeployment(ctx context.Context, deploymentName string, applicationName string) error {
+func (dm *ARMManagementClient) ShowDeployment(ctx context.Context, deploymentName string, applicationName string) (*radclient.DeploymentResource, error) {
 	dc := radclient.NewDeploymentClient(dm.Connection, dm.SubscriptionID)
 
 	response, err := dc.Get(ctx, dm.ResourceGroup, applicationName, deploymentName, nil)
@@ -190,18 +131,11 @@ func (dm *ARMManagementClient) ShowDeployment(ctx context.Context, deploymentNam
 		var httpresp azcore.HTTPResponse
 		if ok := errors.As(err, &httpresp); ok && httpresp.RawResponse().StatusCode == http.StatusNotFound {
 			errorMessage := fmt.Sprintf("deployment '%s' for application '%s' and resource group '%s' was not found", deploymentName, applicationName, dm.ResourceGroup)
-			return radclient.NewRadiusError("ResourceNotFound", errorMessage)
+			return nil, radclient.NewRadiusError("ResourceNotFound", errorMessage)
 		}
 
-		return utils.UnwrapErrorFromRawResponse(err)
+		return nil, utils.UnwrapErrorFromRawResponse(err)
 	}
 
-	deploymentResource := *response.DeploymentResource
-	deploymentDetails, err := json.MarshalIndent(deploymentResource, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal deployment response as JSON %w", err)
-	}
-
-	fmt.Println(string(deploymentDetails))
-	return err
+	return response.DeploymentResource, err
 }

--- a/pkg/rad/azure/management.go
+++ b/pkg/rad/azure/management.go
@@ -5,9 +5,206 @@
 
 package azure
 
-import "github.com/Azure/radius/pkg/rad/clients"
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/radius/cmd/cli/utils"
+	"github.com/Azure/radius/pkg/rad/clients"
+	"github.com/Azure/radius/pkg/radclient"
+)
 
 type ARMManagementClient struct {
+	AzCred         *azidentity.ChainedTokenCredential
+	Connection     *armcore.Connection
+	ResourceGroup  string
+	SubscriptionID string
 }
 
 var _ clients.ManagementClient = (*ARMManagementClient)(nil)
+
+func (dm *ARMManagementClient) ListApplications(ctx context.Context) error {
+	ac := radclient.NewApplicationClient(dm.Connection, dm.SubscriptionID)
+	response, err := ac.ListByResourceGroup(ctx, dm.ResourceGroup, nil)
+	if err != nil {
+		return utils.UnwrapErrorFromRawResponse(err)
+	}
+
+	applicationsList := *response.ApplicationList
+	applications, err := json.MarshalIndent(applicationsList, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal application response as JSON %w", err)
+	}
+	fmt.Println(string(applications))
+
+	return nil
+}
+
+func (dm *ARMManagementClient) ShowApplication(ctx context.Context, applicationName string) error {
+	ac := radclient.NewApplicationClient(dm.Connection, dm.SubscriptionID)
+	response, err := ac.Get(ctx, dm.ResourceGroup, applicationName, nil)
+	if err != nil {
+		return utils.UnwrapErrorFromRawResponse(err)
+	}
+
+	applicationResource := *response.ApplicationResource
+	applicationDetails, err := json.MarshalIndent(applicationResource, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal application response as JSON %w", err)
+	}
+	fmt.Println(string(applicationDetails))
+
+	return nil
+}
+
+func (dm *ARMManagementClient) DeleteApplication(ctx context.Context, applicationName string) error {
+
+	// Delete deployments: An application can have multiple deployments in it that should be deleted before the application can be deleted.
+	dc := radclient.NewDeploymentClient(dm.Connection, dm.SubscriptionID)
+
+	// Retrieve all the deployments in the application
+	response, err := dc.ListByApplication(ctx, dm.ResourceGroup, applicationName, nil)
+	if err != nil {
+		return utils.UnwrapErrorFromRawResponse(err)
+	}
+
+	// Delete the deployments
+	deploymentResources := *response.DeploymentList
+	for _, deploymentResource := range *deploymentResources.Value {
+		// This is needed until server side implementation is fixed https://github.com/Azure/radius/issues/159
+		deploymentName := *deploymentResource.Name
+
+		poller, err := dc.BeginDelete(ctx, dm.ResourceGroup, applicationName, deploymentName, nil)
+		if err != nil {
+			return utils.UnwrapErrorFromRawResponse(err)
+		}
+
+		_, err = poller.PollUntilDone(ctx, radclient.PollInterval)
+		if err != nil {
+			return utils.UnwrapErrorFromRawResponse(err)
+		}
+
+		fmt.Printf("Deleted deployment '%s'\n", deploymentName)
+	}
+
+	// Delete application
+	ac := radclient.NewApplicationClient(dm.Connection, dm.SubscriptionID)
+
+	_, err = ac.Delete(ctx, dm.ResourceGroup, applicationName, nil)
+	if err != nil {
+		return utils.UnwrapErrorFromRawResponse(err)
+	}
+	fmt.Printf("Application '%s' has been deleted\n", applicationName)
+
+	// TODO
+	// return dm.updateApplicationConfig(applicationName, ac)
+	return nil
+}
+
+func (dm *ARMManagementClient) ListComponents(ctx context.Context, applicationName string) error {
+	componentClient := radclient.NewComponentClient(dm.Connection, dm.SubscriptionID)
+
+	response, err := componentClient.ListByApplication(ctx, dm.ResourceGroup, applicationName, nil)
+	if err != nil {
+		return utils.UnwrapErrorFromRawResponse(err)
+	}
+
+	componentsList := *response.ComponentList
+	components, err := json.MarshalIndent(componentsList, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal component response as JSON %w", err)
+	}
+	fmt.Println(string(components))
+
+	return err
+}
+
+func (dm *ARMManagementClient) ShowComponent(ctx context.Context, applicationName string, componentName string) error {
+	componentClient := radclient.NewComponentClient(dm.Connection, dm.SubscriptionID)
+
+	response, err := componentClient.Get(ctx, dm.ResourceGroup, applicationName, componentName, nil)
+	if err != nil {
+		return utils.UnwrapErrorFromRawResponse(err)
+	}
+
+	componentResource := *response.ComponentResource
+	componentDetails, err := json.MarshalIndent(componentResource, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal component response as JSON %w", err)
+	}
+	fmt.Println(string(componentDetails))
+
+	return err
+}
+
+func (dm *ARMManagementClient) DeleteDeployment(ctx context.Context, deploymentName string, applicationName string) error {
+	dc := radclient.NewDeploymentClient(dm.Connection, dm.SubscriptionID)
+	poller, err := dc.BeginDelete(ctx, dm.ResourceGroup, applicationName, deploymentName, nil)
+	if err != nil {
+		return utils.UnwrapErrorFromRawResponse(err)
+	}
+
+	_, err = poller.PollUntilDone(ctx, radclient.PollInterval)
+	if err != nil {
+		return utils.UnwrapErrorFromRawResponse(err)
+	}
+
+	fmt.Printf("Deployment '%s' deleted.\n", deploymentName)
+	return err
+}
+
+func (dm *ARMManagementClient) ListDeployments(ctx context.Context, applicationName string) error {
+
+	dc := radclient.NewDeploymentClient(dm.Connection, dm.SubscriptionID)
+
+	response, err := dc.ListByApplication(ctx, dm.ResourceGroup, applicationName, nil)
+	if err != nil {
+		var httpresp azcore.HTTPResponse
+		if ok := errors.As(err, &httpresp); ok && httpresp.RawResponse().StatusCode == http.StatusNotFound {
+			errorMessage := fmt.Sprintf("application '%s' was not found in the resource group '%s'", applicationName, dm.ResourceGroup)
+			return radclient.NewRadiusError("ResourceNotFound", errorMessage)
+		}
+
+		return utils.UnwrapErrorFromRawResponse(err)
+	}
+
+	deploymentsList := *response.DeploymentList
+	deployments, err := json.MarshalIndent(deploymentsList, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal deployment response as JSON %w", err)
+	}
+
+	fmt.Println(string(deployments))
+
+	return err
+}
+
+func (dm *ARMManagementClient) ShowDeployment(ctx context.Context, deploymentName string, applicationName string) error {
+	dc := radclient.NewDeploymentClient(dm.Connection, dm.SubscriptionID)
+
+	response, err := dc.Get(ctx, dm.ResourceGroup, applicationName, deploymentName, nil)
+	if err != nil {
+		var httpresp azcore.HTTPResponse
+		if ok := errors.As(err, &httpresp); ok && httpresp.RawResponse().StatusCode == http.StatusNotFound {
+			errorMessage := fmt.Sprintf("deployment '%s' for application '%s' and resource group '%s' was not found", deploymentName, applicationName, dm.ResourceGroup)
+			return radclient.NewRadiusError("ResourceNotFound", errorMessage)
+		}
+
+		return utils.UnwrapErrorFromRawResponse(err)
+	}
+
+	deploymentResource := *response.DeploymentResource
+	deploymentDetails, err := json.MarshalIndent(deploymentResource, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal deployment response as JSON %w", err)
+	}
+
+	fmt.Println(string(deploymentDetails))
+	return err
+}

--- a/pkg/rad/azure/management.go
+++ b/pkg/rad/azure/management.go
@@ -48,26 +48,16 @@ func (dm *ARMManagementClient) ShowApplication(ctx context.Context, applicationN
 	return response.ApplicationResource, err
 }
 
-func (dm *ARMManagementClient) DeleteApplication(ctx context.Context, applicationName string) (*radclient.DeploymentListResponse, error) {
-
-	// Delete deployments: An application can have multiple deployments in it that should be deleted before the application can be deleted.
-	dc := radclient.NewDeploymentClient(dm.Connection, dm.SubscriptionID)
-
-	// Retrieve all the deployments in the application
-	response, err := dc.ListByApplication(ctx, dm.ResourceGroup, applicationName, nil)
-	if err != nil {
-		return nil, utils.UnwrapErrorFromRawResponse(err)
-	}
-
+func (dm *ARMManagementClient) DeleteApplication(ctx context.Context, applicationName string) error {
 	// Delete application
 	ac := radclient.NewApplicationClient(dm.Connection, dm.SubscriptionID)
 
-	_, err = ac.Delete(ctx, dm.ResourceGroup, applicationName, nil)
+	_, err := ac.Delete(ctx, dm.ResourceGroup, applicationName, nil)
 	if err != nil {
-		return nil, utils.UnwrapErrorFromRawResponse(err)
+		return utils.UnwrapErrorFromRawResponse(err)
 	}
 
-	return &response, err
+	return err
 }
 
 func (dm *ARMManagementClient) ListComponents(ctx context.Context, applicationName string) (*radclient.ComponentList, error) {

--- a/pkg/rad/azure/management.go
+++ b/pkg/rad/azure/management.go
@@ -101,10 +101,7 @@ func (dm *ARMManagementClient) DeleteApplication(ctx context.Context, applicatio
 		return utils.UnwrapErrorFromRawResponse(err)
 	}
 	fmt.Printf("Application '%s' has been deleted\n", applicationName)
-
-	// TODO
-	// return dm.updateApplicationConfig(applicationName, ac)
-	return nil
+	return err
 }
 
 func (dm *ARMManagementClient) ListComponents(ctx context.Context, applicationName string) error {

--- a/pkg/rad/azure/management.go
+++ b/pkg/rad/azure/management.go
@@ -1,0 +1,13 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package azure
+
+import "github.com/Azure/radius/pkg/rad/clients"
+
+type ARMManagementClient struct {
+}
+
+var _ clients.ManagementClient = (*ARMManagementClient)(nil)

--- a/pkg/rad/clients/clients.go
+++ b/pkg/rad/clients/clients.go
@@ -30,8 +30,20 @@ type ExposeOptions struct {
 type LogsOptions struct {
 	Application string
 	Component   string
+	Follow      bool
+	Container   string
 }
 
 // ManagementClient is used to interface with management features like listing applications and components.
 type ManagementClient interface {
+	ListApplications(ctx context.Context) error
+	ShowApplication(ctx context.Context, applicationName string) error
+	DeleteApplication(ctx context.Context, applicationName string) error
+
+	ListComponents(ctx context.Context, applicationName string) error
+	ShowComponent(ctx context.Context, applicationName string, componentName string) error
+
+	ListDeployments(ctx context.Context, applicationName string) error
+	ShowDeployment(ctx context.Context, deploymentName string, applicationName string) error
+	DeleteDeployment(ctx context.Context, deploymentName string, applicationName string) error
 }

--- a/pkg/rad/clients/clients.go
+++ b/pkg/rad/clients/clients.go
@@ -7,6 +7,10 @@ package clients
 
 import (
 	"context"
+	"io"
+	"os"
+
+	"github.com/Azure/radius/pkg/radclient"
 )
 
 // DeploymentClient is used to deploy ARM-JSON templates (compiled Bicep output).
@@ -16,8 +20,8 @@ type DeploymentClient interface {
 
 // DiagnosticsClient is used to interface with diagnostics features like logs and port-forwards.
 type DiagnosticsClient interface {
-	Expose(ctx context.Context, options ExposeOptions) error
-	Logs(ctx context.Context, options LogsOptions) error
+	Expose(ctx context.Context, options ExposeOptions) (failed chan error, stop chan struct{}, signals chan os.Signal, err error)
+	Logs(ctx context.Context, options LogsOptions) (io.ReadCloser, error)
 }
 
 type ExposeOptions struct {
@@ -36,14 +40,14 @@ type LogsOptions struct {
 
 // ManagementClient is used to interface with management features like listing applications and components.
 type ManagementClient interface {
-	ListApplications(ctx context.Context) error
-	ShowApplication(ctx context.Context, applicationName string) error
-	DeleteApplication(ctx context.Context, applicationName string) error
+	ListApplications(ctx context.Context) (*radclient.ApplicationList, error)
+	ShowApplication(ctx context.Context, applicationName string) (*radclient.ApplicationResource, error)
+	DeleteApplication(ctx context.Context, applicationName string) (*radclient.DeploymentListResponse, error)
 
-	ListComponents(ctx context.Context, applicationName string) error
-	ShowComponent(ctx context.Context, applicationName string, componentName string) error
+	ListComponents(ctx context.Context, applicationName string) (*radclient.ComponentList, error)
+	ShowComponent(ctx context.Context, applicationName string, componentName string) (*radclient.ComponentResource, error)
 
-	ListDeployments(ctx context.Context, applicationName string) error
-	ShowDeployment(ctx context.Context, deploymentName string, applicationName string) error
+	ListDeployments(ctx context.Context, applicationName string) (*radclient.DeploymentList, error)
+	ShowDeployment(ctx context.Context, deploymentName string, applicationName string) (*radclient.DeploymentResource, error)
 	DeleteDeployment(ctx context.Context, deploymentName string, applicationName string) error
 }

--- a/pkg/rad/clients/clients.go
+++ b/pkg/rad/clients/clients.go
@@ -1,0 +1,37 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package clients
+
+import (
+	"context"
+)
+
+// DeploymentClient is used to deploy ARM-JSON templates (compiled Bicep output).
+type DeploymentClient interface {
+	Deploy(ctx context.Context, content string) error
+}
+
+// DiagnosticsClient is used to interface with diagnostics features like logs and port-forwards.
+type DiagnosticsClient interface {
+	Expose(ctx context.Context, options ExposeOptions) error
+	Logs(ctx context.Context, options LogsOptions) error
+}
+
+type ExposeOptions struct {
+	Application string
+	Component   string
+	Port        int
+	RemotePort  int
+}
+
+type LogsOptions struct {
+	Application string
+	Component   string
+}
+
+// ManagementClient is used to interface with management features like listing applications and components.
+type ManagementClient interface {
+}

--- a/pkg/rad/clients/clients.go
+++ b/pkg/rad/clients/clients.go
@@ -42,7 +42,7 @@ type LogsOptions struct {
 type ManagementClient interface {
 	ListApplications(ctx context.Context) (*radclient.ApplicationList, error)
 	ShowApplication(ctx context.Context, applicationName string) (*radclient.ApplicationResource, error)
-	DeleteApplication(ctx context.Context, applicationName string) (*radclient.DeploymentListResponse, error)
+	DeleteApplication(ctx context.Context, applicationName string) error
 
 	ListComponents(ctx context.Context, applicationName string) (*radclient.ComponentList, error)
 	ShowComponent(ctx context.Context, applicationName string, componentName string) (*radclient.ComponentResource, error)

--- a/pkg/rad/clivalidation.go
+++ b/pkg/rad/clivalidation.go
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
 package rad
 
 import (
@@ -9,7 +14,7 @@ import (
 )
 
 // Used by commands that require a named environment to be an azure cloud environment.
-func ValidateNamedEnvironment(name string) (*environments.AzureCloudEnvironment, error) {
+func ValidateNamedEnvironment(name string) (environments.Environment, error) {
 	v := viper.GetViper()
 	env, err := ReadEnvironmentSection(v)
 	if err != nil {
@@ -21,10 +26,10 @@ func ValidateNamedEnvironment(name string) (*environments.AzureCloudEnvironment,
 		return nil, err
 	}
 
-	return environments.RequireAzureCloud(e)
+	return e, nil
 }
 
-func RequireEnvironment(cmd *cobra.Command) (*environments.AzureCloudEnvironment, error) {
+func RequireEnvironment(cmd *cobra.Command) (environments.Environment, error) {
 	environmentName, err := cmd.Flags().GetString("environment")
 	if err != nil {
 		return nil, err
@@ -34,7 +39,7 @@ func RequireEnvironment(cmd *cobra.Command) (*environments.AzureCloudEnvironment
 	return env, err
 }
 
-func RequireEnvironmentArgs(cmd *cobra.Command, args []string) (*environments.AzureCloudEnvironment, error) {
+func RequireEnvironmentArgs(cmd *cobra.Command, args []string) (environments.Environment, error) {
 	environmentName, err := RequireEnvironmentNameArgs(cmd, args)
 	if err != nil {
 		return nil, err
@@ -60,7 +65,7 @@ func RequireEnvironmentNameArgs(cmd *cobra.Command, args []string) (string, erro
 	return environmentName, err
 }
 
-func RequireApplicationArgs(cmd *cobra.Command, args []string, env *environments.AzureCloudEnvironment) (string, error) {
+func RequireApplicationArgs(cmd *cobra.Command, args []string, env environments.Environment) (string, error) {
 	applicationName, err := cmd.Flags().GetString("application")
 	if err != nil {
 		return "", err
@@ -86,7 +91,7 @@ func RequireApplicationArgs(cmd *cobra.Command, args []string, env *environments
 	return applicationName, nil
 }
 
-func RequireApplication(cmd *cobra.Command, env *environments.AzureCloudEnvironment) (string, error) {
+func RequireApplication(cmd *cobra.Command, env environments.Environment) (string, error) {
 	return RequireApplicationArgs(cmd, []string{}, env)
 }
 

--- a/pkg/rad/config.go
+++ b/pkg/rad/config.go
@@ -132,32 +132,29 @@ func SaveConfig() error {
 	return nil
 }
 
-// func UpdateApplicationConfig(applicationName string,
-// 	ac *radclient.ApplicationClient) error {
+func UpdateApplicationConfig(env environments.Environment, applicationName string) error {
+	// If the application we are deleting is the default application, remove it
+	if env.GetDefaultApplication() == applicationName {
+		v := viper.GetViper()
+		envSection, err := ReadEnvironmentSection(v)
+		if err != nil {
+			return err
+		}
 
-// 	// If the application we are deleting is the default application, remove it
-// 	if dm.Environment.DefaultApplication == applicationName {
-// 		v := viper.GetViper()
-// 		env, err := rad.ReadEnvironmentSection(v)
-// 		if err != nil {
-// 			return err
-// 		}
+		fmt.Printf("Removing default application '%v' from environment '%v'\n", applicationName, env.GetName())
 
-// 		fmt.Printf("Removing default application '%v' from environment '%v'\n", applicationName, dm.Environment.Name)
+		envSection.Items[env.GetName()][environments.EnvironmentKeyDefaultApplication] = ""
 
-// 		env.Items[dm.Environment.Name][environments.EnvironmentKeyDefaultApplication] = ""
+		UpdateEnvironmentSection(v, envSection)
 
-// 		rad.UpdateEnvironmentSection(v, env)
+		err = SaveConfig()
+		if err != nil {
+			return err
+		}
+	}
 
-// 		err = rad.SaveConfig()
-// 		if err != nil {
-// 			return err
-// 		}
-// 	}
-
-// 	return nil
-// }
-
+	return nil
+}
 func (env EnvironmentSection) decodeEnvironmentSection(name string) (environments.Environment, error) {
 	raw, ok := env.Items[cases.Fold().String(name)]
 	if !ok {

--- a/pkg/rad/config.go
+++ b/pkg/rad/config.go
@@ -8,6 +8,8 @@ package rad
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path"
 	"strings"
 
 	"github.com/Azure/radius/pkg/rad/environments"
@@ -15,10 +17,13 @@ import (
 	ut "github.com/go-playground/universal-translator"
 	validator "github.com/go-playground/validator/v10"
 	en_translations "github.com/go-playground/validator/v10/translations/en"
+	"github.com/mitchellh/go-homedir"
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
 	"golang.org/x/text/cases"
 )
+
+var CfgFile string
 
 // EnvironmentKey is the key used for the environment section
 const (
@@ -76,6 +81,82 @@ func (env EnvironmentSection) GetEnvironment(name string) (environments.Environm
 
 	return env.decodeEnvironmentSection(name)
 }
+
+// initConfig reads in config file and ENV variables if set.
+func InitConfig() {
+	if CfgFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(CfgFile)
+	} else {
+		// Find home directory.
+		home, err := homedir.Dir()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		rad := path.Join(home, ".rad")
+		viper.AddConfigPath(rad)
+		viper.SetConfigName("config")
+	}
+
+	// If a config file is found, read it in.
+	err := viper.ReadInConfig()
+	if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+		home, err := homedir.Dir()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		// Set the default config file so we can write to it if desired
+		CfgFile = path.Join(home, ".rad", "config.yaml")
+	} else if err == nil {
+		CfgFile = viper.ConfigFileUsed()
+	}
+}
+
+func SaveConfig() error {
+	dir := path.Dir(CfgFile)
+	_, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		_ = os.MkdirAll(dir, os.ModeDir|0755)
+	}
+
+	err = viper.WriteConfigAs(CfgFile)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Successfully wrote configuration to %v\n", CfgFile)
+	return nil
+}
+
+// func UpdateApplicationConfig(applicationName string,
+// 	ac *radclient.ApplicationClient) error {
+
+// 	// If the application we are deleting is the default application, remove it
+// 	if dm.Environment.DefaultApplication == applicationName {
+// 		v := viper.GetViper()
+// 		env, err := rad.ReadEnvironmentSection(v)
+// 		if err != nil {
+// 			return err
+// 		}
+
+// 		fmt.Printf("Removing default application '%v' from environment '%v'\n", applicationName, dm.Environment.Name)
+
+// 		env.Items[dm.Environment.Name][environments.EnvironmentKeyDefaultApplication] = ""
+
+// 		rad.UpdateEnvironmentSection(v, env)
+
+// 		err = rad.SaveConfig()
+// 		if err != nil {
+// 			return err
+// 		}
+// 	}
+
+// 	return nil
+// }
 
 func (env EnvironmentSection) decodeEnvironmentSection(name string) (environments.Environment, error) {
 	raw, ok := env.Items[cases.Fold().String(name)]

--- a/pkg/rad/config.go
+++ b/pkg/rad/config.go
@@ -132,29 +132,6 @@ func SaveConfig() error {
 	return nil
 }
 
-func UpdateApplicationConfig(env environments.Environment, applicationName string) error {
-	// If the application we are deleting is the default application, remove it
-	if env.GetDefaultApplication() == applicationName {
-		v := viper.GetViper()
-		envSection, err := ReadEnvironmentSection(v)
-		if err != nil {
-			return err
-		}
-
-		fmt.Printf("Removing default application '%v' from environment '%v'\n", applicationName, env.GetName())
-
-		envSection.Items[env.GetName()][environments.EnvironmentKeyDefaultApplication] = ""
-
-		UpdateEnvironmentSection(v, envSection)
-
-		err = SaveConfig()
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
 func (env EnvironmentSection) decodeEnvironmentSection(name string) (environments.Environment, error) {
 	raw, ok := env.Items[cases.Fold().String(name)]
 	if !ok {

--- a/pkg/rad/environments/azure.go
+++ b/pkg/rad/environments/azure.go
@@ -1,0 +1,89 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package environments
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
+	"github.com/Azure/radius/pkg/rad/azure"
+	"github.com/Azure/radius/pkg/rad/clients"
+)
+
+func RequireAzureCloud(e Environment) (*AzureCloudEnvironment, error) {
+	az, ok := e.(*AzureCloudEnvironment)
+	if !ok {
+		return nil, fmt.Errorf("an '%v' environment is required but the kind was '%v'", KindAzureCloud, e.GetKind())
+	}
+
+	return az, nil
+}
+
+// AzureCloudEnvironment represents an Azure Cloud Radius environment.
+type AzureCloudEnvironment struct {
+	Name               string `mapstructure:"name" validate:"required"`
+	Kind               string `mapstructure:"kind" validate:"required"`
+	SubscriptionID     string `mapstructure:"subscriptionid" validate:"required"`
+	ResourceGroup      string `mapstructure:"resourcegroup" validate:"required"`
+	ClusterName        string `mapstructure:"clustername" validate:"required"`
+	DefaultApplication string `mapstructure:"defaultapplication,omitempty"`
+
+	// We tolerate and allow extra fields - this helps with forwards compat.
+	Properties map[string]interface{} `mapstructure:",remain"`
+}
+
+func (e *AzureCloudEnvironment) GetName() string {
+	return e.Name
+}
+
+func (e *AzureCloudEnvironment) GetKind() string {
+	return e.Kind
+}
+
+func (e *AzureCloudEnvironment) GetDefaultApplication() string {
+	return e.DefaultApplication
+}
+
+func (e *AzureCloudEnvironment) GetStatusLink() string {
+	// If there's a problem generating the status link, we don't want to fail noisily, just skip the link.
+	url, err := azure.GenerateAzureEnvUrl(e.SubscriptionID, e.ResourceGroup)
+	if err != nil {
+		return ""
+	}
+
+	return url
+}
+
+func (e *AzureCloudEnvironment) CreateDeploymentClient() (clients.DeploymentClient, error) {
+	dc := resources.NewDeploymentsClient(e.SubscriptionID)
+	armauth, err := azure.GetResourceManagerEndpointAuthorizer()
+	if err != nil {
+		return nil, err
+	}
+
+	dc.Authorizer = armauth
+
+	// Poll faster than the default, many deployments are quick
+	dc.PollingDelay = 5 * time.Second
+
+	// Don't timeout, let the user cancel
+	dc.PollingDuration = 0
+
+	return &azure.ARMDeploymentClient{
+		Client:         dc,
+		SubscriptionID: e.SubscriptionID,
+		ResourceGroup:  e.ResourceGroup,
+	}, nil
+}
+
+func (e *AzureCloudEnvironment) CreateDiagnosticsClient() (clients.DiagnosticsClient, error) {
+	return &azure.ARMDiagnosticsClient{}, nil
+}
+
+func (e *AzureCloudEnvironment) CreateManagementClient() (clients.ManagementClient, error) {
+	return &azure.ARMManagementClient{}, nil
+}

--- a/pkg/rad/environments/generic.go
+++ b/pkg/rad/environments/generic.go
@@ -1,0 +1,32 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package environments
+
+// GenericEnvironment represents an *unknown* kind of environment.
+type GenericEnvironment struct {
+	Name               string `mapstructure:"name" validate:"required"`
+	Kind               string `mapstructure:"kind" validate:"required"`
+	DefaultApplication string `mapstructure:"defaultapplication,omitempty"`
+
+	// Capture arbitrary other properties
+	Properties map[string]interface{} `mapstructure:",remain"`
+}
+
+func (e *GenericEnvironment) GetName() string {
+	return e.Name
+}
+
+func (e *GenericEnvironment) GetKind() string {
+	return e.Kind
+}
+
+func (e *GenericEnvironment) GetDefaultApplication() string {
+	return e.DefaultApplication
+}
+
+func (e *GenericEnvironment) GetStatusLink() string {
+	return ""
+}

--- a/pkg/rad/environments/types.go
+++ b/pkg/rad/environments/types.go
@@ -7,6 +7,8 @@ package environments
 
 import (
 	"fmt"
+
+	"github.com/Azure/radius/pkg/rad/clients"
 )
 
 const (
@@ -18,60 +20,46 @@ type Environment interface {
 	GetName() string
 	GetKind() string
 	GetDefaultApplication() string
+
+	// GetStatusLink provides an optional URL for display of the environment.
+	GetStatusLink() string
 }
 
-// AzureCloudEnvironment represents an Azure Cloud Radius environment.
-type AzureCloudEnvironment struct {
-	Name               string `mapstructure:"name" validate:"required"`
-	Kind               string `mapstructure:"kind" validate:"required"`
-	SubscriptionID     string `mapstructure:"subscriptionid" validate:"required"`
-	ResourceGroup      string `mapstructure:"resourcegroup" validate:"required"`
-	ClusterName        string `mapstructure:"clustername" validate:"required"`
-	DefaultApplication string `mapstructure:"defaultapplication,omitempty"`
-
-	// We tolerate and allow extra fields - this helps with forwards compat.
-	Properties map[string]interface{} `mapstructure:",remain"`
+type DeploymentEnvironment interface {
+	CreateDeploymentClient() (clients.DeploymentClient, error)
 }
 
-func (e *AzureCloudEnvironment) GetName() string {
-	return e.Name
-}
-
-func (e *AzureCloudEnvironment) GetKind() string {
-	return e.Kind
-}
-
-func (e *AzureCloudEnvironment) GetDefaultApplication() string {
-	return e.DefaultApplication
-}
-
-// GenericEnvironment represents an *unknown* kind of environment.
-type GenericEnvironment struct {
-	Name               string `mapstructure:"name" validate:"required"`
-	Kind               string `mapstructure:"kind" validate:"required"`
-	DefaultApplication string `mapstructure:"defaultapplication,omitempty"`
-
-	// Capture arbitrary other properties
-	Properties map[string]interface{} `mapstructure:",remain"`
-}
-
-func (e *GenericEnvironment) GetName() string {
-	return e.Name
-}
-
-func (e *GenericEnvironment) GetKind() string {
-	return e.Kind
-}
-
-func (e *GenericEnvironment) GetDefaultApplication() string {
-	return e.DefaultApplication
-}
-
-func RequireAzureCloud(e Environment) (*AzureCloudEnvironment, error) {
-	az, ok := e.(*AzureCloudEnvironment)
+func CreateDeploymentClient(env Environment) (clients.DeploymentClient, error) {
+	de, ok := env.(DeploymentEnvironment)
 	if !ok {
-		return nil, fmt.Errorf("an '%v' environment is required but the kind was '%v'", KindAzureCloud, e.GetKind())
+		return nil, fmt.Errorf("an environment of kind '%s' does not support deployment", env.GetKind())
 	}
 
-	return az, nil
+	return de.CreateDeploymentClient()
+}
+
+type DiagnosticsEnvironment interface {
+	CreateDiagnosticsClient() (clients.DiagnosticsClient, error)
+}
+
+func CreateDiagnosticsClient(env Environment) (clients.DiagnosticsClient, error) {
+	de, ok := env.(DiagnosticsEnvironment)
+	if !ok {
+		return nil, fmt.Errorf("an environment of kind '%s' does not support diagnostics operations", env.GetKind())
+	}
+
+	return de.CreateDiagnosticsClient()
+}
+
+type ManagementEnvironment interface {
+	CreateManagementClient() (clients.ManagementClient, error)
+}
+
+func CreateManagementClient(env Environment) (clients.ManagementClient, error) {
+	me, ok := env.(ManagementEnvironment)
+	if !ok {
+		return nil, fmt.Errorf("an environment of kind '%s' does not support management operations", env.GetKind())
+	}
+
+	return me.CreateManagementClient()
 }


### PR DESCRIPTION
For part of https://github.com/Azure/radius/issues/495

This refactors all application, component, deploy, and deployment commands to use a client abstraction, allowing for an easy addition of k8s.

- Client functions doesn't include updating config. For example, `rad application delete` will remove the defaultapplication if present. This functionality isn't done by the client and rather is still in the CLI.
- I can see us changing the client return types for list/show to return strings instead of printing in the function.
- Doesn't modify env functions for now, I think the only commands that calls out to azure are `env init azure` and `env delete`. Env delete would be the only one we'd want a client abstraction for, and we can probably live with an if check in code for now.