### PR TITLE
Use local registry for push/pull in local dev

### DIFF
--- a/cmd/rad/cmd/envInitDev.go
+++ b/cmd/rad/cmd/envInitDev.go
@@ -105,7 +105,10 @@ var envInitLocalCmd = &cobra.Command{
 			"context":     cluster.ContextName,
 			"clustername": cluster.ClusterName,
 			"namespace":   "default",
-			"registry":    cluster.Registry,
+			"registry": &environments.Registry{
+				PushEndpoint: cluster.RegistryPushEndpoint,
+				PullEndpoint: cluster.RegistryPullEndpoint,
+			},
 		}
 
 		if params.Providers != nil {

--- a/go.mod
+++ b/go.mod
@@ -146,6 +146,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
+	github.com/novln/docker-parser v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -804,6 +804,8 @@ github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/novln/docker-parser v1.0.0 h1:PjEBd9QnKixcWczNGyEdfUrP6GR0YUilAqG7Wksg3uc=
+github.com/novln/docker-parser v1.0.0/go.mod h1:oCeM32fsoUwkwByB5wVjsrsVQySzPWkl3JdlTn1txpE=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.5/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/pkg/cli/builders/types.go
+++ b/pkg/cli/builders/types.go
@@ -7,15 +7,15 @@ package builders
 
 import (
 	"context"
-	"io"
 	"path"
 
+	"github.com/project-radius/radius/pkg/cli/environments"
 	"github.com/project-radius/radius/pkg/cli/output"
 )
 
 type Options struct {
 	BaseDirectory string
-	Stderr        io.Writer
+	Registry      *environments.Registry
 	Output        *output.Stream
 	Values        interface{}
 }

--- a/pkg/cli/environments/azure.go
+++ b/pkg/cli/environments/azure.go
@@ -58,6 +58,10 @@ func (e *AzureCloudEnvironment) GetDefaultApplication() string {
 	return e.DefaultApplication
 }
 
+func (e *AzureCloudEnvironment) GetContainerRegistry() *Registry {
+	return nil
+}
+
 func (e *AzureCloudEnvironment) GetStatusLink() string {
 	// If there's a problem generating the status link, we don't want to fail noisily, just skip the link.
 	url, err := azure.GenerateAzureEnvUrl(e.SubscriptionID, e.ResourceGroup)

--- a/pkg/cli/environments/dev.go
+++ b/pkg/cli/environments/dev.go
@@ -30,8 +30,8 @@ type LocalEnvironment struct {
 	Namespace   string `mapstructure:"namespace" validate:"required"`
 	ClusterName string `mapstructure:"clustername" validate:"required"`
 
-	// Registry is the docker/OCI registry we're using for images. This will probably be a localhost URL.
-	Registry string `mapstructure:"registry,omitempty"`
+	// Registry is the docker/OCI registry we're using for images.
+	Registry *Registry `mapstructure:"registry,omitempty"`
 
 	// APIServerBaseURL is an override for local debugging. This allows us us to run the controller + API Service outside the
 	// cluster.
@@ -56,6 +56,10 @@ func (e *LocalEnvironment) GetDefaultApplication() string {
 
 func (e *LocalEnvironment) GetStatusLink() string {
 	return ""
+}
+
+func (e *LocalEnvironment) GetContainerRegistry() *Registry {
+	return e.Registry
 }
 
 func (e *LocalEnvironment) HasAzureProvider() bool {

--- a/pkg/cli/environments/generic.go
+++ b/pkg/cli/environments/generic.go
@@ -27,6 +27,10 @@ func (e *GenericEnvironment) GetDefaultApplication() string {
 	return e.DefaultApplication
 }
 
+func (e *GenericEnvironment) GetContainerRegistry() *Registry {
+	return nil
+}
+
 func (e *GenericEnvironment) GetStatusLink() string {
 	return ""
 }

--- a/pkg/cli/environments/kubernetes.go
+++ b/pkg/cli/environments/kubernetes.go
@@ -38,6 +38,10 @@ func (e *KubernetesEnvironment) GetDefaultApplication() string {
 	return e.DefaultApplication
 }
 
+func (e *KubernetesEnvironment) GetContainerRegistry() *Registry {
+	return nil
+}
+
 // No Status Link for kubernetes
 func (e *KubernetesEnvironment) GetStatusLink() string {
 	return ""

--- a/pkg/cli/environments/localrp.go
+++ b/pkg/cli/environments/localrp.go
@@ -49,6 +49,10 @@ func (e *LocalRPEnvironment) GetDefaultApplication() string {
 	return e.DefaultApplication
 }
 
+func (e *LocalRPEnvironment) GetContainerRegistry() *Registry {
+	return nil
+}
+
 func (e *LocalRPEnvironment) GetStatusLink() string {
 	// If there's a problem generating the status link, we don't want to fail noisily, just skip the link.
 	url, err := azure.GenerateAzureEnvUrl(e.SubscriptionID, e.ResourceGroup)

--- a/pkg/cli/environments/types.go
+++ b/pkg/cli/environments/types.go
@@ -27,6 +27,22 @@ type Environment interface {
 
 	// GetStatusLink provides an optional URL for display of the environment.
 	GetStatusLink() string
+
+	// GetContainerRegistry provides an optional container registry override. The registry is used
+	// by the 'rad app ...' family of commands for development purposes.
+	GetContainerRegistry() *Registry
+}
+
+// Registry represent the configuration for a container registry.
+type Registry struct {
+	// PushEndpoint is the endpoint used for push commands. For a local container registry this hostname
+	// is expected to be accessible from the host machine.
+	PushEndpoint string `mapstructure:"pushendpoint" validate:"required"`
+
+	// PullEndpoint is the endpoing used to pull by the runtime. For a local container registry this hostname
+	// is expected to be accessible by the runtime. Can be the same as PushEndpoint if the registry has a routable
+	// address.
+	PullEndpoint string `mapstructure:"pullendpoint" validate:"required"`
 }
 
 type Providers struct {

--- a/pkg/cli/k3d/lifecycle.go
+++ b/pkg/cli/k3d/lifecycle.go
@@ -49,7 +49,7 @@ func (c *ServerLifecycleClient) GetStatus(ctx context.Context) (interface{}, []o
 		data.Nodes = nodes
 	}
 
-	registry, err := c.getRegistryEndpoint(ctx)
+	registry, err := c.GetRegistryEndpoint(ctx)
 	if err != nil {
 		data.Registry = fmt.Sprintf("error %s", err.Error())
 	} else {
@@ -175,7 +175,7 @@ func (c *ServerLifecycleClient) getNodeStatus(ctx context.Context) (string, erro
 	}
 }
 
-func (c *ServerLifecycleClient) getRegistryEndpoint(ctx context.Context) (string, error) {
+func (c *ServerLifecycleClient) GetRegistryEndpoint(ctx context.Context) (string, error) {
 	cmd := exec.CommandContext(ctx, "docker", "port", fmt.Sprintf("%s-registry", c.ClusterName))
 	b := bytes.Buffer{}
 	cmd.Stdout = &b

--- a/pkg/cli/stages/processor.go
+++ b/pkg/cli/stages/processor.go
@@ -20,6 +20,8 @@ import (
 )
 
 func (p *processor) ProcessBuild(ctx context.Context, stage radyaml.BuildStage) error {
+	registry := p.Options.Environment.GetContainerRegistry()
+
 	// We'll run the build in parallel - each output gets its own output stream.
 	group, ctx := errgroup.WithContext(ctx)
 	streams := output.NewStreamGroup(p.Stdout)
@@ -44,7 +46,7 @@ func (p *processor) ProcessBuild(ctx context.Context, stage radyaml.BuildStage) 
 
 			result, err := builder.Build(ctx, builders.Options{
 				BaseDirectory: p.BaseDirectory,
-				Stderr:        p.Stderr,
+				Registry:      registry,
 				Output:        stream,
 				Values:        target.Values,
 			})


### PR DESCRIPTION
This change adds support for utilizing the local container registry
created by k3d. We already provision the registry during environment
setup for local dev, and this change wires it up.

To accomplish this we add a generic 'registry override' capability to
environments. This allows a user to specify the registry they want to
use for producting in code and treat the local registry as an
implementation detail of radius. The goal is that users don't even need
to know this is happening, things just go fast.

We will likely need to expand this functionality in general for
registries/environments in the future for Radius as a whole - for
example better support for private registries. Just making a note for
posterity that this PR adds a specific feature related to registries,
but there will be more to do here.

The main detail in this change to be aware of is that registry push/pull
is asymmetric when it comes to local dev. You don't use the same URL to
push as you do pull, since the networking behaviors (DNS) are different
in each case.
