### PR TITLE
Add Azure resource type to database and rest data model

### DIFF
--- a/pkg/radrp/db/resources.go
+++ b/pkg/radrp/db/resources.go
@@ -5,8 +5,6 @@
 
 package db
 
-import "github.com/Azure/radius/pkg/azure/azresources"
-
 // RadiusResource represents one of the child resources of Application as stored in the database.
 type RadiusResource struct {
 	ID              string `bson:"_id"`
@@ -44,7 +42,7 @@ type AzureResource struct {
 	Type            string `bson:"type"`
 
 	// Radius resources that connect to this Azure resource
-	RadiusConnections []azresources.ResourceID `bson:"radiusConnections"`
+	RadiusConnectionIDs []string `bson:"radiusConnectionIDs"`
 }
 
 // see renderers.SecretValueReference for description

--- a/pkg/radrp/db/resources.go
+++ b/pkg/radrp/db/resources.go
@@ -40,6 +40,7 @@ type AzureResource struct {
 	ResourceGroup   string `bson:"resourceGroup"`
 	ApplicationName string `bson:"applicationName"`
 	ResourceName    string `bson:"resourceName"`
+	ResourceKind    string `bson:"resourceKind"`
 	Type            string `bson:"type"`
 
 	// Radius resources that connect to this Azure resource

--- a/pkg/radrp/db/resources.go
+++ b/pkg/radrp/db/resources.go
@@ -5,6 +5,8 @@
 
 package db
 
+import "github.com/Azure/radius/pkg/azure/azresources"
+
 // RadiusResource represents one of the child resources of Application as stored in the database.
 type RadiusResource struct {
 	ID              string `bson:"_id"`
@@ -29,6 +31,19 @@ type RadiusResourceStatus struct {
 	ProvisioningState string           `bson:"provisioningState"`
 	HealthState       string           `bson:"healthState"`
 	OutputResources   []OutputResource `bson:"outputResources,omitempty" structs:"-"` // Ignore stateful property during serialization
+}
+
+// AzureResource represents reference to an existing non-Radius azure resource that Radius resources connect to.
+type AzureResource struct {
+	ID              string `bson:"_id"`
+	SubscriptionID  string `bson:"subscriptionId"`
+	ResourceGroup   string `bson:"resourceGroup"`
+	ApplicationName string `bson:"applicationName"`
+	ResourceName    string `bson:"resourceName"`
+	Type            string `bson:"type"`
+
+	// Radius resources that connect to this Azure resource
+	RadiusConnections []azresources.ResourceID `bson:"radiusConnections"`
 }
 
 // see renderers.SecretValueReference for description

--- a/pkg/radrp/frontend/resourceprovider/convert.go
+++ b/pkg/radrp/frontend/resourceprovider/convert.go
@@ -129,3 +129,12 @@ func NewRestOutputResourceStatus(original []db.OutputResource) []rest.OutputReso
 	}
 	return rrs
 }
+
+func NewRestAzureResource(resource db.AzureResource) AzureResource {
+	return AzureResource{
+		ID:   resource.ID,
+		Name: resource.ResourceName,
+		Kind: resource.ResourceKind,
+		Type: resource.Type,
+	}
+}

--- a/pkg/radrp/frontend/resourceprovider/rest.go
+++ b/pkg/radrp/frontend/resourceprovider/rest.go
@@ -39,6 +39,7 @@ type RadiusResourceList struct {
 	Value []RadiusResource `json:"value"`
 }
 
+// AzureResource over the wire format for non-Radius Azure resources that are referenced from Radius resources in the application. These resources do not have output resources and may not support all the other properties included in RadiusResource type.
 type AzureResource struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`

--- a/pkg/radrp/frontend/resourceprovider/rest.go
+++ b/pkg/radrp/frontend/resourceprovider/rest.go
@@ -39,6 +39,13 @@ type RadiusResourceList struct {
 	Value []RadiusResource `json:"value"`
 }
 
+type AzureResource struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+	Type string `json:"type"`
+}
+
 // ListSecretsInput is used for the RP's 'listSecrets' custom action.
 type ListSecretsInput struct {
 	// TargetID is the resource ID of the Radius resource for which secrets are being listed.

--- a/pkg/resourcekinds/resource_kinds.go
+++ b/pkg/resourcekinds/resource_kinds.go
@@ -8,6 +8,7 @@ package resourcekinds
 // ResourceKinds supported. The RP determines how these are created/deleted and the HealthService determines how
 // health checks are handled for these
 const (
+	Azure                            = "azure"
 	Kubernetes                       = "kubernetes"
 	Deployment                       = "Deployment"
 	Service                          = "Service"


### PR DESCRIPTION
# Description

Update data model to support RBAC for non-Radius Azure resources. Adds new database and rest data type for Azure resource.

## Issue reference
https://github.com/Azure/radius/issues/1419

## Checklist

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change - N/A
* [ ] Adds necessary E2E tests for change - N/A
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
