### PR TITLE
Omit empty fields in `rad env show` YAML

### DIFF
--- a/cmd/cli/cmd/envShow.go
+++ b/cmd/cli/cmd/envShow.go
@@ -47,9 +47,7 @@ func showEnvironment(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Println()
 	fmt.Println(string(b))
-	fmt.Println()
 	return nil
 
 }

--- a/pkg/rad/environments/azure.go
+++ b/pkg/rad/environments/azure.go
@@ -29,12 +29,12 @@ func RequireAzureCloud(e Environment) (*AzureCloudEnvironment, error) {
 
 // AzureCloudEnvironment represents an Azure Cloud Radius environment.
 type AzureCloudEnvironment struct {
-	Name                      string `mapstructure:"name" validate:"required" yaml:",omitempty"`
-	Kind                      string `mapstructure:"kind" validate:"required" yaml:",omitempty"`
-	SubscriptionID            string `mapstructure:"subscriptionid" validate:"required" yaml:",omitempty"`
-	ResourceGroup             string `mapstructure:"resourcegroup" validate:"required" yaml:",omitempty"`
-	ControlPlaneResourceGroup string `mapstring:"controlplaneresourcegroup" validate:"required" yaml:",omitempty"`
-	ClusterName               string `mapstructure:"clustername" validate:"required" yaml:",omitempty"`
+	Name                      string `mapstructure:"name" validate:"required"`
+	Kind                      string `mapstructure:"kind" validate:"required"`
+	SubscriptionID            string `mapstructure:"subscriptionid" validate:"required"`
+	ResourceGroup             string `mapstructure:"resourcegroup" validate:"required"`
+	ControlPlaneResourceGroup string `mapstring:"controlplaneresourcegroup" validate:"required"`
+	ClusterName               string `mapstructure:"clustername" validate:"required"`
 	DefaultApplication        string `mapstructure:"defaultapplication" yaml:",omitempty"`
 
 	// We tolerate and allow extra fields - this helps with forwards compat.

--- a/pkg/rad/environments/azure.go
+++ b/pkg/rad/environments/azure.go
@@ -29,16 +29,16 @@ func RequireAzureCloud(e Environment) (*AzureCloudEnvironment, error) {
 
 // AzureCloudEnvironment represents an Azure Cloud Radius environment.
 type AzureCloudEnvironment struct {
-	Name                      string `mapstructure:"name" validate:"required"`
-	Kind                      string `mapstructure:"kind" validate:"required"`
-	SubscriptionID            string `mapstructure:"subscriptionid" validate:"required"`
-	ResourceGroup             string `mapstructure:"resourcegroup" validate:"required"`
-	ControlPlaneResourceGroup string `mapstring:"controlplaneresourcegroup" validate:"required"`
-	ClusterName               string `mapstructure:"clustername" validate:"required"`
-	DefaultApplication        string `mapstructure:"defaultapplication,omitempty"`
+	Name                      string `mapstructure:"name" validate:"required" yaml:",omitempty"`
+	Kind                      string `mapstructure:"kind" validate:"required" yaml:",omitempty"`
+	SubscriptionID            string `mapstructure:"subscriptionid" validate:"required" yaml:",omitempty"`
+	ResourceGroup             string `mapstructure:"resourcegroup" validate:"required" yaml:",omitempty"`
+	ControlPlaneResourceGroup string `mapstring:"controlplaneresourcegroup" validate:"required" yaml:",omitempty"`
+	ClusterName               string `mapstructure:"clustername" validate:"required" yaml:",omitempty"`
+	DefaultApplication        string `mapstructure:"defaultapplication" yaml:",omitempty"`
 
 	// We tolerate and allow extra fields - this helps with forwards compat.
-	Properties map[string]interface{} `mapstructure:",remain"`
+	Properties map[string]interface{} `mapstructure:",remain" yaml:",omitempty"`
 }
 
 func (e *AzureCloudEnvironment) GetName() string {


### PR DESCRIPTION
Fixes https://github.com/Azure/radius/issues/491

The output is already YAML-formatted (even though with single level of nesting it seems not like so). However, we can omit some empty fields.

Current output:

```
$ rad env show

name: nghiatran-rg
kind: azure
subscriptionid: 66d1209e-1382-45d3-99bb-650e6bf63fc0
resourcegroup: nghiatran-rg
controlplaneresourcegroup: RE-nghiatran-rg
clustername: radius-aks-x363y7um65gue
defaultapplication: ""
properties: {}
```

New output:
```
$ go run ./cmd/cli env show
name: nghiatran-rg
kind: azure
subscriptionid: 66d1209e-1382-45d3-99bb-650e6bf63fc0
resourcegroup: nghiatran-rg
controlplaneresourcegroup: RE-nghiatran-rg
clustername: radius-aks-x363y7um65gue
```