### PR TITLE
updated rad env delete to delete k8s environment and resources

### DIFF
--- a/cmd/rad/cmd/envDelete.go
+++ b/cmd/rad/cmd/envDelete.go
@@ -121,7 +121,7 @@ func deleteEnv(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		if err = deleteAllApplications(cmd.Context(), kub); err != nil {
+		if err = runEnvUninstallKubernetes(); err != nil {
 			return err
 		}
 	}

--- a/cmd/rad/cmd/envUninstallKubernetes.go
+++ b/cmd/rad/cmd/envUninstallKubernetes.go
@@ -27,6 +27,10 @@ func init() {
 }
 
 func envUninstallKubernetes(cmd *cobra.Command, args []string) error {
+	return runEnvUninstallKubernetes()
+}
+
+func runEnvUninstallKubernetes() error {
 	err := kubectl.RunCLICommandSilent("delete", "gatewayclasses", "haproxy", "--ignore-not-found", "true")
 
 	if err != nil {


### PR DESCRIPTION
# Description

Changed rad env delete to copy behavior of env uninstall for k8s, fixing issue with crashing radius controller.

## Issue reference

Please reference the issue this PR will close: #_1990_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
