### PR TITLE
Prevent crosstalk between test runs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -141,6 +141,16 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOVER: '^1.16.0'
+
+      # Timeout used for Azure functional tests
+      AZURE_FUNCTIONALTEST_TIMEOUT: 60m
+
+      # Amount of time we are willing to wait for an available environment
+      AZURE_ENVIRONMENT_RESERVE_TIMEOUT: 60m
+
+      # The amount of time during which we consider an environment lease valid.
+      # Includes a generous extra grace period for the building of tests and cleanup/deletion
+      AZURE_ENVIRONMENT_LEASE_TIMEOUT: 120m
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -206,7 +216,8 @@ jobs:
           --accountname ${{ secrets.INTEGRATION_TEST_STORAGE_NAME }} \
           --tablename environments \
           --configpath ~/.rad/config.yaml \
-          --timeout 60
+          --timeout ${{ env.AZURE_ENVIRONMENT_RESERVE_TIMEOUT }} \
+          --lease-timeout ${{ env.AZURE_ENVIRONMENT_LEASE_TIMEOUT }}
         # Print config for sanity check
         cat ~/.rad/config.yaml
         # Output environment name
@@ -234,6 +245,7 @@ jobs:
         export AZURE_TENANT_ID=${{ secrets.INTEGRATION_TEST_TENANT_ID }}
         export AZURE_CLIENT_ID=${{ secrets.INTEGRATION_TEST_SP_APP_ID }}
         export AZURE_CLIENT_SECRET=${{ secrets.INTEGRATION_TEST_SP_PASSWORD }}
+        export TEST_TIMEOUT=${{ env.AZURE_FUNCTIONALTEST_TIMEOUT }}
         cd $GITHUB_WORKSPACE
         echo "PATH is $PATH"
         which rad || { echo "cannot find rad"; exit 1; }

--- a/build/test.mk
+++ b/build/test.mk
@@ -5,13 +5,16 @@
 
 ##@ Test
 
+# Will be set by our build workflow, this is just a default
+TEST_TIMEOUT ?=1h
+
 .PHONY: test
 test: ## Runs unit tests, excluding kubernetes controller tests
 	go test ./pkg/...
 
 .PHONY: test-integration
 test-integration: ## Runs integration tests
-	go test ./test/integrationtests/... -timeout 1h -v -parallel 20
+	go test ./test/integrationtests/... -timeout ${TEST_TIMEOUT} -v -parallel 20
 
 ENVTEST_ASSETS_DIR=$(shell pwd)/bin
 K8S_VERSION=1.19.2


### PR DESCRIPTION
While looking at PR #616, I noticed that we haven't kept our test run
timeout and our environment lease timeout in sync. Our environment lease
timeout is 30 mins and our test run timeout is 60 minutes.

That means that any time a test run has an environment in use for 30
minutes, there's a risk that another test run will start using it as
well. This can of course lead to double-deletion.

The fix for these is to keep these two values in the same file
`build.yaml` and make sure sure that the lease expiry time is pretty
generous.