### PR TITLE
Fix race condition

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -60,10 +60,9 @@ jobs:
         id: gitdiff
         run: |
           git diff --exit-code
-      # TODO: Investigate why this is failing
-      # - name: Check failures
-      #   if: steps.gitdiff.outcome != 'success'
-      #   run: |
-      #     echo "Generated code is not up to date, run 'make generate' to update generated code."
-      #     exit 1
+      - name: Check failures
+        if: steps.gitdiff.outcome != 'success'
+        run: |
+          echo "Generated code is not up to date, run 'make generate' to update generated code."
+          exit 1
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -60,9 +60,10 @@ jobs:
         id: gitdiff
         run: |
           git diff --exit-code
-      - name: Check failures
-        if: steps.gitdiff.outcome != 'success'
-        run: |
-          echo "Generated code is not up to date, run 'make generate' to update generated code."
-          exit 1
+      # TODO: Investigate why this is failing
+      # - name: Check failures
+      #   if: steps.gitdiff.outcome != 'success'
+      #   run: |
+      #     echo "Generated code is not up to date, run 'make generate' to update generated code."
+      #     exit 1
 

--- a/pkg/health/handlers/kubernetes_deployment.go
+++ b/pkg/health/handlers/kubernetes_deployment.go
@@ -61,7 +61,7 @@ func (handler *kubernetesDeploymentHandler) GetHealthState(ctx context.Context, 
 		Resource: healthcontract.ResourceInfo{
 			HealthID:     resourceInfo.HealthID,
 			ResourceID:   resourceInfo.ResourceID,
-			ResourceKind: resourcekinds.ResourceKindKubernetes,
+			ResourceKind: resourcekinds.Kubernetes,
 		},
 		HealthState:             healthState,
 		HealthStateErrorDetails: healthStateErrorDetails,

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -21,9 +21,6 @@ import (
 	"github.com/Azure/radius/pkg/radlogger"
 )
 
-// HealthMonitoringInitialDelay is the delay after which the health service will start monitoring the resource
-const HealthMonitoringInitialDelay = time.Second * 5
-
 // ChannelBufferSize defines the buffer size for the Watch channel to receive health state changes from push mode watchers
 const ChannelBufferSize = 100
 
@@ -126,16 +123,7 @@ func (h Monitor) RegisterResource(ctx context.Context, registerMsg healthcontrac
 		}
 
 		// Watch health state
-		go func() {
-			// HealthMonitoringInitialDelay is required to avoid a race condition where the health updates start getting pushed to RP
-			// when the RP has not yet updated the component with outputresources in DB
-			// As a result, the initial health updates get missed. This is especially required
-			// when the health handler is operating in push mode where the health state may never be updated if there
-			// are no updates to the health state after the initial missed updates.
-			// To avoid this, start monitoring the output resources with a delay
-			time.Sleep(HealthMonitoringInitialDelay)
-			healthHandler.GetHealthState(ctx, healthInfo.Resource, options)
-		}()
+		go healthHandler.GetHealthState(ctx, healthInfo.Resource, options)
 	} else if mode == handleroptions.HealthHandlerModePull {
 		// Need to actively probe the health periodically
 		h.probeHealth(ctx, healthHandler, healthInfo)

--- a/pkg/radrp/backend/healthlistener/service.go
+++ b/pkg/radrp/backend/healthlistener/service.go
@@ -76,7 +76,7 @@ func (s *Service) UpdateHealth(ctx context.Context, healthUpdateMsg healthcontra
 
 	resourceID, err := azresources.Parse(id)
 	if err != nil {
-		logger.Error(err, "Invalid resource ID")
+		logger.Error(err, fmt.Sprintf("Invalid resource ID: %s", id))
 		return false
 	}
 	cid := resources.ResourceID{ResourceID: resourceID}

--- a/pkg/radrp/db/types.go
+++ b/pkg/radrp/db/types.go
@@ -142,6 +142,7 @@ type ComponentTrait struct {
 type OutputResource struct {
 	LocalID            string               `bson:"id"`
 	HealthID           string               `bson:"healthId"`
+	ResourceID         string               `bson:"resourceId"`
 	ResourceKind       string               `bson:"resourceKind"`
 	OutputResourceInfo interface{}          `bson:"outputResourceInfo"`
 	Managed            bool                 `bson:"managed"`

--- a/pkg/radrp/deployment/deployment_processor.go
+++ b/pkg/radrp/deployment/deployment_processor.go
@@ -193,6 +193,7 @@ func (dp *deploymentProcessor) UpdateDeployment(ctx context.Context, appName str
 					SubscriptionID: action.Definition.SubscriptionID,
 					ResourceGroup:  action.Definition.ResourceGroup,
 				}
+				// Save the healthID on the resource
 				healthID := outputResourceInfo.GetHealthID()
 				resource.HealthID = healthID
 

--- a/pkg/radrp/deployment/deployment_processor.go
+++ b/pkg/radrp/deployment/deployment_processor.go
@@ -318,7 +318,6 @@ func (dp *deploymentProcessor) UpdateDeployment(ctx context.Context, appName str
 func addDBOutputResource(resource outputresource.OutputResource, dbOutputResources *[]db.OutputResource) {
 	// Save the output resource to DB
 	dbr := db.OutputResource{
-		ResourceID:         resource.GetResourceID(),
 		Managed:            resource.Managed,
 		HealthID:           resource.HealthID,
 		LocalID:            resource.LocalID,
@@ -471,7 +470,7 @@ func (dp *deploymentProcessor) RegisterForHealthChecks(ctx context.Context, appI
 	errs := []error{}
 	for _, or := range component.Properties.Status.OutputResources {
 		outputResourceInfo := healthcontract.ResourceDetails{
-			ResourceID:     or.ResourceID,
+			ResourceID:     or.GetResourceID(),
 			ResourceKind:   or.ResourceKind,
 			ApplicationID:  appID,
 			ComponentID:    component.Name,

--- a/pkg/radrp/deployment/deployment_processor.go
+++ b/pkg/radrp/deployment/deployment_processor.go
@@ -465,9 +465,10 @@ func (dp *deploymentProcessor) processBindings(ctx context.Context, w workloads.
 func (dp *deploymentProcessor) RegisterForHealthChecks(ctx context.Context, appID string, component db.Component) error {
 	logger := radlogger.GetLogger(ctx)
 	logger = logger.WithValues(
+		radlogger.LogFieldAppID, appID,
 		radlogger.LogFieldComponentName, component.Name,
 	)
-	var errs []error
+	errs := []error{}
 	for _, or := range component.Properties.Status.OutputResources {
 		outputResourceInfo := healthcontract.ResourceDetails{
 			ResourceID:     or.ResourceID,

--- a/pkg/radrp/deployment/deployment_processor.go
+++ b/pkg/radrp/deployment/deployment_processor.go
@@ -486,7 +486,12 @@ func (dp *deploymentProcessor) RegisterForHealthChecks(ctx context.Context, appI
 			radlogger.LogFieldLocalID, or.LocalID,
 			radlogger.LogFieldHealthID, or.HealthID).Info(fmt.Sprintf("Registered output resource with HealthID: %s for health checks", or.HealthID))
 	}
-	return &CompositeError{errs}
+
+	if len(errs) > 0 {
+		return &CompositeError{Errors: errs}
+	}
+
+	return nil
 }
 
 func (dp *deploymentProcessor) registerOutputResourceForHealthChecks(ctx context.Context, healthInfo healthcontract.ResourceDetails, healthID string, options healthcontract.HealthCheckOptions) {

--- a/pkg/radrp/deployment/deployment_processor_test.go
+++ b/pkg/radrp/deployment/deployment_processor_test.go
@@ -89,17 +89,25 @@ func Test_DeploymentProcessor_RegistersOutputResourcesWithHealthService(t *testi
 				OutputResources: []db.OutputResource{
 					{
 						LocalID:            "L1",
-						ResourceID:         "ResourceID_1",
 						HealthID:           "HealthID_1",
 						OutputResourceType: outputresource.TypeARM,
 						ResourceKind:       "Kind1",
+						OutputResourceInfo: outputresource.ARMInfo{
+							ID:           "ResourceID_1",
+							ResourceType: "Dummy1",
+							APIVersion:   "2021-01-01",
+						},
 					},
 					{
 						LocalID:            "L2",
-						ResourceID:         "ResourceID_2",
 						HealthID:           "HealthID_2",
 						OutputResourceType: outputresource.TypeARM,
 						ResourceKind:       "Kind1",
+						OutputResourceInfo: outputresource.ARMInfo{
+							ID:           "ResourceID_2",
+							ResourceType: "Dummy2",
+							APIVersion:   "2021-01-01",
+						},
 					},
 				},
 			},

--- a/pkg/radrp/deployment/deployment_processor_test.go
+++ b/pkg/radrp/deployment/deployment_processor_test.go
@@ -7,7 +7,6 @@ package deployment
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/Azure/radius/pkg/handlers"
@@ -66,33 +65,9 @@ func Test_DeploymentProcessor_OrderActions(t *testing.T) {
 func Test_DeploymentProcessor_RegistersOutputResourcesWithHealthService(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockResourceHandler := handlers.NewMockResourceHandler(ctrl)
-	mockResourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(2).Return(map[string]string{}, nil)
 	mockHealthHandler := handlers.NewMockHealthHandler(ctrl)
 	mockHealthHandler.EXPECT().GetHealthOptions(gomock.Any()).Times(2).Return(healthcontract.HealthCheckOptions{})
 	mockRendererKind := renderers.NewMockWorkloadRenderer(ctrl)
-	mockRendererKind.EXPECT().Render(gomock.Any(), gomock.Any()).AnyTimes().Return([]outputresource.OutputResource{
-		{
-			LocalID:  "abc",
-			Kind:     "Kind1",
-			HealthID: "HealthID_1",
-			Type:     outputresource.TypeARM,
-			Info: outputresource.ARMInfo{
-				ID: "ResourceID_1",
-			},
-		},
-		{
-			LocalID:  "xyz",
-			Kind:     "Kind1",
-			HealthID: "HealthID_2",
-			Type:     outputresource.TypeKubernetes,
-			Info: outputresource.K8sInfo{
-				Name:      "name1",
-				Namespace: "ns1",
-				Kind:      "Deployment",
-			},
-		},
-	}, nil)
-	mockRendererKind.EXPECT().AllocateBindings(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(map[string]components.BindingState{}, nil)
 	model := model.NewModel(map[string]workloads.WorkloadRenderer{
 		"Dummy1": mockRendererKind,
 	}, map[string]model.Handlers{
@@ -107,23 +82,29 @@ func Test_DeploymentProcessor_RegistersOutputResourcesWithHealthService(t *testi
 		ResourceRegistrationWithHealthChannel: registrationChannel,
 	}}
 
-	actions := map[string]ComponentAction{
-		"C": {
-			ComponentName: "C",
-			Operation:     CreateWorkload,
-			Component: &components.GenericComponent{
-				Kind: "Dummy1",
-			},
-			Definition: &db.Component{
-				Kind: "Kind1",
-				Properties: db.ComponentProperties{
-					Uses: []db.ComponentDependency{},
+	c := db.Component{
+		Kind: "Kind1",
+		Properties: db.ComponentProperties{
+			Status: db.ComponentStatus{
+				OutputResources: []db.OutputResource{
+					{
+						LocalID:            "L1",
+						ResourceID:         "ResourceID_1",
+						HealthID:           "HealthID_1",
+						OutputResourceType: outputresource.TypeARM,
+						ResourceKind:       "Kind1",
+					},
+					{
+						LocalID:            "L2",
+						ResourceID:         "ResourceID_2",
+						HealthID:           "HealthID_2",
+						OutputResourceType: outputresource.TypeARM,
+						ResourceKind:       "Kind1",
+					},
 				},
 			},
 		},
 	}
-
-	deployStatus := db.DeploymentStatus{}
 
 	var ctx context.Context
 	logger, err := radlogger.NewTestLogger(t)
@@ -133,7 +114,7 @@ func Test_DeploymentProcessor_RegistersOutputResourcesWithHealthService(t *testi
 	} else {
 		ctx = logr.NewContext(context.Background(), logger)
 	}
-	err = dp.UpdateDeployment(ctx, "A", "A", &deployStatus, actions)
+	err = dp.RegisterForHealthChecks(ctx, "A", c)
 	require.NoError(t, err, "Update Deployment failed")
 
 	// Registration for first output resource
@@ -141,33 +122,14 @@ func Test_DeploymentProcessor_RegistersOutputResourcesWithHealthService(t *testi
 	require.Equal(t, healthcontract.ActionRegister, msg1.Action)
 	require.Equal(t, "ResourceID_1", msg1.ResourceInfo.ResourceID)
 	require.Equal(t, "Kind1", msg1.ResourceInfo.ResourceKind)
-	outputResourceInfo1 := healthcontract.ResourceDetails{
-		ResourceID:    "ResourceID_1",
-		ResourceKind:  "Kind1",
-		ApplicationID: "A",
-		ComponentID:   "C",
-	}
-	require.Equal(t, outputResourceInfo1.GetHealthID(), msg1.ResourceInfo.HealthID)
+	require.Equal(t, "HealthID_1", msg1.ResourceInfo.HealthID)
 
 	// Registration for second output resource
 	msg2 := <-registrationChannel
 	require.Equal(t, healthcontract.ActionRegister, msg2.Action)
 	require.Equal(t, "Kind1", msg2.ResourceInfo.ResourceKind)
-
-	kID := healthcontract.KubernetesID{
-		Kind:      "Deployment",
-		Namespace: "ns1",
-		Name:      "name1",
-	}
-	resourceID, _ := json.Marshal(kID)
-	require.Equal(t, string(resourceID), msg2.ResourceInfo.ResourceID)
-	outputResourceInfo2 := healthcontract.ResourceDetails{
-		ResourceID:    string(resourceID),
-		ResourceKind:  "Kind1",
-		ApplicationID: "A",
-		ComponentID:   "C",
-	}
-	require.Equal(t, outputResourceInfo2.GetHealthID(), msg2.ResourceInfo.HealthID)
+	require.Equal(t, "ResourceID_2", msg2.ResourceInfo.ResourceID)
+	require.Equal(t, "HealthID_2", msg2.ResourceInfo.HealthID)
 }
 
 func Test_DeploymentProcessor_UnregistersOutputResourcesWithHealthService(t *testing.T) {
@@ -190,7 +152,7 @@ func Test_DeploymentProcessor_UnregistersOutputResourcesWithHealthService(t *tes
 			LocalID:  "xyz",
 			Kind:     "Kind1",
 			HealthID: "HealthID_2",
-			Type:     outputresource.TypeKubernetes,
+			Type:     "Kind1",
 			Info: outputresource.K8sInfo{
 				Name:      "name1",
 				Namespace: "ns1",

--- a/pkg/radrp/deployment/mock_deployment_processor.go
+++ b/pkg/radrp/deployment/mock_deployment_processor.go
@@ -49,6 +49,20 @@ func (mr *MockDeploymentProcessorMockRecorder) DeleteDeployment(arg0, arg1, arg2
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDeployment", reflect.TypeOf((*MockDeploymentProcessor)(nil).DeleteDeployment), arg0, arg1, arg2, arg3)
 }
 
+// RegisterForHealthChecks mocks base method.
+func (m *MockDeploymentProcessor) RegisterForHealthChecks(arg0 context.Context, arg1 string, arg2 db.Component) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegisterForHealthChecks", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RegisterForHealthChecks indicates an expected call of RegisterForHealthChecks.
+func (mr *MockDeploymentProcessorMockRecorder) RegisterForHealthChecks(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterForHealthChecks", reflect.TypeOf((*MockDeploymentProcessor)(nil).RegisterForHealthChecks), arg0, arg1, arg2)
+}
+
 // UpdateDeployment mocks base method.
 func (m *MockDeploymentProcessor) UpdateDeployment(arg0 context.Context, arg1, arg2 string, arg3 *db.DeploymentStatus, arg4 map[string]ComponentAction) error {
 	m.ctrl.T.Helper()

--- a/pkg/radrp/frontend/handlerv2/handler_test.go
+++ b/pkg/radrp/frontend/handlerv2/handler_test.go
@@ -1626,6 +1626,7 @@ func Test_UpdateDeployment_FailureCanBeRetried(t *testing.T) {
 				return errors.New("Timeout!")
 			}
 		})
+	test.deploy.EXPECT().RegisterForHealthChecks(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().AnyTimes()
 
 	test.DBCreateApplication(TestApplicationName, db.ApplicationProperties{})
 	rev := test.DBCreateComponent(TestApplicationName, "A", "radius.dev/Test@v1alpha1", db.ComponentProperties{})
@@ -1725,6 +1726,7 @@ func Test_UpdateDeployment_UpdateSuccess(t *testing.T) {
 				return errors.New("timed out")
 			}
 		})
+	test.deploy.EXPECT().RegisterForHealthChecks(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().AnyTimes()
 
 	test.DBCreateApplication(TestApplicationName, db.ApplicationProperties{})
 	test.DBCreateDeployment(TestApplicationName, "default", db.DeploymentProperties{})

--- a/pkg/radrp/frontend/resourceproviderv2/resourceprovider.go
+++ b/pkg/radrp/frontend/resourceproviderv2/resourceprovider.go
@@ -518,6 +518,8 @@ func (r *rp) UpdateDeployment(ctx context.Context, d *rest.Deployment) (rest.Res
 			return
 		}
 
+		// Now all the components have been persisted in the DB.
+		// Register the output resources for each component with health service
 		err = r.registerForHealthChecks(ctx, actions)
 		if err != nil {
 			logger.Error(err, "Registration of output resources with health service failed")
@@ -532,7 +534,6 @@ func (r *rp) UpdateDeployment(ctx context.Context, d *rest.Deployment) (rest.Res
 }
 
 func (r *rp) registerForHealthChecks(ctx context.Context, actions map[string]deployment.ComponentAction) error {
-	// Now all the components have been persisted in the DB. Register for health checks
 	var errs []error
 	for _, action := range actions {
 		err := r.deploy.RegisterForHealthChecks(ctx, action.ApplicationName, *action.Definition)

--- a/pkg/radrp/frontend/resourceproviderv2/resourceprovider.go
+++ b/pkg/radrp/frontend/resourceproviderv2/resourceprovider.go
@@ -537,17 +537,15 @@ func (r *rp) UpdateDeployment(ctx context.Context, d *rest.Deployment) (rest.Res
 
 func (r *rp) registerForHealthChecks(ctx context.Context, actions map[string]deployment.ComponentAction) error {
 	errs := []error{}
-	for c, action := range actions {
-		if action.Definition == nil || action.Operation == deployment.DeleteWorkload {
-			fmt.Printf("@@@@@ Ignoring handling of action app: %s, component: %s, op: %s, def: %v @@@@ \n", action.ApplicationName, c, action.Operation, action.Definition)
-			// Do nothing for delete workloads
-			continue
-		}
-		err := r.deploy.RegisterForHealthChecks(ctx, action.ApplicationName, *action.Definition)
-		if err != nil {
-			errs = append(errs, err)
+	for _, action := range actions {
+		if action.Operation == deployment.CreateWorkload || action.Operation == deployment.UpdateWorkload {
+			err := r.deploy.RegisterForHealthChecks(ctx, action.ApplicationName, *action.Definition)
+			if err != nil {
+				errs = append(errs, err)
+			}
 		}
 	}
+	
 	if len(errs) > 0 {
 		return &deployment.CompositeError{Errors: errs}
 	}

--- a/pkg/radrp/frontend/resourceproviderv2/resourceprovider.go
+++ b/pkg/radrp/frontend/resourceproviderv2/resourceprovider.go
@@ -493,6 +493,8 @@ func (r *rp) UpdateDeployment(ctx context.Context, d *rest.Deployment) (rest.Res
 			logger.Error(err, "failed to retrieve application")
 			return
 		}
+
+		logger = logger.WithValues(radlogger.LogFieldAppName, a.Name)
 		// Update the deployment in the application
 		logger.Info("Updating deployment")
 		a.Deployments[id.Resource.Name()] = *d
@@ -534,7 +536,7 @@ func (r *rp) UpdateDeployment(ctx context.Context, d *rest.Deployment) (rest.Res
 }
 
 func (r *rp) registerForHealthChecks(ctx context.Context, actions map[string]deployment.ComponentAction) error {
-	var errs []error
+	errs := []error{}
 	for _, action := range actions {
 		err := r.deploy.RegisterForHealthChecks(ctx, action.ApplicationName, *action.Definition)
 		if err != nil {

--- a/pkg/radrp/frontend/resourceproviderv2/resourceprovider.go
+++ b/pkg/radrp/frontend/resourceproviderv2/resourceprovider.go
@@ -517,6 +517,15 @@ func (r *rp) UpdateDeployment(ctx context.Context, d *rest.Deployment) (rest.Res
 			logger.Error(err, "failed to update application")
 			return
 		}
+
+		// Now all the components have been persisted in the DB. Register for health checks
+		for _, action := range actions {
+			err := r.deploy.RegisterForHealthChecks(ctx, action.ApplicationName, *action.Definition)
+			if err != nil {
+				logger.Error(err, fmt.Sprintf("Registration of output resources with health service failed for component: %s", action.Definition.Name))
+			}
+		}
+
 		logger.WithValues(radlogger.LogFieldOperationStatus, status).Info("completed deployment in the background with status")
 	}()
 

--- a/pkg/radrp/frontend/resourceproviderv2/resourceprovider.go
+++ b/pkg/radrp/frontend/resourceproviderv2/resourceprovider.go
@@ -537,9 +537,9 @@ func (r *rp) UpdateDeployment(ctx context.Context, d *rest.Deployment) (rest.Res
 
 func (r *rp) registerForHealthChecks(ctx context.Context, actions map[string]deployment.ComponentAction) error {
 	errs := []error{}
-	for _, action := range actions {
+	for c, action := range actions {
 		if action.Definition == nil || action.Operation == deployment.DeleteWorkload {
-			fmt.Printf("@@@@@ Ignoring handling of action: %s, op: %s, def: %v @@@@ \n", action.Name, action.Operation, action.Definition)
+			fmt.Printf("@@@@@ Ignoring handling of action app: %s, component: %s, op: %s, def: %v @@@@ \n", action.ApplicationName, c, action.Operation, action.Definition)
 			// Do nothing for delete workloads
 			continue
 		}

--- a/pkg/radrp/frontend/resourceproviderv2/resourceprovider.go
+++ b/pkg/radrp/frontend/resourceproviderv2/resourceprovider.go
@@ -538,6 +538,11 @@ func (r *rp) UpdateDeployment(ctx context.Context, d *rest.Deployment) (rest.Res
 func (r *rp) registerForHealthChecks(ctx context.Context, actions map[string]deployment.ComponentAction) error {
 	errs := []error{}
 	for _, action := range actions {
+		if action.Definition == nil || action.Operation == deployment.DeleteWorkload {
+			fmt.Printf("@@@@@ Ignoring handling of action: %s, op: %s, def: %v @@@@ \n", action.Name, action.Operation, action.Definition)
+			// Do nothing for delete workloads
+			continue
+		}
 		err := r.deploy.RegisterForHealthChecks(ctx, action.ApplicationName, *action.Definition)
 		if err != nil {
 			errs = append(errs, err)

--- a/pkg/radrp/frontend/resourceproviderv2/resourceprovider_deployment_test.go
+++ b/pkg/radrp/frontend/resourceproviderv2/resourceprovider_deployment_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/radius/pkg/radrp/deployment"
 	"github.com/Azure/radius/pkg/renderers/containerv1alpha1"
 	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -179,6 +180,51 @@ func Test_DeploymentCreated_MultipleComponents(t *testing.T) {
 	require.Equal(t, app.Components["C"], *action.Definition)
 	require.Equal(t, revision.Revision(""), action.OldRevision)
 	require.Equal(t, revision.Revision("1"), action.NewRevision)
+}
+
+func Test_DeploymentUpdate_RegistersForHealthChecks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDeploymentProcessor := deployment.NewMockDeploymentProcessor(ctrl)
+	mockDeploymentProcessor.EXPECT().RegisterForHealthChecks(gomock.Any(), gomock.Any(), gomock.Any()).Times(3).Return(nil)
+
+	rp := rp{
+		deploy: mockDeploymentProcessor,
+	}
+
+	actions := map[string]deployment.ComponentAction{
+		"C1": {
+			ApplicationName: "A",
+			ComponentName:   "C1",
+			Definition: &db.Component{
+				Kind:       containerv1alpha1.Kind,
+				Revision:   revision.Revision("1"),
+				Properties: *db.NewComponentProperties(),
+			},
+		},
+		"C2": {
+			ApplicationName: "A",
+			ComponentName:   "C2",
+			Definition: &db.Component{
+				Kind:       containerv1alpha1.Kind,
+				Revision:   revision.Revision("1"),
+				Properties: *db.NewComponentProperties(),
+			},
+		},
+		"C3": {
+			ApplicationName: "A",
+			ComponentName:   "C3",
+			Definition: &db.Component{
+				Kind:       containerv1alpha1.Kind,
+				Revision:   revision.Revision("1"),
+				Properties: *db.NewComponentProperties(),
+			},
+		},
+	}
+
+	ctx := createContext(t)
+	err := rp.registerForHealthChecks(ctx, actions)
+	require.NoError(t, err)
+
 }
 
 func Test_DeploymentUpdated_OneComponent_Deleted(t *testing.T) {

--- a/pkg/radrp/frontend/resourceproviderv2/resourceprovider_deployment_test.go
+++ b/pkg/radrp/frontend/resourceproviderv2/resourceprovider_deployment_test.go
@@ -195,6 +195,7 @@ func Test_DeploymentUpdate_RegistersForHealthChecks(t *testing.T) {
 		"C1": {
 			ApplicationName: "A",
 			ComponentName:   "C1",
+			Operation: deployment.UpdateWorkload,
 			Definition: &db.Component{
 				Kind:       containerv1alpha1.Kind,
 				Revision:   revision.Revision("1"),
@@ -204,6 +205,7 @@ func Test_DeploymentUpdate_RegistersForHealthChecks(t *testing.T) {
 		"C2": {
 			ApplicationName: "A",
 			ComponentName:   "C2",
+			Operation: deployment.UpdateWorkload,
 			Definition: &db.Component{
 				Kind:       containerv1alpha1.Kind,
 				Revision:   revision.Revision("1"),
@@ -213,6 +215,7 @@ func Test_DeploymentUpdate_RegistersForHealthChecks(t *testing.T) {
 		"C3": {
 			ApplicationName: "A",
 			ComponentName:   "C3",
+			Operation: deployment.UpdateWorkload,
 			Definition: &db.Component{
 				Kind:       containerv1alpha1.Kind,
 				Revision:   revision.Revision("1"),


### PR DESCRIPTION
RP Puts all the resources first and then updates the DB with the application in one shot. However, the health registration is done as soon as the output resource is created. At times, the health updates can start coming in before the component is even updated in the DB with the output resources. As a result, the health update gets ignored. This might be okay for the non-k8s health since we poll periodically. But for k8s, there might be no further updates if we miss the initial ones.

This change registers resources for health checks after all app changes have been persisted in the DB