### PR TITLE
Add support for placeholders

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.mongodb.org/mongo-driver v1.5.1
 	go.uber.org/zap v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -898,6 +898,8 @@ github.com/xdg-go/stringprep v1.0.2 h1:6iq84/ryjjeRmMJwxutI51F2GIPlP5BfTvXHeYjyh
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=

--- a/pkg/radrp/outputresource/info.go
+++ b/pkg/radrp/outputresource/info.go
@@ -6,21 +6,31 @@
 package outputresource
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/Azure/radius/pkg/algorithm/graph"
 )
 
 // OutputResource represents the output of rendering a resource
 type OutputResource struct {
-	LocalID      string
-	Type         string
-	Kind         string
-	Deployed     bool
-	Managed      bool
-	Info         interface{}
-	Resource     interface{}
-	Dependencies []OutputResource // resources that are required to be deployed before this resource can be deployed
+	LocalID  string
+	Type     string
+	Kind     string
+	Deployed bool
+	Managed  bool
+	Info     interface{}
+	Resource interface{}
+
+	// Dependencies on OutputResources that are required to be deployed before this resource can be deployed
+	Dependencies []Dependency
+}
+
+// Dependency respresents a dependency on another OutputResource.
+type Dependency struct {
+	// LocalID is the LocalID of the dependency.
+	LocalID string
+	// Placeholder is a slice of optional placeholder values that can copy values from the dependency.
+	Placeholder []Placeholder
 }
 
 // ARMInfo info required to identify an ARM resource
@@ -55,7 +65,7 @@ func (resource OutputResource) GetDependencies() ([]string, error) {
 	dependencies := []string{}
 	for _, dependency := range resource.Dependencies {
 		if dependency.LocalID == "" {
-			return dependencies, fmt.Errorf("missing localID for outputresource kind: %s", dependency.Kind)
+			return dependencies, errors.New("missing localID for outputresource")
 		}
 		dependencies = append(dependencies, dependency.LocalID)
 	}

--- a/pkg/radrp/outputresource/outputresource_test.go
+++ b/pkg/radrp/outputresource/outputresource_test.go
@@ -6,7 +6,6 @@
 package outputresource
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,11 +30,11 @@ func TestGetDependencies_MissingLocalID(t *testing.T) {
 		LocalID:      LocalIDRoleAssignmentKVKeys,
 		Type:         TypeARM,
 		Kind:         KindAzureRoleAssignment,
-		Dependencies: []OutputResource{testResource1},
+		Dependencies: []Dependency{{LocalID: testResource1.LocalID}},
 	}
 
 	_, err := testResource2.GetDependencies()
-	expectedErrorMsg := fmt.Sprintf("missing localID for outputresource kind: %s", KindAzureRoleAssignment)
+	expectedErrorMsg := "missing localID for outputresource"
 	require.EqualError(t, err, expectedErrorMsg)
 }
 
@@ -77,14 +76,17 @@ func getTestOutputResourceWithDependencies() (OutputResource, map[string]OutputR
 		LocalID:      LocalIDRoleAssignmentKVKeys,
 		Type:         TypeARM,
 		Kind:         KindAzureRoleAssignment,
-		Dependencies: []OutputResource{managedIdentity},
+		Dependencies: []Dependency{{LocalID: managedIdentity.LocalID}},
 	}
 
 	aadPodIdentity := OutputResource{
-		LocalID:      LocalIDAADPodIdentity,
-		Type:         TypeAADPodIdentity,
-		Kind:         KindAzurePodIdentity,
-		Dependencies: []OutputResource{managedIdentity, roleAssignmentKeys},
+		LocalID: LocalIDAADPodIdentity,
+		Type:    TypeAADPodIdentity,
+		Kind:    KindAzurePodIdentity,
+		Dependencies: []Dependency{
+			{LocalID: managedIdentity.LocalID},
+			{LocalID: roleAssignmentKeys.LocalID},
+		},
 	}
 
 	outputResources := map[string]OutputResource{

--- a/pkg/radrp/outputresource/placeholder.go
+++ b/pkg/radrp/outputresource/placeholder.go
@@ -1,0 +1,55 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package outputresource
+
+import (
+	"github.com/xeipuuv/gojsonpointer"
+)
+
+// Placeholder represents a placeholder value in a resource that can get and set a value.
+//
+// Placeholders specify a source and destination using JSON-Pointer notation: https://datatracker.ietf.org/doc/html/rfc6901.
+// Placeholders operate on weakly-typed JSON documents (map[string]interface{} and similar).
+type Placeholder struct {
+	// SourcePointer is the JSON-Pointer to a value in the source document.
+	SourcePointer string
+
+	// DestinationPointer is the JSON-Pointer to a value in the destination document.
+	DestinationPointer string
+}
+
+// GetValue gets a go value from the provided document using SourcePointer. GetValue will return an error if the property
+// pointed to by SourcePointer does not exist.
+func (p Placeholder) GetValue(resource interface{}) (interface{}, error) {
+	pointer, err := gojsonpointer.NewJsonPointer(p.SourcePointer)
+	if err != nil {
+		return nil, err
+	}
+
+	value, _, err := pointer.Get(resource)
+	if err != nil {
+		return nil, err
+	}
+
+	return value, nil
+}
+
+// ApplyValue sets a go value on the provided document using DestinationPointer. SetValue can be used
+// to set an existing property or create a new one. SetValue will return an error if any of the intermediate
+// properties pointed to by DestinationPointer are missing.
+func (p Placeholder) ApplyValue(resource interface{}, value interface{}) error {
+	pointer, err := gojsonpointer.NewJsonPointer(p.DestinationPointer)
+	if err != nil {
+		return err
+	}
+
+	_, err = pointer.Set(resource, value)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/radrp/outputresource/placeholder_test.go
+++ b/pkg/radrp/outputresource/placeholder_test.go
@@ -1,0 +1,96 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package outputresource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Placeholder_GetValue(t *testing.T) {
+	resource := map[string]interface{}{
+		"foo": map[string]interface{}{
+			"bar": "good",
+		},
+		"baz": "bad",
+	}
+
+	t.Run("invalid", func(t *testing.T) {
+		placeholder := Placeholder{
+			SourcePointer: "invalid//",
+		}
+
+		_, err := placeholder.GetValue(resource)
+		require.Error(t, err)
+	})
+
+	t.Run("found", func(t *testing.T) {
+		placeholder := Placeholder{
+			SourcePointer: "/foo/bar",
+		}
+
+		value, err := placeholder.GetValue(resource)
+		require.NoError(t, err)
+		require.Equal(t, "good", value)
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		placeholder := Placeholder{
+			SourcePointer: "/foo/baz",
+		}
+
+		_, err := placeholder.GetValue(resource)
+		require.Error(t, err)
+	})
+}
+
+func Test_Placeholder_SetValue(t *testing.T) {
+	resource := map[string]interface{}{
+		"foo": map[string]interface{}{
+			"bar": "good",
+		},
+		"baz": "bad",
+	}
+
+	t.Run("invalid", func(t *testing.T) {
+		placeholder := Placeholder{
+			DestinationPointer: "invalid//",
+		}
+
+		err := placeholder.ApplyValue(resource, 3)
+		require.Error(t, err)
+	})
+
+	t.Run("set-value", func(t *testing.T) {
+		placeholder := Placeholder{
+			DestinationPointer: "/foo/bar",
+		}
+
+		err := placeholder.ApplyValue(resource, "very-good")
+		require.NoError(t, err)
+		require.Equal(t, "very-good", resource["foo"].(map[string]interface{})["bar"])
+	})
+
+	t.Run("add-value", func(t *testing.T) {
+		placeholder := Placeholder{
+			DestinationPointer: "/foo/another",
+		}
+
+		err := placeholder.ApplyValue(resource, "very-good")
+		require.NoError(t, err)
+		require.Equal(t, "very-good", resource["foo"].(map[string]interface{})["another"])
+	})
+
+	t.Run("missing-intermediate", func(t *testing.T) {
+		placeholder := Placeholder{
+			DestinationPointer: "/foo/missing/another",
+		}
+
+		err := placeholder.ApplyValue(resource, "very-good")
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
This change adds support for placeholders as part of a resource
dependency, this will allow you to copy values from a dependendent
output resource into the body of another resource.

I'm adding the basic plumbing in this PR and kachawla will wire it up to
the deployment processor.

As a recent example of this take a look at how Kubernetes support for
MongoDB works. It 'renders' a Service, Secret, and StatefulSet. The
names of the Service and Secret need to get baked into the `spec` of
the  StatefulSet. This placeholder functionality is for expressing this
kind of dependency.