### PR TITLE
Implement dependency ordering for output resource

### DIFF
--- a/pkg/algorithm/graph/compute.go
+++ b/pkg/algorithm/graph/compute.go
@@ -20,17 +20,28 @@ func ComputeDependencyGraph(items []DependencyItem) (DependencyGraph, error) {
 		key := item.Key()
 
 		keys = append(keys, key)
+
+		dependencies, err := item.GetDependencies()
+		if err != nil {
+			return DependencyGraph{}, err
+		}
+
 		setsByKey[key] = set{
 			setsByKey:    setsByKey,
 			item:         item,
-			dependencies: item.GetDependencies(),
+			dependencies: dependencies,
 		}
 	}
 
 	// Now validate by walking all dependencies and ensure they exist in the graph
 	missing := map[string]bool{}
 	for _, item := range items {
-		for _, d := range item.GetDependencies() {
+		dependencies, err := item.GetDependencies()
+		if err != nil {
+			return DependencyGraph{}, err
+		}
+
+		for _, d := range dependencies {
 			_, ok := setsByKey[d]
 			if !ok {
 				missing[d] = true

--- a/pkg/algorithm/graph/types.go
+++ b/pkg/algorithm/graph/types.go
@@ -18,7 +18,7 @@ func (dg DependencyGraph) Lookup(key string) (DependencySet, bool) {
 
 type DependencyItem interface {
 	Key() string
-	GetDependencies() []string
+	GetDependencies() ([]string, error)
 }
 
 type DependencySet interface {

--- a/pkg/radrp/deployment/componentaction_test.go
+++ b/pkg/radrp/deployment/componentaction_test.go
@@ -15,8 +15,10 @@ import (
 func Test_ComponentAction_GetDependencies_Null(t *testing.T) {
 	// action.Component will be null for a delete action
 	action := ComponentAction{}
+	dependencies, err := action.GetDependencies()
+	require.NoError(t, err)
 
-	require.Empty(t, action.GetDependencies())
+	require.Empty(t, dependencies)
 }
 
 func Test_ComponentAction_GetDependencies_None(t *testing.T) {
@@ -24,7 +26,10 @@ func Test_ComponentAction_GetDependencies_None(t *testing.T) {
 		Component: &components.GenericComponent{},
 	}
 
-	require.Empty(t, action.GetDependencies())
+	dependencies, err := action.GetDependencies()
+	require.NoError(t, err)
+
+	require.Empty(t, dependencies)
 }
 
 func Test_ComponentAction_GetDependencies_Some(t *testing.T) {
@@ -47,5 +52,8 @@ func Test_ComponentAction_GetDependencies_Some(t *testing.T) {
 		},
 	}
 
-	require.Equal(t, []string{"A", "C"}, action.GetDependencies())
+	dependencies, err := action.GetDependencies()
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"A", "C"}, dependencies)
 }

--- a/pkg/radrp/deployment/deployment_processor.go
+++ b/pkg/radrp/deployment/deployment_processor.go
@@ -58,9 +58,9 @@ func (action ComponentAction) Key() string {
 	return action.ComponentName
 }
 
-func (action ComponentAction) GetDependencies() []string {
+func (action ComponentAction) GetDependencies() ([]string, error) {
 	if action.Component == nil {
-		return []string{}
+		return []string{}, nil
 	}
 
 	dependencies := []string{}
@@ -73,7 +73,7 @@ func (action ComponentAction) GetDependencies() []string {
 		dependencies = append(dependencies, expr.Component)
 	}
 
-	return dependencies
+	return dependencies, nil
 }
 
 //go:generate mockgen -destination=../../../mocks/mock_deployment_processor.go -package=mocks github.com/Azure/radius/pkg/radrp/deployment DeploymentProcessor

--- a/pkg/radrp/outputresource/info.go
+++ b/pkg/radrp/outputresource/info.go
@@ -13,14 +13,14 @@ import (
 
 // OutputResource represents the output of rendering a resource
 type OutputResource struct {
-	LocalID   string `validate:"required"`
-	Type      string
-	Kind      string
-	Deployed  bool
-	Managed   bool
-	Info      interface{}
-	Resource  interface{}
-	DependsOn []OutputResource // resources that are required to be deployed before this resource can be deployed
+	LocalID      string
+	Type         string
+	Kind         string
+	Deployed     bool
+	Managed      bool
+	Info         interface{}
+	Resource     interface{}
+	Dependencies []OutputResource // resources that are required to be deployed before this resource can be deployed
 }
 
 // ARMInfo info required to identify an ARM resource
@@ -53,7 +53,7 @@ func (resource OutputResource) Key() string {
 // GetDependencies returns list of localId of output resources the resource depends on.
 func (resource OutputResource) GetDependencies() ([]string, error) {
 	dependencies := []string{}
-	for _, dependency := range resource.DependsOn {
+	for _, dependency := range resource.Dependencies {
 		if dependency.LocalID == "" {
 			return dependencies, fmt.Errorf("missing localID for outputresource kind: %s", dependency.Kind)
 		}
@@ -64,7 +64,7 @@ func (resource OutputResource) GetDependencies() ([]string, error) {
 }
 
 // OrderOutputResources returns output resources ordered based on deployment order
-func (resource OutputResource) OrderOutputResources(outputResources []OutputResource) ([]OutputResource, error) {
+func OrderOutputResources(outputResources []OutputResource) ([]OutputResource, error) {
 	unorderedItems := []graph.DependencyItem{}
 	for _, outputResource := range outputResources {
 		unorderedItems = append(unorderedItems, outputResource)

--- a/pkg/radrp/outputresource/info.go
+++ b/pkg/radrp/outputresource/info.go
@@ -5,15 +5,22 @@
 
 package outputresource
 
+import (
+	"fmt"
+
+	"github.com/Azure/radius/pkg/algorithm/graph"
+)
+
 // OutputResource represents the output of rendering a resource
 type OutputResource struct {
-	Resource interface{}
-	Kind     string
-	LocalID  string
-	Deployed bool
-	Managed  bool
-	Type     string
-	Info     interface{}
+	LocalID   string `validate:"required"`
+	Type      string
+	Kind      string
+	Deployed  bool
+	Managed   bool
+	Info      interface{}
+	Resource  interface{}
+	DependsOn []OutputResource // resources that are required to be deployed before this resource can be deployed
 }
 
 // ARMInfo info required to identify an ARM resource
@@ -36,4 +43,47 @@ type AADPodIdentity struct {
 	AKSClusterName string `bson:"aksClusterName"`
 	Name           string `bson:"name"`
 	Namespace      string `bson:"namespace"`
+}
+
+// Key localID of the output resource is used as the key in DependencyItem for output resources.
+func (resource OutputResource) Key() string {
+	return resource.LocalID
+}
+
+// GetDependencies returns list of localId of output resources the resource depends on.
+func (resource OutputResource) GetDependencies() ([]string, error) {
+	dependencies := []string{}
+	for _, dependency := range resource.DependsOn {
+		if dependency.LocalID == "" {
+			return dependencies, fmt.Errorf("missing localID for outputresource kind: %s", dependency.Kind)
+		}
+		dependencies = append(dependencies, dependency.LocalID)
+	}
+
+	return dependencies, nil
+}
+
+// OrderOutputResources returns output resources ordered based on deployment order
+func (resource OutputResource) OrderOutputResources(outputResources []OutputResource) ([]OutputResource, error) {
+	unorderedItems := []graph.DependencyItem{}
+	for _, outputResource := range outputResources {
+		unorderedItems = append(unorderedItems, outputResource)
+	}
+
+	dependencyGraph, err := graph.ComputeDependencyGraph(unorderedItems)
+	if err != nil {
+		return nil, err
+	}
+
+	orderedItems, err := dependencyGraph.Order()
+	if err != nil {
+		return nil, err
+	}
+
+	orderedOutput := []OutputResource{}
+	for _, item := range orderedItems {
+		orderedOutput = append(orderedOutput, item.(OutputResource))
+	}
+
+	return orderedOutput, nil
 }

--- a/pkg/radrp/outputresource/outputresource_test.go
+++ b/pkg/radrp/outputresource/outputresource_test.go
@@ -1,0 +1,97 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package outputresource
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDependencies(t *testing.T) {
+	outputResource, _ := getTestOutputResourceWithDependencies()
+
+	dependencies, err := outputResource.GetDependencies()
+	require.NoError(t, err)
+	require.Equal(t, []string{LocalIDUserAssignedManagedIdentityKV, LocalIDRoleAssignmentKVKeys},
+		dependencies)
+}
+
+func TestGetDependencies_MissingLocalID(t *testing.T) {
+	testResource1 := OutputResource{
+		Type: TypeARM,
+		Kind: KindAzureRoleAssignment,
+	}
+
+	testResource2 := OutputResource{
+		LocalID:      LocalIDRoleAssignmentKVKeys,
+		Type:         TypeARM,
+		Kind:         KindAzureRoleAssignment,
+		Dependencies: []OutputResource{testResource1},
+	}
+
+	_, err := testResource2.GetDependencies()
+	expectedErrorMsg := fmt.Sprintf("missing localID for outputresource kind: %s", KindAzureRoleAssignment)
+	require.EqualError(t, err, expectedErrorMsg)
+}
+
+func TestGetDependencies_Empty(t *testing.T) {
+	testOutputResource := OutputResource{
+		LocalID: LocalIDUserAssignedManagedIdentityKV,
+		Type:    TypeARM,
+		Kind:    KindAzureUserAssignedManagedIdentity,
+	}
+
+	dependencies, err := testOutputResource.GetDependencies()
+	require.NoError(t, err)
+	require.Empty(t, dependencies)
+}
+
+func TestOrderOutputResources(t *testing.T) {
+	_, outputResourcesMap := getTestOutputResourceWithDependencies()
+	outputResources := []OutputResource{}
+	for _, resource := range outputResourcesMap {
+		outputResources = append(outputResources, resource)
+	}
+	ordered, err := OrderOutputResources(outputResources)
+	require.NoError(t, err)
+
+	expected := []OutputResource{outputResourcesMap[LocalIDUserAssignedManagedIdentityKV], outputResourcesMap[LocalIDRoleAssignmentKVKeys],
+		outputResourcesMap[LocalIDAADPodIdentity]}
+	require.Equal(t, expected, ordered)
+}
+
+// Returns output resource with multiple dependencies and a map of localID/unordered list of output resources
+func getTestOutputResourceWithDependencies() (OutputResource, map[string]OutputResource) {
+	managedIdentity := OutputResource{
+		LocalID: LocalIDUserAssignedManagedIdentityKV,
+		Type:    TypeARM,
+		Kind:    KindAzureUserAssignedManagedIdentity,
+	}
+
+	roleAssignmentKeys := OutputResource{
+		LocalID:      LocalIDRoleAssignmentKVKeys,
+		Type:         TypeARM,
+		Kind:         KindAzureRoleAssignment,
+		Dependencies: []OutputResource{managedIdentity},
+	}
+
+	aadPodIdentity := OutputResource{
+		LocalID:      LocalIDAADPodIdentity,
+		Type:         TypeAADPodIdentity,
+		Kind:         KindAzurePodIdentity,
+		Dependencies: []OutputResource{managedIdentity, roleAssignmentKeys},
+	}
+
+	outputResources := map[string]OutputResource{
+		LocalIDAADPodIdentity:                aadPodIdentity,
+		LocalIDUserAssignedManagedIdentityKV: managedIdentity,
+		LocalIDRoleAssignmentKVKeys:          roleAssignmentKeys,
+	}
+
+	return aadPodIdentity, outputResources
+}


### PR DESCRIPTION
Implement DependencyItem interface for output resources. Using local ID as the unique identifier for output resource.