### PR TITLE
Add default values for cluster options

### DIFF
--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -136,7 +136,7 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 		return fmt.Errorf("an environment named %s already exists. Use `rad env delete %s` to delete or select a different name", params.Name, params.Name)
 	}
 
-	cliOptions := helm.ClusterOptions{
+	cliOptions := helm.CLIClusterOptions{
 		Namespace: sharedArgs.Namespace,
 		Radius: helm.RadiusOptions{
 			ChartPath:     sharedArgs.ChartPath,

--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -136,7 +136,7 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 		return fmt.Errorf("an environment named %s already exists. Use `rad env delete %s` to delete or select a different name", params.Name, params.Name)
 	}
 
-	clusterOptions := helm.ClusterOptions{
+	cliOptions := helm.ClusterOptions{
 		Namespace: sharedArgs.Namespace,
 		Radius: helm.RadiusOptions{
 			ChartPath:     sharedArgs.ChartPath,
@@ -149,6 +149,8 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 			AzureProvider: azureProvider,
 		},
 	}
+
+	clusterOptions := helm.PopulateDefaultClusterOptions(cliOptions)
 
 	var k8sGoClient client_go.Interface
 	var runtimeClient runtime_client.Client

--- a/cmd/rad/cmd/envInitAzure.go
+++ b/cmd/rad/cmd/envInitAzure.go
@@ -135,7 +135,7 @@ func initAzureRadEnvironment(cmd *cobra.Command, args []string) error {
 			Tag:       a.Tag,
 		},
 	}
-	clusterOptions := helm.NewClusterOptions(cliOptions)
+	clusterOptions := helm.PopulateDefaultClusterOptions(cliOptions)
 
 	clusterOptions.Radius.AzureProvider = &radazure.Provider{
 		SubscriptionID:      a.SubscriptionID,

--- a/cmd/rad/cmd/envInitAzure.go
+++ b/cmd/rad/cmd/envInitAzure.go
@@ -127,7 +127,7 @@ func initAzureRadEnvironment(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	cliOptions := helm.ClusterOptions{
+	cliOptions := helm.CLIClusterOptions{
 		Namespace: a.Namespace,
 		Radius: helm.RadiusOptions{
 			ChartPath: a.ChartPath,

--- a/pkg/cli/helm/cluster.go
+++ b/pkg/cli/helm/cluster.go
@@ -100,6 +100,10 @@ func PopulateDefaultClusterOptions(cliOptions CLIClusterOptions) ClusterOptions 
 		options.Radius.UCPTag = cliOptions.Radius.UCPTag
 	}
 
+	if cliOptions.Radius.AzureProvider != nil {
+		options.Radius.AzureProvider = cliOptions.Radius.AzureProvider
+	}
+
 	return options
 }
 

--- a/pkg/cli/helm/cluster.go
+++ b/pkg/cli/helm/cluster.go
@@ -58,7 +58,7 @@ func NewDefaultClusterOptions() ClusterOptions {
 	}
 }
 
-func NewClusterOptions(cliOptions ClusterOptions) ClusterOptions {
+func PopulateDefaultClusterOptions(cliOptions ClusterOptions) ClusterOptions {
 	options := NewDefaultClusterOptions()
 
 	// If any of the CLI options are provided, override the default options.

--- a/pkg/cli/helm/cluster.go
+++ b/pkg/cli/helm/cluster.go
@@ -23,6 +23,11 @@ const (
 	DaprDefaultVersion         = "1.6.0"
 )
 
+type CLIClusterOptions struct {
+	Namespace string
+	Radius    RadiusOptions
+}
+
 type ClusterOptions struct {
 	Namespace string
 	Dapr      DaprOptions
@@ -58,7 +63,7 @@ func NewDefaultClusterOptions() ClusterOptions {
 	}
 }
 
-func PopulateDefaultClusterOptions(cliOptions ClusterOptions) ClusterOptions {
+func PopulateDefaultClusterOptions(cliOptions CLIClusterOptions) ClusterOptions {
 	options := NewDefaultClusterOptions()
 
 	// If any of the CLI options are provided, override the default options.

--- a/pkg/cli/helm/cluster_test.go
+++ b/pkg/cli/helm/cluster_test.go
@@ -1,0 +1,38 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package helm
+
+import (
+	"testing"
+
+	"github.com/project-radius/radius/pkg/version"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CanSetCLIOptions(t *testing.T) {
+	cliOptions := CLIClusterOptions{
+		Namespace: "namespace",
+		Radius: RadiusOptions{
+			ChartPath: "chartpath",
+			Image:     "image",
+			Tag:       "tag",
+		},
+	}
+	clusterOptions := PopulateDefaultClusterOptions(cliOptions)
+
+	require.Equal(t, "namespace", clusterOptions.Namespace)
+	require.Equal(t, "chartpath", clusterOptions.Radius.ChartPath)
+	require.Equal(t, "image", clusterOptions.Radius.Image)
+	require.Equal(t, "tag", clusterOptions.Radius.Tag)
+}
+
+func Test_DefaultsToHelmChartVersionValue(t *testing.T) {
+	clusterOptions := PopulateDefaultClusterOptions(CLIClusterOptions{})
+
+	// Not checking other values due to potential failures on release builds, the chart version
+	// is primarily the mail regression we see.
+	require.Equal(t, version.ChartVersion(), clusterOptions.Radius.ChartVersion)
+}


### PR DESCRIPTION
# Description

Populate default values for cluster options. This was causing the 0.12 version of the helm chart to be installed instead of the latest version.

## Issue reference

Fixes https://github.com/project-radius/radius/issues/2694

