### PR TITLE
Removing check for empty environment name

### DIFF
--- a/cmd/rad/cmd/envInitAzure.go
+++ b/cmd/rad/cmd/envInitAzure.go
@@ -192,12 +192,12 @@ func validate(cmd *cobra.Command, args []string) (arguments, error) {
 	}
 
 	if !interactive {
+		if subscriptionID == "" || resourceGroup == "" || location == "" {
+			return arguments{}, errors.New("subscription id, resource group and location must be specified")
+		}
 		if name == "" {
 			name = resourceGroup
 			output.LogInfo("No environment name provided, using: %v", name)
-		}
-		if subscriptionID == "" || resourceGroup == "" || location == "" {
-			return arguments{}, errors.New("subscription id, resource group and location must be specified")
 		}
 	}
 

--- a/cmd/rad/cmd/envInitAzure.go
+++ b/cmd/rad/cmd/envInitAzure.go
@@ -181,10 +181,6 @@ func validate(cmd *cobra.Command, args []string) (arguments, error) {
 	if err != nil {
 		return arguments{}, err
 	}
-	if name == "" {
-		name = resourceGroup
-		output.LogInfo("No environment name provided, using: %v", name)
-	}
 
 	location, err := cmd.Flags().GetString("location")
 	if err != nil {

--- a/cmd/rad/cmd/envInitAzure.go
+++ b/cmd/rad/cmd/envInitAzure.go
@@ -187,12 +187,18 @@ func validate(cmd *cobra.Command, args []string) (arguments, error) {
 		return arguments{}, err
 	}
 
-	if interactive && (subscriptionID != "" || resourceGroup != "" || location != "") {
-		return arguments{}, errors.New("subcription id, resource group or location cannot be specified with interactive")
+	if interactive && (subscriptionID != "" || resourceGroup != "" || location != "" || name != "") {
+		return arguments{}, errors.New("subcription id, resource group, location or environment name cannot be specified with interactive")
 	}
 
-	if !interactive && (subscriptionID == "" || resourceGroup == "" || location == "") {
-		return arguments{}, errors.New("subscription id, resource group and location must be specified")
+	if !interactive {
+		if name == "" {
+			name = resourceGroup
+			output.LogInfo("No environment name provided, using: %v", name)
+		}
+		if subscriptionID == "" || resourceGroup == "" || location == "" {
+			return arguments{}, errors.New("subscription id, resource group and location must be specified")
+		}
 	}
 
 	deploymentTemplate, err := cmd.Flags().GetString("deployment-template")

--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.6.1.6515",
-      "templateHash": "12931903957622840575"
+      "version": "0.6.11.53198",
+      "templateHash": "10374101846025393636"
     }
   },
   "parameters": {
@@ -194,8 +194,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.6.1.6515",
-              "templateHash": "1091669613424611220"
+              "version": "0.6.11.53198",
+              "templateHash": "9652338613199054654"
             }
           },
           "parameters": {


### PR DESCRIPTION
# Description

Removed validation check for empty environment name in interactive mode
Output:
> rad env init azure -i
Use Subscription 'Radius Dev'? [Y/n]
...


## Issue reference

Please reference the issue this PR will close: radius-project/core-team#617 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
