### PR TITLE
Store fully qualified resource name for non-Radius Azure resources

### DIFF
--- a/pkg/radrp/backend/deployment/deployment_test.go
+++ b/pkg/radrp/backend/deployment/deployment_test.go
@@ -82,7 +82,7 @@ var (
 			"connections": map[string]interface{}{
 				"testAzureConnection": map[string]string{
 					"kind":   "Azure",
-					"source": "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Microsoft.ServiceBus/namespaces/test-namespace",
+					"source": "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Microsoft.ServiceBus/namespaces/test-namespace/queues/test-queue",
 					"role":   "administrator",
 				},
 			},
@@ -94,13 +94,13 @@ var (
 	}
 
 	testDBAzureResource = db.AzureResource{
-		ID:                  "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Microsoft.ServiceBus/namespaces/test-namespace",
+		ID:                  "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Microsoft.ServiceBus/namespaces/test-namespace/queues/test-queue",
 		SubscriptionID:      subscriptionID,
 		ResourceGroup:       resourceGroup,
 		ApplicationName:     testApplicationName,
-		ResourceName:        "test-namespace",
+		ResourceName:        "test-namespace/test-queue",
 		ResourceKind:        resourcekinds.Azure,
-		Type:                "Microsoft.ServiceBus/namespaces",
+		Type:                "Microsoft.ServiceBus/namespaces/queues",
 		RadiusConnectionIDs: []string{testRadiusARMID},
 	}
 )

--- a/pkg/radrp/backend/deployment/deploymentprocessor.go
+++ b/pkg/radrp/backend/deployment/deploymentprocessor.go
@@ -89,7 +89,7 @@ func (dp *deploymentProcessor) Deploy(ctx context.Context, operationID azresourc
 			ID:             azureResourceID.ID,
 			SubscriptionID: azureResourceID.SubscriptionID,
 			ResourceGroup:  azureResourceID.ResourceGroup,
-			ResourceName:   azureResourceID.Name(),
+			ResourceName:   azureResourceID.QualifiedName(),
 			ResourceKind:   resourcekinds.Azure,
 			Type:           azureResourceID.Type(),
 			// Add Radius application context, since the Azure resource could belong to a different resource group/subscription outside of application context


### PR DESCRIPTION
# Description

Store `dbaccount/db` instead of `db`

## Issue reference

Please reference the issue this PR will close: https://github.com/project-radius/radius/issues/1773

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
