### PR TITLE
Environment need a namespace on the resource

### DIFF
--- a/pkg/corerp/backend/deployment/deployment_test.go
+++ b/pkg/corerp/backend/deployment/deployment_test.go
@@ -175,11 +175,57 @@ func Test_Render(t *testing.T) {
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return(requiredResources, nil, nil)
 		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		cr := store.Object{
+			Metadata: store.Metadata{
+				ID: testResource.ID,
+			},
+			Data: testResource,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&cr, nil)
+		application := datamodel.Application{
+			TrackedResource: v1.TrackedResource{
+				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+			},
+			Properties: datamodel.ApplicationProperties{
+				Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+			},
+		}
+		ar := store.Object{
+			Metadata: store.Metadata{
+				ID: application.ID,
+			},
+			Data: application,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&ar, nil)
+		environment := datamodel.Environment{
+			TrackedResource: v1.TrackedResource{
+				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+			},
+			Properties: datamodel.EnvironmentProperties{
+				Compute: datamodel.EnvironmentCompute{
+					KubernetesCompute: datamodel.KubernetesComputeProperties{
+						Namespace: "radius-test",
+					},
+				},
+			},
+		}
+		er := store.Object{
+			Metadata: store.Metadata{
+				ID: environment.ID,
+			},
+			Data: environment,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
 		httprouteA := datamodel.HTTPRoute{
 			TrackedResource: v1.TrackedResource{
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A",
 			},
-			Properties: &datamodel.HTTPRouteProperties{},
+			Properties: &datamodel.HTTPRouteProperties{
+				Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+			},
 		}
 		nr := store.Object{
 			Metadata: store.Metadata{
@@ -187,6 +233,7 @@ func Test_Render(t *testing.T) {
 			},
 			Data: httprouteA,
 		}
+
 		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&nr, nil)
 
 		rendererOutput, err := dp.Render(ctx, resourceID, testResource)
@@ -205,11 +252,57 @@ func Test_Render(t *testing.T) {
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return(requiredResources, nil, nil)
 		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		cr := store.Object{
+			Metadata: store.Metadata{
+				ID: testResource.ID,
+			},
+			Data: testResource,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&cr, nil)
+		application := datamodel.Application{
+			TrackedResource: v1.TrackedResource{
+				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+			},
+			Properties: datamodel.ApplicationProperties{
+				Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+			},
+		}
+		ar := store.Object{
+			Metadata: store.Metadata{
+				ID: application.ID,
+			},
+			Data: application,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&ar, nil)
+		environment := datamodel.Environment{
+			TrackedResource: v1.TrackedResource{
+				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+			},
+			Properties: datamodel.EnvironmentProperties{
+				Compute: datamodel.EnvironmentCompute{
+					KubernetesCompute: datamodel.KubernetesComputeProperties{
+						Namespace: "radius-test",
+					},
+				},
+			},
+		}
+		er := store.Object{
+			Metadata: store.Metadata{
+				ID: environment.ID,
+			},
+			Data: environment,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
 		httprouteA := datamodel.HTTPRoute{
 			TrackedResource: v1.TrackedResource{
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A",
 			},
-			Properties: &datamodel.HTTPRouteProperties{},
+			Properties: &datamodel.HTTPRouteProperties{
+				Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+			},
 		}
 		nr := store.Object{
 			Metadata: store.Metadata{
@@ -235,11 +328,57 @@ func Test_Render(t *testing.T) {
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return(requiredResources, nil, nil)
 		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		cr := store.Object{
+			Metadata: store.Metadata{
+				ID: testResource.ID,
+			},
+			Data: testResource,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&cr, nil)
+		application := datamodel.Application{
+			TrackedResource: v1.TrackedResource{
+				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+			},
+			Properties: datamodel.ApplicationProperties{
+				Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+			},
+		}
+		ar := store.Object{
+			Metadata: store.Metadata{
+				ID: application.ID,
+			},
+			Data: application,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&ar, nil)
+		environment := datamodel.Environment{
+			TrackedResource: v1.TrackedResource{
+				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+			},
+			Properties: datamodel.EnvironmentProperties{
+				Compute: datamodel.EnvironmentCompute{
+					KubernetesCompute: datamodel.KubernetesComputeProperties{
+						Namespace: "radius-test",
+					},
+				},
+			},
+		}
+		er := store.Object{
+			Metadata: store.Metadata{
+				ID: environment.ID,
+			},
+			Data: environment,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
 		httprouteA := datamodel.HTTPRoute{
 			TrackedResource: v1.TrackedResource{
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A",
 			},
-			Properties: &datamodel.HTTPRouteProperties{},
+			Properties: &datamodel.HTTPRouteProperties{
+				Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+			},
 		}
 		nr := store.Object{
 			Metadata: store.Metadata{
@@ -263,11 +402,57 @@ func Test_Render(t *testing.T) {
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return(requiredResources, nil, nil)
 		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(renderers.RendererOutput{}, errors.New("failed to render the resource"))
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		cr := store.Object{
+			Metadata: store.Metadata{
+				ID: testResource.ID,
+			},
+			Data: testResource,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&cr, nil)
+		application := datamodel.Application{
+			TrackedResource: v1.TrackedResource{
+				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+			},
+			Properties: datamodel.ApplicationProperties{
+				Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+			},
+		}
+		ar := store.Object{
+			Metadata: store.Metadata{
+				ID: application.ID,
+			},
+			Data: application,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&ar, nil)
+		environment := datamodel.Environment{
+			TrackedResource: v1.TrackedResource{
+				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+			},
+			Properties: datamodel.EnvironmentProperties{
+				Compute: datamodel.EnvironmentCompute{
+					KubernetesCompute: datamodel.KubernetesComputeProperties{
+						Namespace: "radius-test",
+					},
+				},
+			},
+		}
+		er := store.Object{
+			Metadata: store.Metadata{
+				ID: environment.ID,
+			},
+			Data: environment,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
 		httprouteA := datamodel.HTTPRoute{
 			TrackedResource: v1.TrackedResource{
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A",
 			},
-			Properties: &datamodel.HTTPRouteProperties{},
+			Properties: &datamodel.HTTPRouteProperties{
+				Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+			},
 		}
 		nr := store.Object{
 			Metadata: store.Metadata{
@@ -303,11 +488,57 @@ func Test_Render(t *testing.T) {
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return(requiredResources, nil, nil)
 		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		cr := store.Object{
+			Metadata: store.Metadata{
+				ID: testResource.ID,
+			},
+			Data: testResource,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&cr, nil)
+		application := datamodel.Application{
+			TrackedResource: v1.TrackedResource{
+				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+			},
+			Properties: datamodel.ApplicationProperties{
+				Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+			},
+		}
+		ar := store.Object{
+			Metadata: store.Metadata{
+				ID: application.ID,
+			},
+			Data: application,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&ar, nil)
+		environment := datamodel.Environment{
+			TrackedResource: v1.TrackedResource{
+				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+			},
+			Properties: datamodel.EnvironmentProperties{
+				Compute: datamodel.EnvironmentCompute{
+					KubernetesCompute: datamodel.KubernetesComputeProperties{
+						Namespace: "radius-test",
+					},
+				},
+			},
+		}
+		er := store.Object{
+			Metadata: store.Metadata{
+				ID: environment.ID,
+			},
+			Data: environment,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
 		httprouteA := datamodel.HTTPRoute{
 			TrackedResource: v1.TrackedResource{
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A",
 			},
-			Properties: &datamodel.HTTPRouteProperties{},
+			Properties: &datamodel.HTTPRouteProperties{
+				Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+			},
 		}
 		nr := store.Object{
 			Metadata: store.Metadata{
@@ -332,11 +563,57 @@ func Test_Render(t *testing.T) {
 
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return(requiredResources, nil, nil)
 		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		cr := store.Object{
+			Metadata: store.Metadata{
+				ID: testResource.ID,
+			},
+			Data: testResource,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&cr, nil)
+		application := datamodel.Application{
+			TrackedResource: v1.TrackedResource{
+				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+			},
+			Properties: datamodel.ApplicationProperties{
+				Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+			},
+		}
+		ar := store.Object{
+			Metadata: store.Metadata{
+				ID: application.ID,
+			},
+			Data: application,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&ar, nil)
+		environment := datamodel.Environment{
+			TrackedResource: v1.TrackedResource{
+				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+			},
+			Properties: datamodel.EnvironmentProperties{
+				Compute: datamodel.EnvironmentCompute{
+					KubernetesCompute: datamodel.KubernetesComputeProperties{
+						Namespace: "radius-test",
+					},
+				},
+			},
+		}
+		er := store.Object{
+			Metadata: store.Metadata{
+				ID: environment.ID,
+			},
+			Data: environment,
+		}
+		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
 		httprouteA := datamodel.HTTPRoute{
 			TrackedResource: v1.TrackedResource{
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A",
 			},
-			Properties: &datamodel.HTTPRouteProperties{},
+			Properties: &datamodel.HTTPRouteProperties{
+				Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+			},
 		}
 		nr := store.Object{
 			Metadata: store.Metadata{

--- a/pkg/corerp/backend/deployment/deployment_test.go
+++ b/pkg/corerp/backend/deployment/deployment_test.go
@@ -174,10 +174,8 @@ func Test_Render(t *testing.T) {
 
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return(requiredResources, nil, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(4).Return(mocks.db, nil)
+
 		cr := store.Object{
 			Metadata: store.Metadata{
 				ID: testResource.ID,
@@ -251,10 +249,8 @@ func Test_Render(t *testing.T) {
 
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return(requiredResources, nil, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(4).Return(mocks.db, nil)
+
 		cr := store.Object{
 			Metadata: store.Metadata{
 				ID: testResource.ID,
@@ -327,10 +323,8 @@ func Test_Render(t *testing.T) {
 
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return(requiredResources, nil, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(4).Return(mocks.db, nil)
+
 		cr := store.Object{
 			Metadata: store.Metadata{
 				ID: testResource.ID,
@@ -400,11 +394,9 @@ func Test_Render(t *testing.T) {
 		requiredResources := []resources.ID{depId1}
 
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return(requiredResources, nil, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(4).Return(mocks.db, nil)
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(renderers.RendererOutput{}, errors.New("failed to render the resource"))
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+
 		cr := store.Object{
 			Metadata: store.Metadata{
 				ID: testResource.ID,
@@ -487,10 +479,8 @@ func Test_Render(t *testing.T) {
 
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return(requiredResources, nil, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(4).Return(mocks.db, nil)
+
 		cr := store.Object{
 			Metadata: store.Metadata{
 				ID: testResource.ID,
@@ -562,10 +552,8 @@ func Test_Render(t *testing.T) {
 		requiredResources := []resources.ID{depId1}
 
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return(requiredResources, nil, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
+		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(4).Return(mocks.db, nil)
+
 		cr := store.Object{
 			Metadata: store.Metadata{
 				ID: testResource.ID,

--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -62,7 +62,7 @@ type ResourceData struct {
 	OutputResources []outputresource.OutputResource
 	ComputedValues  map[string]interface{}
 	SecretValues    map[string]rp.SecretValueReference
-	AppId           resources.ID // Application ID for which the resource is created
+	AppID           resources.ID // Application ID for which the resource is created
 }
 
 func (dp *deploymentProcessor) Render(ctx context.Context, resourceID resources.ID, resource conv.DataModelInterface) (renderers.RendererOutput, error) {
@@ -80,7 +80,7 @@ func (dp *deploymentProcessor) Render(ctx context.Context, resourceID resources.
 		return renderers.RendererOutput{}, fmt.Errorf("failed to fetch resource to get the namespace %w", err)
 	}
 	// 2. fetch the application resource from the DB to get the environment info
-	environment, err := dp.getApplication(ctx, res.AppId)
+	environment, err := dp.getEnvironmentFromApplication(ctx, res.AppID)
 	if err != nil {
 		return renderers.RendererOutput{}, fmt.Errorf("failed to fetch application resource to get the namespace %w", err)
 	}
@@ -455,7 +455,7 @@ func (dp *deploymentProcessor) buildResourceDependency(resourceID, appID resourc
 		OutputResources: outputResources,
 		ComputedValues:  computedValues,
 		SecretValues:    secretValues,
-		AppId:           appID,
+		AppID:           appID,
 	}
 }
 
@@ -493,8 +493,8 @@ func (dp *deploymentProcessor) getRendererDependency(ctx context.Context, depend
 	return rendererDependency, nil
 }
 
-// getApplication fetches the application resource from the db for getting the environment to fetch the environment resource
-func (dp *deploymentProcessor) getApplication(ctx context.Context, appID resources.ID) (environment string, err error) {
+// getEnvironmentFromApplication fetches the application resource from the db for getting the environment to fetch the environment resource
+func (dp *deploymentProcessor) getEnvironmentFromApplication(ctx context.Context, appID resources.ID) (environment string, err error) {
 	var res *store.Object
 	var sc store.StorageClient
 	sc, err = dp.sp.GetStorageClient(ctx, appID.Type())

--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -84,7 +84,7 @@ func (dp *deploymentProcessor) Render(ctx context.Context, resourceID resources.
 	if err != nil {
 		return renderers.RendererOutput{}, fmt.Errorf("failed to fetch application resource to get the namespace %w", err)
 	}
-	// 3. fetch the environment resource from th db to get the Namespace
+	// 3. fetch the environment resource from the db to get the Namespace
 	namespace, err := dp.getEnvironmentNamespace(ctx, environment)
 	if err != nil {
 		return renderers.RendererOutput{}, fmt.Errorf("failed to fetch environment resource to get the namespace %w", err)
@@ -357,13 +357,8 @@ func (dp *deploymentProcessor) fetchSecret(ctx context.Context, dependency Resou
 	return dp.secretClient.FetchSecret(ctx, match.Identity, reference.Action, reference.ValueSelector)
 }
 
-<<<<<<< Updated upstream
-func (dp *deploymentProcessor) getEnvOptions(ctx context.Context) (renderers.EnvironmentOptions, error) {
-	if dp.k8sClient != nil {
-=======
 func (dp *deploymentProcessor) getEnvOptions(ctx context.Context, namespace string) (renderers.EnvironmentOptions, error) {
 	if dp.k8s != nil {
->>>>>>> Stashed changes
 		// If the public endpoint override is specified (Local Dev scenario), then use it.
 		publicEndpoint := os.Getenv("RADIUS_PUBLIC_ENDPOINT_OVERRIDE")
 		if publicEndpoint != "" {

--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -358,7 +358,7 @@ func (dp *deploymentProcessor) fetchSecret(ctx context.Context, dependency Resou
 }
 
 func (dp *deploymentProcessor) getEnvOptions(ctx context.Context, namespace string) (renderers.EnvironmentOptions, error) {
-	if dp.k8s != nil {
+	if dp.k8sClient != nil {
 		// If the public endpoint override is specified (Local Dev scenario), then use it.
 		publicEndpoint := os.Getenv("RADIUS_PUBLIC_ENDPOINT_OVERRIDE")
 		if publicEndpoint != "" {


### PR DESCRIPTION
# Description

The resources needs to be deployed under a namespace. Adding the namespace to the resource properties. It requires:
1. fetch the resource from the DB and get the application info
2. fetch the application resource from the DB to get the environment info
3. fetch the environment resource from the db to get the Namespace


## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[#2797]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
