### PR TITLE
Add support for secret values in connection in k8s

### DIFF
--- a/deploy/Chart/crds/radius.dev_applications.yaml
+++ b/deploy/Chart/crds/radius.dev_applications.yaml
@@ -115,6 +115,9 @@ spec:
                       type: string
                   type: object
                 type: object
+              secretValues:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
             type: object
         type: object
     served: true

--- a/deploy/Chart/crds/radius.dev_containercomponents.yaml
+++ b/deploy/Chart/crds/radius.dev_containercomponents.yaml
@@ -126,6 +126,9 @@ spec:
                       type: string
                   type: object
                 type: object
+              secretValues:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
             type: object
         type: object
     served: true

--- a/deploy/Chart/crds/radius.dev_daprioinvokeroutes.yaml
+++ b/deploy/Chart/crds/radius.dev_daprioinvokeroutes.yaml
@@ -126,6 +126,9 @@ spec:
                       type: string
                   type: object
                 type: object
+              secretValues:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
             type: object
         type: object
     served: true

--- a/deploy/Chart/crds/radius.dev_dapriopubsubtopiccomponents.yaml
+++ b/deploy/Chart/crds/radius.dev_dapriopubsubtopiccomponents.yaml
@@ -126,6 +126,9 @@ spec:
                       type: string
                   type: object
                 type: object
+              secretValues:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
             type: object
         type: object
     served: true

--- a/deploy/Chart/crds/radius.dev_dapriostatestorecomponents.yaml
+++ b/deploy/Chart/crds/radius.dev_dapriostatestorecomponents.yaml
@@ -126,6 +126,9 @@ spec:
                       type: string
                   type: object
                 type: object
+              secretValues:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
             type: object
         type: object
     served: true

--- a/deploy/Chart/crds/radius.dev_grpcroutes.yaml
+++ b/deploy/Chart/crds/radius.dev_grpcroutes.yaml
@@ -126,6 +126,9 @@ spec:
                       type: string
                   type: object
                 type: object
+              secretValues:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
             type: object
         type: object
     served: true

--- a/deploy/Chart/crds/radius.dev_httproutes.yaml
+++ b/deploy/Chart/crds/radius.dev_httproutes.yaml
@@ -126,6 +126,9 @@ spec:
                       type: string
                   type: object
                 type: object
+              secretValues:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
             type: object
         type: object
     served: true

--- a/deploy/Chart/crds/radius.dev_mongodbcomponents.yaml
+++ b/deploy/Chart/crds/radius.dev_mongodbcomponents.yaml
@@ -126,6 +126,9 @@ spec:
                       type: string
                   type: object
                 type: object
+              secretValues:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
             type: object
         type: object
     served: true

--- a/deploy/Chart/crds/radius.dev_rabbitmqcomponents.yaml
+++ b/deploy/Chart/crds/radius.dev_rabbitmqcomponents.yaml
@@ -126,6 +126,9 @@ spec:
                       type: string
                   type: object
                 type: object
+              secretValues:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
             type: object
         type: object
     served: true

--- a/deploy/Chart/crds/radius.dev_rediscomponents.yaml
+++ b/deploy/Chart/crds/radius.dev_rediscomponents.yaml
@@ -126,6 +126,9 @@ spec:
                       type: string
                   type: object
                 type: object
+              secretValues:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
             type: object
         type: object
     served: true

--- a/deploy/Chart/crds/radius.dev_resources.yaml
+++ b/deploy/Chart/crds/radius.dev_resources.yaml
@@ -127,6 +127,9 @@ spec:
                       type: string
                   type: object
                 type: object
+              secretValues:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
             type: object
         type: object
     served: true

--- a/pkg/kubernetes/api/radius/v1alpha3/resource_types.go
+++ b/pkg/kubernetes/api/radius/v1alpha3/resource_types.go
@@ -30,6 +30,11 @@ type ResourceStatus struct {
 	ComputedValues *runtime.RawExtension `json:"computedValues,omitempty"`
 
 	// +optional
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:PreserveUnknownFields
+	SecretValues *runtime.RawExtension `json:"secretValues,omitempty"`
+
+	// +optional
 	Resources map[string]corev1.ObjectReference `json:"resources,omitempty"`
 
 	// +optional

--- a/pkg/kubernetes/api/radius/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/kubernetes/api/radius/v1alpha3/zz_generated.deepcopy.go
@@ -842,6 +842,11 @@ func (in *ResourceStatus) DeepCopyInto(out *ResourceStatus) {
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SecretValues != nil {
+		in, out := &in.SecretValues, &out.SecretValues
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources
 		*out = make(map[string]v1.ObjectReference, len(*in))

--- a/pkg/kubernetes/controllers/radius/resource_controller.go
+++ b/pkg/kubernetes/controllers/radius/resource_controller.go
@@ -7,10 +7,12 @@ package controllers
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"time"
 
+	"github.com/Azure/radius/pkg/azure/azresources"
 	"github.com/Azure/radius/pkg/cli/armtemplate"
 	"github.com/Azure/radius/pkg/kubernetes"
 	radiusv1alpha3 "github.com/Azure/radius/pkg/kubernetes/api/radius/v1alpha3"
@@ -225,57 +227,27 @@ func (r *ResourceReconciler) RenderResource(ctx context.Context, req ctrl.Reques
 	}
 
 	deps := map[string]renderers.RendererDependency{}
-
 	for _, reference := range references {
-		// Get resource filtered on application type.
-		resourceType := reference.Types[len(reference.Types)-1]
-		unst := &unstructured.Unstructured{}
-
-		// TODO determine this correctly
-		unst.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   "radius.dev",
-			Version: "v1alpha3",
-			Kind:    armtemplate.GetKindFromArmType(resourceType.Type),
-		})
-
-		err = r.Client.Get(ctx, client.ObjectKey{
-			Namespace: req.Namespace,
-			Name:      resourceType.Name,
-		}, unst)
+		dependency, err := r.GetRenderDependency(ctx, req.Namespace, reference)
 		if err != nil {
-			// TODO make this wait without an error?
+			err = fmt.Errorf("failed to fetch rendering dependency %q of resource %q: %w", reference, resource.Name, err)
+			r.recorder.Eventf(resource, "Warning", "Invalid", "Resource could not get dependencies", err)
+			log.Error(err, "failed to render resource")
 			return nil, false, err
 		}
 
-		k8sResource := &radiusv1alpha3.Resource{}
-		err = runtime.DefaultUnstructuredConverter.FromUnstructured(unst.Object, k8sResource)
-		if err != nil {
-			return nil, false, err
-		}
-
-		computedValues := map[string]interface{}{}
-
-		err = json.Unmarshal(k8sResource.Status.ComputedValues.Raw, &computedValues)
-		if err != nil {
-			return nil, false, err
-		}
-
-		deps[reference.ID] = renderers.RendererDependency{
-			ComputedValues: computedValues,
-			ResourceID:     reference,
-			Definition:     unst.Object,
-		}
+		deps[reference.ID] = *dependency
 	}
 
-	resources, err := resourceType.Renderer().Render(ctx, *w, deps)
+	output, err := resourceType.Renderer().Render(ctx, *w, deps)
 	if err != nil {
 		r.recorder.Eventf(resource, "Warning", "Invalid", "Resource had errors during rendering: %v'", err)
 		log.Error(err, "failed to render resources for resource")
 		return nil, false, err
 	}
 
-	log.Info("rendered output resources", "count", len(resources.Resources))
-	return &resources, true, nil
+	log.Info("rendered output resources", "count", len(output.Resources))
+	return &output, true, nil
 }
 
 func (r *ResourceReconciler) ApplyState(
@@ -383,6 +355,14 @@ func (r *ResourceReconciler) ApplyState(
 		resource.Status.ComputedValues = &runtime.RawExtension{Raw: data}
 	}
 
+	if desired.SecretValues != nil {
+		data, err := json.Marshal(desired.ComputedValues)
+		if err != nil {
+			return err
+		}
+		resource.Status.SecretValues = &runtime.RawExtension{Raw: data}
+	}
+
 	// Can't use resource type to update as it will assume the wrong type
 	unst, err := runtime.DefaultUnstructuredConverter.ToUnstructured(resource)
 	if err != nil {
@@ -400,6 +380,119 @@ func (r *ResourceReconciler) ApplyState(
 
 	log.Info("applied output resources", "count", len(desired.Resources), "deleted", len(actual))
 	return nil
+}
+
+func (r *ResourceReconciler) GetRenderDependency(ctx context.Context, namespace string, id azresources.ResourceID) (*renderers.RendererDependency, error) {
+	// Find the Kubernetes resource based on the resourceID.
+	if len(id.Types) < 3 {
+		return nil, fmt.Errorf("dependency %q is not a radius resource", id)
+	}
+
+	resourceType := id.Types[2]
+	unst := &unstructured.Unstructured{}
+
+	// TODO determine this correctly
+	unst.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "radius.dev",
+		Version: "v1alpha3",
+		Kind:    armtemplate.GetKindFromArmType(resourceType.Type),
+	})
+
+	err := r.Client.Get(ctx, client.ObjectKey{
+		Namespace: namespace,
+		Name:      resourceType.Name,
+	}, unst)
+	if err != nil {
+		// TODO make this wait without an error?
+		return nil, err
+	}
+
+	k8sResource := &radiusv1alpha3.Resource{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unst.Object, k8sResource)
+	if err != nil {
+		return nil, err
+	}
+
+	// The 'Definition' we provide to a dependency is actually the 'properties' node
+	// of the ARM resource. Since 'spec.Template' stores the whole ARM resource we need
+	// to drill down into 'properties'.
+	body := map[string]interface{}{}
+	err = json.Unmarshal(k8sResource.Spec.Template.Raw, &body)
+	if err != nil {
+		return nil, err
+	}
+
+	properties := map[string]interface{}{}
+	obj, ok := body["properties"]
+	if ok {
+		// If properties is present it should be an object. It's not required in all cases.
+		properties, ok = obj.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("expected %q to be a JSON object", "properties")
+		}
+	}
+
+	// The 'ComputedValues' we provide to the dependency are a combination of the computed values
+	// we store in status, and secrets we store separately.
+	values := map[string]interface{}{}
+
+	computedValues := map[string]renderers.ComputedValueReference{}
+	if k8sResource.Status.ComputedValues != nil {
+		err = json.Unmarshal(k8sResource.Status.ComputedValues.Raw, &computedValues)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for k, v := range computedValues {
+		values[k] = v.Value
+	}
+
+	// The 'SecretValues' we store as part of the resource status (from render output) are references
+	// to secrets, we need to fetch the values and pass them to the renderer.
+	secretValues := map[string]renderers.SecretValueReference{}
+	if k8sResource.Status.SecretValues != nil {
+		err = json.Unmarshal(k8sResource.Status.SecretValues.Raw, &secretValues)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for k, v := range secretValues {
+		// Each value needs to be looked up in a secret where it's stored. The reference
+		// to the secret will be in the output resources.
+		secretRef, ok := k8sResource.Status.Resources[v.LocalID]
+		if !ok {
+			return nil, fmt.Errorf("could not find a matching resource for LocalID %q", v.LocalID)
+		}
+
+		secret := corev1.Secret{}
+		err = r.Client.Get(ctx, client.ObjectKey{Namespace: secretRef.Namespace, Name: secretRef.Name}, &secret)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve secret of dependency: %w", err)
+		}
+
+		encodedValue, ok := secret.Data[v.ValueSelector]
+		if !ok {
+			return nil, fmt.Errorf("secret did contain expected key: %q", v.ValueSelector)
+		}
+
+		// Right now we just assume the value is a string.
+		//
+		// NOTE: Kubernetes secrets are stored as base64 encoded text.
+		decodedValue, err := base64.RawStdEncoding.DecodeString(string(encodedValue))
+		if err != nil {
+			return nil, err
+		}
+
+		values[k] = string(decodedValue)
+	}
+
+	return &renderers.RendererDependency{
+		ComputedValues: values,
+		ResourceID:     id,
+		Definition:     properties,
+	}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/kubernetes/controllers/radius/resource_controller_test.go
+++ b/pkg/kubernetes/controllers/radius/resource_controller_test.go
@@ -1,0 +1,133 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package controllers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/radius/pkg/azure/azresources"
+	radiusv1alpha3 "github.com/Azure/radius/pkg/kubernetes/api/radius/v1alpha3"
+	"github.com/Azure/radius/pkg/renderers"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	Namespace       = "test-namespace"
+	ApplicationName = "test-application"
+	ResourceName    = "test-resource"
+)
+
+var resourceID = azresources.MakeID(
+	"kubernetes",
+	Namespace,
+	azresources.ResourceType{Type: "Microsoft.CustomProviders/resourceProviders", Name: "radiusv3"},
+	azresources.ResourceType{Type: "Application", Name: ApplicationName},
+	azresources.ResourceType{Type: "ContainerComponent", Name: ResourceName})
+
+func Test_GetRenderDependency(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(radiusv1alpha3.AddToScheme(scheme))
+
+	// Simulate a *rendered* component
+	resource := radiusv1alpha3.ContainerComponent{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: radiusv1alpha3.GroupVersion.String(),
+			Kind:       "ContainerComponent",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      ResourceName,
+			Namespace: Namespace,
+		},
+		Spec: radiusv1alpha3.ResourceSpec{
+			Template: rawOrPanic(map[string]interface{}{
+				"properties": map[string]interface{}{
+					"definition-property": "definition-value",
+				},
+			}),
+		},
+		Status: radiusv1alpha3.ResourceStatus{
+			Resources: map[string]corev1.ObjectReference{
+				"SecretLocalID": {
+					Namespace:  Namespace,
+					Name:       "some-secret",
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+			},
+			ComputedValues: rawOrPanic(map[string]renderers.ComputedValueReference{
+				"computed-property": {
+					Value: "computed-value",
+				},
+			}),
+			SecretValues: rawOrPanic(map[string]renderers.SecretValueReference{
+				"secret-property": {
+					LocalID:       "SecretLocalID",
+					ValueSelector: "secret-key",
+				},
+			}),
+		},
+	}
+
+	// And the secret that holds the secret values
+	secret := corev1.Secret{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "some-secret",
+			Namespace: Namespace,
+		},
+		Data: map[string][]byte{
+			"secret-key": []byte(base64.RawStdEncoding.EncodeToString([]byte("secret-value"))),
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&resource, &secret).Build()
+
+	controller := ResourceReconciler{
+		Client: c,
+	}
+
+	id, err := azresources.Parse(resourceID)
+	require.NoError(t, err)
+
+	dependency, err := controller.GetRenderDependency(context.Background(), Namespace, id)
+	require.NoError(t, err)
+	require.NotNil(t, dependency)
+
+	expected := renderers.RendererDependency{
+		ResourceID: id,
+		Definition: map[string]interface{}{
+			"definition-property": "definition-value",
+		},
+		ComputedValues: map[string]interface{}{
+			"computed-property": "computed-value",
+			"secret-property":   "secret-value",
+		},
+	}
+
+	require.Equal(t, expected, *dependency)
+}
+
+func rawOrPanic(obj interface{}) *runtime.RawExtension {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		panic(err)
+	}
+
+	return &runtime.RawExtension{Raw: b}
+}


### PR DESCRIPTION
This change enables the use of secrets in Kuberentes from inside the
renderer. The current code only provides the renderer access to the
non-secret values, so secrets would be omitted.

Also fixed an issue with how we were transforming the 'defintion' when
passing into the the renderer and added a unit test.