### PR TITLE
Make role optional for Azure connections

### DIFF
--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -636,9 +636,6 @@ func (r Renderer) makeRoleAssignmentsForResource(ctx context.Context, connection
 	var roleNames []string
 	var armResourceIdentifier string
 	if connection.IAM.Kind.IsKind(datamodel.KindAzure) {
-		if len(connection.IAM.Roles) < 1 {
-			return nil, fmt.Errorf("rbac permissions are required to access Azure connections")
-		}
 		roleNames = append(roleNames, connection.IAM.Roles...)
 		armResourceIdentifier = connection.Source
 	} else {

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -684,7 +684,7 @@ func Test_Render_AzureConnection(t *testing.T) {
 	require.Len(t, outputResource, 1)
 }
 
-func Test_Render_AzureConnectionMissingRoleError(t *testing.T) {
+func Test_Render_AzureConnectionEmptyRoleAllowed(t *testing.T) {
 	testARMID := makeResourceID(t, "ResourceType", "test-azure-resource").String()
 	properties := datamodel.ContainerProperties{
 		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
@@ -709,8 +709,7 @@ func Test_Render_AzureConnectionMissingRoleError(t *testing.T) {
 		},
 	}
 	_, err := renderer.Render(createContext(t), resource, renderers.RenderOptions{Dependencies: dependencies})
-	require.Error(t, err)
-	require.Equal(t, "rbac permissions are required to access Azure connections", err.Error())
+	require.NoError(t, err)
 }
 
 func Test_Render_EphemeralVolumes(t *testing.T) {


### PR DESCRIPTION
# Description

Role names are optional for azure connections: https://github.com/project-radius/radius/issues/1989

## Issue reference

https://github.com/project-radius/radius/issues/1989

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
