### PR TITLE
Lowercasing RadiusResource lookup key on retrieval as well as in input initializing new application model

### DIFF
--- a/pkg/connectorrp/model/application_model.go
+++ b/pkg/connectorrp/model/application_model.go
@@ -7,7 +7,6 @@ package model
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/project-radius/radius/pkg/azure/armauth"
 	"github.com/project-radius/radius/pkg/connectorrp/handlers"
@@ -37,7 +36,7 @@ func NewApplicationModel(arm *armauth.ArmConfig, k8s client.Client) (Application
 
 	radiusResourceModel := []RadiusResourceModel{
 		{
-			ResourceType: strings.ToLower(mongodatabases.ResourceType),
+			ResourceType: mongodatabases.ResourceType,
 			Renderer:     &mongodatabases.Renderer{},
 		},
 		{

--- a/pkg/connectorrp/model/application_model.go
+++ b/pkg/connectorrp/model/application_model.go
@@ -40,29 +40,29 @@ func NewApplicationModel(arm *armauth.ArmConfig, k8s client.Client) (Application
 			Renderer:     &mongodatabases.Renderer{},
 		},
 		{
-			ResourceType: strings.ToLower(sqldatabases.ResourceType),
+			ResourceType: sqldatabases.ResourceType,
 			Renderer:     &sqldatabases.Renderer{},
 		},
 		{
-			ResourceType: strings.ToLower(rediscaches.ResourceType),
+			ResourceType: rediscaches.ResourceType,
 			Renderer:     &rediscaches.Renderer{},
 		},
 		{
-			ResourceType: strings.ToLower(rabbitmqmessagequeues.ResourceType),
+			ResourceType: rabbitmqmessagequeues.ResourceType,
 			Renderer:     &rabbitmqmessagequeues.Renderer{},
 		},
 		{
-			ResourceType: strings.ToLower(daprinvokehttproutes.ResourceType),
+			ResourceType: daprinvokehttproutes.ResourceType,
 			Renderer:     &daprinvokehttproutes.Renderer{},
 		},
 		{
-			ResourceType: strings.ToLower(daprpubsubbrokers.ResourceType),
+			ResourceType: daprpubsubbrokers.ResourceType,
 			Renderer: &daprpubsubbrokers.Renderer{
 				PubSubs: daprpubsubbrokers.SupportedPubSubKindValues,
 			},
 		},
 		{
-			ResourceType: strings.ToLower(daprsecretstores.ResourceType),
+			ResourceType: daprsecretstores.ResourceType,
 			Renderer: &daprsecretstores.Renderer{
 				SecretStores: daprsecretstores.SupportedSecretStoreKindValues,
 			},

--- a/pkg/connectorrp/model/types.go
+++ b/pkg/connectorrp/model/types.go
@@ -31,6 +31,7 @@ func (m ApplicationModel) GetOutputResources() []OutputResourceModel {
 	return m.outputResources
 }
 
+// LookupRadiusResourceModel is a case insensitive lookup for resourceType
 func (m ApplicationModel) LookupRadiusResourceModel(resourceType string) (*RadiusResourceModel, error) {
 	resource, ok := m.radiusResourceLookup[strings.ToLower(resourceType)]
 	if !ok {

--- a/pkg/connectorrp/model/types.go
+++ b/pkg/connectorrp/model/types.go
@@ -67,7 +67,7 @@ type OutputResourceModel struct {
 func NewModel(radiusResources []RadiusResourceModel, outputResources []OutputResourceModel, supportedProviders map[string]bool) ApplicationModel {
 	radiusResourceLookup := map[string]RadiusResourceModel{}
 	for _, radiusResource := range radiusResources {
-		radiusResourceLookup[radiusResource.ResourceType] = radiusResource
+		radiusResourceLookup[strings.ToLower(radiusResource.ResourceType)] = radiusResource
 	}
 
 	outputResourceLookup := map[resourcemodel.ResourceType]OutputResourceModel{}

--- a/pkg/corerp/backend/deployment/deployment_test.go
+++ b/pkg/corerp/backend/deployment/deployment_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -51,7 +50,7 @@ func setup(t *testing.T) SharedMocks {
 	model := model.NewModel(
 		[]model.RadiusResourceModel{
 			{
-				ResourceType: strings.ToLower(container.ResourceType),
+				ResourceType: container.ResourceType,
 				Renderer:     renderer,
 			},
 		},

--- a/pkg/corerp/backend/deployment/deployment_test.go
+++ b/pkg/corerp/backend/deployment/deployment_test.go
@@ -105,6 +105,13 @@ func getTestResource() datamodel.ContainerResource {
 	return *testResource
 }
 
+func getLowerCaseTestResource() datamodel.ContainerResource {
+	rawDataModel := radiustesting.ReadFixture("containerresourcedatamodellowercase.json")
+	testResource := &datamodel.ContainerResource{}
+	_ = json.Unmarshal(rawDataModel, testResource)
+	return *testResource
+}
+
 func getTestRendererOutput() renderers.RendererOutput {
 	testOutputResources := []outputresource.OutputResource{
 		{
@@ -152,6 +159,36 @@ func Test_Render(t *testing.T) {
 	dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil}
 	t.Run("verify render success", func(t *testing.T) {
 		testResource := getTestResource()
+		testRendererOutput := getTestRendererOutput()
+		resourceID := getTestResourceID(testResource.ID)
+
+		depId1, _ := resources.Parse("/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A")
+		requiredResources := []resources.ID{depId1}
+
+		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
+		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return(requiredResources, nil, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		httprouteA := datamodel.HTTPRoute{
+			TrackedResource: v1.TrackedResource{
+				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A",
+			},
+			Properties: &datamodel.HTTPRouteProperties{},
+		}
+		nr := store.Object{
+			Metadata: store.Metadata{
+				ID: httprouteA.ID,
+			},
+			Data: httprouteA,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&nr, nil)
+
+		rendererOutput, err := dp.Render(ctx, resourceID, testResource)
+		require.NoError(t, err)
+		require.Equal(t, len(testRendererOutput.Resources), len(rendererOutput.Resources))
+	})
+
+	t.Run("verify render success lowercase resourcetype", func(t *testing.T) {
+		testResource := getLowerCaseTestResource()
 		testRendererOutput := getTestRendererOutput()
 		resourceID := getTestResourceID(testResource.ID)
 

--- a/pkg/corerp/backend/deployment/deployment_test.go
+++ b/pkg/corerp/backend/deployment/deployment_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -50,7 +51,7 @@ func setup(t *testing.T) SharedMocks {
 	model := model.NewModel(
 		[]model.RadiusResourceModel{
 			{
-				ResourceType: container.ResourceType,
+				ResourceType: strings.ToLower(container.ResourceType),
 				Renderer:     renderer,
 			},
 		},

--- a/pkg/corerp/backend/deployment/testdata/containerresourcedatamodellowercase.json
+++ b/pkg/corerp/backend/deployment/testdata/containerresourcedatamodellowercase.json
@@ -1,0 +1,60 @@
+{
+    "id": "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/containers/test-resource",
+    "name": "test-resource",
+    "type": "applications.core/containers",
+    "systemData": {
+        "createdBy": "fakeid@live.com",
+        "createdByType": "User",
+        "createdAt": "2021-09-24T19:09:54.2403864Z",
+        "lastModifiedBy": "fakeid@live.com",
+        "lastModifiedByType": "User",
+        "lastModifiedAt": "2021-09-24T20:09:54.2403864Z"
+    },
+    "tags": {
+        "env": "dev"
+    },
+    "properties": {
+        "status": {
+          "outputResources": [{
+            "LocalID": "Service",
+            "ResourceType": {
+              "Type": "Service",
+              "Provider": "kubernetes"
+            }
+          }]
+        },
+        "provisioningState": "Succeeded",
+        "application": "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+        "connections": { 
+            "inventory": { 
+              "source": "inventory_route_id", 
+              "iam": {
+                "kind": "Http",
+                "roles": [
+                  "administrator"
+                ]
+              }
+            } 
+          },
+        "container": { 
+            "image": "radius.azurecr.io/webapptutorial-todoapp",
+            "livenessProbe": {
+              "kind": "tcp",
+              "tcp": {
+                "healthProbeBase": {
+                  "failureThreshold": 5,
+                  "initialDelaySeconds": 5,
+                  "periodSeconds": 5
+                },
+                "containerPort": 8080
+              }
+            },
+            "ports": {
+              "web":{
+                "containerPort": 5000,
+                "provides": "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application/HttpRoute/B"
+              }
+            }
+        }
+    }
+}

--- a/pkg/corerp/backend/deployment/testdata/containerresourcedatamodeluppercase.json
+++ b/pkg/corerp/backend/deployment/testdata/containerresourcedatamodeluppercase.json
@@ -1,0 +1,60 @@
+{
+    "id": "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/containers/test-resource",
+    "name": "test-resource",
+    "type": "APPLICATIONS.CORE/CONTAINERS",
+    "systemData": {
+        "createdBy": "fakeid@live.com",
+        "createdByType": "User",
+        "createdAt": "2021-09-24T19:09:54.2403864Z",
+        "lastModifiedBy": "fakeid@live.com",
+        "lastModifiedByType": "User",
+        "lastModifiedAt": "2021-09-24T20:09:54.2403864Z"
+    },
+    "tags": {
+        "env": "dev"
+    },
+    "properties": {
+        "status": {
+          "outputResources": [{
+            "LocalID": "Service",
+            "ResourceType": {
+              "Type": "Service",
+              "Provider": "kubernetes"
+            }
+          }]
+        },
+        "provisioningState": "Succeeded",
+        "application": "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+        "connections": { 
+            "inventory": { 
+              "source": "inventory_route_id", 
+              "iam": {
+                "kind": "Http",
+                "roles": [
+                  "administrator"
+                ]
+              }
+            } 
+          },
+        "container": { 
+            "image": "radius.azurecr.io/webapptutorial-todoapp",
+            "livenessProbe": {
+              "kind": "tcp",
+              "tcp": {
+                "healthProbeBase": {
+                  "failureThreshold": 5,
+                  "initialDelaySeconds": 5,
+                  "periodSeconds": 5
+                },
+                "containerPort": 8080
+              }
+            },
+            "ports": {
+              "web":{
+                "containerPort": 5000,
+                "provides": "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application/HttpRoute/B"
+              }
+            }
+        }
+    }
+}

--- a/pkg/corerp/model/application_model.go
+++ b/pkg/corerp/model/application_model.go
@@ -7,6 +7,7 @@ package model
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/project-radius/radius/pkg/azure/armauth"
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
@@ -60,17 +61,17 @@ func NewApplicationModel(arm *armauth.ArmConfig, k8s client.Client) (Application
 
 	radiusResourceModel := []RadiusResourceModel{
 		{
-			ResourceType: container.ResourceType,
+			ResourceType: strings.ToLower(container.ResourceType),
 			Renderer: &container.Renderer{
 				RoleAssignmentMap: roleAssignmentMap,
 			},
 		},
 		{
-			ResourceType: httproute.ResourceType,
+			ResourceType: strings.ToLower(httproute.ResourceType),
 			Renderer:     &httproute.Renderer{},
 		},
 		{
-			ResourceType: gateway.ResourceType,
+			ResourceType: strings.ToLower(gateway.ResourceType),
 			Renderer:     &gateway.Renderer{},
 		},
 	}

--- a/pkg/corerp/model/application_model.go
+++ b/pkg/corerp/model/application_model.go
@@ -7,7 +7,6 @@ package model
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/project-radius/radius/pkg/azure/armauth"
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
@@ -61,17 +60,17 @@ func NewApplicationModel(arm *armauth.ArmConfig, k8s client.Client) (Application
 
 	radiusResourceModel := []RadiusResourceModel{
 		{
-			ResourceType: strings.ToLower(container.ResourceType),
+			ResourceType: container.ResourceType,
 			Renderer: &container.Renderer{
 				RoleAssignmentMap: roleAssignmentMap,
 			},
 		},
 		{
-			ResourceType: strings.ToLower(httproute.ResourceType),
+			ResourceType: httproute.ResourceType,
 			Renderer:     &httproute.Renderer{},
 		},
 		{
-			ResourceType: strings.ToLower(gateway.ResourceType),
+			ResourceType: gateway.ResourceType,
 			Renderer:     &gateway.Renderer{},
 		},
 	}

--- a/pkg/corerp/model/types.go
+++ b/pkg/corerp/model/types.go
@@ -31,6 +31,7 @@ func (m ApplicationModel) GetOutputResources() []OutputResourceModel {
 	return m.outputResources
 }
 
+// LookupRadiusResourceModel is a case insensitive lookup for resourceType
 func (m ApplicationModel) LookupRadiusResourceModel(resourceType string) (*RadiusResourceModel, error) {
 	resource, ok := m.radiusResourceLookup[strings.ToLower(resourceType)]
 	if !ok {

--- a/pkg/corerp/model/types.go
+++ b/pkg/corerp/model/types.go
@@ -7,6 +7,7 @@ package model
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/project-radius/radius/pkg/corerp/handlers"
 	"github.com/project-radius/radius/pkg/corerp/renderers"
@@ -31,7 +32,7 @@ func (m ApplicationModel) GetOutputResources() []OutputResourceModel {
 }
 
 func (m ApplicationModel) LookupRadiusResourceModel(resourceType string) (*RadiusResourceModel, error) {
-	resource, ok := m.radiusResourceLookup[resourceType]
+	resource, ok := m.radiusResourceLookup[strings.ToLower(resourceType)]
 	if !ok {
 		return nil, fmt.Errorf("radius resource type '%s' is unsupported", resourceType)
 	}

--- a/pkg/corerp/model/types.go
+++ b/pkg/corerp/model/types.go
@@ -67,7 +67,7 @@ type OutputResourceModel struct {
 func NewModel(radiusResources []RadiusResourceModel, outputResources []OutputResourceModel, supportedProviders map[string]bool) ApplicationModel {
 	radiusResourceLookup := map[string]RadiusResourceModel{}
 	for _, radiusResource := range radiusResources {
-		radiusResourceLookup[radiusResource.ResourceType] = radiusResource
+		radiusResourceLookup[strings.ToLower(radiusResource.ResourceType)] = radiusResource
 	}
 
 	outputResourceLookup := map[resourcemodel.ResourceType]OutputResourceModel{}


### PR DESCRIPTION

# Description

Fix for issue #2796. Lowercasing RadiusResource lookup key on retrieval as well as in input initializing new application model.
To test locally, altered case in pkg/corerp/backend/deployment/testdata/containerresourcedatamodel.json and ran existing unit tests repeatedly.

#2796 

Please reference the issue this PR will close: #2796 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
