### PR TITLE
Standardize pattern for LRO deletion

### DIFF
--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -28,7 +28,6 @@ import (
 	radazure "github.com/Azure/radius/pkg/cli/azure"
 	"github.com/Azure/radius/pkg/cli/output"
 	"github.com/Azure/radius/pkg/cli/prompt"
-	"github.com/Azure/radius/pkg/cli/util"
 	"github.com/Azure/radius/pkg/keys"
 	"github.com/Azure/radius/pkg/version"
 	"github.com/google/uuid"
@@ -397,7 +396,7 @@ func findExistingEnvironment(ctx context.Context, authorizer autorest.Authorizer
 	cpc := azclients.NewCustomResourceProviderClient(subscriptionID, authorizer)
 
 	_, err := cpc.Get(ctx, resourceGroup, "radius")
-	if detail, ok := util.ExtractDetailedError(err); ok && detail.StatusCode == 404 {
+	if azclients.Is404Error(err) {
 		// not found - will need to be created
 		return false, "", nil
 	} else if err != nil {

--- a/pkg/roleassignment/roleassignment.go
+++ b/pkg/roleassignment/roleassignment.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/Azure/radius/pkg/azclients"
-	"github.com/Azure/radius/pkg/cli/util"
 	"github.com/Azure/radius/pkg/radlogger"
 	"github.com/gofrs/uuid"
 )
@@ -57,7 +56,7 @@ func Create(ctx context.Context, auth autorest.Authorizer, subscriptionID string
 		}
 
 		// Check the error and determine if it is ignorable/retryable
-		detailed, ok := util.ExtractDetailedError(err)
+		detailed, ok := azclients.ExtractDetailedError(err)
 		if !ok {
 			return nil, err
 		}

--- a/pkg/workloads/containerv1alpha1/render.go
+++ b/pkg/workloads/containerv1alpha1/render.go
@@ -29,7 +29,6 @@ import (
 	"github.com/Azure/radius/pkg/azclients"
 	"github.com/Azure/radius/pkg/azresources"
 	"github.com/Azure/radius/pkg/azure/armauth"
-	"github.com/Azure/radius/pkg/cli/util"
 	"github.com/Azure/radius/pkg/keys"
 	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/model/components"
@@ -558,7 +557,7 @@ func (r Renderer) createPodIdentity(ctx context.Context, msi msi.Identity, conta
 		}
 
 		// Check the error and determine if it is retryable
-		detailed, ok := util.ExtractDetailedError(err)
+		detailed, ok := azclients.ExtractDetailedError(err)
 		if !ok {
 			return podIdentity, err
 		}


### PR DESCRIPTION
Fixes: radius-project/core-team#1291

This change makes all of our *long-running* resource deletion code
consistent and fixes some bugs.

This is the result of finding a crash in tests when these Azure SDK
calls return an error. In general the issue here is that the existing
code inspects the *non-error* return value when an error is returned.
There's no guarantees about the state of the object when that happens.
We also need to make sure to *early-exit* the function when a 404
happens, the code was continuing, which was a bug.

Also moved this to `pkg/azure/` per-discussion for code reorganization.