### PR TITLE
rad cli change for stand-alone

### DIFF
--- a/pkg/cli/environments/azure.go
+++ b/pkg/cli/environments/azure.go
@@ -40,6 +40,7 @@ type AzureCloudEnvironment struct {
 	APIServerBaseURL           string `mapstructure:"apiserverbaseurl,omitempty"`
 	APIDeploymentEngineBaseURL string `mapstructure:"apideploymentenginebaseurl,omitempty"`
 
+	EnableUCP bool `mapstructure:"enableucp,omitempty"`
 	// We tolerate and allow extra fields - this helps with forwards compat.
 	Properties map[string]interface{} `mapstructure:",remain" yaml:",omitempty"`
 }
@@ -72,7 +73,7 @@ func (e *AzureCloudEnvironment) GetStatusLink() string {
 
 func (e *AzureCloudEnvironment) CreateDeploymentClient(ctx context.Context) (clients.DeploymentClient, error) {
 	//third parameter indicates this is not UCP env.
-	url, roundTripper, err := kubernetes.GetBaseUrlAndRoundTripperForDeploymentEngine(e.APIDeploymentEngineBaseURL, e.Context, false)
+	url, roundTripper, err := kubernetes.GetBaseUrlAndRoundTripperForDeploymentEngine(e.APIDeploymentEngineBaseURL, e.Context, e.EnableUCP)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/environments/azure.go
+++ b/pkg/cli/environments/azure.go
@@ -72,7 +72,6 @@ func (e *AzureCloudEnvironment) GetStatusLink() string {
 
 func (e *AzureCloudEnvironment) CreateDeploymentClient(ctx context.Context) (clients.DeploymentClient, error) {
 	//third parameter indicates this is not UCP env.
-	//both not UCP env and UCP env not applicable are indicated by value "no"
 	url, roundTripper, err := kubernetes.GetBaseUrlAndRoundTripperForDeploymentEngine(e.APIDeploymentEngineBaseURL, e.Context, false)
 	if err != nil {
 		return nil, err

--- a/pkg/cli/environments/azure.go
+++ b/pkg/cli/environments/azure.go
@@ -71,7 +71,9 @@ func (e *AzureCloudEnvironment) GetStatusLink() string {
 }
 
 func (e *AzureCloudEnvironment) CreateDeploymentClient(ctx context.Context) (clients.DeploymentClient, error) {
-	url, roundTripper, err := kubernetes.GetBaseUrlAndRoundTripperForDeploymentEngine(e.APIDeploymentEngineBaseURL, e.Context)
+	//third parameter indicates this is not UCP env.
+	//both not UCP env and UCP env not applicable are indicated by value "no"
+	url, roundTripper, err := kubernetes.GetBaseUrlAndRoundTripperForDeploymentEngine(e.APIDeploymentEngineBaseURL, e.Context, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/environments/azure.go
+++ b/pkg/cli/environments/azure.go
@@ -72,7 +72,6 @@ func (e *AzureCloudEnvironment) GetStatusLink() string {
 }
 
 func (e *AzureCloudEnvironment) CreateDeploymentClient(ctx context.Context) (clients.DeploymentClient, error) {
-	//third parameter indicates this is not UCP env.
 	url, roundTripper, err := kubernetes.GetBaseUrlAndRoundTripperForDeploymentEngine(e.APIDeploymentEngineBaseURL, e.Context, e.EnableUCP)
 	if err != nil {
 		return nil, err

--- a/pkg/cli/environments/dev.go
+++ b/pkg/cli/environments/dev.go
@@ -39,6 +39,7 @@ type LocalEnvironment struct {
 	APIDeploymentEngineBaseURL string     `mapstructure:"apideploymentenginebaseurl,omitempty"`
 	Providers                  *Providers `mapstructure:"providers"`
 
+	EnableUCP bool `mapstructure:"enableucp,omitempty"`
 	// We tolerate and allow extra fields - this helps with forwards compat.
 	Properties map[string]interface{} `mapstructure:",remain"`
 }
@@ -88,7 +89,7 @@ func (s *devsender) Do(request *http.Request) (*http.Response, error) {
 
 func (e *LocalEnvironment) CreateDeploymentClient(ctx context.Context) (clients.DeploymentClient, error) {
 	//third parameter indicates this is not UCP env.
-	url, roundTripper, err := kubernetes.GetBaseUrlAndRoundTripperForDeploymentEngine(e.APIDeploymentEngineBaseURL, e.Context, false)
+	url, roundTripper, err := kubernetes.GetBaseUrlAndRoundTripperForDeploymentEngine(e.APIDeploymentEngineBaseURL, e.Context, e.EnableUCP)
 
 	if err != nil {
 		return nil, err

--- a/pkg/cli/environments/dev.go
+++ b/pkg/cli/environments/dev.go
@@ -87,7 +87,10 @@ func (s *devsender) Do(request *http.Request) (*http.Response, error) {
 }
 
 func (e *LocalEnvironment) CreateDeploymentClient(ctx context.Context) (clients.DeploymentClient, error) {
-	url, roundTripper, err := kubernetes.GetBaseUrlAndRoundTripperForDeploymentEngine(e.APIDeploymentEngineBaseURL, e.Context)
+	//third parameter indicates this is not UCP env.
+	//both not UCP env and UCP env not applicable are indicated by value "no"
+
+	url, roundTripper, err := kubernetes.GetBaseUrlAndRoundTripperForDeploymentEngine(e.APIDeploymentEngineBaseURL, e.Context, false)
 
 	if err != nil {
 		return nil, err

--- a/pkg/cli/environments/dev.go
+++ b/pkg/cli/environments/dev.go
@@ -88,8 +88,6 @@ func (s *devsender) Do(request *http.Request) (*http.Response, error) {
 
 func (e *LocalEnvironment) CreateDeploymentClient(ctx context.Context) (clients.DeploymentClient, error) {
 	//third parameter indicates this is not UCP env.
-	//both not UCP env and UCP env not applicable are indicated by value "no"
-
 	url, roundTripper, err := kubernetes.GetBaseUrlAndRoundTripperForDeploymentEngine(e.APIDeploymentEngineBaseURL, e.Context, false)
 
 	if err != nil {

--- a/pkg/cli/environments/dev.go
+++ b/pkg/cli/environments/dev.go
@@ -88,7 +88,6 @@ func (s *devsender) Do(request *http.Request) (*http.Response, error) {
 }
 
 func (e *LocalEnvironment) CreateDeploymentClient(ctx context.Context) (clients.DeploymentClient, error) {
-	//third parameter indicates this is not UCP env.
 	url, roundTripper, err := kubernetes.GetBaseUrlAndRoundTripperForDeploymentEngine(e.APIDeploymentEngineBaseURL, e.Context, e.EnableUCP)
 
 	if err != nil {

--- a/pkg/cli/environments/kubernetes.go
+++ b/pkg/cli/environments/kubernetes.go
@@ -27,7 +27,7 @@ type KubernetesEnvironment struct {
 	DefaultApplication         string `mapstructure:"defaultapplication,omitempty"`
 	APIServerBaseURL           string `mapstructure:"apiserverbaseurl,omitempty"`
 	APIDeploymentEngineBaseURL string `mapstructure:"apideploymentenginebaseurl,omitempty"`
-
+	EnableUCP                  bool   `mapstructure:"enableucp,omitempty"`
 	// We tolerate and allow extra fields - this helps with forwards compat.
 	Properties map[string]interface{} `mapstructure:",remain"`
 }
@@ -38,6 +38,10 @@ func (e *KubernetesEnvironment) GetName() string {
 
 func (e *KubernetesEnvironment) GetKind() string {
 	return e.Kind
+}
+
+func (e *KubernetesEnvironment) GetEnableUCP() bool {
+	return e.EnableUCP
 }
 
 func (e *KubernetesEnvironment) GetDefaultApplication() string {
@@ -64,7 +68,7 @@ func (s *sender) Do(request *http.Request) (*http.Response, error) {
 }
 
 func (e *KubernetesEnvironment) CreateDeploymentClient(ctx context.Context) (clients.DeploymentClient, error) {
-	url, roundTripper, err := kubernetes.GetBaseUrlAndRoundTripperForDeploymentEngine(e.APIDeploymentEngineBaseURL, e.Context)
+	url, roundTripper, err := kubernetes.GetBaseUrlAndRoundTripperForDeploymentEngine(e.APIDeploymentEngineBaseURL, e.Context, e.EnableUCP)
 
 	if err != nil {
 		return nil, err

--- a/pkg/cli/environments/kubernetes.go
+++ b/pkg/cli/environments/kubernetes.go
@@ -28,6 +28,7 @@ type KubernetesEnvironment struct {
 	APIServerBaseURL           string `mapstructure:"apiserverbaseurl,omitempty"`
 	APIDeploymentEngineBaseURL string `mapstructure:"apideploymentenginebaseurl,omitempty"`
 	EnableUCP                  bool   `mapstructure:"enableucp,omitempty"`
+
 	// We tolerate and allow extra fields - this helps with forwards compat.
 	Properties map[string]interface{} `mapstructure:",remain"`
 }

--- a/pkg/cli/kubernetes/kubernetes.go
+++ b/pkg/cli/kubernetes/kubernetes.go
@@ -39,10 +39,11 @@ import (
 )
 
 const (
-	APIServerBasePath   = "/apis/api.radius.dev/v1alpha3"
-	UCPBasePath         = "/apis/api.ucp.dev/v1alpha3/planes/deploymentengine" //"/apis/api.bicep.dev/v1alpha3"
-	Location            = "Location"
-	AzureAsyncOperation = "Azure-AsyncOperation"
+	APIServerBasePath        = "/apis/api.radius.dev/v1alpha3"
+	DeploymentEngineBasePath = "/apis/api.bicep.dev/v1alpha3"
+	UCPBasePath              = "/apis/api.ucp.dev/v1alpha3/planes/deployments"
+	Location                 = "Location"
+	AzureAsyncOperation      = "Azure-AsyncOperation"
 )
 
 var (
@@ -123,14 +124,20 @@ func CreateAPIServerConnection(context string, overrideURL string) (string, *arm
 }
 
 func GetBaseUrlForDeploymentEngine(overrideURL string) string {
-	return strings.TrimSuffix(overrideURL, "/") + UCPBasePath
+	return strings.TrimSuffix(overrideURL, "/") + DeploymentEngineBasePath
 }
 
-func GetBaseUrlAndRoundTripperForDeploymentEngine(overrideURL string, context string) (string, http.RoundTripper, error) {
+func GetBaseUrlAndRoundTripperForDeploymentEngine(overrideURL string, context string, enableucp bool) (string, http.RoundTripper, error) {
 	var baseURL string
 	var roundTripper http.RoundTripper
+	var basePath string
+	if enableucp == true {
+		basePath = UCPBasePath
+	} else {
+		basePath = DeploymentEngineBasePath
+	}
 	if overrideURL != "" {
-		baseURL = strings.TrimSuffix(overrideURL, "/") + UCPBasePath
+		baseURL = strings.TrimSuffix(overrideURL, "/") + basePath
 		roundTripper = NewLocationRewriteRoundTripper(overrideURL, http.DefaultTransport)
 	} else {
 		restConfig, err := GetConfig(context)
@@ -143,7 +150,7 @@ func GetBaseUrlAndRoundTripperForDeploymentEngine(overrideURL string, context st
 			return "", nil, err
 		}
 
-		baseURL = strings.TrimSuffix(restConfig.Host+restConfig.APIPath, "/") + UCPBasePath
+		baseURL = strings.TrimSuffix(restConfig.Host+restConfig.APIPath, "/") + basePath
 		roundTripper = NewLocationRewriteRoundTripper(restConfig.Host, roundTripper)
 	}
 	return baseURL, roundTripper, nil

--- a/pkg/cli/kubernetes/kubernetes.go
+++ b/pkg/cli/kubernetes/kubernetes.go
@@ -41,7 +41,7 @@ import (
 const (
 	APIServerBasePath        = "/apis/api.radius.dev/v1alpha3"
 	DeploymentEngineBasePath = "/apis/api.bicep.dev/v1alpha3"
-	UCPBasePath              = "/apis/api.ucp.dev/v1alpha3/planes/deployments"
+	UCPBasePath              = "/apis/api.ucp.dev/v1alpha3/planes/deployments/local"
 	Location                 = "Location"
 	AzureAsyncOperation      = "Azure-AsyncOperation"
 )
@@ -131,7 +131,7 @@ func GetBaseUrlAndRoundTripperForDeploymentEngine(overrideURL string, context st
 	var baseURL string
 	var roundTripper http.RoundTripper
 	var basePath string
-	if enableucp == true {
+	if enableucp {
 		basePath = UCPBasePath
 	} else {
 		basePath = DeploymentEngineBasePath

--- a/pkg/cli/kubernetes/kubernetes.go
+++ b/pkg/cli/kubernetes/kubernetes.go
@@ -39,10 +39,10 @@ import (
 )
 
 const (
-	APIServerBasePath        = "/apis/api.radius.dev/v1alpha3"
-	DeploymentEngineBasePath = "/apis/api.bicep.dev/v1alpha3"
-	Location                 = "Location"
-	AzureAsyncOperation      = "Azure-AsyncOperation"
+	APIServerBasePath   = "/apis/api.radius.dev/v1alpha3"
+	UCPBasePath         = "/apis/api.ucp.dev/v1alpha3/planes/deploymentengine" //"/apis/api.bicep.dev/v1alpha3"
+	Location            = "Location"
+	AzureAsyncOperation = "Azure-AsyncOperation"
 )
 
 var (
@@ -123,14 +123,14 @@ func CreateAPIServerConnection(context string, overrideURL string) (string, *arm
 }
 
 func GetBaseUrlForDeploymentEngine(overrideURL string) string {
-	return strings.TrimSuffix(overrideURL, "/") + DeploymentEngineBasePath
+	return strings.TrimSuffix(overrideURL, "/") + UCPBasePath
 }
 
 func GetBaseUrlAndRoundTripperForDeploymentEngine(overrideURL string, context string) (string, http.RoundTripper, error) {
 	var baseURL string
 	var roundTripper http.RoundTripper
 	if overrideURL != "" {
-		baseURL = strings.TrimSuffix(overrideURL, "/") + DeploymentEngineBasePath
+		baseURL = strings.TrimSuffix(overrideURL, "/") + UCPBasePath
 		roundTripper = NewLocationRewriteRoundTripper(overrideURL, http.DefaultTransport)
 	} else {
 		restConfig, err := GetConfig(context)
@@ -143,7 +143,7 @@ func GetBaseUrlAndRoundTripperForDeploymentEngine(overrideURL string, context st
 			return "", nil, err
 		}
 
-		baseURL = strings.TrimSuffix(restConfig.Host+restConfig.APIPath, "/") + DeploymentEngineBasePath
+		baseURL = strings.TrimSuffix(restConfig.Host+restConfig.APIPath, "/") + UCPBasePath
 		roundTripper = NewLocationRewriteRoundTripper(restConfig.Host, roundTripper)
 	}
 	return baseURL, roundTripper, nil

--- a/pkg/cli/kubernetes/kubernetes.go
+++ b/pkg/cli/kubernetes/kubernetes.go
@@ -41,7 +41,7 @@ import (
 const (
 	APIServerBasePath        = "/apis/api.radius.dev/v1alpha3"
 	DeploymentEngineBasePath = "/apis/api.bicep.dev/v1alpha3"
-	UCPBasePath              = "/apis/api.ucp.dev/v1alpha3/planes/deployments/local"
+	DeploymentsUCPPath       = "/apis/api.ucp.dev/v1alpha3/planes/deployments/local"
 	Location                 = "Location"
 	AzureAsyncOperation      = "Azure-AsyncOperation"
 )
@@ -132,7 +132,7 @@ func GetBaseUrlAndRoundTripperForDeploymentEngine(overrideURL string, context st
 	var roundTripper http.RoundTripper
 	var basePath string
 	if enableUCP {
-		basePath = UCPBasePath
+		basePath = DeploymentsUCPPath
 	} else {
 		basePath = DeploymentEngineBasePath
 	}

--- a/pkg/cli/kubernetes/kubernetes.go
+++ b/pkg/cli/kubernetes/kubernetes.go
@@ -127,7 +127,7 @@ func GetBaseUrlForDeploymentEngine(overrideURL string) string {
 	return strings.TrimSuffix(overrideURL, "/") + DeploymentEngineBasePath
 }
 
-func GetBaseUrlAndRoundTripperForDeploymentEngine(overrideURL string, context string, enableucp bool) (string, http.RoundTripper, error) {
+func GetBaseUrlAndRoundTripperForDeploymentEngine(overrideURL string, context string, enableUCP bool) (string, http.RoundTripper, error) {
 	var baseURL string
 	var roundTripper http.RoundTripper
 	var basePath string

--- a/pkg/cli/kubernetes/kubernetes.go
+++ b/pkg/cli/kubernetes/kubernetes.go
@@ -131,7 +131,7 @@ func GetBaseUrlAndRoundTripperForDeploymentEngine(overrideURL string, context st
 	var baseURL string
 	var roundTripper http.RoundTripper
 	var basePath string
-	if enableucp {
+	if enableUCP {
 		basePath = UCPBasePath
 	} else {
 		basePath = DeploymentEngineBasePath


### PR DESCRIPTION
# Description

Rad cli should talk to UCP in a stand mode deployment using UCP ID.
For this, we change the base URL for kubernetes env to "/apis/api.ucp.dev/v1alpha3/planes/deploymentengine"
"/planes/deployment" portion of url is compliant with UCP id and helps UCP to understand this is a request to be proxied to deploymentengine.


## Issue reference

Please reference the issue this PR will close: #2285


## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
