### PR TITLE
Add x-ms-skip-url-encoding to rootscope

### DIFF
--- a/pkg/cli/clients_new/generated/zz_generated_genericresources_client.go
+++ b/pkg/cli/clients_new/generated/zz_generated_genericresources_client.go
@@ -57,7 +57,7 @@ func (client *GenericResourcesClient) createOrUpdateCreateRequest(ctx context.Co
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if client.resourceType == "" {
 		return nil, errors.New("parameter client.resourceType cannot be empty")
 	}
@@ -122,7 +122,7 @@ func (client *GenericResourcesClient) deleteCreateRequest(ctx context.Context, r
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if client.resourceType == "" {
 		return nil, errors.New("parameter client.resourceType cannot be empty")
 	}
@@ -178,7 +178,7 @@ func (client *GenericResourcesClient) getCreateRequest(ctx context.Context, reso
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if client.resourceType == "" {
 		return nil, errors.New("parameter client.resourceType cannot be empty")
 	}
@@ -240,7 +240,7 @@ func (client *GenericResourcesClient) listByRootScopeCreateRequest(ctx context.C
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if client.resourceType == "" {
 		return nil, errors.New("parameter client.resourceType cannot be empty")
 	}

--- a/pkg/cli/swagger/genericResource.json
+++ b/pkg/cli/swagger/genericResource.json
@@ -470,7 +470,8 @@
         "required": true,
         "type": "string",
         "description": "The scope in which the resource is present. For Azure resource this would be /subscriptions/{subscriptionID}/resourceGroup/{resourcegroupID}",
-        "minLength": 1
+        "minLength": 1,
+        "x-ms-skip-url-encoding": true
       },
       "ResourceType": {
         "name": "resourceType",

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_daprinvokehttproutes_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_daprinvokehttproutes_client.go
@@ -56,7 +56,7 @@ func (client *DaprInvokeHTTPRoutesClient) createOrUpdateCreateRequest(ctx contex
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if daprInvokeHTTPRouteName == "" {
 		return nil, errors.New("parameter daprInvokeHTTPRouteName cannot be empty")
 	}
@@ -117,7 +117,7 @@ func (client *DaprInvokeHTTPRoutesClient) deleteCreateRequest(ctx context.Contex
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if daprInvokeHTTPRouteName == "" {
 		return nil, errors.New("parameter daprInvokeHTTPRouteName cannot be empty")
 	}
@@ -169,7 +169,7 @@ func (client *DaprInvokeHTTPRoutesClient) getCreateRequest(ctx context.Context, 
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if daprInvokeHTTPRouteName == "" {
 		return nil, errors.New("parameter daprInvokeHTTPRouteName cannot be empty")
 	}
@@ -227,7 +227,7 @@ func (client *DaprInvokeHTTPRoutesClient) listByRootScopeCreateRequest(ctx conte
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_daprpubsubbrokers_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_daprpubsubbrokers_client.go
@@ -56,7 +56,7 @@ func (client *DaprPubSubBrokersClient) createOrUpdateCreateRequest(ctx context.C
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if daprPubSubBrokerName == "" {
 		return nil, errors.New("parameter daprPubSubBrokerName cannot be empty")
 	}
@@ -117,7 +117,7 @@ func (client *DaprPubSubBrokersClient) deleteCreateRequest(ctx context.Context, 
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if daprPubSubBrokerName == "" {
 		return nil, errors.New("parameter daprPubSubBrokerName cannot be empty")
 	}
@@ -169,7 +169,7 @@ func (client *DaprPubSubBrokersClient) getCreateRequest(ctx context.Context, dap
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if daprPubSubBrokerName == "" {
 		return nil, errors.New("parameter daprPubSubBrokerName cannot be empty")
 	}
@@ -227,7 +227,7 @@ func (client *DaprPubSubBrokersClient) listByRootScopeCreateRequest(ctx context.
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_daprsecretstores_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_daprsecretstores_client.go
@@ -56,7 +56,7 @@ func (client *DaprSecretStoresClient) createOrUpdateCreateRequest(ctx context.Co
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if daprSecretStoreName == "" {
 		return nil, errors.New("parameter daprSecretStoreName cannot be empty")
 	}
@@ -117,7 +117,7 @@ func (client *DaprSecretStoresClient) deleteCreateRequest(ctx context.Context, d
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if daprSecretStoreName == "" {
 		return nil, errors.New("parameter daprSecretStoreName cannot be empty")
 	}
@@ -169,7 +169,7 @@ func (client *DaprSecretStoresClient) getCreateRequest(ctx context.Context, dapr
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if daprSecretStoreName == "" {
 		return nil, errors.New("parameter daprSecretStoreName cannot be empty")
 	}
@@ -227,7 +227,7 @@ func (client *DaprSecretStoresClient) listByRootScopeCreateRequest(ctx context.C
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_daprstatestores_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_daprstatestores_client.go
@@ -56,7 +56,7 @@ func (client *DaprStateStoresClient) createOrUpdateCreateRequest(ctx context.Con
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if daprStateStoreName == "" {
 		return nil, errors.New("parameter daprStateStoreName cannot be empty")
 	}
@@ -117,7 +117,7 @@ func (client *DaprStateStoresClient) deleteCreateRequest(ctx context.Context, da
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if daprStateStoreName == "" {
 		return nil, errors.New("parameter daprStateStoreName cannot be empty")
 	}
@@ -169,7 +169,7 @@ func (client *DaprStateStoresClient) getCreateRequest(ctx context.Context, daprS
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if daprStateStoreName == "" {
 		return nil, errors.New("parameter daprStateStoreName cannot be empty")
 	}
@@ -227,7 +227,7 @@ func (client *DaprStateStoresClient) listByRootScopeCreateRequest(ctx context.Co
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_extenders_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_extenders_client.go
@@ -56,7 +56,7 @@ func (client *ExtendersClient) createOrUpdateCreateRequest(ctx context.Context, 
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if extenderName == "" {
 		return nil, errors.New("parameter extenderName cannot be empty")
 	}
@@ -117,7 +117,7 @@ func (client *ExtendersClient) deleteCreateRequest(ctx context.Context, extender
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if extenderName == "" {
 		return nil, errors.New("parameter extenderName cannot be empty")
 	}
@@ -169,7 +169,7 @@ func (client *ExtendersClient) getCreateRequest(ctx context.Context, extenderNam
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if extenderName == "" {
 		return nil, errors.New("parameter extenderName cannot be empty")
 	}
@@ -227,7 +227,7 @@ func (client *ExtendersClient) listByRootScopeCreateRequest(ctx context.Context,
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
@@ -284,7 +284,7 @@ func (client *ExtendersClient) listSecretsCreateRequest(ctx context.Context, ext
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if extenderName == "" {
 		return nil, errors.New("parameter extenderName cannot be empty")
 	}

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_mongodatabases_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_mongodatabases_client.go
@@ -56,7 +56,7 @@ func (client *MongoDatabasesClient) createOrUpdateCreateRequest(ctx context.Cont
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if mongoDatabaseName == "" {
 		return nil, errors.New("parameter mongoDatabaseName cannot be empty")
 	}
@@ -117,7 +117,7 @@ func (client *MongoDatabasesClient) deleteCreateRequest(ctx context.Context, mon
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if mongoDatabaseName == "" {
 		return nil, errors.New("parameter mongoDatabaseName cannot be empty")
 	}
@@ -169,7 +169,7 @@ func (client *MongoDatabasesClient) getCreateRequest(ctx context.Context, mongoD
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if mongoDatabaseName == "" {
 		return nil, errors.New("parameter mongoDatabaseName cannot be empty")
 	}
@@ -227,7 +227,7 @@ func (client *MongoDatabasesClient) listByRootScopeCreateRequest(ctx context.Con
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
@@ -284,7 +284,7 @@ func (client *MongoDatabasesClient) listSecretsCreateRequest(ctx context.Context
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if mongoDatabaseName == "" {
 		return nil, errors.New("parameter mongoDatabaseName cannot be empty")
 	}

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_rabbitmqmessagequeues_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_rabbitmqmessagequeues_client.go
@@ -56,7 +56,7 @@ func (client *RabbitMQMessageQueuesClient) createOrUpdateCreateRequest(ctx conte
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if rabbitMQMessageQueueName == "" {
 		return nil, errors.New("parameter rabbitMQMessageQueueName cannot be empty")
 	}
@@ -117,7 +117,7 @@ func (client *RabbitMQMessageQueuesClient) deleteCreateRequest(ctx context.Conte
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if rabbitMQMessageQueueName == "" {
 		return nil, errors.New("parameter rabbitMQMessageQueueName cannot be empty")
 	}
@@ -169,7 +169,7 @@ func (client *RabbitMQMessageQueuesClient) getCreateRequest(ctx context.Context,
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if rabbitMQMessageQueueName == "" {
 		return nil, errors.New("parameter rabbitMQMessageQueueName cannot be empty")
 	}
@@ -227,7 +227,7 @@ func (client *RabbitMQMessageQueuesClient) listByRootScopeCreateRequest(ctx cont
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
@@ -284,7 +284,7 @@ func (client *RabbitMQMessageQueuesClient) listSecretsCreateRequest(ctx context.
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if rabbitMQMessageQueueName == "" {
 		return nil, errors.New("parameter rabbitMQMessageQueueName cannot be empty")
 	}

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_rediscaches_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_rediscaches_client.go
@@ -56,7 +56,7 @@ func (client *RedisCachesClient) createOrUpdateCreateRequest(ctx context.Context
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if redisCacheName == "" {
 		return nil, errors.New("parameter redisCacheName cannot be empty")
 	}
@@ -117,7 +117,7 @@ func (client *RedisCachesClient) deleteCreateRequest(ctx context.Context, redisC
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if redisCacheName == "" {
 		return nil, errors.New("parameter redisCacheName cannot be empty")
 	}
@@ -169,7 +169,7 @@ func (client *RedisCachesClient) getCreateRequest(ctx context.Context, redisCach
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if redisCacheName == "" {
 		return nil, errors.New("parameter redisCacheName cannot be empty")
 	}
@@ -227,7 +227,7 @@ func (client *RedisCachesClient) listByRootScopeCreateRequest(ctx context.Contex
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
@@ -284,7 +284,7 @@ func (client *RedisCachesClient) listSecretsCreateRequest(ctx context.Context, r
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if redisCacheName == "" {
 		return nil, errors.New("parameter redisCacheName cannot be empty")
 	}

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_sqldatabases_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_sqldatabases_client.go
@@ -56,7 +56,7 @@ func (client *SQLDatabasesClient) createOrUpdateCreateRequest(ctx context.Contex
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if sqlDatabaseName == "" {
 		return nil, errors.New("parameter sqlDatabaseName cannot be empty")
 	}
@@ -117,7 +117,7 @@ func (client *SQLDatabasesClient) deleteCreateRequest(ctx context.Context, sqlDa
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if sqlDatabaseName == "" {
 		return nil, errors.New("parameter sqlDatabaseName cannot be empty")
 	}
@@ -169,7 +169,7 @@ func (client *SQLDatabasesClient) getCreateRequest(ctx context.Context, sqlDatab
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if sqlDatabaseName == "" {
 		return nil, errors.New("parameter sqlDatabaseName cannot be empty")
 	}
@@ -227,7 +227,7 @@ func (client *SQLDatabasesClient) listByRootScopeCreateRequest(ctx context.Conte
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err

--- a/pkg/corerp/api/v20220315privatepreview/zz_generated_applications_client.go
+++ b/pkg/corerp/api/v20220315privatepreview/zz_generated_applications_client.go
@@ -56,7 +56,7 @@ func (client *ApplicationsClient) createOrUpdateCreateRequest(ctx context.Contex
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if applicationName == "" {
 		return nil, errors.New("parameter applicationName cannot be empty")
 	}
@@ -117,7 +117,7 @@ func (client *ApplicationsClient) deleteCreateRequest(ctx context.Context, appli
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if applicationName == "" {
 		return nil, errors.New("parameter applicationName cannot be empty")
 	}
@@ -169,7 +169,7 @@ func (client *ApplicationsClient) getCreateRequest(ctx context.Context, applicat
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if applicationName == "" {
 		return nil, errors.New("parameter applicationName cannot be empty")
 	}
@@ -227,7 +227,7 @@ func (client *ApplicationsClient) listByScopeCreateRequest(ctx context.Context, 
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
@@ -284,7 +284,7 @@ func (client *ApplicationsClient) updateCreateRequest(ctx context.Context, appli
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if applicationName == "" {
 		return nil, errors.New("parameter applicationName cannot be empty")
 	}

--- a/pkg/corerp/api/v20220315privatepreview/zz_generated_containers_client.go
+++ b/pkg/corerp/api/v20220315privatepreview/zz_generated_containers_client.go
@@ -56,7 +56,7 @@ func (client *ContainersClient) createOrUpdateCreateRequest(ctx context.Context,
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
 	}
@@ -117,7 +117,7 @@ func (client *ContainersClient) deleteCreateRequest(ctx context.Context, contain
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
 	}
@@ -169,7 +169,7 @@ func (client *ContainersClient) getCreateRequest(ctx context.Context, containerN
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
 	}
@@ -227,7 +227,7 @@ func (client *ContainersClient) listByScopeCreateRequest(ctx context.Context, op
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
@@ -284,7 +284,7 @@ func (client *ContainersClient) updateCreateRequest(ctx context.Context, contain
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if containerName == "" {
 		return nil, errors.New("parameter containerName cannot be empty")
 	}

--- a/pkg/corerp/api/v20220315privatepreview/zz_generated_environments_client.go
+++ b/pkg/corerp/api/v20220315privatepreview/zz_generated_environments_client.go
@@ -56,7 +56,7 @@ func (client *EnvironmentsClient) createOrUpdateCreateRequest(ctx context.Contex
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if environmentName == "" {
 		return nil, errors.New("parameter environmentName cannot be empty")
 	}
@@ -117,7 +117,7 @@ func (client *EnvironmentsClient) deleteCreateRequest(ctx context.Context, envir
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if environmentName == "" {
 		return nil, errors.New("parameter environmentName cannot be empty")
 	}
@@ -169,7 +169,7 @@ func (client *EnvironmentsClient) getCreateRequest(ctx context.Context, environm
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if environmentName == "" {
 		return nil, errors.New("parameter environmentName cannot be empty")
 	}
@@ -227,7 +227,7 @@ func (client *EnvironmentsClient) listByScopeCreateRequest(ctx context.Context, 
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
@@ -284,7 +284,7 @@ func (client *EnvironmentsClient) updateCreateRequest(ctx context.Context, envir
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if environmentName == "" {
 		return nil, errors.New("parameter environmentName cannot be empty")
 	}

--- a/pkg/corerp/api/v20220315privatepreview/zz_generated_gateways_client.go
+++ b/pkg/corerp/api/v20220315privatepreview/zz_generated_gateways_client.go
@@ -56,7 +56,7 @@ func (client *GatewaysClient) createOrUpdateCreateRequest(ctx context.Context, g
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if gatewayName == "" {
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}
@@ -117,7 +117,7 @@ func (client *GatewaysClient) deleteCreateRequest(ctx context.Context, gatewayNa
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if gatewayName == "" {
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}
@@ -169,7 +169,7 @@ func (client *GatewaysClient) getCreateRequest(ctx context.Context, gatewayName 
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if gatewayName == "" {
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}
@@ -227,7 +227,7 @@ func (client *GatewaysClient) listByScopeCreateRequest(ctx context.Context, opti
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
@@ -284,7 +284,7 @@ func (client *GatewaysClient) updateCreateRequest(ctx context.Context, gatewayNa
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if gatewayName == "" {
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}

--- a/pkg/corerp/api/v20220315privatepreview/zz_generated_httproutes_client.go
+++ b/pkg/corerp/api/v20220315privatepreview/zz_generated_httproutes_client.go
@@ -56,7 +56,7 @@ func (client *HTTPRoutesClient) createOrUpdateCreateRequest(ctx context.Context,
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if httpRouteName == "" {
 		return nil, errors.New("parameter httpRouteName cannot be empty")
 	}
@@ -117,7 +117,7 @@ func (client *HTTPRoutesClient) deleteCreateRequest(ctx context.Context, httpRou
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if httpRouteName == "" {
 		return nil, errors.New("parameter httpRouteName cannot be empty")
 	}
@@ -169,7 +169,7 @@ func (client *HTTPRoutesClient) getCreateRequest(ctx context.Context, httpRouteN
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if httpRouteName == "" {
 		return nil, errors.New("parameter httpRouteName cannot be empty")
 	}
@@ -227,7 +227,7 @@ func (client *HTTPRoutesClient) listByScopeCreateRequest(ctx context.Context, op
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(	client.ep, urlPath))
 	if err != nil {
 		return nil, err
@@ -284,7 +284,7 @@ func (client *HTTPRoutesClient) updateCreateRequest(ctx context.Context, httpRou
 	if client.rootScope == "" {
 		return nil, errors.New("parameter client.rootScope cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", url.PathEscape(client.rootScope))
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	if httpRouteName == "" {
 		return nil, errors.New("parameter httpRouteName cannot be empty")
 	}

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/global.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/global.json
@@ -93,7 +93,8 @@
       "required": true,
       "type": "string",
       "description": "The scope in which the resource is present. For Azure resource this would be /subscriptions/{subscriptionID}/resourceGroup/{resourcegroupID}",
-      "minLength": 1
+      "minLength": 1,
+      "x-ms-skip-url-encoding": true
     }
   },
   "paths": {

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/environments.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/environments.json
@@ -134,7 +134,7 @@
           ],
           "parameters": [
             {
-              "$ref": "./global.json#/parameters/RootScopeParameter"
+              "$ref": "global.json#/parameters/RootScopeParameter"
             },
             {
               "$ref": "../../../../../common-types/resource-management/v2/types.json#/parameters/ApiVersionParameter"
@@ -189,7 +189,7 @@
           ],
           "parameters": [
             {
-              "$ref": "./global.json#/parameters/RootScopeParameter"
+              "$ref": "global.json#/parameters/RootScopeParameter"
             },
             {
               "$ref": "../../../../../common-types/resource-management/v2/types.json#/parameters/ApiVersionParameter"
@@ -244,7 +244,7 @@
           ],
           "parameters": [
             {
-              "$ref": "./global.json#/parameters/RootScopeParameter"
+              "$ref": "global.json#/parameters/RootScopeParameter"
             },
             {
               "$ref": "../../../../../common-types/resource-management/v2/types.json#/parameters/ApiVersionParameter"

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/global.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/global.json
@@ -86,7 +86,8 @@
       "required": true,
       "type": "string",
       "description": "The scope in which the resource is present. For Azure resource this would be /subscriptions/{subscriptionID}/resourceGroup/{resourcegroupID}",
-      "minLength": 1
+      "minLength": 1,
+      "x-ms-skip-url-encoding": true
     }
   },
   "paths": {


### PR DESCRIPTION
# Description

This is to prevent autorest client from encoding {rootScope}

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #2903

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
