### PR TITLE
Support listSecrets custom action

### DIFF
--- a/deploy/rp-full.input.json
+++ b/deploy/rp-full.input.json
@@ -638,6 +638,13 @@
                             "location": "[resourceGroup().location]",
                             "tags": "[parameters('resourceTags')]",
                             "properties": {
+                                "actions": [
+                                    {
+                                        "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]",
+                                        "name": "listSecrets",
+                                        "routingType": "Proxy"
+                                    }
+                                ],
                                 "resourceTypes": "[parameters('resourceTypes')]"
                             }
                         },

--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -633,6 +633,13 @@
                             "location": "[resourceGroup().location]",
                             "name": "radiusv3",
                             "properties": {
+                                "actions": [
+                                    {
+                                        "endpoint": "[concat('https://', parameters('siteName'), '.azurewebsites.net/{requestPath}')]",
+                                        "name": "listSecrets",
+                                        "routingType": "Proxy"
+                                    }
+                                ],
                                 "resourceTypes": "[parameters('resourceTypes')]"
                             },
                             "tags": "[parameters('resourceTags')]",


### PR DESCRIPTION
This change adds support for an ARM 'custom action' that will pass
through the CustomRP infrastructure into our RP.

I've added support to the compiler to allow *programmatic access to
secrets*. ex: `foo: db.connectionString()`. Where our component types
support secret values, the Bicep compiler will inject a function symbol
that maps to this new custom action. This is similar to how handling of
secrets generally works in ARM, but more streamlined.

The next change after this one will add the RP functionality to
implement this. It's good to separate manifest changes from the code
changes, because the manifest is not applied by the CI.