### PR TITLE
Updating httproute.properties.port to be integer type

### DIFF
--- a/pkg/azure/radclient/zz_generated_models.go
+++ b/pkg/azure/radclient/zz_generated_models.go
@@ -1874,7 +1874,7 @@ type HTTPRouteProperties struct {
 	Hostname *string `json:"hostname,omitempty"`
 
 	// The port number for the route. Defaults to 80. Readonly.
-	Port *float32 `json:"port,omitempty"`
+	Port *int32 `json:"port,omitempty"`
 
 	// The scheme used for traffic. Readonly.
 	Scheme *string `json:"scheme,omitempty"`

--- a/pkg/radrp/schema/resources/httproute.json
+++ b/pkg/radrp/schema/resources/httproute.json
@@ -31,7 +31,7 @@
         },
         "port": {
           "description": "The port number for the route. Defaults to 80. Readonly.",
-          "type": "number"
+          "type": "integer"
         },
         "scheme": {
           "description": "The scheme used for traffic. Readonly.",

--- a/schemas/rest-api-specs/radius.json
+++ b/schemas/rest-api-specs/radius.json
@@ -1195,7 +1195,7 @@
         },
         "port": {
           "description": "The port number for the route. Defaults to 80. Readonly.",
-          "type": "number"
+          "type": "integer"
         },
         "scheme": {
           "description": "The scheme used for traffic. Readonly.",


### PR DESCRIPTION
# Description

* Fixed issue where httproute.json schema sets type as float32 instead of int32
