### PR TITLE
Fixups for removal of Component suffix

### DIFF
--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -23,6 +23,7 @@ const (
 	LabelManagedBy          = "app.kubernetes.io/managed-by"
 	LabelManagedByRadiusRP  = "radius-rp"
 	LabelAADPodIdentity     = "aadpodidbinding"
+	Test                    = "sure"
 
 	FieldManager      = "radius-rp"
 	AnnotationLocalID = "radius.dev/local-id"


### PR DESCRIPTION
This PR is to force the e2e tests to run, and will contain any fixups we need for Azure scenarios after removing the component suffix.

This might require a few tries to clear out any 'existing' environments that were created before the rename.
