### PR TITLE
Redesign behavior of Scope queries

### DIFF
--- a/pkg/ucp/frontend/ucphandler/planes/planes.go
+++ b/pkg/ucp/frontend/ucphandler/planes/planes.go
@@ -108,7 +108,6 @@ func (ucp *ucpHandler) CreateOrUpdate(ctx context.Context, db store.StorageClien
 func (ucp *ucpHandler) List(ctx context.Context, db store.StorageClient, path string) (rest.Response, error) {
 	var query store.Query
 	query.RootScope = path
-	query.ScopeRecursive = true
 	query.IsScopeQuery = true
 	listOfPlanes, err := planesdb.GetScope(ctx, db, query)
 	if err != nil {

--- a/pkg/ucp/frontend/ucphandler/planes/planes_ucphandler_test.go
+++ b/pkg/ucp/frontend/ucphandler/planes/planes_ucphandler_test.go
@@ -120,7 +120,6 @@ func Test_ListPlane(t *testing.T) {
 
 	var query store.Query
 	query.RootScope = path
-	query.ScopeRecursive = true
 	query.IsScopeQuery = true
 
 	expectedPlaneList := rest.PlaneList{}

--- a/pkg/ucp/frontend/ucphandler/resourcegroups/resource_groups.go
+++ b/pkg/ucp/frontend/ucphandler/resourcegroups/resource_groups.go
@@ -90,10 +90,6 @@ func (ucp *ucpHandler) List(ctx context.Context, db store.StorageClient, path st
 		return nil, err
 	}
 	query.RootScope = resources.SegmentSeparator + resources.PlanesSegment + resources.SegmentSeparator + planeType + resources.SegmentSeparator + planeName
-
-	// TODO: This is a temporary workaround till #2740 is fixed.
-	query.ScopeRecursive = true
-
 	query.IsScopeQuery = true
 	query.ResourceType = "resourcegroups"
 	listOfResourceGroups, err := resourcegroupsdb.GetScope(ctx, db, query)

--- a/pkg/ucp/frontend/ucphandler/resourcegroups/resourcegroups_ucphandler_test.go
+++ b/pkg/ucp/frontend/ucphandler/resourcegroups/resourcegroups_ucphandler_test.go
@@ -68,11 +68,11 @@ func Test_ListResourceGroups(t *testing.T) {
 	path := "/planes/radius/local/resourceGroups"
 	var testHandler = NewResourceGroupsUCPHandler(Options{})
 
-	var query store.Query
-	query.RootScope = "/planes/radius/local"
-	query.ScopeRecursive = true
-	query.IsScopeQuery = true
-	query.ResourceType = "resourcegroups"
+	query := store.Query{
+		RootScope:    "/planes/radius/local",
+		IsScopeQuery: true,
+		ResourceType: "resourcegroups",
+	}
 
 	testResourceGroupID := "/planes/radius/local/resourceGroups/test-rg"
 	testResourceGroupName := "test-rg"

--- a/pkg/ucp/resources/id_test.go
+++ b/pkg/ucp/resources/id_test.go
@@ -62,7 +62,20 @@ func Test_ParseValidIDs(t *testing.T) {
 			types:    []TypeSegment{},
 			provider: "",
 		},
-
+		{
+			id:       "/planes/",
+			expected: "/planes",
+			scopes:   []ScopeSegment{},
+			types:    []TypeSegment{},
+			provider: "",
+		},
+		{
+			id:       "/",
+			expected: "/",
+			scopes:   []ScopeSegment{},
+			types:    []TypeSegment{},
+			provider: "",
+		},
 		{
 			id:       "/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/",
 			expected: "/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders",
@@ -392,6 +405,22 @@ func Test_Truncate_Success(t *testing.T) {
 	require.Equal(t, "/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius", truncated.id)
 }
 
+func Test_Truncate_Success_Scope(t *testing.T) {
+	id, err := Parse("/subscriptions/s1/resourceGroups/r1/")
+	require.NoError(t, err)
+
+	truncated := id.Truncate()
+	require.Equal(t, "/subscriptions/s1", truncated.id)
+}
+
+func Test_Truncate_Success_Scope_UCP(t *testing.T) {
+	id, err := Parse("/planes/azure/azurecloud/subscriptions/s1/resourceGroups/r1/")
+	require.NoError(t, err)
+
+	truncated := id.Truncate()
+	require.Equal(t, "/planes/azure/azurecloud/subscriptions/s1", truncated.id)
+}
+
 func Test_Truncate_Success_UCP(t *testing.T) {
 	id, err := Parse("/planes/azure/azurecloud/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app")
 	require.NoError(t, err)
@@ -414,6 +443,14 @@ func Test_Truncate_ReturnsSelfForTopLevelResource_UCP(t *testing.T) {
 
 	truncated := id.Truncate()
 	require.Equal(t, "/planes/azure/azurecloud/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius", truncated.id)
+}
+
+func Test_Truncate_ReturnsSelfForTopLevelScope_UCP(t *testing.T) {
+	id, err := Parse("/planes/")
+	require.NoError(t, err)
+
+	truncated := id.Truncate()
+	require.Equal(t, "/planes", truncated.id)
 }
 
 func Test_IdParsing_WithNoTypeSegments(t *testing.T) {

--- a/pkg/ucp/store/apiserverstore/apiserverclient.go
+++ b/pkg/ucp/store/apiserverstore/apiserverclient.go
@@ -40,6 +40,7 @@ import (
 	"github.com/project-radius/radius/pkg/ucp/resources"
 	"github.com/project-radius/radius/pkg/ucp/store"
 	ucpv1alpha1 "github.com/project-radius/radius/pkg/ucp/store/apiserverstore/api/ucp.dev/v1alpha1"
+	"github.com/project-radius/radius/pkg/ucp/store/storeutil"
 	"github.com/project-radius/radius/pkg/ucp/util/etag"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,7 +121,7 @@ func (c *APIServerClient) Query(ctx context.Context, query store.Query, options 
 				continue
 			}
 
-			if idMatchesQuery(id, query) {
+			if storeutil.IDMatchesQuery(id, query) {
 				converted, err := readEntry(&entry)
 				if err != nil {
 					return nil, err
@@ -395,16 +396,16 @@ func assignLabels(resource *ucpv1alpha1.Resource) labels.Set {
 			continue
 		}
 
-		if id.IsScope() {
-			set[LabelKind] = store.UCPScopePrefix
-		} else {
-			set[LabelKind] = store.UCPResourcePrefix
-		}
+		prefix, rootScope, _, resourceType := storeutil.ExtractStorageParts(id)
+		set[LabelKind] = prefix
 
-		scopes := id.ScopeSegments()
-		for _, scope := range scopes {
-			scope.Type = strings.ReplaceAll(scope.Type, resources.SegmentSeparator, "-")
-			key := fmt.Sprintf(LabelScopeFormat, strings.ToLower(scope.Type))
+		// We need to take apart the root scope so we can turn it into key-value-pairs.
+		parsedRootScope, err := resources.Parse(rootScope)
+		if err != nil {
+			continue
+		}
+		for _, scope := range parsedRootScope.ScopeSegments() {
+			key := fmt.Sprintf(LabelScopeFormat, strings.ToLower(strings.ReplaceAll(scope.Type, resources.SegmentSeparator, "-")))
 			value := strings.ToLower(scope.Name)
 
 			existing, ok := set[key]
@@ -413,13 +414,6 @@ func assignLabels(resource *ucpv1alpha1.Resource) labels.Set {
 			}
 
 			set[key] = value
-		}
-
-		var resourceType string
-		if id.IsScope() {
-			resourceType = scopes[len(scopes)-1].Type
-		} else {
-			resourceType = id.Type()
 		}
 
 		// '/' is not valid in a label values, so we use '_'
@@ -443,14 +437,14 @@ func createLabelSelector(query store.Query) (labels.Selector, error) {
 
 	selector := labels.NewSelector()
 	if query.IsScopeQuery {
-		requirement, err := labels.NewRequirement(LabelKind, selection.Equals, []string{store.UCPScopePrefix})
+		requirement, err := labels.NewRequirement(LabelKind, selection.Equals, []string{storeutil.ScopePrefix})
 		if err != nil {
 			return nil, err
 		}
 
 		selector = selector.Add(*requirement)
 	} else {
-		requirement, err := labels.NewRequirement(LabelKind, selection.Equals, []string{store.UCPResourcePrefix})
+		requirement, err := labels.NewRequirement(LabelKind, selection.Equals, []string{storeutil.ResourcePrefix})
 		if err != nil {
 			return nil, err
 		}
@@ -459,8 +453,7 @@ func createLabelSelector(query store.Query) (labels.Selector, error) {
 	}
 
 	for _, scope := range id.ScopeSegments() {
-		scope.Type = strings.ReplaceAll(scope.Type, resources.SegmentSeparator, "-")
-		key := fmt.Sprintf(LabelScopeFormat, strings.ToLower(scope.Type))
+		key := fmt.Sprintf(LabelScopeFormat, strings.ToLower(strings.ReplaceAll(scope.Type, resources.SegmentSeparator, "-")))
 		value := strings.ToLower(scope.Name)
 
 		requirement, err := labels.NewRequirement(key, selection.In, []string{value, LabelValueMultiple})
@@ -540,67 +533,4 @@ func convert(obj *store.Object) (*ucpv1alpha1.ResourceEntry, error) {
 	}
 
 	return &resource, nil
-}
-
-func idMatchesQuery(id resources.ID, query store.Query) bool {
-	if query.ScopeRecursive && !strings.HasPrefix(normalize(id.RootScope()), normalize(query.RootScope)) {
-		// Example:
-		// id is /planes/radius/local/resourceGroups/cool-group/providers/Applications.Core/applications/cool-app
-		// query.RootScope is /planes/azure/azurecloud
-		//
-		// Query root scope is not a prefix
-		return false
-	} else if !query.ScopeRecursive && normalize(id.RootScope()) != normalize(query.RootScope) {
-		// Example:
-		// id is /planes/radius/local/resourceGroups/cool-group/providers/Applications.Core/applications/cool-app
-		// query.RootScope is /planes/radius/local/resourceGroups/another-group
-		//
-		// Query root scope does not match
-		return false
-	}
-
-	if query.RoutingScopePrefix != "" && !strings.HasPrefix(normalize(id.RoutingScope()), normalize(query.RoutingScopePrefix)) {
-		// Example:
-		// id is /planes/radius/local/resourceGroups/cool-group/providers/Some.Resource/type1/name1/type2/name2
-		// query.RoutingScopePrefix is /planes/radius/local/resourceGroups/cool-group/providers/Some.Resource/type1/anothername
-		//
-		// Query routing scope is not a prefix
-		return false
-	}
-
-	if query.ResourceType != "" && query.IsScopeQuery {
-		// Example:
-		// id is /planes/radius/local/resourceGroups/cool-group
-		// query.ResourceType is subscriptions
-		//
-		// Query resource type is not a match
-		scopes := id.ScopeSegments()
-		resourceType := scopes[len(scopes)-1].Type
-		return strings.EqualFold(resourceType, query.ResourceType)
-	} else if query.ResourceType != "" && !strings.EqualFold(id.Type(), query.ResourceType) {
-		// Example:
-		// id is /planes/radius/local/resourceGroups/cool-group/providers/Applications.Core/applications/cool-app
-		// query.ResourceType is Applications.Core/containers
-		//
-		// Query resource type is not a match
-		return false
-	}
-
-	return true
-}
-
-func normalize(part string) string {
-	if len(part) == 0 {
-		return ""
-	}
-
-	if !strings.HasPrefix(part, resources.SegmentSeparator) {
-		part = resources.SegmentSeparator + part
-	}
-
-	if !strings.HasSuffix(part, resources.SegmentSeparator) {
-		part = part + resources.SegmentSeparator
-	}
-
-	return strings.ToLower(part)
 }

--- a/pkg/ucp/store/apiserverstore/apiserverclient_test.go
+++ b/pkg/ucp/store/apiserverstore/apiserverclient_test.go
@@ -105,10 +105,9 @@ func Test_APIServer_Client(t *testing.T) {
 		require.NoError(t, err)
 
 		expected := map[string]string{
-			"ucp.dev/kind":                 "scope",
-			"ucp.dev/resource-type":        "resourcegroups",
-			"ucp.dev/scope-radius":         "local",
-			"ucp.dev/scope-resourcegroups": "group1",
+			"ucp.dev/kind":          "scope",
+			"ucp.dev/resource-type": "resourcegroups",
+			"ucp.dev/scope-radius":  "local",
 		}
 
 		require.Equal(t, expected, resource.Labels)
@@ -565,10 +564,9 @@ func Test_AssignLabels_Scope_NoConflicts(t *testing.T) {
 	}
 
 	expected := labels.Set{
-		"ucp.dev/kind":                 "scope",
-		"ucp.dev/resource-type":        "resourcegroups",
-		"ucp.dev/scope-radius":         "local",
-		"ucp.dev/scope-resourcegroups": "cool-group",
+		"ucp.dev/kind":          "scope",
+		"ucp.dev/resource-type": "resourcegroups",
+		"ucp.dev/scope-radius":  "local",
 	}
 
 	labels := assignLabels(&resource)
@@ -666,7 +664,7 @@ func Test_CreateLabelSelector_UCPID(t *testing.T) {
 	require.True(t, selector.Matches(set))
 }
 
-func Test_CreateLabelSelector(t *testing.T) {
+func Test_CreateLabelSelector_ResourceQuery(t *testing.T) {
 	query := store.Query{
 		RootScope:    "/planes/radius/local/resourceGroups/cool-group",
 		ResourceType: "Applications.Core/containers",
@@ -702,6 +700,50 @@ func Test_CreateLabelSelector(t *testing.T) {
 			{
 				// Match!
 				ID: "/planes/radius/local/resourceGroups/cool-group/providers/Applications.Core/containers/backend",
+			},
+		},
+	}
+	set = assignLabels(&resource)
+	require.True(t, selector.Matches(set))
+}
+
+func Test_CreateLabelSelector_ScopeQuery(t *testing.T) {
+	query := store.Query{
+		RootScope:    "/planes/radius/local",
+		ResourceType: "resourceGroups",
+		IsScopeQuery: true,
+	}
+
+	selector, err := createLabelSelector(query)
+	require.NoError(t, err)
+
+	resource := ucpv1alpha1.Resource{
+		Entries: []ucpv1alpha1.ResourceEntry{
+			{
+				// Wrong resource type
+				ID: "/planes/radius/local/subscriptions/cool-subscription",
+			},
+		},
+	}
+	set := assignLabels(&resource)
+	require.False(t, selector.Matches(set))
+
+	resource = ucpv1alpha1.Resource{
+		Entries: []ucpv1alpha1.ResourceEntry{
+			{
+				// Different scope
+				ID: "/planes/radius/local/resourceGroups/another-group/anotherScope/cool-name",
+			},
+		},
+	}
+	set = assignLabels(&resource)
+	require.False(t, selector.Matches(set))
+
+	resource = ucpv1alpha1.Resource{
+		Entries: []ucpv1alpha1.ResourceEntry{
+			{
+				// Match!
+				ID: "/planes/radius/local/resourceGroups/cool-group",
 			},
 		},
 	}

--- a/pkg/ucp/store/storeutil/doc.go
+++ b/pkg/ucp/store/storeutil/doc.go
@@ -1,0 +1,9 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+// storeutil contains utility functions for implementing storage backends. The store package only
+// has dependencies on the std library (intentionally) so that clients of the store are easy to
+// reference.
+package storeutil

--- a/pkg/ucp/store/storeutil/id.go
+++ b/pkg/ucp/store/storeutil/id.go
@@ -1,0 +1,86 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package storeutil
+
+import (
+	"strings"
+
+	"github.com/project-radius/radius/pkg/ucp/resources"
+	"github.com/project-radius/radius/pkg/ucp/store"
+)
+
+const (
+	ScopePrefix    = "scope"
+	ResourcePrefix = "resource"
+)
+
+// ExtractStorageParts extracts the main components of the resource id in a way that easily
+// supports our storage abstraction. Returns a tuple of the (prefix, rootScope, routingScope, resourceType)
+func ExtractStorageParts(id resources.ID) (string, string, string, string) {
+	if id.IsScope() {
+		// For a scope we encode the last scope segment as the routing scope, and the previous
+		// scope segments as the root scope. This gives us the most desirable behavior for
+		// queries and recursion.
+
+		prefix := ScopePrefix
+		rootScope := NormalizePart(id.Truncate().RootScope())
+
+		last := resources.ScopeSegment{}
+		if len(id.ScopeSegments()) > 0 {
+			last = id.ScopeSegments()[len(id.ScopeSegments())-1]
+		}
+		routingScope := NormalizePart(last.Type + resources.SegmentSeparator + last.Name)
+		resourceType := strings.ToLower(last.Type)
+
+		return prefix, rootScope, routingScope, resourceType
+	} else {
+		prefix := ResourcePrefix
+		rootScope := NormalizePart(id.RootScope())
+		routingScope := NormalizePart(id.RoutingScope())
+		resourceType := strings.ToLower(id.Type())
+
+		return prefix, rootScope, routingScope, resourceType
+	}
+}
+
+func IDMatchesQuery(id resources.ID, query store.Query) bool {
+	prefix, rootScope, routingScope, resourceType := ExtractStorageParts(id)
+	if query.IsScopeQuery && !strings.EqualFold(prefix, ScopePrefix) {
+		return false
+	} else if !query.IsScopeQuery && !strings.EqualFold(prefix, ResourcePrefix) {
+		return false
+	}
+
+	if query.ScopeRecursive && !strings.HasPrefix(rootScope, NormalizePart(query.RootScope)) {
+		return false
+	} else if !query.ScopeRecursive && !strings.EqualFold(rootScope, NormalizePart(query.RootScope)) {
+		return false
+	}
+
+	if query.RoutingScopePrefix != "" && !strings.HasPrefix(routingScope, NormalizePart(query.RoutingScopePrefix)) {
+		return false
+	}
+
+	if query.ResourceType != "" && !strings.EqualFold(resourceType, query.ResourceType) {
+		return false
+	}
+
+	return true
+}
+
+func NormalizePart(part string) string {
+	if len(part) == 0 {
+		return ""
+	}
+	if !strings.HasPrefix(part, resources.SegmentSeparator) {
+		part = resources.SegmentSeparator + part
+	}
+	if !strings.HasSuffix(part, resources.SegmentSeparator) {
+		part = part + resources.SegmentSeparator
+	}
+
+	return strings.ToLower(part)
+}

--- a/pkg/ucp/store/storeutil/id_test.go
+++ b/pkg/ucp/store/storeutil/id_test.go
@@ -1,0 +1,248 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package storeutil
+
+import (
+	"testing"
+
+	"github.com/project-radius/radius/pkg/ucp/resources"
+	"github.com/project-radius/radius/pkg/ucp/store"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ExtractStorageParts(t *testing.T) {
+	type testcase struct {
+		ID           string
+		Prefix       string
+		RootScope    string
+		RoutingScope string
+		ResourceType string
+	}
+
+	cases := []testcase{
+		{
+			ID:           "/", // Not a valid case, just testing that we don't panic.
+			Prefix:       ScopePrefix,
+			RootScope:    "/",
+			RoutingScope: "/",
+			ResourceType: "",
+		},
+		{
+			ID:           "/planes", // Not a valid case, just testing that we don't panic.
+			Prefix:       ScopePrefix,
+			RootScope:    "/planes/",
+			RoutingScope: "/",
+			ResourceType: "",
+		},
+		{
+			ID:           "/planes/radius/local",
+			Prefix:       ScopePrefix,
+			RootScope:    "/planes/",
+			RoutingScope: "/radius/local/",
+			ResourceType: "radius",
+		},
+		{
+			ID:           "/planes/radius/local/resourceGroups/cool-group",
+			Prefix:       ScopePrefix,
+			RootScope:    "/planes/radius/local/",
+			RoutingScope: "/resourcegroups/cool-group/",
+			ResourceType: "resourcegroups",
+		},
+		{
+			ID:           "/subscriptions/cool-sub/resourceGroups/cool-group/",
+			Prefix:       ScopePrefix,
+			RootScope:    "/subscriptions/cool-sub/",
+			RoutingScope: "/resourcegroups/cool-group/",
+			ResourceType: "resourcegroups",
+		},
+		{
+			ID:           "/planes/radius/local/resourceGroups/cool-group/providers/Applications.Core/applications/cool-app",
+			Prefix:       ResourcePrefix,
+			RootScope:    "/planes/radius/local/resourcegroups/cool-group/",
+			RoutingScope: "/applications.core/applications/cool-app/",
+			ResourceType: "applications.core/applications",
+		},
+		{
+			ID:           "/subscriptions/cool-sub/resourceGroups/cool-group/providers/Applications.Core/applications/cool-app/nested/cool-nested",
+			Prefix:       ResourcePrefix,
+			RootScope:    "/subscriptions/cool-sub/resourcegroups/cool-group/",
+			RoutingScope: "/applications.core/applications/cool-app/nested/cool-nested/",
+			ResourceType: "applications.core/applications/nested",
+		},
+		{
+			ID:           "/subscriptions/cool-sub/resourceGroups/cool-group/providers/Applications.Core/applications/cool-app",
+			Prefix:       ResourcePrefix,
+			RootScope:    "/subscriptions/cool-sub/resourcegroups/cool-group/",
+			RoutingScope: "/applications.core/applications/cool-app/",
+			ResourceType: "applications.core/applications",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.ID, func(t *testing.T) {
+			id, err := resources.Parse(tc.ID)
+			require.NoError(t, err)
+
+			prefix, rootScope, routingScope, resourceType := ExtractStorageParts(id)
+			require.Equal(t, tc.Prefix, prefix)
+			require.Equal(t, tc.RootScope, rootScope)
+			require.Equal(t, tc.RoutingScope, routingScope)
+			require.Equal(t, tc.ResourceType, resourceType)
+		})
+	}
+}
+
+func Test_IDMatchesQuery(t *testing.T) {
+	type testcase struct {
+		ID      string
+		Query   store.Query
+		IsMatch bool
+	}
+
+	cases := []testcase{
+		// Tests in this section target block-coverage of all of our negative cases.
+		{
+			ID: "/planes/radius/local",
+			Query: store.Query{
+				IsScopeQuery: false, // mismatched query type
+			},
+		},
+		{
+			ID: "/planes/radius/local/resourceGroups/cool-group/providers/Applications.Core/applications/cool-app",
+			Query: store.Query{
+				IsScopeQuery: true, // mismatched query type
+			},
+		},
+		{
+			ID: "/planes/radius/local/resourceGroups/cool-group",
+			Query: store.Query{
+				RootScope:    "/planes/radius/local/resourceGroups/cool-group", // mismatched root scope
+				IsScopeQuery: true,
+			},
+		},
+		{
+			ID: "/planes/radius/local/resourceGroups/cool-group",
+			Query: store.Query{
+				RootScope:      "/planes/radius/another-plane", // mismatched root scope
+				ScopeRecursive: true,
+				IsScopeQuery:   true,
+			},
+		},
+		{
+			ID: "/subscriptions/cool-sub/resourceGroups/cool-group/providers/Applications.Core/applications/cool-app/nested/cool-nested",
+			Query: store.Query{
+				RootScope:          "/subscriptions/cool-sub/resourceGroups/cool-group",
+				RoutingScopePrefix: "Applications.Core/applications/different-app", // mismatched routing scope prefix
+				IsScopeQuery:       false,
+			},
+		},
+		{
+			ID: "/planes/radius/local/resourceGroups/cool-group/providers/Applications.Core/applications/cool-app",
+			Query: store.Query{
+				RootScope:    "/planes/radius/local/resourceGroups",
+				ResourceType: "Applications.Core/containers", // mismatched resource type
+				IsScopeQuery: false,
+			},
+		},
+
+		// Tests in this section target our main use-cases for the query logic.
+		{
+			ID: "/planes/radius/local",
+			Query: store.Query{
+				RootScope:    "/planes", // list all planes (regardless of type)
+				IsScopeQuery: true,
+			},
+			IsMatch: true,
+		},
+		{
+			ID: "/planes/radius/local",
+			Query: store.Query{
+				RootScope:    "/planes", // list all planes (specific type)
+				ResourceType: "radius",
+				IsScopeQuery: true,
+			},
+			IsMatch: true,
+		},
+		{
+			ID: "/planes/radius/local/resourceGroups/cool-group",
+			Query: store.Query{
+				RootScope:    "/planes/radius/local/", // list all resource groups
+				ResourceType: "resourceGroups",
+				IsScopeQuery: true,
+			},
+			IsMatch: true,
+		},
+		{
+			ID: "/planes/radius/local/resourceGroups/cool-group",
+			Query: store.Query{
+				RootScope:      "/planes", // list all resource groups across planes
+				ResourceType:   "resourceGroups",
+				ScopeRecursive: true,
+				IsScopeQuery:   true,
+			},
+			IsMatch: true,
+		},
+		{
+			ID: "/planes/radius/local/resourceGroups/cool-group/providers/Applications.Core/applications/cool-app",
+			Query: store.Query{
+				RootScope:      "/planes/radius/local", // list all resources in plane
+				ScopeRecursive: true,
+				IsScopeQuery:   false,
+			},
+			IsMatch: true,
+		},
+		{
+			ID: "/planes/radius/local/resourceGroups/cool-group/providers/Applications.Core/applications/cool-app",
+			Query: store.Query{
+				RootScope:      "/planes/radius/local/resourceGroups/cool-group", // list all resources in resource group
+				ScopeRecursive: false,
+				IsScopeQuery:   false,
+			},
+			IsMatch: true,
+		},
+		{
+			ID: "/planes/radius/local/resourceGroups/cool-group/providers/Applications.Core/applications/cool-app",
+			Query: store.Query{
+				RootScope:      "/planes/radius/local/resourceGroups/cool-group", // list all applications in resource group
+				ResourceType:   "Applications.Core/applications",
+				ScopeRecursive: false,
+				IsScopeQuery:   false,
+			},
+			IsMatch: true,
+		},
+		{
+			ID: "/planes/radius/local/resourceGroups/cool-group/providers/Applications.Core/applications/cool-app",
+			Query: store.Query{
+				RootScope:      "/planes/radius/local/", // list all applications in plane
+				ResourceType:   "Applications.Core/applications",
+				ScopeRecursive: true,
+				IsScopeQuery:   false,
+			},
+			IsMatch: true,
+		},
+		{
+			ID: "/planes/radius/local/resourceGroups/cool-group/providers/Applications.Core/applications/cool-app/nested/cool-nested",
+			Query: store.Query{
+				RootScope:          "/planes/radius/local/resourceGroups/cool-group", // list nested resources
+				RoutingScopePrefix: "/Applications.Core/applications/cool-app",
+				ResourceType:       "Applications.Core/applications/nested",
+				ScopeRecursive:     false,
+				IsScopeQuery:       false,
+			},
+			IsMatch: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.ID, func(t *testing.T) {
+			id, err := resources.Parse(tc.ID)
+			require.NoError(t, err)
+
+			isMatch := IDMatchesQuery(id, tc.Query)
+			require.Equal(t, tc.IsMatch, isMatch)
+		})
+	}
+}

--- a/test/ucp/storetest/shared.go
+++ b/test/ucp/storetest/shared.go
@@ -39,7 +39,8 @@ var ResourceGroup2ID = parseOrPanic(ResourceGroup2Scope)
 var Resource1ID = parseOrPanic(ResourceGroup1Scope + "/providers/" + ResourcePath1)
 var Resource2ID = parseOrPanic(ResourceGroup2Scope + "/providers/" + ResourcePath2)
 var NestedResource1ID = parseOrPanic(ResourceGroup1Scope + "/providers/" + NestedResourcePath1)
-var ARMResource = parseOrPanic(ARMResourceScope + "/providers/" + ResourcePath1)
+var ARMResourceID = parseOrPanic(ARMResourceScope + "/providers/" + ResourcePath1)
+var RadiusPlaneID = parseOrPanic(RadiusScope)
 
 var ResourceGroup1Data = map[string]interface{}{
 	"value": "1",
@@ -72,6 +73,13 @@ var NestedData1 = map[string]interface{}{
 	"value": "3",
 	"properties": map[string]interface{}{
 		"resource": "3",
+	},
+}
+
+var RadiusPlaneData = map[string]interface{}{
+	"value:": "1",
+	"properties": map[string]interface{}{
+		"plane": "1",
 	},
 }
 
@@ -161,12 +169,12 @@ func RunTest(t *testing.T, client store.StorageClient, clear func(t *testing.T))
 		clear(t)
 		// Testing that we can work with both UCP and ARM IDs.
 
-		obj1 := createObject(ARMResource, Data1)
+		obj1 := createObject(ARMResourceID, Data1)
 		err := client.Save(ctx, &obj1)
 		require.NoError(t, err)
 		require.NotEmpty(t, obj1.ETag)
 
-		obj1Get, err := client.Get(ctx, ARMResource.String())
+		obj1Get, err := client.Get(ctx, ARMResourceID.String())
 		require.NoError(t, err)
 		compareObjects(t, &obj1, obj1Get)
 		require.Equal(t, obj1Get.ETag, obj1.ETag)
@@ -366,6 +374,10 @@ func RunTest(t *testing.T, client store.StorageClient, clear func(t *testing.T))
 		err = client.Save(ctx, &obj2)
 		require.NoError(t, err)
 
+		plane1 := createObject(RadiusPlaneID, RadiusPlaneData)
+		err = client.Save(ctx, &plane1)
+		require.NoError(t, err)
+
 		t.Run("query_resources_at_resource_group_scope", func(t *testing.T) {
 			objs, err := client.Query(ctx, store.Query{RootScope: ResourceGroup1Scope})
 			require.NoError(t, err)
@@ -417,18 +429,14 @@ func RunTest(t *testing.T, client store.StorageClient, clear func(t *testing.T))
 		t.Run("query_scopes_at_resource_group_scope", func(t *testing.T) {
 			objs, err := client.Query(ctx, store.Query{RootScope: ResourceGroup1Scope, IsScopeQuery: true})
 			require.NoError(t, err)
-			expected := []store.Object{
-				group1,
-			}
+			expected := []store.Object{}
 			CompareObjectLists(t, expected, objs.Items)
 		})
 
 		t.Run("query_scopes_at_resource_group_scope_with_type_filter", func(t *testing.T) {
 			objs, err := client.Query(ctx, store.Query{RootScope: ResourceGroup1Scope, IsScopeQuery: true, ResourceType: "resourceGroups"})
 			require.NoError(t, err)
-			expected := []store.Object{
-				group1,
-			}
+			expected := []store.Object{}
 			CompareObjectLists(t, expected, objs.Items)
 		})
 
@@ -484,6 +492,51 @@ func RunTest(t *testing.T, client store.StorageClient, clear func(t *testing.T))
 			expected := []store.Object{
 				nested1,
 			}
+			CompareObjectLists(t, expected, objs.Items)
+		})
+
+		t.Run("query_scopes_at_plane_scope", func(t *testing.T) {
+			objs, err := client.Query(ctx, store.Query{RootScope: PlaneScope, IsScopeQuery: true})
+			require.NoError(t, err)
+			expected := []store.Object{
+				plane1,
+			}
+			CompareObjectLists(t, expected, objs.Items)
+		})
+
+		t.Run("query_scopes_at_plane_scope_with_type_filter", func(t *testing.T) {
+			objs, err := client.Query(ctx, store.Query{RootScope: PlaneScope, IsScopeQuery: true, ResourceType: "radius"})
+			require.NoError(t, err)
+			expected := []store.Object{
+				plane1,
+			}
+			CompareObjectLists(t, expected, objs.Items)
+		})
+
+		t.Run("query_scopes_at_plane_scope_recursive", func(t *testing.T) {
+			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ScopeRecursive: true, IsScopeQuery: true})
+			require.NoError(t, err)
+			expected := []store.Object{
+				group1,
+				group2,
+			}
+			CompareObjectLists(t, expected, objs.Items)
+		})
+
+		t.Run("query_scopes_at_with_type_filter", func(t *testing.T) {
+			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, IsScopeQuery: true, ResourceType: "resourcegroups"})
+			require.NoError(t, err)
+			expected := []store.Object{
+				group1,
+				group2,
+			}
+			CompareObjectLists(t, expected, objs.Items)
+		})
+
+		t.Run("query_scopes_at_with_type_filter_non_matching", func(t *testing.T) {
+			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, IsScopeQuery: true, ResourceType: "subscriptions"})
+			require.NoError(t, err)
+			expected := []store.Object{}
 			CompareObjectLists(t, expected, objs.Items)
 		})
 


### PR DESCRIPTION
Fixes: #2740

This change adjusts the behavior of Scope queries to be
more useful for our scenarios in UCP.

The scenarios that are impacted (where we had unuseful behaviors) are
related to queries of planes and resource groups for UCP. No behaviors
of the data store for our RPs are affected as they do not use Scope
queries.

The kinds of things done by our RPs are to "list <type> at <scope>" and
occaisionally to "list <type> at <scope> recursively". For example,
listing all `Applications.Core/containers` resources in a resource group
or subscription (recursive case). Translating the words ("list <type> at
<scope>") to our Query API has the desired effect for these cases.

The scope query API is unfortunately NOT symmetric, it does not
currently provide the same guarantees. Here's an example of an un-useful
behavior. Right now a query to "list all scopes at
`/planes/radius/local`" would return `/planes/radius/local`

We actually wanted to get:

```txt
/planes/radius/local/resourceGroups/group1
/planes/radius/local/resourceGroups/group2
```

The current workaround of course is to "list all scopes at <scope>
recursively". This would return the following:

```txt
/planes/radius/local
/planes/radius/local/resourceGroups/group1
/planes/radius/local/resourceGroups/group2
```

This is also unhelpful because because we don't expect
`/planes/radius/local` to be included.

The change here is to make the behavior symmetrical by storing data the
same way for scopes as we do for resources. We chop off the last segment
and treat that as the "effective routing scope" and store the previous
segments as the "effective root scope".

This query will now return:

```txt
/planes/radius/local/resourceGroups/group1
/planes/radius/local/resourceGroups/group2
```
