### PR TITLE
Adding resource + listSecrets to routes

### DIFF
--- a/pkg/armrpc/servicecontext/armrequestcontext.go
+++ b/pkg/armrpc/servicecontext/armrequestcontext.go
@@ -165,7 +165,7 @@ type ARMRequestContext struct {
 func FromARMRequest(r *http.Request, pathBase string) (*ARMRequestContext, error) {
 	log := radlogger.GetLogger(r.Context())
 	path := strings.TrimPrefix(r.URL.Path, pathBase)
-	azID, err := resources.Parse(path)
+	azID, err := resources.ParseByMethod(path, r.Method)
 	if err != nil {
 		log.V(radlogger.Debug).Info(fmt.Sprintf("URL was not a valid resource id: %v", r.URL.Path))
 		// do not stop extracting headers. handler needs to care invalid resource id.

--- a/pkg/ucp/resources/id.go
+++ b/pkg/ucp/resources/id.go
@@ -7,6 +7,7 @@ package resources
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 )
 
@@ -328,6 +329,22 @@ func (ri ID) Truncate() ID {
 
 		return result
 	}
+}
+
+// ParseByMethod is a helper function to extract the custom actions from the id.
+// If there is a custom action in the request, then the method will be POST. To be able
+// to get the proper type, we need to remove the custom action from the id.
+func ParseByMethod(id string, method string) (ID, error) {
+	parsedID, err := Parse(id)
+	if err != nil {
+		return ID{}, err
+	}
+
+	if method == http.MethodPost {
+		parsedID = parsedID.Truncate()
+	}
+
+	return parsedID, nil
 }
 
 // Parse parses a resource ID.

--- a/pkg/ucp/resources/id_test.go
+++ b/pkg/ucp/resources/id_test.go
@@ -499,11 +499,11 @@ func Test_Truncate_ReturnsSelfForTopLevelScope_UCP(t *testing.T) {
 }
 
 func Test_Truncate_WithCustomAction(t *testing.T) {
-	id, err := Parse("/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0/listSecrets")
+	id, err := Parse("/planes/radius/local/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0/listSecrets")
 	require.NoError(t, err)
 
 	truncated := id.Truncate()
-	require.Equal(t, "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0", truncated.id)
+	require.Equal(t, "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0", truncated.id)
 }
 
 func Test_IdParsing_WithNoTypeSegments(t *testing.T) {
@@ -725,94 +725,107 @@ func Test_ValidateResourceType_Invalid(t *testing.T) {
 
 func Test_ParseByMethod(t *testing.T) {
 	testCases := []struct {
-		desc     string
-		id       string
-		method   string
-		err      bool
-		expected string
+		desc   string
+		id     string
+		method string
+		err    bool
+		eID    string
+		eRType string
 	}{
 		{
-			desc:     "ucp-post-with-custom-action",
-			id:       "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0/listSecrets",
-			method:   http.MethodPost,
-			err:      false,
-			expected: "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			desc:   "ucp-post-with-custom-action",
+			id:     "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0/listSecrets",
+			method: http.MethodPost,
+			err:    false,
+			eID:    "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			eRType: "Applications.Connector/mongoDatabases",
 		},
 		{
-			desc:     "ucp-get",
-			id:       "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
-			method:   http.MethodGet,
-			err:      false,
-			expected: "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			desc:   "ucp-get",
+			id:     "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			method: http.MethodGet,
+			err:    false,
+			eID:    "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			eRType: "Applications.Connector/mongoDatabases",
 		},
 		{
-			desc:     "ucp-list",
-			id:       "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases",
-			method:   http.MethodGet,
-			err:      false,
-			expected: "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases",
+			desc:   "ucp-list",
+			id:     "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases",
+			method: http.MethodGet,
+			err:    false,
+			eID:    "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases",
+			eRType: "Applications.Connector/mongoDatabases",
 		},
 		{
-			desc:     "ucp-put",
-			id:       "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
-			method:   http.MethodPut,
-			err:      false,
-			expected: "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			desc:   "ucp-put",
+			id:     "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			method: http.MethodPut,
+			err:    false,
+			eID:    "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			eRType: "Applications.Connector/mongoDatabases",
 		},
 		{
-			desc:     "ucp-patch",
-			id:       "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
-			method:   http.MethodPatch,
-			err:      false,
-			expected: "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			desc:   "ucp-patch",
+			id:     "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			method: http.MethodPatch,
+			err:    false,
+			eID:    "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			eRType: "Applications.Connector/mongoDatabases",
 		},
 		{
-			desc:     "ucp-delete",
-			id:       "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
-			method:   http.MethodDelete,
-			err:      false,
-			expected: "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			desc:   "ucp-delete",
+			id:     "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			method: http.MethodDelete,
+			err:    false,
+			eID:    "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			eRType: "Applications.Connector/mongoDatabases",
 		}, {
-			desc:     "arm-post-with-custom-action",
-			id:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0/listSecrets",
-			method:   http.MethodPost,
-			err:      false,
-			expected: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			desc:   "arm-post-with-custom-action",
+			id:     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0/listSecrets",
+			method: http.MethodPost,
+			err:    false,
+			eID:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			eRType: "Applications.Connector/mongoDatabases",
 		},
 		{
-			desc:     "arm-get",
-			id:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
-			method:   http.MethodGet,
-			err:      false,
-			expected: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			desc:   "arm-get",
+			id:     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			method: http.MethodGet,
+			err:    false,
+			eID:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			eRType: "Applications.Connector/mongoDatabases",
 		},
 		{
-			desc:     "arm-list",
-			id:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases",
-			method:   http.MethodGet,
-			err:      false,
-			expected: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases",
+			desc:   "arm-list",
+			id:     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases",
+			method: http.MethodGet,
+			err:    false,
+			eID:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases",
+			eRType: "Applications.Connector/mongoDatabases",
 		},
 		{
-			desc:     "arm-put",
-			id:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
-			method:   http.MethodPut,
-			err:      false,
-			expected: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			desc:   "arm-put",
+			id:     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			method: http.MethodPut,
+			err:    false,
+			eID:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			eRType: "Applications.Connector/mongoDatabases",
 		},
 		{
-			desc:     "arm-patch",
-			id:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
-			method:   http.MethodPatch,
-			err:      false,
-			expected: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			desc:   "arm-patch",
+			id:     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			method: http.MethodPatch,
+			err:    false,
+			eID:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			eRType: "Applications.Connector/mongoDatabases",
 		},
 		{
-			desc:     "arm-delete",
-			id:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
-			method:   http.MethodDelete,
-			err:      false,
-			expected: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			desc:   "arm-delete",
+			id:     "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			method: http.MethodDelete,
+			err:    false,
+			eID:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			eRType: "Applications.Connector/mongoDatabases",
 		},
 	}
 
@@ -823,7 +836,8 @@ func Test_ParseByMethod(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.expected, parsedID.String())
+				require.Equal(t, tt.eID, parsedID.String())
+				require.Equal(t, tt.eRType, parsedID.Type())
 			}
 		})
 	}

--- a/pkg/ucp/resources/id_test.go
+++ b/pkg/ucp/resources/id_test.go
@@ -7,6 +7,7 @@ package resources
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/project-radius/radius/pkg/azure/azresources"
@@ -497,6 +498,14 @@ func Test_Truncate_ReturnsSelfForTopLevelScope_UCP(t *testing.T) {
 	require.Equal(t, "/planes", truncated.id)
 }
 
+func Test_Truncate_WithCustomAction(t *testing.T) {
+	id, err := Parse("/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0/listSecrets")
+	require.NoError(t, err)
+
+	truncated := id.Truncate()
+	require.Equal(t, "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0", truncated.id)
+}
+
 func Test_IdParsing_WithNoTypeSegments(t *testing.T) {
 	idStr := "/planes/radius/local/"
 	id, err := Parse(idStr)
@@ -710,6 +719,112 @@ func Test_ValidateResourceType_Invalid(t *testing.T) {
 		t.Run(fmt.Sprintf("%d: %v", i, v.testID.id), func(t *testing.T) {
 			err := v.testID.ValidateResourceType(v.testKnownType)
 			require.Errorf(t, err, "resource '%s' does not match the expected resource type %s", v.testID.id)
+		})
+	}
+}
+
+func Test_ParseByMethod(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		id       string
+		method   string
+		err      bool
+		expected string
+	}{
+		{
+			desc:     "ucp-post-with-custom-action",
+			id:       "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0/listSecrets",
+			method:   http.MethodPost,
+			err:      false,
+			expected: "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+		},
+		{
+			desc:     "ucp-get",
+			id:       "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			method:   http.MethodGet,
+			err:      false,
+			expected: "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+		},
+		{
+			desc:     "ucp-list",
+			id:       "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases",
+			method:   http.MethodGet,
+			err:      false,
+			expected: "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases",
+		},
+		{
+			desc:     "ucp-put",
+			id:       "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			method:   http.MethodPut,
+			err:      false,
+			expected: "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+		},
+		{
+			desc:     "ucp-patch",
+			id:       "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			method:   http.MethodPatch,
+			err:      false,
+			expected: "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+		},
+		{
+			desc:     "ucp-delete",
+			id:       "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			method:   http.MethodDelete,
+			err:      false,
+			expected: "/planes/radius/local/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+		}, {
+			desc:     "arm-post-with-custom-action",
+			id:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0/listSecrets",
+			method:   http.MethodPost,
+			err:      false,
+			expected: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+		},
+		{
+			desc:     "arm-get",
+			id:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			method:   http.MethodGet,
+			err:      false,
+			expected: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+		},
+		{
+			desc:     "arm-list",
+			id:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases",
+			method:   http.MethodGet,
+			err:      false,
+			expected: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases",
+		},
+		{
+			desc:     "arm-put",
+			id:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			method:   http.MethodPut,
+			err:      false,
+			expected: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+		},
+		{
+			desc:     "arm-patch",
+			id:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			method:   http.MethodPatch,
+			err:      false,
+			expected: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+		},
+		{
+			desc:     "arm-delete",
+			id:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+			method:   http.MethodDelete,
+			err:      false,
+			expected: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/ytimocin-rg/providers/Applications.Connector/mongoDatabases/mongo-database-0",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.desc, func(t *testing.T) {
+			parsedID, err := ParseByMethod(tt.id, tt.method)
+			if tt.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, parsedID.String())
+			}
 		})
 	}
 }

--- a/pkg/validator/apivalidator.go
+++ b/pkg/validator/apivalidator.go
@@ -26,7 +26,7 @@ const (
 func APIValidator(loader *Loader) func(h http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
-			rID, err := resources.Parse(r.URL.Path)
+			rID, err := resources.ParseByMethod(r.URL.Path, r.Method)
 			if err != nil {
 				resp := invalidResourceIDResponse(r.URL.Path)
 				if err := resp.Apply(r.Context(), w, r); err != nil {


### PR DESCRIPTION
# Description
When a request with a custom action comes in, the API Validator cannot validate the request because resource type is returned as resource+customAction (for example; Applications.Connector/mongoDatabases/listSecrets). We need to make sure that we don't return the custom action when getting the type for a resource.

## Issue reference
Please reference the issue this PR will close: #2947 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
