### PR TITLE
Add experiment request tracing

### DIFF
--- a/cmd/rp/main.go
+++ b/cmd/rp/main.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/go-autorest/tracing"
 	"github.com/Azure/radius/pkg/model"
 	"github.com/Azure/radius/pkg/radlogger"
 	"github.com/Azure/radius/pkg/radrp"
@@ -100,6 +101,9 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Enable tracing for Track1 Azure SDKs
+	tracing.Register(&radlogger.Tracer{})
 
 	logger, flushLogs, err := radlogger.NewLogger(fmt.Sprintf("radRP-%s", arm.ResourceGroup))
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/Azure/go-autorest/autorest/azure/cli v0.4.2
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/dnaeon/go-vcr v1.1.0 // indirect
 	github.com/fatih/structs v1.1.0
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa

--- a/pkg/radlogger/autorest.go
+++ b/pkg/radlogger/autorest.go
@@ -1,0 +1,72 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+package radlogger
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/go-autorest/tracing"
+)
+
+var _ tracing.Tracer = (*Tracer)(nil)
+
+// Tracer adds tracing support for autorest track 1 SDKs.
+type Tracer struct {
+}
+
+func (t *Tracer) NewTransport(base *http.Transport) http.RoundTripper {
+	return base
+}
+
+func (t *Tracer) StartSpan(ctx context.Context, name string) context.Context {
+	spans := activeSpans(ctx)
+	spans = append(spans, name)
+
+	logger := GetLogger(ctx)
+	if logger != nil {
+		formatted := strings.Join(spans, "/")
+		logger.Info(fmt.Sprintf("Starting Span: %s", formatted), LogFieldSpan, formatted)
+	}
+
+	return context.WithValue(ctx, key, spans)
+}
+
+func (t *Tracer) EndSpan(ctx context.Context, httpStatusCode int, err error) {
+	spans := activeSpans(ctx)
+
+	logger := GetLogger(ctx)
+	if logger != nil {
+		formatted := strings.Join(spans, "/")
+
+		if err == nil {
+			logger.Info(
+				fmt.Sprintf("Ending Span: %s", formatted),
+				LogFieldSpan, formatted,
+				LogFieldStatusCode, httpStatusCode)
+		} else {
+			logger.Error(
+				err,
+				fmt.Sprintf("Ending Span with error: %s", formatted),
+				LogFieldSpan, formatted,
+				LogFieldStatusCode, httpStatusCode)
+		}
+	}
+}
+
+type spanKey string
+
+var key = spanKey("Radius Tracer")
+
+func activeSpans(ctx context.Context) []string {
+	obj := ctx.Value(key)
+	if obj != nil {
+		return obj.([]string)
+	}
+
+	return []string{}
+}

--- a/pkg/radlogger/logfields.go
+++ b/pkg/radlogger/logfields.go
@@ -25,4 +25,6 @@ const (
 	LogFieldSubscriptionID     = "subscriptionID"
 	LogFieldWorkLoadKind       = "workloadKind"
 	LogFieldWorkLoadName       = "workloadName"
+	LogFieldSpan               = "span"
+	LogFieldStatusCode         = "statusCode"
 )


### PR DESCRIPTION
This change should integrate our logging system with Autorest's tracing
support, giving us some more detail about what's happening on the wire.