### PR TITLE
rad env list ucp support

### DIFF
--- a/cmd/rad/cmd/envList.go
+++ b/cmd/rad/cmd/envList.go
@@ -30,7 +30,12 @@ func getEnvConfigs(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if true /*featureflag.EnableUnifiedControlPlane.IsActive() one Ariel's change is merged */ {
+	isUCPEnabled := false
+	if env.GetKind() == environments.KindKubernetes {
+		isUCPEnabled = env.(*environments.KubernetesEnvironment).GetEnableUCP()
+	}
+
+	if isUCPEnabled {
 		client, err := environments.CreateUCPManagementClient(cmd.Context(), env)
 		if err != nil {
 			return err

--- a/cmd/rad/cmd/envList.go
+++ b/cmd/rad/cmd/envList.go
@@ -12,6 +12,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/environments"
 	"github.com/project-radius/radius/pkg/cli/objectformats"
 	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -40,95 +41,119 @@ func getEnvConfigs(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-
 		envList, err := client.ListEnv(cmd.Context())
-
 		if err != nil {
 			return err
 		}
+		return displayEnvListUCP(envList, cmd)
+	} else {
+		return displayEnvList(cmd)
+	}
+}
 
-		format, err := cli.RequireOutput(cmd)
-		if err != nil {
-			return err
-		}
+func displayEnvListUCP(envList []v20220315privatepreview.EnvironmentResource, cmd *cobra.Command) error {
+	format, err := cli.RequireOutput(cmd)
+	if err != nil {
+		return err
+	}
 
+	if format == "table" {
 		err = output.Write(format, envList, cmd.OutOrStdout(), objectformats.GetGenericEnvironmentTableFormat())
 		if err != nil {
 			return err
 		}
-
-		return nil
+	} else if format == "json" {
+		err = output.Write(format, envList, cmd.OutOrStdout(), output.FormatterOptions{Columns: []output.Column{}})
+		if err != nil {
+			return err
+		}
+	} else if format == "list" {
+		b, err := yaml.Marshal(envList)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
 
 	} else {
-		config := ConfigFromContext(cmd.Context())
-		env, err := cli.ReadEnvironmentSection(config)
-
+		err = output.Write(format, envList, cmd.OutOrStdout(), objectformats.GetGenericEnvironmentTableFormat())
 		if err != nil {
 			return err
-		}
-
-		if len(env.Items) == 0 {
-			fmt.Println("No environments found. Use 'rad env init' to initialize.")
-			return nil
-		}
-
-		format, err := cli.RequireOutput(cmd)
-		if err != nil {
-			return err
-		}
-		if format == "json" {
-			hasError, err := displayErrors(format, cmd, env)
-			if err != nil {
-				return err
-			}
-			if !hasError {
-				err = output.Write(format, &env, cmd.OutOrStdout(), output.FormatterOptions{Columns: []output.Column{}})
-				if err != nil {
-					return err
-				}
-			}
-		} else if format == "list" {
-			b, err := yaml.Marshal(&env)
-			if err != nil {
-				return err
-			}
-			fmt.Println(string(b))
-			_, err = displayErrors(format, cmd, env)
-			if err != nil {
-				return err
-			}
-		} else {
-			//default format is table
-			fmt.Println("default: " + env.Default)
-			var envList []interface{}
-
-			for key := range env.Items {
-				env, _ := env.GetEnvironment(key)
-				if env != nil {
-					envList = append(envList, env)
-				} else {
-					undefinedEnv := &environments.GenericEnvironment{
-						Name: key,
-						Kind: "unknown",
-					}
-					envList = append(envList, undefinedEnv)
-				}
-			}
-
-			formatter := objectformats.GetGenericEnvironmentTableFormat()
-			err = output.Write(format, envList, cmd.OutOrStdout(), formatter)
-			if err != nil {
-				return err
-			}
-
-			_, err = displayErrors(format, cmd, env)
-			if err != nil {
-				return err
-			}
 		}
 	}
 
 	return nil
+}
+
+func displayEnvList(cmd *cobra.Command) error {
+
+	config := ConfigFromContext(cmd.Context())
+	env, err := cli.ReadEnvironmentSection(config)
+
+	if err != nil {
+		return err
+	}
+
+	if len(env.Items) == 0 {
+		fmt.Println("No environments found. Use 'rad env init' to initialize.")
+		return nil
+	}
+
+	format, err := cli.RequireOutput(cmd)
+	if err != nil {
+		return err
+	}
+	if format == "json" {
+		hasError, err := displayErrors(format, cmd, env)
+		if err != nil {
+			return err
+		}
+		if !hasError {
+			err = output.Write(format, &env, cmd.OutOrStdout(), output.FormatterOptions{Columns: []output.Column{}})
+			if err != nil {
+				return err
+			}
+		}
+	} else if format == "list" {
+		b, err := yaml.Marshal(&env)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
+		_, err = displayErrors(format, cmd, env)
+		if err != nil {
+			return err
+		}
+	} else {
+		//default format is table
+		fmt.Println("default: " + env.Default)
+		var envList []interface{}
+
+		for key := range env.Items {
+			env, _ := env.GetEnvironment(key)
+			if env != nil {
+				envList = append(envList, env)
+			} else {
+				undefinedEnv := &environments.GenericEnvironment{
+					Name: key,
+					Kind: "unknown",
+				}
+				envList = append(envList, undefinedEnv)
+			}
+		}
+
+		formatter := objectformats.GetGenericEnvironmentTableFormat()
+		err = output.Write(format, envList, cmd.OutOrStdout(), formatter)
+		if err != nil {
+			return err
+		}
+
+		_, err = displayErrors(format, cmd, env)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+
 }
 
 func init() {

--- a/pkg/cli/clients/clients.go
+++ b/pkg/cli/clients/clients.go
@@ -119,7 +119,7 @@ type ManagementClient interface {
 // ManagementClient is used to interface with management features like listing applications and resources.
 type AppManagementClient interface {
 	//ListAllResourcesByApplication(ctx context.Context, applicationName string) error
-	ListEnv(ctx context.Context) ([]v20220315privatepreview.EnvironmentResourceList, error)
+	ListEnv(ctx context.Context) ([]v20220315privatepreview.EnvironmentResource, error)
 }
 
 func ShallowCopy(params DeploymentParameters) DeploymentParameters {

--- a/pkg/cli/clients/clients.go
+++ b/pkg/cli/clients/clients.go
@@ -13,6 +13,7 @@ import (
 	"github.com/project-radius/radius/pkg/azure/azresources"
 	"github.com/project-radius/radius/pkg/azure/radclient"
 	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
 )
 
 // NOTE: parameters in the template engine follow the structure:
@@ -113,6 +114,12 @@ type ManagementClient interface {
 
 	ShowResource(ctx context.Context, applicationName, resourceType, resourceName, resourceGroup, resourceSubscriptionID string) (interface{}, error)
 	ListAllResourcesByApplication(ctx context.Context, applicationName string) (*radclient.RadiusResourceList, error)
+}
+
+// ManagementClient is used to interface with management features like listing applications and resources.
+type AppManagementClient interface {
+	//ListAllResourcesByApplication(ctx context.Context, applicationName string) error
+	ListEnv(ctx context.Context) ([]v20220315privatepreview.EnvironmentResourceList, error)
 }
 
 func ShallowCopy(params DeploymentParameters) DeploymentParameters {

--- a/pkg/cli/environments/azure.go
+++ b/pkg/cli/environments/azure.go
@@ -127,7 +127,7 @@ func (e *AzureCloudEnvironment) CreateDiagnosticsClient(ctx context.Context) (cl
 		return nil, err
 	}
 
-	_, con, err := kubernetes.CreateAPIServerConnection(e.Context, e.RadiusRPLocalURL)
+	_, con, err := kubernetes.CreateAPIServerConnection(e.Context, e.RadiusRPLocalURL, e.EnableUCP)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func (e *AzureCloudEnvironment) CreateDiagnosticsClient(ctx context.Context) (cl
 }
 
 func (e *AzureCloudEnvironment) CreateManagementClient(ctx context.Context) (clients.ManagementClient, error) {
-	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.RadiusRPLocalURL)
+	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.RadiusRPLocalURL, e.EnableUCP)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func (e *AzureCloudEnvironment) CreateManagementClient(ctx context.Context) (cli
 }
 
 func (e *AzureCloudEnvironment) CreateUCPManagementClient(ctx context.Context) (clients.AppManagementClient, error) {
-	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.UCPLocalURL)
+	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.UCPLocalURL, e.EnableUCP)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/environments/azure.go
+++ b/pkg/cli/environments/azure.go
@@ -155,3 +155,18 @@ func (e *AzureCloudEnvironment) CreateManagementClient(ctx context.Context) (cli
 		SubscriptionID:  e.SubscriptionID,
 	}, nil
 }
+
+func (e *AzureCloudEnvironment) CreateUCPManagementClient(ctx context.Context) (clients.AppManagementClient, error) {
+	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.APIServerBaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &kubernetes.ARMUCPManagementClient{
+		EnvironmentName: e.Name,
+		Connection:      connection,
+		Scope:           "/Subscriptions/" + e.SubscriptionID + "/ResourceGroups" + e.ResourceGroup,
+		//ResourceGroup:   e.Namespace, // Temporarily set resource group and subscription id to the namespace
+		//SubscriptionID:  e.Namespace,
+	}, nil
+}

--- a/pkg/cli/environments/azure.go
+++ b/pkg/cli/environments/azure.go
@@ -157,7 +157,7 @@ func (e *AzureCloudEnvironment) CreateManagementClient(ctx context.Context) (cli
 }
 
 func (e *AzureCloudEnvironment) CreateUCPManagementClient(ctx context.Context) (clients.AppManagementClient, error) {
-	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.APIServerBaseURL)
+	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.UCPLocalURL)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (e *AzureCloudEnvironment) CreateUCPManagementClient(ctx context.Context) (
 	return &kubernetes.ARMUCPManagementClient{
 		EnvironmentName: e.Name,
 		Connection:      connection,
-		Scope:           "/Subscriptions/" + e.SubscriptionID + "/ResourceGroups" + e.ResourceGroup,
+		RootScope:       "/Subscriptions/" + e.SubscriptionID + "/ResourceGroups" + e.ResourceGroup,
 		//ResourceGroup:   e.Namespace, // Temporarily set resource group and subscription id to the namespace
 		//SubscriptionID:  e.Namespace,
 	}, nil

--- a/pkg/cli/environments/dev.go
+++ b/pkg/cli/environments/dev.go
@@ -156,7 +156,7 @@ func (e *LocalEnvironment) CreateDiagnosticsClient(ctx context.Context) (clients
 		return nil, err
 	}
 
-	_, con, err := kubernetes.CreateAPIServerConnection(e.Context, e.RadiusRPLocalURL)
+	_, con, err := kubernetes.CreateAPIServerConnection(e.Context, e.RadiusRPLocalURL, e.EnableUCP)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func (e *LocalEnvironment) CreateDiagnosticsClient(ctx context.Context) (clients
 }
 
 func (e *LocalEnvironment) CreateManagementClient(ctx context.Context) (clients.ManagementClient, error) {
-	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.RadiusRPLocalURL)
+	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.RadiusRPLocalURL, e.EnableUCP)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func (e *LocalEnvironment) CreateManagementClient(ctx context.Context) (clients.
 }
 
 func (e *LocalEnvironment) CreateUCPManagementClient(ctx context.Context) (clients.AppManagementClient, error) {
-	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.UCPLocalURL)
+	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.UCPLocalURL, e.EnableUCP)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/environments/dev.go
+++ b/pkg/cli/environments/dev.go
@@ -189,7 +189,7 @@ func (e *LocalEnvironment) CreateManagementClient(ctx context.Context) (clients.
 }
 
 func (e *LocalEnvironment) CreateUCPManagementClient(ctx context.Context) (clients.AppManagementClient, error) {
-	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.APIServerBaseURL)
+	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.UCPLocalURL)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func (e *LocalEnvironment) CreateUCPManagementClient(ctx context.Context) (clien
 	return &kubernetes.ARMUCPManagementClient{
 		EnvironmentName: e.Name,
 		Connection:      connection,
-		Scope:           "/ResourceGroups/dummy", // + e.ResourceGroup,
+		RootScope:       "/ResourceGroups/dummy", // + e.ResourceGroup,
 		//	ResourceGroup:   e.Namespace, // Temporarily set resource group and subscription id to the namespace
 		//	SubscriptionID:  e.Namespace,
 	}, nil

--- a/pkg/cli/environments/dev.go
+++ b/pkg/cli/environments/dev.go
@@ -188,6 +188,21 @@ func (e *LocalEnvironment) CreateManagementClient(ctx context.Context) (clients.
 	}, nil
 }
 
+func (e *LocalEnvironment) CreateUCPManagementClient(ctx context.Context) (clients.AppManagementClient, error) {
+	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.APIServerBaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &kubernetes.ARMUCPManagementClient{
+		EnvironmentName: e.Name,
+		Connection:      connection,
+		Scope:           "/ResourceGroups/dummy", // + e.ResourceGroup,
+		//	ResourceGroup:   e.Namespace, // Temporarily set resource group and subscription id to the namespace
+		//	SubscriptionID:  e.Namespace,
+	}, nil
+}
+
 func (e *LocalEnvironment) CreateServerLifecycleClient(ctx context.Context) (clients.ServerLifecycleClient, error) {
 	return &k3d.ServerLifecycleClient{
 		ClusterName: e.ClusterName,

--- a/pkg/cli/environments/kubernetes.go
+++ b/pkg/cli/environments/kubernetes.go
@@ -143,6 +143,6 @@ func (e *KubernetesEnvironment) CreateUCPManagementClient(ctx context.Context) (
 	return &kubernetes.ARMUCPManagementClient{
 		EnvironmentName: e.Name,
 		Connection:      connection,
-		RootScope:       "/ResourceGroups/dummy", //+ e.ResourceGroup,
+		RootScope:       "ResourceGroups/default", //+ e.ResourceGroup,
 	}, nil
 }

--- a/pkg/cli/environments/kubernetes.go
+++ b/pkg/cli/environments/kubernetes.go
@@ -135,7 +135,7 @@ func (e *KubernetesEnvironment) CreateManagementClient(ctx context.Context) (cli
 }
 
 func (e *KubernetesEnvironment) CreateUCPManagementClient(ctx context.Context) (clients.AppManagementClient, error) {
-	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.APIServerBaseURL)
+	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.UCPLocalURL)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func (e *KubernetesEnvironment) CreateUCPManagementClient(ctx context.Context) (
 	return &kubernetes.ARMUCPManagementClient{
 		EnvironmentName: e.Name,
 		Connection:      connection,
-		Scope:           "/ResourceGroups/dummy", //+ e.ResourceGroup,
+		RootScope:       "/ResourceGroups/dummy", //+ e.ResourceGroup,
 		//ResourceGroup:   e.Namespace, // Temporarily set resource group and subscription id to the namespace
 		//SubscriptionID:  e.Namespace,
 	}, nil

--- a/pkg/cli/environments/kubernetes.go
+++ b/pkg/cli/environments/kubernetes.go
@@ -105,7 +105,7 @@ func (e *KubernetesEnvironment) CreateDiagnosticsClient(ctx context.Context) (cl
 		return nil, err
 	}
 
-	_, con, err := kubernetes.CreateAPIServerConnection(e.Context, e.RadiusRPLocalURL)
+	_, con, err := kubernetes.CreateAPIServerConnection(e.Context, e.RadiusRPLocalURL, e.EnableUCP)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (e *KubernetesEnvironment) CreateDiagnosticsClient(ctx context.Context) (cl
 }
 
 func (e *KubernetesEnvironment) CreateManagementClient(ctx context.Context) (clients.ManagementClient, error) {
-	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.RadiusRPLocalURL)
+	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.RadiusRPLocalURL, e.EnableUCP)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (e *KubernetesEnvironment) CreateManagementClient(ctx context.Context) (cli
 }
 
 func (e *KubernetesEnvironment) CreateUCPManagementClient(ctx context.Context) (clients.AppManagementClient, error) {
-	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.UCPLocalURL)
+	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.UCPLocalURL, e.EnableUCP)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,5 @@ func (e *KubernetesEnvironment) CreateUCPManagementClient(ctx context.Context) (
 		EnvironmentName: e.Name,
 		Connection:      connection,
 		RootScope:       "/ResourceGroups/dummy", //+ e.ResourceGroup,
-		//ResourceGroup:   e.Namespace, // Temporarily set resource group and subscription id to the namespace
-		//SubscriptionID:  e.Namespace,
 	}, nil
 }

--- a/pkg/cli/environments/kubernetes.go
+++ b/pkg/cli/environments/kubernetes.go
@@ -133,3 +133,18 @@ func (e *KubernetesEnvironment) CreateManagementClient(ctx context.Context) (cli
 		SubscriptionID:  e.Namespace,
 	}, nil
 }
+
+func (e *KubernetesEnvironment) CreateUCPManagementClient(ctx context.Context) (clients.AppManagementClient, error) {
+	_, connection, err := kubernetes.CreateAPIServerConnection(e.Context, e.APIServerBaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &kubernetes.ARMUCPManagementClient{
+		EnvironmentName: e.Name,
+		Connection:      connection,
+		Scope:           "/ResourceGroups/dummy", //+ e.ResourceGroup,
+		//ResourceGroup:   e.Namespace, // Temporarily set resource group and subscription id to the namespace
+		//SubscriptionID:  e.Namespace,
+	}, nil
+}

--- a/pkg/cli/environments/types.go
+++ b/pkg/cli/environments/types.go
@@ -80,6 +80,10 @@ type ManagementEnvironment interface {
 	CreateManagementClient(ctx context.Context) (clients.ManagementClient, error)
 }
 
+type UCPManagementEnvironment interface {
+	CreateUCPManagementClient(ctx context.Context) (clients.AppManagementClient, error)
+}
+
 func CreateManagementClient(ctx context.Context, env Environment) (clients.ManagementClient, error) {
 	me, ok := env.(ManagementEnvironment)
 	if !ok {
@@ -87,6 +91,15 @@ func CreateManagementClient(ctx context.Context, env Environment) (clients.Manag
 	}
 
 	return me.CreateManagementClient(ctx)
+}
+
+func CreateUCPManagementClient(ctx context.Context, env Environment) (clients.AppManagementClient, error) {
+	me, ok := env.(UCPManagementEnvironment)
+	if !ok {
+		return nil, fmt.Errorf("an environment of kind '%s' does not support management operations", env.GetKind())
+	}
+
+	return me.CreateUCPManagementClient(ctx)
 }
 
 type ServerLifecycleEnvironment interface {

--- a/pkg/cli/kubernetes/ucp_management.go
+++ b/pkg/cli/kubernetes/ucp_management.go
@@ -1,0 +1,29 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/project-radius/radius/pkg/cli/clients"
+	"github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
+)
+
+//TODO: Change subId and ResourceId to scope
+type ARMUCPManagementClient struct {
+	Connection      *arm.Connection
+	EnvironmentName string
+	Scope           string
+}
+
+var _ clients.AppManagementClient = (*ARMUCPManagementClient)(nil)
+
+func (um *ARMUCPManagementClient) ListEnv(ctx context.Context) ([]v20220315privatepreview.EnvironmentResourceList, error) {
+
+	return nil, nil
+
+}

--- a/pkg/cli/kubernetes/ucp_management.go
+++ b/pkg/cli/kubernetes/ucp_management.go
@@ -10,20 +10,30 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/project-radius/radius/pkg/cli/clients"
-	"github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
+	v20220315privatepreview "github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
 )
 
 //TODO: Change subId and ResourceId to scope
 type ARMUCPManagementClient struct {
 	Connection      *arm.Connection
 	EnvironmentName string
-	Scope           string
+	RootScope       string
 }
 
 var _ clients.AppManagementClient = (*ARMUCPManagementClient)(nil)
 
-func (um *ARMUCPManagementClient) ListEnv(ctx context.Context) ([]v20220315privatepreview.EnvironmentResourceList, error) {
+func (um *ARMUCPManagementClient) ListEnv(ctx context.Context) ([]v20220315privatepreview.EnvironmentResource, error) {
 
-	return nil, nil
+	envClient := v20220315privatepreview.NewEnvironmentsClient(um.Connection, um.RootScope)
+	envListPager := envClient.ListByScope(&v20220315privatepreview.EnvironmentsListByScopeOptions{})
+	envResourceList := []v20220315privatepreview.EnvironmentResource{}
+	for envListPager.NextPage(ctx) {
+		currEnvPage := envListPager.PageResponse().EnvironmentResourceList.Value
+		for _, env := range currEnvPage {
+			envResourceList = append(envResourceList, *env)
+		}
+	}
+
+	return envResourceList, nil
 
 }

--- a/pkg/cli/objectformats/objectformats.go
+++ b/pkg/cli/objectformats/objectformats.go
@@ -73,11 +73,7 @@ func GetGenericEnvironmentTableFormat() output.FormatterOptions {
 			},
 			{
 				Heading:  "KIND",
-				JSONPath: "{ .Kind }",
-			},
-			{
-				Heading:  "DEFAULT APPLICATION",
-				JSONPath: "{ .DefaultApplication }",
+				JSONPath: "{ .properties.compute.Kind }",
 			},
 		},
 	}

--- a/test/functional/azure/test.go
+++ b/test/functional/azure/test.go
@@ -37,10 +37,10 @@ func NewTestOptions(t *testing.T) TestOptions {
 	az, err := environments.RequireAzureCloud(env)
 	require.NoError(t, err, "environment was not azure cloud")
 
-	_, radiusConnection, err := kubernetes.CreateAPIServerConnection(az.Context, az.RadiusRPLocalURL)
+	_, radiusConnection, err := kubernetes.CreateAPIServerConnection(az.Context, az.RadiusRPLocalURL, false)
 	require.NoError(t, err, "failed to create API Server connection")
 
-	radiusBaseURL, radiusRoundTripper, err := kubernetes.GetBaseUrlAndRoundTripper(az.RadiusRPLocalURL, "api.radius.dev", az.Context)
+	radiusBaseURL, radiusRoundTripper, err := kubernetes.GetBaseUrlAndRoundTripper(az.RadiusRPLocalURL, "api.radius.dev", az.Context, false)
 	require.NoError(t, err, "failed to create API Server round-tripper")
 
 	return TestOptions{


### PR DESCRIPTION
# Description

changes to support rad env list in ucp env.

NOTE: currently I have hard coded the scope value as RootScope: "/ResourceGroups/dummy". It should be accessible from "env" as env.resourceGroup once rad env creation is working for ucp enabled scenario

## Issue reference



Please reference the issue this PR will close: #2609 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
