### PR TITLE
Update Dapr StateStore and PubSub to appmodel v3

### DIFF
--- a/pkg/model/azure/azure.go
+++ b/pkg/model/azure/azure.go
@@ -63,6 +63,8 @@ func NewAzureModel(arm armauth.ArmConfig, k8s client.Client) model.ApplicationMo
 func NewAzureModelV3(arm armauth.ArmConfig, k8s client.Client) model.ApplicationModelV3 {
 	renderers := map[string]renderers.Renderer{
 		containerv1alpha3.ResourceType:       &containerv1alpha3.Renderer{},
+		daprpubsubv1alpha1.ResourceType:      &renderers.V1RendererAdapter{Inner: &daprpubsubv1alpha1.Renderer{}},
+		daprstatestorev1alpha1.ResourceType:  &renderers.V1RendererAdapter{Inner: &daprstatestorev1alpha1.Renderer{}},
 		servicebusqueuev1alpha1.ResourceType: &renderers.V1RendererAdapter{Inner: &servicebusqueuev1alpha1.Renderer{}},
 	}
 

--- a/pkg/renderers/daprpubsubv1alpha1/render.go
+++ b/pkg/renderers/daprpubsubv1alpha1/render.go
@@ -19,6 +19,8 @@ import (
 	"github.com/Azure/radius/pkg/workloads"
 )
 
+var _ renderers.AdaptableRenderer = (*Renderer)(nil)
+
 // Renderer is the WorkloadRenderer implementation for the dapr pubsub workload.
 type Renderer struct {
 }
@@ -128,4 +130,27 @@ func (r Renderer) Render(ctx context.Context, w workloads.InstantiatedWorkload) 
 		}
 		return []outputresource.OutputResource{resource}, nil
 	}
+}
+
+func (r *Renderer) GetKind() string {
+	return Kind
+}
+
+func (r *Renderer) GetComputedValues(ctx context.Context, workload workloads.InstantiatedWorkload) (map[string]renderers.ComputedValueReference, map[string]renderers.SecretValueReference, error) {
+	values := map[string]renderers.ComputedValueReference{
+		"namespace": {
+			LocalID:           outputresource.LocalIDAzureServiceBusTopic,
+			PropertyReference: handlers.ServiceBusNamespaceNameKey,
+		},
+		"pubSubName": {
+			LocalID:           outputresource.LocalIDAzureServiceBusTopic,
+			PropertyReference: handlers.ComponentNameKey,
+		},
+		"topic": {
+			LocalID:           outputresource.LocalIDAzureServiceBusTopic,
+			PropertyReference: handlers.ServiceBusTopicNameKey,
+		},
+	}
+	secrets := map[string]renderers.SecretValueReference{}
+	return values, secrets, nil
 }

--- a/pkg/renderers/daprpubsubv1alpha1/types.go
+++ b/pkg/renderers/daprpubsubv1alpha1/types.go
@@ -9,7 +9,10 @@ import (
 	"github.com/Azure/radius/pkg/azure/azresources"
 )
 
-const Kind = "dapr.io/PubSubTopic@v1alpha1"
+const (
+	Kind         = "dapr.io/PubSubTopic@v1alpha1"
+	ResourceType = "dapr.io.PubSubTopicComponent"
+)
 
 var TopicResourceType = azresources.KnownType{
 	Types: []azresources.ResourceType{

--- a/pkg/renderers/daprstatestorev1alpha1/types.go
+++ b/pkg/renderers/daprstatestorev1alpha1/types.go
@@ -9,7 +9,10 @@ import (
 	"github.com/Azure/radius/pkg/azure/azresources"
 )
 
-const Kind = "dapr.io/StateStore@v1alpha1"
+const (
+	Kind         = "dapr.io/StateStore@v1alpha1"
+	ResourceType = "dapr.io.StateStoreComponent"
+)
 
 var StorageAccountResourceType = azresources.KnownType{
 	Types: []azresources.ResourceType{

--- a/test/functional/azure/resources/dapr_pubsub_servicebus_test.go
+++ b/test/functional/azure/resources/dapr_pubsub_servicebus_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/Azure/radius/pkg/keys"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
 	"github.com/Azure/radius/pkg/radrp/rest"
+	"github.com/Azure/radius/pkg/renderers/containerv1alpha3"
+	"github.com/Azure/radius/pkg/renderers/daprpubsubv1alpha1"
 	"github.com/Azure/radius/pkg/resourcekinds"
 	"github.com/Azure/radius/test/azuretest"
 	"github.com/Azure/radius/test/validation"
@@ -47,6 +49,7 @@ func Test_DaprPubSubServiceBusManaged(t *testing.T) {
 					{
 						ApplicationName: application,
 						ComponentName:   "publisher",
+						ResourceType:    containerv1alpha3.ResourceType,
 						OutputResources: map[string]validation.ExpectedOutputResource{
 							outputresource.LocalIDDeployment: validation.NewOutputResource(outputresource.LocalIDDeployment, outputresource.TypeKubernetes, resourcekinds.Kubernetes, true, false, rest.OutputResourceStatus{}),
 							outputresource.LocalIDSecret:     validation.NewOutputResource(outputresource.LocalIDSecret, outputresource.TypeKubernetes, resourcekinds.Kubernetes, true, false, rest.OutputResourceStatus{}),
@@ -55,6 +58,7 @@ func Test_DaprPubSubServiceBusManaged(t *testing.T) {
 					{
 						ApplicationName: application,
 						ComponentName:   "pubsub",
+						ResourceType:    daprpubsubv1alpha1.ResourceType,
 						OutputResources: map[string]validation.ExpectedOutputResource{
 							outputresource.LocalIDAzureServiceBusTopic: validation.NewOutputResource(outputresource.LocalIDAzureServiceBusTopic, outputresource.TypeARM, resourcekinds.DaprPubSubTopicAzureServiceBus, true, false, rest.OutputResourceStatus{}),
 						},
@@ -70,6 +74,9 @@ func Test_DaprPubSubServiceBusManaged(t *testing.T) {
 			},
 		},
 	})
+
+	test.Version = validation.AppModelV3
+	test.SkipDeletion = true
 
 	test.Test(t)
 }
@@ -103,6 +110,7 @@ func Test_DaprPubSubServiceBusUnmanaged(t *testing.T) {
 					{
 						ApplicationName: application,
 						ComponentName:   "publisher",
+						ResourceType:    containerv1alpha3.ResourceType,
 						OutputResources: map[string]validation.ExpectedOutputResource{
 							outputresource.LocalIDDeployment: validation.NewOutputResource(outputresource.LocalIDDeployment, outputresource.TypeKubernetes, resourcekinds.Kubernetes, true, false, rest.OutputResourceStatus{}),
 							outputresource.LocalIDSecret:     validation.NewOutputResource(outputresource.LocalIDSecret, outputresource.TypeKubernetes, resourcekinds.Kubernetes, true, false, rest.OutputResourceStatus{}),
@@ -111,6 +119,7 @@ func Test_DaprPubSubServiceBusUnmanaged(t *testing.T) {
 					{
 						ApplicationName: application,
 						ComponentName:   "pubsub",
+						ResourceType:    daprpubsubv1alpha1.ResourceType,
 						OutputResources: map[string]validation.ExpectedOutputResource{
 							outputresource.LocalIDAzureServiceBusTopic: validation.NewOutputResource(outputresource.LocalIDAzureServiceBusTopic, outputresource.TypeARM, resourcekinds.DaprPubSubTopicAzureServiceBus, false, false, rest.OutputResourceStatus{}),
 						},
@@ -126,6 +135,9 @@ func Test_DaprPubSubServiceBusUnmanaged(t *testing.T) {
 			},
 		},
 	})
+
+	test.Version = validation.AppModelV3
+	test.SkipDeletion = true
 
 	test.Test(t)
 }

--- a/test/functional/azure/resources/testdata/azure-resources-dapr-pubsub-servicebus-managed.bicep
+++ b/test/functional/azure/resources/testdata/azure-resources-dapr-pubsub-servicebus-managed.bicep
@@ -1,24 +1,22 @@
-resource app 'radius.dev/Applications@v1alpha1' = {
+resource app 'radius.dev/Application@v1alpha3' = {
   name: 'azure-resources-dapr-pubsub-servicebus-managed'
 
-  resource publisher 'Components' = {
+  resource publisher 'ContainerComponent' = {
     name: 'publisher'
-    kind: 'radius.dev/Container@v1alpha1'
     properties: {
-      run: {
-        container: {
-          image: 'radius.azurecr.io/magpie:latest'
+      connections: {
+        daprpubsub: {
+          kind: 'dapr.io/PubSubTopic'
+          source: pubsub.id
         }
       }
-      uses: [
-        {
-          binding: pubsub.properties.bindings.default
-          env: {
-            BINDING_DAPRPUBSUB_NAME: pubsub.properties.bindings.default.pubSubName
-            BINDING_DAPRPUBSUB_TOPIC: pubsub.properties.bindings.default.topic
-          }
+      container: {
+        image: 'radius.azurecr.io/magpie:latest'
+        env: {
+          BINDING_DAPRPUBSUB_NAME: pubsub.properties.pubSubName
+          BINDING_DAPRPUBSUB_TOPIC: pubsub.properties.topic
         }
-      ]
+      }
       traits: [
         {
           kind: 'dapr.io/App@v1alpha1'
@@ -29,15 +27,12 @@ resource app 'radius.dev/Applications@v1alpha1' = {
     }
   }
   
-  resource pubsub 'Components' = {
+  resource pubsub 'dapr.io.PubSubTopicComponent' = {
     name: 'pubsub'
-    kind: 'dapr.io/PubSubTopic@v1alpha1'
     properties: {
-      config: {
-        kind: 'pubsub.azure.servicebus'
-        topic: 'TOPIC_A'
-        managed: true
-      }
+      kind: 'pubsub.azure.servicebus'
+      topic: 'TOPIC_A'
+      managed: true
     }
   }
 }

--- a/test/functional/azure/resources/testdata/azure-resources-dapr-pubsub-servicebus-unmanaged.bicep
+++ b/test/functional/azure/resources/testdata/azure-resources-dapr-pubsub-servicebus-unmanaged.bicep
@@ -1,24 +1,22 @@
-resource app 'radius.dev/Applications@v1alpha1' = {
+resource app 'radius.dev/Application@v1alpha3' = {
   name: 'azure-resources-dapr-pubsub-servicebus-unmanaged'
 
-  resource publisher 'Components' = {
+  resource publisher 'ContainerComponent' = {
     name: 'publisher'
-    kind: 'radius.dev/Container@v1alpha1'
     properties: {
-      run: {
-        container: {
-          image: 'radius.azurecr.io/magpie:latest'
+      connections: {
+        daprpubsub: {
+          kind: 'dapr.io/PubSubTopic'
+          source: pubsub.id
         }
       }
-      uses: [
-        {
-          binding: pubsub.properties.bindings.default
-          env: {
-            BINDING_DAPRPUBSUB_NAME: pubsub.properties.bindings.default.pubSubName
-            BINDING_DAPRPUBSUB_TOPIC: pubsub.properties.bindings.default.topic
-          }
+      container: {
+        image: 'radius.azurecr.io/magpie:latest'
+        env: {
+          BINDING_DAPRPUBSUB_NAME: pubsub.properties.pubSubName
+          BINDING_DAPRPUBSUB_TOPIC: pubsub.properties.topic
         }
-      ]
+      }
       traits: [
         {
           kind: 'dapr.io/App@v1alpha1'
@@ -29,14 +27,11 @@ resource app 'radius.dev/Applications@v1alpha1' = {
     }
   }
   
-  resource pubsub 'Components' = {
+  resource pubsub 'dapr.io.PubSubTopicComponent' = {
     name: 'pubsub'
-    kind: 'dapr.io/PubSubTopic@v1alpha1'
     properties: {
-      config: {
-        kind: 'pubsub.azure.servicebus'
-        resource: namespace::topic.id
-      }
+      kind: 'pubsub.azure.servicebus'
+      resource: namespace::topic.id
     }
   }
 }


### PR DESCRIPTION
This change adds renderer support for AppModelv3 using the existing
adapter pattern. Since these renderers use the 'properties pattern' they
can just fit right in.