### PR TITLE
Improve the error message from CLI output by using YAML.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
+	github.com/ghodss/yaml v1.0.0
 	github.com/gibson042/canonicaljson-go v1.0.3
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/zapr v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -278,6 +278,7 @@ github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXt
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7 h1:LofdAjjjqCSXMwLGgOgnE+rdPuvX9DxCqaHwKy7i/ko=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gibson042/canonicaljson-go v1.0.3 h1:EAyF8L74AWabkyUmrvEFHEt/AGFQeD6RfwbAuf0j1bI=
 github.com/gibson042/canonicaljson-go v1.0.3/go.mod h1:DsLpJTThXyGNO+KZlI85C1/KDcImpP67k/RKVjcaEqo=


### PR DESCRIPTION
Since the error message from CLI output has some nested JSON, we attempt to reparse all as YAML, which has good readability even in case of nesting thanks to the `|` quoting syntax.

Part of https://github.com/Azure/radius/issues/31 

We should still follow up with nesting reduction, but this will be a good first step to make the error looks nice. New error output will look like this
```
Error from Radius resource provider:
code: DownstreamEndpointError
details:
- code: Downstream
  message: |
    error:
      code: ""
      message: the resource with id '/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourceGroups/nghiatran-rg/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/foo'
        was not found
      target: /subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourceGroups/nghiatran-rg/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/foo
message: The resource provider 'radius' received a non-success response 'NotFound'
  from the downstream endpoint for the request 'GET' on 'Applications/foo'. Please
  refer to additional info for details.
```