### PR TITLE
Update blob upload action

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Parse release version and set enviroment variables
         run: python ./.github/scripts/get_release_version.py
       - name: Upload deployment template
-        uses: bacongobbler/azure-blob-storage-upload@v1.1.1
+        uses: bacongobbler/azure-blob-storage-upload@v1.2.0
         with:
           source_dir: 'deploy'
           container_name: 'environment'
@@ -29,7 +29,7 @@ jobs:
           sync: true
           extra_args: '--destination-path ${{ env.REL_CHANNEL }} --pattern rp-full.json'
       - name: Upload deployment script
-        uses: bacongobbler/azure-blob-storage-upload@v1.1.1
+        uses: bacongobbler/azure-blob-storage-upload@v1.2.0
         with:
           source_dir: 'deploy'
           container_name: 'environment'
@@ -66,7 +66,7 @@ jobs:
         run: |
           echo $REL_CHANNEL > stable.txt
       - name: 'Update latest version marker'
-        uses: bacongobbler/azure-blob-storage-upload@v1.1.1
+        uses: bacongobbler/azure-blob-storage-upload@v1.2.0
         if: ${{ success() && steps.compare.outputs.comparison-result == '>' }}
         with:
           container_name: 'version'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -287,21 +287,21 @@ jobs:
         with:
           name: rad_cli_windows_amd64
           path: rad_cli_windows_amd64
-      - uses: bacongobbler/azure-blob-storage-upload@v1.1.1
+      - uses: bacongobbler/azure-blob-storage-upload@v1.2.0
         with:
           source_dir: rad_cli_darwin_amd64
           container_name: 'tools'
           connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
           sync: true
           extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/macos-x64/ --pattern rad'
-      - uses: bacongobbler/azure-blob-storage-upload@v1.1.1
+      - uses: bacongobbler/azure-blob-storage-upload@v1.2.0
         with:
           source_dir: rad_cli_linux_amd64
           container_name: 'tools'
           connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
           sync: true
           extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-x64/ --pattern rad'
-      - uses: bacongobbler/azure-blob-storage-upload@v1.1.1
+      - uses: bacongobbler/azure-blob-storage-upload@v1.2.0
         with:
           source_dir: rad_cli_windows_amd64
           container_name: 'tools'


### PR DESCRIPTION
Fixes: #562

The base image that's used by the 1.1.1 version of this github action is
not available. The 1.2.0 version is now based on the `latest` tag of the
CLI image and should be stable.