### PR TITLE
Parse resource id from listsecrets request route

### DIFF
--- a/pkg/connectorrp/frontend/controller/mongodatabases/listsecretsmongodatabase.go
+++ b/pkg/connectorrp/frontend/controller/mongodatabases/listsecretsmongodatabase.go
@@ -36,7 +36,8 @@ func (ctrl *ListSecretsMongoDatabase) Run(ctx context.Context, req *http.Request
 	sCtx := servicecontext.ARMRequestContextFromContext(ctx)
 
 	resource := &datamodel.MongoDatabase{}
-	_, err := ctrl.GetResource(ctx, sCtx.ResourceID.String(), resource)
+	parsedResourceID := sCtx.ResourceID.Truncate()
+	_, err := ctrl.GetResource(ctx, parsedResourceID.String(), resource)
 	if err != nil {
 		if errors.Is(&store.ErrNotFound{}, err) {
 			return rest.NewNotFoundResponse(sCtx.ResourceID), nil

--- a/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/listsecretsrabbitmq.go
+++ b/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/listsecretsrabbitmq.go
@@ -36,7 +36,8 @@ func (ctrl *ListSecretsRabbitMQMessageQueue) Run(ctx context.Context, req *http.
 	sCtx := servicecontext.ARMRequestContextFromContext(ctx)
 
 	resource := &datamodel.RabbitMQMessageQueue{}
-	_, err := ctrl.GetResource(ctx, sCtx.ResourceID.String(), resource)
+	parsedResourceID := sCtx.ResourceID.Truncate()
+	_, err := ctrl.GetResource(ctx, parsedResourceID.String(), resource)
 	if err != nil {
 		if errors.Is(&store.ErrNotFound{}, err) {
 			return rest.NewNotFoundResponse(sCtx.ResourceID), nil

--- a/pkg/connectorrp/frontend/controller/rediscaches/listsecretsrediscache.go
+++ b/pkg/connectorrp/frontend/controller/rediscaches/listsecretsrediscache.go
@@ -36,7 +36,8 @@ func (ctrl *ListSecretsRedisCache) Run(ctx context.Context, req *http.Request) (
 	sCtx := servicecontext.ARMRequestContextFromContext(ctx)
 
 	resource := &datamodel.RedisCache{}
-	_, err := ctrl.GetResource(ctx, sCtx.ResourceID.String(), resource)
+	parsedResourceID := sCtx.ResourceID.Truncate()
+	_, err := ctrl.GetResource(ctx, parsedResourceID.String(), resource)
 	if err != nil {
 		if errors.Is(&store.ErrNotFound{}, err) {
 			return rest.NewNotFoundResponse(sCtx.ResourceID), nil

--- a/pkg/connectorrp/frontend/handler/routes.go
+++ b/pkg/connectorrp/frontend/handler/routes.go
@@ -102,7 +102,7 @@ func AddRoutes(ctx context.Context, sp dataprovider.DataStorageProvider, sm mana
 			HandlerFactory: mongo_ctrl.NewDeleteMongoDatabase,
 		},
 		{
-			ParentRouter:   mongoResourceRouter.Path("/listsecrets").Subrouter(),
+			ParentRouter:   mongoResourceRouter.PathPrefix("/listsecrets").Subrouter(),
 			ResourceType:   mongo_ctrl.ResourceTypeName,
 			Method:         mongo_ctrl.OperationListSecret,
 			HandlerFactory: mongo_ctrl.NewListSecretsMongoDatabase,
@@ -258,7 +258,7 @@ func AddRoutes(ctx context.Context, sp dataprovider.DataStorageProvider, sm mana
 			HandlerFactory: redis_ctrl.NewDeleteRedisCache,
 		},
 		{
-			ParentRouter:   redisResourceRouter.Path("/listsecrets").Subrouter(),
+			ParentRouter:   redisResourceRouter.PathPrefix("/listsecrets").Subrouter(),
 			ResourceType:   redis_ctrl.ResourceTypeName,
 			Method:         redis_ctrl.OperationListSecret,
 			HandlerFactory: redis_ctrl.NewListSecretsRedisCache,
@@ -294,7 +294,7 @@ func AddRoutes(ctx context.Context, sp dataprovider.DataStorageProvider, sm mana
 			HandlerFactory: rabbitmq_ctrl.NewDeleteRabbitMQMessageQueue,
 		},
 		{
-			ParentRouter:   rabbitmqResourceRouter.Path("/listsecrets").Subrouter(),
+			ParentRouter:   rabbitmqResourceRouter.PathPrefix("/listsecrets").Subrouter(),
 			ResourceType:   rabbitmq_ctrl.ResourceTypeName,
 			Method:         rabbitmq_ctrl.OperationListSecret,
 			HandlerFactory: rabbitmq_ctrl.NewListSecretsRabbitMQMessageQueue,


### PR DESCRIPTION
# Description

Request route for listsecrets has the action name as prefix which should be removed to get the resource id. 
List secrets request example:
route id: `subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/mongoDatabases/mongotest/listsecrets`
resource id returned after truncation: `subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/mongoDatabases/mongotest`

Tested locally:
```
% curl --location --request POST 'http://localhost:8080/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/mongoDatabases/mongotest/listsecrets?api-version=2022-03-15-privatepreview'
{
  "connectionString": "test-secrets",
  "password": "",
  "username": ""
}
```

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
