### PR TITLE
Allow json charset content-type

### DIFF
--- a/pkg/corerp/frontend/controller/util.go
+++ b/pkg/corerp/frontend/controller/util.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -27,7 +28,12 @@ var (
 // ReadJSONBody extracts the content from request.
 func ReadJSONBody(r *http.Request) ([]byte, error) {
 	defer r.Body.Close()
-	contentType := r.Header.Get(ContentTypeHeaderKey)
+
+	contentType := strings.ToLower(strings.TrimSpace(r.Header.Get(ContentTypeHeaderKey)))
+	if i := strings.Index(contentType, ";"); i > -1 {
+		contentType = contentType[0:i]
+	}
+
 	if contentType != "application/json" {
 		return nil, ErrUnsupportedContentType
 	}

--- a/pkg/corerp/frontend/controller/util_test.go
+++ b/pkg/corerp/frontend/controller/util_test.go
@@ -10,27 +10,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReadJSONBody_ExtractJSONContent(t *testing.T) {
-	// arrange
+func TestReadJSONBody(t *testing.T) {
 	content, _ := json.Marshal(map[string]string{
 		"id":   "fakeID",
 		"type": "fakeType",
 	})
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPut, "http://github.com", bytes.NewBuffer(content))
-	req.Header.Set("Content-Type", "application/json")
-	// act
-	parsed, err := ReadJSONBody(req)
-	// assert
-	require.NoError(t, err)
-	require.Equal(t, string(content), string(parsed))
-}
 
-func TestReadJSONBody_NonJSONContent(t *testing.T) {
-	// arrange
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPut, "http://github.com", bytes.NewBufferString("fakebody"))
-	req.Header.Set("Content-Type", "plain/text")
-	// act
-	_, err := ReadJSONBody(req)
-	// assert
-	require.ErrorIs(t, err, ErrUnsupportedContentType)
+	contentTypeTests := []struct {
+		contentType string
+		body        []byte
+		err         error
+	}{
+		{"application/json", content, nil},
+		{"application/json; charset=utf8", content, nil},
+		{"application/json;    charset=utf8", content, nil},
+		{"Application/Json;    charset=utf8    ", content, nil},
+		{"plain/text", content, ErrUnsupportedContentType},
+	}
+
+	for _, tc := range contentTypeTests {
+		t.Run(tc.contentType, func(t *testing.T) {
+			req, _ := http.NewRequestWithContext(context.Background(), http.MethodPut, "http://github.com", bytes.NewBuffer(tc.body))
+			req.Header.Set("Content-Type", tc.contentType)
+			// act
+			parsed, err := ReadJSONBody(req)
+			// assert
+			if tc.err != nil {
+				require.ErrorIs(t, tc.err, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, string(tc.body), string(parsed))
+			}
+		})
+	}
 }

--- a/pkg/corerp/frontend/handler/handler.go
+++ b/pkg/corerp/frontend/handler/handler.go
@@ -61,7 +61,7 @@ func registerHandler(ctx context.Context, sp dataprovider.DataStorageProvider, p
 // Responds with an HTTP 500
 func internalServerError(ctx context.Context, w http.ResponseWriter, req *http.Request, err error) {
 	logger := radlogger.GetLogger(ctx)
-	logger.Error(err, "unhandled error")
+	logger.V(radlogger.Debug).Error(err, "unhandled error")
 
 	// Try to use the ARM format to send back the error info
 	body := armerrors.ErrorResponse{


### PR DESCRIPTION
# Description

ARM send `application/json; charset=utf8` to RP. This fix will allow it. 

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
