### PR TITLE
reduce delay between failed retries on dpmt engine requests

### DIFF
--- a/pkg/azure/clients/clients.go
+++ b/pkg/azure/clients/clients.go
@@ -6,6 +6,8 @@
 package clients
 
 import (
+	"time"
+
 	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/features"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerregistry/mgmt/containerregistry"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/containerservice/mgmt/containerservice"
@@ -127,6 +129,7 @@ func NewDeploymentsClientWithBaseURI(uri string, subscriptionID string) resource
 	dc := resources.NewDeploymentsClientWithBaseURI(uri, subscriptionID)
 	// Don't set a timeout, the user can cancel the command if they want a timeout.
 	dc.PollingDuration = 0
+	dc.RetryDuration = 3 * time.Second
 
 	return dc
 }


### PR DESCRIPTION
# Description

Reduces the delay time in between retries to failed requests to the deployment engine, improving rad-cli responsiveness and UX. Total wait time (including all  retries) to get an answer  <= 10 sec 

## Issue reference

Please reference the issue this PR will close: #2168 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [x] Extended the documentation / Created issue for it
