### PR TITLE
remove metadata from bicep output

### DIFF
--- a/build/generate.mk
+++ b/build/generate.mk
@@ -9,10 +9,16 @@
 generate: generate-arm-json generate-radclient generate-go generate-bicep-types ## Generates all targets.
 
 .PHONY: generate-arm-json
-generate-arm-json: ## Generates ARM-JSON from our environment creation Bicep files
+generate-arm-json: generate-jq-installed ## Generates ARM-JSON from our environment creation Bicep files
 	@echo "$(ARROW) Updating ARM-JSON..."
 	az bicep build --file deploy/rp-full.bicep
 	jq 'del(.metadata)' deploy/rp-full.json  > deploy/rp-full.tmp && mv deploy/rp-full.tmp deploy/rp-full.json
+
+.PHONY: generate-jq-installed
+generate-jq-installed:
+	@echo "$(ARROW) Detecting jq..."
+	@which node > /dev/null || { echo "jq is a required dependency"; exit 1; }
+	@echo "$(ARROW) OK"
 
 .PHONY: generate-node-installed
 generate-node-installed:

--- a/build/generate.mk
+++ b/build/generate.mk
@@ -12,6 +12,7 @@ generate: generate-arm-json generate-radclient generate-go generate-bicep-types 
 generate-arm-json: ## Generates ARM-JSON from our environment creation Bicep files
 	@echo "$(ARROW) Updating ARM-JSON..."
 	az bicep build --file deploy/rp-full.bicep
+	jq 'del(.metadata)' deploy/rp-full.json  > deploy/rp-full.tmp && mv deploy/rp-full.tmp deploy/rp-full.json
 
 .PHONY: generate-node-installed
 generate-node-installed:

--- a/deploy/rp-full.json
+++ b/deploy/rp-full.json
@@ -1,13 +1,6 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "0.6.11.53198",
-      "templateHash": "10374101846025393636"
-    }
-  },
   "parameters": {
     "clusterName": {
       "type": "string",


### PR DESCRIPTION
# Description

Removes metadata key from bicep build output so that bicep version no longer breaks the build. 

The `metadata` section in ARM-JSON is non-semantic https://github.com/project-radius/radius/blob/main/deploy/rp-full.json
 
They just use this for telemetry purposes like tracking version usage across Bicep releases. It doesn't affect the behavior of the deployment engine.