### PR TITLE
ignore pod expiration error for watch in functional tests

### DIFF
--- a/test/validation/k8s.go
+++ b/test/validation/k8s.go
@@ -551,7 +551,11 @@ func (pm PodMonitor) ValidateRunning(ctx context.Context, t *testing.T) {
 				if event.Type == watchk8s.Error {
 					status, ok := event.Object.(*metav1.Status)
 					if ok {
-						t.Errorf("pod watch error with status reason: %s, message: %s", status.Reason, status.Message)
+						if status.Reason == "Expired" {
+							t.Logf("skipped pod watch expiration error: %s", status.Message)
+						} else {
+							t.Errorf("pod watch error with status reason: %s, message: %s", status.Reason, status.Message)
+						}
 					}
 				}
 				require.IsTypef(t, &corev1.Pod{}, event.Object, "object %T is not a pod", event.Object)


### PR DESCRIPTION
# Description

Some tests are failing on flaky test with k8s watch: too old resource version. Skipping these errors since it seems to not be an issue that should fail a test.

## Issue reference

Please reference the issue this PR will close: #_1848_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
