### PR TITLE
Implement progress (spinners) for deployment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,8 +25,10 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.8.0
+	github.com/gosuri/uilive v0.0.4
 	github.com/klauspost/compress v1.11.12 // indirect
 	github.com/marstr/randname v0.0.0-20181206212954-d5b0f288ab8c
+	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -530,6 +530,8 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gosuri/uilive v0.0.4 h1:hUEBpQDj8D8jXgtCdBu7sWsy5sbW/5GhuO8KBwJ2jyY=
+github.com/gosuri/uilive v0.0.4/go.mod h1:V/epo5LjjlDE5RJUcqx8dbw+zc93y5Ya3yg8tfZ74VI=
 github.com/gosuri/uitable v0.0.4 h1:IG2xLKRvErL3uhY6e1BylFzG+aJiwQviDDTfOKeKTpY=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
@@ -675,6 +677,8 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-oci8 v0.0.7/go.mod h1:wjDx6Xm9q7dFtHJvIlrI99JytznLw5wQ4R+9mNXJwGI=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -1244,6 +1248,8 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=

--- a/pkg/azure/clients/clients.go
+++ b/pkg/azure/clients/clients.go
@@ -220,6 +220,13 @@ func NewFileSharesClient(subscriptionID string, authorizer autorest.Authorizer) 
 	return fc
 }
 
+func NewOperationsClient(subscriptionID string, authorizer autorest.Authorizer) resources.DeploymentOperationsClient {
+	doc := resources.NewDeploymentOperationsClient(subscriptionID)
+	doc.Authorizer = authorizer
+	doc.PollingDuration = 0
+	return doc
+}
+
 func NewRoleDefinitionsClient(subscriptionID string, authorizer autorest.Authorizer) authorization.RoleDefinitionsClient {
 	rc := authorization.NewRoleDefinitionsClient(subscriptionID)
 	rc.Authorizer = authorizer

--- a/pkg/cli/azure/deploy.go
+++ b/pkg/cli/azure/deploy.go
@@ -9,30 +9,73 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
 	"github.com/Azure/radius/pkg/azure/azresources"
 	"github.com/Azure/radius/pkg/cli/clients"
+	"github.com/Azure/radius/pkg/radrp/rest"
 	"github.com/google/uuid"
 )
 
+// OperationPollInterval is the interval used for polling of deployment operations for progress.
+const OperationPollInterval time.Duration = time.Second * 5
+
 type ARMDeploymentClient struct {
-	ResourceGroup  string
-	SubscriptionID string
-	Client         resources.DeploymentsClient
+	ResourceGroup    string
+	SubscriptionID   string
+	Client           resources.DeploymentsClient
+	OperationsClient resources.DeploymentOperationsClient
 }
 
 var _ clients.DeploymentClient = (*ARMDeploymentClient)(nil)
 
 func (dc *ARMDeploymentClient) Deploy(ctx context.Context, options clients.DeploymentOptions) (clients.DeploymentResult, error) {
-	template := map[string]interface{}{}
-	err := json.Unmarshal([]byte(options.Template), &template)
+	// Used for graceful shutdown of the polling listener.
+	wg := sync.WaitGroup{}
+	defer func() {
+		wg.Wait()
+		if options.ProgressChan != nil {
+			close(options.ProgressChan)
+		}
+	}()
+
+	name := fmt.Sprintf("rad-deploy-%v", uuid.New().String())
+	future, err := dc.startDeployment(ctx, name, options)
 	if err != nil {
 		return clients.DeploymentResult{}, err
 	}
 
-	name := fmt.Sprintf("rad-deploy-%v", uuid.New().String())
-	op, err := dc.Client.CreateOrUpdate(ctx, dc.ResourceGroup, name, resources.Deployment{
+	if options.ProgressChan != nil {
+		// To monitor the progress we have to do polling. We cancel that once
+		// the operation completes.
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		wg.Add(1)
+		go func() {
+			_ = dc.monitorProgress(ctx, name, options.ProgressChan)
+			wg.Done()
+		}()
+	}
+
+	summary, err := dc.waitForCompletion(ctx, *future)
+	if err != nil {
+		return clients.DeploymentResult{}, err
+	}
+
+	return summary, nil
+}
+
+func (dc *ARMDeploymentClient) startDeployment(ctx context.Context, name string, options clients.DeploymentOptions) (*resources.DeploymentsCreateOrUpdateFuture, error) {
+	template := map[string]interface{}{}
+	err := json.Unmarshal([]byte(options.Template), &template)
+	if err != nil {
+		return nil, err
+	}
+
+	future, err := dc.Client.CreateOrUpdate(ctx, dc.ResourceGroup, name, resources.Deployment{
 		Properties: &resources.DeploymentProperties{
 			Template:   template,
 			Parameters: options.Parameters,
@@ -40,25 +83,10 @@ func (dc *ARMDeploymentClient) Deploy(ctx context.Context, options clients.Deplo
 		},
 	})
 	if err != nil {
-		return clients.DeploymentResult{}, err
+		return nil, err
 	}
 
-	err = op.WaitForCompletionRef(ctx, dc.Client.Client)
-	if err != nil {
-		return clients.DeploymentResult{}, err
-	}
-
-	deployment, err := op.Result(dc.Client)
-	if err != nil {
-		return clients.DeploymentResult{}, err
-	}
-
-	summary, err := dc.createSummary(deployment)
-	if err != nil {
-		return clients.DeploymentResult{}, err
-	}
-
-	return summary, nil
+	return &future, nil
 }
 
 func (dc *ARMDeploymentClient) createSummary(deployment resources.DeploymentExtended) (clients.DeploymentResult, error) {
@@ -92,4 +120,98 @@ func (dc *ARMDeploymentClient) createSummary(deployment resources.DeploymentExte
 	}
 
 	return clients.DeploymentResult{Resources: resources, Outputs: outputs}, nil
+}
+
+func (dc *ARMDeploymentClient) waitForCompletion(ctx context.Context, future resources.DeploymentsCreateOrUpdateFuture) (clients.DeploymentResult, error) {
+	err := future.WaitForCompletionRef(ctx, dc.Client.Client)
+	if err != nil {
+		return clients.DeploymentResult{}, err
+	}
+
+	deployment, err := future.Result(dc.Client)
+	if err != nil {
+		return clients.DeploymentResult{}, err
+	}
+
+	summary, err := dc.createSummary(deployment)
+	if err != nil {
+		return clients.DeploymentResult{}, err
+	}
+
+	return summary, nil
+}
+
+func (dc *ARMDeploymentClient) monitorProgress(ctx context.Context, name string, progressChan chan<- clients.ResourceProgress) error {
+	// A note about this: since we're doing polling we might not see all of the operations
+	// complete before the overall deployment completes. That's fine, this will be handled
+	// by the presentation layer. In this code we just cancel when we're told to.
+	//
+	// However we do need to 'drain' on cancellation. That is, we wait will communicate
+	// back to the caller when we're fully-shut-down. This prevents writing to a closed channel.
+
+	// Also nothing listens to errors if we report them here. It's just a convenient way to degrade gracefully
+	// in the event of an issue.
+
+	// We need to track the status so we can report the deltas
+	status := map[string]clients.ResourceStatus{}
+
+	// Now loop forever for updates. We're relying on cancellation of the context to terminate.
+	for ctx.Err() == nil {
+		time.Sleep(OperationPollInterval)
+
+		operations, err := dc.listOperations(ctx, name)
+		if err != nil && err == ctx.Err() {
+			return nil
+		} else if err != nil {
+			return err
+		}
+
+		for _, operation := range operations {
+			if operation.Properties == nil || operation.Properties.TargetResource == nil || operation.Properties.TargetResource.ID == nil {
+				continue
+			}
+
+			provisioningState := rest.OperationStatus(*operation.Properties.ProvisioningState)
+			id, err := azresources.Parse(*operation.Properties.TargetResource.ID)
+			if err != nil {
+				return err
+			}
+
+			current := status[id.ID]
+			next := clients.StatusStarted
+			if rest.SuccededStatus == provisioningState {
+				next = clients.StatusCompleted
+			} else if rest.IsTeminalStatus(provisioningState) {
+				next = clients.StatusFailed
+			}
+
+			if current != next && progressChan != nil {
+				status[id.ID] = next
+				progressChan <- clients.ResourceProgress{
+					Resource: id,
+					Status:   next,
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (dc *ARMDeploymentClient) listOperations(ctx context.Context, name string) ([]resources.DeploymentOperation, error) {
+	operationList, err := dc.OperationsClient.List(ctx, dc.ResourceGroup, name, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	operations := []resources.DeploymentOperation{}
+	for ; operationList.NotDone(); err = operationList.NextWithContext(ctx) {
+		if err != nil {
+			return nil, err
+		}
+
+		operations = append(operations, operationList.Values()...)
+	}
+
+	return operations, nil
 }

--- a/pkg/cli/clients/clients.go
+++ b/pkg/cli/clients/clients.go
@@ -38,6 +38,23 @@ type DeploymentOptions struct {
 
 	// Parameters is the set of parameters passed to the deployment.
 	Parameters DeploymentParameters
+
+	// ProgressChan is a channel used to signal progress of the deployment operation.
+	// The deployment client MUST close the channel if it was provided.
+	ProgressChan chan<- ResourceProgress
+}
+
+type ResourceStatus string
+
+const (
+	StatusStarted   ResourceStatus = "Started"
+	StatusFailed    ResourceStatus = "Failed"
+	StatusCompleted ResourceStatus = "Completed"
+)
+
+type ResourceProgress struct {
+	Resource azresources.ResourceID
+	Status   ResourceStatus
 }
 
 type DeploymentOutput struct {

--- a/pkg/cli/deploy/progress.go
+++ b/pkg/cli/deploy/progress.go
@@ -1,0 +1,156 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package deploy
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/Azure/radius/pkg/cli/clients"
+	"github.com/Azure/radius/pkg/cli/output"
+	"github.com/gosuri/uilive"
+	"github.com/mattn/go-isatty"
+)
+
+func NewProgressListener(progressChan <-chan clients.ResourceProgress) ProgressListener {
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		return &InteractiveListener{
+			progressChan: progressChan,
+			writerDone:   &sync.WaitGroup{},
+			Spinner:      output.ProgressDefaultSpinner,
+		}
+	} else {
+		return &NoOpListener{
+			progressChan: progressChan,
+		}
+	}
+}
+
+type ProgressListener interface {
+	// Run is called to print progress to the command line. This should be called from
+	// a goroutine because it blocks until the progress channel is closed.
+	Run()
+}
+
+type NoOpListener struct {
+	progressChan <-chan clients.ResourceProgress
+}
+
+func (listener *NoOpListener) Run() {
+	for range listener.progressChan {
+		// Do nothing except drain the updates.
+	}
+}
+
+type InteractiveListener struct {
+	progressChan <-chan clients.ResourceProgress
+	Spinner      []string
+	mutex        sync.Mutex
+	entries      []Entry
+	spinnerIndex int
+	writerDone   *sync.WaitGroup
+}
+
+type Entry struct {
+	// FinalState is an optional token that will replace the spinner with static text.
+	FinalState string
+
+	// Format is the format string used to build the output line. It is expected to contain a placeholder
+	// for the spinner/final-state token.
+	Format string
+}
+
+func (listener *InteractiveListener) addEntry(format string) int {
+	listener.mutex.Lock()
+	defer listener.mutex.Unlock()
+
+	listener.entries = append(listener.entries, Entry{Format: format})
+	return len(listener.entries) - 1
+}
+
+func (listener *InteractiveListener) updateEntry(index int, state string, format string) {
+	listener.mutex.Lock()
+	defer listener.mutex.Unlock()
+
+	listener.entries[index] = Entry{FinalState: state, Format: format}
+}
+
+func (listener *InteractiveListener) Run() {
+	ticker := time.NewTicker(500 * time.Millisecond)
+
+	progressDone := make(chan struct{})
+	writerDone := make(chan struct{})
+
+	// Main loop that updates spinner position and writes output. This runs concurrently with accepting updates.
+	go func() {
+		writer := uilive.New()
+		writer.Start()
+
+		paint := func() {
+			listener.mutex.Lock()
+
+			// Advance to next spinner position
+			listener.spinnerIndex = (listener.spinnerIndex + 1) % len(listener.Spinner)
+
+			// Replay all output lines
+			for _, entry := range listener.entries {
+				if entry.FinalState == "" {
+					fmt.Fprintf(writer.Newline(), entry.Format+"\n", listener.Spinner[listener.spinnerIndex])
+				} else {
+					fmt.Fprintf(writer.Newline(), entry.Format+"\n", entry.FinalState)
+				}
+			}
+			listener.mutex.Unlock()
+		}
+
+	writer:
+		for {
+			select {
+			case <-progressDone:
+				paint() // Update UI once then terminate
+				break writer
+			case <-ticker.C:
+				paint()
+			}
+		}
+
+		writer.Stop()
+		close(writerDone)
+	}()
+
+	// Storage for resources we've already 'seen'. This doesn't need to be accessed concurrently.
+	resourceToLineIndexMap := map[string]int{}
+
+	// Main loop that processes updates to resources. This runs concurrently with writing output.
+	for update := range listener.progressChan {
+		if !output.ShowResource(update.Resource) {
+			continue
+		}
+
+		// NOTE: resources can go immediately to the Completed state without first
+		// going to the started state.
+		line, found := resourceToLineIndexMap[update.Resource.ID]
+		if !found {
+			line = listener.addEntry(output.FormatResourceForProgressDisplay(update.Resource))
+			resourceToLineIndexMap[update.Resource.ID] = line
+		}
+
+		switch update.Status {
+		case clients.StatusFailed:
+			listener.updateEntry(line, output.ProgressFailed, output.FormatResourceForProgressDisplay(update.Resource))
+
+		case clients.StatusCompleted:
+			listener.updateEntry(line, output.ProgressCompleted, output.FormatResourceForProgressDisplay(update.Resource))
+		}
+	}
+
+	// Force a final UI update and drain any updates in progress.
+	ticker.Stop()
+	close(progressDone)
+	<-writerDone
+}

--- a/pkg/cli/environments/azure.go
+++ b/pkg/cli/environments/azure.go
@@ -79,9 +79,10 @@ func (e *AzureCloudEnvironment) CreateDeploymentClient(ctx context.Context) (cli
 	dc.PollingDelay = 5 * time.Second
 
 	return &azure.ARMDeploymentClient{
-		Client:         dc,
-		SubscriptionID: e.SubscriptionID,
-		ResourceGroup:  e.ResourceGroup,
+		Client:           dc,
+		OperationsClient: azclients.NewOperationsClient(e.SubscriptionID, armauth),
+		SubscriptionID:   e.SubscriptionID,
+		ResourceGroup:    e.ResourceGroup,
 	}, nil
 }
 

--- a/pkg/cli/output/resources.go
+++ b/pkg/cli/output/resources.go
@@ -11,6 +11,13 @@ import (
 	"github.com/Azure/radius/pkg/azure/azresources"
 )
 
+const (
+	ProgressFailed    = "Failed"
+	ProgressCompleted = "Completed"
+)
+
+var ProgressDefaultSpinner = []string{".  ", ".. ", "..."}
+
 // ShowResource returns true if the resource should be displayed to the user.
 func ShowResource(id azresources.ResourceID) bool {
 	if len(id.Types) == 1 && id.Types[0].Name == "radiusv3" {
@@ -23,7 +30,14 @@ func ShowResource(id azresources.ResourceID) bool {
 
 // FormatResourceForDisplay returns a display string for the resource type and name.
 func FormatResourceForDisplay(id azresources.ResourceID) string {
-	return fmt.Sprintf("%-20s %-15s", FormatResourceTypeForDisplay(id), FormatResourceNameForDisplay(id))
+	return fmt.Sprintf("%-15s %-20s", FormatResourceNameForDisplay(id), FormatResourceTypeForDisplay(id))
+}
+
+// FormatResourceForProgressDisplay returns a display string for a progress spinner, resource type, and name.
+func FormatResourceForProgressDisplay(id azresources.ResourceID) string {
+	// NOTE: this format string creates ... a format string! That's intentional
+	// because the progress tracker needs somewhere to put the progress.
+	return fmt.Sprintf("%s %-15s %-20s", "%-20s", FormatResourceNameForDisplay(id), FormatResourceTypeForDisplay(id))
 }
 
 // FormatResourceNameForDisplay returns a display string for the resource name.

--- a/pkg/cli/stages/run_test.go
+++ b/pkg/cli/stages/run_test.go
@@ -393,6 +393,10 @@ type MockDeploymentClient struct {
 }
 
 func (dc *MockDeploymentClient) Deploy(ctx context.Context, options clients.DeploymentOptions) (clients.DeploymentResult, error) {
+	if options.ProgressChan != nil {
+		close(options.ProgressChan)
+	}
+
 	result := clients.DeploymentResult{}
 	if len(dc.Results) > dc.count {
 		result = dc.Results[dc.count]


### PR DESCRIPTION
This change implements a progress notifications for deployments as part
of the deployment client as well as a console UI that shows while
operations are in progress and which are completed.

The tricky thing here is that we need to show multiple 'bars' or
'spinners' since we have concurrent operations. No existing go library
with an OSS licence handles this well. The libraries out there either
support a single 'spinner' or have other limitations that would be
unacceptable. For this reason I had to go somewhat lower level and use a
dependency of one of the 'spinner' libraries to do what we want.

