### PR TITLE
Fixing TargetPort bug in Container renderer

### DIFF
--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -22,7 +22,6 @@ import (
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
 	"github.com/project-radius/radius/pkg/corerp/renderers"
-	"github.com/project-radius/radius/pkg/corerp/renderers/httproute"
 	"github.com/project-radius/radius/pkg/handlers"
 	"github.com/project-radius/radius/pkg/kubernetes"
 	"github.com/project-radius/radius/pkg/providers"
@@ -178,16 +177,21 @@ func (r Renderer) makeDeployment(ctx context.Context, resource datamodel.Contain
 			if err != nil {
 				return []outputresource.OutputResource{}, nil, err
 			}
+
 			routeName := resourceId.Name()
+			routeType := resourceId.TypeSegments()[len(resourceId.TypeSegments())-1].Type
+			routeTypeParts := strings.Split(routeType, "/")
+
+			routeTypeSuffix := routeTypeParts[len(routeTypeParts)-1]
 
 			routes = append(routes, struct {
 				Name string
 				Type string
-			}{Name: routeName, Type: httproute.ResourceTypeSuffix})
+			}{Name: routeName, Type: routeTypeSuffix})
 
 			ports = append(ports, corev1.ContainerPort{
 				// Name generation logic has to match the code in HttpRoute
-				Name:          kubernetes.GetShortenedTargetPortName(applicationName + httproute.ResourceTypeSuffix + routeName),
+				Name:          kubernetes.GetShortenedTargetPortName(applicationName + routeTypeSuffix + routeName),
 				ContainerPort: port.ContainerPort,
 				Protocol:      corev1.ProtocolTCP,
 			})

--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -179,16 +179,11 @@ func (r Renderer) makeDeployment(ctx context.Context, resource datamodel.Contain
 				return []outputresource.OutputResource{}, nil, err
 			}
 			routeName := resourceId.Name()
-			routeType := resourceId.TypeSegments()[len(resourceId.TypeSegments())-1].Type
-
-			typeParts := strings.Split(routeType, "/")
-
-			resourceTypeSuffix := typeParts[len(typeParts)-1]
 
 			routes = append(routes, struct {
 				Name string
 				Type string
-			}{Name: routeName, Type: resourceTypeSuffix})
+			}{Name: routeName, Type: httproute.ResourceTypeSuffix})
 
 			ports = append(ports, corev1.ContainerPort{
 				// Name generation logic has to match the code in HttpRoute

--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -22,6 +22,7 @@ import (
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
 	"github.com/project-radius/radius/pkg/corerp/renderers"
+	"github.com/project-radius/radius/pkg/corerp/renderers/httproute"
 	"github.com/project-radius/radius/pkg/handlers"
 	"github.com/project-radius/radius/pkg/kubernetes"
 	"github.com/project-radius/radius/pkg/providers"
@@ -191,7 +192,7 @@ func (r Renderer) makeDeployment(ctx context.Context, resource datamodel.Contain
 
 			ports = append(ports, corev1.ContainerPort{
 				// Name generation logic has to match the code in HttpRoute
-				Name:          kubernetes.GetShortenedTargetPortName(applicationName + resourceTypeSuffix + routeName),
+				Name:          kubernetes.GetShortenedTargetPortName(applicationName + httproute.ResourceTypeSuffix + routeName),
 				ContainerPort: port.ContainerPort,
 				Protocol:      corev1.ProtocolTCP,
 			})

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -324,7 +324,7 @@ func Test_Render_PortConnectedToRoute(t *testing.T) {
 				"web": {
 					ContainerPort: 5000,
 					Protocol:      datamodel.ProtocolTCP,
-					Provides:      makeResourceID(t, "HttpRoute", "A").String(),
+					Provides:      makeResourceID(t, "httpRoutes", "A").String(),
 				},
 			},
 		},
@@ -340,7 +340,7 @@ func Test_Render_PortConnectedToRoute(t *testing.T) {
 
 	labels := kubernetes.MakeDescriptiveLabels(applicationName, resource.Name)
 	podLabels := kubernetes.MakeDescriptiveLabels(applicationName, resource.Name)
-	podLabels["radius.dev/route-http-a"] = "true"
+	podLabels["radius.dev/route-httproutes-a"] = "true"
 
 	t.Run("verify deployment", func(t *testing.T) {
 		deployment, _ := kubernetes.FindDeployment(output.Resources)
@@ -359,7 +359,7 @@ func Test_Render_PortConnectedToRoute(t *testing.T) {
 		routeID := makeResourceID(t, "HttpRoute", "A")
 
 		expected := v1.ContainerPort{
-			Name:          kubernetes.GetShortenedTargetPortName(applicationName + "HttpRoute" + routeID.Name()),
+			Name:          kubernetes.GetShortenedTargetPortName(applicationName + "httpRoutes" + routeID.Name()),
 			ContainerPort: 5000,
 			Protocol:      v1.ProtocolTCP,
 		}

--- a/pkg/kubernetes/object.go
+++ b/pkg/kubernetes/object.go
@@ -125,7 +125,7 @@ func GetShortenedTargetPortName(name string) string {
 	// targetPort can only be a maximum of 15 characters long.
 	// 32 bit number should always be less than that.
 	h := fnv.New32a()
-	h.Write([]byte(name))
+	h.Write([]byte(strings.ToLower(name)))
 	return "a" + fmt.Sprint(h.Sum32())
 }
 


### PR DESCRIPTION
# Description

* Fixes bug in container renderer where the target port was set incorrectly, meaning that the container could not be accessed via gateway.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #2942

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
