### PR TITLE
add fix to remove environment from config.yaml once deleted from server

### DIFF
--- a/cmd/rad/cmd/envDelete.go
+++ b/cmd/rad/cmd/envDelete.go
@@ -73,9 +73,17 @@ func deleteEnvResource(cmd *cobra.Command, args []string) error {
 		err = client.DeleteEnv(cmd.Context(), envName)
 		if err == nil {
 			output.LogInfo("Environment deleted")
+		} else {
+			return err
+		}
+
+		// Delete env from the config, update default env if needed
+		err = deleteEnvFromConfig(cmd.Context(), config, env.GetName())
+		if err == nil {
+			output.LogInfo("Environment removed from config.yaml")
+
 		}
 		return err
-
 	} else {
 		return deleteEnvLegacy(cmd, args)
 	}


### PR DESCRIPTION
# Description

rad delete was missing to delete the env entry from config.yaml after cleaning it up in the server. 
Added the config.yaml cleanup functionality.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
