### PR TITLE
Added an unique localID for the trafficSplit CRD

### DIFF
--- a/pkg/radrp/outputresource/local_ids.go
+++ b/pkg/radrp/outputresource/local_ids.go
@@ -65,6 +65,7 @@ const (
 	LocalIDService                      = "Service"
 	LocalIDStatefulSet                  = "StatefulSet"
 	LocalIDUserAssignedManagedIdentity  = "UserAssignedManagedIdentity"
+	LocalIDTrafficSplit                 = "TrafficSplit"
 
 	// Obsolete when we remove AppModelV1
 	LocalIDRoleAssignmentKVKeys         = "RoleAssignment-KVKeys"

--- a/pkg/renderers/httproutev1alpha3/render.go
+++ b/pkg/renderers/httproutev1alpha3/render.go
@@ -87,6 +87,7 @@ func (r Renderer) Render(ctx context.Context, options renderers.RenderOptions) (
 	// Check if trafficsplit properties are configured for this HttpRoute. If yes, a TrafficSplit object will be created.
 	if len(route.Routes) > 0 {
 		trafficsplit = r.makeTrafficSplit(resource, route, options)
+		trafficsplit.LocalID = "TrafficSplit"
 		outputs = append(outputs, trafficsplit)
 	}
 	return renderers.RendererOutput{

--- a/pkg/renderers/httproutev1alpha3/render.go
+++ b/pkg/renderers/httproutev1alpha3/render.go
@@ -87,7 +87,6 @@ func (r Renderer) Render(ctx context.Context, options renderers.RenderOptions) (
 	// Check if trafficsplit properties are configured for this HttpRoute. If yes, a TrafficSplit object will be created.
 	if len(route.Routes) > 0 {
 		trafficsplit = r.makeTrafficSplit(resource, route, options)
-		trafficsplit.LocalID = "TrafficSplit"
 		outputs = append(outputs, trafficsplit)
 	}
 	return renderers.RendererOutput{
@@ -159,7 +158,7 @@ func (r *Renderer) makeTrafficSplit(resource renderers.RendererResource, route *
 		}
 		trafficsplit.Spec.Backends = append(trafficsplit.Spec.Backends, tsBackend)
 	}
-	return outputresource.NewKubernetesOutputResource(resourcekinds.Service, outputresource.LocalIDService, trafficsplit, trafficsplit.ObjectMeta)
+	return outputresource.NewKubernetesOutputResource(resourcekinds.TrafficSplit, outputresource.LocalIDTrafficSplit, trafficsplit, trafficsplit.ObjectMeta)
 }
 
 func (r Renderer) convert(resource renderers.RendererResource) (*radclient.HTTPRouteProperties, error) {

--- a/pkg/resourcekinds/resource_kinds.go
+++ b/pkg/resourcekinds/resource_kinds.go
@@ -33,4 +33,5 @@ const (
 	AzureRedis                       = "azure.redis"
 	AzureFileShare                   = "azure.fileshare"
 	AzureFileShareStorageAccount     = "azure.fileshare.account"
+	TrafficSplit                     = "TrafficSplit"
 )


### PR DESCRIPTION
# Description
A simple one line of change. The details can be found in issue radius-project/core-team#677.

Essentially, when we previously deployed a HttpRoute that is configured with traffic split properties, we were able to create a CRD for trafficsplit in the namespace, but we were unable to create a service for this HttpRoute. This PR will fix this issue
## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: radius-project/core-team#677 
