### PR TITLE
Amending unclear wording in release docs

### DIFF
--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1318.3566",
-      "templateHash": "11168135648387855983"
+      "version": "0.5.6.12127",
+      "templateHash": "7246368144384583769"
     }
   },
   "parameters": {
@@ -194,8 +194,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1318.3566",
-              "templateHash": "2344374782324897682"
+              "version": "0.5.6.12127",
+              "templateHash": "12717349771132450659"
             }
           },
           "parameters": {

--- a/docs/contributing/contributing-code/release-process.md
+++ b/docs/contributing/contributing-code/release-process.md
@@ -89,7 +89,7 @@ Do not start the release until the following scenarios are validated:
    
    You can find this file in the storage account under `version/stable.txt`.
 
-5. Update the docs
+5. Update the project-radius/docs repository
    
    1. Within GitHub delete the branch for the prior Radius release, *e.g. `release/0.1`*.
    1. Create a new branch named `release/X.Y` from `main`, using the release version number.


### PR DESCRIPTION
I think that we can change "Update the docs" to mention explicitly that this is in the separate docs repository rather than the docs section of the radius repository, as that step confused me for a bit.