### PR TITLE
Fixing some cases where we should return an err rather than nil

### DIFF
--- a/pkg/cli/azure/deploy.go
+++ b/pkg/cli/azure/deploy.go
@@ -104,7 +104,7 @@ func (dc *ARMDeploymentClient) createSummary(deployment resources.DeploymentExte
 
 		id, err := azresources.Parse(*resource.ID)
 		if err != nil {
-			return clients.DeploymentResult{}, nil
+			return clients.DeploymentResult{}, err
 		}
 
 		resources = append(resources, id)

--- a/pkg/cli/azure/deploy.go
+++ b/pkg/cli/azure/deploy.go
@@ -113,12 +113,12 @@ func (dc *ARMDeploymentClient) createSummary(deployment resources.DeploymentExte
 	outputs := map[string]clients.DeploymentOutput{}
 	b, err := json.Marshal(&deployment.Properties.Outputs)
 	if err != nil {
-		return clients.DeploymentResult{}, nil
+		return clients.DeploymentResult{}, err
 	}
 
 	err = json.Unmarshal(b, &outputs)
 	if err != nil {
-		return clients.DeploymentResult{}, nil
+		return clients.DeploymentResult{}, err
 	}
 
 	return clients.DeploymentResult{Resources: resources, Outputs: outputs}, nil


### PR DESCRIPTION
# Description

Found when investigating https://github.com/project-radius/deployment-engine/issues/49. We need to return errs in some places here.

I'd love to find some linter that handles this case, I searched for one and nothing quite handles it (probably because there are cases where you'd like to return nil, but still quite annoying).