### PR TITLE
`rad --version` to also print the `rad-bicep` version

### DIFF
--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Azure/radius/pkg/rad"
+	"github.com/Azure/radius/pkg/rad/bicep"
 	"github.com/Azure/radius/pkg/rad/output"
 	"github.com/Azure/radius/pkg/version"
 	"github.com/spf13/cobra"
@@ -50,7 +51,7 @@ func init() {
 
 	// Initialize support for --version
 	RootCmd.Version = version.Release()
-	template := fmt.Sprintf("Release: %s \nVersion: %s\nCommit: %s\n", version.Release(), version.Version(), version.Commit())
+	template := fmt.Sprintf("Release: %s \nVersion: %s\nBicep version: %s\nCommit: %s\n", version.Release(), version.Version(), bicep.Version(), version.Commit())
 	RootCmd.SetVersionTemplate(template)
 
 	RootCmd.Flags().BoolP("version", "v", false, "version for radius")


### PR DESCRIPTION
Obtain the bicep version from running `rad-bicep`.  Since the `RootCmd.Version` gets populated even when we don't run `rad --version`, we can't just exit when `rad-bicep` isn't installed. Instead we will just show an "unknown" version with some info about the error.

Fixes https://github.com/Azure/radius/issues/284 

Example output:

```
$ go run ./cmd/cli --version
Release: edge 
Version: edge
Bicep version: 0.1.11
Commit: unknown
```

When `bicep` isn't installed
```
$ rm ~/.rad/bin/rad-bicep 
$ go run ./cmd/cli --version
Release: edge 
Version: edge
Bicep version: unknown (failed executing "/Users/nghia/.rad/bin/rad-bicep --version": fork/exec /Users/nghia/.rad/bin/rad-bicep: no such file or directory)
Commit: unknown
```
