### PR TITLE
Enhancements to rad shortcode

### DIFF
--- a/docs/content/app-model/components-model.md
+++ b/docs/content/app-model/components-model.md
@@ -37,20 +37,7 @@ Different [binding types]({{< ref bindings-model.md >}}) may also have additiona
 
 In the following example a container offers an HTTP binding on port 3000:
 
-```sh
-resource store 'Components' = {
-  name: 'storefront'
-  kind: 'radius.dev/Container@v1alpha1'
-  properties: {
-    bindings: 
-      web: {
-        kind: 'http'
-        targetPort: 3000
-      }
-    ]
-  }
-}
-```
+{{< rad file="snippets/components-model-storefront.bicep" embed=true marker="//SAMPLE" replace-key-hide="//HIDE" replace-value-hide="run: {...}" >}}
 
 ## Uses
 

--- a/docs/content/app-model/snippets/components-model-storefront.bicep
+++ b/docs/content/app-model/snippets/components-model-storefront.bicep
@@ -1,0 +1,25 @@
+resource app 'radius.dev/Applications@v1alpha1' = {
+  name: 'storefront-app'
+
+  //SAMPLE
+  resource store 'Components' = {
+    name: 'storefront'
+    kind: 'radius.dev/Container@v1alpha1'
+    properties: {
+      //HIDE
+      run: { 
+        container: {
+          image: 'foo'
+        }
+      }
+      //HIDE
+      bindings: {
+        web: {
+          kind: 'http'
+          targetPort: 3000
+        }
+      }
+    }
+  }
+  //SAMPLE
+}

--- a/docs/content/contributing/contributing-docs.md
+++ b/docs/content/contributing/contributing-docs.md
@@ -141,6 +141,125 @@ As an example, for this specific section the complete reference to the page and 
 {{</* ref "contributing-docs.md#referencing-sections-in-other-pages" */>}}
 ```
 
+### Code snippets
+
+Use the `rad` shortcode to reference code snippets from a file. By convention place code snippets in a `snippets` folder.
+
+{{</* rad file="snippets/mysample.bicep" embed=true */>}}
+
+{{% alert title="Warning" color="warning" %}}
+All Bicep sample code should be self-contained in separate files, not in markdown. We validate all `.bicep` files as part of the build for syntactic and semantic correctness, and so all `.bicep` sample code must be complete and correct. Use the techniques described here to highlight the parts of the sample code users should focus on.
+{{% /alert %}}
+
+Use the `embed` parameter (default `false`) to include a download link and embed the content in the page.
+
+Use the `lang` (default `bicep`) parameter to configure the language used for syntax highlighting.
+
+Use the `marker` parameter to limit the embedded snipped to a portion of the sample file. This is useful when you want to show just a portion of a larger file. The typical way to do this is surround the interesting code with comments, and then pass the comment text into `marker`.
+
+The shortcode below and code sample:
+
+{{</* rad file="snippets/mysample.bicep" embed=true marker="//SAMPLE" */>}}
+
+```bicep
+// in snippets/mysample.bicep
+resource app 'radius.dev/Applications@v1alpha1' = {
+  name: 'storefront-app'
+
+  //SAMPLE
+  resource store 'Components' = {
+    name: 'storefront'
+    kind: 'radius.dev/Container@v1alpha1'
+    properties: {
+      run: { 
+        container: {
+          image: 'foo'
+        }
+      }
+      bindings: {
+        web: {
+          kind: 'http'
+          targetPort: 3000
+        }
+      }
+    }
+  }
+  //SAMPLE
+}
+```
+
+Will result in the following output:
+
+```bicep
+  resource store 'Components' = {
+    name: 'storefront'
+    kind: 'radius.dev/Container@v1alpha1'
+    properties: {
+      run: { 
+        container: {
+          image: 'foo'
+        }
+      }
+      bindings: {
+        web: {
+          kind: 'http'
+          targetPort: 3000
+        }
+      }
+    }
+  }
+```
+
+Use the `replace-key-[token]` and `replace-value-[token]` parameters to limit the embedded snipped to a portion of the sample file. This is useful when you want abbreviate a portion of the code sample. Multiple replacements are supported with multiple values of `token`. 
+
+The shortcode below and code sample:
+
+{{</* rad file="snippets/mysample.bicep" embed=true marker="//SAMPLE" replace-key-run="//RUN" replace-value-run="run: {...}" replace-key-bindings="//BINDINGS" replace-value-bindings="bindings: {...}" */>}}
+
+```bicep
+// in snippets/mysample.bicep
+resource app 'radius.dev/Applications@v1alpha1' = {
+  name: 'storefront-app'
+
+  //SAMPLE
+  resource store 'Components' = {
+    name: 'storefront'
+    kind: 'radius.dev/Container@v1alpha1'
+    properties: {
+      //RUN
+      run: { 
+        container: {
+          image: 'foo'
+        }
+      }
+      //RUN
+      //BINDINGS
+      bindings: {
+        web: {
+          kind: 'http'
+          targetPort: 3000
+        }
+      }
+      //BINDINGS
+    }
+  }
+  //SAMPLE
+}
+```
+
+Will result in the following output:
+
+```bicep
+  resource store 'Components' = {
+    name: 'storefront'
+    kind: 'radius.dev/Container@v1alpha1'
+    properties: {
+      run: {...}
+      bindings: {...}
+    }
+  }
+```
+
 ### Images
 
 The markdown spec used by Docsy and Hugo does not give an option to resize images using markdown notation. Instead, raw HTML is used.

--- a/docs/layouts/shortcodes/rad.html
+++ b/docs/layouts/shortcodes/rad.html
@@ -5,5 +5,20 @@
 {{ $embed := .Get "embed" | default false }}
 <a href={{ print $file }} download>Download template file</a><br /><br />
 {{ if $embed }}
+{{ if isset .Params "marker" }}
+    {{ $marker := .Get "marker" }}
+    {{ $regex := printf "(?s).*%s%s%s.*" $marker `(\n)?(?P<inner>.*?)(\n\s+)?` $marker }}
+    {{ $fileContents = replaceRE $regex "$inner" $fileContents}}
+{{ end }}
+{{ range $key, $value := $.Params }}
+    {{ if hasPrefix $key "replace-key" }}
+        {{ $replace := $value }}
+        {{ $replaceValueParameter := printf "replace-value-%s" (slicestr $key (len "replace-key-")) }}
+        <p>{{ $replaceValueParameter }}</p>
+        {{ $replaceWith := index $.Params $replaceValueParameter }}
+        {{ $regex := printf "(?s)%s%s%s" $replace `(\n)?(?P<inner>.*?)(\n\s+)?` $replace }}
+        {{ $fileContents = replaceRE $regex $replaceWith $fileContents}}
+    {{ end }}
+{{ end }}
 {{ (print "```" $lang "\n" $fileContents "\n```") | markdownify }}
 {{ end }}


### PR DESCRIPTION
Part of: radius-project/core-team#1026

This change enhances the `rad` shortcode for code snippets to allow:
- Including a subregion of code in the output instead of a whole file
- Doing replacements to abbreviate regions of the code

This adds up to use being able to use fully-valid `.bicep` files that
can be validated, but still have a lot of control over what shows up in
the docs.