### PR TITLE
Adding environment check to `rad env init kubernetes`

### DIFF
--- a/cmd/rad/cmd/envInitDev.go
+++ b/cmd/rad/cmd/envInitDev.go
@@ -69,7 +69,7 @@ func initDevRadEnvironment(cmd *cobra.Command, args []string) error {
 
 	_, foundConflict := env.Items[params.Name]
 	if foundConflict {
-		return fmt.Errorf("an environment named %s already exists. Use `rad env delete %s to delete or select a different name", params.Name, params.Name)
+		return fmt.Errorf("an environment named %s already exists. Use `rad env delete %s` to delete or select a different name", params.Name, params.Name)
 	}
 
 	// Create environment

--- a/cmd/rad/cmd/envInitKubernetes.go
+++ b/cmd/rad/cmd/envInitKubernetes.go
@@ -78,12 +78,27 @@ func installKubernetes(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	step := output.BeginStep("Installing Radius...")
+	config := ConfigFromContext(cmd.Context())
+	env, err := cli.ReadEnvironmentSection(config)
+	if err != nil {
+		return err
+	}
 
 	client, runtimeClient, contextName, err := createKubernetesClients("")
 	if err != nil {
 		return err
 	}
+
+	if environmentName == "" {
+		environmentName = contextName
+	}
+
+	_, foundConflict := env.Items[environmentName]
+	if foundConflict {
+		return fmt.Errorf("an environment named %s already exists. Use `rad env delete %s to delete or select a different name", environmentName, environmentName)
+	}
+
+	step := output.BeginStep("Installing Radius...")
 
 	err = installRadius(cmd.Context(), client, runtimeClient, namespace, chartPath, image, tag)
 	if err != nil {
@@ -101,17 +116,6 @@ func installKubernetes(cmd *cobra.Command, args []string) error {
 	}
 
 	output.CompleteStep(step)
-
-	config := ConfigFromContext(cmd.Context())
-
-	env, err := cli.ReadEnvironmentSection(config)
-	if err != nil {
-		return err
-	}
-
-	if environmentName == "" {
-		environmentName = contextName
-	}
 
 	env.Items[environmentName] = map[string]interface{}{
 		"kind":      environments.KindKubernetes,

--- a/cmd/rad/cmd/envInitKubernetes.go
+++ b/cmd/rad/cmd/envInitKubernetes.go
@@ -95,7 +95,7 @@ func installKubernetes(cmd *cobra.Command, args []string) error {
 
 	_, foundConflict := env.Items[environmentName]
 	if foundConflict {
-		return fmt.Errorf("an environment named %s already exists. Use `rad env delete %s to delete or select a different name", environmentName, environmentName)
+		return fmt.Errorf("an environment named %s already exists. Use `rad env delete %s` to delete or select a different name", environmentName, environmentName)
 	}
 
 	step := output.BeginStep("Installing Radius...")


### PR DESCRIPTION
# Description

* Added path for `rad env init kubernetes` to fail if there is already an environment with the current name
* added trailing backtick in `envInitDev.go`

## Issue reference radius-project/core-team#558 

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: radius-project/core-team#558 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
