### PR TITLE
Use correct application in K8s Gateway tests

### DIFF
--- a/test/functional/kubernetes/resources/gateway_test.go
+++ b/test/functional/kubernetes/resources/gateway_test.go
@@ -70,10 +70,8 @@ func Test_Gateway(t *testing.T) {
 				},
 			},
 			PostStepVerify: func(ctx context.Context, t *testing.T, at kubernetes.ApplicationTest) {
-				// Get hostname from root HTTPProxy
-				// Note: this just gets the hostname from the first root proxy
-				// that it finds. Testing multiple gateways here will not work.
-				hostname, err := functional.GetHostnameForHTTPProxy(ctx, at.Options.Client)
+				// Get hostname from root HTTPProxy in 'application' namespace
+				hostname, err := functional.GetHostnameForHTTPProxy(ctx, at.Options.Client, application)
 				require.NoError(t, err)
 				t.Logf("found root proxy with hostname: {%s}", hostname)
 

--- a/test/functional/testUtil.go
+++ b/test/functional/testUtil.go
@@ -52,10 +52,10 @@ func setDefault() (string, string) {
 	return defaultDockerReg, imageTag
 }
 
-func GetHostnameForHTTPProxy(ctx context.Context, client runtime_client.Client) (string, error) {
+func GetHostnameForHTTPProxy(ctx context.Context, client runtime_client.Client, application string) (string, error) {
 	var httpproxies contourv1.HTTPProxyList
 
-	err := client.List(ctx, &httpproxies, &runtime_client.ListOptions{})
+	err := client.List(ctx, &httpproxies, &runtime_client.ListOptions{Namespace: application})
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
# Description

* Fixed a flakiness issue where sometimes k8s gateway tests would use the wrong hostname for sending http requests to port-forwarded envoy pod

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
