### PR TITLE
Add support for programmatic secrets to K8s

### DIFF
--- a/pkg/kubernetes/controllers/bicep/deploymenttemplate_controller.go
+++ b/pkg/kubernetes/controllers/bicep/deploymenttemplate_controller.go
@@ -7,22 +7,28 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/Azure/radius/pkg/azure/azresources"
 	"github.com/Azure/radius/pkg/cli/armtemplate"
 	"github.com/Azure/radius/pkg/kubernetes"
 	bicepv1alpha3 "github.com/Azure/radius/pkg/kubernetes/api/bicep/v1alpha3"
 	radiusv1alpha3 "github.com/Azure/radius/pkg/kubernetes/api/radius/v1alpha3"
 	"github.com/Azure/radius/pkg/kubernetes/converters"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // DeploymentTemplateReconciler reconciles a Arm object
@@ -82,6 +88,10 @@ func (r *DeploymentTemplateReconciler) ApplyState(ctx context.Context, req ctrl.
 		Options:   options,
 		Deployed:  deployed,
 		Variables: map[string]interface{}{},
+
+		CustomActionCallback: func(id string, apiVersion string, action string, payload interface{}) (interface{}, error) {
+			return r.InvokeCustomAction(ctx, req.Namespace, id, apiVersion, action, payload)
+		},
 	}
 
 	for name, variable := range template.Variables {
@@ -177,6 +187,74 @@ func (r *DeploymentTemplateReconciler) ApplyState(ctx context.Context, req ctrl.
 	}
 
 	return reconcile.Result{}, nil
+}
+
+func (r *DeploymentTemplateReconciler) InvokeCustomAction(ctx context.Context, namespace string, id string, apiVersion string, action string, payload interface{}) (interface{}, error) {
+	if action != "listSecrets" {
+		return nil, fmt.Errorf("only %q is supported", "listSecrets")
+	}
+
+	// We can ignore ID in this case because it reference to the Radius Custom RP name ('radiusv3')
+	// The resource ID we actually want is inside the payload.
+	type ListSecretsInput = struct {
+		TargetID string `json:"targetID"`
+	}
+
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, errors.New("failed to read listSecrets payload")
+	}
+
+	input := ListSecretsInput{}
+	err = json.Unmarshal(b, &input)
+	if err != nil {
+		return nil, errors.New("failed to read listSecrets payload")
+	}
+
+	targetID, err := azresources.Parse(input.TargetID)
+	if err != nil {
+		return nil, fmt.Errorf("resource id %q is invalid: %w", id, err)
+	}
+
+	if len(targetID.Types) != 3 {
+		return nil, fmt.Errorf("resource id must refer to a Radius resource, was: %q", id)
+	}
+
+	unst := unstructured.Unstructured{}
+	unst.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "radius.dev",
+		Version: "v1alpha3",
+		Kind:    armtemplate.GetKindFromArmType(targetID.Types[2].Type),
+	})
+
+	err = r.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: targetID.Types[2].Name}, &unst)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve resource matching id %q: %w", id, err)
+	}
+
+	resource := radiusv1alpha3.Resource{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unst.Object, &resource)
+	if err != nil {
+		return nil, err
+	}
+
+	secretValues, err := converters.GetSecretValues(resource.Status)
+	if err != nil {
+		return nil, err
+	}
+
+	secretClient := converters.SecretClient{Client: r.Client}
+	values := map[string]interface{}{}
+	for key, reference := range secretValues {
+		value, err := secretClient.LookupSecretValue(ctx, resource.Status, reference)
+		if err != nil {
+			return nil, err
+		}
+
+		values[key] = value
+	}
+
+	return values, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/kubernetes/controllers/radius/resource_controller.go
+++ b/pkg/kubernetes/controllers/radius/resource_controller.go
@@ -346,20 +346,17 @@ func (r *ResourceReconciler) ApplyState(
 
 	// Only support strings for now
 	if desired.ComputedValues != nil {
-		data, err := json.Marshal(desired.ComputedValues)
+		err := converters.SetComputedValues(&resource.Status, desired.ComputedValues)
 		if err != nil {
 			return err
 		}
-		// TODO convert from computed value to to interface{}
-		resource.Status.ComputedValues = &runtime.RawExtension{Raw: data}
 	}
 
 	if desired.SecretValues != nil {
-		data, err := json.Marshal(desired.SecretValues)
+		err := converters.SetSecretValues(&resource.Status, desired.SecretValues)
 		if err != nil {
 			return err
 		}
-		resource.Status.SecretValues = &runtime.RawExtension{Raw: data}
 	}
 
 	// Can't use resource type to update as it will assume the wrong type
@@ -435,12 +432,9 @@ func (r *ResourceReconciler) GetRenderDependency(ctx context.Context, namespace 
 	// we store in status, and secrets we store separately.
 	values := map[string]interface{}{}
 
-	computedValues := map[string]renderers.ComputedValueReference{}
-	if k8sResource.Status.ComputedValues != nil {
-		err = json.Unmarshal(k8sResource.Status.ComputedValues.Raw, &computedValues)
-		if err != nil {
-			return nil, err
-		}
+	computedValues, err := converters.GetComputedValues(k8sResource.Status)
+	if err != nil {
+		return nil, err
 	}
 
 	for k, v := range computedValues {
@@ -449,39 +443,19 @@ func (r *ResourceReconciler) GetRenderDependency(ctx context.Context, namespace 
 
 	// The 'SecretValues' we store as part of the resource status (from render output) are references
 	// to secrets, we need to fetch the values and pass them to the renderer.
-	secretValues := map[string]renderers.SecretValueReference{}
-	if k8sResource.Status.SecretValues != nil {
-		err = json.Unmarshal(k8sResource.Status.SecretValues.Raw, &secretValues)
-		if err != nil {
-			return nil, err
-		}
+	secretValues, err := converters.GetSecretValues(k8sResource.Status)
+	if err != nil {
+		return nil, err
 	}
 
+	secretClient := converters.SecretClient{Client: r.Client}
 	for k, v := range secretValues {
-		// Each value needs to be looked up in a secret where it's stored. The reference
-		// to the secret will be in the output resources.
-		secretRef, ok := k8sResource.Status.Resources[v.LocalID]
-		if !ok {
-			return nil, fmt.Errorf("could not find a matching resource for LocalID %q", v.LocalID)
-		}
-
-		secret := corev1.Secret{}
-		err = r.Client.Get(ctx, client.ObjectKey{Namespace: secretRef.Namespace, Name: secretRef.Name}, &secret)
-		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve secret of dependency: %w", err)
-		}
-
-		encodedValue, ok := secret.Data[v.ValueSelector]
-		if !ok {
-			return nil, fmt.Errorf("secret did contain expected key: %q", v.ValueSelector)
-		}
-
-		decodedValue := string(encodedValue)
+		value, err := secretClient.LookupSecretValue(ctx, k8sResource.Status, v)
 		if err != nil {
 			return nil, err
 		}
 
-		values[k] = decodedValue
+		values[k] = value
 	}
 
 	return &renderers.RendererDependency{

--- a/pkg/kubernetes/converters/converters.go
+++ b/pkg/kubernetes/converters/converters.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/radius/pkg/kubernetes"
 	radiusv1alpha3 "github.com/Azure/radius/pkg/kubernetes/api/radius/v1alpha3"
 	"github.com/Azure/radius/pkg/renderers"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // Since the resource will be processed by an ARM template we need to convert it to an ARM-like representation.
@@ -74,5 +75,49 @@ func ConvertToRenderResource(original *radiusv1alpha3.Resource, result *renderer
 		}
 	}
 
+	return nil
+}
+
+func GetComputedValues(status radiusv1alpha3.ResourceStatus) (map[string]renderers.ComputedValueReference, error) {
+	computedValues := map[string]renderers.ComputedValueReference{}
+	if status.ComputedValues != nil {
+		err := json.Unmarshal(status.ComputedValues.Raw, &computedValues)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return computedValues, nil
+}
+
+func SetComputedValues(status *radiusv1alpha3.ResourceStatus, values map[string]renderers.ComputedValueReference) error {
+	data, err := json.Marshal(values)
+	if err != nil {
+		return err
+	}
+	// TODO convert from computed value to to interface{}
+	status.ComputedValues = &runtime.RawExtension{Raw: data}
+	return nil
+}
+
+func GetSecretValues(status radiusv1alpha3.ResourceStatus) (map[string]renderers.SecretValueReference, error) {
+	secretValues := map[string]renderers.SecretValueReference{}
+	if status.SecretValues != nil {
+		err := json.Unmarshal(status.SecretValues.Raw, &secretValues)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return secretValues, nil
+}
+
+func SetSecretValues(status *radiusv1alpha3.ResourceStatus, values map[string]renderers.SecretValueReference) error {
+	raw, err := json.Marshal(values)
+	if err != nil {
+		return err
+	}
+
+	status.SecretValues = &runtime.RawExtension{Raw: raw}
 	return nil
 }

--- a/pkg/kubernetes/converters/secretclient.go
+++ b/pkg/kubernetes/converters/secretclient.go
@@ -1,0 +1,43 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package converters
+
+import (
+	"context"
+	"fmt"
+
+	radiusv1alpha3 "github.com/Azure/radius/pkg/kubernetes/api/radius/v1alpha3"
+	"github.com/Azure/radius/pkg/renderers"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SecretClient can be used to look up the value of a SecretValueReference from the underlying Kubernetes Secret that stores it.
+type SecretClient struct {
+	Client client.Client
+}
+
+func (sc *SecretClient) LookupSecretValue(ctx context.Context, status radiusv1alpha3.ResourceStatus, secretReference renderers.SecretValueReference) (string, error) {
+	// Each value needs to be looked up in a secret where it's stored. The reference
+	// to the secret will be in the output resources.
+	outputResource, ok := status.Resources[secretReference.LocalID]
+	if !ok {
+		return "", fmt.Errorf("could not find a matching resource for LocalID %q", secretReference.LocalID)
+	}
+
+	secret := corev1.Secret{}
+	err := sc.Client.Get(ctx, client.ObjectKey{Namespace: outputResource.Namespace, Name: outputResource.Name}, &secret)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve secret of dependency: %w", err)
+	}
+
+	value, ok := secret.Data[secretReference.ValueSelector]
+	if !ok {
+		return "", fmt.Errorf("secret did contain expected key: %q", secretReference.ValueSelector)
+	}
+
+	return string(value), nil
+}

--- a/test/functional/kubernetes/resources/testdata/kubernetes-resources-mongo.bicep
+++ b/test/functional/kubernetes/resources/testdata/kubernetes-resources-mongo.bicep
@@ -6,6 +6,11 @@ resource app 'radius.dev/Application@v1alpha3' = {
     properties: {
       container: {
         image: 'radius.azurecr.io/magpie:latest'
+
+        // This is here so we make sure to exercise the 'programmatic secrets' code path.
+        env: {
+          DB_CONNECTION: mongodb.connectionString()
+        }
       }
       connections: {
         mongodb: {


### PR DESCRIPTION
Fixes: #595

This change adds support for programmatic secret access to the K8s
deployment engine. This means an expression like `db.connectionString()`
will result in a secret-based lookup for one of the radius types. We
don't support any other kind of 'custom actions' at this time other than
parity with what we do for the Radius RP.