### PR TITLE
MAINT: reduce trigger scope to only relevant files

### DIFF
--- a/.github/workflows/static-website.yaml
+++ b/.github/workflows/static-website.yaml
@@ -8,7 +8,7 @@ on:
       - 'docs/**'
       - 'cmd/rad/**'
       - 'cmd/docgen/**'
-      - '.github/workflows/**'
+      - '.github/workflows/*website.yaml'
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
@@ -17,7 +17,7 @@ on:
       - 'docs/**'
       - 'cmd/rad/**'
       - 'cmd/docgen/**'
-      - '.github/workflows/**'
+      - '.github/workflows/*website.yaml'
 
 jobs:
   build_and_deploy_docs:


### PR DESCRIPTION
# Description

I am reducing the scope of the path only to relevant files so we don't waste time and monay generating a static website when no changes affecting the website are made. As a side effect we also reduce the probability of hitting the limit of simultaneous generated websites (10)

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: N\A

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
