### PR TITLE
Using release version instead of latest for radius-rp tag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -143,7 +143,7 @@ jobs:
           password: '${{ secrets.DOCKER_PASSWORD }}'
       - name: make docker-push (latest)
         run: make docker-push
-        if: (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') # push image on push to main or tag
+        if: (github.ref == 'refs/heads/main') && !startsWith(github.ref, 'refs/tags/v') # push image on push to main or tag
         env:
           DOCKER_REGISTRY: ${{ env.DOCKER_REGISTRY }}
           DOCKER_TAG_VERSION: latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -143,7 +143,7 @@ jobs:
           password: '${{ secrets.DOCKER_PASSWORD }}'
       - name: make docker-push (latest)
         run: make docker-push
-        if: (github.ref == 'refs/heads/main') && !startsWith(github.ref, 'refs/tags/v') # push image on push to main or tag
+        if: (github.ref == 'refs/heads/main')) # push image to latest on merge to main
         env:
           DOCKER_REGISTRY: ${{ env.DOCKER_REGISTRY }}
           DOCKER_TAG_VERSION: latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -143,7 +143,7 @@ jobs:
           password: '${{ secrets.DOCKER_PASSWORD }}'
       - name: make docker-push (latest)
         run: make docker-push
-        if: (github.ref == 'refs/heads/main')) # push image to latest on merge to main
+        if: (github.ref == 'refs/heads/main') # push image to latest on merge to main
         env:
           DOCKER_REGISTRY: ${{ env.DOCKER_REGISTRY }}
           DOCKER_TAG_VERSION: latest

--- a/cmd/rad/cmd/envInitKubernetes.go
+++ b/cmd/rad/cmd/envInitKubernetes.go
@@ -130,7 +130,13 @@ func installKubernetes(cmd *cobra.Command, args []string) error {
 	options.Namespace = namespace
 	options.Radius.ChartPath = chartPath
 	options.Radius.Image = image
-	options.Radius.Tag = tag
+
+	// If tag is set by CLI, use that.
+	// Otherwise, use the default tag for the release.
+	if tag != "" {
+		options.Radius.Tag = tag
+	}
+
 	options.Radius.AzureProvider = azureProvider
 
 	err = helm.InstallOnCluster(cmd.Context(), options, client, runtimeClient)

--- a/pkg/cli/helm/cluster.go
+++ b/pkg/cli/helm/cluster.go
@@ -41,6 +41,12 @@ func NewDefaultClusterOptions() ClusterOptions {
 		chartVersion = fmt.Sprintf("~%s", version.ChartVersion())
 	}
 
+	// By default we use the release semver for the rp tag.
+	tag := version.Release()
+	if version.IsEdgeChannel() {
+		tag = "latest"
+	}
+
 	return ClusterOptions{
 		Namespace: "default",
 		Dapr: DaprOptions{
@@ -53,6 +59,7 @@ func NewDefaultClusterOptions() ClusterOptions {
 		},
 		Radius: RadiusOptions{
 			ChartVersion: chartVersion,
+			Tag:          tag,
 		},
 	}
 }

--- a/pkg/cli/helm/cluster.go
+++ b/pkg/cli/helm/cluster.go
@@ -41,8 +41,7 @@ func NewDefaultClusterOptions() ClusterOptions {
 		chartVersion = fmt.Sprintf("~%s", version.ChartVersion())
 	}
 
-	// By default we use the release semver for the rp tag.
-	tag := version.Release()
+	tag := version.Channel()
 	if version.IsEdgeChannel() {
 		tag = "latest"
 	}


### PR DESCRIPTION
* Fixing issue where `rad` would always use latest version of `radius-rp` image.
* Removing container image push to latest on git tag.

Fixes radius-project/core-team#621 
Fixes radius-project/radius#2143