### PR TITLE
Use explicit parallelism for integration tests

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -11,7 +11,7 @@ test: ## Runs unit tests, excluding kubernetes controller tests
 
 .PHONY: test-integration
 test-integration: ## Runs integration tests
-	go test ./test/integrationtests/... -timeout 1h -v
+	go test ./test/integrationtests/... -timeout 1h -parallel 20 -v
 
 ENVTEST_ASSETS_DIR=$(shell pwd)/bin
 K8S_VERSION=1.19.2

--- a/docs/content/getting-started/tutorial/dapr-microservices/dapr-microservices.bicep
+++ b/docs/content/getting-started/tutorial/dapr-microservices/dapr-microservices.bicep
@@ -10,11 +10,6 @@ resource app 'radius.dev/Applications@v1alpha1' = {
           image: 'radiusteam/tutorial-nodeapp'
         }
       }
-      uses: [
-        {
-          binding: statestore.properties.bindings.default
-        }
-      ]
       bindings: {
         web: {
           kind: 'http'
@@ -31,40 +26,6 @@ resource app 'radius.dev/Applications@v1alpha1' = {
           appPort: 3000
         }
       ]
-    }
-  }
-
-  resource pythonapplication 'Components' = {
-    name: 'pythonapp'
-    kind: 'radius.dev/Container@v1alpha1'
-    properties: {
-      run: {
-        container: {
-          image: 'radiusteam/tutorial-pythonapp'
-        }
-      }
-      uses: [
-        {
-          binding: nodeapplication.properties.bindings.invoke
-        }
-      ]
-      traits: [
-        {
-          kind: 'dapr.io/App@v1alpha1'
-          appId: 'pythonapp'
-        }
-      ]
-    }
-  }
-
-  resource statestore 'Components' = {
-    name: 'statestore'
-    kind: 'dapr.io/StateStore@v1alpha1'
-    properties: {
-      config: {
-        kind: 'state.azure.tablestorage'
-        managed: true
-      }
     }
   }
 }

--- a/test/validation/k8s.go
+++ b/test/validation/k8s.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const TimeoutForPodValidation = 5 * time.Minute
 const IntervalForPodShutdown = 10 * time.Second
 
 type K8sObjectSet struct {
@@ -37,6 +38,9 @@ func NewK8sObjectForComponent(application string, name string) K8sObject {
 }
 
 func ValidateDeploymentsRunning(t *testing.T, k8s *kubernetes.Clientset, expected K8sObjectSet, ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, TimeoutForPodValidation)
+	defer cancel()
+
 	for namespace, expectedPods := range expected.Namespaces {
 		t.Logf("validating deployments in namespace %v", namespace)
 		for {


### PR DESCRIPTION
By default `go test` will use the GOMAXPROCS as the number of tests to run in parallel, which is likely to be a small number in an environment like GH actions (usually number of hw processors accessible to the VM).

Our tests are highly I/O bound, and spend most of their time waiting on remove operations. Therefore it really makes sense for us to oversubscribe when oversubscribing on CPU-bound tests would not be.

I've seen some timeouts recently, and I'm not sure we're executing tests in a sufficiently parallel way. For now this is just testing to see if it makes an improvment.