### PR TITLE
Make data store configurable for RP and worker

### DIFF
--- a/cmd/appcore-async/radius-dev.yaml
+++ b/cmd/appcore-async/radius-dev.yaml
@@ -17,6 +17,23 @@ storageProvider:
     database: applicationscore
     # Set primary key to in this configuration or to RADIUS_STORAGEPROVIDER_COSMOSDB_MASTERKEY environment variable
     masterKey: set-me-in-a-different-way
+
+  # Uncomment to use the Kubernetes APIServer store. 
+  # This supports two modes:
+  # - incluster = true => uses the credentials/service-account of a pod. FOR PRODUCTION USE.
+  # - incluster = false => uses your LOCAL kubernetes context. For TESTING
+
+  # provider: "apiserver"
+  # apiserver:
+  #   incluster: true
+  #   context: <specify your kubernetes context name when incluster = false - leave blank to use default>
+  #   namespace: 'default'
+
+  # Uncomment to use the etcd store. Right now this only supports running in-memory (not for production use).
+  # provider: "etcd"
+  # etcd:
+  #   inmemory: true
+
 workerServer:
   port: 2222
 metricsProvider:

--- a/cmd/appcore-rp/radius-dev.yaml
+++ b/cmd/appcore-rp/radius-dev.yaml
@@ -17,6 +17,22 @@ storageProvider:
     database: applicationscore
     # Set primary key to in this configuration or to RADIUS_STORAGEPROVIDER_COSMOSDB_MASTERKEY environment variable
     masterKey: set-me-in-a-different-way
+  
+  # Uncomment to use the Kubernetes APIServer store. 
+  # This supports two modes:
+  # - incluster = true => uses the credentials/service-account of a pod. FOR PRODUCTION USE.
+  # - incluster = false => uses your LOCAL kubernetes context. For TESTING
+  #
+  # provider: "apiserver"
+  # apiserver:
+  #   incluster: false
+  #   context: ''
+  #   namespace: 'default'
+
+  # Uncomment to use the etcd store. Right now this only supports running in-memory (not for production use).
+  # provider: "etcd"
+  # etcd:
+  #   inmemory: true
 server:
   host: "0.0.0.0"
   port: 8080
@@ -28,3 +44,4 @@ metricsProvider:
     endpoint: "/metrics"
 featureFlags:
   - "PLACEHOLDER"
+  

--- a/pkg/corerp/dataprovider/factory.go
+++ b/pkg/corerp/dataprovider/factory.go
@@ -7,16 +7,85 @@ package dataprovider
 
 import (
 	context "context"
+	"errors"
 	"fmt"
+	"path/filepath"
 
+	"github.com/mitchellh/go-homedir"
 	store "github.com/project-radius/radius/pkg/ucp/store"
+	"github.com/project-radius/radius/pkg/ucp/store/apiserverstore"
+	ucpv1alpha1 "github.com/project-radius/radius/pkg/ucp/store/apiserverstore/api/ucp.dev/v1alpha1"
 	"github.com/project-radius/radius/pkg/ucp/store/cosmosdb"
+	"github.com/project-radius/radius/pkg/ucp/store/etcdstore"
+	etcdclient "go.etcd.io/etcd/client/v3"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type storageFactoryFunc func(context.Context, StorageProviderOptions, string) (store.StorageClient, error)
 
 var storageClientFactory = map[StorageProviderType]storageFactoryFunc{
-	CosmosDBProvider: initCosmosDBClient,
+	TypeAPIServer: initAPIServerClient,
+	TypeCosmosDB:  initCosmosDBClient,
+	TypeETCD:      initETCDClient,
+}
+
+func initAPIServerClient(ctx context.Context, opt StorageProviderOptions, _ string) (store.StorageClient, error) {
+	if opt.APIServer.Namespace == "" {
+		return nil, errors.New("failed to initialize APIServer client: namespace is required")
+	}
+
+	var err error
+	var config *rest.Config
+
+	if opt.APIServer.InCluster {
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize APIServer client: %w", err)
+		}
+	} else {
+		home, err := homedir.Dir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize APIServer client: %w", err)
+		}
+
+		kubeConfig := filepath.Join(home, ".kube", "config")
+		cmdconfig, err := clientcmd.LoadFromFile(kubeConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize APIServer client: %w", err)
+		}
+
+		clientconfig := clientcmd.NewNonInteractiveClientConfig(*cmdconfig, opt.APIServer.Context, nil, nil)
+		config, err = clientconfig.ClientConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize APIServer client: %w", err)
+		}
+	}
+
+	// We only need to interact with UCP's store types.
+	scheme := runtime.NewScheme()
+
+	// Safe to ignore, this will only fail for duplicates, which there clearly won't be.
+	_ = ucpv1alpha1.AddToScheme(scheme)
+
+	options := runtimeclient.Options{
+		Scheme: scheme,
+
+		// The client will log info the console that we don't really care about.
+		Opts: runtimeclient.WarningHandlerOptions{
+			SuppressWarnings: true,
+		},
+	}
+
+	rc, err := runtimeclient.New(config, options)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize APIServer client: %w", err)
+	}
+
+	client := apiserverstore.NewAPIServerClient(rc, opt.APIServer.Namespace)
+	return client, nil
 }
 
 func initCosmosDBClient(ctx context.Context, opt StorageProviderOptions, collectionName string) (store.StorageClient, error) {
@@ -37,4 +106,27 @@ func initCosmosDBClient(ctx context.Context, opt StorageProviderOptions, collect
 	}
 
 	return dbclient, nil
+}
+
+func initETCDClient(ctx context.Context, opt StorageProviderOptions, _ string) (store.StorageClient, error) {
+	if !opt.ETCD.InMemory {
+		return nil, errors.New("failed to initialize etcd client: inmemory is the only supported mode for now")
+	}
+	if opt.ETCD.Client == nil {
+		return nil, errors.New("failed to initialize etcd client: ETCDOptions.Client is nil, this is a bug")
+	}
+
+	// Initialize the storage client once the storage service has started
+	obj, err := opt.ETCD.Client.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize etcd client: %w", err)
+	}
+
+	clientconfig := obj.(*etcdclient.Config)
+	client, err := etcdclient.New(*clientconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize etcd client: %w", err)
+	}
+	etcdClient := etcdstore.NewETCDClient(client)
+	return etcdClient, nil
 }

--- a/pkg/corerp/dataprovider/options.go
+++ b/pkg/corerp/dataprovider/options.go
@@ -5,10 +5,34 @@
 
 package dataprovider
 
+import "github.com/project-radius/radius/pkg/ucp/hosting"
+
 // StorageProviderOptions represents the data storage provider options.
 type StorageProviderOptions struct {
+	// Provider configures the storage provider.
 	Provider StorageProviderType `yaml:"provider"`
-	CosmosDB CosmosDBOptions     `yaml:"cosmosdb,omitempty"`
+
+	// APIServer configures options for the Kubernetes APIServer store. Will be ignored if another store is configured.
+	APIServer APIServerOptions `yaml:"apiserver,omitempty"`
+
+	// CosmosDB configures options for the CosmosDB store. Will be ignored if another store is configured.
+	CosmosDB CosmosDBOptions `yaml:"cosmosdb,omitempty"`
+
+	// ETCD configures options for the etcd store. Will be ignored if another store is configured.
+	ETCD ETCDOptions `yaml:"etcd,omitempty"`
+}
+
+// APIServerOptions represents options for the configuring the Kubernetes APIServer store.
+type APIServerOptions struct {
+	// InCluster configures the APIServer store to use "in-cluster" credentials. Use this when running inside a Kubernetes cluster.
+	InCluster bool `yaml:"incluster"`
+
+	// Context configures the Kubernetes context name to use for the connection. Use this for NON-production scenarios to test
+	// against a specific cluster.
+	Context string `yaml:"context"`
+
+	// Namespace configures the Kubernetes namespace used for data-storage. The namespace must already exist.
+	Namespace string `yaml:"namespace"`
 }
 
 // CosmosDBOptions represents cosmosdb options for data storage provider.
@@ -17,4 +41,16 @@ type CosmosDBOptions struct {
 	Database             string `yaml:"database"`
 	MasterKey            string `yaml:"masterKey"`
 	CollectionThroughput int    `yaml:"collectionThroughput,omitempty"`
+}
+
+// ETCDOptions represents options for the configuring the etcd store.
+type ETCDOptions struct {
+	// InMemory configures the etcd store to run in-memory with the resource provider. This is not suitable for production use.
+	InMemory bool `yaml:"inmemory"`
+
+	// Client is used to access the etcd client when running in memory.
+	//
+	// NOTE: when we run etcd in memory it will be registered as its own hosting.Service with its own startup/shutdown lifecyle.
+	// We need a way to share state between the etcd service and the things that want to consume it. This is that.
+	Client *hosting.AsyncValue `yaml:"-"`
 }

--- a/pkg/corerp/dataprovider/types.go
+++ b/pkg/corerp/dataprovider/types.go
@@ -15,8 +15,14 @@ import (
 type StorageProviderType string
 
 const (
-	// CosmosDBProvider represents CosmosDB provider.
-	CosmosDBProvider StorageProviderType = "cosmosdb"
+	// TypeAPIServer represents the Kubernetes APIServer provider.
+	TypeAPIServer StorageProviderType = "apiserver"
+
+	// TypeCosmosDB represents CosmosDB provider.
+	TypeCosmosDB StorageProviderType = "cosmosdb"
+
+	// TypeETCD represents the etcd provider.
+	TypeETCD StorageProviderType = "etcd"
 )
 
 //go:generate mockgen -destination=./mock_datastorage_provider.go -package=dataprovider -self_package github.com/project-radius/radius/pkg/corerp/dataprovider github.com/project-radius/radius/pkg/corerp/dataprovider DataStorageProvider

--- a/pkg/corerp/frontend/service.go
+++ b/pkg/corerp/frontend/service.go
@@ -81,7 +81,7 @@ func (s *Service) Run(ctx context.Context) error {
 		s.Options.Config.MetricsProvider,
 	)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	// Handle shutdown based on the context

--- a/pkg/corerp/hostoptions/hostoptions.go
+++ b/pkg/corerp/hostoptions/hostoptions.go
@@ -8,6 +8,7 @@
 package hostoptions
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -48,9 +49,12 @@ func loadConfig(configPath string) (*ProviderConfig, error) {
 	}
 
 	conf := &ProviderConfig{}
-	err = yaml.Unmarshal(buf, conf)
+	decoder := yaml.NewDecoder(bytes.NewBuffer(buf))
+	decoder.KnownFields(true)
+
+	err = decoder.Decode(conf)
 	if err != nil {
-		return nil, fmt.Errorf("fails to load yaml: %w", err)
+		return nil, fmt.Errorf("failed to load yaml: %w", err)
 	}
 
 	// TODO: improve the way to override the configration via env var.

--- a/pkg/ucp/store/etcdstore/etcdclient.go
+++ b/pkg/ucp/store/etcdstore/etcdclient.go
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-// Package etcdstore stores resources using ETCd. Our usage for ETCd is optimized for the kinds
+// Package etcdstore stores resources using etcd. Our usage for etcd is optimized for the kinds
 // of hierarchical and type-based queries common in a resource provider.
 //
 // Our key prefix scheme builds a hierarchy using '|' as a separator as '|' is illegal in an
@@ -260,7 +260,7 @@ func idFromKey(key []byte) (resources.ID, error) {
 	// sample valid key:
 	// scope|ucp:/planes/radius/local/resourceGroups/cool-group/|/Applications.Core/applications/cool-app/
 	if len(parts) != 3 {
-		return resources.ID{}, errors.New("the ETCd key '%q' is invalid because it does not have 3 sections")
+		return resources.ID{}, errors.New("the etcd key '%q' is invalid because it does not have 3 sections")
 	}
 
 	if parts[2] == "" {

--- a/pkg/ucp/store/etcdstore/etcdclient_test.go
+++ b/pkg/ucp/store/etcdstore/etcdclient_test.go
@@ -32,7 +32,7 @@ func Test_ETCDClient(t *testing.T) {
 		// https://github.com/golang/go/issues/40343
 		//
 		// If you need to see the logging output while you are testing, then comment out the next line
-		// and you'll be able to see the spam from ETCd.
+		// and you'll be able to see the spam from etcd.
 		//
 		// This is caught by the race checker and will fail your pr if you do it.
 		ctx := context.Background()


### PR DESCRIPTION
This change makes the data store configurable for the CoreRP and Core
async worker using our existing configuration files. Now this will
support:

- ETC.d (in memory) for dev/test
- APIServer (Kubernetes) for dev/test and production self-host

See the configuration files for examples of how to configure this.
