### PR TITLE
removed version setting in cobra root that enables rad -v

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -15,7 +15,7 @@ assignees: ''
 **OS/rad version**
 <!--What operating system and rad cli version are you running?-->
 
-<!-- PASTE OUTPUT OF rad --version -->
+<!-- PASTE OUTPUT OF rad version -->
 
 **Screenshots**
 <!--If applicable, add screenshots to help explain your problem-->

--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -6,7 +6,6 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -66,12 +65,6 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
-
-	// Initialize support for --version
-	RootCmd.Version = "foo" // needs to be set to non-empty string, actual version is set via SetVersionTemplate()
-	buf := new(bytes.Buffer)
-	writeVersionString(output.FormatList, buf)
-	RootCmd.SetVersionTemplate(buf.String())
 
 	RootCmd.PersistentFlags().StringVar(&configHolder.ConfigFilePath, "config", "", "config file (default \"$HOME/.rad/config.yaml\")")
 


### PR DESCRIPTION
# Description

Removed -v and --version flags from rad cli since we have rad version.

## Issue reference

Please reference the issue this PR will close: #1570

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
