### PR TITLE
Removing the applicationID check if applicationId is empty

### DIFF
--- a/pkg/connectorrp/renderers/daprpubsubbrokers/renderer.go
+++ b/pkg/connectorrp/renderers/daprpubsubbrokers/renderer.go
@@ -56,14 +56,14 @@ func (r *Renderer) Render(ctx context.Context, dm conv.DataModelInterface, optio
 		return renderers.RendererOutput{}, fmt.Errorf("Renderer not found for kind: %s", kind)
 	}
 
-	var applicationID resources.ID
-	var err error
+	var applicationName string
 	if resource.Properties.Application != "" {
-		applicationID, err = resources.Parse(resource.Properties.Application)
+		applicationID, err := resources.Parse(resource.Properties.Application)
 		if err != nil {
 			return renderers.RendererOutput{}, errors.New("the 'application' field must be a valid resource id")
 		}
+		applicationName = applicationID.Name()
 	}
 
-	return pubSubFunc(*resource, applicationID.Name(), options.Namespace)
+	return pubSubFunc(*resource, applicationName, options.Namespace)
 }

--- a/pkg/connectorrp/renderers/daprpubsubbrokers/renderer.go
+++ b/pkg/connectorrp/renderers/daprpubsubbrokers/renderer.go
@@ -56,9 +56,13 @@ func (r *Renderer) Render(ctx context.Context, dm conv.DataModelInterface, optio
 		return renderers.RendererOutput{}, fmt.Errorf("Renderer not found for kind: %s", kind)
 	}
 
-	applicationID, err := resources.Parse(resource.Properties.Application)
-	if err != nil {
-		return renderers.RendererOutput{}, errors.New("the 'application' field must be a valid resource id")
+	var applicationID resources.ID
+	var err error
+	if resource.Properties.Application != "" {
+		applicationID, err = resources.Parse(resource.Properties.Application)
+		if err != nil {
+			return renderers.RendererOutput{}, errors.New("the 'application' field must be a valid resource id")
+		}
 	}
 
 	return pubSubFunc(*resource, applicationID.Name(), options.Namespace)

--- a/pkg/connectorrp/renderers/daprsecretstores/renderer.go
+++ b/pkg/connectorrp/renderers/daprsecretstores/renderer.go
@@ -46,16 +46,16 @@ func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface, option
 	if secretStoreFunc == nil {
 		return renderers.RendererOutput{}, fmt.Errorf("%s is not supported. Supported kind values: %s", properties.Kind, getAlphabeticallySortedKeys(r.SecretStores))
 	}
-	var applicationID resources.ID
-	var err error
+	var applicationName string
 	if resource.Properties.Application != "" {
-		applicationID, err = resources.Parse(resource.Properties.Application)
+		applicationID, err := resources.Parse(resource.Properties.Application)
 		if err != nil {
 			return renderers.RendererOutput{}, errors.New("the 'application' field must be a valid resource id")
 		}
+		applicationName = applicationID.Name()
 	}
 
-	resoures, err := secretStoreFunc(*resource, applicationID.Name(), options.Namespace)
+	resoures, err := secretStoreFunc(*resource, applicationName, options.Namespace)
 	if err != nil {
 		return renderers.RendererOutput{}, err
 	}

--- a/pkg/connectorrp/renderers/daprsecretstores/renderer.go
+++ b/pkg/connectorrp/renderers/daprsecretstores/renderer.go
@@ -46,10 +46,13 @@ func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface, option
 	if secretStoreFunc == nil {
 		return renderers.RendererOutput{}, fmt.Errorf("%s is not supported. Supported kind values: %s", properties.Kind, getAlphabeticallySortedKeys(r.SecretStores))
 	}
-
-	applicationID, err := resources.Parse(resource.Properties.Application)
-	if err != nil {
-		return renderers.RendererOutput{}, errors.New("the 'application' field must be a valid resource id")
+	var applicationID resources.ID
+	var err error
+	if resource.Properties.Application != "" {
+		applicationID, err = resources.Parse(resource.Properties.Application)
+		if err != nil {
+			return renderers.RendererOutput{}, errors.New("the 'application' field must be a valid resource id")
+		}
 	}
 
 	resoures, err := secretStoreFunc(*resource, applicationID.Name(), options.Namespace)

--- a/pkg/connectorrp/renderers/daprstatestores/renderer.go
+++ b/pkg/connectorrp/renderers/daprstatestores/renderer.go
@@ -50,16 +50,16 @@ func (r *Renderer) Render(ctx context.Context, dm conv.DataModelInterface, optio
 		return renderers.RendererOutput{}, fmt.Errorf("%s is not supported. Supported kind values: %s", properties.Kind, getAlphabeticallySortedKeys(r.StateStores))
 	}
 
-	var applicationID resources.ID
-	var err error
+	var applicationName string
 	if resource.Properties.Application != "" {
-		applicationID, err = resources.Parse(resource.Properties.Application)
+		applicationID, err := resources.Parse(resource.Properties.Application)
 		if err != nil {
 			return renderers.RendererOutput{}, errors.New("the 'application' field must be a valid resource id")
 		}
+		applicationName = applicationID.Name()
 	}
 
-	resoures, err := stateStoreFunc(*resource, applicationID.Name(), options.Namespace)
+	resoures, err := stateStoreFunc(*resource, applicationName, options.Namespace)
 	if err != nil {
 		return renderers.RendererOutput{}, err
 	}

--- a/pkg/connectorrp/renderers/daprstatestores/renderer.go
+++ b/pkg/connectorrp/renderers/daprstatestores/renderer.go
@@ -50,9 +50,13 @@ func (r *Renderer) Render(ctx context.Context, dm conv.DataModelInterface, optio
 		return renderers.RendererOutput{}, fmt.Errorf("%s is not supported. Supported kind values: %s", properties.Kind, getAlphabeticallySortedKeys(r.StateStores))
 	}
 
-	applicationID, err := resources.Parse(resource.Properties.Application)
-	if err != nil {
-		return renderers.RendererOutput{}, errors.New("the 'application' field must be a valid resource id")
+	var applicationID resources.ID
+	var err error
+	if resource.Properties.Application != "" {
+		applicationID, err = resources.Parse(resource.Properties.Application)
+		if err != nil {
+			return renderers.RendererOutput{}, errors.New("the 'application' field must be a valid resource id")
+		}
 	}
 
 	resoures, err := stateStoreFunc(*resource, applicationID.Name(), options.Namespace)


### PR DESCRIPTION
# Description

I was running into "the 'application' field must be a valid resource id" error when i was testing daprSecretStore if application is not provided. 

Added the changes to remove the check if application if "".

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
