### PR TITLE
Add AppModelv3 Container Renderer

### DIFF
--- a/pkg/kubernetes/object.go
+++ b/pkg/kubernetes/object.go
@@ -6,6 +6,9 @@
 package kubernetes
 
 import (
+	"fmt"
+	"hash/fnv"
+
 	"github.com/Azure/radius/pkg/radrp/outputresource"
 	"github.com/Azure/radius/pkg/resourcekinds"
 	appsv1 "k8s.io/api/apps/v1"
@@ -64,4 +67,14 @@ func FindSecret(resources []outputresource.OutputResource) (*corev1.Secret, outp
 	}
 
 	return nil, outputresource.OutputResource{}
+}
+
+// GetShortenedTargetPortName is used to generate a unique port name based on a resource id.
+// This is used to link up the a Service and Deployment.
+func GetShortenedTargetPortName(name string) string {
+	// targetPort can only be a maximum of 15 characters long.
+	// 32 bit number should always be less than that.
+	h := fnv.New32a()
+	h.Write([]byte(name))
+	return "a" + fmt.Sprint(h.Sum32())
 }

--- a/pkg/radrp/outputresource/info.go
+++ b/pkg/radrp/outputresource/info.go
@@ -12,6 +12,9 @@ import (
 	"github.com/Azure/radius/pkg/algorithm/graph"
 	"github.com/Azure/radius/pkg/health"
 	"github.com/Azure/radius/pkg/healthcontract"
+	"github.com/Azure/radius/pkg/resourcekinds"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // OutputResource represents the output of rendering a resource
@@ -167,4 +170,21 @@ func NewOutputResource(
 	}
 
 	return or
+}
+
+func NewKubernetesOutputResource(localID string, obj runtime.Object, objectMeta metav1.ObjectMeta) OutputResource {
+	return OutputResource{
+		Kind:     resourcekinds.Kubernetes,
+		LocalID:  localID,
+		Deployed: false,
+		Managed:  true,
+		Type:     TypeKubernetes,
+		Info: K8sInfo{
+			Kind:       obj.GetObjectKind().GroupVersionKind().Kind,
+			APIVersion: obj.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+			Name:       objectMeta.Name,
+			Namespace:  objectMeta.Namespace,
+		},
+		Resource: obj,
+	}
 }

--- a/pkg/renderers/containerv1alpha3/render.go
+++ b/pkg/renderers/containerv1alpha3/render.go
@@ -1,0 +1,342 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package containerv1alpha3
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/radius/pkg/azure/armauth"
+	"github.com/Azure/radius/pkg/azure/azresources"
+	"github.com/Azure/radius/pkg/handlers"
+	"github.com/Azure/radius/pkg/kubernetes"
+	"github.com/Azure/radius/pkg/radrp/outputresource"
+	"github.com/Azure/radius/pkg/renderers"
+	"github.com/Azure/radius/pkg/resourcekinds"
+)
+
+// Renderer is the WorkloadRenderer implementation for containerized workload.
+type Renderer struct {
+	Arm armauth.ArmConfig
+}
+
+func (r Renderer) GetDependencyIDs(ctx context.Context, resource renderers.RendererResource) ([]azresources.ResourceID, error) {
+	properties, err := r.convert(resource)
+	if err != nil {
+		return nil, err
+	}
+
+	// Right now we only have things in connections and ports as rendering dependencies - we'll add more things
+	// in the future... eg: volumes
+	//
+	// Anywhere we accept a resource ID in the model should have its value returned from here
+	deps := []azresources.ResourceID{}
+	for _, connection := range properties.Connections {
+		resourceId, err := azresources.Parse(connection.Source)
+		if err != nil {
+			return nil, err
+		}
+		deps = append(deps, resourceId)
+	}
+
+	for _, port := range properties.Container.Ports {
+		if port.Provides == "" {
+			continue
+		}
+
+		resourceId, err := azresources.Parse(port.Provides)
+		if err != nil {
+			return nil, err
+		}
+		deps = append(deps, resourceId)
+	}
+
+	return deps, nil
+}
+
+// Render is the WorkloadRenderer implementation for containerized workload.
+func (r Renderer) Render(ctx context.Context, resource renderers.RendererResource, dependencies map[string]renderers.RendererDependency) (renderers.RendererOutput, error) {
+	outputResources := []outputresource.OutputResource{}
+
+	cw, err := r.convert(resource)
+	if err != nil {
+		return renderers.RendererOutput{Resources: outputResources}, err
+	}
+
+	// Create the deployment as the primary workload
+	deployment, secretData, err := r.makeDeployment(ctx, resource, dependencies, cw)
+	if err != nil {
+		return renderers.RendererOutput{}, err
+	}
+	outputResources = append(outputResources, deployment)
+
+	// If there are secrets we'll use a Kubernetes secret to hold them. This is already referenced
+	// by the deployment.
+	if len(secretData) > 0 {
+		outputResources = append(outputResources, r.makeSecret(ctx, resource, secretData))
+	}
+
+	// Connections might require a role assignment to grant access.
+	roles := []outputresource.OutputResource{}
+	for _, connection := range cw.Connections {
+		if !r.isIdentitySupported(connection) {
+			continue
+		}
+
+		roles = append(roles, r.makeRoleAssignmentsForResource(ctx, resource, connection)...)
+	}
+
+	// If we created role assigmments then we will need an identity and the mapping of the identity to AKS.
+	if len(roles) > 0 {
+		outputResources = append(outputResources, r.makeManagedIdentity(ctx, resource))
+		outputResources = append(outputResources, r.makePodIdentity(ctx, resource, roles))
+	}
+
+	return renderers.RendererOutput{Resources: outputResources}, nil
+}
+
+func (r Renderer) convert(resource renderers.RendererResource) (*ContainerProperties, error) {
+	properties := &ContainerProperties{}
+	err := resource.ConvertDefinition(properties)
+	if err != nil {
+		return nil, err
+	}
+
+	return properties, nil
+}
+
+func (r Renderer) makeDeployment(ctx context.Context, resource renderers.RendererResource, dependencies map[string]renderers.RendererDependency, cc *ContainerProperties) (outputresource.OutputResource, map[string][]byte, error) {
+	ports := []corev1.ContainerPort{}
+	for _, port := range cc.Container.Ports {
+		if port.Provides != "" {
+			resourceId, err := azresources.Parse(port.Provides)
+			if err != nil {
+				return outputresource.OutputResource{}, nil, err
+			}
+			ports = append(ports, corev1.ContainerPort{
+				Name:          kubernetes.GetShortenedTargetPortName(resourceId.Type() + resourceId.Name()),
+				ContainerPort: int32(*port.ContainerPort),
+				Protocol:      corev1.ProtocolTCP,
+			})
+		} else {
+			ports = append(ports, corev1.ContainerPort{
+				ContainerPort: int32(*port.ContainerPort),
+				Protocol:      corev1.ProtocolTCP,
+			})
+		}
+
+	}
+	container := corev1.Container{
+		Name:  resource.ResourceName,
+		Image: cc.Container.Image,
+		// TODO: use better policies than this when we have a good versioning story
+		ImagePullPolicy: corev1.PullPolicy("Always"),
+		Ports:           ports,
+		Env:             []corev1.EnvVar{},
+	}
+
+	// We build the environment variable list in a stable order for testability
+	env := map[string]corev1.EnvVar{}
+
+	// For the values that come from connections we back them with secretData. We'll extract the values
+	// and return them.
+	secretData := map[string][]byte{}
+
+	// Take each connection and create environment variables for each part
+	for name, con := range cc.Connections {
+		properties := dependencies[con.Source]
+		for key, value := range properties.ComputedValues {
+			name := fmt.Sprintf("%s_%s_%s", "CONNECTION", strings.ToUpper(name), strings.ToUpper(key))
+
+			// We'll store each value in a secret named with the same name as the resource.
+			// We'll use the environment variable names as keys.
+			source := corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: resource.ResourceName,
+					},
+					Key: name,
+				},
+			}
+			switch v := value.(type) {
+			case string:
+				secretData[name] = []byte(v)
+				env[name] = corev1.EnvVar{Name: name, ValueFrom: &source}
+			case float64: // Float is used by the JSON serializer
+				secretData[name] = []byte(strconv.Itoa(int(v)))
+				env[name] = corev1.EnvVar{Name: name, ValueFrom: &source}
+			case int:
+				secretData[name] = []byte(strconv.Itoa(v))
+				env[name] = corev1.EnvVar{Name: name, ValueFrom: &source}
+			}
+		}
+	}
+
+	for k, v := range cc.Container.Env {
+		switch val := v.(type) {
+		case string:
+			env[k] = corev1.EnvVar{Name: k, Value: val}
+		case float64: // Float is used by the JSON serializer
+			env[k] = corev1.EnvVar{Name: k, Value: strconv.Itoa(int(val))}
+		case int:
+			env[k] = corev1.EnvVar{Name: k, Value: strconv.Itoa(val)}
+		}
+	}
+
+	// Append in sorted order
+	for _, key := range getSortedKeys(env) {
+		container.Env = append(container.Env, env[key])
+	}
+
+	deployment := appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resource.ResourceName,
+			Namespace: resource.ApplicationName,
+			Labels:    kubernetes.MakeDescriptiveLabels(resource.ApplicationName, resource.ResourceName),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: kubernetes.MakeSelectorLabels(resource.ApplicationName, resource.ResourceName),
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: kubernetes.MakeDescriptiveLabels(resource.ApplicationName, resource.ResourceName),
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{container},
+				},
+			},
+		},
+	}
+
+	output := outputresource.NewKubernetesOutputResource(outputresource.LocalIDDeployment, &deployment, deployment.ObjectMeta)
+	return output, secretData, nil
+}
+
+func (r Renderer) makeSecret(ctx context.Context, resource renderers.RendererResource, secrets map[string][]byte) outputresource.OutputResource {
+	secret := corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resource.ResourceName,
+			Namespace: resource.ApplicationName,
+			Labels:    kubernetes.MakeDescriptiveLabels(resource.ApplicationName, resource.ResourceName),
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: secrets,
+	}
+
+	output := outputresource.NewKubernetesOutputResource(outputresource.LocalIDSecret, &secret, secret.ObjectMeta)
+	return output
+}
+
+func (r Renderer) isIdentitySupported(connection ContainerConnection) bool {
+	// Right now we don't actually enable identities for any of the resources, but we have the code in place.
+	// Will be re-enabled very soon.
+	return false
+}
+
+// Builds a user-assigned managed identity output resource.
+func (r Renderer) makeManagedIdentity(ctx context.Context, resource renderers.RendererResource) outputresource.OutputResource {
+	managedIdentityName := resource.ApplicationName + "-" + resource.ResourceName + "-msi"
+	identityOutputResource := outputresource.OutputResource{
+		Type:     outputresource.TypeARM,
+		Kind:     resourcekinds.AzureUserAssignedManagedIdentity,
+		LocalID:  outputresource.LocalIDUserAssignedManagedIdentityKV,
+		Deployed: false,
+		Managed:  true,
+		Resource: map[string]string{
+			handlers.ManagedKey:                  "true",
+			handlers.UserAssignedIdentityNameKey: managedIdentityName,
+		},
+	}
+
+	return identityOutputResource
+}
+
+// Builds an AKS pod-identity output resource.
+func (r Renderer) makePodIdentity(ctx context.Context, resource renderers.RendererResource, roles []outputresource.OutputResource) outputresource.OutputResource {
+
+	// Note: Pod Identity name cannot have camel case
+	podIdentityName := fmt.Sprintf("podid-%s-%s", strings.ToLower(resource.ApplicationName), strings.ToLower(resource.ResourceName))
+
+	// Managed identity with required role assignments should be created first
+	dependencies := []outputresource.Dependency{
+		{
+			LocalID: outputresource.LocalIDUserAssignedManagedIdentityKV,
+		},
+	}
+
+	for _, role := range roles {
+		dependencies = append(dependencies, outputresource.Dependency{LocalID: role.LocalID})
+	}
+
+	outputResource := outputresource.OutputResource{
+		LocalID:  outputresource.LocalIDAADPodIdentity,
+		Type:     outputresource.TypeAADPodIdentity,
+		Kind:     resourcekinds.AzurePodIdentity,
+		Managed:  true,
+		Deployed: false,
+		Resource: map[string]string{
+			handlers.ManagedKey:            "true",
+			handlers.PodIdentityNameKey:    podIdentityName,
+			handlers.PodIdentityClusterKey: r.Arm.K8sClusterName,
+			handlers.PodNamespaceKey:       resource.ApplicationName,
+		},
+		Dependencies: dependencies,
+	}
+
+	return outputResource
+}
+
+// Assigns roles/permissions to a specific resource for the managed identity resource.
+func (r Renderer) makeRoleAssignmentsForResource(ctx context.Context, resource renderers.RendererResource, connection ContainerConnection) []outputresource.OutputResource {
+	outputResources := []outputresource.OutputResource{}
+
+	roleAssignmentDependencies := []outputresource.Dependency{
+		{
+			LocalID: outputresource.LocalIDUserAssignedManagedIdentityKV,
+		},
+	}
+	roleAssignment := outputresource.OutputResource{
+		Kind:     resourcekinds.AzureRoleAssignment,
+		LocalID:  outputresource.LocalIDRoleAssignmentKVSecretsCerts,
+		Managed:  true,
+		Deployed: false,
+		Type:     outputresource.TypeARM,
+		Resource: map[string]string{
+			// TODO
+		},
+		Dependencies: roleAssignmentDependencies,
+	}
+
+	outputResources = append(outputResources, roleAssignment)
+	return outputResources
+}
+
+func getSortedKeys(env map[string]corev1.EnvVar) []string {
+	keys := []string{}
+	for k := range env {
+		key := k
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/renderers/containerv1alpha3/render_test.go
+++ b/pkg/renderers/containerv1alpha3/render_test.go
@@ -1,0 +1,392 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package containerv1alpha3
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/Azure/radius/pkg/azure/azresources"
+	"github.com/Azure/radius/pkg/kubernetes"
+	"github.com/Azure/radius/pkg/radlogger"
+	"github.com/Azure/radius/pkg/radrp/outputresource"
+	"github.com/Azure/radius/pkg/renderers"
+	"github.com/Azure/radius/pkg/resourcekinds"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+)
+
+const applicationName = "test-app"
+const resourceName = "test-container"
+const envVarName1 = "TEST_VAR_1"
+const envVarValue1 = "TEST_VALUE_1"
+const envVarName2 = "TEST_VAR_2"
+const envVarValue2 = 81
+
+func createContext(t *testing.T) context.Context {
+	logger, err := radlogger.NewTestLogger(t)
+	if err != nil {
+		t.Log("Unable to initialize logger")
+		return context.Background()
+	}
+	return logr.NewContext(context.Background(), logger)
+}
+
+func makeResource(t *testing.T, properties ContainerProperties) renderers.RendererResource {
+	b, err := json.Marshal(&properties)
+	require.NoError(t, err)
+
+	definition := map[string]interface{}{}
+	err = json.Unmarshal(b, &definition)
+	require.NoError(t, err)
+
+	return renderers.RendererResource{
+		ApplicationName: applicationName,
+		ResourceName:    resourceName,
+		ResourceType:    "ContainerComponent",
+		Definition:      definition,
+	}
+}
+
+func makeResourceID(t *testing.T, resourceType string, resourceName string) azresources.ResourceID {
+	id, err := azresources.Parse(azresources.MakeID(
+		"test-subscription",
+		"test-resourcegroup",
+		azresources.ResourceType{
+			Type: "radius.dev/Application",
+			Name: applicationName,
+		},
+		azresources.ResourceType{
+			Type: resourceType,
+			Name: resourceName,
+		}))
+	require.NoError(t, err)
+
+	return id
+}
+
+func Test_GetDependencyIDs_Success(t *testing.T) {
+	properties := ContainerProperties{
+		Connections: map[string]ContainerConnection{
+			"A": {
+				Kind:   "Http",
+				Source: makeResourceID(t, "HttpRoute", "A").ID,
+			},
+			"B": {
+				Kind:   "Http",
+				Source: makeResourceID(t, "HttpRoute", "B").ID,
+			},
+		},
+		Container: Container{
+			Image: "someimage:latest",
+			Ports: map[string]ContainerPort{
+				"web": {
+					ContainerPort: to.IntPtr(5000),
+					Provides:      makeResourceID(t, "HttpRoute", "C").ID,
+				},
+			},
+		},
+	}
+	resource := makeResource(t, properties)
+
+	renderer := Renderer{}
+	ids, err := renderer.GetDependencyIDs(createContext(t), resource)
+	require.NoError(t, err)
+
+	expected := []azresources.ResourceID{
+		makeResourceID(t, "HttpRoute", "A"),
+		makeResourceID(t, "HttpRoute", "B"),
+		makeResourceID(t, "HttpRoute", "C"),
+	}
+	require.ElementsMatch(t, expected, ids)
+}
+
+func Test_GetDependencyIDs_InvalidId(t *testing.T) {
+	properties := ContainerProperties{
+		Connections: map[string]ContainerConnection{
+			"A": {
+				Kind:   "Http",
+				Source: "not a resource id obviously...",
+			},
+		},
+		Container: Container{
+			Image: "someimage:latest",
+		},
+	}
+	resource := makeResource(t, properties)
+
+	renderer := Renderer{}
+	ids, err := renderer.GetDependencyIDs(createContext(t), resource)
+	require.Error(t, err)
+	require.Empty(t, ids)
+}
+
+// This test verifies most of the 'basics' of rendering a deployment. These verifications are not
+// repeated in other tests becase the code is simple for these cases.
+//
+// If you add minor features, add them here.
+func Test_Render_Basic(t *testing.T) {
+	properties := ContainerProperties{
+		Container: Container{
+			Image: "someimage:latest",
+			Env: map[string]interface{}{
+				envVarName1: envVarValue1,
+				envVarName2: envVarValue2,
+			},
+		},
+	}
+	resource := makeResource(t, properties)
+	dependencies := map[string]renderers.RendererDependency{}
+
+	renderer := Renderer{}
+	output, err := renderer.Render(createContext(t), resource, dependencies)
+	require.NoError(t, err)
+	require.Empty(t, output.ComputedValues)
+	require.Empty(t, output.SecretValues)
+
+	labels := kubernetes.MakeDescriptiveLabels(resource.ApplicationName, resource.ResourceName)
+	matchLabels := kubernetes.MakeSelectorLabels(resource.ApplicationName, resource.ResourceName)
+
+	t.Run("verify deployment", func(t *testing.T) {
+		deployment, outputResource := kubernetes.FindDeployment(output.Resources)
+		require.NotNil(t, deployment)
+
+		expectedOutputResource := outputresource.OutputResource{
+			Kind:     resourcekinds.Kubernetes,
+			LocalID:  outputresource.LocalIDDeployment,
+			Deployed: false,
+			Managed:  true,
+			Type:     outputresource.TypeKubernetes,
+			Info: outputresource.K8sInfo{
+				Kind:       deployment.TypeMeta.Kind,
+				APIVersion: deployment.TypeMeta.APIVersion,
+				Name:       deployment.ObjectMeta.Name,
+				Namespace:  deployment.ObjectMeta.Namespace,
+			},
+			Resource: deployment,
+		}
+
+		require.Equal(t, outputResource, expectedOutputResource)
+
+		// Only real thing to verify here is the image and the labels
+		require.Equal(t, labels, deployment.Labels)
+		require.Equal(t, labels, deployment.Spec.Template.Labels)
+		require.Equal(t, matchLabels, deployment.Spec.Selector.MatchLabels)
+
+		require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		require.Equal(t, resourceName, container.Name)
+		require.Equal(t, properties.Container.Image, container.Image)
+		require.Equal(t, v1.PullAlways, container.ImagePullPolicy)
+
+		expectedEnv := []v1.EnvVar{
+			{Name: envVarName1, Value: envVarValue1},
+			{Name: envVarName2, Value: strconv.Itoa(envVarValue2)},
+		}
+		require.Equal(t, expectedEnv, container.Env)
+
+	})
+	require.Len(t, output.Resources, 1)
+}
+
+func Test_Render_PortWithoutRoute(t *testing.T) {
+	properties := ContainerProperties{
+		Container: Container{
+			Image: "someimage:latest",
+			Ports: map[string]ContainerPort{
+				"web": {
+					ContainerPort: to.IntPtr(5000),
+					Protocol:      "TCP",
+				},
+			},
+		},
+	}
+	resource := makeResource(t, properties)
+	dependencies := map[string]renderers.RendererDependency{}
+
+	renderer := Renderer{}
+	output, err := renderer.Render(createContext(t), resource, dependencies)
+	require.NoError(t, err)
+	require.Empty(t, output.ComputedValues)
+	require.Empty(t, output.SecretValues)
+
+	t.Run("verify deployment", func(t *testing.T) {
+		deployment, _ := kubernetes.FindDeployment(output.Resources)
+		require.NotNil(t, deployment)
+
+		require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+		container := deployment.Spec.Template.Spec.Containers[0]
+
+		require.Len(t, container.Ports, 1)
+		port := container.Ports[0]
+
+		expected := v1.ContainerPort{
+			ContainerPort: 5000,
+			Protocol:      v1.ProtocolTCP,
+		}
+		require.Equal(t, expected, port)
+
+	})
+	require.Len(t, output.Resources, 1)
+}
+
+func Test_Render_PortConnectedToRoute(t *testing.T) {
+	properties := ContainerProperties{
+		Container: Container{
+			Image: "someimage:latest",
+			Ports: map[string]ContainerPort{
+				"web": {
+					ContainerPort: to.IntPtr(5000),
+					Protocol:      "TCP",
+					Provides:      makeResourceID(t, "HttpRoute", "A").ID,
+				},
+			},
+		},
+	}
+	resource := makeResource(t, properties)
+	dependencies := map[string]renderers.RendererDependency{}
+
+	renderer := Renderer{}
+	output, err := renderer.Render(createContext(t), resource, dependencies)
+	require.NoError(t, err)
+	require.Empty(t, output.ComputedValues)
+	require.Empty(t, output.SecretValues)
+
+	t.Run("verify deployment", func(t *testing.T) {
+		deployment, _ := kubernetes.FindDeployment(output.Resources)
+		require.NotNil(t, deployment)
+
+		require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+		container := deployment.Spec.Template.Spec.Containers[0]
+
+		require.Len(t, container.Ports, 1)
+		port := container.Ports[0]
+
+		routeID := makeResourceID(t, "HttpRoute", "A")
+
+		expected := v1.ContainerPort{
+			Name:          kubernetes.GetShortenedTargetPortName(routeID.Type() + routeID.Name()),
+			ContainerPort: 5000,
+			Protocol:      v1.ProtocolTCP,
+		}
+		require.Equal(t, expected, port)
+	})
+	require.Len(t, output.Resources, 1)
+}
+
+func Test_Render_Connections(t *testing.T) {
+	properties := ContainerProperties{
+		Connections: map[string]ContainerConnection{
+			"A": {
+				Kind:   "A",
+				Source: makeResourceID(t, "ResourceType", "A").ID,
+			},
+		},
+		Container: Container{
+			Image: "someimage:latest",
+			Env: map[string]interface{}{
+				envVarName1: envVarValue1,
+				envVarName2: envVarValue2,
+			},
+		},
+	}
+	resource := makeResource(t, properties)
+	dependencies := map[string]renderers.RendererDependency{
+		(makeResourceID(t, "ResourceType", "A").ID): {
+			ResourceID: makeResourceID(t, "ResourceType", "A"),
+			Definition: map[string]interface{}{},
+			ComputedValues: map[string]interface{}{
+				"ComputedKey1": "ComputedValue1",
+				"ComputedKey2": 82,
+			},
+		},
+	}
+
+	renderer := Renderer{}
+	output, err := renderer.Render(createContext(t), resource, dependencies)
+	require.NoError(t, err)
+	require.Empty(t, output.ComputedValues)
+	require.Empty(t, output.SecretValues)
+
+	labels := kubernetes.MakeDescriptiveLabels(resource.ApplicationName, resource.ResourceName)
+
+	t.Run("verify deployment", func(t *testing.T) {
+		deployment, _ := kubernetes.FindDeployment(output.Resources)
+		require.NotNil(t, deployment)
+
+		require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		require.Equal(t, resourceName, container.Name)
+		require.Equal(t, properties.Container.Image, container.Image)
+		require.Equal(t, v1.PullAlways, container.ImagePullPolicy)
+
+		expectedEnv := []v1.EnvVar{
+			{
+				Name: "CONNECTION_A_COMPUTEDKEY1",
+				ValueFrom: &v1.EnvVarSource{
+					SecretKeyRef: &v1.SecretKeySelector{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: resource.ResourceName,
+						},
+						Key: "CONNECTION_A_COMPUTEDKEY1",
+					},
+				},
+			},
+			{
+				Name: "CONNECTION_A_COMPUTEDKEY2",
+				ValueFrom: &v1.EnvVarSource{
+					SecretKeyRef: &v1.SecretKeySelector{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: resource.ResourceName,
+						},
+						Key: "CONNECTION_A_COMPUTEDKEY2",
+					},
+				},
+			},
+			{Name: envVarName1, Value: envVarValue1},
+			{Name: envVarName2, Value: strconv.Itoa(envVarValue2)},
+		}
+		require.Equal(t, expectedEnv, container.Env)
+	})
+
+	t.Run("verify secret", func(t *testing.T) {
+		secret, outputResource := kubernetes.FindSecret(output.Resources)
+		require.NotNil(t, secret)
+
+		expectedOutputResource := outputresource.OutputResource{
+			Kind:     resourcekinds.Kubernetes,
+			LocalID:  outputresource.LocalIDSecret,
+			Deployed: false,
+			Managed:  true,
+			Type:     outputresource.TypeKubernetes,
+			Info: outputresource.K8sInfo{
+				Kind:       secret.TypeMeta.Kind,
+				APIVersion: secret.TypeMeta.APIVersion,
+				Name:       secret.ObjectMeta.Name,
+				Namespace:  secret.ObjectMeta.Namespace,
+			},
+			Resource: secret,
+		}
+		require.Equal(t, outputResource, expectedOutputResource)
+
+		require.Equal(t, resourceName, secret.Name)
+		require.Equal(t, applicationName, secret.Namespace)
+		require.Equal(t, labels, secret.Labels)
+		require.Empty(t, secret.Annotations)
+
+		require.Equal(t, outputResource.LocalID, outputresource.LocalIDSecret)
+		require.Len(t, secret.Data, 2)
+		require.Equal(t, "ComputedValue1", string(secret.Data["CONNECTION_A_COMPUTEDKEY1"]))
+		require.Equal(t, "82", string(secret.Data["CONNECTION_A_COMPUTEDKEY2"]))
+	})
+	require.Len(t, output.Resources, 2)
+}

--- a/pkg/renderers/containerv1alpha3/types.go
+++ b/pkg/renderers/containerv1alpha3/types.go
@@ -1,0 +1,111 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package containerv1alpha3
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	Kind         = "ContainerComponent"
+	kindProperty = "kind"
+)
+
+// ContainerProperties represents the 'properties' node of a ContainerComponent resource.
+type ContainerProperties struct {
+	Container   Container                      `json:"container,omitempty"`
+	Connections map[string]ContainerConnection `json:"connections,omitempty"`
+	Traits      []ContainerTrait               `json:"traits,omitempty"`
+}
+
+type Container struct {
+	Image string                   `json:"image"`
+	Ports map[string]ContainerPort `json:"ports,omitempty"`
+	Env   map[string]interface{}   `json:"env,omitempty"`
+}
+
+type ContainerPort struct {
+	Provides      string `json:"provides"`
+	Protocol      string `json:"protocol"`
+	ContainerPort *int   `json:"containerPort"`
+}
+
+type ContainerConnection struct {
+	Kind   string `json:"kind"`
+	Source string `json:"source"`
+}
+
+type ContainerTrait struct {
+	Kind                 string
+	AdditionalProperties map[string]interface{}
+}
+
+func (ct ContainerTrait) MarshalJSON() ([]byte, error) {
+	properties := map[string]interface{}{}
+	for k, v := range ct.AdditionalProperties {
+		properties[k] = v
+	}
+
+	properties[kindProperty] = ct.Kind
+	return json.Marshal(properties)
+}
+
+func (ct *ContainerTrait) UnmarshalJSON(b []byte) error {
+	properties := map[string]interface{}{}
+	err := json.Unmarshal(b, &properties)
+	if err != nil {
+		return err
+	}
+
+	obj, ok := properties[kindProperty]
+	if !ok {
+		return fmt.Errorf("the '%s' property is required", kindProperty)
+	}
+
+	kind, ok := obj.(string)
+	if !ok {
+		return fmt.Errorf("the '%s' property must be a string", kindProperty)
+	}
+
+	delete(properties, kindProperty)
+
+	ct.Kind = kind
+	ct.AdditionalProperties = properties
+	return nil
+}
+
+func (resource ContainerProperties) FindTrait(kind string, trait interface{}) (bool, error) {
+	traits := resource.Traits
+	if traits == nil {
+		return false, nil
+	}
+	for _, v := range traits {
+		if v.Kind == kind {
+			return v.As(kind, trait)
+		}
+	}
+
+	return false, nil
+}
+
+func (resource ContainerTrait) As(kind string, specific interface{}) (bool, error) {
+	if resource.Kind != kind {
+		return false, nil
+	}
+
+	bytes, err := json.Marshal(resource)
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal generic trait value: %w", err)
+	}
+
+	err = json.Unmarshal(bytes, specific)
+	if err != nil {
+		return false, fmt.Errorf("failed to unmarshal JSON as value of type %T: %w", specific, err)
+	}
+
+	return true, nil
+}

--- a/pkg/renderers/types.go
+++ b/pkg/renderers/types.go
@@ -7,6 +7,8 @@ package renderers
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/Azure/radius/pkg/azure/azresources"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
@@ -58,4 +60,19 @@ type SecretValueReference struct {
 	LocalID       string
 	Action        string
 	ValueSelector string
+}
+
+// ConvertDefinition can be used to convert `.Definition` to a strongly-typed struct.
+func (r RendererResource) ConvertDefinition(properties interface{}) error {
+	b, err := json.Marshal(r.Definition)
+	if err != nil {
+		return fmt.Errorf("failed to marshal resource definition: %w", err)
+	}
+
+	err = json.Unmarshal(b, properties)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal resource definition: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This change adds a copy of the container renderer that's updated to
AppModel v3's semantics. This builds on the work that jkotalik has done
in parallel but also merges in functionality that was merged to main
since that work started.

I used the v1 tests as the starting point to keep us honest here.