### PR TITLE
Use sub and resource group for unique names

### DIFF
--- a/deploy/rp-full.input.json
+++ b/deploy/rp-full.input.json
@@ -43,7 +43,7 @@
         },
         "siteName": {
             "type": "string",
-            "defaultValue": "[concat('radius-rp-', uniqueString(parameters('controlPlaneResourceGroup')))]",
+            "defaultValue": "[concat('radius-rp-', uniqueString(subscription().id, parameters('controlPlaneResourceGroup')))]",
             "metadata": {
                 "description": "The name of your Web Site."
             }
@@ -64,7 +64,7 @@
         },
         "accountName": {
             "type": "string",
-            "defaultValue": "[concat('radius-rp-', uniquestring(parameters('controlPlaneResourceGroup')))]",
+            "defaultValue": "[concat('radius-rp-', uniquestring(subscription().id, parameters('controlPlaneResourceGroup')))]",
             "metadata": {
                 "description": "The unique name of the cosmos db account."
             }
@@ -78,7 +78,7 @@
         },
         "clusterName": {
             "type": "string",
-            "defaultValue": "[concat('radius-aks-', uniqueString(parameters('controlPlaneResourceGroup')))]",
+            "defaultValue": "[concat('radius-aks-', uniqueString(subscription().id, parameters('controlPlaneResourceGroup')))]",
             "metadata": {
                 "description": "The name of the Managed Cluster resource."
             }
@@ -99,7 +99,7 @@
         },
         "deploymentScriptIdentityName": {
             "type": "string",
-            "defaultValue": "[concat('radius-deployment-id-', uniqueString(parameters('controlPlaneResourceGroup')))]",
+            "defaultValue": "[concat('radius-deployment-id-', uniqueString(subscription().id, parameters('controlPlaneResourceGroup')))]",
             "metadata": {
                 "description": "The identity name to use for the deployment script."
             }

--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -16,7 +16,7 @@
             "type": "string"
         },
         "accountName": {
-            "defaultValue": "[concat('radius-rp-', uniquestring(parameters('controlPlaneResourceGroup')))]",
+            "defaultValue": "[concat('radius-rp-', uniquestring(subscription().id, parameters('controlPlaneResourceGroup')))]",
             "metadata": {
                 "description": "The unique name of the cosmos db account."
             },
@@ -30,7 +30,7 @@
             "type": "string"
         },
         "clusterName": {
-            "defaultValue": "[concat('radius-aks-', uniqueString(parameters('controlPlaneResourceGroup')))]",
+            "defaultValue": "[concat('radius-aks-', uniqueString(subscription().id, parameters('controlPlaneResourceGroup')))]",
             "metadata": {
                 "description": "The name of the Managed Cluster resource."
             },
@@ -50,7 +50,7 @@
             "type": "string"
         },
         "deploymentScriptIdentityName": {
-            "defaultValue": "[concat('radius-deployment-id-', uniqueString(parameters('controlPlaneResourceGroup')))]",
+            "defaultValue": "[concat('radius-deployment-id-', uniqueString(subscription().id, parameters('controlPlaneResourceGroup')))]",
             "metadata": {
                 "description": "The identity name to use for the deployment script."
             },
@@ -113,7 +113,7 @@
             "type": "object"
         },
         "siteName": {
-            "defaultValue": "[concat('radius-rp-', uniqueString(parameters('controlPlaneResourceGroup')))]",
+            "defaultValue": "[concat('radius-rp-', uniqueString(subscription().id, parameters('controlPlaneResourceGroup')))]",
             "metadata": {
                 "description": "The name of your Web Site."
             },


### PR DESCRIPTION
Fixes: radius-project/radius#1599

This change adds the subscription id as a seed value for generating
unique names in our environment deployment template. Previously we were
just using the environment name (same as the resource group) but not
considering the subscription. The result is that environments with the
same name across different subs would collide.

