### PR TITLE
Add support for stage overrides 'profiles'

### DIFF
--- a/cmd/rad/cmd/appDeploy.go
+++ b/cmd/rad/cmd/appDeploy.go
@@ -34,6 +34,11 @@ By default 'rad app deploy' will run all stages. You can specify a stage at the 
 which stages run. If you specify a stage at the command line all stages before and including the specified
 stage are run. Stages after the specified stage are skipped.
 
+A named profile can be specified using the '--profile' command line option. Profiles allow you to define
+overrides in rad.yaml for specific deployment profiles of the application. For example, you could replace
+the infrastructure used by the application in development scenarios by defining a 'dev' profile that overrides
+the infra phase with a different file.
+
 You can specify parameters at the command line using the '--parameter' flag ('-p' for short). Parameters
 specified at the command line apply to all stages and must therefore exist in the template file for every stage. 
 
@@ -59,6 +64,11 @@ rad app deploy
 # deploy to a specific environment
 
 rad app deploy --environment production
+
+
+# deploy a profile of the application
+
+rad app deploy --profile staging
 
 
 # specify the 'infra' stage
@@ -92,8 +102,9 @@ rad app deploy --parameters @myfile.json --parameters version=latest
 func init() {
 	applicationCmd.AddCommand(appDeployCmd)
 	appDeployCmd.Flags().StringP("environment", "e", "", "The environment name")
-	appDeployCmd.Flags().StringP("radfile", "r", "", "The path to rad.yaml. The default is './rad/rad.yaml'")
+	appDeployCmd.Flags().StringP("radfile", "r", "", "The path to rad.yaml. The default is './rad.yaml'")
 	appDeployCmd.Flags().StringArrayP("parameters", "p", []string{}, "Specify parameters for the deployment")
+	appDeployCmd.Flags().String("profile", "", "Specify profile of the application for deployment")
 }
 
 func deployApplication(cmd *cobra.Command, args []string) error {
@@ -114,6 +125,11 @@ func deployApplication(cmd *cobra.Command, args []string) error {
 	}
 
 	parameterArgs, err := cmd.Flags().GetStringArray("parameters")
+	if err != nil {
+		return err
+	}
+
+	profile, err := cmd.Flags().GetString("profile")
 	if err != nil {
 		return err
 	}
@@ -158,6 +174,7 @@ func deployApplication(cmd *cobra.Command, args []string) error {
 		BaseDirectory: baseDir,
 		Manifest:      manifest,
 		Parameters:    parameters,
+		Profile:       profile,
 		FinalStage:    stage,
 	}
 

--- a/pkg/cli/radyaml/parse_test.go
+++ b/pkg/cli/radyaml/parse_test.go
@@ -39,6 +39,13 @@ stages:
 - name: infra
   bicep:
     template: infra.bicep
+  profiles:
+    dev: 
+      bicep:
+        template: infra-dev.bicep
+    staging: 
+      bicep:
+        template: infra-staging.bicep
 - name: app
   bicep:
     template: app.bicep
@@ -54,6 +61,18 @@ stages:
 				Name: "infra",
 				Bicep: &BicepStage{
 					Template: to.StringPtr("infra.bicep"),
+				},
+				Profiles: map[string]Profile{
+					"dev": {
+						Bicep: &BicepStage{
+							Template: to.StringPtr("infra-dev.bicep"),
+						},
+					},
+					"staging": {
+						Bicep: &BicepStage{
+							Template: to.StringPtr("infra-staging.bicep"),
+						},
+					},
 				},
 			},
 			{

--- a/pkg/cli/radyaml/profiles.go
+++ b/pkg/cli/radyaml/profiles.go
@@ -1,0 +1,58 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package radyaml
+
+import "strings"
+
+func (stage Stage) ApplyProfile(profile string) (Stage, error) {
+	var override *Profile
+	for name, p := range stage.Profiles {
+		if strings.EqualFold(name, profile) {
+			copy := p
+			override = &copy
+			break
+		}
+	}
+
+	// If there are no matching profiles to override, then we return the stage
+	// as-is.
+	if override == nil {
+		return stage, nil
+	}
+
+	copy := stage
+	bicep, err := CombineBicepStage(stage.Bicep, override.Bicep)
+	if err != nil {
+		return Stage{}, err
+	}
+
+	copy.Bicep = bicep
+	return copy, nil
+}
+
+func CombineBicepStage(main *BicepStage, override *BicepStage) (*BicepStage, error) {
+	if main == nil {
+		return override, nil
+	}
+
+	if override == nil {
+		return main, nil
+	}
+
+	// If we get here, both stages define Bicep settings and we need to combine them.
+	combined := BicepStage{}
+	combined.Template = overrideString(main.Template, override.Template)
+	return &combined, nil
+}
+
+// Generics please :-/
+func overrideString(main *string, override *string) *string {
+	if override == nil {
+		return main
+	}
+
+	return override
+}

--- a/pkg/cli/radyaml/profiles_test.go
+++ b/pkg/cli/radyaml/profiles_test.go
@@ -1,0 +1,143 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package radyaml
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/to"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ApplyProfile_Valid(t *testing.T) {
+	cases := []struct {
+		Description string
+		Main        Stage
+		Expected    Stage
+	}{
+		{
+			Description: "EmptyStage",
+			Main: Stage{
+				Name: "test-stage",
+			},
+			Expected: Stage{
+				Name: "test-stage",
+			},
+		},
+		{
+			Description: "NoOverrides",
+			Main: Stage{
+				Name: "test-stage",
+				Bicep: &BicepStage{
+					Template: to.StringPtr("test.bicep"),
+				},
+			},
+			Expected: Stage{
+				Name: "test-stage",
+				Bicep: &BicepStage{
+					Template: to.StringPtr("test.bicep"),
+				},
+			},
+		},
+		{
+			Description: "NoMatchingOverride",
+			Main: Stage{
+				Name: "test-stage",
+				Bicep: &BicepStage{
+					Template: to.StringPtr("test.bicep"),
+				},
+				Profiles: map[string]Profile{
+					"nope": {
+						Bicep: &BicepStage{
+							Template: to.StringPtr("another.bicep"),
+						},
+					},
+				},
+			},
+			Expected: Stage{
+				Name: "test-stage",
+				Bicep: &BicepStage{
+					Template: to.StringPtr("test.bicep"),
+				},
+			},
+		},
+		{
+			Description: "EmptyOverride",
+			Main: Stage{
+				Name: "test-stage",
+				Bicep: &BicepStage{
+					Template: to.StringPtr("test.bicep"),
+				},
+				Profiles: map[string]Profile{
+					"test": {
+						Bicep: nil,
+					},
+				},
+			},
+			Expected: Stage{
+				Name: "test-stage",
+				Bicep: &BicepStage{
+					Template: to.StringPtr("test.bicep"),
+				},
+			},
+		},
+		{
+			Description: "OverrideTemplate",
+			Main: Stage{
+				Name: "test-stage",
+				Bicep: &BicepStage{
+					Template: to.StringPtr("test.bicep"),
+				},
+				Profiles: map[string]Profile{
+					"test": {
+						Bicep: &BicepStage{
+							Template: to.StringPtr("override.bicep"),
+						},
+					},
+				},
+			},
+			Expected: Stage{
+				Name: "test-stage",
+				Bicep: &BicepStage{
+					Template: to.StringPtr("override.bicep"),
+				},
+			},
+		},
+		{
+			Description: "EmptyMain",
+			Main: Stage{
+				Name:  "test-stage",
+				Bicep: nil,
+				Profiles: map[string]Profile{
+					"test": {
+						Bicep: &BicepStage{
+							Template: to.StringPtr("override.bicep"),
+						},
+					},
+				},
+			},
+			Expected: Stage{
+				Name: "test-stage",
+				Bicep: &BicepStage{
+					Template: to.StringPtr("override.bicep"),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Description, func(t *testing.T) {
+			actual, err := c.Main.ApplyProfile("test")
+			require.NoError(t, err)
+
+			// our 'expected' results don't declare the set of profiles
+			expected := c.Expected
+			expected.Profiles = c.Main.Profiles
+
+			require.Equal(t, expected, actual)
+		})
+	}
+}

--- a/pkg/cli/radyaml/types.go
+++ b/pkg/cli/radyaml/types.go
@@ -5,16 +5,25 @@
 
 package radyaml
 
+// Manifest represents the overall content of a rad.yaml.
 type Manifest struct {
 	Name   string  `yaml:"name"`
 	Stages []Stage `yaml:"stages,omitempty"`
 }
 
+// Stage represents a stage of processing inside rad.yaml.
 type Stage struct {
-	Name  string      `yaml:"name"`
+	Name     string             `yaml:"name"`
+	Profiles map[string]Profile `yaml:"profiles,omitempty"`
+	Bicep    *BicepStage        `yaml:"bicep,omitempty"`
+}
+
+// Profile represents an override profile for a stage.
+type Profile struct {
 	Bicep *BicepStage `yaml:"bicep,omitempty"`
 }
 
+// Bicep stage represents a Bicep deployment as part of a stage or profile.
 type BicepStage struct {
 	Template *string `yaml:"template,omitempty"`
 }

--- a/pkg/cli/stages/types.go
+++ b/pkg/cli/stages/types.go
@@ -18,6 +18,7 @@ type Options struct {
 	BaseDirectory string
 	Manifest      radyaml.Manifest
 	FinalStage    string
+	Profile       string
 	Parameters    clients.DeploymentParameters
 
 	// BicepBuildFunc supports overriding the build build process for testing.


### PR DESCRIPTION
Fixes: #1453

This change adds the ability to override a stage depending on the
'profile' supplied at the command line. This is useful for cases where a
user wants to specify a different iac file or possible *no* iac file for
a stage depending on the 'profile' of the app being deployed.

- eg: I want to override my infrastructure for a simplified 'dev'
  configuration or 'staging' configuration.
- eg: My team is responsible for 'dev' infra but my ops team manages
  the infra for us in production.

We have other work items tracking expanding this feature set, so this
will be done in a series of follow-ups.

# Description

_Please explain the changes you've made._

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
