### PR TITLE
Remove back-compat code for 0.2 environments

### DIFF
--- a/pkg/rad/config.go
+++ b/pkg/rad/config.go
@@ -170,12 +170,6 @@ func (env EnvironmentSection) decodeEnvironmentSection(name string) (environment
 
 		decoded.Name = name
 
-		// See #565: this is temporary code that handles the case where the app resource group and control plane group are the same
-		// as it was in 0.2.
-		if decoded.ControlPlaneResourceGroup == "" {
-			decoded.ControlPlaneResourceGroup = decoded.ResourceGroup
-		}
-
 		err = validate(decoded)
 		if err != nil {
 			return nil, fmt.Errorf("the environment entry '%v' is invalid: %w", name, err)
@@ -190,12 +184,6 @@ func (env EnvironmentSection) decodeEnvironmentSection(name string) (environment
 		}
 
 		decoded.Name = name
-
-		// See #565: this is temporary code that handles the case where the app resource group and control plane group are the same
-		// as it was in 0.2.
-		if decoded.ControlPlaneResourceGroup == "" {
-			decoded.ControlPlaneResourceGroup = decoded.ResourceGroup
-		}
 
 		err = validate(decoded)
 		if err != nil {

--- a/pkg/rad/config_test.go
+++ b/pkg/rad/config_test.go
@@ -128,6 +128,7 @@ environment:
       kind: azure
       subscriptionid: testsub
       resourcegroup: testrg
+      controlplaneresourcegroup: FAKE-testrg
       clustername: testcluster
       extra: testextra
 `
@@ -148,6 +149,7 @@ environment:
 	require.Equal(t, "azure", aenv.Kind)
 	require.Equal(t, "testsub", aenv.SubscriptionID)
 	require.Equal(t, "testrg", aenv.ResourceGroup)
+	require.Equal(t, "FAKE-testrg", aenv.ControlPlaneResourceGroup)
 	require.Equal(t, map[string]interface{}{"extra": "testextra"}, aenv.Properties)
 }
 

--- a/pkg/radrp/armauth/auth.go
+++ b/pkg/radrp/armauth/auth.go
@@ -40,20 +40,10 @@ func GetArmConfig() (ArmConfig, error) {
 
 	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
 	if subscriptionID == "" {
-		// See #565: this is temporary code that handles the case where the app resource group and control plane group are the same
-		// as it was in 0.2.
-		subscriptionID = os.Getenv("K8S_SUBSCRIPTION_ID")
-	}
-	if subscriptionID == "" {
 		return ArmConfig{}, errors.New("required env-var ARM_SUBSCRIPTION_ID is missing")
 	}
 
 	resourceGroup := os.Getenv("ARM_RESOURCE_GROUP")
-	if resourceGroup == "" {
-		// See #565: this is temporary code that handles the case where the app resource group and control plane group are the same
-		// as it was in 0.2.
-		resourceGroup = os.Getenv("K8S_RESOURCE_GROUP")
-	}
 	if resourceGroup == "" {
 		return ArmConfig{}, errors.New("required env-var ARM_RESOURCE_GROUP is missing")
 	}

--- a/test/integrationtests/environment_test.go
+++ b/test/integrationtests/environment_test.go
@@ -33,15 +33,8 @@ func TestAzureEnvironmentSetup(t *testing.T) {
 	require.NoError(t, err, "failed to create kubernetes client")
 
 	t.Run("Validate App Resource Group", func(t *testing.T) {
-		// See #565: this is temporary code that handles the case where the app resource group and control plane group are the same
-		// as it was in 0.2.
-		isSingleResourceGroup := env.ResourceGroup == env.ControlPlaneResourceGroup
-		if isSingleResourceGroup {
-			return
-		}
 
 		resources := listRadiusEnvironmentResources(ctx, t, env, config, env.ResourceGroup)
-
 		require.Equal(t, len(resources), 1, "Number of resources created by init step is less than expected")
 
 		_, found := resources["Microsoft.CustomProviders/resourceProviders"]
@@ -66,41 +59,19 @@ func TestAzureEnvironmentSetup(t *testing.T) {
 		_, found = resources["Microsoft.Web/sites"]
 		require.True(t, found, "Microsoft.Web/sites resource not created")
 
-		// See #565: this is temporary code that handles the case where the app resource group and control plane group are the same
-		// as it was in 0.2.
-		isSingleResourceGroup := env.ResourceGroup == env.ControlPlaneResourceGroup
-		if isSingleResourceGroup {
-			_, found = resources["Microsoft.CustomProviders/resourceProviders"]
-			require.True(t, found, "Microsoft.CustomProviders/resourceProviders resource not created")
-
-			// Currently, we have a retention policy on the deploymentScript for 1 day.
-			// "retentionInterval": "P1D"
-			// This means the script may or may not be present when checking the number of resources
-			// if the environment was created over a day ago.
-			// Verify that either 6 or 7 resources are present, and only check the deploymentScripts
-			// if there are 6 resources
-			if len(resources) == 7 {
-				_, found = resources["Microsoft.Resources/deploymentScripts"]
-				require.True(t, found, "Microsoft.Resources/deploymentScripts resource not created")
-			}
-
-			require.GreaterOrEqual(t, len(resources), 6, "Number of resources created by init step is less than expected")
-			require.LessOrEqual(t, len(resources), 7, "Number of resources created by init step is greater than expected")
-		} else {
-			// Currently, we have a retention policy on the deploymentScript for 1 day.
-			// "retentionInterval": "P1D"
-			// This means the script may or may not be present when checking the number of resources
-			// if the environment was created over a day ago.
-			// Verify that either 5 or 6 resources are present, and only check the deploymentScripts
-			// if there are 6 resources
-			if len(resources) == 6 {
-				_, found = resources["Microsoft.Resources/deploymentScripts"]
-				require.True(t, found, "Microsoft.Resources/deploymentScripts resource not created")
-			}
-
-			require.GreaterOrEqual(t, len(resources), 5, "Number of resources created by init step is less than expected")
-			require.LessOrEqual(t, len(resources), 6, "Number of resources created by init step is greater than expected")
+		// Currently, we have a retention policy on the deploymentScript for 1 day.
+		// "retentionInterval": "P1D"
+		// This means the script may or may not be present when checking the number of resources
+		// if the environment was created over a day ago.
+		// Verify that either 5 or 6 resources are present, and only check the deploymentScripts
+		// if there are 6 resources
+		if len(resources) == 6 {
+			_, found = resources["Microsoft.Resources/deploymentScripts"]
+			require.True(t, found, "Microsoft.Resources/deploymentScripts resource not created")
 		}
+
+		require.GreaterOrEqual(t, len(resources), 5, "Number of resources created by init step is less than expected")
+		require.LessOrEqual(t, len(resources), 6, "Number of resources created by init step is greater than expected")
 
 	})
 


### PR DESCRIPTION
Fixes: #565

This change removes code that handles the back-compat cases, basically
the way that Radius environments looked and worked when they were a
single resource group instead of two.