### PR TITLE
Removing default text for output format as flag uses the cmd flag default

### DIFF
--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -77,10 +77,10 @@ func init() {
 	RootCmd.SetVersionTemplate(template)
 
 	RootCmd.Flags().BoolP("version", "v", false, "version for radius")
-	RootCmd.PersistentFlags().StringVar(&configHolder.ConfigFilePath, "config", "", "config file (default is $HOME/.rad/config.yaml)")
+	RootCmd.PersistentFlags().StringVar(&configHolder.ConfigFilePath, "config", "", "config file (default \"$HOME/.rad/config.yaml\")")
 
-	outputDescription := fmt.Sprintf("output format (default is %s, supported formats are %s)", output.DefaultFormat, strings.Join(output.SupportedFormats(), ", "))
-	RootCmd.PersistentFlags().StringP("output", "o", "table", outputDescription)
+	outputDescription := fmt.Sprintf("output format (supported formats are %s)", strings.Join(output.SupportedFormats(), ", "))
+	RootCmd.PersistentFlags().StringP("output", "o", output.DefaultFormat, outputDescription)
 }
 
 // The dance we do with config is kinda complex. We want commands to be able to retrieve a config (*viper.Viper)


### PR DESCRIPTION
# Description

Fixing to remove the extra default output format text as flag already uses the cmd flag default. 

After Fix:

![image](https://user-images.githubusercontent.com/29718984/143954263-d59cf7a5-9f59-4131-b439-ec76f4ad1d04.png)

## Issue reference

Fixes #1493 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [x] Extended the documentation / Created issue for it
