### PR TITLE
Add `make install` target for convenience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@
 ARROW := \033[34;1m=>\033[0m
 
 # order matters for these
-include build/help.mk build/version.mk build/build.mk build/generate.mk build/test.mk build/controller.mk build/docker.mk build/localenv.mk
+include build/help.mk build/version.mk build/build.mk build/generate.mk build/test.mk build/controller.mk build/docker.mk build/localenv.mk build/install.mk

--- a/build/install.mk
+++ b/build/install.mk
@@ -1,0 +1,27 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+##@ Install
+
+RAD_LOCATION := $(shell which rad)
+
+.PHONY: install
+install: build-binaries ## Installs a local build for development
+	mkdir -p $(HOME)/.rad/{crd,bin}
+
+	@echo "$(ARROW) Installing rad"
+	cp $(OUT_DIR)/$(GOOS)_$(GOARCH)/$(BUILDTYPE_DIR)/rad$(BINARY_EXT) $(RAD_LOCATION)
+
+	@echo "$(ARROW) Installing radiusd"
+	cp $(OUT_DIR)/$(GOOS)_$(GOARCH)/$(BUILDTYPE_DIR)/radiusd$(BINARY_EXT) $(HOME)/.rad/bin/
+	@echo "$(ARROW) Installing radius-controller"
+	cp $(OUT_DIR)/$(GOOS)_$(GOARCH)/$(BUILDTYPE_DIR)/radius-controller$(BINARY_EXT) $(HOME)/.rad/bin/
+
+	@echo "$(ARROW) Installing CRDs"
+	rm $(HOME)/.rad/crd/*
+	cp -R deploy/Chart/CRDs/ $(HOME)/.rad/crd/
+
+	@echo "$(ARROW) Displaying output"
+	tree $(HOME)/.rad -a


### PR DESCRIPTION
This change adds a new makefile target to 'install' our bits as a local
working copy. I've been using this to iterate quickly on the local dev
scenario that uses `radiusd` but its generally useful as well for
updating `rad` locally.