### PR TITLE
[WIP] Streamline configuration options loading

### DIFF
--- a/cmd/appcore-rp/radius-dev.yaml
+++ b/cmd/appcore-rp/radius-dev.yaml
@@ -2,6 +2,12 @@
 environment:
   name: Dev
   roleLocation: "global"
+azureAd:
+  clientId: appid
+  tenantId: tenantId
+  clientSecret: secret
+kubernetes:
+  environment: local
 storageProvider:
   provider: "etcd"
   etcd:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v56.3.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0
+	github.com/Azure/azure-sdk-for-go/sdk/to v0.1.5
 	github.com/Azure/go-autorest/autorest v0.11.20
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.7
 	github.com/Azure/go-autorest/autorest/azure/cli v0.4.4
@@ -31,6 +32,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gosuri/uilive v0.0.4
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/marstr/randname v0.0.0-20181206212954-d5b0f288ab8c
 	github.com/mattn/go-isatty v0.0.14
 	github.com/mitchellh/go-homedir v1.1.0
@@ -71,7 +73,6 @@ require (
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/to v0.1.5 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -996,6 +996,8 @@ github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaR
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
 github.com/karrick/godirwalk v1.15.8 h1:7+rWAZPn9zuRxaIqqT8Ohs2Q2Ac0msBqwRdxNCr2VVs=
 github.com/karrick/godirwalk v1.15.8/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -2499,7 +2501,6 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.19/go.mod h1:LEScyz
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.25/go.mod h1:Mlj9PNLmG9bZ6BHFwFKDo5afkpWyUISkb9Me0GnK66I=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.27/go.mod h1:tq2nT0Kx7W+/f2JVE+zxYtUhdjuELJkVpNz+x/QN5R4=
 sigs.k8s.io/controller-runtime v0.8.3/go.mod h1:U/l+DUopBc1ecfRZ5aviA9JDmGFQKvLf5YkZNx2e0sU=
-sigs.k8s.io/controller-runtime v0.9.0/go.mod h1:TgkfvrhhEw3PlI0BRL/5xM+89y3/yc0ZDfdbTl84si8=
 sigs.k8s.io/controller-runtime v0.9.2/go.mod h1:TxzMCHyEUpaeuOiZx/bIdc2T81vfs/aKdvJt9wuu0zk=
 sigs.k8s.io/controller-runtime v0.9.6/go.mod h1:q6PpkM5vqQubEKUKOM6qr06oXGzOBcCby1DA9FbyZeA=
 sigs.k8s.io/controller-runtime v0.11.0 h1:DqO+c8mywcZLFJWILq4iktoECTyn30Bkj0CwgqMpZWQ=

--- a/pkg/armrpc/frontend/controller/controller.go
+++ b/pkg/armrpc/frontend/controller/controller.go
@@ -162,7 +162,7 @@ func BuildTrackedResource(ctx context.Context) v1.TrackedResource {
 		ID:       requestCtx.ResourceID.String(),
 		Name:     requestCtx.ResourceID.Name(),
 		Type:     requestCtx.ResourceID.Type(),
-		Location: serviceOpt.Env.RoleLocation,
+		Location: serviceOpt.Environment.RoleLocation,
 	}
 
 	return trackedResource

--- a/pkg/armrpc/frontend/server/service.go
+++ b/pkg/armrpc/frontend/server/service.go
@@ -58,18 +58,21 @@ func (s *Service) Init(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	s.OperationStatusManager = manager.New(opSC, reqQueueClient, s.ProviderName, s.Options.Config.Env.RoleLocation)
+	s.OperationStatusManager = manager.New(opSC, reqQueueClient, s.ProviderName, s.Options.Config.Environment.RoleLocation)
 
-	scheme := clientgoscheme.Scheme
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(csidriver.AddToScheme(scheme))
-	utilruntime.Must(contourv1.AddToScheme(scheme))
+	// TODO: Instead of creating client in startup, it is better for controller to create clients.
+	if s.Options.K8sConfig != nil {
+		scheme := clientgoscheme.Scheme
+		utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+		utilruntime.Must(csidriver.AddToScheme(scheme))
+		utilruntime.Must(contourv1.AddToScheme(scheme))
 
-	k8s, err := controller_runtime.New(s.Options.K8sConfig, controller_runtime.Options{Scheme: scheme})
-	if err != nil {
-		return err
+		k8s, err := controller_runtime.New(s.Options.K8sConfig, controller_runtime.Options{Scheme: scheme})
+		if err != nil {
+			return err
+		}
+		s.KubeClient = k8s
 	}
-	s.KubeClient = k8s
 
 	if s.Options.Arm != nil {
 		s.SecretClient = renderers.NewSecretValueClient(*s.Options.Arm)

--- a/pkg/armrpc/hostoptions/providerconfig.go
+++ b/pkg/armrpc/hostoptions/providerconfig.go
@@ -6,6 +6,8 @@
 package hostoptions
 
 import (
+	"github.com/project-radius/radius/pkg/client/azuread"
+	kubeenv "github.com/project-radius/radius/pkg/client/kubernetes"
 	"github.com/project-radius/radius/pkg/telemetry/metrics/provider"
 	"github.com/project-radius/radius/pkg/ucp/dataprovider"
 	qprovider "github.com/project-radius/radius/pkg/ucp/queue/provider"
@@ -13,8 +15,9 @@ import (
 
 // ProviderConfig includes the resource provider configuration.
 type ProviderConfig struct {
-	Env             EnvironmentOptions                  `yaml:"environment"`
-	Identity        IdentityOptions                     `yaml:"identity"`
+	Environment     EnvironmentOptions                  `yaml:"environment"`
+	AzureAD         *azuread.Options                    `yaml:"azureAd,omitempty"`
+	Kubernetes      *kubeenv.Options                    `yaml:"kubernetes,omitempty"`
 	StorageProvider dataprovider.StorageProviderOptions `yaml:"storageProvider"`
 	QueueProvider   qprovider.QueueProviderOptions      `yaml:"queueProvider"`
 	Server          *ServerOptions                      `yaml:"server,omitempty"`

--- a/pkg/client/azuread/client.go
+++ b/pkg/client/azuread/client.go
@@ -1,0 +1,127 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package azuread
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+)
+
+type AuthMethod string
+
+// Authentication methods
+const (
+	ServicePrincipalAuth AuthMethod = "ServicePrincipal"
+	ManagedIdentityAuth  AuthMethod = "ManagedIdentity"
+	CliAuth              AuthMethod = "CLI"
+)
+
+// Options is the configuration we use for managing ARM resources
+type Options struct {
+	// Instance represents Azure AD endpoint.
+	Instance string `yaml:"instance,omitempty"`
+	// ClientID represents Service Principal or Azure AD application ID.
+	ClientID string `yaml:"clientId"`
+	// TenantID represents Tenant ID of servie principal.
+	TenantID string `yaml:"tenantId"`
+	// ClientSecret represents the client secret of ClientID.
+	ClientSecret string `yaml:"clientSecret,omitempty"`
+}
+
+// GetAuthorizer returns an ARM authorizer and the client ID for the current process
+func GetAuthorizer(opts *Options) (autorest.Authorizer, error) {
+	authMethod := opts.AuthenticationMethod()
+
+	var auth autorest.Authorizer
+	var err error
+	if authMethod == ServicePrincipalAuth {
+		auth, err = opts.authServicePrincipal()
+	} else if authMethod == ManagedIdentityAuth {
+		auth, err = opts.authMSI()
+	} else {
+		auth, err = opts.authCLI()
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to authorize with auth type %q: %w", authMethod, err)
+	}
+
+	return auth, nil
+}
+
+func (i *Options) authServicePrincipal() (autorest.Authorizer, error) {
+	clientcfg := auth.NewClientCredentialsConfig(i.ClientID, i.ClientSecret, i.TenantID)
+	auth, err := clientcfg.Authorizer()
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := clientcfg.ServicePrincipalToken()
+	if err != nil {
+		return nil, err
+	}
+
+	err = token.EnsureFresh()
+	if err != nil {
+		return nil, err
+	}
+
+	return auth, nil
+}
+
+func (i *Options) authMSI() (autorest.Authorizer, error) {
+	config := auth.NewMSIConfig()
+	token, err := config.ServicePrincipalToken()
+	if err != nil {
+		return nil, err
+	}
+
+	err = token.EnsureFresh()
+	if err != nil {
+		return nil, err
+	}
+
+	auth, err := config.Authorizer()
+	if err != nil {
+		return nil, err
+	}
+
+	return auth, nil
+}
+
+func (i *Options) authCLI() (autorest.Authorizer, error) {
+	settings, err := auth.GetSettingsFromEnvironment()
+	if err != nil {
+		return nil, err
+	}
+
+	auth, err := auth.NewAuthorizerFromCLIWithResource(settings.Environment.ResourceManagerEndpoint)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return auth, nil
+}
+
+// AuthMethod returns the authentication method used by the RP
+func (i *Options) AuthenticationMethod() AuthMethod {
+	if i.ClientID != "" && i.ClientSecret != "" && i.TenantID != "" {
+		return ServicePrincipalAuth
+	}
+
+	settings, err := auth.GetSettingsFromEnvironment()
+	if err == nil && settings.Values[auth.ClientID] != "" && settings.Values[auth.ClientSecret] != "" {
+		return ServicePrincipalAuth
+	} else if os.Getenv("MSI_ENDPOINT") != "" || os.Getenv("IDENTITY_ENDPOINT") != "" {
+		return ManagedIdentityAuth
+	} else {
+		return CliAuth
+	}
+}

--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -1,0 +1,162 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/project-radius/radius/pkg/azure/clients"
+	"github.com/project-radius/radius/pkg/client/azuread"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type KubernetesEnvironment string
+
+const (
+	KubeLocal     KubernetesEnvironment = "local"
+	KubeInCluster KubernetesEnvironment = "cluster"
+	KubeAKS       KubernetesEnvironment = "azure"
+)
+
+// Options is the configuration we use for kubernetes client
+type Options struct {
+	// Environment represents kubernetes environment type.
+	Environment KubernetesEnvironment `yaml:"environment"`
+	// Azure represents azure kubernetes service option.
+	Azure *AKSClusterOptions `yaml:"azure,omitempty"`
+}
+
+// AKSClusterOptions represents the options for Azure Kubernetes Service.
+type AKSClusterOptions struct {
+	// SubscriptionID is subscription id where AKS is created.
+	SubscriptionID string `yaml:"subscriptionId"`
+	// ResourceGroup is ResourceGroup where AKS is created.
+	ResourceGroup string `yaml:"resourceGroup"`
+	// ClusterName is AKS cluster name.
+	ClusterName string `yaml:"clusterName"`
+
+	// Identity must be set.
+	Identity *azuread.Options
+}
+
+// GetKubeConfig gets the Kubernetes config
+func GetKubeConfig(opts *Options) (*rest.Config, error) {
+	var config *rest.Config
+	var err error
+
+	switch opts.Environment {
+	case KubeLocal:
+		config, err = createLocal()
+		if err != nil {
+			return nil, err
+		}
+	case KubeInCluster:
+		config, err = createCluster()
+		if err != nil {
+			return nil, err
+		}
+	case KubeAKS:
+		config, err = createRemote(opts.Azure)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, errors.New("unsupported kubernetes environment")
+	}
+
+	return config, nil
+}
+
+func createLocal() (*rest.Config, error) {
+	var kubeConfig string
+	if home := homeDir(); home != "" {
+		kubeConfig = filepath.Join(home, ".kube", "config")
+	} else {
+		return nil, errors.New("no HOME directory, cannot find kubeconfig")
+	}
+
+	log.Printf("Using %s for kube config", kubeConfig)
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+func createCluster() (*rest.Config, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", "")
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+func homeDir() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	return os.Getenv("USERPROFILE") // windows
+}
+
+func createRemote(opts *AKSClusterOptions) (*rest.Config, error) {
+	if opts == nil {
+		return nil, errors.New("AKSClusterOptions is nil")
+	}
+
+	if opts.Identity == nil {
+		return nil, errors.New("Identity is nil")
+	}
+
+	if opts.ClusterName == "" {
+		return nil, errors.New("clusterName is unset")
+	}
+
+	if opts.ResourceGroup == "" {
+		return nil, errors.New("resourceGroup is unset")
+	}
+
+	if opts.SubscriptionID == "" {
+		return nil, errors.New("subscriptionId is unset")
+	}
+
+	auth, err := azuread.GetAuthorizer(opts.Identity)
+	if err != nil {
+		return nil, fmt.Errorf("cannot authorize with ARM: %w", err)
+	}
+
+	aks := clients.NewManagedClustersClient(opts.SubscriptionID, auth)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	res, err := aks.ListClusterAdminCredentials(ctx, opts.ResourceGroup, opts.ClusterName, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if len(*res.Kubeconfigs) == 0 {
+		return nil, errors.New("no admin credentials found")
+	}
+
+	config, err := clientcmd.NewClientConfigFromBytes(*(*res.Kubeconfigs)[0].Value)
+	if err != nil {
+		return nil, err
+	}
+
+	clientconfig, err := config.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return clientconfig, nil
+}

--- a/pkg/corerp/testing/armtest.go
+++ b/pkg/corerp/testing/armtest.go
@@ -45,7 +45,7 @@ func ARMTestContextFromRequest(req *http.Request) context.Context {
 	armctx, _ := servicecontext.FromARMRequest(req, "")
 	ctx = servicecontext.WithARMRequestContext(ctx, armctx)
 	ctx = hostoptions.WithContext(ctx, &hostoptions.ProviderConfig{
-		Env: hostoptions.EnvironmentOptions{RoleLocation: "West US"},
+		Environment: hostoptions.EnvironmentOptions{RoleLocation: "West US"},
 	})
 	return ctx
 }


### PR DESCRIPTION
# Description

This change is to leverage https://github.com/kelseyhightower/envconfig to construct config struct via environment variables automatically instead of calling `os.GetEnv()`

Once we load config yaml, env variable can override the value using envconfig. for example, if we want to override value of ProviderConfig.Server.Host, we can set `RADIUS_SERVER_HOST` env var to override the value after loading yaml file. 

```go
// ProviderConfig includes the resource provider configuration.
type ProviderConfig struct {
	Environment     EnvironmentOptions                  `yaml:"environment"`
	AzureAD         *azuread.Options                    `yaml:"azureAd,omitempty"`
	Kubernetes      *kubeenv.Options                    `yaml:"kubernetes,omitempty"`
	StorageProvider dataprovider.StorageProviderOptions `yaml:"storageProvider"`
	QueueProvider   qprovider.QueueProviderOptions      `yaml:"queueProvider"`
	Server          *ServerOptions                      `yaml:"server,omitempty"`
	WorkerServer    *WorkerServerOptions                `yaml:"workerServer,omitempty"`
	MetricsProvider provider.MetricsProviderOptions     `yaml:"metricsProvider"`

	// FeatureFlags includes the list of feature flags.
	FeatureFlags []string `yaml:"featureFlags"`
}

// ServerOptions includes http server bootstrap options.
type ServerOptions struct {
	Host     string               `yaml:"host"`
	Port     int                  `yaml:"port"`
	PathBase string               `yaml:"pathBase,omitempty"`
	AuthType AuthentificationType `yaml:"authType,omitempty"`
	// ArmMetadataEndpoints provides the client certification to authenticate between ARM and RP.
	// https://armwiki.azurewebsites.net/authorization/AuthenticateBetweenARMandRP.html
	ArmMetadataEndpoint string `yaml:"armMetadataEndpoint,omitempty"`
	// EnableAuth when set the arm client authetication will be performed
	EnableArmAuth bool `yaml:"enableArmAuth,omitempty"`
}
```

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #2820 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
