### PR TITLE
Changing GetPartitionKey function to use PlaneNamespace instead of duplicated code

### DIFF
--- a/pkg/ucp/store/cosmosdb/cosmosdbstorageclient.go
+++ b/pkg/ucp/store/cosmosdb/cosmosdbstorageclient.go
@@ -7,7 +7,6 @@ package cosmosdb
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -436,15 +435,7 @@ func GetPartitionKey(id resources.ID) (string, error) {
 	partitionKey := NormalizeSubscriptionID(id.FindScope(resources.SubscriptionsSegment))
 
 	if id.IsUCPQualfied() {
-		if len(id.ScopeSegments()) < 1 {
-			return "", errors.New("invalid UCP resource id")
-		}
-		scopeSegment := id.ScopeSegments()[0]
-		storageKeys, err := CombineStorageKeys(scopeSegment.Type, scopeSegment.Name)
-		if err != nil {
-			return "", err
-		}
-		partitionKey = NormalizeLetterOrDigitToUpper(storageKeys)
+		partitionKey = NormalizeLetterOrDigitToUpper(id.PlaneNamespace())
 	}
 
 	return partitionKey, nil


### PR DESCRIPTION
# Description
Changing GetPartitionKey function to use PlaneNamespace instead of duplicated code

## Issue reference
Please reference the issue this PR will close: #2616 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
