### PR TITLE
Ignore container logs when running locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ vendor/
 # Build Output
 bin/
 dist/
+logs/
 radius-rp
 !radius-rp/
 radius-rp.exe

--- a/test/kubernetestest/kubernetestest.go
+++ b/test/kubernetestest/kubernetestest.go
@@ -198,7 +198,7 @@ func (at ApplicationTest) Test(t *testing.T) {
 
 	logPrefix := os.Getenv(ContainerLogPathEnvVar)
 	if logPrefix == "" {
-		logPrefix = "./container_logs"
+		logPrefix = "./logs"
 	}
 
 	// Only start capturing controller logs once.


### PR DESCRIPTION
container_logs is a folder created on each run of a k8s functional test which contains the logs of each pod created.

Currently it isn't ignored.