### PR TITLE
Don't delete the resource group if we are deleting an environment

### DIFF
--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -6,9 +6,11 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Azure/radius/pkg/cli"
+	"github.com/Azure/radius/pkg/cli/clients"
 	"github.com/Azure/radius/pkg/cli/environments"
 	"github.com/Azure/radius/pkg/cli/prompt"
 	"github.com/spf13/cobra"
@@ -63,30 +65,39 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	deploymentList, err := client.ListDeployments(cmd.Context(), applicationName)
+	err = appDeleteInner(cmd.Context(), client, applicationName, env)
 	if err != nil {
 		return err
 	}
 
-	// Delete the deployments
+	err = updateApplicationConfig(config, env, applicationName)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+func appDeleteInner(ctx context.Context, client clients.ManagementClient, applicationName string, env environments.Environment) error {
+	deploymentList, err := client.ListDeployments(ctx, applicationName)
+	if err != nil {
+		return err
+	}
+
 	for _, deploymentResource := range deploymentList.Value {
+		// Delete the deployments
 		// This is needed until server side implementation is fixed https://github.com/Azure/radius/issues/159
 		deploymentName := *deploymentResource.Name
-		err = client.DeleteDeployment(cmd.Context(), applicationName, deploymentName)
+		err = client.DeleteDeployment(ctx, applicationName, deploymentName)
 		if err != nil {
 			return fmt.Errorf("delete deployment error: %w", err)
 		}
 		fmt.Printf("Deployment '%s' deleted.\n", deploymentName)
 	}
 
-	err = client.DeleteApplication(cmd.Context(), applicationName)
+	err = client.DeleteApplication(ctx, applicationName)
 	if err != nil {
 		return fmt.Errorf("delete application error: %w", err)
-	}
-
-	err = updateApplicationConfig(config, env, applicationName)
-	if err != nil {
-		return err
 	}
 
 	fmt.Printf("Application '%s' has been deleted\n", applicationName)

--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -101,7 +101,7 @@ func appDeleteInner(ctx context.Context, client clients.ManagementClient, applic
 		return fmt.Errorf("delete application error: %w", err)
 	}
 
-	fmt.Printf("Application '%s' has been deleted. Updating config file\n", applicationName)
+	fmt.Printf("Application '%s' has been deleted.\n", applicationName)
 	return nil
 }
 

--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -101,7 +101,7 @@ func appDeleteInner(ctx context.Context, client clients.ManagementClient, applic
 		return fmt.Errorf("delete application error: %w", err)
 	}
 
-	fmt.Printf("Application '%s' has been deleted\n", applicationName)
+	fmt.Printf("Application '%s' has been deleted. Updating config file\n", applicationName)
 	return nil
 }
 

--- a/cmd/cli/cmd/appDelete.go
+++ b/cmd/cli/cmd/appDelete.go
@@ -78,6 +78,7 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 	return err
 }
 
+// appDeleteInner deletes an application without argument/flag validation.
 func appDeleteInner(ctx context.Context, client clients.ManagementClient, applicationName string, env environments.Environment) error {
 	deploymentList, err := client.ListDeployments(ctx, applicationName)
 	if err != nil {

--- a/cmd/cli/cmd/envDelete.go
+++ b/cmd/cli/cmd/envDelete.go
@@ -73,7 +73,7 @@ func deleteEnv(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		// Delete environment, this will delete the resource group and all the resources in it
+		// Delete environment, this will delete all the resources in the resource group
 		if err = deleteRadiusResourcesInResourceGroup(cmd.Context(), authorizer, az.ResourceGroup, az.SubscriptionID); err != nil {
 			return err
 		}

--- a/cmd/cli/cmd/envDelete.go
+++ b/cmd/cli/cmd/envDelete.go
@@ -124,6 +124,9 @@ func deleteRadiusResourcesInResourceGroup(ctx context.Context, authorizer autore
 	}
 
 	for ; page.NotDone(); err = page.NextWithContext(ctx) {
+		if err != nil {
+			return err
+		}
 		for _, r := range page.Values() {
 			defaultApiVersion, err := azclients.GetDefaultAPIVersion(ctx, subscriptionID, authorizer, *r.Type)
 			if err != nil {

--- a/cmd/cli/cmd/envDelete.go
+++ b/cmd/cli/cmd/envDelete.go
@@ -139,12 +139,9 @@ func deleteRadiusResourcesInResourceGroup(ctx context.Context, authorizer autore
 			if err = future.WaitForCompletionRef(ctx, resourceClient.Client); err != nil {
 				return err
 			}
-			res, err := future.Result(resourceClient)
+			_, err = future.Result(resourceClient)
 			if err != nil {
 				return err
-			}
-			if res.StatusCode != 204 {
-				return fmt.Errorf("Failed to delete resource: %v", res.StatusCode)
 			}
 		}
 	}

--- a/cmd/cli/cmd/envDelete.go
+++ b/cmd/cli/cmd/envDelete.go
@@ -138,7 +138,7 @@ func deleteRadiusResourcesInResourceGroup(ctx context.Context, authorizer autore
 				return err
 			}
 
-			output.LogInfo("Deleting radius resource %s", r.Name)
+			output.LogInfo("Deleting radius resource %s", *r.Name)
 
 			future, err := resourceClient.DeleteByID(ctx, *r.ID, defaultApiVersion)
 			if err != nil {

--- a/cmd/cli/cmd/envDelete.go
+++ b/cmd/cli/cmd/envDelete.go
@@ -93,6 +93,7 @@ func deleteEnv(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// deleteAllApplications deletes all applications from a resource group.
 func deleteAllApplications(ctx context.Context, authorizer autorest.Authorizer, resourceGroup string, subscriptionID string, env *environments.AzureCloudEnvironment) error {
 	client, err := environments.CreateManagementClient(ctx, env)
 	if err != nil {
@@ -113,11 +114,12 @@ func deleteAllApplications(ctx context.Context, authorizer autorest.Authorizer, 
 	return nil
 }
 
+// deleteRadiusResourcesInResourceGroup deletes all radius resources from the customer/user resource group.
+// Currently the custom resource provider is the only resource in the user's environment that has this tag.
 func deleteRadiusResourcesInResourceGroup(ctx context.Context, authorizer autorest.Authorizer, resourceGroup string, subscriptionID string) error {
 	resourceClient := azclients.NewResourcesClient(subscriptionID, authorizer)
 
-	// Filter for all resources by rad-environment=True and delete them.
-	// Currently the custom resource provider is the only resource in the user's environment that has this tag.
+	// Filter for all resources by rad-environment=True.
 	page, err := resourceClient.ListByResourceGroup(ctx, resourceGroup, "tagName eq '"+keys.TagRadiusEnvironment+"' and tagValue eq 'True'", "", nil)
 	if err != nil {
 		return err
@@ -132,7 +134,7 @@ func deleteRadiusResourcesInResourceGroup(ctx context.Context, authorizer autore
 			if err != nil {
 				return err
 			}
-			future, err := resourceClient.Delete(ctx, resourceGroup, "", "", *r.Type, *r.Name, defaultApiVersion)
+			future, err := resourceClient.Delete(ctx, resourceGroup, "" /* resourceProviderNamespace */, "" /* parentResourcePath */, *r.Type, *r.Name, defaultApiVersion)
 			if err != nil {
 				return err
 			}

--- a/cmd/cli/cmd/envDelete.go
+++ b/cmd/cli/cmd/envDelete.go
@@ -137,6 +137,9 @@ func deleteRadiusResourcesInResourceGroup(ctx context.Context, authorizer autore
 			if err != nil {
 				return err
 			}
+
+			output.LogInfo("Deleting radius resource %s", r.Name)
+
 			future, err := resourceClient.DeleteByID(ctx, *r.ID, defaultApiVersion)
 			if err != nil {
 				return err

--- a/pkg/azclients/common.go
+++ b/pkg/azclients/common.go
@@ -1,0 +1,41 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package azclients
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/go-autorest/autorest"
+)
+
+func GetDefaultAPIVersion(ctx context.Context, subscriptionId string, authorizer autorest.Authorizer, entireType string) (string, error) {
+	parts := strings.Split(entireType, "/")
+	provider := parts[0]
+	resourceType := parts[1]
+
+	providerc := NewProvidersClient(subscriptionId, authorizer)
+
+	p, err := providerc.Get(ctx, provider, "")
+	if err != nil {
+		return "", err
+	}
+
+	for _, rt := range *p.ResourceTypes {
+		if strings.EqualFold(*rt.ResourceType, resourceType) {
+			if rt.DefaultAPIVersion != nil {
+				return *rt.DefaultAPIVersion, nil
+			} else if rt.APIProfiles != nil && len(*rt.APIVersions) > 0 {
+				return (*rt.APIVersions)[0], nil
+			} else {
+				return "", fmt.Errorf("no valid api version for type %s", entireType)
+			}
+		}
+	}
+
+	return "", nil // unreachable
+}

--- a/pkg/azclients/common.go
+++ b/pkg/azclients/common.go
@@ -29,7 +29,7 @@ func GetDefaultAPIVersion(ctx context.Context, subscriptionId string, authorizer
 		if strings.EqualFold(*rt.ResourceType, resourceType) {
 			if rt.DefaultAPIVersion != nil {
 				return *rt.DefaultAPIVersion, nil
-			} else if rt.APIProfiles != nil && len(*rt.APIVersions) > 0 {
+			} else if rt.APIVersions != nil && len(*rt.APIVersions) > 0 {
 				return (*rt.APIVersions)[0], nil
 			} else {
 				return "", fmt.Errorf("no valid api version for type %s", entireType)

--- a/pkg/azclients/common.go
+++ b/pkg/azclients/common.go
@@ -13,10 +13,10 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 )
 
-func GetDefaultAPIVersion(ctx context.Context, subscriptionId string, authorizer autorest.Authorizer, t string /* type */) (string, error) {
-	parts := strings.Split(t, "/")
+func GetDefaultAPIVersion(ctx context.Context, subscriptionId string, authorizer autorest.Authorizer, resourceType string) (string, error) {
+	parts := strings.Split(resourceType, "/")
 	provider := parts[0]
-	resourceType := parts[1]
+	typeWithoutProvider := parts[1]
 
 	providerc := NewProvidersClient(subscriptionId, authorizer)
 
@@ -28,13 +28,13 @@ func GetDefaultAPIVersion(ctx context.Context, subscriptionId string, authorizer
 	// For preview API versions, the DefaultAPIVersion isn't set,
 	// so get the first from the list of APIVersions instead.
 	for _, rt := range *p.ResourceTypes {
-		if strings.EqualFold(*rt.ResourceType, resourceType) {
+		if strings.EqualFold(*rt.ResourceType, typeWithoutProvider) {
 			if rt.DefaultAPIVersion != nil {
 				return *rt.DefaultAPIVersion, nil
 			} else if rt.APIVersions != nil && len(*rt.APIVersions) > 0 {
 				return (*rt.APIVersions)[0], nil
 			} else {
-				return "", fmt.Errorf("no valid api version for type %s", t)
+				return "", fmt.Errorf("no valid api version for type %s", resourceType)
 			}
 		}
 	}

--- a/pkg/azclients/common.go
+++ b/pkg/azclients/common.go
@@ -13,8 +13,8 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 )
 
-func GetDefaultAPIVersion(ctx context.Context, subscriptionId string, authorizer autorest.Authorizer, entireType string) (string, error) {
-	parts := strings.Split(entireType, "/")
+func GetDefaultAPIVersion(ctx context.Context, subscriptionId string, authorizer autorest.Authorizer, t string /* type */) (string, error) {
+	parts := strings.Split(t, "/")
 	provider := parts[0]
 	resourceType := parts[1]
 
@@ -25,6 +25,8 @@ func GetDefaultAPIVersion(ctx context.Context, subscriptionId string, authorizer
 		return "", err
 	}
 
+	// For preview API versions, the DefaultAPIVersion isn't set,
+	// so get the first from the list of APIVersions instead.
 	for _, rt := range *p.ResourceTypes {
 		if strings.EqualFold(*rt.ResourceType, resourceType) {
 			if rt.DefaultAPIVersion != nil {
@@ -32,7 +34,7 @@ func GetDefaultAPIVersion(ctx context.Context, subscriptionId string, authorizer
 			} else if rt.APIVersions != nil && len(*rt.APIVersions) > 0 {
 				return (*rt.APIVersions)[0], nil
 			} else {
-				return "", fmt.Errorf("no valid api version for type %s", entireType)
+				return "", fmt.Errorf("no valid api version for type %s", t)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/Azure/radius/issues/90

- Delete the ControlPlaneResourceGroup always
- Delete all applications that are part of the environment
- Delete all resources in the ResourceGroup that belong to radius (custom resource provider)