### PR TITLE
Spiking kubectl plugin

### DIFF
--- a/install/kubectl-deploy
+++ b/install/kubectl-deploy
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rad deploy $@

--- a/install/kubectl-radius
+++ b/install/kubectl-radius
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rad $@


### PR DESCRIPTION
Fixes https://github.com/Azure/radius/issues/663

Drafting to spike, there is work to upload the scripts and installing them as well.

@AaronCrawfis would like your input here.

This enables two scenarios with kubectl:
```
kubectl radius <ANY_COMMAND>
```

This is just a wrapper around radius right now. I think the core scenarios that we care about here are primarily installation into k8s. I could imaging we potentially expose something like `kubectl radius install` to make it easier to work with.

```
kubectl deploy <.bicep>
```

This is specifically targeted to deployment. 
