### PR TITLE
Update path to UCP to be lowercase

### DIFF
--- a/pkg/validator/loader.go
+++ b/pkg/validator/loader.go
@@ -107,7 +107,8 @@ func LoadSpec(ctx context.Context, providerName string, specs fs.FS, rootScopePr
 			PathLoader: func(path string) (json.RawMessage, error) {
 				// Trim before 'specification' to convert relative path.
 				first := strings.Index(path, "specification")
-				data, err := fs.ReadFile(l.specFiles, path[first:])
+				suffix := path[first:]
+				data, err := fs.ReadFile(l.specFiles, suffix)
 				return json.RawMessage(data), err
 			},
 		})

--- a/swagger/specs.go
+++ b/swagger/specs.go
@@ -19,6 +19,6 @@ var (
 	//go:embed specification/common-types/resource-management/v2/types.json
 	SpecFiles embed.FS
 
-	//go:embed specification/ucp/resource-manager/UCP/preview/2022-03-15-privatepreview/*.json
+	//go:embed specification/ucp/resource-manager/ucp/preview/2022-03-15-privatepreview/*.json
 	SpecFilesUCP embed.FS
 )


### PR DESCRIPTION
# Description

Updates UCP loading path to be lowercase to handle _windows_. I'm not sure if we need to update other swagger loading locations for the core/connector rps. If we do, I'll make a follow up PR.

## Issue reference

Fixes https://github.com/project-radius/radius/issues/2775

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
