### PR TITLE
change deployment engine image tag

### DIFF
--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -1,7 +1,7 @@
 global:
   engine:
     image: radius.azurecr.io/deployment-engine
-    tag: latest
+    tag: 108f7c6d9a8caecf836c63dc8ea4d718b04a9854
   extensibility:
     image: radius.azurecr.io/bicep-extensibility
     tag: latest


### PR DESCRIPTION
Changing what image radius uses for the deployment engine from the latest tag to a stable tag for now, so that changes in the deployment engine don't cause a regression in radius.