### PR TITLE
Fix small bug in rad resource show for Azure connections

### DIFF
--- a/pkg/cli/clivalidation.go
+++ b/pkg/cli/clivalidation.go
@@ -116,8 +116,8 @@ func RequireAzureResource(cmd *cobra.Command, args []string) (azureResource Azur
 		return AzureResource{}, err
 	}
 	return AzureResource{
-		Name:           results[0],
-		ResourceType:   results[1],
+		ResourceType:   results[0],
+		Name:           results[1],
 		ResourceGroup:  results[2],
 		SubscriptionID: results[3],
 	}, nil


### PR DESCRIPTION
# Description

Resource type and name were swapped while reading the input arguments.

Tested locally
```% go run cmd/rad/main.go resource show -t Microsoft.DocumentDB/databaseAccounts -r dbacc-a091ddbd-331c-5233-b0c0-00f5759a77eb -g kachawla-3 -s 66d1209e-1382-45d3-99bb-650e6bf63fc0
RESOURCE                                    TYPE                                   PROVISIONING_STATE  HEALTH_STATE
dbacc-a091ddbd-331c-5233-b0c0-00f5759a77eb  Microsoft.DocumentDB/databaseAccounts                      
```

```
 % go run cmd/rad/main.go resource show -t Microsoft.DocumentDB/databaseAccounts -r dbacc-a091ddbd-331c-5233-b0c0-00f5759a77eb -g kachawla-3 -s 66d1209e-1382-45d3-99bb-650e6bf63fc0 -o json
{
  "id": "/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourceGroups/kachawla-3/providers/Microsoft.DocumentDB/databaseAccounts/dbacc-a091ddbd-331c-5233-b0c0-00f5759a77eb",
  "name": "dbacc-a091ddbd-331c-5233-b0c0-00f5759a77eb",
  "properties": {
    "applicationResourceGroup": "kachawla-3",
    "applicationSubscriptionID": "66d1209e-1382-45d3-99bb-650e6bf63fc0",
    "resourceGroup": "kachawla-3",
    "subscriptionID": "66d1209e-1382-45d3-99bb-650e6bf63fc0"
  },
  "type": "Microsoft.DocumentDB/databaseAccounts"
}
```

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
