### PR TITLE
Adds support for replicas for component expose and logs

### DIFF
--- a/cmd/cli/cmd/componentExpose.go
+++ b/cmd/cli/cmd/componentExpose.go
@@ -52,6 +52,11 @@ rad component expose --application icecream-store orders --port 5000 --remote-po
 			return err
 		}
 
+		replica, err := cmd.Flags().GetString("replica")
+		if err != nil {
+			return err
+		}
+
 		if remotePort == -1 {
 			remotePort = localPort
 		}
@@ -66,7 +71,8 @@ rad component expose --application icecream-store orders --port 5000 --remote-po
 			Application: application,
 			Component:   component,
 			Port:        localPort,
-			RemotePort:  remotePort})
+			RemotePort:  remotePort,
+			Replica:     replica})
 
 		if err != nil {
 			return err
@@ -101,4 +107,5 @@ func init() {
 	}
 
 	exposeCmd.Flags().IntP("remote-port", "r", -1, "specify the remote port")
+	exposeCmd.Flags().String("replica", "", "specify the replica to expose")
 }

--- a/cmd/cli/cmd/componentLogs.go
+++ b/cmd/cli/cmd/componentLogs.go
@@ -72,7 +72,7 @@ rad component logs orders --application icecream-store --container daprd`,
 			return err
 		}
 
-		stream, err := client.Logs(cmd.Context(), clients.LogsOptions{
+		streams, err := client.Logs(cmd.Context(), clients.LogsOptions{
 			Application: application,
 			Component:   component,
 			Follow:      follow,
@@ -81,46 +81,74 @@ rad component logs orders --application icecream-store --container daprd`,
 			return err
 		}
 
-		defer stream.Close()
+		logErrors := make(chan error, len(streams))
+		for _, logInfo := range streams {
 
-		// We can keep reading this until cancellation occurs.
-		if follow {
-			// Sending to stderr so it doesn't interfere with parsing
-			fmt.Fprintf(os.Stderr, "Streaming logs from component %s. Press CTRL+C to exit...\n", component)
-		}
+			// We can keep reading this until cancellation occurs.
+			if follow {
+				// Sending to stderr so it doesn't interfere with parsing
+				fmt.Fprintf(os.Stderr, "Streaming logs from replica %s for component %s. Press CTRL+C to exit...\n", logInfo.Name, component)
+			}
 
-		hasLogs := false
-		reader := bufio.NewReader(stream)
-		for {
-			line, prefix, err := reader.ReadLine()
-			if err == context.Canceled {
-				// CTRL+C => done
-				return nil
-			} else if err == io.EOF {
-				// End of stream
-				//
-				// Output a status message to stderr if there were no logs for non-streaming
-				// so an interactive user gets *some* feedback.
-				if !follow && !hasLogs {
-					fmt.Fprintln(os.Stderr, "Component's log is currently empty.")
+			go func(info clients.LogStream) {
+				stream := info.Stream
+				defer stream.Close()
+
+				name := info.Name
+				hasLogs := false
+				reader := bufio.NewReader(stream)
+				startLine := true
+				for {
+					line, prefix, err := reader.ReadLine()
+					if err == context.Canceled {
+						// CTRL+C => done
+						logErrors <- nil
+						return
+					} else if err == io.EOF {
+						// End of stream
+						//
+						// Output a status message to stderr if there were no logs for non-streaming
+						// so an interactive user gets *some* feedback.
+						if !follow && !hasLogs {
+							fmt.Fprintln(os.Stderr, "Component's log is currently empty.")
+						}
+						logErrors <- nil
+						return
+					} else if err != nil {
+						logErrors <- err
+						return
+					}
+
+					hasLogs = true
+
+					// Handle the case where a partial line is returned
+					if prefix {
+						if startLine {
+							fmt.Print("[" + name + "] " + string(line))
+						} else {
+							fmt.Print(string(line))
+						}
+						startLine = false
+						continue
+					}
+
+					if startLine {
+						fmt.Println("[" + name + "] " + string(line))
+					} else {
+						fmt.Println(string(line))
+					}
+					startLine = true
 				}
-
-				return nil
-			} else if err != nil {
-				return fmt.Errorf("failed to read log stream %T: %w", err, err)
-			}
-
-			hasLogs = true
-
-			// Handle the case where a partial line is returned
-			if prefix {
-				fmt.Print(string(line))
-				continue
-			}
-
-			fmt.Println(string(line))
+			}(logInfo)
 		}
-
+		for i := 0; i < len(streams); i++ {
+			err := <-logErrors
+			if err != nil {
+				// TODO format
+				fmt.Fprintln(os.Stderr, err)
+			}
+		}
+		return nil
 	},
 }
 
@@ -129,4 +157,5 @@ func init() {
 
 	logsCmd.Flags().String("container", "", "specify the container from which logs should be streamed")
 	logsCmd.Flags().BoolP("follow", "f", false, "specify that logs should be stream until the command is canceled")
+	logsCmd.Flags().String("replica", "", "specify the replica to collect logs from")
 }

--- a/cmd/cli/cmd/componentLogs.go
+++ b/cmd/cli/cmd/componentLogs.go
@@ -90,6 +90,7 @@ rad component logs orders --application icecream-store --container daprd`,
 				fmt.Fprintf(os.Stderr, "Streaming logs from replica %s for component %s. Press CTRL+C to exit...\n", logInfo.Name, component)
 			}
 
+			// Kind of go routine to read the logs from each stream.
 			go func(info clients.LogStream) {
 				stream := info.Stream
 				defer stream.Close()
@@ -141,6 +142,7 @@ rad component logs orders --application icecream-store --container daprd`,
 				}
 			}(logInfo)
 		}
+
 		for i := 0; i < len(streams); i++ {
 			err := <-logErrors
 			if err != nil {

--- a/cmd/cli/cmd/componentLogs.go
+++ b/cmd/cli/cmd/componentLogs.go
@@ -90,7 +90,7 @@ rad component logs orders --application icecream-store --container daprd`,
 				fmt.Fprintf(os.Stderr, "Streaming logs from replica %s for component %s. Press CTRL+C to exit...\n", logInfo.Name, component)
 			}
 
-			// Kind of go routine to read the logs from each stream.
+			// Kick off go routine to read the logs from each stream.
 			go func(info clients.LogStream) {
 				stream := info.Stream
 				defer stream.Close()

--- a/pkg/cli/clients/clients.go
+++ b/pkg/cli/clients/clients.go
@@ -21,7 +21,7 @@ type DeploymentClient interface {
 // DiagnosticsClient is used to interface with diagnostics features like logs and port-forwards.
 type DiagnosticsClient interface {
 	Expose(ctx context.Context, options ExposeOptions) (failed chan error, stop chan struct{}, signals chan os.Signal, err error)
-	Logs(ctx context.Context, options LogsOptions) (io.ReadCloser, error)
+	Logs(ctx context.Context, options LogsOptions) ([]LogStream, error)
 }
 
 type ExposeOptions struct {
@@ -29,6 +29,7 @@ type ExposeOptions struct {
 	Component   string
 	Port        int
 	RemotePort  int
+	Replica     string
 }
 
 type LogsOptions struct {
@@ -36,6 +37,12 @@ type LogsOptions struct {
 	Component   string
 	Follow      bool
 	Container   string
+	Replica     string
+}
+
+type LogStream struct {
+	Name   string
+	Stream io.ReadCloser
 }
 
 // ManagementClient is used to interface with management features like listing applications and components.


### PR DESCRIPTION
Output from multiple pods for rad component logs:
![image](https://user-images.githubusercontent.com/8302101/129285878-0fe64234-17f4-48c3-a138-b49c93469a2b.png)

If multiple replicas, picks first/random pod to expose:

![image](https://user-images.githubusercontent.com/8302101/129285951-6aace9a1-0577-43e3-91df-9792fd2c585b.png)

Can specify --replica for a replica name.

Currently doesn't limit the number of pods to get logs from. Could maybe cause issues if someone has dozens of pods.

Drafting for feedback as well as discoverability on replica names as I don't think radius does a good job exposing that. 