### PR TITLE
Convert  CoreRP HTTPRoute Controller to async based on Container updates

### DIFF
--- a/pkg/corerp/frontend/controller/httproutes/createorupdatehttproute.go
+++ b/pkg/corerp/frontend/controller/httproutes/createorupdatehttproute.go
@@ -70,7 +70,7 @@ func (e *CreateOrUpdateHTTPRoute) Run(ctx context.Context, req *http.Request) (r
 		return rest.NewPreconditionFailedResponse(serviceCtx.ResourceID.String(), err.Error()), nil
 	}
 
-	UpdateExistingResourceData(ctx, existingResource, newResource)
+	enrichMetadata(ctx, existingResource, newResource)
 
 	nr, err := e.SaveResource(ctx, serviceCtx.ResourceID.String(), newResource, etag)
 	if err != nil {
@@ -114,8 +114,8 @@ func (e *CreateOrUpdateHTTPRoute) Validate(ctx context.Context, req *http.Reques
 	return dm, err
 }
 
-// UpdateExistingResourceData updates the HTTPRoute resource before it is saved to the DB.
-func UpdateExistingResourceData(ctx context.Context, er *datamodel.HTTPRoute, nr *datamodel.HTTPRoute) {
+// enrichMetadata updates the HTTPRoute resource before it is saved to the DB.
+func enrichMetadata(ctx context.Context, er *datamodel.HTTPRoute, nr *datamodel.HTTPRoute) {
 	sc := servicecontext.ARMRequestContextFromContext(ctx)
 	nr.SystemData = ctrl.UpdateSystemData(er.SystemData, *sc.SystemData())
 	if er.CreatedAPIVersion != "" {

--- a/pkg/corerp/frontend/controller/httproutes/createorupdatehttproute.go
+++ b/pkg/corerp/frontend/controller/httproutes/createorupdatehttproute.go
@@ -17,6 +17,7 @@ import (
 	"github.com/project-radius/radius/pkg/armrpc/servicecontext"
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
 	"github.com/project-radius/radius/pkg/corerp/datamodel/converter"
+	"github.com/project-radius/radius/pkg/corerp/frontend/controller"
 	"github.com/project-radius/radius/pkg/radrp/rest"
 	"github.com/project-radius/radius/pkg/ucp/store"
 )
@@ -62,7 +63,7 @@ func (e *CreateOrUpdateHTTPRoute) Run(ctx context.Context, req *http.Request) (r
 	}
 
 	if exists && !existingResource.Properties.ProvisioningState.IsTerminal() {
-		return rest.NewConflictResponse(OngoingAsyncOperationOnResourceMessage), nil
+		return rest.NewConflictResponse(controller.OngoingAsyncOperationOnResourceMessage), nil
 	}
 
 	err = ctrl.ValidateETag(*serviceCtx, etag)

--- a/pkg/corerp/frontend/controller/httproutes/deletehttproute.go
+++ b/pkg/corerp/frontend/controller/httproutes/deletehttproute.go
@@ -16,6 +16,7 @@ import (
 	ctrl "github.com/project-radius/radius/pkg/armrpc/frontend/controller"
 	"github.com/project-radius/radius/pkg/armrpc/servicecontext"
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
+	"github.com/project-radius/radius/pkg/corerp/frontend/controller"
 	"github.com/project-radius/radius/pkg/radrp/rest"
 	"github.com/project-radius/radius/pkg/ucp/store"
 )

--- a/pkg/corerp/frontend/controller/httproutes/deletehttproute.go
+++ b/pkg/corerp/frontend/controller/httproutes/deletehttproute.go
@@ -22,8 +22,8 @@ import (
 
 var (
 	_ ctrl.Controller = (*DeleteHTTPRoute)(nil)
-	// AsyncDeleteContainerOperationTimeout is the default timeout duration of async delete container operation.
-	AsyncDeleteContainerOperationTimeout = time.Duration(120) * time.Second
+	// AsyncDeleteHTTPRouteOperationTimeout is the default timeout duration of async delete httproute operation.
+	AsyncDeleteHTTPRouteOperationTimeout = time.Duration(120) * time.Second
 )
 
 // DeleteHTTPRoute is the controller implementation to delete HTTPRoute resource.
@@ -59,7 +59,7 @@ func (e *DeleteHTTPRoute) Run(ctx context.Context, req *http.Request) (rest.Resp
 		return rest.NewPreconditionFailedResponse(serviceCtx.ResourceID.String(), err.Error()), nil
 	}
 
-	err = e.AsyncOperation.QueueAsyncOperation(ctx, serviceCtx, AsyncDeleteContainerOperationTimeout)
+	err = e.AsyncOperation.QueueAsyncOperation(ctx, serviceCtx, AsyncDeleteHTTPRouteOperationTimeout)
 	if err != nil {
 		existingResource.Properties.ProvisioningState = v1.ProvisioningStateFailed
 		_, rbErr := e.SaveResource(ctx, serviceCtx.ResourceID.String(), existingResource, etag)

--- a/pkg/corerp/frontend/controller/httproutes/deletehttproute.go
+++ b/pkg/corerp/frontend/controller/httproutes/deletehttproute.go
@@ -51,7 +51,7 @@ func (e *DeleteHTTPRoute) Run(ctx context.Context, req *http.Request) (rest.Resp
 	}
 
 	if !existingResource.Properties.ProvisioningState.IsTerminal() {
-		return rest.NewConflictResponse(OngoingAsyncOperationOnResourceMessage), nil
+		return rest.NewConflictResponse(ctrl.OngoingAsyncOperationOnResourceMessage), nil
 	}
 
 	err = ctrl.ValidateETag(*serviceCtx, etag)

--- a/pkg/corerp/frontend/controller/httproutes/deletehttproute.go
+++ b/pkg/corerp/frontend/controller/httproutes/deletehttproute.go
@@ -51,7 +51,7 @@ func (e *DeleteHTTPRoute) Run(ctx context.Context, req *http.Request) (rest.Resp
 	}
 
 	if !existingResource.Properties.ProvisioningState.IsTerminal() {
-		return rest.NewConflictResponse(ctrl.OngoingAsyncOperationOnResourceMessage), nil
+		return rest.NewConflictResponse(controller.OngoingAsyncOperationOnResourceMessage), nil
 	}
 
 	err = ctrl.ValidateETag(*serviceCtx, etag)

--- a/pkg/corerp/frontend/controller/httproutes/deletehttproute.go
+++ b/pkg/corerp/frontend/controller/httproutes/deletehttproute.go
@@ -9,7 +9,9 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	manager "github.com/project-radius/radius/pkg/armrpc/asyncoperation/statusmanager"
 	ctrl "github.com/project-radius/radius/pkg/armrpc/frontend/controller"
 	"github.com/project-radius/radius/pkg/armrpc/servicecontext"
@@ -18,7 +20,11 @@ import (
 	"github.com/project-radius/radius/pkg/ucp/store"
 )
 
-var _ ctrl.Controller = (*DeleteHTTPRoute)(nil)
+var (
+	_ ctrl.Controller = (*DeleteHTTPRoute)(nil)
+	// AsyncDeleteContainerOperationTimeout is the default timeout duration of async delete container operation.
+	AsyncDeleteContainerOperationTimeout = time.Duration(120) * time.Second
+)
 
 // DeleteHTTPRoute is the controller implementation to delete HTTPRoute resource.
 type DeleteHTTPRoute struct {
@@ -40,8 +46,12 @@ func (e *DeleteHTTPRoute) Run(ctx context.Context, req *http.Request) (rest.Resp
 		return nil, err
 	}
 
-	if etag == "" {
+	if err != nil && errors.Is(&store.ErrNotFound{}, err) {
 		return rest.NewNoContentResponse(), nil
+	}
+
+	if !existingResource.Properties.ProvisioningState.IsTerminal() {
+		return rest.NewConflictResponse(OngoingAsyncOperationOnResourceMessage), nil
 	}
 
 	err = ctrl.ValidateETag(*serviceCtx, etag)
@@ -49,14 +59,18 @@ func (e *DeleteHTTPRoute) Run(ctx context.Context, req *http.Request) (rest.Resp
 		return rest.NewPreconditionFailedResponse(serviceCtx.ResourceID.String(), err.Error()), nil
 	}
 
-	// TODO: handle async deletion later.
-	err = e.DataStore.Delete(ctx, serviceCtx.ResourceID.String())
+	err = e.AsyncOperation.QueueAsyncOperation(ctx, serviceCtx, AsyncDeleteContainerOperationTimeout)
 	if err != nil {
-		if errors.Is(&store.ErrNotFound{}, err) {
-			return rest.NewNoContentResponse(), nil
+		existingResource.Properties.ProvisioningState = v1.ProvisioningStateFailed
+		_, rbErr := e.SaveResource(ctx, serviceCtx.ResourceID.String(), existingResource, etag)
+		if rbErr != nil {
+			return nil, rbErr
 		}
 		return nil, err
 	}
 
-	return rest.NewOKResponse(nil), nil
+	existingResource.Properties.ProvisioningState = v1.ProvisioningStateDeleting
+
+	return rest.NewAsyncOperationResponse(existingResource, existingResource.TrackedResource.Location, http.StatusAccepted,
+		serviceCtx.ResourceID, serviceCtx.OperationID), nil
 }

--- a/pkg/corerp/frontend/controller/httproutes/deletehttproute_test.go
+++ b/pkg/corerp/frontend/controller/httproutes/deletehttproute_test.go
@@ -8,125 +8,98 @@ package httproutes
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	"github.com/project-radius/radius/pkg/armrpc/asyncoperation/statusmanager"
+	"github.com/project-radius/radius/pkg/corerp/datamodel"
 	radiustesting "github.com/project-radius/radius/pkg/corerp/testing"
-	"github.com/project-radius/radius/pkg/radrp/armerrors"
 	"github.com/project-radius/radius/pkg/ucp/store"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDeleteHTTPRouteRun_20220315PrivatePreview(t *testing.T) {
-	mctrl := gomock.NewController(t)
-	defer mctrl.Finish()
+	setupTest := func(tb testing.TB) (func(tb testing.TB), *store.MockStorageClient, *statusmanager.MockStatusManager) {
+		mctrl := gomock.NewController(t)
+		mds := store.NewMockStorageClient(mctrl)
+		msm := statusmanager.NewMockStatusManager(mctrl)
 
-	mStorageClient := store.NewMockStorageClient(mctrl)
-	ctx := context.Background()
+		return func(tb testing.TB) {
+			mctrl.Finish()
+		}, mds, msm
+	}
 
 	t.Parallel()
 
-	t.Run("delete non-existing resource", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		req, _ := radiustesting.GetARMTestHTTPRequest(ctx, http.MethodDelete, testHeaderfile, nil)
-		ctx := radiustesting.ARMTestContextFromRequest(req)
-
-		mStorageClient.
-			EXPECT().
-			Get(gomock.Any(), gomock.Any()).
-			DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
-				return nil, &store.ErrNotFound{}
-			})
-
-		ctl, err := NewDeleteHTTPRoute(mStorageClient, nil)
-
-		require.NoError(t, err)
-		resp, err := ctl.Run(ctx, req)
-		require.NoError(t, err)
-		err = resp.Apply(ctx, w, req)
-		require.NoError(t, err)
-
-		result := w.Result()
-		require.Equal(t, http.StatusNoContent, result.StatusCode)
-
-		body := result.Body
-		defer body.Close()
-		payload, err := ioutil.ReadAll(body)
-		require.NoError(t, err)
-		require.Empty(t, payload, "response body should be empty")
-	})
-
-	existingResourceDeletionCases := []struct {
-		desc               string
-		ifMatchETag        string
-		resourceETag       string
-		expectedStatusCode int
-		shouldFail         bool
+	deleteCases := []struct {
+		desc     string
+		etag     string
+		curState v1.ProvisioningState
+		getErr   error
+		qErr     error
+		saveErr  error
+		code     int
 	}{
-		{"delete-existing-resource-no-if-match", "", "random-etag", http.StatusOK, false},
-		{"delete-not-existing-resource-no-if-match", "", "", http.StatusNoContent, true},
-		{"delete-existing-resource-matching-if-match", "matching-etag", "matching-etag", http.StatusOK, false},
-		{"delete-existing-resource-not-matching-if-match", "not-matching-etag", "another-etag", http.StatusPreconditionFailed, true},
-		{"delete-not-existing-resource-*-if-match", "*", "", http.StatusNoContent, true},
-		{"delete-existing-resource-*-if-match", "*", "random-etag", http.StatusOK, false},
+		{"async-delete-non-existing-resource-no-etag", "", v1.ProvisioningStateNone, &store.ErrNotFound{}, nil, nil, http.StatusNoContent},
+		{"async-delete-existing-resource-not-in-terminal-state", "", v1.ProvisioningStateUpdating, nil, nil, nil, http.StatusConflict},
+		{"async-delete-existing-resource-success", "", v1.ProvisioningStateSucceeded, nil, nil, nil, http.StatusAccepted},
 	}
 
-	for _, tt := range existingResourceDeletionCases {
+	for _, tt := range deleteCases {
 		t.Run(tt.desc, func(t *testing.T) {
+			teardownTest, mds, msm := setupTest(t)
+			defer teardownTest(t)
+
 			w := httptest.NewRecorder()
 
-			req, _ := radiustesting.GetARMTestHTTPRequest(ctx, http.MethodDelete, testHeaderfile, nil)
-			req.Header.Set("If-Match", tt.ifMatchETag)
+			req, _ := radiustesting.GetARMTestHTTPRequest(context.Background(), http.MethodDelete, testHeaderfile, nil)
+			req.Header.Set("If-Match", tt.etag)
 
 			ctx := radiustesting.ARMTestContextFromRequest(req)
-			_, hrtDataModel, _ := getTestModels20220315privatepreview()
+			_, appDataModel, _ := getTestModels20220315privatepreview()
 
-			mStorageClient.
-				EXPECT().
+			appDataModel.Properties.ProvisioningState = tt.curState
+
+			mds.EXPECT().
 				Get(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
-					return &store.Object{
-						Metadata: store.Metadata{ID: id, ETag: tt.resourceETag},
-						Data:     hrtDataModel,
-					}, nil
-				})
+				Return(&store.Object{
+					Metadata: store.Metadata{ID: appDataModel.ID},
+					Data:     appDataModel,
+				}, tt.getErr).
+				Times(1)
 
-			if !tt.shouldFail {
-				mStorageClient.
-					EXPECT().
-					Delete(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, id string, _ ...store.DeleteOptions) error {
-						return nil
-					})
+			if tt.getErr == nil && appDataModel.Properties.ProvisioningState.IsTerminal() {
+				msm.EXPECT().QueueAsyncOperation(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(tt.qErr).
+					Times(1)
+
+				if tt.qErr != nil {
+					mds.EXPECT().Save(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(tt.saveErr).
+						Times(1)
+				}
 			}
 
-			ctl, err := NewDeleteHTTPRoute(mStorageClient, nil)
+			ctl, err := NewDeleteHTTPRoute(mds, msm)
 			require.NoError(t, err)
+
 			resp, err := ctl.Run(ctx, req)
 			require.NoError(t, err)
+
 			err = resp.Apply(ctx, w, req)
 			require.NoError(t, err)
 
 			result := w.Result()
-			require.Equal(t, tt.expectedStatusCode, result.StatusCode)
+			require.Equal(t, tt.code, result.StatusCode)
 
-			body := result.Body
-			defer body.Close()
-			payload, err := ioutil.ReadAll(body)
-			require.NoError(t, err)
-
-			if result.StatusCode == http.StatusOK || result.StatusCode == http.StatusNoContent {
-				// We return either http.StatusOK or http.StatusNoContent without a response body for success.
-				require.Empty(t, payload, "response body should be empty")
-			} else {
-				armerr := armerrors.ErrorResponse{}
-				err = json.Unmarshal(payload, &armerr)
-				require.NoError(t, err)
-				require.Equal(t, armerrors.PreconditionFailed, armerr.Error.Code)
-				require.NotEmpty(t, armerr.Error.Target)
+			// If happy path, expect that the returned object has Deleting state
+			if tt.code == http.StatusAccepted {
+				actualOutput := &datamodel.HTTPRoute{}
+				_ = json.Unmarshal(w.Body.Bytes(), actualOutput)
+				require.Equal(t, v1.ProvisioningStateDeleting, actualOutput.Properties.ProvisioningState)
 			}
 		})
 	}

--- a/pkg/corerp/frontend/controller/httproutes/types.go
+++ b/pkg/corerp/frontend/controller/httproutes/types.go
@@ -7,4 +7,6 @@ package httproutes
 
 const (
 	ResourceTypeName = "Applications.Core/httproutes"
+
+	OngoingAsyncOperationOnResourceMessage = "the source or target resource group is locked (e.g. move already in progress, resource group is being deleted)"
 )

--- a/pkg/corerp/frontend/controller/httproutes/types.go
+++ b/pkg/corerp/frontend/controller/httproutes/types.go
@@ -7,6 +7,4 @@ package httproutes
 
 const (
 	ResourceTypeName = "Applications.Core/httproutes"
-
-	OngoingAsyncOperationOnResourceMessage = "the source or target resource group is locked (e.g. move already in progress, resource group is being deleted)"
 )


### PR DESCRIPTION
# Description

Update core RP HTTPRoute Resource APIs Controller to async version based on Container controller updates.

## Issue reference
https://github.com/project-radius/core-team/issues/243

Please reference the issue this PR will close: #[243](https://github.com/project-radius/core-team/issues/243)

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
