### PR TITLE
Fix handling of resource deletion in controller

### DIFF
--- a/pkg/kubernetes/controllers/radius/application_controller.go
+++ b/pkg/kubernetes/controllers/radius/application_controller.go
@@ -33,7 +33,9 @@ func (r *ApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	_ = r.Log.WithValues("application", req.NamespacedName)
 	app := &radiusv1alpha3.Application{}
 	err := r.Client.Get(ctx, req.NamespacedName, app)
-	if err != nil {
+	if err != nil && client.IgnoreNotFound(err) == nil {
+		return ctrl.Result{}, nil
+	} else if err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/pkg/kubernetes/controllers/radius/resource_controller.go
+++ b/pkg/kubernetes/controllers/radius/resource_controller.go
@@ -115,17 +115,17 @@ func (r *ResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	log := r.Log.WithValues("resource", req.NamespacedName)
 
 	unst, err := r.Dynamic.Resource(r.GVR).Namespace(req.Namespace).Get(ctx, req.Name, v1.GetOptions{})
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	resource := &radiusv1alpha3.Resource{}
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unst.Object, resource)
 	if err != nil && client.IgnoreNotFound(err) == nil {
 		// Resource was deleted - we don't need to handle this because it will cascade
 		return ctrl.Result{}, nil
 	} else if err != nil {
 		log.Error(err, "failed to retrieve resource")
+		return ctrl.Result{}, err
+	}
+
+	resource := &radiusv1alpha3.Resource{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(unst.Object, resource)
+	if err != nil {
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
This change fixes the handling of 'not found' reconcile requests. When a
resource is being deleted it will trigger a reconcile, but the
underlying resource is gone. This is for the controller to clean up any
resources it needs to (GC). We don't need this so the right thing to do
is just return success.

Right now we report these 'not founds' as errors which causes them to
loop.
