### PR TITLE
Skip localdev integration tests except for PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -279,6 +279,7 @@ jobs:
     name: Run K3s Local Dev tests
     needs: [ 'build', 'images' ]
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/pull/') # Run on PR only
     env:
       # Timeout used for functional tests
       LOCALDEV_FUNCTIONALTEST_TIMEOUT: 20m


### PR DESCRIPTION
This change disables the local dev integration tests for tags and pushes
to main. We don't generally run tests in those cases since we run as
part of the PR.

This is causing failures right now when a push to main happens, and
using extra cycles. The failures are because the publish assets phase
cleans up the build artifacts before the tests start, leading to
failures with downloading the needed artifacts.
