### PR TITLE
Don't wait for all pods when application delete is running

### DIFF
--- a/test/azuretest/applicationtest.go
+++ b/test/azuretest/applicationtest.go
@@ -193,7 +193,7 @@ func (at ApplicationTest) Test(t *testing.T) {
 	} else {
 		t.Logf("validating deletion of resources for %s", at.Description)
 		for _, ns := range at.CollectAllNamespaces() {
-			validation.ValidateNoPodsInNamespace(ctx, t, at.Options.K8sClient, ns)
+			validation.ValidateNoPodsInApplication(ctx, t, at.Options.K8sClient, ns, at.Application)
 		}
 		t.Logf("finished deletion of resources for %s", at.Description)
 	}

--- a/test/kubernetestest/kubernetestest.go
+++ b/test/kubernetestest/kubernetestest.go
@@ -318,7 +318,7 @@ func (at ApplicationTest) Test(t *testing.T) {
 	} else {
 		t.Logf("validating deletion of pods for %s", at.Description)
 		for _, ns := range at.CollectAllNamespaces() {
-			validation.ValidateNoPodsInNamespace(ctx, t, at.Options.K8sClient, ns)
+			validation.ValidateNoPodsInApplication(ctx, t, at.Options.K8sClient, ns, at.Application)
 		}
 		t.Logf("finished deletion of pods for %s", at.Description)
 	}


### PR DESCRIPTION
# Description

Don't wait for all pods to be removed from a namespace before a test completes

## Issue reference

Fixes https://github.com/Azure/radius/issues/1243

