### PR TITLE
Fixing retry error in Gateway tests

### DIFF
--- a/test/functional/kubernetes/resources/gateway_test.go
+++ b/test/functional/kubernetes/resources/gateway_test.go
@@ -123,17 +123,20 @@ func testGatewayWithPortforward(t *testing.T, ctx context.Context, at kubernetes
 		baseURL := fmt.Sprintf("http://%s:%d", localHostname, localPort)
 		t.Logf("Portforward session active at %s", baseURL)
 
-		if err := testGatewayAvailability(t, hostname, baseURL+"/healthz", 200); err != nil {
+		if err := testGatewayAvailability(t, hostname, baseURL, "healthz", 200); err != nil {
+			close(stopChan)
 			return err
 		}
 
 		// Both of these URLs route to the same backend service,
 		// but /backend2 maps to / which allows it to access /healthz
-		if err := testGatewayAvailability(t, hostname, baseURL+"/backend2/healthz", 200); err != nil {
+		if err := testGatewayAvailability(t, hostname, baseURL, "backend2/healthz", 200); err != nil {
+			close(stopChan)
 			return err
 		}
 
-		if err := testGatewayAvailability(t, hostname, baseURL+"/backend1/healthz", 404); err != nil {
+		if err := testGatewayAvailability(t, hostname, baseURL, "backend1/healthz", 404); err != nil {
+			close(stopChan)
 			return err
 		}
 
@@ -144,8 +147,10 @@ func testGatewayWithPortforward(t *testing.T, ctx context.Context, at kubernetes
 
 }
 
-func testGatewayAvailability(t *testing.T, hostname, url string, expectedStatusCode int) error {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+func testGatewayAvailability(t *testing.T, hostname, baseURL, path string, expectedStatusCode int) error {
+	req, err := autorest.Prepare(&http.Request{},
+		autorest.WithBaseURL(baseURL),
+		autorest.WithPath(path))
 	if err != nil {
 		return err
 	}
@@ -153,7 +158,10 @@ func testGatewayAvailability(t *testing.T, hostname, url string, expectedStatusC
 	req.Host = hostname
 
 	// Send requests to backing container via port-forward
-	response, err := autorest.Send(req, autorest.DoErrorUnlessStatusCode(expectedStatusCode), autorest.DoRetryForDuration(retryTimeout, retryBackoff), autorest.WithLogging(functional.NewTestLogger(t)))
+	response, err := autorest.Send(req,
+		autorest.WithLogging(functional.NewTestLogger(t)),
+		autorest.DoErrorUnlessStatusCode(expectedStatusCode),
+		autorest.DoRetryForDuration(retryTimeout, retryBackoff))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

* Closing stop channel in case of failed port-forward session for gateway tests
* Aligning use of autorest with official documentation

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
