### PR TITLE
Watch more types in k8s controller

### DIFF
--- a/cmd/radius-controller/main.go
+++ b/cmd/radius-controller/main.go
@@ -116,6 +116,7 @@ func main() {
 		RestConfig:    ctrl.GetConfigOrDie(),
 		RestMapper:    mapper,
 		ResourceTypes: radcontroller.DefaultResourceTypes,
+		WatchTypes:    radcontroller.DefaultWatchTypes,
 		SkipWebhooks:  os.Getenv("SKIP_WEBHOOKS") == "true",
 	}
 

--- a/cmd/radius-controller/main.go
+++ b/cmd/radius-controller/main.go
@@ -53,11 +53,13 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var modelName string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&modelName, "model", "kubernetes", "The resource model to use.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -68,6 +70,13 @@ func main() {
 
 	// Get certificate from volume mounted environment variable
 	certDir := os.Getenv("TLS_CERT_DIR")
+
+	model := radcontroller.NewKubernetesModel()
+	if modelName == "kubernetes" {
+		utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	} else if modelName == "local" {
+		model = radcontroller.NewLocalModel()
+	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,

--- a/cmd/radius-controller/main.go
+++ b/cmd/radius-controller/main.go
@@ -53,13 +53,11 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
-	var modelName string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&modelName, "model", "kubernetes", "The resource model to use.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -70,13 +68,6 @@ func main() {
 
 	// Get certificate from volume mounted environment variable
 	certDir := os.Getenv("TLS_CERT_DIR")
-
-	model := radcontroller.NewKubernetesModel()
-	if modelName == "kubernetes" {
-		utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	} else if modelName == "local" {
-		model = radcontroller.NewLocalModel()
-	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,

--- a/pkg/kubernetes/controllers/radius/register.go
+++ b/pkg/kubernetes/controllers/radius/register.go
@@ -25,6 +25,7 @@ import (
 	radiusv1alpha3 "github.com/Azure/radius/pkg/kubernetes/api/radius/v1alpha3"
 	bicepcontroller "github.com/Azure/radius/pkg/kubernetes/controllers/bicep"
 	"github.com/Azure/radius/pkg/kubernetes/webhook"
+	gatewayv1alpha1 "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 var DefaultResourceTypes = []struct {
@@ -48,6 +49,8 @@ var DefaultWatchTypes = []client.Object{
 	&appsv1.Deployment{},
 	&corev1.Secret{},
 	&appsv1.StatefulSet{},
+	&gatewayv1alpha1.Gateway{},
+	&gatewayv1alpha1.HTTPRoute{},
 }
 
 type Options struct {
@@ -63,6 +66,7 @@ type Options struct {
 		client.Object
 		client.ObjectList
 	}
+	WatchTypes   []client.Object
 	SkipWebhooks bool
 }
 
@@ -150,7 +154,7 @@ func (c *RadiusController) SetupWithManager(mgr ctrl.Manager) error {
 			}
 
 			resource.GVR = gvr.Resource
-			err = resource.SetupWithManager(mgr)
+			err = resource.SetupWithManager(mgr, c.options.WatchTypes)
 			if err != nil {
 				return fmt.Errorf("failed to setup Resource controller for %T: %w", resource.ObjectType, err)
 			}

--- a/pkg/kubernetes/controllers/radius/register.go
+++ b/pkg/kubernetes/controllers/radius/register.go
@@ -44,13 +44,16 @@ var DefaultResourceTypes = []struct {
 	{&radiusv1alpha3.Gateway{}, &radiusv1alpha3.GatewayList{}},
 }
 
-var DefaultWatchTypes = []client.Object{
-	&corev1.Service{},
-	&appsv1.Deployment{},
-	&corev1.Secret{},
-	&appsv1.StatefulSet{},
-	&gatewayv1alpha1.Gateway{},
-	&gatewayv1alpha1.HTTPRoute{},
+var DefaultWatchTypes = []struct {
+	client.Object
+	client.ObjectList
+}{
+	{&corev1.Service{}, &corev1.ServiceList{}},
+	{&appsv1.Deployment{}, &appsv1.DeploymentList{}},
+	{&corev1.Secret{}, &corev1.SecretList{}},
+	{&appsv1.StatefulSet{}, &appsv1.StatefulSetList{}},
+	{&gatewayv1alpha1.Gateway{}, &gatewayv1alpha1.GatewayList{}},
+	{&gatewayv1alpha1.HTTPRoute{}, &gatewayv1alpha1.HTTPRouteList{}},
 }
 
 type Options struct {

--- a/pkg/kubernetes/controllers/radius/register.go
+++ b/pkg/kubernetes/controllers/radius/register.go
@@ -173,16 +173,18 @@ func (c *RadiusController) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	if err = (&radiusv1alpha3.Application{}).SetupWebhookWithManager(mgr); err != nil {
-		return fmt.Errorf("failed to setup Application webhook: %w", err)
-	}
+	if !c.options.SkipWebhooks {
+		if err = (&radiusv1alpha3.Application{}).SetupWebhookWithManager(mgr); err != nil {
+			return fmt.Errorf("failed to setup Application webhook: %w", err)
+		}
 
-	if err = (&webhook.ResourceWebhook{}).SetupWebhookWithManager(mgr); err != nil {
-		return fmt.Errorf("failed to setup Resource webhook: %w", err)
-	}
+		if err = (&webhook.ResourceWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+			return fmt.Errorf("failed to setup Resource webhook: %w", err)
+		}
 
-	if err = (&bicepv1alpha3.DeploymentTemplate{}).SetupWebhookWithManager(mgr); err != nil {
-		return fmt.Errorf("failed to setup DeploymentTemplate webhook: %w", err)
+		if err = (&bicepv1alpha3.DeploymentTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+			return fmt.Errorf("failed to setup DeploymentTemplate webhook: %w", err)
+		}
 	}
 
 	return nil

--- a/pkg/kubernetes/controllers/radius/register.go
+++ b/pkg/kubernetes/controllers/radius/register.go
@@ -43,6 +43,13 @@ var DefaultResourceTypes = []struct {
 	{&radiusv1alpha3.Gateway{}, &radiusv1alpha3.GatewayList{}},
 }
 
+var DefaultWatchTypes = []client.Object{
+	&corev1.Service{},
+	&appsv1.Deployment{},
+	&corev1.Secret{},
+	&appsv1.StatefulSet{},
+}
+
 type Options struct {
 	AppModel      model.ApplicationModel
 	Client        client.Client

--- a/pkg/kubernetes/controllers/radius/register.go
+++ b/pkg/kubernetes/controllers/radius/register.go
@@ -131,16 +131,12 @@ func (c *RadiusController) SetupWithManager(mgr ctrl.Manager) error {
 	// We create some indexes for watched types - this is done once because
 	// we create a reconciler per-resource-type right now.
 
-	// Index deployments by the owner (any resource besides application)
-	err = mgr.GetFieldIndexer().IndexField(context.Background(), &appsv1.Deployment{}, CacheKeyController, extractOwnerKey)
-	if err != nil {
-		return fmt.Errorf("failed to register index for %s: %w", "Deployment", err)
-	}
-
-	// Index services by the owner (any resource besides application)
-	err = mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Service{}, CacheKeyController, extractOwnerKey)
-	if err != nil {
-		return fmt.Errorf("failed to register index for %s: %w", "Service", err)
+	// Index watched types by the owner (any resource besides application)
+	for _, r := range c.options.WatchTypes {
+		err = mgr.GetFieldIndexer().IndexField(context.Background(), r.Object, CacheKeyController, extractOwnerKey)
+		if err != nil {
+			return fmt.Errorf("failed to register index for %s: %w", "Deployment", err)
+		}
 	}
 
 	for _, resource := range c.resources {

--- a/pkg/kubernetes/controllers/radius/resource_controller.go
+++ b/pkg/kubernetes/controllers/radius/resource_controller.go
@@ -184,7 +184,7 @@ func (r *ResourceReconciler) FetchKubernetesResources(ctx context.Context, log l
 		list.SetGroupVersionKind(a.ObjectList.GetObjectKind().GroupVersionKind())
 		err := r.Client.List(ctx, list, client.InNamespace(resource.Namespace), client.MatchingFields{CacheKeyController: resource.Kind + resource.Name})
 		if err != nil {
-			log.Error(err, "failed to retrieve %T", a.ObjectList)
+			log.Error(err, fmt.Sprintf("failed to retrieve %T", a.ObjectList))
 			return nil, err
 		}
 

--- a/pkg/kubernetes/controllers/radius/resource_controller.go
+++ b/pkg/kubernetes/controllers/radius/resource_controller.go
@@ -191,6 +191,10 @@ func (r *ResourceReconciler) FetchKubernetesResources(ctx context.Context, log l
 			results = append(results, o)
 			return nil
 		})
+		if err != nil {
+			log.Error(err, "failed to get types")
+			return nil, err
+		}
 	}
 
 	log.Info("found existing resource for resource", "count", len(results))

--- a/test/kubernetestest/controllertest.go
+++ b/test/kubernetestest/controllertest.go
@@ -133,6 +133,7 @@ func StartController() error {
 		RestConfig:    cfg,
 		RestMapper:    mapper,
 		ResourceTypes: radcontroller.DefaultResourceTypes,
+		WatchTypes:    radcontroller.DefaultWatchTypes,
 		SkipWebhooks:  false,
 	}
 

--- a/test/kubernetestest/controllertest.go
+++ b/test/kubernetestest/controllertest.go
@@ -136,11 +136,14 @@ func StartController() error {
 		RestConfig:    cfg,
 		RestMapper:    mapper,
 		ResourceTypes: radcontroller.DefaultResourceTypes,
-		WatchTypes: []client.Object{
-			&corev1.Service{},
-			&appsv1.Deployment{},
-			&corev1.Secret{},
-			&appsv1.StatefulSet{},
+		WatchTypes: []struct {
+			client.Object
+			client.ObjectList
+		}{
+			{&corev1.Service{}, &corev1.ServiceList{}},
+			{&appsv1.Deployment{}, &appsv1.DeploymentList{}},
+			{&corev1.Secret{}, &corev1.SecretList{}},
+			{&appsv1.StatefulSet{}, &appsv1.StatefulSetList{}},
 		},
 		SkipWebhooks: false,
 	}

--- a/test/kubernetestest/controllertest.go
+++ b/test/kubernetestest/controllertest.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -35,6 +36,8 @@ import (
 	kubernetesmodel "github.com/Azure/radius/pkg/model/kubernetes"
 	"github.com/Azure/radius/test/validation"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
 	memory "k8s.io/client-go/discovery/cached"
@@ -133,8 +136,13 @@ func StartController() error {
 		RestConfig:    cfg,
 		RestMapper:    mapper,
 		ResourceTypes: radcontroller.DefaultResourceTypes,
-		WatchTypes:    radcontroller.DefaultWatchTypes,
-		SkipWebhooks:  false,
+		WatchTypes: []client.Object{
+			&corev1.Service{},
+			&appsv1.Deployment{},
+			&corev1.Secret{},
+			&appsv1.StatefulSet{},
+		},
+		SkipWebhooks: false,
 	}
 
 	controller := radcontroller.NewRadiusController(&controllerOptions)


### PR DESCRIPTION
# Description

Adds more watch types (gateway, secret, etc) for radius to redeploy the resource if it's changed.

Build off https://github.com/Azure/radius/pull/1355, this PR currently uses it as a base.

## Issue reference

Part of https://github.com/Azure/radius/issues/1082, there are more places we need to make k8s data driven but it's a starting place.

