### PR TITLE
Add validation pre-requisite to release process

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Project Radius documentation
+
+The docs for Project Radius are at https://radapp.dev, with the source in the [project-radius/docs repo](https://github.com/project-radius/docs).
+
+## Contributing to Project Radius
+
+To contribute to Project Radius, refer to the [contributing docs](./contributing/).

--- a/docs/contributing/contributing-code/release-process.md
+++ b/docs/contributing/contributing-code/release-process.md
@@ -24,7 +24,7 @@ Do not start the release until the following scenarios are validated:
 | OS | WebApp Tutorial | Dapr Tutorial | eShop Sample | Container Apps Sample |
 |:--:|:---------------:|:-------------:|:------------:|:---------------------:|
 | macOS local   | ✅ | ✅ | ✅ | ✅ |
-| Windows local | ✅ | ✅ | - | ✅ |
+| Windows local | ✅ | - | - | ✅ |
 | Kubernetes    | ✅ | ✅ | ✅ | ✅ |
 | Azure         | ✅ | ✅ | ✅ | ✅ |
 

--- a/docs/contributing/contributing-code/release-process.md
+++ b/docs/contributing/contributing-code/release-process.md
@@ -8,6 +8,26 @@ Our release process for Project Radius is based on git tags. Pushing a new tag w
 - Determine the release version. This is in the form `v.<major>.<minor>.<patch>`
 - Determine the release channel This is in the form `<major>.<minor>`
 
+### Test tutorials and samples
+
+> This step is manual, however it could be automated in the future.
+
+Before a release can be started, all [tutorials](https://edge.radapp.dev/user-guides/tutorials/) and [samples](https://edge.radapp.dev/user-guides/samples/) must be validated across local (Windows and macOS), Kubernetes, and Azure.
+
+1. Install the latest edge rad CLI release
+1. Run through each tutorial, step by step, confirming each step works as expected on a local environment (make sure to be on the edge site)
+1. Run through each sample, step by step, confirming each step works as expected on a local environment (make sure to be on the edge site)
+1. Repeat on Windows local, Kubernetes, and Azure
+
+Do not start the release until the following scenarios are validated:
+
+| OS | WebApp Tutorial | Dapr Tutorial | eShop Sample | Container Apps Sample |
+|:--:|:---------------:|:-------------:|:------------:|:---------------------:|
+| Windows local | ✅ | ✅ | ✅ | ✅ |
+| macOS local   | ✅ | ✅ | ✅ | ✅ |
+| Kubernetes    | ✅ | ✅ | ✅ | ✅ |
+| Azure         | ✅ | ✅ | ✅ | ✅ |
+
 ## Performing a release
 
 1. In the Bicep fork: `radius-compiler` branch at the time of writing

--- a/docs/contributing/contributing-code/release-process.md
+++ b/docs/contributing/contributing-code/release-process.md
@@ -23,8 +23,8 @@ Do not start the release until the following scenarios are validated:
 
 | OS | WebApp Tutorial | Dapr Tutorial | eShop Sample | Container Apps Sample |
 |:--:|:---------------:|:-------------:|:------------:|:---------------------:|
-| Windows local | ✅ | ✅ | ✅ | ✅ |
 | macOS local   | ✅ | ✅ | ✅ | ✅ |
+| Windows local | ✅ | ✅ | - | ✅ |
 | Kubernetes    | ✅ | ✅ | ✅ | ✅ |
 | Azure         | ✅ | ✅ | ✅ | ✅ |
 


### PR DESCRIPTION
We've had broken tutorials or samples in many of the previous releases.

Adding manual steps to validate tutorials and samples until we automate this process.