### PR TITLE
Add connections to Dapr tutorial and fix errata

### DIFF
--- a/docs/content/user-guides/tutorials/dapr-microservices/code/nodeapp/app.js
+++ b/docs/content/user-guides/tutorials/dapr-microservices/code/nodeapp/app.js
@@ -10,13 +10,18 @@ app.use(bodyParser.json());
 const daprPort = process.env.DAPR_HTTP_PORT; 
 const daprGRPCPort = process.env.DAPR_GRPC_PORT;
 
-const stateStoreName = `statestore`;
+const stateStoreName =  process.env.CONNECTION_ORDERS_STATESTORENAME;
 const stateUrl = `http://localhost:${daprPort}/v1.0/state/${stateStoreName}`;
 const port = 3000;
 
 app.get('/order', (_req, res) => {
     if (!process.env.DAPR_HTTP_PORT) {
         res.status(400).send({message: "The container is running, but Dapr has not been configured."});
+        return;
+    }
+
+    if (!process.env.CONNECTION_ORDERS_STATESTORENAME) {
+        res.status(400).send({message: "The container is running, but the state store name is not set."});
         return;
     }
 

--- a/docs/content/user-guides/tutorials/dapr-microservices/code/ui/Startup.cs
+++ b/docs/content/user-guides/tutorials/dapr-microservices/code/ui/Startup.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http;
 using Dapr.Client;
 using Microsoft.AspNetCore.Builder;
@@ -21,7 +22,9 @@ namespace ui
         {
             services.AddRazorPages();
             services.AddServerSideBlazor();
-            services.AddSingleton<HttpClient>(DaprClient.CreateInvokeHttpClient("backend"));
+
+            var appId = Environment.GetEnvironmentVariable("CONNECTION_BACKEND_APPID");
+            services.AddSingleton<HttpClient>(DaprClient.CreateInvokeHttpClient(appId));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/docs/content/user-guides/tutorials/dapr-microservices/dapr-microservices-add-dapr/index.md
+++ b/docs/content/user-guides/tutorials/dapr-microservices/dapr-microservices-add-dapr/index.md
@@ -53,6 +53,18 @@ Once the state store is defined as a component, you can connect to it by referen
 
 {{< rad file="snippets/app.bicep" embed=true marker="//SAMPLE" replace-key-run="//RUN" replace-value-run="container: {...}" replace-key-bindings="//BINDINGS" replace-value-bindings="bindings: {...}" replace-key-statestore="//STATESTORE" replace-value-statestore="resource statestore 'dapr.io.StateStoreComponent' = {...}" replace-key-traits="//TRAITS" replace-value-traits="traits: [...]" >}}
 
+### Injected settings from connections
+
+Adding a connection to the state store also configures environment variables inside the the `statestore` component.
+
+Because the connection is called `orders` inside `backend`, Radius will inject information related to the state store using environment variables like `CONNECTION_ORDERS_STATESTORENAME`. The application code inside `backend` uses this environment variable to access the state store name and avoid hardcoding.
+
+```js
+const stateStoreName =  process.env.CONNECTION_ORDERS_STATESTORENAME;
+```
+
+See the [connections]({{< ref "connections-model#injected-values" >}}) page for more information about this feature.
+
 ## Deploy application with Dapr
 
 {{% alert title="Make sure Dapr is initialized" color="warning" %}}
@@ -82,7 +94,7 @@ For Azure environments, Dapr is managed for you and you do not need to manually 
    You should see both `backend` and `statestore` components in your `dapr-tutorial` application. Example output:
 
    ```
-   RESOURCE   KIND
+   RESOURCE   TYPE
    backend     ContainerComponent
    statestore  dapr.io.StateStoreComponent
    ```
@@ -90,7 +102,7 @@ For Azure environments, Dapr is managed for you and you do not need to manually 
 1. To test out the state store, open a local tunnel on port 3000 again:
 
    ```sh
-   rad resource expose backend --application dapr-tutorial --port 3000
+   rad resource expose ContainerComponent backend --application dapr-tutorial --port 3000
    ```
 
 1. Visit the the URL [http://localhost:3000/order](http://localhost:3000/order) in your browser. You should see the following message:

--- a/docs/content/user-guides/tutorials/dapr-microservices/dapr-microservices-add-dapr/index.md
+++ b/docs/content/user-guides/tutorials/dapr-microservices/dapr-microservices-add-dapr/index.md
@@ -55,7 +55,7 @@ Once the state store is defined as a component, you can connect to it by referen
 
 ### Injected settings from connections
 
-Adding a connection to the state store also configures environment variables inside the the `statestore` component.
+Adding a connection to the state store also [configures environment variables]({{< ref "dapr-statestore#provided-data" >}}) inside the the `statestore` component.
 
 Because the connection is called `orders` inside `backend`, Radius will inject information related to the state store using environment variables like `CONNECTION_ORDERS_STATESTORENAME`. The application code inside `backend` uses this environment variable to access the state store name and avoid hardcoding.
 

--- a/docs/content/user-guides/tutorials/dapr-microservices/dapr-microservices-add-ui/index.md
+++ b/docs/content/user-guides/tutorials/dapr-microservices/dapr-microservices-add-ui/index.md
@@ -17,10 +17,17 @@ Another container component is used to specify a few properties about the order 
 
 - **resource type**: `ContainerComponent` indicates you are using a generic container.
 - **container image**: `radius.azurecr.io/daprtutorial-frontend` is a Docker image the container will run.
-- **connections**: `backendDapr.id` declares the intention for `frontend` to communicate with `backend` through the `backendDapr` Dapr HTTP Route.
+- **connections**: `daprBackend.id` declares the intention for `frontend` to communicate with `backend` through the `daprBackend` Dapr HTTP Route.
 - **traits**: `dapr.io/Sidecar` configures Dapr on the container.
 
 {{< rad file="snippets/app.bicep" marker="//FRONTEND" embed=true >}}
+
+As before with connections, the `frontend` component is using an environment variable to get information about the the `backend`'s route. This avoids hardcoding:
+
+```C#
+var appId = Environment.GetEnvironmentVariable("CONNECTION_BACKEND_APPID");
+services.AddSingleton<HttpClient>(DaprClient.CreateInvokeHttpClient(appId));
+```
   
 ## Deploy application
 
@@ -37,7 +44,7 @@ Another container component is used to specify a few properties about the order 
 1. To test out the frontend microservice, open a local tunnel on port 80:
 
    ```sh
-   rad resource expose frontend --application dapr-tutorial --port 5000 --remote-port 80
+   rad resource expose ContainerComponent frontend --application dapr-tutorial --port 5000 --remote-port 80
    ```
 
 1. Visit [http://localhost:5000](http://localhost:5000) in your browser and submit orders.

--- a/docs/content/user-guides/tutorials/dapr-microservices/dapr-microservices-add-ui/snippets/app.bicep
+++ b/docs/content/user-guides/tutorials/dapr-microservices/dapr-microservices-add-ui/snippets/app.bicep
@@ -17,12 +17,13 @@ resource app 'radius.dev/Application@v1alpha3' = {
       connections: {
         backend: {
           kind: 'dapr.io/DaprHttp'
-          source: backendDapr.id
+          source: daprBackend.id
         }
       }
       traits: [
         {
           kind: 'dapr.io/Sidecar@v1alpha1'
+          appId: 'frontend'
         }
       ]
     }
@@ -46,13 +47,13 @@ resource app 'radius.dev/Application@v1alpha3' = {
           kind: 'dapr.io/Sidecar@v1alpha1'
           appId: 'backend'
           appPort: 3000
-          provides: backendDapr.id
+          provides: daprBackend.id
         }
       ]
     }
   }
 
-  resource backendDapr 'dapr.io.DaprHttpRoute' = {
+  resource daprBackend 'dapr.io.DaprHttpRoute' = {
     name: 'backend-dapr'
     properties: {
       appId: 'backend'


### PR DESCRIPTION
This change adds more prominent use in code of the environment variables
defined by connections.

Also fixing any mistakes and inconsistencies in the docs and examples