### PR TITLE
Dapr not found does not cause rad env uninstall kubernetes to fail

### DIFF
--- a/pkg/cli/helm/daprclient.go
+++ b/pkg/cli/helm/daprclient.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	daprReleaseName = "dapr"
-	daprHelmRepo    = "https://dapr.github.io/helm-charts/"
+	daprReleaseName   = "dapr"
+	daprHelmRepo      = "https://dapr.github.io/helm-charts/"
+	daprNotFoundError = "uninstall: Release not loaded: dapr: release: not found"
 )
 
 func ApplyDaprHelmChart(version string) error {
@@ -74,5 +75,9 @@ func RunDaprHelmUninstall(helmConf *helm.Configuration) error {
 	uninstallClient.Timeout = timeout
 	uninstallClient.Wait = true
 	_, err := uninstallClient.Run(daprReleaseName)
+	if err.Error() == daprNotFoundError {
+		output.LogInfo("Dapr not found")
+		return nil
+	}
 	return err
 }

--- a/pkg/cli/helm/daprclient.go
+++ b/pkg/cli/helm/daprclient.go
@@ -7,6 +7,7 @@ package helm
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -49,7 +50,7 @@ func ApplyDaprHelmChart(version string) error {
 	// The upgrade client's install option doesn't seem to work, so we have to check the history of releases manually
 	// and invoke the install client.
 	_, err = histClient.Run(daprReleaseName)
-	if err == driver.ErrReleaseNotFound {
+	if errors.Is(err, driver.ErrReleaseNotFound) {
 
 		err = runDaprHelmInstall(helmConf, helmChart)
 		if err != nil {
@@ -75,7 +76,7 @@ func RunDaprHelmUninstall(helmConf *helm.Configuration) error {
 	uninstallClient.Timeout = timeout
 	uninstallClient.Wait = true
 	_, err := uninstallClient.Run(daprReleaseName)
-	if err.Error() == daprNotFoundError {
+	if errors.Is(err, driver.ErrReleaseNotFound) {
 		output.LogInfo("Dapr not found")
 		return nil
 	}

--- a/pkg/cli/helm/daprclient.go
+++ b/pkg/cli/helm/daprclient.go
@@ -18,9 +18,8 @@ import (
 )
 
 const (
-	daprReleaseName   = "dapr"
-	daprHelmRepo      = "https://dapr.github.io/helm-charts/"
-	daprNotFoundError = "uninstall: Release not loaded: dapr: release: not found"
+	daprReleaseName = "dapr"
+	daprHelmRepo    = "https://dapr.github.io/helm-charts/"
 )
 
 func ApplyDaprHelmChart(version string) error {

--- a/pkg/cli/helm/haproxyclient.go
+++ b/pkg/cli/helm/haproxyclient.go
@@ -7,6 +7,7 @@ package helm
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -60,7 +61,7 @@ func ApplyHAProxyHelmChart(version string, options HAProxyOptions) error {
 	// The upgrade client's install option doesn't seem to work, so we have to check the history of releases manually
 	// and invoke the install client.
 	_, err = histClient.Run(haproxyReleaseName)
-	if err == driver.ErrReleaseNotFound {
+	if errors.Is(err, driver.ErrReleaseNotFound) {
 
 		err = runHAProxyHelmInstall(helmConf, helmChart)
 		if err != nil {

--- a/pkg/cli/helm/haproxyclient.go
+++ b/pkg/cli/helm/haproxyclient.go
@@ -107,5 +107,9 @@ func RunHAProxyHelmUninstall(helmConf *helm.Configuration) error {
 	uninstallClient.Timeout = timeout
 	uninstallClient.Wait = true
 	_, err := uninstallClient.Run(haproxyReleaseName)
+	if errors.Is(err, driver.ErrReleaseNotFound) {
+		output.LogInfo("HAProxy Ingress not found")
+		return nil
+	}
 	return err
 }

--- a/pkg/cli/helm/radiusclient.go
+++ b/pkg/cli/helm/radiusclient.go
@@ -7,6 +7,7 @@ package helm
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -62,7 +63,7 @@ func ApplyRadiusHelmChart(chartPath string, chartVersion string, containerImage 
 	// The upgrade client's install option doesn't seem to work, so we have to check the history of releases manually
 	// and invoke the install client.
 	_, err = histClient.Run(radiusReleaseName)
-	if err == driver.ErrReleaseNotFound {
+	if errors.Is(err, driver.ErrReleaseNotFound) {
 		output.LogInfo("Installing new Radius Kubernetes environment to namespace: %s", RadiusSystemNamespace)
 
 		err = runRadiusHelmInstall(helmConf, helmChart)

--- a/pkg/cli/helm/radiusclient.go
+++ b/pkg/cli/helm/radiusclient.go
@@ -118,5 +118,9 @@ func RunRadiusHelmUninstall(helmConf *helm.Configuration) error {
 	uninstallClient.Timeout = timeout
 	uninstallClient.Wait = true
 	_, err := uninstallClient.Run(radiusReleaseName)
+	if errors.Is(err, driver.ErrReleaseNotFound) {
+		output.LogInfo("Radius not found")
+		return nil
+	}
 	return err
 }


### PR DESCRIPTION
# Description

dapr uninstall ignores dapr not found error, allowing env uninstall to continue

## Issue reference

Please reference the issue this PR will close: #_1982_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
