### PR TITLE
Dynamic query for resources in K8s validation

### DIFF
--- a/test/azuretest/applicationtest.go
+++ b/test/azuretest/applicationtest.go
@@ -126,7 +126,7 @@ func (at ApplicationTest) Test(t *testing.T) {
 				// ValidateObjectsRunning triggers its own assertions, no need to handle errors
 				if step.Objects != nil {
 					t.Logf("validating creation of objects for %s", step.Executor.GetDescription())
-					validation.ValidateObjectsRunning(ctx, t, at.Options.K8sClient, *step.Objects)
+					validation.ValidateObjectsRunning(ctx, t, at.Options.K8sClient, at.Options.DynamicClient, *step.Objects)
 					t.Logf("finished creation of validating objects for %s", step.Executor.GetDescription())
 				}
 			}

--- a/test/azuretest/azuretest.go
+++ b/test/azuretest/azuretest.go
@@ -16,6 +16,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/environments"
 	"github.com/project-radius/radius/pkg/cli/kubernetes"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/dynamic"
 	k8s "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -43,6 +44,9 @@ func NewTestOptions(t *testing.T) TestOptions {
 	k8s, _, err := kubernetes.CreateTypedClient(k8sconfig.CurrentContext)
 	require.NoError(t, err, "failed to create kubernetes client")
 
+	dynamicClient, err := kubernetes.CreateDynamicClient(k8sconfig.CurrentContext)
+	require.NoError(t, err, "failed to create kubernetes dyamic client")
+
 	client, err := kubernetes.CreateRuntimeClient(k8sconfig.CurrentContext, kubernetes.Scheme)
 	require.NoError(t, err, "failed to create runtime client")
 
@@ -53,6 +57,7 @@ func NewTestOptions(t *testing.T) TestOptions {
 		Environment:    az,
 		K8sClient:      k8s,
 		Client:         client,
+		DynamicClient:  dynamicClient,
 	}
 }
 
@@ -63,4 +68,5 @@ type TestOptions struct {
 	Environment    *environments.AzureCloudEnvironment
 	K8sClient      *k8s.Clientset
 	Client         client.Client
+	DynamicClient  dynamic.Interface
 }

--- a/test/functional/azure/cli/appdeploy_test.go
+++ b/test/functional/azure/cli/appdeploy_test.go
@@ -42,7 +42,7 @@ func Test_AppDeploy_ScaffoldedApp(t *testing.T) {
 	t.Logf("done deploying %s with `rad app deploy`", application)
 
 	// Running for the side effect of making sure the pods are started.
-	validation.ValidateObjectsRunning(ctx, t, options.K8sClient, validation.K8sObjectSet{
+	validation.ValidateObjectsRunning(ctx, t, options.K8sClient, options.DynamicClient, validation.K8sObjectSet{
 		Namespaces: map[string][]validation.K8sObject{
 			application: {
 				validation.NewK8sPodForResource(application, "demo"),

--- a/test/functional/azure/cli/cli_test.go
+++ b/test/functional/azure/cli/cli_test.go
@@ -52,7 +52,7 @@ func Test_CLI(t *testing.T) {
 	t.Logf("finished deploying %s from file %s", application, template)
 
 	// Running for the side effect of making sure the pods are started.
-	validation.ValidateObjectsRunning(ctx, t, options.K8sClient, validation.K8sObjectSet{
+	validation.ValidateObjectsRunning(ctx, t, options.K8sClient, options.DynamicClient, validation.K8sObjectSet{
 		Namespaces: map[string][]validation.K8sObject{
 			application: {
 				validation.NewK8sPodForResource(application, "a"),
@@ -192,7 +192,7 @@ func Test_CLI_DeploymentParameters(t *testing.T) {
 	t.Logf("finished deploying %s from file %s", application, template)
 
 	// Running for the side effect of making sure the pods are started.
-	validation.ValidateObjectsRunning(ctx, t, options.K8sClient, validation.K8sObjectSet{
+	validation.ValidateObjectsRunning(ctx, t, options.K8sClient, options.DynamicClient, validation.K8sObjectSet{
 		Namespaces: map[string][]validation.K8sObject{
 			application: {
 				validation.NewK8sPodForResource(application, "a"),

--- a/test/functional/azure/environment/environment_test.go
+++ b/test/functional/azure/environment/environment_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/project-radius/radius/test/testcontext"
 	"github.com/project-radius/radius/test/validation"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestAzureEnvironment(t *testing.T) {
@@ -57,12 +58,72 @@ func TestAzureEnvironment(t *testing.T) {
 		expectedPods := validation.K8sObjectSet{
 			Namespaces: map[string][]validation.K8sObject{
 				"radius-system": {
-					validation.NewK8sPodForResource("app", "dapr-dashboard"),
-					validation.NewK8sPodForResource("app", "dapr-operator"),
-					validation.NewK8sPodForResource("app", "dapr-placement-server"),
-					validation.NewK8sPodForResource("app", "dapr-sentry"),
-					validation.NewK8sPodForResource("app", "dapr-sidecar-injector"),
-					validation.NewK8sPodForResource("app", "haproxy-ingress"),
+					validation.K8sObject{
+						GroupVersionResource: schema.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Kind: "Pod",
+						Labels: map[string]string{
+							"app": "dapr-dashboard",
+						},
+					},
+					validation.K8sObject{
+						GroupVersionResource: schema.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Kind: "Pod",
+						Labels: map[string]string{
+							"app": "dapr-operator",
+						},
+					},
+					validation.K8sObject{
+						GroupVersionResource: schema.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Kind: "Pod",
+						Labels: map[string]string{
+							"app": "dapr-placement-server",
+						},
+					},
+					validation.K8sObject{
+						GroupVersionResource: schema.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Kind: "Pod",
+						Labels: map[string]string{
+							"app": "dapr-sentry",
+						},
+					},
+					validation.K8sObject{
+						GroupVersionResource: schema.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Kind: "Pod",
+						Labels: map[string]string{
+							"app": "dapr-sidecar-injector",
+						},
+					},
+					validation.K8sObject{
+						GroupVersionResource: schema.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Kind: "Pod",
+						Labels: map[string]string{
+							"app.kubernetes.io/name": "haproxy-ingress",
+						},
+					},
 				},
 			},
 		}

--- a/test/functional/azure/environment/environment_test.go
+++ b/test/functional/azure/environment/environment_test.go
@@ -56,22 +56,18 @@ func TestAzureEnvironment(t *testing.T) {
 	t.Run("Validate Kubernetes Runtime", func(t *testing.T) {
 		expectedPods := validation.K8sObjectSet{
 			Namespaces: map[string][]validation.K8sObject{
-				// verify dapr
-				"dapr-system": {
+				"radius-system": {
 					validation.NewK8sPodForResource("app", "dapr-dashboard"),
 					validation.NewK8sPodForResource("app", "dapr-operator"),
 					validation.NewK8sPodForResource("app", "dapr-placement-server"),
 					validation.NewK8sPodForResource("app", "dapr-sentry"),
 					validation.NewK8sPodForResource("app", "dapr-sidecar-injector"),
-				},
-				// verify haproxy
-				"radius-system": {
 					validation.NewK8sPodForResource("app", "haproxy-ingress"),
 				},
 			},
 		}
 
-		validation.ValidateObjectsRunning(ctx, t, options.K8sClient, expectedPods)
+		validation.ValidateObjectsRunning(ctx, t, options.K8sClient, options.DynamicClient, expectedPods)
 	})
 }
 

--- a/test/kubernetestest/kubernetestest.go
+++ b/test/kubernetestest/kubernetestest.go
@@ -261,7 +261,7 @@ func (at ApplicationTest) Test(t *testing.T) {
 			} else {
 				if step.K8sObjects != nil {
 					t.Logf("validating creation of objects for %s", step.Executor.GetDescription())
-					validation.ValidateObjectsRunning(ctx, t, at.Options.K8sClient, *step.K8sObjects)
+					validation.ValidateObjectsRunning(ctx, t, at.Options.K8sClient, at.Options.DynamicClient, *step.K8sObjects)
 					t.Logf("finished creation of validating objects for %s", step.Executor.GetDescription())
 				}
 			}

--- a/test/validation/k8s.go
+++ b/test/validation/k8s.go
@@ -278,7 +278,6 @@ func ValidateObjectsRunning(ctx context.Context, t *testing.T, k8s *kubernetes.C
 			select {
 			case <-time.After(IntervalForResourceCreation):
 				for resourceGVR, expectedInNamespace := range namespaceTypes {
-					fmt.Printf("%s, %s", resourceGVR, expected)
 					r, err := restMapper.KindFor(resourceGVR)
 					assert.NoErrorf(t, err, "failed to get kind for %s", resourceGVR)
 
@@ -458,17 +457,6 @@ func matchesActualLabels(expectedResources []K8sObject, actualResources []unstru
 		if !resourceExists {
 			remaining = append(remaining, expectedResource)
 		}
-		// if err != nil {
-		// 	t.Logf("failed to find resource with %s", resource)
-		// 	newExpected = append(newExpected, resource)
-		// 	continue
-		// }
-
-		// if r.Kind != resource.Kind {
-		// 	t.Logf("Kind %s does not match resource %s", r.Kind, resource)
-		// 	newExpected = append(newExpected, resource)
-		// 	continue
-		// }
 	}
 	return remaining
 }

--- a/test/validation/k8s.go
+++ b/test/validation/k8s.go
@@ -292,7 +292,7 @@ func ValidateObjectsRunning(ctx context.Context, t *testing.T, k8s *kubernetes.C
 					}
 					assert.NoErrorf(t, err, "could not list deployed resources of type %s in namespace %s", resourceGVR.GroupResource(), namespace)
 
-					validated = matchesActualLabels(expectedInNamespace, deployedResources.Items)
+					validated = validated && matchesActualLabels(expectedInNamespace, deployedResources.Items)
 				}
 			case <-ctx.Done():
 				assert.Fail(t, "timed out after waiting for services to be created")
@@ -453,6 +453,10 @@ func matchesActualLabels(expectedResources []K8sObject, actualResources []unstru
 		if !resourceExists {
 			remaining = append(remaining, expectedResource)
 		}
+	}
+
+	for _, remainingResource := range remaining {
+		log.Printf("Failed to validate resource with of type %s with labels %s", remainingResource.GroupVersionResource.Resource, remainingResource.Labels)
 	}
 	return len(remaining) == 0
 }

--- a/test/validation/k8s.go
+++ b/test/validation/k8s.go
@@ -291,6 +291,8 @@ func ValidateObjectsRunning(ctx context.Context, t *testing.T, k8s *kubernetes.C
 					} else {
 						deployedResources, err = dynamic.Resource(mapping.Resource).List(ctx, metav1.ListOptions{})
 					}
+					assert.NoErrorf(t, err, "could not list deployed resources of type %s in namespace %s", resourceGVR.GroupResource(), namespace)
+
 					newExpected := matchesActualLabels(expectedInNamespace, deployedResources.Items)
 
 					if len(newExpected) > 0 {


### PR DESCRIPTION
# Description

Changed K8s validation to check for namespace and labels of resources, instead of just GVR/GVK mapping. This should avoid some false positive tests we may have been seeing.

## Issue reference

Please reference the issue this PR will close: #_1977_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
