### PR TITLE
Fix #2191 by using the app name as a namespace for stern to forward logs

### DIFF
--- a/pkg/cli/tools/stern.go
+++ b/pkg/cli/tools/stern.go
@@ -31,7 +31,7 @@ func SternStart(ctx context.Context, context string, namespace string, applicati
 
 	args := []string{
 		"--context", context,
-		"--namespace", namespace,
+		"--namespace", application,
 		"--selector", fmt.Sprintf("radius.dev/application=%s", application),
 
 		// Dapr sidecars are especially noisy, and usually not relevant.


### PR DESCRIPTION
# Description

Fixes radius-project/core-team#599 by adding the the app name as a namespace for stern to forward logs. 

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: radius-project/core-team#599 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
