### PR TITLE
Adding negative test for invalid resource IDs

### DIFF
--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -104,7 +104,6 @@ func (dp *deploymentProcessor) Render(ctx context.Context, resourceID resources.
 	namespace, err := dp.getEnvironmentNamespace(ctx, environment)
 	if err != nil {
 		return renderers.RendererOutput{}, fmt.Errorf("failed to fetch info for environment: %s and deployment namespace for resource: %s with error: %w", environment, resourceID, err)
-
 	}
 
 	// Get resources that the resource being deployed has connection with.

--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -93,17 +93,18 @@ func (dp *deploymentProcessor) Render(ctx context.Context, resourceID resources.
 	// 1. fetch the resource from the DB and get the application info
 	res, err := dp.getResourceDataByID(ctx, resourceID)
 	if err != nil {
-		return renderers.RendererOutput{}, fmt.Errorf("failed to fetch resource to get the namespace %w", err)
+		return renderers.RendererOutput{}, fmt.Errorf("failed to fetch resource info and deployment namespace for resource %s with error: %w", resourceID, err)
 	}
 	// 2. fetch the application resource from the DB to get the environment info
 	environment, err := dp.getEnvironmentIDFromApplicationID(ctx, res.AppID)
 	if err != nil {
-		return renderers.RendererOutput{}, fmt.Errorf("failed to fetch application resource to get the namespace %w", err)
+		return renderers.RendererOutput{}, fmt.Errorf("failed to fetch info for application: %s and deployment namespace for resource: %s with error: %w", res.AppID, resourceID, err)
 	}
 	// 3. fetch the environment resource from the db to get the Namespace
 	namespace, err := dp.getEnvironmentNamespace(ctx, environment)
 	if err != nil {
-		return renderers.RendererOutput{}, fmt.Errorf("failed to fetch environment resource to get the namespace %w", err)
+		return renderers.RendererOutput{}, fmt.Errorf("failed to fetch info for environment: %s and deployment namespace for resource: %s with error: %w", environment, resourceID, err)
+
 	}
 
 	// Get resources that the resource being deployed has connection with.

--- a/test/functional/corerp/mechanics/mechanics_test.go
+++ b/test/functional/corerp/mechanics/mechanics_test.go
@@ -184,7 +184,7 @@ func Test_RedeployWithUpdatedResourceUpdatesResource(t *testing.T) {
 	test.Test(t)
 }
 
-func Test_RedeployWitTwoSeparateResourcesKeepsResource(t *testing.T) {
+func Test_RedeployWithTwoSeparateResourcesKeepsResource(t *testing.T) {
 	name := "corerp-mechanics-redeploy-withtwoseparateresource"
 	templateFmt := "testdata/corerp-mechanics-redeploy-withtwoseparateresource.step%d.bicep"
 
@@ -293,6 +293,30 @@ func Test_CommunicationCycle(t *testing.T) {
 					},
 				},
 			},
+		},
+	}, requiredSecrets)
+
+	test.Test(t)
+}
+
+func Test_InvalidResourceIDs(t *testing.T) {
+	name := "corerp-mechanics-invalid-resourceids"
+	template := "testdata/corerp-mechanics-invalid-resourceids.bicep"
+
+	requiredSecrets := map[string]map[string]string{}
+
+	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
+		{
+			Executor: step.NewDeployErrorExecutor(template),
+			CoreRPResources: &validation.CoreRPResourceSet{
+				Resources: []validation.CoreRPResource{
+					{
+						Name: "corerp-mechanics-invalid-resourceids",
+						Type: validation.ApplicationsResource,
+					},
+				},
+			},
+			K8sObjects: &validation.K8sObjectSet{},
 		},
 	}, requiredSecrets)
 

--- a/test/functional/corerp/mechanics/testdata/corerp-mechanics-invalid-resourceids.bicep
+++ b/test/functional/corerp/mechanics/testdata/corerp-mechanics-invalid-resourceids.bicep
@@ -1,0 +1,51 @@
+import radius as radius
+
+@description('Specifies the location for resources.')
+param location string = 'global'
+
+@description('Specifies the environment for resources.')
+param environment string = 'test'
+
+@description('Specifies the image to be deployed.')
+param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+
+resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
+  name: 'corerp-mechanics-invalid-resourceids'
+  location: location
+  properties: {
+    environment: environment
+  }
+}
+
+resource httpRoute 'Applications.Core/httpRoutes@2022-03-15-privatepreview' = {
+  name: 'invalid-rte'
+  location: location
+  properties: {
+    application: app.location
+  }
+}
+
+resource gateway 'Applications.Core/gateways@2022-03-15-privatepreview' = {
+  name: 'invalid-gtwy'
+  location: location
+  properties: {
+    application: 'not_an_id'
+    routes: [
+      {
+        destination: ''
+        path: ''
+      }
+    ]
+  }
+}
+
+resource container 'Applications.Core/containers@2022-03-15-privatepreview' = {
+  name: 'invalid-ctnr'
+  location: location
+  properties: {
+    application: '/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/default/providers/applications.core/environments/env'
+    container: {
+      image: magpieimage
+    }
+  }
+}


### PR DESCRIPTION
# Description

* Added negative test for invalid resource IDs
* Added `DeployErrorExecutor` which will support future negative tests
* Fixing typos

## Issue reference

This PR doesn't close any issues, but it validates a bug bash scenario.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
