### PR TITLE
Assign port of service correctly

### DIFF
--- a/pkg/workloads/containerv1alpha1/types.go
+++ b/pkg/workloads/containerv1alpha1/types.go
@@ -49,8 +49,6 @@ type HTTPBinding struct {
 func (h HTTPBinding) GetEffectivePort() int {
 	if h.Port != nil {
 		return *h.Port
-	} else if h.TargetPort != nil {
-		return *h.TargetPort
 	} else {
 		return 80
 	}


### PR DESCRIPTION
Fixes: #543

The issue here is that we were computing port for target port and
vice-versa. This isn't right, and was mismatched with what we do for
when we assign bindings.