### PR TITLE
Add output resource info in logs on deployment/deletion

### DIFF
--- a/pkg/radrp/backend/deployment/deploymentprocessor.go
+++ b/pkg/radrp/backend/deployment/deploymentprocessor.go
@@ -135,10 +135,10 @@ func (dp *deploymentProcessor) Delete(ctx context.Context, operationID azresourc
 			return err
 		}
 
-		logger.Info(fmt.Sprintf("Deleting output resource - LocalID: %s, type: %s\n", outputResource.LocalID, outputResource.ResourceKind))
+		logger.Info(fmt.Sprintf("Deleting output resource: %v, LocalID: %s, resource kind: %s\n", outputResource.Identity, outputResource.LocalID, outputResource.ResourceKind))
 		err = outputResourceModel.ResourceHandler.Delete(ctx, handlers.DeleteOptions{
 			Application:            resource.ApplicationName,
-			ResourceName:           resource.ResourceGroup,
+			ResourceName:           resource.ResourceName,
 			ExistingOutputResource: &outputResource,
 		})
 		if err != nil {
@@ -349,7 +349,7 @@ func (dp *deploymentProcessor) deployRenderedResources(ctx context.Context, reso
 	// Example - CosmosDBAccountName consumed by CosmosDBMongo/SQL handler
 	deployedOutputResourceProperties := map[string]map[string]string{}
 	for _, outputResource := range orderedOutputResources {
-		logger.Info(fmt.Sprintf("Deploying output resource - LocalID: %s, type: %s\n", outputResource.LocalID, outputResource.ResourceKind))
+		logger.Info(fmt.Sprintf("Deploying output resource: %v, LocalID: %s, resource kind: %s\n", outputResource.Identity, outputResource.LocalID, outputResource.ResourceKind))
 
 		var existingOutputResourceState db.OutputResource
 		for _, dbOutputResource := range existingDBOutputResources {


### PR DESCRIPTION
# Description

Adding info about output resource being deployed or deleted. Realized that we are missing this info while investigating test failure.

## Issue reference

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
