### PR TITLE
Rename Azure connections 'role' field to 'roles'

### DIFF
--- a/docs/content/concepts/appmodel-concept/components-model/snippets/platform-specific-azure.bicep
+++ b/docs/content/concepts/appmodel-concept/components-model/snippets/platform-specific-azure.bicep
@@ -11,7 +11,7 @@ resource app 'radius.dev/Application@v1alpha3' = {
         translationresource: {
           kind:'azure'
           source: cognitiveServicesAccount.id
-          role: [
+          roles: [
             'Cognitive Services User'
           ]
         }

--- a/docs/content/concepts/appmodel-concept/connections-model/index.md
+++ b/docs/content/concepts/appmodel-concept/connections-model/index.md
@@ -88,7 +88,7 @@ In the following example, a frontend service connects to a backend service via a
 
 Often, platforms will have resources that are not portable across Radius platforms. For example, your application may use an Azure storage account, or specific features of Azure CosmosDB that cannot be abstracted with MongoDB. In this case, runnable Components can define a connection directly to the platform resource in Bicep.
 
-An Azure resource that does not bind to a [Radius portable component type]({{< ref resources >}}) can be defined outside the `radius.dev/Application` resource and added as a connection. To define a connection to an Azure resource the `kind` field should be set to `azure`, and RBAC can be configured by specifying role names in the `role` field.
+An Azure resource that does not bind to a [Radius portable component type]({{< ref resources >}}) can be defined outside the `radius.dev/Application` resource and added as a connection. To define a connection to an Azure resource the `kind` field should be set to `azure`, and RBAC can be configured by specifying role names in the `roles` field.
 
 {{< rad file="snippets/azure-connection.bicep" embed=true marker="//SAMPLE" >}}
 

--- a/docs/content/concepts/appmodel-concept/connections-model/snippets/azure-connection.bicep
+++ b/docs/content/concepts/appmodel-concept/connections-model/snippets/azure-connection.bicep
@@ -11,7 +11,7 @@ resource app 'radius.dev/Application@v1alpha3' = {
         storageresource: {
           kind:'azure'
           source: storageAccount.id
-          role: [
+          roles: [
             'Reader and Data Access'
             'Storage Blob Data Contributor'
           ]

--- a/pkg/azure/radclient/zz_generated_models.go
+++ b/pkg/azure/radclient/zz_generated_models.go
@@ -591,14 +591,14 @@ type ContainerConnection struct {
 	Source *string `json:"source,omitempty"`
 
 	// RBAC permissions to be assigned on the source resource
-	Role []*string `json:"role,omitempty"`
+	Roles []*string `json:"roles,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type ContainerConnection.
 func (c ContainerConnection) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "kind", c.Kind)
-	populate(objectMap, "role", c.Role)
+	populate(objectMap, "roles", c.Roles)
 	populate(objectMap, "source", c.Source)
 	return json.Marshal(objectMap)
 }

--- a/pkg/radrp/schema/resources/container.json
+++ b/pkg/radrp/schema/resources/container.json
@@ -207,7 +207,7 @@
           "description": "The source of the connection",
           "type": "string"
         },
-        "role": {
+        "roles": {
           "description": "RBAC permissions to be assigned on the source resource",
           "type": "array",
           "items": {

--- a/pkg/renderers/containerv1alpha3/render.go
+++ b/pkg/renderers/containerv1alpha3/render.go
@@ -627,10 +627,10 @@ func (r Renderer) makeRoleAssignmentsForResource(ctx context.Context, connection
 	var roleNames []string
 	var armResourceIdentifier string
 	if *connection.Kind == radclient.ContainerConnectionKindAzure {
-		if len(connection.Role) < 1 {
+		if len(connection.Roles) < 1 {
 			return nil, fmt.Errorf("rbac permissions are required to access Azure connections")
 		}
-		for _, role := range connection.Role {
+		for _, role := range connection.Roles {
 			roleNames = append(roleNames, *role)
 		}
 		armResourceIdentifier = *connection.Source

--- a/pkg/renderers/containerv1alpha3/render_test.go
+++ b/pkg/renderers/containerv1alpha3/render_test.go
@@ -96,7 +96,7 @@ func Test_GetDependencyIDs_Success(t *testing.T) {
 			"testAzureConnection": {
 				Kind:   radclient.ContainerConnectionKindAzure.ToPtr(),
 				Source: to.StringPtr(testAzureResourceID.ID),
-				Role:   []*string{to.StringPtr("administrator")},
+				Roles:  []*string{to.StringPtr("administrator")},
 			},
 		},
 		Container: &radclient.ContainerPropertiesContainer{
@@ -180,7 +180,7 @@ func Test_GetDependencyIDs_InvalidAzureResourceId(t *testing.T) {
 			"AzureResourceTest": {
 				Kind:   radclient.ContainerConnectionKindAzure.ToPtr(),
 				Source: to.StringPtr("/subscriptions/test-sub-id/providers/Microsoft.ServiceBus/namespaces/testNamespace"),
-				Role:   []*string{to.StringPtr("reader")},
+				Roles:  []*string{to.StringPtr("reader")},
 			},
 		},
 		Container: &radclient.ContainerPropertiesContainer{
@@ -580,7 +580,7 @@ func Test_Render_AzureConnection(t *testing.T) {
 			"testAzureResourceConnection": {
 				Kind:   radclient.ContainerConnectionKindAzure.ToPtr(),
 				Source: to.StringPtr(testARMID),
-				Role:   []*string{to.StringPtr(expectedRole)},
+				Roles:  []*string{to.StringPtr(expectedRole)},
 			},
 		},
 		Container: &radclient.ContainerPropertiesContainer{

--- a/schemas/rest-api-specs/radius.json
+++ b/schemas/rest-api-specs/radius.json
@@ -407,7 +407,7 @@
           ],
           "type": "string"
         },
-        "role": {
+        "roles": {
           "description": "RBAC permissions to be assigned on the source resource",
           "items": {
             "type": "string"


### PR DESCRIPTION
# Description

Connections role field is currently an array with support for multiple role names, so renaming it to roles is more intuitive.
https://github.com/Azure/radius/blob/main/docs/content/concepts/appmodel-concept/connections-model/snippets/azure-connection.bicep#L14

Corresponding bicep changes are here: https://github.com/ProjectRadius/bicep/pull/60

## Issue reference

https://github.com/Azure/radius/issues/1552

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change -- https://github.com/Azure/radius/pull/1584
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
