### PR TITLE
Removing Dependency field from resource_handler and its implementations

### DIFF
--- a/pkg/handlers/azure_cosmosdb_mongo.go
+++ b/pkg/handlers/azure_cosmosdb_mongo.go
@@ -45,12 +45,6 @@ func (handler *azureCosmosDBMongoHandler) Put(ctx context.Context, options *PutO
 
 	if properties[CosmosDBDatabaseIDKey] == "" {
 		var cosmosDBAccountName string
-		for _, resource := range options.Dependencies {
-			if resource.LocalID == outputresource.LocalIDAzureCosmosAccount {
-				cosmosDBAccountName = resource.Properties[CosmosDBAccountNameKey]
-			}
-		}
-
 		if properties, ok := options.DependencyProperties[outputresource.LocalIDAzureCosmosAccount]; ok {
 			cosmosDBAccountName = properties[CosmosDBAccountNameKey]
 		}

--- a/pkg/handlers/azure_cosmosdb_sql.go
+++ b/pkg/handlers/azure_cosmosdb_sql.go
@@ -43,12 +43,6 @@ func (handler *azureCosmosDBSQLDBHandler) Put(ctx context.Context, options *PutO
 
 	if properties[CosmosDBDatabaseIDKey] == "" {
 		var cosmosDBAccountName string
-		for _, resource := range options.Dependencies {
-			if resource.LocalID == outputresource.LocalIDAzureCosmosAccount {
-				cosmosDBAccountName = resource.Properties[CosmosDBAccountNameKey]
-			}
-		}
-
 		if properties, ok := options.DependencyProperties[outputresource.LocalIDAzureCosmosAccount]; ok {
 			cosmosDBAccountName = properties[CosmosDBAccountNameKey]
 		}

--- a/pkg/handlers/azure_podidentity.go
+++ b/pkg/handlers/azure_podidentity.go
@@ -45,12 +45,6 @@ func (handler *azurePodIdentityHandler) Put(ctx context.Context, options *PutOpt
 
 	// Get dependencies
 	managedIdentityProperties := map[string]string{}
-	for _, resource := range options.Dependencies {
-		if resource.LocalID == outputresource.LocalIDUserAssignedManagedIdentity {
-			managedIdentityProperties = resource.Properties
-		}
-	}
-
 	if properties, ok := options.DependencyProperties[outputresource.LocalIDUserAssignedManagedIdentity]; ok {
 		managedIdentityProperties = properties
 	}

--- a/pkg/handlers/azure_roleassignment.go
+++ b/pkg/handlers/azure_roleassignment.go
@@ -45,12 +45,6 @@ func (handler *azureRoleAssignmentHandler) Put(ctx context.Context, options *Put
 
 	// Get dependencies
 	managedIdentityProperties := map[string]string{}
-	for _, resource := range options.Dependencies {
-		if resource.LocalID == outputresource.LocalIDUserAssignedManagedIdentity {
-			managedIdentityProperties = resource.Properties
-		}
-	}
-
 	if properties, ok := options.DependencyProperties[outputresource.LocalIDUserAssignedManagedIdentity]; ok {
 		managedIdentityProperties = properties
 	}

--- a/pkg/handlers/resource_handler.go
+++ b/pkg/handlers/resource_handler.go
@@ -17,8 +17,6 @@ type PutOptions struct {
 	ResourceName    string
 	Resource        *outputresource.OutputResource
 
-	Dependencies []Dependency
-
 	// ExistingOutputResource is the current state of the output resource persisted in database
 	ExistingOutputResource *db.OutputResource
 


### PR DESCRIPTION
…ations

# Description

As a part of app model v3 [changes](https://github.com/Azure/radius/commit/4e416ad55540208e88bb50e26d961acc8f36109f#diff-52baae41a67933528b6278da9789f2e04b7b9c23e3bc0c7c4c385f6fd75b84a4), dependency properties were moved from [Dependency field](https://github.com/Azure/radius/blob/main/pkg/handlers/resource_handler.go#L20) in PutOptions to [DependencyProperties field](https://github.com/Azure/radius/blob/main/pkg/handlers/resource_handler.go#L26).

This fix is  to remove  Dependency from resource_handler and handler implementations where it is consumed.

## Issue reference

Fixes #1259 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
