### PR TITLE
Core RP deployment: Allow empty application id for connector resource types

### DIFF
--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -449,7 +449,6 @@ func (dp *deploymentProcessor) getResourceDataByID(ctx context.Context, resource
 	case strings.ToLower(mongodatabases.ResourceType):
 		obj := &connector_dm.MongoDatabase{}
 		if res, err = sc.Get(ctx, resourceID.String()); err == nil {
-
 			if err = res.As(obj); err == nil {
 				return dp.buildResourceDependency(resourceID, obj.Properties.Application, obj, obj.Properties.Status.OutputResources, obj.ComputedValues, obj.SecretValues)
 			}
@@ -457,7 +456,6 @@ func (dp *deploymentProcessor) getResourceDataByID(ctx context.Context, resource
 	case strings.ToLower(sqldatabases.ResourceType):
 		obj := &connector_dm.SqlDatabase{}
 		if res, err = sc.Get(ctx, resourceID.String()); err == nil {
-
 			if err = res.As(obj); err == nil {
 				return dp.buildResourceDependency(resourceID, obj.Properties.Application, obj, obj.Properties.Status.OutputResources, obj.ComputedValues, obj.SecretValues)
 			}
@@ -465,7 +463,6 @@ func (dp *deploymentProcessor) getResourceDataByID(ctx context.Context, resource
 	case strings.ToLower(rediscaches.ResourceType):
 		obj := &connector_dm.RedisCache{}
 		if res, err = sc.Get(ctx, resourceID.String()); err == nil {
-
 			if err = res.As(obj); err == nil {
 				return dp.buildResourceDependency(resourceID, obj.Properties.Application, obj, obj.Properties.Status.OutputResources, obj.ComputedValues, obj.SecretValues)
 			}
@@ -473,7 +470,6 @@ func (dp *deploymentProcessor) getResourceDataByID(ctx context.Context, resource
 	case strings.ToLower(rabbitmqmessagequeues.ResourceType):
 		obj := &connector_dm.RabbitMQMessageQueue{}
 		if res, err = sc.Get(ctx, resourceID.String()); err == nil {
-
 			if err = res.As(obj); err == nil {
 				return dp.buildResourceDependency(resourceID, obj.Properties.Application, obj, obj.Properties.Status.OutputResources, obj.ComputedValues, obj.SecretValues)
 			}
@@ -481,7 +477,6 @@ func (dp *deploymentProcessor) getResourceDataByID(ctx context.Context, resource
 	case strings.ToLower(extenders.ResourceType):
 		obj := &connector_dm.Extender{}
 		if res, err = sc.Get(ctx, resourceID.String()); err == nil {
-
 			if err = res.As(obj); err == nil {
 				return dp.buildResourceDependency(resourceID, obj.Properties.Application, obj, obj.Properties.Status.OutputResources, obj.ComputedValues, obj.SecretValues)
 			}
@@ -489,7 +484,6 @@ func (dp *deploymentProcessor) getResourceDataByID(ctx context.Context, resource
 	case strings.ToLower(daprstatestores.ResourceType):
 		obj := &connector_dm.DaprStateStore{}
 		if res, err = sc.Get(ctx, resourceID.String()); err == nil {
-
 			if err = res.As(obj); err == nil {
 				return dp.buildResourceDependency(resourceID, obj.Properties.Application, obj, obj.Properties.Status.OutputResources, obj.ComputedValues, obj.SecretValues)
 			}
@@ -497,7 +491,6 @@ func (dp *deploymentProcessor) getResourceDataByID(ctx context.Context, resource
 	case strings.ToLower(daprsecretstores.ResourceType):
 		obj := &connector_dm.DaprSecretStore{}
 		if res, err = sc.Get(ctx, resourceID.String()); err == nil {
-
 			if err = res.As(obj); err == nil {
 				return dp.buildResourceDependency(resourceID, obj.Properties.Application, obj, obj.Properties.Status.OutputResources, obj.ComputedValues, obj.SecretValues)
 			}
@@ -505,7 +498,6 @@ func (dp *deploymentProcessor) getResourceDataByID(ctx context.Context, resource
 	case strings.ToLower(daprpubsubbrokers.ResourceType):
 		obj := &connector_dm.DaprPubSubBroker{}
 		if res, err = sc.Get(ctx, resourceID.String()); err == nil {
-
 			if err = res.As(obj); err == nil {
 				return dp.buildResourceDependency(resourceID, obj.Properties.Application, obj, obj.Properties.Status.OutputResources, obj.ComputedValues, obj.SecretValues)
 			}
@@ -513,7 +505,6 @@ func (dp *deploymentProcessor) getResourceDataByID(ctx context.Context, resource
 	case strings.ToLower(daprinvokehttproutes.ResourceType):
 		obj := &connector_dm.DaprInvokeHttpRoute{}
 		if res, err = sc.Get(ctx, resourceID.String()); err == nil {
-
 			if err = res.As(obj); err == nil {
 				return dp.buildResourceDependency(resourceID, obj.Properties.Application, obj, obj.Properties.Status.OutputResources, obj.ComputedValues, obj.SecretValues)
 			}

--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-openapi/jsonpointer"
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	connector_dm "github.com/project-radius/radius/pkg/connectorrp/datamodel"
+
 	"github.com/project-radius/radius/pkg/connectorrp/renderers/daprinvokehttproutes"
 	"github.com/project-radius/radius/pkg/connectorrp/renderers/daprpubsubbrokers"
 	"github.com/project-radius/radius/pkg/connectorrp/renderers/daprsecretstores"
@@ -41,6 +42,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	controller_runtime "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ConnectorRPNamespace = "Applications.Connector"
 )
 
 //go:generate mockgen -destination=./mock_deploymentprocessor.go -package=deployment -self_package github.com/project-radius/radius/pkg/corerp/backend/deployment github.com/project-radius/radius/pkg/corerp/backend/deployment DeploymentProcessor
@@ -86,7 +91,7 @@ func (dp *deploymentProcessor) Render(ctx context.Context, resourceID resources.
 
 	// get namespace for deploying the resource
 	// 1. fetch the resource from the DB and get the application info
-	res, err := dp.getRequiredDependenciesByID(ctx, resourceID)
+	res, err := dp.getResourceDataByID(ctx, resourceID)
 	if err != nil {
 		return renderers.RendererOutput{}, fmt.Errorf("failed to fetch resource to get the namespace %w", err)
 	}
@@ -288,7 +293,7 @@ func (dp *deploymentProcessor) Delete(ctx context.Context, id resources.ID, depl
 func (dp *deploymentProcessor) fetchDependencies(ctx context.Context, resourceIDs []resources.ID) (map[string]renderers.RendererDependency, error) {
 	rendererDependencies := map[string]renderers.RendererDependency{}
 	for _, id := range resourceIDs {
-		rd, err := dp.getRequiredDependenciesByID(ctx, id)
+		rd, err := dp.getResourceDataByID(ctx, id)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch required resource dependencies %q: %w", id.String(), err)
 		}
@@ -407,8 +412,8 @@ func (dp *deploymentProcessor) getEnvOptions(ctx context.Context, namespace stri
 	return renderers.EnvironmentOptions{Namespace: namespace}, nil
 }
 
-// getRequiredDependenciesByID is to get the resource dependencies.
-func (dp *deploymentProcessor) getRequiredDependenciesByID(ctx context.Context, resourceID resources.ID) (ResourceData, error) {
+// getResourceDataByID fetches resource for the provided id from the data store
+func (dp *deploymentProcessor) getResourceDataByID(ctx context.Context, resourceID resources.ID) (ResourceData, error) {
 	var res *store.Object
 	var err error
 	var sc store.StorageClient
@@ -521,10 +526,20 @@ func (dp *deploymentProcessor) getRequiredDependenciesByID(ctx context.Context, 
 }
 
 func (dp *deploymentProcessor) buildResourceDependency(resourceID resources.ID, application string, resource conv.DataModelInterface, outputResources []outputresource.OutputResource, computedValues map[string]interface{}, secretValues map[string]rp.SecretValueReference) (ResourceData, error) {
-	appID, err := resources.Parse(application)
-	if err != nil {
-		return ResourceData{}, fmt.Errorf("failed to parse application from the property: %w ", err)
+	var appID resources.ID
+	if application != "" {
+		parsedID, err := resources.Parse(application)
+		if err != nil {
+			return ResourceData{}, fmt.Errorf("failed to parse application from the property: %w ", err)
+		}
+		appID = parsedID
+	} else if strings.EqualFold(resourceID.ProviderNamespace(), ConnectorRPNamespace) {
+		// Application id is optional for connector resource types
+		appID = resources.ID{}
+	} else {
+		return ResourceData{}, fmt.Errorf("missing required application id for the resource %s", resourceID.String())
 	}
+
 	return ResourceData{
 		ID:              resourceID,
 		Resource:        resource,


### PR DESCRIPTION
# Description

Allow empty application id for connector resource types.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
