### PR TITLE
Upgrade mariner image to 2.0 and ensure that the latest ca-cert is installed

### DIFF
--- a/deploy/images/appcore-rp/Dockerfile
+++ b/deploy/images/appcore-rp/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
-RUN yum -y install ca-certificates
+RUN yum -y install wget ca-certificates 
 
 # Install libifxaudit
 RUN wget https://packages.microsoft.com/centos/7/prod/libifxaudit-1.0-1525.x86_64.rpm && rpm -i libifxaudit-1.0-1525.x86_64.rpm

--- a/deploy/images/appcore-rp/Dockerfile
+++ b/deploy/images/appcore-rp/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
-RUN yum install ca-certificates
+RUN yum -y install ca-certificates
 
 # Install libifxaudit
 RUN wget https://packages.microsoft.com/centos/7/prod/libifxaudit-1.0-1525.x86_64.rpm && rpm -i libifxaudit-1.0-1525.x86_64.rpm

--- a/deploy/images/appcore-rp/Dockerfile
+++ b/deploy/images/appcore-rp/Dockerfile
@@ -1,4 +1,6 @@
-FROM mcr.microsoft.com/cbl-mariner/base/core:1.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+
+RUN yum install ca-certificates
 
 # Install libifxaudit
 RUN wget https://packages.microsoft.com/centos/7/prod/libifxaudit-1.0-1525.x86_64.rpm && rpm -i libifxaudit-1.0-1525.x86_64.rpm

--- a/deploy/images/appcore-rp/Dockerfile
+++ b/deploy/images/appcore-rp/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
-RUN yum -y install wget ca-certificates 
+RUN yum -y install wget ca-certificates shadow-utils
 
 # Install libifxaudit
 RUN wget https://packages.microsoft.com/centos/7/prod/libifxaudit-1.0-1525.x86_64.rpm && rpm -i libifxaudit-1.0-1525.x86_64.rpm


### PR DESCRIPTION
# Description

Upgrade mariner image to 2.0 and ensure that the latest ca-cert is installed

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
