### PR TITLE
Add queue provider to cloud config

### DIFF
--- a/cmd/appcore-rp/radius-cloud.yaml
+++ b/cmd/appcore-rp/radius-cloud.yaml
@@ -17,6 +17,8 @@ storageProvider:
     database: applicationscore
     # Set primary key to in this configuration or to RADIUS_STORAGEPROVIDER_COSMOSDB_MASTERKEY environment variable
     masterKey: set-me-in-a-different-way
+queueProvider:
+  provider: inmemory
 server:
   host: "0.0.0.0"
   port: 8080


### PR DESCRIPTION
# Description

Queue client creation will fail if there is no queue provider in the configs.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
