### PR TITLE
artifact should contain only rad executable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,7 +97,9 @@ jobs:
         uses: actions/upload-artifact@master
         with:
           name: rad_cli_${{ matrix.target_os}}_${{ matrix.target_arch}}
-          path: ./dist/${{ matrix.target_os}}_${{ matrix.target_arch}}/release/
+          path: |
+            ./dist/${{ matrix.target_os}}_${{ matrix.target_arch}}/release/rad
+            ./dist/${{ matrix.target_os}}_${{ matrix.target_arch}}/release/rad.exe
           if-no-files-found: error
 
   # Logic here:


### PR DESCRIPTION
# Description

Uploaded build artifacts should contain only rad binary rather than all of the binaries in the release folder.

## Issue reference

https://github.com/project-radius/radius/issues/1730)



Please reference the issue this PR will close: #1730 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
