### PR TITLE
Migrate KeyVault Component support to AppModel v3

### DIFF
--- a/pkg/handlers/azure_keyvault.go
+++ b/pkg/handlers/azure_keyvault.go
@@ -55,12 +55,15 @@ func (handler *azureKeyVaultHandler) Put(ctx context.Context, options *PutOption
 		// store vault so we can use later
 		properties[KeyVaultNameKey] = *kv.Name
 		properties[KeyVaultIDKey] = *kv.ID
+		properties[KeyVaultURIKey] = *kv.Properties.VaultURI
 	} else {
 		// This is mostly called for the side-effect of verifying that the keyvault exists.
-		_, err := handler.GetKeyVaultByID(ctx, properties[KeyVaultIDKey])
+		kv, err := handler.GetKeyVaultByID(ctx, properties[KeyVaultIDKey])
 		if err != nil {
 			return nil, err
 		}
+
+		properties[KeyVaultURIKey] = *kv.Properties.VaultURI
 	}
 
 	if options.Resource.Deployed {

--- a/pkg/renderers/keyvaultv1alpha3/render.go
+++ b/pkg/renderers/keyvaultv1alpha3/render.go
@@ -1,0 +1,88 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package keyvaultv1alpha3
+
+import (
+	"context"
+
+	"github.com/Azure/radius/pkg/azure/armauth"
+	"github.com/Azure/radius/pkg/azure/azresources"
+	"github.com/Azure/radius/pkg/handlers"
+	"github.com/Azure/radius/pkg/radrp/outputresource"
+	"github.com/Azure/radius/pkg/renderers"
+	"github.com/Azure/radius/pkg/resourcekinds"
+)
+
+var _ renderers.Renderer = (*Renderer)(nil)
+
+type Renderer struct {
+	Arm armauth.ArmConfig
+}
+
+func (r *Renderer) GetDependencyIDs(ctx context.Context, workload renderers.RendererResource) ([]azresources.ResourceID, error) {
+	return nil, nil
+}
+
+func (r *Renderer) Render(ctx context.Context, resource renderers.RendererResource, dependencies map[string]renderers.RendererDependency) (renderers.RendererOutput, error) {
+	properties := KeyVaultComponentProperties{}
+	err := resource.ConvertDefinition(&properties)
+	if err != nil {
+		return renderers.RendererOutput{}, err
+	}
+
+	output := renderers.RendererOutput{}
+
+	if properties.Managed {
+		if properties.Resource != "" {
+			return renderers.RendererOutput{}, renderers.ErrResourceSpecifiedForManagedResource
+		}
+
+		resource := outputresource.OutputResource{
+			Resource: map[string]string{
+				handlers.ManagedKey: "true",
+			},
+			Deployed:     false,
+			LocalID:      outputresource.LocalIDKeyVault,
+			Managed:      true,
+			ResourceKind: resourcekinds.AzureKeyVault,
+		}
+
+		output.Resources = append(output.Resources, resource)
+	} else {
+		if properties.Resource == "" {
+			return renderers.RendererOutput{}, renderers.ErrResourceMissingForUnmanagedResource
+		}
+
+		vaultID, err := renderers.ValidateResourceID(properties.Resource, KeyVaultResourceType, outputresource.LocalIDKeyVault)
+		if err != nil {
+			return renderers.RendererOutput{}, err
+		}
+
+		resource := outputresource.OutputResource{
+			LocalID:      outputresource.LocalIDKeyVault,
+			ResourceKind: resourcekinds.AzureKeyVault,
+			Managed:      false,
+			Deployed:     true,
+			Resource: map[string]string{
+				handlers.ManagedKey: "false",
+
+				handlers.KeyVaultIDKey:   vaultID.ID,
+				handlers.KeyVaultNameKey: vaultID.Types[0].Name,
+			},
+		}
+
+		output.Resources = append(output.Resources, resource)
+	}
+
+	output.ComputedValues = map[string]renderers.ComputedValueReference{
+		"uri": {
+			LocalID:           outputresource.LocalIDKeyVault,
+			PropertyReference: handlers.KeyVaultURIKey,
+		},
+	}
+
+	return output, nil
+}

--- a/pkg/renderers/keyvaultv1alpha3/render_test.go
+++ b/pkg/renderers/keyvaultv1alpha3/render_test.go
@@ -1,0 +1,136 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package keyvaultv1alpha3
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/radius/pkg/handlers"
+	"github.com/Azure/radius/pkg/radlogger"
+	"github.com/Azure/radius/pkg/radrp/outputresource"
+	"github.com/Azure/radius/pkg/renderers"
+	"github.com/Azure/radius/pkg/resourcekinds"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+)
+
+func createContext(t *testing.T) context.Context {
+	logger, err := radlogger.NewTestLogger(t)
+	if err != nil {
+		t.Log("Unable to initialize logger")
+		return context.Background()
+	}
+	return logr.NewContext(context.Background(), logger)
+}
+
+func Test_Render_Managed_Success(t *testing.T) {
+	ctx := createContext(t)
+	renderer := Renderer{}
+
+	resource := renderers.RendererResource{
+		ApplicationName: "test-app",
+		ResourceName:    "test-vault",
+		ResourceType:    ResourceType,
+		Definition: map[string]interface{}{
+			"managed": true,
+		},
+	}
+
+	output, err := renderer.Render(ctx, resource, map[string]renderers.RendererDependency{})
+	require.NoError(t, err)
+
+	require.Equal(t, outputresource.LocalIDKeyVault, output.Resources[0].LocalID)
+	require.Equal(t, resourcekinds.AzureKeyVault, output.Resources[0].ResourceKind)
+
+	expectedProperties := map[string]string{
+		handlers.ManagedKey: "true",
+	}
+	require.Equal(t, expectedProperties, output.Resources[0].Resource)
+
+	expectedComputedValues := map[string]renderers.ComputedValueReference{
+		"uri": {
+			LocalID:           outputresource.LocalIDKeyVault,
+			PropertyReference: handlers.KeyVaultURIKey,
+		},
+	}
+
+	require.Equal(t, expectedComputedValues, output.ComputedValues)
+	require.Empty(t, output.SecretValues)
+}
+
+func Test_Render_Unmanaged_Success(t *testing.T) {
+	ctx := createContext(t)
+	renderer := Renderer{}
+
+	resource := renderers.RendererResource{
+		ApplicationName: "test-app",
+		ResourceName:    "test-vault",
+		ResourceType:    ResourceType,
+		Definition: map[string]interface{}{
+			"resource": "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.KeyVault/vaults/test-vault",
+		},
+	}
+
+	output, err := renderer.Render(ctx, resource, map[string]renderers.RendererDependency{})
+	require.NoError(t, err)
+
+	require.Equal(t, outputresource.LocalIDKeyVault, output.Resources[0].LocalID)
+	require.Equal(t, resourcekinds.AzureKeyVault, output.Resources[0].ResourceKind)
+
+	expectedProperties := map[string]string{
+		handlers.ManagedKey:      "false",
+		handlers.KeyVaultIDKey:   "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.KeyVault/vaults/test-vault",
+		handlers.KeyVaultNameKey: "test-vault",
+	}
+	require.Equal(t, expectedProperties, output.Resources[0].Resource)
+
+	expectedComputedValues := map[string]renderers.ComputedValueReference{
+		"uri": {
+			LocalID:           outputresource.LocalIDKeyVault,
+			PropertyReference: handlers.KeyVaultURIKey,
+		},
+	}
+
+	require.Equal(t, expectedComputedValues, output.ComputedValues)
+	require.Empty(t, output.SecretValues)
+}
+
+func Test_Render_Unmanaged_MissingResource(t *testing.T) {
+	ctx := createContext(t)
+	renderer := Renderer{}
+
+	resource := renderers.RendererResource{
+		ApplicationName: "test-app",
+		ResourceName:    "test-vault",
+		ResourceType:    ResourceType,
+		Definition: map[string]interface{}{
+			"managed": false,
+		},
+	}
+
+	_, err := renderer.Render(ctx, resource, map[string]renderers.RendererDependency{})
+	require.Error(t, err)
+	require.Equal(t, renderers.ErrResourceMissingForUnmanagedResource.Error(), err.Error())
+}
+
+func Test_Render_Unmanaged_InvalidResourceType(t *testing.T) {
+	ctx := createContext(t)
+	renderer := Renderer{}
+
+	resource := renderers.RendererResource{
+		ApplicationName: "test-app",
+		ResourceName:    "test-vault",
+		ResourceType:    ResourceType,
+		Definition: map[string]interface{}{
+			"resource": "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.SomethingElse/vaults/test-vault",
+		},
+	}
+
+	_, err := renderer.Render(ctx, resource, map[string]renderers.RendererDependency{})
+	require.Error(t, err)
+	require.Equal(t, "the 'resource' field must refer to a KeyVault", err.Error())
+}

--- a/pkg/renderers/keyvaultv1alpha3/types.go
+++ b/pkg/renderers/keyvaultv1alpha3/types.go
@@ -1,0 +1,26 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package keyvaultv1alpha3
+
+import (
+	"github.com/Azure/radius/pkg/azure/azresources"
+)
+
+const ResourceType = "azure.com.KeyVaultComponent"
+
+var KeyVaultResourceType = azresources.KnownType{
+	Types: []azresources.ResourceType{
+		{
+			Type: azresources.KeyVaultVaults,
+			Name: "*",
+		},
+	},
+}
+
+type KeyVaultComponentProperties struct {
+	Managed  bool   `json:"managed"`
+	Resource string `json:"resource"`
+}


### PR DESCRIPTION
This change updates the KeyVault render to use AppModelv3. It doesn't
fully enable the scenario that we cover in the tutorial, this is just
the addition of the renderer support.