### PR TITLE
Use namespace from ResourceID and create namespace in rad env init

### DIFF
--- a/cmd/rad/cmd/envInitKubernetes.go
+++ b/cmd/rad/cmd/envInitKubernetes.go
@@ -95,7 +95,7 @@ var envInitKubernetesCmd = &cobra.Command{
 		}
 
 		// Make sure namespace passed in exists.
-		err = kubernetes.CreateNamespace(cmd.Context(), client, namespace)
+		err = kubernetes.EnsureNamespace(cmd.Context(), client, namespace)
 		if err != nil {
 			return err
 		}
@@ -105,7 +105,7 @@ var envInitKubernetesCmd = &cobra.Command{
 		// The controller and other resources are all deployed to the
 		// 'radius-system' namespace. The namespace passed in will be
 		// where pods/services/deployments will be put for rad deploy.
-		err = kubernetes.CreateNamespace(cmd.Context(), client, helm.RadiusSystemNamespace)
+		err = kubernetes.EnsureNamespace(cmd.Context(), client, helm.RadiusSystemNamespace)
 		if err != nil {
 			return err
 		}

--- a/cmd/rad/cmd/envInitKubernetes.go
+++ b/cmd/rad/cmd/envInitKubernetes.go
@@ -94,6 +94,12 @@ var envInitKubernetesCmd = &cobra.Command{
 			return err
 		}
 
+		// Make sure namespace passed in exists.
+		err = kubernetes.CreateNamespace(cmd.Context(), client, namespace)
+		if err != nil {
+			return err
+		}
+
 		// Do note: the namespace passed in to rad env init kubernetes
 		// doesn't match the namespace where we deploy the controller to.
 		// The controller and other resources are all deployed to the

--- a/pkg/cli/kubernetes/kubernetes.go
+++ b/pkg/cli/kubernetes/kubernetes.go
@@ -125,7 +125,7 @@ func CreateRuntimeClient(context string, scheme *runtime.Scheme) (client.Client,
 	return c, nil
 }
 
-func CreateNamespace(ctx context.Context, client *k8s.Clientset, namespace string) error {
+func EnsureNamespace(ctx context.Context, client *k8s.Clientset, namespace string) error {
 	namespaceApply := applycorev1.Namespace(namespace)
 
 	// Use Apply instead of Create to avoid failures on a namespace already existing.

--- a/pkg/kubernetes/apiserver/resourceprovider_test.go
+++ b/pkg/kubernetes/apiserver/resourceprovider_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	Namespace = "default"
+	Namespace = "mynamespace"
 )
 
 func Test_ListApplication(t *testing.T) {

--- a/test/kubernetestest/controllertest.go
+++ b/test/kubernetestest/controllertest.go
@@ -194,7 +194,7 @@ func StopController() error {
 
 func (ct ControllerTest) Test(t *testing.T) error {
 	// Make sure namespace exists
-	err := kubernetes.CreateNamespace(ct.Context, ct.Options.K8s, ct.ControllerStep.Namespace)
+	err := kubernetes.EnsureNamespace(ct.Context, ct.Options.K8s, ct.ControllerStep.Namespace)
 	require.NoError(t, err, "failed to create namespace")
 
 	items, err := ioutil.ReadDir(ct.ControllerStep.TemplateFolder)


### PR DESCRIPTION
Fixes https://github.com/Azure/radius/issues/1603

- Uses the namespace passed into the resourceID rather than always using default.
- Modified tests to use a new custom namespace name to verify.
- Creates namespace that is targeted by `rad env init kubernetes`.
  - Should we create the user required namespace here? I think it's the behavior that makes the most sense (if the namespace exists, noop) 


