### PR TITLE
Skip `deploy_tests` and `kubernetes_tests` when we only change docs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,8 +29,6 @@ jobs:
   build:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     runs-on: ${{ matrix.os }}
-    needs: pre_check
-    if: ${{ needs.pre_check.outputs.should_skip != 'true' }}
     env:
       GOVER: '^1.17'
       GOOS: ${{ matrix.target_os }}
@@ -88,8 +86,6 @@ jobs:
   images:
     name: Container image build
     runs-on: ubuntu-latest
-    needs: pre_check
-    if: ${{ needs.pre_check.outputs.should_skip != 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -256,8 +252,8 @@ jobs:
         path: ./${{ env.RADIUS_CONTAINER_LOG_BASE }}
   deploy_tests:
     name: Run deployment tests
-    needs: [ 'build', 'images' ]
-    if: startsWith(github.ref, 'refs/pull/') # run on PR
+    needs: [ 'build', 'images', 'pre_check' ]
+    if: ${{ startsWith(github.ref, 'refs/pull/') && needs.pre_check.outputs.should_skip != 'true' }} # run on PR
     runs-on: ubuntu-latest
     env:
       GOVER: '^1.17'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,13 +16,13 @@ on:
       - main
       - release/*
 jobs:
-  # The pre_check job determined whether we should skip some workflow
+  # The pre_check job determines whether we should skip some workflow
   # jobs.  Currently, it seems that for Required jobs, only the
   # un-parameterized jobs can be skipped while meeting the
   # requirements. For example, `kubernetes_tests` and `deploy_tests`
   # jobs can be skipped while `build` and `image` can't
-  # be. Fortunately, these two jobs are the longest longing as well as
-  # the most resource intensive.
+  # be. Fortunately, the former two jobs are the longest longing as
+  # well as the most resource intensive.
   #
   # The reason for this pecularity seems to be that if a job is
   # skipped entirely, the parameter expansion logic did not kick in
@@ -41,7 +41,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
         with:
-          paths_ignore: '["**.md", "**.yaml"]'
+          paths_ignore: '["**.md"]'
 
   build:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
@@ -202,7 +202,7 @@ jobs:
   kubernetes_tests:
     name: Run Kubernetes tests
     needs: [ 'build', 'images', 'pre_check' ]
-    if: ${{ startsWith(github.ref, 'refs/pull/') && needs.pre_check.outputs.should_skip != 'true' }}
+    if: ${{ startsWith(github.ref, 'refs/pull/') && needs.pre_check.outputs.should_skip != 'true' }} # run on PR
     runs-on: ubuntu-latest
     env:
       GOVER: '^1.17'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,23 @@ on:
       - main
       - release/*
 jobs:
+  # The pre_check job determined whether we should skip some workflow
+  # jobs.  Currently, it seems that for Required jobs, only the
+  # un-parameterized jobs can be skipped while meeting the
+  # requirements. For example, `kubernetes_tests` and `deploy_tests`
+  # jobs can be skipped while `build` and `image` can't
+  # be. Fortunately, these two jobs are the longest longing as well as
+  # the most resource intensive.
+  #
+  # The reason for this pecularity seems to be that if a job is
+  # skipped entirely, the parameter expansion logic did not kick in
+  # and did not generate the parameterized job. Once this is confirmed
+  # we can probably workaround by adding a dependent "Done" job for
+  # parameterized jobs, and only consider those as required.
+  #
+  # However, the `build` and `images` jobs are considerably less
+  # expensive than the `kubernetes_tests` and `deploy_tests` steps, so
+  # it may not be worth complicating our workflow for small gain.
   pre_check:
     runs-on: ubuntu-latest
     outputs:
@@ -184,7 +201,7 @@ jobs:
           az acr helm push --name radius ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}/radius-${{ env.REL_CHANNEL }}.0.tgz --force
   kubernetes_tests:
     name: Run Kubernetes tests
-    needs: [ 'build', 'images' ]
+    needs: [ 'build', 'images', 'pre_check' ]
     if: ${{ startsWith(github.ref, 'refs/pull/') && needs.pre_check.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,9 +16,20 @@ on:
       - main
       - release/*
 jobs:
+  pre_check:
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          paths_ignore: '["**.md"]'
+
   build:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     runs-on: ${{ matrix.os }}
+    needs: pre_check
+    if: ${{ needs.pre_check.outputs.should_skip != 'true' }}
     env:
       GOVER: '^1.17'
       GOOS: ${{ matrix.target_os }}
@@ -76,6 +87,8 @@ jobs:
   images:
     name: Container image build
     runs-on: ubuntu-latest
+    needs: pre_check
+    if: ${{ needs.pre_check.outputs.should_skip != 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
         with:
-          paths_ignore: '["**.md"]'
+          paths_ignore: '["**.md", "**.yaml"]'
 
   build:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -185,7 +185,7 @@ jobs:
   kubernetes_tests:
     name: Run Kubernetes tests
     needs: [ 'build', 'images' ]
-    if: startsWith(github.ref, 'refs/pull/') # run on PR
+    if: ${{ startsWith(github.ref, 'refs/pull/') && needs.pre_check.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     env:
       GOVER: '^1.17'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,7 @@ on:
       - release/*
 jobs:
   pre_check:
+    runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:


### PR DESCRIPTION
Will save some Azure resources for other workflows and also expedite small doc changes.