### PR TITLE
Add support for per-stage parameters and overrides

### DIFF
--- a/cmd/rad/cmd/appDeploy.go
+++ b/cmd/rad/cmd/appDeploy.go
@@ -135,8 +135,8 @@ func deployApplication(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	parser := cli.ParameterParser{FileSystem: cli.OSFileSystem{}}
-	parameters, err := parser.Parse(parameterArgs)
+	parser := bicep.ParameterParser{FileSystem: bicep.OSFileSystem{}}
+	parameters, err := parser.Parse(parameterArgs...)
 	if err != nil {
 		return err
 	}

--- a/cmd/rad/cmd/appRun.go
+++ b/cmd/rad/cmd/appRun.go
@@ -78,8 +78,8 @@ func runApplication(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	parser := cli.ParameterParser{FileSystem: cli.OSFileSystem{}}
-	parameters, err := parser.Parse(parameterArgs)
+	parser := bicep.ParameterParser{FileSystem: bicep.OSFileSystem{}}
+	parameters, err := parser.Parse(parameterArgs...)
 	if err != nil {
 		return err
 	}

--- a/cmd/rad/cmd/deploy.go
+++ b/cmd/rad/cmd/deploy.go
@@ -96,8 +96,8 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	parser := cli.ParameterParser{FileSystem: cli.OSFileSystem{}}
-	parameters, err := parser.Parse(parameterArgs)
+	parser := bicep.ParameterParser{FileSystem: bicep.OSFileSystem{}}
+	parameters, err := parser.Parse(parameterArgs...)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/bicep/deployment_parameters.go
+++ b/pkg/cli/bicep/deployment_parameters.go
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-package cli
+package bicep
 
 import (
 	"encoding/json"
@@ -28,7 +28,7 @@ func (OSFileSystem) Open(name string) (fs.File, error) {
 	return os.Open(name)
 }
 
-func (pp ParameterParser) Parse(inputs []string) (clients.DeploymentParameters, error) {
+func (pp ParameterParser) Parse(inputs ...string) (clients.DeploymentParameters, error) {
 	output := clients.DeploymentParameters{}
 	for _, input := range inputs {
 		// Parameters get merged with the later ones taking precendence. ParseSingleParameter handles
@@ -113,11 +113,11 @@ func (pp ParameterParser) mergeParameters(output clients.DeploymentParameters, i
 
 func (pp ParameterParser) mergeSingleParameter(output clients.DeploymentParameters, name string, input interface{}) {
 	// We intentionally overwrite duplicates.
-	parameter, ok := output[name]
-	if !ok {
-		parameter = map[string]interface{}{}
-		output[name] = parameter
-	}
+	output[name] = NewParameter(input)
+}
 
-	parameter["value"] = input
+func NewParameter(value interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"value": value,
+	}
 }

--- a/pkg/cli/bicep/deployment_parameters_test.go
+++ b/pkg/cli/bicep/deployment_parameters_test.go
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-package cli
+package bicep
 
 import (
 	"testing"
@@ -27,7 +27,7 @@ func Test_Parameters_Invalid(t *testing.T) {
 
 	for _, input := range inputs {
 		t.Run(input, func(t *testing.T) {
-			parameters, err := parser.Parse([]string{input})
+			parameters, err := parser.Parse(input)
 			require.Error(t, err)
 			require.Nil(t, parameters)
 		})
@@ -53,7 +53,7 @@ func Test_ParseParameters_Overwrite(t *testing.T) {
 		},
 	}
 
-	parameters, err := parser.Parse(inputs)
+	parameters, err := parser.Parse(inputs...)
 	require.NoError(t, err)
 
 	expected := clients.DeploymentParameters{

--- a/pkg/cli/radyaml/profiles.go
+++ b/pkg/cli/radyaml/profiles.go
@@ -81,7 +81,7 @@ func CombineBuildTarget(main *BuildTarget, override *BuildTarget) (*BuildTarget,
 	if strings.EqualFold(main.Builder, override.Builder) {
 		return &BuildTarget{
 			Builder: main.Builder,
-			Values:  overrideMap(main.Values, override.Values),
+			Values:  overrideMapInterface(main.Values, override.Values),
 		}, nil
 	}
 
@@ -100,6 +100,8 @@ func CombineBicepStage(main *BicepStage, override *BicepStage) (*BicepStage, err
 	// If we get here, both stages define Bicep settings and we need to combine them.
 	combined := BicepStage{}
 	combined.Template = overrideString(main.Template, override.Template)
+	combined.ParameterFile = overrideString(main.ParameterFile, override.ParameterFile)
+	combined.Parameters = overrideMapString(main.Parameters, override.Parameters)
 	return &combined, nil
 }
 
@@ -112,7 +114,29 @@ func overrideString(main *string, override *string) *string {
 	return override
 }
 
-func overrideMap(main map[string]interface{}, override map[string]interface{}) map[string]interface{} {
+func overrideMapString(main map[string]string, override map[string]string) map[string]string {
+	if override == nil {
+		return main
+	}
+
+	if main == nil {
+		return override
+	}
+
+	// If we get here both main and override are non-nil. We want to combine them.
+	combined := map[string]string{}
+	for key, value := range main {
+		combined[key] = value
+	}
+
+	for key, value := range override {
+		combined[key] = value
+	}
+
+	return combined
+}
+
+func overrideMapInterface(main map[string]interface{}, override map[string]interface{}) map[string]interface{} {
 	if override == nil {
 		return main
 	}
@@ -132,7 +156,7 @@ func overrideMap(main map[string]interface{}, override map[string]interface{}) m
 			mainValueMap, isMainValueMap := mainValue.(map[string]interface{})
 			overrideValueMap, isOverrideValueMap := value.(map[string]interface{})
 			if isMainValueMap && isOverrideValueMap {
-				combined[key] = overrideMap(mainValueMap, overrideValueMap)
+				combined[key] = overrideMapInterface(mainValueMap, overrideValueMap)
 				continue
 			}
 		}

--- a/pkg/cli/radyaml/profiles_test.go
+++ b/pkg/cli/radyaml/profiles_test.go
@@ -195,6 +195,44 @@ func Test_ApplyProfile_Valid(t *testing.T) {
 				},
 			},
 		},
+		{
+			Description: "OverrideBicep",
+			Main: Stage{
+				Name: "test-stage",
+				Bicep: &BicepStage{
+					Template:      to.StringPtr("main.bicep"),
+					ParameterFile: to.StringPtr("main.parameters.json"),
+					Parameters: map[string]string{
+						"main1": "original",
+						"main2": "original",
+					},
+				},
+				Profiles: map[string]Profile{
+					"test": {
+						Bicep: &BicepStage{
+							Template:      to.StringPtr("override.bicep"),
+							ParameterFile: to.StringPtr("override.parameters.json"),
+							Parameters: map[string]string{
+								"main2":     "override",
+								"override1": "override",
+							},
+						},
+					},
+				},
+			},
+			Expected: Stage{
+				Name: "test-stage",
+				Bicep: &BicepStage{
+					Template:      to.StringPtr("override.bicep"),
+					ParameterFile: to.StringPtr("override.parameters.json"),
+					Parameters: map[string]string{
+						"main1":     "original",
+						"main2":     "override",
+						"override1": "override",
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/pkg/cli/radyaml/types.go
+++ b/pkg/cli/radyaml/types.go
@@ -35,5 +35,7 @@ type Profile struct {
 
 // Bicep stage represents a Bicep deployment as part of a stage or profile.
 type BicepStage struct {
-	Template *string `yaml:"template,omitempty"`
+	Template      *string           `yaml:"template,omitempty"`
+	ParameterFile *string           `yaml:"parameterFile,omitempty"`
+	Parameters    map[string]string `yaml:"parameters,omitempty"`
 }

--- a/pkg/cli/stages/processor.go
+++ b/pkg/cli/stages/processor.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/project-radius/radius/pkg/cli/bicep"
 	"github.com/project-radius/radius/pkg/cli/builders"
+	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/deploy"
 	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/project-radius/radius/pkg/cli/radyaml"
@@ -95,13 +96,34 @@ func (p *processor) ProcessDeploy(ctx context.Context, stage radyaml.BicepStage)
 		return err
 	}
 
+	// We might have additional parameters that are specific to this stage, so make a copy
+	// that way the parameters don't leak outside the stage.
+	parameters := clients.ShallowCopy(p.Parameters)
+	if stage.ParameterFile != nil {
+		filePath := path.Join(p.BaseDirectory, *stage.ParameterFile)
+
+		parser := bicep.ParameterParser{FileSystem: bicep.OSFileSystem{}}
+		parsedFile, err := parser.Parse(filePath)
+		if err != nil {
+			return err
+		}
+
+		for key, value := range parsedFile {
+			parameters[key] = value
+		}
+	}
+
+	for key, value := range stage.Parameters {
+		parameters[key] = bicep.NewParameter(value)
+	}
+
 	progressText := fmt.Sprintf("Deploying %s...", deployFile)
 	completionText := fmt.Sprintf("Deployed stage %s: %d of %d", p.CurrrentStage.Name, p.CurrrentStage.DisplayIndex, p.CurrrentStage.TotalCount)
 
 	result, err := deploy.DeployWithProgress(ctx, deploy.Options{
 		Environment:    p.Environment,
 		Template:       template,
-		Parameters:     p.Parameters,
+		Parameters:     parameters,
 		ProgressText:   progressText,
 		CompletionText: completionText,
 	})


### PR DESCRIPTION
Fixes: #1455

This change adds support for adding parameters and parameter files
per-stage, which also includes overrides. These definitions are scoped
per-stage and don't interact with other stages.
