### PR TITLE
Validate .bicep files

### DIFF
--- a/.github/workflows/validate-bicep.yaml
+++ b/.github/workflows/validate-bicep.yaml
@@ -1,0 +1,29 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+name: Validate Bicep Code
+on:
+  pull_request:
+    branches:
+      - main
+      - release/*
+jobs:
+  build:
+    name: Validate Bicep Code
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v2
+    - name: Parse release version and set environment variables
+      run: python ./.github/scripts/get_release_version.py
+    - name: Download rad-bicep
+      run: |
+        curl https://radiuspublic.blob.core.windows.net/tools/bicep/${{ env.REL_CHANNEL }}/linux-x64/rad-bicep --output rad-bicep
+        chmod +x rad-bicep
+        ./rad-bicep --version
+    - name: Verify bicep files
+      run: ./build/validate-bicep.sh
+      env: 
+        BICEP_PATH: .

--- a/build/test.mk
+++ b/build/test.mk
@@ -22,3 +22,6 @@ test-get-envtools:
 	
 test-controller: generate-k8s-manifests generate-controller test-get-envtools ## Runs controller tests, note arm64 version not available.
 	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" go test ./test/controllertests/...  
+
+test-validate-bicep: ## Validates that all .bicep files compile cleanly
+	BICEP_PATH="${HOME}/.rad/bin" ./build/validate-bicep.sh

--- a/build/validate-bicep.sh
+++ b/build/validate-bicep.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+BICEP_EXECUTABLE="rad-bicep"
+if [[ ! -z $BICEP_PATH ]]
+then
+    BICEP_EXECUTABLE="$BICEP_PATH/$BICEP_EXECUTABLE"
+fi
+
+FILES=$(find . -type f -name "*.bicep")
+FAILURES=()
+for F in $FILES
+do
+    echo "validating $F"
+    # We need to run the rad-bicep and fail in one of two cases:
+    # - non-zero exit code
+    # - non-empty stderr 
+    #
+    # We also don't want to dirty any files on disk.
+    #
+    # This complicated little block does that:
+    # - Compiled output (ARM templates) go to rad-bicep's stdout
+    # - rad-bicep's stdout goes to /dev/null
+    # - rad-bicep's stderr goes to the variable
+    exec 3>&1
+    STDERR=$($BICEP_EXECUTABLE build $F --stdout 2>&1 1>/dev/null)
+    EXITCODE=$?
+    exec 3>&-
+
+    if [[ ! $EXITCODE -eq 0 || ! -z $STDERR ]]
+    then
+        echo $STDERR
+        FAILURES+=$F
+    fi
+done
+
+for F in $FAILURES
+do
+  echo "Failed: $F"
+done
+
+exit ${#FAILURES[@]}


### PR DESCRIPTION
Part of: radius-project/core-team#1026

This change validates that all of our .bicep files build cleanly (no
warnings, no errors) using the channel's compiler.