### PR TITLE
Remove patch version from image tag

### DIFF
--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -1,2 +1,2 @@
 container: radius.azurecr.io/radius-controller
-tag: 0.4 # Tag for radius-controller image, include patch version updates.
+tag: 0.4 # Tag for radius-controller image, exclude patch version.

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -1,2 +1,2 @@
 container: radius.azurecr.io/radius-controller
-tag: 0.4.0 # Tag for radius-controller image, include patch version updates.
+tag: 0.4 # Tag for radius-controller image, include patch version updates.


### PR DESCRIPTION
Found an issue with rad env init kubernetes which cause the radius controller to try downloading the wrong image. This is because the version of the docker images we produce doesn't include a patch version (ex versions [here](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourceGroups/assets/providers/Microsoft.ContainerRegistry/registries/radius/repository) are 0.4 instead of 0.4.0). 

So for the 0.4 release, we'll update it here and consider a broader conversation on whether our docker images should include a patch version or not.