### PR TITLE
Propagate rendering failures

### DIFF
--- a/pkg/renderers/dapr/decorator.go
+++ b/pkg/renderers/dapr/decorator.go
@@ -60,12 +60,12 @@ func (r *Renderer) Render(ctx context.Context, options renderers.RenderOptions) 
 	dependencies := options.Dependencies
 	output, err := r.Inner.Render(ctx, renderers.RenderOptions{Resource: resource, Dependencies: dependencies})
 	if err != nil {
-		return renderers.RendererOutput{}, nil
+		return renderers.RendererOutput{}, err
 	}
 
 	trait, err := r.FindTrait(resource)
 	if err != nil {
-		return renderers.RendererOutput{}, nil
+		return renderers.RendererOutput{}, err
 	}
 
 	if trait == nil {

--- a/pkg/renderers/manualscalev1alpha3/decorator.go
+++ b/pkg/renderers/manualscalev1alpha3/decorator.go
@@ -33,14 +33,14 @@ func (r *Renderer) Render(ctx context.Context, options renderers.RenderOptions) 
 	// Let the inner renderer do its work
 	output, err := r.Inner.Render(ctx, options)
 	if err != nil {
-		return renderers.RendererOutput{}, nil
+		return renderers.RendererOutput{}, err
 	}
 	resource := options.Resource
 
 	container := radclient.ContainerProperties{}
 	err = resource.ConvertDefinition(&container)
 	if err != nil {
-		return renderers.RendererOutput{}, nil
+		return renderers.RendererOutput{}, err
 	}
 
 	for _, t := range container.Traits {


### PR DESCRIPTION
These renderers fail to propagate errors returned by the inner renderer.
The result is that errors are silenced that should be returned to the
user.

I found this bug will doing some prototyping for functions integration. The result of this is that it silences errors that occur during rendering resulting in an "empty" output and nothing deployed.