### PR TITLE
Fix lint build

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -54,7 +54,6 @@ jobs:
         with:
           node-version: '16'
           cache: 'npm'
-        run: npm install
       - name: Install autorest
         run: npm install -g autorest
       - name: Install mockgen


### PR DESCRIPTION
`npm install` is run in next step. Can't have uses and run in same step