### PR TITLE
Make sure working dir (from Spec) is used by Executable

### DIFF
--- a/pkg/kubernetes/controllers/radius/executable_controller.go
+++ b/pkg/kubernetes/controllers/radius/executable_controller.go
@@ -357,7 +357,7 @@ func toEnvArray(env map[string]string) []string {
 	return retval
 }
 
-func makeCommand(ctx context.Context, executable *radiusv1alpha1.Executable) *exec.Cmd {
+func makeCommand(ctx context.Context, executable *radiusv1alpha3.Executable) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, executable.Spec.Executable)
 	cmdArgs := []string{executable.Spec.Executable}
 	cmdArgs = append(cmdArgs, executable.Spec.Args...)

--- a/pkg/kubernetes/controllers/radius/executable_controller.go
+++ b/pkg/kubernetes/controllers/radius/executable_controller.go
@@ -8,6 +8,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"os/exec"
 	"sync"
 	"time"
 
@@ -221,18 +222,14 @@ func (r *ExecutableReconciler) manageReplicas(ctx context.Context, executable *r
 func (r *ExecutableReconciler) startReplica(ctx context.Context, executable *radiusv1alpha3.Executable, log logr.Logger) {
 	var err error
 	var rs radiusv1alpha3.ReplicaStatus
-	env := toEnvArray(executable.Spec.Env)
 
 	log.Info("starting replica...",
 		"executable", executable.Spec.Executable,
 		"args", fmt.Sprintf("%v", executable.Spec.Args),
-		"env", fmt.Sprintf("%v", env))
-	pid, startWaiting, err := r.ProcessExecutor.StartProcess(
-		ctx,
-		executable.Spec.Executable,
-		executable.Spec.Args,
-		env,
-		r)
+		"env", fmt.Sprintf("%v", executable.Spec.Env))
+
+	cmd := makeCommand(ctx, executable)
+	pid, startWaiting, err := r.ProcessExecutor.StartProcess(ctx, cmd, r)
 	if err != nil {
 		log.Error(err, "failed to start a replica")
 		rs.PID = InvalidPID
@@ -358,6 +355,18 @@ func toEnvArray(env map[string]string) []string {
 		i++
 	}
 	return retval
+}
+
+func makeCommand(ctx context.Context, executable *radiusv1alpha1.Executable) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, executable.Spec.Executable)
+	cmdArgs := make([]string, 1)
+	cmdArgs[0] = executable.Spec.Executable
+	cmdArgs = append(cmdArgs, executable.Spec.Args...)
+	cmd.Args = cmdArgs
+	env := toEnvArray(executable.Spec.Env)
+	cmd.Env = env
+	cmd.Dir = executable.Spec.WorkingDirectory
+	return cmd
 }
 
 func (r *ExecutableReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/kubernetes/controllers/radius/executable_controller.go
+++ b/pkg/kubernetes/controllers/radius/executable_controller.go
@@ -359,8 +359,7 @@ func toEnvArray(env map[string]string) []string {
 
 func makeCommand(ctx context.Context, executable *radiusv1alpha1.Executable) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, executable.Spec.Executable)
-	cmdArgs := make([]string, 1)
-	cmdArgs[0] = executable.Spec.Executable
+	cmdArgs := []string{executable.Spec.Executable}
 	cmdArgs = append(cmdArgs, executable.Spec.Args...)
 	cmd.Args = cmdArgs
 	env := toEnvArray(executable.Spec.Env)

--- a/pkg/process/os_executor.go
+++ b/pkg/process/os_executor.go
@@ -18,14 +18,7 @@ func NewOSExecutor() Executor {
 	return &OSExecutor{}
 }
 
-func (e *OSExecutor) StartProcess(ctx context.Context, exe string, args []string, env []string, handler ProcessExitHandler) (int, func(), error) {
-	cmd := exec.CommandContext(ctx, exe)
-	cmdArgs := make([]string, 1)
-	cmdArgs[0] = exe
-	cmdArgs = append(cmdArgs, args...)
-	cmd.Args = cmdArgs
-	cmd.Env = env
-
+func (e *OSExecutor) StartProcess(ctx context.Context, cmd *exec.Cmd, handler ProcessExitHandler) (int, func(), error) {
 	if err := cmd.Start(); err != nil {
 		return 0, nil, err
 	}

--- a/pkg/process/types.go
+++ b/pkg/process/types.go
@@ -7,11 +7,12 @@ package process
 
 import (
 	"context"
+	"os/exec"
 )
 
 type Executor interface {
 	// CONSIDER making this call accept a exec.Cmd instance instead
-	StartProcess(ctx context.Context, exe string, args []string, env []string, exitHandler ProcessExitHandler) (pid int, startWaitForProcessExit func(), err error)
+	StartProcess(ctx context.Context, cmd *exec.Cmd, exitHandler ProcessExitHandler) (pid int, startWaitForProcessExit func(), err error)
 
 	StopProcess(pid int) error
 }

--- a/test/integration/localdev/executable_controller_test.go
+++ b/test/integration/localdev/executable_controller_test.go
@@ -151,9 +151,9 @@ func ensureNamespace(ctx context.Context, namespace string) error {
 	return client.Create(ctx, &nsObject, &runtimeclient.CreateOptions{})
 }
 
-func ensureReplicasRunning(ctx context.Context, exeName string, n int) error {
+func ensureReplicasRunning(ctx context.Context, cmdPath string, n int) error {
 	waitReplicaStarted := func() (bool, error) {
-		runninReplicas := executor.FindAll(exeName, func(pe ProcessExecution) bool {
+		runninReplicas := executor.FindAll(cmdPath, func(pe ProcessExecution) bool {
 			return pe.EndedAt.IsZero()
 		})
 

--- a/test/integration/localdev/test_process_executor.go
+++ b/test/integration/localdev/test_process_executor.go
@@ -84,13 +84,13 @@ func (e *TestProcessExecutor) SimulateProcessExit(t *testing.T, pid int, exitCod
 	}
 }
 
-func (e *TestProcessExecutor) FindAll(exeName string, cond func(pe ProcessExecution) bool) []ProcessExecution {
+func (e *TestProcessExecutor) FindAll(cmdPath string, cond func(pe ProcessExecution) bool) []ProcessExecution {
 	retval := make([]ProcessExecution, 0)
 	e.m.RLock()
 	defer e.m.RUnlock()
 
 	for _, pe := range e.Executions {
-		if pe.Cmd.Path == exeName {
+		if pe.Cmd.Path == cmdPath {
 			include := true
 			if cond != nil {
 				include = cond(pe)


### PR DESCRIPTION
I also changed the interface to process executor to use `exec.Cmd` as the input parameter--the list of `StartProcess()` method was getting too long, and would be even longer when we add stdout/stderr tracking. This is a change that @rynowak suggested in the previous PR.