### PR TITLE
Adding generator for the Custom RP manifest

### DIFF
--- a/build/generate.mk
+++ b/build/generate.mk
@@ -6,7 +6,15 @@
 ##@ Generate (Code and Schema Generation)
 
 .PHONY: generate
-generate: generate-radclient generate-go generate-k8s-manifests generate-controller ## Generates all targets.
+generate: generate-rp-manifest generate-radclient generate-go generate-k8s-manifests generate-controller ## Generates all targets.
+
+.PHONY: generate-rp-manifest
+generate-rp-manifest: ## Generates Custom RP manifest that registers our resource types.
+	@echo "$(ARROW) Updating manifest..."
+	go run cmd/rp-manifest-gen/main.go \
+		--input deploy/rp-full.input.json \
+		--output deploy/rp-full.json \
+		--resources pkg/radrp/schemav3/resource-types.json
 
 .PHONY: generate-node-installed
 generate-node-installed:

--- a/cmd/cli/cmd/envInitAzure.go
+++ b/cmd/cli/cmd/envInitAzure.go
@@ -404,6 +404,14 @@ func findExistingEnvironment(ctx context.Context, authorizer autorest.Authorizer
 		return false, "", err
 	}
 
+	_, err = cpc.Get(ctx, resourceGroup, "radiusv3")
+	if clients.Is404Error(err) {
+		// not found - will need to be created
+		return false, "", nil
+	} else if err != nil {
+		return false, "", err
+	}
+
 	// Custom Provider already exists, find the cluster...
 	mcc := clients.NewManagedClustersClient(subscriptionID, authorizer)
 

--- a/cmd/rp-manifest-gen/main.go
+++ b/cmd/rp-manifest-gen/main.go
@@ -1,0 +1,149 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sort"
+
+	"github.com/Azure/radius/pkg/radrp/schemav3"
+	"github.com/spf13/cobra"
+)
+
+var RootCmd = &cobra.Command{
+	Use:   "rad",
+	Short: "Radius RP manifest generator",
+	Long: `Radius RP manifest generator
+	
+	The manfifest generator is used to update our Custom Provider manifest when the set of types we expose
+	changes. We need to supply the list of resource types when registering a Custom Provider and we data-drive
+	the authoring of this list to make things more maintainable.`,
+	SilenceErrors: true,
+	SilenceUsage:  true,
+	RunE:          run,
+}
+
+func init() {
+	RootCmd.Flags().String("input", "", "The input file (rp-full.input.json)")
+	RootCmd.Flags().String("output", "", "The output file (rp-full.json). Will be overwritten")
+	RootCmd.Flags().String("resources", "", "The resource manifest (resource-types.json)")
+
+	_ = RootCmd.MarkPersistentFlagRequired("input")
+	_ = RootCmd.MarkPersistentFlagRequired("output")
+	_ = RootCmd.MarkPersistentFlagRequired("resources")
+}
+
+func main() {
+	if err := RootCmd.ExecuteContext(context.Background()); err != nil {
+		fmt.Println("Error:", err)
+		os.Exit(1)
+	}
+}
+
+func run(cmd *cobra.Command, args []string) error {
+	inputFile, err := cmd.Flags().GetString("input")
+	if err != nil {
+		return err
+	}
+
+	outputFile, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return err
+	}
+	resourcesFile, err := cmd.Flags().GetString("resources")
+	if err != nil {
+		return err
+	}
+
+	inputBytes, err := ioutil.ReadFile(inputFile)
+	if err != nil {
+		return fmt.Errorf("failed to read file %q: %w", inputFile, err)
+	}
+
+	template := map[string]interface{}{}
+	err = json.Unmarshal(inputBytes, &template)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal JSON %q: %w", inputFile, err)
+	}
+
+	resourcesBytes, err := ioutil.ReadFile(resourcesFile)
+	if err != nil {
+		return fmt.Errorf("failed to read file %q: %w", resourcesFile, err)
+	}
+
+	manifest := schemav3.Manifest{}
+	err = json.Unmarshal(resourcesBytes, &manifest)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal JSON %q: %w", inputFile, err)
+	}
+
+	// Update the template content in memory and then overwrite the file.
+	err = update(template, manifest)
+	if err != nil {
+		return err
+	}
+
+	outputBytes, err := json.MarshalIndent(template, "", "    ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+
+	err = ioutil.WriteFile(outputFile, outputBytes, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type resourceTypeEntry struct {
+	Name        string `json:"name"`
+	RoutingType string `json:"routingType"`
+	Endpoint    string `json:"endpoint"`
+}
+
+func NewResourceTypeEntry(resourceType string) resourceTypeEntry {
+	if resourceType != "Application" {
+		resourceType = "Application/" + resourceType
+	}
+
+	return resourceTypeEntry{
+		Name:        resourceType,
+		RoutingType: "Proxy",
+		Endpoint:    "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]",
+	}
+}
+
+func update(template map[string]interface{}, manifest schemav3.Manifest) error {
+	// We're going to modify the template by setting the 'resourceTypes' variable at the top level
+	// of scope. This allows us to avoid coupling to the structure of the template, we're just coupled
+	// to two variable names instead: 'siteName' and 'resourceTypes'
+	//
+	// We don't use parameters for this because we want to be able to view/diff the structure
+	// of the template as part of a PR.
+	variables, ok := template["variables"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("cannot find variables node")
+	}
+
+	// Sort types for consistency
+	types := []string{}
+	entries := []resourceTypeEntry{}
+	for resourceType := range manifest.Resources {
+		types = append(types, resourceType)
+	}
+	sort.Strings(types)
+
+	for _, resourceType := range types {
+		entries = append(entries, NewResourceTypeEntry(resourceType))
+	}
+
+	variables["resourceTypes"] = entries
+	return nil
+}

--- a/deploy/rp-full.input.json
+++ b/deploy/rp-full.input.json
@@ -1,150 +1,151 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
-    "outputs": {
-        "clusterName": {
-            "type": "string",
-            "value": "[parameters('clusterName')]"
-        }
-    },
     "parameters": {
-        "_scriptUri": {
-            "defaultValue": "[format('https://radiuspublic.blob.core.windows.net/environment/{0}/initialize-cluster.sh', parameters('channel'))]",
+        "location": {
+            "type": "string",
             "metadata": {
-                "description": "URI of the script to execute. Used for testing."
-            },
-            "type": "string"
-        },
-        "accountName": {
-            "defaultValue": "[concat('radius-rp-', uniquestring(parameters('controlPlaneResourceGroup')))]",
-            "metadata": {
-                "description": "The unique name of the cosmos db account."
-            },
-            "type": "string"
+                "description": "Location for all resources."
+            }
         },
         "channel": {
+            "type": "string",
             "defaultValue": "edge",
             "metadata": {
                 "description": "channel to use for RP image and deployment script"
-            },
-            "type": "string"
+            }
         },
-        "clusterName": {
-            "defaultValue": "[concat('radius-aks-', uniqueString(parameters('controlPlaneResourceGroup')))]",
+        "resourceGroup": {
+            "type": "string",
             "metadata": {
-                "description": "The name of the Managed Cluster resource."
-            },
-            "type": "string"
+                "description": "resource group where applications will be deployed"
+            }
         },
         "controlPlaneResourceGroup": {
+            "type": "string",
             "metadata": {
                 "description": "resource group where Radius control-plane will be deployed"
-            },
-            "type": "string"
+            }
         },
-        "databaseName": {
-            "defaultValue": "radius-rp-db",
+        "_scriptUri": {
+            "type": "string",
+            "defaultValue": "[format('https://radiuspublic.blob.core.windows.net/environment/{0}/initialize-cluster.sh', parameters('channel'))]",
             "metadata": {
-                "description": "The database name."
-            },
-            "type": "string"
-        },
-        "deploymentScriptIdentityName": {
-            "defaultValue": "[concat('radius-deployment-id-', uniqueString(parameters('controlPlaneResourceGroup')))]",
-            "metadata": {
-                "description": "The identity name to use for the deployment script."
-            },
-            "type": "string"
+                "description": "URI of the script to execute. Used for testing."
+            }
         },
         "image": {
+            "type": "string",
             "defaultValue": "[format('radiusteam/radius-rp:{0}', if(equals(parameters('channel'), 'edge'), 'latest', parameters('channel')))]",
             "metadata": {
                 "description": "The container image to deploy."
-            },
-            "type": "string"
+            }
         },
-        "location": {
+        "siteName": {
+            "type": "string",
+            "defaultValue": "[concat('radius-rp-', uniqueString(parameters('controlPlaneResourceGroup')))]",
             "metadata": {
-                "description": "Location for all resources."
-            },
-            "type": "string"
-        },
-        "logAnalyticsWorkspaceID": {
-            "defaultValue": "",
-            "metadata": {
-                "description": "The ARM resource ID of the log analytics workspace where the Radius Resource Provider logs will be redirected to."
-            },
-            "type": "string"
+                "description": "The name of your Web Site."
+            }
         },
         "logAnalyticsWorkspaceName": {
+            "type": "string",
             "defaultValue": "",
             "metadata": {
                 "description": "The log analytics workspace name where the Radius Resource Provider logs will be redirected to."
-            },
-            "type": "string"
+            }
+        },
+        "logAnalyticsWorkspaceID": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The ARM resource ID of the log analytics workspace where the Radius Resource Provider logs will be redirected to."
+            }
+        },
+        "accountName": {
+            "type": "string",
+            "defaultValue": "[concat('radius-rp-', uniquestring(parameters('controlPlaneResourceGroup')))]",
+            "metadata": {
+                "description": "The unique name of the cosmos db account."
+            }
+        },
+        "databaseName": {
+            "type": "string",
+            "defaultValue": "radius-rp-db",
+            "metadata": {
+                "description": "The database name."
+            }
+        },
+        "clusterName": {
+            "type": "string",
+            "defaultValue": "[concat('radius-aks-', uniqueString(parameters('controlPlaneResourceGroup')))]",
+            "metadata": {
+                "description": "The name of the Managed Cluster resource."
+            }
         },
         "registryId": {
+            "type": "string",
             "defaultValue": "",
             "metadata": {
                 "description": "The resource id of the ACR container registry"
-            },
-            "type": "string"
+            }
         },
         "registryName": {
+            "type": "string",
             "defaultValue": "",
             "metadata": {
                 "description": "The name of the ACR container registry"
-            },
-            "type": "string"
+            }
         },
-        "resourceGroup": {
+        "deploymentScriptIdentityName": {
+            "type": "string",
+            "defaultValue": "[concat('radius-deployment-id-', uniqueString(parameters('controlPlaneResourceGroup')))]",
             "metadata": {
-                "description": "resource group where applications will be deployed"
-            },
-            "type": "string"
+                "description": "The identity name to use for the deployment script."
+            }
         },
         "resourceTags": {
+            "type": "object",
             "defaultValue": {
                 "rad-environment": true
             },
             "metadata": {
                 "description": "The tags to apply to each resource"
-            },
-            "type": "object"
-        },
-        "siteName": {
-            "defaultValue": "[concat('radius-rp-', uniqueString(parameters('controlPlaneResourceGroup')))]",
-            "metadata": {
-                "description": "The name of your Web Site."
-            },
-            "type": "string"
+            }
         }
+    },
+    "variables": {
+        "controlPlaneDeploymentName": "[concat('rad-control-plane-', guid(parameters('resourceGroup')))]",
+        "rpDeploymentName": "[concat('rad-rp-', guid(parameters('resourceGroup')))]",
+        "resourceTypes": []
     },
     "resources": [
         {
+            "type": "Microsoft.Resources/resourceGroups",
             "apiVersion": "2020-10-01",
-            "location": "[parameters('location')]",
             "name": "[parameters('resourceGroup')]",
-            "type": "Microsoft.Resources/resourceGroups"
+            "location": "[parameters('location')]"
         },
         {
+            "type": "Microsoft.Resources/resourceGroups",
             "apiVersion": "2020-10-01",
-            "location": "[parameters('location')]",
             "name": "[parameters('controlPlaneResourceGroup')]",
-            "type": "Microsoft.Resources/resourceGroups"
+            "location": "[parameters('location')]"
         },
         {
+            "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
+            "name": "[variables('controlPlaneDeploymentName')]",
+            "resourceGroup": "[parameters('controlPlaneResourceGroup')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Resources/resourceGroups', parameters('resourceGroup'))]",
                 "[resourceId('Microsoft.Resources/resourceGroups', parameters('controlPlaneResourceGroup'))]"
             ],
-            "name": "[variables('controlPlaneDeploymentName')]",
             "properties": {
+                "mode": "Incremental",
                 "expressionEvaluationOptions": {
                     "scope": "Inner"
                 },
-                "mode": "Incremental",
                 "parameters": {
                     "_scriptUri": {
                         "value": "[parameters('_scriptUri')]"
@@ -167,12 +168,6 @@
                     "image": {
                         "value": "[parameters('image')]"
                     },
-                    "logAnalyticsWorkspaceID": {
-                        "value": "[parameters('logAnalyticsWorkspaceID')]"
-                    },
-                    "logAnalyticsWorkspaceName": {
-                        "value": "[parameters('logAnalyticsWorkspaceName')]"
-                    },
                     "registryId": {
                         "value": "[parameters('registryId')]"
                     },
@@ -187,6 +182,12 @@
                     },
                     "siteName": {
                         "value": "[parameters('siteName')]"
+                    },
+                    "logAnalyticsWorkspaceName": {
+                        "value": "[parameters('logAnalyticsWorkspaceName')]"
+                    },
+                    "logAnalyticsWorkspaceID": {
+                        "value": "[parameters('logAnalyticsWorkspaceID')]"
                     }
                 },
                 "template": {
@@ -214,12 +215,6 @@
                         "image": {
                             "type": "string"
                         },
-                        "logAnalyticsWorkspaceID": {
-                            "type": "string"
-                        },
-                        "logAnalyticsWorkspaceName": {
-                            "type": "string"
-                        },
                         "registryId": {
                             "type": "string"
                         },
@@ -234,39 +229,61 @@
                         },
                         "siteName": {
                             "type": "string"
+                        },
+                        "logAnalyticsWorkspaceName": {
+                            "type": "string"
+                        },
+                        "logAnalyticsWorkspaceID": {
+                            "type": "string"
                         }
+                    },
+                    "variables": {
+                        "clusteridentityroledefinitionid": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('managedIdentityOperatorRole'))]",
+                        "clusteridentityroledefinitionname": "[guid(parameters('clusterName'), resourceGroup().name, subscription().subscriptionId)]",
+                        "registrypullroledefinitionid": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('acrPullRole'))]",
+                        "registrypullroledefinitionname": "[guid(if(equals(parameters('registryName'), ''), 'fake', parameters('registryName')), subscription().subscriptionId)]",
+                        "registrypullroledefinitionfullname": "[concat(if(equals(parameters('registryName'), ''), 'fake', parameters('registryName')), '/Microsoft.Authorization/', variables('registrypullroledefinitionname'))]",
+                        "contributorRole": "b24988ac-6180-42a0-ab88-20f7382dd24c",
+                        "hostingPlanName": "[concat('radius-rp-plan-', resourceGroup().name)]",
+                        "managedIdentityOperatorRole": "f1a07417-d97a-45cb-824c-7a7467783830",
+                        "acrPullRole": "7f951dda-4ed3-4680-a7ca-43fe172d538d",
+                        "deploymentRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('contributorRole'))]",
+                        "deploymentRoleDefinitionName": "[guid(parameters('deploymentScriptIdentityName'), subscription().subscriptionId)]",
+                        "ownerRole": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+                        "rpRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('ownerRole'))]",
+                        "rpControlPlaneRoleDefinitionName": "[guid(parameters('siteName'), parameters('controlPlaneResourceGroup'), subscription().subscriptionId)]",
+                        "loganalyticsworkspacename": "[concat(parameters('siteName'), '/Microsoft.Insights/', if(equals(parameters('logAnalyticsWorkspaceID'), ''), 'fake', parameters('logAnalyticsWorkspaceName')))]"
                     },
                     "resources": [
                         {
+                            "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+                            "name": "[parameters('deploymentScriptIdentityName')]",
                             "apiVersion": "2018-11-30",
                             "location": "[resourceGroup().location]",
-                            "name": "[parameters('deploymentScriptIdentityName')]",
-                            "tags": "[parameters('resourceTags')]",
-                            "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+                            "tags": "[parameters('resourceTags')]"
                         },
                         {
+                            "type": "Microsoft.Authorization/roleAssignments",
                             "apiVersion": "2018-09-01-preview",
+                            "name": "[variables('deploymentRoleDefinitionName')]",
+                            "tags": "[parameters('resourceTags')]",
                             "dependsOn": [
                                 "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('deploymentScriptIdentityName'))]"
                             ],
-                            "name": "[variables('deploymentRoleDefinitionName')]",
                             "properties": {
+                                "roleDefinitionId": "[variables('deploymentRoleDefinitionId')]",
                                 "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('deploymentScriptIdentityName'))).principalId]",
-                                "principalType": "ServicePrincipal",
-                                "roleDefinitionId": "[variables('deploymentRoleDefinitionId')]"
-                            },
-                            "tags": "[parameters('resourceTags')]",
-                            "type": "Microsoft.Authorization/roleAssignments"
+                                "principalType": "ServicePrincipal"
+                            }
                         },
                         {
-                            "apiVersion": "2020-03-01",
-                            "kind": "MongoDB",
-                            "location": "[resourceGroup().location]",
+                            "type": "Microsoft.DocumentDB/databaseAccounts",
                             "name": "[parameters('accountName')]",
+                            "apiVersion": "2020-03-01",
+                            "location": "[resourceGroup().location]",
+                            "tags": "[parameters('resourceTags')]",
+                            "kind": "MongoDB",
                             "properties": {
-                                "apiProperties": {
-                                    "serverVersion": "3.6"
-                                },
                                 "capabilities": [
                                     {
                                         "name": "EnableMongo"
@@ -275,180 +292,178 @@
                                         "name": "DisableRateLimitingResponses"
                                     }
                                 ],
-                                "databaseAccountOfferType": "Standard",
                                 "locations": [
                                     {
+                                        "locationName": "[resourceGroup().location]",
                                         "failoverPriority": 0,
-                                        "isZoneRedundant": false,
-                                        "locationName": "[resourceGroup().location]"
+                                        "isZoneRedundant": false
                                     }
-                                ]
-                            },
-                            "tags": "[parameters('resourceTags')]",
-                            "type": "Microsoft.DocumentDB/databaseAccounts"
+                                ],
+                                "databaseAccountOfferType": "Standard",
+                                "apiProperties": {
+                                    "serverVersion": "3.6"
+                                }
+                            }
                         },
                         {
-                            "apiVersion": "2020-03-01",
-                            "dependsOn": [
-                                "[resourceId('Microsoft.DocumentDB/databaseAccounts/', parameters('accountName'))]"
-                            ],
+                            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases",
                             "name": "[concat(parameters('accountName'), '/', parameters('databaseName'))]",
+                            "apiVersion": "2020-03-01",
+                            "tags": "[parameters('resourceTags')]",
+                            "dependsOn": [ "[resourceId('Microsoft.DocumentDB/databaseAccounts/', parameters('accountName'))]" ],
                             "properties": {
-                                "options": {
-                                    "throughput": "400"
-                                },
                                 "resource": {
                                     "id": "[parameters('databaseName')]"
-                                }
-                            },
-                            "tags": "[parameters('resourceTags')]",
-                            "type": "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases"
+                                },
+                                "options": { "throughput": "400" }
+                            }
                         },
                         {
+                            "type": "Microsoft.DocumentDb/databaseAccounts/mongodbDatabases/collections",
+                            "name": "[concat(parameters('accountName'), '/', parameters('databaseName'), '/', 'applications')]",
                             "apiVersion": "2020-03-01",
+                            "tags": "[parameters('resourceTags')]",
                             "dependsOn": [
                                 "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('accountName'), parameters('databaseName'))]"
                             ],
-                            "name": "[concat(parameters('accountName'), '/', parameters('databaseName'), '/', 'applications')]",
                             "properties": {
-                                "options": {},
                                 "resource": {
                                     "id": "applications",
+                                    "shardKey": { "subscriptionId": "Hash" },
                                     "indexes": [],
                                     "options": {
-                                        "If-Match": "\u003cETag\u003e"
-                                    },
-                                    "shardKey": {
-                                        "subscriptionId": "Hash"
+                                        "If-Match": "<ETag>"
                                     }
-                                }
-                            },
-                            "tags": "[parameters('resourceTags')]",
-                            "type": "Microsoft.DocumentDb/databaseAccounts/mongodbDatabases/collections"
+                                },
+                                "options": {}
+                            }
                         },
                         {
                             "apiVersion": "2020-11-01",
+                            "type": "Microsoft.ContainerService/managedClusters",
+                            "location": "[resourceGroup().location]",
+                            "name": "[parameters('clusterName')]",
+                            "tags": "[parameters('resourceTags')]",
                             "identity": {
                                 "type": "SystemAssigned"
                             },
-                            "location": "[resourceGroup().location]",
-                            "name": "[parameters('clusterName')]",
                             "properties": {
+                                "dnsPrefix": "[parameters('clusterName')]",
                                 "agentPoolProfiles": [
                                     {
-                                        "count": 1,
-                                        "mode": "System",
                                         "name": "agentpool",
+                                        "count": 1,
                                         "osDiskSizeGB": 0,
+                                        "vmSize": "Standard_B2ms",
                                         "storageProfile": "ManagedDisks",
-                                        "vmSize": "Standard_B2ms"
+                                        "mode": "System"
                                     }
                                 ],
-                                "dnsPrefix": "[parameters('clusterName')]",
                                 "enableRBAC": true,
-                                "networkProfile": {
-                                    "networkPlugin": "azure"
-                                },
                                 "podIdentityProfile": {
                                     "enabled": true
+                                },
+                                "networkProfile": {
+                                    "networkPlugin": "azure"
                                 }
-                            },
-                            "tags": "[parameters('resourceTags')]",
-                            "type": "Microsoft.ContainerService/managedClusters"
+                            }
                         },
                         {
+                            "type": "Microsoft.Authorization/roleAssignments",
                             "apiVersion": "2018-09-01-preview",
+                            "name": "[variables('clusterIdentityRoleDefinitionName')]",
+                            "tags": "[parameters('resourceTags')]",
                             "dependsOn": [
                                 "[resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName'))]"
                             ],
-                            "name": "[variables('clusterIdentityRoleDefinitionName')]",
                             "properties": {
                                 "principalId": "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName')), '2020-11-01', 'full').identity.principalId]",
                                 "principalType": "ServicePrincipal",
                                 "roleDefinitionId": "[variables('clusterIdentityRoleDefinitionId')]"
-                            },
-                            "tags": "[parameters('resourceTags')]",
-                            "type": "Microsoft.Authorization/roleAssignments"
+                            }
                         },
                         {
-                            "apiVersion": "2017-05-01",
                             "condition": "[not(equals(parameters('registryId'), ''))]",
+                            "type": "Microsoft.ContainerRegistry/registries/providers/roleAssignments",
+                            "apiVersion": "2017-05-01",
+                            "name": "[variables('registrypullroledefinitionfullname')]",
+                            "tags": "[parameters('resourceTags')]",
                             "dependsOn": [
                                 "[resourceId('Microsoft.ContainerService/managedClusters/', parameters('clusterName'))]"
                             ],
-                            "name": "[variables('registrypullroledefinitionfullname')]",
                             "properties": {
                                 "principalId": "[reference(resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName')), '2020-11-01').identityProfile.kubeletidentity.objectId]",
                                 "principalType": "ServicePrincipal",
                                 "roleDefinitionId": "[variables('registrypullroledefinitionid')]"
-                            },
-                            "tags": "[parameters('resourceTags')]",
-                            "type": "Microsoft.ContainerRegistry/registries/providers/roleAssignments"
+                            }
                         },
                         {
+                            "type": "Microsoft.Resources/deploymentScripts",
                             "apiVersion": "2020-10-01",
+                            "name": "deploy-radius-runtime",
+                            "location": "[resourceGroup().location]",
+                            "tags": "[parameters('resourceTags')]",
                             "dependsOn": [
                                 "[resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName'))]",
                                 "[resourceId('Microsoft.Authorization/roleAssignments', variables('deploymentRoleDefinitionName'))]"
                             ],
+                            "kind": "AzureCLI",
                             "identity": {
                                 "type": "userAssigned",
                                 "userAssignedIdentities": {
                                     "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('deploymentScriptIdentityName'))]": {}
                                 }
                             },
-                            "kind": "AzureCLI",
-                            "location": "[resourceGroup().location]",
-                            "name": "deploy-radius-runtime",
                             "properties": {
-                                "arguments": "[concat('\"', resourceGroup().name, '\" \"', parameters('clusterName'), '\"')]",
-                                "azCliVersion": "2.0.80",
-                                "cleanupPreference": "OnSuccess",
                                 "forceUpdateTag": 1,
+                                "azCliVersion": "2.0.80",
+                                "arguments": "[concat('\"', resourceGroup().name, '\" \"', parameters('clusterName'), '\"')]",
                                 "primaryScriptUri": "[parameters('_scriptUri')]",
-                                "retentionInterval": "P1D",
                                 "supportingScriptUris": [],
-                                "timeout": "PT30M"
-                            },
-                            "tags": "[parameters('resourceTags')]",
-                            "type": "Microsoft.Resources/deploymentScripts"
+                                "timeout": "PT30M",
+                                "cleanupPreference": "OnSuccess",
+                                "retentionInterval": "P1D"
+                            }
                         },
                         {
+                            "type": "Microsoft.Web/serverfarms",
                             "apiVersion": "2018-02-01",
-                            "kind": "linux",
-                            "location": "[resourceGroup().location]",
                             "name": "[variables('hostingPlanName')]",
+                            "location": "[resourceGroup().location]",
+                            "tags": "[parameters('resourceTags')]",
+                            "sku": {
+                                "name": "B1",
+                                "capacity": 0
+                            },
+                            "kind": "linux",
                             "properties": {
                                 "name": "[variables('hostingPlanName')]",
                                 "reserved": true
-                            },
-                            "sku": {
-                                "capacity": 0,
-                                "name": "B1"
-                            },
-                            "tags": "[parameters('resourceTags')]",
-                            "type": "Microsoft.Web/serverfarms"
+                            }
                         },
                         {
+                            "type": "Microsoft.Web/sites",
                             "apiVersion": "2020-06-01",
+                            "name": "[parameters('siteName')]",
+                            "location": "[resourceGroup().location]",
+                            "tags": "[parameters('resourceTags')]",
+                            "identity": {
+                                "type": "SystemAssigned"
+                            },
                             "dependsOn": [
                                 "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
                                 "[resourceId('Microsoft.DocumentDB/databaseAccounts/mongodbDatabases', parameters('accountName'), parameters('databaseName'))]",
                                 "[resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName'))]",
                                 "[resourceId('Microsoft.Resources/deploymentScripts', 'deploy-radius-runtime')]"
                             ],
-                            "identity": {
-                                "type": "SystemAssigned"
-                            },
                             "kind": "app,linux,container",
-                            "location": "[resourceGroup().location]",
-                            "name": "[parameters('siteName')]",
                             "properties": {
+                                "serverFarmId": "[variables('hostingPlanName')]",
                                 "clientCertEnabled": true,
                                 "clientCertMode": "Optional",
                                 "httpsOnly": true,
-                                "serverFarmId": "[variables('hostingPlanName')]",
                                 "siteConfig": {
+                                    "linuxFxVersion": "[concat('DOCKER|', parameters('image'))]",
                                     "appSettings": [
                                         {
                                             "name": "MONGODB_CONNECTION_STRING",
@@ -478,90 +493,73 @@
                                             "name": "K8S_SUBSCRIPTION_ID",
                                             "value": "[subscription().subscriptionId]"
                                         }
-                                    ],
-                                    "linuxFxVersion": "[concat('DOCKER|', parameters('image'))]"
+                                    ]
                                 }
-                            },
-                            "tags": "[parameters('resourceTags')]",
-                            "type": "Microsoft.Web/sites"
+                            }
                         },
                         {
-                            "apiVersion": "2017-05-01-preview",
                             "condition": "[not(equals(parameters('logAnalyticsWorkspaceID'), ''))]",
-                            "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites', parameters('siteName'))]"
-                            ],
+                            "type": "Microsoft.Web/sites/providers/diagnosticSettings",
+                            "apiVersion": "2017-05-01-preview",
                             "name": "[variables('loganalyticsworkspacename')]",
+                            "dependsOn":[
+                                "[resourceId('Microsoft.Web/sites', parameters('siteName'))]"
+                            ],    
                             "properties": {
-                                "logs": [
-                                    {
-                                        "category": "AppServiceConsoleLogs",
-                                        "enabled": true
-                                    }
-                                ],
-                                "metrics": [
-                                    {
-                                        "category": "AllMetrics",
-                                        "enabled": true
-                                    }
-                                ],
-                                "workspaceId": "[parameters('logAnalyticsWorkspaceID')]"
-                            },
-                            "type": "Microsoft.Web/sites/providers/diagnosticSettings"
+                              "workspaceId": "[parameters('logAnalyticsWorkspaceID')]",
+                              "logs": [
+                                {
+                                  "category": "AppServiceConsoleLogs",
+                                  "enabled": true
+                                }
+                              ],
+                              "metrics": [
+                                {
+                                  "category": "AllMetrics",
+                                  "enabled": true
+                                }
+                              ]
+                            }
                         },
                         {
+                            "type": "Microsoft.Authorization/roleAssignments",
                             "apiVersion": "2018-09-01-preview",
+                            "name": "[variables('rpControlPlaneRoleDefinitionName')]",
+                            "tags": "[parameters('resourceTags')]",
                             "dependsOn": [
                                 "[resourceId('Microsoft.Web/sites', parameters('siteName'))]"
                             ],
-                            "name": "[variables('rpControlPlaneRoleDefinitionName')]",
                             "properties": {
+                                "roleDefinitionId": "[variables('rpRoleDefinitionId')]",
                                 "principalId": "[reference(resourceId('Microsoft.Web/sites', parameters('siteName')), '2019-08-01', 'full').identity.principalId]",
-                                "principalType": "ServicePrincipal",
-                                "roleDefinitionId": "[variables('rpRoleDefinitionId')]"
-                            },
-                            "tags": "[parameters('resourceTags')]",
-                            "type": "Microsoft.Authorization/roleAssignments"
+                                "principalType": "ServicePrincipal"
+                            }
                         }
-                    ],
-                    "variables": {
-                        "acrPullRole": "7f951dda-4ed3-4680-a7ca-43fe172d538d",
-                        "clusteridentityroledefinitionid": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('managedIdentityOperatorRole'))]",
-                        "clusteridentityroledefinitionname": "[guid(parameters('clusterName'), resourceGroup().name, subscription().subscriptionId)]",
-                        "contributorRole": "b24988ac-6180-42a0-ab88-20f7382dd24c",
-                        "deploymentRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('contributorRole'))]",
-                        "deploymentRoleDefinitionName": "[guid(parameters('deploymentScriptIdentityName'), subscription().subscriptionId)]",
-                        "hostingPlanName": "[concat('radius-rp-plan-', resourceGroup().name)]",
-                        "loganalyticsworkspacename": "[concat(parameters('siteName'), '/Microsoft.Insights/', if(equals(parameters('logAnalyticsWorkspaceID'), ''), 'fake', parameters('logAnalyticsWorkspaceName')))]",
-                        "managedIdentityOperatorRole": "f1a07417-d97a-45cb-824c-7a7467783830",
-                        "ownerRole": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
-                        "registrypullroledefinitionfullname": "[concat(if(equals(parameters('registryName'), ''), 'fake', parameters('registryName')), '/Microsoft.Authorization/', variables('registrypullroledefinitionname'))]",
-                        "registrypullroledefinitionid": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('acrPullRole'))]",
-                        "registrypullroledefinitionname": "[guid(if(equals(parameters('registryName'), ''), 'fake', parameters('registryName')), subscription().subscriptionId)]",
-                        "rpControlPlaneRoleDefinitionName": "[guid(parameters('siteName'), parameters('controlPlaneResourceGroup'), subscription().subscriptionId)]",
-                        "rpRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('ownerRole'))]"
-                    }
+                    ]
                 }
-            },
-            "resourceGroup": "[parameters('controlPlaneResourceGroup')]",
-            "type": "Microsoft.Resources/deployments"
+            }
         },
         {
+            "type": "Microsoft.Resources/deployments",
             "apiVersion": "2020-10-01",
+            "name": "[variables('rpDeploymentName')]",
+            "resourceGroup": "[parameters('resourceGroup')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Resources/resourceGroups', parameters('resourceGroup'))]",
                 "[resourceId('Microsoft.Resources/resourceGroups', parameters('controlPlaneResourceGroup'))]",
                 "[variables('controlPlaneDeploymentName')]"
             ],
-            "name": "[variables('rpDeploymentName')]",
             "properties": {
+                "mode": "Incremental",
                 "expressionEvaluationOptions": {
                     "scope": "Inner"
                 },
-                "mode": "Incremental",
                 "parameters": {
                     "clusterName": {
                         "value": "[parameters('clusterName')]"
+                    },
+                    "siteName": {
+                        "value": "[parameters('siteName')]"
                     },
                     "controlPlaneResourceGroup": {
                         "value": "[parameters('controlPlaneResourceGroup')]"
@@ -571,144 +569,109 @@
                     },
                     "resourceTypes": {
                         "value": "[variables('resourceTypes')]"
-                    },
-                    "siteName": {
-                        "value": "[parameters('siteName')]"
                     }
                 },
                 "template": {
                     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
                     "contentVersion": "1.0.0.0",
+                    "variables": {
+                        "managedIdentityOperatorRole": "f1a07417-d97a-45cb-824c-7a7467783830",
+                        "clusteridentityroledefinitionid": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('managedIdentityOperatorRole'))]",
+                        "clusteridentityroledefinitionname": "[guid(parameters('clusterName'), resourceGroup().name, subscription().subscriptionId)]",
+                        "ownerRole": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+                        "rpRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('ownerRole'))]",
+                        "rpGroupRoleDefinitionName": "[guid(parameters('siteName'), resourceGroup().name, subscription().subscriptionId)]"
+                    },
                     "parameters": {
                         "clusterName": {
-                            "type": "string"
-                        },
-                        "controlPlaneResourceGroup": {
                             "type": "string"
                         },
                         "resourceTags": {
                             "type": "object"
                         },
-                        "resourceTypes": {
-                            "type": "array"
-                        },
                         "siteName": {
                             "type": "string"
+                        },
+                        "controlPlaneResourceGroup": {
+                            "type": "string"
+                        },
+                        "resourceTypes": {
+                            "type": "array"
                         }
                     },
                     "resources": [
                         {
                             "apiVersion": "2018-09-01-preview",
-                            "location": "[resourceGroup().location]",
+                            "type": "Microsoft.CustomProviders/resourceProviders",
                             "name": "radius",
+                            "location": "[resourceGroup().location]",
+                            "tags": "[parameters('resourceTags')]",
                             "properties": {
                                 "resourceTypes": [
                                     {
-                                        "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]",
                                         "name": "Applications",
-                                        "routingType": "Proxy"
+                                        "routingType": "Proxy",
+                                        "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
                                     },
                                     {
-                                        "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]",
                                         "name": "Applications/Components",
-                                        "routingType": "Proxy"
+                                        "routingType": "Proxy",
+                                        "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
                                     },
                                     {
-                                        "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]",
                                         "name": "Applications/Scopes",
-                                        "routingType": "Proxy"
+                                        "routingType": "Proxy",
+                                        "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
                                     },
                                     {
-                                        "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]",
                                         "name": "Applications/Deployments",
-                                        "routingType": "Proxy"
+                                        "routingType": "Proxy",
+                                        "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
                                     }
                                 ]
-                            },
-                            "tags": "[parameters('resourceTags')]",
-                            "type": "Microsoft.CustomProviders/resourceProviders"
+                            }
                         },
                         {
                             "apiVersion": "2018-09-01-preview",
-                            "location": "[resourceGroup().location]",
+                            "type": "Microsoft.CustomProviders/resourceProviders",
                             "name": "radiusv3",
+                            "location": "[resourceGroup().location]",
+                            "tags": "[parameters('resourceTags')]",
                             "properties": {
                                 "resourceTypes": "[parameters('resourceTypes')]"
-                            },
-                            "tags": "[parameters('resourceTags')]",
-                            "type": "Microsoft.CustomProviders/resourceProviders"
+                            }
                         },
                         {
+                            "type": "Microsoft.Authorization/roleAssignments",
                             "apiVersion": "2018-09-01-preview",
                             "name": "[variables('rpGroupRoleDefinitionName')]",
-                            "properties": {
-                                "principalId": "[reference(concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('controlPlaneResourceGroup'), '/providers/Microsoft.Web/sites/', parameters('siteName')), '2019-08-01', 'full').identity.principalId]",
-                                "principalType": "ServicePrincipal",
-                                "roleDefinitionId": "[variables('rpRoleDefinitionId')]"
-                            },
                             "tags": "[parameters('resourceTags')]",
-                            "type": "Microsoft.Authorization/roleAssignments"
+                            "properties": {
+                                "roleDefinitionId": "[variables('rpRoleDefinitionId')]",
+                                "principalId": "[reference(concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('controlPlaneResourceGroup'), '/providers/Microsoft.Web/sites/', parameters('siteName')), '2019-08-01', 'full').identity.principalId]",
+                                "principalType": "ServicePrincipal"
+                            }
                         },
                         {
+                            "type": "Microsoft.Authorization/roleAssignments",
                             "apiVersion": "2018-09-01-preview",
                             "name": "[variables('clusterIdentityRoleDefinitionName')]",
+                            "tags": "[parameters('resourceTags')]",
                             "properties": {
                                 "principalId": "[reference(concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('controlPlaneResourceGroup'), '/providers/Microsoft.ContainerService/managedClusters/', parameters('clusterName')), '2020-11-01', 'full').identity.principalId]",
                                 "principalType": "ServicePrincipal",
                                 "roleDefinitionId": "[variables('clusterIdentityRoleDefinitionId')]"
-                            },
-                            "tags": "[parameters('resourceTags')]",
-                            "type": "Microsoft.Authorization/roleAssignments"
+                            }
                         }
-                    ],
-                    "variables": {
-                        "clusteridentityroledefinitionid": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('managedIdentityOperatorRole'))]",
-                        "clusteridentityroledefinitionname": "[guid(parameters('clusterName'), resourceGroup().name, subscription().subscriptionId)]",
-                        "managedIdentityOperatorRole": "f1a07417-d97a-45cb-824c-7a7467783830",
-                        "ownerRole": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
-                        "rpGroupRoleDefinitionName": "[guid(parameters('siteName'), resourceGroup().name, subscription().subscriptionId)]",
-                        "rpRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('ownerRole'))]"
-                    }
+                    ]
                 }
-            },
-            "resourceGroup": "[parameters('resourceGroup')]",
-            "type": "Microsoft.Resources/deployments"
+            }
         }
     ],
-    "variables": {
-        "controlPlaneDeploymentName": "[concat('rad-control-plane-', guid(parameters('resourceGroup')))]",
-        "resourceTypes": [
-            {
-                "name": "Application",
-                "routingType": "Proxy",
-                "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
-            },
-            {
-                "name": "Application/ContainerComponent",
-                "routingType": "Proxy",
-                "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
-            },
-            {
-                "name": "Application/azure.com.CosmosDBMongoComponent",
-                "routingType": "Proxy",
-                "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
-            },
-            {
-                "name": "Application/azure.com.CosmosDBSQLComponent",
-                "routingType": "Proxy",
-                "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
-            },
-            {
-                "name": "Application/azure.com.KeyVaultComponent",
-                "routingType": "Proxy",
-                "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
-            },
-            {
-                "name": "Application/azure.com.ServiceBusQueueComponent",
-                "routingType": "Proxy",
-                "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]"
-            }
-        ],
-        "rpDeploymentName": "[concat('rad-rp-', guid(parameters('resourceGroup')))]"
+    "outputs": {
+        "clusterName": {
+            "type": "string",
+            "value": "[parameters('clusterName')]"
+        }
     }
 }

--- a/deploy/rp-full.input.parameters.json
+++ b/deploy/rp-full.input.parameters.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "value": "test-location"
+        },
+        "resourceGroup": {
+            "value": "test-rp-group"
+        },
+        "controlPlaneResourceGroup": {
+            "value": "test-control-plane-group"
+        }
+    }
+}

--- a/pkg/radrp/schemav3/loader.go
+++ b/pkg/radrp/schemav3/loader.go
@@ -35,12 +35,12 @@ var (
 )
 
 // manifest is the format of the 'resource-types.json' manifest.
-type manifest struct {
+type Manifest struct {
 	Resources map[string]string `json:"resources"`
 }
 
-func readManifestOrPanic() manifest {
-	manifest := manifest{}
+func readManifestOrPanic() Manifest {
+	manifest := Manifest{}
 	err := json.Unmarshal([]byte(manifestFile), &manifest)
 	if err != nil {
 		log.Fatal("Failed to load resource manifest:", err)


### PR DESCRIPTION
This change adds a generator that will generate the Custom RP manifest
from our 'resource-types.json' file. This automates one of the steps we
need to make the RP work end to end for a new resource type.

After this change, the actual deployment template we use
'rp-full.json' becomes a generated asset. Modify 'rp-full.input.json'.

This approach is preferrable because we'll be able to see an verify the
diff in the manifest when a PR occurs. I also considered an approach of
generating parameters to pass into the deployment when creating an
environment, but the fact that this relies on a file in plaintext rather
than a magic CLI behavior seemed valuable.