### PR TITLE
Added the routes property in the json schema for Http Route

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - release/*
+      - features/*
 
 concurrency:
   # Cancel the previously triggered build for only PR build.

--- a/pkg/azure/radclient/zz_generated_models.go
+++ b/pkg/azure/radclient/zz_generated_models.go
@@ -358,6 +358,17 @@ type BasicRouteProperties struct {
 	Status *RouteStatus `json:"status,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type BasicRouteProperties.
+func (b BasicRouteProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	b.marshalInternal(objectMap)
+	return json.Marshal(objectMap)
+}
+
+func (b BasicRouteProperties) marshalInternal(objectMap map[string]interface{}) {
+	populate(objectMap, "status", b.Status)
+}
+
 type CertificateObjectProperties struct {
 	// REQUIRED; The name of the certificate
 	Name *string `json:"name,omitempty"`
@@ -626,6 +637,14 @@ type DaprHTTPRouteProperties struct {
 	BasicRouteProperties
 	// REQUIRED; The Dapr appId used for the route
 	AppID *string `json:"appId,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DaprHTTPRouteProperties.
+func (d DaprHTTPRouteProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	d.BasicRouteProperties.marshalInternal(objectMap)
+	populate(objectMap, "appId", d.AppID)
+	return json.Marshal(objectMap)
 }
 
 // DaprInvokeHTTPRouteList - List of dapr.io.InvokeHttpRoute resources.
@@ -1876,11 +1895,34 @@ type HTTPRouteProperties struct {
 	// The port number for the route. Defaults to 80. Readonly.
 	Port *int32 `json:"port,omitempty"`
 
+	// Can be used to configure traffic-splitting between various HttpRoutes. Accepts an array of json obects that each only have two keys: desination and weight
+	Routes []*HTTPRoutePropertiesRoutesItem `json:"routes,omitempty"`
+
 	// The scheme used for traffic. Readonly.
 	Scheme *string `json:"scheme,omitempty"`
 
 	// A stable URL that that can be used to route traffic to a resource. Readonly.
 	URL *string `json:"url,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type HTTPRouteProperties.
+func (h HTTPRouteProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	h.BasicRouteProperties.marshalInternal(objectMap)
+	populate(objectMap, "hostname", h.Hostname)
+	populate(objectMap, "port", h.Port)
+	populate(objectMap, "routes", h.Routes)
+	populate(objectMap, "scheme", h.Scheme)
+	populate(objectMap, "url", h.URL)
+	return json.Marshal(objectMap)
+}
+
+type HTTPRoutePropertiesRoutesItem struct {
+	// REQUIRED
+	Destination *string `json:"destination,omitempty"`
+
+	// REQUIRED
+	Weight *int32 `json:"weight,omitempty"`
 }
 
 // HTTPRouteResource - Resource that specifies an HTTP Route. An HTTP Route resource provides a stable URL that can be used to route internal or extrnal

--- a/pkg/radrp/schema/resources/httproute.json
+++ b/pkg/radrp/schema/resources/httproute.json
@@ -33,6 +33,22 @@
           "description": "The port number for the route. Defaults to 80. Readonly.",
           "type": "integer"
         },
+        "routes": {
+          "description": "Can be used to configure traffic-splitting between various HttpRoutes. Accepts an array of json obects that each only have two keys: desination and weight",
+          "type": "array",
+          "items": {
+            "type":"object",
+            "properties": {
+              "destination": {
+                "type":"string"
+              },
+              "weight": {
+                "type":"integer"
+              }
+            },
+            "required": ["destination", "weight"]
+          }
+        },
         "scheme": {
           "description": "The scheme used for traffic. Readonly.",
           "type": "string"

--- a/pkg/radrp/schema/resources/httproute.json
+++ b/pkg/radrp/schema/resources/httproute.json
@@ -46,7 +46,8 @@
                 "type":"integer"
               }
             },
-            "required": ["destination", "weight"]
+            "required": ["destination", "weight"],
+            "additionalProperties": false
           }
         },
         "scheme": {

--- a/pkg/radrp/schema/resources/httproute.json
+++ b/pkg/radrp/schema/resources/httproute.json
@@ -34,7 +34,7 @@
           "type": "integer"
         },
         "routes": {
-          "description": "Can be used to configure traffic-splitting between various HttpRoutes. Accepts an array of json obects that each only have two keys: desination and weight",
+          "description": "Can be used to configure traffic-splitting between various HttpRoutes. Accepts an array of JSON objects that each only have two keys: destination and weight",
           "type": "array",
           "items": {
             "type":"object",

--- a/pkg/radrp/schema/testdata/HttpRoute/httproute-valid.json
+++ b/pkg/radrp/schema/testdata/HttpRoute/httproute-valid.json
@@ -1,4 +1,16 @@
 {
   "id": "id", 
-  "name": "name"
+  "name": "name",
+  "properties" : {
+    "routes": [
+      {
+        "destination":"random_dest.id",
+        "weight":30
+      },
+      {
+        "destination":"random_dest_2.id",
+        "weight":70
+      }
+    ]
+  }
 }

--- a/schemas/rest-api-specs/radius.json
+++ b/schemas/rest-api-specs/radius.json
@@ -1200,6 +1200,7 @@
         "routes": {
           "description": "Can be used to configure traffic-splitting between various HttpRoutes. Accepts an array of json obects that each only have two keys: desination and weight",
           "items": {
+            "additionalProperties": false,
             "properties": {
               "destination": {
                 "type": "string"

--- a/schemas/rest-api-specs/radius.json
+++ b/schemas/rest-api-specs/radius.json
@@ -1197,6 +1197,25 @@
           "description": "The port number for the route. Defaults to 80. Readonly.",
           "type": "integer"
         },
+        "routes": {
+          "description": "Can be used to configure traffic-splitting between various HttpRoutes. Accepts an array of json obects that each only have two keys: desination and weight",
+          "items": {
+            "properties": {
+              "destination": {
+                "type": "string"
+              },
+              "weight": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "destination",
+              "weight"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
         "scheme": {
           "description": "The scheme used for traffic. Readonly.",
           "type": "string"


### PR DESCRIPTION
# Description
In Issue https://github.com/project-radius/radius/issues/2426, we have configured the bicep compiler to add some more properties to the Http Route resource. We now need to configure the json schema in a similar way. 

In httproute.json, I have added a new property called "routes" which is an array of json object. Each json object in the array  will have two keys: "weight" and "destination". Both of these properties are required if the user inputs an array for "routes".

This is identical to the changes that I have made in the bicep compiler. 

Changes will be merged into my feature branch: "features/traffic-splitting"


Please reference the issue this PR will close: radius-project/core-team#656 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
