### PR TITLE
Fix race condition in InMemoryDB and turn on race detector

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,6 +55,9 @@ jobs:
       - name: Run make test (unit tests)
         if: matrix.target_arch != 'arm'
         run: make test
+        env:
+          CGO_ENABLED: 1
+          GOTEST_OPTS: '-race'
       - name: Run make test-controller (controller tests)
         if: matrix.target_arch != 'arm' && matrix.target_os != 'windows'
         run: make test-controller
@@ -172,7 +175,7 @@ jobs:
   kubernetes_tests:
     name: Run Kubernetes tests
     needs: [ 'build', 'images' ]
-    if: startsWith(github.ref, 'refs/pull/') # run on PR 
+    if: startsWith(github.ref, 'refs/pull/') # run on PR
     runs-on: ubuntu-latest
     env:
       GOVER: '^1.16.0'
@@ -236,10 +239,10 @@ jobs:
       with:
         name: container_logs
         path: ./${{ env.RADIUS_CONTAINER_LOG_BASE }}
-  deploy_tests: 
+  deploy_tests:
     name: Run deployment tests
     needs: [ 'build', 'images' ]
-    if: startsWith(github.ref, 'refs/pull/') # run on PR 
+    if: startsWith(github.ref, 'refs/pull/') # run on PR
     runs-on: ubuntu-latest
     env:
       GOVER: '^1.16.0'
@@ -303,7 +306,7 @@ jobs:
             client_payload: { },
           });
 
-      # We select a test environment here and load it into the default 
+      # We select a test environment here and load it into the default
       # radius config so that it will be used by tests
     - name: Reserve test environment
       id: reserve
@@ -378,7 +381,7 @@ jobs:
             owner: context.issue.owner,
             repo: context.issue.repo,
             event_type: "delete-environment",
-            client_payload: { 
+            client_payload: {
               environment: "${{ steps.reserve.outputs.environment }}"
             }
           });
@@ -451,8 +454,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: '${{ secrets.RADIUSTEAM_DOCKERHUB_USERNAME }}' 
-          password: '${{ secrets.RADIUSTEAM_DOCKERHUB_PASSWORD }}' 
+          username: '${{ secrets.RADIUSTEAM_DOCKERHUB_USERNAME }}'
+          password: '${{ secrets.RADIUSTEAM_DOCKERHUB_PASSWORD }}'
       - name: Build and push - Codespaces (latest)
         if: (github.ref == 'refs/heads/main') # push image on push to main
         uses: docker/build-push-action@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,10 +54,10 @@ jobs:
         run: make build
       - name: Run make test (unit tests)
         if: matrix.target_arch != 'arm'
-        run: make test
         env:
-          CGO_ENABLED: 1
           GOTEST_OPTS: '-race'
+        run: |
+          make test
       - name: Run make test-controller (controller tests)
         if: matrix.target_arch != 'arm' && matrix.target_os != 'windows'
         run: make test-controller

--- a/build/test.mk
+++ b/build/test.mk
@@ -11,14 +11,14 @@ RADIUS_CONTAINER_LOG_PATH ?=./dist/container_logs
 
 .PHONY: test
 test: ## Runs unit tests, excluding kubernetes controller tests
-	go test -race ./pkg/...
+	CGO_ENABLED=1 go test -race ./pkg/...
 
 .PHONY: test-functional-azure
 test-functional-azure: ## Runs Azure functional tests
-	go test -race ./test/functional/azure/... -timeout ${TEST_TIMEOUT} -v -parallel 20
+	CGO_ENABLED=1 go test -race ./test/functional/azure/... -timeout ${TEST_TIMEOUT} -v -parallel 20
 
 test-functional-kubernetes: ## Runs Kubernetes functional tests
-	go test -race ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 20
+	CGO_ENABLED=1 go test -race ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 20
 
 ENVTEST_ASSETS_DIR=$(shell pwd)/bin
 K8S_VERSION=1.19.2
@@ -28,7 +28,7 @@ test-get-envtools:
 	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 test-controller: generate-k8s-manifests generate-controller test-get-envtools ## Runs controller tests, note arm64 version not available.
-	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" go -race test ./test/integration/kubernetes/...
+	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" CGO_ENABLED=1 go -race test ./test/integration/kubernetes/...
 
 test-validate-bicep: ## Validates that all .bicep files compile cleanly
 	BICEP_PATH="${HOME}/.rad/bin" ./build/validate-bicep.sh

--- a/build/test.mk
+++ b/build/test.mk
@@ -11,14 +11,14 @@ RADIUS_CONTAINER_LOG_PATH ?=./dist/container_logs
 
 .PHONY: test
 test: ## Runs unit tests, excluding kubernetes controller tests
-	go test ./pkg/...
+	go test -race ./pkg/...
 
 .PHONY: test-functional-azure
 test-functional-azure: ## Runs Azure functional tests
-	go test ./test/functional/azure/... -timeout ${TEST_TIMEOUT} -v -parallel 20
-	
+	go test -race ./test/functional/azure/... -timeout ${TEST_TIMEOUT} -v -parallel 20
+
 test-functional-kubernetes: ## Runs Kubernetes functional tests
-	go test ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 20
+	go test -race ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 20
 
 ENVTEST_ASSETS_DIR=$(shell pwd)/bin
 K8S_VERSION=1.19.2
@@ -28,9 +28,7 @@ test-get-envtools:
 	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 test-controller: generate-k8s-manifests generate-controller test-get-envtools ## Runs controller tests, note arm64 version not available.
-	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" go test ./test/integration/kubernetes/...  
+	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" go test ./test/integration/kubernetes/...
 
 test-validate-bicep: ## Validates that all .bicep files compile cleanly
 	BICEP_PATH="${HOME}/.rad/bin" ./build/validate-bicep.sh
-
-	

--- a/build/test.mk
+++ b/build/test.mk
@@ -28,7 +28,7 @@ test-get-envtools:
 	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 test-controller: generate-k8s-manifests generate-controller test-get-envtools ## Runs controller tests, note arm64 version not available.
-	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" go test ./test/integration/kubernetes/...
+	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" go -race test ./test/integration/kubernetes/...
 
 test-validate-bicep: ## Validates that all .bicep files compile cleanly
 	BICEP_PATH="${HOME}/.rad/bin" ./build/validate-bicep.sh

--- a/build/test.mk
+++ b/build/test.mk
@@ -28,7 +28,7 @@ test-get-envtools:
 	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 test-controller: generate-k8s-manifests generate-controller test-get-envtools ## Runs controller tests, note arm64 version not available.
-	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" CGO_ENABLED=1 go -race test ./test/integration/kubernetes/...
+	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" CGO_ENABLED=1 go test -race ./test/integration/kubernetes/...
 
 test-validate-bicep: ## Validates that all .bicep files compile cleanly
 	BICEP_PATH="${HOME}/.rad/bin" ./build/validate-bicep.sh

--- a/build/test.mk
+++ b/build/test.mk
@@ -11,14 +11,14 @@ RADIUS_CONTAINER_LOG_PATH ?=./dist/container_logs
 
 .PHONY: test
 test: ## Runs unit tests, excluding kubernetes controller tests
-	CGO_ENABLED=1 go test -race ./pkg/...
+	go test ./pkg/... $(GOTEST_OPTS)
 
 .PHONY: test-functional-azure
 test-functional-azure: ## Runs Azure functional tests
-	CGO_ENABLED=1 go test -race ./test/functional/azure/... -timeout ${TEST_TIMEOUT} -v -parallel 20
+	go test ./test/functional/azure/... -timeout ${TEST_TIMEOUT} -v -parallel 20 $(GOTEST_OPTS)
 
 test-functional-kubernetes: ## Runs Kubernetes functional tests
-	CGO_ENABLED=1 go test -race ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 20
+	go test ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 20 $(GOTEST_OPTS)
 
 ENVTEST_ASSETS_DIR=$(shell pwd)/bin
 K8S_VERSION=1.19.2
@@ -28,7 +28,7 @@ test-get-envtools:
 	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 test-controller: generate-k8s-manifests generate-controller test-get-envtools ## Runs controller tests, note arm64 version not available.
-	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" CGO_ENABLED=1 go test -race ./test/integration/kubernetes/...
+	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" go test $(GOTEST_OPTS) ./test/integration/kubernetes/...
 
 test-validate-bicep: ## Validates that all .bicep files compile cleanly
 	BICEP_PATH="${HOME}/.rad/bin" ./build/validate-bicep.sh

--- a/build/test.mk
+++ b/build/test.mk
@@ -11,14 +11,14 @@ RADIUS_CONTAINER_LOG_PATH ?=./dist/container_logs
 
 .PHONY: test
 test: ## Runs unit tests, excluding kubernetes controller tests
-	go test ./pkg/... $(GOTEST_OPTS)
+	CGO_ENABLED=1 go test ./pkg/... $(GOTEST_OPTS)
 
 .PHONY: test-functional-azure
 test-functional-azure: ## Runs Azure functional tests
-	go test ./test/functional/azure/... -timeout ${TEST_TIMEOUT} -v -parallel 20 $(GOTEST_OPTS)
+	CGO_ENABLED=1 go test ./test/functional/azure/... -timeout ${TEST_TIMEOUT} -v -parallel 20 $(GOTEST_OPTS)
 
 test-functional-kubernetes: ## Runs Kubernetes functional tests
-	go test ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 20 $(GOTEST_OPTS)
+	CGO_ENABLED=1 go test ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 20 $(GOTEST_OPTS)
 
 ENVTEST_ASSETS_DIR=$(shell pwd)/bin
 K8S_VERSION=1.19.2
@@ -28,7 +28,7 @@ test-get-envtools:
 	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 test-controller: generate-k8s-manifests generate-controller test-get-envtools ## Runs controller tests, note arm64 version not available.
-	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" go test $(GOTEST_OPTS) ./test/integration/kubernetes/...
+	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" CGO_ENABLED=1 go test $(GOTEST_OPTS) ./test/integration/kubernetes/...
 
 test-validate-bicep: ## Validates that all .bicep files compile cleanly
 	BICEP_PATH="${HOME}/.rad/bin" ./build/validate-bicep.sh

--- a/mocks/inmemory_db.go
+++ b/mocks/inmemory_db.go
@@ -169,7 +169,7 @@ func (s *store) GetApplicationByID(ctx context.Context, id resources.Application
 		return nil, db.ErrNotFound
 	}
 
-	return app, nil
+	return app.DeepCopy(), nil
 }
 
 func (s *store) PatchApplication(ctx context.Context, patch *db.ApplicationPatch) (bool, error) {
@@ -213,24 +213,8 @@ func (s *store) UpdateApplication(ctx context.Context, app *db.Application) (boo
 		list = &map[string]*db.Application{}
 		s.applications[k] = list
 	}
-
 	old := (*list)[app.FriendlyName()]
-	new := &db.Application{}
-
-	if old == nil {
-		new.Components = map[string]db.Component{}
-		new.Deployments = map[string]db.Deployment{}
-		new.Scopes = map[string]db.Scope{}
-	} else {
-		new.Components = old.Components
-		new.Deployments = old.Deployments
-		new.Scopes = old.Scopes
-	}
-
-	new.ResourceBase = app.ResourceBase
-	new.Properties = app.Properties
-
-	(*list)[app.FriendlyName()] = new
+	(*list)[app.FriendlyName()] = app.DeepCopy()
 	return old == nil, nil
 }
 

--- a/pkg/radrp/db/types.go
+++ b/pkg/radrp/db/types.go
@@ -213,6 +213,44 @@ func (app Application) FriendlyName() string {
 }
 
 // FriendlyName gets the short name of the application.
+func (app *Application) DeepCopy() *Application {
+	copy := &Application{
+		ResourceBase: app.ResourceBase,
+	}
+	// These `nil` checks are to make sure we copy `nil` maps as
+	// `nil` maps and not as empty maps.
+	//
+	// Ideally that should not have made a difference, but this way
+	// the resulted copy are more exact than otherwise and would help
+	// in case exact map equality checks were used (like in tests).
+	if app.Properties != nil {
+		copy.Properties = make(map[string]interface{}, len(app.Properties))
+		for k, v := range app.Properties {
+			copy.Properties[k] = v
+		}
+	}
+	if app.Components != nil {
+		copy.Components = make(map[string]Component, len(app.Components))
+		for k, v := range app.Components {
+			copy.Components[k] = v
+		}
+	}
+	if app.Scopes != nil {
+		copy.Scopes = make(map[string]Scope, len(app.Scopes))
+		for k, v := range app.Scopes {
+			copy.Scopes[k] = v
+		}
+	}
+	if app.Deployments != nil {
+		copy.Deployments = make(map[string]Deployment, len(app.Deployments))
+		for k, v := range app.Deployments {
+			copy.Deployments[k] = v
+		}
+	}
+	return copy
+}
+
+// FriendlyName gets the short name of the application.
 func (app ApplicationPatch) FriendlyName() string {
 	// use the last segment of the name
 	if strings.Contains(app.Name, "/") {

--- a/pkg/radrp/db/types.go
+++ b/pkg/radrp/db/types.go
@@ -212,7 +212,7 @@ func (app Application) FriendlyName() string {
 	return app.Name
 }
 
-// FriendlyName gets the short name of the application.
+// DeepCopy returns a deep copy of the Application object.
 func (app *Application) DeepCopy() *Application {
 	copy := &Application{
 		ResourceBase: app.ResourceBase,

--- a/pkg/radrp/resourceprovider.go
+++ b/pkg/radrp/resourceprovider.go
@@ -512,8 +512,7 @@ func (r *rp) UpdateDeployment(ctx context.Context, d *rest.Deployment) (rest.Res
 		}
 
 		logger.Info("Updating application")
-		ok, err := r.db.UpdateApplication(ctx, a)
-		if err != nil || !ok {
+		if _, err = r.db.UpdateApplication(ctx, a); err != nil {
 			logger.Error(err, "failed to update application")
 			return
 		}


### PR DESCRIPTION
There is a race condition in InMemoryDB where we return pointers to the in-memory data. Instead, we should have returned a copy.  When fixing this, we also fixed `InMemoryDB#UpdateApplication()` which seems to be copied from `#PatchApplication()` but should follow a different update sematic.

(`PatchApplication` only updates the `Application#Properties`, while `UpdateApplication` should update the rest of the fields).

Also, turns on https://golang.org/doc/articles/race_detector. This should only make our tests run a tiny bit slower but will help detect race conditions.