### PR TITLE
Display resources and public endpoints of routes

### DIFF
--- a/pkg/azure/radclient/status.go
+++ b/pkg/azure/radclient/status.go
@@ -1,0 +1,34 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package radclient
+
+import (
+	"encoding/json"
+
+	"github.com/Azure/radius/pkg/radrp/rest"
+)
+
+// GetStatus returns the `.properties.status` element of a Radius resource. Will return null if it
+// is not found.
+func (r RadiusResource) GetStatus() (*rest.ComponentStatus, error) {
+	obj, ok := r.Properties["status"]
+	if !ok {
+		return nil, nil
+	}
+
+	b, err := json.Marshal(&obj)
+	if err != nil {
+		return nil, err
+	}
+
+	status := rest.ComponentStatus{}
+	err = json.Unmarshal(b, &status)
+	if err != nil {
+		return nil, err
+	}
+
+	return &status, nil
+}

--- a/pkg/cli/azure/diagnostics.go
+++ b/pkg/cli/azure/diagnostics.go
@@ -1,0 +1,72 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package azure
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/radius/pkg/azure/radclient"
+	"github.com/Azure/radius/pkg/cli/clients"
+	"github.com/Azure/radius/pkg/cli/kubernetes"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type AKSDiagnosticsClient struct {
+	kubernetes.KubernetesDiagnosticsClient
+	ResourceClient radclient.RadiusResourceClient
+	ResourceGroup  string
+	SubscriptionID string
+}
+
+var _ clients.DiagnosticsClient = (*AKSDiagnosticsClient)(nil)
+
+func (dc *AKSDiagnosticsClient) GetPublicEndpoint(ctx context.Context, options clients.EndpointOptions) (*string, error) {
+	// Only HTTP Route is supported
+	if len(options.ResourceID.Types) != 3 || options.ResourceID.Types[2].Type != "HttpRoute" {
+		return nil, nil
+	}
+
+	response, err := dc.ResourceClient.Get(ctx, dc.ResourceGroup, options.ResourceID.Types[1].Name, options.ResourceID.Types[2].Type, options.ResourceID.Types[2].Name, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	status, err := response.RadiusResource.GetStatus()
+	if err != nil {
+		return nil, err
+	} else if status == nil {
+		return nil, nil
+	}
+
+	// TODO: Right now this is VERY coupled to how we do resource creation on the server.
+	// This will be improved as part of https://github.com/Azure/radius/issues/1247 .
+	//
+	// When that change goes in we'll be able to work with the route type directly to get this information.
+	for _, output := range status.OutputResources {
+		gvk, _, _, err := output.OutputResourceInfo.RequireKubernetes()
+		if err != nil {
+			continue // Ignore non-kubernetes
+		}
+
+		// If the component has a Kubernetes HTTPRoute then it's using gateways. Look up the IP address
+		if gvk.Kind != "HTTPRoute" {
+			continue
+		}
+
+		service, err := dc.Client.CoreV1().Services("radius-system").Get(ctx, "haproxy-ingress", metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, in := range service.Status.LoadBalancer.Ingress {
+			endpoint := fmt.Sprintf("http://%s", in.IP)
+			return &endpoint, nil
+		}
+	}
+
+	return nil, nil
+}

--- a/pkg/cli/clients/clients.go
+++ b/pkg/cli/clients/clients.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/Azure/radius/pkg/azure/azresources"
 	"github.com/Azure/radius/pkg/azure/radclient"
 )
 
@@ -30,15 +31,33 @@ import (
 // Note that we're only storing the 'parameters' node of the format described above.
 type DeploymentParameters = map[string]map[string]interface{}
 
+// DeploymentOptions is the options passed when deploying an ARM-JSON template.
+type DeploymentOptions struct {
+	// Template is the text of the ARM-JSON template in string form.
+	Template string
+
+	// Parameters is the set of parameters passed to the deployment.
+	Parameters DeploymentParameters
+}
+
+type DeploymentResult struct {
+	Resources []azresources.ResourceID
+}
+
 // DeploymentClient is used to deploy ARM-JSON templates (compiled Bicep output).
 type DeploymentClient interface {
-	Deploy(ctx context.Context, content string, parameters DeploymentParameters) error
+	Deploy(ctx context.Context, options DeploymentOptions) (DeploymentResult, error)
 }
 
 // DiagnosticsClient is used to interface with diagnostics features like logs and port-forwards.
 type DiagnosticsClient interface {
 	Expose(ctx context.Context, options ExposeOptions) (failed chan error, stop chan struct{}, signals chan os.Signal, err error)
 	Logs(ctx context.Context, options LogsOptions) ([]LogStream, error)
+	GetPublicEndpoint(ctx context.Context, options EndpointOptions) (*string, error)
+}
+
+type EndpointOptions struct {
+	ResourceID azresources.ResourceID
 }
 
 type ExposeOptions struct {

--- a/pkg/cli/environments/localrp.go
+++ b/pkg/cli/environments/localrp.go
@@ -81,9 +81,17 @@ func (e *LocalRPEnvironment) CreateDiagnosticsClient(ctx context.Context) (clien
 		return nil, err
 	}
 
-	return &kubernetes.KubernetesDiagnosticsClient{
-		Client:     k8sClient,
-		RestConfig: config,
+	azcred := &radclient.AnonymousCredential{}
+	con := arm.NewConnection(e.URL, azcred, nil)
+
+	return &azure.AKSDiagnosticsClient{
+		KubernetesDiagnosticsClient: kubernetes.KubernetesDiagnosticsClient{
+			Client:     k8sClient,
+			RestConfig: config,
+		},
+		ResourceClient: *radclient.NewRadiusResourceClient(con, e.SubscriptionID),
+		ResourceGroup:  e.ResourceGroup,
+		SubscriptionID: e.SubscriptionID,
 	}, nil
 }
 

--- a/pkg/cli/kubernetes/diagnostics.go
+++ b/pkg/cli/kubernetes/diagnostics.go
@@ -35,6 +35,10 @@ type KubernetesDiagnosticsClient struct {
 
 var _ clients.DiagnosticsClient = (*KubernetesDiagnosticsClient)(nil)
 
+func (dc *KubernetesDiagnosticsClient) GetPublicEndpoint(ctx context.Context, options clients.EndpointOptions) (*string, error) {
+	return nil, nil
+}
+
 func (dc *KubernetesDiagnosticsClient) Expose(ctx context.Context, options clients.ExposeOptions) (failed chan error, stop chan struct{}, signals chan os.Signal, err error) {
 	namespace := dc.Namespace
 	if namespace == "" {

--- a/pkg/cli/localrp/deployment_client.go
+++ b/pkg/cli/localrp/deployment_client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-10-01/resources"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/radius/pkg/azure/azresources"
 	azclients "github.com/Azure/radius/pkg/azure/clients"
 	"github.com/Azure/radius/pkg/cli/armtemplate"
 	"github.com/Azure/radius/pkg/cli/clients"
@@ -39,20 +40,20 @@ type LocalRPDeploymentClient struct {
 
 var _ clients.DeploymentClient = (*LocalRPDeploymentClient)(nil)
 
-func (dc *LocalRPDeploymentClient) Deploy(ctx context.Context, content string, parameters clients.DeploymentParameters) error {
-	template, err := armtemplate.Parse(content)
+func (dc *LocalRPDeploymentClient) Deploy(ctx context.Context, options clients.DeploymentOptions) (clients.DeploymentResult, error) {
+	template, err := armtemplate.Parse(options.Template)
 	if err != nil {
-		return err
+		return clients.DeploymentResult{}, err
 	}
 
 	resources, err := armtemplate.Eval(template, armtemplate.TemplateOptions{
 		SubscriptionID:         dc.SubscriptionID,
 		ResourceGroup:          dc.ResourceGroup,
-		Parameters:             parameters,
+		Parameters:             options.Parameters,
 		EvaluatePropertiesNode: false,
 	})
 	if err != nil {
-		return err
+		return clients.DeploymentResult{}, err
 	}
 
 	deployed := map[string]map[string]interface{}{}
@@ -61,7 +62,7 @@ func (dc *LocalRPDeploymentClient) Deploy(ctx context.Context, content string, p
 		Options: armtemplate.TemplateOptions{
 			SubscriptionID:         dc.SubscriptionID,
 			ResourceGroup:          dc.ResourceGroup,
-			Parameters:             parameters,
+			Parameters:             options.Parameters,
 			EvaluatePropertiesNode: true,
 		},
 		CustomActionCallback: func(id, apiVersion string, action string, body interface{}) (interface{}, error) {
@@ -74,18 +75,19 @@ func (dc *LocalRPDeploymentClient) Deploy(ctx context.Context, content string, p
 	for name, variable := range template.Variables {
 		value, err := evaluator.VisitValue(variable)
 		if err != nil {
-			return err
+			return clients.DeploymentResult{}, err
 		}
 
 		evaluator.Variables[name] = value
 	}
 
 	// NOTE: this is currently test-only code so we're fairly noisy about what we output here.
+	ids := []azresources.ResourceID{}
 	fmt.Printf("Starting deployment...\n")
 	for _, resource := range resources {
 		body, err := evaluator.VisitMap(resource.Body)
 		if err != nil {
-			return err
+			return clients.DeploymentResult{}, err
 		}
 
 		resource.Body = body
@@ -93,14 +95,22 @@ func (dc *LocalRPDeploymentClient) Deploy(ctx context.Context, content string, p
 		fmt.Printf("Deploying %s %s...\n", resource.Type, resource.Name)
 		response, result, err := dc.deployResource(ctx, dc.Connection, resource)
 		if err != nil {
-			return fmt.Errorf("failed to PUT resource %s %s: %w", resource.Type, resource.Name, err)
+			return clients.DeploymentResult{}, fmt.Errorf("failed to PUT resource %s %s: %w", resource.Type, resource.Name, err)
 		}
 
 		fmt.Printf("succeed with status code %d\n", response.StatusCode)
 		evaluator.Deployed[resource.ID] = result
+
+		parsed, err := azresources.Parse(resource.ID)
+		if err != nil {
+			// We don't expect this to fail, but just in case...
+			return clients.DeploymentResult{}, err
+		}
+
+		ids = append(ids, parsed)
 	}
 
-	return nil
+	return clients.DeploymentResult{Resources: ids}, err
 }
 
 func (dc *LocalRPDeploymentClient) deployResource(ctx context.Context, connection *arm.Connection, resource armtemplate.Resource) (*http.Response, map[string]interface{}, error) {

--- a/pkg/cli/output/resources.go
+++ b/pkg/cli/output/resources.go
@@ -1,0 +1,44 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package output
+
+import (
+	"fmt"
+
+	"github.com/Azure/radius/pkg/azure/azresources"
+)
+
+// ShowResource returns true if the resource should be displayed to the user.
+func ShowResource(id azresources.ResourceID) bool {
+	if len(id.Types) == 1 && id.Types[0].Name == "radiusv3" {
+		// Hide operations on the provider (custom action)
+		return false
+	}
+
+	return true
+}
+
+// FormatResourceForDisplay returns a display string for the resource type and name.
+func FormatResourceForDisplay(id azresources.ResourceID) string {
+	return fmt.Sprintf("%-20s %-15s", FormatResourceTypeForDisplay(id), FormatResourceNameForDisplay(id))
+}
+
+// FormatResourceNameForDisplay returns a display string for the resource name.
+func FormatResourceNameForDisplay(id azresources.ResourceID) string {
+	// Just show the last segment of the resource name.
+	return id.Name()
+}
+
+// FormatResourceTypeForDisplay returns a display string for the resource type.
+func FormatResourceTypeForDisplay(id azresources.ResourceID) string {
+	if len(id.Types) > 0 && id.Types[0].Name == "radiusv3" {
+		// It's a Radius type - just use the last segment.
+		return id.Types[len(id.Types)-1].Type
+	}
+
+	// It's an ARM resource, use the qualified type.
+	return id.Type()
+}

--- a/pkg/resourcemodel/identity.go
+++ b/pkg/resourcemodel/identity.go
@@ -15,6 +15,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type ResourceIdentityKind string
@@ -97,6 +98,15 @@ func (r ResourceIdentity) RequireARM() (string, string, error) {
 	}
 
 	return "", "", fmt.Errorf("expected an %q resource identity, was %q", IdentityKindARM, r.Kind)
+}
+
+func (r ResourceIdentity) RequireKubernetes() (schema.GroupVersionKind, string, string, error) {
+	if r.Kind == IdentityKindKubernetes {
+		data := r.Data.(KubernetesIdentity)
+		return schema.FromAPIVersionAndKind(data.APIVersion, data.Kind), data.Namespace, data.Name, nil
+	}
+
+	return schema.GroupVersionKind{}, "", "", fmt.Errorf("expected an %q resource identity, was %q", IdentityKindKubernetes, r.Kind)
 }
 
 func (r ResourceIdentity) IsSameResource(other ResourceIdentity) bool {


### PR DESCRIPTION
Fixes: #366

This change adds a summary to deployment that will show the deployed
resources as well as any public endpoints that are reachable (right now
that means HttpRoute).

This is blocked for Kubernetes on #1357

Example output:

```txt
➜ dev-rad deploy test/functional/azure/client/testdata/azure-client.bicep
Building Application...
Deploying Application into environment 'rynowak-radius'...

Meanwhile, you can view the environment 'rynowak-radius' at:
https://portal.azure.com/#@72f988bf-86f1-41af-91ab-2d7cd011db47/resource/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourceGroups/rynowak-radius/overview

Deployment In Progress...
Deployment Complete

Resources:
    Application          azure-client
    ContainerComponent   a
    ContainerComponent   b
    HttpRoute            route

Public Endpoints:
    HttpRoute            route           http://51.143.111.139
```