### PR TITLE
Add generic client to OpenAPI spec

### DIFF
--- a/pkg/azure/radclientv3/zz_generated_models.go
+++ b/pkg/azure/radclientv3/zz_generated_models.go
@@ -1313,6 +1313,16 @@ func (r RadiusResource) MarshalJSON() ([]byte, error) {
 	return json.Marshal(objectMap)
 }
 
+// RadiusResourceDeleteOptions contains the optional parameters for the RadiusResource.Delete method.
+type RadiusResourceDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// RadiusResourceGetOptions contains the optional parameters for the RadiusResource.Get method.
+type RadiusResourceGetOptions struct {
+	// placeholder for future optional parameters
+}
+
 // RadiusResourceList - List of RadiusResource resources.
 type RadiusResourceList struct {
 	// REQUIRED; List of RadiusResource resources.

--- a/pkg/azure/radclientv3/zz_generated_radiusresource_client.go
+++ b/pkg/azure/radclientv3/zz_generated_radiusresource_client.go
@@ -30,6 +30,145 @@ func NewRadiusResourceClient(con *armcore.Connection, subscriptionID string) *Ra
 	return &RadiusResourceClient{con: con, subscriptionID: subscriptionID}
 }
 
+// Delete - Deletes a RadiusResource resource.
+// If the operation fails it returns the *ErrorResponse error type.
+func (client *RadiusResourceClient) Delete(ctx context.Context, resourceGroupName string, applicationName string, radiusResourceType string, radiusResourceName string, options *RadiusResourceDeleteOptions) (*http.Response, error) {
+	req, err := client.deleteCreateRequest(ctx, resourceGroupName, applicationName, radiusResourceType, radiusResourceName, options)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.con.Pipeline().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if !resp.HasStatusCode(http.StatusNoContent) {
+		return nil, client.deleteHandleError(resp)
+	}
+	return resp.Response, nil
+}
+
+// deleteCreateRequest creates the Delete request.
+func (client *RadiusResourceClient) deleteCreateRequest(ctx context.Context, resourceGroupName string, applicationName string, radiusResourceType string, radiusResourceName string, options *RadiusResourceDeleteOptions) (*azcore.Request, error) {
+	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomProviders/resourceProviders/radiusv3/Application/{applicationName}/{radiusResourceType}/{radiusResourceName}"
+	if client.subscriptionID == "" {
+		return nil, errors.New("parameter client.subscriptionID cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
+	if resourceGroupName == "" {
+		return nil, errors.New("parameter resourceGroupName cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
+	if applicationName == "" {
+		return nil, errors.New("parameter applicationName cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{applicationName}", url.PathEscape(applicationName))
+	if radiusResourceType == "" {
+		return nil, errors.New("parameter radiusResourceType cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{radiusResourceType}", url.PathEscape(radiusResourceType))
+	if radiusResourceName == "" {
+		return nil, errors.New("parameter radiusResourceName cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{radiusResourceName}", url.PathEscape(radiusResourceName))
+	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.con.Endpoint(), urlPath))
+	if err != nil {
+		return nil, err
+	}
+	req.Telemetry(telemetryInfo)
+	reqQP := req.URL.Query()
+	reqQP.Set("api-version", "2018-09-01-preview")
+	req.URL.RawQuery = reqQP.Encode()
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+// deleteHandleError handles the Delete error response.
+func (client *RadiusResourceClient) deleteHandleError(resp *azcore.Response) error {
+	body, err := resp.Payload()
+	if err != nil {
+		return azcore.NewResponseError(err, resp.Response)
+	}
+		errType := ErrorResponse{raw: string(body)}
+	if err := resp.UnmarshalAsJSON(&errType); err != nil {
+		return azcore.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp.Response)
+	}
+	return azcore.NewResponseError(&errType, resp.Response)
+}
+
+// Get - Gets a RadiusResource resource by name.
+// If the operation fails it returns the *ErrorResponse error type.
+func (client *RadiusResourceClient) Get(ctx context.Context, resourceGroupName string, applicationName string, radiusResourceType string, radiusResourceName string, options *RadiusResourceGetOptions) (RadiusResourceResponse, error) {
+	req, err := client.getCreateRequest(ctx, resourceGroupName, applicationName, radiusResourceType, radiusResourceName, options)
+	if err != nil {
+		return RadiusResourceResponse{}, err
+	}
+	resp, err := client.con.Pipeline().Do(req)
+	if err != nil {
+		return RadiusResourceResponse{}, err
+	}
+	if !resp.HasStatusCode(http.StatusOK) {
+		return RadiusResourceResponse{}, client.getHandleError(resp)
+	}
+	return client.getHandleResponse(resp)
+}
+
+// getCreateRequest creates the Get request.
+func (client *RadiusResourceClient) getCreateRequest(ctx context.Context, resourceGroupName string, applicationName string, radiusResourceType string, radiusResourceName string, options *RadiusResourceGetOptions) (*azcore.Request, error) {
+	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomProviders/resourceProviders/radiusv3/Application/{applicationName}/{radiusResourceType}/{radiusResourceName}"
+	if client.subscriptionID == "" {
+		return nil, errors.New("parameter client.subscriptionID cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
+	if resourceGroupName == "" {
+		return nil, errors.New("parameter resourceGroupName cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
+	if applicationName == "" {
+		return nil, errors.New("parameter applicationName cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{applicationName}", url.PathEscape(applicationName))
+	if radiusResourceType == "" {
+		return nil, errors.New("parameter radiusResourceType cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{radiusResourceType}", url.PathEscape(radiusResourceType))
+	if radiusResourceName == "" {
+		return nil, errors.New("parameter radiusResourceName cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{radiusResourceName}", url.PathEscape(radiusResourceName))
+	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.con.Endpoint(), urlPath))
+	if err != nil {
+		return nil, err
+	}
+	req.Telemetry(telemetryInfo)
+	reqQP := req.URL.Query()
+	reqQP.Set("api-version", "2018-09-01-preview")
+	req.URL.RawQuery = reqQP.Encode()
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+// getHandleResponse handles the Get response.
+func (client *RadiusResourceClient) getHandleResponse(resp *azcore.Response) (RadiusResourceResponse, error) {
+	var val *RadiusResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RadiusResourceResponse{}, err
+	}
+return RadiusResourceResponse{RawResponse: resp.Response, RadiusResource: val}, nil
+}
+
+// getHandleError handles the Get error response.
+func (client *RadiusResourceClient) getHandleError(resp *azcore.Response) error {
+	body, err := resp.Payload()
+	if err != nil {
+		return azcore.NewResponseError(err, resp.Response)
+	}
+		errType := ErrorResponse{raw: string(body)}
+	if err := resp.UnmarshalAsJSON(&errType); err != nil {
+		return azcore.NewResponseError(fmt.Errorf("%s\n%s", string(body), err), resp.Response)
+	}
+	return azcore.NewResponseError(&errType, resp.Response)
+}
+
 // List - List the RadiusResource resources deployed in the application.
 // If the operation fails it returns the *ErrorResponse error type.
 func (client *RadiusResourceClient) List(ctx context.Context, resourceGroupName string, applicationName string, options *RadiusResourceListOptions) (RadiusResourceListResponse, error) {

--- a/pkg/azure/radclientv3/zz_generated_response_types.go
+++ b/pkg/azure/radclientv3/zz_generated_response_types.go
@@ -234,6 +234,15 @@ type RadiusResourceListResponse struct {
 	RawResponse *http.Response
 }
 
+// RadiusResourceResponse is the response envelope for operations that return a RadiusResource type.
+type RadiusResourceResponse struct {
+	// Interface for generic component -- useful for listing components without specifying a type
+	RadiusResource *RadiusResource
+
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+}
+
 // RedisComponentListResponse is the response envelope for operations that return a RedisComponentList type.
 type RedisComponentListResponse struct {
 	// RawResponse contains the underlying HTTP response.

--- a/pkg/tools/codegen/schema/resource_boilerplate.go
+++ b/pkg/tools/codegen/schema/resource_boilerplate.go
@@ -85,6 +85,14 @@ func (r resourceInfo) NameParameterName() string {
 	return lowerFirst(r.BaseName) + "Name"
 }
 
+func (r resourceInfo) TypeParameterType() string {
+	return schemav3.GenericResourceType + "TypeParameter"
+}
+
+func (r resourceInfo) TypeParameterName() string {
+	return lowerFirst(schemav3.GenericResourceType) + "Type"
+}
+
 // Load a resource boilerplate schema for a given type.
 func LoadResourceBoilerplateSchemaForType(r resourceInfo) (*Schema, error) {
 	b := &bytes.Buffer{}

--- a/pkg/tools/codegen/schema/resource_boilerplate.json
+++ b/pkg/tools/codegen/schema/resource_boilerplate.json
@@ -18,6 +18,16 @@
     }
   },
   "parameters": {
+    {{ if .IsGenericResource }}
+    "{{ .TypeParameterType }}": {
+      "x-ms-parameter-location": "method",
+      "description": "The type of the {{ .QualifiedName }}.",
+      "type": "string",
+      "required": true,
+      "in": "path",
+      "name": "{{ .TypeParameterName }}"
+    },
+    {{ end }}
     "{{ .NameParameterType }}": {
       "x-ms-parameter-location": "method",
       "description": "The name of the {{ .QualifiedName }} resource.",
@@ -67,11 +77,12 @@
         "operationId": "{{ .QualifiedName }}_List",
         "description": "List the {{ .QualifiedName }} resources deployed in the application."
       }
-    }
-    {{/* Generic RadiusResource can only be listed - no other operations allowed */}}
-    {{ if not .IsGenericResource }}
-    ,
+    },
+    {{ if .IsGenericResource }}
+    "{{ .BasePath }}/{{ print `{` (.TypeParameterName) `}` }}/{{ print `{` (.NameParameterName) `}` }}": {
+    {{ else }}
     "{{ .BasePath }}/{{ .QualifiedName }}/{{ print `{` (.NameParameterName) `}` }}": {
+    {{ end }}
       "get": {
         "operationId": "{{ .QualifiedName }}_Get",
         "tags": [
@@ -89,6 +100,11 @@
           {{ if not .IsApplication }}
           {
             "$ref": "#/parameters/ApplicationNameParameter"
+          },
+          {{ end }}
+          {{ if .IsGenericResource }}
+          {
+            "$ref": "#/parameters/{{ .TypeParameterType }}"
           },
           {{ end }}
           {
@@ -113,6 +129,7 @@
           }
         }
       },
+      {{ if not .IsGenericResource }}
       "put": {
         "operationId": "{{ .QualifiedName }}_CreateOrUpdate",
         "tags": [
@@ -175,6 +192,7 @@
           }
         }
       },
+      {{ end }}
       "delete": {
         "description": "Deletes a {{ .QualifiedName }} resource.",
         "operationId": "{{ .QualifiedName }}_Delete",
@@ -189,6 +207,11 @@
           {{ if not .IsApplication }}
           {
             "$ref": "#/parameters/ApplicationNameParameter"
+          },
+          {{ end }}
+          {{ if .IsGenericResource }}
+          {
+            "$ref": "#/parameters/{{ .TypeParameterType }}"
           },
           {{ end }}
           {
@@ -214,6 +237,5 @@
         ]
       }
     }
-    {{ end }}
   }
 }

--- a/pkg/tools/codegen/schema/testdata/output.json
+++ b/pkg/tools/codegen/schema/testdata/output.json
@@ -103,6 +103,14 @@
       "in": "path",
       "name": "awesomeComponentName"
     },
+    "RadiusResourceTypeParameter": {
+      "x-ms-parameter-location": "method",
+      "description": "The type of the RadiusResource.",
+      "type": "string",
+      "required": true,
+      "in": "path",
+      "name": "radiusResourceType"
+    },
     "RadiusResourceNameParameter": {
       "x-ms-parameter-location": "method",
       "description": "The name of the RadiusResource resource.",
@@ -113,6 +121,87 @@
     }
   },
   "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomProviders/resourceProviders/radiusv3/Application/{applicationName}/{radiusResourceType}/{radiusResourceName}": {
+      "delete": {
+        "description": "Deletes a RadiusResource resource.",
+        "operationId": "RadiusResource_Delete",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApplicationNameParameter"
+          },
+          {
+            "$ref": "#/parameters/RadiusResourceTypeParameter"
+          },
+          {
+            "$ref": "#/parameters/RadiusResourceNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The RadiusResource resource was successfully deleted."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "tags": [
+          "RadiusResource"
+        ]
+      },
+      "get": {
+        "description": "Gets a RadiusResource resource by name.",
+        "operationId": "RadiusResource_Get",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApplicationNameParameter"
+          },
+          {
+            "$ref": "#/parameters/RadiusResourceTypeParameter"
+          },
+          {
+            "$ref": "#/parameters/RadiusResourceNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The RadiusResource resource was retrieved successfully.",
+            "schema": {
+              "$ref": "#/definitions/RadiusResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "tags": [
+          "RadiusResource"
+        ]
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomProviders/resourceProviders/radiusv3/Application/{applicationName}/radius.com.AwesomeComponent/{awesomeComponentName}": {
       "delete": {
         "description": "Deletes a radius.com.AwesomeComponent resource.",

--- a/schemas/rest-api-specs-v3/radius.json
+++ b/schemas/rest-api-specs-v3/radius.json
@@ -1856,6 +1856,14 @@
       "type": "string",
       "x-ms-parameter-location": "method"
     },
+    "RadiusResourceTypeParameter": {
+      "description": "The type of the RadiusResource.",
+      "in": "path",
+      "name": "radiusResourceType",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
     "RedisComponentNameParameter": {
       "description": "The name of the redislabs.com.Redis resource.",
       "in": "path",
@@ -4130,6 +4138,87 @@
         },
         "tags": [
           "redislabs.com.Redis"
+        ]
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CustomProviders/resourceProviders/radiusv3/Application/{applicationName}/{radiusResourceType}/{radiusResourceName}": {
+      "delete": {
+        "description": "Deletes a RadiusResource resource.",
+        "operationId": "RadiusResource_Delete",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApplicationNameParameter"
+          },
+          {
+            "$ref": "#/parameters/RadiusResourceTypeParameter"
+          },
+          {
+            "$ref": "#/parameters/RadiusResourceNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The RadiusResource resource was successfully deleted."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "tags": [
+          "RadiusResource"
+        ]
+      },
+      "get": {
+        "description": "Gets a RadiusResource resource by name.",
+        "operationId": "RadiusResource_Get",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApplicationNameParameter"
+          },
+          {
+            "$ref": "#/parameters/RadiusResourceTypeParameter"
+          },
+          {
+            "$ref": "#/parameters/RadiusResourceNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The RadiusResource resource was retrieved successfully.",
+            "schema": {
+              "$ref": "#/definitions/RadiusResource"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "tags": [
+          "RadiusResource"
         ]
       }
     }


### PR DESCRIPTION
Part of #1043 

This allows `rad resource show`, `rad resource delete`, and `rad applicationv3 delete` to be simpler and scales well with resource growth.