### PR TITLE
Ignore vendor/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 docs/content/reference/cli/rad*
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/
 
 # Build Output 
 bin/


### PR DESCRIPTION
I am using the `vendor/` directory locally to occasionally change a few lines here and there in the dependencies, and we are currently not checking in vendored code.

If we decide to check in `vendor/` in the future (to improve build speed, avoid deleted dependencies, etc) we can change this back.