### PR TITLE
Adding config.yaml.lock file.

### DIFF
--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -179,7 +179,7 @@ func LoadConfig(configFilePath string) (*viper.Viper, error) {
 	}
 	// Acquire shared lock on the config file.
 	// Retry it every second for 5 times if other goroutine is holding the lock i.e other cmd is writing to the config file.
-	fileLock := flock.New(configFile)
+	fileLock := flock.New(configFile + ".lock")
 	lockCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_, err = fileLock.TryRLockContext(lockCtx, 1*time.Second)
@@ -264,7 +264,7 @@ func SaveConfigOnLock(ctx context.Context, config *viper.Viper, updateConfig fun
 	// Acquire exclusive lock on the config file.
 	// Retry it every second for 5 times if other goroutine is holding the lock i.e other cmd is writing to the config file.
 	configFilePath := GetConfigFilePath(config)
-	fileLock := flock.New(configFilePath)
+	fileLock := flock.New(configFilePath + ".lock")
 	lockCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	_, err := fileLock.TryLockContext(lockCtx, 1*time.Second)

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -75,7 +75,7 @@ func ReadEnvironmentSection(v *viper.Viper) (EnvironmentSection, error) {
 	return section, nil
 }
 
-// Required to be called while holding the exclusive lock on config file.
+// Required to be called while holding the exclusive lock on config.yaml.lock file.
 func UpdateEnvironmentWithLatestConfig(env EnvironmentSection, mergeConfigs func(EnvironmentSection, EnvironmentSection) EnvironmentSection) func(*viper.Viper) error {
 	return func(config *viper.Viper) error {
 
@@ -177,8 +177,9 @@ func LoadConfig(configFilePath string) (*viper.Viper, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Acquire shared lock on the config file.
+	// Acquire shared lock on the config.yaml.lock file.
 	// Retry it every second for 5 times if other goroutine is holding the lock i.e other cmd is writing to the config file.
+	// created a new file config.yaml.lock as windows os doesnt let us acuire lock on a file i.e config.yaml and write to it.
 	fileLock := flock.New(configFile + ".lock")
 	lockCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -261,7 +262,7 @@ func MergeWithLatestConfig(envName string) func(EnvironmentSection, EnvironmentS
 
 // Save Config with exclusive lock on the config file
 func SaveConfigOnLock(ctx context.Context, config *viper.Viper, updateConfig func(*viper.Viper) error) error {
-	// Acquire exclusive lock on the config file.
+	// Acquire exclusive lock on the config.yaml.lock file.
 	// Retry it every second for 5 times if other goroutine is holding the lock i.e other cmd is writing to the config file.
 	configFilePath := GetConfigFilePath(config)
 	fileLock := flock.New(configFilePath + ".lock")


### PR DESCRIPTION
# Description

Windows OS doesn't let us acquire lock on a file (config.yaml) and make writes to the same, so I added a dummy file i.e config.yaml.lock file for locking to handle this case. Where instead of locking on config.yaml for read/write we now lock on  config.yaml.lock.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Closes radius-project/core-team#590 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
