### PR TITLE
Fix version output for Bicep in rad version

### DIFF
--- a/cmd/rad/cmd/version.go
+++ b/cmd/rad/cmd/version.go
@@ -38,19 +38,19 @@ func writeVersionString(format string, w io.Writer) {
 	}
 	_ = output.Write(format, displayVersion, w, output.FormatterOptions{Columns: []output.Column{
 		{
-			Heading:  "Release",
+			Heading:  "RELEASE",
 			JSONPath: "{ .Release }",
 		},
 		{
-			Heading:  "Version",
+			Heading:  "VERSION",
 			JSONPath: "{ .Version }",
 		},
 		{
-			Heading:  "Bicep",
+			Heading:  "BICEP",
 			JSONPath: "{ .Bicep }",
 		},
 		{
-			Heading:  "Commit",
+			Heading:  "COMMIT",
 			JSONPath: "{ .Commit }",
 		},
 	}})

--- a/test/functional/corerp/cli/cli_test.go
+++ b/test/functional/corerp/cli/cli_test.go
@@ -6,11 +6,18 @@
 package resource_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
+	"github.com/project-radius/radius/pkg/cli/bicep"
+	"github.com/project-radius/radius/pkg/cli/objectformats"
+	"github.com/project-radius/radius/test"
 	"github.com/project-radius/radius/test/functional/corerp"
+	"github.com/project-radius/radius/test/functional/kubernetes"
+	"github.com/project-radius/radius/test/radcli"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
 	"github.com/stretchr/testify/require"
@@ -96,4 +103,25 @@ func Test_CLI_DeploymentParameters(t *testing.T) {
 	})
 
 	test.Test(t)
+}
+
+func Test_CLI_version(t *testing.T) {
+	ctx, cancel := test.GetContext(t)
+	defer cancel()
+
+	options := kubernetes.NewTestOptions(t)
+	cli := radcli.NewCLI(t, options.ConfigFilePath)
+
+	output, err := cli.Version(ctx)
+	require.NoError(t, err)
+
+	// Matching logic:
+	//
+	// Release: any word or number characters or hyphen or dot
+	// Version: any work or number characters or hyphen or dot
+	// Bicep: Semver
+	// Commit: any lowercase word or number characters
+	matcher := fmt.Sprintf(`RELEASE\s+VERSION\s+BICEP\s+COMMIT\s*([a-zA-Z0-9-\.]+)\s+([a-zA-Z0-9-\.]+)\s+(%s)\s+([a-z0-9]+)`, bicep.SemanticVersionRegex)
+	expected := regexp.MustCompile(matcher)
+	require.Regexp(t, expected, objectformats.TrimSpaceMulti(output))
 }

--- a/test/radcli/cli.go
+++ b/test/radcli/cli.go
@@ -188,6 +188,13 @@ func (cli *CLI) ResourceExpose(ctx context.Context, applicationName string, reso
 	return cli.RunCommand(ctx, args)
 }
 
+func (cli *CLI) Version(ctx context.Context) (string, error) {
+	args := []string{
+		"version",
+	}
+	return cli.RunCommand(ctx, args)
+}
+
 func (cli *CLI) RunCommand(ctx context.Context, args []string) (string, error) {
 	description := "rad " + strings.Join(args, " ")
 	args = cli.appendStandardArgs(args)


### PR DESCRIPTION
Fixes: radius-project/core-team#714

This change fixes the version output for Bicep. This regressed recently
when the signature of the `runBicep`function was changed to include JSON
unmarshalling. The output of `bicep --version` is not JSON.
