### PR TITLE
Enablement of the first AppModelv3 scenario

### DIFF
--- a/pkg/azure/clients/clients.go
+++ b/pkg/azure/clients/clients.go
@@ -56,6 +56,13 @@ func NewSubscriptionsClient(authorizer autorest.Authorizer) subscriptions.Client
 	return sc
 }
 
+func NewGenericResourceClient(subscriptionID string, authorizer autorest.Authorizer) resources.Client {
+	rc := resources.NewClient(subscriptionID)
+	rc.Authorizer = authorizer
+	rc.PollingDuration = 0
+	return rc
+}
+
 func NewCustomResourceProviderClient(subscriptionID string, authorizer autorest.Authorizer) customproviders.CustomResourceProviderClient {
 	cpc := customproviders.NewCustomResourceProviderClient(subscriptionID)
 	cpc.Authorizer = authorizer

--- a/pkg/cli/environments/localrp.go
+++ b/pkg/cli/environments/localrp.go
@@ -62,6 +62,8 @@ func (e *LocalRPEnvironment) CreateDeploymentClient(ctx context.Context) (client
 	connection := armcore.NewConnection(e.URL, azcred, nil)
 
 	return &localrp.LocalRPDeploymentClient{
+		Authorizer:     nil,
+		BaseURL:        e.URL,
 		Connection:     connection,
 		SubscriptionID: e.SubscriptionID,
 		ResourceGroup:  e.ResourceGroup,

--- a/pkg/cli/localrp/deployment_client.go
+++ b/pkg/cli/localrp/deployment_client.go
@@ -10,21 +10,25 @@ package localrp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/armcore"
-	"github.com/Azure/radius/pkg/azure/radclient"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-10-01/resources"
+	"github.com/Azure/go-autorest/autorest"
+	azclients "github.com/Azure/radius/pkg/azure/clients"
 	"github.com/Azure/radius/pkg/cli/armtemplate"
 	"github.com/Azure/radius/pkg/cli/clients"
-	radresources "github.com/Azure/radius/pkg/radrp/resources"
 )
 
 const PollInterval = 5 * time.Second
 
 type LocalRPDeploymentClient struct {
+	Authorizer     autorest.Authorizer
+	BaseURL        string
 	Connection     *armcore.Connection
 	SubscriptionID string
 	ResourceGroup  string
@@ -39,107 +43,93 @@ func (dc *LocalRPDeploymentClient) Deploy(ctx context.Context, content string) e
 	}
 
 	resources, err := armtemplate.Eval(template, armtemplate.TemplateOptions{
-		SubscriptionID: dc.SubscriptionID,
-		ResourceGroup:  dc.ResourceGroup,
+		SubscriptionID:         dc.SubscriptionID,
+		ResourceGroup:          dc.ResourceGroup,
+		EvaluatePropertiesNode: false,
 	})
 	if err != nil {
 		return err
 	}
 
+	deployed := map[string]map[string]interface{}{}
+	evaluator := &armtemplate.DeploymentEvaluator{
+		Template: template,
+		Options: armtemplate.TemplateOptions{
+			SubscriptionID:         dc.SubscriptionID,
+			ResourceGroup:          dc.ResourceGroup,
+			EvaluatePropertiesNode: true,
+		},
+		Deployed:  deployed,
+		Variables: map[string]interface{}{},
+	}
+
+	for name, variable := range template.Variables {
+		value, err := evaluator.VisitValue(variable)
+		if err != nil {
+			return err
+		}
+
+		evaluator.Variables[name] = value
+	}
+
 	// NOTE: this is currently test-only code so we're fairly noisy about what we output here.
 	fmt.Printf("Starting deployment...\n")
 	for _, resource := range resources {
+		body, err := evaluator.VisitMap(resource.Body)
+		if err != nil {
+			return err
+		}
+
+		resource.Body = body
+
 		fmt.Printf("Deploying %s %s...\n", resource.Type, resource.Name)
-		response, err := dc.deployResource(ctx, dc.Connection, resource)
+		response, result, err := dc.deployResource(ctx, dc.Connection, resource)
 		if err != nil {
 			return fmt.Errorf("failed to PUT resource %s %s: %w", resource.Type, resource.Name, err)
 		}
 
 		fmt.Printf("succeed with status code %d\n", response.StatusCode)
+		evaluator.Deployed[resource.ID] = result
 	}
 
 	return nil
 }
 
-func (dc *LocalRPDeploymentClient) deployResource(ctx context.Context, connection *armcore.Connection, resource armtemplate.Resource) (*http.Response, error) {
-	if resource.Type == radresources.ApplicationResourceType.Type() {
-		return dc.deployApplication(ctx, connection, resource)
-	} else if resource.Type == radresources.ComponentResourceType.Type() {
-		return dc.deployComponent(ctx, connection, resource)
-	} else if resource.Type == radresources.DeploymentResourceType.Type() {
-		return dc.deployDeployment(ctx, connection, resource)
-	}
+func (dc *LocalRPDeploymentClient) deployResource(ctx context.Context, connection *armcore.Connection, resource armtemplate.Resource) (*http.Response, map[string]interface{}, error) {
+	client := azclients.NewGenericResourceClient(dc.SubscriptionID, dc.Authorizer)
+	client.BaseURI = strings.TrimSuffix(dc.BaseURL, "/")
 
-	return nil, fmt.Errorf("unsupported resource type '%s'. radtest only supports radius types", resource.Type)
-}
-
-func (dc *LocalRPDeploymentClient) deployApplication(ctx context.Context, connection *armcore.Connection, resource armtemplate.Resource) (*http.Response, error) {
-	client := radclient.NewApplicationClient(connection, dc.SubscriptionID)
-
-	names := strings.Split(resource.Name, "/")
-	if len(names) != 2 {
-		return nil, fmt.Errorf("expected name in format of 'radius/<application>'. was '%s'", resource.Name)
-	}
-
-	parameters := radclient.ApplicationCreateParameters{}
-	err := resource.Convert(&parameters)
+	converted := resources.GenericResource{}
+	err := resource.Convert(&converted)
 	if err != nil {
-		return nil, err
+		return nil, nil, fmt.Errorf("failed to convert resource %q: %w", resource.ID, err)
 	}
 
-	response, err := client.CreateOrUpdate(ctx, dc.ResourceGroup, names[1], parameters, nil)
+	future, err := client.CreateOrUpdateByID(ctx, strings.TrimPrefix(resource.ID, "/"), resource.APIVersion, converted)
 	if err != nil {
-		return nil, err
+		return nil, nil, fmt.Errorf("failed to PUT resource %q: %w", resource.ID, err)
 	}
 
-	return response.RawResponse, nil
-}
-
-func (dc *LocalRPDeploymentClient) deployComponent(ctx context.Context, connection *armcore.Connection, resource armtemplate.Resource) (*http.Response, error) {
-	client := radclient.NewComponentClient(connection, dc.SubscriptionID)
-
-	names := strings.Split(resource.Name, "/")
-	if len(names) != 3 {
-		return nil, fmt.Errorf("expected name in format of 'radius/<application>/<component>'. was '%s'", resource.Name)
-	}
-
-	parameters := radclient.ComponentCreateParameters{}
-	err := resource.Convert(&parameters)
+	err = future.WaitForCompletionRef(ctx, client.Client)
 	if err != nil {
-		return nil, err
+		return nil, nil, fmt.Errorf("failed to PUT resource %q: %w", resource.ID, err)
 	}
 
-	response, err := client.CreateOrUpdate(ctx, dc.ResourceGroup, names[1], names[2], parameters, nil)
+	generic, err := future.Result(client)
 	if err != nil {
-		return nil, err
+		return nil, nil, fmt.Errorf("failed to PUT resource %q: %w", resource.ID, err)
 	}
 
-	return response.RawResponse, nil
-}
-
-func (dc *LocalRPDeploymentClient) deployDeployment(ctx context.Context, connection *armcore.Connection, resource armtemplate.Resource) (*http.Response, error) {
-	client := radclient.NewDeploymentClient(connection, dc.SubscriptionID)
-
-	names := strings.Split(resource.Name, "/")
-	if len(names) != 3 {
-		return nil, fmt.Errorf("expected name in format of 'radius/<application>/<deployment>'. was '%s'", resource.Name)
-	}
-
-	parameters := radclient.DeploymentCreateParameters{}
-	err := resource.Convert(&parameters)
+	b, err := json.Marshal(&generic)
 	if err != nil {
-		return nil, err
+		return nil, nil, fmt.Errorf("failed to marshal response %q: %w", resource.ID, err)
 	}
 
-	poller, err := client.BeginCreateOrUpdate(ctx, dc.ResourceGroup, names[1], names[2], parameters, nil)
+	result := map[string]interface{}{}
+	err = json.Unmarshal(b, &result)
 	if err != nil {
-		return nil, err
+		return nil, nil, fmt.Errorf("failed to unmarshal response %q: %w", resource.ID, err)
 	}
 
-	response, err := poller.PollUntilDone(ctx, PollInterval)
-	if err != nil {
-		return nil, err
-	}
-
-	return response.RawResponse, nil
+	return future.Response(), result, nil
 }

--- a/pkg/model/azure/azure.go
+++ b/pkg/model/azure/azure.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Azure/radius/pkg/model"
 	"github.com/Azure/radius/pkg/renderers"
 	"github.com/Azure/radius/pkg/renderers/containerv1alpha1"
+	"github.com/Azure/radius/pkg/renderers/containerv1alpha3"
 	"github.com/Azure/radius/pkg/renderers/cosmosdbmongov1alpha1"
 	"github.com/Azure/radius/pkg/renderers/cosmosdbsqlv1alpha1"
 	"github.com/Azure/radius/pkg/renderers/dapr"
@@ -61,7 +62,8 @@ func NewAzureModel(arm armauth.ArmConfig, k8s client.Client) model.ApplicationMo
 
 func NewAzureModelV3(arm armauth.ArmConfig, k8s client.Client) model.ApplicationModelV3 {
 	renderers := map[string]renderers.Renderer{
-		// example: containerv1alpha1.ResourceType: , ...
+		containerv1alpha3.ResourceType:       &containerv1alpha3.Renderer{},
+		servicebusqueuev1alpha1.ResourceType: &renderers.V1RendererAdapter{Inner: &servicebusqueuev1alpha1.Renderer{}},
 	}
 
 	handlers := map[string]model.Handlers{

--- a/pkg/radlogger/logfields.go
+++ b/pkg/radlogger/logfields.go
@@ -26,4 +26,5 @@ const (
 	LogFieldSubscriptionID     = "subscriptionID"
 	LogFieldWorkLoadKind       = "workloadKind"
 	LogFieldWorkLoadName       = "workloadName"
+	LogHTTPStatusCode          = "statusCode"
 )

--- a/pkg/radrp/db/db.go
+++ b/pkg/radrp/db/db.go
@@ -527,7 +527,7 @@ func (d radrpDB) GetV3Application(ctx context.Context, id azresources.ResourceID
 		return item, fmt.Errorf("error querying %v: %w", id, err)
 	}
 
-	err = result.Decode(item)
+	err = result.Decode(&item)
 	if err != nil {
 		return item, fmt.Errorf("error reading %v: %w", id, err)
 	}
@@ -648,7 +648,7 @@ func (d radrpDB) GetV3Resource(ctx context.Context, id azresources.ResourceID) (
 		return item, fmt.Errorf("error querying %v: %w", id, err)
 	}
 
-	err = result.Decode(item)
+	err = result.Decode(&item)
 	if err != nil {
 		return item, fmt.Errorf("error reading %v: %w", id, err)
 	}

--- a/pkg/radrp/frontend/handlerv3/handler.go
+++ b/pkg/radrp/frontend/handlerv3/handler.go
@@ -277,6 +277,8 @@ func badRequest(ctx context.Context, w http.ResponseWriter, req *http.Request, e
 // Responds with an HTTP 500
 func internalServerError(ctx context.Context, w http.ResponseWriter, req *http.Request, err error) {
 	logger := radlogger.GetLogger(ctx)
+	logger.Error(err, "unhandled error")
+
 	// Try to use the ARM format to send back the error info
 	body := armerrors.ErrorResponse{
 		Error: armerrors.ErrorDetails{

--- a/pkg/radrp/frontend/resourceproviderv3/rest.go
+++ b/pkg/radrp/frontend/resourceproviderv3/rest.go
@@ -13,7 +13,7 @@ type ApplicationResource struct {
 	Type       string                 `json:"type"`
 	Name       string                 `json:"name"`
 	Tags       map[string]string      `json:"tags,omitempty"`
-	Location   string                 `json:"omitempty"`
+	Location   string                 `json:"location,omitempty"`
 	Properties map[string]interface{} `json:"properties,omitempty"`
 }
 

--- a/pkg/radrp/frontend/service.go
+++ b/pkg/radrp/frontend/service.go
@@ -78,7 +78,7 @@ func (s *Service) Run(ctx context.Context) error {
 
 	logger.Info(fmt.Sprintf("listening on: '%s'...", s.Options.Address))
 	err = server.ListenAndServe()
-	if err != http.ErrServerClosed {
+	if err == http.ErrServerClosed {
 		// We expect this, safe to ignore.
 		logger.Info("Server stopped...")
 		return nil

--- a/pkg/radrp/rest/results.go
+++ b/pkg/radrp/rest/results.go
@@ -37,13 +37,16 @@ func NewOKResponse(body interface{}) Response {
 }
 
 func (r *OKResponse) Apply(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
+	logger := radlogger.GetLogger(ctx)
+	logger.Info(fmt.Sprintf("responding with status code: %d", http.StatusOK), radlogger.LogHTTPStatusCode, http.StatusOK)
+
 	bytes, err := json.MarshalIndent(r.Body, "", "  ")
 	if err != nil {
 		return fmt.Errorf("error marshaling %T: %w", r.Body, err)
 	}
 
 	w.Header().Add("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, err = w.Write(bytes)
 	if err != nil {
 		return fmt.Errorf("error writing marshaled %T bytes to output: %s", r.Body, err)
@@ -64,13 +67,16 @@ func NewCreatedResponse(body interface{}) Response {
 }
 
 func (r *CreatedResponse) Apply(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
+	logger := radlogger.GetLogger(ctx)
+	logger.Info(fmt.Sprintf("responding with status code: %d", http.StatusCreated), radlogger.LogHTTPStatusCode, http.StatusCreated)
+
 	bytes, err := json.MarshalIndent(r.Body, "", "  ")
 	if err != nil {
 		return fmt.Errorf("error marshaling %T: %w", r.Body, err)
 	}
 
 	w.Header().Add("Content-Type", "application/json")
-	w.WriteHeader(201)
+	w.WriteHeader(http.StatusCreated)
 	_, err = w.Write(bytes)
 	if err != nil {
 		return fmt.Errorf("error writing marshaled %T bytes to output: %s", r.Body, err)
@@ -92,6 +98,9 @@ func NewCreatedAsyncResponse(body interface{}, location string) Response {
 }
 
 func (r *CreatedAsyncResponse) Apply(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
+	logger := radlogger.GetLogger(ctx)
+	logger.Info(fmt.Sprintf("responding with status code: %d", http.StatusCreated), radlogger.LogHTTPStatusCode, http.StatusCreated)
+
 	bytes, err := json.MarshalIndent(r.Body, "", "  ")
 	if err != nil {
 		return fmt.Errorf("error marshaling %T: %w", r.Body, err)
@@ -115,7 +124,7 @@ func (r *CreatedAsyncResponse) Apply(ctx context.Context, w http.ResponseWriter,
 
 	w.Header().Add("Content-Type", "application/json")
 	w.Header().Add("Location", location.String())
-	w.WriteHeader(201)
+	w.WriteHeader(http.StatusCreated)
 	_, err = w.Write(bytes)
 	if err != nil {
 		return fmt.Errorf("error writing marshaled %T bytes to output: %s", r.Body, err)
@@ -138,6 +147,8 @@ func NewAcceptedAsyncResponse(body interface{}, location string) Response {
 
 func (r *AcceptedAsyncResponse) Apply(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
 	logger := radlogger.GetLogger(ctx)
+	logger.Info(fmt.Sprintf("responding with status code: %d", http.StatusAccepted), radlogger.LogHTTPStatusCode, http.StatusAccepted)
+
 	bytes, err := json.MarshalIndent(r.Body, "", "  ")
 	if err != nil {
 		return fmt.Errorf("error marshaling %T: %w", r.Body, err)
@@ -163,7 +174,7 @@ func (r *AcceptedAsyncResponse) Apply(ctx context.Context, w http.ResponseWriter
 
 	w.Header().Add("Content-Type", "application/json")
 	w.Header().Add("Location", location.String())
-	w.WriteHeader(202)
+	w.WriteHeader(http.StatusAccepted)
 	_, err = w.Write(bytes)
 	if err != nil {
 		return fmt.Errorf("error writing marshaled %T bytes to output: %s", r.Body, err)
@@ -212,13 +223,16 @@ func NewBadRequestARMResponse(body armerrors.ErrorResponse) Response {
 }
 
 func (r *BadRequestResponse) Apply(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
+	logger := radlogger.GetLogger(ctx)
+	logger.Info(fmt.Sprintf("responding with status code: %d", http.StatusBadRequest), radlogger.LogHTTPStatusCode, http.StatusBadRequest)
+
 	bytes, err := json.MarshalIndent(r.Body, "", "  ")
 	if err != nil {
 		return fmt.Errorf("error marshaling %T: %w", r.Body, err)
 	}
 
 	w.Header().Add("Content-Type", "application/json")
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	_, err = w.Write(bytes)
 	if err != nil {
 		return fmt.Errorf("error writing marshaled %T bytes to output: %s", r.Body, err)
@@ -254,13 +268,16 @@ func NewValidationErrorResponse(errors validator.ValidationErrors) Response {
 }
 
 func (r *ValidationErrorResponse) Apply(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
+	logger := radlogger.GetLogger(ctx)
+	logger.Info(fmt.Sprintf("responding with status code: %d", http.StatusBadRequest), radlogger.LogHTTPStatusCode, http.StatusBadRequest)
+
 	bytes, err := json.MarshalIndent(r.Body, "", "  ")
 	if err != nil {
 		return fmt.Errorf("error marshaling %T: %w", r.Body, err)
 	}
 
 	w.Header().Add("Content-Type", "application/json")
-	w.WriteHeader(400)
+	w.WriteHeader(http.StatusBadRequest)
 	_, err = w.Write(bytes)
 	if err != nil {
 		return fmt.Errorf("error writing marshaled %T bytes to output: %s", r.Body, err)
@@ -289,13 +306,16 @@ func NewNotFoundResponse(id azresources.ResourceID) Response {
 }
 
 func (r *NotFoundResponse) Apply(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
+	logger := radlogger.GetLogger(ctx)
+	logger.Info(fmt.Sprintf("responding with status code: %d", http.StatusNotFound), radlogger.LogHTTPStatusCode, http.StatusNotFound)
+
 	bytes, err := json.MarshalIndent(r.Body, "", "  ")
 	if err != nil {
 		return fmt.Errorf("error marshaling %T: %w", r.Body, err)
 	}
 
 	w.Header().Add("Content-Type", "application/json")
-	w.WriteHeader(404)
+	w.WriteHeader(http.StatusNotFound)
 	_, err = w.Write(bytes)
 	if err != nil {
 		return fmt.Errorf("error writing marshaled %T bytes to output: %s", r.Body, err)
@@ -323,13 +343,16 @@ func NewConflictResponse(message string) Response {
 }
 
 func (r *ConflictResponse) Apply(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
+	logger := radlogger.GetLogger(ctx)
+	logger.Info(fmt.Sprintf("responding with status code: %d", http.StatusConflict), radlogger.LogHTTPStatusCode, http.StatusConflict)
+
 	bytes, err := json.MarshalIndent(r.Body, "", "  ")
 	if err != nil {
 		return fmt.Errorf("error marshaling %T: %w", r.Body, err)
 	}
 
 	w.Header().Add("Content-Type", "application/json")
-	w.WriteHeader(409)
+	w.WriteHeader(http.StatusConflict)
 	_, err = w.Write(bytes)
 	if err != nil {
 		return fmt.Errorf("error writing marshaled %T bytes to output: %s", r.Body, err)
@@ -349,13 +372,16 @@ func NewInternalServerErrorARMResponse(body armerrors.ErrorResponse) Response {
 }
 
 func (r *InternalServerErrorResponse) Apply(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
+	logger := radlogger.GetLogger(ctx)
+	logger.Info(fmt.Sprintf("responding with status code: %d", http.StatusInternalServerError), radlogger.LogHTTPStatusCode, http.StatusInternalServerError)
+
 	bytes, err := json.MarshalIndent(r.Body, "", "  ")
 	if err != nil {
 		return fmt.Errorf("error marshaling %T: %w", r.Body, err)
 	}
 
 	w.Header().Add("Content-Type", "application/json")
-	w.WriteHeader(500)
+	w.WriteHeader(http.StatusInternalServerError)
 	_, err = w.Write(bytes)
 	if err != nil {
 		return fmt.Errorf("error writing marshaled %T bytes to output: %s", r.Body, err)

--- a/pkg/renderers/containerv1alpha3/types.go
+++ b/pkg/renderers/containerv1alpha3/types.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	Kind         = "ContainerComponent"
 	kindProperty = "kind"
+	ResourceType = "ContainerComponent"
 )
 
 // ContainerProperties represents the 'properties' node of a ContainerComponent resource.

--- a/pkg/renderers/servicebusqueuev1alpha1/types.go
+++ b/pkg/renderers/servicebusqueuev1alpha1/types.go
@@ -9,7 +9,10 @@ import (
 	"github.com/Azure/radius/pkg/azure/azresources"
 )
 
-const Kind = "azure.com/ServiceBusQueue@v1alpha1"
+const (
+	Kind         = "azure.com/ServiceBusQueue@v1alpha1"
+	ResourceType = "azure.com.ServiceBusQueueComponent"
+)
 
 var QueueResourceType = azresources.KnownType{
 	Types: []azresources.ResourceType{

--- a/test/magpie/src/binding.ts
+++ b/test/magpie/src/binding.ts
@@ -49,7 +49,7 @@ export function loadBindings(env: any, providers: { [type: string]: BindingProvi
 }
 
 function parseEnvVar(name: string): { type: string; key: string; } | null {
-    if (!name.startsWith('BINDING_')) {
+    if (!name.startsWith('BINDING_') && !name.startsWith('CONNECTION_')) {
         return null
     }
 


### PR DESCRIPTION
This change enables the servicebus test scenario using AppModel v3.

Please look at the individual commits to understand all of the issues that were addressed. I'm currently working through verifying/fixing the automated test, while will likely require CLI changes. 

I'll be rebasing this as #1060 goes in as well.

Note that the 'Add AppModelv3 Container Renderer' has already been merged to main. This will go away when I rebase