### PR TITLE
Fix Go version to 1.16.8.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     runs-on: ${{ matrix.os }}
     env:
-      GOVER: '^1.16.0'
+      GOVER: '1.16.8'
       GOOS: ${{ matrix.target_os }}
       GOARCH: ${{ matrix.target_arch }}
       GOPROXY: https://proxy.golang.org
@@ -178,7 +178,7 @@ jobs:
     if: startsWith(github.ref, 'refs/pull/') # run on PR
     runs-on: ubuntu-latest
     env:
-      GOVER: '^1.16.0'
+      GOVER: '1.16.8'
       DOCKER_REGISTRY: radius.azurecr.io
       # Timeout used for Kubernetes functional tests
       K8S_FUNCTIONALTEST_TIMEOUT: 60m
@@ -246,7 +246,7 @@ jobs:
     if: startsWith(github.ref, 'refs/pull/') # run on PR
     runs-on: ubuntu-latest
     env:
-      GOVER: '^1.16.0'
+      GOVER: '1.16.8'
 
       # Timeout used for Azure functional tests
       AZURE_FUNCTIONALTEST_TIMEOUT: 60m

--- a/.github/workflows/create-environment.yaml
+++ b/.github/workflows/create-environment.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Create Environment
     runs-on: ubuntu-latest
     env:
-      GOVER: '^1.16.0'
+      GOVER: '1.16.8'
       GOPROXY: https://proxy.golang.org
 
       # Radius Test subscription

--- a/.github/workflows/delete-environment.yaml
+++ b/.github/workflows/delete-environment.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Delete Environment
     runs-on: ubuntu-latest
     env:
-      GOVER: '^1.16.0'
+      GOVER: '1.16.8'
       GOPROXY: https://proxy.golang.org
 
       # Radius Test subscription

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     env:
-      GOVER: '^1.16.0'
+      GOVER: '1.16.8'
       GOPROXY: https://proxy.golang.org
     steps:
       - name: Check out repo
@@ -40,7 +40,7 @@ jobs:
     name: Check generated code
     runs-on: ubuntu-latest
     env:
-      GOVER: '^1.16.0'
+      GOVER: '1.16.8'
       GOPROXY: https://proxy.golang.org
     steps:
       - name: Check out repo

--- a/.github/workflows/staging-website.yaml
+++ b/.github/workflows/staging-website.yaml
@@ -28,7 +28,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     env:
-      GOVER: '^1.16.0'
+      GOVER: '1.16.8'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     env:
-      GOVER: '^1.16.0'
+      GOVER: '1.16.8'
       TUTORIAL_PATH: './docs/content/getting-started/tutorial/'
       CODE_ZIP_PATH: './docs/static/tutorial/'
       HUGO_ENV: production
@@ -64,7 +64,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
     runs-on: ubuntu-latest
     env:
-      GOVER: '^1.16.0'
+      GOVER: '1.16.8'
       TUTORIAL_PATH: './docs/content/getting-started/tutorial/'
       CODE_ZIP_PATH: './docs/static/tutorial/'
       HUGO_ENV: production


### PR DESCRIPTION
It seems that Go 1.17 causes our generated code to differ from 1.16 and causing `make generate` check to fail.

Fixing this for now before 1.17 becomes more widely adopted in the team.