### PR TITLE
Fix a bug with CI/CD flakiness due to resource name being hardcoded

### DIFF
--- a/test/functional/localdev/resources/azure_test.go
+++ b/test/functional/localdev/resources/azure_test.go
@@ -7,7 +7,9 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/stretchr/testify/require"
@@ -52,7 +54,8 @@ func Test_Deploy_AzureResources(t *testing.T) {
 	template := "testdata/azure-resources-storage-account.bicep"
 	ctx := context.TODO()
 	opt := NewLocalDevTestOptions(t)
-	de := step.NewDeployExecutor(template, "storageAccountName=asilverman123445")
+	params := fmt.Sprintf("storageAccountName=test%d", time.Now().Nanosecond())
+	de := step.NewDeployExecutor(template, params)
 	t.Run(de.GetDescription(), func(t *testing.T) {
 		de.Execute(ctx, t, opt.TestOptions)
 


### PR DESCRIPTION
# Description
Making the resource name random so that simultaneous PRs don't experience naming collision

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #2580
