### PR TITLE
Support hybrid dev+azure environments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -163,6 +163,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -968,6 +968,8 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
+github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=

--- a/pkg/cli/armtemplate/armconverter_test.go
+++ b/pkg/cli/armtemplate/armconverter_test.go
@@ -6,6 +6,7 @@
 package armtemplate
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"path"
@@ -46,7 +47,7 @@ func Test_ArmToK8sConversion(t *testing.T) {
 	template, err := Parse(string(content))
 	require.NoError(t, err)
 
-	resources, err := Eval(template, TemplateOptions{
+	resources, err := Eval(context.Background(), template, TemplateOptions{
 		Parameters: map[string]map[string]interface{}{
 			// Setting one required parameter, and using the default value for 'backendRoute' parameter
 			"frontendRoute": {
@@ -86,7 +87,7 @@ func Test_ArmToK8sConversion_ManagedSecret(t *testing.T) {
 	template, err := Parse(string(content))
 	require.NoError(t, err)
 
-	resources, err := Eval(template, TemplateOptions{})
+	resources, err := Eval(context.Background(), template, TemplateOptions{})
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(resources))

--- a/pkg/cli/armtemplate/armtemplate.go
+++ b/pkg/cli/armtemplate/armtemplate.go
@@ -9,10 +9,13 @@
 package armtemplate
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/project-radius/radius/pkg/cli/armtemplate/providers"
 )
 
 const DeploymentResourceType = "Microsoft.Resources/deployments"
@@ -99,6 +102,16 @@ type TemplateOptions struct {
 	SubscriptionID string
 	ResourceGroup  string
 
+	// RadiusSubscriptionID is an override used to build resource IDs for Radius types. Set this when deploying Radius resources to a non-Azure target.
+	// This can be removed when we use extensibility for Radius.
+	RadiusSubscriptionID string
+
+	// RadiusResourceGroup is an override used to build resource IDs for Radius types. Set this when deploying Radius resources to a non-Azure target.
+	// This can be removed when we use extensibility for Radius.
+	RadiusResourceGroup string
+
+	Providers map[string]providers.Provider
+
 	// Parameters stores ARM template parameters in the format they appear when submitting a deployment.
 	//
 	// The full format is documented here: https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/parameter-files
@@ -108,10 +121,12 @@ type TemplateOptions struct {
 	EvaluatePropertiesNode bool
 }
 
-func Eval(template DeploymentTemplate, options TemplateOptions) ([]Resource, error) {
+func Eval(ctx context.Context, template DeploymentTemplate, options TemplateOptions) ([]Resource, error) {
 	eva := &DeploymentEvaluator{
+		Context:   ctx,
 		Template:  template,
 		Options:   options,
+		Providers: options.Providers,
 		Variables: map[string]interface{}{},
 	}
 

--- a/pkg/cli/armtemplate/armtemplate_test.go
+++ b/pkg/cli/armtemplate/armtemplate_test.go
@@ -6,6 +6,7 @@
 package armtemplate
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"path"
@@ -22,7 +23,7 @@ func Test_DeploymentTemplate(t *testing.T) {
 	template, err := Parse(string(content))
 	require.NoError(t, err)
 
-	resources, err := Eval(template, TemplateOptions{
+	resources, err := Eval(context.Background(), template, TemplateOptions{
 		SubscriptionID: "test-sub",
 		ResourceGroup:  "test-group",
 		Parameters: map[string]map[string]interface{}{

--- a/pkg/cli/armtemplate/deploy_evaluator_test.go
+++ b/pkg/cli/armtemplate/deploy_evaluator_test.go
@@ -58,7 +58,7 @@ func Test_DeploymentEvaluator_KubernetesReference(t *testing.T) {
 			template, err := Parse(string(content))
 			require.NoError(t, err)
 
-			resources, err := Eval(template, options)
+			resources, err := Eval(context.Background(), template, options)
 			require.NoError(t, err)
 
 			evaluator := &DeploymentEvaluator{
@@ -118,7 +118,7 @@ func Test_DeploymentEvaluator_ReferenceWorks(t *testing.T) {
 		},
 	}
 
-	resources, err := Eval(template, options)
+	resources, err := Eval(context.Background(), template, options)
 	require.NoError(t, err)
 
 	deployed := map[string]map[string]interface{}{}

--- a/pkg/cli/environments/dev.go
+++ b/pkg/cli/environments/dev.go
@@ -101,6 +101,9 @@ func (e *LocalEnvironment) CreateDeploymentClient(ctx context.Context) (clients.
 		SubscriptionID: subscriptionID,
 		ResourceGroup:  resourceGroup,
 
+		RadiusSubscriptionID: e.Namespace, // YES: this supposed to be the namespace since we're talking to the API Service.
+		RadiusResourceGroup:  e.Namespace,
+
 		// Local Dev supports Radius, Kubernetes, Modules, and optionally Azure
 		Providers: map[string]providers.Provider{
 			providers.RadiusProviderImport: &providers.AzureProvider{
@@ -126,7 +129,7 @@ func (e *LocalEnvironment) CreateDeploymentClient(ctx context.Context) (clients.
 
 		client.Providers[providers.AzureProviderImport] = &providers.AzureProvider{
 			Authorizer:     auth,
-			BaseURL:        baseURL,
+			BaseURL:        "https://management.azure.com",
 			SubscriptionID: subscriptionID,
 			ResourceGroup:  resourceGroup,
 		}

--- a/pkg/cli/localrp/deployment_client.go
+++ b/pkg/cli/localrp/deployment_client.go
@@ -33,7 +33,16 @@ var key = &keyStruct{}
 type LocalRPDeploymentClient struct {
 	SubscriptionID string
 	ResourceGroup  string
-	Providers      map[string]providers.Provider
+
+	// RadiusSubscriptionID is an override used to build resource IDs for Radius types. Set this when deploying Radius resources to a non-Azure target.
+	// This can be removed when we use extensibility for Radius.
+	RadiusSubscriptionID string
+
+	// RadiusResourceGroup is an override used to build resource IDs for Radius types. Set this when deploying Radius resources to a non-Azure target.
+	// This can be removed when we use extensibility for Radius.
+	RadiusResourceGroup string
+
+	Providers map[string]providers.Provider
 }
 
 var _ clients.DeploymentClient = (*LocalRPDeploymentClient)(nil)
@@ -106,10 +115,13 @@ func (dc *LocalRPDeploymentClient) deployTemplate(ctx context.Context, template 
 		progressChan = obj.(chan<- clients.ResourceProgress)
 	}
 
-	resources, err := armtemplate.Eval(template, armtemplate.TemplateOptions{
+	resources, err := armtemplate.Eval(ctx, template, armtemplate.TemplateOptions{
 		SubscriptionID:         dc.SubscriptionID,
 		ResourceGroup:          dc.ResourceGroup,
+		RadiusSubscriptionID:   dc.RadiusSubscriptionID,
+		RadiusResourceGroup:    dc.RadiusResourceGroup,
 		Parameters:             parameters,
+		Providers:              dc.Providers,
 		EvaluatePropertiesNode: false,
 	})
 	if err != nil {

--- a/pkg/kubernetes/controllers/bicep/deploymenttemplate_controller.go
+++ b/pkg/kubernetes/controllers/bicep/deploymenttemplate_controller.go
@@ -127,7 +127,7 @@ func (r *DeploymentTemplateReconciler) ApplyState(ctx context.Context, req ctrl.
 		ResourceGroup:  req.Namespace,
 		Parameters:     parameters,
 	}
-	resources, err := armtemplate.Eval(template, options)
+	resources, err := armtemplate.Eval(ctx, template, options)
 	if err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
This change adds more support for 'hybrid' dev environments where
compute resources are deployed to the dev cluster, and non-compute
resources are deployed to azure.

The main contributions here are:

- Implementing a few more commonly-used ARM expression functions
- Tricky-tricks for resource ID handling.

The most significant thing is that we need to paper over the differences
in Radius running locally vs in Azure at the resource ID level. The IDs
have different meanings depending on whether the resource is a Radius
type or not. This can be simple again when we start using ARM
extensibility E2E for Radius.

As an example we currently encode the K8s namespace as both the subscription ID and resource group when constructing IDs for radius types. This is a problem when the Azure subscription and resource group **also** have semantic meaning.
