### PR TITLE
Add missing flag parse

### DIFF
--- a/cmd/appcore-rp/main.go
+++ b/cmd/appcore-rp/main.go
@@ -30,6 +30,8 @@ func main() {
 		log.Fatal("config-file is empty.")
 	}
 
+	flag.Parse()
+
 	options, err := hostoptions.NewHostOptionsFromEnvironment(configFile)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
# Description

Add missing `flag.Parse()` call to parse cmd flags.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
