### PR TITLE
Change env var format for Container section

### DIFF
--- a/pkg/radrp/resourceprovider_deployment_test.go
+++ b/pkg/radrp/resourceprovider_deployment_test.go
@@ -398,15 +398,9 @@ func Test_DeploymentUpdated_RenderRealisticContainer(t *testing.T) {
 			Run: map[string]interface{}{
 				"container": map[string]interface{}{
 					"image": "rynowak/frontend:0.5.0-dev",
-					"env": []interface{}{
-						map[string]interface{}{
-							"name":  "SERVICE__BACKEND__HOST",
-							"value": "backend",
-						},
-						map[string]interface{}{
-							"name":  "SERVICE__BACKEND__PORT",
-							"value": "80",
-						},
+					"env": map[string]interface{}{
+						"SERVICE__BACKEND__HOST": "backend",
+						"SERVICE__BACKEND__PORT": "80",
 					},
 				},
 			},
@@ -449,11 +443,9 @@ func Test_DeploymentUpdated_RenderRealisticContainer(t *testing.T) {
 	cont := component.Run.Container
 	require.Equal(t, "rynowak/frontend:0.5.0-dev", cont.Image)
 
-	require.Len(t, cont.Environment, 2)
-	require.Equal(t, "SERVICE__BACKEND__HOST", cont.Environment[0].Name)
-	require.Equal(t, "backend", *cont.Environment[0].Value)
-	require.Equal(t, "SERVICE__BACKEND__PORT", cont.Environment[1].Name)
-	require.Equal(t, "80", *cont.Environment[1].Value)
+	require.Len(t, cont.Env, 2)
+	require.Equal(t, "backend", cont.Env["SERVICE__BACKEND__HOST"])
+	require.Equal(t, "80", cont.Env["SERVICE__BACKEND__PORT"])
 }
 
 func Test_DeploymentCreated_RenderContainerWithDapr(t *testing.T) {

--- a/pkg/workloads/containerv1alpha1/render.go
+++ b/pkg/workloads/containerv1alpha1/render.go
@@ -300,7 +300,6 @@ func (r Renderer) createPodIdentityResource(ctx context.Context, w workloads.Ins
 func (r Renderer) Render(ctx context.Context, w workloads.InstantiatedWorkload) ([]workloads.OutputResource, error) {
 	outputResources := []workloads.OutputResource{}
 	cw, err := r.convert(w)
-
 	if err != nil {
 		return []workloads.OutputResource{}, err
 	}

--- a/pkg/workloads/containerv1alpha1/render.go
+++ b/pkg/workloads/containerv1alpha1/render.go
@@ -300,6 +300,7 @@ func (r Renderer) createPodIdentityResource(ctx context.Context, w workloads.Ins
 func (r Renderer) Render(ctx context.Context, w workloads.InstantiatedWorkload) ([]workloads.OutputResource, error) {
 	outputResources := []workloads.OutputResource{}
 	cw, err := r.convert(w)
+
 	if err != nil {
 		return []workloads.OutputResource{}, err
 	}
@@ -392,14 +393,11 @@ func (r Renderer) makeDeployment(ctx context.Context, w workloads.InstantiatedWo
 		Env:             []corev1.EnvVar{},
 	}
 
-	for _, e := range cc.Run.Container.Environment {
-		if e.Value != nil {
-			container.Env = append(container.Env, corev1.EnvVar{
-				Name:  e.Name,
-				Value: *e.Value,
-			})
-			continue
-		}
+	for k, v := range cc.Run.Container.Env {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  k,
+			Value: v,
+		})
 	}
 
 	for _, dep := range cc.Uses {

--- a/pkg/workloads/containerv1alpha1/render_test.go
+++ b/pkg/workloads/containerv1alpha1/render_test.go
@@ -30,7 +30,7 @@ func createContext(t *testing.T) context.Context {
 	return logr.NewContext(context.Background(), logger)
 }
 
-func Test_AllocateBindings_NoHTTPBinding(t *testing.T) {
+func TestAllocateBindings_NoHTTPBinding(t *testing.T) {
 	ctx := createContext(t)
 	renderer := &Renderer{}
 
@@ -59,7 +59,7 @@ func Test_AllocateBindings_NoHTTPBinding(t *testing.T) {
 	require.Len(t, bindings, 0)
 }
 
-func Test_AllocateBindings_HTTPBindings(t *testing.T) {
+func TestAllocateBindings_HTTPBindings(t *testing.T) {
 	ctx := createContext(t)
 	renderer := &Renderer{}
 
@@ -124,7 +124,7 @@ func Test_AllocateBindings_HTTPBindings(t *testing.T) {
 
 }
 
-func Test_Render_Success_DefaultPort(t *testing.T) {
+func TestRender_Success_DefaultPort(t *testing.T) {
 	ctx := createContext(t)
 	renderer := &Renderer{}
 
@@ -137,6 +137,9 @@ func Test_Render_Success_DefaultPort(t *testing.T) {
 			Run: map[string]interface{}{
 				"container": map[string]interface{}{
 					"image": "test/test-image:latest",
+					"env": map[string]string{
+						"APPLICATION_NAME": "Awesome Test Application",
+					},
 				},
 			},
 			Bindings: map[string]components.GenericBinding{
@@ -192,6 +195,11 @@ func Test_Render_Success_DefaultPort(t *testing.T) {
 		require.Equal(t, v1.PullAlways, container.ImagePullPolicy)
 		require.Len(t, container.Ports, 1)
 
+		env := container.Env
+		require.Equal(t, 1, len(env))
+		require.Equal(t, "APPLICATION_NAME", env[0].Name)
+		require.Equal(t, "Awesome Test Application", env[0].Value)
+
 		port := container.Ports[0]
 		require.Equal(t, "test-binding", port.Name)
 		require.Equal(t, v1.ProtocolTCP, port.Protocol)
@@ -216,7 +224,7 @@ func Test_Render_Success_DefaultPort(t *testing.T) {
 	})
 }
 
-func Test_Render_Success_NonDefaultPort(t *testing.T) {
+func TestRender_Success_NonDefaultPort(t *testing.T) {
 	ctx := createContext(t)
 	renderer := &Renderer{}
 

--- a/pkg/workloads/containerv1alpha1/types.go
+++ b/pkg/workloads/containerv1alpha1/types.go
@@ -56,5 +56,4 @@ func (h HTTPBinding) GetEffectiveContainerPort() int {
 	} else {
 		return 80
 	}
-}xm
-z
+}

--- a/pkg/workloads/containerv1alpha1/types.go
+++ b/pkg/workloads/containerv1alpha1/types.go
@@ -31,12 +31,6 @@ type ContainerRunContainer struct {
 	Env   map[string]string `json:"env,omitempty"`
 }
 
-// ContainerEnvVar is the definition of an environment variable
-type ContainerEnvVar struct {
-	Name  string  `json:"name"`
-	Value *string `json:"value,omitempty"`
-}
-
 const KindHTTP = "http"
 
 // HTTPProvidesService is the definition of an 'http' binding for a container.
@@ -62,4 +56,5 @@ func (h HTTPBinding) GetEffectiveContainerPort() int {
 	} else {
 		return 80
 	}
-}
+}xm
+z

--- a/pkg/workloads/containerv1alpha1/types.go
+++ b/pkg/workloads/containerv1alpha1/types.go
@@ -27,8 +27,8 @@ type ContainerRun struct {
 }
 
 type ContainerRunContainer struct {
-	Image       string            `json:"image"`
-	Environment []ContainerEnvVar `json:"env,omitempty"`
+	Image string            `json:"image"`
+	Env   map[string]string `json:"env,omitempty"`
 }
 
 // ContainerEnvVar is the definition of an environment variable


### PR DESCRIPTION
Fixes https://github.com/Azure/radius/issues/577
Fixes https://github.com/Azure/radius/issues/554

Current format:
```
...
          env: [
            {
              name: 'ASPNETCORE_URLS'
              value: 'http://+:5000'
            }
          ]
...
```

New format
```
...
          env: {
            ASPNETCORE_URLS: 'http://+:5000'
          }
...
```