### PR TITLE
Log Analytics workspace as deployment parameter

### DIFF
--- a/.github/workflows/create-environment.yaml
+++ b/.github/workflows/create-environment.yaml
@@ -19,6 +19,8 @@ jobs:
 
       # Radius Test subscription
       INTEGRATION_TEST_SUBSCRIPTION_ID: "85716382-7362-45c3-ae03-2126e459a123"
+      # Log Analytics workspace ID where the test logs will be redirected to.
+      INTEGRATION_TEST_LOGANALYTICS_WORKSPACEID: "/subscriptions/85716382-7362-45c3-ae03-2126e459a123/resourcegroups/radiusrplogs/providers/microsoft.operationalinsights/workspaces/rplogs"
 
     # Rough order of logic here
     #
@@ -79,7 +81,8 @@ jobs:
             -e ${{ steps.generate-resource-group-name.outputs.result }} \
             --subscription-id ${{ env.INTEGRATION_TEST_SUBSCRIPTION_ID }} \
             --resource-group ${{ steps.generate-resource-group-name.outputs.result }} \
-            --location "${{ steps.select-location.outputs.result }}"
+            --location "${{ steps.select-location.outputs.result }} \
+            --loganalytics-workspace-id ${{ env.INTEGRATION_TEST_LOGANALYTICS_WORKSPACEID }}"
       - name: Display Environment (Sanity Check)
         run: go run cmd/cli/main.go env list
       - name: Register Environment

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -103,22 +103,21 @@ func init() {
 	envInitAzureCmd.Flags().StringP("location", "l", "", "The Azure location to use for the environment")
 	envInitAzureCmd.Flags().BoolP("interactive", "i", false, "Specify interactive to choose subscription and resource group interactively")
 	envInitAzureCmd.Flags().String("container-registry", "", "Specify the name of an existing Azure Container Registry to grant the environment access to pull containers from the registry")
-	envInitAzureCmd.Flags().StringP("loganalytics-workspace-id", "w", "", "Specify the ARM resource ID of the log analytics workspace where the logs should be redirected to")
+	envInitAzureCmd.Flags().String("loganalytics-workspace-id", "", "Specify the ARM resource ID of the log analytics workspace where the logs should be redirected to")
 
 	// development support
 	envInitAzureCmd.Flags().StringP("deployment-template", "t", "", "The file path to the deployment template - this can be used to override a custom build of the environment deployment ARM template for testing")
 }
 
 type arguments struct {
-	Name                      string
-	Interactive               bool
-	SubscriptionID            string
-	ResourceGroup             string
-	Location                  string
-	DeploymentTemplate        string
-	ContainerRegistry         string
-	LogAnalyticsWorkspaceName string
-	LogAnalyticsWorkspaceID   string
+	Name                    string
+	Interactive             bool
+	SubscriptionID          string
+	ResourceGroup           string
+	Location                string
+	DeploymentTemplate      string
+	ContainerRegistry       string
+	LogAnalyticsWorkspaceID string
 }
 
 func validate(cmd *cobra.Command, args []string) (arguments, error) {

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -16,18 +16,19 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/arm/operationalinsights"
 	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/features"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerregistry/mgmt/containerregistry"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/operationalinsights/mgmt/operationalinsights"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/customproviders/mgmt/customproviders"
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/subscription/mgmt/subscription"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/Azure/radius/pkg/rad"
-	"github.com/Azure/radius/pkg/rad/azure"
+	radazure "github.com/Azure/radius/pkg/rad/azure"
 	"github.com/Azure/radius/pkg/rad/logger"
 	"github.com/Azure/radius/pkg/rad/prompt"
 	"github.com/Azure/radius/pkg/rad/util"
@@ -102,6 +103,7 @@ func init() {
 	envInitAzureCmd.Flags().StringP("location", "l", "", "The Azure location to use for the environment")
 	envInitAzureCmd.Flags().BoolP("interactive", "i", false, "Specify interactive to choose subscription and resource group interactively")
 	envInitAzureCmd.Flags().String("container-registry", "", "Specify the name of an existing Azure Container Registry to grant the environment access to pull containers from the registry")
+	envInitAzureCmd.Flags().StringP("loganalytics-workspace-id", "w", "", "Specify the ARM resource ID of the log analytics workspace where the logs should be redirected to")
 
 	// development support
 	envInitAzureCmd.Flags().StringP("deployment-template", "t", "", "The file path to the deployment template - this can be used to override a custom build of the environment deployment ARM template for testing")
@@ -170,11 +172,6 @@ func validate(cmd *cobra.Command, args []string) (arguments, error) {
 		return arguments{}, err
 	}
 
-	// logAnalyticsWorkspaceName, err := cmd.Flags().GetString("loganalytics-workspace-name")
-	// if err != nil {
-	// 	return arguments{}, err
-	// }
-
 	logAnalyticsWorkspaceID, err := cmd.Flags().GetString("loganalytics-workspace-id")
 	if err != nil {
 		return arguments{}, err
@@ -185,14 +182,13 @@ func validate(cmd *cobra.Command, args []string) (arguments, error) {
 	}
 
 	return arguments{
-		Name:               name,
-		Interactive:        interactive,
-		SubscriptionID:     subscriptionID,
-		ResourceGroup:      resourceGroup,
-		Location:           location,
-		DeploymentTemplate: deploymentTemplate,
-		ContainerRegistry:  registryName,
-		// LogAnalyticsWorkspaceName: logAnalyticsWorkspaceName,
+		Name:                    name,
+		Interactive:             interactive,
+		SubscriptionID:          subscriptionID,
+		ResourceGroup:           resourceGroup,
+		Location:                location,
+		DeploymentTemplate:      deploymentTemplate,
+		ContainerRegistry:       registryName,
 		LogAnalyticsWorkspaceID: logAnalyticsWorkspaceID,
 	}, nil
 }
@@ -216,23 +212,23 @@ func choose(ctx context.Context) (string, string, error) {
 	return sub.SubscriptionID, resourceGroup, nil
 }
 
-func selectSubscription(ctx context.Context, authorizer autorest.Authorizer) (azure.Subscription, error) {
+func selectSubscription(ctx context.Context, authorizer autorest.Authorizer) (radazure.Subscription, error) {
 	subc := subscription.NewSubscriptionsClient()
 	subc.Authorizer = authorizer
 
-	subs, err := azure.LoadSubscriptionsFromProfile()
+	subs, err := radazure.LoadSubscriptionsFromProfile()
 	if err != nil {
 		// Failed to load subscriptions from the user profile, fall back to online.
-		subs, err = azure.LoadSubscriptionsFromAzure(ctx, authorizer)
+		subs, err = radazure.LoadSubscriptionsFromAzure(ctx, authorizer)
 		if err != nil {
-			return azure.Subscription{}, err
+			return radazure.Subscription{}, err
 		}
 	}
 
 	if subs.Default != nil {
 		confirmed, err := prompt.Confirm(fmt.Sprintf("Use Subscription '%v' [y/n]?", subs.Default.DisplayName))
 		if err != nil {
-			return azure.Subscription{}, err
+			return radazure.Subscription{}, err
 		}
 
 		if confirmed {
@@ -248,13 +244,13 @@ func selectSubscription(ctx context.Context, authorizer autorest.Authorizer) (az
 
 	index, err := prompt.Select("Select Subscription:", names)
 	if err != nil {
-		return azure.Subscription{}, err
+		return radazure.Subscription{}, err
 	}
 
 	return subs.Subscriptions[index], nil
 }
 
-func selectResourceGroup(ctx context.Context, authorizer autorest.Authorizer, sub azure.Subscription) (string, error) {
+func selectResourceGroup(ctx context.Context, authorizer autorest.Authorizer, sub radazure.Subscription) (string, error) {
 	rgc := resources.NewGroupsClient(sub.SubscriptionID)
 	rgc.Authorizer = authorizer
 
@@ -314,7 +310,7 @@ func selectResourceGroup(ctx context.Context, authorizer autorest.Authorizer, su
 }
 
 func connect(ctx context.Context, name string, subscriptionID string, resourceGroup, location string, deploymentTemplate string, registryName string, logAnalyticsWorkspaceID string) error {
-	armauth, err := azure.GetResourceManagerEndpointAuthorizer()
+	armauth, err := radazure.GetResourceManagerEndpointAuthorizer()
 	if err != nil {
 		return err
 	}
@@ -326,7 +322,7 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 		return err
 	}
 
-	envUrl, err := azure.GenerateAzureEnvUrl(subscriptionID, resourceGroup)
+	envUrl, err := radazure.GenerateAzureEnvUrl(subscriptionID, resourceGroup)
 	if err != nil {
 		return err
 	}
@@ -335,7 +331,7 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 		// We already have a provider in this resource group
 		logger.LogInfo("Found existing environment...\n\n"+
 			"Environment '%v' available at:\n%v\n", name, envUrl)
-		err = storeEnvironment(ctx, armauth, name, subscriptionID, resourceGroup, azure.GetControlPlaneResourceGroup(resourceGroup), clusterName)
+		err = storeEnvironment(ctx, armauth, name, subscriptionID, resourceGroup, radazure.GetControlPlaneResourceGroup(resourceGroup), clusterName)
 		if err != nil {
 			return err
 		}
@@ -380,7 +376,7 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 
 	params := deploymentParameters{
 		ResourceGroup:             resourceGroup,
-		ControlPlaneResourceGroup: azure.GetControlPlaneResourceGroup(resourceGroup),
+		ControlPlaneResourceGroup: radazure.GetControlPlaneResourceGroup(resourceGroup),
 		Location:                  location,
 		DeploymentTemplate:        deploymentTemplate,
 		RegistryID:                registryID,
@@ -423,7 +419,7 @@ func findExistingEnvironment(ctx context.Context, authorizer autorest.Authorizer
 	mcc.Authorizer = authorizer
 
 	var cluster *containerservice.ManagedCluster
-	for list, err := mcc.ListByResourceGroupComplete(ctx, azure.GetControlPlaneResourceGroup(resourceGroup)); list.NotDone(); err = list.NextWithContext(ctx) {
+	for list, err := mcc.ListByResourceGroupComplete(ctx, radazure.GetControlPlaneResourceGroup(resourceGroup)); list.NotDone(); err = list.NextWithContext(ctx) {
 		if err != nil {
 			return false, "", fmt.Errorf("cannot read AKS clusters: %w", err)
 		}
@@ -436,7 +432,7 @@ func findExistingEnvironment(ctx context.Context, authorizer autorest.Authorizer
 	}
 
 	if cluster == nil {
-		return false, "", fmt.Errorf("could not find an AKS instance in resource group '%v'", azure.GetControlPlaneResourceGroup(resourceGroup))
+		return false, "", fmt.Errorf("could not find an AKS instance in resource group '%v'", radazure.GetControlPlaneResourceGroup(resourceGroup))
 	}
 
 	return true, *cluster.Name, nil
@@ -504,19 +500,22 @@ func validateRegistry(ctx context.Context, authorizer autorest.Authorizer, subsc
 
 func validateLogAnalyticsWorkspace(ctx context.Context, authorizer autorest.Authorizer, subscriptionID string, logAnalyticsWorkspaceID string) (string, error) {
 	step := logger.BeginStep("Validating Log Analytics Workspace ID for %s...", logAnalyticsWorkspaceID)
-	l, err := azure.ParseResourceID(logAnalyticsWorkspaceID)
+	resource, err := azure.ParseResourceID(logAnalyticsWorkspaceID)
 	if err != nil {
 		return "", fmt.Errorf("invalid log analytics workspace id: %w", err)
 	}
-
-	lwc := operationalinsights.NewWorkspacesClient(subscriptionID)
+	lwc := operationalinsights.NewWorkspacesClient(resource.SubscriptionID)
 	lwc.Authorizer = authorizer
-	lwc.Get(logAnalyticsWorkspaceID)
-
+	_, err = lwc.Get(ctx, resource.ResourceGroup, resource.ResourceName)
+	if err != nil {
+		return "", fmt.Errorf("could not retrieve log analytics workspace: %w", err)
+	}
+	logger.CompleteStep(step)
+	return resource.ResourceName, nil
 }
 
 func deployEnvironment(ctx context.Context, authorizer autorest.Authorizer, name string, subscriptionID string, params deploymentParameters) (resources.DeploymentExtended, error) {
-	envUrl, err := azure.GenerateAzureEnvUrl(subscriptionID, params.ResourceGroup)
+	envUrl, err := radazure.GenerateAzureEnvUrl(subscriptionID, params.ResourceGroup)
 	if err != nil {
 		return resources.DeploymentExtended{}, err
 	}
@@ -553,6 +552,12 @@ func deployEnvironment(ctx context.Context, authorizer autorest.Authorizer, name
 		},
 		"registryName": map[string]interface{}{
 			"value": params.RegistryName,
+		},
+		"logAnalyticsWorkspaceName": map[string]interface{}{
+			"value": params.LogAnalyticsWorkspaceName,
+		},
+		"logAnalyticsWorkspaceID": map[string]interface{}{
+			"value": params.LogAnalyticsWorkspaceID,
 		},
 	}
 

--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -487,54 +487,55 @@
                             }
                         },
                         {
-                            "condition": "[not(equals(parameters('logAnalyticsWorkspaceName'), ''))]",
+                            "condition": "[not(equals(parameters('logAnalyticsWorkspaceID'), ''))]",
                             "type": "Microsoft.Web/sites/providers/diagnosticSettings",
-                            "apiVersion": "2020-01-01-preview",
+                            "apiVersion": "2017-05-01-preview",
                             "name": "[concat(parameters('siteName'),'/Microsoft.Insights/', parameters('logAnalyticsWorkspaceName'))]",
                             "dependsOn":[
+                                "[resourceId('Microsoft.Web/sites', parameters('siteName'))]"
                             ],    
                             "properties": {
-                            "workspaceId": "[parameters('logAnalyticsWorkspaceID')]",
-                            "logs": [
+                              "workspaceId": "[parameters('logAnalyticsWorkspaceID')]",
+                              "logs": [
                                 {
-                                "category": "AppServiceAntivirusScanAuditLogs",
-                                "enabled": false
+                                  "category": "AppServiceAntivirusScanAuditLogs",
+                                  "enabled": false
                                 },
                                 {
-                                "category": "AppServiceHTTPLogs",
-                                "enabled": false
+                                  "category": "AppServiceHTTPLogs",
+                                  "enabled": false
                                 },
                                 {
-                                "category": "AppServiceConsoleLogs",
-                                "enabled": true
+                                  "category": "AppServiceConsoleLogs",
+                                  "enabled": true
                                 },
                                 {
-                                "category": "AppServiceAppLogs",
-                                "enabled": true
+                                  "category": "AppServiceAppLogs",
+                                  "enabled": false
                                 },
                                 {
-                                "category": "AppServiceFileAuditLogs",
-                                "enabled": false
+                                  "category": "AppServiceFileAuditLogs",
+                                  "enabled": false
                                 },
                                 {
-                                "category": "AppServiceAuditLogs",
-                                "enabled": true
+                                  "category": "AppServiceAuditLogs",
+                                  "enabled": false
                                 },
                                 {
-                                "category": "AppServiceIPSecAuditLogs",
-                                "enabled": true
+                                  "category": "AppServiceIPSecAuditLogs",
+                                  "enabled": false
                                 },
                                 {
-                                "category": "AppServicePlatformLogs",
-                                "enabled": false
+                                  "category": "AppServicePlatformLogs",
+                                  "enabled": false
                                 }
-                            ],
-                            "metrics": [
+                              ],
+                              "metrics": [
                                 {
-                                "category": "AllMetrics",
-                                "enabled": true
+                                  "category": "AllMetrics",
+                                  "enabled": true
                                 }
-                            ]
+                              ]
                             }
                         },
                         {

--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -48,6 +48,20 @@
                 "description": "The name of your Web Site."
             }
         },
+        "logAnalyticsWorkspaceName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The log analytics workspace name where the Radius Resource Provider logs will be redirected to."
+            }
+        },
+        "logAnalyticsWorkspaceID": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The ARM resource ID of the log analytics workspace where the Radius Resource Provider logs will be redirected to."
+            }
+        },
         "accountName": {
             "type": "string",
             "defaultValue": "[concat('radius-rp-', uniquestring(parameters('controlPlaneResourceGroup')))]",
@@ -167,6 +181,12 @@
                     },
                     "siteName": {
                         "value": "[parameters('siteName')]"
+                    },
+                    "logAnalyticsWorkspaceName": {
+                        "value": "[parameters('logAnalyticsWorkspaceName')]"
+                    },
+                    "logAnalyticsWorkspaceID": {
+                        "value": "[parameters('logAnalyticsWorkspaceID')]"
                     }
                 },
                 "template": {
@@ -207,6 +227,12 @@
                             "type": "object"
                         },
                         "siteName": {
+                            "type": "string"
+                        },
+                        "logAnalyticsWorkspaceName": {
+                            "type": "string"
+                        },
+                        "logAnalyticsWorkspaceID": {
                             "type": "string"
                         }
                     },
@@ -461,6 +487,57 @@
                             }
                         },
                         {
+                            "condition": "[not(equals(parameters('logAnalyticsWorkspaceName'), ''))]",
+                            "type": "Microsoft.Web/sites/providers/diagnosticSettings",
+                            "apiVersion": "2020-01-01-preview",
+                            "name": "[concat(parameters('siteName'),'/Microsoft.Insights/', parameters('logAnalyticsWorkspaceName'))]",
+                            "dependsOn":[
+                            ],    
+                            "properties": {
+                            "workspaceId": "[parameters('logAnalyticsWorkspaceID')]",
+                            "logs": [
+                                {
+                                "category": "AppServiceAntivirusScanAuditLogs",
+                                "enabled": false
+                                },
+                                {
+                                "category": "AppServiceHTTPLogs",
+                                "enabled": false
+                                },
+                                {
+                                "category": "AppServiceConsoleLogs",
+                                "enabled": true
+                                },
+                                {
+                                "category": "AppServiceAppLogs",
+                                "enabled": true
+                                },
+                                {
+                                "category": "AppServiceFileAuditLogs",
+                                "enabled": false
+                                },
+                                {
+                                "category": "AppServiceAuditLogs",
+                                "enabled": true
+                                },
+                                {
+                                "category": "AppServiceIPSecAuditLogs",
+                                "enabled": true
+                                },
+                                {
+                                "category": "AppServicePlatformLogs",
+                                "enabled": false
+                                }
+                            ],
+                            "metrics": [
+                                {
+                                "category": "AllMetrics",
+                                "enabled": true
+                                }
+                            ]
+                            }
+                        },
+                        {
                             "type": "Microsoft.Authorization/roleAssignments",
                             "apiVersion": "2018-09-01-preview",
                             "name": "[variables('rpControlPlaneRoleDefinitionName')]",
@@ -500,6 +577,12 @@
                     "siteName": {
                         "value": "[parameters('siteName')]"
                     },
+                    "logAnalyticsWorkspaceName": {
+                        "value": "[parameters('logAnalyticsWorkspaceName')]"
+                    },
+                    "logAnalyticsWorkspaceID": {
+                        "value": "[parameters('logAnalyticsWorkspaceID')]"
+                    },
                     "controlPlaneResourceGroup": {
                         "value": "[parameters('controlPlaneResourceGroup')]"
                     },
@@ -526,6 +609,12 @@
                             "type": "object"
                         },
                         "siteName": {
+                            "type": "string"
+                        },
+                        "logAnalyticsWorkspaceName": {
+                            "type": "string"
+                        },
+                        "logAnalyticsWorkspaceID": {
                             "type": "string"
                         },
                         "controlPlaneResourceGroup": {

--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -250,7 +250,8 @@
                         "deploymentRoleDefinitionName": "[guid(parameters('deploymentScriptIdentityName'), subscription().subscriptionId)]",
                         "ownerRole": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
                         "rpRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('ownerRole'))]",
-                        "rpControlPlaneRoleDefinitionName": "[guid(parameters('siteName'), parameters('controlPlaneResourceGroup'), subscription().subscriptionId)]"
+                        "rpControlPlaneRoleDefinitionName": "[guid(parameters('siteName'), parameters('controlPlaneResourceGroup'), subscription().subscriptionId)]",
+                        "loganalyticsworkspacename": "[concat(parameters('siteName'), '/Microsoft.Insights/', if(equals(parameters('logAnalyticsWorkspaceID'), ''), 'fake', parameters('logAnalyticsWorkspaceName')))]"
                     },
                     "resources": [
                         {
@@ -490,7 +491,7 @@
                             "condition": "[not(equals(parameters('logAnalyticsWorkspaceID'), ''))]",
                             "type": "Microsoft.Web/sites/providers/diagnosticSettings",
                             "apiVersion": "2017-05-01-preview",
-                            "name": "[concat(parameters('siteName'),'/Microsoft.Insights/', parameters('logAnalyticsWorkspaceName'))]",
+                            "name": "[variables('loganalyticsworkspacename')]",
                             "dependsOn":[
                                 "[resourceId('Microsoft.Web/sites', parameters('siteName'))]"
                             ],    

--- a/pkg/radrp/deployment/deployment_processor.go
+++ b/pkg/radrp/deployment/deployment_processor.go
@@ -410,9 +410,10 @@ func (dp *deploymentProcessor) DeleteDeployment(ctx context.Context, appName str
 		}
 	}
 
-	logger.Info(fmt.Sprintf("Deletion of deployment completed with %d errors", len(errs)))
+	compositeErr := CompositeError{errs}
+	logger.Error(fmt.Errorf(compositeErr.Error()), fmt.Sprintf("Deletion of deployment completed with %d errors", len(errs)))
 	if len(errs) > 0 {
-		return &CompositeError{errs}
+		return &compositeErr
 	}
 
 	return nil


### PR DESCRIPTION
- Make Log Analytics workspace as deployment parameter
- Modify test environment creation to point to a specific log analytics workspace. This will enable to us to view logs for failed tests