### PR TITLE
Change to user credentials instead of monitoring credentials

### DIFF
--- a/pkg/azure/aks/aks.go
+++ b/pkg/azure/aks/aks.go
@@ -27,7 +27,7 @@ func GetAKSMonitoringCredentials(ctx context.Context, subscriptionID string, res
 	// since it's non-obvious that we'd store credentials in your ~/.rad directory
 	mcc := clients.NewManagedClustersClient(subscriptionID, armauth)
 
-	results, err := mcc.ListClusterMonitoringUserCredentials(ctx, resourceGroup, clusterName, "")
+	results, err := mcc.ListClusterUserCredentials(ctx, resourceGroup, clusterName, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list AKS cluster credentials: %w", err)
 	}


### PR DESCRIPTION
This is more aligned with what the Azure CLI does https://github.com/Azure/azure-cli/blob/azure-cli-2.28.0/src/azure-cli/azure/cli/command_modules/acs/custom.py#L2662 , so will reduce maintenance for us as well as reduce confusion for our users.