### PR TITLE
Schema change for K8s extension fields of MongoDBComponent

### DIFF
--- a/pkg/azure/radclient/zz_generated_models.go
+++ b/pkg/azure/radclient/zz_generated_models.go
@@ -1971,6 +1971,8 @@ type MongoDBComponentProperties struct {
 
 	// The ID of the user-managed DB with Mongo API to use for this Component
 	Resource *string `json:"resource,omitempty"`
+
+	// Secrets provided by unmanaged resources,
 	Secrets *MongoDBComponentPropertiesSecrets `json:"secrets,omitempty"`
 }
 
@@ -2021,6 +2023,7 @@ func (m *MongoDBComponentProperties) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MongoDBComponentPropertiesSecrets - Secrets provided by unmanaged resources,
 type MongoDBComponentPropertiesSecrets struct {
 	// The connection string used to connect to this DB
 	ConnectionString *string `json:"connectionString,omitempty"`

--- a/pkg/azure/radclient/zz_generated_models.go
+++ b/pkg/azure/radclient/zz_generated_models.go
@@ -1960,19 +1960,29 @@ func (m MongoDBComponentList) MarshalJSON() ([]byte, error) {
 
 type MongoDBComponentProperties struct {
 	BasicComponentProperties
+	// The host name of the MongoDB to which you are connecting
+	Host *string `json:"host,omitempty"`
+
 	// Indicates if the resource is Radius-managed. If false, a Resource must be specified
 	Managed *bool `json:"managed,omitempty"`
 
+	// The port value of the MongoDB to which you are connecting
+	Port *int32 `json:"port,omitempty"`
+
 	// The ID of the user-managed DB with Mongo API to use for this Component
 	Resource *string `json:"resource,omitempty"`
+	Secrets *MongoDBComponentPropertiesSecrets `json:"secrets,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type MongoDBComponentProperties.
 func (m MongoDBComponentProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	m.BasicComponentProperties.marshalInternal(objectMap)
+	populate(objectMap, "host", m.Host)
 	populate(objectMap, "managed", m.Managed)
+	populate(objectMap, "port", m.Port)
 	populate(objectMap, "resource", m.Resource)
+	populate(objectMap, "secrets", m.Secrets)
 	return json.Marshal(objectMap)
 }
 
@@ -1985,11 +1995,20 @@ func (m *MongoDBComponentProperties) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
+		case "host":
+				err = unpopulate(val, &m.Host)
+				delete(rawMsg, key)
 		case "managed":
 				err = unpopulate(val, &m.Managed)
 				delete(rawMsg, key)
+		case "port":
+				err = unpopulate(val, &m.Port)
+				delete(rawMsg, key)
 		case "resource":
 				err = unpopulate(val, &m.Resource)
+				delete(rawMsg, key)
+		case "secrets":
+				err = unpopulate(val, &m.Secrets)
 				delete(rawMsg, key)
 		}
 		if err != nil {
@@ -2000,6 +2019,17 @@ func (m *MongoDBComponentProperties) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return nil
+}
+
+type MongoDBComponentPropertiesSecrets struct {
+	// The connection string used to connect to this DB
+	ConnectionString *string `json:"connectionString,omitempty"`
+
+	// The password for this MongoDB instance
+	Password *string `json:"password,omitempty"`
+
+	// The password for this MongoDB instance
+	Username *string `json:"username,omitempty"`
 }
 
 // MongoDBComponentResource - The mongodb.com/MongoDB component is a portable component which can be deployed to any Radius platform.

--- a/pkg/radrp/schema/components/mongodb.json
+++ b/pkg/radrp/schema/components/mongodb.json
@@ -35,6 +35,35 @@
           "example": [
             "account::mongodb.id"
           ]
+        },
+        "host": {
+          "description": "The host name of the MongoDB to which you are connecting",
+          "type": "string"
+        },
+        "port": {
+          "description": "The port value of the MongoDB to which you are connecting",
+          "type": "integer",
+          "example": [
+            27017
+          ]
+        },
+        "secrets": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "username": {
+              "description": "The password for this MongoDB instance",
+              "type": "string"
+            },
+            "password": {
+              "description": "The password for this MongoDB instance",
+              "type": "string"
+            },
+            "connectionString": {
+              "description": "The connection string used to connect to this DB",
+              "type": "string"
+            }
+          }
         }
       }
     }

--- a/pkg/radrp/schema/components/mongodb.json
+++ b/pkg/radrp/schema/components/mongodb.json
@@ -49,6 +49,7 @@
         },
         "secrets": {
           "type": "object",
+          "description": "Secrets provided by unmanaged resources,",
           "additionalProperties": false,
           "properties": {
             "username": {

--- a/pkg/radrp/schema/testdata/mongodb.com.MongoDBComponent/mongodb-invalid.json
+++ b/pkg/radrp/schema/testdata/mongodb.com.MongoDBComponent/mongodb-invalid.json
@@ -8,6 +8,9 @@
     "host": 42,
     "port": "should-be-number",
     "secrets": {
+      "username": 42,
+      "password": 42,
+      "connectionString": 42,
       "extra": "foo"
     }
   }

--- a/pkg/radrp/schema/testdata/mongodb.com.MongoDBComponent/mongodb-invalid.json
+++ b/pkg/radrp/schema/testdata/mongodb.com.MongoDBComponent/mongodb-invalid.json
@@ -4,6 +4,11 @@
   "kind": "mongodb.com/Mongo@v1alpha1",
   "properties": {
     "managed": true,
-    "extra": "foo"
+    "extra": "foo",
+    "host": 42,
+    "port": "should-be-number",
+    "secrets": {
+      "extra": "foo"
+    }
   }
 }

--- a/pkg/radrp/schema/testdata/mongodb.com.MongoDBComponent/mongodb-invalid.txt
+++ b/pkg/radrp/schema/testdata/mongodb.com.MongoDBComponent/mongodb-invalid.txt
@@ -1,3 +1,6 @@
 (root).id: Invalid type. Expected: string, given: integer
 (root).name: Invalid type. Expected: string, given: integer
+(root).properties.host: Invalid type. Expected: string, given: integer
+(root).properties.port: Invalid type. Expected: integer, given: string
 (root).properties: Additional property extra is not allowed
+(root).properties.secrets: Additional property extra is not allowed

--- a/pkg/radrp/schema/testdata/mongodb.com.MongoDBComponent/mongodb-invalid.txt
+++ b/pkg/radrp/schema/testdata/mongodb.com.MongoDBComponent/mongodb-invalid.txt
@@ -4,3 +4,6 @@
 (root).properties.port: Invalid type. Expected: integer, given: string
 (root).properties: Additional property extra is not allowed
 (root).properties.secrets: Additional property extra is not allowed
+(root).properties.secrets.username: Invalid type. Expected: string, given: integer
+(root).properties.secrets.password: Invalid type. Expected: string, given: integer
+(root).properties.secrets.connectionString: Invalid type. Expected: string, given: integer

--- a/pkg/radrp/schema/testdata/mongodb.com.MongoDBComponent/mongodb-valid.json
+++ b/pkg/radrp/schema/testdata/mongodb.com.MongoDBComponent/mongodb-valid.json
@@ -4,6 +4,13 @@
   "kind": "mongodb.com/Mongo@v1alpha1",
   "properties": {
     "managed": true,
-    "resource": "foo"
+    "resource": "foo",
+    "host": "host",
+    "port": 80,
+    "secrets": {
+      "username": "username",
+      "password": "password",
+      "connectionString": "connectionString"
+    }
   }
 }

--- a/schemas/rest-api-specs/radius.json
+++ b/schemas/rest-api-specs/radius.json
@@ -1316,9 +1316,20 @@
         }
       ],
       "properties": {
+        "host": {
+          "description": "The host name of the MongoDB to which you are connecting",
+          "type": "string"
+        },
         "managed": {
           "description": "Indicates if the resource is Radius-managed. If false, a Resource must be specified",
           "type": "boolean"
+        },
+        "port": {
+          "description": "The port value of the MongoDB to which you are connecting",
+          "example": [
+            27017
+          ],
+          "type": "integer"
         },
         "resource": {
           "description": "The ID of the user-managed DB with Mongo API to use for this Component",
@@ -1326,6 +1337,24 @@
             "account::mongodb.id"
           ],
           "type": "string"
+        },
+        "secrets": {
+          "additionalProperties": false,
+          "properties": {
+            "connectionString": {
+              "description": "The connection string used to connect to this DB",
+              "type": "string"
+            },
+            "password": {
+              "description": "The password for this MongoDB instance",
+              "type": "string"
+            },
+            "username": {
+              "description": "The password for this MongoDB instance",
+              "type": "string"
+            }
+          },
+          "type": "object"
         }
       },
       "type": "object"

--- a/schemas/rest-api-specs/radius.json
+++ b/schemas/rest-api-specs/radius.json
@@ -1340,6 +1340,7 @@
         },
         "secrets": {
           "additionalProperties": false,
+          "description": "Secrets provided by unmanaged resources,",
           "properties": {
             "connectionString": {
               "description": "The connection string used to connect to this DB",


### PR DESCRIPTION
# Description

Add K8s extension fields of MongoDBComponent. With this change, we will allow the following Bicep:
```
resource app 'radius.dev/Application@v1alpha3' = {
  name: 'myapp'

  resource db 'mongodb.com.MongoDBComponent' = {
    name: 'db'
    host: ${someK8sResource.property}
    port: ${...}
    secrets: {
      username: base64ToString(${someK8sSecret['user-name']})
      password: base64ToString(${someK8sSecret['password']})
      connectionString: '${...}'
    }
  }

}
```
## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Part of radius-project/core-team#406.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
