### PR TITLE
Fix dapr appid being returned by route

### DIFF
--- a/pkg/renderers/daprhttproutev1alpha3/render.go
+++ b/pkg/renderers/daprhttproutev1alpha3/render.go
@@ -22,6 +22,17 @@ func (r *Renderer) GetDependencyIDs(ctx context.Context, resource renderers.Rend
 }
 
 func (r Renderer) Render(ctx context.Context, resource renderers.RendererResource, dependencies map[string]renderers.RendererDependency) (renderers.RendererOutput, error) {
-	// There's nothing to do here. There's no rendering output from a Dapr Http Route.
-	return renderers.RendererOutput{}, nil
+	properties := DaprHttpRouteProperties{}
+	err := resource.ConvertDefinition(&properties)
+	if err != nil {
+		return renderers.RendererOutput{}, err
+	}
+
+	return renderers.RendererOutput{
+		ComputedValues: map[string]renderers.ComputedValueReference{
+			"appId": {
+				Value: properties.AppID,
+			},
+		},
+	}, nil
 }

--- a/pkg/renderers/daprhttproutev1alpha3/render_test.go
+++ b/pkg/renderers/daprhttproutev1alpha3/render_test.go
@@ -1,0 +1,59 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package daprhttproutev1alpha3
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/radius/pkg/radlogger"
+	"github.com/Azure/radius/pkg/renderers"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	applicationName = "test-app"
+	resourceName    = "test-route"
+)
+
+func createContext(t *testing.T) context.Context {
+	logger, err := radlogger.NewTestLogger(t)
+	if err != nil {
+		t.Log("Unable to initialize logger")
+		return context.Background()
+	}
+	return logr.NewContext(context.Background(), logger)
+}
+
+func Test_Render_Managed_Success(t *testing.T) {
+	ctx := createContext(t)
+	renderer := Renderer{}
+
+	resource := renderers.RendererResource{
+		ApplicationName: applicationName,
+		ResourceName:    resourceName,
+		ResourceType:    ResourceType,
+		Definition: map[string]interface{}{
+			"appId": "test-appId",
+		},
+	}
+
+	output, err := renderer.Render(ctx, resource, map[string]renderers.RendererDependency{})
+	require.NoError(t, err)
+	require.NoError(t, err)
+
+	require.Empty(t, output.Resources)
+
+	expectedComputedValues := map[string]renderers.ComputedValueReference{
+		"appId": {
+			Value: "test-appId",
+		},
+	}
+	require.Equal(t, expectedComputedValues, output.ComputedValues)
+
+	require.Empty(t, output.SecretValues)
+}

--- a/test/functional/azure/tutorial/tutorial_test.go
+++ b/test/functional/azure/tutorial/tutorial_test.go
@@ -56,6 +56,7 @@ func Test_TutorialDaprMicroservices(t *testing.T) {
 						ResourceType:    containerv1alpha3.ResourceType,
 						OutputResources: map[string]validation.ExpectedOutputResource{
 							outputresource.LocalIDDeployment: validation.NewOutputResource(outputresource.LocalIDDeployment, outputresource.TypeKubernetes, resourcekinds.Kubernetes, true, false, rest.OutputResourceStatus{}),
+							outputresource.LocalIDSecret:     validation.NewOutputResource(outputresource.LocalIDSecret, outputresource.TypeKubernetes, resourcekinds.Kubernetes, true, false, rest.OutputResourceStatus{}),
 						},
 					},
 					{


### PR DESCRIPTION
Fixes: #1193

This functionality to return the app id as a computed value was missing,
resulting in being missing from 'connections'.