### PR TITLE
Add management client for Radius Kubernetes

### DIFF
--- a/cmd/cli/cmd/deploymentShow.go
+++ b/cmd/cli/cmd/deploymentShow.go
@@ -47,7 +47,7 @@ func showDeployment(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	deploymentResource, err := client.ShowDeployment(cmd.Context(), deploymentName, applicationName)
+	deploymentResource, err := client.ShowDeployment(cmd.Context(), applicationName, deploymentName)
 	if err != nil {
 		return err
 	}

--- a/pkg/keys/annotations.go
+++ b/pkg/keys/annotations.go
@@ -1,0 +1,13 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package keys
+
+// Commonly-used and Radius-Specific annotations for Kubernetes
+const (
+	AnnotationsApplication = "radius.dev/applications"
+	AnnotationsComponent   = "radius.dev/components"
+	AnnotationsDeployment  = "radius.dev/deployments"
+)

--- a/pkg/kubernetes/controllers/component_controller.go
+++ b/pkg/kubernetes/controllers/component_controller.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/radius/pkg/keys"
 	radiusv1alpha1 "github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
 	"github.com/Azure/radius/pkg/model"
 	"github.com/Azure/radius/pkg/radrp/components"
@@ -68,8 +69,8 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		log.Error(err, "failed to retrieve component")
 		return ctrl.Result{}, err
 	}
-	applicationName := component.Annotations["radius.dev/applications"]
-	componentName := component.Annotations["radius.dev/components"]
+	applicationName := component.Annotations[keys.AnnotationsApplication]
+	componentName := component.Annotations[keys.AnnotationsComponent]
 
 	log = log.WithValues(
 		"application", applicationName,
@@ -254,11 +255,11 @@ func GetMissingBindings(generic *components.GenericComponent, r *ComponentReconc
 
 		found := false
 		for _, pp := range providers.Items {
-			if pp.Annotations["radius.dev/applications"] != applicationName {
+			if pp.Annotations[keys.AnnotationsApplication] != applicationName {
 				continue
 			}
 
-			if pp.Annotations["radius.dev/components"] != key.Component {
+			if pp.Annotations[keys.AnnotationsComponent] != key.Component {
 				continue
 			}
 
@@ -460,7 +461,7 @@ func (r *ComponentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func extractApplicationKey(obj client.Object) []string {
 	component := obj.(*radiusv1alpha1.Component)
-	return []string{component.Annotations["radius.dev/applications"]}
+	return []string{component.Annotations[keys.AnnotationsApplication]}
 }
 
 func extractOwnerKey(obj client.Object) []string {

--- a/pkg/kubernetes/controllers/converters.go
+++ b/pkg/kubernetes/controllers/converters.go
@@ -8,6 +8,7 @@ package controllers
 import (
 	"encoding/json"
 
+	"github.com/Azure/radius/pkg/keys"
 	radiusv1alpha1 "github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
 	"github.com/Azure/radius/pkg/radrp/components"
 	"k8s.io/apimachinery/pkg/conversion"
@@ -16,7 +17,7 @@ import (
 func ConvertComponentToInternal(a interface{}, b interface{}, scope conversion.Scope) error {
 	original := a.(*radiusv1alpha1.Component)
 	result := b.(*components.GenericComponent)
-	result.Name = original.Annotations["radius.dev/components"]
+	result.Name = original.Annotations[keys.AnnotationsComponent]
 	result.Kind = original.Spec.Kind
 
 	if original.Spec.Config != nil {

--- a/pkg/kubernetes/controllers/converters_test.go
+++ b/pkg/kubernetes/controllers/converters_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/Azure/radius/pkg/keys"
 	"github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
 	radiusv1alpha1 "github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
 	"github.com/Azure/radius/pkg/radrp/components"
@@ -76,8 +77,8 @@ func Test_ConvertComponentToInternal(t *testing.T) {
 			Name:      "frontend",
 			Namespace: "default",
 			Annotations: map[string]string{
-				"radius.dev/applications": "frontend-backend",
-				"radius.dev/components":   "frontend",
+				keys.AnnotationsApplication: "frontend-backend",
+				keys.AnnotationsComponent:   "frontend",
 			},
 		},
 		Spec: v1alpha1.ComponentSpec{

--- a/pkg/rad/clients/clients.go
+++ b/pkg/rad/clients/clients.go
@@ -48,6 +48,6 @@ type ManagementClient interface {
 	ShowComponent(ctx context.Context, applicationName string, componentName string) (*radclient.ComponentResource, error)
 
 	ListDeployments(ctx context.Context, applicationName string) (*radclient.DeploymentList, error)
-	ShowDeployment(ctx context.Context, deploymentName string, applicationName string) (*radclient.DeploymentResource, error)
-	DeleteDeployment(ctx context.Context, deploymentName string, applicationName string) error
+	ShowDeployment(ctx context.Context, applicationName string, deploymentName string) (*radclient.DeploymentResource, error)
+	DeleteDeployment(ctx context.Context, applicationName string, deploymentName string) error
 }

--- a/pkg/rad/environments/kubernetes.go
+++ b/pkg/rad/environments/kubernetes.go
@@ -65,3 +65,15 @@ func (e *KubernetesEnvironment) CreateDiagnosticsClient(ctx context.Context) (cl
 		Namespace:  e.Namespace,
 	}, nil
 }
+
+func (e *KubernetesEnvironment) CreateManagementClient(ctx context.Context) (clients.ManagementClient, error) {
+	client, err := kubernetes.CreateRuntimeClient(e.Context, kubernetes.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	return &kubernetes.KubernetesManagementClient{
+		Client:    client,
+		Namespace: e.Namespace,
+	}, nil
+}

--- a/pkg/rad/kubernetes/converters.go
+++ b/pkg/rad/kubernetes/converters.go
@@ -1,0 +1,121 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package kubernetes
+
+import (
+	"encoding/json"
+
+	radiusv1alpha1 "github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/to"
+	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/radclient"
+)
+
+func ConvertK8sApplicationToARM(input radiusv1alpha1.Application) (*radclient.ApplicationResource, error) {
+	result := radclient.ApplicationResource{}
+	result.Name = to.StringPtr(input.Annotations[keys.AnnotationsApplication])
+
+	// There's nothing in properties for an application
+	result.Properties = map[string]interface{}{}
+
+	return &result, nil
+}
+
+func ConvertK8sComponentToARM(input radiusv1alpha1.Component) (*radclient.ComponentResource, error) {
+	result := radclient.ComponentResource{}
+	result.Name = to.StringPtr(input.Annotations[keys.AnnotationsComponent])
+	result.Kind = &input.Spec.Kind
+	result.Properties = &radclient.ComponentProperties{}
+
+	if input.Spec.Config != nil {
+		bytes, err := input.Spec.Config.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+
+		result.Properties.Config = map[string]interface{}{}
+		err = json.Unmarshal(bytes, &result.Properties.Config)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if input.Spec.Run != nil {
+		bytes, err := input.Spec.Run.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+
+		result.Properties.Run = map[string]interface{}{}
+		err = json.Unmarshal(bytes, &result.Properties.Run)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	result.Properties.Bindings = map[string]interface{}{}
+
+	bindingBytes, err := input.Spec.Bindings.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(bindingBytes, &result.Properties.Bindings)
+	if err != nil {
+		return nil, err
+	}
+
+	if input.Spec.Uses != nil {
+		for _, raw := range *input.Spec.Uses {
+			bytes, err := raw.MarshalJSON()
+			if err != nil {
+				return nil, err
+			}
+
+			dependency := map[string]interface{}{}
+			err = json.Unmarshal(bytes, &dependency)
+			if err != nil {
+				return nil, err
+			}
+
+			result.Properties.Uses = append(result.Properties.Uses, dependency)
+		}
+	}
+
+	if input.Spec.Traits != nil {
+		for _, raw := range *input.Spec.Traits {
+			bytes, err := raw.MarshalJSON()
+			if err != nil {
+				return nil, err
+			}
+
+			t := map[string]interface{}{}
+			err = json.Unmarshal(bytes, &t)
+			if err != nil {
+				return nil, err
+			}
+
+			result.Properties.Traits = append(result.Properties.Traits, t)
+		}
+	}
+
+	return &result, nil
+}
+
+func ConvertK8sDeploymentToARM(input radiusv1alpha1.Deployment) (*radclient.DeploymentResource, error) {
+	result := radclient.DeploymentResource{}
+	result.Name = to.StringPtr(input.Annotations[keys.AnnotationsDeployment])
+	result.Properties = &radclient.DeploymentProperties{}
+
+	for _, dc := range input.Spec.Components {
+		converted := radclient.DeploymentPropertiesComponentsItem{
+			ComponentName: to.StringPtr(dc.ComponentName),
+		}
+		result.Properties.Components = append(result.Properties.Components, &converted)
+	}
+
+	return &result, nil
+}

--- a/pkg/rad/kubernetes/converters_test.go
+++ b/pkg/rad/kubernetes/converters_test.go
@@ -1,0 +1,233 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package kubernetes
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/to"
+	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
+	radiusv1alpha1 "github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
+	"github.com/Azure/radius/pkg/radclient"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_ConvertK8sApplicationToARM(t *testing.T) {
+	original := radiusv1alpha1.Application{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "radius.dev/v1alpha1",
+			Kind:       "Application",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "frontend-backend",
+			Namespace: "default",
+			Annotations: map[string]string{
+				keys.AnnotationsApplication: "frontend-backend",
+			},
+		},
+		Spec: v1alpha1.ApplicationSpec{},
+	}
+
+	expected := &radclient.ApplicationResource{
+		TrackedResource: radclient.TrackedResource{
+			Resource: radclient.Resource{
+				Name: to.StringPtr("frontend-backend"),
+			},
+		},
+		Properties: map[string]interface{}{},
+	}
+
+	actual, err := ConvertK8sApplicationToARM(original)
+	require.NoError(t, err, "failed to convert application")
+
+	require.Equal(t, expected, actual)
+}
+
+func Test_ConvertK8sComponentToARM(t *testing.T) {
+	uses := map[string]interface{}{
+		"binding": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'frontend')).bindings.default]",
+		"env": map[string]interface{}{
+			"SERVICE__BACKEND__HOST": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'frontend')).bindings.default.host]",
+		},
+		"secrets": map[string]interface{}{
+			"store": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'frontend')).bindings.default]",
+			"keys": map[string]interface{}{
+				"secret": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'frontend')).bindings.default]",
+			},
+		},
+	}
+	usesJson, err := json.Marshal(uses)
+	require.NoError(t, err, "failed to marshal uses json")
+
+	trait := map[string]interface{}{
+		"kind":    "radius.dev/InboundRoute@v1alpha1",
+		"binding": "web",
+	}
+
+	traitJson, err := json.Marshal(trait)
+	require.NoError(t, err, "failed to marshal traits json")
+
+	config := map[string]interface{}{
+		"managed": "true",
+	}
+
+	configJson, err := json.Marshal(config)
+	require.NoError(t, err, "failed to marshal config json")
+
+	bindings := map[string]interface{}{
+		"default": map[string]interface{}{
+			"kind": "http",
+		},
+	}
+
+	bindingJson, err := json.Marshal(bindings)
+	require.NoError(t, err, "failed to marshal bindings json")
+
+	run := map[string]interface{}{
+		"container": map[string]interface{}{
+			"image": "rynowak/frontend:0.5.0-dev",
+		},
+	}
+
+	runJson, err := json.Marshal(run)
+	require.NoError(t, err, "failed to marshal run json")
+
+	original := radiusv1alpha1.Component{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "radius.dev/v1alpha1",
+			Kind:       "Component",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "frontend",
+			Namespace: "default",
+			Annotations: map[string]string{
+				keys.AnnotationsApplication: "frontend-backend",
+				keys.AnnotationsComponent:   "frontend",
+			},
+		},
+		Spec: v1alpha1.ComponentSpec{
+			Kind:      "Component",
+			Run:       &runtime.RawExtension{Raw: runJson},
+			Bindings:  runtime.RawExtension{Raw: bindingJson},
+			Hierarchy: []string{"frontend-backend", "frontend"},
+			Uses: &[]runtime.RawExtension{
+				{
+					Raw: usesJson,
+				},
+			},
+			Traits: &[]runtime.RawExtension{
+				{
+					Raw: traitJson,
+				},
+			},
+			Config: &runtime.RawExtension{Raw: configJson},
+		},
+	}
+
+	expected := &radclient.ComponentResource{
+		TrackedResource: radclient.TrackedResource{
+			Resource: radclient.Resource{
+				Name: to.StringPtr("frontend"),
+			},
+		},
+		Kind: to.StringPtr("Component"),
+		Properties: &radclient.ComponentProperties{
+			Config: map[string]interface{}{
+				"managed": "true",
+			},
+			Run: map[string]interface{}{
+				"container": map[string]interface{}{
+					"image": "rynowak/frontend:0.5.0-dev",
+				},
+			},
+			Bindings: map[string]interface{}{
+				"default": map[string]interface{}{
+					"kind": "http",
+				},
+			},
+			Uses: []map[string]interface{}{
+				{
+					"binding": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'frontend')).bindings.default]",
+					"env": map[string]interface{}{
+						"SERVICE__BACKEND__HOST": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'frontend')).bindings.default.host]",
+					},
+					"secrets": map[string]interface{}{
+						"store": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'frontend')).bindings.default]",
+						"keys": map[string]interface{}{
+							"secret": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'frontend')).bindings.default]",
+						},
+					},
+				},
+			},
+			Traits: []map[string]interface{}{
+				{
+					"kind":    "radius.dev/InboundRoute@v1alpha1",
+					"binding": "web",
+				},
+			},
+		},
+	}
+
+	actual, err := ConvertK8sComponentToARM(original)
+	require.NoError(t, err, "failed to convert component")
+
+	require.Equal(t, expected, actual)
+}
+
+func Test_ConvertK8sDeploymentToARM(t *testing.T) {
+	original := radiusv1alpha1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "radius.dev/v1alpha1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "frontend-backend-default",
+			Namespace: "default",
+			Annotations: map[string]string{
+				keys.AnnotationsApplication: "frontend-backend",
+				keys.AnnotationsDeployment:  "default",
+			},
+		},
+		Spec: radiusv1alpha1.DeploymentSpec{
+			Components: []radiusv1alpha1.DeploymentComponent{
+				{
+					ComponentName: "frontend",
+				},
+				{
+					ComponentName: "backend",
+				},
+			},
+		},
+	}
+
+	expected := &radclient.DeploymentResource{
+		TrackedResource: radclient.TrackedResource{
+			Resource: radclient.Resource{
+				Name: to.StringPtr("default"),
+			},
+		},
+		Properties: &radclient.DeploymentProperties{
+			Components: []*radclient.DeploymentPropertiesComponentsItem{
+				{
+					ComponentName: to.StringPtr("frontend"),
+				},
+				{
+					ComponentName: to.StringPtr("backend"),
+				},
+			},
+		},
+	}
+
+	actual, err := ConvertK8sDeploymentToARM(original)
+	require.NoError(t, err, "failed to convert deployment")
+
+	require.Equal(t, expected, actual)
+}

--- a/pkg/rad/kubernetes/kubernetes.go
+++ b/pkg/rad/kubernetes/kubernetes.go
@@ -12,12 +12,14 @@ import (
 	"path/filepath"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/dynamic"
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func ReadKubeConfig() (*api.Config, error) {
@@ -62,6 +64,20 @@ func CreateTypedClient(context string) (*k8s.Clientset, *rest.Config, error) {
 	}
 
 	return client, merged, err
+}
+
+func CreateRuntimeClient(context string, scheme *runtime.Scheme) (client.Client, error) {
+	merged, err := getConfig(context)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := client.New(merged, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
 }
 
 func CreateNamespace(ctx context.Context, client *k8s.Clientset, namespace string) error {

--- a/pkg/rad/kubernetes/management.go
+++ b/pkg/rad/kubernetes/management.go
@@ -1,0 +1,217 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/radius/pkg/keys"
+	radiusv1alpha1 "github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
+	"github.com/Azure/radius/pkg/rad/clients"
+	"github.com/Azure/radius/pkg/radclient"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type KubernetesManagementClient struct {
+	Client    client.Client
+	Namespace string
+}
+
+var Scheme = runtime.NewScheme()
+
+func init() {
+	_ = clientgoscheme.AddToScheme(Scheme)
+	_ = radiusv1alpha1.AddToScheme(Scheme)
+}
+
+// NOTE: for now we translate the K8s objects into the ARM format.
+// see: https://github.com/Azure/radius/issues/774
+var _ clients.ManagementClient = (*KubernetesManagementClient)(nil)
+
+func (mc *KubernetesManagementClient) ListApplications(ctx context.Context) (*radclient.ApplicationList, error) {
+	applications := radiusv1alpha1.ApplicationList{}
+	err := mc.Client.List(ctx, &applications, &client.ListOptions{Namespace: mc.Namespace})
+	if err != nil {
+		return nil, err
+	}
+
+	converted := []*radclient.ApplicationResource{}
+	for _, item := range applications.Items {
+		application, err := ConvertK8sApplicationToARM(item)
+		if err != nil {
+			return nil, err
+		}
+
+		converted = append(converted, application)
+	}
+
+	return &radclient.ApplicationList{Value: converted}, nil
+}
+
+func (mc *KubernetesManagementClient) ShowApplication(ctx context.Context, applicationName string) (*radclient.ApplicationResource, error) {
+	// We don't have a guarantee that the application name is the same
+	// as the k8s resource name, so we have to filter on the client.
+	applications := radiusv1alpha1.ApplicationList{}
+	err := mc.Client.List(ctx, &applications, &client.ListOptions{Namespace: mc.Namespace})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, item := range applications.Items {
+		if item.Annotations[keys.AnnotationsApplication] == applicationName {
+			application, err := ConvertK8sApplicationToARM(item)
+			if err != nil {
+				return nil, err
+			}
+
+			return application, nil
+		}
+	}
+
+	return nil, fmt.Errorf("application %s was not found", applicationName)
+}
+
+func (mc *KubernetesManagementClient) DeleteApplication(ctx context.Context, applicationName string) error {
+	// We don't have a guarantee that the application name is the same
+	// as the k8s resource name, so we have to filter on the client.
+	applications := radiusv1alpha1.ApplicationList{}
+	err := mc.Client.List(ctx, &applications, &client.ListOptions{Namespace: mc.Namespace})
+	if err != nil {
+		return err
+	}
+
+	for _, item := range applications.Items {
+		if item.Annotations[keys.AnnotationsApplication] == applicationName {
+			err = mc.Client.Delete(ctx, &item, &client.DeleteOptions{})
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("application %s was not found", applicationName)
+}
+
+func (mc *KubernetesManagementClient) ListComponents(ctx context.Context, applicationName string) (*radclient.ComponentList, error) {
+	components := radiusv1alpha1.ComponentList{}
+	err := mc.Client.List(ctx, &components, &client.ListOptions{Namespace: mc.Namespace})
+	if err != nil {
+		return nil, err
+	}
+
+	converted := []*radclient.ComponentResource{}
+	for _, item := range components.Items {
+		if item.Annotations[keys.AnnotationsApplication] == applicationName {
+			component, err := ConvertK8sComponentToARM(item)
+			if err != nil {
+				return nil, err
+			}
+
+			converted = append(converted, component)
+		}
+	}
+
+	return &radclient.ComponentList{Value: converted}, nil
+}
+
+func (mc *KubernetesManagementClient) ShowComponent(ctx context.Context, applicationName string, componentName string) (*radclient.ComponentResource, error) {
+	// We don't have a guarantee that the component name is the same
+	// as the k8s resource name, so we have to filter on the client.
+	components := radiusv1alpha1.ComponentList{}
+	err := mc.Client.List(ctx, &components, &client.ListOptions{Namespace: mc.Namespace})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, item := range components.Items {
+		if item.Annotations[keys.AnnotationsApplication] == applicationName &&
+			item.Annotations[keys.AnnotationsComponent] == componentName {
+			component, err := ConvertK8sComponentToARM(item)
+			if err != nil {
+				return nil, err
+			}
+
+			return component, nil
+		}
+	}
+
+	return nil, fmt.Errorf("component %s was not found", componentName)
+}
+
+func (mc *KubernetesManagementClient) DeleteDeployment(ctx context.Context, applicationName string, deploymentName string) error {
+	// We don't have a guarantee that the deployment name is the same
+	// as the k8s resource name, so we have to filter on the client.
+	deployments := radiusv1alpha1.DeploymentList{}
+	err := mc.Client.List(ctx, &deployments, &client.ListOptions{Namespace: mc.Namespace})
+	if err != nil {
+		return err
+	}
+
+	for _, item := range deployments.Items {
+		if item.Annotations[keys.AnnotationsApplication] == applicationName &&
+			item.Annotations[keys.AnnotationsDeployment] == deploymentName {
+			err = mc.Client.Delete(ctx, &item)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("deployment %s was not found", deploymentName)
+}
+
+func (mc *KubernetesManagementClient) ListDeployments(ctx context.Context, applicationName string) (*radclient.DeploymentList, error) {
+	deployments := radiusv1alpha1.DeploymentList{}
+	err := mc.Client.List(ctx, &deployments, &client.ListOptions{Namespace: mc.Namespace})
+	if err != nil {
+		return nil, err
+	}
+
+	converted := []*radclient.DeploymentResource{}
+	for _, item := range deployments.Items {
+		if item.Annotations[keys.AnnotationsApplication] == applicationName {
+			deployment, err := ConvertK8sDeploymentToARM(item)
+			if err != nil {
+				return nil, err
+			}
+
+			converted = append(converted, deployment)
+		}
+	}
+
+	return &radclient.DeploymentList{Value: converted}, nil
+}
+
+func (mc *KubernetesManagementClient) ShowDeployment(ctx context.Context, applicationName string, deploymentName string) (*radclient.DeploymentResource, error) {
+	// We don't have a guarantee that the deployment name is the same
+	// as the k8s resource name, so we have to filter on the client.
+	deployments := radiusv1alpha1.DeploymentList{}
+	err := mc.Client.List(ctx, &deployments, &client.ListOptions{Namespace: mc.Namespace})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, item := range deployments.Items {
+		if item.Annotations[keys.AnnotationsApplication] == applicationName &&
+			item.Annotations[keys.AnnotationsDeployment] == deploymentName {
+			deployment, err := ConvertK8sDeploymentToARM(item)
+			if err != nil {
+				return nil, err
+			}
+
+			return deployment, nil
+		}
+	}
+
+	return nil, fmt.Errorf("deployment %s was not found", deploymentName)
+}

--- a/test/controllertests/k8scontroller_test.go
+++ b/test/controllertests/k8scontroller_test.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
+	"github.com/Azure/radius/pkg/keys"
 	"github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
 	radiusv1alpha1 "github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
 	"github.com/Azure/radius/pkg/kubernetes/controllers"
@@ -134,7 +135,7 @@ func TestK8sController(t *testing.T) {
 					Name:      "radius-frontend-backend",
 					Namespace: "frontend-backend",
 					Annotations: map[string]string{
-						"radius.dev/applications": "frontend-backend",
+						keys.AnnotationsApplication: "frontend-backend",
 					},
 				},
 				Spec: radiusv1alpha1.ApplicationSpec{
@@ -151,8 +152,8 @@ func TestK8sController(t *testing.T) {
 						Name:      "frontend",
 						Namespace: "frontend-backend",
 						Annotations: map[string]string{
-							"radius.dev/applications": "frontend-backend",
-							"radius.dev/components":   "frontend",
+							keys.AnnotationsApplication: "frontend-backend",
+							keys.AnnotationsComponent:   "frontend",
 						},
 					},
 					Spec: TestComponentSpec{
@@ -188,8 +189,8 @@ func TestK8sController(t *testing.T) {
 						Name:      "backend",
 						Namespace: "frontend-backend",
 						Annotations: map[string]string{
-							"radius.dev/applications": "frontend-backend",
-							"radius.dev/components":   "backend",
+							keys.AnnotationsApplication: "frontend-backend",
+							keys.AnnotationsComponent:   "backend",
 						},
 					},
 					Spec: TestComponentSpec{


### PR DESCRIPTION
Fixes: #760

This change adds support for interacting with Kubernetes via `rad
component list` and similar commands. For now this support is based on a
conversion to the types we return from ARM. This will result in the same
experience we have for Azure environments.

In the future we might want to introduce a *format neutral*
representation for use this CLI. I didn't puruse that in this PR because
we're currently having active discussions about the shape of the model
that will impact this.