### PR TITLE
Fix Bicep Extensibility for Kubernetes

### DIFF
--- a/deploy/Chart/charts/de/templates/de.yaml
+++ b/deploy/Chart/charts/de/templates/de.yaml
@@ -46,7 +46,7 @@ spec:
         - name: ASPNETCORE_URLS
           value: http://+:5000
         image: {{ .Values.global.extensibility.image }}:{{ .Values.global.extensibility.tag }}
-        name: bicep-de-extensibility
+        name: bicep-extensibility
         ports:
         - containerPort: 5000
           name: bicep-de-ext
@@ -108,7 +108,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: bicep-de-extensibility
+  name: bicep-extensibility
   namespace: {{ .Release.Namespace }}
 spec:
   ports:

--- a/test/functional/corerp/mechanics/k8s_extensibility_test.go
+++ b/test/functional/corerp/mechanics/k8s_extensibility_test.go
@@ -1,0 +1,55 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package mechanics_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ktest "github.com/project-radius/radius/test/functional/kubernetes"
+	"github.com/project-radius/radius/test/step"
+	"github.com/project-radius/radius/test/validation"
+	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func Test_Kubernetes_Extensibility(t *testing.T) {
+	template := "testdata/k8s-extensibility/connection-string.bicep"
+	application := "corerp-mechanics-k8s-extensibility"
+	test := ktest.NewApplicationTest(t, application, []ktest.TestStep{
+		{
+			Executor:           step.NewDeployExecutor(template),
+			RadiusResources:    &validation.ResourceSet{},
+			K8sOutputResources: loadResources("testdata/k8s-extensibility", "secret.output.yaml"),
+
+			// TODO: https://github.com/Azure/bicep/issues/7553
+			// this bug blocks the use of 'existing' for Kubernetes resources. Once that's fixed we can
+			// restore those resources to the test.
+
+			// K8sOutputResources: loadResources("testdata/k8s-extensibility", ".output.yaml"),
+		},
+	}, loadResources("testdata/k8s-extensibility", ".input.yaml")...)
+
+	test.Test(t)
+}
+
+func loadResources(dir string, suffix string) []unstructured.Unstructured {
+	objects := []unstructured.Unstructured{}
+	_ = filepath.Walk(dir, func(path string, info os.FileInfo, _ error) error {
+		if !strings.HasSuffix(info.Name(), suffix) {
+			return nil
+		}
+		var r unstructured.Unstructured
+		b, _ := ioutil.ReadFile(path)
+		_ = yaml.Unmarshal(b, &r.Object)
+		objects = append(objects, r)
+		return nil
+	})
+	return objects
+}

--- a/test/functional/corerp/mechanics/testdata/k8s-extensibility/connection-string.bicep
+++ b/test/functional/corerp/mechanics/testdata/k8s-extensibility/connection-string.bicep
@@ -1,0 +1,47 @@
+import radius as radius
+import kubernetes as kubernetes {
+  namespace: 'corerp-mechanics-k8s-extensibility'
+  kubeConfig: ''
+}
+
+// TODO: https://github.com/Azure/bicep/issues/7553 
+// this bug blocks the use of 'existing' for Kubernetes resources. Once that's fixed we can
+// restore these to the test. 
+
+// resource redisService 'core/Service@v1' existing = {
+//   metadata: {
+//     name: 'redis-master'
+//   }
+// }
+
+// resource redisSecret 'core/Secret@v1' existing = {
+//   metadata: {
+//     name: 'redis'
+//   }
+// }
+
+resource secret 'core/Secret@v1' = {
+  metadata: {
+    name: 'redis-conn'
+    labels: {
+      format: 'k8s-extension'
+    }
+  }
+
+  stringData: {
+    connectionString: 'redis-master.corerp-mechanics-k8s-extensibility.svc.cluster.local,password=awesome'
+    // TODO: https://github.com/Azure/bicep/issues/7553 
+    //connectionString: '${redisService.metadata.name}.${redisService.metadata.namespace}.svc.cluster.local,password=${base64ToString(redisSecret.data.redisPassword)}'
+  }
+}
+
+param environment string
+
+// Our test framework wants an app, but we don't really want any radius resources for this test.
+resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
+  name: 'corerp-mechanics-k8s-extensibility'
+  location: 'global'
+  properties: {
+    environment: environment
+  }
+}

--- a/test/functional/corerp/mechanics/testdata/k8s-extensibility/secret.input.yaml
+++ b/test/functional/corerp/mechanics/testdata/k8s-extensibility/secret.input.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis
+  namespace: corerp-mechanics-k8s-extensibility
+type: Opaque
+data:
+  'redisPassword': YXdlc29tZQ==

--- a/test/functional/corerp/mechanics/testdata/k8s-extensibility/secret.output.yaml
+++ b/test/functional/corerp/mechanics/testdata/k8s-extensibility/secret.output.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-conn
+  namespace: corerp-mechanics-k8s-extensibility
+  labels:
+    format: custom
+data:
+  connectionString: cmVkaXMtbWFzdGVyLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwscGFzc3dvcmQ9YXdlc29tZQ==
+type: Opaque

--- a/test/functional/corerp/mechanics/testdata/k8s-extensibility/service.input.yaml
+++ b/test/functional/corerp/mechanics/testdata/k8s-extensibility/service.input.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  namespace: corerp-mechanics-k8s-extensibility
+spec:
+  type: ExternalName
+  externalName: redis.radius.dev


### PR DESCRIPTION
Fixes: radius-project/core-team#773

This change fixes Bicep Extensibility for Kubernetes. The problem was a
simple mismatch of hostnames.

Most of the changes here were to enable an existing test in some kind of
reasonable form. The existing test for Kubernetes is blocked by
https://github.com/Azure/bicep/issues/7553 but with some minor
changes we can still verify the 'hello world' for Kubernetes, which we
need for one of our samples.

We'll also be fixing azure/bicep#7553 shortly.
