### PR TITLE
Add preliminary 'builder' support

### DIFF
--- a/cmd/rad/cmd/appDeploy.go
+++ b/cmd/rad/cmd/appDeploy.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Azure/radius/pkg/cli"
 	"github.com/Azure/radius/pkg/cli/bicep"
+	"github.com/Azure/radius/pkg/cli/builders"
 	"github.com/Azure/radius/pkg/cli/output"
 	"github.com/Azure/radius/pkg/cli/radyaml"
 	"github.com/Azure/radius/pkg/cli/stages"
@@ -173,9 +174,13 @@ func deployApplication(cmd *cobra.Command, args []string) error {
 		Environment:   env,
 		BaseDirectory: baseDir,
 		Manifest:      manifest,
+		Builders:      builders.DefaultBuilders(),
 		Parameters:    parameters,
 		Profile:       profile,
 		FinalStage:    stage,
+
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
 	}
 
 	_, err = stages.Run(cmd.Context(), options)

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	golang.org/x/text v0.3.7
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/ini.v1 v1.66.2
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	gotest.tools v2.2.0+incompatible
 	helm.sh/helm/v3 v3.6.1

--- a/pkg/cli/builders/docker.go
+++ b/pkg/cli/builders/docker.go
@@ -1,0 +1,87 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package builders
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+var _ Builder = (*dockerBuilder)(nil)
+
+type dockerBuilder struct {
+}
+
+type dockerInput struct {
+	Context    string `json:"context"`
+	DockerFile string `json:"dockerFile"`
+	Image      string `json:"image"`
+}
+
+func (builder *dockerBuilder) Build(ctx context.Context, options Options) (Output, error) {
+	b, err := json.Marshal(&options.Values)
+	if err != nil {
+		return Output{}, err
+	}
+
+	input := dockerInput{}
+	err = json.Unmarshal(b, &input)
+	if err != nil {
+		return Output{}, err
+	}
+
+	if input.Context == "" {
+		return Output{}, fmt.Errorf("%s is required", "context")
+	}
+	if input.Image == "" {
+		return Output{}, fmt.Errorf("%s is required", "image")
+	}
+	if input.DockerFile == "" {
+		input.DockerFile = "Dockerfile"
+	}
+
+	input.Context = NormalizePath(options.BaseDirectory, input.Context)
+	input.DockerFile = NormalizePath(input.Context, input.DockerFile)
+
+	args := []string{
+		"build",
+		input.Context,
+		"-f", input.DockerFile,
+		"-t", input.Image,
+	}
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.Stdout = options.Stdout
+	cmd.Stderr = options.Stderr
+
+	fmt.Printf("running: %s\n", cmd.String())
+	err = cmd.Run()
+	if err != nil {
+		return Output{}, err
+	}
+
+	args = []string{
+		"push",
+		input.Image,
+	}
+	cmd = exec.CommandContext(ctx, "docker", args...)
+	cmd.Stdout = options.Stdout
+	cmd.Stderr = options.Stderr
+
+	err = cmd.Run()
+	if err != nil {
+		return Output{}, err
+	}
+
+	output := Output{
+		Result: map[string]interface{}{
+			"image": input.Image,
+		},
+	}
+
+	return output, nil
+}

--- a/pkg/cli/builders/types.go
+++ b/pkg/cli/builders/types.go
@@ -1,0 +1,43 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package builders
+
+import (
+	"context"
+	"io"
+	"path"
+)
+
+type Options struct {
+	BaseDirectory string
+	Stderr        io.Writer
+	Stdout        io.Writer
+	Values        interface{}
+}
+
+type Output struct {
+	// Result is a value representing the build output. If provided non-nil, the Result will be
+	// added as a parameter for the stage to consume.
+	Result interface{}
+}
+
+type Builder interface {
+	Build(ctx context.Context, options Options) (Output, error)
+}
+
+func NormalizePath(base string, p string) string {
+	if path.IsAbs(p) {
+		return p
+	}
+
+	return path.Join(base, p)
+}
+
+func DefaultBuilders() map[string]Builder {
+	return map[string]Builder{
+		"docker": &dockerBuilder{},
+	}
+}

--- a/pkg/cli/radyaml/marshal.go
+++ b/pkg/cli/radyaml/marshal.go
@@ -1,0 +1,41 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package radyaml
+
+import (
+	"errors"
+
+	"gopkg.in/yaml.v3"
+)
+
+var _ yaml.Marshaler = (*BuildTarget)(nil)
+var _ yaml.Unmarshaler = (*BuildTarget)(nil)
+
+func (bt BuildTarget) MarshalYAML() (interface{}, error) {
+	return map[string]interface{}{
+		bt.Builder: bt.Values,
+	}, nil
+}
+
+func (bt *BuildTarget) UnmarshalYAML(node *yaml.Node) error {
+	raw := map[string]map[string]interface{}{}
+	err := node.Decode(&raw)
+	if err != nil {
+		return err
+	}
+
+	if len(raw) != 1 {
+		return errors.New("a build target should specify a single builder")
+	}
+
+	for key, value := range raw {
+		bt.Builder = key
+		bt.Values = value
+		return nil
+	}
+
+	panic("unreachable code")
+}

--- a/pkg/cli/radyaml/profiles.go
+++ b/pkg/cli/radyaml/profiles.go
@@ -5,7 +5,9 @@
 
 package radyaml
 
-import "strings"
+import (
+	"strings"
+)
 
 func (stage Stage) ApplyProfile(profile string) (Stage, error) {
 	var override *Profile
@@ -24,13 +26,66 @@ func (stage Stage) ApplyProfile(profile string) (Stage, error) {
 	}
 
 	copy := stage
+
+	build, err := CombineBuildStage(stage.Build, override.Build)
+	if err != nil {
+		return Stage{}, err
+	}
+
 	bicep, err := CombineBicepStage(stage.Bicep, override.Bicep)
 	if err != nil {
 		return Stage{}, err
 	}
 
+	copy.Build = build
 	copy.Bicep = bicep
 	return copy, nil
+}
+
+func CombineBuildStage(main BuildStage, override BuildStage) (BuildStage, error) {
+	if main == nil {
+		return override, nil
+	}
+
+	if override == nil {
+		return main, nil
+	}
+
+	// If we get here, both stages define Build settings and we need to combine them.
+	combined := BuildStage{}
+	for key, value := range main {
+		combined[key] = value
+	}
+
+	for key, value := range override {
+		target, err := CombineBuildTarget(combined[key], value)
+		if err != nil {
+			return nil, err
+		}
+
+		combined[key] = target
+	}
+
+	return combined, nil
+}
+
+func CombineBuildTarget(main *BuildTarget, override *BuildTarget) (*BuildTarget, error) {
+	if main == nil {
+		return override, nil
+	}
+
+	if override == nil {
+		return main, nil
+	}
+
+	if strings.EqualFold(main.Builder, override.Builder) {
+		return &BuildTarget{
+			Builder: main.Builder,
+			Values:  overrideMap(main.Values, override.Values),
+		}, nil
+	}
+
+	return override, nil
 }
 
 func CombineBicepStage(main *BicepStage, override *BicepStage) (*BicepStage, error) {
@@ -55,4 +110,35 @@ func overrideString(main *string, override *string) *string {
 	}
 
 	return override
+}
+
+func overrideMap(main map[string]interface{}, override map[string]interface{}) map[string]interface{} {
+	if override == nil {
+		return main
+	}
+
+	if main == nil {
+		return override
+	}
+
+	// If we get here both main and override are non-nil. We want to combine them recursively.
+	combined := map[string]interface{}{}
+	for key, value := range main {
+		combined[key] = value
+	}
+
+	for key, value := range override {
+		if mainValue, ok := combined[key]; ok {
+			mainValueMap, isMainValueMap := mainValue.(map[string]interface{})
+			overrideValueMap, isOverrideValueMap := value.(map[string]interface{})
+			if isMainValueMap && isOverrideValueMap {
+				combined[key] = overrideMap(mainValueMap, overrideValueMap)
+				continue
+			}
+		}
+
+		combined[key] = value
+	}
+
+	return combined
 }

--- a/pkg/cli/radyaml/types.go
+++ b/pkg/cli/radyaml/types.go
@@ -14,12 +14,22 @@ type Manifest struct {
 // Stage represents a stage of processing inside rad.yaml.
 type Stage struct {
 	Name     string             `yaml:"name"`
+	Build    BuildStage         `yaml:"build,omitempty"`
 	Profiles map[string]Profile `yaml:"profiles,omitempty"`
 	Bicep    *BicepStage        `yaml:"bicep,omitempty"`
 }
 
+type BuildStage = map[string]*BuildTarget
+
+// BuildTarget implements its own serialization so we can enforce some constraints.
+type BuildTarget struct {
+	Builder string
+	Values  map[string]interface{}
+}
+
 // Profile represents an override profile for a stage.
 type Profile struct {
+	Build BuildStage  `yaml:"build,omitempty"`
 	Bicep *BicepStage `yaml:"bicep,omitempty"`
 }
 

--- a/pkg/cli/stages/run.go
+++ b/pkg/cli/stages/run.go
@@ -81,13 +81,20 @@ func Run(ctx context.Context, options Options) ([]StageResult, error) {
 		output.LogInfo("")
 		step := output.BeginStep("Processing stage %s: %d of %d", processor.CurrrentStage.Name, processor.CurrrentStage.DisplayIndex, processor.CurrrentStage.TotalCount)
 
+		if stage.Build != nil {
+			err := processor.ProcessBuild(ctx, stage.Build)
+			if err != nil {
+				return nil, fmt.Errorf("stage %s failed: %w", processor.CurrrentStage.Name, err)
+			}
+		}
+
 		if stage.Bicep != nil {
 			err := processor.ProcessDeploy(ctx, *stage.Bicep)
 			if err != nil {
 				return nil, fmt.Errorf("stage %s failed: %w", processor.CurrrentStage.Name, err)
 			}
 		} else {
-			output.LogInfo("Nothing to do for stage %s...", processor.CurrrentStage.Name)
+			output.LogInfo("No deployment step for stage %s...", processor.CurrrentStage.Name)
 		}
 
 		output.CompleteStep(step)

--- a/pkg/cli/stages/types.go
+++ b/pkg/cli/stages/types.go
@@ -7,7 +7,9 @@ package stages
 
 import (
 	"context"
+	"io"
 
+	"github.com/Azure/radius/pkg/cli/builders"
 	"github.com/Azure/radius/pkg/cli/clients"
 	"github.com/Azure/radius/pkg/cli/environments"
 	"github.com/Azure/radius/pkg/cli/radyaml"
@@ -19,6 +21,9 @@ type Options struct {
 	Manifest      radyaml.Manifest
 	FinalStage    string
 	Profile       string
+	Stdout        io.Writer
+	Stderr        io.Writer
+	Builders      map[string]builders.Builder
 	Parameters    clients.DeploymentParameters
 
 	// BicepBuildFunc supports overriding the build build process for testing.


### PR DESCRIPTION
Part of: #1556

This change adds preliminary support for builds as part of 'rad.yaml'.
Users can describe build tasks as part of 'rad.yaml' and those build
tasks will run as part of deployment. In particular the build results
can be consumed by IAC code as a parameter.

This change is preliminary and adds the general framework along with a
**very** simple builder integration for docker/Dockerfiles. The
intention here is that we will grow a plugin ecosystem of 'builders'
that can be maintained by the community and is loosely coupled to
Radius. We need build support for inner-loop experiences that work with
`rad`.

