### PR TITLE
Set infinite timeout for all ARM calls

### DIFF
--- a/cmd/cli/cmd/envDelete.go
+++ b/cmd/cli/cmd/envDelete.go
@@ -92,8 +92,6 @@ func deleteEnv(cmd *cobra.Command, args []string) error {
 func deleteResourceGroup(ctx context.Context, authorizer autorest.Authorizer, resourceGroup string, subscriptionID string) error {
 	rgc := resources.NewGroupsClient(subscriptionID)
 	rgc.Authorizer = authorizer
-
-	// Don't timeout, let the user cancel
 	rgc.PollingDuration = 0
 
 	logger.LogInfo("Deleting resource group %v", resourceGroup)

--- a/cmd/cli/cmd/envDelete.go
+++ b/cmd/cli/cmd/envDelete.go
@@ -9,9 +9,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/Azure/radius/pkg/rad/logger"
@@ -90,9 +90,7 @@ func deleteEnv(cmd *cobra.Command, args []string) error {
 
 // Deletes resource group and all its resources
 func deleteResourceGroup(ctx context.Context, authorizer autorest.Authorizer, resourceGroup string, subscriptionID string) error {
-	rgc := resources.NewGroupsClient(subscriptionID)
-	rgc.Authorizer = authorizer
-	rgc.PollingDuration = 0
+	rgc := azclients.NewGroupsClient(subscriptionID, authorizer)
 
 	logger.LogInfo("Deleting resource group %v", resourceGroup)
 

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -261,7 +261,7 @@ func selectResourceGroup(ctx context.Context, authorizer autorest.Authorizer, su
 
 	logger.LogInfo("Resource Group '%v' will be created...", name)
 
-	subc := azclients.NewSubscriptionsClient(authorizer)
+	subc := azclients.NewSubscriptionClient(authorizer)
 
 	locations, err := subc.ListLocations(ctx, sub.SubscriptionID)
 	if err != nil {
@@ -430,7 +430,7 @@ func findExistingEnvironment(ctx context.Context, authorizer autorest.Authorizer
 func validateSubscription(ctx context.Context, authorizer autorest.Authorizer, subscriptionID string, resourceGroup string) (*resources.Group, error) {
 	step := logger.BeginStep("Validating Subscription...")
 
-	sc := azclients.NewSubscriptionsClient(authorizer)
+	sc := azclients.NewSubscriptionClient(authorizer)
 
 	_, err := sc.Get(ctx, subscriptionID)
 	if err != nil {

--- a/cmd/testenv/cmd/updaterp.go
+++ b/cmd/testenv/cmd/updaterp.go
@@ -104,7 +104,6 @@ func init() {
 
 func updateRP(ctx context.Context, auth autorest.Authorizer, env environments.AzureCloudEnvironment, image string, checkVersion string) error {
 	webc := azclients.NewWebClient(env.SubscriptionID, auth)
-	webc.PollingDuration = 0
 
 	list, err := webc.ListByResourceGroupComplete(ctx, env.ControlPlaneResourceGroup, nil)
 	if err != nil {

--- a/cmd/testenv/cmd/updaterp.go
+++ b/cmd/testenv/cmd/updaterp.go
@@ -105,6 +105,7 @@ func init() {
 func updateRP(ctx context.Context, auth autorest.Authorizer, env environments.AzureCloudEnvironment, image string, checkVersion string) error {
 	webc := web.NewAppsClient(env.SubscriptionID)
 	webc.Authorizer = auth
+	webc.PollingDuration = 0
 
 	list, err := webc.ListByResourceGroupComplete(ctx, env.ControlPlaneResourceGroup, nil)
 	if err != nil {

--- a/cmd/testenv/cmd/updaterp.go
+++ b/cmd/testenv/cmd/updaterp.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/azcli"
 	"github.com/Azure/radius/pkg/rad/environments"
@@ -102,7 +103,7 @@ func init() {
 }
 
 func updateRP(ctx context.Context, auth autorest.Authorizer, env environments.AzureCloudEnvironment, image string, checkVersion string) error {
-	webc := azclients.NewAppsClient(env.SubscriptionID, auth)
+	webc := azclients.NewWebClient(env.SubscriptionID, auth)
 	webc.PollingDuration = 0
 
 	list, err := webc.ListByResourceGroupComplete(ctx, env.ControlPlaneResourceGroup, nil)

--- a/cmd/testenv/cmd/updaterp.go
+++ b/cmd/testenv/cmd/updaterp.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/web/mgmt/web"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/radius/pkg/rad"
 	"github.com/Azure/radius/pkg/rad/azcli"
@@ -103,8 +102,7 @@ func init() {
 }
 
 func updateRP(ctx context.Context, auth autorest.Authorizer, env environments.AzureCloudEnvironment, image string, checkVersion string) error {
-	webc := web.NewAppsClient(env.SubscriptionID)
-	webc.Authorizer = auth
+	webc := azclients.NewAppsClient(env.SubscriptionID, auth)
 	webc.PollingDuration = 0
 
 	list, err := webc.ListByResourceGroupComplete(ctx, env.ControlPlaneResourceGroup, nil)

--- a/pkg/azclients/clients.go
+++ b/pkg/azclients/clients.go
@@ -8,12 +8,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/msi/mgmt/msi"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/operationalinsights/mgmt/operationalinsights"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/subscriptions"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/servicebus/mgmt/servicebus"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/storage/mgmt/storage"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/web/mgmt/web"
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/authorization/mgmt/authorization"
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/customproviders/mgmt/customproviders"
+	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/subscription/mgmt/subscription"
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-03-15/documentdb"
 	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/2015-05-01-preview/sql"
 	"github.com/Azure/go-autorest/autorest"
@@ -26,8 +26,8 @@ func NewGroupsClient(subscriptionID string, authorizer autorest.Authorizer) reso
 	return rgc
 }
 
-func NewSubscriptionsClient(authorizer autorest.Authorizer) subscriptions.Client {
-	sc := subscriptions.NewClient()
+func NewSubscriptionClient(authorizer autorest.Authorizer) subscription.Client {
+	sc := subscription.NewClient()
 	sc.Authorizer = authorizer
 	sc.PollingDuration = 0
 	return sc

--- a/pkg/azclients/clients.go
+++ b/pkg/azclients/clients.go
@@ -1,0 +1,191 @@
+package azclients
+
+import (
+	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/features"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerregistry/mgmt/containerregistry"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/keyvault/mgmt/keyvault"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/msi/mgmt/msi"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/operationalinsights/mgmt/operationalinsights"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/subscriptions"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/servicebus/mgmt/servicebus"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/storage/mgmt/storage"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/web/mgmt/web"
+	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/authorization/mgmt/authorization"
+	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/customproviders/mgmt/customproviders"
+	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2021-03-15/documentdb"
+	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/2015-05-01-preview/sql"
+	"github.com/Azure/go-autorest/autorest"
+)
+
+func NewGroupsClient(subscriptionID string, authorizer autorest.Authorizer) resources.GroupsClient {
+	rgc := resources.NewGroupsClient(subscriptionID)
+	rgc.Authorizer = authorizer
+	rgc.PollingDuration = 0
+	return rgc
+}
+
+func NewSubscriptionsClient(authorizer autorest.Authorizer) subscriptions.Client {
+	sc := subscriptions.NewClient()
+	sc.Authorizer = authorizer
+	sc.PollingDuration = 0
+	return sc
+}
+
+func NewCustomResourceProviderClient(subscriptionID string, authorizer autorest.Authorizer) customproviders.CustomResourceProviderClient {
+	cpc := customproviders.NewCustomResourceProviderClient(subscriptionID)
+	cpc.Authorizer = authorizer
+	cpc.PollingDuration = 0
+	return cpc
+}
+
+func NewManagedClustersClient(subscriptionID string, authorizer autorest.Authorizer) containerservice.ManagedClustersClient {
+	mcc := containerservice.NewManagedClustersClient(subscriptionID)
+	mcc.Authorizer = authorizer
+	mcc.PollingDuration = 0
+	return mcc
+}
+
+func NewFeaturesClient(subscriptionID string, authorizer autorest.Authorizer) features.Client {
+	fc := features.NewClient(subscriptionID)
+	fc.Authorizer = authorizer
+	fc.PollingDuration = 0
+	return fc
+}
+
+func NewProvidersClient(subscriptionID string, authorizer autorest.Authorizer) resources.ProvidersClient {
+	pc := resources.NewProvidersClient(subscriptionID)
+	pc.Authorizer = authorizer
+	pc.PollingDuration = 0
+	return pc
+}
+
+func NewRegistriesClient(subscriptionID string, authorizer autorest.Authorizer) containerregistry.RegistriesClient {
+	crc := containerregistry.NewRegistriesClient(subscriptionID)
+	crc.Authorizer = authorizer
+	crc.PollingDuration = 0
+	return crc
+}
+
+func NewWorkspacesClient(subscriptionID string, authorizer autorest.Authorizer) operationalinsights.WorkspacesClient {
+	lwc := operationalinsights.NewWorkspacesClient(subscriptionID)
+	lwc.Authorizer = authorizer
+	lwc.PollingDuration = 0
+	return lwc
+}
+
+func NewDeploymentsClient(subscriptionID string, authorizer autorest.Authorizer) resources.DeploymentsClient {
+	dc := resources.NewDeploymentsClient(subscriptionID)
+	dc.Authorizer = authorizer
+
+	// Don't set a timeout, the user can cancel the command if they want a timeout.
+	dc.PollingDuration = 0
+
+	return dc
+}
+
+func NewWebClient(subscriptionID string, authorizer autorest.Authorizer) web.AppsClient {
+	webc := web.NewAppsClient(subscriptionID)
+	webc.Authorizer = authorizer
+	webc.PollingDuration = 0
+	return webc
+}
+
+func NewDatabaseAccountsClient(subscriptionID string, authorizer autorest.Authorizer) documentdb.DatabaseAccountsClient {
+	cdbc := documentdb.NewDatabaseAccountsClient(subscriptionID)
+	cdbc.Authorizer = authorizer
+	cdbc.PollingDuration = 0
+	return cdbc
+}
+
+func NewMongoDBResourcesClient(subscriptionID string, authorizer autorest.Authorizer) documentdb.MongoDBResourcesClient {
+	mdbrc := documentdb.NewMongoDBResourcesClient(subscriptionID)
+	mdbrc.Authorizer = authorizer
+	mdbrc.PollingDuration = 0
+	return mdbrc
+}
+
+func NewSQLResourcesClient(subscriptionID string, authorizer autorest.Authorizer) documentdb.SQLResourcesClient {
+	sqlc := documentdb.NewSQLResourcesClient(subscriptionID)
+	sqlc.Authorizer = authorizer
+	sqlc.PollingDuration = 0
+	return sqlc
+}
+
+func NewVaultsClient(subscriptionID string, authorizer autorest.Authorizer) keyvault.VaultsClient {
+	vc := keyvault.NewVaultsClient(subscriptionID)
+	vc.Authorizer = authorizer
+	vc.PollingDuration = 0
+	return vc
+}
+
+func NewUserAssignedIdentitiesClient(subscriptionID string, authorizer autorest.Authorizer) msi.UserAssignedIdentitiesClient {
+	msiClient := msi.NewUserAssignedIdentitiesClient(subscriptionID)
+	msiClient.Authorizer = authorizer
+	msiClient.PollingDuration = 0
+	return msiClient
+}
+
+func NewServiceBusNamespacesClient(subscriptionID string, authorizer autorest.Authorizer) servicebus.NamespacesClient {
+	sbc := servicebus.NewNamespacesClient(subscriptionID)
+	sbc.Authorizer = authorizer
+	sbc.PollingDuration = 0
+	return sbc
+}
+
+func NewTopicsClient(subscriptionID string, authorizer autorest.Authorizer) servicebus.TopicsClient {
+	tc := servicebus.NewTopicsClient(subscriptionID)
+	tc.Authorizer = authorizer
+	tc.PollingDuration = 0
+	return tc
+}
+
+func NewQueuesClient(subscriptionID string, authorizer autorest.Authorizer) servicebus.QueuesClient {
+	tc := servicebus.NewQueuesClient(subscriptionID)
+	tc.Authorizer = authorizer
+	tc.PollingDuration = 0
+	return tc
+}
+
+func NewDatabasesClient(subscriptionID string, authorizer autorest.Authorizer) sql.DatabasesClient {
+	sqlc := sql.NewDatabasesClient(subscriptionID)
+	sqlc.Authorizer = authorizer
+	sqlc.PollingDuration = 0
+	return sqlc
+}
+
+func NewServersClient(subscriptionID string, authorizer autorest.Authorizer) sql.ServersClient {
+	sc := sql.NewServersClient(subscriptionID)
+	sc.Authorizer = authorizer
+	sc.PollingDuration = 0
+	return sc
+}
+
+func NewAccountsClient(subscriptionID string, authorizer autorest.Authorizer) storage.AccountsClient {
+	ac := storage.NewAccountsClient(subscriptionID)
+	ac.Authorizer = authorizer
+	ac.PollingDuration = 0
+	return ac
+}
+
+func NewRoleDefinitionsClient(subscriptionID string, authorizer autorest.Authorizer) authorization.RoleDefinitionsClient {
+	rc := authorization.NewRoleDefinitionsClient(subscriptionID)
+	rc.Authorizer = authorizer
+	rc.PollingDuration = 0
+	return rc
+}
+
+func NewRoleAssignmentsClient(subscriptionID string, authorizer autorest.Authorizer) authorization.RoleAssignmentsClient {
+	rc := authorization.NewRoleAssignmentsClient(subscriptionID)
+	rc.Authorizer = authorizer
+	rc.PollingDuration = 0
+	return rc
+}
+
+func NewResourcesClient(subscriptionID string, authorizer autorest.Authorizer) resources.Client {
+	rc := resources.NewClient(subscriptionID)
+	rc.Authorizer = authorizer
+	rc.PollingDuration = 0
+	return rc
+}

--- a/pkg/azclients/clients.go
+++ b/pkg/azclients/clients.go
@@ -20,9 +20,18 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 )
 
+// Contains all Azure Clients we want to use in radius.
+// Allows us to set an infinite timeout by default for each client
+// and maintain all client versions in a single place.
+
+// All Azure Clients should be put in this file. If you see "New(.*)Client" elsewhere,
+// please move it to this file.
+
 func NewGroupsClient(subscriptionID string, authorizer autorest.Authorizer) resources.GroupsClient {
 	rgc := resources.NewGroupsClient(subscriptionID)
 	rgc.Authorizer = authorizer
+
+	// Don't timeout, let the user cancel
 	rgc.PollingDuration = 0
 	return rgc
 }
@@ -129,10 +138,10 @@ func NewVaultsClient(subscriptionID string, authorizer autorest.Authorizer) keyv
 }
 
 func NewUserAssignedIdentitiesClient(subscriptionID string, authorizer autorest.Authorizer) msi.UserAssignedIdentitiesClient {
-	msiClient := msi.NewUserAssignedIdentitiesClient(subscriptionID)
-	msiClient.Authorizer = authorizer
-	msiClient.PollingDuration = 0
-	return msiClient
+	msic := msi.NewUserAssignedIdentitiesClient(subscriptionID)
+	msic.Authorizer = authorizer
+	msic.PollingDuration = 0
+	return msic
 }
 
 func NewServiceBusNamespacesClient(subscriptionID string, authorizer autorest.Authorizer) servicebus.NamespacesClient {

--- a/pkg/azclients/clients.go
+++ b/pkg/azclients/clients.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/msi/mgmt/msi"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/operationalinsights/mgmt/operationalinsights"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/subscriptions"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/servicebus/mgmt/servicebus"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/storage/mgmt/storage"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/web/mgmt/web"
@@ -26,8 +27,15 @@ func NewGroupsClient(subscriptionID string, authorizer autorest.Authorizer) reso
 	return rgc
 }
 
-func NewSubscriptionClient(authorizer autorest.Authorizer) subscription.Client {
-	sc := subscription.NewClient()
+func NewSubscriptionClient(authorizer autorest.Authorizer) subscription.SubscriptionsClient {
+	sc := subscription.NewSubscriptionsClient()
+	sc.Authorizer = authorizer
+	sc.PollingDuration = 0
+	return sc
+}
+
+func NewSubscriptionsClient(authorizer autorest.Authorizer) subscriptions.Client {
+	sc := subscriptions.NewClient()
 	sc.Authorizer = authorizer
 	sc.PollingDuration = 0
 	return sc

--- a/pkg/rad/azure/aks.go
+++ b/pkg/rad/azure/aks.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
+	"github.com/Azure/radius/pkg/azclients"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -24,9 +24,7 @@ func GetAKSMonitoringCredentials(ctx context.Context, subscriptionID string, res
 	// Currently we go to AKS every time to ask for credentials, we don't
 	// cache them locally. This could be done in the future, but skipping it for now
 	// since it's non-obvious that we'd store credentials in your ~/.rad directory
-	mcc := containerservice.NewManagedClustersClient(subscriptionID)
-	mcc.Authorizer = armauth
-	mcc.PollingDuration = 0
+	mcc := azclients.NewManagedClustersClient(subscriptionID, armauth)
 
 	results, err := mcc.ListClusterMonitoringUserCredentials(ctx, resourceGroup, clusterName)
 	if err != nil {

--- a/pkg/rad/azure/aks.go
+++ b/pkg/rad/azure/aks.go
@@ -26,6 +26,7 @@ func GetAKSMonitoringCredentials(ctx context.Context, subscriptionID string, res
 	// since it's non-obvious that we'd store credentials in your ~/.rad directory
 	mcc := containerservice.NewManagedClustersClient(subscriptionID)
 	mcc.Authorizer = armauth
+	mcc.PollingDuration = 0
 
 	results, err := mcc.ListClusterMonitoringUserCredentials(ctx, resourceGroup, clusterName)
 	if err != nil {

--- a/pkg/rad/azure/subscriptions.go
+++ b/pkg/rad/azure/subscriptions.go
@@ -62,7 +62,7 @@ func LoadSubscriptionsFromProfile() (SubscriptionResult, error) {
 
 // LoadSubscriptionsFromAzure uses ARM to find subscription data.
 func LoadSubscriptionsFromAzure(ctx context.Context, authorizer autorest.Authorizer) (SubscriptionResult, error) {
-	subc := azclients.NewSubscriptionsClient(authorizer)
+	subc := azclients.NewSubscriptionClient(authorizer)
 
 	// ARM doesn't have the concept of a "default" subscription so we skip it here.
 	result := SubscriptionResult{}

--- a/pkg/rad/azure/subscriptions.go
+++ b/pkg/rad/azure/subscriptions.go
@@ -64,6 +64,7 @@ func LoadSubscriptionsFromProfile() (SubscriptionResult, error) {
 func LoadSubscriptionsFromAzure(ctx context.Context, authorizer autorest.Authorizer) (SubscriptionResult, error) {
 	subc := subscription.NewSubscriptionsClient()
 	subc.Authorizer = authorizer
+	subc.PollingDuration = 0
 
 	// ARM doesn't have the concept of a "default" subscription so we skip it here.
 	result := SubscriptionResult{}

--- a/pkg/rad/azure/subscriptions.go
+++ b/pkg/rad/azure/subscriptions.go
@@ -9,9 +9,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/subscription/mgmt/subscription"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/cli"
+	"github.com/Azure/radius/pkg/azclients"
 )
 
 // SubscriptionResult is the result of loading Azure subscriptions for the user.
@@ -62,9 +62,7 @@ func LoadSubscriptionsFromProfile() (SubscriptionResult, error) {
 
 // LoadSubscriptionsFromAzure uses ARM to find subscription data.
 func LoadSubscriptionsFromAzure(ctx context.Context, authorizer autorest.Authorizer) (SubscriptionResult, error) {
-	subc := subscription.NewSubscriptionsClient()
-	subc.Authorizer = authorizer
-	subc.PollingDuration = 0
+	subc := azclients.NewSubscriptionsClient(authorizer)
 
 	// ARM doesn't have the concept of a "default" subscription so we skip it here.
 	result := SubscriptionResult{}

--- a/pkg/rad/environments/azure.go
+++ b/pkg/rad/environments/azure.go
@@ -10,9 +10,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/rad/azure"
 	"github.com/Azure/radius/pkg/rad/clients"
 	"github.com/Azure/radius/pkg/rad/kubernetes"
@@ -65,19 +65,14 @@ func (e *AzureCloudEnvironment) GetStatusLink() string {
 }
 
 func (e *AzureCloudEnvironment) CreateDeploymentClient(ctx context.Context) (clients.DeploymentClient, error) {
-	dc := resources.NewDeploymentsClient(e.SubscriptionID)
 	armauth, err := azure.GetResourceManagerEndpointAuthorizer()
 	if err != nil {
 		return nil, err
 	}
 
-	dc.Authorizer = armauth
-
+	dc := azclients.NewDeploymentsClient(e.SubscriptionID, armauth)
 	// Poll faster than the default, many deployments are quick
 	dc.PollingDelay = 5 * time.Second
-
-	// Don't timeout, let the user cancel
-	dc.PollingDuration = 0
 
 	return &azure.ARMDeploymentClient{
 		Client:         dc,

--- a/pkg/radrp/handlers/azure_cosmosdb_base.go
+++ b/pkg/radrp/handlers/azure_cosmosdb_base.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/cosmos-db/mgmt/documentdb"
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/keys"
 	"github.com/Azure/radius/pkg/rad/util"
 	"github.com/Azure/radius/pkg/radlogger"
@@ -51,9 +52,7 @@ func (handler *azureCosmosDBBaseHandler) GetCosmosDBAccountByID(ctx context.Cont
 		return nil, fmt.Errorf("failed to parse CosmosDB Account resource id: %w", err)
 	}
 
-	cosmosDBClient := documentdb.NewDatabaseAccountsClient(parsed.SubscriptionID)
-	cosmosDBClient.Authorizer = handler.arm.Auth
-	cosmosDBClient.PollingDuration = 0
+	cosmosDBClient := azclients.NewDatabaseAccountsClient(parsed.SubscriptionID, handler.arm.Auth)
 
 	account, err := cosmosDBClient.Get(ctx, parsed.ResourceGroup, parsed.Types[0].Name)
 	if err != nil {
@@ -65,9 +64,7 @@ func (handler *azureCosmosDBBaseHandler) GetCosmosDBAccountByID(ctx context.Cont
 
 // CreateCosmosDBAccount creates CosmosDB account. Account name is randomly generated with specified database name as prefix.
 func (handler *azureCosmosDBBaseHandler) CreateCosmosDBAccount(ctx context.Context, properties map[string]string, databaseKind documentdb.DatabaseAccountKind, options PutOptions) (*documentdb.DatabaseAccountGetResults, error) {
-	cosmosDBClient := documentdb.NewDatabaseAccountsClient(handler.arm.SubscriptionID)
-	cosmosDBClient.Authorizer = handler.arm.Auth
-	cosmosDBClient.PollingDuration = 0
+	cosmosDBClient := azclients.NewDatabaseAccountsClient(handler.arm.SubscriptionID, handler.arm.Auth)
 
 	accountName, err := generateCosmosDBAccountName(ctx, properties, cosmosDBClient)
 	if err != nil {
@@ -111,9 +108,7 @@ func (handler *azureCosmosDBBaseHandler) CreateCosmosDBAccount(ctx context.Conte
 
 // DeleteCosmosDBAccount deletes CosmosDB account for the specified account name
 func (handler *azureCosmosDBBaseHandler) DeleteCosmosDBAccount(ctx context.Context, accountName string) error {
-	cosmosDBClient := documentdb.NewDatabaseAccountsClient(handler.arm.SubscriptionID)
-	cosmosDBClient.Authorizer = handler.arm.Auth
-	cosmosDBClient.PollingDuration = 0
+	cosmosDBClient := azclients.NewDatabaseAccountsClient(handler.arm.SubscriptionID, handler.arm.Auth)
 
 	accountFuture, err := cosmosDBClient.Delete(ctx, handler.arm.ResourceGroup, accountName)
 	if err != nil {

--- a/pkg/radrp/handlers/azure_cosmosdb_base.go
+++ b/pkg/radrp/handlers/azure_cosmosdb_base.go
@@ -53,6 +53,7 @@ func (handler *azureCosmosDBBaseHandler) GetCosmosDBAccountByID(ctx context.Cont
 
 	cosmosDBClient := documentdb.NewDatabaseAccountsClient(parsed.SubscriptionID)
 	cosmosDBClient.Authorizer = handler.arm.Auth
+	cosmosDBClient.PollingDuration = 0
 
 	account, err := cosmosDBClient.Get(ctx, parsed.ResourceGroup, parsed.Types[0].Name)
 	if err != nil {
@@ -66,6 +67,7 @@ func (handler *azureCosmosDBBaseHandler) GetCosmosDBAccountByID(ctx context.Cont
 func (handler *azureCosmosDBBaseHandler) CreateCosmosDBAccount(ctx context.Context, properties map[string]string, databaseKind documentdb.DatabaseAccountKind, options PutOptions) (*documentdb.DatabaseAccountGetResults, error) {
 	cosmosDBClient := documentdb.NewDatabaseAccountsClient(handler.arm.SubscriptionID)
 	cosmosDBClient.Authorizer = handler.arm.Auth
+	cosmosDBClient.PollingDuration = 0
 
 	accountName, err := generateCosmosDBAccountName(ctx, properties, cosmosDBClient)
 	if err != nil {
@@ -111,6 +113,7 @@ func (handler *azureCosmosDBBaseHandler) CreateCosmosDBAccount(ctx context.Conte
 func (handler *azureCosmosDBBaseHandler) DeleteCosmosDBAccount(ctx context.Context, accountName string) error {
 	cosmosDBClient := documentdb.NewDatabaseAccountsClient(handler.arm.SubscriptionID)
 	cosmosDBClient.Authorizer = handler.arm.Auth
+	cosmosDBClient.PollingDuration = 0
 
 	accountFuture, err := cosmosDBClient.Delete(ctx, handler.arm.ResourceGroup, accountName)
 	if err != nil {

--- a/pkg/radrp/handlers/azure_cosmosdb_mongo.go
+++ b/pkg/radrp/handlers/azure_cosmosdb_mongo.go
@@ -109,6 +109,7 @@ func (handler *azureCosmosDBMongoHandler) GetDatabaseByID(ctx context.Context, d
 
 	mongoClient := documentdb.NewMongoDBResourcesClient(parsed.SubscriptionID)
 	mongoClient.Authorizer = handler.arm.Auth
+	mongoClient.PollingDuration = 0
 
 	account, err := mongoClient.GetMongoDBDatabase(ctx, parsed.ResourceGroup, parsed.Types[0].Name, parsed.Types[1].Name)
 	if err != nil {
@@ -121,6 +122,7 @@ func (handler *azureCosmosDBMongoHandler) GetDatabaseByID(ctx context.Context, d
 func (handler *azureCosmosDBMongoHandler) CreateDatabase(ctx context.Context, accountName string, dbName string, options PutOptions) (*documentdb.MongoDBDatabaseGetResults, error) {
 	mrc := documentdb.NewMongoDBResourcesClient(handler.arm.SubscriptionID)
 	mrc.Authorizer = handler.arm.Auth
+	mrc.PollingDuration = 0
 
 	dbfuture, err := mrc.CreateUpdateMongoDBDatabase(ctx, handler.arm.ResourceGroup, accountName, dbName, documentdb.MongoDBDatabaseCreateUpdateParameters{
 		MongoDBDatabaseCreateUpdateProperties: &documentdb.MongoDBDatabaseCreateUpdateProperties{
@@ -155,6 +157,7 @@ func (handler *azureCosmosDBMongoHandler) CreateDatabase(ctx context.Context, ac
 func (handler *azureCosmosDBMongoHandler) DeleteDatabase(ctx context.Context, accountName string, dbName string) error {
 	mrc := documentdb.NewMongoDBResourcesClient(handler.arm.SubscriptionID)
 	mrc.Authorizer = handler.arm.Auth
+	mrc.PollingDuration = 0
 
 	// It's possible that this is a retry and we already deleted the account on a previous attempt.
 	// When that happens a delete for the database (a nested resource) can fail with a 404, but it's

--- a/pkg/radrp/handlers/azure_cosmosdb_mongo.go
+++ b/pkg/radrp/handlers/azure_cosmosdb_mongo.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/cosmos-db/mgmt/documentdb"
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/keys"
 	"github.com/Azure/radius/pkg/rad/util"
 	"github.com/Azure/radius/pkg/radrp/armauth"
@@ -107,9 +108,7 @@ func (handler *azureCosmosDBMongoHandler) GetDatabaseByID(ctx context.Context, d
 		return nil, fmt.Errorf("failed to parse CosmosDB Mongo Database resource id: %w", err)
 	}
 
-	mongoClient := documentdb.NewMongoDBResourcesClient(parsed.SubscriptionID)
-	mongoClient.Authorizer = handler.arm.Auth
-	mongoClient.PollingDuration = 0
+	mongoClient := azclients.NewMongoDBResourcesClient(parsed.SubscriptionID, handler.arm.Auth)
 
 	account, err := mongoClient.GetMongoDBDatabase(ctx, parsed.ResourceGroup, parsed.Types[0].Name, parsed.Types[1].Name)
 	if err != nil {
@@ -120,9 +119,7 @@ func (handler *azureCosmosDBMongoHandler) GetDatabaseByID(ctx context.Context, d
 }
 
 func (handler *azureCosmosDBMongoHandler) CreateDatabase(ctx context.Context, accountName string, dbName string, options PutOptions) (*documentdb.MongoDBDatabaseGetResults, error) {
-	mrc := documentdb.NewMongoDBResourcesClient(handler.arm.SubscriptionID)
-	mrc.Authorizer = handler.arm.Auth
-	mrc.PollingDuration = 0
+	mrc := azclients.NewMongoDBResourcesClient(handler.arm.SubscriptionID, handler.arm.Auth)
 
 	dbfuture, err := mrc.CreateUpdateMongoDBDatabase(ctx, handler.arm.ResourceGroup, accountName, dbName, documentdb.MongoDBDatabaseCreateUpdateParameters{
 		MongoDBDatabaseCreateUpdateProperties: &documentdb.MongoDBDatabaseCreateUpdateProperties{
@@ -155,9 +152,7 @@ func (handler *azureCosmosDBMongoHandler) CreateDatabase(ctx context.Context, ac
 }
 
 func (handler *azureCosmosDBMongoHandler) DeleteDatabase(ctx context.Context, accountName string, dbName string) error {
-	mrc := documentdb.NewMongoDBResourcesClient(handler.arm.SubscriptionID)
-	mrc.Authorizer = handler.arm.Auth
-	mrc.PollingDuration = 0
+	mrc := azclients.NewMongoDBResourcesClient(handler.arm.SubscriptionID, handler.arm.Auth)
 
 	// It's possible that this is a retry and we already deleted the account on a previous attempt.
 	// When that happens a delete for the database (a nested resource) can fail with a 404, but it's

--- a/pkg/radrp/handlers/azure_cosmosdb_sql.go
+++ b/pkg/radrp/handlers/azure_cosmosdb_sql.go
@@ -113,6 +113,7 @@ func (handler *azureCosmosDBSQLDBHandler) GetDatabaseByID(ctx context.Context, d
 
 	mongoClient := documentdb.NewSQLResourcesClient(parsed.SubscriptionID)
 	mongoClient.Authorizer = handler.arm.Auth
+	mongoClient.PollingDuration = 0
 
 	account, err := mongoClient.GetSQLDatabase(ctx, parsed.ResourceGroup, parsed.Types[0].Name, parsed.Types[1].Name)
 	if err != nil {
@@ -125,6 +126,7 @@ func (handler *azureCosmosDBSQLDBHandler) GetDatabaseByID(ctx context.Context, d
 func (handler *azureCosmosDBSQLDBHandler) CreateDatabase(ctx context.Context, accountName string, dbName string, options PutOptions) (*documentdb.SQLDatabaseGetResults, error) {
 	sqlClient := documentdb.NewSQLResourcesClient(handler.arm.SubscriptionID)
 	sqlClient.Authorizer = handler.arm.Auth
+	sqlClient.PollingDuration = 0
 
 	dbfuture, err := sqlClient.CreateUpdateSQLDatabase(ctx, handler.arm.ResourceGroup, accountName, dbName, documentdb.SQLDatabaseCreateUpdateParameters{
 		SQLDatabaseCreateUpdateProperties: &documentdb.SQLDatabaseCreateUpdateProperties{
@@ -160,6 +162,7 @@ func (handler *azureCosmosDBSQLDBHandler) CreateDatabase(ctx context.Context, ac
 func (handler *azureCosmosDBSQLDBHandler) DeleteDatabase(ctx context.Context, accountName string, dbName string) error {
 	sqlClient := documentdb.NewSQLResourcesClient(handler.arm.SubscriptionID)
 	sqlClient.Authorizer = handler.arm.Auth
+	sqlClient.PollingDuration = 0
 
 	dbfuture, err := sqlClient.DeleteSQLDatabase(ctx, handler.arm.ResourceGroup, accountName, dbName)
 	if err != nil && dbfuture.Response().StatusCode != 404 {

--- a/pkg/radrp/handlers/azure_cosmosdb_sql.go
+++ b/pkg/radrp/handlers/azure_cosmosdb_sql.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/cosmos-db/mgmt/documentdb"
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/keys"
 	"github.com/Azure/radius/pkg/rad/util"
 	"github.com/Azure/radius/pkg/radrp/armauth"
@@ -111,11 +112,9 @@ func (handler *azureCosmosDBSQLDBHandler) GetDatabaseByID(ctx context.Context, d
 		return nil, fmt.Errorf("failed to parse CosmosDB SQL Database resource id: %w", err)
 	}
 
-	mongoClient := documentdb.NewSQLResourcesClient(parsed.SubscriptionID)
-	mongoClient.Authorizer = handler.arm.Auth
-	mongoClient.PollingDuration = 0
+	sqlClient := azclients.NewSQLResourcesClient(parsed.SubscriptionID, handler.arm.Auth)
 
-	account, err := mongoClient.GetSQLDatabase(ctx, parsed.ResourceGroup, parsed.Types[0].Name, parsed.Types[1].Name)
+	account, err := sqlClient.GetSQLDatabase(ctx, parsed.ResourceGroup, parsed.Types[0].Name, parsed.Types[1].Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get CosmosDB SQL Database: %w", err)
 	}
@@ -124,9 +123,7 @@ func (handler *azureCosmosDBSQLDBHandler) GetDatabaseByID(ctx context.Context, d
 }
 
 func (handler *azureCosmosDBSQLDBHandler) CreateDatabase(ctx context.Context, accountName string, dbName string, options PutOptions) (*documentdb.SQLDatabaseGetResults, error) {
-	sqlClient := documentdb.NewSQLResourcesClient(handler.arm.SubscriptionID)
-	sqlClient.Authorizer = handler.arm.Auth
-	sqlClient.PollingDuration = 0
+	sqlClient := azclients.NewSQLResourcesClient(handler.arm.SubscriptionID, handler.arm.Auth)
 
 	dbfuture, err := sqlClient.CreateUpdateSQLDatabase(ctx, handler.arm.ResourceGroup, accountName, dbName, documentdb.SQLDatabaseCreateUpdateParameters{
 		SQLDatabaseCreateUpdateProperties: &documentdb.SQLDatabaseCreateUpdateProperties{
@@ -160,9 +157,7 @@ func (handler *azureCosmosDBSQLDBHandler) CreateDatabase(ctx context.Context, ac
 }
 
 func (handler *azureCosmosDBSQLDBHandler) DeleteDatabase(ctx context.Context, accountName string, dbName string) error {
-	sqlClient := documentdb.NewSQLResourcesClient(handler.arm.SubscriptionID)
-	sqlClient.Authorizer = handler.arm.Auth
-	sqlClient.PollingDuration = 0
+	sqlClient := azclients.NewSQLResourcesClient(handler.arm.SubscriptionID, handler.arm.Auth)
 
 	dbfuture, err := sqlClient.DeleteSQLDatabase(ctx, handler.arm.ResourceGroup, accountName, dbName)
 	if err != nil && dbfuture.Response().StatusCode != 404 {

--- a/pkg/radrp/handlers/azure_keyvault.go
+++ b/pkg/radrp/handlers/azure_keyvault.go
@@ -113,7 +113,7 @@ func (handler *azureKeyVaultHandler) GetKeyVaultByID(ctx context.Context, id str
 func (handler *azureKeyVaultHandler) CreateKeyVault(ctx context.Context, vaultName string, options PutOptions) (*keyvault.Vault, error) {
 	kvc := azclients.NewVaultsClient(handler.arm.SubscriptionID, handler.arm.Auth)
 
-	sc := azclients.NewSubscriptionsClient(handler.arm.Auth)
+	sc := azclients.NewSubscriptionClient(handler.arm.Auth)
 
 	s, err := sc.Get(ctx, handler.arm.SubscriptionID)
 	if err != nil {

--- a/pkg/radrp/handlers/azure_keyvault.go
+++ b/pkg/radrp/handlers/azure_keyvault.go
@@ -113,7 +113,7 @@ func (handler *azureKeyVaultHandler) GetKeyVaultByID(ctx context.Context, id str
 func (handler *azureKeyVaultHandler) CreateKeyVault(ctx context.Context, vaultName string, options PutOptions) (*keyvault.Vault, error) {
 	kvc := azclients.NewVaultsClient(handler.arm.SubscriptionID, handler.arm.Auth)
 
-	sc := azclients.NewSubscriptionClient(handler.arm.Auth)
+	sc := azclients.NewSubscriptionsClient(handler.arm.Auth)
 
 	s, err := sc.Get(ctx, handler.arm.SubscriptionID)
 	if err != nil {

--- a/pkg/radrp/handlers/azure_keyvault.go
+++ b/pkg/radrp/handlers/azure_keyvault.go
@@ -102,6 +102,7 @@ func (handler *azureKeyVaultHandler) GetKeyVaultByID(ctx context.Context, id str
 
 	kvc := keyvault.NewVaultsClient(handler.arm.SubscriptionID)
 	kvc.Authorizer = handler.arm.Auth
+	kvc.PollingDuration = 0
 
 	kv, err := kvc.Get(ctx, parsed.ResourceGroup, parsed.Types[0].Name)
 	if err != nil {
@@ -114,9 +115,11 @@ func (handler *azureKeyVaultHandler) GetKeyVaultByID(ctx context.Context, id str
 func (handler *azureKeyVaultHandler) CreateKeyVault(ctx context.Context, vaultName string, options PutOptions) (*keyvault.Vault, error) {
 	kvc := keyvault.NewVaultsClient(handler.arm.SubscriptionID)
 	kvc.Authorizer = handler.arm.Auth
+	kvc.PollingDuration = 0
 
 	sc := subscriptions.NewClient()
 	sc.Authorizer = handler.arm.Auth
+	sc.PollingDuration = 0
 	s, err := sc.Get(ctx, handler.arm.SubscriptionID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to find subscription: %w", err)
@@ -169,6 +172,7 @@ func (handler *azureKeyVaultHandler) CreateKeyVault(ctx context.Context, vaultNa
 func (handler *azureKeyVaultHandler) DeleteKeyVault(ctx context.Context, vaultName string) error {
 	kvClient := keyvault.NewVaultsClient(handler.arm.SubscriptionID)
 	kvClient.Authorizer = handler.arm.Auth
+	kvClient.PollingDelay = 0
 
 	_, err := kvClient.Delete(ctx, handler.arm.ResourceGroup, vaultName)
 	if err != nil {

--- a/pkg/radrp/handlers/azure_podidentity.go
+++ b/pkg/radrp/handlers/azure_podidentity.go
@@ -10,9 +10,9 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/msi/mgmt/msi"
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/radrp/armauth"
 )
 
@@ -48,9 +48,7 @@ func (handler *azurePodIdentityHandler) Delete(ctx context.Context, options Dele
 
 	// Conceptually this resource is always 'managed'
 
-	mcc := containerservice.NewManagedClustersClient(handler.arm.SubscriptionID)
-	mcc.Authorizer = handler.arm.Auth
-	mcc.PollingDuration = 0
+	mcc := azclients.NewManagedClustersClient(handler.arm.SubscriptionID, handler.arm.Auth)
 
 	// Get the cluster and modify it to remove pod identity
 	managedCluster, err := mcc.Get(ctx, handler.arm.K8sResourceGroup, podidentityCluster)
@@ -107,9 +105,7 @@ func (handler *azurePodIdentityHandler) Delete(ctx context.Context, options Dele
 }
 
 func (handler *azurePodIdentityHandler) deleteManagedIdentity(ctx context.Context, msiResourceID string) error {
-	msiClient := msi.NewUserAssignedIdentitiesClient(handler.arm.SubscriptionID)
-	msiClient.Authorizer = handler.arm.Auth
-	msiClient.PollingDuration = 0
+	msiClient := azclients.NewUserAssignedIdentitiesClient(handler.arm.SubscriptionID, handler.arm.Auth)
 
 	msiResource, err := azure.ParseResourceID(msiResourceID)
 	if err != nil {

--- a/pkg/radrp/handlers/azure_podidentity.go
+++ b/pkg/radrp/handlers/azure_podidentity.go
@@ -50,6 +50,7 @@ func (handler *azurePodIdentityHandler) Delete(ctx context.Context, options Dele
 
 	mcc := containerservice.NewManagedClustersClient(handler.arm.SubscriptionID)
 	mcc.Authorizer = handler.arm.Auth
+	mcc.PollingDuration = 0
 
 	// Get the cluster and modify it to remove pod identity
 	managedCluster, err := mcc.Get(ctx, handler.arm.K8sResourceGroup, podidentityCluster)
@@ -108,6 +109,8 @@ func (handler *azurePodIdentityHandler) Delete(ctx context.Context, options Dele
 func (handler *azurePodIdentityHandler) deleteManagedIdentity(ctx context.Context, msiResourceID string) error {
 	msiClient := msi.NewUserAssignedIdentitiesClient(handler.arm.SubscriptionID)
 	msiClient.Authorizer = handler.arm.Auth
+	msiClient.PollingDuration = 0
+
 	msiResource, err := azure.ParseResourceID(msiResourceID)
 	if err != nil {
 		return fmt.Errorf("failed to delete user assigned managed identity: %w", err)

--- a/pkg/radrp/handlers/azure_servicebus.go
+++ b/pkg/radrp/handlers/azure_servicebus.go
@@ -132,6 +132,7 @@ func (handler *azureServiceBusBaseHandler) GetNamespaceByID(ctx context.Context,
 
 	sbc := servicebus.NewNamespacesClient(parsed.SubscriptionID)
 	sbc.Authorizer = handler.arm.Auth
+	sbc.PollingDuration = 0
 
 	// Check if a service bus namespace exists in the resource group for this application
 	namespace, err := sbc.Get(ctx, parsed.ResourceGroup, parsed.Types[0].Name)
@@ -145,6 +146,7 @@ func (handler *azureServiceBusBaseHandler) GetNamespaceByID(ctx context.Context,
 func (handler *azureServiceBusBaseHandler) LookupSharedManagedNamespaceFromResourceGroup(ctx context.Context, application string) (*servicebus.SBNamespace, error) {
 	sbc := servicebus.NewNamespacesClient(handler.arm.SubscriptionID)
 	sbc.Authorizer = handler.arm.Auth
+	sbc.PollingDuration = 0
 
 	// Check if a service bus namespace exists in the resource group for this application
 	list, err := sbc.ListByResourceGroupComplete(ctx, handler.arm.ResourceGroup)
@@ -167,6 +169,7 @@ func (handler *azureServiceBusBaseHandler) LookupSharedManagedNamespaceFromResou
 func (handler *azureServiceBusBaseHandler) CreateNamespace(ctx context.Context, application string) (*servicebus.SBNamespace, error) {
 	sbc := servicebus.NewNamespacesClient(handler.arm.SubscriptionID)
 	sbc.Authorizer = handler.arm.Auth
+	sbc.PollingDuration = 0
 
 	location, err := getResourceGroupLocation(ctx, handler.arm)
 	if err != nil {
@@ -210,6 +213,7 @@ func (handler *azureServiceBusBaseHandler) CreateNamespace(ctx context.Context, 
 func (handler *azureServiceBusBaseHandler) CreateTopic(ctx context.Context, namespaceName string, topicName string) (*servicebus.SBTopic, error) {
 	tc := servicebus.NewTopicsClient(handler.arm.SubscriptionID)
 	tc.Authorizer = handler.arm.Auth
+	tc.PollingDuration = 0
 
 	topic, err := tc.CreateOrUpdate(ctx, handler.arm.ResourceGroup, namespaceName, topicName, servicebus.SBTopic{
 		Name: to.StringPtr(topicName),
@@ -235,6 +239,7 @@ func (handler *azureServiceBusBaseHandler) GetTopicByID(ctx context.Context, id 
 
 	tc := servicebus.NewTopicsClient(parsed.SubscriptionID)
 	tc.Authorizer = handler.arm.Auth
+	tc.PollingDuration = 0
 
 	topic, err := tc.Get(ctx, parsed.ResourceGroup, parsed.Types[0].Name, parsed.Types[1].Name)
 	if err != nil {
@@ -247,6 +252,7 @@ func (handler *azureServiceBusBaseHandler) GetTopicByID(ctx context.Context, id 
 func (handler *azureServiceBusBaseHandler) CreateQueue(ctx context.Context, namespaceName string, queueName string) (*servicebus.SBQueue, error) {
 	qc := servicebus.NewQueuesClient(handler.arm.SubscriptionID)
 	qc.Authorizer = handler.arm.Auth
+	qc.PollingDuration = 0
 
 	queue, err := qc.CreateOrUpdate(ctx, handler.arm.ResourceGroup, namespaceName, queueName, servicebus.SBQueue{
 		Name: to.StringPtr(queueName),
@@ -270,6 +276,7 @@ func (handler *azureServiceBusBaseHandler) GetQueueByID(ctx context.Context, id 
 
 	qc := servicebus.NewQueuesClient(parsed.ID)
 	qc.Authorizer = handler.arm.Auth
+	qc.PollingDuration = 0
 
 	queue, err := qc.Get(ctx, parsed.ResourceGroup, parsed.Types[0].Name, parsed.Types[1].Name)
 	if err != nil {
@@ -282,6 +289,7 @@ func (handler *azureServiceBusBaseHandler) GetQueueByID(ctx context.Context, id 
 func (handler *azureServiceBusBaseHandler) GetConnectionString(ctx context.Context, namespaceName string) (*string, error) {
 	sbc := servicebus.NewNamespacesClient(handler.arm.SubscriptionID)
 	sbc.Authorizer = handler.arm.Auth
+	sbc.PollingDuration = 0
 
 	accessKeys, err := sbc.ListKeys(ctx, handler.arm.ResourceGroup, namespaceName, "RootManageSharedAccessKey")
 	if err != nil {
@@ -299,6 +307,7 @@ func (handler *azureServiceBusBaseHandler) DeleteNamespace(ctx context.Context, 
 	// The last queue in the service bus namespace was deleted. Now delete the namespace as well
 	sbc := servicebus.NewNamespacesClient(handler.arm.SubscriptionID)
 	sbc.Authorizer = handler.arm.Auth
+	sbc.PollingDuration = 0
 
 	sbNamespaceFuture, err := sbc.Delete(ctx, handler.arm.ResourceGroup, namespaceName)
 	if err != nil && sbNamespaceFuture.Response().StatusCode != 404 {
@@ -322,6 +331,7 @@ func (handler *azureServiceBusBaseHandler) DeleteNamespace(ctx context.Context, 
 func (handler *azureServiceBusBaseHandler) DeleteTopic(ctx context.Context, namespaceName string, topicName string) (bool, error) {
 	tc := servicebus.NewTopicsClient(handler.arm.SubscriptionID)
 	tc.Authorizer = handler.arm.Auth
+	tc.PollingDuration = 0
 
 	// We might see a 404 here due the namespace already being deleted. This is benign and could occur on retry
 	// of a failed deletion. Either way if the namespace is gone then the topic is gone.
@@ -350,6 +360,7 @@ func (handler *azureServiceBusBaseHandler) DeleteTopic(ctx context.Context, name
 func (handler *azureServiceBusBaseHandler) DeleteQueue(ctx context.Context, namespaceName, queueName string) (bool, error) {
 	qc := servicebus.NewQueuesClient(handler.arm.SubscriptionID)
 	qc.Authorizer = handler.arm.Auth
+	qc.PollingDuration = 0
 
 	result, err := qc.Delete(ctx, handler.arm.ResourceGroup, namespaceName, queueName)
 	if err != nil && result.StatusCode != 404 {

--- a/pkg/radrp/handlers/dapr_statestore_sqlserver.go
+++ b/pkg/radrp/handlers/dapr_statestore_sqlserver.go
@@ -147,6 +147,7 @@ func (handler *daprStateStoreSQLServerHandler) Delete(ctx context.Context, optio
 	// Delete database
 	sqlDBClient := sql.NewDatabasesClient(handler.arm.SubscriptionID)
 	sqlDBClient.Authorizer = handler.arm.Auth
+	sqlDBClient.PollingDuration = 0
 	response, err := sqlDBClient.Delete(ctx, handler.arm.ResourceGroup, serverName, databaseName)
 	if err != nil && response.StatusCode != 404 {
 		return fmt.Errorf("failed to delete sql database `%s`: %w", databaseName, err)
@@ -155,6 +156,7 @@ func (handler *daprStateStoreSQLServerHandler) Delete(ctx context.Context, optio
 	// Delete the server
 	sqlServerClient := sql.NewServersClient(handler.arm.SubscriptionID)
 	sqlServerClient.Authorizer = handler.arm.Auth
+	sqlServerClient.PollingDuration = 0
 	future, err := sqlServerClient.Delete(ctx, handler.arm.ResourceGroup, serverName)
 	if err != nil && future.Response().StatusCode != 404 {
 		return fmt.Errorf("failed to delete sql server `%s`: %w", serverName, err)
@@ -176,9 +178,10 @@ func (handler *daprStateStoreSQLServerHandler) Delete(ctx context.Context, optio
 // createServer creates SQL server instance with a generated unique server name prefixed with specified database name
 func (handler *daprStateStoreSQLServerHandler) createServer(ctx context.Context, location *string, databaseName string, password string, options PutOptions) (string, error) {
 	logger := radlogger.GetLogger(ctx)
-	
+
 	sqlServerClient := sql.NewServersClient(handler.arm.SubscriptionID)
 	sqlServerClient.Authorizer = handler.arm.Auth
+	sqlServerClient.PollingDuration = 0
 
 	var serverName = ""
 	retryAttempts := 10
@@ -240,6 +243,7 @@ func (handler *daprStateStoreSQLServerHandler) createServer(ctx context.Context,
 func (handler *daprStateStoreSQLServerHandler) createSQLDB(ctx context.Context, location *string, serverName string, dbName string, options PutOptions) error {
 	sqlDBClient := sql.NewDatabasesClient(handler.arm.SubscriptionID)
 	sqlDBClient.Authorizer = handler.arm.Auth
+	sqlDBClient.PollingDuration = 0
 
 	future, err := sqlDBClient.CreateOrUpdate(
 		ctx,

--- a/pkg/radrp/handlers/dapr_statestore_storage.go
+++ b/pkg/radrp/handlers/dapr_statestore_storage.go
@@ -109,6 +109,7 @@ func (handler *daprStateStoreAzureStorageHandler) GenerateStorageAccountName(ctx
 	logger := radlogger.GetLogger(ctx)
 	sc := storage.NewAccountsClient(handler.arm.SubscriptionID)
 	sc.Authorizer = handler.arm.Auth
+	sc.PollingDuration = 0
 
 	// names are kinda finicky here - they have to be unique across azure.
 	name := ""
@@ -148,6 +149,7 @@ func (handler *daprStateStoreAzureStorageHandler) GetStorageAccountByID(ctx cont
 
 	sac := storage.NewAccountsClient(parsed.SubscriptionID)
 	sac.Authorizer = handler.arm.Auth
+	sac.PollingDuration = 0
 
 	account, err := sac.GetProperties(ctx, parsed.ResourceGroup, parsed.Types[0].Name, storage.AccountExpand(""))
 	if err != nil {
@@ -165,6 +167,7 @@ func (handler *daprStateStoreAzureStorageHandler) CreateStorageAccount(ctx conte
 
 	sc := storage.NewAccountsClient(handler.arm.SubscriptionID)
 	sc.Authorizer = handler.arm.Auth
+	sc.PollingDuration = 0
 
 	future, err := sc.Create(ctx, handler.arm.ResourceGroup, accountName, storage.AccountCreateParameters{
 		Location: location,
@@ -245,6 +248,7 @@ func (handler *daprStateStoreAzureStorageHandler) CreateDaprStateStore(ctx conte
 func (handler *daprStateStoreAzureStorageHandler) FindStorageKey(ctx context.Context, accountName string) (*storage.AccountKey, error) {
 	sc := storage.NewAccountsClient(handler.arm.SubscriptionID)
 	sc.Authorizer = handler.arm.Auth
+	sc.PollingDuration = 0
 
 	keys, err := sc.ListKeys(ctx, handler.arm.ResourceGroup, accountName, "")
 	if err != nil {
@@ -270,6 +274,7 @@ func (handler *daprStateStoreAzureStorageHandler) FindStorageKey(ctx context.Con
 func (handler *daprStateStoreAzureStorageHandler) DeleteStorageAccount(ctx context.Context, accountName string) error {
 	sc := storage.NewAccountsClient(handler.arm.SubscriptionID)
 	sc.Authorizer = handler.arm.Auth
+	sc.PollingDuration = 0
 
 	_, err := sc.Delete(ctx, handler.arm.ResourceGroup, accountName)
 	if err != nil {

--- a/pkg/radrp/handlers/dapr_statestore_storage.go
+++ b/pkg/radrp/handlers/dapr_statestore_storage.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/storage/mgmt/storage"
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/keys"
 	"github.com/Azure/radius/pkg/radlogger"
 	"github.com/Azure/radius/pkg/radrp/armauth"
@@ -107,9 +108,7 @@ func (handler *daprStateStoreAzureStorageHandler) Delete(ctx context.Context, op
 
 func (handler *daprStateStoreAzureStorageHandler) GenerateStorageAccountName(ctx context.Context, baseName string) (*string, error) {
 	logger := radlogger.GetLogger(ctx)
-	sc := storage.NewAccountsClient(handler.arm.SubscriptionID)
-	sc.Authorizer = handler.arm.Auth
-	sc.PollingDuration = 0
+	sc := azclients.NewAccountsClient(handler.arm.SubscriptionID, handler.arm.Auth)
 
 	// names are kinda finicky here - they have to be unique across azure.
 	name := ""
@@ -147,9 +146,7 @@ func (handler *daprStateStoreAzureStorageHandler) GetStorageAccountByID(ctx cont
 		return nil, fmt.Errorf("failed to parse Storage Account resource id: %w", err)
 	}
 
-	sac := storage.NewAccountsClient(parsed.SubscriptionID)
-	sac.Authorizer = handler.arm.Auth
-	sac.PollingDuration = 0
+	sac := azclients.NewAccountsClient(parsed.SubscriptionID, handler.arm.Auth)
 
 	account, err := sac.GetProperties(ctx, parsed.ResourceGroup, parsed.Types[0].Name, storage.AccountExpand(""))
 	if err != nil {
@@ -165,9 +162,7 @@ func (handler *daprStateStoreAzureStorageHandler) CreateStorageAccount(ctx conte
 		return nil, err
 	}
 
-	sc := storage.NewAccountsClient(handler.arm.SubscriptionID)
-	sc.Authorizer = handler.arm.Auth
-	sc.PollingDuration = 0
+	sc := azclients.NewAccountsClient(handler.arm.SubscriptionID, handler.arm.Auth)
 
 	future, err := sc.Create(ctx, handler.arm.ResourceGroup, accountName, storage.AccountCreateParameters{
 		Location: location,
@@ -246,9 +241,7 @@ func (handler *daprStateStoreAzureStorageHandler) CreateDaprStateStore(ctx conte
 }
 
 func (handler *daprStateStoreAzureStorageHandler) FindStorageKey(ctx context.Context, accountName string) (*storage.AccountKey, error) {
-	sc := storage.NewAccountsClient(handler.arm.SubscriptionID)
-	sc.Authorizer = handler.arm.Auth
-	sc.PollingDuration = 0
+	sc := azclients.NewAccountsClient(handler.arm.SubscriptionID, handler.arm.Auth)
 
 	keys, err := sc.ListKeys(ctx, handler.arm.ResourceGroup, accountName, "")
 	if err != nil {
@@ -272,9 +265,7 @@ func (handler *daprStateStoreAzureStorageHandler) FindStorageKey(ctx context.Con
 }
 
 func (handler *daprStateStoreAzureStorageHandler) DeleteStorageAccount(ctx context.Context, accountName string) error {
-	sc := storage.NewAccountsClient(handler.arm.SubscriptionID)
-	sc.Authorizer = handler.arm.Auth
-	sc.PollingDuration = 0
+	sc := azclients.NewAccountsClient(handler.arm.SubscriptionID, handler.arm.Auth)
 
 	_, err := sc.Delete(ctx, handler.arm.ResourceGroup, accountName)
 	if err != nil {

--- a/pkg/radrp/handlers/util.go
+++ b/pkg/radrp/handlers/util.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/radrp/armauth"
 	"github.com/Azure/radius/pkg/radrp/db"
 	"github.com/Azure/radius/pkg/workloads"
@@ -42,9 +42,7 @@ func mergeProperties(resource workloads.OutputResource, existing *db.DeploymentR
 }
 
 func getResourceGroupLocation(ctx context.Context, armConfig armauth.ArmConfig) (*string, error) {
-	rgc := resources.NewGroupsClient(armConfig.SubscriptionID)
-	rgc.Authorizer = armConfig.Auth
-	rgc.PollingDuration = 0
+	rgc := azclients.NewGroupsClient(armConfig.SubscriptionID, armConfig.Auth)
 
 	resourceGroup, err := rgc.Get(ctx, armConfig.ResourceGroup)
 	if err != nil {

--- a/pkg/radrp/handlers/util.go
+++ b/pkg/radrp/handlers/util.go
@@ -44,6 +44,7 @@ func mergeProperties(resource workloads.OutputResource, existing *db.DeploymentR
 func getResourceGroupLocation(ctx context.Context, armConfig armauth.ArmConfig) (*string, error) {
 	rgc := resources.NewGroupsClient(armConfig.SubscriptionID)
 	rgc.Authorizer = armConfig.Auth
+	rgc.PollingDuration = 0
 
 	resourceGroup, err := rgc.Get(ctx, armConfig.ResourceGroup)
 	if err != nil {

--- a/pkg/radrp/k8sauth/client.go
+++ b/pkg/radrp/k8sauth/client.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/radrp/armauth"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -121,12 +121,12 @@ func createRemote() (*rest.Config, error) {
 		return nil, errors.New("required env-var K8S_SUBSCRIPTION_ID not found")
 	}
 
-	aks := containerservice.NewManagedClustersClient(subscriptionID)
 	auth, err := armauth.GetArmAuthorizer()
 	if err != nil {
 		return nil, fmt.Errorf("cannot authorize with ARM: %w", err)
 	}
-	aks.Authorizer = auth
+
+	aks := azclients.NewManagedClustersClient(subscriptionID, auth)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/pkg/roleassignment/roleassignment.go
+++ b/pkg/roleassignment/roleassignment.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/authorization/mgmt/authorization"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/rad/util"
 	"github.com/Azure/radius/pkg/radlogger"
 	"github.com/gofrs/uuid"
@@ -20,9 +21,7 @@ import (
 // Create assigns the specified role name to the Identity over the specified scope
 func Create(ctx context.Context, auth autorest.Authorizer, subscriptionID string, resourceGroup, principalID, scope, roleName string) (*authorization.RoleAssignment, error) {
 	logger := radlogger.GetLogger(ctx)
-	rdc := authorization.NewRoleDefinitionsClient(subscriptionID)
-	rdc.Authorizer = auth
-	rdc.PollingDuration = 0
+	rdc := azclients.NewRoleDefinitionsClient(subscriptionID, auth)
 
 	roleFilter := fmt.Sprintf("roleName eq '%s'", roleName)
 	roleList, err := rdc.List(ctx, scope, roleFilter)
@@ -30,9 +29,7 @@ func Create(ctx context.Context, auth autorest.Authorizer, subscriptionID string
 		return nil, fmt.Errorf("failed to create role assignment for user assigned managed identity: %w", err)
 	}
 
-	rac := authorization.NewRoleAssignmentsClient(subscriptionID)
-	rac.Authorizer = auth
-	rac.PollingDuration = 0
+	rac := azclients.NewRoleAssignmentsClient(subscriptionID, auth)
 	raName, _ := uuid.NewV4()
 
 	MaxRetries := 100

--- a/pkg/roleassignment/roleassignment.go
+++ b/pkg/roleassignment/roleassignment.go
@@ -22,6 +22,7 @@ func Create(ctx context.Context, auth autorest.Authorizer, subscriptionID string
 	logger := radlogger.GetLogger(ctx)
 	rdc := authorization.NewRoleDefinitionsClient(subscriptionID)
 	rdc.Authorizer = auth
+	rdc.PollingDuration = 0
 
 	roleFilter := fmt.Sprintf("roleName eq '%s'", roleName)
 	roleList, err := rdc.List(ctx, scope, roleFilter)
@@ -31,6 +32,7 @@ func Create(ctx context.Context, auth autorest.Authorizer, subscriptionID string
 
 	rac := authorization.NewRoleAssignmentsClient(subscriptionID)
 	rac.Authorizer = auth
+	rac.PollingDuration = 0
 	raName, _ := uuid.NewV4()
 
 	MaxRetries := 100

--- a/pkg/workloads/containerv1alpha1/render.go
+++ b/pkg/workloads/containerv1alpha1/render.go
@@ -99,6 +99,7 @@ func (r Renderer) createManagedIdentity(ctx context.Context, identityName, locat
 	// Create a user assigned managed identity
 	msiClient := msi.NewUserAssignedIdentitiesClient(r.Arm.SubscriptionID)
 	msiClient.Authorizer = r.Arm.Auth
+	msiClient.PollingDuration = 0
 	id, err := msiClient.CreateOrUpdate(context.Background(), r.Arm.ResourceGroup, identityName, msi.Identity{
 		Location: to.StringPtr(location),
 	})
@@ -139,6 +140,7 @@ func (r Renderer) createManagedIdentityForKeyVault(ctx context.Context, store co
 
 	g := resources.NewGroupsClient(r.Arm.SubscriptionID)
 	g.Authorizer = r.Arm.Auth
+	g.PollingDuration = 0
 	rg, err := g.Get(ctx, r.Arm.ResourceGroup)
 	if err != nil {
 		// Even if the operation fails, return the output resources created so far
@@ -171,6 +173,7 @@ func (r Renderer) createManagedIdentityForKeyVault(ctx context.Context, store co
 
 	kvc := keyvault.NewVaultsClient(r.Arm.SubscriptionID)
 	kvc.Authorizer = r.Arm.Auth
+	kvc.PollingDuration = 0
 	if err != nil {
 		// Even if the operation fails, return the output resources created so far
 		// TODO: This is temporary. Once there are no resources actually deployed during render phase,
@@ -532,6 +535,7 @@ func (r Renderer) createPodIdentity(ctx context.Context, msi msi.Identity, conta
 	// Get AKS cluster name in current resource group
 	mcc := containerservice.NewManagedClustersClient(r.Arm.K8sSubscriptionID)
 	mcc.Authorizer = r.Arm.Auth
+	mcc.PollingDuration = 0
 
 	// Note: Pod Identity name cannot have camel case
 	podIdentityName := "podid-" + strings.ToLower(containerName)
@@ -645,6 +649,7 @@ func (r Renderer) createSecret(ctx context.Context, kvURI, secretName string, se
 
 	dc := resources.NewDeploymentsClient(r.Arm.SubscriptionID)
 	dc.Authorizer = r.Arm.Auth
+	dc.PollingDuration = 0
 	parameters := map[string]interface{}{}
 	deploymentProperties := &resources.DeploymentProperties{
 		Parameters: parameters,

--- a/pkg/workloads/containerv1alpha1/render.go
+++ b/pkg/workloads/containerv1alpha1/render.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/keys"
 	"github.com/Azure/radius/pkg/rad/util"
 	"github.com/Azure/radius/pkg/radlogger"
@@ -97,9 +98,7 @@ func (r Renderer) createManagedIdentity(ctx context.Context, identityName, locat
 	logger := radlogger.GetLogger(ctx)
 	localID := workloads.LocalIDUserAssignedManagedIdentityKV
 	// Create a user assigned managed identity
-	msiClient := msi.NewUserAssignedIdentitiesClient(r.Arm.SubscriptionID)
-	msiClient.Authorizer = r.Arm.Auth
-	msiClient.PollingDuration = 0
+	msiClient := azclients.NewUserAssignedIdentitiesClient(r.Arm.SubscriptionID, r.Arm.Auth)
 	id, err := msiClient.CreateOrUpdate(context.Background(), r.Arm.ResourceGroup, identityName, msi.Identity{
 		Location: to.StringPtr(location),
 	})
@@ -138,10 +137,9 @@ func (r Renderer) createManagedIdentityForKeyVault(ctx context.Context, store co
 	// Create user assigned managed identity
 	managedIdentityName := kvName + "-" + cw.Name + "-msi"
 
-	g := resources.NewGroupsClient(r.Arm.SubscriptionID)
-	g.Authorizer = r.Arm.Auth
-	g.PollingDuration = 0
-	rg, err := g.Get(ctx, r.Arm.ResourceGroup)
+	rgc := azclients.NewGroupsClient(r.Arm.SubscriptionID, r.Arm.Auth)
+
+	rg, err := rgc.Get(ctx, r.Arm.ResourceGroup)
 	if err != nil {
 		// Even if the operation fails, return the output resources created so far
 		// TODO: This is temporary. Once there are no resources actually deployed during render phase,
@@ -171,9 +169,7 @@ func (r Renderer) createManagedIdentityForKeyVault(ctx context.Context, store co
 	}
 	outputResources = append(outputResources, res)
 
-	kvc := keyvault.NewVaultsClient(r.Arm.SubscriptionID)
-	kvc.Authorizer = r.Arm.Auth
-	kvc.PollingDuration = 0
+	kvc := azclients.NewVaultsClient(r.Arm.SubscriptionID, r.Arm.Auth)
 	if err != nil {
 		// Even if the operation fails, return the output resources created so far
 		// TODO: This is temporary. Once there are no resources actually deployed during render phase,
@@ -533,9 +529,7 @@ func (r Renderer) createPodIdentity(ctx context.Context, msi msi.Identity, conta
 	}
 
 	// Get AKS cluster name in current resource group
-	mcc := containerservice.NewManagedClustersClient(r.Arm.K8sSubscriptionID)
-	mcc.Authorizer = r.Arm.Auth
-	mcc.PollingDuration = 0
+	mcc := azclients.NewManagedClustersClient(r.Arm.K8sSubscriptionID, r.Arm.Auth)
 
 	// Note: Pod Identity name cannot have camel case
 	podIdentityName := "podid-" + strings.ToLower(containerName)
@@ -647,9 +641,7 @@ func (r Renderer) createSecret(ctx context.Context, kvURI, secretName string, se
 		},
 	}
 
-	dc := resources.NewDeploymentsClient(r.Arm.SubscriptionID)
-	dc.Authorizer = r.Arm.Auth
-	dc.PollingDuration = 0
+	dc := azclients.NewDeploymentsClient(r.Arm.SubscriptionID, r.Arm.Auth)
 	parameters := map[string]interface{}{}
 	deploymentProperties := &resources.DeploymentProperties{
 		Parameters: parameters,

--- a/pkg/workloads/cosmosdbmongov1alpha1/render.go
+++ b/pkg/workloads/cosmosdbmongov1alpha1/render.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/cosmos-db/mgmt/documentdb"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/radlogger"
 	"github.com/Azure/radius/pkg/radrp/armauth"
 	"github.com/Azure/radius/pkg/radrp/components"
@@ -42,9 +42,7 @@ func (r Renderer) AllocateBindings(ctx context.Context, workload workloads.Insta
 	logger.Info(fmt.Sprintf("fulfilling service for account: %v db: %v", accountname, dbname))
 
 	// cosmos uses the following format for mongo: mongodb://{accountname}:{key}@{endpoint}:{port}/{database}?...{params}
-	dac := documentdb.NewDatabaseAccountsClient(r.Arm.SubscriptionID)
-	dac.Authorizer = r.Arm.Auth
-	dac.PollingDuration = 0
+	dac := azclients.NewDatabaseAccountsClient(r.Arm.SubscriptionID, r.Arm.Auth)
 
 	css, err := dac.ListConnectionStrings(ctx, r.Arm.ResourceGroup, accountname)
 	if err != nil {

--- a/pkg/workloads/cosmosdbmongov1alpha1/render.go
+++ b/pkg/workloads/cosmosdbmongov1alpha1/render.go
@@ -44,6 +44,7 @@ func (r Renderer) AllocateBindings(ctx context.Context, workload workloads.Insta
 	// cosmos uses the following format for mongo: mongodb://{accountname}:{key}@{endpoint}:{port}/{database}?...{params}
 	dac := documentdb.NewDatabaseAccountsClient(r.Arm.SubscriptionID)
 	dac.Authorizer = r.Arm.Auth
+	dac.PollingDuration = 0
 
 	css, err := dac.ListConnectionStrings(ctx, r.Arm.ResourceGroup, accountname)
 	if err != nil {

--- a/pkg/workloads/cosmosdbsqlv1alpha1/render.go
+++ b/pkg/workloads/cosmosdbsqlv1alpha1/render.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/cosmos-db/mgmt/documentdb"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/radlogger"
 	"github.com/Azure/radius/pkg/radrp/armauth"
 	"github.com/Azure/radius/pkg/radrp/components"
@@ -40,9 +40,7 @@ func (r Renderer) AllocateBindings(ctx context.Context, workload workloads.Insta
 
 	logger.Info(fmt.Sprintf("fulfilling service for account: %v, db: %v", accountname, dbname))
 
-	cosmosDBClient := documentdb.NewDatabaseAccountsClient(r.Arm.SubscriptionID)
-	cosmosDBClient.Authorizer = r.Arm.Auth
-	cosmosDBClient.PollingDuration = 0
+	cosmosDBClient := azclients.NewDatabaseAccountsClient(r.Arm.SubscriptionID, r.Arm.Auth)
 
 	connectionStrings, err := cosmosDBClient.ListConnectionStrings(ctx, r.Arm.ResourceGroup, accountname)
 	if err != nil {

--- a/pkg/workloads/cosmosdbsqlv1alpha1/render.go
+++ b/pkg/workloads/cosmosdbsqlv1alpha1/render.go
@@ -42,6 +42,7 @@ func (r Renderer) AllocateBindings(ctx context.Context, workload workloads.Insta
 
 	cosmosDBClient := documentdb.NewDatabaseAccountsClient(r.Arm.SubscriptionID)
 	cosmosDBClient.Authorizer = r.Arm.Auth
+	cosmosDBClient.PollingDuration = 0
 
 	connectionStrings, err := cosmosDBClient.ListConnectionStrings(ctx, r.Arm.ResourceGroup, accountname)
 	if err != nil {

--- a/pkg/workloads/keyvaultv1alpha1/render.go
+++ b/pkg/workloads/keyvaultv1alpha1/render.go
@@ -36,6 +36,7 @@ func (r Renderer) AllocateBindings(ctx context.Context, workload workloads.Insta
 	vaultName := properties[handlers.KeyVaultNameKey]
 	kvClient := keyvault.NewVaultsClient(r.Arm.SubscriptionID)
 	kvClient.Authorizer = r.Arm.Auth
+	kvClient.PollingDuration = 0
 	vault, err := kvClient.Get(ctx, r.Arm.ResourceGroup, vaultName)
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch keyvault")

--- a/pkg/workloads/keyvaultv1alpha1/render.go
+++ b/pkg/workloads/keyvaultv1alpha1/render.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/radrp/armauth"
 	"github.com/Azure/radius/pkg/radrp/components"
 	"github.com/Azure/radius/pkg/radrp/handlers"
@@ -34,9 +35,7 @@ func (r Renderer) AllocateBindings(ctx context.Context, workload workloads.Insta
 
 	properties := resources[0].Properties
 	vaultName := properties[handlers.KeyVaultNameKey]
-	kvClient := keyvault.NewVaultsClient(r.Arm.SubscriptionID)
-	kvClient.Authorizer = r.Arm.Auth
-	kvClient.PollingDuration = 0
+	kvClient := azclients.NewVaultsClient(r.Arm.SubscriptionID, r.Arm.Auth)
 	vault, err := kvClient.Get(ctx, r.Arm.ResourceGroup, vaultName)
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch keyvault")

--- a/pkg/workloads/servicebusqueuev1alpha1/render.go
+++ b/pkg/workloads/servicebusqueuev1alpha1/render.go
@@ -37,7 +37,7 @@ func (r Renderer) AllocateBindings(ctx context.Context, workload workloads.Insta
 	namespaceName := properties[handlers.ServiceBusNamespaceNameKey]
 	queueName := properties[handlers.ServiceBusQueueNameKey]
 
-	sbClient := azclients.NewNamespacesClient(r.Arm.SubscriptionID, r.Arm.Auth)
+	sbClient := azclients.NewServiceBusNamespacesClient(r.Arm.SubscriptionID, r.Arm.Auth)
 	accessKeys, err := sbClient.ListKeys(ctx, r.Arm.ResourceGroup, namespaceName, "RootManageSharedAccessKey")
 
 	if err != nil {

--- a/pkg/workloads/servicebusqueuev1alpha1/render.go
+++ b/pkg/workloads/servicebusqueuev1alpha1/render.go
@@ -39,6 +39,7 @@ func (r Renderer) AllocateBindings(ctx context.Context, workload workloads.Insta
 
 	sbClient := servicebus.NewNamespacesClient(r.Arm.SubscriptionID)
 	sbClient.Authorizer = r.Arm.Auth
+	sbClient.PollingDuration = 0
 	accessKeys, err := sbClient.ListKeys(ctx, r.Arm.ResourceGroup, namespaceName, "RootManageSharedAccessKey")
 
 	if err != nil {

--- a/pkg/workloads/servicebusqueuev1alpha1/render.go
+++ b/pkg/workloads/servicebusqueuev1alpha1/render.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/servicebus/mgmt/servicebus"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/radrp/armauth"
 	"github.com/Azure/radius/pkg/radrp/components"
 	"github.com/Azure/radius/pkg/radrp/handlers"
@@ -37,9 +37,7 @@ func (r Renderer) AllocateBindings(ctx context.Context, workload workloads.Insta
 	namespaceName := properties[handlers.ServiceBusNamespaceNameKey]
 	queueName := properties[handlers.ServiceBusQueueNameKey]
 
-	sbClient := servicebus.NewNamespacesClient(r.Arm.SubscriptionID)
-	sbClient.Authorizer = r.Arm.Auth
-	sbClient.PollingDuration = 0
+	sbClient := azclients.NewNamespacesClient(r.Arm.SubscriptionID, r.Arm.Auth)
 	accessKeys, err := sbClient.ListKeys(ctx, r.Arm.ResourceGroup, namespaceName, "RootManageSharedAccessKey")
 
 	if err != nil {

--- a/test/functional/azure/environment/environment_test.go
+++ b/test/functional/azure/environment/environment_test.go
@@ -9,8 +9,8 @@ import (
 	"context"
 	"testing"
 
-	azresources "github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/keys"
 	"github.com/Azure/radius/pkg/rad/environments"
 	"github.com/Azure/radius/test/azuretest"
@@ -91,9 +91,7 @@ func TestAzureEnvironment(t *testing.T) {
 
 func listRadiusEnvironmentResources(ctx context.Context, t *testing.T, env *environments.AzureCloudEnvironment, auth autorest.Authorizer, resourceGroup string) map[string]string {
 	resourceMap := make(map[string]string)
-	resc := azresources.NewClient(env.SubscriptionID)
-	resc.Authorizer = auth
-	resc.PollingDuration = 0
+	resc := azclients.NewResourcesClient(env.SubscriptionID, auth)
 
 	for page, err := resc.ListByResourceGroup(ctx, resourceGroup, "", "", nil); page.NotDone(); err = page.NextWithContext(ctx) {
 		require.NoError(t, err, "failed to list resources")

--- a/test/functional/azure/environment/environment_test.go
+++ b/test/functional/azure/environment/environment_test.go
@@ -93,6 +93,7 @@ func listRadiusEnvironmentResources(ctx context.Context, t *testing.T, env *envi
 	resourceMap := make(map[string]string)
 	resc := azresources.NewClient(env.SubscriptionID)
 	resc.Authorizer = auth
+	resc.PollingDuration = 0
 
 	for page, err := resc.ListByResourceGroup(ctx, resourceGroup, "", "", nil); page.NotDone(); err = page.NextWithContext(ctx) {
 		require.NoError(t, err, "failed to list resources")

--- a/test/functional/azure/resources/cosmosdb_mongo_test.go
+++ b/test/functional/azure/resources/cosmosdb_mongo_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/cosmos-db/mgmt/documentdb"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/test/azuretest"
 	"github.com/Azure/radius/test/validation"
 	"github.com/stretchr/testify/require"
@@ -60,9 +61,7 @@ func Test_CosmosDBMongoUnmanaged(t *testing.T) {
 	// We don't need to delete these, they will be deleted as part of the resource group cleanup.
 	test.PostDeleteVerify = func(ctx context.Context, t *testing.T, at azuretest.ApplicationTest) {
 		// Verify that the cosmosdb resources were not deleted
-		ac := documentdb.NewDatabaseAccountsClient(at.Options.Environment.SubscriptionID)
-		ac.Authorizer = at.Options.ARMAuthorizer
-		ac.PollingDuration = 0
+		ac := azclients.NewDatabaseAccountsClient(at.Options.Environment.SubscriptionID, at.Options.ARMAuthorizer)
 
 		// We have to use a generated name due to uniqueness requirements, so lookup based on tags
 		var account *documentdb.DatabaseAccountGetResults
@@ -79,9 +78,7 @@ func Test_CosmosDBMongoUnmanaged(t *testing.T) {
 
 		require.NotNilf(t, account, "failed to find database account with 'radiustest' tag")
 
-		dbc := documentdb.NewMongoDBResourcesClient(at.Options.Environment.SubscriptionID)
-		dbc.Authorizer = at.Options.ARMAuthorizer
-		dbc.PollingDuration = 0
+		dbc := azclients.NewMongoDBResourcesClient(at.Options.Environment.SubscriptionID, at.Options.ARMAuthorizer)
 		_, err = dbc.GetMongoDBDatabase(context.Background(), at.Options.Environment.ResourceGroup, *account.Name, "mydb")
 		require.NoErrorf(t, err, "failed to find mongo database")
 	}

--- a/test/functional/azure/resources/cosmosdb_mongo_test.go
+++ b/test/functional/azure/resources/cosmosdb_mongo_test.go
@@ -62,6 +62,7 @@ func Test_CosmosDBMongoUnmanaged(t *testing.T) {
 		// Verify that the cosmosdb resources were not deleted
 		ac := documentdb.NewDatabaseAccountsClient(at.Options.Environment.SubscriptionID)
 		ac.Authorizer = at.Options.ARMAuthorizer
+		ac.PollingDuration = 0
 
 		// We have to use a generated name due to uniqueness requirements, so lookup based on tags
 		var account *documentdb.DatabaseAccountGetResults
@@ -80,7 +81,7 @@ func Test_CosmosDBMongoUnmanaged(t *testing.T) {
 
 		dbc := documentdb.NewMongoDBResourcesClient(at.Options.Environment.SubscriptionID)
 		dbc.Authorizer = at.Options.ARMAuthorizer
-
+		dbc.PollingDuration = 0
 		_, err = dbc.GetMongoDBDatabase(context.Background(), at.Options.Environment.ResourceGroup, *account.Name, "mydb")
 		require.NoErrorf(t, err, "failed to find mongo database")
 	}

--- a/test/functional/azure/resources/dapr_pubsub_servicebus_test.go
+++ b/test/functional/azure/resources/dapr_pubsub_servicebus_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/servicebus/mgmt/servicebus"
+	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/test/azuretest"
 	"github.com/Azure/radius/test/validation"
 	"github.com/stretchr/testify/require"
@@ -62,9 +63,7 @@ func Test_DaprPubSubServiceBusUnmanaged(t *testing.T) {
 	// We don't need to delete these, they will be deleted as part of the resource group cleanup.
 	test.PostDeleteVerify = func(ctx context.Context, t *testing.T, at azuretest.ApplicationTest) {
 		// Verify that the servicebus resources were not deleted
-		nsc := servicebus.NewNamespacesClient(at.Options.Environment.SubscriptionID)
-		nsc.Authorizer = at.Options.ARMAuthorizer
-		nsc.PollingDuration = 0
+		nsc := azclients.NewServiceBusNamespacesClient(at.Options.Environment.SubscriptionID, at.Options.ARMAuthorizer)
 		// We have to use a generated name due to uniqueness requirements, so lookup based on tags
 		var ns *servicebus.SBNamespace
 		list, err := nsc.ListByResourceGroup(context.Background(), at.Options.Environment.ResourceGroup)
@@ -85,9 +84,7 @@ func Test_DaprPubSubServiceBusUnmanaged(t *testing.T) {
 
 		require.NotNilf(t, ns, "failed to find servicebus namespace with 'radiustest' tag")
 
-		tc := servicebus.NewTopicsClient(at.Options.Environment.SubscriptionID)
-		tc.Authorizer = at.Options.ARMAuthorizer
-		tc.PollingDuration = 0
+		tc := azclients.NewTopicsClient(at.Options.Environment.SubscriptionID, at.Options.ARMAuthorizer)
 
 		_, err = tc.Get(context.Background(), at.Options.Environment.ResourceGroup, *ns.Name, "TOPIC_A")
 		require.NoErrorf(t, err, "failed to find servicebus topic")

--- a/test/functional/azure/resources/dapr_pubsub_servicebus_test.go
+++ b/test/functional/azure/resources/dapr_pubsub_servicebus_test.go
@@ -64,7 +64,7 @@ func Test_DaprPubSubServiceBusUnmanaged(t *testing.T) {
 		// Verify that the servicebus resources were not deleted
 		nsc := servicebus.NewNamespacesClient(at.Options.Environment.SubscriptionID)
 		nsc.Authorizer = at.Options.ARMAuthorizer
-
+		nsc.PollingDuration = 0
 		// We have to use a generated name due to uniqueness requirements, so lookup based on tags
 		var ns *servicebus.SBNamespace
 		list, err := nsc.ListByResourceGroup(context.Background(), at.Options.Environment.ResourceGroup)
@@ -87,6 +87,7 @@ func Test_DaprPubSubServiceBusUnmanaged(t *testing.T) {
 
 		tc := servicebus.NewTopicsClient(at.Options.Environment.SubscriptionID)
 		tc.Authorizer = at.Options.ARMAuthorizer
+		tc.PollingDuration = 0
 
 		_, err = tc.Get(context.Background(), at.Options.Environment.ResourceGroup, *ns.Name, "TOPIC_A")
 		require.NoErrorf(t, err, "failed to find servicebus topic")


### PR DESCRIPTION
Fixes https://github.com/Azure/radius/issues/716

As discussed, sets the timeouts to infinite (or remove timeout) for all calls with ARM clients. Unless a context is passed in, then it will use the timeout on the context.

Open question: Do we remove the timeout for test calls? I'd assume yes, but want to make sure.