### PR TITLE
Enrich async operation timeout error message

### DIFF
--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -261,7 +261,7 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 			logger.Info("Cancelling async operation.")
 
 			opCancel()
-			errMessage := fmt.Sprintf("Operation timed out. Type: %s, Timeout duration: %f s", asyncReq.OperationType, asyncReq.Timeout().Seconds())
+			errMessage := fmt.Sprintf("Operation (%s) has timed out because it was processing longer than %f s.", asyncReq.OperationType, asyncReq.Timeout().Seconds())
 			result := ctrl.NewCanceledResult(errMessage)
 			result.Error.Target = asyncReq.ResourceID
 			w.completeOperation(ctx, message, result, asyncCtrl.StorageClient())

--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -261,7 +261,7 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 			logger.Info("Cancelling async operation.")
 
 			opCancel()
-			errMessage := fmt.Sprintf("Operation (%s) has timed out because it was processing longer than %f s.", asyncReq.OperationType, asyncReq.Timeout().Seconds())
+			errMessage := fmt.Sprintf("Operation (%s) has timed out because it was processing longer than %d s.", asyncReq.OperationType, int(asyncReq.Timeout().Seconds()))
 			result := ctrl.NewCanceledResult(errMessage)
 			result.Error.Target = asyncReq.ResourceID
 			w.completeOperation(ctx, message, result, asyncCtrl.StorageClient())

--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -261,7 +261,10 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 			logger.Info("Cancelling async operation.")
 
 			opCancel()
-			w.completeOperation(ctx, message, ctrl.NewCanceledResult("async operation timeout"), asyncCtrl.StorageClient())
+			errMessage := fmt.Sprintf("Operation timed out. Type: %s, Timeout duration: %f s", asyncReq.OperationType, asyncReq.Timeout().Seconds())
+			result := ctrl.NewCanceledResult(errMessage)
+			result.Error.Target = asyncReq.ResourceID
+			w.completeOperation(ctx, message, result, asyncCtrl.StorageClient())
 			return
 
 		case <-ctx.Done():

--- a/pkg/armrpc/asyncoperation/worker/worker_runoperation_test.go
+++ b/pkg/armrpc/asyncoperation/worker/worker_runoperation_test.go
@@ -521,7 +521,7 @@ func TestRunOperation_Timeout(t *testing.T) {
 	tCtx.mockSC.EXPECT().Save(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	tCtx.mockSM.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, _ resources.ID, _ uuid.UUID, state v1.ProvisioningState, _ *time.Time, opError *armerrors.ErrorDetails) error {
-			if state == v1.ProvisioningStateCanceled && strings.HasPrefix(opError.Message, "Operation timed out. Type: APPLICATIONS.CORE/ENVIRONMENTS|PUT, Timeout duration: ") &&
+			if state == v1.ProvisioningStateCanceled && strings.HasPrefix(opError.Message, "Operation (APPLICATIONS.CORE/ENVIRONMENTS|PUT) has timed out because it was processing longer than") &&
 				strings.HasPrefix(opError.Target, "/subscriptions/00000000-0000-0000-0000-000000000000") {
 				return nil
 			}

--- a/pkg/corerp/frontend/controller/containers/createorupdatecontainer.go
+++ b/pkg/corerp/frontend/controller/containers/createorupdatecontainer.go
@@ -25,7 +25,7 @@ var _ ctrl.Controller = (*CreateOrUpdateContainer)(nil)
 
 var (
 	// AsyncPutContainerOperationTimeout is the default timeout duration of async put container operation.
-	AsyncPutContainerOperationTimeout = time.Duration(120) * time.Second
+	AsyncPutContainerOperationTimeout = time.Duration(5) * time.Minute
 )
 
 // CreateOrUpdateContainer is the controller implementation to create or update a container resource.


### PR DESCRIPTION
# Description

This changes increase the timeout to 5 mins for Container type and provides the detail error information when operation time out.

Example:

```json
{
           Code: "OperationCanceled",
	   Message: "Operation (APPLICATIONS.CORE/ENVIRONMENTS|PUT) has timed out because it was processing longer than 0.010000 s",
	   Target: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/c0d79c31-1ec3-440f-8276-910ce08a3f7e"
}
```

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: radius-project/core-team#761 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
