### PR TITLE
Fixing up timeouts and fixing flaky test

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -11,4 +11,4 @@ test: ## Runs unit tests.
 
 .PHONY: test-integration
 test-integration: ## Runs integration tests
-	go test ./test/integrationtests/... -timeout 3600s
+	go test ./test/integrationtests/... -timeout 1h -v

--- a/test/integrationtests/deploy_test.go
+++ b/test/integrationtests/deploy_test.go
@@ -35,7 +35,8 @@ import (
 
 // Tests application deployment using radius
 func TestDeployment(t *testing.T) {
-	ctx := utils.GetContext(t)
+	ctx, cancel := utils.GetContext(t)
+	defer cancel()
 
 	config, err := config.NewAzureConfig()
 	require.NoError(t, err, "failed to initialize azure config")

--- a/test/integrationtests/deploy_test.go
+++ b/test/integrationtests/deploy_test.go
@@ -35,16 +35,7 @@ import (
 
 // Tests application deployment using radius
 func TestDeployment(t *testing.T) {
-	var ctx context.Context
-	deadline, ok := t.Deadline()
-	if ok {
-		// no timeout specified,
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithDeadline(context.Background(), deadline)
-		defer cancel()
-	} else {
-		ctx = context.Background()
-	}
+	ctx := utils.GetContext(t)
 
 	config, err := config.NewAzureConfig()
 	require.NoError(t, err, "failed to initialize azure config")

--- a/test/integrationtests/deploy_test.go
+++ b/test/integrationtests/deploy_test.go
@@ -276,10 +276,15 @@ func TestDeployment(t *testing.T) {
 		},
 	}
 
-	for _, row := range table {
-		test := NewApplicationTest(options, row)
-		t.Run(row.Description, test.Test)
-	}
+	// Nest parallel subtests into outer Run to have function wait for all tests
+	// to finish before returning.
+	// See: https://golang.org/pkg/testing/#hdr-Subtests_and_Sub_benchmarks
+	t.Run("deploytests", func(t *testing.T) {
+		for _, row := range table {
+			test := NewApplicationTest(options, row)
+			t.Run(row.Description, test.Test)
+		}
+	})
 }
 
 type Row struct {
@@ -321,13 +326,14 @@ func (at ApplicationTest) Test(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 
-	// Global deadline from -timeout flag passed into go test
+	// Inside the integration test code we rely on the context for timeout/cancellation functionality.
+	// We expect the caller to wire this out to the test timeout system, or a stricter timeout if desired.
 
 	// Deploy the application
 	t.Run(fmt.Sprintf("deploy %s", at.Row.Description), func(t *testing.T) {
 		templateFilePath := filepath.Join(cwd, at.Row.Template)
 		t.Logf("deploying %s from file %s", at.Row.Description, at.Row.Template)
-		err := utils.RunRadDeployCommand(templateFilePath, at.Options.Environment.ConfigPath, at.Options.Context)
+		err := utils.RunRadDeployCommand(at.Options.Context, templateFilePath, at.Options.Environment.ConfigPath)
 		require.NoErrorf(t, err, "failed to delete %s", at.Row.Description)
 
 		// ValidatePodsRunning triggers its own assertions, no need to handle errors
@@ -342,11 +348,11 @@ func (at ApplicationTest) Test(t *testing.T) {
 	// In the future we can add more subtests here for multi-phase tests that change what's deployed.
 
 	// Cleanup code here will run regardless of pass/fail of subtests
-	err = utils.RunRadApplicationDeleteCommand(at.Row.Application, at.Options.Environment.ConfigPath, at.Options.Context)
+	err = utils.RunRadApplicationDeleteCommand(at.Options.Context, at.Row.Application, at.Options.Environment.ConfigPath)
 	require.NoErrorf(t, err, "failed to delete %s", at.Row.Description)
 
 	for ns := range at.Row.Pods.Namespaces {
-		validation.ValidateNoPodsInNamespace(t, at.Options.K8s, ns, at.Options.Context)
+		validation.ValidateNoPodsInNamespace(at.Options.Context, t, at.Options.K8s, ns)
 	}
 
 	// Custom verification is expected to use `t` to trigger its own assertions

--- a/test/integrationtests/deploy_test.go
+++ b/test/integrationtests/deploy_test.go
@@ -339,7 +339,7 @@ func (at ApplicationTest) Test(t *testing.T) {
 		require.NoErrorf(t, err, "failed to delete %s", at.Row.Description)
 
 		// ValidatePodsRunning triggers its own assertions, no need to handle errors
-		validation.ValidatePodsRunning(t, at.Options.K8s, at.Row.Pods)
+		validation.ValidatePodsRunning(t, at.Options.K8s, at.Row.Pods, at.Options.Context)
 
 		// Custom verification is expected to use `t` to trigger its own assertions
 		if at.Row.PostDeployVerify != nil {
@@ -354,7 +354,7 @@ func (at ApplicationTest) Test(t *testing.T) {
 	require.NoErrorf(t, err, "failed to delete %s", at.Row.Description)
 
 	for ns := range at.Row.Pods.Namespaces {
-		validation.ValidateNoPodsInNamespace(t, at.Options.K8s, ns)
+		validation.ValidateNoPodsInNamespace(t, at.Options.K8s, ns, at.Options.Context)
 	}
 
 	// Custom verification is expected to use `t` to trigger its own assertions

--- a/test/integrationtests/environment_test.go
+++ b/test/integrationtests/environment_test.go
@@ -6,7 +6,6 @@
 package integrationtests
 
 import (
-	"context"
 	"testing"
 
 	azresources "github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
@@ -19,8 +18,7 @@ import (
 )
 
 func TestAzureEnvironmentSetup(t *testing.T) {
-	ctx := context.Background()
-
+	ctx := utils.GetContext(t)
 	config, err := config.NewAzureConfig()
 	require.NoError(t, err, "failed to initialize azure config")
 
@@ -99,5 +97,5 @@ func TestAzureEnvironmentSetup(t *testing.T) {
 		},
 	}
 
-	validation.ValidatePodsRunning(t, k8s, expectedPods)
+	validation.ValidatePodsRunning(t, k8s, expectedPods, ctx)
 }

--- a/test/integrationtests/environment_test.go
+++ b/test/integrationtests/environment_test.go
@@ -18,7 +18,9 @@ import (
 )
 
 func TestAzureEnvironmentSetup(t *testing.T) {
-	ctx := utils.GetContext(t)
+	ctx, cancel := utils.GetContext(t)
+	defer cancel()
+
 	config, err := config.NewAzureConfig()
 	require.NoError(t, err, "failed to initialize azure config")
 

--- a/test/integrationtests/environment_test.go
+++ b/test/integrationtests/environment_test.go
@@ -56,8 +56,8 @@ func TestAzureEnvironmentSetup(t *testing.T) {
 	// if the environment was created over a day ago.
 	// Verify that either 6 or 7 resources are present, and only check the deploymentScripts
 	// if there are 7 resources
-	require.GreaterOrEqual(t, 6, len(resourceMap), "Number of resources created by init step is less than expected")
-	require.LessOrEqual(t, 7, len(resourceMap), "Number of resources created by init step is greater than expected")
+	require.GreaterOrEqual(t, len(resourceMap), 6, "Number of resources created by init step is less than expected")
+	require.LessOrEqual(t, len(resourceMap), 7, "Number of resources created by init step is greater than expected")
 
 	_, found := resourceMap["Microsoft.ContainerService/managedClusters"]
 	require.True(t, found, "Microsoft.ContainerService/managedClusters resource not created")

--- a/test/utils/rad_helpers.go
+++ b/test/utils/rad_helpers.go
@@ -14,7 +14,7 @@ import (
 )
 
 // RunRadDeployCommand runs rad deploy command and times out after specified duration
-func RunRadDeployCommand(templateFilePath, configFilePath string, ctx context.Context) error {
+func RunRadDeployCommand(ctx context.Context, templateFilePath, configFilePath string) error {
 	// Check if the template file path exists
 	if _, err := os.Stat(templateFilePath); err != nil {
 		return fmt.Errorf("could not find template file: %s - %w", templateFilePath, err)
@@ -36,7 +36,7 @@ func RunRadDeployCommand(templateFilePath, configFilePath string, ctx context.Co
 }
 
 // RunRadApplicationDeleteCommand deletes all applications deployed by Radius in the specified resource group
-func RunRadApplicationDeleteCommand(applicationName, configFilePath string, ctx context.Context) error {
+func RunRadApplicationDeleteCommand(ctx context.Context, applicationName, configFilePath string) error {
 	// Create the command with our context
 	var cmd *exec.Cmd
 	if configFilePath == "" {

--- a/test/utils/rad_helpers.go
+++ b/test/utils/rad_helpers.go
@@ -71,16 +71,14 @@ func RunCommand(ctx context.Context, cmd *exec.Cmd) error {
 	return err
 }
 
-func GetContext(t *testing.T) context.Context {
+func GetContext(t *testing.T) (context.Context, context.CancelFunc) {
 	var ctx context.Context
+	var cancel context.CancelFunc
 	deadline, ok := t.Deadline()
 	if ok {
-		// no timeout specified,
-		var cancel context.CancelFunc
 		ctx, cancel = context.WithDeadline(context.Background(), deadline)
-		defer cancel()
 	} else {
-		ctx = context.Background()
+		ctx, cancel = context.WithCancel(context.Background())
 	}
-	return ctx
+	return ctx, cancel
 }

--- a/test/utils/rad_helpers.go
+++ b/test/utils/rad_helpers.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"testing"
 )
 
 // RunRadDeployCommand runs rad deploy command and times out after specified duration
@@ -68,4 +69,18 @@ func RunCommand(ctx context.Context, cmd *exec.Cmd) error {
 	}
 
 	return err
+}
+
+func GetContext(t *testing.T) context.Context {
+	var ctx context.Context
+	deadline, ok := t.Deadline()
+	if ok {
+		// no timeout specified,
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(context.Background(), deadline)
+		defer cancel()
+	} else {
+		ctx = context.Background()
+	}
+	return ctx
 }

--- a/test/utils/rad_helpers.go
+++ b/test/utils/rad_helpers.go
@@ -10,18 +10,14 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"time"
 )
 
-// RunRadDeployCommand runs rad deploy command and times out after specified timeout
-func RunRadDeployCommand(templateFilePath, configFilePath string, timeout time.Time) error {
+// RunRadDeployCommand runs rad deploy command and times out after specified duration
+func RunRadDeployCommand(templateFilePath, configFilePath string, ctx context.Context) error {
 	// Check if the template file path exists
 	if _, err := os.Stat(templateFilePath); err != nil {
 		return fmt.Errorf("could not find template file: %s - %w", templateFilePath, err)
 	}
-
-	ctx, cancel := context.WithDeadline(context.Background(), timeout)
-	defer cancel() // The cancel should be deferred so resources are cleaned up
 
 	// Create the command with our context
 	var cmd *exec.Cmd
@@ -39,10 +35,7 @@ func RunRadDeployCommand(templateFilePath, configFilePath string, timeout time.T
 }
 
 // RunRadApplicationDeleteCommand deletes all applications deployed by Radius in the specified resource group
-func RunRadApplicationDeleteCommand(applicationName, configFilePath string, timeout time.Time) error {
-	ctx, cancel := context.WithDeadline(context.Background(), timeout)
-	defer cancel() // The cancel should be deferred so resources are cleaned up
-
+func RunRadApplicationDeleteCommand(applicationName, configFilePath string, ctx context.Context) error {
 	// Create the command with our context
 	var cmd *exec.Cmd
 	if configFilePath == "" {

--- a/test/utils/rad_helpers.go
+++ b/test/utils/rad_helpers.go
@@ -14,13 +14,13 @@ import (
 )
 
 // RunRadDeployCommand runs rad deploy command and times out after specified timeout
-func RunRadDeployCommand(templateFilePath, configFilePath string, timeout time.Duration) error {
+func RunRadDeployCommand(templateFilePath, configFilePath string, timeout time.Time) error {
 	// Check if the template file path exists
 	if _, err := os.Stat(templateFilePath); err != nil {
 		return fmt.Errorf("could not find template file: %s - %w", templateFilePath, err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithDeadline(context.Background(), timeout)
 	defer cancel() // The cancel should be deferred so resources are cleaned up
 
 	// Create the command with our context
@@ -39,8 +39,8 @@ func RunRadDeployCommand(templateFilePath, configFilePath string, timeout time.D
 }
 
 // RunRadApplicationDeleteCommand deletes all applications deployed by Radius in the specified resource group
-func RunRadApplicationDeleteCommand(applicationName, configFilePath string, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+func RunRadApplicationDeleteCommand(applicationName, configFilePath string, timeout time.Time) error {
+	ctx, cancel := context.WithDeadline(context.Background(), timeout)
 	defer cancel() // The cancel should be deferred so resources are cleaned up
 
 	// Create the command with our context

--- a/test/validation/k8s.go
+++ b/test/validation/k8s.go
@@ -100,7 +100,6 @@ func ValidatePodsRunning(t *testing.T, k8s *kubernetes.Clientset, expected PodSe
 
 					t.Logf("watching pod %v for status.. current: %v", pod.Name, pod.Status)
 
-				// allow max of 60 seconds to pass without updates
 				case <-ctx.Done():
 					assert.Failf(t, "timed out after waiting for pod %v to enter running status", actualPod.Name)
 					break loop
@@ -110,7 +109,7 @@ func ValidatePodsRunning(t *testing.T, k8s *kubernetes.Clientset, expected PodSe
 	}
 }
 
-func ValidateNoPodsInNamespace(t *testing.T, k8s *kubernetes.Clientset, namespace string, ctx context.Context) {
+func ValidateNoPodsInNamespace(ctx context.Context, t *testing.T, k8s *kubernetes.Clientset, namespace string) {
 	actualPods, err := k8s.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{})
 	assert.NoErrorf(t, err, "failed to list pods in namespace %s", namespace)
 


### PR DESCRIPTION
Fixes https://github.com/Azure/radius/issues/549

- Adds verbose logging to make test-integration
- Increases timeout to 1 hour, removes per operation timeouts for deploy and delete.
- Fixes flaky test by conditionally checking if the deployment script is present or not.