### PR TITLE
Fix small grammar issue in `rad env init azure`

### DIFF
--- a/cmd/rad/cmd/envInitAzure.go
+++ b/cmd/rad/cmd/envInitAzure.go
@@ -327,7 +327,7 @@ func selectResourceGroup(ctx context.Context, authorizer autorest.Authorizer, su
 }
 
 func selectEnvironmentName(ctx context.Context, defaultName string) (string, error) {
-	promptStr := fmt.Sprintf("Enter a Environment name [%s]:", defaultName)
+	promptStr := fmt.Sprintf("Enter an Environment name [%s]:", defaultName)
 	return prompt.TextWithDefault(promptStr, &defaultName, prompt.EmptyValidator)
 }
 


### PR DESCRIPTION
# Description

Switch from `a` to `an`

