### PR TITLE
Unmanaged Redis on Kubernetes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,4 +56,5 @@ require (
 	rsc.io/letsencrypt v0.0.3 // indirect
 	sigs.k8s.io/controller-runtime v0.9.2
 	sigs.k8s.io/gateway-api v0.3.0
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/pkg/cli/armtemplate/armconverter_test.go
+++ b/pkg/cli/armtemplate/armconverter_test.go
@@ -11,8 +11,12 @@ import (
 	"path"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
 )
 
 func Test_ArmToK8sConversion(t *testing.T) {
@@ -54,8 +58,9 @@ func Test_ArmToK8sConversion(t *testing.T) {
 
 	actual := map[string]*unstructured.Unstructured{}
 	for _, resource := range resources {
-		k8sInfo, err := ConvertToK8s(resource, "default")
+		k8sInfo, secrets, err := ConvertToK8s(resource, "default")
 		require.NoError(t, err)
+		assert.Empty(t, secrets)
 		actual[k8sInfo.GetObjectKind().GroupVersionKind().Kind+"-"+k8sInfo.GetName()] = k8sInfo
 	}
 
@@ -72,6 +77,44 @@ func Test_ArmToK8sConversion(t *testing.T) {
 
 		require.JSONEq(t, string(expectedUns), string(actualUns))
 	}
+}
+
+func Test_ArmToK8sConversion_ManagedSecret(t *testing.T) {
+	content, err := ioutil.ReadFile("testdata/managed-secret/template.json")
+	require.NoError(t, err)
+
+	template, err := Parse(string(content))
+	require.NoError(t, err)
+
+	resources, err := Eval(template, TemplateOptions{})
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(resources))
+	k8sInfo, secret, err := ConvertToK8s(resources[0], "default")
+	require.NoError(t, err)
+
+	// Compare the scraped secret content.
+	secretContent, err := ioutil.ReadFile("testdata/managed-secret/secret.yaml")
+	require.NoError(t, err)
+	expectedSecret := map[string]string{}
+	require.NoError(t, yaml.Unmarshal(secretContent, &expectedSecret))
+	if diff := cmp.Diff(expectedSecret, secret); diff != "" {
+		t.Errorf("unexpected diff in secret -(want, +got): %s", diff)
+	}
+
+	// Now verify that secrets are all redacted
+	spec, hasSpec := k8sInfo.Object["spec"].(map[string]interface{})
+	require.True(t, hasSpec)
+	tmplRaw, hasTemplate := spec["template"].(runtime.RawExtension)
+	require.True(t, hasTemplate)
+	tmpl := make(map[string]interface{})
+	require.NoError(t, json.Unmarshal(tmplRaw.Raw, &tmpl))
+	body, hasBody := tmpl["body"].(map[string]interface{})
+	require.True(t, hasBody)
+	properties, hasProperties := body["properties"].(map[string]interface{})
+	require.True(t, hasProperties)
+	_, hasSecrets := properties["secrets"].(map[string]interface{})
+	require.False(t, hasSecrets)
 }
 
 func TestUnwrapK8sUnstructured(t *testing.T) {
@@ -203,13 +246,14 @@ func TestUnwrapK8sUnstructured(t *testing.T) {
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			output, err := ConvertToK8s(tc.input, "default")
+			output, secrets, err := ConvertToK8s(tc.input, "default")
 			if err != nil {
 				require.True(t, tc.expectedErr != "", "unexpected err %v", err)
 				require.Regexp(t, tc.expectedErr, err.Error())
 				return
 			}
 			require.Equal(t, tc.expected, *output)
+			assert.Empty(t, secrets)
 		})
 	}
 }

--- a/pkg/cli/armtemplate/testdata/managed-secret/redis.yaml
+++ b/pkg/cli/armtemplate/testdata/managed-secret/redis.yaml
@@ -1,0 +1,32 @@
+apiVersion: radius.dev/v1alpha3
+kind: RedisComponent
+metadata:
+  annotations:
+    radius.dev/application: kubernetes-resources-redis-unmanaged
+    radius.dev/resource: redis
+    radius.dev/resource-type: redislabs.com.RedisComponent
+  labels:
+    app.kubernetes.io/managed-by: radius-rp
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: kubernetes-resources-redis-unmanaged
+    radius.dev/application: kubernetes-resources-redis-unmanaged
+    radius.dev/resource: redis
+    radius.dev/resource-type: redislabs.com.RedisComponent
+  name: kubernetes-resources-redis-unmanaged-redis
+  namespace: default
+spec:
+  application: kubernetes-resources-redis-unmanaged
+  resource: redis
+  template:
+    apiVersion: 2018-09-01-preview
+    body:
+      properties:
+        host: my-redis.com
+        port: 1234
+        secrets:
+          connectionString: '*****'
+          password: '*****'
+    dependsOn: []
+    id: /subscriptions//resourceGroups//providers/Microsoft.CustomProviders/resourceProviders/radiusv3/Application/kubernetes-resources-redis-unmanaged/redislabs.com.RedisComponent/redis
+    name: radiusv3/kubernetes-resources-redis-unmanaged/redis
+    type: Microsoft.CustomProviders/resourceProviders/Application/redislabs.com.RedisComponent

--- a/pkg/cli/armtemplate/testdata/managed-secret/secret.yaml
+++ b/pkg/cli/armtemplate/testdata/managed-secret/secret.yaml
@@ -1,0 +1,2 @@
+connectionString: connectionString
+password: password

--- a/pkg/cli/armtemplate/testdata/managed-secret/template.json
+++ b/pkg/cli/armtemplate/testdata/managed-secret/template.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1004.46306",
+      "templateHash": "5971979958412524905"
+    }
+  },
+  "functions": [],
+  "resources": [
+    {
+      "type": "Microsoft.CustomProviders/resourceProviders/Application/redislabs.com.RedisComponent",
+      "apiVersion": "2018-09-01-preview",
+      "name": "[format('{0}/{1}/{2}', 'radiusv3', 'kubernetes-resources-redis-unmanaged', 'redis')]",
+      "properties": {
+        "host": "my-redis.com",
+        "port": 1234,
+        "secrets": {
+          "connectionString": "connectionString",
+          "password": "password"
+        }
+      }
+    }
+  ]
+}

--- a/pkg/kubernetes/controllers/radius/resource_controller.go
+++ b/pkg/kubernetes/controllers/radius/resource_controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Azure/radius/pkg/cli/armtemplate"
 	"github.com/Azure/radius/pkg/healthcontract"
 	"github.com/Azure/radius/pkg/kubernetes"
+	"github.com/Azure/radius/pkg/kubernetes/api/radius/v1alpha3"
 	radiusv1alpha3 "github.com/Azure/radius/pkg/kubernetes/api/radius/v1alpha3"
 	"github.com/Azure/radius/pkg/kubernetes/converters"
 	"github.com/Azure/radius/pkg/model"
@@ -433,7 +434,12 @@ func (r *ResourceReconciler) ApplyState(
 			}
 			// Mention the scraped secret resource in the local ID so that we can refer
 			// to it in ComputedValues.
-			resource.Status.Resources[localId] = *or
+			resource.Status.Resources[localId] = &v1alpha3.OutputResource{
+				Resource: *or,
+				Status: radiusv1alpha3.OutputResourceStatus{
+					ProvisioningState: kubernetes.ProvisioningStateProvisioned,
+				},
+			}
 
 			// Do not delete scraped secret. While the `ownerRef` mechanism was use
 			// so that the scraped secret is cleaned up whenever our resource is cleaned up,
@@ -512,7 +518,7 @@ func outputResourceToKubernetesObject(namespace string, outputResource outputres
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
-	annotations[AnnotationLocalID] = outputResource.LocalID
+	annotations[kubernetes.AnnotationLocalID] = outputResource.LocalID
 	obj.SetAnnotations(annotations)
 
 	return obj, nil

--- a/pkg/kubernetes/controllers/radius/resource_controller.go
+++ b/pkg/kubernetes/controllers/radius/resource_controller.go
@@ -199,8 +199,11 @@ func (r *ResourceReconciler) UpdateResourceStatus(ctx context.Context, log logr.
 		or, err := r.getOutputResource(desired, a)
 		if err != nil {
 			// No output resource to update the state for
-			log.Error(err, fmt.Sprintf("Unable to find output resource with name: %s-%s", a.GetNamespace(), a.GetName()))
+			log.Error(err, fmt.Sprintf("Unable to find output resource with name: %s/%s", a.GetNamespace(), a.GetName()))
 			return
+		}
+		if or == nil {
+			continue
 		}
 
 		var healthState string

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -23,7 +23,8 @@ const (
 	LabelManagedBy          = "app.kubernetes.io/managed-by"
 	LabelManagedByRadiusRP  = "radius-rp"
 
-	FieldManager = "radius-rp"
+	FieldManager      = "radius-rp"
+	AnnotationLocalID = "radius.dev/local-id"
 )
 
 // NOTE: the difference between descriptive labels and selector labels

--- a/pkg/kubernetes/object.go
+++ b/pkg/kubernetes/object.go
@@ -139,18 +139,18 @@ func GetShortenedTargetPortName(name string) string {
 
 // MakeScrapedSecretName creates a Secret scraped from input values passed through
 // from the deployment template.
-func MakeScrapedSecretName(appName string, resourceType string, resourceName string) string {
-	return strings.ToLower(appName + "-" + resourceType + "-" + resourceName)
+func MakeScrapedSecretName(appName string, resourceKind string, resourceName string) string {
+	return strings.ToLower(appName + "-" + resourceKind + "-" + resourceName)
 }
 
-func MakeScrapedSecret(appName string, resourceType string, resourceName string) *corev1.Secret {
+func MakeScrapedSecret(appName string, resourceKind string, resourceName string) *corev1.Secret {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   MakeScrapedSecretName(appName, resourceType, resourceName),
+			Name:   MakeScrapedSecretName(appName, resourceKind, resourceName),
 			Labels: MakeDescriptiveLabels(appName, resourceName),
 			Annotations: map[string]string{
 				AnnotationLocalID: outputresource.LocalIDScrapedSecret,

--- a/pkg/radrp/outputresource/local_ids.go
+++ b/pkg/radrp/outputresource/local_ids.go
@@ -57,6 +57,7 @@ const (
 	LocalIDRabbitMQService              = "KubernetesRabbitMQService"
 	LocalIDRedisDeployment              = "KubernetesRedisDeployment"
 	LocalIDRedisService                 = "KubernetesRedisService"
+	LocalIDScrapedSecret                = "KubernetesScrapedSecret"
 	LocalIDSecret                       = "Secret"
 	LocalIDService                      = "Service"
 	LocalIDStatefulSet                  = "StatefulSet"

--- a/pkg/renderers/redisv1alpha3/kubernetesrender_test.go
+++ b/pkg/renderers/redisv1alpha3/kubernetesrender_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/Azure/radius/pkg/radlogger"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
 	"github.com/Azure/radius/pkg/renderers"
-	"github.com/Azure/radius/pkg/resourcekinds"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
@@ -142,12 +141,6 @@ func TestRenderUnmanagedRedis(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := renderers.RendererOutput{
-		Resources: []outputresource.OutputResource{{
-			ResourceKind: resourcekinds.Kubernetes,
-			LocalID:      outputresource.LocalIDScrapedSecret,
-			Resource: kubernetes.MakeScrapedSecret(
-				input.ApplicationName, "RedisComponent", input.ResourceName),
-		}},
 		ComputedValues: map[string]renderers.ComputedValueReference{
 			"host": {
 				Value: to.StringPtr("hello.com"),

--- a/pkg/renderers/redisv1alpha3/kubernetesrender_test.go
+++ b/pkg/renderers/redisv1alpha3/kubernetesrender_test.go
@@ -9,11 +9,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/Azure/radius/pkg/kubernetes"
 	"github.com/Azure/radius/pkg/radlogger"
+	"github.com/Azure/radius/pkg/radrp/outputresource"
 	"github.com/Azure/radius/pkg/renderers"
+	"github.com/Azure/radius/pkg/resourcekinds"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -114,23 +118,57 @@ func Test_Render_Managed_Kubernetes_Success(t *testing.T) {
 	require.Empty(t, output.SecretValues)
 }
 
-func Test_Render_KubernetesRedis_Unmanaged_Failure(t *testing.T) {
+func TestRenderUnmanagedRedis(t *testing.T) {
 	ctx := createContext(t)
 	renderer := KubernetesRenderer{}
 
-	resource := renderers.RendererResource{
+	input := renderers.RendererResource{
 		ApplicationName: "test-app",
 		ResourceName:    "test-redis",
 		ResourceType:    ResourceType,
 		Definition: map[string]interface{}{
-			"managed": false,
+			"host": "hello.com",
+			"port": 1234,
+			"secrets": map[string]interface{}{
+				"connectionString": "***",
+				"password":         "***",
+			},
 		},
 	}
-
-	_, err := renderer.Render(ctx, renderers.RenderOptions{
-		Resource:     resource,
+	output, err := renderer.Render(ctx, renderers.RenderOptions{
+		Resource:     input,
 		Dependencies: map[string]renderers.RendererDependency{},
 	})
-	require.Error(t, err)
-	require.Equal(t, "only managed = true is supported for the Kubernetes Redis Component", err.Error())
+	require.NoError(t, err)
+
+	expected := renderers.RendererOutput{
+		Resources: []outputresource.OutputResource{{
+			ResourceKind: resourcekinds.Kubernetes,
+			LocalID:      outputresource.LocalIDScrapedSecret,
+			Resource: kubernetes.MakeScrapedSecret(
+				input.ApplicationName, "RedisComponent", input.ResourceName),
+		}},
+		ComputedValues: map[string]renderers.ComputedValueReference{
+			"host": {
+				Value: to.StringPtr("hello.com"),
+			},
+			"port": {
+				Value: to.Int32Ptr(1234),
+			},
+			"username": {
+				Value: "",
+			},
+		},
+		SecretValues: map[string]renderers.SecretValueReference{
+			"password": {
+				LocalID:       outputresource.LocalIDScrapedSecret,
+				ValueSelector: "password",
+			},
+			"connectionString": {
+				LocalID:       outputresource.LocalIDScrapedSecret,
+				ValueSelector: "connectionString",
+			},
+		},
+	}
+	assert.DeepEqual(t, expected, output)
 }

--- a/test/functional/kubernetes/resources/redis_unmanaged_test.go
+++ b/test/functional/kubernetes/resources/redis_unmanaged_test.go
@@ -1,0 +1,51 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package resource_test
+
+import (
+	"testing"
+
+	"github.com/Azure/radius/pkg/radrp/outputresource"
+	"github.com/Azure/radius/pkg/radrp/rest"
+	"github.com/Azure/radius/pkg/resourcekinds"
+	"github.com/Azure/radius/test/kubernetestest"
+	"github.com/Azure/radius/test/validation"
+)
+
+func TestRedisUnmanaged(t *testing.T) {
+	template := "testdata/kubernetes-resources-redis-unmanaged/kubernetes-resources-redis-unmanaged.bicep"
+	application := "kubernetes-resources-redis-unmanaged"
+	test := kubernetestest.NewApplicationTest(t, application, []kubernetestest.Step{
+		{
+			Executor: kubernetestest.NewDeployStepExecutor(template),
+			RadiusResources: &validation.ResourceSet{
+				Resources: []validation.RadiusResource{
+					{
+						ApplicationName: application,
+						ResourceName:    "todoapp",
+						OutputResources: map[string]validation.ExpectedOutputResource{
+							outputresource.LocalIDScrapedSecret: validation.NewOutputResource(
+								outputresource.LocalIDScrapedSecret,
+								outputresource.TypeKubernetes,
+								resourcekinds.Kubernetes, true, false, rest.OutputResourceStatus{}),
+						},
+					},
+				},
+			},
+			Pods: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					"default": {
+						// This will ensure that all the connection-properties
+						// were populated correctly.
+						validation.NewK8sObjectForResource(application, "todoapp"),
+					},
+				},
+			},
+		},
+	}, loadResources("testdata/kubernetes-resources-redis-unmanaged", ".input.yaml")...)
+
+	test.Test(t)
+}

--- a/test/functional/kubernetes/resources/testdata/kubernetes-resources-redis-unmanaged/kubernetes-resources-redis-unmanaged.bicep
+++ b/test/functional/kubernetes/resources/testdata/kubernetes-resources-redis-unmanaged/kubernetes-resources-redis-unmanaged.bicep
@@ -1,0 +1,46 @@
+import kubernetes from kubernetes
+
+resource redisService 'kubernetes.core/Service@v1' existing = {
+  metadata: {
+    name: 'redis-svc'
+  }
+}
+
+resource redisSecret 'kubernetes.core/Secret@v1' existing = {
+  metadata: {
+    name: 'redis-pw'
+  }
+}
+
+resource app 'radius.dev/Application@v1alpha3' = {
+  name: 'kubernetes-resources-redis-unmanaged'
+
+  resource webapp 'ContainerComponent' = {
+    name: 'todoapp'
+    properties: {
+      container: {
+        image: 'radius.azurecr.io/magpie:latest'
+        env: {
+        }
+      }
+      connections: {
+        redis: {
+          kind: 'redislabs.com/Redis'
+          source: redis.id
+        }
+      }
+    }
+  }
+
+  resource redis 'redislabs.com.RedisComponent' = {
+    name: 'redis'
+    properties: {
+      host: '${redisService.metadata.name}.${redisService.metadata.namespace}.svc.cluster.local'
+      port: redisService.spec.ports[0].port
+      secrets: {
+        connectionString: '${redisService.metadata.name}.${redisService.metadata.namespace}.svc.cluster.local:${redisService.spec.ports[0].port},password=${base64ToString(redisSecret.data['redis-password'])}'
+        password: base64ToString(redisSecret.data['redis-password'])
+      }
+    }
+  }
+}

--- a/test/functional/kubernetes/resources/testdata/kubernetes-resources-redis-unmanaged/secret.input.yaml
+++ b/test/functional/kubernetes/resources/testdata/kubernetes-resources-redis-unmanaged/secret.input.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-pw
+  namespace: default
+type: Opaque
+data:
+  'redis-password': YXdlc29tZQ==

--- a/test/functional/kubernetes/resources/testdata/kubernetes-resources-redis-unmanaged/secret.output.yaml
+++ b/test/functional/kubernetes/resources/testdata/kubernetes-resources-redis-unmanaged/secret.output.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-conn
+  namespace: default
+  labels:
+    format: custom
+data:
+  connectionString: cmVkaXMtbWFzdGVyLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwscGFzc3dvcmQ9YXdlc29tZQ==
+type: Opaque

--- a/test/functional/kubernetes/resources/testdata/kubernetes-resources-redis-unmanaged/service.input.yaml
+++ b/test/functional/kubernetes/resources/testdata/kubernetes-resources-redis-unmanaged/service.input.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-svc
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+  - name: tcp-redis
+    port: 6379
+    protocol: TCP
+    targetPort: redis
+  clusterIP: None


### PR DESCRIPTION
# Description

Support unmanaged Redis on Kubernetes.

## Issue reference

Part of radius-project/core-team#406 : In this step we scrape out the rendered secrets. Then we use them, together with other connection-provided properties, in the unmanaged `RedisComponent`'s `Status` as `ComputedValues`.

These `ComputedValues` are then handled by the existing connection-handling logic of `ContainerComponent` and thus will be rendered correctly in the pods as `SecretRef` env vars.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
