### PR TITLE
Apply server side retry to CosmosDB

### DIFF
--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -283,6 +283,14 @@
                             "tags": "[parameters('resourceTags')]",
                             "kind": "MongoDB",
                             "properties": {
+                                "capabilities": [
+                                    {
+                                        "name": "EnableMongo"
+                                    },
+                                    {
+                                        "name": "DisableRateLimitingResponses"
+                                    }
+                                ],
                                 "locations": [
                                     {
                                         "locationName": "[resourceGroup().location]",


### PR DESCRIPTION
Part of: #676

This will set up CosmosDB to handle retries on the server side. This
should eliminate the cases where we've had queries fail and cause test
timeouts.