### PR TITLE
Use preview version of role assignment

### DIFF
--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -236,15 +236,15 @@
                         },
                         {
                             "type": "Microsoft.Authorization/roleAssignments",
-                            "apiVersion": "2017-09-01",
+                            "apiVersion": "2018-09-01-preview",
                             "name": "[variables('deploymentRoleDefinitionName')]",
                             "tags": "[parameters('resourceTags')]",
                             "dependsOn": [
-                                "[parameters('deploymentScriptIdentityName')]"
+                                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('deploymentScriptIdentityName'))]"
                             ],
                             "properties": {
                                 "roleDefinitionId": "[variables('deploymentRoleDefinitionId')]",
-                                "principalId": "[reference(parameters('deploymentScriptIdentityName')).principalId]",
+                                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('deploymentScriptIdentityName'))).principalId]",
                                 "principalType": "ServicePrincipal"
                             }
                         },
@@ -334,7 +334,7 @@
                         },
                         {
                             "type": "Microsoft.Authorization/roleAssignments",
-                            "apiVersion": "2017-09-01",
+                            "apiVersion": "2018-09-01-preview",
                             "name": "[variables('clusterIdentityRoleDefinitionName')]",
                             "tags": "[parameters('resourceTags')]",
                             "dependsOn": [
@@ -462,7 +462,7 @@
                         },
                         {
                             "type": "Microsoft.Authorization/roleAssignments",
-                            "apiVersion": "2017-09-01",
+                            "apiVersion": "2018-09-01-preview",
                             "name": "[variables('rpControlPlaneRoleDefinitionName')]",
                             "tags": "[parameters('resourceTags')]",
                             "dependsOn": [
@@ -566,7 +566,7 @@
                         },
                         {
                             "type": "Microsoft.Authorization/roleAssignments",
-                            "apiVersion": "2017-09-01",
+                            "apiVersion": "2018-09-01-preview",
                             "name": "[variables('rpGroupRoleDefinitionName')]",
                             "tags": "[parameters('resourceTags')]",
                             "properties": {
@@ -577,7 +577,7 @@
                         },
                         {
                             "type": "Microsoft.Authorization/roleAssignments",
-                            "apiVersion": "2017-09-01",
+                            "apiVersion": "2018-09-01-preview",
                             "name": "[variables('clusterIdentityRoleDefinitionName')]",
                             "tags": "[parameters('resourceTags')]",
                             "properties": {


### PR DESCRIPTION
Fixes: #598

Unfortunately we have to use a preview version of this resource in order
to get at all resonable behavior.

See: https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-template#new-service-principal

Unfortunately the ARM tools will recommend that you change the version
for better validation. Double-unfortunately we *cannot* put comments in
our ARM template due to the way we read it for `rad env init azure`.