### PR TITLE
Fix invalid operation status id generation

### DIFF
--- a/pkg/armrpc/asyncoperation/statusmanager/mock_statusmanager.go
+++ b/pkg/armrpc/asyncoperation/statusmanager/mock_statusmanager.go
@@ -14,6 +14,7 @@ import (
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	servicecontext "github.com/project-radius/radius/pkg/armrpc/servicecontext"
 	armerrors "github.com/project-radius/radius/pkg/radrp/armerrors"
+	resources "github.com/project-radius/radius/pkg/ucp/resources"
 )
 
 // MockStatusManager is a mock of StatusManager interface.
@@ -40,7 +41,7 @@ func (m *MockStatusManager) EXPECT() *MockStatusManagerMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockStatusManager) Delete(arg0 context.Context, arg1 string, arg2 uuid.UUID) error {
+func (m *MockStatusManager) Delete(arg0 context.Context, arg1 resources.ID, arg2 uuid.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -54,7 +55,7 @@ func (mr *MockStatusManagerMockRecorder) Delete(arg0, arg1, arg2 interface{}) *g
 }
 
 // Get mocks base method.
-func (m *MockStatusManager) Get(arg0 context.Context, arg1 string, arg2 uuid.UUID) (*Status, error) {
+func (m *MockStatusManager) Get(arg0 context.Context, arg1 resources.ID, arg2 uuid.UUID) (*Status, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*Status)
@@ -83,7 +84,7 @@ func (mr *MockStatusManagerMockRecorder) QueueAsyncOperation(arg0, arg1, arg2 in
 }
 
 // Update mocks base method.
-func (m *MockStatusManager) Update(arg0 context.Context, arg1 string, arg2 uuid.UUID, arg3 v1.ProvisioningState, arg4 *time.Time, arg5 *armerrors.ErrorDetails) error {
+func (m *MockStatusManager) Update(arg0 context.Context, arg1 resources.ID, arg2 uuid.UUID, arg3 v1.ProvisioningState, arg4 *time.Time, arg5 *armerrors.ErrorDetails) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)

--- a/pkg/armrpc/asyncoperation/statusmanager/statusmanager.go
+++ b/pkg/armrpc/asyncoperation/statusmanager/statusmanager.go
@@ -55,12 +55,8 @@ func New(storeClient store.StorageClient, q queue.Client, providerName, location
 
 // operationStatusResourceID function is to build the operationStatus resourceID.
 func (aom *statusManager) operationStatusResourceID(id resources.ID, operationID uuid.UUID) string {
-	prefix := ""
-	if id.IsUCPQualfied() {
-		prefix = "/planes"
-	}
-	scope := id.ScopeSegments()[0]
-	return fmt.Sprintf("%s/%s/%s/providers/%s/locations/%s/operationstatuses/%s", prefix, scope.Type, scope.Name, aom.providerName, aom.location, operationID)
+	prefix := id.PlaneScope()
+	return fmt.Sprintf("%s/providers/%s/locations/%s/operationstatuses/%s", prefix, aom.providerName, aom.location, operationID)
 }
 
 func (aom *statusManager) QueueAsyncOperation(ctx context.Context, sCtx *servicecontext.ARMRequestContext, operationTimeout time.Duration) error {

--- a/pkg/armrpc/asyncoperation/statusmanager/statusmanager.go
+++ b/pkg/armrpc/asyncoperation/statusmanager/statusmanager.go
@@ -55,8 +55,7 @@ func New(storeClient store.StorageClient, q queue.Client, providerName, location
 
 // operationStatusResourceID function is to build the operationStatus resourceID.
 func (aom *statusManager) operationStatusResourceID(id resources.ID, operationID uuid.UUID) string {
-	prefix := id.PlaneScope()
-	return fmt.Sprintf("%s/providers/%s/locations/%s/operationstatuses/%s", prefix, aom.providerName, aom.location, operationID)
+	return fmt.Sprintf("%s/providers/%s/locations/%s/operationstatuses/%s", id.PlaneScope(), aom.providerName, aom.location, operationID)
 }
 
 func (aom *statusManager) QueueAsyncOperation(ctx context.Context, sCtx *servicecontext.ARMRequestContext, operationTimeout time.Duration) error {

--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -271,7 +271,7 @@ func (w *AsyncRequestProcessWorker) updateResourceAndOperationStatus(ctx context
 	}
 
 	now := time.Now().UTC()
-	err = w.sm.Update(ctx, rID.RootScope(), operationID, state, &now, opErr)
+	err = w.sm.Update(ctx, rID, operationID, state, &now, opErr)
 	if err != nil {
 		logger.Error(err, "failed to update operationstatus", "OperationID", operationID.String())
 		return err
@@ -286,7 +286,7 @@ func (w *AsyncRequestProcessWorker) isDuplicated(ctx context.Context, sc store.S
 		return false, err
 	}
 
-	status, err := w.sm.Get(ctx, rID.RootScope(), operationID)
+	status, err := w.sm.Get(ctx, rID, operationID)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/ucp/resources/id.go
+++ b/pkg/ucp/resources/id.go
@@ -126,6 +126,31 @@ func (ri ID) RootScope() string {
 	return SegmentSeparator + joined
 }
 
+// PlaneScope returns plane or subscription scope without resourceGroup
+//
+// Examples:
+//	/subscriptions/{guid}
+//	/planes/radius/local
+func (ri ID) PlaneScope() string {
+	segments := []string{}
+	for _, t := range ri.scopeSegments {
+		if !strings.EqualFold(t.Type, ResourceGroupsSegment) {
+			segments = append(segments, t.Type)
+			if t.Name != "" {
+				segments = append(segments, t.Name)
+			}
+			break
+		}
+	}
+
+	joined := strings.Join(segments, SegmentSeparator)
+	if ri.IsUCPQualfied() {
+		return SegmentSeparator + PlanesSegment + SegmentSeparator + joined
+	}
+
+	return SegmentSeparator + joined
+}
+
 // ProviderNamespace returns the providers part of the ID
 //
 // Examples:

--- a/pkg/ucp/resources/id_test.go
+++ b/pkg/ucp/resources/id_test.go
@@ -465,6 +465,38 @@ func Test_IdParsing_WithNoTypeSegments(t *testing.T) {
 	require.Equal(t, "", routingScope)
 }
 
+func TestPlaneScope(t *testing.T) {
+	tests := []struct {
+		desc       string
+		id         string
+		planeScope string
+	}{
+		{
+			desc:       "Azure resource id",
+			id:         "/subscriptions/s1/resourceGroups/r1/providers/Applications.Core/applications/cool-app",
+			planeScope: "/subscriptions/s1",
+		},
+		{
+			desc:       "UCP resource id",
+			id:         "/planes/radius/local/resourceGroups/r1/providers/Applications.Core/applications/cool-app",
+			planeScope: "/planes/radius/local",
+		},
+		{
+			desc:       "No subscription or plane level types",
+			id:         "/resourceGroups/r1/providers/Applications.Core/applications/cool-app",
+			planeScope: "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			rID, err := Parse(tt.id)
+			require.NoError(t, err)
+			require.Equal(t, tt.planeScope, rID.PlaneScope())
+		})
+	}
+}
+
 func TestPlaneNamespace(t *testing.T) {
 	tests := []struct {
 		desc     string


### PR DESCRIPTION
# Description

OperationStatus ID is subscription-level resource id, but statusamanger generates an operation status id which includes resourceGroups segment. This is the fix to generate subscription-level resource id.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: radius-project/core-team#702

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
