### PR TITLE
Make RadiusResource very generic to retain all data

### DIFF
--- a/pkg/azure/radclientv3/zz_generated_models.go
+++ b/pkg/azure/radclientv3/zz_generated_models.go
@@ -1174,8 +1174,8 @@ type RabbitmqComMessageQueueListOptions struct {
 // RadiusResource - Interface for generic component -- useful for listing components without specifying a type
 type RadiusResource struct {
 	ProxyResource
-	// REQUIRED; Basic properties of a component.
-	Properties *BasicComponentProperties `json:"properties,omitempty"`
+	// REQUIRED; Any object
+	Properties map[string]interface{} `json:"properties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type RadiusResource.

--- a/pkg/cli/objectformats/objectformats_test.go
+++ b/pkg/cli/objectformats/objectformats_test.go
@@ -86,8 +86,8 @@ func Test_FormatResourceTable(t *testing.T) {
 				Type: to.StringPtr("my/very/CoolResource"),
 			},
 		},
-		Properties: &radclientv3.BasicComponentProperties{
-			Status: &radclientv3.ComponentStatus{
+		Properties: map[string]interface{}{
+			"status": &radclientv3.ComponentStatus{
 				HealthState:       to.StringPtr("Healthy"),
 				ProvisioningState: to.StringPtr("Provisioned"),
 			},

--- a/pkg/radrp/schemav3/components/radius.json
+++ b/pkg/radrp/schemav3/components/radius.json
@@ -15,7 +15,7 @@
       ],
       "properties": {
         "properties": {
-          "$ref": "basic-component.json#/definitions/BasicComponentProperties"
+          "type": "object"
         }
       }
     }

--- a/schemas/rest-api-specs-v3/radius.json
+++ b/schemas/rest-api-specs-v3/radius.json
@@ -1159,7 +1159,7 @@
       "description": "Interface for generic component -- useful for listing components without specifying a type",
       "properties": {
         "properties": {
-          "$ref": "#/definitions/BasicComponentProperties"
+          "type": "object"
         }
       },
       "required": [


### PR DESCRIPTION
This is so that we can get all the information needed for both `-o json` and `-o table` use cases.

Part of #1043 