### PR TITLE
Fix error reporting for env creation/deletion

### DIFF
--- a/.github/workflows/create-environment.yaml
+++ b/.github/workflows/create-environment.yaml
@@ -97,8 +97,8 @@ jobs:
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOWID: ${{ env.GITHUB_RUN_ID }}
-          WORKFLOWURL: 'https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}'
+          WORKFLOWID: ${{ github.run_id }}
+          WORKFLOWURL: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         with:
           filename: .github/ISSUE_TEMPLATE/environment-failure.md
       - name: Cleanup on failure

--- a/.github/workflows/delete-environment.yaml
+++ b/.github/workflows/delete-environment.yaml
@@ -74,7 +74,7 @@ jobs:
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOWID: ${{ env.GITHUB_RUN_ID }}
-          WORKFLOWURL: 'https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}'
+          WORKFLOWID: ${{ github.run_id }}
+          WORKFLOWURL: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         with:
           filename: .github/ISSUE_TEMPLATE/environment-failure.md


### PR DESCRIPTION
This should be the correct way to reference the github repository and
run id that we need to construct links.