### PR TITLE
Update user facing OutputResource payload

### DIFF
--- a/pkg/armrpc/api/v1/types.go
+++ b/pkg/armrpc/api/v1/types.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/project-radius/radius/pkg/radrp/outputresource"
 	"github.com/project-radius/radius/pkg/rp"
 )
 
@@ -144,5 +145,20 @@ type BasicResourceProperties struct {
 }
 
 type ResourceStatus struct {
-	OutputResources []map[string]interface{} `json:"outputResources,omitempty"`
+	OutputResources []outputresource.OutputResource `json:"outputResources,omitempty"`
+}
+
+// OutputResource contains some internal fields like resources/dependencies that shouldn't be inlcuded in the user response
+func BuildExternalOutputResources(outputResources []outputresource.OutputResource) []map[string]interface{} {
+	var externalOutputResources []map[string]interface{}
+	for _, or := range outputResources {
+		externalOutput := map[string]interface{}{
+			"LocalID":  or.LocalID,
+			"Provider": or.ResourceType.Provider,
+			"Identity": or.Identity.Data,
+		}
+		externalOutputResources = append(externalOutputResources, externalOutput)
+	}
+
+	return externalOutputResources
 }

--- a/pkg/connectorrp/api/v20220315privatepreview/daprinvokehttproute_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/daprinvokehttproute_conversion.go
@@ -24,11 +24,6 @@ func (src *DaprInvokeHTTPRouteResource) ConvertTo() (conv.DataModelInterface, er
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: datamodel.DaprInvokeHttpRouteProperties{
-			BasicResourceProperties: v1.BasicResourceProperties{
-				Status: v1.ResourceStatus{
-					OutputResources: GetOutputResourcesForVersionedResource(src.Properties.Status),
-				},
-			},
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 			Environment:       to.String(src.Properties.Environment),
 			Application:       to.String(src.Properties.Application),
@@ -57,7 +52,7 @@ func (dst *DaprInvokeHTTPRouteResource) ConvertFrom(src conv.DataModelInterface)
 	dst.Properties = &DaprInvokeHTTPRouteProperties{
 		BasicResourceProperties: BasicResourceProperties{
 			Status: &ResourceStatus{
-				OutputResources: GetOutputResourcesForDatamodel(&daprHttpRoute.Properties.Status),
+				OutputResources: v1.BuildExternalOutputResources(daprHttpRoute.Properties.Status.OutputResources),
 			},
 		},
 		ProvisioningState: fromProvisioningStateDataModel(daprHttpRoute.Properties.ProvisioningState),

--- a/pkg/connectorrp/api/v20220315privatepreview/daprinvokehttproute_conversion_test.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/daprinvokehttproute_conversion_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
+	"github.com/project-radius/radius/pkg/radrp/outputresource"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,7 +27,6 @@ func TestDaprInvokeHttpRoute_ConvertVersionedToDataModel(t *testing.T) {
 		// act
 		dm, err := versionedResource.ConvertTo()
 
-		resourceType := map[string]interface{}{"Provider": "DaprInvokeHttpRouteProvider", "Type": "HttpRoute"}
 		// assert
 		require.NoError(t, err)
 		convertedResource := dm.(*datamodel.DaprInvokeHttpRoute)
@@ -38,8 +38,7 @@ func TestDaprInvokeHttpRoute_ConvertVersionedToDataModel(t *testing.T) {
 		require.Equal(t, "daprAppId", string(convertedResource.Properties.AppId))
 		require.Equal(t, "2022-03-15-privatepreview", convertedResource.InternalMetadata.UpdatedAPIVersion)
 		if payload == "daprinvokehttprouteresource.json" {
-			require.Equal(t, "Deployment", convertedResource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, convertedResource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, []outputresource.OutputResource(nil), convertedResource.Properties.Status.OutputResources)
 		}
 	}
 }
@@ -57,19 +56,17 @@ func TestDaprInvokeHttpRoute_ConvertDataModelToVersioned(t *testing.T) {
 		versionedResource := &DaprInvokeHTTPRouteResource{}
 		err = versionedResource.ConvertFrom(resource)
 
-		resourceType := map[string]interface{}{"Provider": "DaprInvokeHttpRouteProvider", "Type": "HttpRoute"}
-
 		// assert
 		require.NoError(t, err)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/daprInvokeHttpRoutes/daprHttpRoute0", resource.ID)
-		require.Equal(t, "daprHttpRoute0", resource.Name)
-		require.Equal(t, "Applications.Connector/daprInvokeHttpRoutes", resource.Type)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication", resource.Properties.Application)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", resource.Properties.Environment)
-		require.Equal(t, "daprAppId", string(resource.Properties.AppId))
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/daprInvokeHttpRoutes/daprHttpRoute0", *versionedResource.ID)
+		require.Equal(t, "daprHttpRoute0", *versionedResource.Name)
+		require.Equal(t, "Applications.Connector/daprInvokeHttpRoutes", *versionedResource.Type)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication", *versionedResource.Properties.Application)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", *versionedResource.Properties.Environment)
+		require.Equal(t, "daprAppId", string(*versionedResource.Properties.AppID))
 		if payload == "daprinvokehttprouteresource.json" {
-			require.Equal(t, "Deployment", resource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, resource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, "Deployment", versionedResource.Properties.Status.OutputResources[0]["LocalID"])
+			require.Equal(t, "ExtenderProvider", versionedResource.Properties.Status.OutputResources[0]["Provider"])
 		}
 	}
 }

--- a/pkg/connectorrp/api/v20220315privatepreview/daprpubsubbroker_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/daprpubsubbroker_conversion.go
@@ -18,11 +18,6 @@ import (
 // ConvertTo converts from the versioned DaprPubSubBroker resource to version-agnostic datamodel.
 func (src *DaprPubSubBrokerResource) ConvertTo() (conv.DataModelInterface, error) {
 	daprPubSubproperties := datamodel.DaprPubSubBrokerProperties{
-		BasicResourceProperties: v1.BasicResourceProperties{
-			Status: v1.ResourceStatus{
-				OutputResources: GetOutputResourcesForVersionedResource(src.Properties.GetDaprPubSubBrokerProperties().Status),
-			},
-		},
 		ProvisioningState: toProvisioningStateDataModel(src.Properties.GetDaprPubSubBrokerProperties().ProvisioningState),
 		Environment:       to.String(src.Properties.GetDaprPubSubBrokerProperties().Environment),
 		Application:       to.String(src.Properties.GetDaprPubSubBrokerProperties().Application),
@@ -75,7 +70,7 @@ func (dst *DaprPubSubBrokerResource) ConvertFrom(src conv.DataModelInterface) er
 	props := &DaprPubSubBrokerProperties{
 		BasicResourceProperties: BasicResourceProperties{
 			Status: &ResourceStatus{
-				OutputResources: GetOutputResourcesForDatamodel(&daprPubSub.Properties.Status),
+				OutputResources: v1.BuildExternalOutputResources(daprPubSub.Properties.Status.OutputResources),
 			},
 		},
 		ProvisioningState: fromProvisioningStateDataModel(daprPubSub.Properties.ProvisioningState),

--- a/pkg/connectorrp/api/v20220315privatepreview/daprpubsubbroker_conversion_test.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/daprpubsubbroker_conversion_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
+	"github.com/project-radius/radius/pkg/radrp/outputresource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,7 +29,6 @@ func TestDaprPubSubBroker_ConvertVersionedToDataModel(t *testing.T) {
 		// act
 		dm, err := versionedResource.ConvertTo()
 
-		resourceType := map[string]interface{}{"Provider": "kubernetes", "Type": "DaprPubSubProvider"}
 		// assert
 		require.NoError(t, err)
 		convertedResource := dm.(*datamodel.DaprPubSubBroker)
@@ -48,8 +48,7 @@ func TestDaprPubSubBroker_ConvertVersionedToDataModel(t *testing.T) {
 			require.Equal(t, "pubsub.kafka", convertedResource.Properties.DaprPubSubGeneric.Type)
 			require.Equal(t, "v1", convertedResource.Properties.DaprPubSubGeneric.Version)
 			require.Equal(t, "bar", convertedResource.Properties.DaprPubSubGeneric.Metadata["foo"])
-			require.Equal(t, "Deployment", convertedResource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, convertedResource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, []outputresource.OutputResource(nil), convertedResource.Properties.Status.OutputResources)
 		default:
 			assert.Fail(t, "Kind of DaprPubSubBroker is specified.")
 		}
@@ -71,7 +70,6 @@ func TestDaprPubSubBroker_ConvertDataModelToVersioned(t *testing.T) {
 		versionedResource := &DaprPubSubBrokerResource{}
 		err = versionedResource.ConvertFrom(resource)
 
-		resourceType := map[string]interface{}{"Provider": "kubernetes", "Type": "DaprPubSubProvider"}
 		// assert
 		require.NoError(t, err)
 		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/daprPubSubBrokers/daprPubSub0", resource.ID)
@@ -83,8 +81,8 @@ func TestDaprPubSubBroker_ConvertDataModelToVersioned(t *testing.T) {
 		case datamodel.DaprPubSubBrokerKindAzureServiceBus:
 			require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.ServiceBus/namespaces/testQueue", resource.Properties.DaprPubSubAzureServiceBus.Resource)
 			require.Equal(t, "pubsub.azure.servicebus", string(resource.Properties.Kind))
-			require.Equal(t, "Deployment", resource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, resource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, "Deployment", versionedResource.Properties.GetDaprPubSubBrokerProperties().Status.OutputResources[0]["LocalID"])
+			require.Equal(t, "kubernetes", versionedResource.Properties.GetDaprPubSubBrokerProperties().Status.OutputResources[0]["Provider"])
 		case datamodel.DaprPubSubBrokerKindGeneric:
 			require.Equal(t, "generic", string(resource.Properties.Kind))
 			require.Equal(t, "pubsub.kafka", resource.Properties.DaprPubSubGeneric.Type)

--- a/pkg/connectorrp/api/v20220315privatepreview/daprsecretstore_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/daprsecretstore_conversion.go
@@ -24,11 +24,6 @@ func (src *DaprSecretStoreResource) ConvertTo() (conv.DataModelInterface, error)
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: datamodel.DaprSecretStoreProperties{
-			BasicResourceProperties: v1.BasicResourceProperties{
-				Status: v1.ResourceStatus{
-					OutputResources: GetOutputResourcesForVersionedResource(src.Properties.Status),
-				},
-			},
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 			Environment:       to.String(src.Properties.Environment),
 			Application:       to.String(src.Properties.Application),
@@ -60,7 +55,7 @@ func (dst *DaprSecretStoreResource) ConvertFrom(src conv.DataModelInterface) err
 	dst.Properties = &DaprSecretStoreProperties{
 		BasicResourceProperties: BasicResourceProperties{
 			Status: &ResourceStatus{
-				OutputResources: GetOutputResourcesForDatamodel(&daprSecretStore.Properties.Status),
+				OutputResources: v1.BuildExternalOutputResources(daprSecretStore.Properties.Status.OutputResources),
 			},
 		},
 		ProvisioningState: fromProvisioningStateDataModel(daprSecretStore.Properties.ProvisioningState),

--- a/pkg/connectorrp/api/v20220315privatepreview/daprsecretstore_conversion_test.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/daprsecretstore_conversion_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
+	"github.com/project-radius/radius/pkg/radrp/outputresource"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,7 +27,6 @@ func TestDaprSecretStore_ConvertVersionedToDataModel(t *testing.T) {
 		// act
 		dm, err := versionedResource.ConvertTo()
 
-		resourceType := map[string]interface{}{"Provider": "kubernetes", "Type": "Secret"}
 		// assert
 		require.NoError(t, err)
 		convertedResource := dm.(*datamodel.DaprSecretStore)
@@ -41,8 +41,7 @@ func TestDaprSecretStore_ConvertVersionedToDataModel(t *testing.T) {
 		require.Equal(t, "bar", convertedResource.Properties.Metadata["foo"])
 		require.Equal(t, "2022-03-15-privatepreview", convertedResource.InternalMetadata.UpdatedAPIVersion)
 		if payload == "daprsecretstoreresource.json" {
-			require.Equal(t, "Deployment", convertedResource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, convertedResource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, []outputresource.OutputResource(nil), convertedResource.Properties.Status.OutputResources)
 		}
 	}
 }
@@ -60,22 +59,20 @@ func TestDaprSecretStore_ConvertDataModelToVersioned(t *testing.T) {
 		versionedResource := &DaprSecretStoreResource{}
 		err = versionedResource.ConvertFrom(resource)
 
-		resourceType := map[string]interface{}{"Provider": "kubernetes", "Type": "Secret"}
-
 		// assert
 		require.NoError(t, err)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/daprSecretStores/daprSecretStore0", resource.ID)
-		require.Equal(t, "daprSecretStore0", resource.Name)
-		require.Equal(t, "Applications.Connector/daprSecretStores", resource.Type)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication", resource.Properties.Application)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", resource.Properties.Environment)
-		require.Equal(t, "generic", string(resource.Properties.Kind))
-		require.Equal(t, "secretstores.hashicorp.vault", resource.Properties.Type)
-		require.Equal(t, "v1", resource.Properties.Version)
-		require.Equal(t, "bar", resource.Properties.Metadata["foo"])
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/daprSecretStores/daprSecretStore0", *versionedResource.ID)
+		require.Equal(t, "daprSecretStore0", *versionedResource.Name)
+		require.Equal(t, "Applications.Connector/daprSecretStores", *versionedResource.Type)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication", *versionedResource.Properties.Application)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", *versionedResource.Properties.Environment)
+		require.Equal(t, "generic", string(*versionedResource.Properties.Kind))
+		require.Equal(t, "secretstores.hashicorp.vault", *versionedResource.Properties.Type)
+		require.Equal(t, "v1", *versionedResource.Properties.Version)
+		require.Equal(t, "bar", versionedResource.Properties.Metadata["foo"])
 		if payload == "daprsecretstoreresource.json" {
-			require.Equal(t, "Deployment", resource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, resource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, "Deployment", versionedResource.Properties.Status.OutputResources[0]["LocalID"])
+			require.Equal(t, "ExtenderProvider", versionedResource.Properties.Status.OutputResources[0]["Provider"])
 		}
 	}
 

--- a/pkg/connectorrp/api/v20220315privatepreview/daprstatestore_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/daprstatestore_conversion.go
@@ -13,11 +13,6 @@ import (
 // ConvertTo converts from the versioned DaprStateStore resource to version-agnostic datamodel.
 func (src *DaprStateStoreResource) ConvertTo() (conv.DataModelInterface, error) {
 	daprStateStoreProperties := datamodel.DaprStateStoreProperties{
-		BasicResourceProperties: v1.BasicResourceProperties{
-			Status: v1.ResourceStatus{
-				OutputResources: GetOutputResourcesForVersionedResource(src.Properties.GetDaprStateStoreProperties().Status),
-			},
-		},
 		ProvisioningState: toProvisioningStateDataModel(src.Properties.GetDaprStateStoreProperties().ProvisioningState),
 		Environment:       to.String(src.Properties.GetDaprStateStoreProperties().Environment),
 		Application:       to.String(src.Properties.GetDaprStateStoreProperties().Application),
@@ -75,7 +70,7 @@ func (dst *DaprStateStoreResource) ConvertFrom(src conv.DataModelInterface) erro
 	props := &DaprStateStoreProperties{
 		BasicResourceProperties: BasicResourceProperties{
 			Status: &ResourceStatus{
-				OutputResources: GetOutputResourcesForDatamodel(&daprStateStore.Properties.Status),
+				OutputResources: v1.BuildExternalOutputResources(daprStateStore.Properties.Status.OutputResources),
 			},
 		},
 		ProvisioningState: fromProvisioningStateDataModel(daprStateStore.Properties.ProvisioningState),

--- a/pkg/connectorrp/api/v20220315privatepreview/daprstatestore_conversion_test.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/daprstatestore_conversion_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
+	"github.com/project-radius/radius/pkg/radrp/outputresource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,7 +29,6 @@ func TestDaprStateStore_ConvertVersionedToDataModel(t *testing.T) {
 		// act
 		dm, err := versionedResource.ConvertTo()
 
-		resourceType := map[string]interface{}{"Provider": "kubernetes", "Type": "DaprStateStoreProvider"}
 		// assert
 		require.NoError(t, err)
 		convertedResource := dm.(*datamodel.DaprStateStore)
@@ -46,16 +46,14 @@ func TestDaprStateStore_ConvertVersionedToDataModel(t *testing.T) {
 		case datamodel.DaprStateStoreKindStateSqlServer:
 			require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.Sql/servers/testServer/databases/testDatabase", convertedResource.Properties.DaprStateStoreSQLServer.Resource)
 			require.Equal(t, "state.sqlserver", string(convertedResource.Properties.Kind))
-			require.Equal(t, "Deployment", convertedResource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, convertedResource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, []outputresource.OutputResource(nil), convertedResource.Properties.Status.OutputResources)
 
 		case datamodel.DaprStateStoreKindGeneric:
 			require.Equal(t, "generic", string(convertedResource.Properties.Kind))
 			require.Equal(t, "state.zookeeper", convertedResource.Properties.DaprStateStoreGeneric.Type)
 			require.Equal(t, "v1", convertedResource.Properties.DaprStateStoreGeneric.Version)
 			require.Equal(t, "bar", convertedResource.Properties.DaprStateStoreGeneric.Metadata["foo"])
-			require.Equal(t, "Deployment", convertedResource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, convertedResource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, []outputresource.OutputResource(nil), convertedResource.Properties.Status.OutputResources)
 		default:
 			assert.Fail(t, "Kind of DaprStateStore is specified.")
 		}
@@ -77,7 +75,6 @@ func TestDaprStateStore_ConvertDataModelToVersioned(t *testing.T) {
 		versionedResource := &DaprStateStoreResource{}
 		err = versionedResource.ConvertFrom(resource)
 
-		resourceType := map[string]interface{}{"Provider": "kubernetes", "Type": "DaprStateStoreProvider"}
 		// assert
 		require.NoError(t, err)
 		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/daprStateStores/daprStateStore0", resource.ID)
@@ -89,8 +86,8 @@ func TestDaprStateStore_ConvertDataModelToVersioned(t *testing.T) {
 		case datamodel.DaprStateStoreKindAzureTableStorage:
 			require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.Storage/storageAccounts/tableServices/tables/testTable", resource.Properties.DaprStateStoreAzureTableStorage.Resource)
 			require.Equal(t, "state.azure.tablestorage", string(resource.Properties.Kind))
-			require.Equal(t, "Deployment", resource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, resource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, "Deployment", versionedResource.Properties.GetDaprStateStoreProperties().BasicResourceProperties.Status.OutputResources[0]["LocalID"])
+			require.Equal(t, "kubernetes", versionedResource.Properties.GetDaprStateStoreProperties().BasicResourceProperties.Status.OutputResources[0]["Provider"])
 		case datamodel.DaprStateStoreKindStateSqlServer:
 			require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.Sql/servers/testServer/databases/testDatabase", resource.Properties.DaprStateStoreSQLServer.Resource)
 			require.Equal(t, "state.sqlserver", string(resource.Properties.Kind))
@@ -99,8 +96,8 @@ func TestDaprStateStore_ConvertDataModelToVersioned(t *testing.T) {
 			require.Equal(t, "state.zookeeper", resource.Properties.DaprStateStoreGeneric.Type)
 			require.Equal(t, "v1", resource.Properties.DaprStateStoreGeneric.Version)
 			require.Equal(t, "bar", resource.Properties.DaprStateStoreGeneric.Metadata["foo"])
-			require.Equal(t, "Deployment", resource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, resource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, "Deployment", versionedResource.Properties.GetDaprStateStoreProperties().BasicResourceProperties.Status.OutputResources[0]["LocalID"])
+			require.Equal(t, "kubernetes", versionedResource.Properties.GetDaprStateStoreProperties().BasicResourceProperties.Status.OutputResources[0]["Provider"])
 		default:
 			assert.Fail(t, "Kind of DaprStateStore is specified.")
 		}

--- a/pkg/connectorrp/api/v20220315privatepreview/extender_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/extender_conversion.go
@@ -25,11 +25,6 @@ func (src *ExtenderResource) ConvertTo() (conv.DataModelInterface, error) {
 		},
 		Properties: datamodel.ExtenderProperties{
 			ExtenderResponseProperties: datamodel.ExtenderResponseProperties{
-				BasicResourceProperties: v1.BasicResourceProperties{
-					Status: v1.ResourceStatus{
-						OutputResources: GetOutputResourcesForVersionedResource(src.Properties.Status),
-					},
-				},
 				ProvisioningState:    toProvisioningStateDataModel(src.Properties.ProvisioningState),
 				Environment:          to.String(src.Properties.Environment),
 				Application:          to.String(src.Properties.Application),
@@ -55,11 +50,6 @@ func (src *ExtenderResponseResource) ConvertTo() (conv.DataModelInterface, error
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: datamodel.ExtenderResponseProperties{
-			BasicResourceProperties: v1.BasicResourceProperties{
-				Status: v1.ResourceStatus{
-					OutputResources: GetOutputResourcesForVersionedResource(src.Properties.Status),
-				},
-			},
 			ProvisioningState:    toProvisioningStateDataModel(src.Properties.ProvisioningState),
 			Environment:          to.String(src.Properties.Environment),
 			Application:          to.String(src.Properties.Application),
@@ -89,7 +79,7 @@ func (dst *ExtenderResource) ConvertFrom(src conv.DataModelInterface) error {
 		ExtenderResponseProperties: ExtenderResponseProperties{
 			BasicResourceProperties: BasicResourceProperties{
 				Status: &ResourceStatus{
-					OutputResources: GetOutputResourcesForDatamodel(&extender.Properties.Status),
+					OutputResources: v1.BuildExternalOutputResources(extender.Properties.Status.OutputResources),
 				},
 			},
 			ProvisioningState:    fromProvisioningStateDataModel(extender.Properties.ProvisioningState),
@@ -118,7 +108,7 @@ func (dst *ExtenderResponseResource) ConvertFrom(src conv.DataModelInterface) er
 	dst.Properties = &ExtenderResponseProperties{
 		BasicResourceProperties: BasicResourceProperties{
 			Status: &ResourceStatus{
-				OutputResources: GetOutputResourcesForDatamodel(&extender.Properties.Status),
+				OutputResources: v1.BuildExternalOutputResources(extender.Properties.Status.OutputResources),
 			},
 		},
 		ProvisioningState:    fromProvisioningStateDataModel(extender.Properties.ProvisioningState),

--- a/pkg/connectorrp/api/v20220315privatepreview/extender_conversion_test.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/extender_conversion_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
+	"github.com/project-radius/radius/pkg/radrp/outputresource"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,7 +28,6 @@ func TestExtender_ConvertVersionedToDataModel(t *testing.T) {
 		// act
 		dm, err := versionedResource.ConvertTo()
 
-		resourceType := map[string]interface{}{"Provider": "ExtenderProvider", "Type": "Extender"}
 		secrets := map[string]interface{}{"accountSid": "sid", "authToken:": "token"}
 		// assert
 		require.NoError(t, err)
@@ -39,8 +39,7 @@ func TestExtender_ConvertVersionedToDataModel(t *testing.T) {
 		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", convertedResource.Properties.Environment)
 		require.Equal(t, "222-222-2222", convertedResource.Properties.AdditionalProperties["fromNumber"])
 		if payload == "extenderresource.json" {
-			require.Equal(t, "Deployment", convertedResource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, convertedResource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, []outputresource.OutputResource(nil), convertedResource.Properties.Status.OutputResources)
 			require.Equal(t, secrets, convertedResource.Properties.Secrets)
 		}
 	}
@@ -60,7 +59,6 @@ func TestExtender_ConvertDataModelToVersioned(t *testing.T) {
 		versionedResource := &ExtenderResource{}
 		err = versionedResource.ConvertFrom(resource)
 
-		resourceType := map[string]interface{}{"Provider": "ExtenderProvider", "Type": "Extender"}
 		secrets := map[string]interface{}{"accountSid": "sid", "authToken:": "token"}
 		// assert
 		require.NoError(t, err)
@@ -71,8 +69,8 @@ func TestExtender_ConvertDataModelToVersioned(t *testing.T) {
 		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", resource.Properties.Environment)
 		require.Equal(t, "222-222-2222", resource.Properties.AdditionalProperties["fromNumber"])
 		if payload == "extenderresourcedatamodel.json" {
-			require.Equal(t, "Deployment", resource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, resource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, "Deployment", versionedResource.Properties.Status.OutputResources[0]["LocalID"])
+			require.Equal(t, "ExtenderProvider", versionedResource.Properties.Status.OutputResources[0]["Provider"])
 			require.Equal(t, secrets, resource.Properties.Secrets)
 		}
 	}
@@ -91,7 +89,6 @@ func TestExtenderResponse_ConvertVersionedToDataModel(t *testing.T) {
 		// act
 		dm, err := versionedResource.ConvertTo()
 
-		resourceType := map[string]interface{}{"Provider": "ExtenderProvider", "Type": "Extender"}
 		// assert
 		require.NoError(t, err)
 		convertedResource := dm.(*datamodel.Extender)
@@ -102,8 +99,7 @@ func TestExtenderResponse_ConvertVersionedToDataModel(t *testing.T) {
 		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", convertedResource.Properties.Environment)
 		require.Equal(t, "222-222-2222", convertedResource.Properties.AdditionalProperties["fromNumber"])
 		if payload == "extenderresource.json" {
-			require.Equal(t, "Deployment", convertedResource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, convertedResource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, []outputresource.OutputResource(nil), convertedResource.Properties.Status.OutputResources)
 		}
 	}
 }
@@ -122,7 +118,6 @@ func TestExtenderResponse_ConvertDataModelToVersioned(t *testing.T) {
 		versionedResource := &ExtenderResource{}
 		err = versionedResource.ConvertFrom(resource)
 
-		resourceType := map[string]interface{}{"Provider": "ExtenderProvider", "Type": "Extender"}
 		// assert
 		require.NoError(t, err)
 		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/extenders/extender0", resource.ID)
@@ -132,8 +127,8 @@ func TestExtenderResponse_ConvertDataModelToVersioned(t *testing.T) {
 		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", resource.Properties.Environment)
 		require.Equal(t, "222-222-2222", resource.Properties.AdditionalProperties["fromNumber"])
 		if payload == "extenderresourcedatamodel.json" {
-			require.Equal(t, "Deployment", resource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, resource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, "Deployment", versionedResource.Properties.Status.OutputResources[0]["LocalID"])
+			require.Equal(t, "ExtenderProvider", versionedResource.Properties.Status.OutputResources[0]["Provider"])
 		}
 	}
 }

--- a/pkg/connectorrp/api/v20220315privatepreview/mongodatabase_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/mongodatabase_conversion.go
@@ -24,11 +24,6 @@ func (src *MongoDatabaseResponseResource) ConvertTo() (conv.DataModelInterface, 
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: datamodel.MongoDatabaseResponseProperties{
-			BasicResourceProperties: v1.BasicResourceProperties{
-				Status: v1.ResourceStatus{
-					OutputResources: GetOutputResourcesForVersionedResource(src.Properties.Status),
-				},
-			},
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 			Environment:       to.String(src.Properties.Environment),
 			Application:       to.String(src.Properties.Application),
@@ -63,11 +58,6 @@ func (src *MongoDatabaseResource) ConvertTo() (conv.DataModelInterface, error) {
 		},
 		Properties: datamodel.MongoDatabaseProperties{
 			MongoDatabaseResponseProperties: datamodel.MongoDatabaseResponseProperties{
-				BasicResourceProperties: v1.BasicResourceProperties{
-					Status: v1.ResourceStatus{
-						OutputResources: GetOutputResourcesForVersionedResource(src.Properties.Status),
-					},
-				},
 				ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 				Environment:       to.String(src.Properties.Environment),
 				Application:       to.String(src.Properties.Application),
@@ -100,7 +90,7 @@ func (dst *MongoDatabaseResponseResource) ConvertFrom(src conv.DataModelInterfac
 	dst.Properties = &MongoDatabaseResponseProperties{
 		BasicResourceProperties: BasicResourceProperties{
 			Status: &ResourceStatus{
-				OutputResources: GetOutputResourcesForDatamodel(&mongo.Properties.Status),
+				OutputResources: v1.BuildExternalOutputResources(mongo.Properties.Status.OutputResources),
 			},
 		},
 		ProvisioningState: fromProvisioningStateDataModel(mongo.Properties.ProvisioningState),
@@ -130,7 +120,7 @@ func (dst *MongoDatabaseResource) ConvertFrom(src conv.DataModelInterface) error
 		MongoDatabaseResponseProperties: MongoDatabaseResponseProperties{
 			BasicResourceProperties: BasicResourceProperties{
 				Status: &ResourceStatus{
-					OutputResources: GetOutputResourcesForDatamodel(&mongo.Properties.Status),
+					OutputResources: v1.BuildExternalOutputResources(mongo.Properties.Status.OutputResources),
 				},
 			},
 			ProvisioningState: fromProvisioningStateDataModel(mongo.Properties.ProvisioningState),
@@ -174,20 +164,4 @@ func (src *MongoDatabaseSecrets) ConvertTo() (conv.DataModelInterface, error) {
 		Password:         to.String(src.Password),
 	}
 	return converted, nil
-}
-
-func GetOutputResourcesForVersionedResource(status *ResourceStatus) []map[string]interface{} {
-	var outputResources []map[string]interface{}
-	if status != nil {
-		outputResources = status.OutputResources
-	}
-	return outputResources
-}
-
-func GetOutputResourcesForDatamodel(status *v1.ResourceStatus) []map[string]interface{} {
-	var outputResources []map[string]interface{}
-	if status != nil {
-		outputResources = status.OutputResources
-	}
-	return outputResources
 }

--- a/pkg/connectorrp/api/v20220315privatepreview/rabbitmq_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/rabbitmq_conversion.go
@@ -31,11 +31,6 @@ func (src *RabbitMQMessageQueueResource) ConvertTo() (conv.DataModelInterface, e
 		},
 		Properties: datamodel.RabbitMQMessageQueueProperties{
 			RabbitMQMessageQueueResponseProperties: datamodel.RabbitMQMessageQueueResponseProperties{
-				BasicResourceProperties: v1.BasicResourceProperties{
-					Status: v1.ResourceStatus{
-						OutputResources: GetOutputResourcesForVersionedResource(src.Properties.Status),
-					},
-				},
 				ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 				Environment:       to.String(src.Properties.Environment),
 				Application:       to.String(src.Properties.Application),
@@ -61,11 +56,6 @@ func (src *RabbitMQMessageQueueResponseResource) ConvertTo() (conv.DataModelInte
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: datamodel.RabbitMQMessageQueueResponseProperties{
-			BasicResourceProperties: v1.BasicResourceProperties{
-				Status: v1.ResourceStatus{
-					OutputResources: GetOutputResourcesForVersionedResource(src.Properties.Status),
-				},
-			},
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 			Environment:       to.String(src.Properties.Environment),
 			Application:       to.String(src.Properties.Application),
@@ -95,7 +85,7 @@ func (dst *RabbitMQMessageQueueResource) ConvertFrom(src conv.DataModelInterface
 		RabbitMQMessageQueueResponseProperties: RabbitMQMessageQueueResponseProperties{
 			BasicResourceProperties: BasicResourceProperties{
 				Status: &ResourceStatus{
-					OutputResources: GetOutputResourcesForDatamodel(&rabbitmq.Properties.Status),
+					OutputResources: v1.BuildExternalOutputResources(rabbitmq.Properties.Status.OutputResources),
 				},
 			},
 			ProvisioningState: fromProvisioningStateDataModel(rabbitmq.Properties.ProvisioningState),
@@ -129,7 +119,7 @@ func (dst *RabbitMQMessageQueueResponseResource) ConvertFrom(src conv.DataModelI
 	dst.Properties = &RabbitMQMessageQueueResponseProperties{
 		BasicResourceProperties: BasicResourceProperties{
 			Status: &ResourceStatus{
-				OutputResources: GetOutputResourcesForDatamodel(&rabbitmq.Properties.Status),
+				OutputResources: v1.BuildExternalOutputResources(rabbitmq.Properties.Status.OutputResources),
 			},
 		},
 		ProvisioningState: fromProvisioningStateDataModel(rabbitmq.Properties.ProvisioningState),

--- a/pkg/connectorrp/api/v20220315privatepreview/rabbitmq_conversion_test.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/rabbitmq_conversion_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
+	"github.com/project-radius/radius/pkg/radrp/outputresource"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,7 +27,6 @@ func TestRabbitMQMessageQueue_ConvertVersionedToDataModel(t *testing.T) {
 
 		// act
 		dm, err := versionedResource.ConvertTo()
-		resourceType := map[string]interface{}{"Provider": "rabbitmqProvider", "Type": "rabbitmq"}
 
 		// assert
 		require.NoError(t, err)
@@ -40,8 +40,7 @@ func TestRabbitMQMessageQueue_ConvertVersionedToDataModel(t *testing.T) {
 		require.Equal(t, "connection://string", convertedResource.Properties.Secrets.ConnectionString)
 		require.Equal(t, "2022-03-15-privatepreview", convertedResource.InternalMetadata.UpdatedAPIVersion)
 		if payload == "rabbitmqresource.json" {
-			require.Equal(t, "Deployment", convertedResource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, convertedResource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, []outputresource.OutputResource(nil), convertedResource.Properties.Status.OutputResources)
 		}
 	}
 }
@@ -59,19 +58,18 @@ func TestRabbitMQMessageQueue_ConvertDataModelToVersioned(t *testing.T) {
 		versionedResource := &RabbitMQMessageQueueResource{}
 		err = versionedResource.ConvertFrom(resource)
 
-		resourceType := map[string]interface{}{"Provider": "rabbitmqProvider", "Type": "rabbitmq"}
 		// assert
 		require.NoError(t, err)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/rabbitMQMessageQueues/rabbitmq0", resource.ID)
-		require.Equal(t, "rabbitmq0", resource.Name)
-		require.Equal(t, "Applications.Connector/rabbitMQMessageQueues", resource.Type)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication", resource.Properties.Application)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", resource.Properties.Environment)
-		require.Equal(t, "testQueue", resource.Properties.Queue)
-		require.Equal(t, "connection://string", resource.Properties.Secrets.ConnectionString)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/rabbitMQMessageQueues/rabbitmq0", *versionedResource.ID)
+		require.Equal(t, "rabbitmq0", *versionedResource.Name)
+		require.Equal(t, "Applications.Connector/rabbitMQMessageQueues", *versionedResource.Type)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication", *versionedResource.Properties.Application)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", *versionedResource.Properties.Environment)
+		require.Equal(t, "testQueue", *versionedResource.Properties.Queue)
+		require.Equal(t, "connection://string", *versionedResource.Properties.Secrets.ConnectionString)
 		if payload == "rabbitmqresourcedatamodel.json" {
-			require.Equal(t, "Deployment", resource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, resource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, "Deployment", versionedResource.Properties.Status.OutputResources[0]["LocalID"])
+			require.Equal(t, "rabbitmqProvider", versionedResource.Properties.Status.OutputResources[0]["Provider"])
 		}
 	}
 }
@@ -88,7 +86,6 @@ func TestRabbitMQMessageQueueResponse_ConvertVersionedToDataModel(t *testing.T) 
 
 		// act
 		dm, err := versionedResource.ConvertTo()
-		resourceType := map[string]interface{}{"Provider": "rabbitmqProvider", "Type": "rabbitmq"}
 
 		// assert
 		require.NoError(t, err)
@@ -101,8 +98,7 @@ func TestRabbitMQMessageQueueResponse_ConvertVersionedToDataModel(t *testing.T) 
 		require.Equal(t, "testQueue", convertedResource.Properties.Queue)
 		require.Equal(t, "2022-03-15-privatepreview", convertedResource.InternalMetadata.UpdatedAPIVersion)
 		if payload == "rabbitmqresource.json" {
-			require.Equal(t, "Deployment", convertedResource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, convertedResource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, []outputresource.OutputResource(nil), convertedResource.Properties.Status.OutputResources)
 		}
 	}
 }
@@ -120,18 +116,17 @@ func TestRabbitMQMessageQueueResponse_ConvertDataModelToVersioned(t *testing.T) 
 		versionedResource := &RabbitMQMessageQueueResource{}
 		err = versionedResource.ConvertFrom(resource)
 
-		resourceType := map[string]interface{}{"Provider": "rabbitmqProvider", "Type": "rabbitmq"}
 		// assert
 		require.NoError(t, err)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/rabbitMQMessageQueues/rabbitmq0", resource.ID)
-		require.Equal(t, "rabbitmq0", resource.Name)
-		require.Equal(t, "Applications.Connector/rabbitMQMessageQueues", resource.Type)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication", resource.Properties.Application)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", resource.Properties.Environment)
-		require.Equal(t, "testQueue", resource.Properties.Queue)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/rabbitMQMessageQueues/rabbitmq0", *versionedResource.ID)
+		require.Equal(t, "rabbitmq0", *versionedResource.Name)
+		require.Equal(t, "Applications.Connector/rabbitMQMessageQueues", *versionedResource.Type)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication", *versionedResource.Properties.Application)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", *versionedResource.Properties.Environment)
+		require.Equal(t, "testQueue", *versionedResource.Properties.Queue)
 		if payload == "rabbitmqresponseresourcedatamodel.json" {
-			require.Equal(t, "Deployment", resource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, resource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, "Deployment", versionedResource.Properties.Status.OutputResources[0]["LocalID"])
+			require.Equal(t, "rabbitmqProvider", versionedResource.Properties.Status.OutputResources[0]["Provider"])
 		}
 	}
 }

--- a/pkg/connectorrp/api/v20220315privatepreview/rediscache_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/rediscache_conversion.go
@@ -32,11 +32,6 @@ func (src *RedisCacheResource) ConvertTo() (conv.DataModelInterface, error) {
 		},
 		Properties: datamodel.RedisCacheProperties{
 			RedisCacheResponseProperties: datamodel.RedisCacheResponseProperties{
-				BasicResourceProperties: v1.BasicResourceProperties{
-					Status: v1.ResourceStatus{
-						OutputResources: GetOutputResourcesForVersionedResource(src.Properties.Status),
-					},
-				},
 				ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 				Environment:       to.String(src.Properties.Environment),
 				Application:       to.String(src.Properties.Application),
@@ -64,11 +59,6 @@ func (src *RedisCacheResponseResource) ConvertTo() (conv.DataModelInterface, err
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: datamodel.RedisCacheResponseProperties{
-			BasicResourceProperties: v1.BasicResourceProperties{
-				Status: v1.ResourceStatus{
-					OutputResources: GetOutputResourcesForVersionedResource(src.Properties.Status),
-				},
-			},
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 			Environment:       to.String(src.Properties.Environment),
 			Application:       to.String(src.Properties.Application),
@@ -100,7 +90,7 @@ func (dst *RedisCacheResource) ConvertFrom(src conv.DataModelInterface) error {
 		RedisCacheResponseProperties: RedisCacheResponseProperties{
 			BasicResourceProperties: BasicResourceProperties{
 				Status: &ResourceStatus{
-					OutputResources: GetOutputResourcesForDatamodel(&redis.Properties.Status),
+					OutputResources: v1.BuildExternalOutputResources(redis.Properties.Status.OutputResources),
 				},
 			},
 			ProvisioningState: fromProvisioningStateDataModel(redis.Properties.ProvisioningState),
@@ -137,7 +127,7 @@ func (dst *RedisCacheResponseResource) ConvertFrom(src conv.DataModelInterface) 
 	dst.Properties = &RedisCacheResponseProperties{
 		BasicResourceProperties: BasicResourceProperties{
 			Status: &ResourceStatus{
-				OutputResources: GetOutputResourcesForDatamodel(&redis.Properties.Status),
+				OutputResources: v1.BuildExternalOutputResources(redis.Properties.Status.OutputResources),
 			},
 		},
 		ProvisioningState: fromProvisioningStateDataModel(redis.Properties.ProvisioningState),

--- a/pkg/connectorrp/api/v20220315privatepreview/rediscache_conversion_test.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/rediscache_conversion_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
+	"github.com/project-radius/radius/pkg/radrp/outputresource"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,7 +27,6 @@ func TestRedisCache_ConvertVersionedToDataModel(t *testing.T) {
 		// act
 		dm, err := versionedResource.ConvertTo()
 
-		resourceType := map[string]interface{}{"Provider": "azure", "Type": "azure.redis"}
 		// assert
 		require.NoError(t, err)
 		convertedResource := dm.(*datamodel.RedisCache)
@@ -42,8 +42,7 @@ func TestRedisCache_ConvertVersionedToDataModel(t *testing.T) {
 		if payload == "rediscacheresource.json" {
 			require.Equal(t, "test-connection-string", convertedResource.Properties.Secrets.ConnectionString)
 			require.Equal(t, "testPassword", convertedResource.Properties.Secrets.Password)
-			require.Equal(t, "Deployment", convertedResource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, convertedResource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, []outputresource.OutputResource(nil), convertedResource.Properties.Status.OutputResources)
 		}
 	}
 }
@@ -61,22 +60,21 @@ func TestRedisCache_ConvertDataModelToVersioned(t *testing.T) {
 		versionedResource := &RedisCacheResource{}
 		err = versionedResource.ConvertFrom(resource)
 
-		resourceType := map[string]interface{}{"Provider": "azure", "Type": "azure.redis"}
 		// assert
 		require.NoError(t, err)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/redisCaches/redis0", resource.ID)
-		require.Equal(t, "redis0", resource.Name)
-		require.Equal(t, "Applications.Connector/redisCaches", resource.Type)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication", resource.Properties.Application)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", resource.Properties.Environment)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Microsoft.Cache/Redis/testCache", resource.Properties.Resource)
-		require.Equal(t, "myrediscache.redis.cache.windows.net", resource.Properties.Host)
-		require.Equal(t, int32(10255), resource.Properties.Port)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/redisCaches/redis0", *versionedResource.ID)
+		require.Equal(t, "redis0", *versionedResource.Name)
+		require.Equal(t, "Applications.Connector/redisCaches", *versionedResource.Type)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication", *versionedResource.Properties.Application)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", *versionedResource.Properties.Environment)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Microsoft.Cache/Redis/testCache", *versionedResource.Properties.Resource)
+		require.Equal(t, "myrediscache.redis.cache.windows.net", *versionedResource.Properties.Host)
+		require.Equal(t, int32(10255), *versionedResource.Properties.Port)
 		if payload == "rediscacheresourcedatamodel.json" {
-			require.Equal(t, "test-connection-string", resource.Properties.Secrets.ConnectionString)
-			require.Equal(t, "testPassword", resource.Properties.Secrets.Password)
-			require.Equal(t, "Deployment", resource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, resource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, "test-connection-string", *versionedResource.Properties.Secrets.ConnectionString)
+			require.Equal(t, "testPassword", *versionedResource.Properties.Secrets.Password)
+			require.Equal(t, "Deployment", versionedResource.Properties.Status.OutputResources[0]["LocalID"])
+			require.Equal(t, "azure", versionedResource.Properties.Status.OutputResources[0]["Provider"])
 		}
 	}
 }
@@ -93,7 +91,6 @@ func TestRedisCacheResponse_ConvertVersionedToDataModel(t *testing.T) {
 		// act
 		dm, err := versionedResource.ConvertTo()
 
-		resourceType := map[string]interface{}{"Provider": "azure", "Type": "azure.redis"}
 		// assert
 		require.NoError(t, err)
 		convertedResource := dm.(*datamodel.RedisCache)
@@ -107,8 +104,7 @@ func TestRedisCacheResponse_ConvertVersionedToDataModel(t *testing.T) {
 		require.Equal(t, int32(10255), convertedResource.Properties.Port)
 		require.Equal(t, "2022-03-15-privatepreview", convertedResource.InternalMetadata.UpdatedAPIVersion)
 		if payload == "rediscacheresource.json" {
-			require.Equal(t, "Deployment", convertedResource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, convertedResource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, []outputresource.OutputResource(nil), convertedResource.Properties.Status.OutputResources)
 		}
 	}
 }
@@ -126,20 +122,19 @@ func TestRedisCacheResponse_ConvertDataModelToVersioned(t *testing.T) {
 		versionedResource := &RedisCacheResource{}
 		err = versionedResource.ConvertFrom(resource)
 
-		resourceType := map[string]interface{}{"Provider": "azure", "Type": "azure.redis"}
 		// assert
 		require.NoError(t, err)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/redisCaches/redis0", resource.ID)
-		require.Equal(t, "redis0", resource.Name)
-		require.Equal(t, "Applications.Connector/redisCaches", resource.Type)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication", resource.Properties.Application)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", resource.Properties.Environment)
-		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Microsoft.Cache/Redis/testCache", resource.Properties.Resource)
-		require.Equal(t, "myrediscache.redis.cache.windows.net", resource.Properties.Host)
-		require.Equal(t, int32(10255), resource.Properties.Port)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/redisCaches/redis0", *versionedResource.ID)
+		require.Equal(t, "redis0", *versionedResource.Name)
+		require.Equal(t, "Applications.Connector/redisCaches", *versionedResource.Type)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication", *versionedResource.Properties.Application)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", *versionedResource.Properties.Environment)
+		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Microsoft.Cache/Redis/testCache", *versionedResource.Properties.Resource)
+		require.Equal(t, "myrediscache.redis.cache.windows.net", *versionedResource.Properties.Host)
+		require.Equal(t, int32(10255), *versionedResource.Properties.Port)
 		if payload == "rediscacheresourcedatamodel.json" {
-			require.Equal(t, "Deployment", resource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, resource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, "Deployment", versionedResource.Properties.Status.OutputResources[0]["LocalID"])
+			require.Equal(t, "azure", versionedResource.Properties.Status.OutputResources[0]["Provider"])
 		}
 	}
 }

--- a/pkg/connectorrp/api/v20220315privatepreview/sqldatabase_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/sqldatabase_conversion.go
@@ -24,11 +24,6 @@ func (src *SQLDatabaseResource) ConvertTo() (conv.DataModelInterface, error) {
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: datamodel.SqlDatabaseProperties{
-			BasicResourceProperties: v1.BasicResourceProperties{
-				Status: v1.ResourceStatus{
-					OutputResources: GetOutputResourcesForVersionedResource(src.Properties.Status),
-				},
-			},
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 			Environment:       to.String(src.Properties.Environment),
 			Application:       to.String(src.Properties.Application),
@@ -59,7 +54,7 @@ func (dst *SQLDatabaseResource) ConvertFrom(src conv.DataModelInterface) error {
 	dst.Properties = &SQLDatabaseProperties{
 		BasicResourceProperties: BasicResourceProperties{
 			Status: &ResourceStatus{
-				OutputResources: GetOutputResourcesForDatamodel(&sql.Properties.Status),
+				OutputResources: v1.BuildExternalOutputResources(sql.Properties.Status.OutputResources),
 			},
 		},
 		ProvisioningState: fromProvisioningStateDataModel(sql.Properties.ProvisioningState),

--- a/pkg/connectorrp/api/v20220315privatepreview/sqldatabase_conversion_test.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/sqldatabase_conversion_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
+	"github.com/project-radius/radius/pkg/radrp/outputresource"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,7 +28,6 @@ func TestSqlDatabase_ConvertVersionedToDataModel(t *testing.T) {
 		// act
 		dm, err := versionedResource.ConvertTo()
 
-		resourceType := map[string]interface{}{"Provider": "azure", "Type": "azure.sql.database"}
 		// assert
 		require.NoError(t, err)
 		convertedResource := dm.(*datamodel.SqlDatabase)
@@ -41,8 +41,7 @@ func TestSqlDatabase_ConvertVersionedToDataModel(t *testing.T) {
 		if payload == "sqldatabaseresource.json" {
 			require.Equal(t, "testAccount1.sql.cosmos.azure.com", convertedResource.Properties.Server)
 			require.Equal(t, "testDatabase", convertedResource.Properties.Database)
-			require.Equal(t, "Deployment", convertedResource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, convertedResource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, []outputresource.OutputResource(nil), convertedResource.Properties.Status.OutputResources)
 		}
 	}
 }
@@ -61,7 +60,6 @@ func TestSqlDatabase_ConvertDataModelToVersioned(t *testing.T) {
 		versionedResource := &SQLDatabaseResource{}
 		err = versionedResource.ConvertFrom(resource)
 
-		resourceType := map[string]interface{}{"Provider": "azure", "Type": "azure.sql.database"}
 		// assert
 		require.NoError(t, err)
 		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Connector/sqlDatabases/sql0", resource.ID)
@@ -73,8 +71,8 @@ func TestSqlDatabase_ConvertDataModelToVersioned(t *testing.T) {
 		if payload == "sqldatabaseresourcedatamodel.json" {
 			require.Equal(t, "testAccount1.sql.cosmos.azure.com", resource.Properties.Server)
 			require.Equal(t, "testDatabase", resource.Properties.Database)
-			require.Equal(t, "Deployment", resource.Properties.Status.OutputResources[0]["LocalID"])
-			require.Equal(t, resourceType, resource.Properties.Status.OutputResources[0]["ResourceType"])
+			require.Equal(t, "Deployment", versionedResource.Properties.Status.OutputResources[0]["LocalID"])
+			require.Equal(t, "azure", versionedResource.Properties.Status.OutputResources[0]["Provider"])
 		}
 	}
 

--- a/pkg/connectorrp/api/v20220315privatepreview/testdata/mongodatabaseresource.json
+++ b/pkg/connectorrp/api/v20220315privatepreview/testdata/mongodatabaseresource.json
@@ -14,7 +14,6 @@
         },
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
-        "resource": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Microsoft.DocumentDB/databaseAccounts/testAccount/mongodbDatabases/db",
         "host": "testAccount1.mongo.cosmos.azure.com",
         "port": 10255,
         "secrets": {

--- a/pkg/connectorrp/api/v20220315privatepreview/testdata/mongodatabaseresourcedatamodel.json
+++ b/pkg/connectorrp/api/v20220315privatepreview/testdata/mongodatabaseresourcedatamodel.json
@@ -16,7 +16,7 @@
     "properties": {
         "status": {
             "outputResources": [{
-              "LocalID": "Deployment",
+              "LocalID": "AzureCosmosAccount",
               "ResourceType": {
                 "Type": "azure.cosmosdb.mongo",
                 "Provider": "azure"
@@ -25,7 +25,6 @@
         },
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
-        "resource": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Microsoft.DocumentDB/databaseAccounts/testAccount/mongodbDatabases/db",
         "host": "testAccount1.mongo.cosmos.azure.com",
         "port": 10255,
         "secrets": {

--- a/pkg/connectorrp/api/v20220315privatepreview/testdata/mongodatabaseresponseresourcedatamodel.json
+++ b/pkg/connectorrp/api/v20220315privatepreview/testdata/mongodatabaseresponseresourcedatamodel.json
@@ -16,7 +16,7 @@
     "properties": {
         "status": {
             "outputResources": [{
-              "LocalID": "Deployment",
+              "LocalID": "AzureCosmosAccount",
               "ResourceType": {
                 "Type": "azure.cosmosdb.mongo",
                 "Provider": "azure"

--- a/pkg/connectorrp/frontend/controller/daprinvokehttproutes/testdata/20220315privatepreview_datamodel.json
+++ b/pkg/connectorrp/frontend/controller/daprinvokehttproutes/testdata/20220315privatepreview_datamodel.json
@@ -12,15 +12,6 @@
         "lastModifiedByType": "User"
     },
     "properties": {
-        "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "HttpRoute",
-              "Provider": "DaprInvokeHttpRouteProvider"
-            }
-          }]
-        },
         "provisioningState": "Succeeded",
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",

--- a/pkg/connectorrp/frontend/controller/daprinvokehttproutes/testdata/20220315privatepreview_input.json
+++ b/pkg/connectorrp/frontend/controller/daprinvokehttproutes/testdata/20220315privatepreview_input.json
@@ -1,15 +1,6 @@
 {
     "location": "West US",
     "properties": {
-        "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "HttpRoute",
-              "Provider": "DaprInvokeHttpRouteProvider"
-            }
-          }]
-        },
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
         "appId": "daprAppId"

--- a/pkg/connectorrp/frontend/controller/daprinvokehttproutes/testdata/20220315privatepreview_output.json
+++ b/pkg/connectorrp/frontend/controller/daprinvokehttproutes/testdata/20220315privatepreview_output.json
@@ -4,13 +4,7 @@
     "name": "daprInvokeHttpRoute0",
     "properties": {
         "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "HttpRoute",
-              "Provider": "DaprInvokeHttpRouteProvider"
-            }
-          }]
+          "outputResources": null
         },
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",

--- a/pkg/connectorrp/frontend/controller/daprpubsubbrokers/testdata/20220315privatepreview_datamodel.json
+++ b/pkg/connectorrp/frontend/controller/daprpubsubbrokers/testdata/20220315privatepreview_datamodel.json
@@ -12,15 +12,6 @@
         "lastModifiedByType": "User"
     },
     "properties": {
-        "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "DaprPubSubProvider",
-              "Provider": "kubernetes"
-            }
-          }]
-        },
         "provisioningState": "Succeeded",
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",

--- a/pkg/connectorrp/frontend/controller/daprpubsubbrokers/testdata/20220315privatepreview_input.json
+++ b/pkg/connectorrp/frontend/controller/daprpubsubbrokers/testdata/20220315privatepreview_input.json
@@ -1,15 +1,6 @@
 {
     "location": "West US",
     "properties": {
-        "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "DaprPubSubProvider",
-              "Provider": "kubernetes"
-            }
-          }]
-        },
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
         "resource": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.ServiceBus/namespaces/testQueue",

--- a/pkg/connectorrp/frontend/controller/daprpubsubbrokers/testdata/20220315privatepreview_output.json
+++ b/pkg/connectorrp/frontend/controller/daprpubsubbrokers/testdata/20220315privatepreview_output.json
@@ -4,13 +4,7 @@
     "name": "daprpubsub0",
     "properties": {
         "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "DaprPubSubProvider",
-              "Provider": "kubernetes"
-            }
-          }]
+          "outputResources": null
         },
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",

--- a/pkg/connectorrp/frontend/controller/daprsecretstores/testdata/20220315privatepreview_datamodel.json
+++ b/pkg/connectorrp/frontend/controller/daprsecretstores/testdata/20220315privatepreview_datamodel.json
@@ -12,15 +12,6 @@
         "lastModifiedByType": "User"
     },
     "properties": {
-        "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "Secret",
-              "Provider": "kubernetes"
-            }
-          }]
-        },
         "provisioningState": "Succeeded",
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",

--- a/pkg/connectorrp/frontend/controller/daprsecretstores/testdata/20220315privatepreview_input.json
+++ b/pkg/connectorrp/frontend/controller/daprsecretstores/testdata/20220315privatepreview_input.json
@@ -1,15 +1,6 @@
 {
     "location": "West US",
     "properties": {
-        "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "Secret",
-              "Provider": "kubernetes"
-            }
-          }]
-        },
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
         "kind": "generic",

--- a/pkg/connectorrp/frontend/controller/daprsecretstores/testdata/20220315privatepreview_output.json
+++ b/pkg/connectorrp/frontend/controller/daprsecretstores/testdata/20220315privatepreview_output.json
@@ -4,13 +4,7 @@
     "name": "daprSecretStore0",
     "properties": {
         "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "Secret",
-              "Provider": "kubernetes"
-            }
-          }]
+          "outputResources": null
         },
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",

--- a/pkg/connectorrp/frontend/controller/daprstatestores/testdata/20220315privatepreview_datamodel.json
+++ b/pkg/connectorrp/frontend/controller/daprstatestores/testdata/20220315privatepreview_datamodel.json
@@ -12,15 +12,6 @@
         "lastModifiedByType": "User"
     },
     "properties": {
-        "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "DaprStateStoreProvider",
-              "Provider": "kubernetes"
-            }
-          }]
-        },
         "provisioningState": "Succeeded",
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",

--- a/pkg/connectorrp/frontend/controller/daprstatestores/testdata/20220315privatepreview_input.json
+++ b/pkg/connectorrp/frontend/controller/daprstatestores/testdata/20220315privatepreview_input.json
@@ -1,15 +1,6 @@
 {
     "location": "West US",
     "properties": {
-        "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "DaprStateStoreProvider",
-              "Provider": "kubernetes"
-            }
-          }]
-        },
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
         "kind": "state.azure.tablestorage",

--- a/pkg/connectorrp/frontend/controller/daprstatestores/testdata/20220315privatepreview_output.json
+++ b/pkg/connectorrp/frontend/controller/daprstatestores/testdata/20220315privatepreview_output.json
@@ -4,13 +4,7 @@
     "name": "daprstatestore0",
     "properties": {
         "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "DaprStateStoreProvider",
-              "Provider": "kubernetes"
-            }
-          }]
+          "outputResources": null
         },
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",

--- a/pkg/connectorrp/frontend/controller/extenders/testdata/20220315privatepreview_datamodel.json
+++ b/pkg/connectorrp/frontend/controller/extenders/testdata/20220315privatepreview_datamodel.json
@@ -12,15 +12,6 @@
         "lastModifiedByType": "User"
     },
     "properties": {
-      "status": {
-        "outputResources": [{
-          "LocalID": "Deployment",
-          "ResourceType": {
-            "Type": "extenderType",
-            "Provider": "extenderProvider"
-          }
-        }]
-      },
       "provisioningState": "Succeeded",
       "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/testApplication",
       "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/environments/env0",

--- a/pkg/connectorrp/frontend/controller/extenders/testdata/20220315privatepreview_input.json
+++ b/pkg/connectorrp/frontend/controller/extenders/testdata/20220315privatepreview_input.json
@@ -1,15 +1,6 @@
 {
     "location": "West US",
     "properties": {
-      "status": {
-        "outputResources": [{
-          "LocalID": "Deployment",
-          "ResourceType": {
-            "Type": "extenderType",
-            "Provider": "extenderProvider"
-          }
-        }]
-      },
       "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/testApplication",
       "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/environments/env0",
       "fromNumber": "222-222-2222",

--- a/pkg/connectorrp/frontend/controller/extenders/testdata/20220315privatepreview_output.json
+++ b/pkg/connectorrp/frontend/controller/extenders/testdata/20220315privatepreview_output.json
@@ -4,13 +4,7 @@
     "name": "extender0",
     "properties": {
         "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "extenderType",
-              "Provider": "extenderProvider"
-            }
-          }]
+          "outputResources": null
         },
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/testApplication",
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/environments/env0",

--- a/pkg/connectorrp/frontend/controller/extenders/testdata/20220315privatepreviewgetandlist_output.json
+++ b/pkg/connectorrp/frontend/controller/extenders/testdata/20220315privatepreviewgetandlist_output.json
@@ -4,13 +4,7 @@
     "name": "extender0",
     "properties": {
         "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "extenderType",
-              "Provider": "extenderProvider"
-            }
-          }]
+          "outputResources": null
         },
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/testApplication",
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/environments/env0",

--- a/pkg/connectorrp/frontend/controller/mongodatabases/createorupdatemongodatabase.go
+++ b/pkg/connectorrp/frontend/controller/mongodatabases/createorupdatemongodatabase.go
@@ -51,15 +51,7 @@ func (mongo *CreateOrUpdateMongoDatabase) Run(ctx context.Context, req *http.Req
 		return nil, err
 	}
 
-	var outputResources []map[string]interface{}
-	for _, deployedOutputResource := range deploymentOutput.Resources {
-		outputResource := map[string]interface{}{
-			deployedOutputResource.LocalID: deployedOutputResource,
-		}
-		outputResources = append(outputResources, outputResource)
-	}
-
-	newResource.Properties.BasicResourceProperties.Status.OutputResources = outputResources
+	newResource.Properties.BasicResourceProperties.Status.OutputResources = deploymentOutput.Resources
 	newResource.InternalMetadata.ComputedValues = deploymentOutput.ComputedValues
 	newResource.InternalMetadata.SecretValues = deploymentOutput.SecretValues
 

--- a/pkg/connectorrp/frontend/controller/mongodatabases/createorupdatemongodatabase_test.go
+++ b/pkg/connectorrp/frontend/controller/mongodatabases/createorupdatemongodatabase_test.go
@@ -173,6 +173,7 @@ func getDeploymentProcessorOutputs() (renderers.RendererOutput, deployment.Deplo
 					Type:     resourcekinds.AzureCosmosAccount,
 					Provider: providers.ProviderAzure,
 				},
+				Identity: resourcemodel.ResourceIdentity{},
 			},
 		},
 		SecretValues: map[string]rp.SecretValueReference{

--- a/pkg/connectorrp/frontend/controller/mongodatabases/testdata/20220315privatepreview_datamodel.json
+++ b/pkg/connectorrp/frontend/controller/mongodatabases/testdata/20220315privatepreview_datamodel.json
@@ -14,27 +14,12 @@
     "properties": {
         "status": {
           "outputResources": [{
-            "AzureCosmosAccount": {
               "LocalID": "AzureCosmosAccount",
               "Dependencies": null,
-              "Deployed": false,
               "ResourceType": {
                 "type": "azure.cosmosdb.account",
                 "provider": "azure"
-              },
-              "Resource": null,
-              "Identity": {
-                "data": null,
-                "resourceType": null
-              },
-              "Status": {
-                "HealthErrorDetails": "",
-                "HealthState": "",
-                "ProvisioningErrorDetails": "",
-                "ProvisioningState": "",
-                "Replicas": null
               }
-            }
           }]
         },
         "provisioningState": "Succeeded",

--- a/pkg/connectorrp/frontend/controller/mongodatabases/testdata/20220315privatepreview_output.json
+++ b/pkg/connectorrp/frontend/controller/mongodatabases/testdata/20220315privatepreview_output.json
@@ -5,27 +5,9 @@
     "properties": {
         "status": {
             "outputResources": [{
-              "AzureCosmosAccount": {
-                "LocalID": "AzureCosmosAccount",
-                "Dependencies": null,
-                "Deployed": false,
-                "ResourceType": {
-                  "type": "azure.cosmosdb.account",
-                  "provider": "azure"
-                },
-                "Resource": null,
-                "Identity": {
-                  "data": null,
-                  "resourceType": null
-                },
-                "Status": {
-                  "HealthErrorDetails": "",
-                  "HealthState": "",
-                  "ProvisioningErrorDetails": "",
-                  "ProvisioningState": "",
-                  "Replicas": null
-                }
-              }
+              "LocalID": "AzureCosmosAccount",
+              "Provider": "azure",
+              "Identity": null
             }]
         },
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",

--- a/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/testdata/20220315privatepreview_datamodel.json
+++ b/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/testdata/20220315privatepreview_datamodel.json
@@ -12,15 +12,6 @@
         "lastModifiedByType": "User"
     },
     "properties": {
-        "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "rabbitmq",
-              "Provider": "rabbitmqProvider"
-            }
-          }]
-        },
         "provisioningState": "Succeeded",
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",

--- a/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/testdata/20220315privatepreview_input.json
+++ b/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/testdata/20220315privatepreview_input.json
@@ -1,15 +1,6 @@
 {
     "location": "West US",
     "properties": {
-        "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "rabbitmq",
-              "Provider": "rabbitmqProvider"
-            }
-          }]
-        },
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
         "queue": "testQueue",

--- a/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/testdata/20220315privatepreview_output.json
+++ b/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/testdata/20220315privatepreview_output.json
@@ -4,13 +4,7 @@
     "name": "rabbitmq0",
     "properties": {
         "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "rabbitmq",
-              "Provider": "rabbitmqProvider"
-            }
-          }]
+          "outputResources": null
         },
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",

--- a/pkg/connectorrp/frontend/controller/rediscaches/testdata/20220315privatepreview_datamodel.json
+++ b/pkg/connectorrp/frontend/controller/rediscaches/testdata/20220315privatepreview_datamodel.json
@@ -12,15 +12,6 @@
         "lastModifiedByType": "User"
     },
     "properties": {
-      "status": {
-        "outputResources": [{
-          "LocalID": "Deployment",
-          "ResourceType": {
-            "Type": "azure.redis",
-            "Provider": "azure"
-          }
-        }]
-      },
       "provisioningState": "Succeeded",
       "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
       "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",

--- a/pkg/connectorrp/frontend/controller/rediscaches/testdata/20220315privatepreview_input.json
+++ b/pkg/connectorrp/frontend/controller/rediscaches/testdata/20220315privatepreview_input.json
@@ -1,15 +1,6 @@
 {
     "location": "West US",
     "properties": {
-      "status": {
-        "outputResources": [{
-          "LocalID": "Deployment",
-          "ResourceType": {
-            "Type": "azure.redis",
-            "Provider": "azure"
-          }
-        }]
-      },
       "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
       "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
       "resource": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Microsoft.Cache/Redis/testCache",

--- a/pkg/connectorrp/frontend/controller/rediscaches/testdata/20220315privatepreview_output.json
+++ b/pkg/connectorrp/frontend/controller/rediscaches/testdata/20220315privatepreview_output.json
@@ -4,13 +4,7 @@
     "name": "redis0",
     "properties": {
         "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "azure.redis",
-              "Provider": "azure"
-            }
-          }]
+          "outputResources": null
         },
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",

--- a/pkg/connectorrp/frontend/controller/sqldatabases/testdata/20220315privatepreview_datamodel.json
+++ b/pkg/connectorrp/frontend/controller/sqldatabases/testdata/20220315privatepreview_datamodel.json
@@ -12,15 +12,6 @@
         "lastModifiedByType": "User"
     },
     "properties": {
-        "status": {
-            "outputResources": [{
-              "LocalID": "Deployment",
-              "ResourceType": {
-                "Type": "azure.sql.database",
-                "Provider": "azure"
-              }
-            }]
-        },
         "provisioningState": "Succeeded",
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",

--- a/pkg/connectorrp/frontend/controller/sqldatabases/testdata/20220315privatepreview_input.json
+++ b/pkg/connectorrp/frontend/controller/sqldatabases/testdata/20220315privatepreview_input.json
@@ -1,15 +1,6 @@
 {
     "location": "West US",
     "properties": {
-        "status": {
-          "outputResources": [{
-            "LocalID": "Deployment",
-            "ResourceType": {
-              "Type": "azure.sql.database",
-              "Provider": "azure"
-            }
-          }]
-        },
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",
         "resource": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Microsoft.Sql/servers/testServer/databases/testDatabase",

--- a/pkg/connectorrp/frontend/controller/sqldatabases/testdata/20220315privatepreview_output.json
+++ b/pkg/connectorrp/frontend/controller/sqldatabases/testdata/20220315privatepreview_output.json
@@ -4,13 +4,7 @@
     "name": "sql0",
     "properties": {
         "status": {
-            "outputResources": [{
-              "LocalID": "Deployment",
-              "ResourceType": {
-                "Type": "azure.sql.database",
-                "Provider": "azure"
-              }
-            }]
+            "outputResources": null
         },
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication",
         "environment": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0",

--- a/pkg/connectorrp/frontend/deployment/deploymentprocessor.go
+++ b/pkg/connectorrp/frontend/deployment/deploymentprocessor.go
@@ -78,7 +78,7 @@ func (dp *deploymentProcessor) Render(ctx context.Context, id resources.ID, reso
 }
 
 func (dp *deploymentProcessor) getResourceRenderer(id resources.ID) (renderers.Renderer, error) {
-	radiusResourceModel, err := dp.appmodel.LookupRadiusResourceModel(id.TypeSegments()[len(id.TypeSegments())-1].Type) // Lookup using resource type
+	radiusResourceModel, err := dp.appmodel.LookupRadiusResourceModel(id.Type()) // Lookup using resource type
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/corerp/api/v20220315privatepreview/container_conversion.go
+++ b/pkg/corerp/api/v20220315privatepreview/container_conversion.go
@@ -75,13 +75,6 @@ func (src *ContainerResource) ConvertTo() (conv.DataModelInterface, error) {
 		}
 	}
 
-	resourceStatus := v1.ResourceStatus{}
-	if src.Properties.BasicResourceProperties.Status != nil {
-		resourceStatus = v1.ResourceStatus{
-			OutputResources: src.Properties.BasicResourceProperties.Status.OutputResources,
-		}
-	}
-
 	converted := &datamodel.ContainerResource{
 		TrackedResource: v1.TrackedResource{
 			ID:       to.String(src.ID),
@@ -91,9 +84,6 @@ func (src *ContainerResource) ConvertTo() (conv.DataModelInterface, error) {
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: datamodel.ContainerProperties{
-			BasicResourceProperties: v1.BasicResourceProperties{
-				Status: resourceStatus,
-			},
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 			Application:       to.String(src.Properties.Application),
 			Connections:       connections,
@@ -186,7 +176,7 @@ func (dst *ContainerResource) ConvertFrom(src conv.DataModelInterface) error {
 	dst.Properties = &ContainerProperties{
 		BasicResourceProperties: BasicResourceProperties{
 			Status: &ResourceStatus{
-				OutputResources: c.Properties.BasicResourceProperties.Status.OutputResources,
+				OutputResources: v1.BuildExternalOutputResources(c.Properties.Status.OutputResources),
 			},
 		},
 		ProvisioningState: fromProvisioningStateDataModel(c.Properties.ProvisioningState),

--- a/pkg/corerp/api/v20220315privatepreview/container_conversion_test.go
+++ b/pkg/corerp/api/v20220315privatepreview/container_conversion_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
+	"github.com/project-radius/radius/pkg/radrp/outputresource"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,7 +22,6 @@ func TestContainerConvertVersionedToDataModel(t *testing.T) {
 	r := &ContainerResource{}
 	err := json.Unmarshal(rawPayload, r)
 	require.NoError(t, err)
-	resourceType := map[string]interface{}{"Provider": "aks", "Type": "containers"}
 
 	// act
 	dm, err := r.ConvertTo()
@@ -43,8 +43,7 @@ func TestContainerConvertVersionedToDataModel(t *testing.T) {
 	require.Equal(t, datamodel.TCPHealthProbe, tcpProbe.Kind)
 	require.Equal(t, to.Float32Ptr(5), tcpProbe.TCP.InitialDelaySeconds)
 	require.Equal(t, int32(8080), tcpProbe.TCP.ContainerPort)
-	require.Equal(t, "Deployment", ct.Properties.Status.OutputResources[0]["LocalID"])
-	require.Equal(t, resourceType, ct.Properties.Status.OutputResources[0]["ResourceType"])
+	require.Equal(t, []outputresource.OutputResource(nil), ct.Properties.Status.OutputResources)
 	require.Equal(t, "2022-03-15-privatepreview", ct.InternalMetadata.UpdatedAPIVersion)
 }
 
@@ -54,7 +53,6 @@ func TestContainerConvertDataModelToVersioned(t *testing.T) {
 	r := &datamodel.ContainerResource{}
 	err := json.Unmarshal(rawPayload, r)
 	require.NoError(t, err)
-	resourceType := map[string]interface{}{"Provider": "aks", "Type": "containers"}
 
 	// act
 	versioned := &ContainerResource{}
@@ -72,8 +70,8 @@ func TestContainerConvertDataModelToVersioned(t *testing.T) {
 	require.Equal(t, "azure", string(val.IAM.Kind))
 	require.Equal(t, "read", val.IAM.Roles[0])
 	require.Equal(t, "radius.azurecr.io/webapptutorial-todoapp", r.Properties.Container.Image)
-	require.Equal(t, "Deployment", r.Properties.Status.OutputResources[0]["LocalID"])
-	require.Equal(t, resourceType, r.Properties.Status.OutputResources[0]["ResourceType"])
+	require.Equal(t, "Deployment", versioned.Properties.Status.OutputResources[0]["LocalID"])
+	require.Equal(t, "aks", versioned.Properties.Status.OutputResources[0]["Provider"])
 }
 
 func TestContainerConvertFromValidation(t *testing.T) {

--- a/pkg/corerp/api/v20220315privatepreview/gateway_conversion.go
+++ b/pkg/corerp/api/v20220315privatepreview/gateway_conversion.go
@@ -37,11 +37,6 @@ func (src *GatewayResource) ConvertTo() (conv.DataModelInterface, error) {
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: datamodel.GatewayProperties{
-			BasicResourceProperties: v1.BasicResourceProperties{
-				Status: v1.ResourceStatus{
-					OutputResources: src.Properties.BasicResourceProperties.Status.OutputResources,
-				},
-			},
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 			Application:       to.String(src.Properties.Application),
 			Hostname: &datamodel.GatewayPropertiesHostname{
@@ -86,7 +81,7 @@ func (dst *GatewayResource) ConvertFrom(src conv.DataModelInterface) error {
 	dst.Properties = &GatewayProperties{
 		BasicResourceProperties: BasicResourceProperties{
 			Status: &ResourceStatus{
-				OutputResources: g.Properties.BasicResourceProperties.Status.OutputResources,
+				OutputResources: v1.BuildExternalOutputResources(g.Properties.Status.OutputResources),
 			},
 		},
 		ProvisioningState: fromProvisioningStateDataModel(g.Properties.ProvisioningState),

--- a/pkg/corerp/api/v20220315privatepreview/gateway_conversion_test.go
+++ b/pkg/corerp/api/v20220315privatepreview/gateway_conversion_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
+	"github.com/project-radius/radius/pkg/radrp/outputresource"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,8 +25,6 @@ func TestGatewayConvertVersionedToDataModel(t *testing.T) {
 	// act
 	dm, err := r.ConvertTo()
 
-	resourceType := map[string]interface{}{"Provider": "kubernetes", "Type": "Gateway"}
-
 	// assert
 	require.NoError(t, err)
 	ct := dm.(*datamodel.Gateway)
@@ -38,8 +37,7 @@ func TestGatewayConvertVersionedToDataModel(t *testing.T) {
 	require.Equal(t, "mydestination", ct.Properties.Routes[0].Destination)
 	require.Equal(t, "mypath", ct.Properties.Routes[0].Path)
 	require.Equal(t, "myreplaceprefix", ct.Properties.Routes[0].ReplacePrefix)
-	require.Equal(t, "Deployment", ct.Properties.Status.OutputResources[0]["LocalID"])
-	require.Equal(t, resourceType, ct.Properties.Status.OutputResources[0]["ResourceType"])
+	require.Equal(t, []outputresource.OutputResource(nil), ct.Properties.Status.OutputResources)
 	require.Equal(t, "2022-03-15-privatepreview", ct.InternalMetadata.UpdatedAPIVersion)
 }
 
@@ -54,7 +52,6 @@ func TestGatewayConvertDataModelToVersioned(t *testing.T) {
 	versioned := &GatewayResource{}
 	err = versioned.ConvertFrom(r)
 
-	resourceType := map[string]interface{}{"Provider": "kubernetes", "Type": "Gateway"}
 	// assert
 	require.NoError(t, err)
 	require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/gateways/gateway0", r.ID)
@@ -66,8 +63,8 @@ func TestGatewayConvertDataModelToVersioned(t *testing.T) {
 	require.Equal(t, "mydestination", r.Properties.Routes[0].Destination)
 	require.Equal(t, "mypath", r.Properties.Routes[0].Path)
 	require.Equal(t, "myreplaceprefix", r.Properties.Routes[0].ReplacePrefix)
-	require.Equal(t, "Deployment", r.Properties.Status.OutputResources[0]["LocalID"])
-	require.Equal(t, resourceType, r.Properties.Status.OutputResources[0]["ResourceType"])
+	require.Equal(t, "Deployment", versioned.Properties.Status.OutputResources[0]["LocalID"])
+	require.Equal(t, "kubernetes", versioned.Properties.Status.OutputResources[0]["Provider"])
 }
 
 func TestGatewayConvertFromValidation(t *testing.T) {

--- a/pkg/corerp/api/v20220315privatepreview/httproute_conversion.go
+++ b/pkg/corerp/api/v20220315privatepreview/httproute_conversion.go
@@ -26,11 +26,6 @@ func (src *HTTPRouteResource) ConvertTo() (conv.DataModelInterface, error) {
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: &datamodel.HTTPRouteProperties{
-			BasicResourceProperties: v1.BasicResourceProperties{
-				Status: v1.ResourceStatus{
-					OutputResources: src.Properties.BasicResourceProperties.Status.OutputResources,
-				},
-			},
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
 			Application:       to.String(src.Properties.Application),
 			Hostname:          to.String(src.Properties.Hostname),
@@ -62,7 +57,7 @@ func (dst *HTTPRouteResource) ConvertFrom(src conv.DataModelInterface) error {
 	dst.Properties = &HTTPRouteProperties{
 		BasicResourceProperties: BasicResourceProperties{
 			Status: &ResourceStatus{
-				OutputResources: route.Properties.BasicResourceProperties.Status.OutputResources,
+				OutputResources: v1.BuildExternalOutputResources(route.Properties.Status.OutputResources),
 			},
 		},
 		ProvisioningState: fromProvisioningStateDataModel(route.Properties.ProvisioningState),

--- a/pkg/corerp/api/v20220315privatepreview/httproute_conversion_test.go
+++ b/pkg/corerp/api/v20220315privatepreview/httproute_conversion_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
+	"github.com/project-radius/radius/pkg/radrp/outputresource"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,7 +25,6 @@ func TestHTTPRouteConvertVersionedToDataModel(t *testing.T) {
 	// act
 	dm, err := r.ConvertTo()
 
-	resourceType := map[string]interface{}{"Provider": "kubernetes", "Type": "HttpRoute"}
 	// assert
 	require.NoError(t, err)
 	ct := dm.(*datamodel.HTTPRoute)
@@ -36,8 +36,7 @@ func TestHTTPRouteConvertVersionedToDataModel(t *testing.T) {
 	require.Equal(t, int32(8080), ct.Properties.Port)
 	require.Equal(t, "http", ct.Properties.Scheme)
 	require.Equal(t, "http://testapplications.com/httproute/", ct.Properties.URL)
-	require.Equal(t, "Deployment", ct.Properties.Status.OutputResources[0]["LocalID"])
-	require.Equal(t, resourceType, ct.Properties.Status.OutputResources[0]["ResourceType"])
+	require.Equal(t, []outputresource.OutputResource(nil), ct.Properties.Status.OutputResources)
 	require.Equal(t, "2022-03-15-privatepreview", ct.InternalMetadata.UpdatedAPIVersion)
 }
 
@@ -52,7 +51,6 @@ func TestHTTPRouteConvertDataModelToVersioned(t *testing.T) {
 	versioned := &HTTPRouteResource{}
 	err = versioned.ConvertFrom(r)
 
-	resourceType := map[string]interface{}{"Provider": "kubernetes", "Type": "HttpRoute"}
 	// assert
 	require.NoError(t, err)
 	require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/httpRoutes/route0", r.ID)
@@ -63,8 +61,8 @@ func TestHTTPRouteConvertDataModelToVersioned(t *testing.T) {
 	require.Equal(t, int32(8080), r.Properties.Port)
 	require.Equal(t, "http", r.Properties.Scheme)
 	require.Equal(t, "http://testapplications.com/httproute/", r.Properties.URL)
-	require.Equal(t, "Deployment", r.Properties.Status.OutputResources[0]["LocalID"])
-	require.Equal(t, resourceType, r.Properties.Status.OutputResources[0]["ResourceType"])
+	require.Equal(t, "Deployment", versioned.Properties.Status.OutputResources[0]["LocalID"])
+	require.Equal(t, "kubernetes", versioned.Properties.Status.OutputResources[0]["Provider"])
 }
 
 func TestHTTPRouteConvertFromValidation(t *testing.T) {

--- a/pkg/corerp/backend/controller/containers/createcontainer.go
+++ b/pkg/corerp/backend/controller/containers/createcontainer.go
@@ -60,15 +60,7 @@ func (c *UpdateContainer) Run(ctx context.Context, request *ctrl.Request) (ctrl.
 	}
 
 	// Update the resource with deployed outputResources
-	deployedOuputResources := deploymentOutput.DeployedOutputResources
-	var outputResources []map[string]interface{}
-	for _, deployedOutputResource := range deployedOuputResources {
-		outputResource := map[string]interface{}{
-			deployedOutputResource.LocalID: deployedOutputResource,
-		}
-		outputResources = append(outputResources, outputResource)
-	}
-	existingResource.Properties.BasicResourceProperties.Status.OutputResources = outputResources
+	existingResource.Properties.BasicResourceProperties.Status.OutputResources = deploymentOutput.DeployedOutputResources
 	existingResource.InternalMetadata.ComputedValues = deploymentOutput.ComputedValues
 	existingResource.InternalMetadata.SecretValues = deploymentOutput.SecretValues
 

--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -397,13 +397,11 @@ func (dp *deploymentProcessor) getRequiredResourceDependencies(ctx context.Conte
 	return ResourceDependency{}, err
 }
 
-func (dp *deploymentProcessor) buildResourceDependency(resourceID resources.ID, outputResources []map[string]interface{}, computedValues map[string]interface{}, secretValues map[string]rp.SecretValueReference) ResourceDependency {
+func (dp *deploymentProcessor) buildResourceDependency(resourceID resources.ID, outputResources []outputresource.OutputResource, computedValues map[string]interface{}, secretValues map[string]rp.SecretValueReference) ResourceDependency {
 	lst := []map[string]outputresource.OutputResource{}
 	for _, r := range outputResources {
 		mp := map[string]outputresource.OutputResource{}
-		for k, v := range r {
-			mp[k] = v.(outputresource.OutputResource)
-		}
+		mp[r.LocalID] = r
 		lst = append(lst, mp)
 	}
 

--- a/pkg/corerp/frontend/controller/containers/testdata/container20220315privatepreview_datamodel.json
+++ b/pkg/corerp/frontend/controller/containers/testdata/container20220315privatepreview_datamodel.json
@@ -59,6 +59,13 @@
                     "ResourceType": {
                         "Provider": "azure",
                         "Type": "aks"
+                    },
+                    "Identity": {
+                      "data": null,
+                      "resourceType": {
+                        "Type": "aks",
+                        "Provider": "azure"
+                      }
                     }
                 }
             ]

--- a/pkg/corerp/frontend/controller/containers/testdata/container20220315privatepreview_input.json
+++ b/pkg/corerp/frontend/controller/containers/testdata/container20220315privatepreview_input.json
@@ -45,18 +45,6 @@
                 "initialDelaySeconds": 5,
                 "kind": "tcp"
             }
-        },
-        "provisioningState": "Updating",
-        "status": {
-            "outputResources": [
-                {
-                    "LocalID": "Deployment",
-                    "ResourceType": {
-                        "Provider": "azure",
-                        "Type": "aks"
-                    }
-                }
-            ]
         }
     }
 }

--- a/pkg/corerp/frontend/controller/containers/testdata/container20220315privatepreview_output.json
+++ b/pkg/corerp/frontend/controller/containers/testdata/container20220315privatepreview_output.json
@@ -52,9 +52,10 @@
             "outputResources": [
                 {
                     "LocalID": "Deployment",
-                    "ResourceType": {
-                        "Provider": "azure",
-                        "Type": "aks"
+                    "Provider": "azure",
+                    "Identity": {
+                        "apiVersion": "",
+                        "id": ""
                     }
                 }
             ]

--- a/pkg/corerp/frontend/controller/gateway/testdata/gateway20220315privatepreview_datamodel.json
+++ b/pkg/corerp/frontend/controller/gateway/testdata/gateway20220315privatepreview_datamodel.json
@@ -21,6 +21,13 @@
               "ResourceType": {
                 "Type": "Gateway",
                 "Provider": "kubernetes"
+              },
+              "Identity": {
+                "data": null,
+                "resourceType": {
+                  "Type": "httproutes",
+                  "Provider": "aks"
+                }
               }
             }]
         },

--- a/pkg/corerp/frontend/controller/gateway/testdata/gateway20220315privatepreview_input.json
+++ b/pkg/corerp/frontend/controller/gateway/testdata/gateway20220315privatepreview_input.json
@@ -1,15 +1,6 @@
 {
     "location": "West US",
     "properties": {
-        "status": {
-            "outputResources": [{
-              "LocalID": "Deployment",
-              "ResourceType": {
-                "Type": "Gateway",
-                "Provider": "kubernetes"
-              }
-            }]
-        },
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
         "hostname": {
             "fullyQualifiedHostname": "myapp.mydomain.com",

--- a/pkg/corerp/frontend/controller/gateway/testdata/gateway20220315privatepreview_output.json
+++ b/pkg/corerp/frontend/controller/gateway/testdata/gateway20220315privatepreview_output.json
@@ -18,9 +18,11 @@
         "status": {
             "outputResources": [{
               "LocalID": "Deployment",
-              "ResourceType": {
-                "Type": "Gateway",
-                "Provider": "kubernetes"
+              "Provider": "kubernetes",
+              "Identity": {
+                "aksClusterName": "",
+                "name": "",
+                "namespace": ""
               }
             }]
         },

--- a/pkg/corerp/frontend/controller/httproutes/testdata/httproute20220315privatepreview_datamodel.json
+++ b/pkg/corerp/frontend/controller/httproutes/testdata/httproute20220315privatepreview_datamodel.json
@@ -18,6 +18,14 @@
               "ResourceType": {
                 "Type": "httproutes",
                 "Provider": "aks"
+              },
+              "Resource": null,
+              "Identity": {
+                "data": null,
+                "resourceType": {
+                  "Type": "httproutes",
+                  "Provider": "aks"
+                }
               }
             }]
           },

--- a/pkg/corerp/frontend/controller/httproutes/testdata/httproute20220315privatepreview_input.json
+++ b/pkg/corerp/frontend/controller/httproutes/testdata/httproute20220315privatepreview_input.json
@@ -1,16 +1,6 @@
 {
     "location": "West US",
     "properties": {
-        "status": {
-            "outputResources": [{
-              "LocalID": "Deployment",
-              "ResourceType": {
-                "Type": "httproutes",
-                "Provider": "aks"
-              }
-            }]
-          },
-        "provisioningState": "Succeeded",
         "application": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
         "hostname": "foo.example.com",
         "port": 8080,

--- a/pkg/corerp/frontend/controller/httproutes/testdata/httproute20220315privatepreview_output.json
+++ b/pkg/corerp/frontend/controller/httproutes/testdata/httproute20220315privatepreview_output.json
@@ -6,9 +6,11 @@
         "status": {
             "outputResources": [{
               "LocalID": "Deployment",
-              "ResourceType": {
-                "Type": "httproutes",
-                "Provider": "aks"
+              "Provider": "aks",
+              "Identity": {
+                "aksClusterName": "",
+                "name": "",
+                "namespace": ""
               }
             }]
           },


### PR DESCRIPTION
# Description

With the new core and connector RP schema and implementation we are returning all the internal fields for output resource https://github.com/project-radius/radius/blob/main/pkg/radrp/outputresource/info.go#L19 in response payload. Updating outputresource response to only include fields that are relevant for users.

Also, output resources are added by the RP and are never expected to be provided as a part of the request, so removing it from versioned to internal data model conversion.

## Issue reference

https://github.com/project-radius/core-team/issues/258

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
