### PR TITLE
Add additional error codes for `NotFound` and `Conflict`

### DIFF
--- a/pkg/radrp/armerrors/errors.go
+++ b/pkg/radrp/armerrors/errors.go
@@ -10,16 +10,16 @@ package armerrors
 // We get to define our own codes and document them, these are just examples, but consistency doesn't hurt.
 const (
 	// Used for generic validation errors.
-	CodeInvalid = "BadRequest"
+	Invalid = "BadRequest"
 
 	// Used for internal/unclassified failures.
-	CodeInternal = "Internal"
+	Internal = "Internal"
 
 	// Used for NotFound error.
-	CodeNotFound = "NotFound"
+	NotFound = "NotFound"
 
 	// Used for Conflict error.
-	CodeConflict = "Conflict"
+	Conflict = "Conflict"
 )
 
 // see : https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/common-api-details.md#error-response-content

--- a/pkg/radrp/armerrors/errors.go
+++ b/pkg/radrp/armerrors/errors.go
@@ -14,6 +14,12 @@ const (
 
 	// Used for internal/unclassified failures.
 	CodeInternal = "Internal"
+
+	// Used for NotFound error.
+	CodeNotFound = "NotFound"
+
+	// Used for Conflict error.
+	CodeConflict = "Conflict"
 )
 
 // see : https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/common-api-details.md#error-response-content

--- a/pkg/radrp/handler_test.go
+++ b/pkg/radrp/handler_test.go
@@ -345,7 +345,7 @@ func Test_GetApplication_NotFound(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
-			Code:    armerrors.CodeNotFound,
+			Code:    armerrors.NotFound,
 			Target:  id.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", id.ID),
 		},
@@ -543,7 +543,7 @@ func Test_GetComponent_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
-			Code:    armerrors.CodeNotFound,
+			Code:    armerrors.NotFound,
 			Target:  id.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", id.ID),
 		},
@@ -566,7 +566,7 @@ func Test_GetComponent_NotFound(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
-			Code:    armerrors.CodeNotFound,
+			Code:    armerrors.NotFound,
 			Target:  id.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", id.ID),
 		},
@@ -620,7 +620,7 @@ func Test_ListComponents_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
-			Code:    armerrors.CodeNotFound,
+			Code:    armerrors.NotFound,
 			Target:  a.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", a.ID),
 		},
@@ -700,7 +700,7 @@ func Test_UpdateComponent_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
-			Code:    armerrors.CodeNotFound,
+			Code:    armerrors.NotFound,
 			Target:  a.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", a.ID),
 		},
@@ -891,7 +891,7 @@ func Test_GetDeployment_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
-			Code:    armerrors.CodeNotFound,
+			Code:    armerrors.NotFound,
 			Target:  id.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", id.ID),
 		},
@@ -914,7 +914,7 @@ func Test_GetDeployment_NotFound(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
-			Code:    armerrors.CodeNotFound,
+			Code:    armerrors.NotFound,
 			Target:  id.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", id.ID),
 		},
@@ -965,7 +965,7 @@ func Test_ListDeployments_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
-			Code:    armerrors.CodeNotFound,
+			Code:    armerrors.NotFound,
 			Target:  a.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", a.ID),
 		},
@@ -1043,7 +1043,7 @@ func Test_UpdateDeployment_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
-			Code:    armerrors.CodeNotFound,
+			Code:    armerrors.NotFound,
 			Target:  a.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", a.ID),
 		},
@@ -1176,7 +1176,7 @@ func Test_UpdateDeployment_Create_ValidationFailure(t *testing.T) {
 
 	require.Equal(t, 400, code)
 	require.NotNil(t, armerr)
-	require.Equal(t, armerrors.CodeInvalid, armerr.Error.Code)
+	require.Equal(t, armerrors.Invalid, armerr.Error.Code)
 	require.Equal(t, "deployment was invalid :(", armerr.Error.Message)
 }
 
@@ -1241,7 +1241,7 @@ func Test_UpdateDeployment_Create_Failure(t *testing.T) {
 
 	require.Equal(t, 500, code)
 	require.NotNil(t, armerr)
-	require.Equal(t, armerrors.CodeInternal, armerr.Error.Code)
+	require.Equal(t, armerrors.Internal, armerr.Error.Code)
 	require.Equal(t, "deployment failed :(", armerr.Error.Message)
 }
 
@@ -1325,7 +1325,7 @@ func Test_UpdateDeployment_FailureCanBeRetried(t *testing.T) {
 
 	require.Equal(t, 500, code)
 	require.NotNil(t, armerr)
-	require.Equal(t, armerrors.CodeInternal, armerr.Error.Code)
+	require.Equal(t, armerrors.Internal, armerr.Error.Code)
 	require.Equal(t, "deployment failed :(", armerr.Error.Message)
 
 	// Now retry and it should succeed
@@ -1595,7 +1595,7 @@ func Test_DeleteDeployment_Found_ValidationFailure(t *testing.T) {
 
 	require.Equal(t, 400, code)
 	require.NotNil(t, armerr)
-	require.Equal(t, armerrors.CodeInvalid, armerr.Error.Code)
+	require.Equal(t, armerrors.Invalid, armerr.Error.Code)
 	require.Equal(t, "deletion was invalid :(", armerr.Error.Message)
 }
 
@@ -1653,7 +1653,7 @@ func Test_DeleteDeployment_Found_Failed(t *testing.T) {
 
 	require.Equal(t, 500, code)
 	require.NotNil(t, armerr)
-	require.Equal(t, armerrors.CodeInternal, armerr.Error.Code)
+	require.Equal(t, armerrors.Internal, armerr.Error.Code)
 	require.Equal(t, "deletion failed :(", armerr.Error.Message)
 }
 
@@ -1670,7 +1670,7 @@ func Test_GetScope_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
-			Code:    armerrors.CodeNotFound,
+			Code:    armerrors.NotFound,
 			Target:  id.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", id.ID),
 		},
@@ -1693,7 +1693,7 @@ func Test_GetScope_NotFound(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
-			Code:    armerrors.CodeNotFound,
+			Code:    armerrors.NotFound,
 			Target:  id.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", id.ID),
 		},
@@ -1743,7 +1743,7 @@ func Test_ListScopes_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
-			Code:    armerrors.CodeNotFound,
+			Code:    armerrors.NotFound,
 			Target:  a.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", a.ID),
 		},
@@ -1819,7 +1819,7 @@ func Test_UpdateScopes_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
-			Code:    armerrors.CodeNotFound,
+			Code:    armerrors.NotFound,
 			Target:  a.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", a.ID),
 		},

--- a/pkg/radrp/handler_test.go
+++ b/pkg/radrp/handler_test.go
@@ -345,6 +345,7 @@ func Test_GetApplication_NotFound(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
+			Code:    armerrors.CodeNotFound,
 			Target:  id.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", id.ID),
 		},
@@ -542,6 +543,7 @@ func Test_GetComponent_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
+			Code:    armerrors.CodeNotFound,
 			Target:  id.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", id.ID),
 		},
@@ -564,6 +566,7 @@ func Test_GetComponent_NotFound(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
+			Code:    armerrors.CodeNotFound,
 			Target:  id.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", id.ID),
 		},
@@ -617,6 +620,7 @@ func Test_ListComponents_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
+			Code:    armerrors.CodeNotFound,
 			Target:  a.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", a.ID),
 		},
@@ -696,6 +700,7 @@ func Test_UpdateComponent_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
+			Code:    armerrors.CodeNotFound,
 			Target:  a.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", a.ID),
 		},
@@ -886,6 +891,7 @@ func Test_GetDeployment_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
+			Code:    armerrors.CodeNotFound,
 			Target:  id.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", id.ID),
 		},
@@ -908,6 +914,7 @@ func Test_GetDeployment_NotFound(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
+			Code:    armerrors.CodeNotFound,
 			Target:  id.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", id.ID),
 		},
@@ -958,6 +965,7 @@ func Test_ListDeployments_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
+			Code:    armerrors.CodeNotFound,
 			Target:  a.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", a.ID),
 		},
@@ -1035,6 +1043,7 @@ func Test_UpdateDeployment_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
+			Code:    armerrors.CodeNotFound,
 			Target:  a.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", a.ID),
 		},
@@ -1661,6 +1670,7 @@ func Test_GetScope_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
+			Code:    armerrors.CodeNotFound,
 			Target:  id.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", id.ID),
 		},
@@ -1683,6 +1693,7 @@ func Test_GetScope_NotFound(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
+			Code:    armerrors.CodeNotFound,
 			Target:  id.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", id.ID),
 		},
@@ -1732,6 +1743,7 @@ func Test_ListScopes_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
+			Code:    armerrors.CodeNotFound,
 			Target:  a.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", a.ID),
 		},
@@ -1807,6 +1819,7 @@ func Test_UpdateScopes_NoApplication(t *testing.T) {
 
 	expected := &armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
+			Code:    armerrors.CodeNotFound,
 			Target:  a.ID,
 			Message: fmt.Sprintf("the resource with id '%s' was not found", a.ID),
 		},

--- a/pkg/radrp/resourceprovider.go
+++ b/pkg/radrp/resourceprovider.go
@@ -438,7 +438,7 @@ func (r *rp) UpdateDeployment(ctx context.Context, d *rest.Deployment) (rest.Res
 			// Composite error is what we use for validation problems
 			status = rest.FailedStatus
 			failure = &armerrors.ErrorDetails{
-				Code:    armerrors.CodeInvalid,
+				Code:    armerrors.Invalid,
 				Message: err.Error(),
 				Target:  id.Resource.ID,
 			}
@@ -447,7 +447,7 @@ func (r *rp) UpdateDeployment(ctx context.Context, d *rest.Deployment) (rest.Res
 			// Other errors represent a generic failure, this should map to a 500.
 			status = rest.FailedStatus
 			failure = &armerrors.ErrorDetails{
-				Code:    armerrors.CodeInternal,
+				Code:    armerrors.Internal,
 				Message: err.Error(),
 				Target:  id.Resource.ID,
 			}
@@ -582,14 +582,14 @@ func (r *rp) DeleteDeployment(ctx context.Context, id resources.ResourceID) (res
 			// Composite error is what we use for validation problems
 			status = rest.FailedStatus
 			failure = &armerrors.ErrorDetails{
-				Code:    armerrors.CodeInvalid,
+				Code:    armerrors.Invalid,
 				Message: err.Error(),
 				Target:  d.Resource.ID,
 			}
 		} else if err != nil {
 			status = rest.FailedStatus
 			failure = &armerrors.ErrorDetails{
-				Code:    armerrors.CodeInternal,
+				Code:    armerrors.Internal,
 				Message: err.Error(),
 				Target:  d.Resource.ID,
 			}
@@ -760,7 +760,7 @@ func (r *rp) GetDeploymentOperationByID(ctx context.Context, id resources.Resour
 	// The resource body just has the provisioning status, and doesn't have the ability to give a reason
 	// for failure. We use the operation for that. If there's a failure, return it in the ARM format,
 	// otherwise we just want to return the same thing the deployment resource would return.
-	if operation.Error != nil && operation.Error.Code == armerrors.CodeInvalid {
+	if operation.Error != nil && operation.Error.Code == armerrors.Invalid {
 		// Operation failed with a validation or business logic error
 		return rest.NewBadRequestARMResponse(armerrors.ErrorResponse{
 			Error: *operation.Error,

--- a/pkg/radrp/rest/results.go
+++ b/pkg/radrp/rest/results.go
@@ -197,6 +197,7 @@ func NewBadRequestResponse(message string) Response {
 	return &BadRequestResponse{
 		Body: armerrors.ErrorResponse{
 			Error: armerrors.ErrorDetails{
+				Code:    armerrors.CodeInvalid,
 				Message: message,
 			},
 		},
@@ -233,6 +234,7 @@ type ValidationErrorResponse struct {
 func NewValidationErrorResponse(errors validator.ValidationErrors) Response {
 	body := armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
+			Code:    armerrors.CodeInvalid,
 			Message: errors.Error(),
 		},
 	}
@@ -277,6 +279,7 @@ func NewNotFoundResponse(id resources.ResourceID) Response {
 	return &NotFoundResponse{
 		Body: armerrors.ErrorResponse{
 			Error: armerrors.ErrorDetails{
+				Code:    armerrors.CodeNotFound,
 				Message: fmt.Sprintf("the resource with id '%s' was not found", id.ID),
 				Target:  id.ID,
 			},
@@ -311,6 +314,7 @@ func NewConflictResponse(message string) Response {
 	return &ConflictResponse{
 		Body: armerrors.ErrorResponse{
 			Error: armerrors.ErrorDetails{
+				Code:    armerrors.CodeConflict,
 				Message: message,
 			},
 		},

--- a/pkg/radrp/rest/results.go
+++ b/pkg/radrp/rest/results.go
@@ -197,7 +197,7 @@ func NewBadRequestResponse(message string) Response {
 	return &BadRequestResponse{
 		Body: armerrors.ErrorResponse{
 			Error: armerrors.ErrorDetails{
-				Code:    armerrors.CodeInvalid,
+				Code:    armerrors.Invalid,
 				Message: message,
 			},
 		},
@@ -234,7 +234,7 @@ type ValidationErrorResponse struct {
 func NewValidationErrorResponse(errors validator.ValidationErrors) Response {
 	body := armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{
-			Code:    armerrors.CodeInvalid,
+			Code:    armerrors.Invalid,
 			Message: errors.Error(),
 		},
 	}
@@ -279,7 +279,7 @@ func NewNotFoundResponse(id resources.ResourceID) Response {
 	return &NotFoundResponse{
 		Body: armerrors.ErrorResponse{
 			Error: armerrors.ErrorDetails{
-				Code:    armerrors.CodeNotFound,
+				Code:    armerrors.NotFound,
 				Message: fmt.Sprintf("the resource with id '%s' was not found", id.ID),
 				Target:  id.ID,
 			},
@@ -314,7 +314,7 @@ func NewConflictResponse(message string) Response {
 	return &ConflictResponse{
 		Body: armerrors.ErrorResponse{
 			Error: armerrors.ErrorDetails{
-				Code:    armerrors.CodeConflict,
+				Code:    armerrors.Conflict,
 				Message: message,
 			},
 		},


### PR DESCRIPTION
Part of #846.

As suggested in https://github.com/Azure/radius/issues/846#issuecomment-896425502, this PR adds the codes `NotFound` and `Conflict` and makes sure our error response uses these in the appropriate scenario. This will help with fixing #690 and #846.

