### PR TITLE
Force registering provider after registering feature

### DIFF
--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -477,9 +477,11 @@ func registerSubscription(ctx context.Context, authorizer autorest.Authorizer, s
 			return fmt.Errorf("failed to register subscription: %v for feature: %v/%v: %w", subscriptionID, namespace, feature, err)
 		}
 
-		// We've seen customers still hitting issues where they hit the error:
+		// See: https://github.com/Azure/radius/issues/520
+		// We've seen users still hitting issues where they see the error:
 		// "PodIdentity addon is not allowed since feature 'Microsoft.ContainerService/EnablePodIdentityPreview' is not enabled"
-		// Force the provider to be registered, causing the RP to refresh it's info.
+		// Our working theory is that we need to force the provider to be registered again,
+		// causing the RP to refresh it's info about features.
 		_, err = providerClient.Register(ctx, namespace)
 		if err != nil {
 			return fmt.Errorf("failed to register subscription: %v for provider %v: %w", subscriptionID, namespace, err)


### PR DESCRIPTION
Fixes https://github.com/Azure/radius/issues/520

Working theory is that we need to force registration of the provider to propagate changes for the podidentity feature.

A warning on the az cli is emitted when you register the feature:
```
Once the feature 'EnablePodIdentityPreview' is unregistered, invoking 'az provider register -n Microsoft.ContainerService' is required to get the change propagated
```
this is for unregistration but the point still stands.

