### PR TITLE
Add adapter to renderers

### DIFF
--- a/pkg/radrp/db/types_v3.go
+++ b/pkg/radrp/db/types_v3.go
@@ -32,7 +32,8 @@ type RadiusResource struct {
 	ApplicationName string `bson:"applicationName"`
 	ResourceName    string `bson:"resourceName"`
 
-	Definition map[string]interface{} `bson:"definition"`
+	Definition     map[string]interface{} `bson:"definition"`
+	ComputedValues map[string]interface{} `bson:"computedValues"`
 
 	Status            RadiusResourceStatus `bson:"status"`
 	ProvisioningState string               `bson:"provisioningState"`

--- a/pkg/radrp/frontend/resourceproviderv3/convert.go
+++ b/pkg/radrp/frontend/resourceproviderv3/convert.go
@@ -78,6 +78,11 @@ func NewRestRadiusResource(resource db.RadiusResource) RadiusResource {
 			properties[k] = v
 		}
 	}
+	if resource.ComputedValues != nil {
+		for k, v := range resource.ComputedValues {
+			properties[k] = v
+		}
+	}
 	properties["provisioningState"] = resource.ProvisioningState
 
 	return RadiusResource{

--- a/pkg/renderers/adapter.go
+++ b/pkg/renderers/adapter.go
@@ -1,0 +1,78 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package renderers
+
+import (
+	context "context"
+
+	"github.com/Azure/radius/pkg/azure/azresources"
+	"github.com/Azure/radius/pkg/model/components"
+	"github.com/Azure/radius/pkg/workloads"
+)
+
+// Defines an interface for renderers that can work with AppModelv3 through an adapter.
+//
+// These workloads have the following limitations:
+// - No support for 'run', 'uses', 'traits'
+// - No user-defined 'bindings'
+// - No support for creating resources during rendering
+//
+// Generally this is our non-runnable components
+type AdaptableRenderer interface {
+	workloads.WorkloadRenderer
+
+	// Refers to the renderer v1 kind, we need to pass this through to the renderer in case it validates it.
+	GetKind() string
+
+	GetComputedValues(ctx context.Context, workload workloads.InstantiatedWorkload) (map[string]ComputedValueReference, map[string]SecretValueReference, error)
+}
+
+var _ Renderer = (*V1RendererAdapter)(nil)
+
+type V1RendererAdapter struct {
+	Inner AdaptableRenderer
+}
+
+func (r *V1RendererAdapter) GetDependencyIDs(ctx context.Context, resource RendererResource) ([]azresources.ResourceID, error) {
+	// Implementations that use this adapter do not support dependencies
+	return nil, nil
+}
+
+func (r *V1RendererAdapter) Render(ctx context.Context, resource RendererResource, dependencies map[string]RendererDependency) (RendererOutput, error) {
+	// Our task here is to call into the wrapper render function and then interpret the results into our new format.
+
+	// The supported component types only use the 'config' section in our old format (see comments on AdaptableRenderer)
+	workload := workloads.InstantiatedWorkload{
+		Application: resource.ApplicationName,
+		Name:        resource.ResourceName,
+		Workload: components.GenericComponent{
+			Name:     resource.ResourceName,
+			Kind:     r.Inner.GetKind(),
+			Config:   resource.Definition,
+			Run:      map[string]interface{}{},
+			Bindings: map[string]components.GenericBinding{},
+			Uses:     []components.GenericDependency{},
+			Traits:   []components.GenericTrait{},
+		},
+		BindingValues: map[components.BindingKey]components.BindingState{},
+	}
+
+	resources, err := r.Inner.Render(ctx, workload)
+	if err != nil {
+		return RendererOutput{}, err
+	}
+
+	computedValues, secretValues, err := r.Inner.GetComputedValues(ctx, workload)
+	if err != nil {
+		return RendererOutput{}, err
+	}
+
+	return RendererOutput{
+		Resources:      resources,
+		ComputedValues: computedValues,
+		SecretValues:   secretValues,
+	}, nil
+}

--- a/pkg/renderers/servicebusqueuev1alpha1/renderer.go
+++ b/pkg/renderers/servicebusqueuev1alpha1/renderer.go
@@ -20,6 +20,8 @@ import (
 	"github.com/Azure/radius/pkg/workloads"
 )
 
+var _ renderers.AdaptableRenderer = (*Renderer)(nil)
+
 // Renderer is the WorkloadRenderer implementation for the service bus workload.
 type Renderer struct {
 	Arm armauth.ArmConfig
@@ -122,4 +124,35 @@ func (r Renderer) Render(ctx context.Context, w workloads.InstantiatedWorkload) 
 		// It's already in the correct format
 		return []outputresource.OutputResource{resource}, nil
 	}
+}
+
+func (r *Renderer) GetKind() string {
+	return Kind
+}
+func (r *Renderer) GetComputedValues(ctx context.Context, workload workloads.InstantiatedWorkload) (map[string]renderers.ComputedValueReference, map[string]renderers.SecretValueReference, error) {
+	computedValues := map[string]renderers.ComputedValueReference{
+		"namespace": {
+			LocalID:           outputresource.LocalIDAzureServiceBusQueue,
+			PropertyReference: handlers.ServiceBusNamespaceNameKey,
+		},
+		"queue": {
+			LocalID:           outputresource.LocalIDAzureServiceBusQueue,
+			PropertyReference: handlers.ServiceBusQueueNameKey,
+		},
+		"connectionString": {
+			LocalID:           outputresource.LocalIDAzureServiceBusQueue,
+			PropertyReference: handlers.ServiceBusNamespaceConnectionStringKey,
+		},
+		"namespaceConnectionString": {
+			LocalID:           outputresource.LocalIDAzureServiceBusQueue,
+			PropertyReference: handlers.ServiceBusNamespaceConnectionStringKey,
+		},
+		"queueConnectionString": {
+			LocalID:           outputresource.LocalIDAzureServiceBusQueue,
+			PropertyReference: handlers.ServiceBusQueueConnectionStringKey,
+		},
+	}
+	secretValues := map[string]renderers.SecretValueReference{}
+
+	return computedValues, secretValues, nil
 }

--- a/pkg/renderers/types.go
+++ b/pkg/renderers/types.go
@@ -36,12 +36,25 @@ type RendererOutput struct {
 	SecretValues   map[string]SecretValueReference
 }
 
+// ComputedValueReference represents a non-secret value that can accessed once the output resources
+// have been deployed.
 type ComputedValueReference struct {
-	LocalID       string
-	ValueSelector string
+	// ComputedValueReference might hold a static value in `.Value` or might be a reference
+	// that needs to be looked up. If `.Value` is set then treat this as a static value.
+	// If `.Value == nil` then use the `.PropertyReference` to look up a property in the property
+	// bag returned from deploying the resource via `handler.Put`.
+
+	LocalID           string
+	PropertyReference string
+	Value             interface{}
 }
 
+// SecretValueReference represents a secret value that can accessed on the output resources
+// have been deployed.
 type SecretValueReference struct {
+	// SecretValueReference always needs to be resolved against a deployed resource. These
+	// are secrets so we don't want to store them.
+
 	LocalID       string
 	Action        string
 	ValueSelector string


### PR DESCRIPTION
This change adds some missing things for the computed value construct
that we discussed previous.

Also this change demonstrates how we can adapt a subset of the  existing
v1 renderers to use the new renderer contract and code path without
rewriting it as a transitional measure. I can adapt the rest of these in
a follow-up change after we review the pattern.

This is preferrable to doing a 'big bang' rewrite because because we'll
be able to migrate each scenario individually.