### PR TITLE
EXAMPLE of code changes for decoupling the Core RP from Azure

### DIFF
--- a/cmd/appcore-rp/radius-dev.yaml
+++ b/cmd/appcore-rp/radius-dev.yaml
@@ -1,7 +1,7 @@
 # This is an example of configuration file.
 cloudEnvironment:
-  name: AzureCloud
-  roleLocation: West US
+  name: UCP
+  roleLocation: global
 identity: # 1P AAD APP authentication
   clientId: "PLACEHOLDER"
   instance: "https://login.windows.net"
@@ -10,7 +10,7 @@ identity: # 1P AAD APP authentication
   audience: "https://management.core.windows.net"
   pemCertPath: "/var/certs/rp-aad-app.pem"
 storageProvider:
-  provider: "cosmosdb"
+  provider: "memory"
   cosmosdb:
     # Create your own SQL API Cosmos DB account and set url in this configuration or to RADIUS_STORAGEPROVIDER_COSMOSDB_URL environment variable
     url: https://radius-eastus-test.documents.azure.com:443/

--- a/pkg/corerp/dataprovider/factory.go
+++ b/pkg/corerp/dataprovider/factory.go
@@ -7,6 +7,7 @@ package dataprovider
 
 import (
 	context "context"
+	"fmt"
 
 	store "github.com/project-radius/radius/pkg/store"
 	"github.com/project-radius/radius/pkg/store/cosmosdb"
@@ -28,11 +29,11 @@ func initCosmosDBClient(ctx context.Context, opt StorageProviderOptions, collect
 	}
 	dbclient, err := cosmosdb.NewCosmosDBStorageClient(sopt)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create CosmosDB client - configuration may be invalid: %w", err)
 	}
 
 	if err = dbclient.Init(ctx); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize CosmosDB client - configuration may be invalid: %w", err)
 	}
 
 	return dbclient, nil

--- a/pkg/corerp/dataprovider/factory.go
+++ b/pkg/corerp/dataprovider/factory.go
@@ -17,6 +17,7 @@ type storageFactoryFunc func(context.Context, StorageProviderOptions, string) (s
 
 var storageClientFactory = map[StorageProviderType]storageFactoryFunc{
 	CosmosDBProvider: initCosmosDBClient,
+	InMemoryProvider: NewInMemoryProvider,
 }
 
 func initCosmosDBClient(ctx context.Context, opt StorageProviderOptions, collectionName string) (store.StorageClient, error) {

--- a/pkg/corerp/dataprovider/memory.go
+++ b/pkg/corerp/dataprovider/memory.go
@@ -1,0 +1,80 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package dataprovider
+
+import (
+	context "context"
+	"crypto/sha1"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	store "github.com/project-radius/radius/pkg/store"
+)
+
+func NewInMemoryProvider(ctx context.Context, options StorageProviderOptions, resourceType string) (store.StorageClient, error) {
+	return &InMemoryStore{options: options, resourceType: resourceType, m: sync.Mutex{}, data: map[string]store.Object{}}, nil
+}
+
+type InMemoryStore struct {
+	options      StorageProviderOptions
+	resourceType string
+
+	m    sync.Mutex
+	data map[string]store.Object
+}
+
+func (s *InMemoryStore) Query(ctx context.Context, query store.Query, options ...store.QueryOptions) (*store.ObjectQueryResult, error) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	result := store.ObjectQueryResult{}
+
+	return &result, nil
+}
+
+func (s *InMemoryStore) Get(ctx context.Context, id string, options ...store.GetOptions) (*store.Object, error) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	result, ok := s.data[id]
+	if ok {
+		return &result, nil
+	}
+
+	return nil, &store.ErrNotFound{}
+}
+
+func (s *InMemoryStore) Delete(ctx context.Context, id string, options ...store.DeleteOptions) error {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	_, ok := s.data[id]
+	if ok {
+		delete(s.data, id)
+		return nil
+	}
+
+	return &store.ErrNotFound{}
+}
+
+func (s *InMemoryStore) Save(ctx context.Context, obj *store.Object, options ...store.SaveOptions) (*store.Object, error) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	b, err := json.Marshal(obj.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	hash := sha1.Sum(b)
+	etag := fmt.Sprintf("\"%d-%x\"", int(len(hash)), hash)
+	obj.ETag = etag
+
+	s.data[obj.ID] = *obj
+
+	return obj, nil
+}

--- a/pkg/corerp/dataprovider/types.go
+++ b/pkg/corerp/dataprovider/types.go
@@ -17,6 +17,9 @@ type StorageProviderType string
 const (
 	// CosmosDBProvider represents CosmosDB provider.
 	CosmosDBProvider StorageProviderType = "cosmosdb"
+
+	// InMemoryProvider is an in-memory ephemeral store useful for testing.
+	InMemoryProvider StorageProviderType = "memory"
 )
 
 //go:generate mockgen -destination=./mock_datastorage_provider.go -package=dataprovider -self_package github.com/project-radius/radius/pkg/corerp/dataprovider github.com/project-radius/radius/pkg/corerp/dataprovider DataStorageProvider

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
@@ -47,9 +47,9 @@ func (e *CreateOrUpdateEnvironment) Run(ctx context.Context, req *http.Request) 
 	}
 
 	existingResource := &datamodel.Environment{}
-	etag, err := e.GetResource(ctx, serviceCtx.ResourceID.ID, existingResource)
+	etag, err := e.GetResource(ctx, serviceCtx.ResourceID.String(), existingResource)
 	if req.Method == http.MethodPatch && errors.Is(&store.ErrNotFound{}, err) {
-		return rest.NewNotFoundResponse(serviceCtx.ResourceID), nil
+		return rest.NewNotFoundResponseUCP(serviceCtx.ResourceID), nil
 	}
 	if err != nil && !errors.Is(&store.ErrNotFound{}, err) {
 		return nil, err
@@ -62,7 +62,7 @@ func (e *CreateOrUpdateEnvironment) Run(ctx context.Context, req *http.Request) 
 
 	UpdateExistingResourceData(ctx, existingResource, newResource)
 
-	nr, err := e.SaveResource(ctx, serviceCtx.ResourceID.ID, newResource, etag)
+	nr, err := e.SaveResource(ctx, serviceCtx.ResourceID.String(), newResource, etag)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +95,8 @@ func (e *CreateOrUpdateEnvironment) Validate(ctx context.Context, req *http.Requ
 
 	// TODO: Add more validation e.g. schema, identity, etc.
 
-	dm.ID = serviceCtx.ResourceID.ID
-	dm.TrackedResource.ID = serviceCtx.ResourceID.ID
+	dm.ID = serviceCtx.ResourceID.String()
+	dm.TrackedResource.ID = serviceCtx.ResourceID.String()
 	dm.TrackedResource.Name = serviceCtx.ResourceID.Name()
 	dm.TrackedResource.Type = serviceCtx.ResourceID.Type()
 	dm.TrackedResource.Location = serviceOpt.CloudEnv.RoleLocation

--- a/pkg/corerp/frontend/controller/environments/deleteenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/deleteenvironment.go
@@ -63,5 +63,5 @@ func (e *DeleteEnvironment) Run(ctx context.Context, req *http.Request) (rest.Re
 		return nil, err
 	}
 
-	return rest.NewOKResponse("deleted successfully"), nil
+	return rest.NewOKResponse(nil), nil
 }

--- a/pkg/corerp/frontend/controller/environments/deleteenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/deleteenvironment.go
@@ -40,7 +40,7 @@ func (e *DeleteEnvironment) Run(ctx context.Context, req *http.Request) (rest.Re
 
 	// Read resource metadata from the storage
 	existingResource := &datamodel.Environment{}
-	etag, err := e.GetResource(ctx, serviceCtx.ResourceID.ID, existingResource)
+	etag, err := e.GetResource(ctx, serviceCtx.ResourceID.String(), existingResource)
 	if err != nil && !errors.Is(&store.ErrNotFound{}, err) {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (e *DeleteEnvironment) Run(ctx context.Context, req *http.Request) (rest.Re
 	}
 
 	// TODO: handle async deletion later.
-	err = e.DBClient.Delete(ctx, serviceCtx.ResourceID.ID)
+	err = e.DBClient.Delete(ctx, serviceCtx.ResourceID.String())
 	if err != nil {
 		if errors.Is(&store.ErrNotFound{}, err) {
 			return rest.NewNoContentResponse(), nil

--- a/pkg/corerp/frontend/controller/environments/getenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/getenvironment.go
@@ -40,9 +40,9 @@ func (e *GetEnvironment) Run(ctx context.Context, req *http.Request) (rest.Respo
 	serviceCtx := servicecontext.ARMRequestContextFromContext(ctx)
 
 	existingResource := &datamodel.Environment{}
-	_, err := e.GetResource(ctx, serviceCtx.ResourceID.ID, existingResource)
+	_, err := e.GetResource(ctx, serviceCtx.ResourceID.String(), existingResource)
 	if err != nil && errors.Is(&store.ErrNotFound{}, err) {
-		return rest.NewNotFoundResponse(serviceCtx.ResourceID), nil
+		return rest.NewNotFoundResponseUCP(serviceCtx.ResourceID), nil
 	}
 
 	versioned, _ := converter.EnvironmentDataModelToVersioned(existingResource, serviceCtx.APIVersion)

--- a/pkg/corerp/frontend/controller/environments/listenvironments.go
+++ b/pkg/corerp/frontend/controller/environments/listenvironments.go
@@ -7,7 +7,6 @@ package environments
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -51,8 +50,7 @@ func (e *ListEnvironments) Run(ctx context.Context, req *http.Request) (rest.Res
 	}
 
 	query := store.Query{
-		RootScope: fmt.Sprintf("/subscriptions/%s/resourceGroup/%s",
-			serviceCtx.ResourceID.SubscriptionID, serviceCtx.ResourceID.ResourceGroup),
+		RootScope:    serviceCtx.ResourceID.RootScope(),
 		ResourceType: serviceCtx.ResourceID.Type(),
 	}
 

--- a/pkg/corerp/frontend/handler/routes.go
+++ b/pkg/corerp/frontend/handler/routes.go
@@ -7,6 +7,7 @@ package handler
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -64,7 +65,7 @@ func AddRoutes(ctx context.Context, sp dataprovider.DataStorageProvider, jobEngi
 
 	for _, h := range handlers {
 		if err := registerHandler(ctx, sp, h.parent, h.resourcetype, h.method, h.routeName, h.fn); err != nil {
-			return err
+			return fmt.Errorf("failed to register %s handler for route %s: %w", h.method, h.routeName, err)
 		}
 	}
 

--- a/pkg/corerp/frontend/server/server.go
+++ b/pkg/corerp/frontend/server/server.go
@@ -20,8 +20,8 @@ import (
 const (
 	versionEndpoint = "/version"
 	healthzEndpoint = "/healthz"
-	versionAPIName = "versionAPI"
-	healthzAPIName = "heathzAPI"
+	versionAPIName  = "versionAPI"
+	healthzAPIName  = "heathzAPI"
 )
 
 type ServerOptions struct {
@@ -29,14 +29,17 @@ type ServerOptions struct {
 	PathBase string
 	// TODO: implement client cert based authentication for arm
 	EnableAuth bool
-	Configure  func(*mux.Router)
+	Configure  func(*mux.Router) error
 }
 
 // NewServer will create a server that can listen on the provided address and serve requests.
-func NewServer(ctx context.Context, options ServerOptions, metricsProviderConfig mp.MetricsOptions) *http.Server {
+func NewServer(ctx context.Context, options ServerOptions, metricsProviderConfig mp.MetricsOptions) (*http.Server, error) {
 	r := mux.NewRouter()
 	if options.Configure != nil {
-		options.Configure(r)
+		err := options.Configure(r)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	r.Use(middleware.Recoverer)
@@ -59,7 +62,7 @@ func NewServer(ctx context.Context, options ServerOptions, metricsProviderConfig
 		},
 	}
 
-	return server
+	return server, nil
 }
 
 func reportVersion(w http.ResponseWriter, req *http.Request) {

--- a/pkg/corerp/frontend/service.go
+++ b/pkg/corerp/frontend/service.go
@@ -47,6 +47,10 @@ func (s *Service) Run(ctx context.Context) error {
 			PathBase: s.Options.Config.Server.PathBase,
 			// TODO: implement ARM client certificate auth.
 			Configure: func(router *mux.Router) error {
+				if s.Options.Config.CloudEnv.Name == "UCP" {
+					return handler.AddUCPRoutes(ctx, storageProvider, nil, router, handler.DefaultValidatorFactory, "")
+				}
+
 				return handler.AddRoutes(ctx, storageProvider, nil, router, handler.DefaultValidatorFactory, "")
 			},
 		},

--- a/pkg/corerp/middleware/armrequestctx_test.go
+++ b/pkg/corerp/middleware/armrequestctx_test.go
@@ -24,7 +24,7 @@ func TestARMRequestCtx(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			rpcCtx := servicecontext.ARMRequestContextFromContext(r.Context())
 
-			_, _ = w.Write([]byte(rpcCtx.ResourceID.SubscriptionID))
+			_, _ = w.Write([]byte(rpcCtx.ResourceID.ScopeSegments()[0].Name))
 		})
 
 	handler := ARMRequestCtx(testPathBase)(r)

--- a/pkg/corerp/servicecontext/armrequestcontext.go
+++ b/pkg/corerp/servicecontext/armrequestcontext.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/project-radius/radius/pkg/azure/azresources"
 	"github.com/project-radius/radius/pkg/corerp/api/armrpcv1"
 	"github.com/project-radius/radius/pkg/radlogger"
+	"github.com/project-radius/radius/pkg/resources"
 )
 
 // The below contants are the headers in request from ARM.
@@ -93,7 +93,7 @@ var (
 // ARMRequestContext represents the service context including proxy request header values.
 type ARMRequestContext struct {
 	// ResourceID represents arm resource ID extracted from resource id.
-	ResourceID azresources.ResourceID
+	ResourceID resources.ID
 
 	// ClientRequestID represents the client request id from arm request.
 	ClientRequestID string
@@ -140,7 +140,7 @@ type ARMRequestContext struct {
 func FromARMRequest(r *http.Request, pathBase string) (*ARMRequestContext, error) {
 	log := radlogger.GetLogger(r.Context())
 	path := strings.TrimPrefix(r.URL.Path, pathBase)
-	azID, err := azresources.Parse(path)
+	azID, err := resources.Parse(path)
 	if err != nil {
 		log.V(radlogger.Debug).Info("URL was not a valid resource id: %v", r.URL.Path)
 		// do not stop extracting headers. handler needs to care invalid resource id.

--- a/pkg/corerp/servicecontext/armrequestcontext_test.go
+++ b/pkg/corerp/servicecontext/armrequestcontext_test.go
@@ -23,11 +23,11 @@ func TestFromARMRequest(t *testing.T) {
 	require.Equal(t, "2022-03-15-privatepreview", serviceCtx.APIVersion)
 	require.Equal(t, "00000000-0000-0000-0000-000000000001", serviceCtx.ClientTenantID)
 	require.Equal(t, "00000000-0000-0000-0000-000000000002", serviceCtx.HomeTenantID)
-	require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", serviceCtx.ResourceID.ID)
-	require.Equal(t, "00000000-0000-0000-0000-000000000000", serviceCtx.ResourceID.SubscriptionID)
-	require.Equal(t, "radius-test-rg", serviceCtx.ResourceID.ResourceGroup)
-	require.Equal(t, "Applications.Core/environments", serviceCtx.ResourceID.Types[0].Type)
-	require.Equal(t, "env0", serviceCtx.ResourceID.Types[0].Name)
+	require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", serviceCtx.ResourceID.String())
+	require.Equal(t, "00000000-0000-0000-0000-000000000000", serviceCtx.ResourceID.ScopeSegments()[0].Type)
+	require.Equal(t, "radius-test-rg", serviceCtx.ResourceID.ScopeSegments()[1].Type)
+	require.Equal(t, "Applications.Core/environments", serviceCtx.ResourceID.Type())
+	require.Equal(t, "env0", serviceCtx.ResourceID.Name())
 	require.True(t, len(serviceCtx.OperationID) > 0)
 }
 

--- a/pkg/hosting/hosting.go
+++ b/pkg/hosting/hosting.go
@@ -103,7 +103,9 @@ func (host *Host) Run(ctx context.Context, serviceErrors chan<- LifecycleMessage
 			defer func() {
 				value := recover()
 				if value != nil {
+					// Log here to force the original call stack to be logged.
 					err := fmt.Errorf("service %s paniced: %v", service.Name(), value)
+					logger.WithValues().Error(err, "recovered from panic")
 					messages <- LifecycleMessage{Name: service.Name(), Err: err}
 				}
 			}()

--- a/pkg/radrp/rest/results.go
+++ b/pkg/radrp/rest/results.go
@@ -17,6 +17,7 @@ import (
 	"github.com/project-radius/radius/pkg/azure/azresources"
 	"github.com/project-radius/radius/pkg/radlogger"
 	"github.com/project-radius/radius/pkg/radrp/armerrors"
+	"github.com/project-radius/radius/pkg/resources"
 )
 
 // Translation of internal representation of health state to user facing values
@@ -330,6 +331,18 @@ func NewNotFoundResponse(id azresources.ResourceID) Response {
 				Code:    armerrors.NotFound,
 				Message: fmt.Sprintf("the resource with id '%s' was not found", id.ID),
 				Target:  id.ID,
+			},
+		},
+	}
+}
+
+func NewNotFoundResponseUCP(id resources.ID) Response {
+	return &NotFoundResponse{
+		Body: armerrors.ErrorResponse{
+			Error: armerrors.ErrorDetails{
+				Code:    armerrors.NotFound,
+				Message: fmt.Sprintf("the resource with id '%s' was not found", id.String()),
+				Target:  id.String(),
 			},
 		},
 	}

--- a/pkg/radrp/rest/results.go
+++ b/pkg/radrp/rest/results.go
@@ -68,6 +68,11 @@ func (r *OKResponse) Apply(ctx context.Context, w http.ResponseWriter, req *http
 		w.Header().Add(key, element)
 	}
 
+	if r.Body == nil {
+		w.WriteHeader(http.StatusOK)
+		return nil
+	}
+
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, err = w.Write(bytes)

--- a/pkg/resources/id.go
+++ b/pkg/resources/id.go
@@ -1,0 +1,365 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package resources
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	SegmentSeparator = "/"
+	PlanesSegment    = "planes"
+	ProvidersSegment = "providers"
+	UCPPrefix        = "ucp:"
+)
+
+// ID represents an ARM or UCP resource id. ID is immutable once created. Use Parse() to create IDs and use
+// String() to convert back to strings.
+type ID struct {
+	id            string
+	scopeSegments []ScopeSegment
+	typeSegments  []TypeSegment
+}
+
+// ScopeSegment represents one of the root-scope pairs of a resource ID.
+type ScopeSegment struct {
+	// Type is the type of the scope.
+	//
+	// Example:
+	//	resourceGroup
+	//	subscription
+	//
+	Type string
+	Name string
+}
+
+// TypeSegment represents one of the type/name pairs of a resource ID.
+type TypeSegment struct {
+	// Type one of the segments of a resource type. This will be a namespace/type combo for the first
+	// segment, and a simple name for subsequent ones.
+	//
+	// Example:
+	//	Microsoft.Resources/deployment
+	//  database
+	//
+	Type string
+	Name string
+}
+
+// IsEmpty returns true if the ID is empty.
+func (ri ID) IsEmpty() bool {
+	return ri.id == ""
+}
+
+// IsCollection returns true if the ID represents a collection (final segment has no name).
+func (ri ID) IsCollection() bool {
+	if ri.IsScope() {
+		return ri.scopeSegments[len(ri.scopeSegments)-1].Name == ""
+	}
+
+	return ri.typeSegments[len(ri.typeSegments)-1].Name == ""
+}
+
+// IsScope returns true if the ID represents a scope.
+func (ri ID) IsScope() bool {
+	return !ri.IsEmpty() && len(ri.typeSegments) == 0
+}
+
+// IsUCPQualfied returns true if the ID has a UCP qualifier ('ucp:/').
+func (ri ID) IsUCPQualfied() bool {
+	return strings.HasPrefix(ri.id, UCPPrefix)
+}
+
+// ScopeSegments gets the slice of root-scope segments.
+func (ri ID) ScopeSegments() []ScopeSegment {
+	return ri.scopeSegments
+}
+
+// TypeSegments gets the slice of type segments.
+func (ri ID) TypeSegments() []TypeSegment {
+	return ri.typeSegments
+}
+
+func (ri ID) String() string {
+	return ri.id
+}
+
+// RootScope returns the root-scope (the part before 'providers'). This includes 'ucp:' prefix.
+//
+// Examples:
+//	/subscriptions{guid}/resourceGroups/cool-group
+//	/planes/radius/local/resourceGroups/cool-group
+func (ri ID) RootScope() string {
+	segments := []string{}
+	for _, t := range ri.scopeSegments {
+		segments = append(segments, t.Type)
+		if t.Name != "" {
+			segments = append(segments, t.Name)
+		}
+	}
+
+	joined := strings.Join(segments, SegmentSeparator)
+	if ri.IsUCPQualfied() {
+		return UCPPrefix + SegmentSeparator + PlanesSegment + SegmentSeparator + joined
+	}
+
+	return SegmentSeparator + joined
+}
+
+// RoutingScope returns the routing-scope (the part after 'providers').
+//
+// Examples:
+//	/Applications.Core/applications/my-app
+func (ri ID) RoutingScope() string {
+	segments := []string{}
+	for _, t := range ri.typeSegments {
+		segments = append(segments, t.Type)
+		if t.Name != "" {
+			segments = append(segments, t.Name)
+		}
+	}
+
+	return strings.Join(segments, SegmentSeparator)
+}
+
+// Type returns the fully-qualified resource type of a ResourceID.
+func (ri ID) Type() string {
+	types := make([]string, len(ri.typeSegments))
+	for i, t := range ri.typeSegments {
+		types[i] = t.Type
+	}
+	return strings.Join(types, SegmentSeparator)
+}
+
+// QualifiedName gets the fully-qualified resource name (eg. `radiusv3/myapp/mycontainer`).
+func (ri ID) QualifiedName() string {
+	names := make([]string, len(ri.typeSegments))
+	for i, t := range ri.typeSegments {
+		names[i] = t.Name
+	}
+	return strings.Join(names, SegmentSeparator)
+}
+
+// Name gets the resource or scope name.
+func (ri ID) Name() string {
+	if len(ri.typeSegments) == 0 && len(ri.scopeSegments) == 0 {
+		return ""
+	}
+
+	if len(ri.typeSegments) == 0 {
+		return ri.scopeSegments[len(ri.scopeSegments)-1].Name
+	}
+
+	return ri.typeSegments[len(ri.typeSegments)-1].Name
+}
+
+// Append appends a type/name pair to the ResourceID.
+func (ri ID) Append(resourceType TypeSegment) ID {
+	types := append(ri.typeSegments, resourceType)
+
+	if ri.IsUCPQualfied() {
+		result, err := Parse(MakeUCPID(ri.scopeSegments, types...))
+		if err != nil {
+			panic(err) // Should not be possible.
+		}
+
+		return result
+	} else {
+		result, err := Parse(MakeRelativeID(ri.scopeSegments, types...))
+		if err != nil {
+			panic(err) // Should not be possible.
+		}
+
+		return result
+	}
+}
+
+// Truncate removes the last type/name pair of the ResourceID. Calling truncate on a top level resource has no effect.
+func (ri ID) Truncate() ID {
+	if len(ri.typeSegments) < 2 {
+		return ri
+	}
+
+	if ri.IsUCPQualfied() {
+		result, err := Parse(MakeUCPID(ri.scopeSegments, ri.typeSegments[0:len(ri.typeSegments)-1]...))
+		if err != nil {
+			panic(err) // Should not be possible.
+		}
+
+		return result
+	} else {
+		result, err := Parse(MakeRelativeID(ri.scopeSegments, ri.typeSegments[0:len(ri.typeSegments)-1]...))
+		if err != nil {
+			panic(err) // Should not be possible.
+		}
+
+		return result
+	}
+}
+
+// Parse parses a resource ID.
+func Parse(id string) (ID, error) {
+	isUCPQualified := false
+	if strings.HasPrefix(id, UCPPrefix+SegmentSeparator+PlanesSegment) {
+		isUCPQualified = true
+		id = strings.TrimPrefix(id, UCPPrefix+SegmentSeparator+PlanesSegment)
+	}
+
+	// trim the leading and ending / so we don't end up with an empty segment - we disallow
+	// empty segments in the middle of the string
+	id = strings.TrimPrefix(id, SegmentSeparator)
+	id = strings.TrimSuffix(id, SegmentSeparator)
+
+	// The minimum segment count is 2 since we can parse "root scope only" ids.
+	segments := strings.Split(id, SegmentSeparator)
+	if len(segments) < 2 {
+		return ID{}, invalid(id)
+	}
+
+	// Check up front for empty segments
+	for _, s := range segments {
+		if s == "" {
+			return ID{}, invalid(id)
+		}
+	}
+
+	// Parse scopes - iterate until we get to "providers"
+	scopes := []ScopeSegment{}
+	i := 0
+	for i < len(segments) {
+		if len(segments)-i < 2 {
+			// odd number of non-providers segments remaining, this is invalid.
+			return ID{}, invalid(id)
+		}
+
+		// We're done parsing scopes
+		if strings.ToLower(segments[i]) == ProvidersSegment {
+			i++ // advance past "providers"
+			break
+		}
+
+		if strings.ToLower(segments[i+1]) == ProvidersSegment {
+			// odd number of non-providers segments inside the root scope, this is invalid.
+			return ID{}, invalid(id)
+		}
+
+		scopes = append(scopes, ScopeSegment{Type: segments[i], Name: segments[i+1]})
+		i += 2
+	}
+
+	// We might not have a "providers" segment at all, if that's the case then this ID refers to
+	// a scope.
+	if len(segments)-i == 0 {
+		normalized := ""
+		if isUCPQualified {
+			normalized = MakeUCPID(scopes, []TypeSegment{}...)
+		} else {
+			normalized = MakeRelativeID(scopes, []TypeSegment{}...)
+		}
+
+		return ID{
+			id:            normalized,
+			scopeSegments: scopes,
+			typeSegments:  []TypeSegment{},
+		}, nil
+	}
+
+	// Now that're past providers, we're looking for the namespace/type - that is
+	// at least 2 segments.
+	if len(segments)-i < 2 {
+		return ID{}, invalid(id)
+	}
+
+	resourceType := TypeSegment{Type: fmt.Sprintf("%s/%s", segments[i], segments[i+1])}
+	i += 2
+
+	// We intentionally tolerate a "collection" id that omits the last name segment
+	if len(segments)-i > 0 {
+		resourceType.Name = segments[i]
+		i++
+	}
+	types := []TypeSegment{resourceType}
+
+	for i < len(segments) {
+		rt := TypeSegment{Type: segments[i]}
+		i++
+
+		// check for a resource name
+		if len(segments)-i == 0 {
+			// This is a collection.
+			types = append(types, rt)
+			break
+		}
+
+		// we have a name - keep parsing
+		rt.Name = segments[i]
+		i++
+
+		types = append(types, rt)
+	}
+
+	normalized := ""
+	if isUCPQualified {
+		normalized = MakeUCPID(scopes, types...)
+	} else {
+		normalized = MakeRelativeID(scopes, types...)
+	}
+
+	return ID{
+		id:            normalized,
+		scopeSegments: scopes,
+		typeSegments:  types,
+	}, nil
+}
+
+func invalid(id string) error {
+	return fmt.Errorf("'%s' is not a valid resource id", id)
+}
+
+// MakeUCPID creates a fully-qualified UCP resource ID.
+func MakeUCPID(scopes []ScopeSegment, resourceTypes ...TypeSegment) string {
+	segments := []string{
+		PlanesSegment,
+	}
+	for _, scope := range scopes {
+		segments = append(segments, scope.Type, scope.Name)
+	}
+
+	if len(resourceTypes) != 0 {
+		segments = append(segments, ProvidersSegment)
+
+		for _, rt := range resourceTypes {
+			segments = append(segments, rt.Type)
+			if rt.Name != "" {
+				segments = append(segments, rt.Name)
+			}
+		}
+	}
+
+	return UCPPrefix + SegmentSeparator + strings.Join(segments, SegmentSeparator)
+}
+
+// MakeRelativeID makes a plane-relative resource ID (ARM style).
+func MakeRelativeID(scopes []ScopeSegment, resourceTypes ...TypeSegment) string {
+	segments := []string{}
+	for _, scope := range scopes {
+		segments = append(segments, scope.Type, scope.Name)
+	}
+
+	if len(resourceTypes) != 0 {
+		segments = append(segments, ProvidersSegment)
+
+		for _, rt := range resourceTypes {
+			segments = append(segments, rt.Type)
+			if rt.Name != "" {
+				segments = append(segments, rt.Name)
+			}
+		}
+	}
+
+	return SegmentSeparator + strings.Join(segments, SegmentSeparator)
+}

--- a/pkg/resources/id_test.go
+++ b/pkg/resources/id_test.go
@@ -1,0 +1,381 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package resources
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ParseInvalidIDs(t *testing.T) {
+	values := []string{
+		"",
+		"/subscriptions/{%s}/resourceGroups/{%s}/providers/Microsoft.CustomProviders/",
+		"//subscriptions/{%s}/resourceGroups/{%s}/providers/Microsoft.CustomProviders/resourceProviders",
+		"/subscriptions/{%s}/resourceGroups/{%s}/providers/Microsoft.CustomProviders/resourceProviders//",
+		"/subscriptions/{%s}/resourceGroups/{%s}/providers/Microsoft.CustomProviders//",
+		"/subscriptions/{%s}/resourceGroups/{%s}/ddproviders/Microsoft.CustomProviders/resourceProviders",
+		"/subscriptions/{%s}/resourceGroups//providers/Microsoft.CustomProviders/resourceProviders",
+		"/subscriptions/{%s}/resourceGroups/providers/Microsoft.CustomProviders/resourceProviders",
+		"ucp:/",
+		"ucp:/planes",
+		"ucp:/planes/radius/",
+		"ucp:/planes/radius/local/resourceGroups//providers/Microsoft.CustomProviders/resourceProviders",
+	}
+
+	for i, v := range values {
+		t.Run(fmt.Sprintf("%d: %v", i, v), func(t *testing.T) {
+			_, err := Parse(v)
+			require.Errorf(t, err, "shouldn't have parsed %s", v)
+		})
+	}
+}
+
+func Test_ParseValidIDs(t *testing.T) {
+	values := []struct {
+		id       string
+		expected string
+		scopes   []ScopeSegment
+		types    []TypeSegment
+	}{
+		{
+			id:       "/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders",
+			expected: "/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders",
+			scopes: []ScopeSegment{
+				{Type: "subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "Microsoft.CustomProviders/resourceProviders"},
+			},
+		},
+		{
+			id:       "/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/",
+			expected: "/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders",
+			scopes: []ScopeSegment{
+				{Type: "subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "Microsoft.CustomProviders/resourceProviders"},
+			},
+		},
+		{
+			id:       "subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders",
+			expected: "/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders",
+			scopes: []ScopeSegment{
+				{Type: "subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "Microsoft.CustomProviders/resourceProviders"},
+			},
+		},
+		{
+			id:       "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders",
+			expected: "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders",
+			scopes: []ScopeSegment{
+				{Type: "Subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "Microsoft.CustomProviders/resourceProviders"},
+			},
+		},
+		{
+			id:       "/Subscriptions/s1/resourceGroups/r1/providers/foo/bar",
+			expected: "/Subscriptions/s1/resourceGroups/r1/providers/foo/bar",
+			scopes: []ScopeSegment{
+				{Type: "Subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "foo/bar"},
+			},
+		},
+		{
+			id:       "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius",
+			expected: "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius",
+			scopes: []ScopeSegment{
+				{Type: "Subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "Microsoft.CustomProviders/resourceProviders", Name: "radius"},
+			},
+		},
+		{
+			id:       "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/",
+			expected: "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius",
+			scopes: []ScopeSegment{
+				{Type: "Subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "Microsoft.CustomProviders/resourceProviders", Name: "radius"},
+			},
+		},
+		{
+			id:       "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/",
+			expected: "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius",
+			scopes: []ScopeSegment{
+				{Type: "Subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "Microsoft.CustomProviders/resourceProviders", Name: "radius"},
+			},
+		},
+		{
+			id:       "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications",
+			expected: "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications",
+			scopes: []ScopeSegment{
+				{Type: "Subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "Microsoft.CustomProviders/resourceProviders", Name: "radius"},
+				{Type: "Applications"},
+			},
+		},
+		{
+			id:       "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app",
+			expected: "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app",
+			scopes: []ScopeSegment{
+				{Type: "Subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "Microsoft.CustomProviders/resourceProviders", Name: "radius"},
+				{Type: "Applications", Name: "test-app"},
+			},
+		},
+		{
+			id:       "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app/Containers",
+			expected: "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app/Containers",
+			scopes: []ScopeSegment{
+				{Type: "Subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "Microsoft.CustomProviders/resourceProviders", Name: "radius"},
+				{Type: "Applications", Name: "test-app"},
+				{Type: "Containers"},
+			},
+		},
+		{
+			id:       "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app/Containers/test",
+			expected: "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app/Containers/test",
+			scopes: []ScopeSegment{
+				{Type: "Subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "Microsoft.CustomProviders/resourceProviders", Name: "radius"},
+				{Type: "Applications", Name: "test-app"},
+				{Type: "Containers", Name: "test"},
+			},
+		},
+		{
+			id:       "ucp:/planes/azure/azurecloud/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app/Containers/test",
+			expected: "ucp:/planes/azure/azurecloud/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app/Containers/test",
+			scopes: []ScopeSegment{
+				{Type: "azure", Name: "azurecloud"},
+				{Type: "subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "Microsoft.CustomProviders/resourceProviders", Name: "radius"},
+				{Type: "Applications", Name: "test-app"},
+				{Type: "Containers", Name: "test"},
+			},
+		},
+		{
+			id:       "ucp:/planes/radius/local/resourceGroups/r1/providers/Applications.Core/applications/cool-app",
+			expected: "ucp:/planes/radius/local/resourceGroups/r1/providers/Applications.Core/applications/cool-app",
+			scopes: []ScopeSegment{
+				{Type: "radius", Name: "local"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "Applications.Core/applications", Name: "cool-app"},
+			},
+		},
+		{
+			id:       "ucp:/planes/radius/local/",
+			expected: "ucp:/planes/radius/local",
+			scopes: []ScopeSegment{
+				{Type: "radius", Name: "local"},
+			},
+			types: []TypeSegment{},
+		},
+		{
+			id:       "ucp:/planes/radius/local/resourceGroups/r1",
+			expected: "ucp:/planes/radius/local/resourceGroups/r1",
+			scopes: []ScopeSegment{
+				{Type: "radius", Name: "local"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{},
+		},
+	}
+
+	for i, v := range values {
+		t.Run(fmt.Sprintf("%d: %v", i, v.id), func(t *testing.T) {
+			id, err := Parse(v.id)
+			require.NoError(t, err)
+
+			require.Equalf(t, v.expected, id.id, "id comparison failed for %s", v.id)
+			require.Equalf(t, v.scopes, id.scopeSegments, "scope comparison failed for %s", v.id)
+
+			require.Lenf(t, id.typeSegments, len(v.types), "types comparison failed for %s", v.id)
+			for i := range id.typeSegments {
+				require.Equalf(t, v.types[i], id.typeSegments[i], "types comparison failed for %s", v.id)
+			}
+		})
+	}
+}
+
+func Test_MakeRelativeID(t *testing.T) {
+	values := []struct {
+		expected string
+		scopes   []ScopeSegment
+		types    []TypeSegment
+	}{
+		{
+			expected: "/subscriptions/s1/resourceGroups/r1/providers/foo/bar",
+			scopes: []ScopeSegment{
+				{Type: "subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "foo/bar"},
+			},
+		},
+		{
+			expected: "/subscriptions/s1/resourceGroups/r1/providers/foo/bar/radius",
+			scopes: []ScopeSegment{
+				{Type: "subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "foo/bar", Name: "radius"},
+			},
+		},
+		{
+			expected: "/subscriptions/s1/resourceGroups/r1/providers/foo/bar/radius/t1",
+			scopes: []ScopeSegment{
+				{Type: "subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "foo/bar", Name: "radius"},
+				{Type: "t1"},
+			},
+		},
+		{
+			expected: "/subscriptions/s1/resourceGroups/r1/providers/foo/bar/radius/t1/n1/t2",
+			scopes: []ScopeSegment{
+				{Type: "subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "foo/bar", Name: "radius"},
+				{Type: "t1", Name: "n1"},
+				{Type: "t2"},
+			},
+		},
+		{
+			expected: "/subscriptions/s1/resourceGroups/r1/providers/foo/bar/radius/t1/n1/t2/n2",
+			scopes: []ScopeSegment{
+				{Type: "subscriptions", Name: "s1"},
+				{Type: "resourceGroups", Name: "r1"},
+			},
+			types: []TypeSegment{
+				{Type: "foo/bar", Name: "radius"},
+				{Type: "t1", Name: "n1"},
+				{Type: "t2", Name: "n2"},
+			},
+		},
+	}
+
+	for i, v := range values {
+		scopes := []ScopeSegment{
+			{Type: "subscriptions", Name: "s1"},
+			{Type: "resourceGroups", Name: "r1"},
+		}
+		t.Run(fmt.Sprintf("%d: %v", i, v.expected), func(t *testing.T) {
+			actual := MakeRelativeID(scopes, v.types...)
+			require.Equal(t, v.expected, actual)
+		})
+	}
+}
+
+func Test_Append_Collection(t *testing.T) {
+	id, err := Parse("/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app")
+	require.NoError(t, err)
+
+	appended := id.Append(TypeSegment{Name: "", Type: "test-resource"})
+	require.Equal(t, "/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app/test-resource", appended.id)
+}
+
+func Test_Append_Collection_UCP(t *testing.T) {
+	id, err := Parse("ucp:/planes/azure/azurecloud/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app")
+	require.NoError(t, err)
+
+	appended := id.Append(TypeSegment{Name: "", Type: "test-resource"})
+	require.Equal(t, "ucp:/planes/azure/azurecloud/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app/test-resource", appended.id)
+}
+
+func Test_Append_NamedResource(t *testing.T) {
+	id, err := Parse("/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app")
+	require.NoError(t, err)
+
+	appended := id.Append(TypeSegment{Name: "test-name", Type: "test-resource"})
+	require.Equal(t, "/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app/test-resource/test-name", appended.id)
+}
+
+func Test_Append_NamedResource_UCP(t *testing.T) {
+	id, err := Parse("ucp:/planes/azure/azurecloud/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app")
+	require.NoError(t, err)
+
+	appended := id.Append(TypeSegment{Name: "test-name", Type: "test-resource"})
+	require.Equal(t, "ucp:/planes/azure/azurecloud/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app/test-resource/test-name", appended.id)
+}
+
+func Test_Truncate_Success(t *testing.T) {
+	id, err := Parse("/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app")
+	require.NoError(t, err)
+
+	truncated := id.Truncate()
+	require.Equal(t, "/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius", truncated.id)
+}
+
+func Test_Truncate_Success_UCP(t *testing.T) {
+	id, err := Parse("ucp:/planes/azure/azurecloud/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app")
+	require.NoError(t, err)
+
+	truncated := id.Truncate()
+	require.Equal(t, "ucp:/planes/azure/azurecloud/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius", truncated.id)
+}
+
+func Test_Truncate_ReturnsSelfForTopLevelResource(t *testing.T) {
+	id, err := Parse("/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius")
+	require.NoError(t, err)
+
+	truncated := id.Truncate()
+	require.Equal(t, "/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius", truncated.id)
+}
+
+func Test_Truncate_ReturnsSelfForTopLevelResource_UCP(t *testing.T) {
+	id, err := Parse("ucp:/planes/azure/azurecloud/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius")
+	require.NoError(t, err)
+
+	truncated := id.Truncate()
+	require.Equal(t, "ucp:/planes/azure/azurecloud/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius", truncated.id)
+}


### PR DESCRIPTION
**DO NOT MERGE**

This is just an example - I did an exploratory hack and cut every possible corner. 

**TLDR:** it will be relatively straightforward for us to get some basic E2Es working with UCP. 

Big changes here: 

- I totally hacked the database layer. We already have a plane to converge the implementations in project-radius/ucp with this. That work doesn't have any unknowns.
- I integrated the UCP resource ID parser. This supports non-Azure IDs.
- I added a new set of routes that support the URL paths UCP will be using

That's it 😆 