### PR TITLE
Mark scraped secret as healthy after creation

### DIFF
--- a/pkg/kubernetes/controllers/radius/resource_controller.go
+++ b/pkg/kubernetes/controllers/radius/resource_controller.go
@@ -441,7 +441,8 @@ func (r *ResourceReconciler) ApplyState(
 				Resource: *or,
 				Status: radiusv1alpha3.OutputResourceStatus{
 					ProvisioningState: kubernetes.ProvisioningStateProvisioned,
-					HealthState:       healthcontract.HealthStateHealthy,
+					// Kubernetes Secrets are always healthy after they are created.
+					HealthState: healthcontract.HealthStateHealthy,
 				},
 			}
 

--- a/pkg/kubernetes/controllers/radius/resource_controller.go
+++ b/pkg/kubernetes/controllers/radius/resource_controller.go
@@ -441,6 +441,7 @@ func (r *ResourceReconciler) ApplyState(
 				Resource: *or,
 				Status: radiusv1alpha3.OutputResourceStatus{
 					ProvisioningState: kubernetes.ProvisioningStateProvisioned,
+					HealthState:       healthcontract.HealthStateHealthy,
 				},
 			}
 


### PR DESCRIPTION
# Description
Mark the scraped secret (created by the deployment template) as healthy when created. Secrets don't have  progress / state after creation so once created they should always be marked as healthy.

## Issue reference

This fixes an issue where we showed the K8s unmanaged resources as Unhealthy due to missing health status of the scraped secret.

We are in the progress of changing the scraped secret to not be referred to by LocalID, and thus _not_ used in the health status of K8s unmanaged resource which is the better long term fix.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
