### PR TITLE
Determine/Update length restrictions in resource names

### DIFF
--- a/cadl/cadl-output/openapi.json
+++ b/cadl/cadl-output/openapi.json
@@ -441,8 +441,8 @@
       "in": "path",
       "required": true,
       "description": "environment name",
-      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-      "maxLength": 128,
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "maxLength": 63,
       "type": "string",
       "x-ms-parameter-location": "method"
     }

--- a/cadl/cadl-output/openapi.json
+++ b/cadl/cadl-output/openapi.json
@@ -441,7 +441,7 @@
       "in": "path",
       "required": true,
       "description": "environment name",
-      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
       "maxLength": 63,
       "type": "string",
       "x-ms-parameter-location": "method"

--- a/cadl/environment.cadl
+++ b/cadl/environment.cadl
@@ -33,8 +33,8 @@ model EnvironmentProperties {
 
 model EnvironmentResource is TrackedResource<EnvironmentProperties> {
   @doc("environment name")
-  @maxLength(128)
-  @pattern("^[a-z0-9]+(-[a-z0-9]+)*")
+  @maxLength(63)
+  @pattern("^[a-z0-9]+(-[a-z0-9]+)*$")
   @key("environmentName")
   @path
   @segment("{environmentName}")

--- a/cadl/environment.cadl
+++ b/cadl/environment.cadl
@@ -34,7 +34,7 @@ model EnvironmentProperties {
 model EnvironmentResource is TrackedResource<EnvironmentProperties> {
   @doc("environment name")
   @maxLength(63)
-  @pattern("^[a-z0-9]+(-[a-z0-9]+)*$")
+  @pattern("^[a-z]([-a-z0-9]*[a-z0-9])?$")
   @key("environmentName")
   @path
   @segment("{environmentName}")

--- a/pkg/cli/swagger/genericResource.json
+++ b/pkg/cli/swagger/genericResource.json
@@ -460,8 +460,8 @@
         "in": "path",
         "required": true,
         "type": "string",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-        "maxLength": 128,
+        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "maxLength": 63,
         "x-ms-parameter-location": "method"
       },
       "RootScopeParameter": {

--- a/pkg/cli/swagger/genericResource.json
+++ b/pkg/cli/swagger/genericResource.json
@@ -460,7 +460,7 @@
         "in": "path",
         "required": true,
         "type": "string",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
         "maxLength": 63,
         "x-ms-parameter-location": "method"
       },

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -6,9 +6,7 @@
 package kubernetes
 
 import (
-	"encoding/hex"
 	"fmt"
-	"hash/fnv"
 	"strings"
 )
 
@@ -52,7 +50,7 @@ func MakeDescriptiveLabels(application string, resource string) map[string]strin
 	return map[string]string{
 		LabelRadiusApplication: application,
 		LabelRadiusResource:    resource,
-		LabelName:              MakeResourceName(application, resource),
+		LabelName:              resource,
 		LabelPartOf:            application,
 		LabelManagedBy:         LabelManagedByRadiusRP,
 	}
@@ -123,7 +121,6 @@ func MakeResourceCRDLabels(application string, resourceType string, resource str
 
 // MakeResourceName returns hash of application + "-" + resource
 func MakeResourceName(application string, resource string) string {
-<<<<<<< HEAD
 	if application != "" && resource != "" {
 		return strings.ToLower(application + "-" + resource)
 	}
@@ -138,10 +135,4 @@ func MakeResourceName(application string, resource string) string {
 
 	// We should never have this case
 	return "resource-name"
-=======
-	rn := fnv.New64a()
-	rn.Write([]byte(application + "-" + resource))
-	hashrn := hex.EncodeToString(rn.Sum(nil))
-	return hashrn
->>>>>>> 2bc77365 (returning hash to avoid length restrictions on label)
 }

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -121,6 +121,7 @@ func MakeResourceCRDLabels(application string, resourceType string, resource str
 	}
 }
 
+// MakeResourceName returns hash of application + "-" + resource
 func MakeResourceName(application string, resource string) string {
 <<<<<<< HEAD
 	if application != "" && resource != "" {

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -119,7 +119,6 @@ func MakeResourceCRDLabels(application string, resourceType string, resource str
 	}
 }
 
-// MakeResourceName returns hash of application + "-" + resource
 func MakeResourceName(application string, resource string) string {
 	if application != "" && resource != "" {
 		return strings.ToLower(application + "-" + resource)

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -6,7 +6,9 @@
 package kubernetes
 
 import (
+	"encoding/hex"
 	"fmt"
+	"hash/fnv"
 	"strings"
 )
 
@@ -120,6 +122,7 @@ func MakeResourceCRDLabels(application string, resourceType string, resource str
 }
 
 func MakeResourceName(application string, resource string) string {
+<<<<<<< HEAD
 	if application != "" && resource != "" {
 		return strings.ToLower(application + "-" + resource)
 	}
@@ -134,4 +137,10 @@ func MakeResourceName(application string, resource string) string {
 
 	// We should never have this case
 	return "resource-name"
+=======
+	rn := fnv.New64a()
+	rn.Write([]byte(application + "-" + resource))
+	hashrn := hex.EncodeToString(rn.Sum(nil))
+	return hashrn
+>>>>>>> 2bc77365 (returning hash to avoid length restrictions on label)
 }

--- a/pkg/validator/apivalidator_test.go
+++ b/pkg/validator/apivalidator_test.go
@@ -279,7 +279,7 @@ func runTest(t *testing.T, resourceIDUrl string) {
 					Details: []armerrors.ErrorDetails{
 						{
 							Code:    "InvalidRequestContent",
-							Message: "environmentName in path should be at most 128 chars long",
+							Message: "environmentName in path should be at most 63 chars long",
 						},
 					},
 				},
@@ -302,7 +302,7 @@ func runTest(t *testing.T, resourceIDUrl string) {
 					Details: []armerrors.ErrorDetails{
 						{
 							Code:    "InvalidRequestContent",
-							Message: "environmentName in path should be at most 128 chars long",
+							Message: "environmentName in path should be at most 63 chars long",
 						},
 					},
 				},

--- a/pkg/validator/apivalidator_test.go
+++ b/pkg/validator/apivalidator_test.go
@@ -21,11 +21,15 @@ import (
 )
 
 const (
-	envRoute     = "/providers/applications.core/environments/{environmentName}"
-	armIDUrl     = "http://localhost:8080/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0"
-	ucpIDUrl     = "http://localhost:8080/planes/radius/local/resourceGroups/radius-test-rg/providers/applications.core/environments/env0"
-	longarmIDUrl = "http://localhost:8080/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/largeEnvName14161820222426283032343638404244464850525456586062646668707274767880828486889092949698100102104106108120122124126128130"
-	longucpIDUrl = "http://localhost:8080/planes/radius/local/resourceGroups/radius-test-rg/providers/applications.core/environments/largeEnvName14161820222426283032343638404244464850525456586062646668707274767880828486889092949698100102104106108120122124126128130"
+	envRoute           = "/providers/applications.core/environments/{environmentName}"
+	armIDUrl           = "http://localhost:8080/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0"
+	ucpIDUrl           = "http://localhost:8080/planes/radius/local/resourceGroups/radius-test-rg/providers/applications.core/environments/env0"
+	longarmIDUrl       = "http://localhost:8080/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/largeEnvName14161820222426283032343638404244464850525456586062646668707274767880828486889092949698100102104106108120122124126128130"
+	longucpIDUrl       = "http://localhost:8080/planes/radius/local/resourceGroups/radius-test-rg/providers/applications.core/environments/largeEnvName14161820222426283032343638404244464850525456586062646668707274767880828486889092949698100102104106108120122124126128130"
+	underscorearmIDUrl = "http://localhost:8080/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env_name0"
+	underscoreucpIDUrl = "http://localhost:8080/planes/radius/local/resourceGroups/radius-test-rg/providers/applications.core/environments/env_name0"
+	digitarmIDUrl      = "http://localhost:8080/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/0env"
+	digitucpIDUrl      = "http://localhost:8080/planes/radius/local/resourceGroups/radius-test-rg/providers/applications.core/environments/0env"
 
 	operationGetRoute    = "/providers/applications.core/operations"
 	subscriptionPUTRoute = "/subscriptions/{subscriptions}/resourceGroups/{resourceGroup}"
@@ -303,6 +307,98 @@ func runTest(t *testing.T, resourceIDUrl string) {
 						{
 							Code:    "InvalidRequestContent",
 							Message: "environmentName in path should be at most 63 chars long",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:            "underscore not allowed in name",
+			method:          http.MethodPut,
+			rootScope:       "/{rootScope:.*}",
+			route:           envRoute,
+			apiVersion:      "2022-03-15-privatepreview",
+			contentFilePath: "put-environments-valid.json",
+			url:             underscorearmIDUrl,
+			responseCode:    400,
+			validationErr: &armerrors.ErrorResponse{
+				Error: armerrors.ErrorDetails{
+					Code:    "HttpRequestPayloadAPISpecValidationFailed",
+					Target:  "applications.core/environments/env_name0",
+					Message: "HTTP request payload failed validation against API specification with one or more errors. Please see details for more information.",
+					Details: []armerrors.ErrorDetails{
+						{
+							Code:    "InvalidRequestContent",
+							Message: "environmentName in path should match '^[a-z]([-a-z0-9]*[a-z0-9])?$'",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:            "underscore not allowed in name",
+			method:          http.MethodPut,
+			rootScope:       "/{rootScope:.*}",
+			route:           envRoute,
+			apiVersion:      "2022-03-15-privatepreview",
+			contentFilePath: "put-environments-valid.json",
+			url:             underscoreucpIDUrl,
+			responseCode:    400,
+			validationErr: &armerrors.ErrorResponse{
+				Error: armerrors.ErrorDetails{
+					Code:    "HttpRequestPayloadAPISpecValidationFailed",
+					Target:  "applications.core/environments/env_name0",
+					Message: "HTTP request payload failed validation against API specification with one or more errors. Please see details for more information.",
+					Details: []armerrors.ErrorDetails{
+						{
+							Code:    "InvalidRequestContent",
+							Message: "environmentName in path should match '^[a-z]([-a-z0-9]*[a-z0-9])?$'",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:            "name cannot start with digit",
+			method:          http.MethodPut,
+			rootScope:       "/{rootScope:.*}",
+			route:           envRoute,
+			apiVersion:      "2022-03-15-privatepreview",
+			contentFilePath: "put-environments-valid.json",
+			url:             digitarmIDUrl,
+			responseCode:    400,
+			validationErr: &armerrors.ErrorResponse{
+				Error: armerrors.ErrorDetails{
+					Code:    "HttpRequestPayloadAPISpecValidationFailed",
+					Target:  "applications.core/environments/0env",
+					Message: "HTTP request payload failed validation against API specification with one or more errors. Please see details for more information.",
+					Details: []armerrors.ErrorDetails{
+						{
+							Code:    "InvalidRequestContent",
+							Message: "environmentName in path should match '^[a-z]([-a-z0-9]*[a-z0-9])?$'",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:            "name cannot start with digit",
+			method:          http.MethodPut,
+			rootScope:       "/{rootScope:.*}",
+			route:           envRoute,
+			apiVersion:      "2022-03-15-privatepreview",
+			contentFilePath: "put-environments-valid.json",
+			url:             digitucpIDUrl,
+			responseCode:    400,
+			validationErr: &armerrors.ErrorResponse{
+				Error: armerrors.ErrorDetails{
+					Code:    "HttpRequestPayloadAPISpecValidationFailed",
+					Target:  "applications.core/environments/0env",
+					Message: "HTTP request payload failed validation against API specification with one or more errors. Please see details for more information.",
+					Details: []armerrors.ErrorDetails{
+						{
+							Code:    "InvalidRequestContent",
+							Message: "environmentName in path should match '^[a-z]([-a-z0-9]*[a-z0-9])?$'",
 						},
 					},
 				},

--- a/pkg/validator/apivalidator_test.go
+++ b/pkg/validator/apivalidator_test.go
@@ -21,9 +21,12 @@ import (
 )
 
 const (
-	envRoute             = "/providers/applications.core/environments/{environmentName}"
-	armIDUrl             = "http://localhost:8080/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0"
-	ucpIDUrl             = "http://localhost:8080/planes/radius/local/resourceGroups/radius-test-rg/providers/applications.core/environments/env0"
+	envRoute     = "/providers/applications.core/environments/{environmentName}"
+	armIDUrl     = "http://localhost:8080/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0"
+	ucpIDUrl     = "http://localhost:8080/planes/radius/local/resourceGroups/radius-test-rg/providers/applications.core/environments/env0"
+	longarmIDUrl = "http://localhost:8080/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/largeEnvName14161820222426283032343638404244464850525456586062646668707274767880828486889092949698100102104106108120122124126128130"
+	longucpIDUrl = "http://localhost:8080/planes/radius/local/resourceGroups/radius-test-rg/providers/applications.core/environments/largeEnvName14161820222426283032343638404244464850525456586062646668707274767880828486889092949698100102104106108120122124126128130"
+
 	operationGetRoute    = "/providers/applications.core/operations"
 	subscriptionPUTRoute = "/subscriptions/{subscriptions}/resourceGroups/{resourceGroup}"
 )
@@ -254,6 +257,52 @@ func runTest(t *testing.T, resourceIDUrl string) {
 						{
 							Code:    "InvalidRequestContent",
 							Message: "The request content was invalid and could not be deserialized.",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:            "env name too long",
+			method:          http.MethodPut,
+			rootScope:       "/{rootScope:.*}",
+			route:           envRoute,
+			apiVersion:      "2022-03-15-privatepreview",
+			contentFilePath: "put-environments-valid.json",
+			url:             longarmIDUrl,
+			responseCode:    400,
+			validationErr: &armerrors.ErrorResponse{
+				Error: armerrors.ErrorDetails{
+					Code:    "HttpRequestPayloadAPISpecValidationFailed",
+					Target:  "applications.core/environments/largeEnvName14161820222426283032343638404244464850525456586062646668707274767880828486889092949698100102104106108120122124126128130",
+					Message: "HTTP request payload failed validation against API specification with one or more errors. Please see details for more information.",
+					Details: []armerrors.ErrorDetails{
+						{
+							Code:    "InvalidRequestContent",
+							Message: "environmentName in path should be at most 128 chars long",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:            "env name too long",
+			method:          http.MethodPut,
+			rootScope:       "/{rootScope:.*}",
+			route:           envRoute,
+			apiVersion:      "2022-03-15-privatepreview",
+			contentFilePath: "put-environments-valid.json",
+			url:             longucpIDUrl,
+			responseCode:    400,
+			validationErr: &armerrors.ErrorResponse{
+				Error: armerrors.ErrorDetails{
+					Code:    "HttpRequestPayloadAPISpecValidationFailed",
+					Target:  "applications.core/environments/largeEnvName14161820222426283032343638404244464850525456586062646668707274767880828486889092949698100102104106108120122124126128130",
+					Message: "HTTP request payload failed validation against API specification with one or more errors. Please see details for more information.",
+					Details: []armerrors.ErrorDetails{
+						{
+							Code:    "InvalidRequestContent",
+							Message: "environmentName in path should be at most 128 chars long",
 						},
 					},
 				},

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/daprInvokeHttpRoutes.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/daprInvokeHttpRoutes.json
@@ -294,8 +294,8 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-      "maxLength": 128,
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "maxLength": 63,
       "x-ms-parameter-location": "method"
     }
   }

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/daprInvokeHttpRoutes.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/daprInvokeHttpRoutes.json
@@ -294,7 +294,7 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
       "maxLength": 63,
       "x-ms-parameter-location": "method"
     }

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/daprPubSubBrokers.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/daprPubSubBrokers.json
@@ -353,8 +353,8 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-      "maxLength": 128,
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "maxLength": 63,
       "x-ms-parameter-location": "method"
     }
   }

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/daprPubSubBrokers.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/daprPubSubBrokers.json
@@ -353,7 +353,7 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
       "maxLength": 63,
       "x-ms-parameter-location": "method"
     }

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/daprSecretStores.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/daprSecretStores.json
@@ -321,7 +321,7 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
       "maxLength": 63,
       "x-ms-parameter-location": "method"
     }

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/daprSecretStores.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/daprSecretStores.json
@@ -321,8 +321,8 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-      "maxLength": 128,
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "maxLength": 63,
       "x-ms-parameter-location": "method"
     }
   }

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/daprStateStores.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/daprStateStores.json
@@ -377,7 +377,7 @@
         "in": "path",
         "required": true,
         "type": "string",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
         "maxLength": 63,
         "x-ms-parameter-location": "method"
       }

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/daprStateStores.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/daprStateStores.json
@@ -377,8 +377,8 @@
         "in": "path",
         "required": true,
         "type": "string",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-        "maxLength": 128,
+        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "maxLength": 63,
         "x-ms-parameter-location": "method"
       }
     }

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/extenders.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/extenders.json
@@ -378,8 +378,8 @@
         "in": "path",
         "required": true,
         "type": "string",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-        "maxLength": 128,
+        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "maxLength": 63,
         "x-ms-parameter-location": "method"
       }
     }

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/extenders.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/extenders.json
@@ -378,7 +378,7 @@
         "in": "path",
         "required": true,
         "type": "string",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
         "maxLength": 63,
         "x-ms-parameter-location": "method"
       }

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/mongoDatabases.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/mongoDatabases.json
@@ -415,8 +415,8 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-      "maxLength": 128,
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "maxLength": 63,
       "x-ms-parameter-location": "method"
     }
   }

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/mongoDatabases.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/mongoDatabases.json
@@ -415,7 +415,7 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
       "maxLength": 63,
       "x-ms-parameter-location": "method"
     }

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/rabbitMQMessageQueues.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/rabbitMQMessageQueues.json
@@ -388,8 +388,8 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-      "maxLength": 128,
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "maxLength": 63,
       "x-ms-parameter-location": "method"
     }
   }

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/rabbitMQMessageQueues.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/rabbitMQMessageQueues.json
@@ -388,7 +388,7 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
       "maxLength": 63,
       "x-ms-parameter-location": "method"
     }

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/redisCaches.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/redisCaches.json
@@ -418,8 +418,8 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-      "maxLength": 128,
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "maxLength": 63,
       "x-ms-parameter-location": "method"
     }
   }

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/redisCaches.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/redisCaches.json
@@ -418,7 +418,7 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
       "maxLength": 63,
       "x-ms-parameter-location": "method"
     }

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/sqlDatabases.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/sqlDatabases.json
@@ -302,8 +302,8 @@
         "in": "path",
         "required": true,
         "type": "string",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-        "maxLength": 128,
+        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "maxLength": 63,
         "x-ms-parameter-location": "method"
       }
     }

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/sqlDatabases.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/sqlDatabases.json
@@ -302,7 +302,7 @@
         "in": "path",
         "required": true,
         "type": "string",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
         "maxLength": 63,
         "x-ms-parameter-location": "method"
       }

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/applications.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/applications.json
@@ -339,8 +339,8 @@
         "required": true,
         "type": "string",
         "description": "The name of the application.",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-        "maxLength": 128,
+        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "maxLength": 63,
         "x-ms-parameter-location": "method"
       }
     }

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/applications.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/applications.json
@@ -339,7 +339,7 @@
         "required": true,
         "type": "string",
         "description": "The name of the application.",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",  
         "maxLength": 63,
         "x-ms-parameter-location": "method"
       }

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/containers.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/containers.json
@@ -731,7 +731,7 @@
         "required": true,
         "type": "string",
         "description": "The name of the conatiner.",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
         "maxLength": 63,
         "x-ms-parameter-location": "method"
       }

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/containers.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/containers.json
@@ -731,8 +731,8 @@
         "required": true,
         "type": "string",
         "description": "The name of the conatiner.",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-        "maxLength": 128,
+        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "maxLength": 63,
         "x-ms-parameter-location": "method"
       }
     }

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/environments.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/environments.json
@@ -374,7 +374,7 @@
         "required": true,
         "type": "string",
         "description": "The name of the environment",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
         "maxLength": 63,
         "x-ms-parameter-location": "method"
       }

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/environments.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/environments.json
@@ -374,8 +374,8 @@
         "required": true,
         "type": "string",
         "description": "The name of the environment",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-        "maxLength": 128,
+        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "maxLength": 63,
         "x-ms-parameter-location": "method"
       }
     }

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/gateways.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/gateways.json
@@ -400,8 +400,8 @@
         "required": true,
         "type": "string",
         "description": "The name of the Gateway.",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-        "maxLength": 128,
+        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "maxLength": 63,
         "x-ms-parameter-location": "method"
       }
     }

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/gateways.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/gateways.json
@@ -400,7 +400,7 @@
         "required": true,
         "type": "string",
         "description": "The name of the Gateway.",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
         "maxLength": 63,
         "x-ms-parameter-location": "method"
       }

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/httpRoutes.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/httpRoutes.json
@@ -365,8 +365,8 @@
         "required": true,
         "type": "string",
         "description": "The name of the HTTP Route.",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-        "maxLength": 128,
+        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "maxLength": 63,
         "x-ms-parameter-location": "method"
       }
     }

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/httpRoutes.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2022-03-15-privatepreview/httpRoutes.json
@@ -365,7 +365,7 @@
         "required": true,
         "type": "string",
         "description": "The name of the HTTP Route.",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
         "maxLength": 63,
         "x-ms-parameter-location": "method"
       }

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-03-15-privatepreview/ucp.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-03-15-privatepreview/ucp.json
@@ -467,7 +467,7 @@
       "ResourceGroupName": {
         "type": "string",
         "description": "The name of the resource group",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
         "maxLength": 63
       },
       "ErrorDetail": {
@@ -547,7 +547,7 @@
         "required": true,
         "type": "string",
         "description": "The type of the plane",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
         "maxLength": 63,
         "x-ms-parameter-location": "method"
       },
@@ -557,7 +557,7 @@
           "required": true,
           "type": "string",
           "description": "The name of the plane",
-          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
           "maxLength": 63,
           "x-ms-parameter-location": "method"
       },
@@ -567,7 +567,7 @@
         "required": true,
         "type": "string",
         "description": "The name of the resource group",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
         "maxLength": 63,
         "x-ms-parameter-location": "method"
       }

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-03-15-privatepreview/ucp.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-03-15-privatepreview/ucp.json
@@ -547,8 +547,8 @@
         "required": true,
         "type": "string",
         "description": "The type of the plane",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-        "maxLength": 128,
+        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "maxLength": 63,
         "x-ms-parameter-location": "method"
       },
       "PlaneNameParameter": {

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-03-15-privatepreview/ucp.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-03-15-privatepreview/ucp.json
@@ -467,8 +467,8 @@
       "ResourceGroupName": {
         "type": "string",
         "description": "The name of the resource group",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-        "maxLength": 128
+        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "maxLength": 63
       },
       "ErrorDetail": {
         "description": "The error detail.",
@@ -557,8 +557,8 @@
           "required": true,
           "type": "string",
           "description": "The name of the plane",
-          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-          "maxLength": 128,
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+          "maxLength": 63,
           "x-ms-parameter-location": "method"
       },
       "ResourceGroupNameParameter": {
@@ -567,8 +567,8 @@
         "required": true,
         "type": "string",
         "description": "The name of the resource group",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*",
-        "maxLength": 128,
+        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+        "maxLength": 63,
         "x-ms-parameter-location": "method"
       }
     }


### PR DESCRIPTION
# Description

Updating MakeResourceName() to return a hash to avoid length restrictions in kubernetes labels

radius-project/core-team#579 

Please reference the issue this PR will close: radius-project/core-team#579, radius-project/core-team#782, radius-project/core-team#743

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
