### PR TITLE
Update schema to support RBAC on connections

### DIFF
--- a/pkg/azure/radclient/zz_generated_constants.go
+++ b/pkg/azure/radclient/zz_generated_constants.go
@@ -57,6 +57,7 @@ func (c CheckNameAvailabilityReason) ToPtr() *CheckNameAvailabilityReason {
 type ContainerConnectionKind string
 
 const (
+	ContainerConnectionKindAzure ContainerConnectionKind = "azure"
 	ContainerConnectionKindAzureComKeyVault ContainerConnectionKind = "azure.com/KeyVault"
 	ContainerConnectionKindAzureComServiceBusQueue ContainerConnectionKind = "azure.com/ServiceBusQueue"
 	ContainerConnectionKindDaprIoDaprHTTP ContainerConnectionKind = "dapr.io/DaprHttp"
@@ -73,6 +74,7 @@ const (
 // PossibleContainerConnectionKindValues returns the possible values for the ContainerConnectionKind const type.
 func PossibleContainerConnectionKindValues() []ContainerConnectionKind {
 	return []ContainerConnectionKind{	
+		ContainerConnectionKindAzure,
 		ContainerConnectionKindAzureComKeyVault,
 		ContainerConnectionKindAzureComServiceBusQueue,
 		ContainerConnectionKindDaprIoDaprHTTP,

--- a/pkg/azure/radclient/zz_generated_models.go
+++ b/pkg/azure/radclient/zz_generated_models.go
@@ -584,11 +584,23 @@ func (c ContainerComponentResource) MarshalJSON() ([]byte, error) {
 
 // ContainerConnection - Specifies a connection from the container to another resource
 type ContainerConnection struct {
-	// The kind of connection
+	// REQUIRED; The kind of connection
 	Kind *ContainerConnectionKind `json:"kind,omitempty"`
 
-	// The source of the connection
+	// REQUIRED; The source of the connection
 	Source *string `json:"source,omitempty"`
+
+	// RBAC permissions to be assigned on the source resource
+	Role []*string `json:"role,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ContainerConnection.
+func (c ContainerConnection) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "kind", c.Kind)
+	populate(objectMap, "role", c.Role)
+	populate(objectMap, "source", c.Source)
+	return json.Marshal(objectMap)
 }
 
 // ContainerPort - Specifies a listening port for the container

--- a/pkg/radrp/schema/components/container-component.json
+++ b/pkg/radrp/schema/components/container-component.json
@@ -189,6 +189,7 @@
           "description": "The kind of connection",
           "type": "string",
           "enum": [
+            "azure",
             "azure.com/KeyVault",
             "azure.com/ServiceBusQueue",
             "dapr.io/DaprHttp",
@@ -205,8 +206,19 @@
         "source": {
           "description": "The source of the connection",
           "type": "string"
+        },
+        "role": {
+          "description": "RBAC permissions to be assigned on the source resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
-      }
+      },
+      "required": [
+        "kind",
+        "source"
+      ]
     },
     "HealthProbeProperties": {
       "description": "Properties for readiness/liveness probe",

--- a/pkg/radrp/schema/testdata/ContainerComponent/containercomponent-1-invalid.json
+++ b/pkg/radrp/schema/testdata/ContainerComponent/containercomponent-1-invalid.json
@@ -3,10 +3,12 @@
     "connections": {
       "gateway": {
         "kind": "UnknownKind",
-        "anotherThing": true
+        "anotherThing": true,
+        "source": "id"
       },
       "backend": {
-        "kind": "Http"
+        "kind": "Http",
+        "source": "id"
       },
       "frontend": {
         "kind": "Http",

--- a/pkg/radrp/schema/testdata/ContainerComponent/containercomponent-1-invalid.txt
+++ b/pkg/radrp/schema/testdata/ContainerComponent/containercomponent-1-invalid.txt
@@ -1,5 +1,5 @@
 (root).properties.connections.frontend: Additional property anotherThing is not allowed
-(root).properties.connections.gateway.kind: properties.connections.gateway.kind must be one of the following: "azure.com/KeyVault", "azure.com/ServiceBusQueue", "dapr.io/DaprHttp", "dapr.io/PubSubTopic", "dapr.io/StateStore", "Grpc", "Http", "microsoft.com/SQL", "mongo.com/MongoDB", "rabbitmq.com/MessageQueue", "redislabs.com/Redis"
+(root).properties.connections.gateway.kind: properties.connections.gateway.kind must be one of the following: "azure", "azure.com/KeyVault", "azure.com/ServiceBusQueue", "dapr.io/DaprHttp", "dapr.io/PubSubTopic", "dapr.io/StateStore", "Grpc", "Http", "microsoft.com/SQL", "mongo.com/MongoDB", "rabbitmq.com/MessageQueue", "redislabs.com/Redis"
 (root).properties.connections.gateway: Additional property anotherThing is not allowed
 (root).properties.container.env.COol?: Invalid type. Expected: string, given: boolean
 (root).properties.container.image: Invalid type. Expected: string, given: integer

--- a/schemas/rest-api-specs/radius.json
+++ b/schemas/rest-api-specs/radius.json
@@ -409,6 +409,7 @@
         "kind": {
           "description": "The kind of connection",
           "enum": [
+            "azure",
             "azure.com/KeyVault",
             "azure.com/ServiceBusQueue",
             "dapr.io/DaprHttp",
@@ -423,11 +424,22 @@
           ],
           "type": "string"
         },
+        "role": {
+          "description": "RBAC permissions to be assigned on the source resource",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "source": {
           "description": "The source of the connection",
           "type": "string"
         }
       },
+      "required": [
+        "kind",
+        "source"
+      ],
       "type": "object"
     },
     "ContainerPort": {


### PR DESCRIPTION
# Description

Schema update to support https://github.com/Azure/radius/issues/1321

Adds role filed on container connection. This is an array to support multiple roles to be set. At this point I haven't implemented suggestions to show few default role names to prioritize end to end integration over perfecting bicep experience.

## Issue reference

https://github.com/Azure/radius/issues/1482

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it