### PR TITLE
Hide commands that we de-emphasizing with v0.12

### DIFF
--- a/cmd/rad/cmd/appDeploy.go
+++ b/cmd/rad/cmd/appDeploy.go
@@ -96,8 +96,9 @@ rad app deploy --parameters @myfile.json
 
 rad app deploy --parameters @myfile.json --parameters version=latest
 `,
-	Args: cobra.MaximumNArgs(1),
-	RunE: deployApplication,
+	Args:   cobra.MaximumNArgs(1),
+	RunE:   deployApplication,
+	Hidden: true,
 }
 
 func init() {
@@ -171,7 +172,7 @@ func deployApplication(cmd *cobra.Command, args []string) error {
 	}
 
 	options := stages.Options{
-		Workspace:   *workspace,
+		Workspace:     *workspace,
 		BaseDirectory: baseDir,
 		Manifest:      manifest,
 		Builders:      builders.DefaultBuilders(),

--- a/cmd/rad/cmd/appInit.go
+++ b/cmd/rad/cmd/appInit.go
@@ -17,11 +17,12 @@ import (
 
 // appInitCmd command to scaffold
 var appInitCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Scaffold RAD application",
-	Long:  "Scaffolds a starter RAD application in the current directory",
-	Args:  cobra.MaximumNArgs(1),
-	RunE:  initApplication,
+	Use:    "init",
+	Short:  "Scaffold RAD application",
+	Long:   "Scaffolds a starter RAD application in the current directory",
+	Args:   cobra.MaximumNArgs(1),
+	RunE:   initApplication,
+	Hidden: true,
 }
 
 func init() {

--- a/cmd/rad/cmd/appRun.go
+++ b/cmd/rad/cmd/appRun.go
@@ -39,8 +39,9 @@ to affect deployment.
 
 rad app run
 `,
-	Args: cobra.MaximumNArgs(1),
-	RunE: runApplication,
+	Args:   cobra.MaximumNArgs(1),
+	RunE:   runApplication,
+	Hidden: true,
 }
 
 func init() {

--- a/cmd/rad/cmd/envInitDev.go
+++ b/cmd/rad/cmd/envInitDev.go
@@ -28,4 +28,5 @@ var envInitLocalCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return initSelfHosted(cmd, args, Dev)
 	},
+	Hidden: true,
 }


### PR DESCRIPTION
This change hides all of the `rad.yaml` commands and `rad env init dev`.
We'll make a plan for how to revisit this functionality soon.

/cc @emily-potyraj 