### PR TITLE
Update names to have application in them.

### DIFF
--- a/cmd/k8s/main.go
+++ b/cmd/k8s/main.go
@@ -227,5 +227,5 @@ func extractOwnerKey(obj client.Object) []string {
 		return nil
 	}
 
-	return []string{owner.Name}
+	return []string{owner.Kind + owner.Name}
 }

--- a/pkg/cli/armtemplate/armconverter.go
+++ b/pkg/cli/armtemplate/armconverter.go
@@ -56,7 +56,7 @@ func ConvertToK8s(resource Resource, namespace string) (*unstructured.Unstructur
 			"apiVersion": "radius.dev/v1alpha3",
 			"kind":       kind,
 			"metadata": map[string]interface{}{
-				"name":      nameParts[len(nameParts)-1],
+				"name":      applicationName + "." + nameParts[len(nameParts)-1],
 				"namespace": namespace,
 				"labels":    labels,
 			},

--- a/pkg/cli/armtemplate/armconverter.go
+++ b/pkg/cli/armtemplate/armconverter.go
@@ -32,6 +32,8 @@ func ConvertToK8s(resource Resource, namespace string) (*unstructured.Unstructur
 		return nil, errors.New("application name is empty")
 	}
 
+	name := applicationName
+
 	annotations[kubernetes.LabelRadiusApplication] = applicationName
 	spec := map[string]interface{}{
 		"template":    runtime.RawExtension{Raw: data},
@@ -42,6 +44,7 @@ func ConvertToK8s(resource Resource, namespace string) (*unstructured.Unstructur
 		spec["resource"] = resourceName
 		annotations[kubernetes.LabelRadiusResourceType] = resourceType
 		annotations[kubernetes.LabelRadiusResource] = resourceName
+		name = applicationName + "." + resourceName
 	}
 
 	labels := kubernetes.MakeResourceCRDLabels(applicationName, resourceType, resourceName)
@@ -56,7 +59,7 @@ func ConvertToK8s(resource Resource, namespace string) (*unstructured.Unstructur
 			"apiVersion": "radius.dev/v1alpha3",
 			"kind":       kind,
 			"metadata": map[string]interface{}{
-				"name":      applicationName + "." + nameParts[len(nameParts)-1],
+				"name":      name,
 				"namespace": namespace,
 				"labels":    labels,
 			},

--- a/pkg/cli/armtemplate/armconverter.go
+++ b/pkg/cli/armtemplate/armconverter.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/Azure/radius/pkg/kubernetes"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -18,9 +17,6 @@ import (
 
 func ConvertToK8s(resource Resource, namespace string) (*unstructured.Unstructured, error) {
 	annotations := map[string]string{}
-
-	// Compute annotations to capture the name segments
-	nameParts := strings.Split(resource.Name, "/")
 
 	data, err := json.Marshal(resource)
 	if err != nil {

--- a/pkg/cli/armtemplate/armconverter.go
+++ b/pkg/cli/armtemplate/armconverter.go
@@ -40,7 +40,7 @@ func ConvertToK8s(resource Resource, namespace string) (*unstructured.Unstructur
 		spec["resource"] = resourceName
 		annotations[kubernetes.LabelRadiusResourceType] = resourceType
 		annotations[kubernetes.LabelRadiusResource] = resourceName
-		name = applicationName + "." + resourceName
+		name = applicationName + "-" + resourceName
 	}
 
 	labels := kubernetes.MakeResourceCRDLabels(applicationName, resourceType, resourceName)

--- a/pkg/cli/armtemplate/armconverter_test.go
+++ b/pkg/cli/armtemplate/armconverter_test.go
@@ -32,11 +32,11 @@ func Test_ArmToK8sConversion(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := map[string]*unstructured.Unstructured{
-		"HttpRoute-azure-resources-container-httpbinding.frontend":          frontendRouteUnstructured,
+		"HttpRoute-azure-resources-container-httpbinding-frontend":          frontendRouteUnstructured,
 		"Application-azure-resources-container-httpbinding":                 applicationUnstructured,
-		"HttpRoute-azure-resources-container-httpbinding.backend":           backendRouteUnstructured,
-		"ContainerComponent-azure-resources-container-httpbinding.backend":  backendUnstructured,
-		"ContainerComponent-azure-resources-container-httpbinding.frontend": frontendUnstructured,
+		"HttpRoute-azure-resources-container-httpbinding-backend":           backendRouteUnstructured,
+		"ContainerComponent-azure-resources-container-httpbinding-backend":  backendUnstructured,
+		"ContainerComponent-azure-resources-container-httpbinding-frontend": frontendUnstructured,
 	}
 
 	template, err := Parse(string(content))

--- a/pkg/cli/armtemplate/armconverter_test.go
+++ b/pkg/cli/armtemplate/armconverter_test.go
@@ -32,11 +32,11 @@ func Test_ArmToK8sConversion(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := map[string]*unstructured.Unstructured{
-		"HttpRoute-frontend": frontendRouteUnstructured,
-		"Application-azure-resources-container-httpbinding": applicationUnstructured,
-		"HttpRoute-backend":           backendRouteUnstructured,
-		"ContainerComponent-backend":  backendUnstructured,
-		"ContainerComponent-frontend": frontendUnstructured,
+		"HttpRoute-azure-resources-container-httpbinding.frontend":          frontendRouteUnstructured,
+		"Application-azure-resources-container-httpbinding":                 applicationUnstructured,
+		"HttpRoute-azure-resources-container-httpbinding.backend":           backendRouteUnstructured,
+		"ContainerComponent-azure-resources-container-httpbinding.backend":  backendUnstructured,
+		"ContainerComponent-azure-resources-container-httpbinding.frontend": frontendUnstructured,
 	}
 
 	template, err := Parse(string(content))

--- a/pkg/cli/armtemplate/testdata/frontend-backend/ContainerComponent-backend.json
+++ b/pkg/cli/armtemplate/testdata/frontend-backend/ContainerComponent-backend.json
@@ -15,7 +15,7 @@
             "app.kubernetes.io/part-of": "azure-resources-container-httpbinding",
             "app.kubernetes.io/managed-by": "radius-rp"
         },
-        "name": "backend",
+        "name": "azure-resources-container-httpbinding.backend",
         "namespace": "default"
     },
     "spec": {

--- a/pkg/cli/armtemplate/testdata/frontend-backend/ContainerComponent-backend.json
+++ b/pkg/cli/armtemplate/testdata/frontend-backend/ContainerComponent-backend.json
@@ -15,7 +15,7 @@
             "app.kubernetes.io/part-of": "azure-resources-container-httpbinding",
             "app.kubernetes.io/managed-by": "radius-rp"
         },
-        "name": "azure-resources-container-httpbinding.backend",
+        "name": "azure-resources-container-httpbinding-backend",
         "namespace": "default"
     },
     "spec": {

--- a/pkg/cli/armtemplate/testdata/frontend-backend/ContainerComponent-frontend.json
+++ b/pkg/cli/armtemplate/testdata/frontend-backend/ContainerComponent-frontend.json
@@ -15,7 +15,7 @@
             "app.kubernetes.io/part-of": "azure-resources-container-httpbinding",
             "app.kubernetes.io/managed-by": "radius-rp"
         },
-        "name": "frontend",
+        "name": "azure-resources-container-httpbinding.frontend",
         "namespace": "default"
     },
     "spec": {

--- a/pkg/cli/armtemplate/testdata/frontend-backend/ContainerComponent-frontend.json
+++ b/pkg/cli/armtemplate/testdata/frontend-backend/ContainerComponent-frontend.json
@@ -15,7 +15,7 @@
             "app.kubernetes.io/part-of": "azure-resources-container-httpbinding",
             "app.kubernetes.io/managed-by": "radius-rp"
         },
-        "name": "azure-resources-container-httpbinding.frontend",
+        "name": "azure-resources-container-httpbinding-frontend",
         "namespace": "default"
     },
     "spec": {

--- a/pkg/cli/armtemplate/testdata/frontend-backend/HttpRoute-backend.json
+++ b/pkg/cli/armtemplate/testdata/frontend-backend/HttpRoute-backend.json
@@ -15,7 +15,7 @@
             "app.kubernetes.io/part-of": "azure-resources-container-httpbinding",
             "app.kubernetes.io/managed-by": "radius-rp"
         },
-        "name": "backend",
+        "name": "azure-resources-container-httpbinding.backend",
         "namespace": "default"
     },
     "spec": {

--- a/pkg/cli/armtemplate/testdata/frontend-backend/HttpRoute-backend.json
+++ b/pkg/cli/armtemplate/testdata/frontend-backend/HttpRoute-backend.json
@@ -15,7 +15,7 @@
             "app.kubernetes.io/part-of": "azure-resources-container-httpbinding",
             "app.kubernetes.io/managed-by": "radius-rp"
         },
-        "name": "azure-resources-container-httpbinding.backend",
+        "name": "azure-resources-container-httpbinding-backend",
         "namespace": "default"
     },
     "spec": {

--- a/pkg/cli/armtemplate/testdata/frontend-backend/HttpRoute-frontend.json
+++ b/pkg/cli/armtemplate/testdata/frontend-backend/HttpRoute-frontend.json
@@ -15,7 +15,7 @@
             "app.kubernetes.io/part-of": "azure-resources-container-httpbinding",
             "app.kubernetes.io/managed-by": "radius-rp"
         },
-        "name": "frontend",
+        "name": "azure-resources-container-httpbinding.frontend",
         "namespace": "default"
     },
     "spec": {

--- a/pkg/cli/armtemplate/testdata/frontend-backend/HttpRoute-frontend.json
+++ b/pkg/cli/armtemplate/testdata/frontend-backend/HttpRoute-frontend.json
@@ -15,7 +15,7 @@
             "app.kubernetes.io/part-of": "azure-resources-container-httpbinding",
             "app.kubernetes.io/managed-by": "radius-rp"
         },
-        "name": "azure-resources-container-httpbinding.frontend",
+        "name": "azure-resources-container-httpbinding-frontend",
         "namespace": "default"
     },
     "spec": {

--- a/pkg/kubernetes/controllers/bicep/deploymenttemplate_controller.go
+++ b/pkg/kubernetes/controllers/bicep/deploymenttemplate_controller.go
@@ -227,7 +227,7 @@ func (r *DeploymentTemplateReconciler) InvokeCustomAction(ctx context.Context, n
 		Kind:    armtemplate.GetKindFromArmType(targetID.Types[2].Type),
 	})
 
-	err = r.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: targetID.Types[2].Name}, &unst)
+	err = r.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: kubernetes.MakeResourceName(targetID.Types[1].Name, targetID.Types[2].Name)}, &unst)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve resource matching id %q: %w", id, err)
 	}

--- a/pkg/kubernetes/controllers/radius/resource_controller.go
+++ b/pkg/kubernetes/controllers/radius/resource_controller.go
@@ -397,7 +397,7 @@ func (r *ResourceReconciler) GetRenderDependency(ctx context.Context, namespace 
 
 	err := r.Client.Get(ctx, client.ObjectKey{
 		Namespace: namespace,
-		Name:      resourceType.Name,
+		Name:      kubernetes.MakeResourceName(id.Types[1].Name, id.Types[2].Name),
 	}, unst)
 	if err != nil {
 		// TODO make this wait without an error?

--- a/pkg/kubernetes/controllers/radius/resource_controller.go
+++ b/pkg/kubernetes/controllers/radius/resource_controller.go
@@ -170,7 +170,7 @@ func (r *ResourceReconciler) FetchKubernetesResources(ctx context.Context, log l
 	results := []client.Object{}
 
 	deployments := &appsv1.DeploymentList{}
-	err := r.Client.List(ctx, deployments, client.InNamespace(resource.Namespace), client.MatchingFields{CacheKeyController: resource.Name})
+	err := r.Client.List(ctx, deployments, client.InNamespace(resource.Namespace), client.MatchingFields{CacheKeyController: resource.Kind + resource.Name})
 	if err != nil {
 		log.Error(err, "failed to retrieve deployments")
 		return nil, err
@@ -182,7 +182,7 @@ func (r *ResourceReconciler) FetchKubernetesResources(ctx context.Context, log l
 	}
 
 	services := &corev1.ServiceList{}
-	err = r.Client.List(ctx, services, client.InNamespace(resource.Namespace), client.MatchingFields{CacheKeyController: resource.Name})
+	err = r.Client.List(ctx, services, client.InNamespace(resource.Namespace), client.MatchingFields{CacheKeyController: resource.Kind + resource.Name})
 	if err != nil {
 		log.Error(err, "failed to retrieve services")
 		return nil, err

--- a/pkg/kubernetes/controllers/radius/resource_controller_test.go
+++ b/pkg/kubernetes/controllers/radius/resource_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/Azure/radius/pkg/azure/azresources"
+	"github.com/Azure/radius/pkg/kubernetes"
 	radiusv1alpha3 "github.com/Azure/radius/pkg/kubernetes/api/radius/v1alpha3"
 	"github.com/Azure/radius/pkg/renderers"
 	"github.com/Azure/radius/pkg/resourcemodel"
@@ -48,7 +49,7 @@ func Test_GetRenderDependency(t *testing.T) {
 			Kind:       "ContainerComponent",
 		},
 		ObjectMeta: v1.ObjectMeta{
-			Name:      ResourceName,
+			Name:      kubernetes.MakeResourceName(ApplicationName, ResourceName),
 			Namespace: Namespace,
 		},
 		Spec: radiusv1alpha3.ResourceSpec{

--- a/pkg/kubernetes/converters/converters.go
+++ b/pkg/kubernetes/converters/converters.go
@@ -42,7 +42,7 @@ func ConvertToARMResource(original *radiusv1alpha3.Resource, body map[string]int
 }
 
 func ConvertToRenderResource(original *radiusv1alpha3.Resource, result *renderers.RendererResource) error {
-	result.ResourceName = original.Name
+	result.ResourceName = original.Spec.Resource
 	result.ResourceType = original.Annotations[kubernetes.LabelRadiusResourceType]
 	result.ApplicationName = original.Spec.Application
 

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -48,7 +48,7 @@ func MakeDescriptiveLabels(application string, resource string) map[string]strin
 	return map[string]string{
 		LabelRadiusApplication: application,
 		LabelRadiusResource:    resource,
-		LabelName:              resource,
+		LabelName:              application + "." + resource,
 		LabelPartOf:            application,
 		LabelManagedBy:         LabelManagedByRadiusRP,
 	}

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -104,3 +104,7 @@ func MakeResourceCRDLabels(application string, resourceType string, resource str
 		LabelManagedBy:         LabelManagedByRadiusRP,
 	}
 }
+
+func MakeResourceName(application string, resource string) string {
+	return application + "." + resource
+}

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -48,7 +48,7 @@ func MakeDescriptiveLabels(application string, resource string) map[string]strin
 	return map[string]string{
 		LabelRadiusApplication: application,
 		LabelRadiusResource:    resource,
-		LabelName:              application + "." + resource,
+		LabelName:              MakeResourceName(application, resource),
 		LabelPartOf:            application,
 		LabelManagedBy:         LabelManagedByRadiusRP,
 	}
@@ -106,5 +106,5 @@ func MakeResourceCRDLabels(application string, resourceType string, resource str
 }
 
 func MakeResourceName(application string, resource string) string {
-	return application + "." + resource
+	return application + "-" + resource
 }

--- a/pkg/renderers/containerv1alpha3/render.go
+++ b/pkg/renderers/containerv1alpha3/render.go
@@ -236,7 +236,7 @@ func (r Renderer) makeDeployment(ctx context.Context, resource renderers.Rendere
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      resource.ResourceName,
+			Name:      kubernetes.MakeResourceName(resource.ApplicationName, resource.ResourceName),
 			Namespace: resource.ApplicationName,
 			Labels:    kubernetes.MakeDescriptiveLabels(resource.ApplicationName, resource.ResourceName),
 		},

--- a/pkg/renderers/httproutev1alpha3/render.go
+++ b/pkg/renderers/httproutev1alpha3/render.go
@@ -39,13 +39,13 @@ func (r Renderer) Render(ctx context.Context, resource renderers.RendererResourc
 
 	computedValues := map[string]renderers.ComputedValueReference{
 		"host": {
-			Value: resource.ResourceName,
+			Value: kubernetes.MakeResourceName(resource.ApplicationName, resource.ResourceName),
 		},
 		"port": {
 			Value: route.GetEffectivePort(),
 		},
 		"url": {
-			Value: fmt.Sprintf("http://%s:%d", resource.ResourceName, route.GetEffectivePort()),
+			Value: fmt.Sprintf("http://%s:%d", kubernetes.MakeResourceName(resource.ApplicationName, resource.ResourceName), route.GetEffectivePort()),
 		},
 		"scheme": {
 			Value: "http",
@@ -104,7 +104,7 @@ func (r *Renderer) makeIngress(resource renderers.RendererResource, route HttpRo
 			APIVersion: networkingv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      resource.ResourceName,
+			Name:      kubernetes.MakeResourceName(resource.ApplicationName, resource.ResourceName),
 			Namespace: resource.ApplicationName,
 			Labels:    kubernetes.MakeDescriptiveLabels(resource.ApplicationName, resource.ResourceName),
 		},

--- a/pkg/renderers/httproutev1alpha3/render.go
+++ b/pkg/renderers/httproutev1alpha3/render.go
@@ -76,7 +76,7 @@ func (r *Renderer) makeService(resource renderers.RendererResource, route HttpRo
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      resource.ResourceName,
+			Name:      kubernetes.MakeResourceName(resource.ApplicationName, resource.ResourceName),
 			Namespace: resource.ApplicationName,
 			Labels:    kubernetes.MakeDescriptiveLabels(resource.ApplicationName, resource.ResourceName),
 		},

--- a/pkg/renderers/httproutev1alpha3/render_test.go
+++ b/pkg/renderers/httproutev1alpha3/render_test.go
@@ -7,6 +7,7 @@ package httproutev1alpha3
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/Azure/radius/pkg/kubernetes"
@@ -48,10 +49,10 @@ func Test_Render_Defaults(t *testing.T) {
 	require.Empty(t, output.SecretValues)
 
 	expectedValues := map[string]renderers.ComputedValueReference{
-		"host":   {Value: resourceName},
+		"host":   {Value: kubernetes.MakeResourceName(applicationName, resourceName)},
 		"port":   {Value: 80},
 		"scheme": {Value: "http"},
-		"url":    {Value: "http://test-route:80"},
+		"url":    {Value: fmt.Sprintf("http://%s:80", kubernetes.MakeResourceName(applicationName, resourceName))},
 	}
 	require.Equal(t, expectedValues, output.ComputedValues)
 
@@ -60,7 +61,7 @@ func Test_Render_Defaults(t *testing.T) {
 	expectedOutputResource := outputresource.NewKubernetesOutputResource(outputresource.LocalIDService, service, service.ObjectMeta)
 	require.Equal(t, expectedOutputResource, outputResource)
 
-	require.Equal(t, resourceName, service.Name)
+	require.Equal(t, kubernetes.MakeResourceName(resource.ApplicationName, resource.ResourceName), service.Name)
 	require.Equal(t, applicationName, service.Namespace)
 	require.Equal(t, kubernetes.MakeDescriptiveLabels(applicationName, resourceName), service.Labels)
 
@@ -98,10 +99,10 @@ func Test_Render_NonDefaults(t *testing.T) {
 	require.Empty(t, output.SecretValues)
 
 	expectedValues := map[string]renderers.ComputedValueReference{
-		"host":   {Value: resourceName},
+		"host":   {Value: kubernetes.MakeResourceName(applicationName, resourceName)},
 		"port":   {Value: 81},
 		"scheme": {Value: "http"},
-		"url":    {Value: "http://test-route:81"},
+		"url":    {Value: fmt.Sprintf("http://%s:81", kubernetes.MakeResourceName(applicationName, resourceName))},
 	}
 	require.Equal(t, expectedValues, output.ComputedValues)
 
@@ -110,7 +111,7 @@ func Test_Render_NonDefaults(t *testing.T) {
 	expectedOutputResource := outputresource.NewKubernetesOutputResource(outputresource.LocalIDService, service, service.ObjectMeta)
 	require.Equal(t, expectedOutputResource, outputResource)
 
-	require.Equal(t, resourceName, service.Name)
+	require.Equal(t, kubernetes.MakeResourceName(applicationName, resourceName), service.Name)
 	require.Equal(t, applicationName, service.Namespace)
 	require.Equal(t, kubernetes.MakeDescriptiveLabels(applicationName, resourceName), service.Labels)
 
@@ -153,10 +154,10 @@ func Test_Render_GatewayWithWildcardHostname(t *testing.T) {
 
 	// Adding a gateway has no effect on computed values.
 	expectedValues := map[string]renderers.ComputedValueReference{
-		"host":   {Value: resourceName},
+		"host":   {Value: kubernetes.MakeResourceName(applicationName, resourceName)},
 		"port":   {Value: 81},
 		"scheme": {Value: "http"},
-		"url":    {Value: "http://test-route:81"},
+		"url":    {Value: fmt.Sprintf("http://%s:81", kubernetes.MakeResourceName(applicationName, resourceName))},
 	}
 	require.Equal(t, expectedValues, output.ComputedValues)
 
@@ -164,7 +165,7 @@ func Test_Render_GatewayWithWildcardHostname(t *testing.T) {
 	expectedOutputResource := outputresource.NewKubernetesOutputResource(outputresource.LocalIDIngress, ingress, ingress.ObjectMeta)
 	require.Equal(t, expectedOutputResource, outputResource)
 
-	require.Equal(t, resourceName, ingress.Name)
+	require.Equal(t, kubernetes.MakeResourceName(applicationName, resourceName), ingress.Name)
 	require.Equal(t, applicationName, ingress.Namespace)
 	require.Equal(t, kubernetes.MakeDescriptiveLabels(applicationName, resourceName), ingress.Labels)
 
@@ -204,7 +205,7 @@ func Test_Render_WithHostname(t *testing.T) {
 	expectedOutputResource := outputresource.NewKubernetesOutputResource(outputresource.LocalIDIngress, ingress, ingress.ObjectMeta)
 	require.Equal(t, expectedOutputResource, outputResource)
 
-	require.Equal(t, resourceName, ingress.Name)
+	require.Equal(t, kubernetes.MakeResourceName(applicationName, resourceName), ingress.Name)
 	require.Equal(t, applicationName, ingress.Namespace)
 	require.Equal(t, kubernetes.MakeDescriptiveLabels(applicationName, resourceName), ingress.Labels)
 

--- a/pkg/renderers/mongodbv1alpha3/kubernetesrenderer_test.go
+++ b/pkg/renderers/mongodbv1alpha3/kubernetesrenderer_test.go
@@ -88,7 +88,7 @@ func Test_KubernetesRenderer_MakeSecret(t *testing.T) {
 		Namespace:         "test-namespace",
 		Name:              "test-name",
 	}
-	secret := renderer.MakeSecret(options, resourceName, "test-username", "test-password")
+	secret := renderer.MakeSecret(options, "test-username", "test-password")
 
 	expected := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
@@ -104,7 +104,7 @@ func Test_KubernetesRenderer_MakeSecret(t *testing.T) {
 		Data: map[string][]byte{
 			SecretKeyMongoDBAdminUsername:    []byte("test-username"),
 			SecretKeyMongoDBAdminPassword:    []byte("test-password"),
-			SecretKeyMongoDBConnectionString: []byte("mongodb://test-username:test-password@test-db:27017/admin"),
+			SecretKeyMongoDBConnectionString: []byte("mongodb://test-username:test-password@test-name:27017/admin"),
 		},
 	}
 

--- a/pkg/renderers/redisv1alpha3/kubernetesrender.go
+++ b/pkg/renderers/redisv1alpha3/kubernetesrender.go
@@ -81,7 +81,7 @@ func GetKubernetesRedis(resource renderers.RendererResource, properties RedisCom
 			APIVersion: appsv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   resource.ResourceName,
+			Name:   kubernetes.MakeResourceName(resource.ApplicationName, resource.ResourceName),
 			Labels: kubernetes.MakeDescriptiveLabels(resource.ApplicationName, resource.ResourceName),
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/pkg/renderers/redisv1alpha3/kubernetesrender.go
+++ b/pkg/renderers/redisv1alpha3/kubernetesrender.go
@@ -49,7 +49,7 @@ func (r *KubernetesRenderer) Render(ctx context.Context, resource renderers.Rend
 	// For now we don't know the namespace during rendering and so we can't generate a FQDN, so use a simple
 	// one. This should be fine because all of the application's pods are in the same namespace as this
 	// service.
-	host := resource.ResourceName
+	host := kubernetes.MakeResourceName(resource.ApplicationName, resource.ResourceName)
 	port := fmt.Sprint(Port)
 	output := renderers.RendererOutput{
 		Resources: resources,
@@ -121,7 +121,7 @@ func GetKubernetesRedis(resource renderers.RendererResource, properties RedisCom
 			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   resource.ResourceName,
+			Name:   kubernetes.MakeResourceName(resource.ApplicationName, resource.ResourceName),
 			Labels: kubernetes.MakeDescriptiveLabels(resource.ApplicationName, resource.ResourceName),
 		},
 		Spec: corev1.ServiceSpec{

--- a/pkg/renderers/redisv1alpha3/kubernetesrender_test.go
+++ b/pkg/renderers/redisv1alpha3/kubernetesrender_test.go
@@ -57,7 +57,6 @@ func Test_Render_Managed_Kubernetes_Success(t *testing.T) {
 
 	t.Run("verify deployment", func(t *testing.T) {
 		require.Equal(t, "test-app.test-redis", deployment.Name)
-		require.Equal(t, "default", deployment.Namespace)
 		require.Equal(t, labels, deployment.Labels)
 		require.Empty(t, deployment.Annotations)
 
@@ -80,7 +79,6 @@ func Test_Render_Managed_Kubernetes_Success(t *testing.T) {
 
 	t.Run("verify service", func(t *testing.T) {
 		require.Equal(t, "test-app.test-redis", service.Name)
-		require.Equal(t, "default", service.Namespace)
 		require.Equal(t, labels, service.Labels)
 		require.Empty(t, service.Annotations)
 

--- a/pkg/renderers/redisv1alpha3/kubernetesrender_test.go
+++ b/pkg/renderers/redisv1alpha3/kubernetesrender_test.go
@@ -64,7 +64,8 @@ func Test_Render_Managed_Kubernetes_Success(t *testing.T) {
 		kubernetes.LabelRadiusResource:    "test-redis",
 	}
 	t.Run("verify deployment", func(t *testing.T) {
-		require.Equal(t, "test-redis", deployment.Name)
+		require.Equal(t, "test-app.test-redis", deployment.Name)
+		require.Equal(t, "default", deployment.Namespace)
 		require.Equal(t, labels, deployment.Labels)
 		require.Empty(t, deployment.Annotations)
 
@@ -86,7 +87,8 @@ func Test_Render_Managed_Kubernetes_Success(t *testing.T) {
 	})
 
 	t.Run("verify service", func(t *testing.T) {
-		require.Equal(t, "test-redis", service.Name)
+		require.Equal(t, "test-app.test-redis", service.Name)
+		require.Equal(t, "default", service.Namespace)
 		require.Equal(t, labels, service.Labels)
 		require.Empty(t, service.Annotations)
 

--- a/pkg/renderers/redisv1alpha3/kubernetesrender_test.go
+++ b/pkg/renderers/redisv1alpha3/kubernetesrender_test.go
@@ -97,7 +97,7 @@ func Test_Render_Managed_Kubernetes_Success(t *testing.T) {
 
 	expectedComputedValues := map[string]renderers.ComputedValueReference{
 		"host": {
-			Value: "test-redis",
+			Value: "test-app.test-redis",
 		},
 		"port": {
 			Value: "6379",

--- a/pkg/renderers/redisv1alpha3/kubernetesrender_test.go
+++ b/pkg/renderers/redisv1alpha3/kubernetesrender_test.go
@@ -51,18 +51,10 @@ func Test_Render_Managed_Kubernetes_Success(t *testing.T) {
 	service, _ := kubernetes.FindService(output.Resources)
 	require.NotNil(t, service)
 
-	labels := map[string]string{
-		kubernetes.LabelRadiusApplication: "test-app",
-		kubernetes.LabelRadiusResource:    "test-redis",
-		kubernetes.LabelName:              "test-redis",
-		kubernetes.LabelPartOf:            "test-app",
-		kubernetes.LabelManagedBy:         kubernetes.LabelManagedByRadiusRP,
-	}
+	labels := kubernetes.MakeDescriptiveLabels("test-app", "test-redis")
 
-	matchLabels := map[string]string{
-		kubernetes.LabelRadiusApplication: "test-app",
-		kubernetes.LabelRadiusResource:    "test-redis",
-	}
+	matchLabels := kubernetes.MakeSelectorLabels("test-app", "test-redis")
+
 	t.Run("verify deployment", func(t *testing.T) {
 		require.Equal(t, "test-app.test-redis", deployment.Name)
 		require.Equal(t, "default", deployment.Namespace)

--- a/pkg/renderers/redisv1alpha3/kubernetesrender_test.go
+++ b/pkg/renderers/redisv1alpha3/kubernetesrender_test.go
@@ -56,7 +56,7 @@ func Test_Render_Managed_Kubernetes_Success(t *testing.T) {
 	matchLabels := kubernetes.MakeSelectorLabels("test-app", "test-redis")
 
 	t.Run("verify deployment", func(t *testing.T) {
-		require.Equal(t, "test-app.test-redis", deployment.Name)
+		require.Equal(t, "test-app-test-redis", deployment.Name)
 		require.Equal(t, labels, deployment.Labels)
 		require.Empty(t, deployment.Annotations)
 
@@ -78,7 +78,7 @@ func Test_Render_Managed_Kubernetes_Success(t *testing.T) {
 	})
 
 	t.Run("verify service", func(t *testing.T) {
-		require.Equal(t, "test-app.test-redis", service.Name)
+		require.Equal(t, "test-app-test-redis", service.Name)
 		require.Equal(t, labels, service.Labels)
 		require.Empty(t, service.Annotations)
 
@@ -95,7 +95,7 @@ func Test_Render_Managed_Kubernetes_Success(t *testing.T) {
 
 	expectedComputedValues := map[string]renderers.ComputedValueReference{
 		"host": {
-			Value: "test-app.test-redis",
+			Value: "test-app-test-redis",
 		},
 		"port": {
 			Value: "6379",

--- a/test/functional/kubernetes/resources/testdata/kubernetes-resources-container-httpbinding.bicep
+++ b/test/functional/kubernetes/resources/testdata/kubernetes-resources-container-httpbinding.bicep
@@ -2,7 +2,7 @@ resource app 'radius.dev/Application@v1alpha3' = {
   name: 'kubernetes-resources-container-httpbinding'
 
   resource frontendhttp 'HttpRoute' = {
-    name: 'frontend'
+    name: 'frontendhttp'
     properties: {
       port: 80
       gateway: {
@@ -36,7 +36,7 @@ resource app 'radius.dev/Application@v1alpha3' = {
     }
   }
   resource backendhttp 'HttpRoute' = {
-    name: 'backend'
+    name: 'backendhttp'
   }
   resource backend 'ContainerComponent' = {
     name: 'backend'

--- a/test/functional/kubernetes/resources/testdata/kubernetes-resources-container-httpbinding.bicep
+++ b/test/functional/kubernetes/resources/testdata/kubernetes-resources-container-httpbinding.bicep
@@ -2,7 +2,7 @@ resource app 'radius.dev/Application@v1alpha3' = {
   name: 'kubernetes-resources-container-httpbinding'
 
   resource frontendhttp 'HttpRoute' = {
-    name: 'frontendhttp'
+    name: 'frontend'
     properties: {
       port: 80
       gateway: {
@@ -36,7 +36,7 @@ resource app 'radius.dev/Application@v1alpha3' = {
     }
   }
   resource backendhttp 'HttpRoute' = {
-    name: 'backendhttp'
+    name: 'backend'
   }
   resource backend 'ContainerComponent' = {
     name: 'backend'

--- a/test/kubernetestest/controllertest.go
+++ b/test/kubernetestest/controllertest.go
@@ -349,5 +349,5 @@ func extractOwnerKey(obj client.Object) []string {
 		return nil
 	}
 
-	return []string{owner.Name}
+	return []string{owner.Kind + owner.Name}
 }


### PR DESCRIPTION
If two applications are deployed to the same namespace, they will conflict with each other. This change will prefix the name with the application name.