### PR TITLE
consitency across docs for how we reference az login and env deletion

### DIFF
--- a/docs/content/components/azure-components/azure-keyvault/index.md
+++ b/docs/content/components/azure-components/azure-keyvault/index.md
@@ -232,17 +232,7 @@ Vault url: https://kv-blqmk.vault.azure.net/
 
 You have completed this tutorial!
 
-### Cleanup (optional)
-
-When you are ready to clean up and delete the resources you can delete your environment. This will delete:
-
-- The resource group
-- Your Radius environment
-- The application you just deployed
-
-```sh
-rad env delete --name azure --yes
-```
+Note: If you're done with testing, you can use the rad CLI to [delete an environment]({{< ref rad_env_delete.md >}}) to **prevent additional charges in your subscription**. 
 
 ### Bicep file
 

--- a/docs/content/components/azure-components/azure-keyvault/index.md
+++ b/docs/content/components/azure-components/azure-keyvault/index.md
@@ -232,7 +232,9 @@ Vault url: https://kv-blqmk.vault.azure.net/
 
 You have completed this tutorial!
 
-Note: If you're done with testing, you can use the rad CLI to [delete an environment]({{< ref rad_env_delete.md >}}) to **prevent additional charges in your subscription**. 
+{{% alert title="Cleanup" color="warning" %}}
+If you're done with testing, you can use the rad CLI to [delete an environment]({{< ref rad_env_delete.md >}}) to **prevent additional charges in your subscription**.
+{{% /alert %}}
 
 ### Bicep file
 

--- a/docs/content/components/azure-components/azure-servicebus/index.md
+++ b/docs/content/components/azure-components/azure-servicebus/index.md
@@ -217,17 +217,7 @@ Messages: Cool Message 3
 
 You have completed this tutorial!
 
-### Cleanup (optional)
-
-When you are ready to clean up and delete the resources you can delete your environment. This will delete:
-
-- The resource group
-- Your Radius environment
-- The application you just deployed
-
-```sh
-rad env delete -e azure --yes
-```
+Note: If you're done with testing, you can use the rad CLI to [delete an environment]({{< ref rad_env_delete.md >}}) to **prevent additional charges in your subscription**. 
 
 ### Bicep file
 

--- a/docs/content/components/azure-components/azure-servicebus/index.md
+++ b/docs/content/components/azure-components/azure-servicebus/index.md
@@ -217,7 +217,9 @@ Messages: Cool Message 3
 
 You have completed this tutorial!
 
-Note: If you're done with testing, you can use the rad CLI to [delete an environment]({{< ref rad_env_delete.md >}}) to **prevent additional charges in your subscription**. 
+{{% alert title="Cleanup" color="warning" %}}
+If you're done with testing, you can use the rad CLI to [delete an environment]({{< ref rad_env_delete.md >}}) to **prevent additional charges in your subscription**.
+{{% /alert %}}
 
 ### Bicep file
 

--- a/docs/content/components/dapr-components/dapr-pubsub/dapr-pubsub-servicebus/index.md
+++ b/docs/content/components/dapr-components/dapr-pubsub/dapr-pubsub-servicebus/index.md
@@ -189,15 +189,14 @@ resource pubsub 'Components' = {
 
 ### Deploy the application
 
-Now you are ready to deploy this application.
+#### Pre-requisites
 
-First, double-check that you are logged-in to Azure. Switch to your commandline and run the following command:
+- Make sure you have an active [Radius environment]({{< ref create-environment.md >}})
+- Ensure you are logged into Azure using `az login`
 
-```sh
-az login
-```
+#### Deploy template file
 
-Then after that completes, run:
+Submit the Radius template to Azure using:
 
 ```sh
 rad deploy template.bicep
@@ -227,14 +226,4 @@ TOPIC_A :  hello world
 
 You have completed this tutorial!
 
-### (optional) Cleanup
-
-When you are ready to clean up and delete the resources you can delete your environment. This will delete:
-
-- The resource group
-- Your Radius environment
-- The application you just deployed
-
-```sh
-rad env delete -e azure --yes
-```
+Note: If you're done with testing, you can use the rad CLI to [delete an environment]({{< ref rad_env_delete.md >}}) to **prevent additional charges in your subscription**. 

--- a/docs/content/environments/azure-environments/index.md
+++ b/docs/content/environments/azure-environments/index.md
@@ -41,7 +41,7 @@ These steps will walk through how to deploy, manage, and delete environments in 
 ### Pre-requisites
 
 - [Azure subscription](https://signup.azure.com)
-- [az CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
+- [az CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli). Ensure you are logged into Azure using `az login`.
 - [rad CLI]({{< ref install-cli.md >}})
 - (optional) [create a an Azure Container Registry](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-get-started-azure-cli) to use as a private container registry
 
@@ -51,11 +51,6 @@ These steps will walk through how to deploy, manage, and delete environments in 
 While Radius environments are optimized for cost, any costs incurred by the deployment and use of a Radius environment in an Azure subscription are the responsibility of the user. Azure environments currently include a single node AKS cluster, an Azure CosmosDB account, and an App Service which all incur cost if deployed for extended periods.
 {{% /alert %}}
 
-1. Sign into Azure using the az CLI:
-   
-   ```bash
-   az login
-   ```
 1. Deploy a Radius environment interactively:
    
    ```bash
@@ -75,7 +70,7 @@ While Radius environments are optimized for cost, any costs incurred by the depl
 
    {{% /alert %}}
 
-2. Verify deployment
+1. Verify deployment
 
    To verify the environment deployment succeeded, navigate to your subscription at https://portal.azure.com. You should see a new Resource Group with the name you entered during the previous step: 
 
@@ -85,24 +80,17 @@ While Radius environments are optimized for cost, any costs incurred by the depl
 
    <img src="./azure-resources.png" width=500 alt="New resource group that was created">
 
-#### 
-
-## Connect to an existing environment
+### Connect to an existing environment
 
 If you wish to attach to an existing environment instead of deploying a new one, simply specify the name, subscription, and resource group of an existing Radius environment when using the above steps for `rad env init azure`. The rad CLI will append the config for the existing environment to your local config file.
 
 ### Delete an environment
 
-1. Ensure you are still signed into Azure using the az CLI:
-   
-   ```bash
-   az login
-   ```
-1. Use the rad CLI to delete the environment:
+Use the rad CLI to [delete an environment]({{< ref rad_env_delete.md >}}):
 
-   ```bash
-   rad env delete -e azure --yes
-   ```
+```bash
+rad env delete -e azure --yes
+```
 
 ## Related links
 

--- a/docs/content/getting-started/tutorial/dapr-microservices/dapr-microservices-add-pythonapp/index.md
+++ b/docs/content/getting-started/tutorial/dapr-microservices/dapr-microservices-add-pythonapp/index.md
@@ -152,14 +152,17 @@ resource app 'radius.dev/Applications@v1alpha1' = {
 
 1. When you're done testing press CTRL+C to terminate the port-forward. 
 
+You have completed this tutorial!
+
+{{% alert title="Cleanup" color="warning" %}}
+If you're done with testing, you can use the rad CLI to [delete an environment]({{< ref rad_env_delete.md >}}) to **prevent additional charges in your subscription**.
+{{% /alert %}}
+
 ## Next steps
 
 - If you'd like to try another tutorial with your existing environment, go back to the [Radius tutorials]({{< ref tutorial >}}) page. 
-- If you're done with testing, you can use the rad CLI to [delete an environment]({{< ref rad_env_delete.md >}}) to **prevent additional charges in your subscription**. 
 - Related links for Dapr:
   - [Dapr documentation](https://docs.dapr.io/)
   - [Dapr quickstarts](https://github.com/dapr/quickstarts/tree/v1.0.0/hello-world)
-
-You have completed this tutorial!
 
 <br>{{< button text="Try another tutorial" page="tutorial" >}}

--- a/docs/content/getting-started/tutorial/dapr-microservices/dapr-microservices-add-pythonapp/index.md
+++ b/docs/content/getting-started/tutorial/dapr-microservices/dapr-microservices-add-pythonapp/index.md
@@ -155,7 +155,7 @@ resource app 'radius.dev/Applications@v1alpha1' = {
 ## Next steps
 
 - If you'd like to try another tutorial with your existing environment, go back to the [Radius tutorials]({{< ref tutorial >}}) page. 
-- If you're done with testing, use the rad CLI to [delete an environment]({{< ref rad_env_delete.md >}}) to **prevent additional charges in your subscription**. 
+- If you're done with testing, you can use the rad CLI to [delete an environment]({{< ref rad_env_delete.md >}}) to **prevent additional charges in your subscription**. 
 - Related links for Dapr:
   - [Dapr documentation](https://docs.dapr.io/)
   - [Dapr quickstarts](https://github.com/dapr/quickstarts/tree/v1.0.0/hello-world)

--- a/docs/content/getting-started/tutorial/webapp/webapp-add-secretstore/index.md
+++ b/docs/content/getting-started/tutorial/webapp/webapp-add-secretstore/index.md
@@ -11,6 +11,7 @@ In this step you will learn how to add a secret store and connect to it from the
 We'll discuss template.bicep changes and then provide the full, updated file before deployment. 
 
 ## Add kv component
+
 A `kv` secret store component is used to specify a few properties about the KeyVault: 
 
 - **kind:** `azure.com/KeyVault@v1alpha1` represents an Azure Key Vault. 
@@ -208,12 +209,15 @@ resource app 'radius.dev/Applications@v1alpha1' = {
 
 1. When you're done testing press CTRL+C to terminate the port-forward. 
 
+You have completed this tutorial!
+
+{{% alert title="Cleanup" color="warning" %}}
+If you're done with testing, you can use the rad CLI to [delete an environment]({{< ref rad_env_delete.md >}}) to **prevent additional charges in your subscription**.
+{{% /alert %}}
+
 ## Next steps
 
 - To view the website application code used in this tutorial, download the [zipped application code](/tutorial/webapp.zip).
-- If you'd like to try another tutorial with your existing environment, go back to the [Radius tutorials]({{< ref tutorial >}}) page. 
-- If you're done with testing, you can use the rad CLI to [delete an environment]({{< ref rad_env_delete.md >}}) to **prevent additional charges in your subscription**. 
-
-You have completed this tutorial!
+- If you'd like to try another tutorial with your existing environment, go back to the [Radius tutorials]({{< ref tutorial >}}) page.
 
 {{< button text="Try another tutorial" page="tutorial" >}}

--- a/docs/content/getting-started/tutorial/webapp/webapp-add-secretstore/index.md
+++ b/docs/content/getting-started/tutorial/webapp/webapp-add-secretstore/index.md
@@ -212,7 +212,7 @@ resource app 'radius.dev/Applications@v1alpha1' = {
 
 - To view the website application code used in this tutorial, download the [zipped application code](/tutorial/webapp.zip).
 - If you'd like to try another tutorial with your existing environment, go back to the [Radius tutorials]({{< ref tutorial >}}) page. 
-- If you're done with testing, use the rad CLI to [delete an environment]({{< ref rad_env_delete.md >}}) to **prevent additional charges in your subscription**. 
+- If you're done with testing, you can use the rad CLI to [delete an environment]({{< ref rad_env_delete.md >}}) to **prevent additional charges in your subscription**. 
 
 You have completed this tutorial!
 


### PR DESCRIPTION
- az login listed as a prereq instead of a code block (except the Getting Started env creation page)
- env cleanup / deletion references all link to `rad env delete` page instead of code blocks directly on pages