### PR TITLE
Add deployment evaluator piece and add test to show references working

### DIFF
--- a/pkg/cli/armtemplate/armtemplate_test.go
+++ b/pkg/cli/armtemplate/armtemplate_test.go
@@ -84,9 +84,9 @@ func Test_DeploymentTemplate(t *testing.T) {
 					},
 					"uses": []interface{}{
 						map[string]interface{}{
-							"binding": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web]",
+							"binding": "[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web]",
 							"env": map[string]interface{}{
-								"SERVICE__BACKEND__TARGETPORT": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web.targetPort]",
+								"SERVICE__BACKEND__TARGETPORT": "[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web.targetPort]",
 							},
 						},
 					},

--- a/pkg/cli/armtemplate/deploy_evaluator.go
+++ b/pkg/cli/armtemplate/deploy_evaluator.go
@@ -111,7 +111,6 @@ func (eva *DeploymentEvaluator) VisitMap(input map[string]interface{}) (map[stri
 			return nil, err
 		}
 
-		// Maps are pointer-like, so we can just modify them in place
 		output[key] = v
 	}
 

--- a/pkg/cli/armtemplate/deploy_evaluator.go
+++ b/pkg/cli/armtemplate/deploy_evaluator.go
@@ -1,0 +1,277 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package armtemplate
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/Azure/radius/pkg/azure/azresources"
+	"github.com/Azure/radius/pkg/radrp/armexpr"
+)
+
+type DeploymentEvaluator struct {
+	Template  DeploymentTemplate
+	Options   TemplateOptions
+	Deployed  map[string]map[string]interface{}
+	Variables map[string]interface{}
+
+	// Intermediate expression evaluation state
+	Value interface{}
+}
+
+func (eva *DeploymentEvaluator) VisitValue(input interface{}) (interface{}, error) {
+	str, ok := input.(string)
+	if ok {
+		slice, err := eva.VisitString(str)
+		if err != nil {
+			return nil, err
+		}
+
+		return slice, err
+	}
+
+	slice, ok := input.([]interface{})
+	if ok {
+		slice, err := eva.VisitSlice(slice)
+		if err != nil {
+			return nil, err
+		}
+
+		return slice, err
+	}
+
+	m, ok := input.(map[string]interface{})
+	if ok {
+		m, err := eva.VisitMap(m)
+		if err != nil {
+			return nil, err
+		}
+
+		return m, err
+	}
+
+	tree, ok := input.(*armexpr.SyntaxTree)
+	if ok {
+		err := tree.Expression.Accept(eva)
+		if err != nil {
+			return nil, err
+		}
+
+		return eva.Value, nil
+	}
+
+	// No need to analyze a null, bool, or number
+	return input, nil
+}
+
+func (eva *DeploymentEvaluator) VisitString(input string) (interface{}, error) {
+	isExpr, err := armexpr.IsStandardARMExpression(input)
+	if err != nil {
+		return "", err
+	} else if !isExpr {
+		// Not an expression
+		return input, nil
+	}
+
+	syntaxTree, err := armexpr.Parse(input)
+	if err != nil {
+		return "", err
+	}
+
+	err = syntaxTree.Expression.Accept(eva)
+	if err != nil {
+		return "", err
+	}
+
+	return eva.Value, nil
+}
+
+func (eva *DeploymentEvaluator) VisitMap(input map[string]interface{}) (map[string]interface{}, error) {
+	output := map[string]interface{}{}
+
+	for k, v := range input {
+		k, err := eva.VisitString(k)
+		if err != nil {
+			return nil, err
+		}
+
+		key, ok := k.(string)
+		if !ok {
+			return nil, fmt.Errorf("map key must evaluate to a string, was: %+v", k)
+		}
+
+		v, err := eva.VisitValue(v)
+		if err != nil {
+			return nil, err
+		}
+
+		// Maps are pointer-like, so we can just modify them in place
+		output[key] = v
+	}
+
+	return output, nil
+}
+
+func (eva *DeploymentEvaluator) VisitSlice(input []interface{}) ([]interface{}, error) {
+	copy := []interface{}{}
+	for _, v := range input {
+		v, err := eva.VisitValue(v)
+		if err != nil {
+			return nil, err
+		}
+
+		copy = append(copy, v)
+	}
+
+	return copy, nil
+}
+
+func (eva *DeploymentEvaluator) VisitStringLiteral(node *armexpr.StringLiteralNode) error {
+	eva.Value = node.Text[1 : len(node.Text)-1]
+	return nil
+}
+
+func (eva *DeploymentEvaluator) VisitPropertyAccess(node *armexpr.PropertyAccessNode) error {
+	// Recursively evaluate the LHS
+	err := node.Base.Accept(eva)
+	if err != nil {
+		return err
+	}
+
+	if eva.Value == nil {
+		return errors.New("value to access is null")
+	}
+
+	obj, ok := eva.Value.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("value to access should be a map, was: %+v", eva.Value)
+	}
+
+	value, ok := obj[node.Identifier.Text]
+	if !ok {
+		return fmt.Errorf("value did not contain property '%s', was: %+v", node.Identifier.Text, obj)
+	}
+
+	eva.Value = value
+	return nil
+}
+
+func (eva *DeploymentEvaluator) VisitFunctionCall(node *armexpr.FunctionCallNode) error {
+	name := node.Identifier.Text
+
+	args := []interface{}{}
+	for _, argexpr := range node.Args {
+		err := argexpr.Accept(eva)
+		if err != nil {
+			return err
+		}
+
+		args = append(args, eva.Value)
+	}
+
+	if name == "format" {
+		if len(args) < 1 {
+			return fmt.Errorf("at least 1 argument is required for %s", "format")
+		}
+
+		eva.Value = eva.EvaluateFormat(args[0], args[1:])
+		return nil
+	} else if name == "reference" {
+		if len(args) != 1 {
+			return fmt.Errorf("exactly 1 argument required for %s", "reference")
+		}
+
+		result, err := eva.EvaluateReference(args[0])
+		if err != nil {
+			return err
+		}
+
+		eva.Value = result
+		return nil
+	} else if name == "resourceId" {
+		if len(args) < 2 {
+			return fmt.Errorf("at least 2 arguments are required for %s", "resourceId")
+		}
+
+		result, err := eva.EvaluateResourceID(args[0], args[1:])
+		if err != nil {
+			return err
+		}
+
+		eva.Value = result
+		return nil
+	} else if name == "variables" {
+		if len(args) != 1 {
+			return fmt.Errorf("exactle 1 argument is required for %s", "variables")
+		}
+
+		result, err := eva.EvaluateVariable(args[0])
+		if err != nil {
+			return err
+		}
+
+		eva.Value = result
+		return nil
+	} else {
+		return fmt.Errorf("unsupported function '%s'", name)
+	}
+}
+
+func (eva *DeploymentEvaluator) EvaluateFormat(format interface{}, values []interface{}) string {
+	r := regexp.MustCompile(`\{\d+\}`)
+	format = r.ReplaceAllString(format.(string), "%v")
+
+	return fmt.Sprintf(format.(string), values...)
+}
+
+func (eva *DeploymentEvaluator) EvaluateReference(id interface{}) (map[string]interface{}, error) {
+	obj, ok := eva.Deployed[id.(string)]
+	if !ok {
+		return nil, fmt.Errorf("no resource matches id: %s", id)
+	}
+
+	return obj, nil
+}
+
+func (eva *DeploymentEvaluator) EvaluateResourceID(resourceType interface{}, names []interface{}) (string, error) {
+	typeSegments := strings.Split(resourceType.(string), "/")
+
+	if len(typeSegments)-1 != len(names) {
+		return "", errors.New("invalid arguments: wrong number of names")
+	}
+
+	head := azresources.ResourceType{
+		Type: typeSegments[0] + "/" + typeSegments[1],
+		Name: names[0].(string),
+	}
+
+	tail := []azresources.ResourceType{}
+	for i := 1; i < len(names); i++ {
+		tail = append(tail, azresources.ResourceType{
+			Type: typeSegments[i+1],
+			Name: names[i].(string),
+		})
+	}
+
+	id := azresources.MakeID(
+		eva.Options.SubscriptionID,
+		eva.Options.ResourceGroup,
+		head,
+		tail...)
+	return id, nil
+}
+
+func (eva *DeploymentEvaluator) EvaluateVariable(variable interface{}) (interface{}, error) {
+	value, ok := eva.Variables[variable.(string)]
+	if !ok {
+		return nil, fmt.Errorf("no variable matches: %s", variable)
+	}
+
+	return value, nil
+}

--- a/pkg/cli/armtemplate/testdata/frontend-backend.json
+++ b/pkg/cli/armtemplate/testdata/frontend-backend.json
@@ -18,8 +18,7 @@
           {
             "binding": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web]",
             "env": {
-              "SERVICE__BACKEND__HOST": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web.host]",
-              "SERVICE__BACKEND__PORT": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web.port]"
+              "SERVICE__BACKEND__TARGETPORT": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web.targetPort]"
             }
           }
         ],
@@ -48,7 +47,7 @@
         "bindings": {
           "web": {
             "kind": "http",
-            "targetPort": 80
+            "targetPort": 81
           }
         }
       },

--- a/pkg/cli/armtemplate/testdata/frontend-backend.json
+++ b/pkg/cli/armtemplate/testdata/frontend-backend.json
@@ -16,9 +16,9 @@
         },
         "uses": [
           {
-            "binding": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web]",
+            "binding": "[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web]",
             "env": {
-              "SERVICE__BACKEND__TARGETPORT": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web.targetPort]"
+              "SERVICE__BACKEND__TARGETPORT": "[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web.targetPort]"
             }
           }
         ],

--- a/pkg/cli/armtemplate/testdata/frontend-backend/frontend-backend-backend.json
+++ b/pkg/cli/armtemplate/testdata/frontend-backend/frontend-backend-backend.json
@@ -14,7 +14,7 @@
         "bindings": {
             "web": {
                 "kind": "http",
-                "targetPort": 80
+                "targetPort": 81
             }
         },
         "hierarchy": [

--- a/pkg/cli/armtemplate/testdata/frontend-backend/frontend-backend-frontend.json
+++ b/pkg/cli/armtemplate/testdata/frontend-backend/frontend-backend-frontend.json
@@ -32,8 +32,7 @@
             {
                 "binding": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web]",
                 "env": {
-                    "SERVICE__BACKEND__HOST": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web.host]",
-                    "SERVICE__BACKEND__PORT": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web.port]"
+                    "SERVICE__BACKEND__TARGETPORT": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web.targetPort]"
                 }
             }
         ]

--- a/pkg/cli/armtemplate/testdata/frontend-backend/frontend-backend-frontend.json
+++ b/pkg/cli/armtemplate/testdata/frontend-backend/frontend-backend-frontend.json
@@ -30,9 +30,9 @@
         },
         "uses": [
             {
-                "binding": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web]",
+                "binding": "[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web]",
                 "env": {
-                    "SERVICE__BACKEND__TARGETPORT": "[[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web.targetPort]"
+                    "SERVICE__BACKEND__TARGETPORT": "[reference(resourceId('Microsoft.CustomProviders/resourceProviders/Applications/Components', 'radius', 'frontend-backend', 'backend')).bindings.web.targetPort]"
                 }
             }
         ]


### PR DESCRIPTION
First piece of required work for app model v3. This introduces the ability for references to work in the armtemplate, which is required to make app model v3 work.

This doesn't integrate it into the k8s controller as it's throw away work (I already implemented it for app model v3, no point in implementing it for app model v2).

Adds a test to verify that references are evaluated.

Open questions: Should we try to merge the deployment evaluator into the arm evaluator somehow? I think we can figure out a way to merge the two if we require evaluation to always be integrated with individual resources.