### PR TITLE
Bugfixes for API Service

### DIFF
--- a/pkg/cli/radyaml/profiles_test.go
+++ b/pkg/cli/radyaml/profiles_test.go
@@ -8,7 +8,7 @@ package radyaml
 import (
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/kubernetes/apiserver/apiserver.go
+++ b/pkg/kubernetes/apiserver/apiserver.go
@@ -57,7 +57,7 @@ func (api *APIServerExtension) Run(ctx context.Context) error {
 		return err
 	}
 
-	rp := NewResourceProvider(c)
+	rp := NewResourceProvider(c, "/apis/api.radius.dev/v1alpha3")
 	s := server.NewServer(ctx, server.ServerOptions{
 		Address:      fmt.Sprintf(":%v", api.options.Port),
 		Authenticate: false,

--- a/pkg/kubernetes/apiserver/resourceprovider_test.go
+++ b/pkg/kubernetes/apiserver/resourceprovider_test.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	Namespace = "mynamespace"
+	BaseURL   = "/apis/api.radius.dev/v1alpha3/fake"
 )
 
 func Test_ListApplication(t *testing.T) {
@@ -64,7 +65,7 @@ func Test_ListApplication(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&resource1).Build()
 
-	rp := NewResourceProvider(c)
+	rp := NewResourceProvider(c, BaseURL)
 
 	response, err := rp.ListApplications(context.Background(), id)
 	require.NoError(t, err)
@@ -126,7 +127,7 @@ func Test_GetApplication(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&resource1).Build()
 
-	rp := NewResourceProvider(c)
+	rp := NewResourceProvider(c, BaseURL)
 
 	response, err := rp.GetApplication(context.Background(), id)
 	require.NoError(t, err)
@@ -179,7 +180,7 @@ func Test_DeleteApplication(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&resource1).Build()
 
-	rp := NewResourceProvider(c)
+	rp := NewResourceProvider(c, BaseURL)
 
 	response, err := rp.DeleteApplication(context.Background(), id)
 	require.NoError(t, err)
@@ -293,7 +294,7 @@ func Test_ListResources(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&app, &resource1, &resource2).Build()
 
-	rp := NewResourceProvider(c)
+	rp := NewResourceProvider(c, BaseURL)
 
 	response, err := rp.ListResources(context.Background(), id)
 	require.NoError(t, err)
@@ -394,7 +395,7 @@ func Test_ListAllV3ResourcesByApplication(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&app, &resource1).Build()
 
-	rp := NewResourceProvider(c)
+	rp := NewResourceProvider(c, BaseURL)
 
 	response, err := rp.ListAllV3ResourcesByApplication(context.Background(), id)
 	require.NoError(t, err)
@@ -521,7 +522,7 @@ func Test_GetResource(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&app, &resource1, &resource2).Build()
 
-	rp := NewResourceProvider(c)
+	rp := NewResourceProvider(c, BaseURL)
 
 	response, err := rp.GetResource(context.Background(), id)
 	require.NoError(t, err)
@@ -608,7 +609,7 @@ func Test_DeleteResource(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&app, &resource1).Build()
 
-	rp := NewResourceProvider(c)
+	rp := NewResourceProvider(c, BaseURL)
 
 	response, err := rp.DeleteResource(context.Background(), id)
 	require.NoError(t, err)
@@ -724,7 +725,7 @@ func Test_ListSecrets(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&app, &resource1, &secret).Build()
 
-	rp := NewResourceProvider(c)
+	rp := NewResourceProvider(c, BaseURL)
 
 	response, err := rp.ListSecrets(context.Background(), resourceprovider.ListSecretsInput{TargetID: id.ID})
 	require.NoError(t, err)
@@ -817,7 +818,7 @@ func Test_GetOperation(t *testing.T) {
 
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&app, &resource1).Build()
 
-	rp := NewResourceProvider(c)
+	rp := NewResourceProvider(c, BaseURL)
 
 	response, err := rp.GetOperation(context.Background(), id)
 	require.NoError(t, err)


### PR DESCRIPTION
This is bevy of fixes for minor issues I discovered building prototypes on top of the API Service. Mostly the big change here is that I'm using the PUT code path that we haven't tested much. 

- Operation URLs should include the path prefix of our APIService
- PUT operation - deserialization was using wrong type/struct so 
   the output was empty
- PUT operations should 'scrape' secrets to avoid persisting them in
  resource bodies in plaintext.
- List/GET operations are not including the name field for resources
