### PR TITLE
Fix protocol scheme checks in UCP

### DIFF
--- a/pkg/ucp/frontend/ucphandler/planes/planes.go
+++ b/pkg/ucp/frontend/ucphandler/planes/planes.go
@@ -240,12 +240,13 @@ func (ucp *ucpHandler) ProxyRequest(ctx context.Context, db store.StorageClient,
 		TrimPlanesPrefix: (plane.Properties.Kind != rest.PlaneKindUCPNative),
 	}
 
-	// As per https://github.com/golang/go/issues/28940#issuecomment-441749380, the way to check
-	// for http vs https is check the TLS field
+	// // // As per https://github.com/golang/go/issues/28940#issuecomment-441749380, the way to check
+	// // // for http vs https is check the TLS field
 	httpScheme := "http"
 	if r.TLS != nil {
 		httpScheme = "https"
 	}
+	fmt.Printf("@@@@ using httpscheme: %s\n", httpScheme)
 
 	requestInfo := proxy.UCPRequestInfo{
 		PlaneURL:   proxyURL,
@@ -265,6 +266,8 @@ func (ucp *ucpHandler) ProxyRequest(ctx context.Context, db store.StorageClient,
 	// Preserving the query strings on the incoming url on the newly constructed url
 	url.RawQuery = incomingURL.Query().Encode()
 	r.URL = url
+	r.Header.Set("X-Forwarded-Proto", httpScheme)
+
 	ctx = context.WithValue(ctx, proxy.UCPRequestInfoField, requestInfo)
 	sender := proxy.NewARMProxy(options, downstream, nil)
 

--- a/pkg/ucp/proxy/types.go
+++ b/pkg/ucp/proxy/types.go
@@ -139,8 +139,13 @@ func convertHeaderToUCPIDs(ctx context.Context, headerName string, header []stri
 	if requestInfo.PlaneURL == "" {
 		return fmt.Errorf("Could not find plane URL data in %s header", headerName)
 	}
-	if strings.TrimSuffix(requestInfo.PlaneURL, "/") != strings.TrimSuffix(key, "/") {
-		return fmt.Errorf("PlaneURL: %s received in the request context does not match the url found in %s header", requestInfo.PlaneURL, headerName)
+
+	// Match the Plane URL but without the HTTP Scheme since the RP can return a https location/azure-asyncoperation header
+	// based on the protocol scheme
+	requestInfoPlaneID := strings.TrimSuffix(strings.Split(requestInfo.PlaneURL, "//")[1], "/")
+	headerPlaneID := strings.TrimSuffix(strings.Split(key, "//")[1], "/")
+	if !strings.EqualFold(requestInfoPlaneID, headerPlaneID) {
+		return fmt.Errorf("PlaneURL: %s received in the request context does not match the url found in %s header: %s", requestInfo.PlaneURL, headerName, header[0])
 	}
 
 	if requestInfo.UCPHost == "" {

--- a/pkg/ucp/proxy/types_test.go
+++ b/pkg/ucp/proxy/types_test.go
@@ -131,7 +131,7 @@ func Test_ConvertHeaderToUCPIDs(t *testing.T) {
 		ctx := createTestContext(context.Background(), datum.planeURL, datum.planeID, datum.planeKind, datum.httpScheme, datum.ucpHost)
 		err := convertHeaderToUCPIDs(ctx, datum.name, datum.header, &response)
 		require.Error(t, err, "%q should have have failed", datum)
-		require.Equal(t, fmt.Sprintf("PlaneURL: %s received in the request context does not match the url found in %s header", datum.planeURL, datum.name), err.Error())
+		require.Equal(t, fmt.Sprintf("PlaneURL: %s received in the request context does not match the url found in %s header: %s", datum.planeURL, datum.name, datum.header[0]), err.Error())
 	}
 }
 


### PR DESCRIPTION
# Description

UCP matches the plane ID with the protocol scheme but RP can send https location header inspite of being registered with UCP with http

#3049 

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #3049 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
