### PR TITLE
Stop using viper.GetViper()

### DIFF
--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -35,7 +35,8 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	env, err := rad.RequireEnvironment(cmd)
+	config := ConfigFromContext(cmd.Context())
+	env, err := rad.RequireEnvironment(cmd, config)
 	if err != nil {
 		return err
 	}
@@ -82,7 +83,7 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = updateApplicationConfig(env, applicationName)
+	err = updateApplicationConfig(config, env, applicationName)
 	if err != nil {
 		return err
 	}
@@ -91,11 +92,10 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func updateApplicationConfig(env environments.Environment, applicationName string) error {
+func updateApplicationConfig(config *viper.Viper, env environments.Environment, applicationName string) error {
 	// If the application we are deleting is the default application, remove it
 	if env.GetDefaultApplication() == applicationName {
-		v := viper.GetViper()
-		envSection, err := rad.ReadEnvironmentSection(v)
+		envSection, err := rad.ReadEnvironmentSection(config)
 		if err != nil {
 			return err
 		}
@@ -104,9 +104,9 @@ func updateApplicationConfig(env environments.Environment, applicationName strin
 
 		envSection.Items[env.GetName()][environments.EnvironmentKeyDefaultApplication] = ""
 
-		rad.UpdateEnvironmentSection(v, envSection)
+		rad.UpdateEnvironmentSection(config, envSection)
 
-		err = rad.SaveConfig()
+		err = rad.SaveConfig(config)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/cmd/appList.go
+++ b/cmd/cli/cmd/appList.go
@@ -27,7 +27,8 @@ func init() {
 }
 
 func listApplications(cmd *cobra.Command, args []string) error {
-	env, err := rad.RequireEnvironment(cmd)
+	config := ConfigFromContext(cmd.Context())
+	env, err := rad.RequireEnvironment(cmd, config)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/appShow.go
+++ b/cmd/cli/cmd/appShow.go
@@ -26,7 +26,8 @@ func init() {
 }
 
 func showApplication(cmd *cobra.Command, args []string) error {
-	env, err := rad.RequireEnvironment(cmd)
+	config := ConfigFromContext(cmd.Context())
+	env, err := rad.RequireEnvironment(cmd, config)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/appSwitch.go
+++ b/cmd/cli/cmd/appSwitch.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/Azure/radius/pkg/rad/logger"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // appSwitchCmd command to switch applications
@@ -50,8 +49,8 @@ func switchApplications(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no application specified")
 	}
 
-	v := viper.GetViper()
-	env, err := rad.ReadEnvironmentSection(v)
+	config := ConfigFromContext(cmd.Context())
+	env, err := rad.ReadEnvironmentSection(config)
 	if err != nil {
 		return err
 	}
@@ -78,7 +77,7 @@ func switchApplications(cmd *cobra.Command, args []string) error {
 
 	env.Items[e.GetName()][environments.EnvironmentKeyDefaultApplication] = applicationName
 
-	rad.UpdateEnvironmentSection(v, env)
-	err = rad.SaveConfig()
+	rad.UpdateEnvironmentSection(config, env)
+	err = rad.SaveConfig(config)
 	return err
 }

--- a/cmd/cli/cmd/componentExpose.go
+++ b/cmd/cli/cmd/componentExpose.go
@@ -26,7 +26,8 @@ Press CTRL+C to exit the command and terminate the tunnel.`,
 # on local port 5000
 rad component expose --application icecream-store orders --port 5000 --remote-port 80`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		env, err := rad.RequireEnvironment(cmd)
+		config := ConfigFromContext(cmd.Context())
+		env, err := rad.RequireEnvironment(cmd, config)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/cmd/componentList.go
+++ b/cmd/cli/cmd/componentList.go
@@ -26,7 +26,8 @@ func init() {
 }
 
 func listComponents(cmd *cobra.Command, args []string) error {
-	env, err := rad.RequireEnvironment(cmd)
+	config := ConfigFromContext(cmd.Context())
+	env, err := rad.RequireEnvironment(cmd, config)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/componentLogs.go
+++ b/cmd/cli/cmd/componentLogs.go
@@ -38,7 +38,8 @@ rad component logs --application icecream-store orders --follow
 # read logs from the 'daprd' sidecare container of the 'orders' component of the 'icecream-store' application
 rad component logs --application icecream-store orders --container daprd`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		env, err := rad.RequireEnvironment(cmd)
+		config := ConfigFromContext(cmd.Context())
+		env, err := rad.RequireEnvironment(cmd, config)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/cmd/componentShow.go
+++ b/cmd/cli/cmd/componentShow.go
@@ -26,7 +26,8 @@ func init() {
 }
 
 func showComponent(cmd *cobra.Command, args []string) error {
-	env, err := rad.RequireEnvironment(cmd)
+	config := ConfigFromContext(cmd.Context())
+	env, err := rad.RequireEnvironment(cmd, config)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/deploy.go
+++ b/cmd/cli/cmd/deploy.go
@@ -43,7 +43,8 @@ func deploy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	env, err := rad.RequireEnvironment(cmd)
+	config := ConfigFromContext(cmd.Context())
+	env, err := rad.RequireEnvironment(cmd, config)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/deploymentDelete.go
+++ b/cmd/cli/cmd/deploymentDelete.go
@@ -33,7 +33,8 @@ func deleteDeployment(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	env, err := rad.RequireEnvironment(cmd)
+	config := ConfigFromContext(cmd.Context())
+	env, err := rad.RequireEnvironment(cmd, config)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/deploymentList.go
+++ b/cmd/cli/cmd/deploymentList.go
@@ -26,7 +26,8 @@ func init() {
 }
 
 func listDeployments(cmd *cobra.Command, args []string) error {
-	env, err := rad.RequireEnvironment(cmd)
+	config := ConfigFromContext(cmd.Context())
+	env, err := rad.RequireEnvironment(cmd, config)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/deploymentShow.go
+++ b/cmd/cli/cmd/deploymentShow.go
@@ -26,7 +26,8 @@ func init() {
 }
 
 func showDeployment(cmd *cobra.Command, args []string) error {
-	env, err := rad.RequireEnvironment(cmd)
+	config := ConfigFromContext(cmd.Context())
+	env, err := rad.RequireEnvironment(cmd, config)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/envDelete.go
+++ b/cmd/cli/cmd/envDelete.go
@@ -40,8 +40,10 @@ func deleteEnv(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	config := ConfigFromContext(cmd.Context())
+
 	// Validate environment exists, retrieve associated resource group and subscription id
-	env, err := rad.RequireEnvironmentArgs(cmd, args)
+	env, err := rad.RequireEnvironmentArgs(cmd, config, args)
 	if err != nil {
 		return err
 	}
@@ -80,7 +82,7 @@ func deleteEnv(cmd *cobra.Command, args []string) error {
 	logger.LogInfo("Environment deleted")
 
 	// Delete env from the config, update default env if needed
-	if err = deleteEnvFromConfig(az.Name); err != nil {
+	if err = deleteEnvFromConfig(config, az.Name); err != nil {
 		return err
 	}
 
@@ -122,10 +124,9 @@ func deleteResourceGroup(ctx context.Context, authorizer autorest.Authorizer, re
 	return nil
 }
 
-func deleteEnvFromConfig(envName string) error {
+func deleteEnvFromConfig(config *viper.Viper, envName string) error {
 	logger.LogInfo("Updating config")
-	v := viper.GetViper()
-	env, err := rad.ReadEnvironmentSection(v)
+	env, err := rad.ReadEnvironmentSection(config)
 	if err != nil {
 		return err
 	}
@@ -139,8 +140,8 @@ func deleteEnvFromConfig(envName string) error {
 			break
 		}
 	}
-	rad.UpdateEnvironmentSection(v, env)
-	if err = rad.SaveConfig(); err != nil {
+	rad.UpdateEnvironmentSection(config, env)
+	if err = rad.SaveConfig(config); err != nil {
 		return err
 	}
 

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -34,7 +34,6 @@ import (
 	"github.com/Azure/radius/pkg/version"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var supportedLocations = [5]string{
@@ -599,8 +598,8 @@ func findClusterInDeployment(ctx context.Context, deployment resources.Deploymen
 func storeEnvironment(ctx context.Context, authorizer autorest.Authorizer, name string, subscriptionID string, resourceGroup string, controlPlaneResourceGroup string, clusterName string) error {
 	step := logger.BeginStep("Updating Config...")
 
-	v := viper.GetViper()
-	env, err := rad.ReadEnvironmentSection(v)
+	config := ConfigFromContext(ctx)
+	env, err := rad.ReadEnvironmentSection(config)
 	if err != nil {
 		return err
 	}
@@ -615,9 +614,9 @@ func storeEnvironment(ctx context.Context, authorizer autorest.Authorizer, name 
 	if len(env.Items) == 1 {
 		env.Default = name
 	}
-	rad.UpdateEnvironmentSection(v, env)
+	rad.UpdateEnvironmentSection(config, env)
 
-	err = rad.SaveConfig()
+	err = rad.SaveConfig(config)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/envInitLocal.go
+++ b/cmd/cli/cmd/envInitLocal.go
@@ -8,7 +8,6 @@ package cmd
 import (
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var envInitLocalCmd = &cobra.Command{
@@ -16,8 +15,8 @@ var envInitLocalCmd = &cobra.Command{
 	Short: "Initializes a local environment",
 	Long:  `Initializes a local environment`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		v := viper.GetViper()
-		env, err := rad.ReadEnvironmentSection(v)
+		config := ConfigFromContext(cmd.Context())
+		env, err := rad.ReadEnvironmentSection(config)
 		if err != nil {
 			return err
 		}
@@ -28,9 +27,9 @@ var envInitLocalCmd = &cobra.Command{
 		if len(env.Items) == 1 {
 			env.Default = "local"
 		}
-		rad.UpdateEnvironmentSection(v, env)
+		rad.UpdateEnvironmentSection(config, env)
 
-		err = rad.SaveConfig()
+		err = rad.SaveConfig(config)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/cmd/envList.go
+++ b/cmd/cli/cmd/envList.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 )
 
@@ -20,8 +19,8 @@ var envListCmd = &cobra.Command{
 	Long:  `List environments`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		v := viper.GetViper()
-		env, err := rad.ReadEnvironmentSection(v)
+		config := ConfigFromContext(cmd.Context())
+		env, err := rad.ReadEnvironmentSection(config)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/cmd/envMergeCredentials.go
+++ b/cmd/cli/cmd/envMergeCredentials.go
@@ -22,7 +22,8 @@ var envMergeCredentialsCmd = &cobra.Command{
 	Short: "Merge Kubernetes credentials",
 	Long:  "Merge Kubernetes credentials into your local user store. Currently only supports Azure environments",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		env, err := rad.RequireEnvironment(cmd)
+		config := ConfigFromContext(cmd.Context())
+		env, err := rad.RequireEnvironment(cmd, config)
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/cmd/envShow.go
+++ b/cmd/cli/cmd/envShow.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 )
 
@@ -32,8 +31,8 @@ func showEnvironment(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	v := viper.GetViper()
-	env, err := rad.ReadEnvironmentSection(v)
+	config := ConfigFromContext(cmd.Context())
+	env, err := rad.ReadEnvironmentSection(config)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/envSwitch.go
+++ b/cmd/cli/cmd/envSwitch.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/logger"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var envSwitchCmd = &cobra.Command{
@@ -26,8 +25,8 @@ func init() {
 }
 
 func switchEnv(cmd *cobra.Command, args []string) error {
-	v := viper.GetViper()
-	section, err := rad.ReadEnvironmentSection(v)
+	config := ConfigFromContext(cmd.Context())
+	section, err := rad.ReadEnvironmentSection(config)
 	if err != nil {
 		return err
 	}
@@ -49,7 +48,7 @@ func switchEnv(cmd *cobra.Command, args []string) error {
 	}
 
 	// Retrieve associated resource group and subscription id
-	env, err := rad.ValidateNamedEnvironment(envName)
+	env, err := rad.ValidateNamedEnvironment(config, envName)
 	if err != nil {
 		return err
 	}
@@ -66,8 +65,8 @@ func switchEnv(cmd *cobra.Command, args []string) error {
 	logger.LogInfo(text)
 
 	section.Default = envName
-	rad.UpdateEnvironmentSection(v, section)
-	err = rad.SaveConfig()
+	rad.UpdateEnvironmentSection(config, section)
+	err = rad.SaveConfig(config)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -6,6 +6,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/Azure/radius/pkg/rad/output"
 	"github.com/Azure/radius/pkg/version"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // RootCmd is the root command of the rad CLI. This is exported so we can generate docs for it.
@@ -28,14 +30,23 @@ var RootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
+	ctx := context.WithValue(context.Background(), configHolderKey, configHolder)
+	if err := RootCmd.ExecuteContext(ctx); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(1)
 	}
 }
 
 func init() {
-	cobra.OnInitialize(rad.InitConfig)
+	cobra.OnInitialize(func() {
+		v, err := rad.LoadConfig(configHolder.ConfigFilePath)
+		if err != nil {
+			fmt.Printf("Error: failed to load config: %v\n", err)
+			os.Exit(1)
+		}
+
+		configHolder.Config = v
+	})
 
 	// Initialize support for --version
 	RootCmd.Version = version.Release()
@@ -43,8 +54,37 @@ func init() {
 	RootCmd.SetVersionTemplate(template)
 
 	RootCmd.Flags().BoolP("version", "v", false, "version for radius")
-	RootCmd.PersistentFlags().StringVar(&rad.CfgFile, "config", "", "config file (default is $HOME/.rad/config.yaml)")
+	RootCmd.PersistentFlags().StringVar(&configHolder.ConfigFilePath, "config", "", "config file (default is $HOME/.rad/config.yaml)")
 
 	outputDescription := fmt.Sprintf("output format (default is %s, supported formats are %s)", output.DefaultFormat, strings.Join(output.SupportedFormats(), ", "))
 	RootCmd.PersistentFlags().StringP("output", "o", "table", outputDescription)
+}
+
+// The dance we do with config is kinda complex. We want commands to be able to retrieve a config (*viper.Viper)
+// from context. However we need to initialize the context before we can read the config (before argument parsing).
+//
+// The solution is a double-indirection. We add a "ConfigHolder" to the context, and then initialize it later. This
+// way the context is still immutable, but we can add the config when we're ready to (before any command runs).
+
+type contextKey string
+
+func NewContextKey(purpose string) contextKey {
+	return contextKey("radius context " + purpose)
+}
+
+var configHolderKey = NewContextKey("config")
+var configHolder = &ConfigHolder{}
+
+type ConfigHolder struct {
+	ConfigFilePath string
+	Config         *viper.Viper
+}
+
+func ConfigFromContext(ctx context.Context) *viper.Viper {
+	holder := ctx.Value(configHolderKey).(*ConfigHolder)
+	if holder == nil {
+		return nil
+	}
+
+	return holder.Config
 }

--- a/cmd/testenv/cmd/release.go
+++ b/cmd/testenv/cmd/release.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var releaseCmd = &cobra.Command{
@@ -100,9 +99,7 @@ func init() {
 }
 
 func readEnvironmentFromConfigfile(configpath string, name string) (*environments.AzureCloudEnvironment, error) {
-	v := viper.GetViper()
-	v.SetConfigFile(configpath)
-	err := v.ReadInConfig()
+	v, err := rad.LoadConfig(configpath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/testenv/cmd/reserve.go
+++ b/cmd/testenv/cmd/reserve.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/azure"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 const leaseTimeout = 30 * time.Minute
@@ -63,7 +62,11 @@ var reserveCmd = &cobra.Command{
 			return err
 		}
 
-		v := viper.GetViper()
+		v, err := rad.LoadConfig(configpath)
+		if err != nil {
+			return err
+		}
+
 		env, err := rad.ReadEnvironmentSection(v)
 		if err != nil {
 			return err
@@ -82,12 +85,11 @@ var reserveCmd = &cobra.Command{
 		}
 
 		rad.UpdateEnvironmentSection(v, env)
-		err = v.SafeWriteConfigAs(configpath)
+		err = rad.SaveConfig(v)
 		if err != nil {
 			return err
 		}
 
-		fmt.Printf("wrote config to '%v'\n", configpath)
 		return nil
 	},
 }

--- a/cmd/testenv/cmd/updaterp.go
+++ b/cmd/testenv/cmd/updaterp.go
@@ -21,7 +21,6 @@ import (
 	"github.com/Azure/radius/pkg/radrp/armauth"
 	"github.com/Azure/radius/pkg/version"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 const (
@@ -49,9 +48,7 @@ var updateRPCmd = &cobra.Command{
 			return err
 		}
 
-		v := viper.GetViper()
-		v.SetConfigFile(configpath)
-		err = v.ReadInConfig()
+		v, err := rad.LoadConfig(configpath)
 		if err != nil {
 			return err
 		}

--- a/pkg/rad/clivalidation.go
+++ b/pkg/rad/clivalidation.go
@@ -14,9 +14,8 @@ import (
 )
 
 // Used by commands that require a named environment to be an azure cloud environment.
-func ValidateNamedEnvironment(name string) (environments.Environment, error) {
-	v := viper.GetViper()
-	env, err := ReadEnvironmentSection(v)
+func ValidateNamedEnvironment(config *viper.Viper, name string) (environments.Environment, error) {
+	env, err := ReadEnvironmentSection(config)
 	if err != nil {
 		return nil, err
 	}
@@ -29,23 +28,23 @@ func ValidateNamedEnvironment(name string) (environments.Environment, error) {
 	return e, nil
 }
 
-func RequireEnvironment(cmd *cobra.Command) (environments.Environment, error) {
+func RequireEnvironment(cmd *cobra.Command, config *viper.Viper) (environments.Environment, error) {
 	environmentName, err := cmd.Flags().GetString("environment")
 	if err != nil {
 		return nil, err
 	}
 
-	env, err := ValidateNamedEnvironment(environmentName)
+	env, err := ValidateNamedEnvironment(config, environmentName)
 	return env, err
 }
 
-func RequireEnvironmentArgs(cmd *cobra.Command, args []string) (environments.Environment, error) {
+func RequireEnvironmentArgs(cmd *cobra.Command, config *viper.Viper, args []string) (environments.Environment, error) {
 	environmentName, err := RequireEnvironmentNameArgs(cmd, args)
 	if err != nil {
 		return nil, err
 	}
 
-	env, err := ValidateNamedEnvironment(environmentName)
+	env, err := ValidateNamedEnvironment(config, environmentName)
 	return env, err
 }
 


### PR DESCRIPTION
Found this issue while doing some test cleanup. Right now we're using
viper.GetViper() which relies on global mutable state and is thus not
testable.

I was trying to figure out why our test code that reads config doesn't
do it the way we do in `rad`... and yeah that's why....