### PR TITLE
fix field selector to filter out the resource

### DIFF
--- a/pkg/cli/kubernetes/management.go
+++ b/pkg/cli/kubernetes/management.go
@@ -127,7 +127,7 @@ func (mc *KubernetesManagementClient) listAllResourcesByApplication(ctx context.
 	}
 	fieldSelector := map[string]string{}
 	if resourceName != "" {
-		fieldSelector["metadata.name"] = resourceName
+		fieldSelector["metadata.name"] = applicationName + "-" + resourceName
 	}
 	labelSelector := map[string]string{kubernetes.LabelRadiusApplication: applicationName}
 	if resourceType != "" {

--- a/pkg/cli/kubernetes/management.go
+++ b/pkg/cli/kubernetes/management.go
@@ -125,18 +125,10 @@ func (mc *KubernetesManagementClient) listAllResourcesByApplication(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	fieldSelector := map[string]string{}
-	if resourceName != "" {
-		fieldSelector["metadata.name"] = applicationName + "-" + resourceName
-	}
-	labelSelector := map[string]string{kubernetes.LabelRadiusApplication: applicationName}
-	if resourceType != "" {
-		labelSelector[kubernetes.LabelRadiusResourceType] = resourceType
-	}
 	filter := metav1.ListOptions{
-		FieldSelector: labels.SelectorFromSet(labels.Set(fieldSelector)).String(),
-		LabelSelector: labels.SelectorFromSet(labels.Set(labelSelector)).String(),
+		LabelSelector: labels.FormatLabels(kubernetes.MakeSelectorLabels(applicationName, resourceName)),
 	}
+
 	results := []*radclient.RadiusResource{}
 	for _, crd := range crds {
 		resourceClient := mc.DynamicClient.Resource(schema.GroupVersionResource{

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -60,9 +60,14 @@ func MakeDescriptiveLabels(application string, resource string) map[string]strin
 // This function is used to generate the labels used by a Deployment to select its Pods. eg: the Deployment and Pods
 // are the same resource.
 func MakeSelectorLabels(application string, resource string) map[string]string {
+	if resource != "" {
+		return map[string]string{
+			LabelRadiusApplication: application,
+			LabelRadiusResource:    resource,
+		}
+	}
 	return map[string]string{
 		LabelRadiusApplication: application,
-		LabelRadiusResource:    resource,
 	}
 }
 


### PR DESCRIPTION
# Description

rad resource show uses a field selector. This did not have an application name prefixed due to which there was no resource in the filtered list
## Issue reference
#1407 

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
