### PR TITLE
Change structure of scaffolded app

### DIFF
--- a/pkg/cli/clivalidation.go
+++ b/pkg/cli/clivalidation.go
@@ -114,7 +114,7 @@ func RequireRadYAML(cmd *cobra.Command) (string, error) {
 	}
 
 	if radFile == "" {
-		return path.Join(".", "rad", "rad.yaml"), nil
+		return path.Join(".", "rad.yaml"), nil
 	}
 
 	return radFile, nil

--- a/pkg/cli/scaffold/rad.yaml.tmpl
+++ b/pkg/cli/scaffold/rad.yaml.tmpl
@@ -4,7 +4,7 @@ name: {{.ApplicationName}}
 stages:
 - name: infra
   bicep:
-    template: infra.bicep
+    template: iac/infra.bicep
 - name: app
   bicep:
-    template: app.bicep
+    template: iac/app.bicep

--- a/pkg/cli/scaffold/scaffold.go
+++ b/pkg/cli/scaffold/scaffold.go
@@ -40,7 +40,7 @@ func WriteApplication(options Options) ([]string, error) {
 		}
 	}
 
-	err := os.MkdirAll(path.Join(options.BaseDirectory, "rad"), 0755)
+	err := os.MkdirAll(path.Join(options.BaseDirectory, "iac"), 0755)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/scaffold/templates.go
+++ b/pkg/cli/scaffold/templates.go
@@ -34,15 +34,15 @@ var RADYaml ScaffoldTemplate
 func GetApplicationTemplates() []TemplateWorkItem {
 	return []TemplateWorkItem{
 		{
-			FilePath: path.Join("rad", "rad.yaml"),
+			FilePath: path.Join("rad.yaml"),
 			Template: template.Must(template.New("rad.yaml").Parse(RADYaml)),
 		},
 		{
-			FilePath: path.Join("rad", "infra.bicep"),
+			FilePath: path.Join("iac", "infra.bicep"),
 			Template: template.Must(template.New("infra.bicep").Parse(InfrastructureStage)),
 		},
 		{
-			FilePath: path.Join("rad", "app.bicep"),
+			FilePath: path.Join("iac", "app.bicep"),
 			Template: template.Must(template.New("app.bicep").Parse(ApplicationStage)),
 		},
 	}


### PR DESCRIPTION
Fixes: radius-project/core-team#448

This change updates the structure we generate by default for a new
scaffolded application, and also how we locate rad.yaml.

The primary change here is to look for rad.yaml in the user's current
directory rather than at `./rad/rad.yaml`. This has two nice benefits:

- It's more obvious and matches other tools better
- It's more obvious what relatives paths in rad.yaml do

In addition to these we're using the convention of `iac/` for where we
place the bicep files. This matches what `az dev` is doing.
