### PR TITLE
Make V3 components inherit from ProxyResource

### DIFF
--- a/docs/content/contributing/contributing-components.md
+++ b/docs/content/contributing/contributing-components.md
@@ -24,17 +24,17 @@ All components need to have a page under [Components]({{< ref components >}}). E
 
 ### Adding a new Component schema
 
-1. Under the directory `radrp/schemav3/components`, add a JSON Schema file for your Component. See existing Components for example, and also take a look at [JSON Schema Draft 4](https://json-schema.org/specification-links.html#draft-4) for more information.
-1. In your JSON schema, make sure that the new Component inherits from TrackedResource or Proxy Resource, look at existing components JSON schema to see how it is done.
+- Under the directory `radrp/schemav3/components`, add a JSON Schema file for your Component. See existing Components for example, and also take a look at [JSON Schema Draft 4](https://json-schema.org/specification-links.html#draft-4) for more information.
+- In your JSON schema, make sure that the new Component inherits from TrackedResource or Proxy Resource, look at existing components JSON schema to see how it is done.
 >> `TrackedResource` means that a copy of your resource is stored by centralized servers in Azure. When a GET happens, it will hit the cache. TraceResource also has to support tags and also have to have a location. Generally a top level resource is tracked (Application).
 >> `ProxyResource` means that your RP can change the state dynamically. When a GET happens, it will go through to your RP. Since we do things like provide the status/health of the resources IMO proxy is what we want. We also encountered a wierd bug a few months back with CustomRP that we worked around by switching.
-1. Register your schema in the manifest file at `pkg/radrp/schemav3/resource-types.json`.
-1. Add some tests to confirm your JSON schema in the `pkg/radrp/schemav3/testdata/{componentName}` directory. Any JSON file with `*-valid.json` suffix should be accepted by your new schema. Any JSON file with `*-invalid.json` suffix should be rejected by your new schema, with errors matching the content of `*-invalid.txt` file in the same directory.
+- Register your schema in the manifest file at `pkg/radrp/schemav3/resource-types.json`.
+- Add some tests to confirm your JSON schema in the `pkg/radrp/schemav3/testdata/{componentName}` directory. Any JSON file with `*-valid.json` suffix should be accepted by your new schema. Any JSON file with `*-invalid.json` suffix should be rejected by your new schema, with errors matching the content of `*-invalid.txt` file in the same directory.
 
 ### Adding a new Trait schema
 
-1. Under the directory `radrp/schemav3/traits`, add a JSON Schema for your new trait. Note that the `kind` field must be an enum string having an exactly one value. See existing JSON Schema in the same directory as examples.
-2. Update `radrp/schemav3/traits.json` to refer to your new Trait.
+- Under the directory `radrp/schemav3/traits`, add a JSON Schema for your new trait. Note that the `kind` field must be an enum string having an exactly one value. See existing JSON Schema in the same directory as examples.
+- Update `radrp/schemav3/traits.json` to refer to your new Trait.
 
 ## OpenAPI spec
 

--- a/docs/content/contributing/contributing-components.md
+++ b/docs/content/contributing/contributing-components.md
@@ -25,6 +25,7 @@ All components need to have a page under [Components]({{< ref components >}}). E
 ### Adding a new Component schema
 
 1. Under the directory `radrp/schemav3/components`, add a JSON Schema file for your Component. See existing Components for example, and also take a look at [JSON Schema Draft 4](https://json-schema.org/specification-links.html#draft-4) for more information.
+1. In your JSON schema, make sure that the new Component inherits from TrackedResource, look at existing components JSON schema to see how it is done.
 1. Register your schema in the manifest file at `pkg/radrp/schemav3/resource-types.json`.
 1. Add some tests to confirm your JSON schema in the `pkg/radrp/schemav3/testdata/{componentName}` directory. Any JSON file with `*-valid.json` suffix should be accepted by your new schema. Any JSON file with `*-invalid.json` suffix should be rejected by your new schema, with errors matching the content of `*-invalid.txt` file in the same directory.
 

--- a/docs/content/contributing/contributing-components.md
+++ b/docs/content/contributing/contributing-components.md
@@ -27,7 +27,7 @@ All components need to have a page under [Components]({{< ref components >}}). E
 - Under the directory `radrp/schemav3/components`, add a JSON Schema file for your Component. See existing Components for example, and also take a look at [JSON Schema Draft 4](https://json-schema.org/specification-links.html#draft-4) for more information.
 - In your JSON schema, make sure that the new Component inherits from TrackedResource or Proxy Resource, look at existing components JSON schema to see how it is done.
 >> `TrackedResource` means that a copy of your resource is stored by centralized servers in Azure. When a GET happens, it will hit the cache. TraceResource also has to support tags and also have to have a location. Generally a top level resource is tracked (Application).
->> `ProxyResource` means that your RP can change the state dynamically. When a GET happens, it will go through to your RP. Since we do things like provide the status/health of the resources IMO proxy is what we want. We also encountered a wierd bug a few months back with CustomRP that we worked around by switching.
+>> `ProxyResource` means that your RP can change the state dynamically. When a GET happens, it will go through to your RP.
 - Register your schema in the manifest file at `pkg/radrp/schemav3/resource-types.json`.
 - Add some tests to confirm your JSON schema in the `pkg/radrp/schemav3/testdata/{componentName}` directory. Any JSON file with `*-valid.json` suffix should be accepted by your new schema. Any JSON file with `*-invalid.json` suffix should be rejected by your new schema, with errors matching the content of `*-invalid.txt` file in the same directory.
 

--- a/docs/content/contributing/contributing-components.md
+++ b/docs/content/contributing/contributing-components.md
@@ -25,7 +25,9 @@ All components need to have a page under [Components]({{< ref components >}}). E
 ### Adding a new Component schema
 
 1. Under the directory `radrp/schemav3/components`, add a JSON Schema file for your Component. See existing Components for example, and also take a look at [JSON Schema Draft 4](https://json-schema.org/specification-links.html#draft-4) for more information.
-1. In your JSON schema, make sure that the new Component inherits from TrackedResource, look at existing components JSON schema to see how it is done.
+1. In your JSON schema, make sure that the new Component inherits from TrackedResource or Proxy Resource, look at existing components JSON schema to see how it is done.
+>> `TrackedResource` means that a copy of your resource is stored by centralized servers in Azure. When a GET happens, it will hit the cache. TraceResource also has to support tags and also have to have a location. Generally a top level resource is tracked (Application).
+>> `ProxyResource` means that your RP can change the state dynamically. When a GET happens, it will go through to your RP. Since we do things like provide the status/health of the resources IMO proxy is what we want. We also encountered a wierd bug a few months back with CustomRP that we worked around by switching.
 1. Register your schema in the manifest file at `pkg/radrp/schemav3/resource-types.json`.
 1. Add some tests to confirm your JSON schema in the `pkg/radrp/schemav3/testdata/{componentName}` directory. Any JSON file with `*-valid.json` suffix should be accepted by your new schema. Any JSON file with `*-invalid.json` suffix should be rejected by your new schema, with errors matching the content of `*-invalid.txt` file in the same directory.
 

--- a/pkg/azure/radclientv3/zz_generated_models.go
+++ b/pkg/azure/radclientv3/zz_generated_models.go
@@ -599,14 +599,14 @@ type DaprPubSubComponentPropertiesConfig struct {
 
 // DaprPubSubComponentResource - Component for Dapr Pub/Sub
 type DaprPubSubComponentResource struct {
-	TrackedResource
+	ProxyResource
 	// REQUIRED
 	Properties *DaprPubSubComponentProperties `json:"properties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type DaprPubSubComponentResource.
 func (d DaprPubSubComponentResource) MarshalJSON() ([]byte, error) {
-	objectMap := d.TrackedResource.marshalInternal()
+	objectMap := d.ProxyResource.marshalInternal()
 	populate(objectMap, "properties", d.Properties)
 	return json.Marshal(objectMap)
 }
@@ -647,14 +647,14 @@ type DaprStateStoreComponentPropertiesConfig struct {
 
 // DaprStateStoreComponentResource - Component for Dapr state store
 type DaprStateStoreComponentResource struct {
-	TrackedResource
+	ProxyResource
 	// REQUIRED
 	Properties *DaprStateStoreComponentProperties `json:"properties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type DaprStateStoreComponentResource.
 func (d DaprStateStoreComponentResource) MarshalJSON() ([]byte, error) {
-	objectMap := d.TrackedResource.marshalInternal()
+	objectMap := d.ProxyResource.marshalInternal()
 	populate(objectMap, "properties", d.Properties)
 	return json.Marshal(objectMap)
 }
@@ -905,14 +905,14 @@ type MongoDBComponentPropertiesConfig struct {
 
 // MongoDBComponentResource - The mongodb.com/MongoDB component is a portable component which can be deployed to any Radius platform.
 type MongoDBComponentResource struct {
-	TrackedResource
+	ProxyResource
 	// REQUIRED
 	Properties *MongoDBComponentProperties `json:"properties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type MongoDBComponentResource.
 func (m MongoDBComponentResource) MarshalJSON() ([]byte, error) {
-	objectMap := m.TrackedResource.marshalInternal()
+	objectMap := m.ProxyResource.marshalInternal()
 	populate(objectMap, "properties", m.Properties)
 	return json.Marshal(objectMap)
 }
@@ -1098,6 +1098,11 @@ type ProxyResource struct {
 	Resource
 }
 
+func (p ProxyResource) marshalInternal() map[string]interface{} {
+	objectMap := p.Resource.marshalInternal()
+	return objectMap
+}
+
 // RabbitMQComponentList - List of rabbitmq.com.MessageQueue resources.
 type RabbitMQComponentList struct {
 	// REQUIRED; List of rabbitmq.com.MessageQueue resources.
@@ -1134,14 +1139,14 @@ type RabbitMQComponentPropertiesConfig struct {
 
 // RabbitMQComponentResource - The rabbitmq.com/MessageQueue component is a Kubernetes specific component for message brokering.
 type RabbitMQComponentResource struct {
-	TrackedResource
+	ProxyResource
 	// REQUIRED
 	Properties *RabbitMQComponentProperties `json:"properties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type RabbitMQComponentResource.
 func (r RabbitMQComponentResource) MarshalJSON() ([]byte, error) {
-	objectMap := r.TrackedResource.marshalInternal()
+	objectMap := r.ProxyResource.marshalInternal()
 	populate(objectMap, "properties", r.Properties)
 	return json.Marshal(objectMap)
 }
@@ -1208,14 +1213,14 @@ type RedisComponentPropertiesConfig struct {
 
 // RedisComponentResource - The redislabs.com/Redis component is a portable component which can be deployed to any Radius platform.
 type RedisComponentResource struct {
-	TrackedResource
+	ProxyResource
 	// REQUIRED
 	Properties *RedisComponentProperties `json:"properties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type RedisComponentResource.
 func (r RedisComponentResource) MarshalJSON() ([]byte, error) {
-	objectMap := r.TrackedResource.marshalInternal()
+	objectMap := r.ProxyResource.marshalInternal()
 	populate(objectMap, "properties", r.Properties)
 	return json.Marshal(objectMap)
 }

--- a/pkg/azure/radclientv3/zz_generated_models.go
+++ b/pkg/azure/radclientv3/zz_generated_models.go
@@ -599,11 +599,20 @@ type DaprPubSubComponentPropertiesConfig struct {
 
 // DaprPubSubComponentResource - Component for Dapr Pub/Sub
 type DaprPubSubComponentResource struct {
+	TrackedResource
 	// REQUIRED
 	Kind *string `json:"kind,omitempty"`
 
 	// REQUIRED
 	Properties *DaprPubSubComponentProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DaprPubSubComponentResource.
+func (d DaprPubSubComponentResource) MarshalJSON() ([]byte, error) {
+	objectMap := d.TrackedResource.marshalInternal()
+	populate(objectMap, "kind", d.Kind)
+	populate(objectMap, "properties", d.Properties)
+	return json.Marshal(objectMap)
 }
 
 // DaprStateStoreComponentList - List of dapr.io.StateStoreComponent resources.
@@ -642,11 +651,20 @@ type DaprStateStoreComponentPropertiesConfig struct {
 
 // DaprStateStoreComponentResource - Component for Dapr state store
 type DaprStateStoreComponentResource struct {
+	TrackedResource
 	// REQUIRED
 	Kind *string `json:"kind,omitempty"`
 
 	// REQUIRED
 	Properties *DaprStateStoreComponentProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DaprStateStoreComponentResource.
+func (d DaprStateStoreComponentResource) MarshalJSON() ([]byte, error) {
+	objectMap := d.TrackedResource.marshalInternal()
+	populate(objectMap, "kind", d.Kind)
+	populate(objectMap, "properties", d.Properties)
+	return json.Marshal(objectMap)
 }
 
 // DaprTrait - Dapr ComponentTrait
@@ -895,11 +913,20 @@ type MongoDBComponentPropertiesConfig struct {
 
 // MongoDBComponentResource - The mongodb.com/MongoDB component is a portable component which can be deployed to any Radius platform.
 type MongoDBComponentResource struct {
+	TrackedResource
 	// REQUIRED
 	Kind *string `json:"kind,omitempty"`
 
 	// REQUIRED
 	Properties *MongoDBComponentProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type MongoDBComponentResource.
+func (m MongoDBComponentResource) MarshalJSON() ([]byte, error) {
+	objectMap := m.TrackedResource.marshalInternal()
+	populate(objectMap, "kind", m.Kind)
+	populate(objectMap, "properties", m.Properties)
+	return json.Marshal(objectMap)
 }
 
 // MongodbComMongoDBComponentCreateOrUpdateOptions contains the optional parameters for the MongodbComMongoDBComponent.CreateOrUpdate method.
@@ -1119,11 +1146,20 @@ type RabbitMQComponentPropertiesConfig struct {
 
 // RabbitMQComponentResource - The rabbitmq.com/MessageQueue component is a Kubernetes specific component for message brokering.
 type RabbitMQComponentResource struct {
+	TrackedResource
 	// REQUIRED
 	Kind *string `json:"kind,omitempty"`
 
 	// REQUIRED
 	Properties *RabbitMQComponentProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RabbitMQComponentResource.
+func (r RabbitMQComponentResource) MarshalJSON() ([]byte, error) {
+	objectMap := r.TrackedResource.marshalInternal()
+	populate(objectMap, "kind", r.Kind)
+	populate(objectMap, "properties", r.Properties)
+	return json.Marshal(objectMap)
 }
 
 // RabbitmqComMessageQueueCreateOrUpdateOptions contains the optional parameters for the RabbitmqComMessageQueue.CreateOrUpdate method.
@@ -1188,11 +1224,20 @@ type RedisComponentPropertiesConfig struct {
 
 // RedisComponentResource - The redislabs.com/Redis component is a portable component which can be deployed to any Radius platform.
 type RedisComponentResource struct {
+	TrackedResource
 	// REQUIRED
 	Kind *string `json:"kind,omitempty"`
 
 	// REQUIRED
 	Properties *RedisComponentProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RedisComponentResource.
+func (r RedisComponentResource) MarshalJSON() ([]byte, error) {
+	objectMap := r.TrackedResource.marshalInternal()
+	populate(objectMap, "kind", r.Kind)
+	populate(objectMap, "properties", r.Properties)
+	return json.Marshal(objectMap)
 }
 
 // RedislabsComRedisCreateOrUpdateOptions contains the optional parameters for the RedislabsComRedis.CreateOrUpdate method.

--- a/pkg/azure/radclientv3/zz_generated_models.go
+++ b/pkg/azure/radclientv3/zz_generated_models.go
@@ -1,3 +1,4 @@
+//go:build go1.13
 // +build go1.13
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
@@ -9,9 +10,10 @@ package radclientv3
 
 import (
 	"encoding/json"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"reflect"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
 // ApplicationCreateOrUpdateOptions contains the optional parameters for the Application.CreateOrUpdate method.
@@ -394,7 +396,7 @@ type CheckNameAvailabilityResponse struct {
 // ComponentStatus - Status of a component.
 type ComponentStatus struct {
 	// Health state of the component
-	HealthState *string `json:"healthState,omitempty"`
+	HealthState     *string                  `json:"healthState,omitempty"`
 	OutputResources []map[string]interface{} `json:"outputResources,omitempty"`
 
 	// Provisioning state of the component
@@ -446,8 +448,8 @@ type ContainerComponentListOptions struct {
 type ContainerComponentProperties struct {
 	BasicComponentProperties
 	// Dictionary of
-	Connections map[string]*ContainerConnection `json:"connections,omitempty"`
-	Container *ContainerComponentPropertiesContainer `json:"container,omitempty"`
+	Connections map[string]*ContainerConnection        `json:"connections,omitempty"`
+	Container   *ContainerComponentPropertiesContainer `json:"container,omitempty"`
 
 	// Traits spec of the component
 	Traits []map[string]interface{} `json:"traits,omitempty"`
@@ -539,7 +541,7 @@ type DaprIoPubSubComponentListOptions struct {
 
 // DaprIoStateStoreComponentCreateOrUpdateOptions contains the optional parameters for the DaprIoStateStoreComponent.CreateOrUpdate method.
 type DaprIoStateStoreComponentCreateOrUpdateOptions struct {
-	// placeholder for future optional parameters
+	// placeholder for future optional parameterszure
 }
 
 // DaprIoStateStoreComponentDeleteOptions contains the optional parameters for the DaprIoStateStoreComponent.Delete method.
@@ -599,20 +601,11 @@ type DaprPubSubComponentPropertiesConfig struct {
 
 // DaprPubSubComponentResource - Component for Dapr Pub/Sub
 type DaprPubSubComponentResource struct {
-	TrackedResource
 	// REQUIRED
 	Kind *string `json:"kind,omitempty"`
 
 	// REQUIRED
 	Properties *DaprPubSubComponentProperties `json:"properties,omitempty"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type DaprPubSubComponentResource.
-func (d DaprPubSubComponentResource) MarshalJSON() ([]byte, error) {
-	objectMap := d.TrackedResource.marshalInternal()
-	populate(objectMap, "kind", d.Kind)
-	populate(objectMap, "properties", d.Properties)
-	return json.Marshal(objectMap)
 }
 
 // DaprStateStoreComponentList - List of dapr.io.StateStoreComponent resources.
@@ -651,20 +644,11 @@ type DaprStateStoreComponentPropertiesConfig struct {
 
 // DaprStateStoreComponentResource - Component for Dapr state store
 type DaprStateStoreComponentResource struct {
-	TrackedResource
 	// REQUIRED
 	Kind *string `json:"kind,omitempty"`
 
 	// REQUIRED
 	Properties *DaprStateStoreComponentProperties `json:"properties,omitempty"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type DaprStateStoreComponentResource.
-func (d DaprStateStoreComponentResource) MarshalJSON() ([]byte, error) {
-	objectMap := d.TrackedResource.marshalInternal()
-	populate(objectMap, "kind", d.Kind)
-	populate(objectMap, "properties", d.Properties)
-	return json.Marshal(objectMap)
 }
 
 // DaprTrait - Dapr ComponentTrait
@@ -694,11 +678,11 @@ func (d *DaprTrait) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "appId":
-				err = unpopulate(val, &d.AppID)
-				delete(rawMsg, key)
+			err = unpopulate(val, &d.AppID)
+			delete(rawMsg, key)
 		case "appPort":
-				err = unpopulate(val, &d.AppPort)
-				delete(rawMsg, key)
+			err = unpopulate(val, &d.AppPort)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
@@ -808,11 +792,11 @@ func (i *InboundRouteTrait) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "binding":
-				err = unpopulate(val, &i.Binding)
-				delete(rawMsg, key)
+			err = unpopulate(val, &i.Binding)
+			delete(rawMsg, key)
 		case "hostName":
-				err = unpopulate(val, &i.HostName)
-				delete(rawMsg, key)
+			err = unpopulate(val, &i.HostName)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
@@ -867,8 +851,8 @@ func (m *ManualScalingTrait) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "replicas":
-				err = unpopulate(val, &m.Replicas)
-				delete(rawMsg, key)
+			err = unpopulate(val, &m.Replicas)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
@@ -913,20 +897,11 @@ type MongoDBComponentPropertiesConfig struct {
 
 // MongoDBComponentResource - The mongodb.com/MongoDB component is a portable component which can be deployed to any Radius platform.
 type MongoDBComponentResource struct {
-	TrackedResource
 	// REQUIRED
 	Kind *string `json:"kind,omitempty"`
 
 	// REQUIRED
 	Properties *MongoDBComponentProperties `json:"properties,omitempty"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type MongoDBComponentResource.
-func (m MongoDBComponentResource) MarshalJSON() ([]byte, error) {
-	objectMap := m.TrackedResource.marshalInternal()
-	populate(objectMap, "kind", m.Kind)
-	populate(objectMap, "properties", m.Properties)
-	return json.Marshal(objectMap)
 }
 
 // MongodbComMongoDBComponentCreateOrUpdateOptions contains the optional parameters for the MongodbComMongoDBComponent.CreateOrUpdate method.
@@ -973,7 +948,7 @@ type OperationDisplay struct {
 	Description *string `json:"description,omitempty" azure:"ro"`
 
 	// READ-ONLY; The concise, localized friendly name for the operation; suitable for dropdowns. E.g. "Create or Update Virtual Machine", "Restart Virtual
-// Machine".
+	// Machine".
 	Operation *string `json:"operation,omitempty" azure:"ro"`
 
 	// READ-ONLY; The localized friendly form of the resource provider name, e.g. "Microsoft Monitoring Insights" or "Microsoft Compute".
@@ -1051,33 +1026,33 @@ func (o *OperationStatusResult) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "endTime":
-				var aux timeRFC3339
-				err = unpopulate(val, &aux)
-				o.EndTime = (*time.Time)(&aux)
-				delete(rawMsg, key)
+			var aux timeRFC3339
+			err = unpopulate(val, &aux)
+			o.EndTime = (*time.Time)(&aux)
+			delete(rawMsg, key)
 		case "error":
-				err = unpopulate(val, &o.Error)
-				delete(rawMsg, key)
+			err = unpopulate(val, &o.Error)
+			delete(rawMsg, key)
 		case "id":
-				err = unpopulate(val, &o.ID)
-				delete(rawMsg, key)
+			err = unpopulate(val, &o.ID)
+			delete(rawMsg, key)
 		case "name":
-				err = unpopulate(val, &o.Name)
-				delete(rawMsg, key)
+			err = unpopulate(val, &o.Name)
+			delete(rawMsg, key)
 		case "operations":
-				err = unpopulate(val, &o.Operations)
-				delete(rawMsg, key)
+			err = unpopulate(val, &o.Operations)
+			delete(rawMsg, key)
 		case "percentComplete":
-				err = unpopulate(val, &o.PercentComplete)
-				delete(rawMsg, key)
+			err = unpopulate(val, &o.PercentComplete)
+			delete(rawMsg, key)
 		case "startTime":
-				var aux timeRFC3339
-				err = unpopulate(val, &aux)
-				o.StartTime = (*time.Time)(&aux)
-				delete(rawMsg, key)
+			var aux timeRFC3339
+			err = unpopulate(val, &aux)
+			o.StartTime = (*time.Time)(&aux)
+			delete(rawMsg, key)
 		case "status":
-				err = unpopulate(val, &o.Status)
-				delete(rawMsg, key)
+			err = unpopulate(val, &o.Status)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
@@ -1092,7 +1067,7 @@ type Plan struct {
 	Name *string `json:"name,omitempty"`
 
 	// REQUIRED; The 3rd Party artifact that is being procured. E.g. NewRelic. Product maps to the OfferID specified for the artifact at the time of Data Market
-// onboarding.
+	// onboarding.
 	Product *string `json:"product,omitempty"`
 
 	// REQUIRED; The publisher of the 3rd Party Artifact that is being bought. E.g. NewRelic
@@ -1146,20 +1121,11 @@ type RabbitMQComponentPropertiesConfig struct {
 
 // RabbitMQComponentResource - The rabbitmq.com/MessageQueue component is a Kubernetes specific component for message brokering.
 type RabbitMQComponentResource struct {
-	TrackedResource
 	// REQUIRED
 	Kind *string `json:"kind,omitempty"`
 
 	// REQUIRED
 	Properties *RabbitMQComponentProperties `json:"properties,omitempty"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type RabbitMQComponentResource.
-func (r RabbitMQComponentResource) MarshalJSON() ([]byte, error) {
-	objectMap := r.TrackedResource.marshalInternal()
-	populate(objectMap, "kind", r.Kind)
-	populate(objectMap, "properties", r.Properties)
-	return json.Marshal(objectMap)
 }
 
 // RabbitmqComMessageQueueCreateOrUpdateOptions contains the optional parameters for the RabbitmqComMessageQueue.CreateOrUpdate method.
@@ -1224,20 +1190,11 @@ type RedisComponentPropertiesConfig struct {
 
 // RedisComponentResource - The redislabs.com/Redis component is a portable component which can be deployed to any Radius platform.
 type RedisComponentResource struct {
-	TrackedResource
 	// REQUIRED
 	Kind *string `json:"kind,omitempty"`
 
 	// REQUIRED
 	Properties *RedisComponentProperties `json:"properties,omitempty"`
-}
-
-// MarshalJSON implements the json.Marshaller interface for type RedisComponentResource.
-func (r RedisComponentResource) MarshalJSON() ([]byte, error) {
-	objectMap := r.TrackedResource.marshalInternal()
-	populate(objectMap, "kind", r.Kind)
-	populate(objectMap, "properties", r.Properties)
-	return json.Marshal(objectMap)
 }
 
 // RedislabsComRedisCreateOrUpdateOptions contains the optional parameters for the RedislabsComRedis.CreateOrUpdate method.
@@ -1292,27 +1249,27 @@ type ResourceModelWithAllowedPropertySet struct {
 	Identity *ResourceModelWithAllowedPropertySetIdentity `json:"identity,omitempty"`
 
 	// Metadata used by portal/tooling/etc to render different UX experiences for resources of the same type; e.g. ApiApps are a kind of Microsoft.Web/sites
-// type. If supported, the resource provider must
-// validate and persist this value.
+	// type. If supported, the resource provider must
+	// validate and persist this value.
 	Kind *string `json:"kind,omitempty"`
 
 	// The geo-location where the resource lives
 	Location *string `json:"location,omitempty"`
 
 	// The fully qualified resource ID of the resource that manages this resource. Indicates if this resource is managed by another Azure resource. If this
-// is present, complete mode deployment will not
-// delete the resource if it is removed from the template since it is managed by another resource.
-	ManagedBy *string `json:"managedBy,omitempty"`
-	Plan *ResourceModelWithAllowedPropertySetPlan `json:"plan,omitempty"`
-	SKU *ResourceModelWithAllowedPropertySetSKU `json:"sku,omitempty"`
+	// is present, complete mode deployment will not
+	// delete the resource if it is removed from the template since it is managed by another resource.
+	ManagedBy *string                                  `json:"managedBy,omitempty"`
+	Plan      *ResourceModelWithAllowedPropertySetPlan `json:"plan,omitempty"`
+	SKU       *ResourceModelWithAllowedPropertySetSKU  `json:"sku,omitempty"`
 
 	// Resource tags.
 	Tags map[string]*string `json:"tags,omitempty"`
 
 	// READ-ONLY; The etag field is not required. If it is provided in the response body, it must also be provided as a header per the normal etag convention.
-// Entity tags are used for comparing two or more entities
-// from the same requested resource. HTTP/1.1 uses entity tags in the etag (section 14.19), If-Match (section 14.24), If-None-Match (section 14.26), and
-// If-Range (section 14.27) header fields.
+	// Entity tags are used for comparing two or more entities
+	// from the same requested resource. HTTP/1.1 uses entity tags in the etag (section 14.19), If-Match (section 14.24), If-None-Match (section 14.26), and
+	// If-Range (section 14.27) header fields.
 	Etag *string `json:"etag,omitempty" azure:"ro"`
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
@@ -1415,27 +1372,27 @@ func (s *SystemData) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "createdAt":
-				var aux timeRFC3339
-				err = unpopulate(val, &aux)
-				s.CreatedAt = (*time.Time)(&aux)
-				delete(rawMsg, key)
+			var aux timeRFC3339
+			err = unpopulate(val, &aux)
+			s.CreatedAt = (*time.Time)(&aux)
+			delete(rawMsg, key)
 		case "createdBy":
-				err = unpopulate(val, &s.CreatedBy)
-				delete(rawMsg, key)
+			err = unpopulate(val, &s.CreatedBy)
+			delete(rawMsg, key)
 		case "createdByType":
-				err = unpopulate(val, &s.CreatedByType)
-				delete(rawMsg, key)
+			err = unpopulate(val, &s.CreatedByType)
+			delete(rawMsg, key)
 		case "lastModifiedAt":
-				var aux timeRFC3339
-				err = unpopulate(val, &aux)
-				s.LastModifiedAt = (*time.Time)(&aux)
-				delete(rawMsg, key)
+			var aux timeRFC3339
+			err = unpopulate(val, &aux)
+			s.LastModifiedAt = (*time.Time)(&aux)
+			delete(rawMsg, key)
 		case "lastModifiedBy":
-				err = unpopulate(val, &s.LastModifiedBy)
-				delete(rawMsg, key)
+			err = unpopulate(val, &s.LastModifiedBy)
+			delete(rawMsg, key)
 		case "lastModifiedByType":
-				err = unpopulate(val, &s.LastModifiedByType)
-				delete(rawMsg, key)
+			err = unpopulate(val, &s.LastModifiedByType)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
@@ -1483,4 +1440,3 @@ func unpopulate(data json.RawMessage, v interface{}) error {
 	}
 	return json.Unmarshal(data, v)
 }
-

--- a/pkg/azure/radclientv3/zz_generated_models.go
+++ b/pkg/azure/radclientv3/zz_generated_models.go
@@ -1,4 +1,3 @@
-//go:build go1.13
 // +build go1.13
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
@@ -10,10 +9,9 @@ package radclientv3
 
 import (
 	"encoding/json"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"reflect"
 	"time"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
 // ApplicationCreateOrUpdateOptions contains the optional parameters for the Application.CreateOrUpdate method.
@@ -396,7 +394,7 @@ type CheckNameAvailabilityResponse struct {
 // ComponentStatus - Status of a component.
 type ComponentStatus struct {
 	// Health state of the component
-	HealthState     *string                  `json:"healthState,omitempty"`
+	HealthState *string `json:"healthState,omitempty"`
 	OutputResources []map[string]interface{} `json:"outputResources,omitempty"`
 
 	// Provisioning state of the component
@@ -448,8 +446,8 @@ type ContainerComponentListOptions struct {
 type ContainerComponentProperties struct {
 	BasicComponentProperties
 	// Dictionary of
-	Connections map[string]*ContainerConnection        `json:"connections,omitempty"`
-	Container   *ContainerComponentPropertiesContainer `json:"container,omitempty"`
+	Connections map[string]*ContainerConnection `json:"connections,omitempty"`
+	Container *ContainerComponentPropertiesContainer `json:"container,omitempty"`
 
 	// Traits spec of the component
 	Traits []map[string]interface{} `json:"traits,omitempty"`
@@ -541,7 +539,7 @@ type DaprIoPubSubComponentListOptions struct {
 
 // DaprIoStateStoreComponentCreateOrUpdateOptions contains the optional parameters for the DaprIoStateStoreComponent.CreateOrUpdate method.
 type DaprIoStateStoreComponentCreateOrUpdateOptions struct {
-	// placeholder for future optional parameterszure
+	// placeholder for future optional parameters
 }
 
 // DaprIoStateStoreComponentDeleteOptions contains the optional parameters for the DaprIoStateStoreComponent.Delete method.
@@ -601,11 +599,16 @@ type DaprPubSubComponentPropertiesConfig struct {
 
 // DaprPubSubComponentResource - Component for Dapr Pub/Sub
 type DaprPubSubComponentResource struct {
-	// REQUIRED
-	Kind *string `json:"kind,omitempty"`
-
+	TrackedResource
 	// REQUIRED
 	Properties *DaprPubSubComponentProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DaprPubSubComponentResource.
+func (d DaprPubSubComponentResource) MarshalJSON() ([]byte, error) {
+	objectMap := d.TrackedResource.marshalInternal()
+	populate(objectMap, "properties", d.Properties)
+	return json.Marshal(objectMap)
 }
 
 // DaprStateStoreComponentList - List of dapr.io.StateStoreComponent resources.
@@ -644,11 +647,16 @@ type DaprStateStoreComponentPropertiesConfig struct {
 
 // DaprStateStoreComponentResource - Component for Dapr state store
 type DaprStateStoreComponentResource struct {
-	// REQUIRED
-	Kind *string `json:"kind,omitempty"`
-
+	TrackedResource
 	// REQUIRED
 	Properties *DaprStateStoreComponentProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DaprStateStoreComponentResource.
+func (d DaprStateStoreComponentResource) MarshalJSON() ([]byte, error) {
+	objectMap := d.TrackedResource.marshalInternal()
+	populate(objectMap, "properties", d.Properties)
+	return json.Marshal(objectMap)
 }
 
 // DaprTrait - Dapr ComponentTrait
@@ -678,11 +686,11 @@ func (d *DaprTrait) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "appId":
-			err = unpopulate(val, &d.AppID)
-			delete(rawMsg, key)
+				err = unpopulate(val, &d.AppID)
+				delete(rawMsg, key)
 		case "appPort":
-			err = unpopulate(val, &d.AppPort)
-			delete(rawMsg, key)
+				err = unpopulate(val, &d.AppPort)
+				delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
@@ -792,11 +800,11 @@ func (i *InboundRouteTrait) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "binding":
-			err = unpopulate(val, &i.Binding)
-			delete(rawMsg, key)
+				err = unpopulate(val, &i.Binding)
+				delete(rawMsg, key)
 		case "hostName":
-			err = unpopulate(val, &i.HostName)
-			delete(rawMsg, key)
+				err = unpopulate(val, &i.HostName)
+				delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
@@ -851,8 +859,8 @@ func (m *ManualScalingTrait) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "replicas":
-			err = unpopulate(val, &m.Replicas)
-			delete(rawMsg, key)
+				err = unpopulate(val, &m.Replicas)
+				delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
@@ -897,11 +905,16 @@ type MongoDBComponentPropertiesConfig struct {
 
 // MongoDBComponentResource - The mongodb.com/MongoDB component is a portable component which can be deployed to any Radius platform.
 type MongoDBComponentResource struct {
-	// REQUIRED
-	Kind *string `json:"kind,omitempty"`
-
+	TrackedResource
 	// REQUIRED
 	Properties *MongoDBComponentProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type MongoDBComponentResource.
+func (m MongoDBComponentResource) MarshalJSON() ([]byte, error) {
+	objectMap := m.TrackedResource.marshalInternal()
+	populate(objectMap, "properties", m.Properties)
+	return json.Marshal(objectMap)
 }
 
 // MongodbComMongoDBComponentCreateOrUpdateOptions contains the optional parameters for the MongodbComMongoDBComponent.CreateOrUpdate method.
@@ -948,7 +961,7 @@ type OperationDisplay struct {
 	Description *string `json:"description,omitempty" azure:"ro"`
 
 	// READ-ONLY; The concise, localized friendly name for the operation; suitable for dropdowns. E.g. "Create or Update Virtual Machine", "Restart Virtual
-	// Machine".
+// Machine".
 	Operation *string `json:"operation,omitempty" azure:"ro"`
 
 	// READ-ONLY; The localized friendly form of the resource provider name, e.g. "Microsoft Monitoring Insights" or "Microsoft Compute".
@@ -1026,33 +1039,33 @@ func (o *OperationStatusResult) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "endTime":
-			var aux timeRFC3339
-			err = unpopulate(val, &aux)
-			o.EndTime = (*time.Time)(&aux)
-			delete(rawMsg, key)
+				var aux timeRFC3339
+				err = unpopulate(val, &aux)
+				o.EndTime = (*time.Time)(&aux)
+				delete(rawMsg, key)
 		case "error":
-			err = unpopulate(val, &o.Error)
-			delete(rawMsg, key)
+				err = unpopulate(val, &o.Error)
+				delete(rawMsg, key)
 		case "id":
-			err = unpopulate(val, &o.ID)
-			delete(rawMsg, key)
+				err = unpopulate(val, &o.ID)
+				delete(rawMsg, key)
 		case "name":
-			err = unpopulate(val, &o.Name)
-			delete(rawMsg, key)
+				err = unpopulate(val, &o.Name)
+				delete(rawMsg, key)
 		case "operations":
-			err = unpopulate(val, &o.Operations)
-			delete(rawMsg, key)
+				err = unpopulate(val, &o.Operations)
+				delete(rawMsg, key)
 		case "percentComplete":
-			err = unpopulate(val, &o.PercentComplete)
-			delete(rawMsg, key)
+				err = unpopulate(val, &o.PercentComplete)
+				delete(rawMsg, key)
 		case "startTime":
-			var aux timeRFC3339
-			err = unpopulate(val, &aux)
-			o.StartTime = (*time.Time)(&aux)
-			delete(rawMsg, key)
+				var aux timeRFC3339
+				err = unpopulate(val, &aux)
+				o.StartTime = (*time.Time)(&aux)
+				delete(rawMsg, key)
 		case "status":
-			err = unpopulate(val, &o.Status)
-			delete(rawMsg, key)
+				err = unpopulate(val, &o.Status)
+				delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
@@ -1067,7 +1080,7 @@ type Plan struct {
 	Name *string `json:"name,omitempty"`
 
 	// REQUIRED; The 3rd Party artifact that is being procured. E.g. NewRelic. Product maps to the OfferID specified for the artifact at the time of Data Market
-	// onboarding.
+// onboarding.
 	Product *string `json:"product,omitempty"`
 
 	// REQUIRED; The publisher of the 3rd Party Artifact that is being bought. E.g. NewRelic
@@ -1121,11 +1134,16 @@ type RabbitMQComponentPropertiesConfig struct {
 
 // RabbitMQComponentResource - The rabbitmq.com/MessageQueue component is a Kubernetes specific component for message brokering.
 type RabbitMQComponentResource struct {
-	// REQUIRED
-	Kind *string `json:"kind,omitempty"`
-
+	TrackedResource
 	// REQUIRED
 	Properties *RabbitMQComponentProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RabbitMQComponentResource.
+func (r RabbitMQComponentResource) MarshalJSON() ([]byte, error) {
+	objectMap := r.TrackedResource.marshalInternal()
+	populate(objectMap, "properties", r.Properties)
+	return json.Marshal(objectMap)
 }
 
 // RabbitmqComMessageQueueCreateOrUpdateOptions contains the optional parameters for the RabbitmqComMessageQueue.CreateOrUpdate method.
@@ -1190,11 +1208,16 @@ type RedisComponentPropertiesConfig struct {
 
 // RedisComponentResource - The redislabs.com/Redis component is a portable component which can be deployed to any Radius platform.
 type RedisComponentResource struct {
-	// REQUIRED
-	Kind *string `json:"kind,omitempty"`
-
+	TrackedResource
 	// REQUIRED
 	Properties *RedisComponentProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RedisComponentResource.
+func (r RedisComponentResource) MarshalJSON() ([]byte, error) {
+	objectMap := r.TrackedResource.marshalInternal()
+	populate(objectMap, "properties", r.Properties)
+	return json.Marshal(objectMap)
 }
 
 // RedislabsComRedisCreateOrUpdateOptions contains the optional parameters for the RedislabsComRedis.CreateOrUpdate method.
@@ -1249,27 +1272,27 @@ type ResourceModelWithAllowedPropertySet struct {
 	Identity *ResourceModelWithAllowedPropertySetIdentity `json:"identity,omitempty"`
 
 	// Metadata used by portal/tooling/etc to render different UX experiences for resources of the same type; e.g. ApiApps are a kind of Microsoft.Web/sites
-	// type. If supported, the resource provider must
-	// validate and persist this value.
+// type. If supported, the resource provider must
+// validate and persist this value.
 	Kind *string `json:"kind,omitempty"`
 
 	// The geo-location where the resource lives
 	Location *string `json:"location,omitempty"`
 
 	// The fully qualified resource ID of the resource that manages this resource. Indicates if this resource is managed by another Azure resource. If this
-	// is present, complete mode deployment will not
-	// delete the resource if it is removed from the template since it is managed by another resource.
-	ManagedBy *string                                  `json:"managedBy,omitempty"`
-	Plan      *ResourceModelWithAllowedPropertySetPlan `json:"plan,omitempty"`
-	SKU       *ResourceModelWithAllowedPropertySetSKU  `json:"sku,omitempty"`
+// is present, complete mode deployment will not
+// delete the resource if it is removed from the template since it is managed by another resource.
+	ManagedBy *string `json:"managedBy,omitempty"`
+	Plan *ResourceModelWithAllowedPropertySetPlan `json:"plan,omitempty"`
+	SKU *ResourceModelWithAllowedPropertySetSKU `json:"sku,omitempty"`
 
 	// Resource tags.
 	Tags map[string]*string `json:"tags,omitempty"`
 
 	// READ-ONLY; The etag field is not required. If it is provided in the response body, it must also be provided as a header per the normal etag convention.
-	// Entity tags are used for comparing two or more entities
-	// from the same requested resource. HTTP/1.1 uses entity tags in the etag (section 14.19), If-Match (section 14.24), If-None-Match (section 14.26), and
-	// If-Range (section 14.27) header fields.
+// Entity tags are used for comparing two or more entities
+// from the same requested resource. HTTP/1.1 uses entity tags in the etag (section 14.19), If-Match (section 14.24), If-None-Match (section 14.26), and
+// If-Range (section 14.27) header fields.
 	Etag *string `json:"etag,omitempty" azure:"ro"`
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
@@ -1372,27 +1395,27 @@ func (s *SystemData) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "createdAt":
-			var aux timeRFC3339
-			err = unpopulate(val, &aux)
-			s.CreatedAt = (*time.Time)(&aux)
-			delete(rawMsg, key)
+				var aux timeRFC3339
+				err = unpopulate(val, &aux)
+				s.CreatedAt = (*time.Time)(&aux)
+				delete(rawMsg, key)
 		case "createdBy":
-			err = unpopulate(val, &s.CreatedBy)
-			delete(rawMsg, key)
+				err = unpopulate(val, &s.CreatedBy)
+				delete(rawMsg, key)
 		case "createdByType":
-			err = unpopulate(val, &s.CreatedByType)
-			delete(rawMsg, key)
+				err = unpopulate(val, &s.CreatedByType)
+				delete(rawMsg, key)
 		case "lastModifiedAt":
-			var aux timeRFC3339
-			err = unpopulate(val, &aux)
-			s.LastModifiedAt = (*time.Time)(&aux)
-			delete(rawMsg, key)
+				var aux timeRFC3339
+				err = unpopulate(val, &aux)
+				s.LastModifiedAt = (*time.Time)(&aux)
+				delete(rawMsg, key)
 		case "lastModifiedBy":
-			err = unpopulate(val, &s.LastModifiedBy)
-			delete(rawMsg, key)
+				err = unpopulate(val, &s.LastModifiedBy)
+				delete(rawMsg, key)
 		case "lastModifiedByType":
-			err = unpopulate(val, &s.LastModifiedByType)
-			delete(rawMsg, key)
+				err = unpopulate(val, &s.LastModifiedByType)
+				delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
@@ -1440,3 +1463,4 @@ func unpopulate(data json.RawMessage, v interface{}) error {
 	}
 	return json.Unmarshal(data, v)
 }
+

--- a/pkg/azure/radclientv3/zz_generated_models.go
+++ b/pkg/azure/radclientv3/zz_generated_models.go
@@ -194,14 +194,14 @@ func (a AzureCosmosDBMongoComponentProperties) MarshalJSON() ([]byte, error) {
 
 // AzureCosmosDBMongoComponentResource - Component for Azure CosmosDB with Mongo
 type AzureCosmosDBMongoComponentResource struct {
-	TrackedResource
+	ProxyResource
 	// REQUIRED
 	Properties *AzureCosmosDBMongoComponentProperties `json:"properties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type AzureCosmosDBMongoComponentResource.
 func (a AzureCosmosDBMongoComponentResource) MarshalJSON() ([]byte, error) {
-	objectMap := a.TrackedResource.marshalInternal()
+	objectMap := a.ProxyResource.marshalInternal()
 	populate(objectMap, "properties", a.Properties)
 	return json.Marshal(objectMap)
 }
@@ -238,14 +238,14 @@ func (a AzureCosmosDBSQLComponentProperties) MarshalJSON() ([]byte, error) {
 
 // AzureCosmosDBSQLComponentResource - Component for Azure CosmosDB with SQL
 type AzureCosmosDBSQLComponentResource struct {
-	TrackedResource
+	ProxyResource
 	// REQUIRED
 	Properties *AzureCosmosDBSQLComponentProperties `json:"properties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type AzureCosmosDBSQLComponentResource.
 func (a AzureCosmosDBSQLComponentResource) MarshalJSON() ([]byte, error) {
-	objectMap := a.TrackedResource.marshalInternal()
+	objectMap := a.ProxyResource.marshalInternal()
 	populate(objectMap, "properties", a.Properties)
 	return json.Marshal(objectMap)
 }
@@ -292,14 +292,14 @@ func (a AzureKeyVaultComponentProperties) MarshalJSON() ([]byte, error) {
 
 // AzureKeyVaultComponentResource - Component for Azure KeyVault
 type AzureKeyVaultComponentResource struct {
-	TrackedResource
+	ProxyResource
 	// REQUIRED
 	Properties *AzureKeyVaultComponentProperties `json:"properties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type AzureKeyVaultComponentResource.
 func (a AzureKeyVaultComponentResource) MarshalJSON() ([]byte, error) {
-	objectMap := a.TrackedResource.marshalInternal()
+	objectMap := a.ProxyResource.marshalInternal()
 	populate(objectMap, "properties", a.Properties)
 	return json.Marshal(objectMap)
 }
@@ -336,14 +336,14 @@ func (a AzureServiceBusComponentProperties) MarshalJSON() ([]byte, error) {
 
 // AzureServiceBusComponentResource - Component for Azure ServiceBus
 type AzureServiceBusComponentResource struct {
-	TrackedResource
+	ProxyResource
 	// REQUIRED
 	Properties *AzureServiceBusComponentProperties `json:"properties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type AzureServiceBusComponentResource.
 func (a AzureServiceBusComponentResource) MarshalJSON() ([]byte, error) {
-	objectMap := a.TrackedResource.marshalInternal()
+	objectMap := a.ProxyResource.marshalInternal()
 	populate(objectMap, "properties", a.Properties)
 	return json.Marshal(objectMap)
 }
@@ -484,14 +484,14 @@ func (c ContainerComponentPropertiesContainer) MarshalJSON() ([]byte, error) {
 
 // ContainerComponentResource - The radius.dev/Container component provides an abstraction for a container workload that can be run on any Radius platform
 type ContainerComponentResource struct {
-	TrackedResource
+	ProxyResource
 	// REQUIRED
 	Properties *ContainerComponentProperties `json:"properties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type ContainerComponentResource.
 func (c ContainerComponentResource) MarshalJSON() ([]byte, error) {
-	objectMap := c.TrackedResource.marshalInternal()
+	objectMap := c.ProxyResource.marshalInternal()
 	populate(objectMap, "properties", c.Properties)
 	return json.Marshal(objectMap)
 }

--- a/pkg/radrp/schemav3/components/azure-cosmosdb-mongo.json
+++ b/pkg/radrp/schemav3/components/azure-cosmosdb-mongo.json
@@ -10,7 +10,7 @@
       ],
       "allOf": [
         {
-          "$ref": "../common-types.json#/definitions/TrackedResource"
+          "$ref": "../common-types.json#/definitions/ProxyResource"
         }
       ],
       "properties": {

--- a/pkg/radrp/schemav3/components/azure-cosmosdb-sql.json
+++ b/pkg/radrp/schemav3/components/azure-cosmosdb-sql.json
@@ -5,13 +5,13 @@
       "description": "Component for Azure CosmosDB with SQL",
       "type": "object",
       "x-ms-azure-resource": true,
-      "required": [
-        "properties"
-      ],
       "allOf": [
         {
           "$ref": "../common-types.json#/definitions/TrackedResource"
         }
+      ],
+      "required": [
+        "properties"
       ],
       "properties": {
         "properties": {

--- a/pkg/radrp/schemav3/components/azure-cosmosdb-sql.json
+++ b/pkg/radrp/schemav3/components/azure-cosmosdb-sql.json
@@ -7,7 +7,7 @@
       "x-ms-azure-resource": true,
       "allOf": [
         {
-          "$ref": "../common-types.json#/definitions/TrackedResource"
+          "$ref": "../common-types.json#/definitions/ProxyResource"
         }
       ],
       "required": [

--- a/pkg/radrp/schemav3/components/azure-keyvault.json
+++ b/pkg/radrp/schemav3/components/azure-keyvault.json
@@ -10,7 +10,7 @@
       ],
       "allOf": [
         {
-          "$ref": "../common-types.json#/definitions/TrackedResource"
+          "$ref": "../common-types.json#/definitions/ProxyResource"
         }
       ],
       "properties": {

--- a/pkg/radrp/schemav3/components/azure-servicebus.json
+++ b/pkg/radrp/schemav3/components/azure-servicebus.json
@@ -5,13 +5,13 @@
       "description": "Component for Azure ServiceBus",
       "type": "object",
       "x-ms-azure-resource": true,
-      "required": [
-        "properties"
-      ],
       "allOf": [
         {
           "$ref": "../common-types.json#/definitions/TrackedResource"
         }
+      ],
+      "required": [
+        "properties"
       ],
       "properties": {
         "properties": {

--- a/pkg/radrp/schemav3/components/azure-servicebus.json
+++ b/pkg/radrp/schemav3/components/azure-servicebus.json
@@ -7,7 +7,7 @@
       "x-ms-azure-resource": true,
       "allOf": [
         {
-          "$ref": "../common-types.json#/definitions/TrackedResource"
+          "$ref": "../common-types.json#/definitions/ProxyResource"
         }
       ],
       "required": [

--- a/pkg/radrp/schemav3/components/container-component.json
+++ b/pkg/radrp/schemav3/components/container-component.json
@@ -3,15 +3,15 @@
   "definitions": {
     "ContainerComponentResource": {
       "description": "The radius.dev/Container component provides an abstraction for a container workload that can be run on any Radius platform",
-      "required": [
-        "properties"
-      ],
       "type": "object",
       "x-ms-azure-resource": true,
       "allOf": [
         {
           "$ref": "../common-types.json#/definitions/TrackedResource"
         }
+      ],
+      "required": [
+        "properties"
       ],
       "properties": {
         "properties": {

--- a/pkg/radrp/schemav3/components/container-component.json
+++ b/pkg/radrp/schemav3/components/container-component.json
@@ -7,7 +7,7 @@
       "x-ms-azure-resource": true,
       "allOf": [
         {
-          "$ref": "../common-types.json#/definitions/TrackedResource"
+          "$ref": "../common-types.json#/definitions/ProxyResource"
         }
       ],
       "required": [

--- a/pkg/radrp/schemav3/components/dapr-pubsub.json
+++ b/pkg/radrp/schemav3/components/dapr-pubsub.json
@@ -3,6 +3,13 @@
   "definitions": {
     "DaprPubSubComponentResource": {
       "description": "Component for Dapr Pub/Sub",
+      "type": "object",
+      "x-ms-azure-resource": true,
+      "allOf": [
+        {
+          "$ref": "../common-types.json#/definitions/TrackedResource"
+        }
+      ],
       "required": [
         "kind",
         "properties"

--- a/pkg/radrp/schemav3/components/dapr-pubsub.json
+++ b/pkg/radrp/schemav3/components/dapr-pubsub.json
@@ -11,16 +11,9 @@
         }
       ],
       "required": [
-        "kind",
         "properties"
       ],
       "properties": {
-        "kind": {
-          "type": "string",
-          "enum": [
-            "dapr.io/PubSubTopic@v1alpha1"
-          ]
-        },
         "properties": {
           "$ref": "#/definitions/DaprPubSubComponentProperties"
         }

--- a/pkg/radrp/schemav3/components/dapr-pubsub.json
+++ b/pkg/radrp/schemav3/components/dapr-pubsub.json
@@ -7,7 +7,7 @@
       "x-ms-azure-resource": true,
       "allOf": [
         {
-          "$ref": "../common-types.json#/definitions/TrackedResource"
+          "$ref": "../common-types.json#/definitions/ProxyResource"
         }
       ],
       "required": [

--- a/pkg/radrp/schemav3/components/dapr-statestore.json
+++ b/pkg/radrp/schemav3/components/dapr-statestore.json
@@ -3,6 +3,13 @@
   "definitions": {
     "DaprStateStoreComponentResource": {
       "description": "Component for Dapr state store",
+      "type": "object",
+      "x-ms-azure-resource": true,
+      "allOf": [
+        {
+          "$ref": "../common-types.json#/definitions/TrackedResource"
+        }
+      ],
       "required": [
         "kind",
         "properties"

--- a/pkg/radrp/schemav3/components/dapr-statestore.json
+++ b/pkg/radrp/schemav3/components/dapr-statestore.json
@@ -11,16 +11,9 @@
         }
       ],
       "required": [
-        "kind",
         "properties"
       ],
       "properties": {
-        "kind": {
-          "type": "string",
-          "enum": [
-            "dapr.io/StateStore@v1alpha1"
-          ]
-        },
         "properties": {
           "$ref": "#/definitions/DaprStateStoreComponentProperties"
         }

--- a/pkg/radrp/schemav3/components/dapr-statestore.json
+++ b/pkg/radrp/schemav3/components/dapr-statestore.json
@@ -7,7 +7,7 @@
       "x-ms-azure-resource": true,
       "allOf": [
         {
-          "$ref": "../common-types.json#/definitions/TrackedResource"
+          "$ref": "../common-types.json#/definitions/ProxyResource"
         }
       ],
       "required": [

--- a/pkg/radrp/schemav3/components/mongodb.json
+++ b/pkg/radrp/schemav3/components/mongodb.json
@@ -3,6 +3,13 @@
   "definitions": {
     "MongoDBComponentResource": {
       "description": "The mongodb.com/MongoDB component is a portable component which can be deployed to any Radius platform.",
+      "type": "object",
+      "x-ms-azure-resource": true,
+      "allOf": [
+        {
+          "$ref": "../common-types.json#/definitions/TrackedResource"
+        }
+      ],
       "required": [
         "kind",
         "properties"

--- a/pkg/radrp/schemav3/components/mongodb.json
+++ b/pkg/radrp/schemav3/components/mongodb.json
@@ -11,16 +11,9 @@
         }
       ],
       "required": [
-        "kind",
         "properties"
       ],
       "properties": {
-        "kind": {
-          "type": "string",
-          "enum": [
-            "mongodb.com/Mongo@v1alpha1"
-          ]
-        },
         "properties": {
           "$ref": "#/definitions/MongoDBComponentProperties"
         }

--- a/pkg/radrp/schemav3/components/mongodb.json
+++ b/pkg/radrp/schemav3/components/mongodb.json
@@ -7,7 +7,7 @@
       "x-ms-azure-resource": true,
       "allOf": [
         {
-          "$ref": "../common-types.json#/definitions/TrackedResource"
+          "$ref": "../common-types.json#/definitions/ProxyResource"
         }
       ],
       "required": [

--- a/pkg/radrp/schemav3/components/rabbitmq.json
+++ b/pkg/radrp/schemav3/components/rabbitmq.json
@@ -3,6 +3,13 @@
   "definitions": {
     "RabbitMQComponentResource": {
       "description": "The rabbitmq.com/MessageQueue component is a Kubernetes specific component for message brokering.",
+      "type": "object",
+      "x-ms-azure-resource": true,
+      "allOf": [
+        {
+          "$ref": "../common-types.json#/definitions/TrackedResource"
+        }
+      ],
       "required": [
         "kind",
         "properties"

--- a/pkg/radrp/schemav3/components/rabbitmq.json
+++ b/pkg/radrp/schemav3/components/rabbitmq.json
@@ -11,16 +11,9 @@
         }
       ],
       "required": [
-        "kind",
         "properties"
       ],
       "properties": {
-        "kind": {
-          "type": "string",
-          "enum": [
-            "rabbitmq.com/MessageQueue@v1alpha1"
-          ]
-        },
         "properties": {
           "$ref": "#/definitions/RabbitMQComponentProperties"
         }

--- a/pkg/radrp/schemav3/components/rabbitmq.json
+++ b/pkg/radrp/schemav3/components/rabbitmq.json
@@ -7,7 +7,7 @@
       "x-ms-azure-resource": true,
       "allOf": [
         {
-          "$ref": "../common-types.json#/definitions/TrackedResource"
+          "$ref": "../common-types.json#/definitions/ProxyResource"
         }
       ],
       "required": [

--- a/pkg/radrp/schemav3/components/redis.json
+++ b/pkg/radrp/schemav3/components/redis.json
@@ -11,16 +11,9 @@
         }
       ],
       "required": [
-        "kind",
         "properties"
       ],
       "properties": {
-        "kind": {
-          "type": "string",
-          "enum": [
-            "redislabs.com/Redis@v1alpha1"
-          ]
-        },
         "properties": {
           "$ref": "#/definitions/RedisComponentProperties"
         }

--- a/pkg/radrp/schemav3/components/redis.json
+++ b/pkg/radrp/schemav3/components/redis.json
@@ -7,7 +7,7 @@
       "x-ms-azure-resource": true,
       "allOf": [
         {
-          "$ref": "../common-types.json#/definitions/TrackedResource"
+          "$ref": "../common-types.json#/definitions/ProxyResource"
         }
       ],
       "required": [

--- a/pkg/radrp/schemav3/components/redis.json
+++ b/pkg/radrp/schemav3/components/redis.json
@@ -3,6 +3,13 @@
   "definitions": {
     "RedisComponentResource": {
       "description": "The redislabs.com/Redis component is a portable component which can be deployed to any Radius platform.",
+      "type": "object",
+      "x-ms-azure-resource": true,
+      "allOf": [
+        {
+          "$ref": "../common-types.json#/definitions/TrackedResource"
+        }
+      ],
       "required": [
         "kind",
         "properties"

--- a/pkg/radrp/schemav3/testdata/dapr.io.PubSubComponent/daprpubsub-invalid.json
+++ b/pkg/radrp/schemav3/testdata/dapr.io.PubSubComponent/daprpubsub-invalid.json
@@ -1,6 +1,6 @@
 {
-  "id": "id",
-  "name": "name",
+  "id": 42,
+  "name": 42,
   "kind": "dapr.io/PubSubTopic@v1alpha1",
   "properties": {
     "config": {

--- a/pkg/radrp/schemav3/testdata/dapr.io.PubSubComponent/daprpubsub-invalid.json
+++ b/pkg/radrp/schemav3/testdata/dapr.io.PubSubComponent/daprpubsub-invalid.json
@@ -1,7 +1,6 @@
 {
   "id": 42,
   "name": 42,
-  "kind": "dapr.io/PubSubTopic@v1alpha1",
   "properties": {
     "config": {
       "managed": true,

--- a/pkg/radrp/schemav3/testdata/dapr.io.PubSubComponent/daprpubsub-unmanged-valid.json
+++ b/pkg/radrp/schemav3/testdata/dapr.io.PubSubComponent/daprpubsub-unmanged-valid.json
@@ -1,7 +1,6 @@
 {
   "name": "name",
   "id": "id",
-  "kind": "dapr.io/PubSubTopic@v1alpha1",
   "properties": {
     "config": {
       "kind": "dapr.io/pubsub/ServiceBusQueue",

--- a/pkg/radrp/schemav3/testdata/dapr.io.PubSubComponent/daprpubsub-valid.json
+++ b/pkg/radrp/schemav3/testdata/dapr.io.PubSubComponent/daprpubsub-valid.json
@@ -1,7 +1,6 @@
 {
   "id": "id",
   "name": "name",
-  "kind": "dapr.io/PubSubTopic@v1alpha1",
   "properties": {
     "config": {
       "managed": true,

--- a/pkg/radrp/schemav3/testdata/dapr.io.StateStoreComponent/daprstatestore-invalid.json
+++ b/pkg/radrp/schemav3/testdata/dapr.io.StateStoreComponent/daprstatestore-invalid.json
@@ -1,0 +1,11 @@
+{
+    "id": 42,
+    "name": 42,
+    "kind": "dapr.io/StateStore@v1alpha1",
+    "properties": {
+        "config": {
+            "managed": true,
+            "kind": "dapr.io/RedisState"
+        }
+    }
+}

--- a/pkg/radrp/schemav3/testdata/dapr.io.StateStoreComponent/daprstatestore-invalid.json
+++ b/pkg/radrp/schemav3/testdata/dapr.io.StateStoreComponent/daprstatestore-invalid.json
@@ -1,7 +1,6 @@
 {
     "id": 42,
     "name": 42,
-    "kind": "dapr.io/StateStore@v1alpha1",
     "properties": {
         "config": {
             "managed": true,

--- a/pkg/radrp/schemav3/testdata/dapr.io.StateStoreComponent/daprstatestore-invalid.txt
+++ b/pkg/radrp/schemav3/testdata/dapr.io.StateStoreComponent/daprstatestore-invalid.txt
@@ -1,3 +1,2 @@
-(root).properties.config: Additional property extra is not allowed
 (root).id: Invalid type. Expected: string, given: integer
 (root).name: Invalid type. Expected: string, given: integer

--- a/pkg/radrp/schemav3/testdata/dapr.io.StateStoreComponent/daprstatestore-valid.json
+++ b/pkg/radrp/schemav3/testdata/dapr.io.StateStoreComponent/daprstatestore-valid.json
@@ -1,6 +1,5 @@
 {
   "id": "id", "name": "name",
-  "kind": "dapr.io/StateStore@v1alpha1",
   "properties": {
     "config": {
       "managed": true,

--- a/pkg/radrp/schemav3/testdata/mongodb.com.MongoDBComponent/mongodb-invalid.json
+++ b/pkg/radrp/schemav3/testdata/mongodb.com.MongoDBComponent/mongodb-invalid.json
@@ -1,5 +1,6 @@
 {
-  "id": "id", "name": "name",
+  "id": 42,
+  "name": 42,
   "kind": "mongodb.com/Mongo@v1alpha1",
   "properties": {
     "config": {

--- a/pkg/radrp/schemav3/testdata/mongodb.com.MongoDBComponent/mongodb-invalid.txt
+++ b/pkg/radrp/schemav3/testdata/mongodb.com.MongoDBComponent/mongodb-invalid.txt
@@ -1,1 +1,3 @@
 (root).properties.config: Additional property extra is not allowed
+(root).name: Invalid type. Expected: string, given: integer
+(root).id: Invalid type. Expected: string, given: integer

--- a/pkg/radrp/schemav3/testdata/rabbitmq.com.MessageQueue/rabbitmqmessagequeue-invalid.json
+++ b/pkg/radrp/schemav3/testdata/rabbitmq.com.MessageQueue/rabbitmqmessagequeue-invalid.json
@@ -1,5 +1,6 @@
 {
-  "id": "id", "name": "name",
+  "id": 42,
+  "name": 42,
   "kind": "rabbitmq.com/MessageQueue@v1alpha1",
   "properties": {
     "config": {

--- a/pkg/radrp/schemav3/testdata/rabbitmq.com.MessageQueue/rabbitmqmessagequeue-invalid.json
+++ b/pkg/radrp/schemav3/testdata/rabbitmq.com.MessageQueue/rabbitmqmessagequeue-invalid.json
@@ -1,7 +1,6 @@
 {
   "id": 42,
   "name": 42,
-  "kind": "rabbitmq.com/MessageQueue@v1alpha1",
   "properties": {
     "config": {
       "managed": false

--- a/pkg/radrp/schemav3/testdata/rabbitmq.com.MessageQueue/rabbitmqmessagequeue-invalid.txt
+++ b/pkg/radrp/schemav3/testdata/rabbitmq.com.MessageQueue/rabbitmqmessagequeue-invalid.txt
@@ -1,2 +1,4 @@
 (root).properties.config.managed: properties.config.managed must be one of the following: true
 (root).properties.config: queue is required
+(root).name: Invalid type. Expected: string, given: integer
+(root).id: Invalid type. Expected: string, given: integer

--- a/pkg/radrp/schemav3/testdata/rabbitmq.com.MessageQueue/rabbitmqmessagequeue-valid.json
+++ b/pkg/radrp/schemav3/testdata/rabbitmq.com.MessageQueue/rabbitmqmessagequeue-valid.json
@@ -1,6 +1,5 @@
 {
   "id": "id", "name": "name",
-  "kind": "rabbitmq.com/MessageQueue@v1alpha1",
   "properties": {
     "config": {
       "managed": true,

--- a/pkg/radrp/schemav3/testdata/redislabs.com.Redis/redis-invalid.json
+++ b/pkg/radrp/schemav3/testdata/redislabs.com.Redis/redis-invalid.json
@@ -1,5 +1,6 @@
 {
-  "id": "id", "name": "name",
+  "id": 42,
+  "name": 42,
   "kind": "redislabs.com/Redis@v1alpha1",
   "properties": {
     "config": {

--- a/pkg/radrp/schemav3/testdata/redislabs.com.Redis/redis-invalid.json
+++ b/pkg/radrp/schemav3/testdata/redislabs.com.Redis/redis-invalid.json
@@ -1,7 +1,6 @@
 {
   "id": 42,
   "name": 42,
-  "kind": "redislabs.com/Redis@v1alpha1",
   "properties": {
     "config": {
       "managed": false,

--- a/pkg/radrp/schemav3/testdata/redislabs.com.Redis/redis-invalid.txt
+++ b/pkg/radrp/schemav3/testdata/redislabs.com.Redis/redis-invalid.txt
@@ -1,2 +1,4 @@
 (root).properties.config.managed: properties.config.managed must be one of the following: true
 (root).properties.config: Additional property additional is not allowed
+(root).name: Invalid type. Expected: string, given: integer
+(root).id: Invalid type. Expected: string, given: integer

--- a/pkg/radrp/schemav3/testdata/redislabs.com.Redis/redis-valid.json
+++ b/pkg/radrp/schemav3/testdata/redislabs.com.Redis/redis-valid.json
@@ -1,6 +1,5 @@
 {
   "id": "id", "name": "name",
-  "kind": "redislabs.com/Redis@v1alpha1",
   "properties": {
     "config": {
       "managed": true,

--- a/schemas/rest-api-specs-v3/radius.json
+++ b/schemas/rest-api-specs-v3/radius.json
@@ -591,6 +591,11 @@
       ]
     },
     "DaprPubSubComponentResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/TrackedResource"
+        }
+      ],
       "description": "Component for Dapr Pub/Sub",
       "properties": {
         "kind": {
@@ -606,7 +611,9 @@
       "required": [
         "kind",
         "properties"
-      ]
+      ],
+      "type": "object",
+      "x-ms-azure-resource": true
     },
     "DaprStateStoreComponentList": {
       "description": "List of dapr.io.StateStoreComponent resources.",
@@ -662,6 +669,11 @@
       ]
     },
     "DaprStateStoreComponentResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/TrackedResource"
+        }
+      ],
       "description": "Component for Dapr state store",
       "properties": {
         "kind": {
@@ -677,7 +689,9 @@
       "required": [
         "kind",
         "properties"
-      ]
+      ],
+      "type": "object",
+      "x-ms-azure-resource": true
     },
     "DaprTrait": {
       "additionalProperties": false,
@@ -888,6 +902,11 @@
       ]
     },
     "MongoDBComponentResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/TrackedResource"
+        }
+      ],
       "description": "The mongodb.com/MongoDB component is a portable component which can be deployed to any Radius platform.",
       "properties": {
         "kind": {
@@ -903,7 +922,9 @@
       "required": [
         "kind",
         "properties"
-      ]
+      ],
+      "type": "object",
+      "x-ms-azure-resource": true
     },
     "Operation": {
       "description": "Details of a REST API operation, returned from the Resource Provider Operations API",
@@ -1133,6 +1154,11 @@
       ]
     },
     "RabbitMQComponentResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/TrackedResource"
+        }
+      ],
       "description": "The rabbitmq.com/MessageQueue component is a Kubernetes specific component for message brokering.",
       "properties": {
         "kind": {
@@ -1148,7 +1174,9 @@
       "required": [
         "kind",
         "properties"
-      ]
+      ],
+      "type": "object",
+      "x-ms-azure-resource": true
     },
     "RedisComponentList": {
       "description": "List of redislabs.com.Redis resources.",
@@ -1220,6 +1248,11 @@
       ]
     },
     "RedisComponentResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/TrackedResource"
+        }
+      ],
       "description": "The redislabs.com/Redis component is a portable component which can be deployed to any Radius platform.",
       "properties": {
         "kind": {
@@ -1235,7 +1268,9 @@
       "required": [
         "kind",
         "properties"
-      ]
+      ],
+      "type": "object",
+      "x-ms-azure-resource": true
     },
     "Resource": {
       "description": "Common fields that are returned in the response for all Azure Resource Manager resources",

--- a/schemas/rest-api-specs-v3/radius.json
+++ b/schemas/rest-api-specs-v3/radius.json
@@ -593,7 +593,7 @@
     "DaprPubSubComponentResource": {
       "allOf": [
         {
-          "$ref": "#/definitions/TrackedResource"
+          "$ref": "#/definitions/ProxyResource"
         }
       ],
       "description": "Component for Dapr Pub/Sub",
@@ -664,7 +664,7 @@
     "DaprStateStoreComponentResource": {
       "allOf": [
         {
-          "$ref": "#/definitions/TrackedResource"
+          "$ref": "#/definitions/ProxyResource"
         }
       ],
       "description": "Component for Dapr state store",
@@ -890,7 +890,7 @@
     "MongoDBComponentResource": {
       "allOf": [
         {
-          "$ref": "#/definitions/TrackedResource"
+          "$ref": "#/definitions/ProxyResource"
         }
       ],
       "description": "The mongodb.com/MongoDB component is a portable component which can be deployed to any Radius platform.",
@@ -1135,7 +1135,7 @@
     "RabbitMQComponentResource": {
       "allOf": [
         {
-          "$ref": "#/definitions/TrackedResource"
+          "$ref": "#/definitions/ProxyResource"
         }
       ],
       "description": "The rabbitmq.com/MessageQueue component is a Kubernetes specific component for message brokering.",
@@ -1222,7 +1222,7 @@
     "RedisComponentResource": {
       "allOf": [
         {
-          "$ref": "#/definitions/TrackedResource"
+          "$ref": "#/definitions/ProxyResource"
         }
       ],
       "description": "The redislabs.com/Redis component is a portable component which can be deployed to any Radius platform.",

--- a/schemas/rest-api-specs-v3/radius.json
+++ b/schemas/rest-api-specs-v3/radius.json
@@ -112,7 +112,7 @@
     "AzureCosmosDBMongoComponentResource": {
       "allOf": [
         {
-          "$ref": "#/definitions/TrackedResource"
+          "$ref": "#/definitions/ProxyResource"
         }
       ],
       "description": "Component for Azure CosmosDB with Mongo",
@@ -165,7 +165,7 @@
     "AzureCosmosDBSQLComponentResource": {
       "allOf": [
         {
-          "$ref": "#/definitions/TrackedResource"
+          "$ref": "#/definitions/ProxyResource"
         }
       ],
       "description": "Component for Azure CosmosDB with SQL",
@@ -237,7 +237,7 @@
     "AzureKeyVaultComponentResource": {
       "allOf": [
         {
-          "$ref": "#/definitions/TrackedResource"
+          "$ref": "#/definitions/ProxyResource"
         }
       ],
       "description": "Component for Azure KeyVault",
@@ -300,7 +300,7 @@
     "AzureServiceBusComponentResource": {
       "allOf": [
         {
-          "$ref": "#/definitions/TrackedResource"
+          "$ref": "#/definitions/ProxyResource"
         }
       ],
       "description": "Component for Azure ServiceBus",
@@ -468,7 +468,7 @@
     "ContainerComponentResource": {
       "allOf": [
         {
-          "$ref": "#/definitions/TrackedResource"
+          "$ref": "#/definitions/ProxyResource"
         }
       ],
       "description": "The radius.dev/Container component provides an abstraction for a container workload that can be run on any Radius platform",

--- a/schemas/rest-api-specs-v3/radius.json
+++ b/schemas/rest-api-specs-v3/radius.json
@@ -598,18 +598,11 @@
       ],
       "description": "Component for Dapr Pub/Sub",
       "properties": {
-        "kind": {
-          "enum": [
-            "dapr.io/PubSubTopic@v1alpha1"
-          ],
-          "type": "string"
-        },
         "properties": {
           "$ref": "#/definitions/DaprPubSubComponentProperties"
         }
       },
       "required": [
-        "kind",
         "properties"
       ],
       "type": "object",
@@ -676,18 +669,11 @@
       ],
       "description": "Component for Dapr state store",
       "properties": {
-        "kind": {
-          "enum": [
-            "dapr.io/StateStore@v1alpha1"
-          ],
-          "type": "string"
-        },
         "properties": {
           "$ref": "#/definitions/DaprStateStoreComponentProperties"
         }
       },
       "required": [
-        "kind",
         "properties"
       ],
       "type": "object",
@@ -909,18 +895,11 @@
       ],
       "description": "The mongodb.com/MongoDB component is a portable component which can be deployed to any Radius platform.",
       "properties": {
-        "kind": {
-          "enum": [
-            "mongodb.com/Mongo@v1alpha1"
-          ],
-          "type": "string"
-        },
         "properties": {
           "$ref": "#/definitions/MongoDBComponentProperties"
         }
       },
       "required": [
-        "kind",
         "properties"
       ],
       "type": "object",
@@ -1161,18 +1140,11 @@
       ],
       "description": "The rabbitmq.com/MessageQueue component is a Kubernetes specific component for message brokering.",
       "properties": {
-        "kind": {
-          "enum": [
-            "rabbitmq.com/MessageQueue@v1alpha1"
-          ],
-          "type": "string"
-        },
         "properties": {
           "$ref": "#/definitions/RabbitMQComponentProperties"
         }
       },
       "required": [
-        "kind",
         "properties"
       ],
       "type": "object",
@@ -1255,18 +1227,11 @@
       ],
       "description": "The redislabs.com/Redis component is a portable component which can be deployed to any Radius platform.",
       "properties": {
-        "kind": {
-          "enum": [
-            "redislabs.com/Redis@v1alpha1"
-          ],
-          "type": "string"
-        },
         "properties": {
           "$ref": "#/definitions/RedisComponentProperties"
         }
       },
       "required": [
-        "kind",
         "properties"
       ],
       "type": "object",


### PR DESCRIPTION
Without being a `Resource`, Components won't have identifying information (like `Name`). Also since components have Health that ARM doesn't know about, we want them to all be ProxyResource so that all checks go to our RP.