### PR TITLE
Removes patch version from helm chart tag value

### DIFF
--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -1,2 +1,2 @@
 container: radius.azurecr.io/radius-controller
-tag: 0.4 # Tag for radius-controller image.
+tag: 0.5 # Tag for radius-controller image.

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -1,2 +1,2 @@
 container: radius.azurecr.io/radius-controller
-tag: 0.4.0 # Tag for radius-controller image, include patch version updates.
+tag: 0.4 # Tag for radius-controller image.


### PR DESCRIPTION
We made this change in release/0.4 but didn't in main. https://github.com/Azure/radius/commit/4ee5ce9e13e1bebc8bc5e582532b9a4ea01a54e0

Also updating patch version as we are going to branch today. 