### PR TITLE
fix proxy address calculation for UCP

### DIFF
--- a/pkg/ucp/frontend/ucphandler/planes/planes.go
+++ b/pkg/ucp/frontend/ucphandler/planes/planes.go
@@ -212,6 +212,10 @@ func (ucp *ucpHandler) ProxyRequest(ctx context.Context, db store.StorageClient,
 		httpScheme = "https"
 	}
 	ctx = context.WithValue(ctx, proxy.HttpSchemeField, httpScheme)
+	// The Host field in the request that the client makes to UCP contains the UCP Host address
+	// That address will be used to construct the URL for reverse proxying
+	ctx = context.WithValue(ctx, proxy.UCPHostField, r.Host)
+
 	sender := proxy.NewARMProxy(options, downstream, nil)
 	sender.ServeHTTP(w, r.WithContext(ctx))
 

--- a/pkg/ucp/frontend/ucphandler/planes/planes.go
+++ b/pkg/ucp/frontend/ucphandler/planes/planes.go
@@ -203,19 +203,23 @@ func (ucp *ucpHandler) ProxyRequest(ctx context.Context, db store.StorageClient,
 		RoundTripper: http.DefaultTransport,
 		ProxyAddress: ucp.options.Address,
 	}
-	ctx = context.WithValue(ctx, proxy.PlaneUrlField, proxyURL)
-	ctx = context.WithValue(ctx, proxy.PlaneIdField, planePath)
+
 	// As per https://github.com/golang/go/issues/28940#issuecomment-441749380, the way to check
 	// for http vs https is check the TLS field
 	httpScheme := "http"
 	if r.TLS != nil {
 		httpScheme = "https"
 	}
-	ctx = context.WithValue(ctx, proxy.HttpSchemeField, httpScheme)
-	// The Host field in the request that the client makes to UCP contains the UCP Host address
-	// That address will be used to construct the URL for reverse proxying
-	ctx = context.WithValue(ctx, proxy.UCPHostField, r.Host)
 
+	requestInfo := proxy.UCPRequestInfo{
+		PlaneURL:   proxyURL,
+		PlaneID:    planePath,
+		HTTPScheme: httpScheme,
+		// The Host field in the request that the client makes to UCP contains the UCP Host address
+		// That address will be used to construct the URL for reverse proxying
+		UCPHost: r.Host,
+	}
+	ctx = context.WithValue(ctx, proxy.UCPRequestInfoField, requestInfo)
 	sender := proxy.NewARMProxy(options, downstream, nil)
 	sender.ServeHTTP(w, r.WithContext(ctx))
 

--- a/pkg/ucp/proxy/arm_test.go
+++ b/pkg/ucp/proxy/arm_test.go
@@ -21,10 +21,12 @@ import (
 )
 
 func createTestContext(ctx context.Context, planeURL string, planeID string, httpScheme string, ucpHost string) context.Context {
-	ctx = context.WithValue(ctx, PlaneUrlField, planeURL)
-	ctx = context.WithValue(ctx, PlaneIdField, planeID)
-	ctx = context.WithValue(ctx, HttpSchemeField, httpScheme)
-	ctx = context.WithValue(ctx, UCPHostField, ucpHost)
+	ctx = context.WithValue(ctx, UCPRequestInfoField, UCPRequestInfo{
+		PlaneID:    planeID,
+		PlaneURL:   planeURL,
+		HTTPScheme: httpScheme,
+		UCPHost:    ucpHost,
+	})
 	return ctx
 }
 

--- a/pkg/ucp/proxy/arm_test.go
+++ b/pkg/ucp/proxy/arm_test.go
@@ -20,10 +20,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createTestContext(ctx context.Context, planeURL string, planeID string, httpScheme string) context.Context {
+func createTestContext(ctx context.Context, planeURL string, planeID string, httpScheme string, ucpHost string) context.Context {
 	ctx = context.WithValue(ctx, PlaneUrlField, planeURL)
 	ctx = context.WithValue(ctx, PlaneIdField, planeID)
 	ctx = context.WithValue(ctx, HttpSchemeField, httpScheme)
+	ctx = context.WithValue(ctx, UCPHostField, ucpHost)
 	return ctx
 }
 
@@ -51,7 +52,7 @@ func Test_ARM_Baselines(t *testing.T) {
 			pp := NewARMProxy(options, downstream, nil)
 
 			w := httptest.NewRecorder()
-			ctx = createTestContext(ctx, "http://example.com", "/planes/example/local", "http")
+			ctx = createTestContext(ctx, "http://example.com", "/planes/example/local", "http", "localhost:9443")
 			req := baseline.UpstreamRequest.ToTestRequest(ctx)
 
 			// Send the request

--- a/pkg/ucp/proxy/types_test.go
+++ b/pkg/ucp/proxy/types_test.go
@@ -124,8 +124,8 @@ func Test_ConvertHeaderToUCPIDs_NoContextDataSet(t *testing.T) {
 	}
 	err := convertHeaderToUCPIDs(context.Background(), AzureAsyncOperationHeader, []string{"http://example.com/subscriptions/sid/resourceGroups/rg/providers/Microsoft.CustomProviders/resourceProviders/radiusv3/Application/testApp/Container/test"}, &response)
 	require.Error(t, err, "Should have have failed")
-	require.Equal(t, "Could not find plane URL data in Azure-Asyncoperation header", err.Error())
+	require.Equal(t, "Could not find ucp request data in Azure-Asyncoperation header", err.Error())
 	err = convertHeaderToUCPIDs(context.Background(), LocationHeader, []string{"http://example.com/subscriptions/sid/resourceGroups/rg/providers/Microsoft.CustomProviders/resourceProviders/radiusv3/Application/testApp/Container/test"}, &response)
 	require.Error(t, err, "Should have have failed")
-	require.Equal(t, "Could not find plane URL data in Location header", err.Error())
+	require.Equal(t, "Could not find ucp request data in Location header", err.Error())
 }

--- a/pkg/ucp/proxy/types_test.go
+++ b/pkg/ucp/proxy/types_test.go
@@ -22,6 +22,7 @@ func Test_ConvertHeaderToUCPIDs(t *testing.T) {
 		planeURL       string
 		planeID        string
 		httpScheme     string
+		ucpHost        string
 		expectedHeader string
 	}
 	positiveTestData := data{
@@ -32,6 +33,7 @@ func Test_ConvertHeaderToUCPIDs(t *testing.T) {
 			planeURL:       "http://localhost:7443",
 			planeID:        "/planes/test/local",
 			httpScheme:     "http",
+			ucpHost:        "localhost:9443",
 		},
 		{
 			name:           AzureAsyncOperationHeader,
@@ -40,6 +42,7 @@ func Test_ConvertHeaderToUCPIDs(t *testing.T) {
 			planeURL:       "http://localhost:7443",
 			planeID:        "/planes/test/local",
 			httpScheme:     "http",
+			ucpHost:        "localhost:9443",
 		},
 		{
 			name:           LocationHeader,
@@ -48,6 +51,7 @@ func Test_ConvertHeaderToUCPIDs(t *testing.T) {
 			planeURL:       "https://localhost:7443",
 			planeID:        "/planes/test/local",
 			httpScheme:     "https",
+			ucpHost:        "localhost:9443",
 		},
 		{
 			name:           AzureAsyncOperationHeader,
@@ -56,6 +60,7 @@ func Test_ConvertHeaderToUCPIDs(t *testing.T) {
 			planeURL:       "https://example.com",
 			planeID:        "/planes/test/local",
 			httpScheme:     "https",
+			ucpHost:        "localhost:9443",
 		},
 		{
 			name:           AzureAsyncOperationHeader,
@@ -64,6 +69,7 @@ func Test_ConvertHeaderToUCPIDs(t *testing.T) {
 			planeURL:       "https://example.com",
 			planeID:        "/planes/test/local",
 			httpScheme:     "https",
+			ucpHost:        "localhost:9443",
 		},
 		{
 			name:           AzureAsyncOperationHeader,
@@ -72,14 +78,15 @@ func Test_ConvertHeaderToUCPIDs(t *testing.T) {
 			planeURL:       "https://example.com/",
 			planeID:        "/planes/test/local",
 			httpScheme:     "https",
+			ucpHost:        "localhost:9443",
 		},
 	}
 	for _, datum := range positiveTestData {
 		response := http.Response{
 			Header: http.Header{},
 		}
-		ctx := createTestContext(context.Background(), datum.planeURL, datum.planeID, datum.httpScheme)
-		err := convertHeaderToUCPIDs(ctx, "localhost:9443", datum.name, datum.header, &response)
+		ctx := createTestContext(context.Background(), datum.planeURL, datum.planeID, datum.httpScheme, datum.ucpHost)
+		err := convertHeaderToUCPIDs(ctx, datum.name, datum.header, &response)
 		require.NoError(t, err, "%q should have not have failed", datum)
 		// response.SetHeader converts the header into CanonicalMIME format
 		require.Equal(t, datum.expectedHeader, response.Header[textproto.CanonicalMIMEHeaderKey(datum.name)][0])
@@ -104,8 +111,8 @@ func Test_ConvertHeaderToUCPIDs(t *testing.T) {
 		response := http.Response{
 			Header: http.Header{},
 		}
-		ctx := createTestContext(context.Background(), datum.planeURL, datum.planeID, datum.httpScheme)
-		err := convertHeaderToUCPIDs(ctx, "localhost:9443", datum.name, datum.header, &response)
+		ctx := createTestContext(context.Background(), datum.planeURL, datum.planeID, datum.httpScheme, datum.ucpHost)
+		err := convertHeaderToUCPIDs(ctx, datum.name, datum.header, &response)
 		require.Error(t, err, "%q should have have failed", datum)
 		require.Equal(t, fmt.Sprintf("PlaneURL: %s received in the request context does not match the url found in %s header", datum.planeURL, datum.name), err.Error())
 	}
@@ -115,10 +122,10 @@ func Test_ConvertHeaderToUCPIDs_NoContextDataSet(t *testing.T) {
 	response := http.Response{
 		Header: http.Header{},
 	}
-	err := convertHeaderToUCPIDs(context.Background(), "localhost:9443", AzureAsyncOperationHeader, []string{"http://example.com/subscriptions/sid/resourceGroups/rg/providers/Microsoft.CustomProviders/resourceProviders/radiusv3/Application/testApp/Container/test"}, &response)
+	err := convertHeaderToUCPIDs(context.Background(), AzureAsyncOperationHeader, []string{"http://example.com/subscriptions/sid/resourceGroups/rg/providers/Microsoft.CustomProviders/resourceProviders/radiusv3/Application/testApp/Container/test"}, &response)
 	require.Error(t, err, "Should have have failed")
 	require.Equal(t, "Could not find plane URL data in Azure-Asyncoperation header", err.Error())
-	err = convertHeaderToUCPIDs(context.Background(), "localhost:9443", LocationHeader, []string{"http://example.com/subscriptions/sid/resourceGroups/rg/providers/Microsoft.CustomProviders/resourceProviders/radiusv3/Application/testApp/Container/test"}, &response)
+	err = convertHeaderToUCPIDs(context.Background(), LocationHeader, []string{"http://example.com/subscriptions/sid/resourceGroups/rg/providers/Microsoft.CustomProviders/resourceProviders/radiusv3/Application/testApp/Container/test"}, &response)
 	require.Error(t, err, "Should have have failed")
 	require.Equal(t, "Could not find plane URL data in Location header", err.Error())
 }


### PR DESCRIPTION
# Description

Use the host field in the request made by the client to UCP to determine UCP host address while constructing URL
#2365 

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #2365

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
