### PR TITLE
support serverless cosmosdb account

### DIFF
--- a/pkg/corerp/dataprovider/factory.go
+++ b/pkg/corerp/dataprovider/factory.go
@@ -20,10 +20,11 @@ var storageClientFactory = map[StorageProviderType]storageFactoryFunc{
 
 func initCosmosDBClient(ctx context.Context, opt StorageProviderOptions, collectionName string) (store.StorageClient, error) {
 	sopt := &cosmosdb.ConnectionOptions{
-		Url:            opt.CosmosDB.Url,
-		DatabaseName:   opt.CosmosDB.Database,
-		CollectionName: collectionName,
-		MasterKey:      opt.CosmosDB.MasterKey,
+		Url:                  opt.CosmosDB.Url,
+		DatabaseName:         opt.CosmosDB.Database,
+		CollectionName:       collectionName,
+		MasterKey:            opt.CosmosDB.MasterKey,
+		CollectionThroughput: opt.CosmosDB.CollectionThroughput,
 	}
 	dbclient, err := cosmosdb.NewCosmosDBStorageClient(sopt)
 	if err != nil {

--- a/pkg/corerp/dataprovider/options.go
+++ b/pkg/corerp/dataprovider/options.go
@@ -13,7 +13,8 @@ type StorageProviderOptions struct {
 
 // CosmosDBOptions represents cosmosdb options for data storage provider.
 type CosmosDBOptions struct {
-	Url       string `yaml:"url"`
-	Database  string `yaml:"database"`
-	MasterKey string `yaml:"masterKey"`
+	Url                  string `yaml:"url"`
+	Database             string `yaml:"database"`
+	MasterKey            string `yaml:"masterKey"`
+	CollectionThroughput int    `yaml:"collectionThroughput,omitempty"`
 }

--- a/pkg/store/cosmosdb/cosmosdbstorageclient.go
+++ b/pkg/store/cosmosdb/cosmosdbstorageclient.go
@@ -145,7 +145,7 @@ func (c *CosmosDBStorageClient) createCollectionIfNotExists(ctx context.Context)
 		},
 	}
 
-	// CollectionThroughput must be set only if radius uses Provioned throughput mode.
+	// CollectionThroughput needs to be set only if radius uses Provioned throughput mode.
 	if c.options.CollectionThroughput > 0 {
 		opt.OfferThroughput = cosmosapi.OfferThroughput(c.options.CollectionThroughput)
 	}

--- a/pkg/store/cosmosdb/cosmosdbstorageclient.go
+++ b/pkg/store/cosmosdb/cosmosdbstorageclient.go
@@ -145,6 +145,7 @@ func (c *CosmosDBStorageClient) createCollectionIfNotExists(ctx context.Context)
 		},
 	}
 
+	// CollectionThroughput must be set only if radius use Provioned throughput mode.
 	if c.options.CollectionThroughput > 0 {
 		opt.OfferThroughput = cosmosapi.OfferThroughput(c.options.CollectionThroughput)
 	}

--- a/pkg/store/cosmosdb/cosmosdbstorageclient.go
+++ b/pkg/store/cosmosdb/cosmosdbstorageclient.go
@@ -145,7 +145,7 @@ func (c *CosmosDBStorageClient) createCollectionIfNotExists(ctx context.Context)
 		},
 	}
 
-	// CollectionThroughput must be set only if radius use Provioned throughput mode.
+	// CollectionThroughput must be set only if radius uses Provioned throughput mode.
 	if c.options.CollectionThroughput > 0 {
 		opt.OfferThroughput = cosmosapi.OfferThroughput(c.options.CollectionThroughput)
 	}

--- a/pkg/store/cosmosdb/options.go
+++ b/pkg/store/cosmosdb/options.go
@@ -8,8 +8,7 @@ package cosmosdb
 import "github.com/project-radius/radius/pkg/store"
 
 const (
-	defaultQueryItemCount       = 20
-	defaultCollectionThroughPut = 400
+	defaultQueryItemCount = 20
 )
 
 // ConnectionOptions represents connection info to connect CosmosDB

--- a/pkg/store/cosmosdb/options.go
+++ b/pkg/store/cosmosdb/options.go
@@ -8,7 +8,8 @@ package cosmosdb
 import "github.com/project-radius/radius/pkg/store"
 
 const (
-	defaultQueryItemCount = 20
+	defaultQueryItemCount       = 20
+	defaultCollectionThroughPut = 400
 )
 
 // ConnectionOptions represents connection info to connect CosmosDB
@@ -21,6 +22,8 @@ type ConnectionOptions struct {
 	CollectionName string
 	// DefaultQueryItemCount represents the maximum number of items for query.
 	DefaultQueryItemCount int
+	// CollectionThroughput represents shared throughput database share the throughput (RU/s) allocated to that database.
+	CollectionThroughput int
 
 	// MasterKey is the key string for CosmosDB connection.
 	MasterKey string


### PR DESCRIPTION
# Description

This fix is to support serverless cosmosdb account. To create collection in serverless account, we should not set throughput.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
