### PR TITLE
Remove roles from Azure connections test

### DIFF
--- a/test/functional/corerp/resources/azure_connections_test.go
+++ b/test/functional/corerp/resources/azure_connections_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func Test_AzureConnections(t *testing.T) {
-	t.Skip()
 	name := "corerp-azure-connection-database-service"
 	containerResourceName := "db-service"
 	template := "testdata/corerp-azure-connection-database-service.bicep"

--- a/test/functional/corerp/resources/testdata/corerp-azure-connection-database-service.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-azure-connection-database-service.bicep
@@ -26,10 +26,6 @@ resource store 'Applications.Core/containers@2022-03-15-privatepreview' = {
         source: databaseAccount.id
         iam: {
           kind: 'azure'
-          roles: [
-            'Cosmos DB Account Reader Role'
-            '230815da-be43-4aae-9cb4-875f7bd000aa'
-          ]
         }
       }
     }


### PR DESCRIPTION
# Description

Removing roles from Azure connections test since CI/CD setup doesn't work with AKS, and IAM roles are currently only supported on AKS clusters (dependency on pod identities).

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
