### PR TITLE
Install controllers for Azure environments

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -165,7 +165,7 @@ jobs:
     name: Helm chart build
     needs: ['images']
     runs-on: self-hosted
-    if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/pull/')
+    if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/pull/') || (github.ref == 'refs/heads/main')
     env:
       ARTIFACT_DIR: ./dist/Charts
       HELM_PACKAGE_DIR: helm

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,6 +155,16 @@ stages:
             --configpath ~/.rad/config.yaml \
             --image ${{ variables.DOCKER_REGISTRY }}/radius-rp:${{ variables.REL_VERSION }} \
             --check-version ${{ variables.REL_VERSION }}
+      displayName: update RP to match PR
+    - script: |
+        helm upgrade radius \
+          ${{ variables.RADIUS_CHART_LOCATION }} \
+          --install \
+          --create-namespace \
+          --namespace radius-system \
+          --set tag=${{ variables.REL_VERSION }} \
+          --wait
+      displayName: update runtime to match PR
     - script: |
         export PATH=$(Build.SourcesDirectory)/dist:$PATH
         cd $(Build.SourcesDirectory)

--- a/deploy/rp-full.input.json
+++ b/deploy/rp-full.input.json
@@ -41,6 +41,13 @@
                 "description": "The container image to deploy."
             }
         },
+        "imageTag": {
+            "type": "string",
+            "defaultValue": "[if(equals(parameters('channel'), 'edge'), 'latest', parameters('channel'))]",
+            "metadata": {
+                "description": "The container image tag to deploy."
+            }
+        },
         "siteName": {
             "type": "string",
             "defaultValue": "[concat('radius-rp-', uniqueString(subscription().id, parameters('controlPlaneResourceGroup')))]",
@@ -74,6 +81,13 @@
             "defaultValue": "radius-rp-db",
             "metadata": {
                 "description": "The database name."
+            }
+        },
+        "chartVersion": {
+            "type": "string",
+            "defaultValue": "[if(equals(parameters('channel'), 'edge'), '0.42.42-dev', format('~{0}.0', parameters('channel')))]",
+            "metadata": {
+                "description": "The helm chart version."
             }
         },
         "clusterName": {
@@ -156,6 +170,9 @@
                     "clusterName": {
                         "value": "[parameters('clusterName')]"
                     },
+                    "chartVersion": {
+                        "value": "[parameters('chartVersion')]"
+                    },
                     "controlPlaneResourceGroup": {
                         "value": "[parameters('controlPlaneResourceGroup')]"
                     },
@@ -167,6 +184,9 @@
                     },
                     "image": {
                         "value": "[parameters('image')]"
+                    },
+                    "imageTag": {
+                        "value": "[parameters('imageTag')]"
                     },
                     "registryId": {
                         "value": "[parameters('registryId')]"
@@ -200,6 +220,9 @@
                         "accountName": {
                             "type": "string"
                         },
+                        "chartVersion": {
+                            "type": "string"
+                        },
                         "clusterName": {
                             "type": "string"
                         },
@@ -213,6 +236,9 @@
                             "type": "string"
                         },
                         "image": {
+                            "type": "string"
+                        },
+                        "imageTag": {
                             "type": "string"
                         },
                         "registryId": {
@@ -425,7 +451,7 @@
                             "properties": {
                                 "forceUpdateTag": 1,
                                 "azCliVersion": "2.0.80",
-                                "arguments": "[concat('\"', resourceGroup().name, '\" \"', parameters('clusterName'), '\"')]",
+                                "arguments": "[concat('\"', resourceGroup().name, '\" \"', parameters('clusterName'), '\" \"', parameters('chartVersion'),'\" \"', parameters('imageTag'), '\"')]",
                                 "primaryScriptUri": "[parameters('_scriptUri')]",
                                 "supportingScriptUris": [],
                                 "timeout": "PT30M",

--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -29,6 +29,13 @@
             },
             "type": "string"
         },
+        "chartVersion": {
+            "defaultValue": "[if(equals(parameters('channel'), 'edge'), '0.42.42-dev', format('~{0}.0', parameters('channel')))]",
+            "metadata": {
+                "description": "The helm chart version."
+            },
+            "type": "string"
+        },
         "clusterName": {
             "defaultValue": "[concat('radius-aks-', uniqueString(subscription().id, parameters('controlPlaneResourceGroup')))]",
             "metadata": {
@@ -60,6 +67,13 @@
             "defaultValue": "[format('radius.azurecr.io/radius-rp:{0}', if(equals(parameters('channel'), 'edge'), 'latest', parameters('channel')))]",
             "metadata": {
                 "description": "The container image to deploy."
+            },
+            "type": "string"
+        },
+        "imageTag": {
+            "defaultValue": "[if(equals(parameters('channel'), 'edge'), 'latest', parameters('channel'))]",
+            "metadata": {
+                "description": "The container image tag to deploy."
             },
             "type": "string"
         },
@@ -152,6 +166,9 @@
                     "accountName": {
                         "value": "[parameters('accountName')]"
                     },
+                    "chartVersion": {
+                        "value": "[parameters('chartVersion')]"
+                    },
                     "clusterName": {
                         "value": "[parameters('clusterName')]"
                     },
@@ -166,6 +183,9 @@
                     },
                     "image": {
                         "value": "[parameters('image')]"
+                    },
+                    "imageTag": {
+                        "value": "[parameters('imageTag')]"
                     },
                     "logAnalyticsWorkspaceID": {
                         "value": "[parameters('logAnalyticsWorkspaceID')]"
@@ -199,6 +219,9 @@
                         "accountName": {
                             "type": "string"
                         },
+                        "chartVersion": {
+                            "type": "string"
+                        },
                         "clusterName": {
                             "type": "string"
                         },
@@ -212,6 +235,9 @@
                             "type": "string"
                         },
                         "image": {
+                            "type": "string"
+                        },
+                        "imageTag": {
                             "type": "string"
                         },
                         "logAnalyticsWorkspaceID": {
@@ -409,7 +435,7 @@
                             "location": "[resourceGroup().location]",
                             "name": "deploy-radius-runtime",
                             "properties": {
-                                "arguments": "[concat('\"', resourceGroup().name, '\" \"', parameters('clusterName'), '\"')]",
+                                "arguments": "[concat('\"', resourceGroup().name, '\" \"', parameters('clusterName'), '\" \"', parameters('chartVersion'),'\" \"', parameters('imageTag'), '\"')]",
                                 "azCliVersion": "2.0.80",
                                 "cleanupPreference": "OnSuccess",
                                 "forceUpdateTag": 1,


### PR DESCRIPTION
Part of: radius-project/core-team#542

This change installs the Radius helm chart in Azure environments. We'll
be adding runtime functionality to this chart, and in order to take a
dependency on it we need it to exist in all of our environments.

Parts of this change:

- Produce an 'edge' build on pushes to main (0.42.42-dev)
- Install our chart as part of the environment creation script
- Update the AKS cluster as part of functional tests
