### PR TITLE
Support user-specified secrets in Azure unmanaged resources

### DIFF
--- a/pkg/handlers/azure_redis.go
+++ b/pkg/handlers/azure_redis.go
@@ -26,7 +26,9 @@ const (
 	RedisHostKey       = "redishost"
 	RedisUsernameKey   = "redisusername"
 	// On Azure, RedisUsername is empty.
-	RedisUsername = ""
+	RedisUsername            = ""
+	RedisConnectionStringKey = "redisconnectionstring"
+	RedisPasswordKey         = "redispassword"
 )
 
 func NewAzureRedisHandler(arm armauth.ArmConfig) ResourceHandler {

--- a/pkg/model/azure/azure.go
+++ b/pkg/model/azure/azure.go
@@ -22,6 +22,7 @@ import (
 	"github.com/project-radius/radius/pkg/renderers/manualscalev1alpha3"
 	"github.com/project-radius/radius/pkg/renderers/microsoftsqlv1alpha3"
 	"github.com/project-radius/radius/pkg/renderers/mongodbv1alpha3"
+	"github.com/project-radius/radius/pkg/renderers/rabbitmqv1alpha3"
 	"github.com/project-radius/radius/pkg/renderers/volumev1alpha3"
 	"github.com/project-radius/radius/pkg/resourcemodel"
 
@@ -103,6 +104,10 @@ func NewAzureModel(arm armauth.ArmConfig, k8s client.Client) model.ApplicationMo
 		{
 			ResourceType: redisv1alpha3.ResourceType,
 			Renderer:     &redisv1alpha3.AzureRenderer{},
+		},
+		{
+			ResourceType: rabbitmqv1alpha3.ResourceType,
+			Renderer:     &rabbitmqv1alpha3.AzureRenderer{},
 		},
 		{
 			ResourceType: gateway.ResourceType,

--- a/pkg/model/kubernetes/kubernetes.go
+++ b/pkg/model/kubernetes/kubernetes.go
@@ -43,7 +43,7 @@ func NewKubernetesModel(k8s client.Client) model.ApplicationModel {
 		},
 		{
 			ResourceType: rabbitmqv1alpha3.ResourceType,
-			Renderer:     &rabbitmqv1alpha3.Renderer{},
+			Renderer:     &rabbitmqv1alpha3.KubernetesRenderer{},
 		},
 		{
 			ResourceType: redisv1alpha3.ResourceType,

--- a/pkg/radrp/frontend/resourceprovider/convert.go
+++ b/pkg/radrp/frontend/resourceprovider/convert.go
@@ -76,6 +76,11 @@ func NewRestRadiusResource(resource db.RadiusResource) RadiusResource {
 	}
 	properties["provisioningState"] = resource.ProvisioningState
 
+	if resource.Type != "azure.com.KeyVault" {
+		// Scrape out the secrets properties. These are user-specified secrets for
+		// all resources except for azure.com.KeyVault.
+		delete(properties, "secrets")
+	}
 	return RadiusResource{
 		ID:         resource.ID,
 		Type:       resource.Type,

--- a/pkg/radrp/frontend/resourceprovider/resourceprovider_test.go
+++ b/pkg/radrp/frontend/resourceprovider/resourceprovider_test.go
@@ -63,6 +63,9 @@ var testRadiusResource []db.RadiusResource = []db.RadiusResource{
 		},
 		Definition: map[string]interface{}{
 			"data": true,
+			"secrets": map[string]string{
+				"password": "will be redacted in response",
+			},
 		},
 	},
 }

--- a/pkg/renderers/mongodbv1alpha3/azurerenderer.go
+++ b/pkg/renderers/mongodbv1alpha3/azurerenderer.go
@@ -158,6 +158,10 @@ func MakeSecretsAndValues(name string, properties radclient.MongoDBResourcePrope
 		return computedValues, secretValues
 	}
 
+	// Currently user-specfied secrets are stored in the `secrets` property of the resource, and
+	// thus serialized to our database.
+	//
+	// TODO(#1767): We need to store these in a secret store.
 	return map[string]renderers.ComputedValueReference{
 		DatabaseValue: {
 			Value: name,

--- a/pkg/renderers/mongodbv1alpha3/azurerenderer.go
+++ b/pkg/renderers/mongodbv1alpha3/azurerenderer.go
@@ -98,6 +98,10 @@ func RenderManaged(name string, properties radclient.MongoDBResourceProperties) 
 
 func RenderUnmanaged(name string, properties radclient.MongoDBResourceProperties) ([]outputresource.OutputResource, error) {
 	if properties.Secrets != nil {
+		// When the user-specified secret is present, this is the usecase where the user is running
+		// their own custom Redis instance (using a container, or hosted elsewhere).
+		//
+		// In that case we don't have an OutputResaource, only Computed and Secret values.
 		return nil, nil
 	}
 	if properties.Resource == nil || *properties.Resource == "" {

--- a/pkg/renderers/mongodbv1alpha3/azurerenderer_test.go
+++ b/pkg/renderers/mongodbv1alpha3/azurerenderer_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/cosmos-db/mgmt/documentdb"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/go-logr/logr"
 	"github.com/project-radius/radius/pkg/handlers"
 	"github.com/project-radius/radius/pkg/radlogger"
@@ -150,6 +151,43 @@ func Test_Azure_Render_Unmanaged_Success(t *testing.T) {
 		},
 	}
 	require.Equal(t, expectedSecretValues, output.SecretValues)
+}
+func Test_Azure_Render_Unmanaged_UserSpecifiedSecrets(t *testing.T) {
+	ctx := createContext(t)
+	renderer := AzureRenderer{}
+
+	resource := renderers.RendererResource{
+		ApplicationName: applicationName,
+		ResourceName:    resourceName,
+		ResourceType:    ResourceType,
+		Definition: map[string]interface{}{
+			"secrets": map[string]interface{}{
+				"username":         "admin",
+				"password":         "deadbeef",
+				"connectionString": "admin/deadbeef@localhost",
+			},
+		},
+	}
+
+	output, err := renderer.Render(ctx, renderers.RenderOptions{Resource: resource, Dependencies: map[string]renderers.RendererDependency{}})
+	require.NoError(t, err)
+	require.Len(t, output.Resources, 0)
+	expectedComputedValues := map[string]renderers.ComputedValueReference{
+		"database": {
+			Value: resource.ResourceName,
+		},
+		"password": {
+			Value: to.StringPtr("deadbeef"),
+		},
+		"username": {
+			Value: to.StringPtr("admin"),
+		},
+		"connectionString": {
+			Value: to.StringPtr("admin/deadbeef@localhost"),
+		},
+	}
+	require.Equal(t, expectedComputedValues, output.ComputedValues)
+	require.Equal(t, 0, len(output.SecretValues))
 }
 
 func Test_Azure_Render_Unmanaged_MissingResource(t *testing.T) {

--- a/pkg/renderers/mongodbv1alpha3/types.go
+++ b/pkg/renderers/mongodbv1alpha3/types.go
@@ -11,6 +11,8 @@ const (
 	ResourceType          = "mongo.com.MongoDatabase"
 	ConnectionStringValue = "connectionString"
 	DatabaseValue         = "database"
+	UsernameStringValue   = "username"
+	PasswordValue         = "password"
 )
 
 var CosmosMongoResourceType = azresources.KnownType{

--- a/pkg/renderers/rabbitmqv1alpha3/azure_renderer.go
+++ b/pkg/renderers/rabbitmqv1alpha3/azure_renderer.go
@@ -1,0 +1,46 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package rabbitmqv1alpha3
+
+import (
+	"context"
+	"errors"
+
+	"github.com/project-radius/radius/pkg/azure/azresources"
+	"github.com/project-radius/radius/pkg/azure/radclient"
+	"github.com/project-radius/radius/pkg/renderers"
+)
+
+var _ renderers.Renderer = (*AzureRenderer)(nil)
+
+type AzureRenderer struct {
+}
+
+func (r *AzureRenderer) GetDependencyIDs(ctx context.Context, workload renderers.RendererResource) ([]azresources.ResourceID, []azresources.ResourceID, error) {
+	return nil, nil, nil
+}
+
+func (r *AzureRenderer) Render(ctx context.Context, options renderers.RenderOptions) (renderers.RendererOutput, error) {
+	properties := &radclient.RabbitMQMessageQueueResourceProperties{}
+	resource := options.Resource
+	err := resource.ConvertDefinition(&properties)
+	if err != nil {
+		return renderers.RendererOutput{}, err
+	}
+	if properties.Secrets == nil {
+		return renderers.RendererOutput{}, errors.New("secrets must be specified")
+	}
+	return renderers.RendererOutput{
+		ComputedValues: map[string]renderers.ComputedValueReference{
+			"username": {
+				Value: "",
+			},
+			"connectionString": {
+				Value: properties.Secrets.ConnectionString,
+			},
+		},
+	}, nil
+}

--- a/pkg/renderers/rabbitmqv1alpha3/azure_renderer.go
+++ b/pkg/renderers/rabbitmqv1alpha3/azure_renderer.go
@@ -39,9 +39,6 @@ func (r *AzureRenderer) Render(ctx context.Context, options renderers.RenderOpti
 	// TODO(#1767): We need to store these in a secret store.
 	return renderers.RendererOutput{
 		ComputedValues: map[string]renderers.ComputedValueReference{
-			"username": {
-				Value: "",
-			},
 			"connectionString": {
 				Value: properties.Secrets.ConnectionString,
 			},

--- a/pkg/renderers/rabbitmqv1alpha3/azure_renderer.go
+++ b/pkg/renderers/rabbitmqv1alpha3/azure_renderer.go
@@ -33,6 +33,10 @@ func (r *AzureRenderer) Render(ctx context.Context, options renderers.RenderOpti
 	if properties.Secrets == nil {
 		return renderers.RendererOutput{}, errors.New("secrets must be specified")
 	}
+	// Currently user-specfied secrets are stored in the `secrets` property of the resource, and
+	// thus serialized to our database.
+	//
+	// TODO(#1767): We need to store these in a secret store.
 	return renderers.RendererOutput{
 		ComputedValues: map[string]renderers.ComputedValueReference{
 			"username": {

--- a/pkg/renderers/rabbitmqv1alpha3/azure_renderer_test.go
+++ b/pkg/renderers/rabbitmqv1alpha3/azure_renderer_test.go
@@ -1,0 +1,53 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package rabbitmqv1alpha3
+
+import (
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/project-radius/radius/pkg/renderers"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	applicationName = "test-app"
+	resourceName    = "test-rabbitmq"
+)
+
+func Test_Azure_Render_Unmanaged_User_Secrets(t *testing.T) {
+	ctx := createContext(t)
+	renderer := AzureRenderer{}
+
+	resource := renderers.RendererResource{
+		ApplicationName: applicationName,
+		ResourceName:    resourceName,
+		ResourceType:    ResourceType,
+		Definition: map[string]interface{}{
+			"host": "localhost",
+			"port": 42,
+			"secrets": map[string]string{
+				"connectionString": "admin:deadbeef@localhost:42",
+			},
+		},
+	}
+
+	output, err := renderer.Render(ctx, renderers.RenderOptions{Resource: resource, Dependencies: map[string]renderers.RendererDependency{}})
+	require.NoError(t, err)
+
+	require.Len(t, output.Resources, 0)
+
+	expectedComputedValues := map[string]renderers.ComputedValueReference{
+		"username": {
+			Value: "",
+		},
+		"connectionString": {
+			Value: to.StringPtr("admin:deadbeef@localhost:42"),
+		},
+	}
+	require.Equal(t, expectedComputedValues, output.ComputedValues)
+	require.Equal(t, 0, len(output.SecretValues))
+}

--- a/pkg/renderers/rabbitmqv1alpha3/azure_renderer_test.go
+++ b/pkg/renderers/rabbitmqv1alpha3/azure_renderer_test.go
@@ -41,9 +41,6 @@ func Test_Azure_Render_Unmanaged_User_Secrets(t *testing.T) {
 	require.Len(t, output.Resources, 0)
 
 	expectedComputedValues := map[string]renderers.ComputedValueReference{
-		"username": {
-			Value: "",
-		},
 		"connectionString": {
 			Value: to.StringPtr("admin:deadbeef@localhost:42"),
 		},

--- a/pkg/renderers/rabbitmqv1alpha3/kubernetes_renderer.go
+++ b/pkg/renderers/rabbitmqv1alpha3/kubernetes_renderer.go
@@ -26,16 +26,16 @@ const (
 	SecretKeyRabbitMQConnectionString = "RABBITMQ_CONNECTIONSTRING"
 )
 
-var _ renderers.Renderer = (*Renderer)(nil)
+var _ renderers.Renderer = (*KubernetesRenderer)(nil)
 
-type Renderer struct {
+type KubernetesRenderer struct {
 }
 
-func (r *Renderer) GetDependencyIDs(ctx context.Context, resource renderers.RendererResource) ([]azresources.ResourceID, []azresources.ResourceID, error) {
+func (r *KubernetesRenderer) GetDependencyIDs(ctx context.Context, resource renderers.RendererResource) ([]azresources.ResourceID, []azresources.ResourceID, error) {
 	return nil, nil, nil
 }
 
-func (r *Renderer) Render(ctx context.Context, options renderers.RenderOptions) (renderers.RendererOutput, error) {
+func (r *KubernetesRenderer) Render(ctx context.Context, options renderers.RenderOptions) (renderers.RendererOutput, error) {
 	resource := options.Resource
 
 	properties := &radclient.RabbitMQMessageQueueResourceProperties{}

--- a/pkg/renderers/rabbitmqv1alpha3/kubernetes_renderer_test.go
+++ b/pkg/renderers/rabbitmqv1alpha3/kubernetes_renderer_test.go
@@ -31,7 +31,7 @@ func createContext(t *testing.T) context.Context {
 
 func Test_Render_Managed_Kubernetes_Success(t *testing.T) {
 	ctx := createContext(t)
-	renderer := Renderer{}
+	renderer := KubernetesRenderer{}
 
 	dependencies := map[string]renderers.RendererDependency{}
 	resource := renderers.RendererResource{
@@ -115,7 +115,7 @@ func Test_Render_Managed_Kubernetes_Success(t *testing.T) {
 
 func TestRenderUnmanaged(t *testing.T) {
 	ctx := createContext(t)
-	renderer := Renderer{}
+	renderer := KubernetesRenderer{}
 
 	resource := renderers.RendererResource{
 		ApplicationName: "test-app",
@@ -147,7 +147,7 @@ func TestRenderUnmanaged(t *testing.T) {
 }
 
 func TestInvalidKubernetesMissingQueueName(t *testing.T) {
-	renderer := Renderer{}
+	renderer := KubernetesRenderer{}
 
 	dependencies := map[string]renderers.RendererDependency{}
 	resource := renderers.RendererResource{

--- a/pkg/renderers/redisv1alpha3/azurerender.go
+++ b/pkg/renderers/redisv1alpha3/azurerender.go
@@ -126,6 +126,10 @@ func MakeSecretsAndValues(name string, properties radclient.RedisCacheResourcePr
 
 		return computedValues, secretValues
 	}
+	// Currently user-specfied secrets are stored in the `secrets` property of the resource, and
+	// thus serialized to our database.
+	//
+	// TODO(#1767): We need to store these in a secret store.
 	return map[string]renderers.ComputedValueReference{
 		"host": {
 			Value: to.String(properties.Host),

--- a/pkg/renderers/redisv1alpha3/azurerender.go
+++ b/pkg/renderers/redisv1alpha3/azurerender.go
@@ -75,6 +75,10 @@ func RenderManaged(resourceName string, properties radclient.RedisCacheResourceP
 
 func RenderUnmanaged(resourceName string, properties radclient.RedisCacheResourceProperties) (*outputresource.OutputResource, error) {
 	if properties.Secrets != nil {
+		// When the user-specified secret is present, this is the usecase where the user is running
+		// their own custom Redis instance (using a container, or hosted elsewhere).
+		//
+		// In that case we don't have an OutputResaource, only Computed and Secret values.
 		return nil, nil
 	}
 	if properties.Resource == nil || *properties.Resource == "" {

--- a/pkg/renderers/redisv1alpha3/azurerender_test.go
+++ b/pkg/renderers/redisv1alpha3/azurerender_test.go
@@ -87,6 +87,50 @@ func Test_Azure_Render_Unmanaged_Success(t *testing.T) {
 	require.Equal(t, expectedSecretValues, output.SecretValues)
 }
 
+func Test_Azure_Render_Unmanaged_User_Secrets(t *testing.T) {
+	ctx := createContext(t)
+	renderer := AzureRenderer{}
+
+	resource := renderers.RendererResource{
+		ApplicationName: applicationName,
+		ResourceName:    resourceName,
+		ResourceType:    ResourceType,
+		Definition: map[string]interface{}{
+			"host": "localhost",
+			"port": 42,
+			"secrets": map[string]string{
+				"password":         "deadbeef",
+				"connectionString": "admin:deadbeef@localhost:42",
+			},
+		},
+	}
+
+	output, err := renderer.Render(ctx, renderers.RenderOptions{Resource: resource, Dependencies: map[string]renderers.RendererDependency{}})
+	require.NoError(t, err)
+
+	require.Len(t, output.Resources, 0)
+
+	expectedComputedValues := map[string]renderers.ComputedValueReference{
+		"host": {
+			Value: "localhost",
+		},
+		"port": {
+			Value: "42",
+		},
+		"username": {
+			Value: "",
+		},
+		"password": {
+			Value: "deadbeef",
+		},
+		"connectionString": {
+			Value: "admin:deadbeef@localhost:42",
+		},
+	}
+	require.Equal(t, expectedComputedValues, output.ComputedValues)
+	require.Equal(t, 0, len(output.SecretValues))
+}
+
 func Test_Azure_Render_Unmanaged_MissingResource(t *testing.T) {
 	ctx := createContext(t)
 	renderer := AzureRenderer{}

--- a/test/functional/azure/resources/mongodb_test.go
+++ b/test/functional/azure/resources/mongodb_test.go
@@ -135,3 +135,38 @@ func Test_MongoDBUnmanaged(t *testing.T) {
 
 	test.Test(t)
 }
+
+func Test_MongoDBUserSecrets(t *testing.T) {
+	application := "azure-resources-mongodb-user-secrets"
+	template := "testdata/azure-resources-mongodb-user-secrets.bicep"
+	test := azuretest.NewApplicationTest(t, application, []azuretest.Step{
+		{
+			Executor: azuretest.NewDeployStepExecutor(template),
+			AzureResources: &validation.AzureResourceSet{
+				Resources: []validation.ExpectedResource{},
+			},
+			RadiusResources: &validation.ResourceSet{
+				Resources: []validation.RadiusResource{
+					{
+						ApplicationName: application,
+						ResourceName:    "todoapp",
+						ResourceType:    containerv1alpha3.ResourceType,
+						OutputResources: map[string]validation.ExpectedOutputResource{
+							outputresource.LocalIDDeployment: validation.NewOutputResource(outputresource.LocalIDDeployment, outputresource.TypeKubernetes, resourcekinds.Kubernetes, true, false, rest.OutputResourceStatus{}),
+							outputresource.LocalIDSecret:     validation.NewOutputResource(outputresource.LocalIDSecret, outputresource.TypeKubernetes, resourcekinds.Kubernetes, true, false, rest.OutputResourceStatus{}),
+						},
+					},
+				},
+			},
+			Pods: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					application: {
+						validation.NewK8sObjectForResource(application, "todoapp"),
+					},
+				},
+			},
+		},
+	})
+
+	test.Test(t)
+}

--- a/test/functional/azure/resources/redis_test.go
+++ b/test/functional/azure/resources/redis_test.go
@@ -1,0 +1,50 @@
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package resources_test
+
+import (
+	"testing"
+
+	"github.com/project-radius/radius/pkg/radrp/outputresource"
+	"github.com/project-radius/radius/pkg/radrp/rest"
+	"github.com/project-radius/radius/pkg/renderers/containerv1alpha3"
+	"github.com/project-radius/radius/pkg/resourcekinds"
+	"github.com/project-radius/radius/test/azuretest"
+	"github.com/project-radius/radius/test/validation"
+)
+
+func Test_RedisUserSecrets(t *testing.T) {
+	application := "azure-resources-redis-user-secrets"
+	template := "testdata/azure-resources-redis-user-secrets.bicep"
+	test := azuretest.NewApplicationTest(t, application, []azuretest.Step{
+		{
+			Executor: azuretest.NewDeployStepExecutor(template),
+			AzureResources: &validation.AzureResourceSet{
+				Resources: []validation.ExpectedResource{},
+			},
+			RadiusResources: &validation.ResourceSet{
+				Resources: []validation.RadiusResource{
+					{
+						ApplicationName: application,
+						ResourceName:    "todoapp",
+						ResourceType:    containerv1alpha3.ResourceType,
+						OutputResources: map[string]validation.ExpectedOutputResource{
+							outputresource.LocalIDDeployment: validation.NewOutputResource(outputresource.LocalIDDeployment, outputresource.TypeKubernetes, resourcekinds.Kubernetes, true, false, rest.OutputResourceStatus{}),
+							outputresource.LocalIDSecret:     validation.NewOutputResource(outputresource.LocalIDSecret, outputresource.TypeKubernetes, resourcekinds.Kubernetes, true, false, rest.OutputResourceStatus{}),
+						},
+					},
+				},
+			},
+			Pods: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					application: {
+						validation.NewK8sObjectForResource(application, "todoapp"),
+					},
+				},
+			},
+		},
+	})
+
+	test.Test(t)
+}

--- a/test/functional/azure/resources/testdata/azure-resources-mongodb-user-secrets.bicep
+++ b/test/functional/azure/resources/testdata/azure-resources-mongodb-user-secrets.bicep
@@ -1,0 +1,63 @@
+@description('Admin username for the Mongo database. Default is "admin"')
+param username string = 'admin'
+
+@description('Admin password for the Mongo database')
+@secure()
+param password string = newGuid()
+
+resource app 'radius.dev/Application@v1alpha3' = {
+  name: 'azure-resources-mongodb-user-secrets'
+
+  resource webapp 'Container' = {
+    name: 'todoapp'
+    properties: {
+      connections: {
+        mongodb: {
+          kind: 'mongo.com/MongoDB'
+          source: mongo.id
+        }
+      }
+      container: {
+        image: 'radius.azurecr.io/magpie:latest'
+      }
+    }
+  }
+
+	// https://hub.docker.com/_/mongo/
+  resource mongoContainer 'Container' = {
+    name: 'mongo'
+    properties: {
+      container: {
+        image: 'mongo:4.2'
+        env: {
+          MONGO_INITDB_ROOT_USERNAME: username
+          MONGO_INITDB_ROOT_PASSWORD: password
+        }
+        ports: {
+          mongo: {
+            containerPort: 27017
+            provides: mongoRoute.id
+          }
+        }
+      }
+    }
+  }
+
+  resource mongoRoute 'HttpRoute' = {
+    name: 'mongo-route'
+    properties: {
+      port: 27017
+    }
+  }
+
+  resource mongo 'mongo.com.MongoDatabase' = {
+    name: 'mongo'
+    properties: {
+      secrets: {
+        connectionString: 'mongodb://${username}:${password}@${mongoRoute.properties.host}:${mongoRoute.properties.port}'
+        username: username
+        password: password
+      }
+    }
+  }
+}

--- a/test/functional/azure/resources/testdata/azure-resources-mongodb-user-secrets.bicep
+++ b/test/functional/azure/resources/testdata/azure-resources-mongodb-user-secrets.bicep
@@ -23,7 +23,7 @@ resource app 'radius.dev/Application@v1alpha3' = {
     }
   }
 
-	// https://hub.docker.com/_/mongo/
+  // https://hub.docker.com/_/mongo/
   resource mongoContainer 'Container' = {
     name: 'mongo'
     properties: {

--- a/test/functional/azure/resources/testdata/azure-resources-redis-user-secrets.bicep
+++ b/test/functional/azure/resources/testdata/azure-resources-redis-user-secrets.bicep
@@ -1,0 +1,54 @@
+resource app 'radius.dev/Application@v1alpha3' = {
+  name: 'azure-resources-redis-user-secrets'
+
+  resource webapp 'Container' = {
+    name: 'todoapp'
+    properties: {
+      container: {
+        image: 'radius.azurecr.io/magpie:latest'
+        env: {
+        }
+      }
+      connections: {
+        redis: {
+          kind: 'redislabs.com/Redis'
+          source: redis.id
+        }
+      }
+    }
+  }
+
+	resource redisContainer 'Container' = {
+    name: 'redis'
+    properties: {
+      container: {
+        image: 'redis:6.2'
+        ports: {
+          redis: {
+            containerPort: 6379
+            provides: redisRoute.id
+          }
+        }
+      }
+    }
+  }
+
+  resource redisRoute 'HttpRoute' = {
+    name: 'redis-route'
+    properties: {
+      port: 6379
+    }
+  }
+
+  resource redis 'redislabs.com.RedisCache@v1alpha3' = {
+    name: 'redis'
+    properties: {
+      host: redisRoute.properties.host
+      port: redisRoute.properties.port
+      secrets: {
+        connectionString: '${redisRoute.properties.host}:${redisRoute.properties.port}'
+        password: ''
+      }
+    }
+  }
+}

--- a/test/functional/azure/resources/testdata/azure-resources-redis-user-secrets.bicep
+++ b/test/functional/azure/resources/testdata/azure-resources-redis-user-secrets.bicep
@@ -18,7 +18,7 @@ resource app 'radius.dev/Application@v1alpha3' = {
     }
   }
 
-	resource redisContainer 'Container' = {
+  resource redisContainer 'Container' = {
     name: 'redis'
     properties: {
       container: {


### PR DESCRIPTION
# Description

Support user-specified secrets in Azure unmanaged resources (MongDB, RabbitMQ, Redis). This is to support starters.


## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #1681 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
