### PR TITLE
Add AppModelv3 renderer API

### DIFF
--- a/pkg/renderers/types.go
+++ b/pkg/renderers/types.go
@@ -1,0 +1,48 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package renderers
+
+import (
+	"context"
+
+	"github.com/Azure/radius/pkg/azure/azresources"
+	"github.com/Azure/radius/pkg/radrp/outputresource"
+)
+
+type Renderer interface {
+	GetDependencyIDs(ctx context.Context, resource RendererResource) ([]azresources.ResourceID, error)
+	Render(ctx context.Context, resource RendererResource, dependencies map[string]RendererDependency) (RendererOutput, error)
+}
+
+type RendererResource struct {
+	ApplicationName string
+	ResourceName    string
+	ResourceType    string
+	Definition      map[string]interface{}
+}
+
+type RendererDependency struct {
+	ResourceID     azresources.ResourceID
+	Definition     map[string]interface{}
+	ComputedValues map[string]interface{}
+}
+
+type RendererOutput struct {
+	Resources      []outputresource.OutputResource
+	ComputedValues map[string]ComputedValueReference
+	SecretValues   map[string]SecretValueReference
+}
+
+type ComputedValueReference struct {
+	LocalID       string
+	ValueSelector string
+}
+
+type SecretValueReference struct {
+	LocalID       string
+	Action        string
+	ValueSelector string
+}


### PR DESCRIPTION
This change adds a new API contract for renderers that will satisfy the
requirements of AppModel v3.

- Renderers can express dependencies on other resources
- Renderers can access the computed state and secrets of dependencies
- Renderers can return pointers to computed values and secrets from
  their own output

This is doing done as a separate PR with no implementation so the
following work can happen in parallel:

- Adopting the new contracts in the K8s controller
- Developing the new deployment processor in the Azure control-plane
- Creating adapters from the old renderer abstraction to the new one
  (should be possible for many resource types).