### PR TITLE
Fix panic on resource conversion

### DIFF
--- a/pkg/kubernetes/apiserver/convert.go
+++ b/pkg/kubernetes/apiserver/convert.go
@@ -137,7 +137,7 @@ func NewRestRadiusResourceFromUnstructured(input unstructured.Unstructured) (res
 	if statusMap, ok := m["status"]; ok {
 		// Check if there any resources
 		if _, ok := statusMap.(map[string]interface{})["resources"]; !ok {
-			properties["status"] = map[string]interface{}{}
+			properties["status"] = rest.ResourceStatus{}
 		} else {
 			outputResources, err := mapDeepGetMap(m, "status", "resources")
 			if err != nil {

--- a/pkg/kubernetes/apiserver/convert_test.go
+++ b/pkg/kubernetes/apiserver/convert_test.go
@@ -250,6 +250,27 @@ func Test_ConvertK8sResourceToARM(t *testing.T) {
 			},
 		},
 	}, {
+		name: "no status",
+		original: &radiusv1alpha3.HttpRoute{
+			Spec: radiusv1alpha3.ResourceSpec{
+				Template: &runtime.RawExtension{
+					Raw: marshalJSONIgnoreErr(map[string]interface{}{
+						"name": "/app/route-42",
+						"id":   "/the/long/and/winding/route",
+						"type": "/very/long/path/radius.dev/HttpRoute",
+					}),
+				},
+			},
+		},
+		expected: resourceprovider.RadiusResource{
+			Name: "route-42",
+			ID:   "/the/long/and/winding/route",
+			Type: "/very/long/path/radius.dev/HttpRoute",
+			Properties: map[string]interface{}{
+				"status": rest.ResourceStatus{},
+			},
+		},
+	}, {
 		name: "no name",
 		original: &radiusv1alpha3.HttpRoute{
 			Spec: radiusv1alpha3.ResourceSpec{

--- a/pkg/kubernetes/apiserver/resourceprovider_test.go
+++ b/pkg/kubernetes/apiserver/resourceprovider_test.go
@@ -316,7 +316,7 @@ func Test_ListResources(t *testing.T) {
 				Name: resource1Name,
 				Properties: map[string]interface{}{
 					"definition-property": "definition-value",
-					"status":              map[string]interface{}{},
+					"status":              rest.ResourceStatus{},
 				},
 			},
 			{
@@ -325,7 +325,7 @@ func Test_ListResources(t *testing.T) {
 				Name: resource2Name,
 				Properties: map[string]interface{}{
 					"definition-property": "definition-value",
-					"status":              map[string]interface{}{},
+					"status":              rest.ResourceStatus{},
 				},
 			},
 		},
@@ -417,7 +417,7 @@ func Test_ListAllV3ResourcesByApplication(t *testing.T) {
 				Name: resource1Name,
 				Properties: map[string]interface{}{
 					"definition-property": "definition-value",
-					"status":              map[string]interface{}{},
+					"status":              rest.ResourceStatus{},
 				},
 			},
 		},
@@ -542,7 +542,7 @@ func Test_GetResource(t *testing.T) {
 		Name: resource2Name,
 		Properties: map[string]interface{}{
 			"definition-property": "definition-value",
-			"status":              map[string]interface{}{},
+			"status":              rest.ResourceStatus{},
 		},
 	}
 	require.Equal(t, rest.NewOKResponse(expected), response)


### PR DESCRIPTION
# Description

Fixes panic when converting from status of resource to rest.ResourceStatus.

We should backport this to 0.10. With that, we probably need to define what it means to backport 😄 

## Issue reference

Fixes https://github.com/project-radius/radius/issues/2101

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change - need starter tests, out of scope.
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it - not necessary
