### PR TITLE
Add radius RP and database to chart

### DIFF
--- a/deploy/Chart/charts/radius/templates/radius_db.yaml
+++ b/deploy/Chart/charts/radius/templates/radius_db.yaml
@@ -1,0 +1,134 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: radius-db
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: radius-db
+spec:
+  replicas: 1
+  serviceName: radius-db
+  selector:
+    matchLabels:
+      app: radius-db
+  template:
+    metadata:
+      labels:
+        app: radius-db
+    spec:
+      serviceAccountName: radius-db
+      automountServiceAccountToken: true
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: mongo
+        image: mongo:5
+        command:
+        - "mongod"
+        - "--replSet=radius-db"
+        - "--bind_ip_all"
+        env:
+        - name: MONGO_INITDB_DATABASE
+          value: rpdb
+        - name: MONGO_INITDB_ROOT_USERNAME
+          valueFrom: 
+            secretKeyRef: 
+              name: radius-db
+              key: adminUsername
+        - name: MONGO_INITDB_ROOT_PASSWORD
+          valueFrom: 
+            secretKeyRef: 
+              name: radius-db
+              key: adminPassword
+        resources:
+          requests:
+            cpu: 0.2
+            memory: 200Mi
+          limits:
+            cpu: 1.0
+            memory: 1Gi
+        ports:
+        - containerPort: 27017
+        volumeMounts:
+        - name: radius-db-storage-claim
+          mountPath: /data/db
+        securityContext:
+          allowPrivilegeEscalation: false
+      - name: replset-sidecar
+        image: cvallance/mongo-k8s-sidecar
+        env:
+        - name: MONGO_SIDECAR_POD_LABELS
+          value: "app=radius-db"
+        - name: KUBERNETES_MONGO_SERVICE_NAME
+          value: "radius-db"
+  volumeClaimTemplates:
+  - metadata:
+      name: radius-db-storage-claim
+      annotations:
+        volume.beta.kubernetes.io/storage-class: "standard"
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: radius-db
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: radius-db
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: radius-db
+subjects:
+- kind: ServiceAccount
+  name: radius-db
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: radius-db
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: radius-db
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: radius-db
+stringData:
+  adminUsername: mongoadmin
+  adminPassword: securepassword
+  connectionString: 'mongodb://radius-db:27017/rpdb?authSource=admin'
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: radius-db
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: radius-db
+spec:
+  clusterIP: None
+  ports:
+  - port: 27017
+    targetPort: 27017
+  selector:
+    app: radius-db

--- a/deploy/Chart/charts/radius/templates/radius_rp.yaml
+++ b/deploy/Chart/charts/radius/templates/radius_rp.yaml
@@ -1,0 +1,108 @@
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: radius-rp
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: radius-rp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: radius-rp
+  template:
+    metadata:
+      labels:
+        app: radius-rp
+    spec:
+      serviceAccountName: radius-rp
+      automountServiceAccountToken: true
+      containers:
+      - name: radius-rp
+        image: {{ .Values.global.rp.container }}:{{ .Values.global.rp.tag }}
+        env:
+        - name: PORT
+          value: '5000'
+        - name: SKIP_AUTH
+          value: 'true' # Requests are authorized by Kubernetes here.
+        - name: MONGODB_CONNECTION_STRING
+          valueFrom: 
+            secretKeyRef: 
+              name: radius-db # YES this is reading the connection string from the DB's secret
+              key: connectionString
+        - name: MONGODB_DATABASE
+          value: rpdb
+        - name: K8S_CLUSTER
+          value: 'true'
+        - name: SKIP_ARM
+          value: 'true' # Assume no ARM connection for now
+        - name: RADIUS_MODEL
+          value: k8s
+        resources:
+          requests:
+            cpu: 0.2
+            memory: 100Mi
+          limits:
+            cpu: 1.0
+            memory: 500Mi
+        ports:
+        - containerPort: 5000
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: radius-rp
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: radius-rp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: radius-rp
+subjects:
+- kind: ServiceAccount
+  name: radius-rp
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: radius-rp
+rules:
+- apiGroups:
+  - ""
+  - "apps"
+  - "dapr.io"
+  - "networking.k8s.io"
+  - "networking.x-k8s.io"
+  resources:
+  - "*"
+  verbs:
+  - "*"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: radius-rp
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: radius-rp
+stringData: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: radius-rp
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - port: 80
+    targetPort: 5000
+  selector:
+    app: radius-rp

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -8,3 +8,6 @@ global:
   radius:
     container: radius.azurecr.io/radius-controller
     tag: latest # Tag for radius-controller image.
+  rp:
+    container: radius.azurecr.io/radius-rp
+    tag: latest # Tag for radius-rp image.


### PR DESCRIPTION
Fixes: #2013

This change adds the RP and its database to our Helm deployments as part
of the overall pivot towards the RP as the unified implementation of the
control plane.

Note that we'll be getting rid of Mongo in short order. This is just the
first step.

# Description

_Please explain the changes you've made._

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
