### PR TITLE
Add `rad resource logs/expose`

### DIFF
--- a/cmd/cli/cmd/resourceExpose.go
+++ b/cmd/cli/cmd/resourceExpose.go
@@ -1,0 +1,115 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cmd
+
+import (
+	"fmt"
+	"os/signal"
+
+	"github.com/Azure/radius/pkg/cli"
+	"github.com/Azure/radius/pkg/cli/clients"
+	"github.com/Azure/radius/pkg/cli/environments"
+	"github.com/Azure/radius/pkg/radrp/schemav3"
+	"github.com/spf13/cobra"
+)
+
+var resourceExposeCmd = &cobra.Command{
+	Use:   "expose resource",
+	Short: "Exposes a resource for network traffic",
+	Long: `Exposes a port inside a resource for network traffic using a local port.
+This command is useful for testing resources that accept network traffic but are not exposed to the public internet. Exposing a port for testing allows you to send TCP traffic from your local machine to the resource.
+
+Press CTRL+C to exit the command and terminate the tunnel.`,
+	Example: `# expose port 80 on the 'orders' resource of the 'icecream-store' application
+# on local port 5000
+rad resource expose --application icecream-store orders --port 5000 --remote-port 80`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		config := ConfigFromContext(cmd.Context())
+		env, err := cli.RequireEnvironment(cmd, config)
+		if err != nil {
+			return err
+		}
+
+		application, err := cli.RequireApplication(cmd, env)
+		if err != nil {
+			return err
+		}
+
+		resourceType, resourceName, err := cli.RequireResource(cmd, args)
+		if err != nil {
+			return err
+		}
+		if resourceType != schemav3.ContainerComponentType {
+			return fmt.Errorf("only %s is supported", schemav3.ContainerComponentType)
+		}
+
+		localPort, err := cmd.Flags().GetInt("port")
+		if err != nil {
+			return err
+		}
+
+		remotePort, err := cmd.Flags().GetInt("remote-port")
+		if err != nil {
+			return err
+		}
+
+		replica, err := cmd.Flags().GetString("replica")
+		if err != nil {
+			return err
+		}
+
+		if remotePort == -1 {
+			remotePort = localPort
+		}
+
+		client, err := environments.CreateDiagnosticsClient(cmd.Context(), env)
+
+		if err != nil {
+			return err
+		}
+
+		failed, stop, signals, err := client.Expose(cmd.Context(), clients.ExposeOptions{
+			Application: application,
+			Component:   resourceName,
+			Port:        localPort,
+			RemotePort:  remotePort,
+			Replica:     replica})
+
+		if err != nil {
+			return err
+		}
+		// We own stopping the signal created by Expose
+		defer signal.Stop(signals)
+
+		for {
+			select {
+			case <-signals:
+				// shutting down... wait for socket to close
+				close(stop)
+				continue
+			case err := <-failed:
+				if err != nil {
+					return fmt.Errorf("failed to port-forward: %w", err)
+				}
+
+				return nil
+			}
+		}
+	},
+}
+
+func init() {
+	resourceExposeCmd.PersistentFlags().StringP("type", "t", "", "The resource type")
+	resourceExposeCmd.PersistentFlags().StringP("resource", "r", "", "The resource name")
+	resourceExposeCmd.Flags().IntP("remote-port", "R", -1, "specify the remote port")
+	resourceExposeCmd.Flags().String("replica", "", "specify the replica to expose")
+	resourceExposeCmd.Flags().IntP("port", "p", -1, "specify the local port")
+	err := resourceExposeCmd.MarkFlagRequired("port")
+	if err != nil {
+		panic(err)
+	}
+	resourceCmd.AddCommand(resourceExposeCmd)
+}

--- a/cmd/cli/cmd/resourceExpose.go
+++ b/cmd/cli/cmd/resourceExpose.go
@@ -25,7 +25,7 @@ This command is useful for testing resources that accept network traffic but are
 Press CTRL+C to exit the command and terminate the tunnel.`,
 	Example: `# expose port 80 on the 'orders' resource of the 'icecream-store' application
 # on local port 5000
-rad resource expose --application icecream-store orders --port 5000 --remote-port 80`,
+rad resource expose --application icecream-store ContainerComponent orders --port 5000 --remote-port 80`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		config := ConfigFromContext(cmd.Context())
 		env, err := cli.RequireEnvironment(cmd, config)

--- a/cmd/cli/cmd/resourceExpose.go
+++ b/cmd/cli/cmd/resourceExpose.go
@@ -104,7 +104,7 @@ rad resource expose --application icecream-store ContainerComponent orders --por
 func init() {
 	resourceExposeCmd.PersistentFlags().StringP("type", "t", "", "The resource type")
 	resourceExposeCmd.PersistentFlags().StringP("resource", "r", "", "The resource name")
-	resourceExposeCmd.Flags().IntP("remote-port", "R", -1, "specify the remote port")
+	resourceExposeCmd.Flags().IntP("remote-port", "", -1, "specify the remote port")
 	resourceExposeCmd.Flags().String("replica", "", "specify the replica to expose")
 	resourceExposeCmd.Flags().IntP("port", "p", -1, "specify the local port")
 	err := resourceExposeCmd.MarkFlagRequired("port")

--- a/cmd/cli/cmd/resourceLogs.go
+++ b/cmd/cli/cmd/resourceLogs.go
@@ -1,0 +1,113 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Azure/radius/pkg/cli"
+	"github.com/Azure/radius/pkg/cli/clients"
+	"github.com/Azure/radius/pkg/cli/environments"
+	"github.com/Azure/radius/pkg/radrp/schemav3"
+	"github.com/spf13/cobra"
+)
+
+var resourceLogsCmd = &cobra.Command{
+	Use:   "logs [resource]",
+	Short: "Read logs from a running ContainerComponent resource",
+	Long: `Reads logs from a running resource. Currently only supports the resource kind 'radius.dev/Container'.
+This command allows you to access logs of a deployed application and output those logs to the local console.
+
+'rad resource logs' will output all currently available logs for the resource and then exit.
+
+'rad resource logs' will output logs from the resource's primary container. In scenarios like Dapr where multiple containers are in use, the '--container \<name\>' option can specify the desired container.
+
+Specify the '--follow' option to stream additional logs as they are emitted by the resource. When following, press CTRL+C to exit the command and terminate the stream.`,
+	Example: `# read logs from the 'webapp' resource of the current default app
+rad resource logs webapp
+
+# read logs from the 'orders' resource of the 'icecream-store' application
+rad resource logs orders --application icecream-store
+
+# stream logs from the 'orders' resource of the 'icecream-store' application
+rad resource logs orders --application icecream-store --follow
+
+# read logs from the 'daprd' sidecar container of the 'orders' resource of the 'icecream-store' application
+rad resource logs orders --application icecream-store --container daprd`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		config := ConfigFromContext(cmd.Context())
+		env, err := cli.RequireEnvironment(cmd, config)
+		if err != nil {
+			return err
+		}
+
+		application, err := cli.RequireApplication(cmd, env)
+		if err != nil {
+			return err
+		}
+
+		resourceType, resourceName, err := cli.RequireResource(cmd, args)
+		if err != nil {
+			return err
+		}
+		if resourceType != schemav3.ContainerComponentType {
+			return fmt.Errorf("only %s is supported", schemav3.ContainerComponentType)
+		}
+		follow, err := cmd.Flags().GetBool("follow")
+		if err != nil {
+			return err
+		}
+
+		container, err := cmd.Flags().GetString("container")
+		if err != nil {
+			return err
+		}
+
+		client, err := environments.CreateDiagnosticsClient(cmd.Context(), env)
+		if err != nil {
+			return err
+		}
+
+		streams, err := client.Logs(cmd.Context(), clients.LogsOptions{
+			Application: application,
+			Component:   resourceName,
+			Follow:      follow,
+			Container:   container})
+		if err != nil {
+			return err
+		}
+
+		logErrors := make(chan error, len(streams))
+		for _, logInfo := range streams {
+
+			// We can keep reading this until cancellation occurs.
+			if follow {
+				// Sending to stderr so it doesn't interfere with parsing
+				fmt.Fprintf(os.Stderr, "Streaming logs from replica %s for ContainerComponent %s. Press CTRL+C to exit...\n", logInfo.Name, resourceName)
+			}
+
+			// Kick off go routine to read the logs from each stream.
+			go captureLogs(logInfo, logErrors, follow)
+		}
+
+		for i := 0; i < len(streams); i++ {
+			err := <-logErrors
+			if err != nil {
+				// TODO format
+				fmt.Fprintln(os.Stderr, err)
+			}
+		}
+		return nil
+	},
+}
+
+func init() {
+	resourceLogsCmd.Flags().String("container", "", "specify the container from which logs should be streamed")
+	resourceLogsCmd.Flags().BoolP("follow", "f", false, "specify that logs should be stream until the command is canceled")
+	resourceLogsCmd.Flags().String("replica", "", "specify the replica to collect logs from")
+	resourceCmd.AddCommand(resourceLogsCmd)
+}

--- a/cmd/cli/cmd/resourceLogs.go
+++ b/cmd/cli/cmd/resourceLogs.go
@@ -19,7 +19,7 @@ import (
 var resourceLogsCmd = &cobra.Command{
 	Use:   "logs [resource]",
 	Short: "Read logs from a running ContainerComponent resource",
-	Long: `Reads logs from a running resource. Currently only supports the resource kind 'radius.dev/Container'.
+	Long: `Reads logs from a running resource. Currently only supports the resource type 'radius.dev/Container'.
 This command allows you to access logs of a deployed application and output those logs to the local console.
 
 'rad resource logs' will output all currently available logs for the resource and then exit.
@@ -28,16 +28,16 @@ This command allows you to access logs of a deployed application and output thos
 
 Specify the '--follow' option to stream additional logs as they are emitted by the resource. When following, press CTRL+C to exit the command and terminate the stream.`,
 	Example: `# read logs from the 'webapp' resource of the current default app
-rad resource logs webapp
+rad resource logs ContainerComponent webapp
 
 # read logs from the 'orders' resource of the 'icecream-store' application
-rad resource logs orders --application icecream-store
+rad resource logs ContainerComponent orders --application icecream-store
 
 # stream logs from the 'orders' resource of the 'icecream-store' application
-rad resource logs orders --application icecream-store --follow
+rad resource logs ContainerComponent orders --application icecream-store --follow
 
 # read logs from the 'daprd' sidecar container of the 'orders' resource of the 'icecream-store' application
-rad resource logs orders --application icecream-store --container daprd`,
+rad resource logs ContainerComponent orders --application icecream-store --container daprd`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		config := ConfigFromContext(cmd.Context())
 		env, err := cli.RequireEnvironment(cmd, config)

--- a/pkg/radrp/schemav3/loader.go
+++ b/pkg/radrp/schemav3/loader.go
@@ -42,6 +42,8 @@ var (
 const (
 	ApplicationResourceType = "Application"
 	GenericResourceType     = "RadiusResource"
+
+	ContainerComponentType = "ContainerComponent"
 )
 
 // manifest is the format of the 'resource-types.json' manifest.


### PR DESCRIPTION
These are copied from `rad component logs/expose`.  Since resource is ambiguous without the type, I resort to the minimum change of requiring `--type` (either through flag or positional arg) but only allowing `"ContainerComponent"`.