### PR TITLE
Fix persistence of properties

### DIFF
--- a/pkg/handlers/azure_cosmosaccount_mongo.go
+++ b/pkg/handlers/azure_cosmosaccount_mongo.go
@@ -60,7 +60,7 @@ func (handler *azureCosmosAccountMongoHandler) Delete(ctx context.Context, optio
 	if options.ExistingOutputResource == nil {
 		properties = options.Existing.Properties
 	} else {
-		properties = options.ExistingOutputResource.Resource.(map[string]string)
+		properties = options.ExistingOutputResource.PersistedProperties
 	}
 
 	if properties[ManagedKey] != "true" {

--- a/pkg/handlers/azure_cosmosdb_mongo.go
+++ b/pkg/handlers/azure_cosmosdb_mongo.go
@@ -79,7 +79,7 @@ func (handler *azureCosmosDBMongoHandler) Delete(ctx context.Context, options De
 	if options.ExistingOutputResource == nil {
 		properties = options.Existing.Properties
 	} else {
-		properties = options.ExistingOutputResource.Resource.(map[string]string)
+		properties = options.ExistingOutputResource.PersistedProperties
 	}
 
 	if properties[ManagedKey] != "true" {

--- a/pkg/handlers/azure_cosmosdb_sql.go
+++ b/pkg/handlers/azure_cosmosdb_sql.go
@@ -86,7 +86,7 @@ func (handler *azureCosmosDBSQLDBHandler) Delete(ctx context.Context, options De
 	if options.ExistingOutputResource == nil {
 		properties = options.Existing.Properties
 	} else {
-		properties = options.ExistingOutputResource.Resource.(map[string]string)
+		properties = options.ExistingOutputResource.PersistedProperties
 	}
 
 	if properties[ManagedKey] != "true" {

--- a/pkg/handlers/azure_keyvault.go
+++ b/pkg/handlers/azure_keyvault.go
@@ -81,7 +81,7 @@ func (handler *azureKeyVaultHandler) Delete(ctx context.Context, options DeleteO
 	if options.ExistingOutputResource == nil {
 		properties = options.Existing.Properties
 	} else {
-		properties = options.ExistingOutputResource.Resource.(map[string]string)
+		properties = options.ExistingOutputResource.PersistedProperties
 	}
 
 	if properties[ManagedKey] != "true" {

--- a/pkg/handlers/azure_podidentity.go
+++ b/pkg/handlers/azure_podidentity.go
@@ -151,7 +151,7 @@ func (handler *azurePodIdentityHandler) Delete(ctx context.Context, options Dele
 	if options.ExistingOutputResource == nil {
 		properties = options.Existing.Properties
 	} else {
-		properties = options.ExistingOutputResource.Resource.(map[string]string)
+		properties = options.ExistingOutputResource.PersistedProperties
 	}
 
 	podIdentityName := properties[PodIdentityNameKey]

--- a/pkg/handlers/azure_redis.go
+++ b/pkg/handlers/azure_redis.go
@@ -92,7 +92,7 @@ func (handler *azureRedisHandler) Delete(ctx context.Context, options DeleteOpti
 	if options.ExistingOutputResource == nil {
 		properties = options.Existing.Properties
 	} else {
-		properties = options.ExistingOutputResource.Resource.(map[string]string)
+		properties = options.ExistingOutputResource.PersistedProperties
 	}
 
 	if properties[ManagedKey] != "true" {

--- a/pkg/handlers/azure_servicebus.go
+++ b/pkg/handlers/azure_servicebus.go
@@ -141,7 +141,7 @@ func (handler *azureServiceBusQueueHandler) Delete(ctx context.Context, options 
 	if options.ExistingOutputResource == nil {
 		properties = options.Existing.Properties
 	} else {
-		properties = options.ExistingOutputResource.Resource.(map[string]string)
+		properties = options.ExistingOutputResource.PersistedProperties
 	}
 
 	if properties[ManagedKey] != "true" {

--- a/pkg/handlers/dapr_pubsub_servicebus.go
+++ b/pkg/handlers/dapr_pubsub_servicebus.go
@@ -103,7 +103,7 @@ func (handler *daprPubSubServiceBusHandler) Delete(ctx context.Context, options 
 	if options.ExistingOutputResource == nil {
 		properties = options.Existing.Properties
 	} else {
-		properties = options.ExistingOutputResource.Resource.(map[string]string)
+		properties = options.ExistingOutputResource.PersistedProperties
 	}
 
 	namespaceName := properties[ServiceBusNamespaceNameKey]

--- a/pkg/handlers/dapr_statestore_sqlserver.go
+++ b/pkg/handlers/dapr_statestore_sqlserver.go
@@ -126,7 +126,7 @@ func (handler *daprStateStoreSQLServerHandler) Delete(ctx context.Context, optio
 	if options.ExistingOutputResource == nil {
 		properties = options.Existing.Properties
 	} else {
-		properties = options.ExistingOutputResource.Resource.(map[string]string)
+		properties = options.ExistingOutputResource.PersistedProperties
 	}
 
 	item := unstructured.Unstructured{

--- a/pkg/handlers/dapr_statestore_storage.go
+++ b/pkg/handlers/dapr_statestore_storage.go
@@ -94,7 +94,7 @@ func (handler *daprStateStoreAzureStorageHandler) Delete(ctx context.Context, op
 	if options.ExistingOutputResource == nil {
 		properties = options.Existing.Properties
 	} else {
-		properties = options.ExistingOutputResource.Resource.(map[string]string)
+		properties = options.ExistingOutputResource.PersistedProperties
 	}
 
 	accountName := properties[StorageAccountNameKey]

--- a/pkg/handlers/kubernetes.go
+++ b/pkg/handlers/kubernetes.go
@@ -96,7 +96,7 @@ func (handler *kubernetesHandler) Delete(ctx context.Context, options DeleteOpti
 	if options.ExistingOutputResource == nil {
 		properties = options.Existing.Properties
 	} else {
-		properties = options.ExistingOutputResource.Resource.(map[string]string)
+		properties = options.ExistingOutputResource.PersistedProperties
 	}
 
 	item := unstructured.Unstructured{

--- a/pkg/handlers/util.go
+++ b/pkg/handlers/util.go
@@ -14,13 +14,9 @@ import (
 // This is useful for cases where deploying a resource results in storage of generated values like names.
 // By merging properties, the caller gets to see those values and reuse them.
 func mergeProperties(resource outputresource.OutputResource, existing *db.DeploymentResource, dbResource *db.OutputResource) map[string]string {
-	properties := resource.Resource.(map[string]string)
-	if properties == nil {
+	properties, ok := resource.Resource.(map[string]string)
+	if !ok {
 		properties = map[string]string{}
-	}
-
-	if existing == nil {
-		return properties
 	}
 
 	if existing != nil {
@@ -33,7 +29,7 @@ func mergeProperties(resource outputresource.OutputResource, existing *db.Deploy
 	}
 
 	if dbResource != nil {
-		for k, v := range dbResource.Resource.(map[string]string) {
+		for k, v := range dbResource.PersistedProperties {
 			_, ok := properties[k]
 			if !ok {
 				properties[k] = v

--- a/pkg/radrp/backend/deployment/types.go
+++ b/pkg/radrp/backend/deployment/types.go
@@ -212,13 +212,13 @@ func (dp *deploymentProcessor) Deploy(ctx context.Context, operationID azresourc
 
 		// Build database resource - copy updated properties to Resource field
 		dbOutputResource := db.OutputResource{
-			LocalID:            outputResource.LocalID,
-			HealthID:           outputResource.HealthID,
-			ResourceKind:       outputResource.Kind,
-			OutputResourceInfo: outputResource.Info,
-			Managed:            outputResource.Managed,
-			OutputResourceType: outputResource.Type,
-			Resource:           properties,
+			LocalID:             outputResource.LocalID,
+			HealthID:            outputResource.HealthID,
+			ResourceKind:        outputResource.Kind,
+			OutputResourceInfo:  outputResource.Info,
+			Managed:             outputResource.Managed,
+			OutputResourceType:  outputResource.Type,
+			PersistedProperties: properties,
 			Status: db.OutputResourceStatus{
 				ProvisioningState:        db.Provisioned,
 				ProvisioningErrorDetails: "",
@@ -310,7 +310,7 @@ func (dp *deploymentProcessor) Delete(ctx context.Context, operationID azresourc
 			return err
 		}
 
-		healthID := outputResource.Resource.(map[string]string)[healthcontract.HealthIDKey]
+		healthID := outputResource.PersistedProperties[healthcontract.HealthIDKey]
 		dp.unregisterOutputResourceForHealthChecks(ctx, healthID)
 	}
 

--- a/pkg/radrp/db/types.go
+++ b/pkg/radrp/db/types.go
@@ -145,14 +145,21 @@ type ComponentTrait struct {
 
 // OutputResource represents an output resource comprising a Radius component.
 type OutputResource struct {
-	LocalID            string               `bson:"id"`
-	HealthID           string               `bson:"healthId"`
-	ResourceKind       string               `bson:"resourceKind"`
-	OutputResourceInfo interface{}          `bson:"outputResourceInfo"`
-	Managed            bool                 `bson:"managed"`
-	OutputResourceType string               `bson:"outputResourceType"`
-	Resource           interface{}          `bson:"resource"`
-	Status             OutputResourceStatus `bson:"status"`
+	LocalID            string      `bson:"id"`
+	HealthID           string      `bson:"healthId"`
+	ResourceKind       string      `bson:"resourceKind"`
+	OutputResourceInfo interface{} `bson:"outputResourceInfo"`
+	Managed            bool        `bson:"managed"`
+	OutputResourceType string      `bson:"outputResourceType"`
+
+	// We persist properties returned from the resource handler for later use when
+	// processing the same resource again.
+	//
+	// This is an old pattern that we're trying to migrate away from because it requires
+	// a resource handler per-resource type. In general any per-resource type processing
+	// should be done in the renderer.
+	PersistedProperties map[string]string    `bson:"persistedProperties"`
+	Status              OutputResourceStatus `bson:"status"`
 }
 
 // GetResourceID returns the identifier of the entity/resource to be queried by the health service

--- a/pkg/radrp/deployment/deployment_processor.go
+++ b/pkg/radrp/deployment/deployment_processor.go
@@ -312,15 +312,20 @@ func (dp *deploymentProcessor) UpdateDeployment(ctx context.Context, appName str
 }
 
 func addDBOutputResource(resource outputresource.OutputResource, dbOutputResources *[]db.OutputResource) {
+	properties, ok := resource.Resource.(map[string]string)
+	if !ok {
+		properties = nil
+	}
+
 	// Save the output resource to DB
 	dbr := db.OutputResource{
-		Managed:            resource.Managed,
-		HealthID:           resource.HealthID,
-		LocalID:            resource.LocalID,
-		ResourceKind:       resource.Kind,
-		OutputResourceType: resource.Type,
-		OutputResourceInfo: resource.Info,
-		Resource:           resource.Resource,
+		Managed:             resource.Managed,
+		HealthID:            resource.HealthID,
+		LocalID:             resource.LocalID,
+		ResourceKind:        resource.Kind,
+		OutputResourceType:  resource.Type,
+		OutputResourceInfo:  resource.Info,
+		PersistedProperties: properties,
 		Status: db.OutputResourceStatus{
 			ProvisioningState:        resource.Status.ProvisioningState,
 			ProvisioningErrorDetails: resource.Status.ProvisioningErrorDetails,


### PR DESCRIPTION
When we process a resource we allow the 'handler' to persist some state
that will be provided to the handler again when the resource is visited
again (updates/deletes). This is how many of the older resource handlers
communicate about the identity of the resource being updated/deleted,
whether it exists, etc.

This is broken right now for AppModelv3 because of the way Unmarshaling
works in the Mongo driver. We modeled the data as `interface{}` and that
results in us getting a bson-specific data type when it comes back out
of the database. If we model this as `map[string]string{}` (which is a
more accurate reflection of what we use it for) then it will work
successfully.

This isn't an issue in V1 because we process resources as a batch.