### PR TITLE
Integrate RedisCaches and RabbitMQMessageQueue ListSecrets controller with backend

### DIFF
--- a/pkg/connectorrp/frontend/controller/rediscaches/listsecretsrediscache.go
+++ b/pkg/connectorrp/frontend/controller/rediscaches/listsecretsrediscache.go
@@ -16,6 +16,7 @@ import (
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel/converter"
 	"github.com/project-radius/radius/pkg/connectorrp/frontend/deployment"
+	"github.com/project-radius/radius/pkg/connectorrp/renderers"
 	"github.com/project-radius/radius/pkg/radrp/rest"
 	"github.com/project-radius/radius/pkg/ucp/store"
 )
@@ -37,6 +38,8 @@ func (ctrl *ListSecretsRedisCache) Run(ctx context.Context, req *http.Request) (
 	sCtx := servicecontext.ARMRequestContextFromContext(ctx)
 
 	resource := &datamodel.RedisCache{}
+	// Request route for listsecrets has name of the operation as suffix which should be removed to get the resource id.
+	// route id format: subscriptions/<subscription_id>/resourceGroups/<resource_group>/providers/Applications.Connector/mongoDatabases/<resource_name>/listsecrets
 	parsedResourceID := sCtx.ResourceID.Truncate()
 	_, err := ctrl.GetResource(ctx, parsedResourceID.String(), resource)
 	if err != nil {
@@ -46,12 +49,16 @@ func (ctrl *ListSecretsRedisCache) Run(ctx context.Context, req *http.Request) (
 		return nil, err
 	}
 
-	// TODO integrate with deploymentprocessor
-	// output, err := ctrl.JobEngine.FetchSecrets(ctx, sCtx.ResourceID, resource)
-	// if err != nil {
-	// 	return nil, err
-	// }
+	secrets, err := ctrl.DeploymentProcessor.FetchSecrets(ctx, deployment.ResourceData{ID: sCtx.ResourceID, Resource: resource, OutputResources: resource.Properties.Status.OutputResources, ComputedValues: resource.ComputedValues, SecretValues: resource.SecretValues})
+	if err != nil {
+		return nil, err
+	}
 
-	versioned, _ := converter.RedisCacheSecretsDataModelToVersioned(&datamodel.RedisCacheSecrets{}, sCtx.APIVersion)
+	redisSecrets := datamodel.RedisCacheSecrets{
+		Password:         secrets[renderers.PasswordStringHolder].(string),
+		ConnectionString: secrets[renderers.ConnectionStringValue].(string),
+	}
+
+	versioned, _ := converter.RedisCacheSecretsDataModelToVersioned(&redisSecrets, sCtx.APIVersion)
 	return rest.NewOKResponse(versioned), nil
 }

--- a/pkg/connectorrp/frontend/controller/rediscaches/listsecretsrediscache_test.go
+++ b/pkg/connectorrp/frontend/controller/rediscaches/listsecretsrediscache_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/project-radius/radius/pkg/connectorrp/api/v20220315privatepreview"
+	"github.com/project-radius/radius/pkg/connectorrp/frontend/deployment"
+	"github.com/project-radius/radius/pkg/connectorrp/renderers"
 )
 
 func TestListSecrets_20220315PrivatePreview(t *testing.T) {
@@ -26,9 +28,14 @@ func TestListSecrets_20220315PrivatePreview(t *testing.T) {
 	defer mctrl.Finish()
 
 	mStorageClient := store.NewMockStorageClient(mctrl)
+	mDeploymentProcessor := deployment.NewMockDeploymentProcessor(mctrl)
 	ctx := context.Background()
 
 	_, redisDataModel, _ := getTestModels20220315privatepreview()
+	expectedSecrets := map[string]interface{}{
+		renderers.PasswordStringHolder:  "testPassword",
+		renderers.ConnectionStringValue: "test-connection-string",
+	}
 
 	t.Run("listSecrets non-existing resource", func(t *testing.T) {
 		w := httptest.NewRecorder()
@@ -42,7 +49,7 @@ func TestListSecrets_20220315PrivatePreview(t *testing.T) {
 				return nil, &store.ErrNotFound{}
 			})
 
-		ctl, err := NewListSecretsRedisCache(mStorageClient, nil, nil)
+		ctl, err := NewListSecretsRedisCache(mStorageClient, nil, mDeploymentProcessor)
 
 		require.NoError(t, err)
 		resp, err := ctl.Run(ctx, req)
@@ -65,8 +72,9 @@ func TestListSecrets_20220315PrivatePreview(t *testing.T) {
 					Data:     redisDataModel,
 				}, nil
 			})
+		mDeploymentProcessor.EXPECT().FetchSecrets(gomock.Any(), gomock.Any()).Times(1).Return(expectedSecrets, nil)
 
-		ctl, err := NewListSecretsRedisCache(mStorageClient, nil, nil)
+		ctl, err := NewListSecretsRedisCache(mStorageClient, nil, mDeploymentProcessor)
 
 		require.NoError(t, err)
 		resp, err := ctl.Run(ctx, req)
@@ -74,12 +82,11 @@ func TestListSecrets_20220315PrivatePreview(t *testing.T) {
 		_ = resp.Apply(ctx, w, req)
 		require.Equal(t, 200, w.Result().StatusCode)
 
-		actualOutput := &v20220315privatepreview.RedisCacheResource{}
+		actualOutput := &v20220315privatepreview.RedisCacheSecrets{}
 		_ = json.Unmarshal(w.Body.Bytes(), actualOutput)
 
-		// TODO update to expect secrets values after controller is integrated with backend.
-		// require.Equal(t, expectedOutput.Properties.Secrets, actualOutput)
-		require.Equal(t, &v20220315privatepreview.RedisCacheResource{}, actualOutput)
+		require.Equal(t, expectedSecrets[renderers.ConnectionStringValue], *actualOutput.ConnectionString)
+		require.Equal(t, expectedSecrets[renderers.PasswordStringHolder], *actualOutput.Password)
 	})
 
 	t.Run("listSecrets error retrieving resource", func(t *testing.T) {
@@ -93,7 +100,7 @@ func TestListSecrets_20220315PrivatePreview(t *testing.T) {
 				return nil, errors.New("failed to get the resource from data store")
 			})
 
-		ctl, err := NewListSecretsRedisCache(mStorageClient, nil, nil)
+		ctl, err := NewListSecretsRedisCache(mStorageClient, nil, mDeploymentProcessor)
 
 		require.NoError(t, err)
 		_, err = ctl.Run(ctx, req)

--- a/pkg/connectorrp/renderers/rabbitmqmessagequeues/renderer.go
+++ b/pkg/connectorrp/renderers/rabbitmqmessagequeues/renderer.go
@@ -52,7 +52,7 @@ func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface) (rende
 	return renderers.RendererOutput{
 		ComputedValues: values,
 		SecretValues: map[string]rp.SecretValueReference{
-			"connectionString": {
+			renderers.ConnectionStringValue: {
 				Value: properties.Secrets.ConnectionString,
 			},
 		},


### PR DESCRIPTION
# Description

Integrate RedisCaches and RabbitMQMessageQueue ListSecrets controller with deployment processor

## Issue reference

https://github.com/project-radius/core-team/issues/279
https://github.com/project-radius/core-team/issues/278

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
