### PR TITLE
Cleanup after removal of deployment script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -159,17 +159,6 @@ stages:
             --image ${{ variables.DOCKER_REGISTRY }}/radius-rp:${{ variables.REL_VERSION }} \
             --check-version ${{ variables.REL_VERSION }}
       displayName: update RP to match PR
-    # - script: |
-    #     helm upgrade radius \
-    #       ${{ variables.RADIUS_CHART_LOCATION }} \
-    #       --install \
-    #       --create-namespace \
-    #       --namespace radius-system \
-    #       --set container=${{ variables.DOCKER_REGISTRY }}/radius-controller \
-    #       --set tag=${{ variables.REL_VERSION }} \
-    #       --wait \
-    #       --debug
-    #   displayName: update runtime to match PR
     - script: |
         export PATH=$(Build.SourcesDirectory)/dist:$PATH
         cd $(Build.SourcesDirectory)


### PR DESCRIPTION
Fixes: #2010

We've moved this functionality to the CLI, so every test environment is
always created using that PR's bits. There's no need for this extra
update step anymore.
