### PR TITLE
Slim down docker image for appcore rp

### DIFF
--- a/build/docker.mk
+++ b/build/docker.mk
@@ -42,7 +42,7 @@ docker-push-$(1):
 endef
 
 # defines a target for each image
-DOCKER_IMAGES := radius-rp ucpd appcore-rp
+DOCKER_IMAGES := ucpd appcore-rp
 
 $(foreach IMAGE,$(DOCKER_IMAGES),$(eval $(call generateDockerTargets,$(IMAGE),.,./deploy/images/$(IMAGE)/Dockerfile, go)))
 

--- a/deploy/images/appcore-rp/Dockerfile
+++ b/deploy/images/appcore-rp/Dockerfile
@@ -1,23 +1,10 @@
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+# Note: distroless already includes ca-certificates
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
 
-RUN yum -y install wget ca-certificates shadow-utils
+COPY ./* /
 
-# Install libifxaudit
-RUN wget https://packages.microsoft.com/centos/7/prod/libifxaudit-1.0-1525.x86_64.rpm && rpm -i libifxaudit-1.0-1525.x86_64.rpm
-
-WORKDIR /app
-
-RUN mkdir /app/config
-COPY ./* /app/
-
-RUN groupadd --gid 2000 radius
-
-RUN useradd --home "/nonexistent" --shell "/sbin/nologin" --gid radius --uid 1000 radius
-
-RUN chmod 770 /app/appcore-rp
-RUN chown radius.radius -R /app
-
-USER radius
+USER 65532:65532
 
 EXPOSE 8080
-ENTRYPOINT ["/app/appcore-rp"]
+ENTRYPOINT ["/appcore-rp"]

--- a/deploy/images/appcore-rp/Dockerfile.mariner
+++ b/deploy/images/appcore-rp/Dockerfile.mariner
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+
+RUN yum -y install wget ca-certificates shadow-utils
+
+# Install libifxaudit
+RUN wget https://packages.microsoft.com/centos/7/prod/libifxaudit-1.0-1525.x86_64.rpm && rpm -i libifxaudit-1.0-1525.x86_64.rpm
+
+WORKDIR /app
+
+RUN mkdir /app/config
+COPY ./* /app/
+
+RUN groupadd --gid 2000 radius
+
+RUN useradd --home "/nonexistent" --shell "/sbin/nologin" --gid radius --uid 1000 radius
+
+RUN chmod 770 /app/appcore-rp
+RUN chown radius.radius -R /app
+
+USER radius
+
+EXPOSE 8080
+ENTRYPOINT ["/app/appcore-rp"]

--- a/deploy/images/radius-controller/Dockerfile
+++ b/deploy/images/radius-controller/Dockerfile
@@ -1,8 +1,0 @@
-FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-
-COPY ./radius-controller /
-
-USER 65532:65532
-
-ENTRYPOINT ["/radius-controller"]

--- a/deploy/images/radius-rp/Dockerfile
+++ b/deploy/images/radius-rp/Dockerfile
@@ -1,5 +1,0 @@
-FROM alpine
-RUN apk --no-cache add ca-certificates
-COPY ./radius-rp /
-EXPOSE 5000
-ENTRYPOINT /radius-rp

--- a/deploy/images/ucpd/Dockerfile
+++ b/deploy/images/ucpd/Dockerfile
@@ -1,3 +1,4 @@
+# Note: distroless already includes ca-certificates
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 


### PR DESCRIPTION
Part of: #2582

This change switches us to distroless for the appcore rp docker image
from mariner. The overall impact is that the reduces the size from 245mb
to 53mb.

Additionally added ca-certificates to the UCP image. We will need these
to proxy to clouds like AWS and Azure, so adding them now.
