### PR TITLE
Add debug to helm install for more output

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,7 +160,8 @@ stages:
           --create-namespace \
           --namespace radius-system \
           --set tag=${{ variables.REL_VERSION }} \
-          --wait
+          --wait \
+          --debug
       displayName: update runtime to match PR
     - script: |
         export PATH=$(Build.SourcesDirectory)/dist:$PATH


### PR DESCRIPTION
This tasks has failed in some of our PR builds. Adding `--debug` should
produce more output for us to analyze.
