### PR TITLE
Updating to newer node image for magpie test image

### DIFF
--- a/schemas/rest-api-specs/radius.json
+++ b/schemas/rest-api-specs/radius.json
@@ -828,6 +828,9 @@
         },
         "type": {
           "description": "Dapr StateStore type. These strings match the format used by Dapr Kubernetes configuration format.",
+          "example": [
+            "state.zookeeper"
+          ],
           "type": "string"
         },
         "version": {

--- a/test/magpie/Dockerfile
+++ b/test/magpie/Dockerfile
@@ -1,5 +1,5 @@
 # Issues on M1 mac: https://github.com/docker/for-mac/issues/5831
-FROM node:14
+FROM node:17
 
 WORKDIR /usr/src/app
 

--- a/test/magpie/Dockerfile
+++ b/test/magpie/Dockerfile
@@ -1,5 +1,5 @@
 # Issues on M1 mac: https://github.com/docker/for-mac/issues/5831
-FROM node:17
+FROM node:16
 
 WORKDIR /usr/src/app
 

--- a/test/magpie/package.json
+++ b/test/magpie/package.json
@@ -12,10 +12,10 @@
   "devDependencies": {
     "@types/express": "^4.17.13",
     "@types/mssql": "^7.1.3",
-    "@types/redis": "^2.8.31",
-    "@typescript-eslint/eslint-plugin": "^4.28.4",
-    "@typescript-eslint/parser": "^4.28.4",
-    "eslint": "^7.31.0",
+    "@types/redis": "^4.0.11",
+    "@typescript-eslint/eslint-plugin": "^5.10.2",
+    "@typescript-eslint/parser": "^5.10.2",
+    "eslint": "^8.8.0",
     "typescript": "^4.3.5"
   },
   "dependencies": {
@@ -26,8 +26,8 @@
     "amqplib": "^0.8.0",
     "bluebird": "^3.7.2",
     "express": "^4.17.1",
-    "mongodb": "^3.6.10",
-    "mssql": "^8.0.1",
-    "redis": "^3.1.2"
+    "mongodb": "^3.7.3",
+    "mssql": "^7.2.0",
+    "redis": "^4.0.3"
   }
 }

--- a/test/magpie/package.json
+++ b/test/magpie/package.json
@@ -19,7 +19,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@azure/identity": "^1.5.0",
+    "@azure/identity": "^2.0.1",
     "@azure/keyvault-secrets": "^4.2.0",
     "@azure/service-bus": "^7.3.0",
     "@roadwork/dapr-js-sdk": "^0.3.1",
@@ -27,7 +27,7 @@
     "bluebird": "^3.7.2",
     "express": "^4.17.1",
     "mongodb": "^3.6.10",
-    "mssql": "^7.2.1",
+    "mssql": "^8.0.1",
     "redis": "^3.1.2"
   }
 }


### PR DESCRIPTION
# Description

Updating node base container image for node when building magpie.
Using node:14 was resulting in security violations in azure due to a vulnerability in libssh2, which has since been fixed by debian, so updating to newer version of node
Debian vulnerability: https://lists.debian.org/debian-lts-announce/2021/12/msg00013.html

## Issue reference

radius-project/core-team#450 


## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change - NA for this PR
* [x] Adds necessary E2E tests for change- NA for this PR
* [ ] Unit tests passing
* [x] Extended the documentation / Created issue for it-  NA for this PR
