### PR TITLE
Container render/deployment updates

### DIFF
--- a/pkg/azure/clients/common.go
+++ b/pkg/azure/clients/common.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/radius/pkg/azure/armauth"
 )
 
 func GetDefaultAPIVersion(ctx context.Context, subscriptionId string, authorizer autorest.Authorizer, resourceType string) (string, error) {
@@ -40,4 +41,15 @@ func GetDefaultAPIVersion(ctx context.Context, subscriptionId string, authorizer
 	}
 
 	return "", nil // unreachable
+}
+
+func GetResourceGroupLocation(ctx context.Context, armConfig armauth.ArmConfig) (*string, error) {
+	rgc := NewGroupsClient(armConfig.SubscriptionID, armConfig.Auth)
+
+	resourceGroup, err := rgc.Get(ctx, armConfig.ResourceGroup)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get resource group location: %w", err)
+	}
+
+	return resourceGroup.Location, nil
 }

--- a/pkg/azure/roleassignment/roleassignment.go
+++ b/pkg/azure/roleassignment/roleassignment.go
@@ -71,7 +71,7 @@ func Create(ctx context.Context, auth autorest.Authorizer, subscriptionID string
 			return nil, fmt.Errorf("failed to create role assignment with error: %v, statuscode: %v", detailed.Message, detailed.StatusCode)
 		}
 
-		logger.Info(fmt.Sprintf("Failed to create role assignment. Retrying: %d attempt ...", i))
+		logger.Info(fmt.Sprintf("Failed to create role assignment %v. Retrying: %d attempt ...", err, i))
 		time.Sleep(5 * time.Second)
 	}
 

--- a/pkg/handlers/azure_cosmosdb_base.go
+++ b/pkg/handlers/azure_cosmosdb_base.go
@@ -82,7 +82,7 @@ func (handler *azureCosmosDBBaseHandler) CreateCosmosDBAccount(ctx context.Conte
 		}
 	}
 
-	location, err := azclients.GetResourceGroupLocation(ctx, handler.arm)
+	location, err := clients.GetResourceGroupLocation(ctx, handler.arm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handlers/azure_cosmosdb_base.go
+++ b/pkg/handlers/azure_cosmosdb_base.go
@@ -82,7 +82,7 @@ func (handler *azureCosmosDBBaseHandler) CreateCosmosDBAccount(ctx context.Conte
 		}
 	}
 
-	location, err := getResourceGroupLocation(ctx, handler.arm)
+	location, err := azclients.GetResourceGroupLocation(ctx, handler.arm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handlers/azure_keyvault.go
+++ b/pkg/handlers/azure_keyvault.go
@@ -123,7 +123,7 @@ func (handler *azureKeyVaultHandler) CreateKeyVault(ctx context.Context, vaultNa
 		return nil, fmt.Errorf("failed to convert tenantID to UUID: %w", err)
 	}
 
-	location, err := getResourceGroupLocation(ctx, handler.arm)
+	location, err := azclients.GetResourceGroupLocation(ctx, handler.arm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handlers/azure_keyvault.go
+++ b/pkg/handlers/azure_keyvault.go
@@ -123,7 +123,7 @@ func (handler *azureKeyVaultHandler) CreateKeyVault(ctx context.Context, vaultNa
 		return nil, fmt.Errorf("failed to convert tenantID to UUID: %w", err)
 	}
 
-	location, err := azclients.GetResourceGroupLocation(ctx, handler.arm)
+	location, err := clients.GetResourceGroupLocation(ctx, handler.arm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handlers/azure_keyvault_secret.go
+++ b/pkg/handlers/azure_keyvault_secret.go
@@ -12,6 +12,11 @@ import (
 	"github.com/Azure/radius/pkg/healthcontract"
 )
 
+const (
+	KeyVaultSecretNameKey  = "keyvaultsecretname"
+	KeyVaultSecretValueKey = "keyvaultsecretvalue"
+)
+
 // NewAzureKeyVaultSecretHandler initializes a new handler for resources of kind Azure KeyVault Secret
 func NewAzureKeyVaultSecretHandler(arm armauth.ArmConfig) ResourceHandler {
 	return &azureKeyVaultSecretHandler{arm: arm}

--- a/pkg/handlers/azure_keyvault_secret.go
+++ b/pkg/handlers/azure_keyvault_secret.go
@@ -7,9 +7,18 @@ package handlers
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/radius/pkg/azure/armauth"
+	"github.com/Azure/radius/pkg/azure/azresources"
+	"github.com/Azure/radius/pkg/azure/clients"
 	"github.com/Azure/radius/pkg/healthcontract"
+	"github.com/Azure/radius/pkg/radlogger"
+	"github.com/Azure/radius/pkg/radrp/outputresource"
 )
 
 const (
@@ -27,13 +36,79 @@ type azureKeyVaultSecretHandler struct {
 }
 
 func (handler *azureKeyVaultSecretHandler) Put(ctx context.Context, options *PutOptions) (map[string]string, error) {
+	logger := radlogger.GetLogger(ctx)
+	properties := mergeProperties(*options.Resource, options.Existing)
 
-	// if !options.Resource.Deployed {
-	// 	// TODO: right now this resource is already deployed during the rendering process :(
-	// 	// this should be done here instead when we have built a more mature system.
-	// }
+	secretName := properties[KeyVaultSecretNameKey]
+	secretValue := properties[KeyVaultSecretValueKey]
+	keyVaultURI := properties[KeyVaultURIKey]
+	keyVaultSecretsResourceType := azresources.KeyVaultVaults + "/" + azresources.KeyVaultVaultsSecrets
 
-	return map[string]string{}, nil
+	// UserAgent() returns a string of format: Azure-SDK-For-Go/v52.2.0 keyvault/2019-09-01 profiles/latest
+	keyVaultAPIVersion := strings.Split(strings.Split(keyvault.UserAgent(), "keyvault/")[1], " ")[0]
+
+	// KeyVault URI has the format: "https://<kv name>.vault.azure.net"
+	vaultName := strings.Split(strings.Split(keyVaultURI, "https://")[1], ".vault.azure.net")[0]
+	secretFullName := vaultName + "/" + secretName
+	template := map[string]interface{}{
+		"$schema":        "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+		"contentVersion": "1.0.0.0",
+		"parameters":     map[string]interface{}{},
+		"resources": []interface{}{
+			map[string]interface{}{
+				"type":       keyVaultSecretsResourceType,
+				"name":       secretFullName,
+				"apiVersion": keyVaultAPIVersion,
+				"properties": map[string]interface{}{
+					"contentType": "text/plain",
+					"value":       secretValue,
+				},
+			},
+		},
+	}
+
+	dc := clients.NewDeploymentsClient(handler.arm.SubscriptionID, handler.arm.Auth)
+	parameters := map[string]interface{}{}
+	deploymentProperties := &resources.DeploymentProperties{
+		Parameters: parameters,
+		Mode:       resources.DeploymentModeIncremental,
+		Template:   template,
+	}
+	deploymentName := "create-secret-" + vaultName + "-" + secretName
+	resultFuture, err := dc.CreateOrUpdate(context.Background(), handler.arm.ResourceGroup, deploymentName, resources.Deployment{
+		Properties: deploymentProperties,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to create secret: %w", err)
+	}
+
+	err = resultFuture.WaitForCompletionRef(context.Background(), dc.Client)
+	if err != nil {
+		return nil, fmt.Errorf("could not create secret: %w", err)
+	}
+
+	_, err = resultFuture.Result(dc)
+	if err != nil {
+		return nil, fmt.Errorf("could not create secret: %w", err)
+	}
+
+	logger.WithValues(radlogger.LogFieldLocalID, outputresource.LocalIDKeyVaultSecret).Info(fmt.Sprintf("Created secret: %s in Key Vault: %s successfully", secretName, vaultName))
+
+	secretResource := azure.Resource{
+		SubscriptionID: handler.arm.SubscriptionID,
+		ResourceGroup:  handler.arm.ResourceGroup,
+		Provider:       "Microsoft.KeyVault",
+		ResourceType:   keyVaultSecretsResourceType,
+		ResourceName:   secretFullName,
+	}
+
+	options.Resource.Info = outputresource.ARMInfo{
+		ID:           secretResource.String(),
+		ResourceType: keyVaultSecretsResourceType,
+		APIVersion:   keyVaultAPIVersion,
+	}
+
+	return properties, nil
 }
 
 func (handler *azureKeyVaultSecretHandler) Delete(ctx context.Context, options DeleteOptions) error {

--- a/pkg/handlers/azure_podidentity.go
+++ b/pkg/handlers/azure_podidentity.go
@@ -20,6 +20,7 @@ import (
 const (
 	PodIdentityNameKey    = "podidentityname"
 	PodIdentityClusterKey = "podidentitycluster"
+	PodNamespaceKey       = "podnamespace"
 )
 
 func NewAzurePodIdentityHandler(arm armauth.ArmConfig) ResourceHandler {

--- a/pkg/handlers/azure_podidentity.go
+++ b/pkg/handlers/azure_podidentity.go
@@ -7,7 +7,9 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
@@ -15,6 +17,8 @@ import (
 	"github.com/Azure/radius/pkg/azure/armauth"
 	"github.com/Azure/radius/pkg/azure/clients"
 	"github.com/Azure/radius/pkg/healthcontract"
+	"github.com/Azure/radius/pkg/radlogger"
+	"github.com/Azure/radius/pkg/radrp/outputresource"
 )
 
 const (
@@ -32,12 +36,106 @@ type azurePodIdentityHandler struct {
 }
 
 func (handler *azurePodIdentityHandler) Put(ctx context.Context, options *PutOptions) (map[string]string, error) {
+	logger := radlogger.GetLogger(ctx)
 	properties := mergeProperties(*options.Resource, options.Existing)
 
-	// if !options.Resource.Deployed {
-	// TODO: right now this resource is already deployed during the rendering process :(
-	// this should be done here instead when we have built a more mature system.
-	// }
+	if handler.arm.K8sSubscriptionID == "" || handler.arm.K8sResourceGroup == "" || handler.arm.K8sClusterName == "" {
+		return nil, errors.New("pod identity is not supported because the RP is not configured for AKS")
+	}
+
+	// Get dependencies
+	managedIdentityProperties := map[string]string{}
+	for _, resource := range options.Dependencies {
+		if resource.LocalID == outputresource.LocalIDUserAssignedManagedIdentityKV {
+			managedIdentityProperties = resource.Properties
+		}
+	}
+	if len(managedIdentityProperties) == 0 {
+		return nil, errors.New("missing dependency: a user assigned identity is required to create pod identity")
+	}
+
+	// Get AKS cluster name in current resource group and update it to add pod identity
+	clustersClient := clients.NewManagedClustersClient(handler.arm.K8sSubscriptionID, handler.arm.Auth)
+	managedCluster, err := clustersClient.Get(ctx, handler.arm.K8sResourceGroup, handler.arm.K8sClusterName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get managed cluster details for cluster %s in the resource group %s: %w", handler.arm.K8sClusterName, handler.arm.K8sResourceGroup, err)
+	}
+
+	managedCluster.PodIdentityProfile.Enabled = to.BoolPtr(true)
+	managedCluster.PodIdentityProfile.AllowNetworkPluginKubenet = to.BoolPtr(false)
+
+	podIdentityName := properties[PodIdentityNameKey]
+	podNamespace := properties[PodNamespaceKey]
+	clusterPodIdentity := containerservice.ManagedClusterPodIdentity{
+		Name:      &podIdentityName,
+		Namespace: &podNamespace, // Note: The pod identity namespace specified here has to match the namespace in which the application is deployed
+		Identity: &containerservice.UserAssignedIdentity{
+			ResourceID: to.StringPtr(managedIdentityProperties[UserAssignedIdentityIDKey]),
+			ClientID:   to.StringPtr(managedIdentityProperties[UserAssignedIdentityClientIDKey]),
+			ObjectID:   to.StringPtr(managedIdentityProperties[UserAssignedIdentityPrincipalIDKey]),
+		},
+	}
+
+	var identities []containerservice.ManagedClusterPodIdentity
+	if managedCluster.ManagedClusterProperties.PodIdentityProfile.UserAssignedIdentities != nil {
+		identities = *managedCluster.PodIdentityProfile.UserAssignedIdentities
+	}
+	identities = append(identities, clusterPodIdentity)
+
+	// Handling of eventual consistency here can really use some work and improvements, more details:
+	// https://github.com/Azure/radius/issues/1010
+	// https://github.com/Azure/radius/issues/660
+	// For now just moving it over as is from renderer to limit the scope of changes.
+	MaxRetries := 100
+	var resultFuture containerservice.ManagedClustersCreateOrUpdateFuture
+	for i := 0; i <= MaxRetries; i++ {
+		// Retry to wait for the managed identity to propagate
+		if i >= MaxRetries {
+			return nil, fmt.Errorf("failed to add pod identity on the cluster %s: %w", handler.arm.K8sClusterName, err)
+		}
+
+		resultFuture, err = clustersClient.CreateOrUpdate(ctx, handler.arm.K8sResourceGroup, handler.arm.K8sClusterName, containerservice.ManagedCluster{
+			ManagedClusterProperties: &containerservice.ManagedClusterProperties{
+				PodIdentityProfile: &containerservice.ManagedClusterPodIdentityProfile{
+					Enabled:                   to.BoolPtr(true),
+					AllowNetworkPluginKubenet: to.BoolPtr(false),
+					UserAssignedIdentities:    &identities,
+				},
+			},
+			Location: managedCluster.Location,
+		})
+
+		if err == nil {
+			break
+		}
+
+		// Check the error and determine if it is retryable
+		detailed, ok := clients.ExtractDetailedError(err)
+		if !ok {
+			return nil, err
+		}
+
+		// Sometimes, the managed identity takes a while to propagate and the pod identity creation fails with status code = 0
+		// For other reasons, fail
+		if detailed.StatusCode != 0 {
+			return nil, fmt.Errorf("failed to add pod identity on the cluster with error: %v, status code: %v", detailed.Message, detailed.StatusCode)
+		}
+
+		logger.V(radlogger.Verbose).Info("failed to add pod identity. Retrying...")
+		time.Sleep(5 * time.Second)
+		continue
+	}
+
+	err = resultFuture.WaitForCompletionRef(ctx, clustersClient.Client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add pod identity on the cluster: %w", err)
+	}
+
+	options.Resource.Info = outputresource.AADPodIdentityInfo{
+		AKSClusterName: handler.arm.K8sClusterName,
+		Name:           podIdentityName,
+		Namespace:      podNamespace,
+	}
 
 	return properties, nil
 }

--- a/pkg/handlers/azure_redis.go
+++ b/pkg/handlers/azure_redis.go
@@ -112,7 +112,7 @@ func (handler *azureRedisHandler) CreateRedis(ctx context.Context, redisName str
 		Capacity: to.Int32Ptr(1),
 	}
 
-	location, err := azclients.GetResourceGroupLocation(ctx, handler.arm)
+	location, err := clients.GetResourceGroupLocation(ctx, handler.arm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handlers/azure_redis.go
+++ b/pkg/handlers/azure_redis.go
@@ -112,7 +112,7 @@ func (handler *azureRedisHandler) CreateRedis(ctx context.Context, redisName str
 		Capacity: to.Int32Ptr(1),
 	}
 
-	location, err := getResourceGroupLocation(ctx, handler.arm)
+	location, err := azclients.GetResourceGroupLocation(ctx, handler.arm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handlers/azure_roleassignment.go
+++ b/pkg/handlers/azure_roleassignment.go
@@ -12,6 +12,10 @@ import (
 	"github.com/Azure/radius/pkg/healthcontract"
 )
 
+const (
+	RoleNameKey = "rolename"
+)
+
 // NewAzureRoleAssignmentHandler initializes a new handler for resources of kind RoleAssignment
 func NewAzureRoleAssignmentHandler(arm armauth.ArmConfig) ResourceHandler {
 	return &azureRoleAssignmentHandler{arm: arm}

--- a/pkg/handlers/azure_servicebus.go
+++ b/pkg/handlers/azure_servicebus.go
@@ -203,7 +203,7 @@ func (handler *azureServiceBusBaseHandler) LookupSharedManagedNamespaceFromResou
 func (handler *azureServiceBusBaseHandler) CreateNamespace(ctx context.Context, application string) (*servicebus.SBNamespace, error) {
 	sbc := clients.NewServiceBusNamespacesClient(handler.arm.SubscriptionID, handler.arm.Auth)
 
-	location, err := azclients.GetResourceGroupLocation(ctx, handler.arm)
+	location, err := clients.GetResourceGroupLocation(ctx, handler.arm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handlers/azure_servicebus.go
+++ b/pkg/handlers/azure_servicebus.go
@@ -203,7 +203,7 @@ func (handler *azureServiceBusBaseHandler) LookupSharedManagedNamespaceFromResou
 func (handler *azureServiceBusBaseHandler) CreateNamespace(ctx context.Context, application string) (*servicebus.SBNamespace, error) {
 	sbc := clients.NewServiceBusNamespacesClient(handler.arm.SubscriptionID, handler.arm.Auth)
 
-	location, err := getResourceGroupLocation(ctx, handler.arm)
+	location, err := azclients.GetResourceGroupLocation(ctx, handler.arm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handlers/azure_userassigned_managedidentity.go
+++ b/pkg/handlers/azure_userassigned_managedidentity.go
@@ -12,6 +12,12 @@ import (
 	"github.com/Azure/radius/pkg/healthcontract"
 )
 
+const (
+	UserAssignedIdentityNameKey        = "userassignedidentityname"
+	UserAssignedIdentityIDKey          = "userassignedidentityid"
+	UserAssignedIdentityPrincipalIDKey = "userassignedidentityprincipalid"
+)
+
 // NewAzureUserAssignedManagedIdentityHandler initializes a new handler for resources of kind UserAssignedManagedIdentity
 func NewAzureUserAssignedManagedIdentityHandler(arm armauth.ArmConfig) ResourceHandler {
 	return &azureUserAssignedManagedIdentityHandler{arm: arm}

--- a/pkg/handlers/azure_userassigned_managedidentity.go
+++ b/pkg/handlers/azure_userassigned_managedidentity.go
@@ -7,15 +7,23 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/msi/mgmt/msi"
+	"github.com/Azure/azure-sdk-for-go/sdk/to"
 	"github.com/Azure/radius/pkg/azure/armauth"
+	"github.com/Azure/radius/pkg/azure/clients"
 	"github.com/Azure/radius/pkg/healthcontract"
+	"github.com/Azure/radius/pkg/keys"
+	"github.com/Azure/radius/pkg/radlogger"
+	"github.com/Azure/radius/pkg/radrp/outputresource"
 )
 
 const (
 	UserAssignedIdentityNameKey        = "userassignedidentityname"
 	UserAssignedIdentityIDKey          = "userassignedidentityid"
 	UserAssignedIdentityPrincipalIDKey = "userassignedidentityprincipalid"
+	UserAssignedIdentityClientIDKey    = "userassignedidentityclientid"
 )
 
 // NewAzureUserAssignedManagedIdentityHandler initializes a new handler for resources of kind UserAssignedManagedIdentity
@@ -28,13 +36,38 @@ type azureUserAssignedManagedIdentityHandler struct {
 }
 
 func (handler *azureUserAssignedManagedIdentityHandler) Put(ctx context.Context, options *PutOptions) (map[string]string, error) {
+	logger := radlogger.GetLogger(ctx)
+	properties := mergeProperties(*options.Resource, options.Existing)
 
-	// if !options.Resource.Deployed {
-	// 	// TODO: right now this resource is already deployed during the rendering process :(
-	// 	// this should be done here instead when we have built a more mature system.
-	// }
+	rgLocation, err := clients.GetResourceGroupLocation(ctx, handler.arm)
+	if err != nil {
+		return nil, err
+	}
 
-	return map[string]string{}, nil
+	identityName := properties[UserAssignedIdentityNameKey]
+	msiClient := clients.NewUserAssignedIdentitiesClient(handler.arm.SubscriptionID, handler.arm.Auth)
+	identity, err := msiClient.CreateOrUpdate(context.Background(), handler.arm.ResourceGroup, identityName, msi.Identity{
+		Location: to.StringPtr(*rgLocation),
+		Tags:     keys.MakeTagsForRadiusComponent(options.Application, options.Component),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create user assigned managed identity: %w", err)
+	}
+	properties[UserAssignedIdentityIDKey] = *identity.ID
+	properties[UserAssignedIdentityPrincipalIDKey] = identity.PrincipalID.String()
+	properties[UserAssignedIdentityClientIDKey] = identity.ClientID.String()
+
+	options.Resource.Info = outputresource.ARMInfo{
+		ID:           *identity.ID,
+		ResourceType: *identity.Type,
+		APIVersion:   msi.Version(),
+	}
+
+	logger.WithValues(
+		radlogger.LogFieldResourceID, *identity.ID,
+		radlogger.LogFieldLocalID, outputresource.LocalIDUserAssignedManagedIdentityKV).Info("Created managed identity for KeyVault access")
+
+	return properties, nil
 }
 
 func (handler *azureUserAssignedManagedIdentityHandler) Delete(ctx context.Context, options DeleteOptions) error {

--- a/pkg/handlers/dapr_statestore_sqlserver.go
+++ b/pkg/handlers/dapr_statestore_sqlserver.go
@@ -7,6 +7,8 @@ package handlers
 
 import (
 	"context"
+	"math/rand"
+	"time"
 
 	"fmt"
 	"strings"
@@ -251,6 +253,38 @@ func (handler *daprStateStoreSQLServerHandler) createSQLDB(ctx context.Context, 
 	}
 
 	return nil
+}
+
+type PasswordConditions struct {
+	Lower       int
+	Upper       int
+	Digits      int
+	SpecialChar int
+}
+
+func generatePassword(conditions *PasswordConditions) string {
+	pwd := generateString(conditions.Digits, "1234567890") +
+		generateString(conditions.Lower, "abcdefghijklmnopqrstuvwxyz") +
+		generateString(conditions.Upper, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") +
+		generateString(conditions.SpecialChar, "-")
+
+	pwdArray := strings.Split(pwd, "")
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(pwdArray), func(i, j int) {
+		pwdArray[i], pwdArray[j] = pwdArray[j], pwdArray[i]
+	})
+	pwd = strings.Join(pwdArray, "")
+
+	return pwd
+}
+
+func generateString(length int, allowedCharacters string) string {
+	str := ""
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for len(str) < length {
+		str += string(allowedCharacters[rnd.Intn(len(allowedCharacters))])
+	}
+	return str
 }
 
 func NewDaprStateStoreSQLServerHealthHandler(arm armauth.ArmConfig, k8s client.Client) HealthHandler {

--- a/pkg/handlers/dapr_statestore_sqlserver.go
+++ b/pkg/handlers/dapr_statestore_sqlserver.go
@@ -51,7 +51,7 @@ type daprStateStoreSQLServerHandler struct {
 func (handler *daprStateStoreSQLServerHandler) Put(ctx context.Context, options *PutOptions) (map[string]string, error) {
 	properties := mergeProperties(*options.Resource, options.Existing)
 
-	location, err := getResourceGroupLocation(ctx, handler.arm)
+	location, err := azclients.GetResourceGroupLocation(ctx, handler.arm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handlers/dapr_statestore_sqlserver.go
+++ b/pkg/handlers/dapr_statestore_sqlserver.go
@@ -51,7 +51,7 @@ type daprStateStoreSQLServerHandler struct {
 func (handler *daprStateStoreSQLServerHandler) Put(ctx context.Context, options *PutOptions) (map[string]string, error) {
 	properties := mergeProperties(*options.Resource, options.Existing)
 
-	location, err := azclients.GetResourceGroupLocation(ctx, handler.arm)
+	location, err := clients.GetResourceGroupLocation(ctx, handler.arm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handlers/dapr_statestore_storage.go
+++ b/pkg/handlers/dapr_statestore_storage.go
@@ -159,7 +159,7 @@ func (handler *daprStateStoreAzureStorageHandler) GetStorageAccountByID(ctx cont
 }
 
 func (handler *daprStateStoreAzureStorageHandler) CreateStorageAccount(ctx context.Context, accountName string, options PutOptions) (*storage.Account, error) {
-	location, err := getResourceGroupLocation(ctx, handler.arm)
+	location, err := azclients.GetResourceGroupLocation(ctx, handler.arm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handlers/dapr_statestore_storage.go
+++ b/pkg/handlers/dapr_statestore_storage.go
@@ -159,7 +159,7 @@ func (handler *daprStateStoreAzureStorageHandler) GetStorageAccountByID(ctx cont
 }
 
 func (handler *daprStateStoreAzureStorageHandler) CreateStorageAccount(ctx context.Context, accountName string, options PutOptions) (*storage.Account, error) {
-	location, err := azclients.GetResourceGroupLocation(ctx, handler.arm)
+	location, err := clients.GetResourceGroupLocation(ctx, handler.arm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/handlers/kubernetes.go
+++ b/pkg/handlers/kubernetes.go
@@ -39,7 +39,7 @@ func (handler *kubernetesHandler) Put(ctx context.Context, options *PutOptions) 
 	}
 
 	// For a Kubernetes resource we only need to store the ObjectMeta and TypeMeta data
-	p := map[string]string{
+	properties := map[string]string{
 		KubernetesKindKey:       item.GetKind(),
 		KubernetesAPIVersionKey: item.GetAPIVersion(),
 		KubernetesNamespaceKey:  item.GetNamespace(),
@@ -50,7 +50,7 @@ func (handler *kubernetesHandler) Put(ctx context.Context, options *PutOptions) 
 		// This resource is deployed in the Render process
 		// TODO: This will eventually change
 		// For now, no need to process any further
-		return p, nil
+		return properties, nil
 	}
 	err = handler.k8s.Patch(ctx, &item, client.Apply, &client.PatchOptions{FieldManager: kubernetes.FieldManager})
 	if err != nil {
@@ -64,7 +64,7 @@ func (handler *kubernetesHandler) Put(ctx context.Context, options *PutOptions) 
 		APIVersion: item.GetAPIVersion(),
 	}
 
-	return p, err
+	return properties, err
 }
 
 func (handler *kubernetesHandler) PatchNamespace(ctx context.Context, namespace string) error {

--- a/pkg/handlers/util.go
+++ b/pkg/handlers/util.go
@@ -6,14 +6,10 @@
 package handlers
 
 import (
-	"context"
-	"fmt"
 	"math/rand"
 	"strings"
 	"time"
 
-	"github.com/Azure/radius/pkg/azure/armauth"
-	"github.com/Azure/radius/pkg/azure/clients"
 	"github.com/Azure/radius/pkg/radrp/db"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
 )
@@ -39,17 +35,6 @@ func mergeProperties(resource outputresource.OutputResource, existing *db.Deploy
 	}
 
 	return properties
-}
-
-func getResourceGroupLocation(ctx context.Context, armConfig armauth.ArmConfig) (*string, error) {
-	rgc := clients.NewGroupsClient(armConfig.SubscriptionID, armConfig.Auth)
-
-	resourceGroup, err := rgc.Get(ctx, armConfig.ResourceGroup)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get resource group location: %w", err)
-	}
-
-	return resourceGroup.Location, nil
 }
 
 type PasswordConditions struct {

--- a/pkg/handlers/util.go
+++ b/pkg/handlers/util.go
@@ -6,10 +6,6 @@
 package handlers
 
 import (
-	"math/rand"
-	"strings"
-	"time"
-
 	"github.com/Azure/radius/pkg/radrp/db"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
 )
@@ -35,36 +31,4 @@ func mergeProperties(resource outputresource.OutputResource, existing *db.Deploy
 	}
 
 	return properties
-}
-
-type PasswordConditions struct {
-	Lower       int
-	Upper       int
-	Digits      int
-	SpecialChar int
-}
-
-func generatePassword(conditions *PasswordConditions) string {
-	pwd := generateString(conditions.Digits, "1234567890") +
-		generateString(conditions.Lower, "abcdefghijklmnopqrstuvwxyz") +
-		generateString(conditions.Upper, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") +
-		generateString(conditions.SpecialChar, "-")
-
-	pwdArray := strings.Split(pwd, "")
-	rand.Seed(time.Now().UnixNano())
-	rand.Shuffle(len(pwdArray), func(i, j int) {
-		pwdArray[i], pwdArray[j] = pwdArray[j], pwdArray[i]
-	})
-	pwd = strings.Join(pwdArray, "")
-
-	return pwd
-}
-
-func generateString(length int, allowedCharacters string) string {
-	str := ""
-	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
-	for len(str) < length {
-		str += string(allowedCharacters[rnd.Intn(len(allowedCharacters))])
-	}
-	return str
 }

--- a/pkg/kubernetes/object.go
+++ b/pkg/kubernetes/object.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Finds deployment in a list of output resources
-func FindDeployment(resources []outputresource.OutputResource) *appsv1.Deployment {
+func FindDeployment(resources []outputresource.OutputResource) (*appsv1.Deployment, outputresource.OutputResource) {
 	for _, r := range resources {
 		if r.Kind != resourcekinds.Kubernetes {
 			continue
@@ -24,14 +24,14 @@ func FindDeployment(resources []outputresource.OutputResource) *appsv1.Deploymen
 			continue
 		}
 
-		return deployment
+		return deployment, r
 	}
 
-	return nil
+	return nil, outputresource.OutputResource{}
 }
 
 // Finds service in a list of output resources
-func FindService(resources []outputresource.OutputResource) *corev1.Service {
+func FindService(resources []outputresource.OutputResource) (*corev1.Service, outputresource.OutputResource) {
 	for _, r := range resources {
 		if r.Kind != resourcekinds.Kubernetes {
 			continue
@@ -42,8 +42,8 @@ func FindService(resources []outputresource.OutputResource) *corev1.Service {
 			continue
 		}
 
-		return service
+		return service, r
 	}
 
-	return nil
+	return nil, outputresource.OutputResource{}
 }

--- a/pkg/radrp/deployment/deployment_processor.go
+++ b/pkg/radrp/deployment/deployment_processor.go
@@ -193,7 +193,6 @@ func (dp *deploymentProcessor) UpdateDeployment(ctx context.Context, appName str
 					ResourceGroup:  action.Definition.ResourceGroup,
 				}
 				healthID := outputResourceInfo.GetHealthID()
-				properties[healthcontract.HealthIDKey] = healthID
 				resource.HealthID = healthID
 
 				if err != nil {
@@ -206,6 +205,7 @@ func (dp *deploymentProcessor) UpdateDeployment(ctx context.Context, appName str
 					errs = append(errs, fmt.Errorf("error applying workload for component %v %v: %w", properties, action.ComponentName, err))
 					continue
 				}
+				properties[healthcontract.HealthIDKey] = healthID
 
 				resource.Status.ProvisioningState = db.Provisioned
 				resource.Status.ProvisioningErrorDetails = ""

--- a/pkg/radrp/outputresource/info.go
+++ b/pkg/radrp/outputresource/info.go
@@ -72,7 +72,7 @@ type K8sInfo struct {
 }
 
 // AADPodIdentity pod identity for AKS cluster to enable access to keyvault
-type AADPodIdentity struct {
+type AADPodIdentityInfo struct {
 	AKSClusterName string `bson:"aksClusterName"`
 	Name           string `bson:"name"`
 	Namespace      string `bson:"namespace"`
@@ -104,7 +104,7 @@ func (resource OutputResource) GetResourceID() string {
 	if resource.Type == TypeARM {
 		return resource.Info.(ARMInfo).ID
 	} else if resource.Type == TypeAADPodIdentity {
-		return resource.Info.(AADPodIdentity).AKSClusterName + "-" + resource.Info.(AADPodIdentity).Name
+		return resource.Info.(AADPodIdentityInfo).AKSClusterName + "-" + resource.Info.(AADPodIdentityInfo).Name
 	} else if resource.Type == TypeKubernetes {
 		kID := healthcontract.KubernetesID{
 			Kind:      resource.Info.(K8sInfo).Kind,

--- a/pkg/renderers/containerv1alpha1/render.go
+++ b/pkg/renderers/containerv1alpha1/render.go
@@ -260,12 +260,12 @@ func (r Renderer) makeDeployment(ctx context.Context, workload workloads.Instant
 
 		deploymentDependencies = append(deploymentDependencies, outputresource.Dependency{LocalID: outputresource.LocalIDKeyVaultSecret})
 
-		store, err := dep.Secrets.Store.GetMatchingBinding(workload.BindingValues)
+		storeBinding, err := dep.Secrets.Store.GetMatchingBinding(workload.BindingValues)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		keyVaultName, err := r.getKeyVaultName(store)
+		keyVaultName, err := r.getKeyVaultName(storeBinding)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/renderers/containerv1alpha1/render.go
+++ b/pkg/renderers/containerv1alpha1/render.go
@@ -19,12 +19,10 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/authorization/mgmt/authorization"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/keyvault/mgmt/keyvault"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/msi/mgmt/msi"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/Azure/radius/pkg/azure/armauth"
 	"github.com/Azure/radius/pkg/azure/azresources"
@@ -134,11 +132,19 @@ func (r Renderer) createManagedIdentity(ctx context.Context, applicationName str
 		LocalID:  outputresource.LocalIDUserAssignedManagedIdentityKV,
 		Deployed: true,
 		Managed:  true,
-		Info: outputresource.ARMInfo{
-			ID:           *identity.ID,
-			ResourceType: *identity.Type,
-			APIVersion:   msi.Version(),
+		// Info: outputresource.ARMInfo{
+		// 	ID:           *identity.ID,
+		// 	ResourceType: *identity.Type,
+		// 	APIVersion:   msi.Version(),
+		// },
+		Resource: map[string]string{
+			handlers.ManagedKey:                  "true",
+			handlers.KeyVaultNameKey:             keyVaultName,
+			handlers.UserAssignedIdentityNameKey: managedIdentityName,
+			// handlers.UserAssignedIdentityIDKey:          *identity.ID,
+			// handlers.UserAssignedIdentityPrincipalIDKey: identity.PrincipalID.String(),
 		},
+		Dependencies: []outputresource.Dependency{},
 	}
 
 	return &identity, []outputresource.OutputResource{identityOutputResource}, nil
@@ -160,10 +166,17 @@ func (r Renderer) getKeyVaultName(keyVaultBinding components.BindingState) (stri
 }
 
 // Assigns secrets user and cryto user roles to the managed identity for access to the keyvault
-func (r Renderer) assignRoleToManagedIdentity(ctx context.Context, keyVaultName string, managedIdentityName string, managedIdentityID string,
+func (r Renderer) assignRoleToManagedIdentity(ctx context.Context, keyVaultName string, managedIdentityID string,
 	managedIdentityPrincipalID string) ([]outputresource.OutputResource, error) {
 	logger := radlogger.GetLogger(ctx)
 	outputResources := []outputresource.OutputResource{}
+
+	// Managed identity should be created before role can be assigned
+	roleAssignmentDependencies := []outputresource.Dependency{
+		{
+			LocalID: outputresource.LocalIDUserAssignedManagedIdentityKV,
+		},
+	}
 
 	keyVaultClient := clients.NewVaultsClient(r.Arm.SubscriptionID, r.Arm.Auth)
 	keyVault, err := keyVaultClient.Get(ctx, r.Arm.ResourceGroup, keyVaultName)
@@ -172,10 +185,10 @@ func (r Renderer) assignRoleToManagedIdentity(ctx context.Context, keyVaultName 
 	}
 
 	// Assign Key Vault Secrets User role to grant managed identity read-only access to the keyvault for secrets.
-	readSecretsRA, err := roleassignment.Create(ctx, r.Arm.Auth, r.Arm.SubscriptionID, r.Arm.ResourceGroup, managedIdentityPrincipalID, *keyVault.ID, keyVaultSecretsReadRole)
+	_, err = roleassignment.Create(ctx, r.Arm.Auth, r.Arm.SubscriptionID, r.Arm.ResourceGroup, managedIdentityPrincipalID, *keyVault.ID, keyVaultSecretsReadRole)
 	if err != nil {
 		return outputResources,
-			fmt.Errorf("Failed to assign '%s' role to the managed identity '%s' within keyvault '%s' scope : %w", keyVaultSecretsReadRole, managedIdentityName, keyVaultName, err)
+			fmt.Errorf("Failed to assign '%s' role to the managed identity '%s' within keyvault '%s' scope : %w", keyVaultSecretsReadRole, managedIdentityID, keyVaultName, err)
 	}
 
 	readSecretsRAOutputResource := outputresource.OutputResource{
@@ -184,19 +197,27 @@ func (r Renderer) assignRoleToManagedIdentity(ctx context.Context, keyVaultName 
 		Deployed: true,
 		Managed:  true,
 		Type:     outputresource.TypeARM,
-		Info: outputresource.ARMInfo{
-			ID:           *readSecretsRA.ID,
-			ResourceType: *readSecretsRA.Type,
-			APIVersion:   authorization.Version(),
+		// Info: outputresource.ARMInfo{
+		// 	ID:           *readSecretsRA.ID,
+		// 	ResourceType: *readSecretsRA.Type,
+		// 	APIVersion:   authorization.Version(),
+		// },
+		Resource: map[string]string{
+			handlers.ManagedKey:      "true",
+			handlers.RoleNameKey:     keyVaultSecretsReadRole,
+			handlers.KeyVaultNameKey: keyVaultName,
+			handlers.KeyVaultIDKey:   *keyVault.ID,
+			// handlers.UserAssignedIdentityPrincipalIDKey: managedIdentityPrincipalID,
 		},
+		Dependencies: roleAssignmentDependencies,
 	}
 	outputResources = append(outputResources, readSecretsRAOutputResource)
 	logger.WithValues(radlogger.LogFieldLocalID, outputresource.LocalIDRoleAssignmentKVSecretsCerts).Info(fmt.Sprintf("Created %s role assignment for %v to access %v", keyVaultSecretsReadRole, managedIdentityID, *keyVault.ID))
 
 	// Assign Key Vault Crypto User role to grant managed identity permissions to perform operations using encryption keys.
-	cryptoOperationsRA, err := roleassignment.Create(ctx, r.Arm.Auth, r.Arm.SubscriptionID, r.Arm.ResourceGroup, managedIdentityPrincipalID, *keyVault.ID, keyVaultCryptoOperationsRole)
+	_, err = roleassignment.Create(ctx, r.Arm.Auth, r.Arm.SubscriptionID, r.Arm.ResourceGroup, managedIdentityPrincipalID, *keyVault.ID, keyVaultCryptoOperationsRole)
 	if err != nil {
-		return outputResources, fmt.Errorf("Failed to assign '%s' role to the managed identity '%s' within keyvault '%s' scope : %w", keyVaultCryptoOperationsRole, managedIdentityName, keyVaultName, err)
+		return outputResources, fmt.Errorf("Failed to assign '%s' role to the managed identity '%s' within keyvault '%s' scope : %w", keyVaultCryptoOperationsRole, managedIdentityID, keyVaultName, err)
 	}
 
 	cryptoOperationsRAOutputResource := outputresource.OutputResource{
@@ -205,11 +226,19 @@ func (r Renderer) assignRoleToManagedIdentity(ctx context.Context, keyVaultName 
 		Deployed: true,
 		Managed:  true,
 		Type:     outputresource.TypeARM,
-		Info: outputresource.ARMInfo{
-			ID:           *cryptoOperationsRA.ID,
-			ResourceType: *cryptoOperationsRA.Type,
-			APIVersion:   authorization.Version(),
+		// Info: outputresource.ARMInfo{
+		// 	ID:           *cryptoOperationsRA.ID,
+		// 	ResourceType: *cryptoOperationsRA.Type,
+		// 	APIVersion:   authorization.Version(),
+		// },
+		Resource: map[string]string{
+			handlers.ManagedKey:      "true",
+			handlers.RoleNameKey:     keyVaultCryptoOperationsRole,
+			handlers.KeyVaultNameKey: keyVaultName,
+			handlers.KeyVaultIDKey:   *keyVault.ID,
+			// handlers.UserAssignedIdentityPrincipalIDKey: managedIdentityPrincipalID,
 		},
+		Dependencies: roleAssignmentDependencies,
 	}
 	outputResources = append(outputResources, cryptoOperationsRAOutputResource)
 	logger.WithValues(radlogger.LogFieldLocalID, outputresource.LocalIDRoleAssignmentKVKeys).Info(fmt.Sprintf("Created %s role assignment for %s to access %s", keyVaultCryptoOperationsRole, managedIdentityID, *keyVault.ID))
@@ -219,13 +248,13 @@ func (r Renderer) assignRoleToManagedIdentity(ctx context.Context, keyVaultName 
 
 func (r Renderer) createPodIdentityResource(ctx context.Context, w workloads.InstantiatedWorkload, component *ContainerComponent) (outputresource.AADPodIdentity, []outputresource.OutputResource, error) {
 	logger := radlogger.GetLogger(ctx)
-	var podIdentity outputresource.AADPodIdentity
+	var podIdentityInfo outputresource.AADPodIdentity
 
 	outputResources := []outputresource.OutputResource{}
 	for _, dependency := range component.Uses {
 		binding, err := dependency.Binding.GetMatchingBinding(w.BindingValues)
 		if err != nil {
-			return podIdentity, outputResources, err
+			return podIdentityInfo, outputResources, err
 		}
 
 		// If the container depends on a KeyVault, create a pod identity.
@@ -233,137 +262,90 @@ func (r Renderer) createPodIdentityResource(ctx context.Context, w workloads.Ins
 		if binding.Kind == "azure.com/KeyVault" {
 			keyVaultName, err := r.getKeyVaultName(binding)
 			if err != nil {
-				return podIdentity, outputResources, err
+				return podIdentityInfo, outputResources, err
 			}
 
 			// Create a user assigned managed identity
 			userAssignedIdentity, or, err := r.createManagedIdentity(ctx, w.Application, w.Name, keyVaultName)
 			outputResources = append(outputResources, or...)
 			if err != nil {
-				return podIdentity, outputResources, err
+				return podIdentityInfo, outputResources, err
 			}
 
 			// RBAC on managed identity to access the KeyVault
-			roleAssignmentOutputResources, err := r.assignRoleToManagedIdentity(ctx, keyVaultName,
-				*userAssignedIdentity.Name, *userAssignedIdentity.ID, userAssignedIdentity.PrincipalID.String())
+			roleAssignmentOutputResources, err := r.assignRoleToManagedIdentity(ctx, keyVaultName, *userAssignedIdentity.ID,
+				userAssignedIdentity.PrincipalID.String())
 			outputResources = append(outputResources, roleAssignmentOutputResources...)
 			if err != nil {
-				return podIdentity, outputResources, err
+				return podIdentityInfo, outputResources, err
 			}
 
 			// Create pod identity
-			podIdentity, podIdentityOutputResource, err := r.createPodIdentity(ctx, *userAssignedIdentity, component.Name, w.Application)
+			podIdentityInfo, podIdentityOutputResource, err := r.createPodIdentity(ctx, *userAssignedIdentity, component.Name, w.Application)
 			outputResources = append(outputResources, podIdentityOutputResource)
 			if err != nil {
-				return podIdentity, outputResources, err
+				return podIdentityInfo, outputResources, err
 			}
 
-			logger.WithValues(radlogger.LogFieldLocalID, outputresource.LocalIDAADPodIdentity).Info(fmt.Sprintf("Created pod identity %v to bind %v", podIdentity.Name, *userAssignedIdentity.ID))
-			return podIdentity, outputResources, nil
+			logger.WithValues(radlogger.LogFieldLocalID, outputresource.LocalIDAADPodIdentity).Info(fmt.Sprintf("Created pod identity %v to bind %v", podIdentityInfo.Name, *userAssignedIdentity.ID))
+			return podIdentityInfo, outputResources, nil
 		}
 	}
 
-	return podIdentity, outputResources, nil
+	return podIdentityInfo, outputResources, nil
 }
 
 // Render is the WorkloadRenderer implementation for containerized workload.
-func (r Renderer) Render(ctx context.Context, w workloads.InstantiatedWorkload) ([]outputresource.OutputResource, error) {
+func (r Renderer) Render(ctx context.Context, workload workloads.InstantiatedWorkload) ([]outputresource.OutputResource, error) {
 	outputResources := []outputresource.OutputResource{}
-	cw, err := r.convert(w)
-	if err != nil {
-		return []outputresource.OutputResource{}, err
-	}
+	// deploymentDependencies := []outputresource.Dependency{}
 
-	deployment, or, err := r.makeDeployment(ctx, w, cw)
-	if err != nil {
-		return or, err
-	}
-	// Append the output resources created during the makeDeployment phase to the final set
-	outputResources = append(outputResources, or...)
-
-	service, err := r.makeService(ctx, w, cw)
+	component := &ContainerComponent{}
+	err := workload.Workload.AsRequired(Kind, component)
 	if err != nil {
 		return outputResources, err
 	}
 
-	podIdentity, or, err := r.createPodIdentityResource(ctx, w, cw)
+	podIdentityInfo, podIdentityOutputResources, err := r.createPodIdentityResource(ctx, workload, component)
+	outputResources = append(outputResources, podIdentityOutputResources...)
 	if err != nil {
-		return or, fmt.Errorf("unable to add pod identity: %w", err)
-	}
-	if podIdentity.Name != "" {
-		// Add the aadpodidbinding label to the k8s spec for the container
-		deployment.Spec.Template.ObjectMeta.Labels["aadpodidbinding"] = podIdentity.Name
+		return outputResources, err
 	}
 
-	// Append the output resources created for podid creation to the final set
-	outputResources = append(outputResources, or...)
-
-	res := outputresource.OutputResource{
-		Kind:     resourcekinds.Kubernetes,
-		LocalID:  outputresource.LocalIDDeployment,
-		Deployed: false,
-		Managed:  true,
-		Type:     outputresource.TypeKubernetes,
-		Info: outputresource.K8sInfo{
-			Kind:       deployment.TypeMeta.Kind,
-			APIVersion: deployment.TypeMeta.APIVersion,
-			Name:       deployment.ObjectMeta.Name,
-			Namespace:  deployment.ObjectMeta.Namespace,
-		},
-		Resource: deployment,
+	deployment, deploymentOutputResources, err := r.makeDeployment(ctx, workload, component, podIdentityInfo)
+	outputResources = append(outputResources, deploymentOutputResources...)
+	if err != nil {
+		return outputResources, err
 	}
-	outputResources = append(outputResources, res)
 
-	if service != nil {
-		res = outputresource.OutputResource{
-			Kind:     resourcekinds.Kubernetes,
-			LocalID:  outputresource.LocalIDService,
-			Deployed: false,
-			Managed:  true,
-			Type:     outputresource.TypeKubernetes,
-			Info: outputresource.K8sInfo{
-				Kind:       deployment.TypeMeta.Kind,
-				APIVersion: deployment.TypeMeta.APIVersion,
-				Name:       deployment.ObjectMeta.Name,
-				Namespace:  deployment.ObjectMeta.Namespace,
-			},
-			Resource: service,
-		}
-		outputResources = append(outputResources, res)
+	serviceOutputResources, err := r.makeService(ctx, workload, component, deployment)
+	outputResources = append(outputResources, serviceOutputResources...)
+	if err != nil {
+		return outputResources, err
 	}
 
 	return outputResources, nil
 }
 
-func (r Renderer) convert(w workloads.InstantiatedWorkload) (*ContainerComponent, error) {
-	container := &ContainerComponent{}
-	err := w.Workload.AsRequired(Kind, container)
-	if err != nil {
-		return nil, err
-	}
-
-	return container, nil
-}
-
-func (r Renderer) makeDeployment(ctx context.Context, w workloads.InstantiatedWorkload, cc *ContainerComponent) (*appsv1.Deployment, []outputresource.OutputResource, error) {
+func (r Renderer) makeDeployment(ctx context.Context, w workloads.InstantiatedWorkload, component *ContainerComponent, podIdentityInfo outputresource.AADPodIdentity) (*appsv1.Deployment, []outputresource.OutputResource, error) {
 	outputResources := []outputresource.OutputResource{}
-	container := corev1.Container{
-		Name:  cc.Name,
-		Image: cc.Run.Container.Image,
+	deploymentDependencies := []outputresource.Dependency{}
 
-		// TODO: use better policies than this when we have a good versioning story
-		ImagePullPolicy: corev1.PullPolicy("Always"),
+	container := corev1.Container{
+		Name:            component.Name,
+		Image:           component.Run.Container.Image,
+		ImagePullPolicy: corev1.PullPolicy("Always"), // https://github.com/Azure/radius/issues/734
 		Env:             []corev1.EnvVar{},
 	}
 
-	for k, v := range cc.Run.Container.Env {
+	for k, v := range component.Run.Container.Env {
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  k,
 			Value: v,
 		})
 	}
 
-	for _, dep := range cc.Uses {
+	for _, dep := range component.Uses {
 		// Set environment variables in the container
 		for k, v := range dep.Env {
 			str, err := v.EvaluateString(w.BindingValues)
@@ -377,21 +359,23 @@ func (r Renderer) makeDeployment(ctx context.Context, w workloads.InstantiatedWo
 		}
 	}
 
-	for _, dep := range cc.Uses {
+	for _, dep := range component.Uses {
 		if dep.Secrets == nil {
 			continue
 		}
+
+		deploymentDependencies = append(deploymentDependencies, outputresource.Dependency{LocalID: outputresource.LocalIDKeyVaultSecret})
 
 		store, err := dep.Secrets.Store.GetMatchingBinding(w.BindingValues)
 		if err != nil {
 			return nil, outputResources, err
 		}
-		value, ok := store.Properties[handlers.KeyVaultURIKey]
+
+		uri, ok := store.Properties[handlers.KeyVaultURIKey]
 		if !ok {
 			return nil, outputResources, fmt.Errorf("cannot find a keyvault URI for secret store binding %s from component %s", store.Binding, store.Component)
 		}
-
-		uri, ok := value.(string)
+		keyVaultURI, ok := uri.(string)
 		if !ok {
 			return nil, outputResources, fmt.Errorf("value %s for binding for binding %s from component %s is not a string", handlers.KeyVaultURIKey, store.Binding, store.Component)
 		}
@@ -402,24 +386,23 @@ func (r Renderer) makeDeployment(ctx context.Context, w workloads.InstantiatedWo
 			if err != nil {
 				return nil, outputResources, err
 			}
-
 			secrets[k] = value
 		}
 
 		// Create secrets in the specified keyvault
 		for secretName, secretValue := range secrets {
-			or, err := r.createSecret(ctx, uri, secretName, secretValue)
+			secretsOutputResource, err := r.createSecret(ctx, keyVaultURI, secretName, secretValue)
 			if err != nil {
 				return nil, outputResources, fmt.Errorf("could not create secret: %v: %w", secretName, err)
 			}
-			outputResources = append(outputResources, or)
+			outputResources = append(outputResources, secretsOutputResource)
 		}
 	}
 
-	for name, generic := range w.Workload.Bindings {
-		if generic.Kind == KindHTTP {
+	for name, genericBinding := range w.Workload.Bindings {
+		if genericBinding.Kind == KindHTTP {
 			httpBinding := HTTPBinding{}
-			err := generic.AsRequired(KindHTTP, &httpBinding)
+			err := genericBinding.AsRequired(KindHTTP, &httpBinding)
 			if err != nil {
 				return nil, outputResources, err
 			}
@@ -440,7 +423,7 @@ func (r Renderer) makeDeployment(ctx context.Context, w workloads.InstantiatedWo
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cc.Name,
+			Name:      component.Name,
 			Namespace: w.Application,
 			Labels:    kubernetes.MakeDescriptiveLabels(w.Application, w.Name),
 		},
@@ -459,22 +442,46 @@ func (r Renderer) makeDeployment(ctx context.Context, w workloads.InstantiatedWo
 		},
 	}
 
+	if podIdentityInfo.Name != "" {
+		// Add the aadpodidbinding label to the k8s spec for the container
+		deployment.Spec.Template.ObjectMeta.Labels["aadpodidbinding"] = podIdentityInfo.Name
+
+		deploymentDependencies = append(deploymentDependencies, outputresource.Dependency{LocalID: outputresource.LocalIDAADPodIdentity})
+	}
+
+	deploymentOutputResource := outputresource.OutputResource{
+		Kind:     resourcekinds.Kubernetes,
+		LocalID:  outputresource.LocalIDDeployment,
+		Deployed: false,
+		Managed:  true,
+		Type:     outputresource.TypeKubernetes,
+		Info: outputresource.K8sInfo{
+			Kind:       deployment.TypeMeta.Kind,
+			APIVersion: deployment.TypeMeta.APIVersion,
+			Name:       deployment.ObjectMeta.Name,
+			Namespace:  deployment.ObjectMeta.Namespace,
+		},
+		Resource:     &deployment,
+		Dependencies: deploymentDependencies,
+	}
+	outputResources = append(outputResources, deploymentOutputResource)
+
 	return &deployment, outputResources, nil
 }
 
-func (r Renderer) createPodIdentity(ctx context.Context, msi msi.Identity, containerName string, podNamespace string) (outputresource.AADPodIdentity, outputresource.OutputResource, error) {
+func (r Renderer) createPodIdentity(ctx context.Context, userAssignedIdentity msi.Identity, containerName string, podNamespace string) (outputresource.AADPodIdentity, outputresource.OutputResource, error) {
 	logger := radlogger.GetLogger(ctx)
-	var podIdentity outputresource.AADPodIdentity
+	var podIdentityInfo outputresource.AADPodIdentity
 
 	if r.Arm.K8sSubscriptionID == "" || r.Arm.K8sResourceGroup == "" || r.Arm.K8sClusterName == "" {
-		return podIdentity, outputresource.OutputResource{}, errors.New("pod identity is not supported because the RP is not configured for AKS")
+		return podIdentityInfo, outputresource.OutputResource{}, errors.New("pod identity is not supported because the RP is not configured for AKS")
 	}
 
 	// Get AKS cluster name in current resource group and update it to add pod identity
 	clustersClient := clients.NewManagedClustersClient(r.Arm.K8sSubscriptionID, r.Arm.Auth)
 	managedCluster, err := clustersClient.Get(ctx, r.Arm.K8sResourceGroup, r.Arm.K8sClusterName)
 	if err != nil {
-		return podIdentity, outputresource.OutputResource{}, fmt.Errorf("failed to get managed cluster details for cluster %s in the resource group %s: %w", r.Arm.K8sClusterName, r.Arm.K8sResourceGroup, err)
+		return podIdentityInfo, outputresource.OutputResource{}, fmt.Errorf("failed to get managed cluster details for cluster %s in the resource group %s: %w", r.Arm.K8sClusterName, r.Arm.K8sResourceGroup, err)
 	}
 
 	managedCluster.PodIdentityProfile.Enabled = to.BoolPtr(true)
@@ -486,9 +493,9 @@ func (r Renderer) createPodIdentity(ctx context.Context, msi msi.Identity, conta
 		Name:      &podIdentityName,
 		Namespace: &podNamespace, // Note: The pod identity namespace specified here has to match the namespace in which the application is deployed
 		Identity: &containerservice.UserAssignedIdentity{
-			ResourceID: msi.ID,
-			ClientID:   to.StringPtr(msi.ClientID.String()),
-			ObjectID:   to.StringPtr(msi.PrincipalID.String()),
+			ResourceID: userAssignedIdentity.ID,
+			ClientID:   to.StringPtr(userAssignedIdentity.ClientID.String()),
+			ObjectID:   to.StringPtr(userAssignedIdentity.PrincipalID.String()),
 		},
 	}
 
@@ -503,7 +510,7 @@ func (r Renderer) createPodIdentity(ctx context.Context, msi msi.Identity, conta
 	for i := 0; i <= MaxRetries; i++ {
 		// Retry to wait for the managed identity to propagate
 		if i >= MaxRetries {
-			return podIdentity, outputresource.OutputResource{}, fmt.Errorf("failed to add pod identity on the cluster %s: %w", r.Arm.K8sClusterName, err)
+			return podIdentityInfo, outputresource.OutputResource{}, fmt.Errorf("failed to add pod identity on the cluster %s: %w", r.Arm.K8sClusterName, err)
 		}
 
 		resultFuture, err = clustersClient.CreateOrUpdate(ctx, r.Arm.K8sResourceGroup, r.Arm.K8sClusterName, containerservice.ManagedCluster{
@@ -524,13 +531,13 @@ func (r Renderer) createPodIdentity(ctx context.Context, msi msi.Identity, conta
 		// Check the error and determine if it is retryable
 		detailed, ok := clients.ExtractDetailedError(err)
 		if !ok {
-			return podIdentity, outputresource.OutputResource{}, err
+			return podIdentityInfo, outputresource.OutputResource{}, err
 		}
 
 		// Sometimes, the managed identity takes a while to propagate and the pod identity creation fails with status code = 0
 		// For other reasons, fail
 		if detailed.StatusCode != 0 {
-			return podIdentity, outputresource.OutputResource{}, fmt.Errorf("failed to add pod identity on the cluster with error: %v, status code: %v", detailed.Message, detailed.StatusCode)
+			return podIdentityInfo, outputresource.OutputResource{}, fmt.Errorf("failed to add pod identity on the cluster with error: %v, status code: %v", detailed.Message, detailed.StatusCode)
 		}
 
 		logger.V(radlogger.Verbose).Info("failed to add pod identity. Retrying...")
@@ -540,34 +547,47 @@ func (r Renderer) createPodIdentity(ctx context.Context, msi msi.Identity, conta
 
 	err = resultFuture.WaitForCompletionRef(ctx, clustersClient.Client)
 	if err != nil {
-		return podIdentity, outputresource.OutputResource{}, fmt.Errorf("failed to add pod identity on the cluster: %w", err)
+		return podIdentityInfo, outputresource.OutputResource{}, fmt.Errorf("failed to add pod identity on the cluster: %w", err)
 	}
 
-	podIdentity = outputresource.AADPodIdentity{
+	podIdentityInfo = outputresource.AADPodIdentity{
 		AKSClusterName: r.Arm.K8sClusterName,
 		Name:           podIdentityName,
 		Namespace:      podNamespace,
 	}
 
-	outputResource := outputresource.OutputResource{
-		Deployed: true,
-		Kind:     resourcekinds.AzurePodIdentity,
-		Type:     outputresource.TypeAADPodIdentity,
-		LocalID:  outputresource.LocalIDAADPodIdentity,
-		Managed:  true,
-		Info:     podIdentity,
-		Resource: map[string]string{
-			handlers.PodIdentityNameKey:    podIdentity.Name,
-			handlers.PodIdentityClusterKey: podIdentity.AKSClusterName,
+	// Managed identity with required role assignments should be created first
+	podIdentityDependencies := []outputresource.Dependency{
+		{
+			LocalID: outputresource.LocalIDRoleAssignmentKVSecretsCerts,
+		},
+		{
+			LocalID: outputresource.LocalIDRoleAssignmentKVKeys,
 		},
 	}
 
-	return podIdentity, outputResource, nil
+	outputResource := outputresource.OutputResource{
+		LocalID:  outputresource.LocalIDAADPodIdentity,
+		Type:     outputresource.TypeAADPodIdentity,
+		Kind:     resourcekinds.AzurePodIdentity,
+		Managed:  true,
+		Deployed: true,
+		Info:     podIdentityInfo,
+		Resource: map[string]string{
+			handlers.ManagedKey:            "true",
+			handlers.PodIdentityNameKey:    podIdentityName,
+			handlers.PodIdentityClusterKey: podIdentityInfo.AKSClusterName,
+			handlers.PodNamespaceKey:       podNamespace,
+		},
+		Dependencies: podIdentityDependencies,
+	}
+
+	return podIdentityInfo, outputResource, nil
 }
 
 // Create secret in the Key Vault using ARM since ARM has write permissions to create secrets
 // and no special role assignment is needed.
-func (r Renderer) createSecret(ctx context.Context, kvURI, secretName string, secretValue string) (outputresource.OutputResource, error) {
+func (r Renderer) createSecret(ctx context.Context, kvURI string, secretName string, secretValue string) (outputresource.OutputResource, error) {
 	logger := radlogger.GetLogger(ctx)
 
 	// UserAgent() returns a string of format: Azure-SDK-For-Go/v52.2.0 keyvault/2019-09-01 profiles/latest
@@ -601,40 +621,48 @@ func (r Renderer) createSecret(ctx context.Context, kvURI, secretName string, se
 		Template:   template,
 	}
 	deploymentName := "create-secret-" + vaultName + "-" + secretName
-	op, err := dc.CreateOrUpdate(context.Background(), r.Arm.ResourceGroup, deploymentName, resources.Deployment{
+	resultFuture, err := dc.CreateOrUpdate(context.Background(), r.Arm.ResourceGroup, deploymentName, resources.Deployment{
 		Properties: deploymentProperties,
 	})
 	if err != nil {
 		return outputresource.OutputResource{}, fmt.Errorf("unable to create secret: %w", err)
 	}
 
-	err = op.WaitForCompletionRef(context.Background(), dc.Client)
+	err = resultFuture.WaitForCompletionRef(context.Background(), dc.Client)
 	if err != nil {
 		return outputresource.OutputResource{}, fmt.Errorf("could not create secret: %w", err)
 	}
 
-	_, err = op.Result(dc)
+	_, err = resultFuture.Result(dc)
 	if err != nil {
 		return outputresource.OutputResource{}, fmt.Errorf("could not create secret: %w", err)
 	}
 
-	secretResource := azure.Resource{
-		SubscriptionID: r.Arm.SubscriptionID,
-		ResourceGroup:  r.Arm.ResourceGroup,
-		Provider:       "Microsoft.KeyVault",
-		ResourceType:   keyVaultSecretsResourceType,
-		ResourceName:   secretFullName,
-	}
+	// secretResource := azure.Resource{
+	// 	SubscriptionID: r.Arm.SubscriptionID,
+	// 	ResourceGroup:  r.Arm.ResourceGroup,
+	// 	Provider:       "Microsoft.KeyVault",
+	// 	ResourceType:   keyVaultSecretsResourceType,
+	// 	ResourceName:   secretFullName,
+	// }
 	or := outputresource.OutputResource{
-		Kind:     resourcekinds.AzureKeyVaultSecret,
 		LocalID:  outputresource.LocalIDKeyVaultSecret,
+		Type:     outputresource.TypeARM,
+		Kind:     resourcekinds.AzureKeyVaultSecret,
 		Deployed: true,
 		Managed:  true,
-		Type:     outputresource.TypeARM,
-		Info: outputresource.ARMInfo{
-			ID:           secretResource.String(),
-			ResourceType: keyVaultSecretsResourceType,
-			APIVersion:   keyVaultAPIVersion,
+		// Info: outputresource.ARMInfo{
+		// 	ID:           secretResource.String(),
+		// 	ResourceType: keyVaultSecretsResourceType,
+		// 	APIVersion:   keyVaultAPIVersion,
+		// },
+		Resource: map[string]string{
+			handlers.ManagedKey:             "true",
+			handlers.KeyVaultNameKey:        vaultName,
+			handlers.KeyVaultSecretNameKey:  secretName,
+			handlers.KeyVaultSecretValueKey: secretValue,
+			// "KeyVaultSecretFullNameKey":     secretFullName, // TODO remove, should be generated in handler
+			// "deploymentNameKey":             deploymentName, // TODO remove, should be generated in handler
 		},
 	}
 	logger.WithValues(radlogger.LogFieldLocalID, outputresource.LocalIDKeyVaultSecret).Info(fmt.Sprintf("Created secret: %s in Key Vault: %s successfully", secretName, vaultName))
@@ -642,7 +670,8 @@ func (r Renderer) createSecret(ctx context.Context, kvURI, secretName string, se
 	return or, nil
 }
 
-func (r Renderer) makeService(ctx context.Context, w workloads.InstantiatedWorkload, cc *ContainerComponent) (*corev1.Service, error) {
+// func (r Renderer) makeService(ctx context.Context, w workloads.InstantiatedWorkload, cc *ContainerComponent, deployment *appsv1.Deployment) (*corev1.Service, error) {
+func (r Renderer) makeService(ctx context.Context, w workloads.InstantiatedWorkload, cc *ContainerComponent, deployment *appsv1.Deployment) ([]outputresource.OutputResource, error) {
 	service := corev1.Service{
 		TypeMeta: v1.TypeMeta{
 			Kind:       "Service",
@@ -660,12 +689,12 @@ func (r Renderer) makeService(ctx context.Context, w workloads.InstantiatedWorkl
 		},
 	}
 
-	for name, generic := range w.Workload.Bindings {
-		if generic.Kind == KindHTTP {
+	for name, binding := range w.Workload.Bindings {
+		if binding.Kind == KindHTTP {
 			httpBinding := HTTPBinding{}
-			err := generic.AsRequired(KindHTTP, &httpBinding)
+			err := binding.AsRequired(KindHTTP, &httpBinding)
 			if err != nil {
-				return nil, err
+				return []outputresource.OutputResource{}, err
 			}
 
 			port := corev1.ServicePort{
@@ -680,8 +709,30 @@ func (r Renderer) makeService(ctx context.Context, w workloads.InstantiatedWorkl
 	}
 
 	if len(service.Spec.Ports) == 0 {
-		return nil, nil
+		return []outputresource.OutputResource{}, nil
 	}
 
-	return &service, nil
+	serviceDependencies := []outputresource.Dependency{
+		{
+			LocalID: outputresource.LocalIDDeployment,
+		},
+	}
+	serviceOutputResource := outputresource.OutputResource{
+		Kind:     resourcekinds.Kubernetes,
+		LocalID:  outputresource.LocalIDService,
+		Deployed: false,
+		Managed:  true,
+		Type:     outputresource.TypeKubernetes,
+		Info: outputresource.K8sInfo{
+			Kind:       deployment.TypeMeta.Kind,
+			APIVersion: deployment.TypeMeta.APIVersion,
+			Name:       deployment.ObjectMeta.Name,
+			Namespace:  deployment.ObjectMeta.Namespace,
+		},
+		Resource:     &service,
+		Dependencies: serviceDependencies,
+	}
+
+	// return &service, nil
+	return []outputresource.OutputResource{serviceOutputResource}, nil
 }

--- a/pkg/renderers/dapr/decorator_test.go
+++ b/pkg/renderers/dapr/decorator_test.go
@@ -66,7 +66,7 @@ func Test_Render_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resources, 1)
 
-	deployment := kubernetes.FindDeployment(resources)
+	deployment, _ := kubernetes.FindDeployment(resources)
 	require.NotNil(t, deployment)
 
 	expected := map[string]string{

--- a/pkg/renderers/manualscale/decorator_test.go
+++ b/pkg/renderers/manualscale/decorator_test.go
@@ -63,7 +63,7 @@ func Test_Render_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resources, 1)
 
-	deployment := kubernetes.FindDeployment(resources)
+	deployment, _ := kubernetes.FindDeployment(resources)
 	require.NotNil(t, deployment)
 
 	require.Equal(t, int32(2), *deployment.Spec.Replicas)
@@ -94,7 +94,7 @@ func Test_Render_CanSpecifyZero(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resources, 1)
 
-	deployment := kubernetes.FindDeployment(resources)
+	deployment, _ := kubernetes.FindDeployment(resources)
 	require.NotNil(t, deployment)
 
 	require.Equal(t, int32(0), *deployment.Spec.Replicas)

--- a/pkg/renderers/rabbitmqv1alpha1/renderer_test.go
+++ b/pkg/renderers/rabbitmqv1alpha1/renderer_test.go
@@ -50,10 +50,10 @@ func Test_Render_Managed_Kubernetes_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resources, 2)
 
-	deployment := kubernetes.FindDeployment(resources)
+	deployment, _ := kubernetes.FindDeployment(resources)
 	require.NotNil(t, deployment)
 
-	service := kubernetes.FindService(resources)
+	service, _ := kubernetes.FindService(resources)
 	require.NotNil(t, service)
 
 	labels := kubernetes.MakeDescriptiveLabels("test-app", "test-component")

--- a/pkg/renderers/redisv1alpha1/kubernetesrender_test.go
+++ b/pkg/renderers/redisv1alpha1/kubernetesrender_test.go
@@ -50,10 +50,10 @@ func Test_Render_Managed_Kubernetes_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resources, 2)
 
-	deployment := kubernetes.FindDeployment(resources)
+	deployment, _ := kubernetes.FindDeployment(resources)
 	require.NotNil(t, deployment)
 
-	service := kubernetes.FindService(resources)
+	service, _ := kubernetes.FindService(resources)
 	require.NotNil(t, service)
 
 	labels := map[string]string{


### PR DESCRIPTION
Move deployments from renderer for container to deployment processor -> handler by leveraging dependencies between output resources generated by the renderer.

Fixes - https://github.com/Azure/radius/issues/963 and https://github.com/Azure/radius/issues/497

Deletion of resources is currently bundled in one handler for multiple resources, I'll be addressing that as a separate PR to limit the scope of this change.