### PR TITLE
Log output from k8s pods/containers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -179,8 +179,7 @@ jobs:
       DOCKER_REGISTRY: radius.azurecr.io
       # Timeout used for Kubernetes functional tests
       K8S_FUNCTIONALTEST_TIMEOUT: 60m
-      # Used for container output paths
-      RADIUS_CONTAINER_LOG_PATH: $GITHUB_WORKSPACE/dist/container_logs
+      RADIUS_CONTAINER_LOG_BASE: dist/container_logs
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -226,12 +225,13 @@ jobs:
       run: |
         export PATH=$GITHUB_WORKSPACE/dist:$PATH
         export TEST_TIMEOUT=${{ env.K8S_FUNCTIONALTEST_TIMEOUT }}
+        export RADIUS_CONTAINER_LOG_PATH=$GITHUB_WORKSPACE/${{ env.RADIUS_CONTAINER_LOG_BASE }}
         make test-functional-kubernetes
     - name: Upload container logs
       uses: actions/upload-artifact@master
       with:
         name: container_logs
-        path: ${{ env.RADIUS_CONTAINER_LOG_PATH }}
+        path: ./${{ env.RADIUS_CONTAINER_LOG_BASE }}
   deploy_tests: 
     name: Run deployment tests
     needs: [ 'build', 'images' ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -227,6 +227,11 @@ jobs:
         export PATH=$GITHUB_WORKSPACE/dist:$PATH
         export TEST_TIMEOUT=${{ env.K8S_FUNCTIONALTEST_TIMEOUT }}
         make test-functional-kubernetes
+    - name: Upload container logs
+      uses: actions/upload-artifact@master
+      with:
+        name: container_logs
+        path: ${{ env.RADIUS_CONTAINER_LOG_PATH }}
   deploy_tests: 
     name: Run deployment tests
     needs: [ 'build', 'images' ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -179,6 +179,8 @@ jobs:
       DOCKER_REGISTRY: radius.azurecr.io
       # Timeout used for Kubernetes functional tests
       K8S_FUNCTIONALTEST_TIMEOUT: 60m
+      # Used for container output paths
+      RADIUS_CONTAINER_LOG_PATH: ${{ env.ARTIFACT_DIR }}/container_logs/
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -180,7 +180,7 @@ jobs:
       # Timeout used for Kubernetes functional tests
       K8S_FUNCTIONALTEST_TIMEOUT: 60m
       # Used for container output paths
-      RADIUS_CONTAINER_LOG_PATH: ./dist/container_logs/
+      RADIUS_CONTAINER_LOG_PATH: $GITHUB_WORKSPACE/dist/container_logs
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -180,7 +180,7 @@ jobs:
       # Timeout used for Kubernetes functional tests
       K8S_FUNCTIONALTEST_TIMEOUT: 60m
       # Used for container output paths
-      RADIUS_CONTAINER_LOG_PATH: ${{ env.ARTIFACT_DIR }}/container_logs/
+      RADIUS_CONTAINER_LOG_PATH: ./dist/container_logs/
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/build/test.mk
+++ b/build/test.mk
@@ -7,6 +7,7 @@
 
 # Will be set by our build workflow, this is just a default
 TEST_TIMEOUT ?=1h
+RADIUS_CONTAINER_LOG_PATH ?=./dist/container_logs
 
 .PHONY: test
 test: ## Runs unit tests, excluding kubernetes controller tests

--- a/test/kubernetestest/kubernetestest.go
+++ b/test/kubernetestest/kubernetestest.go
@@ -146,13 +146,13 @@ func (at ApplicationTest) Test(t *testing.T) {
 	}
 
 	radiusControllerLogSync.Do(func() {
-		err := validation.StreamContainerLogs(ctx, at.Options.K8sClient, "radius-system", logPrefix)
+		err := validation.SaveContainerLogs(ctx, at.Options.K8sClient, "radius-system", logPrefix)
 		if err != nil {
 			t.Errorf("failed to capture logs from radius controller: %w", err)
 		}
 	})
 
-	err := validation.StreamAndWatchContainerLogs(ctx, at.Options.K8sClient, "default", logPrefix+at.Application, at.Application)
+	err := validation.SaveAndWatchContainerLogsForApp(ctx, at.Options.K8sClient, "default", logPrefix+at.Application, at.Application)
 	if err != nil {
 		t.Errorf("failed to capture logs from radius pods %w", err)
 	}

--- a/test/kubernetestest/kubernetestest.go
+++ b/test/kubernetestest/kubernetestest.go
@@ -139,12 +139,12 @@ func (at ApplicationTest) Test(t *testing.T) {
 	// Each of our tests are isolated to a single application, so they can run in parallel.
 	t.Parallel()
 
-	// Only start capturing controller logs once.
 	logPrefix := os.Getenv(ContainerLogPathEnvVar)
 	if logPrefix == "" {
 		logPrefix = "./container_logs"
 	}
 
+	// Only start capturing controller logs once.
 	radiusControllerLogSync.Do(func() {
 		err := validation.SaveContainerLogs(ctx, at.Options.K8sClient, "radius-system", logPrefix)
 		if err != nil {

--- a/test/kubernetestest/kubernetestest.go
+++ b/test/kubernetestest/kubernetestest.go
@@ -146,13 +146,13 @@ func (at ApplicationTest) Test(t *testing.T) {
 
 	// Only start capturing controller logs once.
 	radiusControllerLogSync.Do(func() {
-		err := validation.SaveContainerLogs(ctx, at.Options.K8sClient, "radius-system", logPrefix)
+		err := validation.SaveLogsForController(ctx, at.Options.K8sClient, "radius-system", logPrefix)
 		if err != nil {
 			t.Errorf("failed to capture logs from radius controller: %w", err)
 		}
 	})
 
-	err := validation.SaveAndWatchContainerLogsForApp(ctx, at.Options.K8sClient, "default", logPrefix+"/"+at.Application, at.Application)
+	err := validation.SaveLogsForApplication(ctx, at.Options.K8sClient, "default", logPrefix+"/"+at.Application, at.Application)
 	if err != nil {
 		t.Errorf("failed to capture logs from radius pods %w", err)
 	}
@@ -175,8 +175,6 @@ func (at ApplicationTest) Test(t *testing.T) {
 			t.Logf("running step %d of %d: %s", i, len(at.Steps), step.Executor.GetDescription())
 			step.Executor.Execute(ctx, t, at.Options)
 			t.Logf("finished running step %d of %d: %s", i, len(at.Steps), step.Executor.GetDescription())
-
-			// after deployment is done, start watching all pods logs.
 
 			if step.Components == nil && step.SkipComponents {
 				t.Logf("skipping validation of components...")

--- a/test/kubernetestest/kubernetestest.go
+++ b/test/kubernetestest/kubernetestest.go
@@ -152,7 +152,7 @@ func (at ApplicationTest) Test(t *testing.T) {
 		}
 	})
 
-	err := validation.SaveAndWatchContainerLogsForApp(ctx, at.Options.K8sClient, "default", logPrefix+at.Application, at.Application)
+	err := validation.SaveAndWatchContainerLogsForApp(ctx, at.Options.K8sClient, "default", logPrefix+"/"+at.Application, at.Application)
 	if err != nil {
 		t.Errorf("failed to capture logs from radius pods %w", err)
 	}

--- a/test/kubernetestest/kubernetestest.go
+++ b/test/kubernetestest/kubernetestest.go
@@ -146,10 +146,16 @@ func (at ApplicationTest) Test(t *testing.T) {
 	}
 
 	radiusControllerLogSync.Do(func() {
-		validation.StreamContainerLogs(ctx, at.Options.K8sClient, "radius-system", logPrefix)
+		err := validation.StreamContainerLogs(ctx, at.Options.K8sClient, "radius-system", logPrefix)
+		if err != nil {
+			t.Errorf("failed to capture logs from radius controller: %w", err)
+		}
 	})
 
-	validation.StreamAndWatchContainerLogs(ctx, at.Options.K8sClient, "default", logPrefix+at.Application, at.Application)
+	err := validation.StreamAndWatchContainerLogs(ctx, at.Options.K8sClient, "default", logPrefix+at.Application, at.Application)
+	if err != nil {
+		t.Errorf("failed to capture logs from radius pods %w", err)
+	}
 
 	cli := radcli.NewCLI(t, at.Options.ConfigFilePath)
 
@@ -210,7 +216,7 @@ func (at ApplicationTest) Test(t *testing.T) {
 
 	// Cleanup code here will run regardless of pass/fail of subtests
 	t.Logf("deleting %s", at.Description)
-	err := cli.ApplicationDelete(ctx, at.Application)
+	err = cli.ApplicationDelete(ctx, at.Application)
 	require.NoErrorf(t, err, "failed to delete %s", at.Description)
 	t.Logf("finished deleting %s", at.Description)
 

--- a/test/validation/k8s.go
+++ b/test/validation/k8s.go
@@ -95,8 +95,8 @@ func ValidateDeploymentsRunning(ctx context.Context, t *testing.T, k8s *kubernet
 	}
 }
 
-// SaveContainerLogs get container logs for all containers in the pod and saves them to disk.
-func StreamContainerLogs(ctx context.Context, k8s *kubernetes.Clientset, namespace string, logPrefix string) error {
+// SaveContainerLogs get container logs for all containers in a namespace and saves them to disk.
+func SaveContainerLogs(ctx context.Context, k8s *kubernetes.Clientset, namespace string, logPrefix string) error {
 	if err := os.MkdirAll(logPrefix, os.ModePerm); err != nil {
 		log.Printf("Failed to create output log directory '%s' Error was: '%s'. Container logs will be discarded", logPrefix, err)
 		return nil
@@ -119,8 +119,8 @@ func StreamContainerLogs(ctx context.Context, k8s *kubernetes.Clientset, namespa
 	return nil
 }
 
-// SaveContainerLogs get container logs for all containers in the pod and saves them to disk.
-func StreamAndWatchContainerLogs(ctx context.Context, k8s *kubernetes.Clientset, namespace string, logPrefix string, appName string) error {
+// SaveAndWatchContainerLogsForApp watches for all containers in a namespace and saves them to disk.
+func SaveAndWatchContainerLogsForApp(ctx context.Context, k8s *kubernetes.Clientset, namespace string, logPrefix string, appName string) error {
 	if err := os.MkdirAll(logPrefix, os.ModePerm); err != nil {
 		log.Printf("Failed to create output log directory '%s' Error was: '%s'. Container logs will be discarded", logPrefix, err)
 		return nil
@@ -162,6 +162,7 @@ func StreamAndWatchContainerLogs(ctx context.Context, k8s *kubernetes.Clientset,
 	return nil
 }
 
+// See https://github.com/dapr/dapr/blob/22bb68bc89a86fc64c2c27dfd219ba68a38fb2ad/tests/platforms/kubernetes/appmanager.go#L706 for reference.
 func streamLogFile(ctx context.Context, podClient v1.PodInterface, pod corev1.Pod, container corev1.Container, logPrefix string) {
 	filename := fmt.Sprintf("%s/%s.%s.log", logPrefix, pod.Name, container.Name)
 	log.Printf("Streaming Kubernetes logs to %s", filename)
@@ -234,8 +235,6 @@ func ValidatePodsRunning(ctx context.Context, t *testing.T, k8s *kubernetes.Clie
 
 				for _, actualPod := range actualPods.Items {
 					// validate that this matches one of our expected pods
-					// Log all output of the pod
-
 					index := matchesExpectedLabels(remaining, actualPod.Labels)
 					if index == nil {
 						// this is not a match

--- a/test/validation/k8s.go
+++ b/test/validation/k8s.go
@@ -177,14 +177,14 @@ func streamLogFile(ctx context.Context, podClient v1.PodInterface, pod corev1.Po
 		if err == io.EOF {
 			break
 		}
-
-		if numBytes == 0 {
-			continue
-		}
-
+		
 		if err != nil {
 			log.Printf("Error reading log stream for %s. Error was %s", filename, err)
 			return
+		}
+
+		if numBytes == 0 {
+			continue
 		}
 
 		_, err = fh.Write(buf[:numBytes])

--- a/test/validation/k8s.go
+++ b/test/validation/k8s.go
@@ -102,7 +102,7 @@ func SaveLogsForController(ctx context.Context, k8s *kubernetes.Clientset, names
 
 // SaveAndWatchContainerLogsForApp watches for all containers in a namespace and saves them to disk.
 func SaveLogsForApplication(ctx context.Context, k8s *kubernetes.Clientset, namespace string, logPrefix string, appName string) error {
-	return watchForPods(ctx, k8s, namespace, logPrefix, fmt.Sprintf("%s=%s", keys.LabelRadiusApplication, appName))
+	return watchForPods(ctx, k8s, namespace, logPrefix, fmt.Sprintf("%s=%s", kuberneteskeys.LabelRadiusApplication, appName))
 }
 
 func watchForPods(ctx context.Context, k8s *kubernetes.Clientset, namespace string, logPrefix string, labelSelector string) error {


### PR DESCRIPTION
Fixes https://github.com/Azure/radius/issues/710
- Captures output from all pods that start, including the radius controller, and uploads them as artifacts
  - Only runs the radius controller log capture once for all test runs
  - Run watch on each application name so each test logs
