### PR TITLE
Add rad app run command

### DIFF
--- a/cmd/rad/cmd/appRun.go
+++ b/cmd/rad/cmd/appRun.go
@@ -1,0 +1,150 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/project-radius/radius/pkg/cli"
+	"github.com/project-radius/radius/pkg/cli/bicep"
+	"github.com/project-radius/radius/pkg/cli/builders"
+	"github.com/project-radius/radius/pkg/cli/environments"
+	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/project-radius/radius/pkg/cli/radyaml"
+	"github.com/project-radius/radius/pkg/cli/stages"
+	"github.com/project-radius/radius/pkg/cli/tools"
+	"github.com/project-radius/radius/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+// appRunCmd command deploys an application interactively based on a rad.yaml
+var appRunCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run a Radius application using rad.yaml",
+	Long: `Run a Radius application using rad.yaml
+
+The app run command uses a 'rad.yaml' config to deploy an application for development purposes. 'rad app run'
+is similar to 'rad app deploy' except it uses the console to stream logs after deployment until the command
+is cancelled. See the documentation of 'rad app deploy' for a full description of the command line options
+to affect deployment.
+`,
+	Example: `
+# run the application (basic)
+
+rad app run
+`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runApplication,
+}
+
+func init() {
+	applicationCmd.AddCommand(appRunCmd)
+	appRunCmd.Flags().StringP("environment", "e", "", "The environment name")
+	appRunCmd.Flags().StringP("radfile", "r", "", "The path to rad.yaml. The default is './rad.yaml'")
+	appRunCmd.Flags().StringArrayP("parameters", "p", []string{}, "Specify parameters for the deployment")
+	appRunCmd.Flags().String("profile", "", "Specify profile of the application for deployment")
+}
+
+func runApplication(cmd *cobra.Command, args []string) error {
+	config := ConfigFromContext(cmd.Context())
+	env, err := cli.RequireEnvironment(cmd, config)
+	if err != nil {
+		return err
+	}
+
+	radFile, err := cli.RequireRadYAML(cmd)
+	if err != nil {
+		return err
+	}
+
+	stage := ""
+	if len(args) == 1 {
+		stage = args[0]
+	}
+
+	parameterArgs, err := cmd.Flags().GetStringArray("parameters")
+	if err != nil {
+		return err
+	}
+
+	profile, err := cmd.Flags().GetString("profile")
+	if err != nil {
+		return err
+	}
+
+	parser := cli.ParameterParser{FileSystem: cli.OSFileSystem{}}
+	parameters, err := parser.Parse(parameterArgs)
+	if err != nil {
+		return err
+	}
+
+	output.LogInfo("Reading %s...", radFile)
+
+	file, err := os.Open(radFile)
+	if err == os.ErrNotExist {
+		return fmt.Errorf("could not find rad.yaml at %q", radFile)
+	} else if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	baseDir := path.Dir(radFile)
+	manifest, err := radyaml.Parse(file)
+	if err != nil {
+		return err
+	}
+
+	ok, err := bicep.IsBicepInstalled()
+	if err != nil {
+		return fmt.Errorf("failed to find rad-bicep: %w", err)
+	}
+
+	if !ok {
+		output.LogInfo(fmt.Sprintf("Downloading Bicep for channel %s...", version.Channel()))
+		err = bicep.DownloadBicep()
+		if err != nil {
+			return fmt.Errorf("failed to download rad-bicep: %w", err)
+		}
+	}
+
+	options := stages.Options{
+		Environment:   env,
+		BaseDirectory: baseDir,
+		Manifest:      manifest,
+		Builders:      builders.DefaultBuilders(),
+		Parameters:    parameters,
+		Profile:       profile,
+		FinalStage:    stage,
+
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+
+	_, err = stages.Run(cmd.Context(), options)
+	if err != nil {
+		return err
+	}
+
+	output.LogInfo("Application %s has been deployed. Press CTRL+C to exit...", manifest.Name)
+	output.LogInfo("")
+
+	if dev, ok := env.(*environments.LocalEnvironment); ok {
+		output.LogInfo("Launching log stream...")
+		err = tools.SternStart(cmd.Context(), dev.Context, dev.Namespace, manifest.Name)
+		if errors.As(err, &tools.ErrToolNotFound{}) {
+			output.LogInfo(err.Error()) // Tolerate missing tool
+		} else if err != nil {
+			return err
+		}
+	}
+
+	// Block until cancelled.
+	<-cmd.Context().Done()
+	return nil
+}

--- a/pkg/cli/tools/err.go
+++ b/pkg/cli/tools/err.go
@@ -1,0 +1,17 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package tools
+
+var _ error = (ErrToolNotFound)(ErrToolNotFound{})
+
+type ErrToolNotFound struct {
+	Tool    string
+	Message string
+}
+
+func (e ErrToolNotFound) Error() string {
+	return e.Message
+}

--- a/pkg/cli/tools/stern.go
+++ b/pkg/cli/tools/stern.go
@@ -1,0 +1,52 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package tools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+const (
+	SternToolName        = "stern"
+	SternNotFoundMessage = "The tool %s was not found on the system PATH. %s can stream logs for your application. See %s for installation instructions."
+	SternInstallerURL    = "https://github.com/wercker/stern#installation"
+)
+
+func SternStart(ctx context.Context, context string, namespace string, application string) error {
+	exe := GetExecutableName(SternToolName)
+	_, err := exec.LookPath(exe)
+	if errors.Is(err, exec.ErrNotFound) {
+		return ErrToolNotFound{
+			Tool:    SternToolName,
+			Message: fmt.Sprintf(SternNotFoundMessage, SternToolName, SternToolName, SternInstallerURL),
+		}
+	}
+
+	args := []string{
+		"--context", context,
+		"--namespace", namespace,
+		"--selector", fmt.Sprintf("radius.dev/application=%s", application),
+
+		// Dapr sidecars are especially noisy, and usually not relevant.
+		"--exclude-container", "daprd",
+	}
+	cmd := exec.CommandContext(ctx, exe, args...)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+
+	err = cmd.Start()
+	if err != nil {
+		return err
+	}
+
+	// Don't block after we successfully start the process. The process will be closed
+	// automatically once we cancel.
+	return nil
+}

--- a/pkg/cli/tools/util.go
+++ b/pkg/cli/tools/util.go
@@ -1,0 +1,17 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package tools
+
+import "runtime"
+
+func GetExecutableName(tool string) string {
+	switch runtime.GOOS {
+	case "windows":
+		return tool + ".exe"
+	default:
+		return tool
+	}
+}


### PR DESCRIPTION
This change adds a `rad app run` command which is very similar to deploy
except it blocks and outputs logs from the apps containers.

This command is a 'hub' for more features we're planning to build as
part of the local dev epic. For right now it just does logs but we plan
to integrate more tools over time.

Currently this integrates `stern` as the log streaming tool, and will
output installation instructions if you don't have it installed.
Longer-term we might choose to bring the functionality we want inside
Radius. For now we're building the local dev features incrementally.

