### PR TITLE
Implement formatting support for CLI

### DIFF
--- a/cmd/cli/cmd/appList.go
+++ b/cmd/cli/cmd/appList.go
@@ -6,11 +6,10 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/environments"
+	"github.com/Azure/radius/pkg/rad/objectformats"
+	"github.com/Azure/radius/pkg/rad/output"
 	"github.com/spf13/cobra"
 )
 
@@ -43,11 +42,15 @@ func listApplications(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	applications, err := json.MarshalIndent(applicationList, "", "  ")
+	format, err := rad.RequireOutput(cmd)
 	if err != nil {
-		return fmt.Errorf("failed to marshal application response as JSON %w", err)
+		return err
 	}
-	fmt.Println(string(applications))
+
+	err = output.Write(format, applicationList.Value, cmd.OutOrStdout(), objectformats.GetApplicationTableFormat())
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/cmd/cli/cmd/appShow.go
+++ b/cmd/cli/cmd/appShow.go
@@ -6,11 +6,10 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/environments"
+	"github.com/Azure/radius/pkg/rad/objectformats"
+	"github.com/Azure/radius/pkg/rad/output"
 	"github.com/spf13/cobra"
 )
 
@@ -46,11 +45,16 @@ func showApplication(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	applicationDetails, err := json.MarshalIndent(applicationResource, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal application response as JSON %w", err)
-	}
-	fmt.Println(string(applicationDetails))
 
-	return err
+	format, err := rad.RequireOutput(cmd)
+	if err != nil {
+		return err
+	}
+
+	err = output.Write(format, applicationResource, cmd.OutOrStdout(), objectformats.GetApplicationTableFormat())
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/cli/cmd/componentList.go
+++ b/cmd/cli/cmd/componentList.go
@@ -6,11 +6,10 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/environments"
+	"github.com/Azure/radius/pkg/rad/objectformats"
+	"github.com/Azure/radius/pkg/rad/output"
 	"github.com/spf13/cobra"
 )
 
@@ -46,11 +45,16 @@ func listComponents(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	components, err := json.MarshalIndent(componentList, "", "  ")
+
+	format, err := rad.RequireOutput(cmd)
 	if err != nil {
-		return fmt.Errorf("failed to marshal component response as JSON %w", err)
+		return err
 	}
 
-	fmt.Println(string(components))
+	err = output.Write(format, componentList.Value, cmd.OutOrStdout(), objectformats.GetComponentTableFormat())
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/cmd/cli/cmd/componentShow.go
+++ b/cmd/cli/cmd/componentShow.go
@@ -6,11 +6,10 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/environments"
+	"github.com/Azure/radius/pkg/rad/objectformats"
+	"github.com/Azure/radius/pkg/rad/output"
 	"github.com/spf13/cobra"
 )
 
@@ -52,11 +51,15 @@ func showComponent(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	componentDetails, err := json.MarshalIndent(componentResource, "", "  ")
+	format, err := rad.RequireOutput(cmd)
 	if err != nil {
-		return fmt.Errorf("failed to marshal component response as JSON %w", err)
+		return err
 	}
-	fmt.Println(string(componentDetails))
+
+	err = output.Write(format, componentResource, cmd.OutOrStdout(), objectformats.GetComponentTableFormat())
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/cmd/cli/cmd/deploymentList.go
+++ b/cmd/cli/cmd/deploymentList.go
@@ -6,11 +6,10 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/environments"
+	"github.com/Azure/radius/pkg/rad/objectformats"
+	"github.com/Azure/radius/pkg/rad/output"
 	"github.com/spf13/cobra"
 )
 
@@ -47,12 +46,15 @@ func listDeployments(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	deployments, err := json.MarshalIndent(deploymentList, "", "  ")
+	format, err := rad.RequireOutput(cmd)
 	if err != nil {
-		return fmt.Errorf("failed to marshal deployment response as JSON %w", err)
+		return err
 	}
 
-	fmt.Println(string(deployments))
+	err = output.Write(format, deploymentList.Value, cmd.OutOrStdout(), objectformats.GetDeploymentTableFormat())
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/cmd/cli/cmd/deploymentShow.go
+++ b/cmd/cli/cmd/deploymentShow.go
@@ -6,11 +6,10 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/environments"
+	"github.com/Azure/radius/pkg/rad/objectformats"
+	"github.com/Azure/radius/pkg/rad/output"
 	"github.com/spf13/cobra"
 )
 
@@ -52,11 +51,15 @@ func showDeployment(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	deploymentDetails, err := json.MarshalIndent(deploymentResource, "", "  ")
+	format, err := rad.RequireOutput(cmd)
 	if err != nil {
-		return fmt.Errorf("failed to marshal deployment response as JSON %w", err)
+		return err
 	}
 
-	fmt.Println(string(deploymentDetails))
+	err = output.Write(format, deploymentResource, cmd.OutOrStdout(), objectformats.GetDeploymentTableFormat())
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -8,8 +8,10 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/Azure/radius/pkg/rad"
+	"github.com/Azure/radius/pkg/rad/output"
 	"github.com/Azure/radius/pkg/version"
 	"github.com/spf13/cobra"
 )
@@ -42,4 +44,7 @@ func init() {
 
 	RootCmd.Flags().BoolP("version", "v", false, "version for radius")
 	RootCmd.PersistentFlags().StringVar(&rad.CfgFile, "config", "", "config file (default is $HOME/.rad/config.yaml)")
+
+	outputDescription := fmt.Sprintf("output format (default is %s, supported formats are %s)", output.DefaultFormat, strings.Join(output.SupportedFormats(), ", "))
+	RootCmd.PersistentFlags().StringP("output", "o", "table", outputDescription)
 }

--- a/pkg/rad/clivalidation.go
+++ b/pkg/rad/clivalidation.go
@@ -103,6 +103,10 @@ func RequireComponent(cmd *cobra.Command, args []string) (string, error) {
 	return required(cmd, args, "component")
 }
 
+func RequireOutput(cmd *cobra.Command) (string, error) {
+	return cmd.Flags().GetString("output")
+}
+
 func required(cmd *cobra.Command, args []string, name string) (string, error) {
 	value, err := cmd.Flags().GetString(name)
 	if err != nil {

--- a/pkg/rad/objectformats/objectformats.go
+++ b/pkg/rad/objectformats/objectformats.go
@@ -1,0 +1,49 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package objectformats
+
+import "github.com/Azure/radius/pkg/rad/output"
+
+func GetApplicationTableFormat() output.FormatterOptions {
+	return output.FormatterOptions{
+		Columns: []output.Column{
+			{
+				Heading:  "APPLICATION",
+				JSONPath: "{ .name }",
+			},
+		},
+	}
+}
+
+func GetComponentTableFormat() output.FormatterOptions {
+	return output.FormatterOptions{
+		Columns: []output.Column{
+			{
+				Heading:  "COMPONENT",
+				JSONPath: "{ .name }",
+			},
+			{
+				Heading:  "KIND",
+				JSONPath: "{ .kind }",
+			},
+		},
+	}
+}
+
+func GetDeploymentTableFormat() output.FormatterOptions {
+	return output.FormatterOptions{
+		Columns: []output.Column{
+			{
+				Heading:  "DEPLOYMENT",
+				JSONPath: "{ .name }",
+			},
+			{
+				Heading:  "COMPONENTS",
+				JSONPath: "{ .properties.components[*].componentName }",
+			},
+		},
+	}
+}

--- a/pkg/rad/objectformats/objectformats_test.go
+++ b/pkg/rad/objectformats/objectformats_test.go
@@ -1,0 +1,96 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package objectformats
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/to"
+	"github.com/Azure/radius/pkg/rad/output"
+	"github.com/Azure/radius/pkg/radclient"
+	"github.com/stretchr/testify/require"
+)
+
+// These are integration tests that test that our table formatting works well e2e
+
+func Test_FormatApplicationTable(t *testing.T) {
+	options := GetApplicationTableFormat()
+
+	// We're just filling in the fields that are read. It's hard to test that something *doesn't* happen.
+	obj := radclient.ApplicationResource{
+		TrackedResource: radclient.TrackedResource{
+			Resource: radclient.Resource{
+				Name: to.StringPtr("test-app"),
+			},
+		},
+	}
+
+	buffer := bytes.Buffer{}
+	err := output.Write(output.FormatTable, &obj, &buffer, options)
+	require.NoError(t, err)
+
+	expected := `APPLICATION
+test-app  
+`
+	require.Equal(t, expected, buffer.String())
+}
+
+func Test_FormatComponentTable(t *testing.T) {
+	options := GetComponentTableFormat()
+
+	// We're just filling in the fields that are read. It's hard to test that something *doesn't* happen.
+	obj := radclient.ComponentResource{
+		TrackedResource: radclient.TrackedResource{
+			Resource: radclient.Resource{
+				Name: to.StringPtr("test-component"),
+			},
+		},
+		Kind: to.StringPtr("radius.dev/TestComponent@v1alpha1"),
+	}
+
+	buffer := bytes.Buffer{}
+	err := output.Write(output.FormatTable, &obj, &buffer, options)
+	require.NoError(t, err)
+
+	expected := `COMPONENT       KIND
+test-component  radius.dev/TestComponent@v1alpha1  
+`
+	require.Equal(t, expected, buffer.String())
+}
+
+func Test_FormatDeploymentTable(t *testing.T) {
+	options := GetDeploymentTableFormat()
+
+	// We're just filling in the fields that are read. It's hard to test that something *doesn't* happen.
+	components := []radclient.DeploymentPropertiesComponentsItem{
+		{
+			ComponentName: to.StringPtr("frontend"),
+		},
+		{
+			ComponentName: to.StringPtr("backend"),
+		},
+	}
+	obj := radclient.DeploymentResource{
+		TrackedResource: radclient.TrackedResource{
+			Resource: radclient.Resource{
+				Name: to.StringPtr("test-deployment"),
+			},
+		},
+		Properties: &radclient.DeploymentProperties{
+			Components: &components,
+		},
+	}
+
+	buffer := bytes.Buffer{}
+	err := output.Write(output.FormatTable, &obj, &buffer, options)
+	require.NoError(t, err)
+
+	expected := `DEPLOYMENT       COMPONENTS
+test-deployment  frontend backend  
+`
+	require.Equal(t, expected, buffer.String())
+}

--- a/pkg/rad/output/formats.go
+++ b/pkg/rad/output/formats.go
@@ -1,0 +1,19 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package output
+
+const (
+	FormatJson    = "json"
+	FormatTable   = "table"
+	DefaultFormat = FormatTable
+)
+
+func SupportedFormats() []string {
+	return []string{
+		FormatJson,
+		FormatTable,
+	}
+}

--- a/pkg/rad/output/formatter.go
+++ b/pkg/rad/output/formatter.go
@@ -1,0 +1,36 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package output
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type FormatterOptions struct {
+	// Columns used for table formatting
+	Columns []Column
+}
+
+type Column struct {
+	Heading  string
+	JSONPath string
+}
+
+type Formatter interface {
+	Format(obj interface{}, writer io.Writer, options FormatterOptions) error
+}
+
+func NewFormatter(format string) (Formatter, error) {
+	if strings.EqualFold(format, FormatJson) {
+		return &JSONFormatter{}, nil
+	} else if strings.EqualFold(format, FormatTable) {
+		return &TableFormatter{}, nil
+	} else {
+		return nil, fmt.Errorf("unsupported format %s", format)
+	}
+}

--- a/pkg/rad/output/json.go
+++ b/pkg/rad/output/json.go
@@ -1,0 +1,35 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package output
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type JSONFormatter struct {
+}
+
+func (f *JSONFormatter) Format(obj interface{}, writer io.Writer, options FormatterOptions) error {
+	b, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	_, err = writer.Write(b)
+	if err != nil {
+		return err
+	}
+
+	_, err = writer.Write([]byte("\n"))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ Formatter = (*JSONFormatter)(nil)

--- a/pkg/rad/output/json_test.go
+++ b/pkg/rad/output/json_test.go
@@ -1,0 +1,70 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package output
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type jsonInput struct {
+	Size   string
+	IsCool bool
+}
+
+func Test_JSON_Scalar(t *testing.T) {
+	obj := jsonInput{
+		Size:   "mega",
+		IsCool: true,
+	}
+
+	formatter := &JSONFormatter{}
+
+	buffer := &bytes.Buffer{}
+	err := formatter.Format(obj, buffer, FormatterOptions{})
+	require.NoError(t, err)
+
+	expected := `{
+  "Size": "mega",
+  "IsCool": true
+}
+`
+	require.Equal(t, expected, buffer.String())
+}
+
+func Test_JSON_Slice(t *testing.T) {
+	obj := []interface{}{
+		jsonInput{
+			Size:   "mega",
+			IsCool: true,
+		},
+		jsonInput{
+			Size:   "medium",
+			IsCool: false,
+		},
+	}
+
+	formatter := &JSONFormatter{}
+
+	buffer := &bytes.Buffer{}
+	err := formatter.Format(obj, buffer, FormatterOptions{})
+	require.NoError(t, err)
+
+	expected := `[
+  {
+    "Size": "mega",
+    "IsCool": true
+  },
+  {
+    "Size": "medium",
+    "IsCool": false
+  }
+]
+`
+	require.Equal(t, expected, buffer.String())
+}

--- a/pkg/rad/output/table.go
+++ b/pkg/rad/output/table.go
@@ -1,0 +1,118 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package output
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"text/tabwriter"
+
+	"k8s.io/client-go/util/jsonpath"
+)
+
+// Based on https://golang.org/pkg/text/tabwriter/
+const (
+	TableColumnMinWidth = 10
+	TableTabSize        = 4
+	TablePadSize        = 2
+	TablePadCharacter   = ' '
+	TableFlags          = 0
+)
+
+type TableFormatter struct {
+}
+
+func (f *TableFormatter) convertToSlice(obj interface{}) ([]interface{}, error) {
+	// We use reflection here because we're building a table and thus need to handle both scalars (structs)
+	// and slices/arrays of structs.
+	values := []interface{}{}
+	value := reflect.ValueOf(obj)
+
+	// Follow pointers at the top level
+	for value.Kind() == reflect.Ptr {
+		if value.IsNil() {
+			return nil, fmt.Errorf("value is nil")
+		}
+
+		value = value.Elem()
+	}
+
+	if value.Kind() == reflect.Struct || value.Kind() == reflect.Interface {
+		values = append(values, value.Interface())
+	} else if value.Kind() == reflect.Slice || value.Kind() == reflect.Array {
+		for i := 0; i < value.Len(); i++ {
+			item := value.Index(i)
+			values = append(values, item.Interface())
+		}
+	} else {
+		return nil, fmt.Errorf("unsupported value kind: %v", value.Kind())
+	}
+
+	return values, nil
+}
+
+func (f *TableFormatter) Format(obj interface{}, writer io.Writer, options FormatterOptions) error {
+	if len(options.Columns) == 0 {
+		return errors.New("no columns were defined, table format is not supported for this command")
+	}
+
+	rows, err := f.convertToSlice(obj)
+	if err != nil {
+		return err
+	}
+
+	headings := []string{}
+	parsers := []*jsonpath.JSONPath{}
+	for _, c := range options.Columns {
+		headings = append(headings, c.Heading)
+
+		p := jsonpath.New(c.Heading).AllowMissingKeys(true)
+		err := p.Parse(c.JSONPath)
+		if err != nil {
+			return err
+		}
+
+		parsers = append(parsers, p)
+	}
+
+	tabs := tabwriter.NewWriter(writer, TableColumnMinWidth, TableTabSize, TablePadSize, TablePadCharacter, TableFlags)
+	_, err = tabs.Write([]byte(strings.Join(headings, "\t") + "\n"))
+	if err != nil {
+		return err
+	}
+
+	for _, row := range rows {
+
+		// For each row evaluate the path and write to output using tab as separator
+		for _, p := range parsers {
+			err := p.Execute(tabs, row)
+			if err != nil {
+				return err
+			}
+			_, err = tabs.Write([]byte("\t"))
+			if err != nil {
+				return err
+			}
+		}
+
+		_, err := tabs.Write([]byte("\n"))
+		if err != nil {
+			return err
+		}
+	}
+
+	err = tabs.Flush()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ Formatter = (*TableFormatter)(nil)

--- a/pkg/rad/output/writer.go
+++ b/pkg/rad/output/writer.go
@@ -1,0 +1,22 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package output
+
+import "io"
+
+func Write(format string, obj interface{}, writer io.Writer, options FormatterOptions) error {
+	formatter, err := NewFormatter(format)
+	if err != nil {
+		return err
+	}
+
+	err = formatter.Format(obj, writer, options)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/rad/output/writer_test.go
+++ b/pkg/rad/output/writer_test.go
@@ -1,0 +1,37 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package output
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type writerInput struct {
+	Size   string
+	IsCool bool
+}
+
+// Just a single E2E test for the Write method, writers are tested in detail elsewhere.
+func Test_Write(t *testing.T) {
+	obj := writerInput{
+		Size:   "mega",
+		IsCool: true,
+	}
+
+	buffer := &bytes.Buffer{}
+	err := Write(FormatJson, obj, buffer, FormatterOptions{})
+	require.NoError(t, err)
+
+	expected := `{
+  "Size": "mega",
+  "IsCool": true
+}
+`
+	require.Equal(t, expected, buffer.String())
+}


### PR DESCRIPTION
Fixes: radius-project/core-team#487

This change decouples the CLI from the output produced by commands like
`rad application list`. The objects returned from the client now flow
through a configurable formatting pipeline.

We have a new global command line option `-o` for choosing output.

The main addition here is support for tabular formats with `-o table`.
We have support for a per-type set of columns to display, and can add
extensible column support in the future.

The default has changed to use table output by default. Tables are for
humans, JSON is for computers. The raw JSON output is accessible with
`-o json`.