### PR TITLE
Enable array access in ARM-JSON parser

### DIFF
--- a/pkg/cli/armtemplate/armtemplate.go
+++ b/pkg/cli/armtemplate/armtemplate.go
@@ -121,6 +121,8 @@ type evaluator struct {
 	PreserveExpressions bool
 }
 
+var _ armexpr.Visitor = &evaluator{}
+
 func Eval(template DeploymentTemplate, options TemplateOptions) ([]Resource, error) {
 	eva := &evaluator{
 		Template: template,
@@ -341,8 +343,13 @@ func (eva *evaluator) VisitStringLiteral(node *armexpr.StringLiteralNode) error 
 	return nil
 }
 
-func (eva *evaluator) VisitPropertyAccess(node *armexpr.PropertyAccessNode) error {
-	return errors.New("property access is not supported")
+func (eva *evaluator) VisitIntLiteral(node *armexpr.IntLiteralNode) error {
+	eva.Value = node.Value
+	return nil
+}
+
+func (eva *evaluator) VisitIndexingNode(node *armexpr.IndexingNode) error {
+	return errors.New("indexing is not supported")
 }
 
 func (eva *evaluator) VisitFunctionCall(node *armexpr.FunctionCallNode) error {

--- a/pkg/cli/armtemplate/testdata/k8s/conn/output.json
+++ b/pkg/cli/armtemplate/testdata/k8s/conn/output.json
@@ -9,7 +9,8 @@
                 }
             },
             "data": {
-                "conn": "redis-master.default.svc.cluster.local,password=awesome"
+                "conn": "redis-master.default.svc.cluster.local,password=awesome",
+                "port": "6379"
             }
         }
     }

--- a/pkg/cli/armtemplate/testdata/k8s/conn/service.yaml
+++ b/pkg/cli/armtemplate/testdata/k8s/conn/service.yaml
@@ -5,3 +5,8 @@ metadata:
   namespace: default
 spec:
   type: ClusterIP
+  ports:
+  - name: tcp-redis
+    port: 6379
+    protocol: TCP
+    targetPort: redis

--- a/pkg/cli/armtemplate/testdata/k8s/conn/template.json
+++ b/pkg/cli/armtemplate/testdata/k8s/conn/template.json
@@ -31,7 +31,8 @@
           }
         },
         "data": {
-          "conn": "[format('{0}.{1}.svc.cluster.local,password={2}', reference(resourceId('kubernetes.core/Service', 'redis-master'), 'v1', 'full').properties.metadata.name, reference(resourceId('kubernetes.core/Service', 'redis-master'), 'v1', 'full').properties.metadata.namespace, base64ToString(reference(resourceId('kubernetes.core/Secret', 'redis'), 'v1', 'full').properties.data.redisPassword))]"
+          "conn": "[format('{0}.{1}.svc.cluster.local,password={2}', reference(resourceId('kubernetes.core/Service', 'redis-master'), 'v1', 'full').properties.metadata.name, reference(resourceId('kubernetes.core/Service', 'redis-master'), 'v1', 'full').properties.metadata.namespace, base64ToString(reference(resourceId('kubernetes.core/Secret', 'redis'), 'v1', 'full').properties.data.redisPassword))]",
+          "port": "[format('{0}', reference(resourceId('kubernetes.core/Service', 'redis-master'), 'v1', 'full').properties.spec.ports[0].port)]"
         }
       }
     }

--- a/pkg/model/components/bindings.go
+++ b/pkg/model/components/bindings.go
@@ -364,7 +364,12 @@ func (visitor *visitor) VisitStringLiteral(node *armexpr.StringLiteralNode) erro
 	return nil
 }
 
-func (visitor *visitor) VisitPropertyAccess(node *armexpr.PropertyAccessNode) error {
+func (visitor *visitor) VisitIntLiteral(node *armexpr.IntLiteralNode) error {
+	visitor.value = node.Value
+	return nil
+}
+
+func (visitor *visitor) VisitIndexingNode(node *armexpr.IndexingNode) error {
 	err := node.Base.Accept(visitor)
 	if err != nil {
 		return err

--- a/pkg/radrp/armexpr/expression.go
+++ b/pkg/radrp/armexpr/expression.go
@@ -46,6 +46,23 @@ func (node *IdentifierNode) GetSpan() Span {
 	return node.Span
 }
 
+type IntLiteralNode struct {
+	Span  Span
+	Value int
+}
+
+func (node *IntLiteralNode) GetSpan() Span {
+	return node.Span
+}
+
+func (node *IntLiteralNode) GetKind() ExpressionKind {
+	return KindString
+}
+
+func (node *IntLiteralNode) Accept(visitor Visitor) error {
+	return visitor.VisitIntLiteral(node)
+}
+
 type StringLiteralNode struct {
 	Span Span
 	Text string
@@ -81,25 +98,25 @@ func (node *FunctionCallNode) Accept(visitor Visitor) error {
 	return visitor.VisitFunctionCall(node)
 }
 
-type PropertyAccessNode struct {
+type IndexingNode struct {
 	Span       Span
 	Base       ExpressionNode
 	Identifier IdentifierNode
-	String     ExpressionNode
+	IndexExpr  ExpressionNode
 }
 
-func (node *PropertyAccessNode) GetSpan() Span {
+func (node *IndexingNode) GetSpan() Span {
 	return node.Span
 }
 
-func (node *PropertyAccessNode) GetKind() ExpressionKind {
+func (node *IndexingNode) GetKind() ExpressionKind {
 	return KindProperty
 }
 
-func (node *PropertyAccessNode) Accept(visitor Visitor) error {
-	return visitor.VisitPropertyAccess(node)
+func (node *IndexingNode) Accept(visitor Visitor) error {
+	return visitor.VisitIndexingNode(node)
 }
 
 var _ ExpressionNode = &StringLiteralNode{}
-var _ ExpressionNode = &PropertyAccessNode{}
+var _ ExpressionNode = &IndexingNode{}
 var _ ExpressionNode = &FunctionCallNode{}

--- a/pkg/radrp/armexpr/parser.go
+++ b/pkg/radrp/armexpr/parser.go
@@ -114,6 +114,9 @@ func ParseExpression(t *tokenizer) (ExpressionNode, error) {
 	} else if unicode.IsNumber(r) {
 		// We only support unsigned int constants now
 		v, err = ParseUnsignedInt(t)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		return nil, errors.New("expected expression")
 	}

--- a/pkg/radrp/armexpr/parser_test.go
+++ b/pkg/radrp/armexpr/parser_test.go
@@ -40,19 +40,19 @@ func Test_Parse_SyntaxTree_Valid(t *testing.T) {
 					Start:  0,
 					Length: 138,
 				},
-				Expression: &PropertyAccessNode{
+				Expression: &IndexingNode{
 					Span: Span{
 						Start:  1,
 						Length: 136,
 					},
-					String: &StringLiteralNode{
+					IndexExpr: &StringLiteralNode{
 						Span: Span{
 							Start:  131,
 							Length: 5,
 						},
 						Text: "'web'",
 					},
-					Base: &PropertyAccessNode{
+					Base: &IndexingNode{
 						Span: Span{
 							Start:  1,
 							Length: 129,
@@ -202,7 +202,6 @@ func Test_Parse_PropertyAccess_Invalid(t *testing.T) {
 		".",
 		"reference()]",
 		"reference()",
-		"[reference()]foo",
 		"",
 	}
 
@@ -394,7 +393,7 @@ func Test_Parse_PropertyAccess_Valid(t *testing.T) {
 	inputs := []input{
 		{
 			Text: "test() .foo",
-			Expected: &PropertyAccessNode{
+			Expected: &IndexingNode{
 				Span: Span{
 					Start:  0,
 					Length: 11,
@@ -411,7 +410,7 @@ func Test_Parse_PropertyAccess_Valid(t *testing.T) {
 		},
 		{
 			Text: "test() .  foo  ",
-			Expected: &PropertyAccessNode{
+			Expected: &IndexingNode{
 				Span: Span{
 					Start:  0,
 					Length: 13,
@@ -422,6 +421,40 @@ func Test_Parse_PropertyAccess_Valid(t *testing.T) {
 						Length: 3,
 					},
 					Text: "foo",
+				},
+				Base: &base,
+			},
+		},
+		{
+			Text: "test() ['foo']",
+			Expected: &IndexingNode{
+				Span: Span{
+					Start:  0,
+					Length: 14,
+				},
+				IndexExpr: &StringLiteralNode{
+					Span: Span{
+						Start:  8,
+						Length: 5,
+					},
+					Text: "'foo'",
+				},
+				Base: &base,
+			},
+		},
+		{
+			Text: "test() [12345]",
+			Expected: &IndexingNode{
+				Span: Span{
+					Start:  0,
+					Length: 14,
+				},
+				IndexExpr: &IntLiteralNode{
+					Span: Span{
+						Start:  8,
+						Length: 5,
+					},
+					Value: 12345,
 				},
 				Base: &base,
 			},

--- a/pkg/radrp/armexpr/visitor.go
+++ b/pkg/radrp/armexpr/visitor.go
@@ -8,5 +8,6 @@ package armexpr
 type Visitor interface {
 	VisitFunctionCall(*FunctionCallNode) error
 	VisitStringLiteral(*StringLiteralNode) error
-	VisitPropertyAccess(*PropertyAccessNode) error
+	VisitIntLiteral(*IntLiteralNode) error
+	VisitIndexingNode(*IndexingNode) error
 }


### PR DESCRIPTION
# Description

Enable array access in ARM-JSON parser. This is required in radius-project/core-team#406 when we have to access the `spec.ports[i].port` property of a `v1/Service` object.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: radius-project/radius#1430 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
