### PR TITLE
Add role location to deployed yamls

### DIFF
--- a/deploy/Chart/charts/appcore-rp/connector-self-host.yaml
+++ b/deploy/Chart/charts/appcore-rp/connector-self-host.yaml
@@ -1,6 +1,7 @@
 # This is an example of configuration file.
 environment:
   name: self-hosted
+  roleLocation: "global"
 storageProvider:
   # Kubernetes APIServer store. 
   # This supports two modes:

--- a/deploy/Chart/charts/appcore-rp/radius-self-host.yaml
+++ b/deploy/Chart/charts/appcore-rp/radius-self-host.yaml
@@ -1,6 +1,7 @@
 # This is an example of configuration file.
 environment:
   name: self-hosted
+  roleLocation: "global"
 storageProvider:
   # Kubernetes APIServer store. 
   # This supports two modes:


### PR DESCRIPTION
Fixes https://github.com/project-radius/radius/issues/2742

I think I have some confusion around why we are not using location from the request body. I guess it doesn't matter for self-hosted?