### PR TITLE
Add panic recovery middleware

### DIFF
--- a/pkg/corerp/frontend/server/server.go
+++ b/pkg/corerp/frontend/server/server.go
@@ -31,6 +31,7 @@ func NewServer(ctx context.Context, options ServerOptions) *http.Server {
 		options.Configure(r)
 	}
 
+	r.Use(middleware.Recoverer)
 	r.Use(middleware.AppendLogValues)
 	r.Use(middleware.ARMRequestCtx(options.PathBase))
 	r.Path("/version").Methods(http.MethodGet).HandlerFunc(reportVersion)

--- a/pkg/corerp/middleware/recoverer.go
+++ b/pkg/corerp/middleware/recoverer.go
@@ -1,0 +1,44 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"runtime"
+
+	"github.com/project-radius/radius/pkg/radlogger"
+	"github.com/project-radius/radius/pkg/radrp/armerrors"
+	"github.com/project-radius/radius/pkg/radrp/rest"
+)
+
+const BufSize = 2048
+
+func Recoverer(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := recover(); err != nil {
+				buf := make([]byte, BufSize)
+				size := runtime.Stack(buf, false)
+				buf = buf[:size]
+
+				log := radlogger.GetLogger(r.Context())
+				msg := fmt.Sprintf("recovering from panic %v: %s", err, buf)
+				log.V(radlogger.Fatal).Info(msg)
+
+				resp := rest.NewInternalServerErrorARMResponse(armerrors.ErrorResponse{
+					Error: armerrors.ErrorDetails{
+						Message: msg,
+					},
+				})
+
+				resp.Apply(r.Context(), w, r)
+			}
+		}()
+
+		h.ServeHTTP(w, r)
+	})
+}

--- a/pkg/corerp/middleware/recoverer_test.go
+++ b/pkg/corerp/middleware/recoverer_test.go
@@ -1,0 +1,38 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecoverer(t *testing.T) {
+	const testPathBase = "/base"
+	w := httptest.NewRecorder()
+	r := mux.NewRouter()
+	r.Path(testPathBase + "/subscriptions/{subscriptionID}/resourcegroups/{resourceGroup}/providers/{providerName}/{resourceType}/{resourceName}").Methods(http.MethodPut).HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			// panic !!!
+			panic("panic test")
+		})
+
+	handler := Recoverer(r)
+
+	testUrl := testPathBase + "/subscriptions/00001b53-0000-0000-0000-00006235a42c/resourcegroups/radius-test-rg/providers/Applications.Core/environments/env0"
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPut, testUrl, nil)
+	handler.ServeHTTP(w, req)
+
+	parsed := w.Body.String()
+	require.Equal(t, 500, w.Result().StatusCode)
+	require.NotEmpty(t, parsed)
+}


### PR DESCRIPTION
# Description

This PR is to add middleware to recover the panic from the handler. This let service continue to run even if panic happens.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Closes #2242 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
