### PR TITLE
Make HTTPS required for custom RP

### DIFF
--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -460,6 +460,7 @@
                                 "serverFarmId": "[variables('hostingPlanName')]",
                                 "clientCertEnabled": true,
                                 "clientCertMode": "Optional",
+                                "httpsOnly": true,
                                 "siteConfig": {
                                     "linuxFxVersion": "[concat('DOCKER|', parameters('image'))]",
                                     "appSettings": [


### PR DESCRIPTION
Fixes: #572

This will configure app service to block HTTP and require HTTPS. This is
beneficial since we DO have a cert as part of app service, so we have no
need for non-encrpyted HTTP.

Fixes an Azure Security Center warning as well.