### PR TITLE
Add support for programmatic access to secrets

### DIFF
--- a/pkg/azure/clients/customaction.go
+++ b/pkg/azure/clients/customaction.go
@@ -23,8 +23,8 @@ type CustomActionResponse struct {
 	Response autorest.Response
 }
 
-func (client CustomActionClient) InvokeCustomAction(ctx context.Context, id string, apiVersion string, action string) (result CustomActionResponse, err error) {
-	req, err := client.InvokeCustomActionPreparer(ctx, id, apiVersion, action)
+func (client CustomActionClient) InvokeCustomAction(ctx context.Context, id string, apiVersion string, action string, body interface{}) (result CustomActionResponse, err error) {
+	req, err := client.InvokeCustomActionPreparer(ctx, id, apiVersion, action, body)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "CustomActionClient", "InvokeCustomAction", nil, "Failure preparing request")
 		return
@@ -45,9 +45,9 @@ func (client CustomActionClient) InvokeCustomAction(ctx context.Context, id stri
 	return
 }
 
-func (client CustomActionClient) InvokeCustomActionPreparer(ctx context.Context, id string, apiVersion string, action string) (*http.Request, error) {
+func (client CustomActionClient) InvokeCustomActionPreparer(ctx context.Context, id string, apiVersion string, action string, body interface{}) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"id":     autorest.Encode("path", id),
+		"id":     autorest.Encode("none", id),
 		"action": autorest.Encode("path", action),
 	}
 
@@ -61,6 +61,10 @@ func (client CustomActionClient) InvokeCustomActionPreparer(ctx context.Context,
 		autorest.WithBaseURL(client.BaseURI),
 		autorest.WithPathParameters("{id}/{action}", pathParameters),
 		autorest.WithQueryParameters(queryParameters))
+	if body != nil {
+		preparer = autorest.DecoratePreparer(preparer, autorest.WithJSON(body))
+	}
+
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
 

--- a/pkg/radrp/backend/deployment/mock_deploymentprocessor.go
+++ b/pkg/radrp/backend/deployment/mock_deploymentprocessor.go
@@ -63,3 +63,18 @@ func (mr *MockDeploymentProcessorMockRecorder) Deploy(arg0, arg1, arg2 interface
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deploy", reflect.TypeOf((*MockDeploymentProcessor)(nil).Deploy), arg0, arg1, arg2)
 }
+
+// FetchSecrets mocks base method.
+func (m *MockDeploymentProcessor) FetchSecrets(arg0 context.Context, arg1 azresources.ResourceID, arg2 db.RadiusResource) (map[string]interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchSecrets", arg0, arg1, arg2)
+	ret0, _ := ret[0].(map[string]interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchSecrets indicates an expected call of FetchSecrets.
+func (mr *MockDeploymentProcessorMockRecorder) FetchSecrets(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchSecrets", reflect.TypeOf((*MockDeploymentProcessor)(nil).FetchSecrets), arg0, arg1, arg2)
+}

--- a/pkg/radrp/frontend/handlerv3/handler.go
+++ b/pkg/radrp/frontend/handlerv3/handler.go
@@ -7,6 +7,7 @@ package handlerv3
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -216,6 +217,34 @@ func (h *handler) DeleteResource(w http.ResponseWriter, req *http.Request) {
 func (h *handler) GetOperation(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	response, err := h.rp.GetOperation(ctx, resourceID(req))
+	if err != nil {
+		internalServerError(ctx, w, req, err)
+		return
+	}
+
+	err = response.Apply(ctx, w, req)
+	if err != nil {
+		internalServerError(ctx, w, req, err)
+		return
+	}
+}
+
+func (h *handler) ListSecrets(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	body, err := readJSONBody(req)
+	if err != nil {
+		badRequest(ctx, w, req, err)
+		return
+	}
+
+	input := resourceproviderv3.ListSecretsInput{}
+	err = json.Unmarshal(body, &input)
+	if err != nil {
+		badRequest(ctx, w, req, err)
+		return
+	}
+
+	response, err := h.rp.ListSecrets(ctx, input)
 	if err != nil {
 		internalServerError(ctx, w, req, err)
 		return

--- a/pkg/radrp/frontend/handlerv3/routes.go
+++ b/pkg/radrp/frontend/handlerv3/routes.go
@@ -22,10 +22,14 @@ func AddRoutes(rp resourceproviderv3.ResourceProvider, router *mux.Router, valid
 	h := handler{rp: rp, validatorFactory: validatorFactory}
 	var subrouter *mux.Router
 
-	var applicationCollectionPath = fmt.Sprintf(
-		"/subscriptions/{%s}/resourceGroups/{%s}/providers/Microsoft.CustomProviders/resourceProviders/radiusv3/Application",
+	var providerPath = fmt.Sprintf(
+		"/subscriptions/{%s}/resourceGroups/{%s}/providers/Microsoft.CustomProviders/resourceProviders/radiusv3",
 		azresources.SubscriptionIDKey,
 		azresources.ResourceGroupKey)
+
+	router.Path(fmt.Sprintf("%s/listSecrets", providerPath)).Methods("POST").HandlerFunc(h.ListSecrets)
+
+	var applicationCollectionPath = fmt.Sprintf("%s/Application", providerPath)
 	var applicationItemPath = fmt.Sprintf("%s/{%s}", applicationCollectionPath, azresources.ApplicationNameKey)
 
 	var resourceCollectionPath = fmt.Sprintf("%s/{%s}", applicationItemPath, azresources.ResourceTypeKey)

--- a/pkg/radrp/frontend/resourceproviderv3/mock_resourceprovider.go
+++ b/pkg/radrp/frontend/resourceproviderv3/mock_resourceprovider.go
@@ -156,6 +156,21 @@ func (mr *MockResourceProviderMockRecorder) ListResources(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResources", reflect.TypeOf((*MockResourceProvider)(nil).ListResources), arg0, arg1)
 }
 
+// ListSecrets mocks base method.
+func (m *MockResourceProvider) ListSecrets(arg0 context.Context, arg1 ListSecretsInput) (rest.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSecrets", arg0, arg1)
+	ret0, _ := ret[0].(rest.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSecrets indicates an expected call of ListSecrets.
+func (mr *MockResourceProviderMockRecorder) ListSecrets(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockResourceProvider)(nil).ListSecrets), arg0, arg1)
+}
+
 // UpdateApplication mocks base method.
 func (m *MockResourceProvider) UpdateApplication(arg0 context.Context, arg1 azresources.ResourceID, arg2 []byte) (rest.Response, error) {
 	m.ctrl.T.Helper()

--- a/pkg/radrp/frontend/resourceproviderv3/rest.go
+++ b/pkg/radrp/frontend/resourceproviderv3/rest.go
@@ -38,3 +38,9 @@ type RadiusResourceStatus = rest.ComponentStatus
 type RadiusResourceList struct {
 	Value []RadiusResource `json:"value"`
 }
+
+// ListSecretsInput is used for the RP's 'listSecrets' custom action.
+type ListSecretsInput struct {
+	// TargetID is the resource ID of the Radius resource for which secrets are being listed.
+	TargetID string `json:"targetId"`
+}

--- a/pkg/renderers/secretvalueclient.go
+++ b/pkg/renderers/secretvalueclient.go
@@ -32,7 +32,7 @@ func (c *client) FetchSecret(ctx context.Context, identity resourcemodel.Resourc
 	}
 
 	custom := clients.NewCustomActionClient(c.ARM.SubscriptionID, c.ARM.Auth)
-	response, err := custom.InvokeCustomAction(ctx, arm.ID, arm.APIVersion, action)
+	response, err := custom.InvokeCustomAction(ctx, arm.ID, arm.APIVersion, action, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/test/functional/azure/mechanics/mechanics_test.go
+++ b/test/functional/azure/mechanics/mechanics_test.go
@@ -9,9 +9,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Azure/radius/pkg/azure/azresources"
+	"github.com/Azure/radius/pkg/keys"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
 	"github.com/Azure/radius/pkg/radrp/rest"
 	"github.com/Azure/radius/pkg/renderers/containerv1alpha3"
+	"github.com/Azure/radius/pkg/renderers/mongodbv1alpha3"
 	"github.com/Azure/radius/pkg/resourcekinds"
 	"github.com/Azure/radius/test/azuretest"
 	"github.com/Azure/radius/test/validation"
@@ -89,5 +92,65 @@ func Test_RedeployWithAnotherComponent(t *testing.T) {
 	})
 
 	test.Version = validation.AppModelV3
+	test.Test(t)
+}
+
+func Test_Secrets_Access(t *testing.T) {
+	application := "azure-mechanics-secrets-access"
+	template := "testdata/azure-mechanics-secrets-access.bicep"
+	test := azuretest.NewApplicationTest(t, application, []azuretest.Step{
+		{
+			Executor: azuretest.NewDeployStepExecutor(template),
+			AzureResources: &validation.AzureResourceSet{
+				Resources: []validation.ExpectedResource{
+					{
+						Type: azresources.DocumentDBDatabaseAccounts,
+						Tags: map[string]string{
+							keys.TagRadiusApplication: application,
+							keys.TagRadiusComponent:   "db",
+						},
+						Children: []validation.ExpectedChildResource{
+							{
+								Type: azresources.DocumentDBDatabaseAccountsMongodDBDatabases,
+								Name: "db",
+							},
+						},
+					},
+				},
+			},
+			Components: &validation.ComponentSet{
+				Components: []validation.Component{
+					{
+						ApplicationName: application,
+						ComponentName:   "todoapp",
+						ResourceType:    containerv1alpha3.ResourceType,
+						OutputResources: map[string]validation.ExpectedOutputResource{
+							outputresource.LocalIDDeployment: validation.NewOutputResource(outputresource.LocalIDDeployment, outputresource.TypeKubernetes, resourcekinds.Kubernetes, true, false, rest.OutputResourceStatus{}),
+							outputresource.LocalIDSecret:     validation.NewOutputResource(outputresource.LocalIDSecret, outputresource.TypeKubernetes, resourcekinds.Kubernetes, true, false, rest.OutputResourceStatus{}),
+						},
+					},
+					{
+						ApplicationName: application,
+						ComponentName:   "db",
+						ResourceType:    mongodbv1alpha3.ResourceType,
+						OutputResources: map[string]validation.ExpectedOutputResource{
+							outputresource.LocalIDAzureCosmosAccount: validation.NewOutputResource(outputresource.LocalIDAzureCosmosAccount, outputresource.TypeARM, resourcekinds.AzureCosmosAccount, true, false, rest.OutputResourceStatus{}),
+							outputresource.LocalIDAzureCosmosDBMongo: validation.NewOutputResource(outputresource.LocalIDAzureCosmosDBMongo, outputresource.TypeARM, resourcekinds.AzureCosmosDBMongo, true, false, rest.OutputResourceStatus{}),
+						},
+					},
+				},
+			},
+			Pods: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					application: {
+						validation.NewK8sObjectForComponent(application, "todoapp"),
+					},
+				},
+			},
+		},
+	})
+
+	test.Version = validation.AppModelV3
+
 	test.Test(t)
 }

--- a/test/functional/azure/mechanics/testdata/azure-mechanics-secrets-access.bicep
+++ b/test/functional/azure/mechanics/testdata/azure-mechanics-secrets-access.bicep
@@ -1,0 +1,29 @@
+
+resource app 'radius.dev/Application@v1alpha3' = {
+  name: 'azure-mechanics-secrets-access'
+
+  resource webapp 'ContainerComponent' = {
+    name: 'todoapp'
+    properties: {
+      connections: {
+        mongodb: {
+          kind: 'mongo.com/MongoDB'
+          source: db.id
+        }
+      }
+      container: {
+        image: 'radius.azurecr.io/magpie:latest'
+        env: {
+          DB_CONNECTION: db.connectionString()
+        }
+      }
+    }
+  }
+
+  resource db 'mongodb.com.MongoDBComponent' = {
+    name: 'db'
+    properties: {
+      managed: true
+    }
+  }
+}

--- a/test/functional/azure/mechanics/testdata/azure-mechanics-secrets-access.json
+++ b/test/functional/azure/mechanics/testdata/azure-mechanics-secrets-access.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.728.21257",
+      "templateHash": "5778095589702522590"
+    }
+  },
+  "functions": [],
+  "resources": [
+    {
+      "type": "Microsoft.CustomProviders/resourceProviders/Application/ContainerComponent",
+      "apiVersion": "2018-09-01-preview",
+      "name": "[format('{0}/{1}/{2}', 'radiusv3', 'azure-mechanics-secrets-access', 'todoapp')]",
+      "properties": {
+        "connections": {
+          "mongodb": {
+            "kind": "mongo.com/MongoDB",
+            "source": "[resourceId('Microsoft.CustomProviders/resourceProviders/Application/mongodb.com.MongoDBComponent', 'radiusv3', 'azure-mechanics-secrets-access', 'db')]"
+          }
+        },
+        "container": {
+          "image": "radius.azurecr.io/magpie:latest",
+          "env": {
+            "DB_CONNECTION": "[listSecrets(resourceId('Microsoft.CustomProviders/resourceProviders', 'radiusv3'), '2018-09-01-preview', createObject('targetId', resourceId('Microsoft.CustomProviders/resourceProviders/Application/mongodb.com.MongoDBComponent', 'radiusv3', 'azure-mechanics-secrets-access', 'db'))).connectionString]"
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.CustomProviders/resourceProviders/Application', 'radiusv3', 'azure-mechanics-secrets-access')]",
+        "[resourceId('Microsoft.CustomProviders/resourceProviders/Application/mongodb.com.MongoDBComponent', 'radiusv3', 'azure-mechanics-secrets-access', 'db')]"
+      ]
+    },
+    {
+      "type": "Microsoft.CustomProviders/resourceProviders/Application/mongodb.com.MongoDBComponent",
+      "apiVersion": "2018-09-01-preview",
+      "name": "[format('{0}/{1}/{2}', 'radiusv3', 'azure-mechanics-secrets-access', 'db')]",
+      "properties": {
+        "managed": true
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.CustomProviders/resourceProviders/Application', 'radiusv3', 'azure-mechanics-secrets-access')]"
+      ]
+    },
+    {
+      "type": "Microsoft.CustomProviders/resourceProviders/Application",
+      "apiVersion": "2018-09-01-preview",
+      "name": "[format('{0}/{1}', 'radiusv3', 'azure-mechanics-secrets-access')]"
+    }
+  ]
+}


### PR DESCRIPTION

This change adds support for programmatic access to secrets from ARM
using a function call. I've already added support for this in the Bicep
compiler, and it will translate the function call into the appropriate
call into the RP. This change adds the backend support and a test.

Example (db is a `mongodb.com.MongoComponent`):

`FOO: db.connectionString()`

This will resolve to a POST against our RP, which the changes in this PR
handle.