### PR TITLE
Add setting to CLI for public endpoint override

### DIFF
--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -113,15 +113,16 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 
 	cliOptions := helm.CLIClusterOptions{
 		Radius: helm.RadiusOptions{
-			Reinstall:     chartArgs.Reinstall,
-			ChartPath:     chartArgs.ChartPath,
-			Image:         chartArgs.Image,
-			Tag:           chartArgs.Tag,
-			UCPImage:      chartArgs.UcpImage,
-			UCPTag:        chartArgs.UcpTag,
-			AppCoreImage:  chartArgs.AppCoreImage,
-			AppCoreTag:    chartArgs.AppCoreTag,
-			AzureProvider: azureProvider,
+			Reinstall:              chartArgs.Reinstall,
+			ChartPath:              chartArgs.ChartPath,
+			Image:                  chartArgs.Image,
+			Tag:                    chartArgs.Tag,
+			UCPImage:               chartArgs.UcpImage,
+			UCPTag:                 chartArgs.UcpTag,
+			AppCoreImage:           chartArgs.AppCoreImage,
+			AppCoreTag:             chartArgs.AppCoreTag,
+			PublicEndpointOverride: chartArgs.PublicEndpointOverride,
+			AzureProvider:          azureProvider,
 		},
 	}
 

--- a/cmd/rad/cmd/installKubernetes.go
+++ b/cmd/rad/cmd/installKubernetes.go
@@ -51,15 +51,16 @@ func installKubernetes(cmd *cobra.Command, args []string) error {
 
 	cliOptions := helm.CLIClusterOptions{
 		Radius: helm.RadiusOptions{
-			Reinstall:     chartArgs.Reinstall,
-			ChartPath:     chartArgs.ChartPath,
-			Image:         chartArgs.Image,
-			Tag:           chartArgs.Tag,
-			UCPImage:      chartArgs.UcpImage,
-			UCPTag:        chartArgs.UcpTag,
-			AppCoreImage:  chartArgs.AppCoreImage,
-			AppCoreTag:    chartArgs.AppCoreTag,
-			AzureProvider: azureProvider,
+			Reinstall:              chartArgs.Reinstall,
+			ChartPath:              chartArgs.ChartPath,
+			Image:                  chartArgs.Image,
+			Tag:                    chartArgs.Tag,
+			UCPImage:               chartArgs.UcpImage,
+			UCPTag:                 chartArgs.UcpTag,
+			AppCoreImage:           chartArgs.AppCoreImage,
+			AppCoreTag:             chartArgs.AppCoreTag,
+			PublicEndpointOverride: chartArgs.PublicEndpointOverride,
+			AzureProvider:          azureProvider,
 		},
 	}
 

--- a/deploy/Chart/charts/appcore-rp/templates/appcore-rp.yaml
+++ b/deploy/Chart/charts/appcore-rp/templates/appcore-rp.yaml
@@ -35,6 +35,10 @@ spec:
           value: 'true'
         - name: SKIP_AUTH
           value: 'true'
+        {{ if .Values.global.rp.publicEndpointOverride}}
+        - name: RADIUS_PUBLIC_ENDPOINT_OVERRIDE
+          value: {{ .Values.global.rp.publicEndpointOverride }}
+        {{ end }}
         name: appcore-rp
         ports:
         - containerPort: 5443

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -22,3 +22,4 @@ global:
     provider:
       azure: {}
     publicEndpointOverride: ''
+    

--- a/pkg/cli/helm/cluster.go
+++ b/pkg/cli/helm/cluster.go
@@ -93,6 +93,10 @@ func PopulateDefaultClusterOptions(cliOptions CLIClusterOptions) ClusterOptions 
 		options.Radius.UCPTag = cliOptions.Radius.UCPTag
 	}
 
+	if cliOptions.Radius.PublicEndpointOverride != "" {
+		options.Radius.PublicEndpointOverride = cliOptions.Radius.PublicEndpointOverride
+	}
+
 	if cliOptions.Radius.AzureProvider != nil {
 		options.Radius.AzureProvider = cliOptions.Radius.AzureProvider
 	}

--- a/pkg/cli/setup/chart.go
+++ b/pkg/cli/setup/chart.go
@@ -16,6 +16,11 @@ type ChartArgs struct {
 	AppCoreTag   string
 	UcpImage     string
 	UcpTag       string
+
+	// PublicEndpointOverride is used to define the public endpoint of the Kubernetes cluster
+	// for display purposes. This is useful when the the actual public IP address of a cluster's ingress
+	// is not a routable IP. This comes up all of the time for a local cluster.
+	PublicEndpointOverride string
 }
 
 // RegisterPersistantChartArgs registers the CLI arguments used for our Helm chart.
@@ -28,6 +33,7 @@ func RegisterPersistantChartArgs(cmd *cobra.Command) {
 	cmd.PersistentFlags().String("appcore-tag", "", "Specify Application.Core RP image tag to use")
 	cmd.PersistentFlags().String("ucp-image", "", "Specify the UCP image to use")
 	cmd.PersistentFlags().String("ucp-tag", "", "Specify the UCP tag to use")
+	cmd.PersistentFlags().String("public-endpoint-override", "", "Specify the public IP address of the Kubernetes cluster")
 }
 
 // ParseChartArgs the arguments we provide for installation of the Helm chart.
@@ -64,15 +70,20 @@ func ParseChartArgs(cmd *cobra.Command) (*ChartArgs, error) {
 	if err != nil {
 		return nil, err
 	}
+	publicEndpointOverride, err := cmd.Flags().GetString("public-endpoint-override")
+	if err != nil {
+		return nil, err
+	}
 
 	return &ChartArgs{
-		Reinstall:    reinstall,
-		ChartPath:    chartPath,
-		Image:        image,
-		Tag:          tag,
-		AppCoreImage: appcoreImage,
-		AppCoreTag:   appcoreTag,
-		UcpImage:     ucpImage,
-		UcpTag:       ucpTag,
+		Reinstall:              reinstall,
+		ChartPath:              chartPath,
+		Image:                  image,
+		Tag:                    tag,
+		AppCoreImage:           appcoreImage,
+		AppCoreTag:             appcoreTag,
+		UcpImage:               ucpImage,
+		UcpTag:                 ucpTag,
+		PublicEndpointOverride: publicEndpointOverride,
 	}, nil
 }


### PR DESCRIPTION
Part of: #2973

This change adds the `--public-endpoint-override` flag to CLI entry
points that install our helm chart. This way we can specify the publicly
accessible entry point of the cluster ingress for local testing, and
have it reflected in Radius commands.

Note that this change sets an existing setting that is supported by the
appcore-rp. We need other changes (URL on gateway) and support for `rad
app status` to test this end to end.
