### PR TITLE
Add AKS autoscaling for the node pool

### DIFF
--- a/deploy/rp-full.input.json
+++ b/deploy/rp-full.input.json
@@ -34,13 +34,6 @@
                 "description": "The container image to deploy."
             }
         },
-        "imageTag": {
-            "type": "string",
-            "defaultValue": "[if(equals(parameters('channel'), 'edge'), 'latest', parameters('channel'))]",
-            "metadata": {
-                "description": "The container image tag to deploy."
-            }
-        },
         "siteName": {
             "type": "string",
             "defaultValue": "[concat('radius-rp-', uniqueString(subscription().id, parameters('controlPlaneResourceGroup')))]",
@@ -155,9 +148,6 @@
                     "image": {
                         "value": "[parameters('image')]"
                     },
-                    "imageTag": {
-                        "value": "[parameters('imageTag')]"
-                    },
                     "registryId": {
                         "value": "[parameters('registryId')]"
                     },
@@ -197,9 +187,6 @@
                             "type": "string"
                         },
                         "image": {
-                            "type": "string"
-                        },
-                        "imageTag": {
                             "type": "string"
                         },
                         "registryId": {
@@ -315,11 +302,14 @@
                                 "agentPoolProfiles": [
                                     {
                                         "name": "agentpool",
-                                        "count": 1,
                                         "osDiskSizeGB": 0,
                                         "vmSize": "Standard_B2ms",
                                         "storageProfile": "ManagedDisks",
-                                        "mode": "System"
+                                        "mode": "System",
+                                        "enableAutoScaling": true,
+                                        "count": 1,
+                                        "minCount": 1,
+                                        "maxCount": 5
                                     }
                                 ],
                                 "enableRBAC": true,

--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -49,13 +49,6 @@
             },
             "type": "string"
         },
-        "imageTag": {
-            "defaultValue": "[if(equals(parameters('channel'), 'edge'), 'latest', parameters('channel'))]",
-            "metadata": {
-                "description": "The container image tag to deploy."
-            },
-            "type": "string"
-        },
         "location": {
             "metadata": {
                 "description": "Location for all resources."
@@ -154,9 +147,6 @@
                     "image": {
                         "value": "[parameters('image')]"
                     },
-                    "imageTag": {
-                        "value": "[parameters('imageTag')]"
-                    },
                     "logAnalyticsWorkspaceID": {
                         "value": "[parameters('logAnalyticsWorkspaceID')]"
                     },
@@ -196,9 +186,6 @@
                             "type": "string"
                         },
                         "image": {
-                            "type": "string"
-                        },
-                        "imageTag": {
                             "type": "string"
                         },
                         "logAnalyticsWorkspaceID": {
@@ -311,6 +298,9 @@
                                 "agentPoolProfiles": [
                                     {
                                         "count": 1,
+                                        "enableAutoScaling": true,
+                                        "maxCount": 5,
+                                        "minCount": 1,
                                         "mode": "System",
                                         "name": "agentpool",
                                         "osDiskSizeGB": 0,


### PR DESCRIPTION
Now that we're deploying the Radius control-plane on our kubernetes
cluster in Azure, we are seeing capacity problems causing test failures
due to pod limits.

This change adds autoscaling as part of the AKS configuration. We're
still creating AKS in a rather frugal configuration, but it will scale
up as needed while we run tests.
