### PR TITLE
Update servicebus test to use AppModel v3

### DIFF
--- a/pkg/azure/azresources/types.go
+++ b/pkg/azure/azresources/types.go
@@ -24,4 +24,7 @@ const (
 	StorageStorageAccountsTables                = "tables"
 	WebServerFarms                              = "Microsoft.Web/serverFarms"
 	WebSites                                    = "Microsoft.Web/sites"
+
+	CustomRPV3Name     = "radiusv3"
+	CustomRPApiVersion = "2018-09-01-preview"
 )

--- a/pkg/healthcontract/health_contract.go
+++ b/pkg/healthcontract/health_contract.go
@@ -64,14 +64,13 @@ type ResourceInfo struct {
 
 // ResourceDetails represents the information needed to uniquely identify an output resource across applications/components
 type ResourceDetails struct {
-	ResourceID     string
-	ResourceKind   string
-	ApplicationID  string
-	ComponentID    string
-	SubscriptionID string
-	ResourceGroup  string
-	Namespace      string
-	Name           string
+	ResourceID   string
+	ResourceKind string
+
+	// The resource ID of the Radius Resource that 'owns' this output resource.
+	OwnerID   string
+	Namespace string
+	Name      string
 }
 
 // KubernetesID represents the ResourceID format for a Kubernetes resource

--- a/pkg/radrp/backend/deployment/types.go
+++ b/pkg/radrp/backend/deployment/types.go
@@ -200,12 +200,9 @@ func (dp *deploymentProcessor) Deploy(ctx context.Context, operationID azresourc
 
 		// Register health checks for the output resource
 		healthResourceDetails := healthcontract.ResourceDetails{
-			ResourceID:     outputResource.GetResourceID(),
-			ResourceKind:   outputResource.Kind,
-			ApplicationID:  resource.ApplicationName,
-			ComponentID:    resource.ResourceName,
-			SubscriptionID: resource.SubscriptionID,
-			ResourceGroup:  resource.ResourceGroup,
+			ResourceID:   outputResource.GetResourceID(),
+			ResourceKind: outputResource.Kind,
+			OwnerID:      resource.ID,
 		}
 		healthID := healthResourceDetails.GetHealthID()
 		outputResource.HealthID = healthID
@@ -337,10 +334,6 @@ func (dp *deploymentProcessor) Delete(ctx context.Context, operationID azresourc
 
 func (dp *deploymentProcessor) registerOutputResourceForHealthChecks(ctx context.Context, resourceDetails healthcontract.ResourceDetails, healthID string, healthCheckOptions healthcontract.HealthCheckOptions) {
 	logger := radlogger.GetLogger(ctx)
-	logger = logger.WithValues(
-		radlogger.LogFieldAppName, resourceDetails.ApplicationID,
-		radlogger.LogFieldResourceName, resourceDetails.ResourceID,
-	)
 
 	if resourceDetails.ResourceID == "" || resourceDetails.ResourceKind == "" || healthID == "" {
 		// This additional check is needed until health check is implemented for all resource types:

--- a/pkg/radrp/deployment/deployment_processor.go
+++ b/pkg/radrp/deployment/deployment_processor.go
@@ -186,12 +186,9 @@ func (dp *deploymentProcessor) UpdateDeployment(ctx context.Context, appName str
 				})
 
 				outputResourceInfo := healthcontract.ResourceDetails{
-					ResourceID:     resource.GetResourceID(),
-					ResourceKind:   resource.Kind,
-					ApplicationID:  appName,
-					ComponentID:    action.ComponentName,
-					SubscriptionID: action.Definition.SubscriptionID,
-					ResourceGroup:  action.Definition.ResourceGroup,
+					ResourceID:   resource.GetResourceID(),
+					ResourceKind: resource.Kind,
+					OwnerID:      action.Definition.ID,
 				}
 				// Save the healthID on the resource
 				healthID := outputResourceInfo.GetHealthID()
@@ -469,12 +466,9 @@ func (dp *deploymentProcessor) RegisterForHealthChecks(ctx context.Context, appI
 	errs := []error{}
 	for _, or := range component.Properties.Status.OutputResources {
 		outputResourceInfo := healthcontract.ResourceDetails{
-			ResourceID:     or.GetResourceID(),
-			ResourceKind:   or.ResourceKind,
-			ApplicationID:  appID,
-			ComponentID:    component.Name,
-			SubscriptionID: component.SubscriptionID,
-			ResourceGroup:  component.ResourceGroup,
+			ResourceID:   or.GetResourceID(),
+			ResourceKind: or.ResourceKind,
+			OwnerID:      component.ID,
 		}
 		resourceType, err := dp.appmodel.LookupResource(or.ResourceKind)
 		if err != nil {

--- a/pkg/radrp/deployment/deployment_processor_test.go
+++ b/pkg/radrp/deployment/deployment_processor_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/radius/pkg/azure/azresources"
 	"github.com/Azure/radius/pkg/handlers"
 	"github.com/Azure/radius/pkg/healthcontract"
 	"github.com/Azure/radius/pkg/model"
@@ -183,17 +184,39 @@ func Test_DeploymentProcessor_UnregistersOutputResourcesWithHealthService(t *tes
 	}}
 
 	outputResourceInfo1 := healthcontract.ResourceDetails{
-		ResourceID:    "ResourceID_1",
-		ResourceKind:  "Kind1",
-		ApplicationID: "A",
-		ComponentID:   "C",
+		ResourceID:   "ResourceID_1",
+		ResourceKind: "Kind1",
+		OwnerID: azresources.MakeID(
+			"test-subscription",
+			"test-resourcegroup",
+			azresources.ResourceType{
+				Type: azresources.CustomProvidersResourceProviders,
+				Name: "radius",
+			}, azresources.ResourceType{
+				Type: "Applications",
+				Name: "A",
+			}, azresources.ResourceType{
+				Type: "Components",
+				Name: "C",
+			}),
 	}
 
 	outputResourceInfo2 := healthcontract.ResourceDetails{
-		ResourceID:    "ns1-name1",
-		ResourceKind:  "Kind1",
-		ApplicationID: "A",
-		ComponentID:   "C",
+		ResourceID:   "ns1-name1",
+		ResourceKind: "Kind1",
+		OwnerID: azresources.MakeID(
+			"test-subscription",
+			"test-resourcegroup",
+			azresources.ResourceType{
+				Type: azresources.CustomProvidersResourceProviders,
+				Name: "radius",
+			}, azresources.ResourceType{
+				Type: "Applications",
+				Name: "A",
+			}, azresources.ResourceType{
+				Type: "Components",
+				Name: "C",
+			}),
 	}
 
 	deployStatus := db.DeploymentStatus{

--- a/test/functional/azure/resources/servicebus_test.go
+++ b/test/functional/azure/resources/servicebus_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/Azure/radius/pkg/keys"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
 	"github.com/Azure/radius/pkg/radrp/rest"
+	"github.com/Azure/radius/pkg/renderers/containerv1alpha3"
+	"github.com/Azure/radius/pkg/renderers/servicebusqueuev1alpha1"
 	"github.com/Azure/radius/pkg/resourcekinds"
 	"github.com/Azure/radius/test/azuretest"
 	"github.com/Azure/radius/test/validation"
@@ -49,6 +51,7 @@ func Test_ServiceBusManaged(t *testing.T) {
 					{
 						ApplicationName: application,
 						ComponentName:   "sender",
+						ResourceType:    containerv1alpha3.ResourceType,
 						OutputResources: map[string]validation.ExpectedOutputResource{
 							outputresource.LocalIDDeployment: validation.NewOutputResource(outputresource.LocalIDDeployment, outputresource.TypeKubernetes, resourcekinds.Kubernetes, true, false, rest.OutputResourceStatus{}),
 							outputresource.LocalIDSecret:     validation.NewOutputResource(outputresource.LocalIDSecret, outputresource.TypeKubernetes, resourcekinds.Kubernetes, true, false, rest.OutputResourceStatus{}),
@@ -57,6 +60,7 @@ func Test_ServiceBusManaged(t *testing.T) {
 					{
 						ApplicationName: application,
 						ComponentName:   "sbq",
+						ResourceType:    servicebusqueuev1alpha1.ResourceType,
 						OutputResources: map[string]validation.ExpectedOutputResource{
 							outputresource.LocalIDAzureServiceBusQueue: validation.NewOutputResource(outputresource.LocalIDAzureServiceBusQueue,
 								outputresource.TypeARM,
@@ -80,6 +84,9 @@ func Test_ServiceBusManaged(t *testing.T) {
 			},
 		},
 	})
+
+	test.Version = validation.AppModelV3
+	test.SkipDeletion = true
 
 	test.Test(t)
 }

--- a/test/functional/azure/resources/testdata/azure-resources-servicebus-managed.bicep
+++ b/test/functional/azure/resources/testdata/azure-resources-servicebus-managed.bicep
@@ -1,35 +1,26 @@
-resource app 'radius.dev/Applications@v1alpha1' = {
+resource app 'radius.dev/Application@v1alpha3' = {
   name: 'azure-resources-servicebus-managed'
 
-  resource sender 'Components' = {
+  resource sender 'ContainerComponent' = {
     name: 'sender'
-    kind: 'radius.dev/Container@v1alpha1'
     properties: {
-      run: {
-        container: {
-          image: 'radius.azurecr.io/magpie:latest'
+      connections: {
+        servicebus: {
+          kind: 'azure.com/ServiceBusQueue'
+          source: sbq.id
         }
       }
-      uses: [
-        {
-          binding: sbq.properties.bindings.default
-          env: {
-            BINDING_SERVICEBUS_CONNECTIONSTRING: sbq.properties.bindings.default.connectionString
-            BINDING_SERVICEBUS_QUEUE: sbq.properties.bindings.default.queue
-          }
-        }
-      ]
+      container: {
+        image: 'radius.azurecr.io/magpie:latest'
+      }
     }
   }
 
-  resource sbq 'Components' = {
+  resource sbq 'azure.com.ServiceBusQueueComponent' = {
     name: 'sbq'
-    kind: 'azure.com/ServiceBusQueue@v1alpha1'
     properties: {
-      config: {
-        managed: true
-        queue: 'radius-queue1'
-      }
+      managed: true
+      queue: 'radius-queue1'
     }
   }
 }

--- a/test/validation/azure.go
+++ b/test/validation/azure.go
@@ -19,6 +19,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type AppModelVersion = string
+
+const (
+	AppModelV2 AppModelVersion = "V2"
+	AppModelV3 AppModelVersion = "V3"
+)
+
 type AzureResourceSet struct {
 	Resources []ExpectedResource
 }


### PR DESCRIPTION
This changes gets our first e2e test working (managed servicebus). I'm
still waiting on the CLI changes so there's no deletion for right now.

I introduced some simplications to the health code to make it work
across v1 and v3. We're passing in the resource ID of the 'owner'
resource for health monitoring rather than a bunch of granular
information. This makes the health system less coupled to the structure
of our resources which is a nice improvement.