### PR TITLE
Adding Deployment readiness informer checker 

### DIFF
--- a/pkg/armrpc/asyncoperation/worker/service.go
+++ b/pkg/armrpc/asyncoperation/worker/service.go
@@ -17,6 +17,7 @@ import (
 	queue "github.com/project-radius/radius/pkg/ucp/queue/client"
 	qprovider "github.com/project-radius/radius/pkg/ucp/queue/provider"
 
+	"k8s.io/client-go/kubernetes"
 	controller_runtime "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -36,6 +37,8 @@ type Service struct {
 	RequestQueue queue.Client
 	// KubeClient is the Kubernetes controller runtime client.
 	KubeClient controller_runtime.Client
+	// KubeClientSet is the Kubernetes client.
+	KubeClientSet kubernetes.Interface
 	// SecretClient is the client to fetch secrets.
 	SecretClient renderers.SecretValueClient
 }
@@ -56,6 +59,11 @@ func (s *Service) Init(ctx context.Context) error {
 	s.Controllers = NewControllerRegistry(s.StorageProvider)
 
 	s.KubeClient, err = kubeclient.CreateKubeClient(s.Options.K8sConfig)
+	if err != nil {
+		return err
+	}
+
+	s.KubeClientSet, err = kubernetes.NewForConfig(s.Options.K8sConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/corerp/backend/deployment/deployment_test.go
+++ b/pkg/corerp/backend/deployment/deployment_test.go
@@ -163,7 +163,7 @@ func Test_Render(t *testing.T) {
 	ctx := createContext(t)
 	mocks := setup(t)
 
-	dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil}
+	dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil, nil}
 	t.Run("verify render success", func(t *testing.T) {
 		testResource := getTestResource()
 		testRendererOutput := getTestRendererOutput()
@@ -355,7 +355,7 @@ func Test_Render(t *testing.T) {
 func Test_Deploy(t *testing.T) {
 	ctx := createContext(t)
 	mocks := setup(t)
-	dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil}
+	dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil, nil}
 
 	t.Run("Verify deploy success", func(t *testing.T) {
 		testResource := getTestResource()
@@ -450,7 +450,7 @@ func Test_Deploy(t *testing.T) {
 func Test_Delete(t *testing.T) {
 	ctx := createContext(t)
 	mocks := setup(t)
-	dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil}
+	dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil, nil}
 
 	t.Run("Verify delete success", func(t *testing.T) {
 		testResource := getTestResource()

--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -29,7 +29,7 @@ import (
 	"github.com/project-radius/radius/pkg/ucp/store"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	controller_runtime "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 //go:generate mockgen -destination=./mock_deploymentprocessor.go -package=deployment -self_package github.com/project-radius/radius/pkg/corerp/backend/deployment github.com/project-radius/radius/pkg/corerp/backend/deployment DeploymentProcessor
@@ -40,7 +40,7 @@ type DeploymentProcessor interface {
 	FetchSecrets(ctx context.Context, resourceData ResourceData) (map[string]interface{}, error)
 }
 
-func NewDeploymentProcessor(appmodel model.ApplicationModel, sp dataprovider.DataStorageProvider, secretClient renderers.SecretValueClient, k8sClient client.Client, k8sClientSet kubernetes.Interface) DeploymentProcessor {
+func NewDeploymentProcessor(appmodel model.ApplicationModel, sp dataprovider.DataStorageProvider, secretClient renderers.SecretValueClient, k8sClient controller_runtime.Client, k8sClientSet kubernetes.Interface) DeploymentProcessor {
 	return &deploymentProcessor{appmodel: appmodel, sp: sp, secretClient: secretClient, k8sClient: k8sClient, k8sClientSet: k8sClientSet}
 }
 
@@ -51,7 +51,7 @@ type deploymentProcessor struct {
 	sp           dataprovider.DataStorageProvider
 	secretClient renderers.SecretValueClient
 	// k8sClient is the Kubernetes controller runtime client.
-	k8sClient client.Client
+	k8sClient controller_runtime.Client
 	// k8sClientSet is the Kubernetes client.
 	k8sClientSet kubernetes.Interface
 }
@@ -360,7 +360,7 @@ func (dp *deploymentProcessor) getEnvOptions(ctx context.Context) (renderers.Env
 
 		// Find the public IP of the cluster (External IP of the contour-envoy service)
 		var services corev1.ServiceList
-		err := dp.k8sClient.List(ctx, &services, &client.ListOptions{Namespace: "radius-system"})
+		err := dp.k8sClient.List(ctx, &services, &controller_runtime.ListOptions{Namespace: "radius-system"})
 		if err != nil {
 			return renderers.EnvironmentOptions{}, fmt.Errorf("failed to look up Services: %w", err)
 		}

--- a/pkg/corerp/backend/service.go
+++ b/pkg/corerp/backend/service.go
@@ -49,7 +49,7 @@ func (w *Service) Run(ctx context.Context) error {
 		return err
 	}
 
-	coreAppModel, err := model.NewApplicationModel(w.Options.Arm, w.KubeClient)
+	coreAppModel, err := model.NewApplicationModel(w.Options.Arm, w.KubeClient, w.KubeClientSet)
 	if err != nil {
 		return fmt.Errorf("failed to initialize application model: %w", err)
 	}
@@ -59,7 +59,7 @@ func (w *Service) Run(ctx context.Context) error {
 		SecretClient: w.SecretClient,
 		KubeClient:   w.KubeClient,
 		GetDeploymentProcessor: func() deployment.DeploymentProcessor {
-			return deployment.NewDeploymentProcessor(coreAppModel, w.StorageProvider, w.SecretClient, w.KubeClient)
+			return deployment.NewDeploymentProcessor(coreAppModel, w.StorageProvider, w.SecretClient, w.KubeClient, w.KubeClientSet)
 		},
 	}
 

--- a/pkg/corerp/handlers/kubernetes.go
+++ b/pkg/corerp/handlers/kubernetes.go
@@ -77,7 +77,10 @@ func (handler *kubernetesHandler) Put(ctx context.Context, resource *outputresou
 		}
 		// Now get the latest available observation of deployment current state
 		// note that there can be a race condition here, by the time it fetches the latest status, deployment might be succeeded
-		status := dep.Status.Conditions[len(dep.Status.Conditions)-1]
+		status := v1.DeploymentCondition{}
+		if len(dep.Status.Conditions) >= 1 {
+			status = dep.Status.Conditions[len(dep.Status.Conditions)-1]
+		}
 
 		return fmt.Errorf("deployment timed out, name: %s, namespace %s, status: %s, reason: %s", item.GetName(), item.GetNamespace(), status.Message, status.Reason)
 	case <-readinessCh:

--- a/pkg/corerp/model/application_model.go
+++ b/pkg/corerp/model/application_model.go
@@ -17,12 +17,13 @@ import (
 	"github.com/project-radius/radius/pkg/providers"
 	"github.com/project-radius/radius/pkg/radrp/outputresource"
 	"github.com/project-radius/radius/pkg/resourcemodel"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/project-radius/radius/pkg/resourcekinds"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func NewApplicationModel(arm *armauth.ArmConfig, k8s client.Client) (ApplicationModel, error) {
+func NewApplicationModel(arm *armauth.ArmConfig, k8sClient client.Client, k8sClientSet kubernetes.Interface) (ApplicationModel, error) {
 	// Configure RBAC support on connections based connection kind.
 	// Role names can be user input or default roles assigned by Radius.
 	// Leave RoleNames field empty if no default roles are supported for a connection kind.
@@ -81,49 +82,49 @@ func NewApplicationModel(arm *armauth.ArmConfig, k8s client.Client) (Application
 				Type:     resourcekinds.Kubernetes,
 				Provider: providers.ProviderKubernetes,
 			},
-			ResourceHandler: handlers.NewKubernetesHandler(k8s),
+			ResourceHandler: handlers.NewKubernetesHandler(k8sClient, k8sClientSet),
 		},
 		{
 			ResourceType: resourcemodel.ResourceType{
 				Type:     resourcekinds.Deployment,
 				Provider: providers.ProviderKubernetes,
 			},
-			ResourceHandler: handlers.NewKubernetesHandler(k8s),
+			ResourceHandler: handlers.NewKubernetesHandler(k8sClient, k8sClientSet),
 		},
 		{
 			ResourceType: resourcemodel.ResourceType{
 				Type:     resourcekinds.Service,
 				Provider: providers.ProviderKubernetes,
 			},
-			ResourceHandler: handlers.NewKubernetesHandler(k8s),
+			ResourceHandler: handlers.NewKubernetesHandler(k8sClient, k8sClientSet),
 		},
 		{
 			ResourceType: resourcemodel.ResourceType{
 				Type:     resourcekinds.Secret,
 				Provider: providers.ProviderKubernetes,
 			},
-			ResourceHandler: handlers.NewKubernetesHandler(k8s),
+			ResourceHandler: handlers.NewKubernetesHandler(k8sClient, k8sClientSet),
 		},
 		{
 			ResourceType: resourcemodel.ResourceType{
 				Type:     resourcekinds.Gateway,
 				Provider: providers.ProviderKubernetes,
 			},
-			ResourceHandler: handlers.NewKubernetesHandler(k8s),
+			ResourceHandler: handlers.NewKubernetesHandler(k8sClient, k8sClientSet),
 		},
 		{
 			ResourceType: resourcemodel.ResourceType{
 				Type:     resourcekinds.KubernetesHTTPRoute,
 				Provider: providers.ProviderKubernetes,
 			},
-			ResourceHandler: handlers.NewKubernetesHandler(k8s),
+			ResourceHandler: handlers.NewKubernetesHandler(k8sClient, k8sClientSet),
 		},
 		{
 			ResourceType: resourcemodel.ResourceType{
 				Type:     resourcekinds.SecretProviderClass,
 				Provider: providers.ProviderKubernetes,
 			},
-			ResourceHandler: handlers.NewKubernetesHandler(k8s),
+			ResourceHandler: handlers.NewKubernetesHandler(k8sClient, k8sClientSet),
 		},
 	}
 


### PR DESCRIPTION
# Description

In the Kubernetes deployment handler, added the informer that watches for the added/modified deployment and return when the deployment is ready based on the condition

https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#complete-deployment

## Issue reference

Please reference the issue this PR will close: #https://github.com/project-radius/radius/issues/2269

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [x] Extended the documentation / Created issue for it
