### PR TITLE
Improve error handling for invalid config

### DIFF
--- a/pkg/corerp/dataprovider/factory.go
+++ b/pkg/corerp/dataprovider/factory.go
@@ -7,6 +7,7 @@ package dataprovider
 
 import (
 	context "context"
+	"fmt"
 
 	store "github.com/project-radius/radius/pkg/store"
 	"github.com/project-radius/radius/pkg/store/cosmosdb"
@@ -28,11 +29,11 @@ func initCosmosDBClient(ctx context.Context, opt StorageProviderOptions, collect
 	}
 	dbclient, err := cosmosdb.NewCosmosDBStorageClient(sopt)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create CosmosDB client - configuration may be invalid: %w", err)
 	}
 
 	if err = dbclient.Init(ctx); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize CosmosDB client - configuration may be invalid: %w", err)
 	}
 
 	return dbclient, nil

--- a/pkg/corerp/frontend/handler/routes.go
+++ b/pkg/corerp/frontend/handler/routes.go
@@ -7,6 +7,7 @@ package handler
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -149,7 +150,7 @@ func AddConnectorRoutes(ctx context.Context, sp dataprovider.DataStorageProvider
 	// Register handlers
 	for _, h := range handlers {
 		if err := registerHandler(ctx, sp, h.parent, h.resourcetype, h.method, h.routeName, h.fn); err != nil {
-			return err
+			return fmt.Errorf("failed to register %s handler for route %s: %w", h.method, h.routeName, err)
 		}
 	}
 

--- a/pkg/corerp/frontend/server/server.go
+++ b/pkg/corerp/frontend/server/server.go
@@ -28,15 +28,18 @@ type ServerOptions struct {
 	Address       string
 	PathBase      string
 	EnableArmAuth bool
-	Configure     func(*mux.Router)
+	Configure     func(*mux.Router) error
 	ArmCertMgr    *authentication.ArmCertManager
 }
 
 // NewServer will create a server that can listen on the provided address and serve requests.
-func NewServer(ctx context.Context, options ServerOptions, metricsProviderConfig mp.MetricsOptions) *http.Server {
+func NewServer(ctx context.Context, options ServerOptions, metricsProviderConfig mp.MetricsOptions) (*http.Server, error) {
 	r := mux.NewRouter()
 	if options.Configure != nil {
-		options.Configure(r)
+		err := options.Configure(r)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	r.Use(middleware.Recoverer)
@@ -64,5 +67,5 @@ func NewServer(ctx context.Context, options ServerOptions, metricsProviderConfig
 		},
 	}
 
-	return server
+	return server, nil
 }

--- a/pkg/corerp/frontend/service.go
+++ b/pkg/corerp/frontend/service.go
@@ -53,29 +53,36 @@ func (s *Service) Run(ctx context.Context) error {
 			return err
 		}
 	}
-	server := server.NewServer(ctx, server.ServerOptions{
+	server, err := server.NewServer(ctx, server.ServerOptions{
 		Address:  address,
 		PathBase: s.Options.Config.Server.PathBase,
 		// set the arm cert manager for managing client certificate
 		ArmCertMgr:    acm,
 		EnableArmAuth: s.Options.Config.Server.EnableArmAuth, // when enabled the client cert validation will be done
-		Configure: func(router *mux.Router) {
+		Configure: func(router *mux.Router) error {
 			// TODO: Once https://github.com/project-radius/radius/issues/2329 is resolved, pass the standaloneMode parameter as true/false
 			// based on the config
-			if err := handler.AddRoutes(ctx, storageProvider, nil, router, handler.DefaultValidatorFactory, "", false); err != nil {
-				panic(err)
+			err := handler.AddRoutes(ctx, storageProvider, nil, router, handler.DefaultValidatorFactory, "", false)
+			if err != nil {
+				return err
 			}
 
 			// TODO Connector RP will be moved into a separate service, for now using core RP's infra to unblock end to end testing
 			// https://github.com/project-radius/core-team/issues/90
 			// TODO: Once https://github.com/project-radius/radius/issues/2329 is resolved, pass the standaloneMode parameter as true/false
 			// based on the config
-			if err := handler.AddConnectorRoutes(ctx, storageProvider, nil, router, handler.DefaultValidatorFactory, "", false); err != nil {
-				panic(err)
+			err = handler.AddConnectorRoutes(ctx, storageProvider, nil, router, handler.DefaultValidatorFactory, "", false)
+			if err != nil {
+				return err
 			}
+
+			return nil
 		}},
 		s.Options.Config.MetricsProvider,
 	)
+	if err != nil {
+		return nil
+	}
 
 	// Handle shutdown based on the context
 	go func() {
@@ -85,7 +92,7 @@ func (s *Service) Run(ctx context.Context) error {
 	}()
 
 	logger.Info(fmt.Sprintf("listening on: '%s'...", address))
-	err := server.ListenAndServe()
+	err = server.ListenAndServe()
 	if err == http.ErrServerClosed {
 		// We expect this, safe to ignore.
 		logger.Info("Server stopped...")

--- a/pkg/hosting/hosting.go
+++ b/pkg/hosting/hosting.go
@@ -103,7 +103,9 @@ func (host *Host) Run(ctx context.Context, serviceErrors chan<- LifecycleMessage
 			defer func() {
 				value := recover()
 				if value != nil {
+					// Log here to force the original call stack to be logged.
 					err := fmt.Errorf("service %s paniced: %v", service.Name(), value)
+					logger.WithValues().Error(err, "recovered from panic")
 					messages <- LifecycleMessage{Name: service.Name(), Err: err}
 				}
 			}()


### PR DESCRIPTION
This change improves the error handling/reporting for cases where you
have an invalid CosmosDB configuration. Previously the error was a panic
with "Failed to create request headers: illegal base64 data at input
byte 3" as the only hint to the problem.

This change removes the panic (now it's just an error) as well as adding
more contextual information using wrapping along the failing code path.

Additionally I improved the logging behavior where panics get handled,
previously we were not logging here, and so there was no way to
determine the call stack the caused the failure.
