### PR TITLE
reduce parallel execution of tests to improve stability

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -15,7 +15,7 @@ test: ## Runs unit tests, excluding kubernetes controller tests
 
 .PHONY: test-functional-azure
 test-functional-azure: ## Runs Azure functional tests
-	CGO_ENABLED=1 go test ./test/functional/azure/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
+	CGO_ENABLED=1 go test ./test/functional/azure/... -timeout ${TEST_TIMEOUT} -v -parallel 20 $(GOTEST_OPTS)
 
 test-functional-kubernetes: ## Runs Kubernetes functional tests
 	CGO_ENABLED=1 go test ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)

--- a/build/test.mk
+++ b/build/test.mk
@@ -15,10 +15,10 @@ test: ## Runs unit tests, excluding kubernetes controller tests
 
 .PHONY: test-functional-azure
 test-functional-azure: ## Runs Azure functional tests
-	CGO_ENABLED=1 go test ./test/functional/azure/... -timeout ${TEST_TIMEOUT} -v -parallel 20 $(GOTEST_OPTS)
+	CGO_ENABLED=1 go test ./test/functional/azure/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
 
 test-functional-kubernetes: ## Runs Kubernetes functional tests
-	CGO_ENABLED=1 go test ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 20 $(GOTEST_OPTS)
+	CGO_ENABLED=1 go test ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
 
 ENVTEST_ASSETS_DIR=$(shell pwd)/bin
 K8S_VERSION=1.19.2


### PR DESCRIPTION
# Description

reduce parallel execution of tests to improve stability. Seems like the kind cluster can't handle the load resulting in broken CI/CD tests

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: N\A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
