### PR TITLE
Add support for role definition id on create role assignment

### DIFF
--- a/docs/content/concepts/appmodel-concept/connections-model/index.md
+++ b/docs/content/concepts/appmodel-concept/connections-model/index.md
@@ -88,7 +88,7 @@ In the following example, a frontend service connects to a backend service via a
 
 Often, platforms will have resources that are not portable across Radius platforms. For example, your application may use an Azure storage account, or specific features of Azure CosmosDB that cannot be abstracted with MongoDB. In this case, runnable Components can define a connection directly to the platform resource in Bicep.
 
-An Azure resource that does not bind to a [Radius portable component type]({{< ref resources >}}) can be defined outside the `radius.dev/Application` resource and added as a connection. To define a connection to an Azure resource the `kind` field should be set to `azure`, and RBAC can be configured by specifying role names in the `roles` field.
+An Azure resource that does not bind to a [Radius portable component type]({{< ref resources >}}) can be defined outside the `radius.dev/Application` resource and added as a connection. To define a connection to an Azure resource the `kind` field should be set to `azure`, and RBAC can be configured by specifying role name or ID in the `roles` field.
 
 {{< rad file="snippets/azure-connection.bicep" embed=true marker="//SAMPLE" >}}
 

--- a/pkg/azure/clients/clients.go
+++ b/pkg/azure/clients/clients.go
@@ -7,7 +7,6 @@ package clients
 
 import (
 	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/features"
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/authorization/mgmt/authorization"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerregistry/mgmt/containerregistry"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/cosmos-db/mgmt/documentdb"
@@ -20,7 +19,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/storage/mgmt/storage"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/web/mgmt/web"
 
-	// "github.com/Azure/azure-sdk-for-go/profiles/preview/preview/authorization/mgmt/authorization"
+	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/authorization/mgmt/authorization"
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/customproviders/mgmt/customproviders"
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/subscription/mgmt/subscription"
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/redis/mgmt/redis"

--- a/pkg/azure/clients/clients.go
+++ b/pkg/azure/clients/clients.go
@@ -7,6 +7,7 @@ package clients
 
 import (
 	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/features"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/authorization/mgmt/authorization"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerregistry/mgmt/containerregistry"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/cosmos-db/mgmt/documentdb"
@@ -18,7 +19,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/servicebus/mgmt/servicebus"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/storage/mgmt/storage"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/web/mgmt/web"
-	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/authorization/mgmt/authorization"
+
+	// "github.com/Azure/azure-sdk-for-go/profiles/preview/preview/authorization/mgmt/authorization"
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/customproviders/mgmt/customproviders"
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/subscription/mgmt/subscription"
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/redis/mgmt/redis"

--- a/pkg/azure/roleassignment/roleassignment.go
+++ b/pkg/azure/roleassignment/roleassignment.go
@@ -93,6 +93,7 @@ func Create(ctx context.Context, auth autorest.Authorizer, subscriptionID, princ
 func getRoleDefinitionID(ctx context.Context, auth autorest.Authorizer, subscriptionID, scope, roleNameOrID string) (roleDefinitionID string, err error) {
 	if strings.HasPrefix(roleNameOrID, "/subscriptions/") {
 		roleDefinitionID = roleNameOrID
+		return
 	}
 
 	roleDefinitionClient := clients.NewRoleDefinitionsClient(subscriptionID, auth)

--- a/pkg/azure/roleassignment/roleassignment.go
+++ b/pkg/azure/roleassignment/roleassignment.go
@@ -7,6 +7,7 @@ package roleassignment
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/authorization/mgmt/authorization"
@@ -18,25 +19,26 @@ import (
 )
 
 // Create assigns the specified role name to the Identity over the specified scope
-func Create(ctx context.Context, auth autorest.Authorizer, subscriptionID string, resourceGroup, principalID, scope, roleName string) (*authorization.RoleAssignment, error) {
+// principalID - The principal ID assigned to the role. This maps to the ID inside the Active Directory. It can point to a user, service principal, or security group.
+// scope - fully qualified identifier of the scope of the role assignment to create. Example: '/subscriptions/{subscription-id}/',
+// '/subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/providers/{resource-provider}/{resource-type}/{resource-name}'
+// roleNameOrID - Name of the role ('Reader') or definition id ('acdd72a7-3385-48ef-bd42-f606fba81ae7') for the role to be assigned.
+func Create(ctx context.Context, auth autorest.Authorizer, subscriptionID, principalID, scope, roleNameOrID string) (*authorization.RoleAssignment, error) {
 	logger := radlogger.GetLogger(ctx)
-	rdc := clients.NewRoleDefinitionsClient(subscriptionID, auth)
 
-	roleFilter := fmt.Sprintf("roleName eq '%s'", roleName)
-	roleList, err := rdc.List(ctx, scope, roleFilter)
-	if err != nil || !roleList.NotDone() {
-		return nil, fmt.Errorf("failed to create role assignment for user assigned managed identity: %w", err)
+	roleDefinitionID, err := getRoleDefinitionID(ctx, auth, subscriptionID, scope, roleNameOrID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create role assignment for role '%s': %w", roleNameOrID, err)
 	}
-
-	rac := clients.NewRoleAssignmentsClient(subscriptionID, auth)
 
 	// Check if role assignment already exists for the managed identity
-	existing, err := rac.List(ctx, fmt.Sprintf("principalID eq '%s'", principalID), "")
+	roleAssignmentClient := clients.NewRoleAssignmentsClient(subscriptionID, auth)
+	existing, err := roleAssignmentClient.List(ctx, fmt.Sprintf("principalID eq '%s'", principalID), "")
 	if err != nil {
-		return nil, fmt.Errorf("failed to list role assignments for user assigned managed identity: %w", err)
+		return nil, fmt.Errorf("failed to create role assignment for role '%s': %w", roleNameOrID, err)
 	}
 	for _, r := range existing.Values() {
-		if *roleList.Values()[0].ID == *r.RoleAssignmentPropertiesWithScope.RoleDefinitionID &&
+		if roleDefinitionID == *r.RoleAssignmentPropertiesWithScope.RoleDefinitionID &&
 			scope == *r.RoleAssignmentPropertiesWithScope.Scope {
 			// The required role assignment already exists
 			return &r, nil
@@ -44,47 +46,76 @@ func Create(ctx context.Context, auth autorest.Authorizer, subscriptionID string
 	}
 
 	// Generate a new role assignment name
-	raName, _ := uuid.NewV4()
+	raName, err := uuid.NewV4()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create role assignment for role '%s': %w", roleNameOrID, err)
+	}
 
+	// Retry to wait for the managed identity to propagate
 	MaxRetries := 100
-	var ra authorization.RoleAssignment
-	for i := 0; i <= MaxRetries; i++ {
-
-		// Retry to wait for the managed identity to propagate
-		if i >= MaxRetries {
-			return nil, fmt.Errorf("failed to create role assignment for user assigned managed identity after %d retries: %w", i, err)
-		}
-
-		ra, err = rac.Create(
+	// var ra authorization.RoleAssignment
+	for i := 0; i < MaxRetries; i++ {
+		roleAssignment, err := roleAssignmentClient.Create(
 			ctx,
 			scope,
 			raName.String(),
 			authorization.RoleAssignmentCreateParameters{
 				RoleAssignmentProperties: &authorization.RoleAssignmentProperties{
 					PrincipalID:      &principalID,
-					RoleDefinitionID: to.StringPtr(*roleList.Values()[0].ID),
+					RoleDefinitionID: to.StringPtr(roleDefinitionID),
 				},
 			})
 
 		if err == nil {
-			return &ra, nil
+			return &roleAssignment, nil
 		}
 
 		// Check the error and determine if it is ignorable/retryable
-		detailed, ok := clients.ExtractDetailedError(err)
+		detailedError, ok := clients.ExtractDetailedError(err)
 		if !ok {
 			return nil, err
 		}
 
 		// Sometimes, the managed identity takes a while to propagate and the role assignment creation fails with status code = 400
 		// For other reasons, fail.
-		if detailed.StatusCode != 400 {
-			return nil, fmt.Errorf("failed to create role assignment with error: %v, statuscode: %v", detailed.Message, detailed.StatusCode)
+		if detailedError.StatusCode != 400 {
+			return nil, fmt.Errorf("failed to create role assignment for role '%s' with error: %v, status code: %v", roleNameOrID, detailedError.Message, detailedError.StatusCode)
 		}
 
-		logger.Info(fmt.Sprintf("Failed to create role assignment %v. Retrying: %d attempt ...", err, i))
+		logger.Info(fmt.Sprintf("Failed to create role assignment for role '%s': %v. Retrying: attempt %d ...", roleNameOrID, err, i))
 		time.Sleep(5 * time.Second)
 	}
 
-	return nil, nil
+	return nil, fmt.Errorf("failed to create role assignment for role '%s': %w", roleNameOrID, err)
+}
+
+// Returns roleDefinitionID: fully qualified identifier of role definition, example: "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+func getRoleDefinitionID(ctx context.Context, auth autorest.Authorizer, subscriptionID, scope, roleNameOrID string) (roleDefinitionID string, err error) {
+	if strings.HasPrefix(roleNameOrID, "/subscriptions/") {
+		roleDefinitionID = roleNameOrID
+	}
+
+	roleDefinitionClient := clients.NewRoleDefinitionsClient(subscriptionID, auth)
+	roleFilter := fmt.Sprintf("roleName eq '%s'", roleNameOrID)
+	roleList, err := roleDefinitionClient.List(ctx, scope, roleFilter)
+	if err != nil {
+		return "", err
+	}
+
+	if len(roleList.Values()) == 0 {
+		// Check if the passed value is a role definition id instead of role name. For example - id for role name "Contributor" is "b24988ac-6180-42a0-ab88-20f7382dd24c"
+		// https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
+		roleDefinition, err := roleDefinitionClient.Get(ctx, scope, roleNameOrID)
+		if err != nil {
+			return "", err
+		} else if roleDefinition == (authorization.RoleDefinition{}) {
+			return "", fmt.Errorf("no role definition was found for the provided role %s", roleNameOrID)
+		} else {
+			roleDefinitionID = *roleDefinition.ID
+		}
+	} else {
+		roleDefinitionID = *roleList.Values()[0].ID
+	}
+
+	return
 }

--- a/pkg/azure/roleassignment/roleassignment.go
+++ b/pkg/azure/roleassignment/roleassignment.go
@@ -10,7 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/authorization/mgmt/authorization"
+	// "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2020-04-01-preview/authorization"
+	// "github.com/Azure/azure-sdk-for-go/profiles/preview/preview/authorization/mgmt/authorization"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/authorization/mgmt/authorization"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/gofrs/uuid"

--- a/pkg/azure/roleassignment/roleassignment.go
+++ b/pkg/azure/roleassignment/roleassignment.go
@@ -10,9 +10,7 @@ import (
 	"strings"
 	"time"
 
-	// "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2020-04-01-preview/authorization"
-	// "github.com/Azure/azure-sdk-for-go/profiles/preview/preview/authorization/mgmt/authorization"
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/authorization/mgmt/authorization"
+	"github.com/Azure/azure-sdk-for-go/profiles/preview/preview/authorization/mgmt/authorization"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/gofrs/uuid"
@@ -35,15 +33,15 @@ func Create(ctx context.Context, auth autorest.Authorizer, subscriptionID, princ
 
 	// Check if role assignment already exists for the managed identity
 	roleAssignmentClient := clients.NewRoleAssignmentsClient(subscriptionID, auth)
-	existing, err := roleAssignmentClient.List(ctx, fmt.Sprintf("principalID eq '%s'", principalID), "")
+	existingRoleAssignments, err := roleAssignmentClient.List(ctx, fmt.Sprintf("principalID eq '%s'", principalID), "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create role assignment for role '%s': %w", roleNameOrID, err)
 	}
-	for _, r := range existing.Values() {
-		if roleDefinitionID == *r.RoleAssignmentPropertiesWithScope.RoleDefinitionID &&
-			scope == *r.RoleAssignmentPropertiesWithScope.Scope {
+	for _, roleAssignment := range existingRoleAssignments.Values() {
+		if roleDefinitionID == *roleAssignment.RoleAssignmentPropertiesWithScope.RoleDefinitionID &&
+			scope == *roleAssignment.RoleAssignmentPropertiesWithScope.Scope {
 			// The required role assignment already exists
-			return &r, nil
+			return &roleAssignment, nil
 		}
 	}
 

--- a/pkg/renderers/containerv1alpha3/render.go
+++ b/pkg/renderers/containerv1alpha3/render.go
@@ -674,8 +674,8 @@ func (r Renderer) makeRoleAssignmentsForResource(ctx context.Context, connection
 			Managed:      true,
 			Deployed:     false,
 			Resource: map[string]string{
-				handlers.RoleNameKey:             roleName,
-				handlers.RoleAssignmentTargetKey: armResourceIdentifier,
+				handlers.RoleNameKey:         roleName,
+				handlers.RoleAssignmentScope: armResourceIdentifier,
 			},
 			Dependencies: []outputresource.Dependency{
 				{
@@ -706,8 +706,8 @@ func (r Renderer) makeRoleAssignmentsForAzureKeyVaultCSIDriver(ctx context.Conte
 			Managed:      true,
 			Deployed:     false,
 			Resource: map[string]string{
-				handlers.RoleNameKey:             roleName,
-				handlers.RoleAssignmentTargetKey: keyVaultID,
+				handlers.RoleNameKey:         roleName,
+				handlers.RoleAssignmentScope: keyVaultID,
 			},
 			Dependencies: []outputresource.Dependency{
 				{

--- a/pkg/renderers/containerv1alpha3/render_test.go
+++ b/pkg/renderers/containerv1alpha3/render_test.go
@@ -498,8 +498,8 @@ func Test_Render_ConnectionWithRoleAssignment(t *testing.T) {
 			Managed:      true,
 			Deployed:     false,
 			Resource: map[string]string{
-				handlers.RoleNameKey:             "TestRole1",
-				handlers.RoleAssignmentTargetKey: makeResourceID(t, "TargetResourceType", "TargetResource").ID,
+				handlers.RoleNameKey:         "TestRole1",
+				handlers.RoleAssignmentScope: makeResourceID(t, "TargetResourceType", "TargetResource").ID,
 			},
 			Dependencies: []outputresource.Dependency{
 				{
@@ -513,8 +513,8 @@ func Test_Render_ConnectionWithRoleAssignment(t *testing.T) {
 			Managed:      true,
 			Deployed:     false,
 			Resource: map[string]string{
-				handlers.RoleNameKey:             "TestRole2",
-				handlers.RoleAssignmentTargetKey: makeResourceID(t, "TargetResourceType", "TargetResource").ID,
+				handlers.RoleNameKey:         "TestRole2",
+				handlers.RoleAssignmentScope: makeResourceID(t, "TargetResourceType", "TargetResource").ID,
 			},
 			Dependencies: []outputresource.Dependency{
 				{
@@ -616,8 +616,8 @@ func Test_Render_AzureConnection(t *testing.T) {
 			Managed:      true,
 			Deployed:     false,
 			Resource: map[string]string{
-				handlers.RoleNameKey:             expectedRole,
-				handlers.RoleAssignmentTargetKey: testARMID,
+				handlers.RoleNameKey:         expectedRole,
+				handlers.RoleAssignmentScope: testARMID,
 			},
 			Dependencies: []outputresource.Dependency{
 				{

--- a/test/functional/azure/resources/azure_connections_test.go
+++ b/test/functional/azure/resources/azure_connections_test.go
@@ -58,6 +58,13 @@ func Test_AzureConnectionCognitiveService(t *testing.T) {
 								Managed:                 true,
 								VerifyStatus:            false,
 							},
+							"role-assignment-2": {
+								SkipLocalIDWhenMatching: true,
+								OutputResourceType:      outputresource.TypeARM,
+								ResourceKind:            resourcekinds.AzureRoleAssignment,
+								Managed:                 true,
+								VerifyStatus:            false,
+							},
 						},
 					},
 				},

--- a/test/functional/azure/resources/testdata/azure-connection-cognitive-service.bicep
+++ b/test/functional/azure/resources/testdata/azure-connection-cognitive-service.bicep
@@ -14,7 +14,6 @@ resource app 'radius.dev/Application@v1alpha3' = {
           roles: [
             'Cognitive Services User'
             '25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68'
-            '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7'
           ]
         }
       }

--- a/test/functional/azure/resources/testdata/azure-connection-cognitive-service.bicep
+++ b/test/functional/azure/resources/testdata/azure-connection-cognitive-service.bicep
@@ -14,7 +14,7 @@ resource app 'radius.dev/Application@v1alpha3' = {
           roles: [
             'Cognitive Services User'
             '25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68'
-            '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/9894cab4-e18a-44aa-828b-cb588cd6f2d7'
+            '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7'
           ]
         }
       }

--- a/test/functional/azure/resources/testdata/azure-connection-cognitive-service.bicep
+++ b/test/functional/azure/resources/testdata/azure-connection-cognitive-service.bicep
@@ -13,6 +13,8 @@ resource app 'radius.dev/Application@v1alpha3' = {
           source: cognitiveServicesAccount.id
           roles: [
             'Cognitive Services User'
+            '25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68'
+            '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/9894cab4-e18a-44aa-828b-cb588cd6f2d7'
           ]
         }
       }


### PR DESCRIPTION
# Description

Connection to Azure resources with support for RBAC was implemented as a part of https://github.com/project-radius/radius/issues/1321. However the original implementation only supported role name as input. This change enables specifying role definition id (https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles).

## Issue reference

https://github.com/project-radius/radius/issues/1553

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
