### PR TITLE
Remove response body from deletes

### DIFF
--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
@@ -57,7 +57,7 @@ func (e *CreateOrUpdateEnvironment) Run(ctx context.Context, req *http.Request) 
 
 	err = ctrl.ValidateETag(*serviceCtx, etag)
 	if err != nil {
-		return rest.NewPreconditionFailedResponse(err.Error()), nil
+		return rest.NewPreconditionFailedResponse(serviceCtx.ResourceID.ID, err.Error()), nil
 	}
 
 	UpdateExistingResourceData(ctx, existingResource, newResource)

--- a/pkg/corerp/frontend/controller/environments/deleteenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/deleteenvironment.go
@@ -51,7 +51,7 @@ func (e *DeleteEnvironment) Run(ctx context.Context, req *http.Request) (rest.Re
 
 	err = ctrl.ValidateETag(*serviceCtx, etag)
 	if err != nil {
-		return rest.NewPreconditionFailedResponse(err.Error()), nil
+		return rest.NewPreconditionFailedResponse(serviceCtx.ResourceID.ID, err.Error()), nil
 	}
 
 	// TODO: handle async deletion later.
@@ -63,5 +63,5 @@ func (e *DeleteEnvironment) Run(ctx context.Context, req *http.Request) (rest.Re
 		return nil, err
 	}
 
-	return rest.NewOKResponse("deleted successfully"), nil
+	return rest.NewOKResponse(nil), nil
 }

--- a/pkg/radrp/rest/results.go
+++ b/pkg/radrp/rest/results.go
@@ -44,10 +44,14 @@ type OKResponse struct {
 	Headers map[string]string
 }
 
+// NewOKResponse creates an OKResponse that will write a 200 OK with the provided body as JSON.
+// Set the body to nil to write an empty 200 OK.
 func NewOKResponse(body interface{}) Response {
 	return &OKResponse{Body: body}
 }
 
+// NewOKResponseWithHeaders creates an OKResponse that will write a 200 OK with the provided body as JSON.
+// Set the body to nil to write an empty 200 OK.
 func NewOKResponseWithHeaders(body interface{}, headers map[string]string) Response {
 	return &OKResponse{
 		Body:    body,
@@ -66,6 +70,11 @@ func (r *OKResponse) Apply(ctx context.Context, w http.ResponseWriter, req *http
 
 	for key, element := range r.Headers {
 		w.Header().Add(key, element)
+	}
+
+	if r.Body == nil {
+		w.WriteHeader(http.StatusOK)
+		return nil
 	}
 
 	w.Header().Add("Content-Type", "application/json")
@@ -557,12 +566,13 @@ type PreconditionFailedResponse struct {
 	Body armerrors.ErrorResponse
 }
 
-func NewPreconditionFailedResponse(message string) Response {
+func NewPreconditionFailedResponse(target string, message string) Response {
 	return &PreconditionFailedResponse{
 		Body: armerrors.ErrorResponse{
 			Error: armerrors.ErrorDetails{
 				Code:    armerrors.PreconditionFailed,
 				Message: message,
+				Target:  target,
 			},
 		},
 	}


### PR DESCRIPTION
Removing an extra message from resource deletion. It's not a great idea
to return a string (vs an object) as JSON as it cannot be
evolved/versioned over time.

Additionally making some small improvements to tests.
