### PR TITLE
Add `secrets` section to Redis components properties

### DIFF
--- a/pkg/azure/radclient/zz_generated_models.go
+++ b/pkg/azure/radclient/zz_generated_models.go
@@ -2070,11 +2070,8 @@ type RedisComponentPropertiesSecrets struct {
 	// The Redis connection string used to connect to the redis cache
 	ConnectionString *string `json:"connectionString,omitempty"`
 
-	// The primary key for this Redis instance
-	PrimaryKey *string `json:"primaryKey,omitempty"`
-
-	// The secondard key for this Redis instance
-	SecondaryKey *string `json:"secondaryKey,omitempty"`
+	// The password for this Redis instance
+	Password *string `json:"password,omitempty"`
 }
 
 // RedisComponentResource - The redislabs.com/Redis component is a portable component which can be deployed to any Radius platform.

--- a/pkg/azure/radclient/zz_generated_models.go
+++ b/pkg/azure/radclient/zz_generated_models.go
@@ -2005,9 +2005,6 @@ func (r RedisComponentList) MarshalJSON() ([]byte, error) {
 
 type RedisComponentProperties struct {
 	BasicComponentProperties
-	// The Redis connection string used to connect to the redis cache
-	ConnectionString *string `json:"connectionString,omitempty"`
-
 	// The host name of the redis cache to which you are connecting
 	Host *string `json:"host,omitempty"`
 
@@ -2019,17 +2016,18 @@ type RedisComponentProperties struct {
 
 	// The ID of the user-managed Redis cache to use for this Component
 	Resource *string `json:"resource,omitempty"`
+	Secrets *RedisComponentPropertiesSecrets `json:"secrets,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type RedisComponentProperties.
 func (r RedisComponentProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	r.BasicComponentProperties.marshalInternal(objectMap)
-	populate(objectMap, "connectionString", r.ConnectionString)
 	populate(objectMap, "host", r.Host)
 	populate(objectMap, "managed", r.Managed)
 	populate(objectMap, "port", r.Port)
 	populate(objectMap, "resource", r.Resource)
+	populate(objectMap, "secrets", r.Secrets)
 	return json.Marshal(objectMap)
 }
 
@@ -2042,9 +2040,6 @@ func (r *RedisComponentProperties) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "connectionString":
-				err = unpopulate(val, &r.ConnectionString)
-				delete(rawMsg, key)
 		case "host":
 				err = unpopulate(val, &r.Host)
 				delete(rawMsg, key)
@@ -2057,6 +2052,9 @@ func (r *RedisComponentProperties) UnmarshalJSON(data []byte) error {
 		case "resource":
 				err = unpopulate(val, &r.Resource)
 				delete(rawMsg, key)
+		case "secrets":
+				err = unpopulate(val, &r.Secrets)
+				delete(rawMsg, key)
 		}
 		if err != nil {
 			return err
@@ -2066,6 +2064,17 @@ func (r *RedisComponentProperties) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return nil
+}
+
+type RedisComponentPropertiesSecrets struct {
+	// The Redis connection string used to connect to the redis cache
+	ConnectionString *string `json:"connectionString,omitempty"`
+
+	// The primary key for this Redis instance
+	PrimaryKey *string `json:"primaryKey,omitempty"`
+
+	// The secondard key for this Redis instance
+	SecondaryKey *string `json:"secondaryKey,omitempty"`
 }
 
 // RedisComponentResource - The redislabs.com/Redis component is a portable component which can be deployed to any Radius platform.

--- a/pkg/radrp/schema/components/redis.json
+++ b/pkg/radrp/schema/components/redis.json
@@ -67,12 +67,8 @@
                 "redis.default.svc.cluster.local:6379"
               ]
             },
-            "primaryKey": {
-              "description": "The primary key for this Redis instance",
-              "type": "string"
-            },
-            "secondaryKey": {
-              "description": "The secondard key for this Redis instance",
+            "password": {
+              "description": "The password for this Redis instance",
               "type": "string"
             }
           }

--- a/pkg/radrp/schema/components/redis.json
+++ b/pkg/radrp/schema/components/redis.json
@@ -39,14 +39,6 @@
             "account::redis.id"
           ]
         },
-        "connectionString": {
-          "description": "The Redis connection string used to connect to the redis cache",
-          "type": "string",
-          "example": [
-            "myrediscache.redis.cache.windows.net:6380",
-            "redis.default.svc.cluster.local:6379"
-          ]
-        },
         "host": {
           "description": "The host name of the redis cache to which you are connecting",
           "type": "string",
@@ -62,6 +54,28 @@
             6380,
             6379
           ]
+        },
+        "secrets": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "connectionString": {
+              "description": "The Redis connection string used to connect to the redis cache",
+              "type": "string",
+              "example": [
+                "myrediscache.redis.cache.windows.net:6380",
+                "redis.default.svc.cluster.local:6379"
+              ]
+            },
+            "primaryKey": {
+              "description": "The primary key for this Redis instance",
+              "type": "string"
+            },
+            "secondaryKey": {
+              "description": "The secondard key for this Redis instance",
+              "type": "string"
+            }
+          }
         }
       }
     }

--- a/pkg/radrp/schema/testdata/redislabs.com.RedisComponent/redis-invalid.json
+++ b/pkg/radrp/schema/testdata/redislabs.com.RedisComponent/redis-invalid.json
@@ -3,6 +3,9 @@
   "name": 42,
   "properties": {
     "managed": true,
-    "additional": "property"
+    "additional": "property",
+    "secrets": {
+      "additional": "property"
+    }
   }
 }

--- a/pkg/radrp/schema/testdata/redislabs.com.RedisComponent/redis-invalid.txt
+++ b/pkg/radrp/schema/testdata/redislabs.com.RedisComponent/redis-invalid.txt
@@ -1,3 +1,4 @@
 (root).id: Invalid type. Expected: string, given: integer
 (root).name: Invalid type. Expected: string, given: integer
 (root).properties: Additional property additional is not allowed
+(root).properties.secrets: Additional property additional is not allowed

--- a/pkg/radrp/schema/testdata/redislabs.com.RedisComponent/redis-valid.json
+++ b/pkg/radrp/schema/testdata/redislabs.com.RedisComponent/redis-valid.json
@@ -3,8 +3,12 @@
   "name": "name",
   "properties": {
     "managed": true,
-    "connectionString": "connection-string",
     "host": "localhost",
-    "port": 6380
+    "port": 6380,
+    "secrets": {
+      "connectionString": "connection-string",
+      "primaryKey": "primary-key",
+      "secondaryKey": "secondary-key"
+    }
   }
 }

--- a/pkg/radrp/schema/testdata/redislabs.com.RedisComponent/redis-valid.json
+++ b/pkg/radrp/schema/testdata/redislabs.com.RedisComponent/redis-valid.json
@@ -7,8 +7,7 @@
     "port": 6380,
     "secrets": {
       "connectionString": "connection-string",
-      "primaryKey": "primary-key",
-      "secondaryKey": "secondary-key"
+      "password": "password"
     }
   }
 }

--- a/schemas/rest-api-specs/radius.json
+++ b/schemas/rest-api-specs/radius.json
@@ -1572,12 +1572,8 @@
               ],
               "type": "string"
             },
-            "primaryKey": {
-              "description": "The primary key for this Redis instance",
-              "type": "string"
-            },
-            "secondaryKey": {
-              "description": "The secondard key for this Redis instance",
+            "password": {
+              "description": "The password for this Redis instance",
               "type": "string"
             }
           },

--- a/schemas/rest-api-specs/radius.json
+++ b/schemas/rest-api-specs/radius.json
@@ -1534,14 +1534,6 @@
         }
       ],
       "properties": {
-        "connectionString": {
-          "description": "The Redis connection string used to connect to the redis cache",
-          "example": [
-            "myrediscache.redis.cache.windows.net:6380",
-            "redis.default.svc.cluster.local:6379"
-          ],
-          "type": "string"
-        },
         "host": {
           "description": "The host name of the redis cache to which you are connecting",
           "example": [
@@ -1568,6 +1560,28 @@
             "account::redis.id"
           ],
           "type": "string"
+        },
+        "secrets": {
+          "additionalProperties": false,
+          "properties": {
+            "connectionString": {
+              "description": "The Redis connection string used to connect to the redis cache",
+              "example": [
+                "myrediscache.redis.cache.windows.net:6380",
+                "redis.default.svc.cluster.local:6379"
+              ],
+              "type": "string"
+            },
+            "primaryKey": {
+              "description": "The primary key for this Redis instance",
+              "type": "string"
+            },
+            "secondaryKey": {
+              "description": "The secondard key for this Redis instance",
+              "type": "string"
+            }
+          },
+          "type": "object"
         }
       },
       "type": "object"


### PR DESCRIPTION
# Description

As part of radius-project/core-team#406 we want to add a `secrets` section to allow users to specify how to construct secrets that are provided by a `connection` to the resource. 

This would allow, when using K8s custom resources, a Bicep that looks like
```
import kubernetes from kubernetes

resource redisService 'kubernetes.core/Service@v1' existing = {
  metadata: {
    name: 'redis-master'
  }
}

resource redisSecret 'kubernetes.core/Secret@v1' existing = {
  metadata: {
    name: 'redis'
  }
}

resource app 'radius.dev/Application@v1alpha3' = {
  ...
  resource redis 'redislabs.com.RedisComponent' = {
    name: 'redis'
    properties: {
      host: '${redisService.metadata.name}.${redisService.metadata.namespace}.svc.cluster.local'
      port: redisService.spec.ports[0].port
      secrets: {
        connectionString: '${redisService.metadata.name}.${redisService.metadata.namespace}.svc.cluster.local:${redisService.spec.ports[0].port},password=${redisSecret.data['redis-password']}'
      }
    }
  }
}
```

## Issue reference

Part of radius-project/core-team#406 (Subtask: Add computed value fields into schema & Bicep compiler for Redis component)

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
