### PR TITLE
Capturing/Handling error when azure env does not exist

### DIFF
--- a/cmd/rad/cmd/envDelete.go
+++ b/cmd/rad/cmd/envDelete.go
@@ -76,7 +76,7 @@ func deleteEnv(cmd *cobra.Command, args []string) error {
 		// 2. Delete all radius resources in the customer/user resource group (ex custom resource provider)
 		// 3. Delete control plane resource group
 		if err = deleteAllApplications(cmd.Context(), az); err != nil {
-			if envErr, ok := err.(*radclient.RadiusError); ok && envErr.Code == "EnvironmentNotFound" {
+			if err, ok := err.(*radclient.RadiusError); ok && err.Code == "EnvironmentNotFound" {
 				output.LogInfo("Environment '%s' not found", az.Name)
 
 				errDelConfig := deleteEnvFromConfig(cmd.Context(), config, env.GetName())

--- a/cmd/rad/cmd/envDelete.go
+++ b/cmd/rad/cmd/envDelete.go
@@ -76,7 +76,7 @@ func deleteEnv(cmd *cobra.Command, args []string) error {
 		// 2. Delete all radius resources in the customer/user resource group (ex custom resource provider)
 		// 3. Delete control plane resource group
 		if err = deleteAllApplications(cmd.Context(), az); err != nil {
-			if errEnvNotFound, okEnvErr := err.(*radclient.RadiusError); okEnvErr && errEnvNotFound.Code == "EnvironmentNotFound" {
+			if envErr, ok := err.(*radclient.RadiusError); ok && envErr.Code == "EnvironmentNotFound" {
 				output.LogInfo("Environment '%s' not found", az.Name)
 
 				errDelConfig := deleteEnvFromConfig(cmd.Context(), config, env.GetName())

--- a/pkg/cli/azure/management.go
+++ b/pkg/cli/azure/management.go
@@ -194,8 +194,8 @@ func isNotFound(err error) bool {
 }
 
 func isEnvNotFound(err error) bool {
-	if errOp, okOpErr := err.(*net.OpError); okOpErr {
-		if errDns, okDnsErr := errOp.Err.(*net.DNSError); okDnsErr && errDns.IsNotFound {
+	if err, ok := err.(*net.OpError); ok {
+		if err, ok := err.Err.(*net.DNSError); ok && err.IsNotFound {
 			return true
 		}
 	}


### PR DESCRIPTION
# Description

Updates to handle use case described i radius-project/core-team#425.  

Listing output after updates:

```txt
All radius-created resources in resource-group lak-testdelenv6-rg will be deleted. Continue deleting? [y/N]? y
Environment 'lak-testdelenv6-env' not found
Updating config
laktry5-env is now the default environment
Successfully wrote configuration to /Users/lakshmi/.rad/config.yaml
Exiting.
```


Please reference the issue this PR will close: radius-project/core-team#425 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
