### PR TITLE
Fix panic in health service logging

### DIFF
--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -100,7 +100,7 @@ func (h Monitor) RegisterResource(ctx context.Context, registerMsg healthcontrac
 	_, ok := h.activeHealthProbes[registration.Token]
 	h.activeHealthProbesMutex.RUnlock()
 	if ok {
-		logger.Info("Resource is already registered with the health service. Ignoring this registration message.", registerMsg.Resource.Identity)
+		logger.Info(fmt.Sprintf("Resource %+v is already registered with the health service. Ignoring this registration message.", registerMsg.Resource.Identity))
 		return nil
 	}
 


### PR DESCRIPTION
I found a panic in local manual testing, this is a recent regression
that I introduced. I reviewed the rest of the file and didn't find any
similar cases.