### PR TITLE
Perform build in parallel for rad deploy

### DIFF
--- a/pkg/cli/builders/types.go
+++ b/pkg/cli/builders/types.go
@@ -9,12 +9,14 @@ import (
 	"context"
 	"io"
 	"path"
+
+	"github.com/project-radius/radius/pkg/cli/output"
 )
 
 type Options struct {
 	BaseDirectory string
 	Stderr        io.Writer
-	Stdout        io.Writer
+	Output        *output.Stream
 	Values        interface{}
 }
 

--- a/pkg/cli/output/streams.go
+++ b/pkg/cli/output/streams.go
@@ -1,0 +1,130 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package output
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/fatih/color"
+)
+
+// NewStreamGroup creates a new StreamGroup for the given writer.
+func NewStreamGroup(out io.Writer) *StreamGroup {
+	return &StreamGroup{out: out}
+}
+
+// StreamGroup represents a group of related output streams of different colors.
+type StreamGroup struct {
+	index int
+	out   io.Writer
+}
+
+func (sg *StreamGroup) NewStream(name string) *Stream {
+	primary := color.New(colorList[sg.index])
+	secondary := color.New(colorList[sg.index], color.Faint)
+	sg.index++
+	return &Stream{name: name, primary: primary, secondary: secondary, out: sg.out}
+}
+
+// Gives us 6 colors x 2 shades = 12 to cycle through where no consecutive entry is similar.
+var colorList = []color.Attribute{
+	color.FgHiCyan,
+	color.FgHiGreen,
+	color.FgHiMagenta,
+	color.FgHiYellow,
+	color.FgHiBlue,
+	color.FgHiRed,
+	color.FgCyan,
+	color.FgGreen,
+	color.FgMagenta,
+	color.FgYellow,
+	color.FgBlue,
+	color.FgRed,
+}
+
+type Stream struct {
+	// foreground is used for the main output
+	primary *color.Color
+	// secondary is used for our formatting (it's less bright)
+	secondary *color.Color
+	out       io.Writer
+	name      string
+}
+
+func (s *Stream) Print(text string) {
+	// NOTE: we're intentionally doing this as a single Fprintf call to avoid interleaving.
+	// If you try to separate the two colors into two lines then you'll end up with interleaving
+	// between colors.
+	fmt.Fprintf(s.out, "%s %s", s.secondary.Sprintf("[%s] ", s.name), s.primary.Sprint(text))
+}
+
+func (s *Stream) Writer() io.WriteCloser {
+	return &StreamWriter{stream: s}
+}
+
+// StreamWriter implements io.Writer for a Stream.
+type StreamWriter struct {
+	stream *Stream
+	buf    bytes.Buffer
+
+	// NOTE: we don't need to be thread-safe here unless we want to consider using
+	// the same writer for multiple processes/purposes.
+	//
+	// The exec APIs guarantee us single-threaded behavior when the same writer
+	// is used for stdout and stderr for a single process.
+}
+
+var _ io.WriteCloser = (*StreamWriter)(nil)
+
+func (w *StreamWriter) Write(p []byte) (int, error) {
+	// The technique here is that we buffer all bytes written to us and output complete
+	// lines to the colorized stream as we see them.
+	//
+	// The residue is handled in Close.
+	n, err := w.buf.Write(p)
+	if err != nil {
+		return n, err
+	}
+
+	err = w.flush(false)
+	if err != nil {
+		return n, err
+	}
+
+	return n, nil
+}
+
+func (w *StreamWriter) Close() error {
+	err := w.flush(true)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (w *StreamWriter) flush(all bool) error {
+	for {
+		line, err := w.buf.ReadString('\n')
+		if err == io.EOF && all && len(line) > 0 {
+			// We get here in the case where we're flushing and there's incomplete
+			// content left (no EOL but EOF)
+			w.stream.Print(line + "\n")
+			return nil
+		} else if err == io.EOF {
+			// We get here when we've just written some content but it's not a complete
+			// line. We'll try again later.
+			return nil
+		} else if err != nil {
+			// Any other error goes here.
+			return err
+		}
+
+		w.stream.Print(line)
+	}
+}

--- a/pkg/cli/stages/processor.go
+++ b/pkg/cli/stages/processor.go
@@ -9,38 +9,63 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"sync"
 
 	"github.com/project-radius/radius/pkg/cli/bicep"
 	"github.com/project-radius/radius/pkg/cli/builders"
 	"github.com/project-radius/radius/pkg/cli/deploy"
 	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/project-radius/radius/pkg/cli/radyaml"
+	"golang.org/x/sync/errgroup"
 )
 
 func (p *processor) ProcessBuild(ctx context.Context, stage radyaml.BuildStage) error {
+	// We'll run the build in parallel - each output gets its own output stream.
+	group, ctx := errgroup.WithContext(ctx)
+	streams := output.NewStreamGroup(p.Stdout)
+
+	// Synchronize access to add results
+	mtx := sync.Mutex{}
+
 	for name, target := range stage {
-		step := output.BeginStep("Processing build %s", name)
+		stream := streams.NewStream(name)
 
-		builder := p.Options.Builders[target.Builder]
-		if builder == nil {
-			return fmt.Errorf("no builder named %s was found", target.Builder)
-		}
+		// Copy induction variables since they are closed-over.
+		name := name
+		target := target
 
-		result, err := builder.Build(ctx, builders.Options{
-			BaseDirectory: p.BaseDirectory,
-			Stderr:        p.Stderr,
-			Stdout:        p.Stdout,
-			Values:        target.Values,
+		group.Go(func() error {
+			stream.Print(fmt.Sprintf("Processing build %s\n", name))
+
+			builder := p.Options.Builders[target.Builder]
+			if builder == nil {
+				return fmt.Errorf("no builder named %s was found", target.Builder)
+			}
+
+			result, err := builder.Build(ctx, builders.Options{
+				BaseDirectory: p.BaseDirectory,
+				Stderr:        p.Stderr,
+				Output:        stream,
+				Values:        target.Values,
+			})
+			if err != nil {
+				return fmt.Errorf("build of %s failed: %w", target.Builder, err)
+			}
+
+			mtx.Lock()
+			defer mtx.Unlock()
+			p.Parameters[name] = map[string]interface{}{
+				"value": result.Result,
+			}
+
+			stream.Print(fmt.Sprintf("Done processing build %s\n", name))
+			return nil
 		})
-		if err != nil {
-			return fmt.Errorf("build of %s failed: %w", target.Builder, err)
-		}
+	}
 
-		p.Parameters[name] = map[string]interface{}{
-			"value": result.Result,
-		}
-
-		output.CompleteStep(step)
+	err := group.Wait()
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/cli/stages/run.go
+++ b/pkg/cli/stages/run.go
@@ -8,6 +8,7 @@ package stages
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/project-radius/radius/pkg/cli/clients"
@@ -19,6 +20,14 @@ import (
 // output to the console.
 func Run(ctx context.Context, options Options) ([]StageResult, error) {
 	output.LogInfo("Using environment %s", options.Environment.GetName())
+
+	// Unit tests don't have to set these.
+	if options.Stderr == nil {
+		options.Stderr = io.Discard
+	}
+	if options.Stdout == nil {
+		options.Stdout = io.Discard
+	}
 
 	// Validate that the desired stage is found
 	length := len(options.Manifest.Stages)


### PR DESCRIPTION
This change adds build parallelism (and colorized output) to rad app
deploy and friends. This is a significant improvement in performance
that scales nicely, especially given than a "no op" container build
and push takes at least 5-10 seconds. For the container apps sample I've
been using this is a ~20s improvement for me when all of the images are
up to date already.

The bulk of the work here is in adjusting the output to be color-coded
and prefixed. I was able to find some good examples to build on here.
The principle is that we implement infra for color-coded and named
output streams, and then layer an `io.Writer` implementation on top.

# Description

_Please explain the changes you've made._

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
