### PR TITLE
Interactive env init kubernetes prompts environment name

### DIFF
--- a/cmd/rad/cmd/envInitKubernetes.go
+++ b/cmd/rad/cmd/envInitKubernetes.go
@@ -66,6 +66,11 @@ func installKubernetes(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	client, runtimeClient, contextName, err := createKubernetesClients("")
+	if err != nil {
+		return err
+	}
+
 	// Configure Azure provider for cloud resources if specified
 	var azureProvider *azure.Provider
 	if interactive {
@@ -77,7 +82,7 @@ func installKubernetes(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Printf("Using %s as namespace name\n", namespace)
 
-		var defaultEnvironmentName = "kubernetes"
+		var defaultEnvironmentName = contextName
 		promptStr = fmt.Sprintf("Enter an environment name [%s]:", defaultEnvironmentName)
 		environmentName, err = prompt.TextWithDefault(promptStr, &defaultEnvironmentName, prompt.EmptyValidator)
 		if err != nil {
@@ -105,11 +110,6 @@ func installKubernetes(cmd *cobra.Command, args []string) error {
 
 	config := ConfigFromContext(cmd.Context())
 	env, err := cli.ReadEnvironmentSection(config)
-	if err != nil {
-		return err
-	}
-
-	client, runtimeClient, contextName, err := createKubernetesClients("")
 	if err != nil {
 		return err
 	}

--- a/cmd/rad/cmd/envInitKubernetes.go
+++ b/cmd/rad/cmd/envInitKubernetes.go
@@ -73,6 +73,11 @@ func installKubernetes(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
+
+		environmentName, err = prompt.Text("Enter an environment name:", prompt.EmptyValidator)
+		if err != nil {
+			return err
+		}
 	} else {
 		// Check if Azure provider configuration is provided
 		// Adding Azure provider is supported only in non-interactive mode

--- a/cmd/rad/cmd/envInitKubernetes.go
+++ b/cmd/rad/cmd/envInitKubernetes.go
@@ -70,7 +70,7 @@ func installKubernetes(cmd *cobra.Command, args []string) error {
 	var azureProvider *azure.Provider
 	if interactive {
 		var defaultNamespace = "default"
-		promptStr := fmt.Sprintf("Enter a namespace name [%s]:", defaultNamespace)
+		promptStr := fmt.Sprintf("Enter a namespace name to deploy apps into [%s]:", defaultNamespace)
 		namespace, err = prompt.TextWithDefault(promptStr, &defaultNamespace, prompt.EmptyValidator)
 		if err != nil {
 			return err

--- a/cmd/rad/cmd/envInitKubernetes.go
+++ b/cmd/rad/cmd/envInitKubernetes.go
@@ -69,15 +69,22 @@ func installKubernetes(cmd *cobra.Command, args []string) error {
 	// Configure Azure provider for cloud resources if specified
 	var azureProvider *azure.Provider
 	if interactive {
-		namespace, err = prompt.Text("Enter a namespace name:", prompt.EmptyValidator)
+		var defaultNamespace = "default"
+		promptStr := fmt.Sprintf("Enter a namespace name [%s]:", defaultNamespace)
+		namespace, err = prompt.TextWithDefault(promptStr, &defaultNamespace, prompt.EmptyValidator)
 		if err != nil {
 			return err
 		}
+		fmt.Printf("Using %s as namespace name\n", namespace)
 
-		environmentName, err = prompt.Text("Enter an environment name:", prompt.EmptyValidator)
+		var defaultEnvironmentName = "kubernetes-env"
+		promptStr = fmt.Sprintf("Enter an environment name [%s]:", defaultEnvironmentName)
+		environmentName, err = prompt.TextWithDefault(promptStr, &defaultEnvironmentName, prompt.EmptyValidator)
 		if err != nil {
 			return err
 		}
+		fmt.Printf("Using %s as environment name\n", environmentName)
+
 	} else {
 		// Check if Azure provider configuration is provided
 		// Adding Azure provider is supported only in non-interactive mode

--- a/cmd/rad/cmd/envInitKubernetes.go
+++ b/cmd/rad/cmd/envInitKubernetes.go
@@ -77,7 +77,7 @@ func installKubernetes(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Printf("Using %s as namespace name\n", namespace)
 
-		var defaultEnvironmentName = "kubernetes-env"
+		var defaultEnvironmentName = "kubernetes"
 		promptStr = fmt.Sprintf("Enter an environment name [%s]:", defaultEnvironmentName)
 		environmentName, err = prompt.TextWithDefault(promptStr, &defaultEnvironmentName, prompt.EmptyValidator)
 		if err != nil {


### PR DESCRIPTION
# Description

Previously, `rad env init kubernetes -i` would not prompt the user to set environment name. This PR aims to fix this behavior and make the process more interactive.

## Issue reference

Please reference the issue this PR will close: #2141 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
