### PR TITLE
Small improvements to integration tests for k8s

### DIFF
--- a/test/integration/kubernetes/frontend-backend_test.go
+++ b/test/integration/kubernetes/frontend-backend_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	err := kubernetestest.StartController()
+	_, err := kubernetestest.StartController()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The change adds a few incremental improvements to how we do integration
tests for kubernetes.

In this changeset:

- Expose the options/clients when starting the server
- Add graceful shutdown of controller manager
- Remove dependency on fixed directory path

To explain the last one ... We need to use `TestMain` to start/stop the
test infrastructure surrounding these integration tests. `TestMain`
needs to exist in **the same file** as the tests, which is very
limiting. The solution is to create a package per-controller or whatever
other granularity you want.

However the test infra currently has a requirement about how many
directories are in its hiearchy, so adding more subpackages makes it
stop functioning. The solution is to make the infra more flexible, which
is what I changed.
