### PR TITLE
Use azure-arm flag to generate resource clients for RP resources

### DIFF
--- a/pkg/connectorrp/api/README.md
+++ b/pkg/connectorrp/api/README.md
@@ -53,6 +53,7 @@ use: "@autorest/go@4.0.0-preview.29"
 module-version: 0.0.1
 file-prefix: zz_generated_
 license-header: MICROSOFT_MIT_NO_VERSION
+azure-arm: true
 ```
 
 ### Output

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_daprinvokehttproutes_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_daprinvokehttproutes_client.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -22,13 +23,14 @@ import (
 // DaprInvokeHTTPRoutesClient contains the methods for the DaprInvokeHTTPRoutes group.
 // Don't use this type directly, use NewDaprInvokeHTTPRoutesClient() instead.
 type DaprInvokeHTTPRoutesClient struct {
-	con *connection
+	ep string
+	pl runtime.Pipeline
 	subscriptionID string
 }
 
 // NewDaprInvokeHTTPRoutesClient creates a new instance of DaprInvokeHTTPRoutesClient with the specified values.
-func NewDaprInvokeHTTPRoutesClient(con *connection, subscriptionID string) *DaprInvokeHTTPRoutesClient {
-	return &DaprInvokeHTTPRoutesClient{con: con, subscriptionID: subscriptionID}
+func NewDaprInvokeHTTPRoutesClient(con *arm.Connection, subscriptionID string) *DaprInvokeHTTPRoutesClient {
+	return &DaprInvokeHTTPRoutesClient{ep: con.Endpoint(), pl: con.NewPipeline(module, version), subscriptionID: subscriptionID}
 }
 
 // CreateOrUpdate - Creates or updates a DaprInvokeHttpRoute resource
@@ -38,7 +40,7 @@ func (client *DaprInvokeHTTPRoutesClient) CreateOrUpdate(ctx context.Context, re
 	if err != nil {
 		return DaprInvokeHTTPRoutesCreateOrUpdateResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return DaprInvokeHTTPRoutesCreateOrUpdateResponse{}, err
 	}
@@ -63,7 +65,7 @@ func (client *DaprInvokeHTTPRoutesClient) createOrUpdateCreateRequest(ctx contex
 		return nil, errors.New("parameter daprInvokeHTTPRouteName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{daprInvokeHttpRouteName}", url.PathEscape(daprInvokeHTTPRouteName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +105,7 @@ func (client *DaprInvokeHTTPRoutesClient) Delete(ctx context.Context, resourceGr
 	if err != nil {
 		return DaprInvokeHTTPRoutesDeleteResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return DaprInvokeHTTPRoutesDeleteResponse{}, err
 	}
@@ -128,7 +130,7 @@ func (client *DaprInvokeHTTPRoutesClient) deleteCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter daprInvokeHTTPRouteName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{daprInvokeHttpRouteName}", url.PathEscape(daprInvokeHTTPRouteName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +161,7 @@ func (client *DaprInvokeHTTPRoutesClient) Get(ctx context.Context, resourceGroup
 	if err != nil {
 		return DaprInvokeHTTPRoutesGetResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return DaprInvokeHTTPRoutesGetResponse{}, err
 	}
@@ -184,7 +186,7 @@ func (client *DaprInvokeHTTPRoutesClient) getCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter daprInvokeHTTPRouteName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{daprInvokeHttpRouteName}", url.PathEscape(daprInvokeHTTPRouteName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +244,7 @@ func (client *DaprInvokeHTTPRoutesClient) listCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +298,7 @@ func (client *DaprInvokeHTTPRoutesClient) listBySubscriptionCreateRequest(ctx co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_daprsecretstores_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_daprsecretstores_client.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -22,13 +23,14 @@ import (
 // DaprSecretStoresClient contains the methods for the DaprSecretStores group.
 // Don't use this type directly, use NewDaprSecretStoresClient() instead.
 type DaprSecretStoresClient struct {
-	con *connection
+	ep string
+	pl runtime.Pipeline
 	subscriptionID string
 }
 
 // NewDaprSecretStoresClient creates a new instance of DaprSecretStoresClient with the specified values.
-func NewDaprSecretStoresClient(con *connection, subscriptionID string) *DaprSecretStoresClient {
-	return &DaprSecretStoresClient{con: con, subscriptionID: subscriptionID}
+func NewDaprSecretStoresClient(con *arm.Connection, subscriptionID string) *DaprSecretStoresClient {
+	return &DaprSecretStoresClient{ep: con.Endpoint(), pl: con.NewPipeline(module, version), subscriptionID: subscriptionID}
 }
 
 // CreateOrUpdate - Creates or updates a DaprSecretStore resource
@@ -38,7 +40,7 @@ func (client *DaprSecretStoresClient) CreateOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return DaprSecretStoresCreateOrUpdateResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return DaprSecretStoresCreateOrUpdateResponse{}, err
 	}
@@ -63,7 +65,7 @@ func (client *DaprSecretStoresClient) createOrUpdateCreateRequest(ctx context.Co
 		return nil, errors.New("parameter daprSecretStoreName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{daprSecretStoreName}", url.PathEscape(daprSecretStoreName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +105,7 @@ func (client *DaprSecretStoresClient) Delete(ctx context.Context, resourceGroupN
 	if err != nil {
 		return DaprSecretStoresDeleteResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return DaprSecretStoresDeleteResponse{}, err
 	}
@@ -128,7 +130,7 @@ func (client *DaprSecretStoresClient) deleteCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter daprSecretStoreName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{daprSecretStoreName}", url.PathEscape(daprSecretStoreName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +161,7 @@ func (client *DaprSecretStoresClient) Get(ctx context.Context, resourceGroupName
 	if err != nil {
 		return DaprSecretStoresGetResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return DaprSecretStoresGetResponse{}, err
 	}
@@ -184,7 +186,7 @@ func (client *DaprSecretStoresClient) getCreateRequest(ctx context.Context, reso
 		return nil, errors.New("parameter daprSecretStoreName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{daprSecretStoreName}", url.PathEscape(daprSecretStoreName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +244,7 @@ func (client *DaprSecretStoresClient) listCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +298,7 @@ func (client *DaprSecretStoresClient) listBySubscriptionCreateRequest(ctx contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_daprstatestores_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_daprstatestores_client.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -22,13 +23,14 @@ import (
 // DaprStateStoresClient contains the methods for the DaprStateStores group.
 // Don't use this type directly, use NewDaprStateStoresClient() instead.
 type DaprStateStoresClient struct {
-	con *connection
+	ep string
+	pl runtime.Pipeline
 	subscriptionID string
 }
 
 // NewDaprStateStoresClient creates a new instance of DaprStateStoresClient with the specified values.
-func NewDaprStateStoresClient(con *connection, subscriptionID string) *DaprStateStoresClient {
-	return &DaprStateStoresClient{con: con, subscriptionID: subscriptionID}
+func NewDaprStateStoresClient(con *arm.Connection, subscriptionID string) *DaprStateStoresClient {
+	return &DaprStateStoresClient{ep: con.Endpoint(), pl: con.NewPipeline(module, version), subscriptionID: subscriptionID}
 }
 
 // CreateOrUpdate - Creates or updates a DaprStateStore resource
@@ -38,7 +40,7 @@ func (client *DaprStateStoresClient) CreateOrUpdate(ctx context.Context, resourc
 	if err != nil {
 		return DaprStateStoresCreateOrUpdateResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return DaprStateStoresCreateOrUpdateResponse{}, err
 	}
@@ -63,7 +65,7 @@ func (client *DaprStateStoresClient) createOrUpdateCreateRequest(ctx context.Con
 		return nil, errors.New("parameter daprStateStoreName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{daprStateStoreName}", url.PathEscape(daprStateStoreName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +105,7 @@ func (client *DaprStateStoresClient) Delete(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return DaprStateStoresDeleteResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return DaprStateStoresDeleteResponse{}, err
 	}
@@ -128,7 +130,7 @@ func (client *DaprStateStoresClient) deleteCreateRequest(ctx context.Context, re
 		return nil, errors.New("parameter daprStateStoreName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{daprStateStoreName}", url.PathEscape(daprStateStoreName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +161,7 @@ func (client *DaprStateStoresClient) Get(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return DaprStateStoresGetResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return DaprStateStoresGetResponse{}, err
 	}
@@ -184,7 +186,7 @@ func (client *DaprStateStoresClient) getCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter daprStateStoreName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{daprStateStoreName}", url.PathEscape(daprStateStoreName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +244,7 @@ func (client *DaprStateStoresClient) listCreateRequest(ctx context.Context, reso
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +298,7 @@ func (client *DaprStateStoresClient) listBySubscriptionCreateRequest(ctx context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_mongodatabases_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_mongodatabases_client.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -22,13 +23,14 @@ import (
 // MongoDatabasesClient contains the methods for the MongoDatabases group.
 // Don't use this type directly, use NewMongoDatabasesClient() instead.
 type MongoDatabasesClient struct {
-	con *connection
+	ep string
+	pl runtime.Pipeline
 	subscriptionID string
 }
 
 // NewMongoDatabasesClient creates a new instance of MongoDatabasesClient with the specified values.
-func NewMongoDatabasesClient(con *connection, subscriptionID string) *MongoDatabasesClient {
-	return &MongoDatabasesClient{con: con, subscriptionID: subscriptionID}
+func NewMongoDatabasesClient(con *arm.Connection, subscriptionID string) *MongoDatabasesClient {
+	return &MongoDatabasesClient{ep: con.Endpoint(), pl: con.NewPipeline(module, version), subscriptionID: subscriptionID}
 }
 
 // CreateOrUpdate - Creates or updates a MongoDatabase resource
@@ -38,7 +40,7 @@ func (client *MongoDatabasesClient) CreateOrUpdate(ctx context.Context, resource
 	if err != nil {
 		return MongoDatabasesCreateOrUpdateResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return MongoDatabasesCreateOrUpdateResponse{}, err
 	}
@@ -63,7 +65,7 @@ func (client *MongoDatabasesClient) createOrUpdateCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter mongoDatabaseName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{mongoDatabaseName}", url.PathEscape(mongoDatabaseName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +105,7 @@ func (client *MongoDatabasesClient) Delete(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return MongoDatabasesDeleteResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return MongoDatabasesDeleteResponse{}, err
 	}
@@ -128,7 +130,7 @@ func (client *MongoDatabasesClient) deleteCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter mongoDatabaseName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{mongoDatabaseName}", url.PathEscape(mongoDatabaseName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +161,7 @@ func (client *MongoDatabasesClient) Get(ctx context.Context, resourceGroupName s
 	if err != nil {
 		return MongoDatabasesGetResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return MongoDatabasesGetResponse{}, err
 	}
@@ -184,7 +186,7 @@ func (client *MongoDatabasesClient) getCreateRequest(ctx context.Context, resour
 		return nil, errors.New("parameter mongoDatabaseName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{mongoDatabaseName}", url.PathEscape(mongoDatabaseName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +244,7 @@ func (client *MongoDatabasesClient) listCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +298,7 @@ func (client *MongoDatabasesClient) listBySubscriptionCreateRequest(ctx context.
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +338,7 @@ func (client *MongoDatabasesClient) ListSecrets(ctx context.Context, resourceGro
 	if err != nil {
 		return MongoDatabasesListSecretsResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return MongoDatabasesListSecretsResponse{}, err
 	}
@@ -361,7 +363,7 @@ func (client *MongoDatabasesClient) listSecretsCreateRequest(ctx context.Context
 		return nil, errors.New("parameter mongoDatabaseName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{mongoDatabaseName}", url.PathEscape(mongoDatabaseName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_pagers.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_pagers.go
@@ -47,7 +47,7 @@ func (p *DaprInvokeHTTPRoutesListBySubscriptionPager) NextPage(ctx context.Conte
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -101,7 +101,7 @@ func (p *DaprInvokeHTTPRoutesListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -155,7 +155,7 @@ func (p *DaprSecretStoresListBySubscriptionPager) NextPage(ctx context.Context) 
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -209,7 +209,7 @@ func (p *DaprSecretStoresListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -263,7 +263,7 @@ func (p *DaprStateStoresListBySubscriptionPager) NextPage(ctx context.Context) b
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -317,7 +317,7 @@ func (p *DaprStateStoresListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -371,7 +371,7 @@ func (p *MongoDatabasesListBySubscriptionPager) NextPage(ctx context.Context) bo
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -425,7 +425,7 @@ func (p *MongoDatabasesListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -479,7 +479,7 @@ func (p *RabbitMQMessageQueuesListBySubscriptionPager) NextPage(ctx context.Cont
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -533,7 +533,7 @@ func (p *RabbitMQMessageQueuesListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -587,7 +587,7 @@ func (p *RedisCachesListBySubscriptionPager) NextPage(ctx context.Context) bool 
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -641,7 +641,7 @@ func (p *RedisCachesListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -695,7 +695,7 @@ func (p *SQLDatabasesListBySubscriptionPager) NextPage(ctx context.Context) bool
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -749,7 +749,7 @@ func (p *SQLDatabasesListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_rabbitmqmessagequeues_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_rabbitmqmessagequeues_client.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -22,13 +23,14 @@ import (
 // RabbitMQMessageQueuesClient contains the methods for the RabbitMQMessageQueues group.
 // Don't use this type directly, use NewRabbitMQMessageQueuesClient() instead.
 type RabbitMQMessageQueuesClient struct {
-	con *connection
+	ep string
+	pl runtime.Pipeline
 	subscriptionID string
 }
 
 // NewRabbitMQMessageQueuesClient creates a new instance of RabbitMQMessageQueuesClient with the specified values.
-func NewRabbitMQMessageQueuesClient(con *connection, subscriptionID string) *RabbitMQMessageQueuesClient {
-	return &RabbitMQMessageQueuesClient{con: con, subscriptionID: subscriptionID}
+func NewRabbitMQMessageQueuesClient(con *arm.Connection, subscriptionID string) *RabbitMQMessageQueuesClient {
+	return &RabbitMQMessageQueuesClient{ep: con.Endpoint(), pl: con.NewPipeline(module, version), subscriptionID: subscriptionID}
 }
 
 // CreateOrUpdate - Creates or updates a RabbitMQMessageQueue resource
@@ -38,7 +40,7 @@ func (client *RabbitMQMessageQueuesClient) CreateOrUpdate(ctx context.Context, r
 	if err != nil {
 		return RabbitMQMessageQueuesCreateOrUpdateResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return RabbitMQMessageQueuesCreateOrUpdateResponse{}, err
 	}
@@ -63,7 +65,7 @@ func (client *RabbitMQMessageQueuesClient) createOrUpdateCreateRequest(ctx conte
 		return nil, errors.New("parameter rabbitMQMessageQueueName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{rabbitMQMessageQueueName}", url.PathEscape(rabbitMQMessageQueueName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +105,7 @@ func (client *RabbitMQMessageQueuesClient) Delete(ctx context.Context, resourceG
 	if err != nil {
 		return RabbitMQMessageQueuesDeleteResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return RabbitMQMessageQueuesDeleteResponse{}, err
 	}
@@ -128,7 +130,7 @@ func (client *RabbitMQMessageQueuesClient) deleteCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter rabbitMQMessageQueueName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{rabbitMQMessageQueueName}", url.PathEscape(rabbitMQMessageQueueName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +161,7 @@ func (client *RabbitMQMessageQueuesClient) Get(ctx context.Context, resourceGrou
 	if err != nil {
 		return RabbitMQMessageQueuesGetResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return RabbitMQMessageQueuesGetResponse{}, err
 	}
@@ -184,7 +186,7 @@ func (client *RabbitMQMessageQueuesClient) getCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter rabbitMQMessageQueueName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{rabbitMQMessageQueueName}", url.PathEscape(rabbitMQMessageQueueName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +244,7 @@ func (client *RabbitMQMessageQueuesClient) listCreateRequest(ctx context.Context
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +298,7 @@ func (client *RabbitMQMessageQueuesClient) listBySubscriptionCreateRequest(ctx c
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_rediscaches_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_rediscaches_client.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -22,13 +23,14 @@ import (
 // RedisCachesClient contains the methods for the RedisCaches group.
 // Don't use this type directly, use NewRedisCachesClient() instead.
 type RedisCachesClient struct {
-	con *connection
+	ep string
+	pl runtime.Pipeline
 	subscriptionID string
 }
 
 // NewRedisCachesClient creates a new instance of RedisCachesClient with the specified values.
-func NewRedisCachesClient(con *connection, subscriptionID string) *RedisCachesClient {
-	return &RedisCachesClient{con: con, subscriptionID: subscriptionID}
+func NewRedisCachesClient(con *arm.Connection, subscriptionID string) *RedisCachesClient {
+	return &RedisCachesClient{ep: con.Endpoint(), pl: con.NewPipeline(module, version), subscriptionID: subscriptionID}
 }
 
 // CreateOrUpdate - Creates or updates a RedisCache resource
@@ -38,7 +40,7 @@ func (client *RedisCachesClient) CreateOrUpdate(ctx context.Context, resourceGro
 	if err != nil {
 		return RedisCachesCreateOrUpdateResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return RedisCachesCreateOrUpdateResponse{}, err
 	}
@@ -63,7 +65,7 @@ func (client *RedisCachesClient) createOrUpdateCreateRequest(ctx context.Context
 		return nil, errors.New("parameter redisCacheName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{redisCacheName}", url.PathEscape(redisCacheName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +105,7 @@ func (client *RedisCachesClient) Delete(ctx context.Context, resourceGroupName s
 	if err != nil {
 		return RedisCachesDeleteResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return RedisCachesDeleteResponse{}, err
 	}
@@ -128,7 +130,7 @@ func (client *RedisCachesClient) deleteCreateRequest(ctx context.Context, resour
 		return nil, errors.New("parameter redisCacheName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{redisCacheName}", url.PathEscape(redisCacheName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +161,7 @@ func (client *RedisCachesClient) Get(ctx context.Context, resourceGroupName stri
 	if err != nil {
 		return RedisCachesGetResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return RedisCachesGetResponse{}, err
 	}
@@ -184,7 +186,7 @@ func (client *RedisCachesClient) getCreateRequest(ctx context.Context, resourceG
 		return nil, errors.New("parameter redisCacheName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{redisCacheName}", url.PathEscape(redisCacheName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +244,7 @@ func (client *RedisCachesClient) listCreateRequest(ctx context.Context, resource
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +298,7 @@ func (client *RedisCachesClient) listBySubscriptionCreateRequest(ctx context.Con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_sqldatabases_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_sqldatabases_client.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -22,13 +23,14 @@ import (
 // SQLDatabasesClient contains the methods for the SQLDatabases group.
 // Don't use this type directly, use NewSQLDatabasesClient() instead.
 type SQLDatabasesClient struct {
-	con *connection
+	ep string
+	pl runtime.Pipeline
 	subscriptionID string
 }
 
 // NewSQLDatabasesClient creates a new instance of SQLDatabasesClient with the specified values.
-func NewSQLDatabasesClient(con *connection, subscriptionID string) *SQLDatabasesClient {
-	return &SQLDatabasesClient{con: con, subscriptionID: subscriptionID}
+func NewSQLDatabasesClient(con *arm.Connection, subscriptionID string) *SQLDatabasesClient {
+	return &SQLDatabasesClient{ep: con.Endpoint(), pl: con.NewPipeline(module, version), subscriptionID: subscriptionID}
 }
 
 // CreateOrUpdate - Creates or updates a SQLDatabase resource
@@ -38,7 +40,7 @@ func (client *SQLDatabasesClient) CreateOrUpdate(ctx context.Context, resourceGr
 	if err != nil {
 		return SQLDatabasesCreateOrUpdateResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return SQLDatabasesCreateOrUpdateResponse{}, err
 	}
@@ -63,7 +65,7 @@ func (client *SQLDatabasesClient) createOrUpdateCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter sqlDatabaseName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{sqlDatabaseName}", url.PathEscape(sqlDatabaseName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +105,7 @@ func (client *SQLDatabasesClient) Delete(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return SQLDatabasesDeleteResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return SQLDatabasesDeleteResponse{}, err
 	}
@@ -128,7 +130,7 @@ func (client *SQLDatabasesClient) deleteCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter sqlDatabaseName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{sqlDatabaseName}", url.PathEscape(sqlDatabaseName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +161,7 @@ func (client *SQLDatabasesClient) Get(ctx context.Context, resourceGroupName str
 	if err != nil {
 		return SQLDatabasesGetResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return SQLDatabasesGetResponse{}, err
 	}
@@ -184,7 +186,7 @@ func (client *SQLDatabasesClient) getCreateRequest(ctx context.Context, resource
 		return nil, errors.New("parameter sqlDatabaseName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{sqlDatabaseName}", url.PathEscape(sqlDatabaseName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +244,7 @@ func (client *SQLDatabasesClient) listCreateRequest(ctx context.Context, resourc
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +298,7 @@ func (client *SQLDatabasesClient) listBySubscriptionCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/corerp/api/README.md
+++ b/pkg/corerp/api/README.md
@@ -50,6 +50,7 @@ use: "@autorest/go@4.0.0-preview.29"
 module-version: 0.0.1
 file-prefix: zz_generated_
 license-header: MICROSOFT_MIT_NO_VERSION
+azure-arm: true
 ```
 
 ### Output

--- a/pkg/corerp/api/v20220315privatepreview/zz_generated_applications_client.go
+++ b/pkg/corerp/api/v20220315privatepreview/zz_generated_applications_client.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -22,13 +23,14 @@ import (
 // ApplicationsClient contains the methods for the Applications group.
 // Don't use this type directly, use NewApplicationsClient() instead.
 type ApplicationsClient struct {
-	con *connection
+	ep string
+	pl runtime.Pipeline
 	subscriptionID string
 }
 
 // NewApplicationsClient creates a new instance of ApplicationsClient with the specified values.
-func NewApplicationsClient(con *connection, subscriptionID string) *ApplicationsClient {
-	return &ApplicationsClient{con: con, subscriptionID: subscriptionID}
+func NewApplicationsClient(con *arm.Connection, subscriptionID string) *ApplicationsClient {
+	return &ApplicationsClient{ep: con.Endpoint(), pl: con.NewPipeline(module, version), subscriptionID: subscriptionID}
 }
 
 // CreateOrUpdate - Create or update an Application.
@@ -38,7 +40,7 @@ func (client *ApplicationsClient) CreateOrUpdate(ctx context.Context, resourceGr
 	if err != nil {
 		return ApplicationsCreateOrUpdateResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return ApplicationsCreateOrUpdateResponse{}, err
 	}
@@ -63,7 +65,7 @@ func (client *ApplicationsClient) createOrUpdateCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter applicationName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{applicationName}", url.PathEscape(applicationName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +105,7 @@ func (client *ApplicationsClient) Delete(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return ApplicationsDeleteResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return ApplicationsDeleteResponse{}, err
 	}
@@ -128,7 +130,7 @@ func (client *ApplicationsClient) deleteCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter applicationName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{applicationName}", url.PathEscape(applicationName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +161,7 @@ func (client *ApplicationsClient) Get(ctx context.Context, resourceGroupName str
 	if err != nil {
 		return ApplicationsGetResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return ApplicationsGetResponse{}, err
 	}
@@ -184,7 +186,7 @@ func (client *ApplicationsClient) getCreateRequest(ctx context.Context, resource
 		return nil, errors.New("parameter applicationName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{applicationName}", url.PathEscape(applicationName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +244,7 @@ func (client *ApplicationsClient) listCreateRequest(ctx context.Context, resourc
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +298,7 @@ func (client *ApplicationsClient) listBySubscriptionCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +338,7 @@ func (client *ApplicationsClient) Update(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return ApplicationsUpdateResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return ApplicationsUpdateResponse{}, err
 	}
@@ -361,7 +363,7 @@ func (client *ApplicationsClient) updateCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter applicationName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{applicationName}", url.PathEscape(applicationName))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/corerp/api/v20220315privatepreview/zz_generated_environments_client.go
+++ b/pkg/corerp/api/v20220315privatepreview/zz_generated_environments_client.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -22,13 +23,14 @@ import (
 // EnvironmentsClient contains the methods for the Environments group.
 // Don't use this type directly, use NewEnvironmentsClient() instead.
 type EnvironmentsClient struct {
-	con *connection
+	ep string
+	pl runtime.Pipeline
 	subscriptionID string
 }
 
 // NewEnvironmentsClient creates a new instance of EnvironmentsClient with the specified values.
-func NewEnvironmentsClient(con *connection, subscriptionID string) *EnvironmentsClient {
-	return &EnvironmentsClient{con: con, subscriptionID: subscriptionID}
+func NewEnvironmentsClient(con *arm.Connection, subscriptionID string) *EnvironmentsClient {
+	return &EnvironmentsClient{ep: con.Endpoint(), pl: con.NewPipeline(module, version), subscriptionID: subscriptionID}
 }
 
 // CreateOrUpdate - Create or update an Environment.
@@ -38,7 +40,7 @@ func (client *EnvironmentsClient) CreateOrUpdate(ctx context.Context, resourceGr
 	if err != nil {
 		return EnvironmentsCreateOrUpdateResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return EnvironmentsCreateOrUpdateResponse{}, err
 	}
@@ -63,7 +65,7 @@ func (client *EnvironmentsClient) createOrUpdateCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter environmentName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{environmentName}", url.PathEscape(environmentName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +105,7 @@ func (client *EnvironmentsClient) Delete(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return EnvironmentsDeleteResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return EnvironmentsDeleteResponse{}, err
 	}
@@ -128,7 +130,7 @@ func (client *EnvironmentsClient) deleteCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter environmentName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{environmentName}", url.PathEscape(environmentName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +161,7 @@ func (client *EnvironmentsClient) Get(ctx context.Context, resourceGroupName str
 	if err != nil {
 		return EnvironmentsGetResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return EnvironmentsGetResponse{}, err
 	}
@@ -184,7 +186,7 @@ func (client *EnvironmentsClient) getCreateRequest(ctx context.Context, resource
 		return nil, errors.New("parameter environmentName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{environmentName}", url.PathEscape(environmentName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +244,7 @@ func (client *EnvironmentsClient) listCreateRequest(ctx context.Context, resourc
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +298,7 @@ func (client *EnvironmentsClient) listBySubscriptionCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +338,7 @@ func (client *EnvironmentsClient) Update(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return EnvironmentsUpdateResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return EnvironmentsUpdateResponse{}, err
 	}
@@ -361,7 +363,7 @@ func (client *EnvironmentsClient) updateCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter environmentName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{environmentName}", url.PathEscape(environmentName))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/corerp/api/v20220315privatepreview/zz_generated_gateways_client.go
+++ b/pkg/corerp/api/v20220315privatepreview/zz_generated_gateways_client.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -22,13 +23,14 @@ import (
 // GatewaysClient contains the methods for the Gateways group.
 // Don't use this type directly, use NewGatewaysClient() instead.
 type GatewaysClient struct {
-	con *connection
+	ep string
+	pl runtime.Pipeline
 	subscriptionID string
 }
 
 // NewGatewaysClient creates a new instance of GatewaysClient with the specified values.
-func NewGatewaysClient(con *connection, subscriptionID string) *GatewaysClient {
-	return &GatewaysClient{con: con, subscriptionID: subscriptionID}
+func NewGatewaysClient(con *arm.Connection, subscriptionID string) *GatewaysClient {
+	return &GatewaysClient{ep: con.Endpoint(), pl: con.NewPipeline(module, version), subscriptionID: subscriptionID}
 }
 
 // CreateOrUpdate - Create or update a Gateway.
@@ -38,7 +40,7 @@ func (client *GatewaysClient) CreateOrUpdate(ctx context.Context, resourceGroupN
 	if err != nil {
 		return GatewaysCreateOrUpdateResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return GatewaysCreateOrUpdateResponse{}, err
 	}
@@ -63,7 +65,7 @@ func (client *GatewaysClient) createOrUpdateCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +105,7 @@ func (client *GatewaysClient) Delete(ctx context.Context, resourceGroupName stri
 	if err != nil {
 		return GatewaysDeleteResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return GatewaysDeleteResponse{}, err
 	}
@@ -128,7 +130,7 @@ func (client *GatewaysClient) deleteCreateRequest(ctx context.Context, resourceG
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +161,7 @@ func (client *GatewaysClient) Get(ctx context.Context, resourceGroupName string,
 	if err != nil {
 		return GatewaysGetResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return GatewaysGetResponse{}, err
 	}
@@ -184,7 +186,7 @@ func (client *GatewaysClient) getCreateRequest(ctx context.Context, resourceGrou
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +244,7 @@ func (client *GatewaysClient) listCreateRequest(ctx context.Context, resourceGro
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +298,7 @@ func (client *GatewaysClient) listBySubscriptionCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +338,7 @@ func (client *GatewaysClient) Update(ctx context.Context, resourceGroupName stri
 	if err != nil {
 		return GatewaysUpdateResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return GatewaysUpdateResponse{}, err
 	}
@@ -361,7 +363,7 @@ func (client *GatewaysClient) updateCreateRequest(ctx context.Context, resourceG
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/corerp/api/v20220315privatepreview/zz_generated_httproutes_client.go
+++ b/pkg/corerp/api/v20220315privatepreview/zz_generated_httproutes_client.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -22,13 +23,14 @@ import (
 // HTTPRoutesClient contains the methods for the HTTPRoutes group.
 // Don't use this type directly, use NewHTTPRoutesClient() instead.
 type HTTPRoutesClient struct {
-	con *connection
+	ep string
+	pl runtime.Pipeline
 	subscriptionID string
 }
 
 // NewHTTPRoutesClient creates a new instance of HTTPRoutesClient with the specified values.
-func NewHTTPRoutesClient(con *connection, subscriptionID string) *HTTPRoutesClient {
-	return &HTTPRoutesClient{con: con, subscriptionID: subscriptionID}
+func NewHTTPRoutesClient(con *arm.Connection, subscriptionID string) *HTTPRoutesClient {
+	return &HTTPRoutesClient{ep: con.Endpoint(), pl: con.NewPipeline(module, version), subscriptionID: subscriptionID}
 }
 
 // CreateOrUpdate - Create or update an HTTP Route.
@@ -38,7 +40,7 @@ func (client *HTTPRoutesClient) CreateOrUpdate(ctx context.Context, resourceGrou
 	if err != nil {
 		return HTTPRoutesCreateOrUpdateResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return HTTPRoutesCreateOrUpdateResponse{}, err
 	}
@@ -63,7 +65,7 @@ func (client *HTTPRoutesClient) createOrUpdateCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter httpRouteName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{httpRouteName}", url.PathEscape(httpRouteName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +105,7 @@ func (client *HTTPRoutesClient) Delete(ctx context.Context, resourceGroupName st
 	if err != nil {
 		return HTTPRoutesDeleteResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return HTTPRoutesDeleteResponse{}, err
 	}
@@ -128,7 +130,7 @@ func (client *HTTPRoutesClient) deleteCreateRequest(ctx context.Context, resourc
 		return nil, errors.New("parameter httpRouteName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{httpRouteName}", url.PathEscape(httpRouteName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +161,7 @@ func (client *HTTPRoutesClient) Get(ctx context.Context, resourceGroupName strin
 	if err != nil {
 		return HTTPRoutesGetResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return HTTPRoutesGetResponse{}, err
 	}
@@ -184,7 +186,7 @@ func (client *HTTPRoutesClient) getCreateRequest(ctx context.Context, resourceGr
 		return nil, errors.New("parameter httpRouteName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{httpRouteName}", url.PathEscape(httpRouteName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +244,7 @@ func (client *HTTPRoutesClient) listCreateRequest(ctx context.Context, resourceG
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +298,7 @@ func (client *HTTPRoutesClient) listBySubscriptionCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +338,7 @@ func (client *HTTPRoutesClient) Update(ctx context.Context, resourceGroupName st
 	if err != nil {
 		return HTTPRoutesUpdateResponse{}, err
 	}
-	resp, err := 	client.con.Pipeline().Do(req)
+	resp, err := 	client.pl.Do(req)
 	if err != nil {
 		return HTTPRoutesUpdateResponse{}, err
 	}
@@ -361,7 +363,7 @@ func (client *HTTPRoutesClient) updateCreateRequest(ctx context.Context, resourc
 		return nil, errors.New("parameter httpRouteName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{httpRouteName}", url.PathEscape(httpRouteName))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.con.Endpoint(), urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/corerp/api/v20220315privatepreview/zz_generated_pagers.go
+++ b/pkg/corerp/api/v20220315privatepreview/zz_generated_pagers.go
@@ -47,7 +47,7 @@ func (p *ApplicationsListBySubscriptionPager) NextPage(ctx context.Context) bool
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -101,7 +101,7 @@ func (p *ApplicationsListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -155,7 +155,7 @@ func (p *EnvironmentsListBySubscriptionPager) NextPage(ctx context.Context) bool
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -209,7 +209,7 @@ func (p *EnvironmentsListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -263,7 +263,7 @@ func (p *GatewaysListBySubscriptionPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -317,7 +317,7 @@ func (p *GatewaysListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -371,7 +371,7 @@ func (p *HTTPRoutesListBySubscriptionPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false
@@ -425,7 +425,7 @@ func (p *HTTPRoutesListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	resp, err := p.	client.con.Pipeline().Do(req)
+	resp, err := p.	client.pl.Do(req)
 	if err != nil {
 		p.err = err
 		return false


### PR DESCRIPTION
# Description

Autorest generator expects azure-arm flag to generate clients for ARM resources http://azure.github.io/autorest/generate/

Autorest generator code: https://github.com/Azure/autorest.go/blob/22148146ca9ff532b9062a7f33804b5057f7aa7d/src/generator/operations.ts#L102

## Issue reference

https://github.com/project-radius/radius/issues/2470

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
