### PR TITLE
Docs showing how to run the deployment engine locally

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,3 @@
 
 # Default rule: anything that doesn't match a more specific rule goes here
 * @project-radius/Radius-Eng
-
-# Docs rule: any PR that touches docs goes here
-/docs/ @project-radius/Radius-PM

--- a/docs/contributing/contributing-code/contributing-code-azure/testing-locally.md
+++ b/docs/contributing/contributing-code/contributing-code-azure/testing-locally.md
@@ -63,6 +63,8 @@ environment:
 
 Now you can run `rad env switch local` and use this environment just like you'd use any other.
 
+**TEMPORARY:** due to limitations in our parsing code for deployment templates, you will need to set the environment variable: `BICEP_SYMBOLIC_NAME_CODEGEN_EXPERIMENTAL` to `false` to avoid errors when deploying to the local environment. This will be fixed in a future release when we move our ARM deployment processing to the real Deployment Engine rather than using our own parsing code.
+
 ## Known Limitations
 
 Since we're simulating the role of centralized ARM features like deployment templates there are some inherent limitations.

--- a/docs/contributing/contributing-code/contributing-code-azure/testing-locally.md
+++ b/docs/contributing/contributing-code/contributing-code-azure/testing-locally.md
@@ -63,11 +63,6 @@ environment:
 
 Now you can run `rad env switch local` and use this environment just like you'd use any other.
 
-**TEMPORARY:** due to limitations in our parsing code for deployment templates, you will need to set the environment variable: `BICEP_SYMBOLIC_NAME_CODEGEN_EXPERIMENTAL` to `false` to avoid errors when deploying to the local environment. This will be fixed in a future release when we move our ARM deployment processing to the real Deployment Engine rather than using our own parsing code.
-
-## Known Limitations
-
-Since we're simulating the role of centralized ARM features like deployment templates there are some inherent limitations.
-
-- Deploying Azure resources with `.bicep` is not supported
-- Using `.bicep` constructs like parameters and variables is not supported
+To run a local RP deployment, a Deployment Engine will run either:
+- Automatically on a random port for the duration of the deployment
+- Specifying a URL that the Deployment Engine will connect to with `apideploymentenginebaseurl` in the localrp environment section.

--- a/docs/contributing/contributing-code/contributing-code-k8s/running-functional.md
+++ b/docs/contributing/contributing-code/contributing-code-k8s/running-functional.md
@@ -40,11 +40,6 @@ The tests use our product functionality (the Radius config file) to configure th
 
 1. Place `rad` on your path.
 1. Make sure `rad-bicep` is downloaded (`rad bicep download`).
-1. Install dapr into the cluster by running
-
-   ```sh
-   dapr init -k --wait
-   ```
 
 1. Run:
 
@@ -60,14 +55,25 @@ You can also run/debug individual tests from VSCode.
 
 Instead of building and installing the Radius Kubernetes controller, you can run the controller locally as a standalone process and have it interact with the cluster accordingly.
 
-Prior to this, you will need to clone the Deployment Engine repo: https://github.com/project-radius/deployment-engine. This will Require installing .NET 6.0.
+Prior to this, you will need to run the Deployment Engine. You may either:
+- Clone the deployment engine repo https://github.com/project-radius/deployment-engine. This will require installing .NET 6.0 and executing:
+    
+    ```bash
+    cd deployment-engine # navigate to the repo
+    dotnet run --project src/DeploymentEngine/DeploymentEngine.csproj
+    ```
+- Run the deployment engine by downloading the binary via testenv:
+    
+    ```bash
+    go run cmd/testenv/main.go de download
+    ~/.rad/bin/arm-de
+    ```
 
 1. Create a Kubernetes cluster (KinD, AKS, etc.).
 1. Add CRDs to the cluster with `make controller-install`.
 1. Place `rad` on your path.
 1. Make sure `rad-bicep` is downloaded (`rad bicep download`).
-1. Install dapr into the cluster by running `dapr init -k --wait`.
-1. Add overrides to the `rad` environment to point to the local API server running AND the deployment engine. The API server is running on http://localhost:7443 by default and the deployment engine is running on https://localhost:7194 by default.
+1. Add overrides to the `rad` environment to point to the local API server running AND the deployment engine. The API server is running on http://localhost:7443 by default and the deployment engine is running on https://localhost:5001 or https://localhost:7194 by default.
 
 ```
 environment:
@@ -80,11 +86,7 @@ environment:
       apiserverbaseurl: http://localhost:7443
       apideploymentenginebaseurl: https://localhost:7194
 ```
-1. Run the Deployment Engine locally by navigating to the deployment engine repo:
-```bash
-cd deployment-engine # navigate to the repo
-dotnet run --project src/DeploymentEngine/DeploymentEngine.csproj
-```
+
 
 1. Set the environment variables `SKIP_APISERVICE_TLS` and `SKIP_WEBHOOKS` to `true` to skip TLS validation and skip webhooks (or in VSCode).
 1. Run the controller locally on command line or VSCode (cmd/radius-controller/main.go).

--- a/docs/contributing/contributing-code/contributing-code-k8s/running-functional.md
+++ b/docs/contributing/contributing-code/contributing-code-k8s/running-functional.md
@@ -60,12 +60,14 @@ You can also run/debug individual tests from VSCode.
 
 Instead of building and installing the Radius Kubernetes controller, you can run the controller locally as a standalone process and have it interact with the cluster accordingly.
 
+Prior to this, you will need to clone the Deployment Engine repo: https://github.com/project-radius/deployment-engine. This will Require installing .NET 6.0.
+
 1. Create a Kubernetes cluster (KinD, AKS, etc.).
 1. Add CRDs to the cluster with `make controller-install`.
 1. Place `rad` on your path.
 1. Make sure `rad-bicep` is downloaded (`rad bicep download`).
 1. Install dapr into the cluster by running `dapr init -k --wait`.
-1. Add an override to the `rad` environment to point to the local API server running. The API server is running on http://localhost:7443 by default.
+1. Add overrides to the `rad` environment to point to the local API server running AND the deployment engine. The API server is running on http://localhost:7443 by default and the deployment engine is running on https://localhost:7194 by default.
 
 ```
 environment:
@@ -76,7 +78,14 @@ environment:
       kind: kubernetes
       namespace: default
       apiserverbaseurl: http://localhost:7443
+      apideploymentenginebaseurl: https://localhost:7194
 ```
+1. Run the Deployment Engine locally by navigating to the deployment engine repo:
+```bash
+cd deployment-engine # navigate to the repo
+dotnet run --project src/DeploymentEngine/DeploymentEngine.csproj
+```
+
 1. Set the environment variables `SKIP_APISERVICE_TLS` and `SKIP_WEBHOOKS` to `true` to skip TLS validation and skip webhooks (or in VSCode).
 1. Run the controller locally on command line or VSCode (cmd/radius-controller/main.go).
 1. Run `make test-functional-kubernetes`

--- a/docs/contributing/contributing-code/contributing-code-k8s/running-functional.md
+++ b/docs/contributing/contributing-code/contributing-code-k8s/running-functional.md
@@ -55,37 +55,36 @@ You can also run/debug individual tests from VSCode.
 
 Instead of building and installing the Radius Kubernetes controller, you can run the controller locally as a standalone process and have it interact with the cluster accordingly.
 
-Prior to this, you will need to run the Deployment Engine. You may either:
-- Clone the deployment engine repo https://github.com/project-radius/deployment-engine. This will require installing .NET 6.0 and executing:
-    
-    ```bash
-    cd deployment-engine # navigate to the repo
-    dotnet run --project src/DeploymentEngine/DeploymentEngine.csproj
-    ```
-- Run the deployment engine by downloading the binary via testenv:
-    
-    ```bash
-    go run cmd/testenv/main.go de download
-    ~/.rad/bin/arm-de
-    ```
-
+1. Prior to this, you will need to run the Deployment Engine. You may either:
+    - Clone the deployment engine repo https://github.com/project-radius/deployment-engine. This will require installing .NET 6.0 and executing:
+        
+        ```bash
+        cd deployment-engine # navigate to the repo
+        dotnet run --project src/DeploymentEngine/DeploymentEngine.csproj
+        ```
+    - Run the deployment engine by downloading the binary via testenv:
+        
+        ```bash
+        go run cmd/testenv/main.go de download
+        ~/.rad/bin/arm-de
+        ```
 1. Create a Kubernetes cluster (KinD, AKS, etc.).
 1. Add CRDs to the cluster with `make controller-install`.
 1. Place `rad` on your path.
 1. Make sure `rad-bicep` is downloaded (`rad bicep download`).
-1. Add overrides to the `rad` environment to point to the local API server running AND the deployment engine. The API server is running on http://localhost:7443 by default and the deployment engine is running on https://localhost:5001 or https://localhost:7194 by default.
+1. Add overrides to the `rad` environment to point to the local API server running and the Deployment Engine. The API server is running on http://localhost:7443 by default and the deployment engine is running on https://localhost:5001 or https://localhost:7194 by default.
 
-```
-environment:
-  default: justin-dev
-  items:
-    justin-dev:
-      context: justin-dev
-      kind: kubernetes
-      namespace: default
-      apiserverbaseurl: http://localhost:7443
-      apideploymentenginebaseurl: https://localhost:7194
-```
+    ```yaml
+    environment:
+    default: justin-dev
+    items:
+        justin-dev:
+        context: justin-dev
+        kind: kubernetes
+        namespace: default
+        apiserverbaseurl: http://localhost:7443
+        apideploymentenginebaseurl: https://localhost:7194
+    ```
 
 
 1. Set the environment variables `SKIP_APISERVICE_TLS` and `SKIP_WEBHOOKS` to `true` to skip TLS validation and skip webhooks (or in VSCode).


### PR DESCRIPTION
Adds docs for debugging with the deployment engine locally based off fallout from the debugging scenario.

