### PR TITLE
Add/Remove kubectl context when connecting with existing env and deleting env respectively

### DIFF
--- a/cmd/rad/cmd/envInitAzure.go
+++ b/cmd/rad/cmd/envInitAzure.go
@@ -435,6 +435,11 @@ func connect(ctx context.Context, name string, subscriptionID string, resourceGr
 		if err != nil {
 			return err
 		}
+		// Merge credentials for the AKS cluster on client machine
+		err = azcli.RunCLICommand("aks", "get-credentials", "--subscription", subscriptionID, "--resource-group", resourceGroup, "--name", clusterName)
+		if err != nil {
+			return err
+		}
 
 		return nil
 	}


### PR DESCRIPTION
# Description

Updated code to add kubectl context to client machine when connecting to existing env created by, for eg., another machine. Also now deleting entries for context, user, cluster from kube config on client when deleting environments. 

possibly related existing issue found: https://github.com/Azure/azure-cli/issues/15302

Please reference the issue this PR will close: radius-project/core-team#647 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
