### PR TITLE
Fix handling of different workspace cases

### DIFF
--- a/cmd/rad/cmd/appSwitch.go
+++ b/cmd/rad/cmd/appSwitch.go
@@ -56,7 +56,7 @@ func switchApplications(cmd *cobra.Command, args []string) error {
 		}
 
 		workspace.DefaultApplication = applicationName
-		section.Items[workspace.Name] = *workspace
+		section.Items[strings.ToLower(workspace.Name)] = *workspace
 		return nil
 	})
 	if err != nil {

--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 	"github.com/spf13/cobra"
@@ -194,7 +195,7 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 			return err
 		}
 	}
-	if foundExisting && !force && workspace.ConnectionEquals(&workspaces.KubernetesConnection{Kind: workspaces.KindKubernetes, Context: contextName}) {
+	if foundExisting && !force && !workspace.ConnectionEquals(&workspaces.KubernetesConnection{Kind: workspaces.KindKubernetes, Context: contextName}) {
 		return fmt.Errorf("the workspace %q already exists. Specify '--force' to overwrite", workspaceName)
 	}
 
@@ -240,7 +241,7 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 
 		err = cli.EditWorkspaces(cmd.Context(), config, func(section *cli.WorkspaceSection) error {
 			section.Default = workspaceName
-			section.Items[workspaceName] = *workspace
+			section.Items[strings.ToLower(workspaceName)] = *workspace
 			return nil
 		})
 		if err != nil {
@@ -271,9 +272,9 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 	}
 
 	err = cli.EditWorkspaces(cmd.Context(), config, func(section *cli.WorkspaceSection) error {
-		ws := section.Items[workspaceName]
+		ws := section.Items[strings.ToLower(workspaceName)]
 		ws.Environment = environmentID
-		section.Items[workspaceName] = ws
+		section.Items[strings.ToLower(workspaceName)] = ws
 		return nil
 	})
 	if err != nil {

--- a/cmd/rad/cmd/envSwitch.go
+++ b/cmd/rad/cmd/envSwitch.go
@@ -70,7 +70,7 @@ func switchEnv(cmd *cobra.Command, args []string) error {
 		}
 
 		workspace.Environment = id.String()
-		section.Items[workspace.Name] = *workspace
+		section.Items[strings.ToLower(workspace.Name)] = *workspace
 		return nil
 	})
 	if err != nil {

--- a/cmd/rad/cmd/workspaceDelete.go
+++ b/cmd/rad/cmd/workspaceDelete.go
@@ -54,7 +54,7 @@ func deleteWorkspace(cmd *cobra.Command, args []string) error {
 	}
 
 	err = cli.EditWorkspaces(cmd.Context(), config, func(section *cli.WorkspaceSection) error {
-		delete(section.Items, workspace.Name)
+		delete(section.Items, strings.ToLower(workspace.Name))
 		if strings.EqualFold(section.Default, workspace.Name) {
 			section.Default = ""
 		}

--- a/cmd/rad/cmd/workspaceInitKubernetes.go
+++ b/cmd/rad/cmd/workspaceInitKubernetes.go
@@ -8,6 +8,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/kubernetes"
@@ -125,6 +126,7 @@ func initWorkspaceKubernetes(cmd *cobra.Command, args []string) error {
 			workspace.ProviderConfig.Azure = azureProvider
 		}
 
+		name := strings.ToLower(name)
 		section.Default = name
 		section.Items[name] = workspace
 

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -254,6 +254,20 @@ func EditWorkspaces(ctx context.Context, config *viper.Viper, editor func(sectio
 			return err
 		}
 
+		// We need to check the workspaces for case-invariance. Viper stores everything as lowercase but it's
+		// possible for us to introduce bugs by creating duplicates. This section is only here so that we can easily identify a bug
+		// in the code that's calling EditWorkspaces.
+		names := map[string]bool{}
+		for name := range section.Items {
+			name = strings.ToLower(name)
+			_, ok := names[name]
+			if ok {
+				return fmt.Errorf("usage of name %q with different casings found. This is a bug in rad, the caller needs to lowercase the name before storage", name)
+			}
+
+			names[name] = true
+		}
+
 		UpdateWorkspaceSection(v, section)
 		return nil
 	})


### PR DESCRIPTION
Fixes: radius-project/core-team#733

Fixes: radius-project/core-team#735

This change fixes the handling of different casing for workspace names
for radius-project/core-team#733. Unfortunately viper lowercases all keys for storage, but it
**SILENTLY TOLERATES**  duplicates that differ by case. This means that
we need to be consistent in using lowercase everywhere we
programmatically interact with the workspace name. I did my best to add
verification for this, so we can avoid introducing more bugs in the
future.

For radius-project/core-team#735 we had the wrong logic on a boolean check - the logic for
determining if a workspace was reusable was inverted. Oops.

# Description

_Please explain the changes you've made._

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
