### PR TITLE
Update input to be pointer instead of value to Render/GetDependency function

### DIFF
--- a/pkg/connectorrp/renderers/daprinvokehttproutes/renderer.go
+++ b/pkg/connectorrp/renderers/daprinvokehttproutes/renderer.go
@@ -20,7 +20,7 @@ type Renderer struct {
 }
 
 func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface) (renderers.RendererOutput, error) {
-	resource, ok := dm.(datamodel.DaprInvokeHttpRoute)
+	resource, ok := dm.(*datamodel.DaprInvokeHttpRoute)
 	if !ok {
 		return renderers.RendererOutput{}, conv.ErrInvalidModelConversion
 	}

--- a/pkg/connectorrp/renderers/daprinvokehttproutes/renderer_test.go
+++ b/pkg/connectorrp/renderers/daprinvokehttproutes/renderer_test.go
@@ -42,7 +42,7 @@ func Test_Render_Success(t *testing.T) {
 			AppId:       "test-appId",
 		},
 	}
-	output, err := renderer.Render(ctx, resource)
+	output, err := renderer.Render(ctx, &resource)
 	require.NoError(t, err)
 	require.NoError(t, err)
 

--- a/pkg/connectorrp/renderers/daprpubsubbrokers/renderer.go
+++ b/pkg/connectorrp/renderers/daprpubsubbrokers/renderer.go
@@ -37,7 +37,7 @@ type Properties struct {
 }
 
 func (r *Renderer) Render(ctx context.Context, dm conv.DataModelInterface) (renderers.RendererOutput, error) {
-	resource, ok := dm.(datamodel.DaprPubSubBroker)
+	resource, ok := dm.(*datamodel.DaprPubSubBroker)
 	if !ok {
 		return renderers.RendererOutput{}, conv.ErrInvalidModelConversion
 	}
@@ -61,5 +61,5 @@ func (r *Renderer) Render(ctx context.Context, dm conv.DataModelInterface) (rend
 		return renderers.RendererOutput{}, errors.New("the 'application' field must be a valid resource id")
 	}
 
-	return pubSubFunc(resource, applicationID.Name())
+	return pubSubFunc(*resource, applicationID.Name())
 }

--- a/pkg/connectorrp/renderers/daprpubsubbrokers/renderer_test.go
+++ b/pkg/connectorrp/renderers/daprpubsubbrokers/renderer_test.go
@@ -55,7 +55,7 @@ func Test_Render_Generic_Success(t *testing.T) {
 		},
 	}
 	renderer.PubSubs = SupportedPubSubKindValues
-	result, err := renderer.Render(context.Background(), resource)
+	result, err := renderer.Render(context.Background(), &resource)
 	require.NoError(t, err)
 	require.Len(t, result.Resources, 1)
 	output := result.Resources[0]
@@ -106,7 +106,7 @@ func Test_Render_Generic_MissingMetadata(t *testing.T) {
 		},
 	}
 	renderer.PubSubs = SupportedPubSubKindValues
-	_, err := renderer.Render(context.Background(), resource)
+	_, err := renderer.Render(context.Background(), &resource)
 	require.Error(t, err)
 	require.Equal(t, "No metadata specified for Dapr component of type pubsub.kafka", err.Error())
 }
@@ -132,7 +132,7 @@ func Test_Render_Generic_MissingType(t *testing.T) {
 		},
 	}
 	renderer.PubSubs = SupportedPubSubKindValues
-	_, err := renderer.Render(context.Background(), resource)
+	_, err := renderer.Render(context.Background(), &resource)
 	require.Error(t, err)
 	require.Equal(t, "No type specified for generic Dapr component", err.Error())
 }
@@ -158,7 +158,7 @@ func Test_Render_Generic_MissingVersion(t *testing.T) {
 		},
 	}
 	renderer.PubSubs = SupportedPubSubKindValues
-	_, err := renderer.Render(context.Background(), resource)
+	_, err := renderer.Render(context.Background(), &resource)
 	require.Error(t, err)
 	require.Equal(t, "No Dapr component version specified for generic Dapr component", err.Error())
 }
@@ -224,7 +224,7 @@ func Test_Render_DaprPubSubTopicAzureServiceBus_Success(t *testing.T) {
 		},
 	}
 	renderer.PubSubs = SupportedPubSubKindValues
-	result, err := renderer.Render(context.Background(), resource)
+	result, err := renderer.Render(context.Background(), &resource)
 	require.NoError(t, err)
 
 	require.Len(t, result.Resources, 1)
@@ -265,7 +265,7 @@ func Test_Render_DaprPubSubTopicAzureServiceBus_InvalidResourceType(t *testing.T
 		},
 	}
 	renderer.PubSubs = SupportedPubSubKindValues
-	_, err := renderer.Render(context.Background(), resource)
+	_, err := renderer.Render(context.Background(), &resource)
 	require.Error(t, err)
 	require.Equal(t, "the 'resource' field must refer to a ServiceBus Topic", err.Error())
 }

--- a/pkg/connectorrp/renderers/daprsecretstores/renderer.go
+++ b/pkg/connectorrp/renderers/daprsecretstores/renderer.go
@@ -36,7 +36,7 @@ type Renderer struct {
 }
 
 func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface) (renderers.RendererOutput, error) {
-	resource, ok := dm.(datamodel.DaprSecretStore)
+	resource, ok := dm.(*datamodel.DaprSecretStore)
 	if !ok {
 		return renderers.RendererOutput{}, conv.ErrInvalidModelConversion
 	}
@@ -52,7 +52,7 @@ func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface) (rende
 		return renderers.RendererOutput{}, errors.New("the 'application' field must be a valid resource id")
 	}
 
-	resoures, err := secretStoreFunc(resource, applicationID.Name())
+	resoures, err := secretStoreFunc(*resource, applicationID.Name())
 	if err != nil {
 		return renderers.RendererOutput{}, err
 	}

--- a/pkg/connectorrp/renderers/daprsecretstores/renderer_test.go
+++ b/pkg/connectorrp/renderers/daprsecretstores/renderer_test.go
@@ -59,7 +59,7 @@ func Test_Render_UnsupportedKind(t *testing.T) {
 		},
 	}
 
-	_, err := renderer.Render(ctx, resource)
+	_, err := renderer.Render(ctx, &resource)
 	require.Error(t, err)
 	require.Equal(t, fmt.Sprintf("azure.keyvault is not supported. Supported kind values: %s", getAlphabeticallySortedKeys(SupportedSecretStoreKindValues)), err.Error())
 }
@@ -85,7 +85,7 @@ func Test_Render_Generic_Success(t *testing.T) {
 		},
 	}
 
-	result, err := renderer.Render(ctx, resource)
+	result, err := renderer.Render(ctx, &resource)
 	require.NoError(t, err)
 
 	require.Len(t, result.Resources, 1)
@@ -142,7 +142,7 @@ func Test_Render_Generic_MissingMetadata(t *testing.T) {
 			Metadata:    map[string]interface{}{},
 		},
 	}
-	_, err := renderer.Render(ctx, resource)
+	_, err := renderer.Render(ctx, &resource)
 	require.Error(t, err)
 	require.Equal(t, "No metadata specified for Dapr component of type secretstores.kubernetes", err.Error())
 }
@@ -167,7 +167,7 @@ func Test_Render_Generic_MissingType(t *testing.T) {
 		},
 	}
 
-	_, err := renderer.Render(ctx, resource)
+	_, err := renderer.Render(ctx, &resource)
 	require.Error(t, err)
 	require.Equal(t, "No type specified for generic Dapr component", err.Error())
 }
@@ -192,7 +192,7 @@ func Test_Render_Generic_MissingVersion(t *testing.T) {
 		},
 	}
 
-	_, err := renderer.Render(ctx, resource)
+	_, err := renderer.Render(ctx, &resource)
 
 	require.Error(t, err)
 	require.Equal(t, "No Dapr component version specified for generic Dapr component", err.Error())

--- a/pkg/connectorrp/renderers/daprstatestores/renderer.go
+++ b/pkg/connectorrp/renderers/daprstatestores/renderer.go
@@ -34,7 +34,7 @@ type Renderer struct {
 }
 
 func (r *Renderer) Render(ctx context.Context, dm conv.DataModelInterface) (renderers.RendererOutput, error) {
-	resource, ok := dm.(datamodel.DaprStateStore)
+	resource, ok := dm.(*datamodel.DaprStateStore)
 	if !ok {
 		return renderers.RendererOutput{}, conv.ErrInvalidModelConversion
 	}
@@ -55,7 +55,7 @@ func (r *Renderer) Render(ctx context.Context, dm conv.DataModelInterface) (rend
 		return renderers.RendererOutput{}, errors.New("the 'application' field must be a valid resource id")
 	}
 
-	resoures, err := stateStoreFunc(resource, applicationID.Name())
+	resoures, err := stateStoreFunc(*resource, applicationID.Name())
 	if err != nil {
 		return renderers.RendererOutput{}, err
 	}

--- a/pkg/connectorrp/renderers/daprstatestores/renderer_test.go
+++ b/pkg/connectorrp/renderers/daprstatestores/renderer_test.go
@@ -50,7 +50,7 @@ func Test_Render_Success(t *testing.T) {
 		},
 	}
 	renderer.StateStores = SupportedStateStoreKindValues
-	result, err := renderer.Render(context.Background(), resource)
+	result, err := renderer.Render(context.Background(), &resource)
 	require.NoError(t, err)
 
 	require.Len(t, result.Resources, 1)
@@ -90,7 +90,7 @@ func Test_Render_InvalidResourceType(t *testing.T) {
 		},
 	}
 	renderer.StateStores = SupportedStateStoreKindValues
-	_, err := renderer.Render(context.Background(), resource)
+	_, err := renderer.Render(context.Background(), &resource)
 	require.Error(t, err)
 	require.Equal(t, "the 'resource' field must refer to a Storage Table", err.Error())
 }
@@ -111,7 +111,7 @@ func Test_Render_SpecifiesUmanagedWithoutResource(t *testing.T) {
 		},
 	}
 	renderer.StateStores = SupportedStateStoreKindValues
-	_, err := renderer.Render(context.Background(), resource)
+	_, err := renderer.Render(context.Background(), &resource)
 	require.Error(t, err)
 	require.Equal(t, renderers.ErrResourceMissingForResource.Error(), err.Error())
 }
@@ -134,7 +134,7 @@ func Test_Render_UnsupportedKind(t *testing.T) {
 		},
 	}
 	renderer.StateStores = SupportedStateStoreKindValues
-	_, err := renderer.Render(context.Background(), resource)
+	_, err := renderer.Render(context.Background(), &resource)
 	require.Error(t, err)
 	require.Equal(t, fmt.Sprintf("state.azure.cosmosdb is not supported. Supported kind values: %s", getAlphabeticallySortedKeys(SupportedStateStoreKindValues)), err.Error())
 }
@@ -161,7 +161,7 @@ func Test_Render_Generic_Success(t *testing.T) {
 		},
 	}
 	renderer.StateStores = SupportedStateStoreKindValues
-	result, err := renderer.Render(context.Background(), resource)
+	result, err := renderer.Render(context.Background(), &resource)
 	require.NoError(t, err)
 	require.Len(t, result.Resources, 1)
 	output := result.Resources[0]
@@ -213,7 +213,7 @@ func Test_Render_Generic_MissingMetadata(t *testing.T) {
 		},
 	}
 	renderer.StateStores = SupportedStateStoreKindValues
-	_, err := renderer.Render(context.Background(), resource)
+	_, err := renderer.Render(context.Background(), &resource)
 	require.Error(t, err)
 	require.Equal(t, "No metadata specified for Dapr component of type state.zookeeper", err.Error())
 }
@@ -239,7 +239,7 @@ func Test_Render_Generic_MissingType(t *testing.T) {
 		},
 	}
 	renderer.StateStores = SupportedStateStoreKindValues
-	_, err := renderer.Render(context.Background(), resource)
+	_, err := renderer.Render(context.Background(), &resource)
 	require.Error(t, err)
 	require.Equal(t, "No type specified for generic Dapr component", err.Error())
 }
@@ -265,7 +265,7 @@ func Test_Render_Generic_MissingVersion(t *testing.T) {
 		},
 	}
 	renderer.StateStores = SupportedStateStoreKindValues
-	_, err := renderer.Render(context.Background(), resource)
+	_, err := renderer.Render(context.Background(), &resource)
 
 	require.Error(t, err)
 	require.Equal(t, "No Dapr component version specified for generic Dapr component", err.Error())

--- a/pkg/connectorrp/renderers/extenders/renderer.go
+++ b/pkg/connectorrp/renderers/extenders/renderer.go
@@ -25,7 +25,7 @@ type Renderer struct {
 }
 
 func (r *Renderer) Render(ctx context.Context, dm conv.DataModelInterface) (renderers.RendererOutput, error) {
-	resource, ok := dm.(datamodel.Extender)
+	resource, ok := dm.(*datamodel.Extender)
 	if !ok {
 		return renderers.RendererOutput{}, conv.ErrInvalidModelConversion
 	}

--- a/pkg/connectorrp/renderers/extenders/renderer_test.go
+++ b/pkg/connectorrp/renderers/extenders/renderer_test.go
@@ -49,7 +49,7 @@ func Test_Render_Success(t *testing.T) {
 		},
 	}
 	renderer := Renderer{}
-	result, err := renderer.Render(ctx, resource)
+	result, err := renderer.Render(ctx, &resource)
 	require.NoError(t, err)
 
 	require.Equal(t, 0, len(result.Resources))

--- a/pkg/connectorrp/renderers/mongodatabases/renderer.go
+++ b/pkg/connectorrp/renderers/mongodatabases/renderer.go
@@ -33,7 +33,7 @@ type Renderer struct {
 }
 
 func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface) (renderers.RendererOutput, error) {
-	resource, ok := dm.(datamodel.MongoDatabase)
+	resource, ok := dm.(*datamodel.MongoDatabase)
 	if !ok {
 		return renderers.RendererOutput{}, conv.ErrInvalidModelConversion
 	}

--- a/pkg/connectorrp/renderers/mongodatabases/renderer_test.go
+++ b/pkg/connectorrp/renderers/mongodatabases/renderer_test.go
@@ -45,7 +45,7 @@ func Test_Render_Success(t *testing.T) {
 		},
 	}
 
-	output, err := renderer.Render(ctx, mongoDBResource)
+	output, err := renderer.Render(ctx, &mongoDBResource)
 	require.NoError(t, err)
 
 	require.Len(t, output.Resources, 2)

--- a/pkg/connectorrp/renderers/mongodatabases/renderer_test.go
+++ b/pkg/connectorrp/renderers/mongodatabases/renderer_test.go
@@ -106,7 +106,7 @@ func Test_Render_UserSpecifiedSecrets(t *testing.T) {
 		},
 	}
 
-	output, err := renderer.Render(ctx, mongoDBResource)
+	output, err := renderer.Render(ctx, &mongoDBResource)
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 0)
 
@@ -143,7 +143,7 @@ func Test_Render_NoResourceSpecified(t *testing.T) {
 		},
 	}
 
-	output, err := renderer.Render(ctx, mongoDBResource)
+	output, err := renderer.Render(ctx, &mongoDBResource)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(output.Resources))
 }
@@ -165,7 +165,7 @@ func Test_Render_InvalidResourceModel(t *testing.T) {
 		},
 	}
 
-	_, err := renderer.Render(ctx, mongoDBResource)
+	_, err := renderer.Render(ctx, &mongoDBResource)
 	require.Error(t, err)
 	require.Equal(t, "invalid model conversion", err.Error())
 }
@@ -189,7 +189,7 @@ func Test_Render_InvalidSourceResourceIdentifier(t *testing.T) {
 		},
 	}
 
-	_, err := renderer.Render(ctx, mongoDBResource)
+	_, err := renderer.Render(ctx, &mongoDBResource)
 	require.Error(t, err)
 	require.Equal(t, "the 'resource' field must be a valid resource id", err.Error())
 }
@@ -213,7 +213,7 @@ func Test_Render_InvalidResourceType(t *testing.T) {
 		},
 	}
 
-	_, err := renderer.Render(ctx, mongoDBResource)
+	_, err := renderer.Render(ctx, &mongoDBResource)
 	require.Error(t, err)
 	require.Equal(t, "the 'resource' field must refer to a CosmosDB Mongo Database", err.Error())
 }

--- a/pkg/connectorrp/renderers/rabbitmqmessagequeues/renderer.go
+++ b/pkg/connectorrp/renderers/rabbitmqmessagequeues/renderer.go
@@ -23,7 +23,7 @@ type Renderer struct {
 
 // Render creates the output resource for the rabbitmqmessagequeues resource.
 func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface) (renderers.RendererOutput, error) {
-	resource, ok := dm.(datamodel.RabbitMQMessageQueue)
+	resource, ok := dm.(*datamodel.RabbitMQMessageQueue)
 	if !ok {
 		return renderers.RendererOutput{}, conv.ErrInvalidModelConversion
 	}

--- a/pkg/connectorrp/renderers/rabbitmqmessagequeues/renderer_test.go
+++ b/pkg/connectorrp/renderers/rabbitmqmessagequeues/renderer_test.go
@@ -47,7 +47,7 @@ func Test_Render_User_Secrets(t *testing.T) {
 		},
 	}
 
-	output, err := renderer.Render(ctx, resource)
+	output, err := renderer.Render(ctx, &resource)
 	require.NoError(t, err)
 
 	require.Len(t, output.Resources, 0)
@@ -85,7 +85,7 @@ func Test_Render_NoQueueSpecified(t *testing.T) {
 			Secrets: datamodel.RabbitMQSecrets{ConnectionString: "admin:deadbeef@localhost:42"},
 		},
 	}
-	_, err := renderer.Render(ctx, resource)
+	_, err := renderer.Render(ctx, &resource)
 	require.Error(t, err)
 	require.Equal(t, "queue name must be specified", err.Error())
 }

--- a/pkg/connectorrp/renderers/rediscaches/renderer.go
+++ b/pkg/connectorrp/renderers/rediscaches/renderer.go
@@ -28,7 +28,7 @@ type Renderer struct {
 }
 
 func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface) (renderers.RendererOutput, error) {
-	resource, ok := dm.(datamodel.RedisCache)
+	resource, ok := dm.(*datamodel.RedisCache)
 	if !ok {
 		return renderers.RendererOutput{}, conv.ErrInvalidModelConversion
 	}

--- a/pkg/connectorrp/renderers/rediscaches/renderer_test.go
+++ b/pkg/connectorrp/renderers/rediscaches/renderer_test.go
@@ -45,7 +45,7 @@ func Test_Render_Success(t *testing.T) {
 		},
 	}
 
-	output, err := renderer.Render(ctx, redisResource)
+	output, err := renderer.Render(ctx, &redisResource)
 	require.NoError(t, err)
 
 	require.Len(t, output.Resources, 1)
@@ -101,7 +101,7 @@ func Test_Render_UserSpecifiedSecrets(t *testing.T) {
 		},
 	}
 
-	output, err := renderer.Render(ctx, redisResource)
+	output, err := renderer.Render(ctx, &redisResource)
 	require.NoError(t, err)
 	require.Len(t, output.Resources, 0)
 
@@ -143,7 +143,7 @@ func Test_Render_NoResourceSpecified(t *testing.T) {
 		},
 	}
 
-	output, err := renderer.Render(ctx, redisResource)
+	output, err := renderer.Render(ctx, &redisResource)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(output.Resources))
 }
@@ -189,7 +189,7 @@ func Test_Render_InvalidSourceResourceIdentifier(t *testing.T) {
 		},
 	}
 
-	_, err := renderer.Render(ctx, redisResource)
+	_, err := renderer.Render(ctx, &redisResource)
 	require.Error(t, err)
 	require.Equal(t, "the 'resource' field must be a valid resource id", err.Error())
 }
@@ -213,7 +213,7 @@ func Test_Render_InvalidResourceType(t *testing.T) {
 		},
 	}
 
-	_, err := renderer.Render(ctx, redisResource)
+	_, err := renderer.Render(ctx, &redisResource)
 	require.Error(t, err)
 	require.Equal(t, "the 'resource' field must refer to a Redis Cache", err.Error())
 }

--- a/pkg/connectorrp/renderers/sqldatabases/renderer.go
+++ b/pkg/connectorrp/renderers/sqldatabases/renderer.go
@@ -34,7 +34,7 @@ type Renderer struct {
 
 // Render creates the output resource for the sqlDatabase resource.
 func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface) (renderers.RendererOutput, error) {
-	resource, ok := dm.(datamodel.SqlDatabase)
+	resource, ok := dm.(*datamodel.SqlDatabase)
 	if !ok {
 		return renderers.RendererOutput{}, conv.ErrInvalidModelConversion
 	}

--- a/pkg/connectorrp/renderers/sqldatabases/renderer_test.go
+++ b/pkg/connectorrp/renderers/sqldatabases/renderer_test.go
@@ -49,7 +49,7 @@ func Test_Render_Success(t *testing.T) {
 		},
 	}
 
-	output, err := renderer.Render(ctx, resource)
+	output, err := renderer.Render(ctx, &resource)
 	require.NoError(t, err)
 
 	require.Len(t, output.Resources, 2)
@@ -106,7 +106,7 @@ func Test_Render_MissingResource(t *testing.T) {
 		},
 	}
 
-	_, err := renderer.Render(ctx, resource)
+	_, err := renderer.Render(ctx, &resource)
 	require.Error(t, err)
 	require.Equal(t, renderers.ErrorResourceOrServerNameMissingFromResource.Error(), err.Error())
 }
@@ -127,7 +127,7 @@ func Test_Render_InvalidResourceType(t *testing.T) {
 		},
 	}
 
-	_, err := renderer.Render(ctx, resource)
+	_, err := renderer.Render(ctx, &resource)
 	require.Error(t, err)
 	require.Equal(t, "the 'resource' field must refer to a SQL Database", err.Error())
 }

--- a/pkg/corerp/backend/controller/containers/createcontainer.go
+++ b/pkg/corerp/backend/controller/containers/createcontainer.go
@@ -39,7 +39,7 @@ func (c *UpdateContainer) Run(ctx context.Context, request *ctrl.Request) (ctrl.
 	}
 
 	// Render the resource
-	rendererOutput, err := c.DeploymentProcessor().Render(ctx, id, existingResource)
+	rendererOutput, err := c.DeploymentProcessor().Render(ctx, id, *existingResource)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/corerp/backend/controller/containers/createcontainer.go
+++ b/pkg/corerp/backend/controller/containers/createcontainer.go
@@ -39,7 +39,7 @@ func (c *UpdateContainer) Run(ctx context.Context, request *ctrl.Request) (ctrl.
 	}
 
 	// Render the resource
-	rendererOutput, err := c.DeploymentProcessor().Render(ctx, id, *existingResource)
+	rendererOutput, err := c.DeploymentProcessor().Render(ctx, id, existingResource)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -54,7 +54,7 @@ type Renderer struct {
 }
 
 func (r Renderer) GetDependencyIDs(ctx context.Context, dm conv.DataModelInterface) (radiusResourceIDs []resources.ID, azureResourceIDs []resources.ID, err error) {
-	resource, ok := dm.(datamodel.ContainerResource)
+	resource, ok := dm.(*datamodel.ContainerResource)
 	if !ok {
 		return nil, nil, conv.ErrInvalidModelConversion
 	}
@@ -108,7 +108,7 @@ func (r Renderer) GetDependencyIDs(ctx context.Context, dm conv.DataModelInterfa
 
 // Render is the WorkloadRenderer implementation for containerized workload.
 func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface, options renderers.RenderOptions) (renderers.RendererOutput, error) {
-	resource, ok := dm.(datamodel.ContainerResource)
+	resource, ok := dm.(*datamodel.ContainerResource)
 	if !ok {
 		return renderers.RendererOutput{}, conv.ErrInvalidModelConversion
 	}
@@ -123,7 +123,7 @@ func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface, option
 	applicationName := appId.Name()
 
 	// Create the deployment as the primary workload
-	deploymentOutputResources, secretData, err := r.makeDeployment(ctx, resource, applicationName, renderers.RenderOptions{Dependencies: dependencies})
+	deploymentOutputResources, secretData, err := r.makeDeployment(ctx, *resource, applicationName, renderers.RenderOptions{Dependencies: dependencies})
 	if err != nil {
 		return renderers.RendererOutput{}, err
 	}
@@ -133,7 +133,7 @@ func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface, option
 	// If there are secrets we'll use a Kubernetes secret to hold them. This is already referenced
 	// by the deployment.
 	if len(secretData) > 0 {
-		outputResources = append(outputResources, r.makeSecret(ctx, resource, applicationName, secretData))
+		outputResources = append(outputResources, r.makeSecret(ctx, *resource, applicationName, secretData))
 	}
 
 	// Connections might require a role assignment to grant access.
@@ -154,8 +154,8 @@ func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface, option
 	// If we created role assigmments then we will need an identity and the mapping of the identity to AKS.
 	if len(roles) > 0 {
 		outputResources = append(outputResources, roles...)
-		outputResources = append(outputResources, r.makeManagedIdentity(ctx, resource, applicationName))
-		outputResources = append(outputResources, r.makePodIdentity(ctx, resource, applicationName, roles))
+		outputResources = append(outputResources, r.makeManagedIdentity(ctx, *resource, applicationName))
+		outputResources = append(outputResources, r.makePodIdentity(ctx, *resource, applicationName, roles))
 	}
 
 	return renderers.RendererOutput{Resources: outputResources}, nil

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -48,7 +48,7 @@ func createContext(t *testing.T) context.Context {
 	return logr.NewContext(context.Background(), logger)
 }
 
-func makeResource(t *testing.T, properties datamodel.ContainerProperties) datamodel.ContainerResource {
+func makeResource(t *testing.T, properties datamodel.ContainerProperties) *datamodel.ContainerResource {
 	resource := datamodel.ContainerResource{
 		TrackedResource: apiv1.TrackedResource{
 			ID:   "/subscriptions/test-sub-id/resourceGroups/test-group/providers/Applications.Core/containers/test-container",
@@ -57,7 +57,7 @@ func makeResource(t *testing.T, properties datamodel.ContainerProperties) datamo
 		},
 		Properties: properties,
 	}
-	return resource
+	return &resource
 }
 
 func makeResourceID(t *testing.T, resourceType string, resourceName string) resources.ID {

--- a/pkg/corerp/renderers/daprextension/renderer.go
+++ b/pkg/corerp/renderers/daprextension/renderer.go
@@ -57,7 +57,7 @@ func (r Renderer) GetDependencyIDs(ctx context.Context, dm conv.DataModelInterfa
 
 // Render augments the container's kubernetes output resource with value for dapr sidecar extension.
 func (r *Renderer) Render(ctx context.Context, dm conv.DataModelInterface, options renderers.RenderOptions) (renderers.RendererOutput, error) {
-	resource, ok := dm.(datamodel.ContainerResource)
+	resource, ok := dm.(*datamodel.ContainerResource)
 	if !ok {
 		return renderers.RendererOutput{}, conv.ErrInvalidModelConversion
 	}
@@ -127,7 +127,7 @@ func (r *Renderer) Render(ctx context.Context, dm conv.DataModelInterface, optio
 }
 
 func (r *Renderer) findExtension(dm conv.DataModelInterface) (*datamodel.DaprSidecarExtension, error) {
-	container, ok := dm.(datamodel.ContainerResource)
+	container, ok := dm.(*datamodel.ContainerResource)
 	if !ok {
 		return nil, conv.ErrInvalidModelConversion
 	}

--- a/pkg/corerp/renderers/daprextension/renderer_test.go
+++ b/pkg/corerp/renderers/daprextension/renderer_test.go
@@ -170,7 +170,7 @@ func Test_Render_Fail_AppIDFromRouteConflict(t *testing.T) {
 	require.Equal(t, "the appId specified on a daprInvokeHttpRoutes must match the appId specified on the extension. Route: \"routeappId\", Extension: \"testappId\"", err.Error())
 }
 
-func makeresource(t *testing.T, properties datamodel.ContainerProperties) datamodel.ContainerResource {
+func makeresource(t *testing.T, properties datamodel.ContainerProperties) *datamodel.ContainerResource {
 	resource := datamodel.ContainerResource{
 		TrackedResource: apiv1.TrackedResource{
 			ID:   "/subscriptions/test-sub-id/resourceGroups/test-group/providers/Applications.Core/containers/test-container",
@@ -179,5 +179,5 @@ func makeresource(t *testing.T, properties datamodel.ContainerProperties) datamo
 		},
 		Properties: properties,
 	}
-	return resource
+	return &resource
 }

--- a/pkg/corerp/renderers/gateway/render.go
+++ b/pkg/corerp/renderers/gateway/render.go
@@ -31,7 +31,7 @@ type Renderer struct {
 // GetDependencyIDs fetches all the httproutes used by the gateway
 func (r Renderer) GetDependencyIDs(ctx context.Context, dm conv.DataModelInterface) (radiusResourceIDs []resources.ID, azureResourceIDs []resources.ID, err error) {
 	// Need all httproutes that are used by this gateway
-	gateway, ok := dm.(datamodel.Gateway)
+	gateway, ok := dm.(*datamodel.Gateway)
 	if !ok {
 		return nil, nil, conv.ErrInvalidModelConversion
 	}
@@ -52,7 +52,7 @@ func (r Renderer) GetDependencyIDs(ctx context.Context, dm conv.DataModelInterfa
 // Render creates the kubernetes output resource for the gateway and its dependency - httproute
 func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface, options renderers.RenderOptions) (renderers.RendererOutput, error) {
 	outputResources := []outputresource.OutputResource{}
-	gateway, ok := dm.(datamodel.Gateway)
+	gateway, ok := dm.(*datamodel.Gateway)
 	if !ok {
 		return renderers.RendererOutput{}, conv.ErrInvalidModelConversion
 	}
@@ -62,11 +62,11 @@ func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface, option
 	}
 	applicationName := appId.Name()
 	gatewayName := kubernetes.MakeResourceName(applicationName, gateway.Name)
-	hostname, err := getHostname(gateway, &gateway.Properties, applicationName, options)
+	hostname, err := getHostname(*gateway, &gateway.Properties, applicationName, options)
 	if err != nil {
 		return renderers.RendererOutput{}, fmt.Errorf("getting hostname failed with error: %s", err)
 	}
-	gatewayObject, err := MakeGateway(options, &gateway, gateway.Name, applicationName, hostname)
+	gatewayObject, err := MakeGateway(options, gateway, gateway.Name, applicationName, hostname)
 	if err != nil {
 		return renderers.RendererOutput{}, err
 	}
@@ -88,7 +88,7 @@ func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface, option
 		},
 	}
 
-	httpRouteObjects, err := MakeHttpRoutes(options, gateway, &gateway.Properties, gatewayName, applicationName)
+	httpRouteObjects, err := MakeHttpRoutes(options, *gateway, &gateway.Properties, gatewayName, applicationName)
 	if err != nil {
 		return renderers.RendererOutput{}, err
 	}

--- a/pkg/corerp/renderers/gateway/render_test.go
+++ b/pkg/corerp/renderers/gateway/render_test.go
@@ -694,8 +694,8 @@ func makeRouteResourceID(routeName string) string {
 		})
 }
 
-func makeResource(t *testing.T, properties datamodel.GatewayProperties) datamodel.Gateway {
-	return datamodel.Gateway{
+func makeResource(t *testing.T, properties datamodel.GatewayProperties) *datamodel.Gateway {
+	return &datamodel.Gateway{
 		TrackedResource: apiv1.TrackedResource{
 			ID:   "/subscriptions/test-sub-id/resourceGroups/test-group/providers/Applications.Core/gateways/test-gateway",
 			Name: resourceName,
@@ -704,11 +704,11 @@ func makeResource(t *testing.T, properties datamodel.GatewayProperties) datamode
 		Properties: properties,
 	}
 }
-func makeDependentResource(t *testing.T, properties datamodel.HTTPRouteProperties) datamodel.HTTPRoute {
+func makeDependentResource(t *testing.T, properties datamodel.HTTPRouteProperties) *datamodel.HTTPRoute {
 	dm := datamodel.HTTPRoute{Properties: &properties}
 	dm.Name = resourceName
 
-	return dm
+	return &dm
 }
 func makeResourceID(t *testing.T, resourceID string) resources.ID {
 	id, err := resources.Parse(resourceID)

--- a/pkg/corerp/renderers/httproute/render.go
+++ b/pkg/corerp/renderers/httproute/render.go
@@ -32,7 +32,7 @@ func (r Renderer) GetDependencyIDs(ctx context.Context, resource conv.DataModelI
 
 func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface, options renderers.RenderOptions) (renderers.RendererOutput, error) {
 
-	route, ok := dm.(datamodel.HTTPRoute)
+	route, ok := dm.(*datamodel.HTTPRoute)
 	if !ok {
 		return renderers.RendererOutput{}, conv.ErrInvalidModelConversion
 	}
@@ -65,7 +65,7 @@ func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface, option
 		},
 	}
 
-	service, err := r.makeService(&route, options)
+	service, err := r.makeService(route, options)
 	if err != nil {
 		return renderers.RendererOutput{}, err
 	}

--- a/pkg/corerp/renderers/httproute/render_test.go
+++ b/pkg/corerp/renderers/httproute/render_test.go
@@ -194,10 +194,10 @@ func makeHTTPRouteProperties(port int32) datamodel.HTTPRouteProperties {
 	return properties
 }
 
-func makeResource(t *testing.T, properties *datamodel.HTTPRouteProperties) datamodel.HTTPRoute {
+func makeResource(t *testing.T, properties *datamodel.HTTPRouteProperties) *datamodel.HTTPRoute {
 
 	dm := datamodel.HTTPRoute{Properties: properties}
 	dm.Name = resourceName
 
-	return dm
+	return &dm
 }

--- a/pkg/corerp/renderers/manualscale/render.go
+++ b/pkg/corerp/renderers/manualscale/render.go
@@ -37,7 +37,7 @@ func (r *Renderer) Render(ctx context.Context, dm conv.DataModelInterface, optio
 		return renderers.RendererOutput{}, err
 	}
 
-	resource, ok := dm.(datamodel.ContainerResource)
+	resource, ok := dm.(*datamodel.ContainerResource)
 	if !ok {
 		return renderers.RendererOutput{}, conv.ErrInvalidModelConversion
 	}

--- a/pkg/corerp/renderers/manualscale/render_test.go
+++ b/pkg/corerp/renderers/manualscale/render_test.go
@@ -104,7 +104,7 @@ func Test_Render_NoExtension(t *testing.T) {
 	require.Nil(t, deployment.Spec.Replicas)
 }
 
-func makeResource(t *testing.T, properties datamodel.ContainerProperties) datamodel.ContainerResource {
+func makeResource(t *testing.T, properties datamodel.ContainerProperties) *datamodel.ContainerResource {
 	resource := datamodel.ContainerResource{
 		TrackedResource: apiv1.TrackedResource{
 			ID:   "/subscriptions/test-sub-id/resourceGroups/test-group/providers/Applications.Core/containers/test-container",
@@ -113,7 +113,7 @@ func makeResource(t *testing.T, properties datamodel.ContainerProperties) datamo
 		},
 		Properties: properties,
 	}
-	return resource
+	return &resource
 }
 
 func makeProperties(t *testing.T, replicas *int32) datamodel.ContainerProperties {


### PR DESCRIPTION
# Description

Update input for DataModelInterface to be value instead of pointer to datamodel.ContainerResource when calling Render function

#2798


Please reference the issue this PR will close: #2798 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
