### PR TITLE
Fix resource group segment name

### DIFF
--- a/pkg/ucp/resources/id.go
+++ b/pkg/ucp/resources/id.go
@@ -14,7 +14,7 @@ const (
 	SegmentSeparator      = "/"
 	PlanesSegment         = "planes"
 	ProvidersSegment      = "providers"
-	ResourceGroupsSegment = "resourcegroups"
+	ResourceGroupsSegment = "resourceGroups"
 	SubscriptionsSegment  = "subscriptions"
 	LocationsSegment      = "locations"
 )
@@ -97,7 +97,7 @@ func (ri ID) String() string {
 // FindScope function gets the scope type and returns the name for that scope if it exists.
 func (ri ID) FindScope(scopeType string) string {
 	for _, t := range ri.scopeSegments {
-		if t.Type == scopeType {
+		if t.Type == scopeType || strings.EqualFold(t.Type, scopeType) {
 			return t.Name
 		}
 	}

--- a/pkg/ucp/resources/id_test.go
+++ b/pkg/ucp/resources/id_test.go
@@ -465,6 +465,30 @@ func Test_IdParsing_WithNoTypeSegments(t *testing.T) {
 	require.Equal(t, "", routingScope)
 }
 
+func Test_FindScope_Subscription(t *testing.T) {
+	id, err := Parse("/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app")
+	require.NoError(t, err)
+
+	scope := id.FindScope(SubscriptionsSegment)
+	require.Equal(t, "s1", scope)
+}
+
+func Test_FindScope_ResourceGroup(t *testing.T) {
+	id, err := Parse("/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app")
+	require.NoError(t, err)
+
+	scope := id.FindScope(ResourceGroupsSegment)
+	require.Equal(t, "r1", scope)
+}
+
+func Test_FindScope_ResourceGroup_CaseInsensitive(t *testing.T) {
+	id, err := Parse("/subscriptions/s1/resourcegroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app")
+	require.NoError(t, err)
+
+	scope := id.FindScope(ResourceGroupsSegment)
+	require.Equal(t, "r1", scope)
+}
+
 func TestPlaneScope(t *testing.T) {
 	tests := []struct {
 		desc       string


### PR DESCRIPTION
# Description

Changing resource group segment to match the case in azure ID's `resourceGroup` instead of `resourcegroup`.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
