### PR TITLE
Allow for 200 OK for RG creation

### DIFF
--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -276,7 +276,7 @@ func createUCPResourceGroup(kubeCtxName, resourceGroupName string, plane string)
 		return "", fmt.Errorf("failed to create UCP resourceGroup: %w", err)
 	}
 
-	if resp.StatusCode != http.StatusCreated {
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("request to create UCP resouceGroup failed with status: %d, request: %+v", resp.StatusCode, resp)
 	}
 	defer resp.Body.Close()

--- a/pkg/cli/kubernetes/kubernetes.go
+++ b/pkg/cli/kubernetes/kubernetes.go
@@ -258,7 +258,6 @@ func CreateRuntimeClient(context string, scheme *runtime.Scheme) (client.Client,
 
 	var c client.Client
 	for i := 0; i < 2; i++ {
-		output.LogInfo("Attempting to get a kubernetes client...")
 		c, err = client.New(merged, client.Options{Scheme: scheme})
 		if err != nil {
 			output.LogInfo(fmt.Errorf("failed to get a kubernetes client: %w", err).Error())


### PR DESCRIPTION
Fixes https://github.com/project-radius/radius/issues/2764

We need to handle 200 OK for rg creation especially if an environment has already been created and deleted. Note, today we don't clean up CRDs for RG storage on env deletion, so if we create an environment once, delete it, then create again, we will get a 200 OK.