### PR TITLE
Implement support for non-radius azure resources in RP API/CLI

### DIFF
--- a/pkg/cli/objectformats/objectformats.go
+++ b/pkg/cli/objectformats/objectformats.go
@@ -34,7 +34,10 @@ func GetResourceTableFormat() output.FormatterOptions {
 				JSONPath: "{ .type }",
 				Transformer: func(t string) string {
 					tokens := strings.Split(t, "/")
-					return tokens[len(tokens)-1]
+					if tokens[0] == "Microsoft.CustomProviders" {
+						return tokens[len(tokens)-1]
+					}
+					return t
 				},
 			},
 			{

--- a/pkg/cli/objectformats/objectformats.go
+++ b/pkg/cli/objectformats/objectformats.go
@@ -36,6 +36,8 @@ func GetResourceTableFormat() output.FormatterOptions {
 					tokens := strings.Split(t, "/")
 					// For Radius resource types only show last part of the resource type. Example: mongodb.com.MongoDBComponent instead of Microsoft.CustomProviders/mongodb.com.MongoDBComponent
 					// For non-Radius resources types, show full resource type, Microsoft.ServiceBus/namespaces for example.
+					// TODO: "Microsoft.CustomProviders" should be updated to reflect Radius RP name once we move out of custom RP mode:
+					// https://github.com/Azure/radius/issues/1534
 					if tokens[0] == "Microsoft.CustomProviders" {
 						return tokens[len(tokens)-1]
 					}

--- a/pkg/cli/objectformats/objectformats.go
+++ b/pkg/cli/objectformats/objectformats.go
@@ -34,6 +34,8 @@ func GetResourceTableFormat() output.FormatterOptions {
 				JSONPath: "{ .type }",
 				Transformer: func(t string) string {
 					tokens := strings.Split(t, "/")
+					// For Radius resource types only show last part of the resource type. Example: mongodb.com.MongoDBComponent instead of Microsoft.CustomProviders/mongodb.com.MongoDBComponent
+					// For non-Radius resources types, show full resource type, Microsoft.ServiceBus/namespaces for example.
 					if tokens[0] == "Microsoft.CustomProviders" {
 						return tokens[len(tokens)-1]
 					}

--- a/pkg/cli/objectformats/objectformats_test.go
+++ b/pkg/cli/objectformats/objectformats_test.go
@@ -54,7 +54,7 @@ func Test_FormatResourceTable(t *testing.T) {
 			ProxyResource: radclient.ProxyResource{
 				Resource: radclient.Resource{
 					Name: to.StringPtr("test-resource"),
-					Type: to.StringPtr("Microsoft.CustomProviders/mongodb.com.MongoDBComponent"),
+					Type: to.StringPtr("Microsoft.CustomProviders/resourceProviders/Application/mongodb.com.MongoDBComponent"),
 				},
 			},
 			Properties: map[string]interface{}{

--- a/pkg/cli/objectformats/objectformats_test.go
+++ b/pkg/cli/objectformats/objectformats_test.go
@@ -49,17 +49,33 @@ func Test_FormatResourceTable(t *testing.T) {
 	options := GetResourceTableFormat()
 
 	// We're just filling in the fields that are read. It's hard to test that something *doesn't* happen.
-	obj := radclient.RadiusResource{
-		ProxyResource: radclient.ProxyResource{
-			Resource: radclient.Resource{
-				Name: to.StringPtr("test-resource"),
-				Type: to.StringPtr("my/very/CoolResource"),
+	obj := []radclient.RadiusResource{
+		{
+			ProxyResource: radclient.ProxyResource{
+				Resource: radclient.Resource{
+					Name: to.StringPtr("test-resource"),
+					Type: to.StringPtr("Microsoft.CustomProviders/mongodb.com.MongoDBComponent"),
+				},
+			},
+			Properties: map[string]interface{}{
+				"status": &radclient.ComponentStatus{
+					HealthState:       to.StringPtr("Healthy"),
+					ProvisioningState: to.StringPtr("Provisioned"),
+				},
 			},
 		},
-		Properties: map[string]interface{}{
-			"status": &radclient.ComponentStatus{
-				HealthState:       to.StringPtr("Healthy"),
-				ProvisioningState: to.StringPtr("Provisioned"),
+		{
+			ProxyResource: radclient.ProxyResource{
+				Resource: radclient.Resource{
+					Name: to.StringPtr("test-azure-resource"),
+					Type: to.StringPtr("Microsoft.ServiceBus/namespaces"),
+				},
+			},
+			Properties: map[string]interface{}{
+				"status": &radclient.ComponentStatus{
+					HealthState:       to.StringPtr("Healthy"),
+					ProvisioningState: to.StringPtr("Provisioned"),
+				},
 			},
 		},
 	}
@@ -68,8 +84,10 @@ func Test_FormatResourceTable(t *testing.T) {
 	err := output.Write(output.FormatTable, &obj, &buffer, options)
 	require.NoError(t, err)
 
-	expected := `RESOURCE       TYPE          PROVISIONING_STATE  HEALTH_STATE
-test-resource  CoolResource  Provisioned         Healthy
+	expected := `RESOURCE             TYPE                             PROVISIONING_STATE  HEALTH_STATE
+test-resource        mongodb.com.MongoDBComponent     Provisioned         Healthy
+test-azure-resource  Microsoft.ServiceBus/namespaces  Provisioned         Healthy
 `
+
 	require.Equal(t, TrimSpaceMulti(expected), TrimSpaceMulti(buffer.String()))
 }

--- a/pkg/radrp/backend/deployment/deploymentprocessor.go
+++ b/pkg/radrp/backend/deployment/deploymentprocessor.go
@@ -88,10 +88,12 @@ func (dp *deploymentProcessor) Deploy(ctx context.Context, operationID azresourc
 			ID:                  azureResourceID.ID,
 			SubscriptionID:      azureResourceID.SubscriptionID,
 			ResourceGroup:       azureResourceID.ResourceGroup,
-			ApplicationName:     resource.ApplicationName,
 			ResourceName:        azureResourceID.Name(),
 			ResourceKind:        resourcekinds.Azure,
 			Type:                azureResourceID.Type(),
+			ApplicationName:     resource.ApplicationName,
+			AppSubscriptionID:   resource.SubscriptionID,
+			AppResourceGroup:    resource.ResourceGroup,
 			RadiusConnectionIDs: []string{resourceID.ID},
 		}
 

--- a/pkg/radrp/db/inmemory_db.go
+++ b/pkg/radrp/db/inmemory_db.go
@@ -99,15 +99,15 @@ func (s *store) DeleteV3Resource(ctx context.Context, id azresources.ResourceID)
 	return errors.New("not implemented")
 }
 
-func (s *store) ListAllAzureResourcesForApplication(ctx context.Context, applicationName string, appSubscriptionID string, appResourceGroup string) ([]AzureResource, error) {
+func (s *store) ListAllAzureResourcesForApplication(ctx context.Context, applicationName, applicationSubscriptionID, applicationResourceGroup string) ([]AzureResource, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (s *store) ListAzureResourcesForResourceType(ctx context.Context, applicationName string, appSubscriptionID string, appResourceGroup string, resourceType string) ([]AzureResource, error) {
+func (s *store) ListAzureResourcesForResourceType(ctx context.Context, applicationName, applicationSubscriptionID, applicationResourceGroup, resourceType string) ([]AzureResource, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (s *store) GetAzureResource(ctx context.Context, applicationName string, azureResourceID string) (AzureResource, error) {
+func (s *store) GetAzureResource(ctx context.Context, applicationName, azureResourceID string) (AzureResource, error) {
 	return AzureResource{}, errors.New("not implemented")
 }
 
@@ -119,10 +119,10 @@ func (s *store) AddAzureResourceConnection(ctx context.Context, radiusResourceID
 	return false, errors.New("not implemented")
 }
 
-func (s *store) DeleteAzureResource(ctx context.Context, applicationName string, azureResourceID string) error {
+func (s *store) DeleteAzureResource(ctx context.Context, applicationName, azureResourceID string) error {
 	return errors.New("not implemented")
 }
 
-func (s *store) RemoveAzureResourceConnection(ctx context.Context, applicationName string, radiusResourceID string, azureResourceID string) (bool, error) {
+func (s *store) RemoveAzureResourceConnection(ctx context.Context, applicationName, radiusResourceID, azureResourceID string) (bool, error) {
 	return false, errors.New("not implemented")
 }

--- a/pkg/radrp/db/inmemory_db.go
+++ b/pkg/radrp/db/inmemory_db.go
@@ -75,7 +75,7 @@ func (s *store) DeleteV3Application(ctx context.Context, id azresources.Resource
 	return errors.New("not implemented")
 }
 
-func (s *store) ListAllV3ResourcesByApplication(ctx context.Context, id azresources.ResourceID) ([]RadiusResource, error) {
+func (s *store) ListAllV3ResourcesByApplication(ctx context.Context, id azresources.ResourceID, applicationName string) ([]RadiusResource, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -99,11 +99,11 @@ func (s *store) DeleteV3Resource(ctx context.Context, id azresources.ResourceID)
 	return errors.New("not implemented")
 }
 
-func (s *store) ListAllAzureResourcesForApplication(ctx context.Context, id azresources.ResourceID, applicationName string) ([]AzureResource, error) {
+func (s *store) ListAllAzureResourcesForApplication(ctx context.Context, applicationName string, appSubscriptionID string, appResourceGroup string) ([]AzureResource, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (s *store) ListAzureResourcesForResourceType(ctx context.Context, id azresources.ResourceID, applicationName string) ([]AzureResource, error) {
+func (s *store) ListAzureResourcesForResourceType(ctx context.Context, applicationName string, appSubscriptionID string, appResourceGroup string, resourceType string) ([]AzureResource, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/pkg/radrp/db/mock_db.go
+++ b/pkg/radrp/db/mock_db.go
@@ -167,48 +167,48 @@ func (mr *MockRadrpDBMockRecorder) GetV3Resource(arg0, arg1 interface{}) *gomock
 }
 
 // ListAllAzureResourcesForApplication mocks base method.
-func (m *MockRadrpDB) ListAllAzureResourcesForApplication(arg0 context.Context, arg1 azresources.ResourceID, arg2 string) ([]AzureResource, error) {
+func (m *MockRadrpDB) ListAllAzureResourcesForApplication(arg0 context.Context, arg1, arg2, arg3 string) ([]AzureResource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAllAzureResourcesForApplication", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ListAllAzureResourcesForApplication", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]AzureResource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListAllAzureResourcesForApplication indicates an expected call of ListAllAzureResourcesForApplication.
-func (mr *MockRadrpDBMockRecorder) ListAllAzureResourcesForApplication(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockRadrpDBMockRecorder) ListAllAzureResourcesForApplication(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllAzureResourcesForApplication", reflect.TypeOf((*MockRadrpDB)(nil).ListAllAzureResourcesForApplication), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllAzureResourcesForApplication", reflect.TypeOf((*MockRadrpDB)(nil).ListAllAzureResourcesForApplication), arg0, arg1, arg2, arg3)
 }
 
 // ListAllV3ResourcesByApplication mocks base method.
-func (m *MockRadrpDB) ListAllV3ResourcesByApplication(arg0 context.Context, arg1 azresources.ResourceID) ([]RadiusResource, error) {
+func (m *MockRadrpDB) ListAllV3ResourcesByApplication(arg0 context.Context, arg1 azresources.ResourceID, arg2 string) ([]RadiusResource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAllV3ResourcesByApplication", arg0, arg1)
+	ret := m.ctrl.Call(m, "ListAllV3ResourcesByApplication", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]RadiusResource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListAllV3ResourcesByApplication indicates an expected call of ListAllV3ResourcesByApplication.
-func (mr *MockRadrpDBMockRecorder) ListAllV3ResourcesByApplication(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRadrpDBMockRecorder) ListAllV3ResourcesByApplication(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllV3ResourcesByApplication", reflect.TypeOf((*MockRadrpDB)(nil).ListAllV3ResourcesByApplication), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllV3ResourcesByApplication", reflect.TypeOf((*MockRadrpDB)(nil).ListAllV3ResourcesByApplication), arg0, arg1, arg2)
 }
 
 // ListAzureResourcesForResourceType mocks base method.
-func (m *MockRadrpDB) ListAzureResourcesForResourceType(arg0 context.Context, arg1 azresources.ResourceID, arg2 string) ([]AzureResource, error) {
+func (m *MockRadrpDB) ListAzureResourcesForResourceType(arg0 context.Context, arg1, arg2, arg3, arg4 string) ([]AzureResource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAzureResourcesForResourceType", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ListAzureResourcesForResourceType", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].([]AzureResource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListAzureResourcesForResourceType indicates an expected call of ListAzureResourcesForResourceType.
-func (mr *MockRadrpDBMockRecorder) ListAzureResourcesForResourceType(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockRadrpDBMockRecorder) ListAzureResourcesForResourceType(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAzureResourcesForResourceType", reflect.TypeOf((*MockRadrpDB)(nil).ListAzureResourcesForResourceType), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAzureResourcesForResourceType", reflect.TypeOf((*MockRadrpDB)(nil).ListAzureResourcesForResourceType), arg0, arg1, arg2, arg3, arg4)
 }
 
 // ListV3Applications mocks base method.

--- a/pkg/radrp/db/resources.go
+++ b/pkg/radrp/db/resources.go
@@ -41,9 +41,9 @@ type AzureResource struct {
 	Type           string `bson:"type"`
 
 	// Details of the application this resource is consumed in
-	ApplicationName   string `bson:"applicationName"`
-	AppSubscriptionID string `bson:"appSubscriptionId"`
-	AppResourceGroup  string `bson:"appResourceGroup"`
+	ApplicationName           string `bson:"applicationName"`
+	ApplicationSubscriptionID string `bson:"applicationSubscriptionId"`
+	ApplicationResourceGroup  string `bson:"applicationResourceGroup"`
 
 	// Radius resources that connect to this Azure resource
 	RadiusConnectionIDs []string `bson:"radiusConnectionIDs"`

--- a/pkg/radrp/db/resources.go
+++ b/pkg/radrp/db/resources.go
@@ -33,13 +33,17 @@ type RadiusResourceStatus struct {
 
 // AzureResource represents reference to an existing non-Radius azure resource that Radius resources connect to.
 type AzureResource struct {
-	ID              string `bson:"_id"`
-	SubscriptionID  string `bson:"subscriptionId"`
-	ResourceGroup   string `bson:"resourceGroup"`
-	ApplicationName string `bson:"applicationName"`
-	ResourceName    string `bson:"resourceName"`
-	ResourceKind    string `bson:"resourceKind"`
-	Type            string `bson:"type"`
+	ID             string `bson:"_id"`
+	SubscriptionID string `bson:"subscriptionId"`
+	ResourceGroup  string `bson:"resourceGroup"`
+	ResourceName   string `bson:"resourceName"`
+	ResourceKind   string `bson:"resourceKind"`
+	Type           string `bson:"type"`
+
+	// Details of the application this resource is consumed in
+	ApplicationName   string `bson:"applicationName"`
+	AppSubscriptionID string `bson:"appSubscriptionId"`
+	AppResourceGroup  string `bson:"appResourceGroup"`
 
 	// Radius resources that connect to this Azure resource
 	RadiusConnectionIDs []string `bson:"radiusConnectionIDs"`

--- a/pkg/radrp/frontend/resourceprovider/convert.go
+++ b/pkg/radrp/frontend/resourceprovider/convert.go
@@ -92,6 +92,17 @@ func NewRestRadiusResource(resource db.RadiusResource) RadiusResource {
 	}
 }
 
+func NewRestRadiusResourceFromAzureResource(azResource db.AzureResource) RadiusResource {
+	// Currently properties for Azure resources is empty, once we implement health check or decide to store additional
+	// metadata about azure resources, it should be included as a part of the properties field.
+	return RadiusResource{
+		ID:         azResource.ID,
+		Type:       azResource.Type,
+		Name:       azResource.ResourceName,
+		Properties: map[string]interface{}{},
+	}
+}
+
 func NewRestRadiusResourceStatus(resourceName string, original db.RadiusResourceStatus) RadiusResourceStatus {
 	ors := NewRestOutputResourceStatus(original.OutputResources)
 
@@ -128,13 +139,4 @@ func NewRestOutputResourceStatus(original []db.OutputResource) []rest.OutputReso
 		rrs = append(rrs, rr)
 	}
 	return rrs
-}
-
-func NewRestAzureResource(resource db.AzureResource) AzureResource {
-	return AzureResource{
-		ID:   resource.ID,
-		Name: resource.ResourceName,
-		Kind: resource.ResourceKind,
-		Type: resource.Type,
-	}
 }

--- a/pkg/radrp/frontend/resourceprovider/resourceprovider.go
+++ b/pkg/radrp/frontend/resourceprovider/resourceprovider.go
@@ -167,8 +167,8 @@ func (r *rp) ListAllV3ResourcesByApplication(ctx context.Context, id azresources
 	}
 
 	applicationName := applicationID.Name()
-	subscriptionID := id.SubscriptionID
-	resourceGroup := id.ResourceGroup
+	applicationSubscriptionID := id.SubscriptionID
+	applicationResourceGroup := id.ResourceGroup
 
 	// List radius resources
 	radiusResources, err := r.db.ListAllV3ResourcesByApplication(ctx, id, applicationName)
@@ -177,7 +177,7 @@ func (r *rp) ListAllV3ResourcesByApplication(ctx context.Context, id azresources
 	}
 
 	// List non-radius azure resources that are referenced from the application
-	azureResources, err := r.db.ListAllAzureResourcesForApplication(ctx, applicationName, subscriptionID, resourceGroup)
+	azureResources, err := r.db.ListAllAzureResourcesForApplication(ctx, applicationName, applicationSubscriptionID, applicationResourceGroup)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/radrp/frontend/resourceprovider/resourceprovider_test.go
+++ b/pkg/radrp/frontend/resourceprovider/resourceprovider_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/radius/pkg/radrp/db"
 	"github.com/Azure/radius/pkg/radrp/outputresource"
 	"github.com/Azure/radius/pkg/radrp/rest"
+	"github.com/Azure/radius/pkg/radrp/schema"
 	"github.com/Azure/radius/pkg/resourcekinds"
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
@@ -107,6 +108,19 @@ var testcases = []testcase{
 		id: parseOrPanic(applicationID(applicationName)),
 	},
 	{
+		description: "ListAllResourcesByApplication",
+		verb:        "List",
+		invoke: func(rp ResourceProvider, ctx context.Context, id azresources.ResourceID) (rest.Response, error) {
+			return rp.ListAllV3ResourcesByApplication(ctx, id)
+		},
+		setupDB: func(database *db.MockRadrpDB, err error) {
+			database.EXPECT().GetV3Application(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(func(interface{}, interface{}) ([]db.RadiusResource, error) {
+				return nil, err
+			})
+		},
+		id: parseOrPanic(fmt.Sprintf("%s/%s", applicationID(applicationName), schema.GenericResourceType)),
+	},
+	{
 		description: "ListResources",
 		verb:        "List",
 		invoke: func(rp ResourceProvider, ctx context.Context, id azresources.ResourceID) (rest.Response, error) {
@@ -179,6 +193,35 @@ var testcases = []testcase{
 	},
 }
 
+func Test_AllEndpoints_RejectInvalidApplicationType(t *testing.T) {
+	ctx := createContext(t)
+
+	id := parseOrPanic(fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/%s/providers/%s/%s/%s/%s",
+		subscriptionID,
+		resourceGroup,
+		azresources.CustomProvidersResourceProviders,
+		providerName,
+		"InvalidApplicationType", applicationName))
+
+	for _, testcase := range testcases {
+		t.Run(testcase.description, func(t *testing.T) {
+			test := createRPTest(t)
+
+			response, err := testcase.invoke(test.rp, ctx, id)
+			require.NoError(t, err)
+
+			expected := armerrors.ErrorResponse{
+				Error: armerrors.ErrorDetails{
+					Code:    armerrors.Invalid,
+					Message: "unsupported resource type",
+				},
+			}
+			require.Equal(t, rest.NewBadRequestARMResponse(expected), response)
+		})
+	}
+}
+
 func Test_AllEndpoints_RejectInvalidResourceID(t *testing.T) {
 	ctx := createContext(t)
 
@@ -186,6 +229,10 @@ func Test_AllEndpoints_RejectInvalidResourceID(t *testing.T) {
 	id := parseOrPanic(resourceID(applicationName, "InvalidResourceType", resourceName))
 
 	for _, testcase := range testcases {
+		if testcase.description == "ListAllResourcesByApplication" {
+			continue
+		}
+
 		t.Run(testcase.description, func(t *testing.T) {
 			test := createRPTest(t)
 
@@ -426,6 +473,90 @@ func Test_DeleteApplication_Conflict(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, rest.NewConflictResponse(db.ErrConflict.Error()), response)
+}
+
+func Test_ListAllResources_Success(t *testing.T) {
+	ctx := createContext(t)
+	test := createRPTest(t)
+
+	requestID := parseOrPanic(fmt.Sprintf("%s/%s", applicationID(applicationName), schema.GenericResourceType))
+	azureConnectionID := "/subscriptions/az-resource-subscription/resourceGroups/az-resource-rg/providers/Microsoft.ServiceBus/namespaces/az-resource-name"
+	expectedRadiusResources := []db.RadiusResource{
+		{
+			ID:                testID,
+			Type:              requestID.Type(),
+			SubscriptionID:    subscriptionID,
+			ResourceGroup:     resourceGroup,
+			ApplicationName:   applicationName,
+			ResourceName:      resourceName,
+			ProvisioningState: string(rest.SuccededStatus),
+			Status:            db.RadiusResourceStatus{},
+			Definition: map[string]interface{}{
+				"data": true,
+			},
+		},
+	}
+	expectedAzureResources := []db.AzureResource{
+		{
+			ID:                  azureConnectionID,
+			SubscriptionID:      "az-resource-subscription",
+			ResourceGroup:       "az-resource-rg",
+			ResourceName:        "az-resource-name",
+			ResourceKind:        resourcekinds.Azure,
+			Type:                "Microsoft.ServiceBus/namespaces",
+			ApplicationName:     applicationName,
+			AppSubscriptionID:   subscriptionID,
+			AppResourceGroup:    resourceGroup,
+			RadiusConnectionIDs: []string{testID},
+		},
+	}
+
+	test.db.EXPECT().GetV3Application(gomock.Any(), gomock.Any()).Times(1).Return(db.ApplicationResource{}, nil)
+	test.db.EXPECT().ListAllV3ResourcesByApplication(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(expectedRadiusResources, nil)
+	test.db.EXPECT().ListAllAzureResourcesForApplication(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(1).Return(expectedAzureResources, nil)
+
+	response, err := test.rp.ListAllV3ResourcesByApplication(ctx, requestID)
+	require.NoError(t, err)
+
+	expectedOutput := RadiusResourceList{
+		Value: []RadiusResource{
+			{
+				ID:   testID,
+				Type: requestID.Type(),
+				Name: resourceName,
+				Properties: map[string]interface{}{
+					"data":              true,
+					"provisioningState": string(rest.SuccededStatus),
+					"status": rest.ComponentStatus{
+						ProvisioningState: "Provisioned",
+						HealthState:       "Healthy",
+						OutputResources:   []rest.OutputResource{},
+					},
+				},
+			},
+			{
+				ID:         azureConnectionID,
+				Type:       "Microsoft.ServiceBus/namespaces",
+				Name:       "az-resource-name",
+				Properties: map[string]interface{}{},
+			},
+		},
+	}
+	require.Equal(t, rest.NewOKResponse(expectedOutput), response)
+}
+
+func Test_ListAllResources_Failure(t *testing.T) {
+	ctx := createContext(t)
+	test := createRPTest(t)
+
+	id := parseOrPanic(fmt.Sprintf("%s/%s", applicationID(applicationName), schema.GenericResourceType))
+
+	test.db.EXPECT().GetV3Application(gomock.Any(), gomock.Any()).Times(1).Return(db.ApplicationResource{}, nil)
+	test.db.EXPECT().ListAllV3ResourcesByApplication(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return([]db.RadiusResource{}, errors.New("database connection error"))
+
+	_, err := test.rp.ListAllV3ResourcesByApplication(ctx, id)
+	require.Error(t, err)
 }
 
 func Test_ListResources_Success(t *testing.T) {

--- a/pkg/radrp/frontend/resourceprovider/resourceprovider_test.go
+++ b/pkg/radrp/frontend/resourceprovider/resourceprovider_test.go
@@ -498,16 +498,16 @@ func Test_ListAllResources_Success(t *testing.T) {
 	}
 	expectedAzureResources := []db.AzureResource{
 		{
-			ID:                  azureConnectionID,
-			SubscriptionID:      "az-resource-subscription",
-			ResourceGroup:       "az-resource-rg",
-			ResourceName:        "az-resource-name",
-			ResourceKind:        resourcekinds.Azure,
-			Type:                "Microsoft.ServiceBus/namespaces",
-			ApplicationName:     applicationName,
-			AppSubscriptionID:   subscriptionID,
-			AppResourceGroup:    resourceGroup,
-			RadiusConnectionIDs: []string{testID},
+			ID:                        azureConnectionID,
+			SubscriptionID:            "az-resource-subscription",
+			ResourceGroup:             "az-resource-rg",
+			ResourceName:              "az-resource-name",
+			ResourceKind:              resourcekinds.Azure,
+			Type:                      "Microsoft.ServiceBus/namespaces",
+			ApplicationName:           applicationName,
+			ApplicationSubscriptionID: subscriptionID,
+			ApplicationResourceGroup:  resourceGroup,
+			RadiusConnectionIDs:       []string{testID},
 		},
 	}
 

--- a/pkg/radrp/frontend/resourceprovider/rest.go
+++ b/pkg/radrp/frontend/resourceprovider/rest.go
@@ -23,6 +23,7 @@ type ApplicationResourceList struct {
 }
 
 // RadiusResource represents one of the child resource types of Application in the ARM wire-format.
+// This also includes non-Radius Azure resources that are referenced from Radius application. These resources do not contain output resources and may not support all the other properties included in RadiusResource type.
 type RadiusResource struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
@@ -37,14 +38,6 @@ type RadiusResourceStatus = rest.ComponentStatus
 // RadiusResourceList represents a list of a child resource type of Application in the ARM wire-format.
 type RadiusResourceList struct {
 	Value []RadiusResource `json:"value"`
-}
-
-// AzureResource over the wire format for non-Radius Azure resources that are referenced from Radius resources in the application. These resources do not have output resources and may not support all the other properties included in RadiusResource type.
-type AzureResource struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Kind string `json:"kind"`
-	Type string `json:"type"`
 }
 
 // ListSecretsInput is used for the RP's 'listSecrets' custom action.


### PR DESCRIPTION
# Description
Update list resources API to include non-radius azure resources in response.

Tested manually on local rp:

```
% radius resource list
RESOURCE                TYPE                             PROVISIONING_STATE
db                      mongodb.com.MongoDBComponent     Provisioned
todoapp                 ContainerComponent               Provisioned
ns-kachawla-test  Microsoft.ServiceBus/namespaces
```

```
% radius resource list -o json
[
.....,
{
    "id": "/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourceGroups/karishmachawla-radius/providers/Microsoft.ServiceBus/namespaces/ns-kachawla-test",
    "name": "ns-kachawla-test",
    "type": "Microsoft.ServiceBus/namespaces"
  }
]
```

## Issue reference
https://github.com/Azure/radius/issues/1503
Design: https://github.com/Azure/radius/issues/1503

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change -- will be working on it next. Pending approval of https://github.com/rynowak/bicep/pull/546. Manual testing response added in description.
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
