### PR TITLE
Enable download of bicep-extensibility compiler when feature flag is set

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -348,6 +348,7 @@ jobs:
         export RADIUS_CONTAINER_LOG_PATH=$GITHUB_WORKSPACE/${{ env.RADIUS_CONTAINER_LOG_BASE }}
         make test-functional-kubernetes
     - name: Run 'rad env delete'
+      if: always()
       run: |
         export PATH=$GITHUB_WORKSPACE/dist:$PATH
         dist/rad env delete dev --yes

--- a/pkg/cli/bicep/bicep.go
+++ b/pkg/cli/bicep/bicep.go
@@ -11,13 +11,11 @@ import (
 	"os"
 
 	"github.com/project-radius/radius/pkg/cli/tools"
+	ff "github.com/project-radius/radius/pkg/featureflag"
 )
 
 const radBicepEnvVar = "RAD_BICEP"
 const binaryName = "rad-bicep"
-
-// Placeholders are for: channel, platform, filename
-const downloadURIFmt = "https://radiuspublic.blob.core.windows.net/tools/bicep/%s/%s/%s"
 
 // IsBicepInstalled returns true if our local copy of bicep is installed
 func IsBicepInstalled() (bool, error) {
@@ -53,6 +51,13 @@ func DeleteBicep() error {
 
 // DownloadBicep updates our local copy of bicep
 func DownloadBicep() error {
+	dirPrefix := "bicep"
+	if ff.EnableBicepExtensibility.IsActive() {
+		dirPrefix = "bicep-extensibility"
+	}
+	// Placeholders are for: channel, platform, filename
+	downloadURIFmt := fmt.Sprint("https://radiuspublic.blob.core.windows.net/tools/", dirPrefix, "/%s/%s/%s")
+
 	uri, err := tools.GetDownloadURI(downloadURIFmt, binaryName)
 	if err != nil {
 		return err

--- a/pkg/cli/tools/binary_tools.go
+++ b/pkg/cli/tools/binary_tools.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 
 	"github.com/mitchellh/go-homedir"
+
 	"github.com/project-radius/radius/pkg/version"
 )
 
@@ -84,15 +85,17 @@ func GetDownloadURI(downloadURIFmt string, binaryName string) (string, error) {
 		return "", err
 	}
 
-	if runtime.GOOS == "darwin" {
-		return fmt.Sprintf(downloadURIFmt, version.Channel(), "macos-x64", filename), nil
-	} else if runtime.GOOS == "linux" {
-		return fmt.Sprintf(downloadURIFmt, version.Channel(), "linux-x64", filename), nil
-	} else if runtime.GOOS == "windows" {
-		return fmt.Sprintf(downloadURIFmt, version.Channel(), "windows-x64", filename), nil
-	} else {
+	var platform string
+	switch runtime.GOOS {
+	case "linux", "windows":
+		platform = runtime.GOOS
+	case "darwin":
+		platform = "macos"
+	default:
 		return "", fmt.Errorf("unsupported platform %s/%s", runtime.GOOS, runtime.GOARCH)
 	}
+
+	return fmt.Sprintf(downloadURIFmt, version.Channel(), fmt.Sprint(platform, "-x64"), filename), nil
 }
 
 func DownloadToFolder(filepath string, resp *http.Response) error {

--- a/pkg/cli/tools/binary_tools_test.go
+++ b/pkg/cli/tools/binary_tools_test.go
@@ -1,0 +1,37 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package tools
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/project-radius/radius/pkg/version"
+)
+
+func TestGetDownloadURI(t *testing.T) {
+	got, gotErr := GetDownloadURI("%s/%s/%s", "test-bin")
+	var want string
+	var wantErr bool
+
+	switch runtime.GOOS {
+	case "darwin":
+		want = fmt.Sprint(version.Channel(), "/macos-x64/test-bin")
+	case "linux", "windows":
+		want = fmt.Sprintf("%s/%s-x64/test-bin", version.Channel(), runtime.GOOS)
+	default:
+		wantErr = true
+	}
+
+	if wantErr {
+		wantErr := fmt.Errorf("unsupported platform %s/%s", runtime.GOOS, runtime.GOARCH)
+		require.ErrorIs(t, wantErr, gotErr, "GetDownloadURI() error = %v, wantErr %v", gotErr, wantErr)
+	}
+	require.Equal(t, want, got, "GetDownloadURI() got = %v, wantErr %v", got, want)
+}

--- a/pkg/featureflag/flags.go
+++ b/pkg/featureflag/flags.go
@@ -1,0 +1,15 @@
+package featureflag
+
+import "os"
+
+type Flag string
+
+const (
+	EnableBicepExtensibility Flag = "RAD_FF_ENABLE_BICEP_EXTENSIBILITY"
+)
+
+// IsActive returns if true if a feature flag is set, and false otherwise
+func (f Flag) IsActive() bool {
+	_, varFound := os.LookupEnv(string(f))
+	return varFound
+}


### PR DESCRIPTION
# Description

Adds a feature flag RAD_BICEP_EXTENSIBILITY_ENABLED to change rad bicep download so that it downloads the Bicep binary from `https://radiuspublic.blob.core.windows.net/tools/bicep-extensibility/**` instead of `https://radiuspublic.blob.core.windows.net/tools/bicep/**`

## Issue reference
Fix for radius-project/core-team#657


