### PR TITLE
Add workaround for proxy in front of API Server

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -328,6 +328,12 @@ jobs:
         export TEST_TIMEOUT=${{ env.LOCALDEV_FUNCTIONALTEST_TIMEOUT }}
         export RADIUS_CONTAINER_LOG_PATH=$GITHUB_WORKSPACE/${{ env.RADIUS_CONTAINER_LOG_BASE }}
         make test-functional-localdev
+    - name: Run Local Dev Kubernetes tests (PR)
+      run: |
+        export PATH=$GITHUB_WORKSPACE/dist:$PATH
+        export TEST_TIMEOUT=${{ env.LOCALDEV_FUNCTIONALTEST_TIMEOUT }}
+        export RADIUS_CONTAINER_LOG_PATH=$GITHUB_WORKSPACE/${{ env.RADIUS_CONTAINER_LOG_BASE }}
+        make test-functional-kubernetes
     - name: Run 'rad env delete'
       run: |
         export PATH=$GITHUB_WORKSPACE/dist:$PATH

--- a/pkg/cli/armtemplate/armconverter.go
+++ b/pkg/cli/armtemplate/armconverter.go
@@ -88,11 +88,16 @@ func scrapeSecrets(resource Resource) map[string]string {
 }
 
 func ConvertToK8sDeploymentTemplate(resource Resource, namespace string, parentName string) (*unstructured.Unstructured, error) {
-	template, hasTemplate := resource.Body["template"].(map[string]interface{})
+	properties, hasProperties := resource.Body["properties"].(map[string]interface{})
+	if !hasProperties {
+		return nil, fmt.Errorf("resource %s/%s has no properties", resource.Type, resource.Name)
+	}
+
+	template, hasTemplate := properties["template"].(map[string]interface{})
 	if !hasTemplate {
 		return nil, fmt.Errorf("resource %s/%s has no template", resource.Type, resource.Name)
 	}
-	parameters, _ := resource.Body["parameters"].(map[string]interface{})
+	parameters, _ := properties["parameters"].(map[string]interface{})
 	uns := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": bicepv1alpha3.GroupVersion.String(),

--- a/pkg/cli/armtemplate/armconverter_test.go
+++ b/pkg/cli/armtemplate/armconverter_test.go
@@ -264,67 +264,85 @@ func TestConvertToK8sDeploymentTemplate(t *testing.T) {
 		input       Resource
 		expected    unstructured.Unstructured
 		expectedErr string
-	}{{
-		name:        "no template",
-		input:       Resource{},
-		expectedErr: "no template",
-	}, {
-		name: "no parameters",
-		input: Resource{
-			Name: "nested",
-			Body: map[string]interface{}{
-				"template": map[string]interface{}{
-					"foo": "bar",
+	}{
+		{
+			name: "no properties",
+			input: Resource{
+				Name: "nested",
+				Body: map[string]interface{}{},
+			},
+			expectedErr: "no properties",
+		},
+		{
+			name: "no template",
+			input: Resource{
+				Name: "nested",
+				Body: map[string]interface{}{
+					"properties": map[string]interface{}{},
 				},
 			},
-		},
-		expected: unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "bicep.dev/v1alpha3",
-				"kind":       "DeploymentTemplate",
-				"metadata": map[string]interface{}{
-					"name":      "deploymenttemplate-xyz-nested",
-					"namespace": "default",
-				},
-				"spec": map[string]interface{}{
-					"content": map[string]interface{}{
-						"foo": "bar",
-					},
-					"parameters": map[string]interface{}(nil),
-				},
-			},
-		},
-	}, {
-		name: "has parameters",
-		input: Resource{
-			Name: "nested",
-			Body: map[string]interface{}{
-				"template": map[string]interface{}{
-					"foo": "bar",
-				},
-				"parameters": map[string]interface{}{
-					"app": "appName",
-				},
-			},
-		},
-		expected: unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": "bicep.dev/v1alpha3",
-				"kind":       "DeploymentTemplate",
-				"metadata": map[string]interface{}{
-					"name":      "deploymenttemplate-xyz-nested",
-					"namespace": "default",
-				},
-				"spec": map[string]interface{}{
-					"content": map[string]interface{}{
-						"foo": "bar",
-					},
-					"parameters": map[string]interface{}{
-						"app": "appName",
+			expectedErr: "no template",
+		}, {
+			name: "no parameters",
+			input: Resource{
+				Name: "nested",
+				Body: map[string]interface{}{
+					"properties": map[string]interface{}{
+						"template": map[string]interface{}{
+							"foo": "bar",
+						},
 					},
 				},
 			},
-		}}} {
+			expected: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "bicep.dev/v1alpha3",
+					"kind":       "DeploymentTemplate",
+					"metadata": map[string]interface{}{
+						"name":      "deploymenttemplate-xyz-nested",
+						"namespace": "default",
+					},
+					"spec": map[string]interface{}{
+						"content": map[string]interface{}{
+							"foo": "bar",
+						},
+						"parameters": map[string]interface{}(nil),
+					},
+				},
+			},
+		}, {
+			name: "has parameters",
+			input: Resource{
+				Name: "nested",
+				Body: map[string]interface{}{
+					"properties": map[string]interface{}{
+						"template": map[string]interface{}{
+							"foo": "bar",
+						},
+						"parameters": map[string]interface{}{
+							"app": "appName",
+						},
+					},
+				},
+			},
+			expected: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "bicep.dev/v1alpha3",
+					"kind":       "DeploymentTemplate",
+					"metadata": map[string]interface{}{
+						"name":      "deploymenttemplate-xyz-nested",
+						"namespace": "default",
+					},
+					"spec": map[string]interface{}{
+						"content": map[string]interface{}{
+							"foo": "bar",
+						},
+						"parameters": map[string]interface{}{
+							"app": "appName",
+						},
+					},
+				},
+			}}} {
 		t.Run(tc.name, func(t *testing.T) {
 			output, err := ConvertToK8sDeploymentTemplate(tc.input, "default", "deploymenttemplate-xyz")
 			if err != nil {

--- a/pkg/cli/armtemplate/providers/arm.go
+++ b/pkg/cli/armtemplate/providers/arm.go
@@ -127,6 +127,9 @@ func (p *AzureProvider) InvokeCustomAction(ctx context.Context, id string, versi
 	client := azclients.NewCustomActionClient(p.SubscriptionID, p.Authorizer)
 	client.BaseURI = strings.TrimSuffix(p.BaseURL, "/")
 	client.PollingDelay = PollInterval
+	client.RetryAttempts = 10
+	client.RetryDuration = 3 * time.Second
+
 	if p.RoundTripper != nil {
 		client.Sender = &sender{RoundTripper: p.RoundTripper}
 	}

--- a/pkg/cli/armtemplate/providers/k8s.go
+++ b/pkg/cli/armtemplate/providers/k8s.go
@@ -88,7 +88,7 @@ func (p *K8sProvider) GetDeployedResource(ctx context.Context, id string, versio
 }
 
 func (p *K8sProvider) DeployResource(ctx context.Context, id string, version string, body map[string]interface{}) (map[string]interface{}, error) {
-	gvr, gvk, name, err := p.extractGroupVersionResourceName(id, version)
+	gvr, gvk, _, err := p.extractGroupVersionResourceName(id, version)
 	if err != nil {
 		return nil, err
 	}
@@ -103,6 +103,7 @@ func (p *K8sProvider) DeployResource(ctx context.Context, id string, version str
 		return nil, err
 	}
 
+	name := obj["metadata"].(map[string]interface{})["name"].(string)
 	r, err := p.client.Resource(gvr).Namespace(p.namespace).Patch(ctx, name, types.ApplyPatchType, b, v1.PatchOptions{FieldManager: "rad"})
 	if err != nil {
 		return nil, err

--- a/pkg/cli/environments/dev.go
+++ b/pkg/cli/environments/dev.go
@@ -31,7 +31,7 @@ type LocalEnvironment struct {
 	ClusterName string `mapstructure:"clustername" validate:"required"`
 
 	// Registry is the docker/OCI registry we're using for images. This will probably be a localhost URL.
-	Registry    string `mapstructure:"registry,omitempty"`
+	Registry string `mapstructure:"registry,omitempty"`
 
 	// APIServerBaseURL is an override for local debugging. This allows us us to run the controller + API Service outside the
 	// cluster.
@@ -67,7 +67,8 @@ func (e *LocalEnvironment) GetAzureProviderDetails() (string, string) {
 		return e.Providers.AzureProvider.SubscriptionID, e.Providers.AzureProvider.ResourceGroup
 	}
 
-	return "test-subscription", "test-resource-group"
+	// Use namespace unless we have an Azure subscription attached.
+	return e.Namespace, e.Namespace
 }
 
 func (e *LocalEnvironment) CreateDeploymentClient(ctx context.Context) (clients.DeploymentClient, error) {

--- a/pkg/cli/k3d/create.go
+++ b/pkg/cli/k3d/create.go
@@ -30,9 +30,9 @@ func CreateCluster(ctx context.Context, name string) (*ClusterConfig, error) {
 		// Create a registry for local images to avoid server roundtrips
 		"--registry-create", config.Registry,
 
-		// Add a new kubernetes context to the config, but don't switch to it
+		// Add a new kubernetes context to the config and switch to it
 		"--kubeconfig-update-default=true",
-		"--kubeconfig-switch-context=false",
+		"--kubeconfig-switch-context=true",
 
 		// Skip the built-in ingress since we're providing our own
 		"--k3s-arg", "--disable=traefik@server:*",

--- a/pkg/cli/localrp/deployment_client.go
+++ b/pkg/cli/localrp/deployment_client.go
@@ -118,6 +118,7 @@ func (dc *LocalRPDeploymentClient) deployTemplate(ctx context.Context, template 
 
 	deployed := map[string]map[string]interface{}{}
 	evaluator := &armtemplate.DeploymentEvaluator{
+		Context:   ctx,
 		Providers: dc.Providers,
 		Template:  template,
 		Options: armtemplate.TemplateOptions{

--- a/pkg/cli/localrp/testdata/modules/infra.bicep
+++ b/pkg/cli/localrp/testdata/modules/infra.bicep
@@ -1,6 +1,7 @@
 import kubernetes from kubernetes
 
 param application string
+param computedValue string
 
 resource secret 'kubernetes.core/Secret@v1' existing = {
   metadata: {
@@ -18,3 +19,4 @@ resource db 'radius.dev/Application/mongo.com.MongoDatabase@v1alpha3' = {
 }
 
 output db resource 'radius.dev/Application/mongo.com.MongoDatabase@v1alpha3' = db
+output computedValue string = computedValue

--- a/pkg/cli/localrp/testdata/modules/template.bicep
+++ b/pkg/cli/localrp/testdata/modules/template.bicep
@@ -18,5 +18,6 @@ module infra 'infra.bicep' = {
   name: 'infra'
   params: {
     application: app.name
+    computedValue: format('{0}', app.name) // test that we evaluate parameters
   }
 }

--- a/pkg/kubernetes/apiserver/convert_test.go
+++ b/pkg/kubernetes/apiserver/convert_test.go
@@ -167,6 +167,11 @@ func Test_ConvertK8sResourceToARM(t *testing.T) {
 				},
 			},
 			Status: radiusv1alpha3.ResourceStatus{
+				ComputedValues: rawOrPanic(map[string]interface{}{
+					"computed": map[string]interface{}{
+						"Value": "yes its a value!",
+					},
+				}),
 				Resources: map[string]*radiusv1alpha3.OutputResource{
 					"Deployment": {
 						Status: radiusv1alpha3.OutputResourceStatus{
@@ -182,7 +187,8 @@ func Test_ConvertK8sResourceToARM(t *testing.T) {
 			ID:   "/very/long/path/container-01",
 			Type: "/very/long/path/radius.dev/Container",
 			Properties: map[string]interface{}{
-				"image": "the-best",
+				"computed": "yes its a value!",
+				"image":    "the-best",
 				"status": rest.ResourceStatus{
 					ProvisioningState: "Provisioned",
 					HealthState:       healthcontract.HealthStateHealthy,

--- a/pkg/kubernetes/apiserver/resourceprovider_test.go
+++ b/pkg/kubernetes/apiserver/resourceprovider_test.go
@@ -685,6 +685,7 @@ func Test_ListSecrets(t *testing.T) {
 			Labels: map[string]string{
 				kubernetes.LabelRadiusApplication: appName,
 			},
+			Generation: 1,
 		},
 		Spec: radiusv1alpha3.ResourceSpec{
 			Template: rawOrPanic(map[string]interface{}{
@@ -699,6 +700,8 @@ func Test_ListSecrets(t *testing.T) {
 			}),
 		},
 		Status: radiusv1alpha3.ResourceStatus{
+			ObservedGeneration: 1,
+			Phrase:             "Deployed",
 			Resources: map[string]*radiusv1alpha3.OutputResource{
 				"SecretLocalID": {
 					Resource: corev1.ObjectReference{
@@ -790,6 +793,7 @@ func Test_GetOperation(t *testing.T) {
 			Labels: map[string]string{
 				kubernetes.LabelRadiusApplication: appName,
 			},
+			Generation: 1,
 		},
 		Spec: radiusv1alpha3.ResourceSpec{
 			Template: rawOrPanic(map[string]interface{}{
@@ -804,6 +808,8 @@ func Test_GetOperation(t *testing.T) {
 			}),
 		},
 		Status: radiusv1alpha3.ResourceStatus{
+			Phrase:             "Deployed",
+			ObservedGeneration: 1,
 			Resources: map[string]*radiusv1alpha3.OutputResource{
 				"LocalID": {
 					Status: radiusv1alpha3.OutputResourceStatus{

--- a/pkg/kubernetes/controllers/bicep/deploymenttemplate_controller.go
+++ b/pkg/kubernetes/controllers/bicep/deploymenttemplate_controller.go
@@ -88,30 +88,6 @@ func (r *DeploymentTemplateReconciler) Reconcile(ctx context.Context, req ctrl.R
 }
 
 func (r *DeploymentTemplateReconciler) evaluateNestedDeployment(req ctrl.Request, evaluator *armtemplate.DeploymentEvaluator, resource armtemplate.Resource, parentName string) (*unstructured.Unstructured, error) {
-	// Before calling this function we would have a resource looking like:
-	// ```
-	// properties:
-	//   template:
-	//     foo: bar
-	//   parameters:
-	//     param1: value1
-	//     param2: value2
-	// ```
-	// `
-	// After calling, the resource would look like
-	// ```
-	// template:
-	//   foo: bar
-	// parameters:
-	//   param1: value1
-	//   param2: value2
-	// ```
-	//
-	// Generally this is not needed when calling VisitResourceBody because VisitMap is recursive.
-	// However, for nested deployment, VisitResourceBody pre-process the "parameters" map at the
-	// root level, therefore we want to make sure the "parameters" map is where it is expected.
-	resource.Body, _ = resource.Body["properties"].(map[string]interface{})
-
 	body, err := evaluator.VisitResourceBody(resource)
 	if err != nil {
 		return nil, err

--- a/test/functional/kubernetes/cli/cli_test.go
+++ b/test/functional/kubernetes/cli/cli_test.go
@@ -119,18 +119,16 @@ func Test_CLI(t *testing.T) {
 					expected := regexp.MustCompile(`RESOURCE\s+TYPE\s+PROVISIONING_STATE\s+HEALTH_STATE
 a\s+Container\s+.*Provisioned\s+.*[h|H]ealthy\s*
 `)
-					match := expected.MatchString(output)
-					require.Equal(t, true, match)
+					require.Regexp(t, expected, output)
 				})
 				t.Run("resource list", func(t *testing.T) {
 					output, err := cli.ResourceList(ctx, application)
 					require.NoError(t, err)
 					expected := regexp.MustCompile(`RESOURCE\s+TYPE\s+PROVISIONING_STATE\s+HEALTH_STATE
-a\s+Container\s+.*Provisioned\s+.*[h|H]ealthy\s*
-b\s+Container\s+.*Provisioned\s+.*[h|H]ealthy\s*
+(a|b)\s+Container\s+.*Provisioned\s+.*[h|H]ealthy\s*
+(a|b)\s+Container\s+.*Provisioned\s+.*[h|H]ealthy\s*
 `)
-					match := expected.MatchString(output)
-					require.Equal(t, true, match)
+					require.Regexp(t, expected, output)
 				})
 
 				t.Run("application show", func(t *testing.T) {
@@ -139,8 +137,7 @@ b\s+Container\s+.*Provisioned\s+.*[h|H]ealthy\s*
 					expected := regexp.MustCompile(`APPLICATION\s+PROVISIONING_STATE\s+HEALTH_STATE
 kubernetes-cli\s+.*Provisioned\s+.*[h|H]ealthy\s*
 `)
-					match := expected.MatchString(output)
-					require.Equal(t, true, match)
+					require.Regexp(t, expected, output)
 				})
 			},
 		},


### PR DESCRIPTION
Fixes: radius-project/core-team#576 

One challenge of working with K3d (or similar) setups is that there is a
proxy in front of the API Server (which is itself a proxy), but only one
of these proxies is injecting Forwarded headers.

This is a problem for us because the ARM-RPC protocol which we have
to use on Azure requires an Absolute and Fully-Qualified URLs. Without
the original scheme/host that is impossible for us.

The fix here is to handle the Location header ourselves on the client
and fix it up. This is a temporary fix and will only be needed while
we're still using ARM-RPC as a protocol.

