### PR TITLE
Include Azure ServiceError in 404 validation

### DIFF
--- a/pkg/cli/util/autoresterr.go
+++ b/pkg/cli/util/autoresterr.go
@@ -54,10 +54,12 @@ func ExtractDetailedError(err error) (autorest.DetailedError, bool) {
 
 // IsAutorest404Error returns true if the error is a 404 payload from an autorest operation.
 func IsAutorest404Error(err error) bool {
-	detailed, ok := ExtractDetailedError(err)
-	if !ok {
-		return false
+	if detailed, ok := ExtractDetailedError(err); ok && detailed.Response != nil && detailed.Response.StatusCode == 404 {
+		return true
+	} else if serviceErr, ok := ExtractServiceError(detailed.Original); ok &&
+		(serviceErr.Code == "ResourceNotFound" || serviceErr.Code == "NotFound") {
+		return true
 	}
 
-	return detailed.Response != nil && detailed.Response.StatusCode == 404
+	return false
 }


### PR DESCRIPTION
Some of the errors returned by Go SDK are ServiceError wrapped in DetailedError. In Radius RP we currently only look at DetailedError type https://github.com/Azure/radius/blob/main/pkg/cli/util/autoresterr.go#L57, while we should also check for ServiceError. Example error response for a scenario where this happened -

Code="ResourceNotFound" Message="The Resource 'Microsoft.DocumentDB/databaseAccounts/db-66495fcdc87649faa34b0' under resource group 'karishmachawla-radius' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix"

https://github.com/Azure/radius/issues/912