### PR TITLE
fix sql server to have the fqdn and database just a name.

### DIFF
--- a/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
+++ b/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
@@ -2,7 +2,7 @@ var adminUsername = 'cooluser'
 var adminPassword = 'p@ssw0rd'
 
 resource app 'radius.dev/Application@v1alpha3' = {
-  name: 'kubernetes-resources-sql'
+  name: 'kubernetes-resourcessql'
 
   resource webapp 'Container' = {
     name: 'todoapp'
@@ -30,8 +30,8 @@ resource app 'radius.dev/Application@v1alpha3' = {
   resource db 'microsoft.com.SQLDatabase' = {
     name: 'db'
     properties: {
-      server: sqlContainer.name
-      database: sqlRoute.properties.url
+      server: sqlRoute.properties.url
+      database: sqlContainer.name
     }
   }
 

--- a/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
+++ b/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
@@ -2,7 +2,7 @@ var adminUsername = 'cooluser'
 var adminPassword = 'p@ssw0rd'
 
 resource app 'radius.dev/Application@v1alpha3' = {
-  name: 'kubernetes-resourcessql'
+  name: 'kubernetes-resources-sql'
 
   resource webapp 'Container' = {
     name: 'todoapp'

--- a/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
+++ b/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
@@ -51,7 +51,6 @@ resource app 'radius.dev/Application@v1alpha3' = {
           ACCEPT_EULA: 'Y'
           MSSQL_PID: 'Developer'
           MSSQL_SA_PASSWORD: adminPassword
-         
         }
         ports: {
           sql: {

--- a/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
+++ b/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
@@ -30,8 +30,8 @@ resource app 'radius.dev/Application@v1alpha3' = {
   resource db 'microsoft.com.SQLDatabase' = {
     name: 'db'
     properties: {
-      server: sqlRoute.properties.url
-      database: sqlContainer.name
+      server: sqlContainer.name
+      database: sqlRoute.properties.url
     }
   }
 

--- a/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
+++ b/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
@@ -16,7 +16,7 @@ resource app 'radius.dev/Application@v1alpha3' = {
       container: {
         image: 'radius.azurecr.io/magpiego:latest'
         env: {
-          CONNECTION_SQL_CONNECTIONSTRING: 'Data Source=tcp:${db.properties.server},1433;Initial Catalog=${db.properties.database};User Id=${adminUsername}@${db.properties.server};Password=${adminPassword};Encrypt=true'
+          CONNECTION_SQL_CONNECTIONSTRING: 'Data Source=tcp:${db.properties.server},1433;Initial Catalog=${db.properties.database};User Id=${adminUsername}@${db.properties.server};Password=${adminPassword};Encrypt=True;TrustServerCertificate=True'
         }
         readinessProbe:{
           kind:'httpGet'
@@ -30,6 +30,7 @@ resource app 'radius.dev/Application@v1alpha3' = {
   resource db 'microsoft.com.SQLDatabase' = {
     name: 'db'
     properties: {
+      
       server: sqlRoute.properties.host
       database: sqlContainer.name
     }
@@ -51,6 +52,7 @@ resource app 'radius.dev/Application@v1alpha3' = {
           ACCEPT_EULA: 'Y'
           MSSQL_PID: 'Developer'
           MSSQL_SA_PASSWORD: adminPassword
+         
         }
         ports: {
           sql: {

--- a/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
+++ b/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
@@ -18,6 +18,11 @@ resource app 'radius.dev/Application@v1alpha3' = {
         env: {
           CONNECTION_SQL_CONNECTIONSTRING: 'Data Source=tcp:${db.properties.server},1433;Initial Catalog=${db.properties.database};User Id=${adminUsername}@${db.properties.server};Password=${adminPassword};Encrypt=true'
         }
+        readinessProbe:{
+          kind:'httpGet'
+          containerPort:3000
+          path: '/healthz'
+        }
       }
     }
   }
@@ -25,8 +30,8 @@ resource app 'radius.dev/Application@v1alpha3' = {
   resource db 'microsoft.com.SQLDatabase' = {
     name: 'db'
     properties: {
-      server: sqlContainer.name
-      database: sqlRoute.properties.url
+      server: sqlRoute.properties.url
+      database: sqlContainer.name
     }
   }
 

--- a/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
+++ b/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
@@ -2,7 +2,7 @@ var adminUsername = 'cooluser'
 var adminPassword = 'p@ssw0rd'
 
 resource app 'radius.dev/Application@v1alpha3' = {
-  name: 'kubernetes-resources-sql'
+  name: 'kubernetes-resource-sql'
 
   resource webapp 'Container' = {
     name: 'todoapp'
@@ -30,7 +30,7 @@ resource app 'radius.dev/Application@v1alpha3' = {
   resource db 'microsoft.com.SQLDatabase' = {
     name: 'db'
     properties: {
-      server: sqlRoute.properties.url
+      server: sqlRoute.properties.host
       database: sqlContainer.name
     }
   }

--- a/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
+++ b/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
@@ -1,4 +1,4 @@
-var adminUsername = 'cooluser'
+var adminUsername = 'sa'
 var adminPassword = 'p@ssw0rd'
 
 resource app 'radius.dev/Application@v1alpha3' = {
@@ -16,7 +16,7 @@ resource app 'radius.dev/Application@v1alpha3' = {
       container: {
         image: 'radius.azurecr.io/magpiego:latest'
         env: {
-          CONNECTION_SQL_CONNECTIONSTRING: 'Data Source=tcp:${db.properties.server},1433;Initial Catalog=${db.properties.database};User Id=${adminUsername}@${db.properties.server};Password=${adminPassword};Encrypt=True;TrustServerCertificate=True'
+          CONNECTION_SQL_CONNECTIONSTRING: 'Data Source=tcp:${db.properties.server},1433;Initial Catalog=${db.properties.database};User Id=${adminUsername};Password=${adminPassword};Encrypt=True;TrustServerCertificate=True'
         }
         readinessProbe:{
           kind:'httpGet'
@@ -32,7 +32,7 @@ resource app 'radius.dev/Application@v1alpha3' = {
     properties: {
       
       server: sqlRoute.properties.host
-      database: sqlContainer.name
+      database: 'master'
     }
   }
 

--- a/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
+++ b/test/functional/kubernetes/resources/testdata/kubernetes-resources-sql.bicep
@@ -30,7 +30,6 @@ resource app 'radius.dev/Application@v1alpha3' = {
   resource db 'microsoft.com.SQLDatabase' = {
     name: 'db'
     properties: {
-      
       server: sqlRoute.properties.host
       database: 'master'
     }


### PR DESCRIPTION
# Description

The current sample bicep for sqlserver needs some fixes 
- server is now fqdn
- username is sa
- master as database
- connection string edited to use sa
- connection trusted to bypass certificate checks
- added readiness probe

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: radius-project/core-team#562

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
