### PR TITLE
Code reorg of k8s

### DIFF
--- a/cmd/k8s/main.go
+++ b/cmd/k8s/main.go
@@ -21,6 +21,7 @@ import (
 
 	radiusv1alpha1 "github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
 	"github.com/Azure/radius/pkg/kubernetes/controllers"
+	"github.com/Azure/radius/pkg/kubernetes/converters"
 	"github.com/Azure/radius/pkg/radrp/components"
 	//+kubebuilder:scaffold:imports
 )
@@ -35,7 +36,7 @@ func init() {
 
 	utilruntime.Must(radiusv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
-	_ = scheme.AddConversionFunc(&radiusv1alpha1.Component{}, &components.GenericComponent{}, controllers.ConvertComponentToInternal)
+	_ = scheme.AddConversionFunc(&radiusv1alpha1.Component{}, &components.GenericComponent{}, converters.ConvertComponentToInternal)
 }
 
 func main() {

--- a/pkg/cli/kubernetes/converters.go
+++ b/pkg/cli/kubernetes/converters.go
@@ -11,13 +11,13 @@ import (
 	radiusv1alpha1 "github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/radclient"
 )
 
 func ConvertK8sApplicationToARM(input radiusv1alpha1.Application) (*radclient.ApplicationResource, error) {
 	result := radclient.ApplicationResource{}
-	result.Name = to.StringPtr(input.Annotations[keys.AnnotationsApplication])
+	result.Name = to.StringPtr(input.Annotations[kubernetes.AnnotationsApplication])
 
 	// There's nothing in properties for an application
 	result.Properties = map[string]interface{}{}
@@ -27,7 +27,7 @@ func ConvertK8sApplicationToARM(input radiusv1alpha1.Application) (*radclient.Ap
 
 func ConvertK8sComponentToARM(input radiusv1alpha1.Component) (*radclient.ComponentResource, error) {
 	result := radclient.ComponentResource{}
-	result.Name = to.StringPtr(input.Annotations[keys.AnnotationsComponent])
+	result.Name = to.StringPtr(input.Annotations[kubernetes.AnnotationsComponent])
 	result.Kind = &input.Spec.Kind
 	result.Properties = &radclient.ComponentProperties{}
 
@@ -107,7 +107,7 @@ func ConvertK8sComponentToARM(input radiusv1alpha1.Component) (*radclient.Compon
 
 func ConvertK8sDeploymentToARM(input radiusv1alpha1.Deployment) (*radclient.DeploymentResource, error) {
 	result := radclient.DeploymentResource{}
-	result.Name = to.StringPtr(input.Annotations[keys.AnnotationsDeployment])
+	result.Name = to.StringPtr(input.Annotations[kubernetes.AnnotationsDeployment])
 	result.Properties = &radclient.DeploymentProperties{}
 
 	for _, dc := range input.Spec.Components {

--- a/pkg/cli/kubernetes/converters_test.go
+++ b/pkg/cli/kubernetes/converters_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
 	radiusv1alpha1 "github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
 	"github.com/Azure/radius/pkg/radclient"
@@ -30,7 +30,7 @@ func Test_ConvertK8sApplicationToARM(t *testing.T) {
 			Name:      "frontend-backend",
 			Namespace: "default",
 			Annotations: map[string]string{
-				keys.AnnotationsApplication: "frontend-backend",
+				kubernetes.AnnotationsApplication: "frontend-backend",
 			},
 		},
 		Spec: v1alpha1.ApplicationSpec{},
@@ -109,8 +109,8 @@ func Test_ConvertK8sComponentToARM(t *testing.T) {
 			Name:      "frontend",
 			Namespace: "default",
 			Annotations: map[string]string{
-				keys.AnnotationsApplication: "frontend-backend",
-				keys.AnnotationsComponent:   "frontend",
+				kubernetes.AnnotationsApplication: "frontend-backend",
+				kubernetes.AnnotationsComponent:   "frontend",
 			},
 		},
 		Spec: v1alpha1.ComponentSpec{
@@ -192,8 +192,8 @@ func Test_ConvertK8sDeploymentToARM(t *testing.T) {
 			Name:      "frontend-backend-default",
 			Namespace: "default",
 			Annotations: map[string]string{
-				keys.AnnotationsApplication: "frontend-backend",
-				keys.AnnotationsDeployment:  "default",
+				kubernetes.AnnotationsApplication: "frontend-backend",
+				kubernetes.AnnotationsDeployment:  "default",
 			},
 		},
 		Spec: radiusv1alpha1.DeploymentSpec{

--- a/pkg/cli/kubernetes/diagnostics.go
+++ b/pkg/cli/kubernetes/diagnostics.go
@@ -15,7 +15,7 @@ import (
 	"os/signal"
 
 	"github.com/Azure/radius/pkg/cli/clients"
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -94,7 +94,7 @@ func getRunningReplica(ctx context.Context, client *k8s.Clientset, namespace str
 	// Right now this connects to a pod related to a component. We can find the pods with the labels
 	// and then choose one that's in the running state.
 	pods, err := client.CoreV1().Pods(namespace).List(ctx, v1.ListOptions{
-		LabelSelector: labels.FormatLabels(keys.MakeSelectorLabels(application, component)),
+		LabelSelector: labels.FormatLabels(kubernetes.MakeSelectorLabels(application, component)),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list running replicas for component %v: %w", component, err)
@@ -142,7 +142,7 @@ func runPortforward(restconfig *rest.Config, client *k8s.Clientset, replica *cor
 
 func getAppContainerName(replica *corev1.Pod) string {
 	// The container name will be the component name
-	component := replica.Labels[keys.LabelRadiusComponent]
+	component := replica.Labels[kubernetes.LabelRadiusComponent]
 	return component
 }
 

--- a/pkg/cli/kubernetes/management.go
+++ b/pkg/cli/kubernetes/management.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/radius/pkg/cli/clients"
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	radiusv1alpha1 "github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
 	"github.com/Azure/radius/pkg/radclient"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -64,7 +64,7 @@ func (mc *KubernetesManagementClient) ShowApplication(ctx context.Context, appli
 	}
 
 	for _, item := range applications.Items {
-		if item.Annotations[keys.AnnotationsApplication] == applicationName {
+		if item.Annotations[kubernetes.AnnotationsApplication] == applicationName {
 			application, err := ConvertK8sApplicationToARM(item)
 			if err != nil {
 				return nil, err
@@ -87,7 +87,7 @@ func (mc *KubernetesManagementClient) DeleteApplication(ctx context.Context, app
 	}
 
 	for _, item := range applications.Items {
-		if item.Annotations[keys.AnnotationsApplication] == applicationName {
+		if item.Annotations[kubernetes.AnnotationsApplication] == applicationName {
 			err = mc.Client.Delete(ctx, &item, &client.DeleteOptions{})
 			if err != nil {
 				return err
@@ -110,7 +110,7 @@ func (mc *KubernetesManagementClient) ListComponents(ctx context.Context, applic
 
 	converted := []*radclient.ComponentResource{}
 	for _, item := range components.Items {
-		if item.Annotations[keys.AnnotationsApplication] == applicationName {
+		if item.Annotations[kubernetes.AnnotationsApplication] == applicationName {
 			component, err := ConvertK8sComponentToARM(item)
 			if err != nil {
 				return nil, err
@@ -133,8 +133,8 @@ func (mc *KubernetesManagementClient) ShowComponent(ctx context.Context, applica
 	}
 
 	for _, item := range components.Items {
-		if item.Annotations[keys.AnnotationsApplication] == applicationName &&
-			item.Annotations[keys.AnnotationsComponent] == componentName {
+		if item.Annotations[kubernetes.AnnotationsApplication] == applicationName &&
+			item.Annotations[kubernetes.AnnotationsComponent] == componentName {
 			component, err := ConvertK8sComponentToARM(item)
 			if err != nil {
 				return nil, err
@@ -155,7 +155,7 @@ func (mc *KubernetesManagementClient) deleteComponentsInApplication(ctx context.
 	}
 
 	for _, item := range components.Items {
-		if item.Annotations[keys.AnnotationsApplication] == applicationName {
+		if item.Annotations[kubernetes.AnnotationsApplication] == applicationName {
 			err = mc.Client.Delete(ctx, &item, &client.DeleteOptions{})
 			if err != nil {
 				return err
@@ -176,8 +176,8 @@ func (mc *KubernetesManagementClient) DeleteDeployment(ctx context.Context, appl
 	}
 
 	for _, item := range deployments.Items {
-		if item.Annotations[keys.AnnotationsApplication] == applicationName &&
-			item.Annotations[keys.AnnotationsDeployment] == deploymentName {
+		if item.Annotations[kubernetes.AnnotationsApplication] == applicationName &&
+			item.Annotations[kubernetes.AnnotationsDeployment] == deploymentName {
 			err = mc.Client.Delete(ctx, &item)
 			if err != nil {
 				return err
@@ -199,7 +199,7 @@ func (mc *KubernetesManagementClient) ListDeployments(ctx context.Context, appli
 
 	converted := []*radclient.DeploymentResource{}
 	for _, item := range deployments.Items {
-		if item.Annotations[keys.AnnotationsApplication] == applicationName {
+		if item.Annotations[kubernetes.AnnotationsApplication] == applicationName {
 			deployment, err := ConvertK8sDeploymentToARM(item)
 			if err != nil {
 				return nil, err
@@ -222,8 +222,8 @@ func (mc *KubernetesManagementClient) ShowDeployment(ctx context.Context, applic
 	}
 
 	for _, item := range deployments.Items {
-		if item.Annotations[keys.AnnotationsApplication] == applicationName &&
-			item.Annotations[keys.AnnotationsDeployment] == deploymentName {
+		if item.Annotations[kubernetes.AnnotationsApplication] == applicationName &&
+			item.Annotations[kubernetes.AnnotationsDeployment] == deploymentName {
 			deployment, err := ConvertK8sDeploymentToARM(item)
 			if err != nil {
 				return nil, err

--- a/pkg/kubernetes/annotations.go
+++ b/pkg/kubernetes/annotations.go
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-package keys
+package kubernetes
 
 // Commonly-used and Radius-Specific annotations for Kubernetes
 const (

--- a/pkg/kubernetes/controllers/component_controller.go
+++ b/pkg/kubernetes/controllers/component_controller.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	radiusv1alpha1 "github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
 	"github.com/Azure/radius/pkg/model"
 	"github.com/Azure/radius/pkg/radrp/components"
@@ -73,8 +73,8 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		log.Error(err, "failed to retrieve component")
 		return ctrl.Result{}, err
 	}
-	applicationName := component.Annotations[keys.AnnotationsApplication]
-	componentName := component.Annotations[keys.AnnotationsComponent]
+	applicationName := component.Annotations[kubernetes.AnnotationsApplication]
+	componentName := component.Annotations[kubernetes.AnnotationsComponent]
 
 	log = log.WithValues(
 		"application", applicationName,
@@ -259,11 +259,11 @@ func GetMissingBindings(generic *components.GenericComponent, r *ComponentReconc
 
 		found := false
 		for _, pp := range providers.Items {
-			if pp.Annotations[keys.AnnotationsApplication] != applicationName {
+			if pp.Annotations[kubernetes.AnnotationsApplication] != applicationName {
 				continue
 			}
 
-			if pp.Annotations[keys.AnnotationsComponent] != key.Component {
+			if pp.Annotations[kubernetes.AnnotationsComponent] != key.Component {
 				continue
 			}
 
@@ -465,7 +465,7 @@ func (r *ComponentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func extractApplicationKey(obj client.Object) []string {
 	component := obj.(*radiusv1alpha1.Component)
-	return []string{component.Annotations[keys.AnnotationsApplication]}
+	return []string{component.Annotations[kubernetes.AnnotationsApplication]}
 }
 
 func extractOwnerKey(obj client.Object) []string {

--- a/pkg/kubernetes/converters/converters.go
+++ b/pkg/kubernetes/converters/converters.go
@@ -3,12 +3,12 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-package controllers
+package converters
 
 import (
 	"encoding/json"
 
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	radiusv1alpha1 "github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
 	"github.com/Azure/radius/pkg/radrp/components"
 	"k8s.io/apimachinery/pkg/conversion"
@@ -17,7 +17,7 @@ import (
 func ConvertComponentToInternal(a interface{}, b interface{}, scope conversion.Scope) error {
 	original := a.(*radiusv1alpha1.Component)
 	result := b.(*components.GenericComponent)
-	result.Name = original.Annotations[keys.AnnotationsComponent]
+	result.Name = original.Annotations[kubernetes.AnnotationsComponent]
 	result.Kind = original.Spec.Kind
 
 	if original.Spec.Config != nil {

--- a/pkg/kubernetes/converters/converters_test.go
+++ b/pkg/kubernetes/converters/converters_test.go
@@ -3,13 +3,13 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-package controllers
+package converters
 
 import (
 	"encoding/json"
 	"testing"
 
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
 	radiusv1alpha1 "github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
 	"github.com/Azure/radius/pkg/radrp/components"
@@ -77,8 +77,8 @@ func Test_ConvertComponentToInternal(t *testing.T) {
 			Name:      "frontend",
 			Namespace: "default",
 			Annotations: map[string]string{
-				keys.AnnotationsApplication: "frontend-backend",
-				keys.AnnotationsComponent:   "frontend",
+				kubernetes.AnnotationsApplication: "frontend-backend",
+				kubernetes.AnnotationsComponent:   "frontend",
 			},
 		},
 		Spec: v1alpha1.ComponentSpec{

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-package keys
+package kubernetes
 
 // Commonly-used and Radius-Specific labels for Kubernetes
 const (

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -11,10 +11,10 @@ const (
 	LabelRadiusComponent   = "radius.dev/component"
 	LabelRadiusRevision    = "radius.dev/revision"
 
-	LabelKubernetesPartOf            = "app.kubernetes.io/part-of"
-	LabelKubernetesName              = "app.kubernetes.io/name"
-	LabelKubernetesManagedBy         = "app.kubernetes.io/managed-by"
-	LabelKubernetesManagedByRadiusRP = "radius-rp"
+	LabelPartOf            = "app.kubernetes.io/part-of"
+	LabelName              = "app.kubernetes.io/name"
+	LabelManagedBy         = "app.kubernetes.io/managed-by"
+	LabelManagedByRadiusRP = "radius-rp"
 
 	FieldManager = "radius-rp"
 )
@@ -39,11 +39,11 @@ const (
 // The descriptive labels are a superset of the selector labels.
 func MakeDescriptiveLabels(application string, component string) map[string]string {
 	return map[string]string{
-		LabelRadiusApplication:   application,
-		LabelRadiusComponent:     component,
-		LabelKubernetesName:      component,
-		LabelKubernetesPartOf:    application,
-		LabelKubernetesManagedBy: LabelKubernetesManagedByRadiusRP,
+		LabelRadiusApplication: application,
+		LabelRadiusComponent:   component,
+		LabelName:              component,
+		LabelPartOf:            application,
+		LabelManagedBy:         LabelManagedByRadiusRP,
 	}
 }
 

--- a/pkg/radrp/handlers/dapr_pubsub_servicebus.go
+++ b/pkg/radrp/handlers/dapr_pubsub_servicebus.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/servicebus/mgmt/servicebus"
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/radrp/armauth"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -137,7 +137,7 @@ func (handler *daprPubSubServiceBusHandler) PatchDaprPubSub(ctx context.Context,
 			"metadata": map[string]interface{}{
 				"namespace": properties[KubernetesNamespaceKey],
 				"name":      properties[ComponentNameKey],
-				"labels":    keys.MakeDescriptiveLabels(options.Application, options.Component),
+				"labels":    kubernetes.MakeDescriptiveLabels(options.Application, options.Component),
 			},
 			"spec": map[string]interface{}{
 				"type":    "pubsub.azure.servicebus",
@@ -152,7 +152,7 @@ func (handler *daprPubSubServiceBusHandler) PatchDaprPubSub(ctx context.Context,
 		},
 	}
 
-	err = handler.k8s.Patch(ctx, &item, client.Apply, &client.PatchOptions{FieldManager: keys.FieldManager})
+	err = handler.k8s.Patch(ctx, &item, client.Apply, &client.PatchOptions{FieldManager: kubernetes.FieldManager})
 	if err != nil {
 		return fmt.Errorf("failed to patch Dapr PubSub: %w", err)
 	}

--- a/pkg/radrp/handlers/dapr_statestore_sqlserver.go
+++ b/pkg/radrp/handlers/dapr_statestore_sqlserver.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/cli/util"
 	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/radlogger"
 	"github.com/Azure/radius/pkg/radrp/armauth"
 	"github.com/gofrs/uuid"
@@ -91,7 +92,7 @@ func (handler *daprStateStoreSQLServerHandler) Put(ctx context.Context, options 
 			"metadata": map[string]interface{}{
 				"name":      properties[KubernetesNameKey],
 				"namespace": properties[KubernetesNamespaceKey],
-				"labels":    keys.MakeDescriptiveLabels(options.Application, options.Component),
+				"labels":    kubernetes.MakeDescriptiveLabels(options.Application, options.Component),
 			},
 			"spec": map[string]interface{}{
 				"type":    "state.sqlserver",
@@ -110,7 +111,7 @@ func (handler *daprStateStoreSQLServerHandler) Put(ctx context.Context, options 
 		},
 	}
 
-	err = handler.k8s.Patch(ctx, &item, client.Apply, &client.PatchOptions{FieldManager: keys.FieldManager})
+	err = handler.k8s.Patch(ctx, &item, client.Apply, &client.PatchOptions{FieldManager: kubernetes.FieldManager})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/radrp/handlers/dapr_statestore_storage.go
+++ b/pkg/radrp/handlers/dapr_statestore_storage.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/azresources"
 	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/radlogger"
 	"github.com/Azure/radius/pkg/radrp/armauth"
 	radresources "github.com/Azure/radius/pkg/radrp/resources"
@@ -204,7 +205,7 @@ func (handler *daprStateStoreAzureStorageHandler) CreateDaprStateStore(ctx conte
 			"metadata": map[string]interface{}{
 				"namespace": properties[KubernetesNamespaceKey],
 				"name":      properties[ComponentNameKey],
-				"labels":    keys.MakeDescriptiveLabels(options.Application, options.Component),
+				"labels":    kubernetes.MakeDescriptiveLabels(options.Application, options.Component),
 			},
 			"spec": map[string]interface{}{
 				"type":    "state.azure.tablestorage",
@@ -227,7 +228,7 @@ func (handler *daprStateStoreAzureStorageHandler) CreateDaprStateStore(ctx conte
 		},
 	}
 
-	err = handler.k8s.Patch(ctx, &item, client.Apply, &client.PatchOptions{FieldManager: keys.FieldManager})
+	err = handler.k8s.Patch(ctx, &item, client.Apply, &client.PatchOptions{FieldManager: kubernetes.FieldManager})
 	if err != nil {
 		return fmt.Errorf("failed to create/update Dapr Component: %w", err)
 	}

--- a/pkg/radrp/handlers/kubernetes.go
+++ b/pkg/radrp/handlers/kubernetes.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -50,7 +50,7 @@ func (handler *kubernetesHandler) Put(ctx context.Context, options PutOptions) (
 		// For now, no need to process any further
 		return p, nil
 	}
-	err = handler.k8s.Patch(ctx, &item, client.Apply, &client.PatchOptions{FieldManager: keys.FieldManager})
+	err = handler.k8s.Patch(ctx, &item, client.Apply, &client.PatchOptions{FieldManager: kubernetes.FieldManager})
 	if err != nil {
 		return nil, err
 	}
@@ -74,13 +74,13 @@ func (handler *kubernetesHandler) PatchNamespace(ctx context.Context, namespace 
 			"metadata": map[string]interface{}{
 				"name": namespace,
 				"labels": map[string]interface{}{
-					keys.LabelKubernetesManagedBy: keys.LabelKubernetesManagedByRadiusRP,
+					kubernetes.LabelKubernetesManagedBy: kubernetes.LabelKubernetesManagedByRadiusRP,
 				},
 			},
 		},
 	}
 
-	err := handler.k8s.Patch(ctx, ns, client.Apply, &client.PatchOptions{FieldManager: keys.FieldManager})
+	err := handler.k8s.Patch(ctx, ns, client.Apply, &client.PatchOptions{FieldManager: kubernetes.FieldManager})
 	if err != nil {
 		// we consider this fatal - without a namespace we won't be able to apply anything else
 		return fmt.Errorf("error applying namespace: %w", err)

--- a/pkg/radrp/handlers/kubernetes.go
+++ b/pkg/radrp/handlers/kubernetes.go
@@ -74,7 +74,7 @@ func (handler *kubernetesHandler) PatchNamespace(ctx context.Context, namespace 
 			"metadata": map[string]interface{}{
 				"name": namespace,
 				"labels": map[string]interface{}{
-					kubernetes.LabelKubernetesManagedBy: kubernetes.LabelKubernetesManagedByRadiusRP,
+					kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
 				},
 			},
 		},

--- a/pkg/workloads/containerv1alpha1/render.go
+++ b/pkg/workloads/containerv1alpha1/render.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Azure/radius/pkg/azresources"
 	"github.com/Azure/radius/pkg/cli/util"
 	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/radlogger"
 	"github.com/Azure/radius/pkg/radrp/armauth"
 	"github.com/Azure/radius/pkg/radrp/components"
@@ -475,15 +476,15 @@ func (r Renderer) makeDeployment(ctx context.Context, w workloads.InstantiatedWo
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cc.Name,
 			Namespace: w.Application,
-			Labels:    keys.MakeDescriptiveLabels(w.Application, w.Name),
+			Labels:    kubernetes.MakeDescriptiveLabels(w.Application, w.Name),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &v1.LabelSelector{
-				MatchLabels: keys.MakeSelectorLabels(w.Application, w.Name),
+				MatchLabels: kubernetes.MakeSelectorLabels(w.Application, w.Name),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: keys.MakeDescriptiveLabels(w.Application, w.Name),
+					Labels: kubernetes.MakeDescriptiveLabels(w.Application, w.Name),
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{container},
@@ -675,10 +676,10 @@ func (r Renderer) makeService(ctx context.Context, w workloads.InstantiatedWorkl
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cc.Name,
 			Namespace: w.Application, // TODO why is this a different namespace
-			Labels:    keys.MakeDescriptiveLabels(w.Application, w.Name),
+			Labels:    kubernetes.MakeDescriptiveLabels(w.Application, w.Name),
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: keys.MakeSelectorLabels(w.Application, w.Name),
+			Selector: kubernetes.MakeSelectorLabels(w.Application, w.Name),
 			Type:     corev1.ServiceTypeClusterIP,
 			Ports:    []corev1.ServicePort{},
 		},

--- a/pkg/workloads/containerv1alpha1/render_test.go
+++ b/pkg/workloads/containerv1alpha1/render_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/radlogger"
 	"github.com/Azure/radius/pkg/radrp/components"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
@@ -164,8 +164,8 @@ func TestRender_Success_DefaultPort(t *testing.T) {
 	service := findService(resources)
 	require.NotNil(t, service)
 
-	labels := keys.MakeDescriptiveLabels("test-app", "test-container")
-	matchLabels := keys.MakeSelectorLabels("test-app", "test-container")
+	labels := kubernetes.MakeDescriptiveLabels("test-app", "test-container")
+	matchLabels := kubernetes.MakeSelectorLabels("test-app", "test-container")
 
 	t.Run("verify deployment", func(t *testing.T) {
 		require.Equal(t, "test-container", deployment.Name)
@@ -252,8 +252,8 @@ func TestRender_Success_NonDefaultPort(t *testing.T) {
 	service := findService(resources)
 	require.NotNil(t, service)
 
-	labels := keys.MakeDescriptiveLabels("test-app", "test-container")
-	matchLabels := keys.MakeSelectorLabels("test-app", "test-container")
+	labels := kubernetes.MakeDescriptiveLabels("test-app", "test-container")
+	matchLabels := kubernetes.MakeSelectorLabels("test-app", "test-container")
 
 	t.Run("verify deployment", func(t *testing.T) {
 		require.Equal(t, "test-container", deployment.Name)

--- a/pkg/workloads/daprstatestorev1alpha1/redis.go
+++ b/pkg/workloads/daprstatestorev1alpha1/redis.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
 	"github.com/Azure/radius/pkg/workloads"
 	appsv1 "k8s.io/api/apps/v1"
@@ -40,15 +40,15 @@ func GetDaprStateStoreKubernetesRedis(w workloads.InstantiatedWorkload, componen
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      component.Name,
 			Namespace: namespace,
-			Labels:    keys.MakeDescriptiveLabels(w.Application, w.Name),
+			Labels:    kubernetes.MakeDescriptiveLabels(w.Application, w.Name),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: keys.MakeSelectorLabels(w.Application, w.Name),
+				MatchLabels: kubernetes.MakeSelectorLabels(w.Application, w.Name),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: keys.MakeDescriptiveLabels(w.Application, w.Name),
+					Labels: kubernetes.MakeDescriptiveLabels(w.Application, w.Name),
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -80,10 +80,10 @@ func GetDaprStateStoreKubernetesRedis(w workloads.InstantiatedWorkload, componen
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      component.Name,
 			Namespace: namespace,
-			Labels:    keys.MakeDescriptiveLabels(w.Application, w.Name),
+			Labels:    kubernetes.MakeDescriptiveLabels(w.Application, w.Name),
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: keys.MakeSelectorLabels(w.Application, w.Name),
+			Selector: kubernetes.MakeSelectorLabels(w.Application, w.Name),
 			Type:     corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{
 				{
@@ -107,7 +107,7 @@ func GetDaprStateStoreKubernetesRedis(w workloads.InstantiatedWorkload, componen
 			"metadata": map[string]interface{}{
 				"name":      component.Name,
 				"namespace": namespace,
-				"labels":    keys.MakeDescriptiveLabels(w.Application, w.Name),
+				"labels":    kubernetes.MakeDescriptiveLabels(w.Application, w.Name),
 			},
 			"spec": map[string]interface{}{
 				"type":    "state.redis",

--- a/pkg/workloads/daprstatestorev1alpha1/render_test.go
+++ b/pkg/workloads/daprstatestorev1alpha1/render_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/radlogger"
 	"github.com/Azure/radius/pkg/radrp/components"
 	"github.com/Azure/radius/pkg/radrp/handlers"
@@ -285,8 +285,8 @@ func Test_Render_K8s_Managed_Success(t *testing.T) {
 	require.Equal(t, outputresource.KindKubernetes, dapr.Kind)
 	resourceDapr := dapr.Resource.(*unstructured.Unstructured)
 
-	labels := keys.MakeDescriptiveLabels("test-app", "test-component")
-	matchLabels := keys.MakeSelectorLabels("test-app", "test-component")
+	labels := kubernetes.MakeDescriptiveLabels("test-app", "test-component")
+	matchLabels := kubernetes.MakeSelectorLabels("test-app", "test-component")
 
 	t.Run("verify deployment", func(t *testing.T) {
 		require.Equal(t, "test-component", resourceDeployment.Name)
@@ -334,7 +334,7 @@ func Test_Render_K8s_Managed_Success(t *testing.T) {
 				"metadata": map[string]interface{}{
 					"name":      "test-component",
 					"namespace": "default",
-					"labels":    keys.MakeDescriptiveLabels("test-app", "test-component"),
+					"labels":    kubernetes.MakeDescriptiveLabels("test-app", "test-component"),
 				},
 				"spec": map[string]interface{}{
 					"type":    "state.redis",

--- a/pkg/workloads/inboundroute/decorator.go
+++ b/pkg/workloads/inboundroute/decorator.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/radrp/components"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
 	"github.com/Azure/radius/pkg/workloads"
@@ -79,7 +79,7 @@ func (r Renderer) Render(ctx context.Context, w workloads.InstantiatedWorkload) 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      w.Name,
 			Namespace: w.Application,
-			Labels:    keys.MakeDescriptiveLabels(w.Application, w.Name),
+			Labels:    kubernetes.MakeDescriptiveLabels(w.Application, w.Name),
 		},
 	}
 

--- a/pkg/workloads/inboundroute/render_test.go
+++ b/pkg/workloads/inboundroute/render_test.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/radlogger"
 	"github.com/Azure/radius/pkg/radrp/components"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
@@ -73,7 +73,7 @@ func Test_Render_Simple(t *testing.T) {
 	require.Equal(t, outputresource.TypeKubernetes, resource.Type)
 	require.True(t, resource.Managed)
 
-	labels := keys.MakeDescriptiveLabels("test-app", "test-container")
+	labels := kubernetes.MakeDescriptiveLabels("test-app", "test-container")
 
 	require.Equal(t, "test-container", ingress.Name)
 	require.Equal(t, "test-app", ingress.Namespace)
@@ -125,7 +125,7 @@ func Test_Render_WithHostname(t *testing.T) {
 	require.Equal(t, outputresource.TypeKubernetes, resource.Type)
 	require.True(t, resource.Managed)
 
-	labels := keys.MakeDescriptiveLabels("test-app", "test-container")
+	labels := kubernetes.MakeDescriptiveLabels("test-app", "test-container")
 
 	require.Equal(t, "test-container", ingress.Name)
 	require.Equal(t, "test-app", ingress.Namespace)

--- a/pkg/workloads/mongodbv1alpha1/kubernetesrenderer.go
+++ b/pkg/workloads/mongodbv1alpha1/kubernetesrenderer.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/radrp/components"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
 	"github.com/Azure/radius/pkg/workloads"
@@ -91,8 +91,8 @@ func (r KubernetesRenderer) Render(ctx context.Context, w workloads.Instantiated
 	}
 
 	options := KubernetesOptions{
-		DescriptiveLabels: keys.MakeDescriptiveLabels(w.Application, w.Name),
-		SelectorLabels:    keys.MakeSelectorLabels(w.Application, w.Name),
+		DescriptiveLabels: kubernetes.MakeDescriptiveLabels(w.Application, w.Name),
+		SelectorLabels:    kubernetes.MakeSelectorLabels(w.Application, w.Name),
 
 		// For now use the component name as the Kubernetes resource name.
 		Name:      w.Name,

--- a/pkg/workloads/mongodbv1alpha1/kubernetesrenderer_test.go
+++ b/pkg/workloads/mongodbv1alpha1/kubernetesrenderer_test.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/radrp/components"
 	"github.com/Azure/radius/pkg/radrp/handlers"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
@@ -34,7 +34,7 @@ func Test_KubernetesRenderer_AllocateBindings(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: "test-namespace",
-			Labels:    keys.MakeDescriptiveLabels("test-application", "test-component"),
+			Labels:    kubernetes.MakeDescriptiveLabels("test-application", "test-component"),
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
@@ -149,8 +149,8 @@ func Test_KubernetesRenderer_Render_Unmanaged_NotSupported(t *testing.T) {
 func Test_KubernetesRenderer_MakeSecret(t *testing.T) {
 	renderer := KubernetesRenderer{}
 	options := KubernetesOptions{
-		DescriptiveLabels: keys.MakeDescriptiveLabels("test-application", "test-component"),
-		SelectorLabels:    keys.MakeSelectorLabels("test-application", "test-component"),
+		DescriptiveLabels: kubernetes.MakeDescriptiveLabels("test-application", "test-component"),
+		SelectorLabels:    kubernetes.MakeSelectorLabels("test-application", "test-component"),
 		Namespace:         "test-namespace",
 		Name:              "test-name",
 	}
@@ -164,7 +164,7 @@ func Test_KubernetesRenderer_MakeSecret(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-name",
 			Namespace: "test-namespace",
-			Labels:    keys.MakeDescriptiveLabels("test-application", "test-component"),
+			Labels:    kubernetes.MakeDescriptiveLabels("test-application", "test-component"),
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
@@ -178,8 +178,8 @@ func Test_KubernetesRenderer_MakeSecret(t *testing.T) {
 func Test_KubernetesRenderer_MakeService(t *testing.T) {
 	renderer := KubernetesRenderer{}
 	options := KubernetesOptions{
-		DescriptiveLabels: keys.MakeDescriptiveLabels("test-application", "test-component"),
-		SelectorLabels:    keys.MakeSelectorLabels("test-application", "test-component"),
+		DescriptiveLabels: kubernetes.MakeDescriptiveLabels("test-application", "test-component"),
+		SelectorLabels:    kubernetes.MakeSelectorLabels("test-application", "test-component"),
 		Namespace:         "test-namespace",
 		Name:              "test-name",
 	}
@@ -193,11 +193,11 @@ func Test_KubernetesRenderer_MakeService(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-name",
 			Namespace: "test-namespace",
-			Labels:    keys.MakeDescriptiveLabels("test-application", "test-component"),
+			Labels:    kubernetes.MakeDescriptiveLabels("test-application", "test-component"),
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP: corev1.ClusterIPNone,
-			Selector:  keys.MakeSelectorLabels("test-application", "test-component"),
+			Selector:  kubernetes.MakeSelectorLabels("test-application", "test-component"),
 		},
 	}
 	require.Equal(t, expected, service)
@@ -206,8 +206,8 @@ func Test_KubernetesRenderer_MakeService(t *testing.T) {
 func Test_KubernetesRenderer_MakeStatefulSet(t *testing.T) {
 	renderer := KubernetesRenderer{}
 	options := KubernetesOptions{
-		DescriptiveLabels: keys.MakeDescriptiveLabels("test-application", "test-component"),
-		SelectorLabels:    keys.MakeSelectorLabels("test-application", "test-component"),
+		DescriptiveLabels: kubernetes.MakeDescriptiveLabels("test-application", "test-component"),
+		SelectorLabels:    kubernetes.MakeSelectorLabels("test-application", "test-component"),
 		Namespace:         "test-namespace",
 		Name:              "test-name",
 	}
@@ -221,16 +221,16 @@ func Test_KubernetesRenderer_MakeStatefulSet(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-name",
 			Namespace: "test-namespace",
-			Labels:    keys.MakeDescriptiveLabels("test-application", "test-component"),
+			Labels:    kubernetes.MakeDescriptiveLabels("test-application", "test-component"),
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: keys.MakeSelectorLabels("test-application", "test-component"),
+				MatchLabels: kubernetes.MakeSelectorLabels("test-application", "test-component"),
 			},
 			ServiceName: "test-service",
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: keys.MakeDescriptiveLabels("test-application", "test-component"),
+					Labels: kubernetes.MakeDescriptiveLabels("test-application", "test-component"),
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{

--- a/pkg/workloads/redisv1alpha1/kubernetesrender.go
+++ b/pkg/workloads/redisv1alpha1/kubernetesrender.go
@@ -58,9 +58,9 @@ func GetKubernetesRedis(w workloads.InstantiatedWorkload, component RedisCompone
 				kubernetes.LabelRadiusApplication: w.Application,
 				kubernetes.LabelRadiusComponent:   component.Name,
 				// TODO get the component revision here...
-				kubernetes.LabelKubernetesName:      component.Name,
-				kubernetes.LabelKubernetesPartOf:    w.Application,
-				kubernetes.LabelKubernetesManagedBy: kubernetes.LabelKubernetesManagedByRadiusRP,
+				kubernetes.LabelName:      component.Name,
+				kubernetes.LabelPartOf:    w.Application,
+				kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -76,9 +76,9 @@ func GetKubernetesRedis(w workloads.InstantiatedWorkload, component RedisCompone
 						kubernetes.LabelRadiusApplication: w.Application,
 						kubernetes.LabelRadiusComponent:   component.Name,
 						// TODO get the component revision here...
-						kubernetes.LabelKubernetesName:      component.Name,
-						kubernetes.LabelKubernetesPartOf:    w.Application,
-						kubernetes.LabelKubernetesManagedBy: kubernetes.LabelKubernetesManagedByRadiusRP,
+						kubernetes.LabelName:      component.Name,
+						kubernetes.LabelPartOf:    w.Application,
+						kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -116,9 +116,9 @@ func GetKubernetesRedis(w workloads.InstantiatedWorkload, component RedisCompone
 				kubernetes.LabelRadiusApplication: w.Application,
 				kubernetes.LabelRadiusComponent:   component.Name,
 				// TODO get the component revision here...
-				kubernetes.LabelKubernetesName:      component.Name,
-				kubernetes.LabelKubernetesPartOf:    w.Application,
-				kubernetes.LabelKubernetesManagedBy: kubernetes.LabelKubernetesManagedByRadiusRP,
+				kubernetes.LabelName:      component.Name,
+				kubernetes.LabelPartOf:    w.Application,
+				kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
 			},
 		},
 		Spec: corev1.ServiceSpec{

--- a/pkg/workloads/redisv1alpha1/kubernetesrender.go
+++ b/pkg/workloads/redisv1alpha1/kubernetesrender.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/radrp/components"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
 	"github.com/Azure/radius/pkg/workloads"
@@ -55,30 +55,30 @@ func GetKubernetesRedis(w workloads.InstantiatedWorkload, component RedisCompone
 			Name:      component.Name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				keys.LabelRadiusApplication: w.Application,
-				keys.LabelRadiusComponent:   component.Name,
+				kubernetes.LabelRadiusApplication: w.Application,
+				kubernetes.LabelRadiusComponent:   component.Name,
 				// TODO get the component revision here...
-				keys.LabelKubernetesName:      component.Name,
-				keys.LabelKubernetesPartOf:    w.Application,
-				keys.LabelKubernetesManagedBy: keys.LabelKubernetesManagedByRadiusRP,
+				kubernetes.LabelKubernetesName:      component.Name,
+				kubernetes.LabelKubernetesPartOf:    w.Application,
+				kubernetes.LabelKubernetesManagedBy: kubernetes.LabelKubernetesManagedByRadiusRP,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					keys.LabelRadiusApplication: w.Application,
-					keys.LabelRadiusComponent:   component.Name,
+					kubernetes.LabelRadiusApplication: w.Application,
+					kubernetes.LabelRadiusComponent:   component.Name,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						keys.LabelRadiusApplication: w.Application,
-						keys.LabelRadiusComponent:   component.Name,
+						kubernetes.LabelRadiusApplication: w.Application,
+						kubernetes.LabelRadiusComponent:   component.Name,
 						// TODO get the component revision here...
-						keys.LabelKubernetesName:      component.Name,
-						keys.LabelKubernetesPartOf:    w.Application,
-						keys.LabelKubernetesManagedBy: keys.LabelKubernetesManagedByRadiusRP,
+						kubernetes.LabelKubernetesName:      component.Name,
+						kubernetes.LabelKubernetesPartOf:    w.Application,
+						kubernetes.LabelKubernetesManagedBy: kubernetes.LabelKubernetesManagedByRadiusRP,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -113,18 +113,18 @@ func GetKubernetesRedis(w workloads.InstantiatedWorkload, component RedisCompone
 			Name:      component.Name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				keys.LabelRadiusApplication: w.Application,
-				keys.LabelRadiusComponent:   component.Name,
+				kubernetes.LabelRadiusApplication: w.Application,
+				kubernetes.LabelRadiusComponent:   component.Name,
 				// TODO get the component revision here...
-				"app.kubernetes.io/name":       component.Name,
-				"app.kubernetes.io/part-of":    w.Application,
-				"app.kubernetes.io/managed-by": "radius-rp",
+				kubernetes.LabelKubernetesName:      component.Name,
+				kubernetes.LabelKubernetesPartOf:    w.Application,
+				kubernetes.LabelKubernetesManagedBy: kubernetes.LabelKubernetesManagedByRadiusRP,
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				keys.LabelRadiusApplication: w.Application,
-				keys.LabelRadiusComponent:   component.Name,
+				kubernetes.LabelRadiusApplication: w.Application,
+				kubernetes.LabelRadiusComponent:   component.Name,
 			},
 			Type: corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{

--- a/pkg/workloads/redisv1alpha1/kubernetesrender_test.go
+++ b/pkg/workloads/redisv1alpha1/kubernetesrender_test.go
@@ -60,11 +60,11 @@ func Test_Render_Managed_Kubernetes_Success(t *testing.T) {
 	require.NotNil(t, service)
 
 	labels := map[string]string{
-		kubernetes.LabelRadiusApplication:   "test-app",
-		kubernetes.LabelRadiusComponent:     "test-component",
-		kubernetes.LabelKubernetesName:      "test-component",
-		kubernetes.LabelKubernetesPartOf:    "test-app",
-		kubernetes.LabelKubernetesManagedBy: kubernetes.LabelKubernetesManagedByRadiusRP,
+		kubernetes.LabelRadiusApplication: "test-app",
+		kubernetes.LabelRadiusComponent:   "test-component",
+		kubernetes.LabelName:              "test-component",
+		kubernetes.LabelPartOf:            "test-app",
+		kubernetes.LabelManagedBy:         kubernetes.LabelManagedByRadiusRP,
 	}
 
 	matchLabels := map[string]string{

--- a/pkg/workloads/redisv1alpha1/kubernetesrender_test.go
+++ b/pkg/workloads/redisv1alpha1/kubernetesrender_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/radlogger"
 	"github.com/Azure/radius/pkg/radrp/components"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
@@ -60,16 +60,16 @@ func Test_Render_Managed_Kubernetes_Success(t *testing.T) {
 	require.NotNil(t, service)
 
 	labels := map[string]string{
-		keys.LabelRadiusApplication:   "test-app",
-		keys.LabelRadiusComponent:     "test-component",
-		keys.LabelKubernetesName:      "test-component",
-		keys.LabelKubernetesPartOf:    "test-app",
-		keys.LabelKubernetesManagedBy: keys.LabelKubernetesManagedByRadiusRP,
+		kubernetes.LabelRadiusApplication:   "test-app",
+		kubernetes.LabelRadiusComponent:     "test-component",
+		kubernetes.LabelKubernetesName:      "test-component",
+		kubernetes.LabelKubernetesPartOf:    "test-app",
+		kubernetes.LabelKubernetesManagedBy: kubernetes.LabelKubernetesManagedByRadiusRP,
 	}
 
 	matchLabels := map[string]string{
-		keys.LabelRadiusApplication: "test-app",
-		keys.LabelRadiusComponent:   "test-component",
+		kubernetes.LabelRadiusApplication: "test-app",
+		kubernetes.LabelRadiusComponent:   "test-component",
 	}
 	t.Run("verify deployment", func(t *testing.T) {
 		require.Equal(t, "test-component", deployment.Name)

--- a/test/functional/azure/environment/environment_test.go
+++ b/test/functional/azure/environment/environment_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/radius/pkg/azresources"
 	"github.com/Azure/radius/pkg/cli/environments"
 	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/test/azuretest"
 	"github.com/Azure/radius/test/utils"
 	"github.com/Azure/radius/test/validation"
@@ -81,7 +82,7 @@ func TestAzureEnvironment(t *testing.T) {
 				},
 				// verify ingress-nginx
 				"radius-system": {
-					validation.K8sObject{Labels: map[string]string{keys.LabelKubernetesName: "ingress-nginx"}},
+					validation.K8sObject{Labels: map[string]string{kubernetes.LabelName: "ingress-nginx"}},
 				},
 			},
 		}

--- a/test/functional/azure/resources/container/container_test.go
+++ b/test/functional/azure/resources/container/container_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/radclient"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
 	"github.com/Azure/radius/test/azuretest"
@@ -116,7 +116,7 @@ func Test_ContainerInboundRoute(t *testing.T) {
 			PostStepVerify: func(ctx context.Context, t *testing.T, at azuretest.ApplicationTest) {
 				// Verify that we've created an ingress resource. We don't verify reachability because allocating
 				// a public IP can take a few minutes.
-				labelset := keys.MakeSelectorLabels(application, "frontend")
+				labelset := kubernetes.MakeSelectorLabels(application, "frontend")
 				matches, err := at.Options.K8sClient.NetworkingV1().Ingresses(application).List(context.Background(), metav1.ListOptions{
 					LabelSelector: labels.SelectorFromSet(labelset).String(),
 				})

--- a/test/integration/kubernetes/k8scontroller_test.go
+++ b/test/integration/kubernetes/k8scontroller_test.go
@@ -21,10 +21,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	"github.com/Azure/radius/pkg/cli/kubernetes"
-	"github.com/Azure/radius/pkg/keys"
+	kuberneteskeys "github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
 	radiusv1alpha1 "github.com/Azure/radius/pkg/kubernetes/api/v1alpha1"
 	"github.com/Azure/radius/pkg/kubernetes/controllers"
+	"github.com/Azure/radius/pkg/kubernetes/converters"
 	"github.com/Azure/radius/pkg/radrp/components"
 	"github.com/Azure/radius/test/utils"
 	"github.com/Azure/radius/test/validation"
@@ -61,7 +62,7 @@ func TestK8sController(t *testing.T) {
 
 	utilruntime.Must(radiusv1alpha1.AddToScheme(scheme))
 
-	err := scheme.AddConversionFunc(&radiusv1alpha1.Component{}, &components.GenericComponent{}, controllers.ConvertComponentToInternal)
+	err := scheme.AddConversionFunc(&radiusv1alpha1.Component{}, &components.GenericComponent{}, converters.ConvertComponentToInternal)
 	require.NoError(t, err, "failed to add conversion func")
 
 	cfg, err := testEnv.Start()
@@ -135,7 +136,7 @@ func TestK8sController(t *testing.T) {
 					Name:      "radius-frontend-backend",
 					Namespace: "frontend-backend",
 					Annotations: map[string]string{
-						keys.AnnotationsApplication: "frontend-backend",
+						kuberneteskeys.AnnotationsApplication: "frontend-backend",
 					},
 				},
 				Spec: radiusv1alpha1.ApplicationSpec{
@@ -152,8 +153,8 @@ func TestK8sController(t *testing.T) {
 						Name:      "frontend",
 						Namespace: "frontend-backend",
 						Annotations: map[string]string{
-							keys.AnnotationsApplication: "frontend-backend",
-							keys.AnnotationsComponent:   "frontend",
+							kuberneteskeys.AnnotationsApplication: "frontend-backend",
+							kuberneteskeys.AnnotationsComponent:   "frontend",
 						},
 					},
 					Spec: TestComponentSpec{
@@ -189,8 +190,8 @@ func TestK8sController(t *testing.T) {
 						Name:      "backend",
 						Namespace: "frontend-backend",
 						Annotations: map[string]string{
-							keys.AnnotationsApplication: "frontend-backend",
-							keys.AnnotationsComponent:   "backend",
+							kuberneteskeys.AnnotationsApplication: "frontend-backend",
+							kuberneteskeys.AnnotationsComponent:   "backend",
 						},
 					},
 					Spec: TestComponentSpec{

--- a/test/validation/k8s.go
+++ b/test/validation/k8s.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/radius/pkg/keys"
+	kuberneteskeys "github.com/Azure/radius/pkg/kubernetes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -39,7 +39,7 @@ func NewK8sObjectForComponent(application string, name string) K8sObject {
 	return K8sObject{
 		// NOTE: we use the selector labels here because the selector labels are intended
 		// to be determininistic. We might add things to the descriptive labels that are NON deterministic.
-		Labels: keys.MakeSelectorLabels(application, name),
+		Labels: kuberneteskeys.MakeSelectorLabels(application, name),
 	}
 }
 


### PR DESCRIPTION
Part of https://github.com/Azure/radius/issues/640.

 - Move kubernetes functionality from keys into pkg/kubernetes and simplify names
 - Move converter functionality from controllers into another package