### PR TITLE
Move appid and envid to BasicResourceProperties

### DIFF
--- a/pkg/armrpc/api/v1/types.go
+++ b/pkg/armrpc/api/v1/types.go
@@ -140,8 +140,15 @@ type InternalMetadata struct {
 	SecretValues map[string]rp.SecretValueReference `json:"secretValues,omitempty"`
 }
 
+// BasicResourceProperties is the basic resource model for radius resources.
 type BasicResourceProperties struct {
-	Status ResourceStatus `json:"status,omitempty"`
+	// Environment represents the id of environment resource.
+	Environment string `json:"environment,omitempty"`
+	// Application represents the id of application resource.
+	Application string `json:"application,omitempty"`
+
+	// Status represents the resource status.
+	Status *ResourceStatus `json:"status,omitempty"`
 }
 
 type ResourceStatus struct {

--- a/pkg/armrpc/api/v1/types.go
+++ b/pkg/armrpc/api/v1/types.go
@@ -148,7 +148,7 @@ type BasicResourceProperties struct {
 	Application string `json:"application,omitempty"`
 
 	// Status represents the resource status.
-	Status *ResourceStatus `json:"status,omitempty"`
+	Status ResourceStatus `json:"status,omitempty"`
 }
 
 type ResourceStatus struct {

--- a/pkg/connectorrp/api/v20220315privatepreview/daprinvokehttproute_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/daprinvokehttproute_conversion.go
@@ -24,9 +24,11 @@ func (src *DaprInvokeHTTPRouteResource) ConvertTo() (conv.DataModelInterface, er
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: datamodel.DaprInvokeHttpRouteProperties{
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Environment: to.String(src.Properties.Environment),
+				Application: to.String(src.Properties.Application),
+			},
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			Environment:       to.String(src.Properties.Environment),
-			Application:       to.String(src.Properties.Application),
 			AppId:             to.String(src.Properties.AppID),
 		},
 		InternalMetadata: v1.InternalMetadata{

--- a/pkg/connectorrp/api/v20220315privatepreview/daprpubsubbroker_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/daprpubsubbroker_conversion.go
@@ -18,9 +18,11 @@ import (
 // ConvertTo converts from the versioned DaprPubSubBroker resource to version-agnostic datamodel.
 func (src *DaprPubSubBrokerResource) ConvertTo() (conv.DataModelInterface, error) {
 	daprPubSubproperties := datamodel.DaprPubSubBrokerProperties{
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Environment: to.String(src.Properties.GetDaprPubSubBrokerProperties().Environment),
+			Application: to.String(src.Properties.GetDaprPubSubBrokerProperties().Application),
+		},
 		ProvisioningState: toProvisioningStateDataModel(src.Properties.GetDaprPubSubBrokerProperties().ProvisioningState),
-		Environment:       to.String(src.Properties.GetDaprPubSubBrokerProperties().Environment),
-		Application:       to.String(src.Properties.GetDaprPubSubBrokerProperties().Application),
 		Kind:              toDaprPubSubBrokerKindDataModel(src.Properties.GetDaprPubSubBrokerProperties().Kind),
 		Topic:             to.String(src.Properties.GetDaprPubSubBrokerProperties().Topic),
 	}

--- a/pkg/connectorrp/api/v20220315privatepreview/daprsecretstore_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/daprsecretstore_conversion.go
@@ -24,14 +24,16 @@ func (src *DaprSecretStoreResource) ConvertTo() (conv.DataModelInterface, error)
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: datamodel.DaprSecretStoreProperties{
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Environment: to.String(src.Properties.Environment),
+				Application: to.String(src.Properties.Application),
+			},
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			Environment:       to.String(src.Properties.Environment),
-			Application:       to.String(src.Properties.Application),
 			Kind:              toDaprSecretStoreKindDataModel(src.Properties.Kind),
 			Type:              to.String(src.Properties.Type),
 			Version:           to.String(src.Properties.Version),
 			Metadata:          src.Properties.Metadata,
-			SecretStoreName:  to.String(src.Properties.SecretStoreName),
+			SecretStoreName:   to.String(src.Properties.SecretStoreName),
 		},
 		InternalMetadata: v1.InternalMetadata{
 			UpdatedAPIVersion: Version,
@@ -66,7 +68,7 @@ func (dst *DaprSecretStoreResource) ConvertFrom(src conv.DataModelInterface) err
 		Type:              to.StringPtr(daprSecretStore.Properties.Type),
 		Version:           to.StringPtr(daprSecretStore.Properties.Version),
 		Metadata:          daprSecretStore.Properties.Metadata,
-		SecretStoreName: to.StringPtr(daprSecretStore.Properties.SecretStoreName),
+		SecretStoreName:   to.StringPtr(daprSecretStore.Properties.SecretStoreName),
 	}
 	return nil
 }

--- a/pkg/connectorrp/api/v20220315privatepreview/daprstatestore_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/daprstatestore_conversion.go
@@ -13,9 +13,11 @@ import (
 // ConvertTo converts from the versioned DaprStateStore resource to version-agnostic datamodel.
 func (src *DaprStateStoreResource) ConvertTo() (conv.DataModelInterface, error) {
 	daprStateStoreProperties := datamodel.DaprStateStoreProperties{
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Environment: to.String(src.Properties.GetDaprStateStoreProperties().Environment),
+			Application: to.String(src.Properties.GetDaprStateStoreProperties().Application),
+		},
 		ProvisioningState: toProvisioningStateDataModel(src.Properties.GetDaprStateStoreProperties().ProvisioningState),
-		Environment:       to.String(src.Properties.GetDaprStateStoreProperties().Environment),
-		Application:       to.String(src.Properties.GetDaprStateStoreProperties().Application),
 		Kind:              toDaprStateStoreKindDataModel(src.Properties.GetDaprStateStoreProperties().Kind),
 		StateStoreName:    to.String(src.Properties.GetDaprStateStoreProperties().StateStoreName),
 	}

--- a/pkg/connectorrp/api/v20220315privatepreview/extender_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/extender_conversion.go
@@ -25,9 +25,11 @@ func (src *ExtenderResource) ConvertTo() (conv.DataModelInterface, error) {
 		},
 		Properties: datamodel.ExtenderProperties{
 			ExtenderResponseProperties: datamodel.ExtenderResponseProperties{
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Environment: to.String(src.Properties.Environment),
+					Application: to.String(src.Properties.Application),
+				},
 				ProvisioningState:    toProvisioningStateDataModel(src.Properties.ProvisioningState),
-				Environment:          to.String(src.Properties.Environment),
-				Application:          to.String(src.Properties.Application),
 				AdditionalProperties: src.Properties.AdditionalProperties,
 			},
 			Secrets: src.Properties.Secrets,
@@ -50,9 +52,11 @@ func (src *ExtenderResponseResource) ConvertTo() (conv.DataModelInterface, error
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: datamodel.ExtenderResponseProperties{
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Environment: to.String(src.Properties.Environment),
+				Application: to.String(src.Properties.Application),
+			},
 			ProvisioningState:    toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			Environment:          to.String(src.Properties.Environment),
-			Application:          to.String(src.Properties.Application),
 			AdditionalProperties: src.Properties.AdditionalProperties,
 		},
 		InternalMetadata: v1.InternalMetadata{

--- a/pkg/connectorrp/api/v20220315privatepreview/mongodatabase_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/mongodatabase_conversion.go
@@ -24,9 +24,11 @@ func (src *MongoDatabaseResponseResource) ConvertTo() (conv.DataModelInterface, 
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: datamodel.MongoDatabaseResponseProperties{
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Environment: to.String(src.Properties.Environment),
+				Application: to.String(src.Properties.Application),
+			},
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			Environment:       to.String(src.Properties.Environment),
-			Application:       to.String(src.Properties.Application),
 			Resource:          to.String(src.Properties.Resource),
 			Host:              to.String(src.Properties.Host),
 			Port:              to.Int32(src.Properties.Port),
@@ -59,9 +61,11 @@ func (src *MongoDatabaseResource) ConvertTo() (conv.DataModelInterface, error) {
 		},
 		Properties: datamodel.MongoDatabaseProperties{
 			MongoDatabaseResponseProperties: datamodel.MongoDatabaseResponseProperties{
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Environment: to.String(src.Properties.Environment),
+					Application: to.String(src.Properties.Application),
+				},
 				ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-				Environment:       to.String(src.Properties.Environment),
-				Application:       to.String(src.Properties.Application),
 				Resource:          to.String(src.Properties.Resource),
 				Host:              to.String(src.Properties.Host),
 				Port:              to.Int32(src.Properties.Port),

--- a/pkg/connectorrp/api/v20220315privatepreview/rabbitmq_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/rabbitmq_conversion.go
@@ -31,9 +31,11 @@ func (src *RabbitMQMessageQueueResource) ConvertTo() (conv.DataModelInterface, e
 		},
 		Properties: datamodel.RabbitMQMessageQueueProperties{
 			RabbitMQMessageQueueResponseProperties: datamodel.RabbitMQMessageQueueResponseProperties{
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Environment: to.String(src.Properties.Environment),
+					Application: to.String(src.Properties.Application),
+				},
 				ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-				Environment:       to.String(src.Properties.Environment),
-				Application:       to.String(src.Properties.Application),
 				Queue:             to.String(src.Properties.Queue),
 			},
 			Secrets: secrets,
@@ -56,9 +58,11 @@ func (src *RabbitMQMessageQueueResponseResource) ConvertTo() (conv.DataModelInte
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: datamodel.RabbitMQMessageQueueResponseProperties{
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Environment: to.String(src.Properties.Environment),
+				Application: to.String(src.Properties.Application),
+			},
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			Environment:       to.String(src.Properties.Environment),
-			Application:       to.String(src.Properties.Application),
 			Queue:             to.String(src.Properties.Queue),
 		},
 		InternalMetadata: v1.InternalMetadata{

--- a/pkg/connectorrp/api/v20220315privatepreview/rediscache_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/rediscache_conversion.go
@@ -32,9 +32,11 @@ func (src *RedisCacheResource) ConvertTo() (conv.DataModelInterface, error) {
 		},
 		Properties: datamodel.RedisCacheProperties{
 			RedisCacheResponseProperties: datamodel.RedisCacheResponseProperties{
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Environment: to.String(src.Properties.Environment),
+					Application: to.String(src.Properties.Application),
+				},
 				ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-				Environment:       to.String(src.Properties.Environment),
-				Application:       to.String(src.Properties.Application),
 				Resource:          to.String(src.Properties.Resource),
 				Host:              to.String(src.Properties.Host),
 				Port:              to.Int32(src.Properties.Port),
@@ -60,9 +62,11 @@ func (src *RedisCacheResponseResource) ConvertTo() (conv.DataModelInterface, err
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: datamodel.RedisCacheResponseProperties{
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Environment: to.String(src.Properties.Environment),
+				Application: to.String(src.Properties.Application),
+			},
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			Environment:       to.String(src.Properties.Environment),
-			Application:       to.String(src.Properties.Application),
 			Resource:          to.String(src.Properties.Resource),
 			Host:              to.String(src.Properties.Host),
 			Port:              to.Int32(src.Properties.Port),

--- a/pkg/connectorrp/api/v20220315privatepreview/sqldatabase_conversion.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/sqldatabase_conversion.go
@@ -24,9 +24,11 @@ func (src *SQLDatabaseResource) ConvertTo() (conv.DataModelInterface, error) {
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: datamodel.SqlDatabaseProperties{
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Environment: to.String(src.Properties.Environment),
+				Application: to.String(src.Properties.Application),
+			},
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			Environment:       to.String(src.Properties.Environment),
-			Application:       to.String(src.Properties.Application),
 			Resource:          to.String(src.Properties.Resource),
 			Database:          to.String(src.Properties.Database),
 			Server:            to.String(src.Properties.Server),

--- a/pkg/connectorrp/datamodel/daprinvokehttproute.go
+++ b/pkg/connectorrp/datamodel/daprinvokehttproute.go
@@ -30,7 +30,5 @@ func (httpRoute DaprInvokeHttpRoute) ResourceTypeName() string {
 type DaprInvokeHttpRouteProperties struct {
 	v1.BasicResourceProperties
 	ProvisioningState v1.ProvisioningState `json:"provisioningState,omitempty"`
-	Environment       string               `json:"environment"`
-	Application       string               `json:"application,omitempty"`
 	AppId             string               `json:"appId"`
 }

--- a/pkg/connectorrp/datamodel/daprpubsubbroker.go
+++ b/pkg/connectorrp/datamodel/daprpubsubbroker.go
@@ -48,8 +48,6 @@ type DaprPubSubAzureServiceBusResourceProperties struct {
 type DaprPubSubBrokerProperties struct {
 	v1.BasicResourceProperties
 	ProvisioningState         v1.ProvisioningState                        `json:"provisioningState,omitempty"`
-	Environment               string                                      `json:"environment"`
-	Application               string                                      `json:"application,omitempty"`
 	Kind                      DaprPubSubBrokerKind                        `json:"kind"`
 	Topic                     string                                      `json:"topic,omitempty"` // Topic name of the Azure ServiceBus resource. Provided by the user.
 	DaprPubSubGeneric         DaprPubSubGenericResourceProperties         `json:"daprPubSubGeneric"`

--- a/pkg/connectorrp/datamodel/daprsecretstore.go
+++ b/pkg/connectorrp/datamodel/daprsecretstore.go
@@ -37,8 +37,6 @@ func (daprSecretStore DaprSecretStore) ResourceTypeName() string {
 type DaprSecretStoreProperties struct {
 	v1.BasicResourceProperties
 	ProvisioningState v1.ProvisioningState   `json:"provisioningState,omitempty"`
-	Environment       string                 `json:"environment"`
-	Application       string                 `json:"application,omitempty"`
 	Kind              DaprSecretStoreKind    `json:"kind"`
 	Type              string                 `json:"type"`
 	Version           string                 `json:"version"`

--- a/pkg/connectorrp/datamodel/daprstatestore.go
+++ b/pkg/connectorrp/datamodel/daprstatestore.go
@@ -39,8 +39,6 @@ func (daprStateStore DaprStateStore) ResourceTypeName() string {
 type DaprStateStoreProperties struct {
 	v1.BasicResourceProperties
 	ProvisioningState               v1.ProvisioningState                              `json:"provisioningState,omitempty"`
-	Environment                     string                                            `json:"environment"`
-	Application                     string                                            `json:"application,omitempty"`
 	StateStoreName                  string                                            `json:"stateStoreName"`
 	Kind                            DaprStateStoreKind                                `json:"kind"`
 	DaprStateStoreSQLServer         DaprStateStoreSQLServerResourceProperties         `json:"daprStateStoreSQLServer"`

--- a/pkg/connectorrp/datamodel/extender.go
+++ b/pkg/connectorrp/datamodel/extender.go
@@ -53,6 +53,4 @@ type ExtenderResponseProperties struct {
 	v1.BasicResourceProperties
 	AdditionalProperties map[string]interface{} `json:"additionalProperties,omitempty"`
 	ProvisioningState    v1.ProvisioningState   `json:"provisioningState,omitempty"`
-	Environment          string                 `json:"environment"`
-	Application          string                 `json:"application,omitempty"`
 }

--- a/pkg/connectorrp/datamodel/mongodatabase.go
+++ b/pkg/connectorrp/datamodel/mongodatabase.go
@@ -46,8 +46,6 @@ func (mongo MongoDatabaseResponse) ResourceTypeName() string {
 type MongoDatabaseResponseProperties struct {
 	v1.BasicResourceProperties
 	ProvisioningState v1.ProvisioningState `json:"provisioningState,omitempty"`
-	Environment       string               `json:"environment"`
-	Application       string               `json:"application,omitempty"`
 	Resource          string               `json:"resource,omitempty"`
 	Host              string               `json:"host,omitempty"`
 	Port              int32                `json:"port,omitempty"`

--- a/pkg/connectorrp/datamodel/rabbitmq.go
+++ b/pkg/connectorrp/datamodel/rabbitmq.go
@@ -46,8 +46,6 @@ func (rabbitmq RabbitMQMessageQueueResponse) ResourceTypeName() string {
 type RabbitMQMessageQueueResponseProperties struct {
 	v1.BasicResourceProperties
 	ProvisioningState v1.ProvisioningState `json:"provisioningState,omitempty"`
-	Environment       string               `json:"environment"`
-	Application       string               `json:"application,omitempty"`
 	Queue             string               `json:"queue"`
 }
 

--- a/pkg/connectorrp/datamodel/rediscache.go
+++ b/pkg/connectorrp/datamodel/rediscache.go
@@ -50,8 +50,6 @@ func (redisSecrets RedisCacheSecrets) IsEmpty() bool {
 type RedisCacheResponseProperties struct {
 	v1.BasicResourceProperties
 	ProvisioningState v1.ProvisioningState `json:"provisioningState,omitempty"`
-	Environment       string               `json:"environment"`
-	Application       string               `json:"application,omitempty"`
 	Resource          string               `json:"resource,omitempty"`
 	Host              string               `json:"host,omitempty"`
 	Port              int32                `json:"port,omitempty"`

--- a/pkg/connectorrp/datamodel/sqldatabase.go
+++ b/pkg/connectorrp/datamodel/sqldatabase.go
@@ -30,8 +30,6 @@ func (sql SqlDatabase) ResourceTypeName() string {
 type SqlDatabaseProperties struct {
 	v1.BasicResourceProperties
 	ProvisioningState v1.ProvisioningState `json:"provisioningState,omitempty"`
-	Environment       string               `json:"environment"`
-	Application       string               `json:"application,omitempty"`
 	Resource          string               `json:"resource,omitempty"`
 	Database          string               `json:"database,omitempty"`
 	Server            string               `json:"server,omitempty"`

--- a/pkg/connectorrp/frontend/deployment/deploymentprocessor_test.go
+++ b/pkg/connectorrp/frontend/deployment/deploymentprocessor_test.go
@@ -42,9 +42,11 @@ func buildTestMongoResource() (resourceID resources.ID, testResource datamodel.M
 		},
 		Properties: datamodel.MongoDatabaseProperties{
 			MongoDatabaseResponseProperties: datamodel.MongoDatabaseResponseProperties{
-				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
-				Resource:    "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				},
+				Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
 			},
 		},
 	}
@@ -106,9 +108,11 @@ func buildTestMongoResourceMixedCaseResourceType() (resourceID resources.ID, tes
 		},
 		Properties: datamodel.MongoDatabaseProperties{
 			MongoDatabaseResponseProperties: datamodel.MongoDatabaseResponseProperties{
-				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
-				Resource:    "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				},
+				Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
 			},
 		},
 	}
@@ -359,9 +363,11 @@ func Test_Render_Success(t *testing.T) {
 			},
 			Properties: datamodel.MongoDatabaseProperties{
 				MongoDatabaseResponseProperties: datamodel.MongoDatabaseResponseProperties{
-					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
-					Resource:    "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
+					BasicResourceProperties: v1.BasicResourceProperties{
+						Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+						Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+					},
+					Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
 				},
 			},
 		}

--- a/pkg/connectorrp/renderers/daprinvokehttproutes/renderer_test.go
+++ b/pkg/connectorrp/renderers/daprinvokehttproutes/renderer_test.go
@@ -37,9 +37,11 @@ func Test_Render_Success(t *testing.T) {
 			Type: "Applications.Connector/daprInvokeHttpRoutes",
 		},
 		Properties: datamodel.DaprInvokeHttpRouteProperties{
-			Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-			Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
-			AppId:       "test-appId",
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+			},
+			AppId: "test-appId",
 		},
 	}
 	output, err := renderer.Render(ctx, &resource, renderers.RenderOptions{})

--- a/pkg/connectorrp/renderers/daprpubsubbrokers/renderer_test.go
+++ b/pkg/connectorrp/renderers/daprpubsubbrokers/renderer_test.go
@@ -46,9 +46,11 @@ func Test_Render_Generic_Success(t *testing.T) {
 			Type: ResourceType,
 		},
 		Properties: datamodel.DaprPubSubBrokerProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Kind:        resourcekinds.DaprGeneric,
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Kind: resourcekinds.DaprGeneric,
 			DaprPubSubGeneric: datamodel.DaprPubSubGenericResourceProperties{
 				Type:    "pubsub.kafka",
 				Version: "v1",
@@ -100,9 +102,11 @@ func Test_Render_Generic_MissingMetadata(t *testing.T) {
 			Type: ResourceType,
 		},
 		Properties: datamodel.DaprPubSubBrokerProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Kind:        resourcekinds.DaprGeneric,
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Kind: resourcekinds.DaprGeneric,
 			DaprPubSubGeneric: datamodel.DaprPubSubGenericResourceProperties{
 				Type:    "pubsub.kafka",
 				Version: "v1",
@@ -125,9 +129,11 @@ func Test_Render_Generic_MissingType(t *testing.T) {
 			Type: ResourceType,
 		},
 		Properties: datamodel.DaprPubSubBrokerProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Kind:        resourcekinds.DaprGeneric,
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Kind: resourcekinds.DaprGeneric,
 			DaprPubSubGeneric: datamodel.DaprPubSubGenericResourceProperties{
 				Metadata: map[string]interface{}{
 					"foo": "bar",
@@ -152,9 +158,11 @@ func Test_Render_Generic_MissingVersion(t *testing.T) {
 			Type: ResourceType,
 		},
 		Properties: datamodel.DaprPubSubBrokerProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Kind:        resourcekinds.DaprGeneric,
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Kind: resourcekinds.DaprGeneric,
 			DaprPubSubGeneric: datamodel.DaprPubSubGenericResourceProperties{
 				Metadata: map[string]interface{}{
 					"foo": "bar",
@@ -222,10 +230,12 @@ func Test_Render_DaprPubSubAzureServiceBus_Success(t *testing.T) {
 			Type: ResourceType,
 		},
 		Properties: datamodel.DaprPubSubBrokerProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Kind:        resourcekinds.DaprPubSubTopicAzureServiceBus,
-			Topic:       "test-topic",
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Kind:  resourcekinds.DaprPubSubTopicAzureServiceBus,
+			Topic: "test-topic",
 			DaprPubSubAzureServiceBus: datamodel.DaprPubSubAzureServiceBusResourceProperties{
 				Resource: serviceBusResourceID,
 			},
@@ -264,9 +274,11 @@ func Test_Render_DaprPubSubMissingTopicName_Success(t *testing.T) {
 			Type: ResourceType,
 		},
 		Properties: datamodel.DaprPubSubBrokerProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Kind:        resourcekinds.DaprPubSubTopicAzureServiceBus,
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Kind: resourcekinds.DaprPubSubTopicAzureServiceBus,
 			DaprPubSubAzureServiceBus: datamodel.DaprPubSubAzureServiceBusResourceProperties{
 				Resource: serviceBusResourceID,
 			},
@@ -305,9 +317,11 @@ func Test_Render_DaprPubSubAzureServiceBus_InvalidResourceType(t *testing.T) {
 			Type: ResourceType,
 		},
 		Properties: datamodel.DaprPubSubBrokerProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Kind:        resourcekinds.DaprPubSubTopicAzureServiceBus,
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Kind: resourcekinds.DaprPubSubTopicAzureServiceBus,
 			DaprPubSubAzureServiceBus: datamodel.DaprPubSubAzureServiceBusResourceProperties{
 				Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.ServiceBus/namespaces/test-namespace/topics/test-topic",
 			},

--- a/pkg/connectorrp/renderers/daprsecretstores/renderer_test.go
+++ b/pkg/connectorrp/renderers/daprsecretstores/renderer_test.go
@@ -53,10 +53,12 @@ func Test_Render_UnsupportedKind(t *testing.T) {
 			Type: "Applications.Connector/daprSecretStores",
 		},
 		Properties: datamodel.DaprSecretStoreProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Type:        ResourceType,
-			Kind:        "azure.keyvault",
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Type: ResourceType,
+			Kind: "azure.keyvault",
 		},
 	}
 
@@ -76,11 +78,13 @@ func Test_Render_Generic_Success(t *testing.T) {
 			Type: "Applications.Connector/daprSecretStores",
 		},
 		Properties: datamodel.DaprSecretStoreProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Type:        ResourceType,
-			Kind:        resourcekinds.DaprGeneric,
-			Version:     daprSecretStoreVersion,
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Type:    ResourceType,
+			Kind:    resourcekinds.DaprGeneric,
+			Version: daprSecretStoreVersion,
 			Metadata: map[string]interface{}{
 				"foo": "bar",
 			},
@@ -136,12 +140,14 @@ func Test_Render_Generic_MissingMetadata(t *testing.T) {
 			Type: "Applications.Connector/daprSecretStores",
 		},
 		Properties: datamodel.DaprSecretStoreProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Type:        "secretstores.kubernetes",
-			Kind:        resourcekinds.DaprGeneric,
-			Version:     daprSecretStoreVersion,
-			Metadata:    map[string]interface{}{},
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Type:     "secretstores.kubernetes",
+			Kind:     resourcekinds.DaprGeneric,
+			Version:  daprSecretStoreVersion,
+			Metadata: map[string]interface{}{},
 		},
 	}
 	_, err := renderer.Render(ctx, &resource, renderers.RenderOptions{Namespace: "radius-test"})
@@ -160,10 +166,12 @@ func Test_Render_Generic_MissingType(t *testing.T) {
 			Type: "Applications.Connector/daprSecretStores",
 		},
 		Properties: datamodel.DaprSecretStoreProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Kind:        resourcekinds.DaprGeneric,
-			Version:     daprSecretStoreVersion,
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Kind:    resourcekinds.DaprGeneric,
+			Version: daprSecretStoreVersion,
 			Metadata: map[string]interface{}{
 				"foo": "bar",
 			},
@@ -186,10 +194,12 @@ func Test_Render_Generic_MissingVersion(t *testing.T) {
 			Type: "Applications.Connector/daprSecretStores",
 		},
 		Properties: datamodel.DaprSecretStoreProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Type:        "secretstores.kubernetes",
-			Kind:        resourcekinds.DaprGeneric,
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Type: "secretstores.kubernetes",
+			Kind: resourcekinds.DaprGeneric,
 			Metadata: map[string]interface{}{
 				"foo": "bar",
 			},

--- a/pkg/connectorrp/renderers/daprstatestores/renderer_test.go
+++ b/pkg/connectorrp/renderers/daprstatestores/renderer_test.go
@@ -43,9 +43,11 @@ func Test_Render_Success(t *testing.T) {
 			Type: "Applications.Connector/daprStateStores",
 		},
 		Properties: datamodel.DaprStateStoreProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Kind:        datamodel.DaprStateStoreKindAzureTableStorage,
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Kind: datamodel.DaprStateStoreKindAzureTableStorage,
 			DaprStateStoreAzureTableStorage: datamodel.DaprStateStoreAzureTableStorageResourceProperties{
 				Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.Storage/storageAccounts/test-account/tableServices/default/tables/mytable",
 			},
@@ -83,9 +85,11 @@ func Test_Render_InvalidResourceType(t *testing.T) {
 			Type: "Applications.Connector/daprStateStores",
 		},
 		Properties: datamodel.DaprStateStoreProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Kind:        "state.azure.tablestorage",
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Kind: "state.azure.tablestorage",
 			DaprStateStoreAzureTableStorage: datamodel.DaprStateStoreAzureTableStorageResourceProperties{
 				Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.SomethingElse/test-storageAccounts/test-account",
 			},
@@ -107,8 +111,10 @@ func Test_Render_SpecifiesUmanagedWithoutResource(t *testing.T) {
 			Type: "Applications.Connector/daprStateStores",
 		},
 		Properties: datamodel.DaprStateStoreProperties{
-			Application:                     applicationID,
-			Environment:                     environmentID,
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
 			Kind:                            "state.azure.tablestorage",
 			DaprStateStoreAzureTableStorage: datamodel.DaprStateStoreAzureTableStorageResourceProperties{},
 		},
@@ -129,9 +135,11 @@ func Test_Render_UnsupportedKind(t *testing.T) {
 			Type: "Applications.Connector/daprStateStores",
 		},
 		Properties: datamodel.DaprStateStoreProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Kind:        "state.azure.cosmosdb",
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Kind: "state.azure.cosmosdb",
 			DaprStateStoreAzureTableStorage: datamodel.DaprStateStoreAzureTableStorageResourceProperties{
 				Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.SomethingElse/test-storageAccounts/test-account",
 			},
@@ -153,9 +161,11 @@ func Test_Render_Generic_Success(t *testing.T) {
 			Type: "Applications.Connector/daprStateStores",
 		},
 		Properties: datamodel.DaprStateStoreProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Kind:        datamodel.DaprStateStoreKindGeneric,
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Kind: datamodel.DaprStateStoreKindGeneric,
 			DaprStateStoreGeneric: datamodel.DaprStateStoreGenericResourceProperties{
 				Type:    stateStoreType,
 				Version: daprStateStoreVersion,
@@ -207,9 +217,11 @@ func Test_Render_Generic_MissingMetadata(t *testing.T) {
 			Type: "Applications.Connector/daprStateStores",
 		},
 		Properties: datamodel.DaprStateStoreProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Kind:        "generic",
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Kind: "generic",
 			DaprStateStoreGeneric: datamodel.DaprStateStoreGenericResourceProperties{
 				Type:     stateStoreType,
 				Metadata: map[string]interface{}{},
@@ -233,9 +245,11 @@ func Test_Render_Generic_MissingType(t *testing.T) {
 			Type: "Applications.Connector/daprStateStores",
 		},
 		Properties: datamodel.DaprStateStoreProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Kind:        "generic",
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Kind: "generic",
 			DaprStateStoreGeneric: datamodel.DaprStateStoreGenericResourceProperties{
 				Metadata: map[string]interface{}{
 					"foo": "bar",
@@ -260,9 +274,11 @@ func Test_Render_Generic_MissingVersion(t *testing.T) {
 			Type: "Applications.Connector/daprStateStores",
 		},
 		Properties: datamodel.DaprStateStoreProperties{
-			Application: applicationID,
-			Environment: environmentID,
-			Kind:        "generic",
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: applicationID,
+				Environment: environmentID,
+			},
+			Kind: "generic",
 			DaprStateStoreGeneric: datamodel.DaprStateStoreGenericResourceProperties{
 				Metadata: map[string]interface{}{
 					"foo": "bar",

--- a/pkg/connectorrp/renderers/extenders/renderer_test.go
+++ b/pkg/connectorrp/renderers/extenders/renderer_test.go
@@ -37,8 +37,10 @@ func Test_Render_Success(t *testing.T) {
 		},
 		Properties: datamodel.ExtenderProperties{
 			ExtenderResponseProperties: datamodel.ExtenderResponseProperties{
-				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				},
 				AdditionalProperties: map[string]interface{}{
 					"foo": "bar",
 				},

--- a/pkg/connectorrp/renderers/mongodatabases/renderer_test.go
+++ b/pkg/connectorrp/renderers/mongodatabases/renderer_test.go
@@ -39,9 +39,11 @@ func Test_Render_Success(t *testing.T) {
 		},
 		Properties: datamodel.MongoDatabaseProperties{
 			MongoDatabaseResponseProperties: datamodel.MongoDatabaseResponseProperties{
-				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
-				Resource:    "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				},
+				Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
 			},
 		},
 	}
@@ -96,8 +98,10 @@ func Test_Render_UserSpecifiedSecrets(t *testing.T) {
 		},
 		Properties: datamodel.MongoDatabaseProperties{
 			MongoDatabaseResponseProperties: datamodel.MongoDatabaseResponseProperties{
-				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				},
 			},
 			Secrets: datamodel.MongoDatabaseSecrets{
 				Username:         userName,
@@ -138,8 +142,10 @@ func Test_Render_NoResourceSpecified(t *testing.T) {
 		},
 		Properties: datamodel.MongoDatabaseProperties{
 			MongoDatabaseResponseProperties: datamodel.MongoDatabaseResponseProperties{
-				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				},
 			},
 		},
 	}
@@ -160,9 +166,11 @@ func Test_Render_InvalidResourceModel(t *testing.T) {
 			Type: "Applications.Connector/mongoDatabases",
 		},
 		Properties: datamodel.SqlDatabaseProperties{
-			Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-			Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
-			Resource:    "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+			},
+			Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
 		},
 	}
 
@@ -183,9 +191,11 @@ func Test_Render_InvalidSourceResourceIdentifier(t *testing.T) {
 		},
 		Properties: datamodel.MongoDatabaseProperties{
 			MongoDatabaseResponseProperties: datamodel.MongoDatabaseResponseProperties{
-				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
-				Resource:    "/subscriptions/test-sub/resourceGroups/test-group/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				},
+				Resource: "/subscriptions/test-sub/resourceGroups/test-group/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
 			},
 		},
 	}
@@ -208,9 +218,11 @@ func Test_Render_InvalidResourceType(t *testing.T) {
 		},
 		Properties: datamodel.MongoDatabaseProperties{
 			MongoDatabaseResponseProperties: datamodel.MongoDatabaseResponseProperties{
-				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
-				Resource:    "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.SomethingElse/databaseAccounts/test-account/mongodbDatabases/test-database",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				},
+				Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.SomethingElse/databaseAccounts/test-account/mongodbDatabases/test-database",
 			},
 		},
 	}

--- a/pkg/connectorrp/renderers/rabbitmqmessagequeues/renderer_test.go
+++ b/pkg/connectorrp/renderers/rabbitmqmessagequeues/renderer_test.go
@@ -40,9 +40,11 @@ func Test_Render_User_Secrets(t *testing.T) {
 		},
 		Properties: datamodel.RabbitMQMessageQueueProperties{
 			RabbitMQMessageQueueResponseProperties: datamodel.RabbitMQMessageQueueResponseProperties{
-				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
-				Queue:       "abc",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				},
+				Queue: "abc",
 			},
 			Secrets: datamodel.RabbitMQSecrets{ConnectionString: "admin:deadbeef@localhost:42"},
 		},
@@ -80,8 +82,10 @@ func Test_Render_NoQueueSpecified(t *testing.T) {
 		},
 		Properties: datamodel.RabbitMQMessageQueueProperties{
 			RabbitMQMessageQueueResponseProperties: datamodel.RabbitMQMessageQueueResponseProperties{
-				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+				},
 			},
 			Secrets: datamodel.RabbitMQSecrets{ConnectionString: "admin:deadbeef@localhost:42"},
 		},

--- a/pkg/connectorrp/renderers/rediscaches/renderer_test.go
+++ b/pkg/connectorrp/renderers/rediscaches/renderer_test.go
@@ -37,11 +37,13 @@ func Test_Render_Success(t *testing.T) {
 		},
 		Properties: datamodel.RedisCacheProperties{
 			RedisCacheResponseProperties: datamodel.RedisCacheResponseProperties{
-				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
-				Resource:    "/subscriptions/test-sub/resourceGroups/testGroup/providers/Microsoft.Cache/Redis/testCache",
-				Host:        "hello.com",
-				Port:        1234,
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+				},
+				Resource: "/subscriptions/test-sub/resourceGroups/testGroup/providers/Microsoft.Cache/Redis/testCache",
+				Host:     "hello.com",
+				Port:     1234,
 			},
 		},
 	}
@@ -91,10 +93,12 @@ func Test_Render_UserSpecifiedSecrets(t *testing.T) {
 		},
 		Properties: datamodel.RedisCacheProperties{
 			RedisCacheResponseProperties: datamodel.RedisCacheResponseProperties{
-				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
-				Host:        "hello.com",
-				Port:        1234,
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+				},
+				Host: "hello.com",
+				Port: 1234,
 			},
 			Secrets: datamodel.RedisCacheSecrets{
 				Password:         password,
@@ -139,8 +143,10 @@ func Test_Render_NoResourceSpecified(t *testing.T) {
 		},
 		Properties: datamodel.RedisCacheProperties{
 			RedisCacheResponseProperties: datamodel.RedisCacheResponseProperties{
-				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+				},
 			},
 		},
 	}
@@ -161,9 +167,11 @@ func Test_Render_InvalidResourceModel(t *testing.T) {
 			Type: "Applications.Connector/mongoDatabases",
 		},
 		Properties: datamodel.SqlDatabaseProperties{
-			Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-			Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
-			Resource:    "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+			},
+			Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
 		},
 	}
 
@@ -184,9 +192,11 @@ func Test_Render_InvalidSourceResourceIdentifier(t *testing.T) {
 		},
 		Properties: datamodel.RedisCacheProperties{
 			RedisCacheResponseProperties: datamodel.RedisCacheResponseProperties{
-				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
-				Resource:    "/subscriptions/test-sub/resourceGroups/testGroup/Microsoft.Cache/Redis/testCache",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+				},
+				Resource: "/subscriptions/test-sub/resourceGroups/testGroup/Microsoft.Cache/Redis/testCache",
 			},
 		},
 	}
@@ -209,9 +219,11 @@ func Test_Render_InvalidResourceType(t *testing.T) {
 		},
 		Properties: datamodel.RedisCacheProperties{
 			RedisCacheResponseProperties: datamodel.RedisCacheResponseProperties{
-				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
-				Resource:    "/subscriptions/test-sub/resourceGroups/testGroup/providers/Microsoft.SomethingElse/Redis/testCache",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+				},
+				Resource: "/subscriptions/test-sub/resourceGroups/testGroup/providers/Microsoft.SomethingElse/Redis/testCache",
 			},
 		},
 	}

--- a/pkg/connectorrp/renderers/sqldatabases/renderer_test.go
+++ b/pkg/connectorrp/renderers/sqldatabases/renderer_test.go
@@ -44,9 +44,11 @@ func Test_Render_Success(t *testing.T) {
 			Type: "Applications.Connector/sqlDatabases",
 		},
 		Properties: datamodel.SqlDatabaseProperties{
-			Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-			Resource:    "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.Sql/servers/test-server/databases/test-database",
-			Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+			},
+			Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.Sql/servers/test-server/databases/test-database",
 		},
 	}
 
@@ -102,8 +104,10 @@ func Test_Render_MissingResource(t *testing.T) {
 			Type: "Applications.Connector/sqlDatabases",
 		},
 		Properties: datamodel.SqlDatabaseProperties{
-			Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-			Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+			},
 		},
 	}
 
@@ -123,9 +127,11 @@ func Test_Render_InvalidResourceType(t *testing.T) {
 			Type: "Applications.Connector/sqlDatabases",
 		},
 		Properties: datamodel.SqlDatabaseProperties{
-			Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-			Resource:    "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.SomethingElse/servers/sqlDatabases/test-database",
-			Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+			},
+			Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.SomethingElse/servers/sqlDatabases/test-database",
 		},
 	}
 

--- a/pkg/corerp/api/v20220315privatepreview/application_conversion.go
+++ b/pkg/corerp/api/v20220315privatepreview/application_conversion.go
@@ -26,8 +26,10 @@ func (src *ApplicationResource) ConvertTo() (conv.DataModelInterface, error) {
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: datamodel.ApplicationProperties{
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Environment: to.String(src.Properties.Environment),
+			},
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			Environment:       to.String(src.Properties.Environment),
 		},
 		InternalMetadata: v1.InternalMetadata{
 			UpdatedAPIVersion: Version,

--- a/pkg/corerp/api/v20220315privatepreview/container_conversion.go
+++ b/pkg/corerp/api/v20220315privatepreview/container_conversion.go
@@ -90,8 +90,10 @@ func (src *ContainerResource) ConvertTo() (conv.DataModelInterface, error) {
 		},
 		Properties: datamodel.ContainerProperties{
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			Application:       to.String(src.Properties.Application),
-			Connections:       connections,
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: to.String(src.Properties.Application),
+			},
+			Connections: connections,
 			Container: datamodel.Container{
 				Image:          to.String(src.Properties.Container.Image),
 				Env:            to.StringMap(src.Properties.Container.Env),

--- a/pkg/corerp/api/v20220315privatepreview/gateway_conversion.go
+++ b/pkg/corerp/api/v20220315privatepreview/gateway_conversion.go
@@ -46,10 +46,12 @@ func (src *GatewayResource) ConvertTo() (conv.DataModelInterface, error) {
 		},
 		Properties: datamodel.GatewayProperties{
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			Application:       to.String(src.Properties.Application),
-			Hostname:          hostname,
-			Routes:            routes,
-			URL:               to.String(src.Properties.URL),
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: to.String(src.Properties.Application),
+			},
+			Hostname: hostname,
+			Routes:   routes,
+			URL:      to.String(src.Properties.URL),
 		},
 		InternalMetadata: v1.InternalMetadata{
 			UpdatedAPIVersion: Version,

--- a/pkg/corerp/api/v20220315privatepreview/httproute_conversion.go
+++ b/pkg/corerp/api/v20220315privatepreview/httproute_conversion.go
@@ -26,8 +26,10 @@ func (src *HTTPRouteResource) ConvertTo() (conv.DataModelInterface, error) {
 			Tags:     to.StringMap(src.Tags),
 		},
 		Properties: &datamodel.HTTPRouteProperties{
+			BasicResourceProperties: v1.BasicResourceProperties{
+				Application: to.String(src.Properties.Application),
+			},
 			ProvisioningState: toProvisioningStateDataModel(src.Properties.ProvisioningState),
-			Application:       to.String(src.Properties.Application),
 			Hostname:          to.String(src.Properties.Hostname),
 			Port:              to.Int32(src.Properties.Port),
 			Scheme:            to.String(src.Properties.Scheme),

--- a/pkg/corerp/backend/deployment/deployment_test.go
+++ b/pkg/corerp/backend/deployment/deployment_test.go
@@ -190,7 +190,9 @@ func Test_Render(t *testing.T) {
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
 			},
 			Properties: datamodel.ApplicationProperties{
-				Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+				},
 			},
 		}
 		ar := store.Object{
@@ -224,7 +226,9 @@ func Test_Render(t *testing.T) {
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A",
 			},
 			Properties: &datamodel.HTTPRouteProperties{
-				Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+				},
 			},
 		}
 		nr := store.Object{
@@ -242,7 +246,9 @@ func Test_Render(t *testing.T) {
 			},
 			Properties: connectorrp_dm.MongoDatabaseProperties{
 				MongoDatabaseResponseProperties: connectorrp_dm.MongoDatabaseResponseProperties{
-					Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+					BasicResourceProperties: v1.BasicResourceProperties{
+						Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+					},
 				},
 			},
 		}
@@ -284,7 +290,9 @@ func Test_Render(t *testing.T) {
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
 			},
 			Properties: datamodel.ApplicationProperties{
-				Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+				},
 			},
 		}
 		ar := store.Object{
@@ -318,7 +326,9 @@ func Test_Render(t *testing.T) {
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A",
 			},
 			Properties: &datamodel.HTTPRouteProperties{
-				Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+				},
 			},
 		}
 		nr := store.Object{
@@ -358,7 +368,9 @@ func Test_Render(t *testing.T) {
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
 			},
 			Properties: datamodel.ApplicationProperties{
-				Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+				},
 			},
 		}
 		ar := store.Object{
@@ -392,7 +404,9 @@ func Test_Render(t *testing.T) {
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A",
 			},
 			Properties: &datamodel.HTTPRouteProperties{
-				Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+				},
 			},
 		}
 		nr := store.Object{
@@ -430,7 +444,9 @@ func Test_Render(t *testing.T) {
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
 			},
 			Properties: datamodel.ApplicationProperties{
-				Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+				},
 			},
 		}
 		ar := store.Object{
@@ -464,7 +480,9 @@ func Test_Render(t *testing.T) {
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A",
 			},
 			Properties: &datamodel.HTTPRouteProperties{
-				Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+				},
 			},
 		}
 		nr := store.Object{
@@ -514,7 +532,9 @@ func Test_Render(t *testing.T) {
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
 			},
 			Properties: datamodel.ApplicationProperties{
-				Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+				},
 			},
 		}
 		ar := store.Object{
@@ -548,7 +568,9 @@ func Test_Render(t *testing.T) {
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A",
 			},
 			Properties: &datamodel.HTTPRouteProperties{
-				Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+				},
 			},
 		}
 		nr := store.Object{
@@ -587,7 +609,9 @@ func Test_Render(t *testing.T) {
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
 			},
 			Properties: datamodel.ApplicationProperties{
-				Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Environment: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/environments/env0",
+				},
 			},
 		}
 		ar := store.Object{
@@ -621,7 +645,9 @@ func Test_Render(t *testing.T) {
 				ID: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A",
 			},
 			Properties: &datamodel.HTTPRouteProperties{
-				Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+				BasicResourceProperties: v1.BasicResourceProperties{
+					Application: "/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/applications/test-application",
+				},
 			},
 		}
 		nr := store.Object{

--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -96,7 +96,7 @@ func (dp *deploymentProcessor) Render(ctx context.Context, resourceID resources.
 		return renderers.RendererOutput{}, fmt.Errorf("failed to fetch resource to get the namespace %w", err)
 	}
 	// 2. fetch the application resource from the DB to get the environment info
-	environment, err := dp.getEnvironmentIDFromApplicationID(ctx, res.AppID)
+	environment, err := dp.getEnvironmentFromApplication(ctx, res.AppID)
 	if err != nil {
 		return renderers.RendererOutput{}, fmt.Errorf("failed to fetch application resource to get the namespace %w", err)
 	}
@@ -576,7 +576,7 @@ func (dp *deploymentProcessor) getRendererDependency(ctx context.Context, depend
 }
 
 // getEnvironmentFromApplication fetches the application resource from the db for getting the environment to fetch the environment resource
-func (dp *deploymentProcessor) getEnvironmentIDFromApplicationID(ctx context.Context, appID resources.ID) (environment string, err error) {
+func (dp *deploymentProcessor) getEnvironmentFromApplication(ctx context.Context, appID resources.ID) (environment string, err error) {
 	var res *store.Object
 	var sc store.StorageClient
 	sc, err = dp.sp.GetStorageClient(ctx, appID.Type())

--- a/pkg/corerp/datamodel/application.go
+++ b/pkg/corerp/datamodel/application.go
@@ -28,6 +28,6 @@ func (e Application) ResourceTypeName() string {
 
 // ApplicationProperties represents the properties of Application.
 type ApplicationProperties struct {
+	v1.BasicResourceProperties
 	ProvisioningState v1.ProvisioningState `json:"provisioningState,omitempty"`
-	Environment       string               `json:"environment"`
 }

--- a/pkg/corerp/datamodel/container.go
+++ b/pkg/corerp/datamodel/container.go
@@ -53,7 +53,6 @@ func (conn ConnectionProperties) GetDisableDefaultEnvVars() bool {
 type ContainerProperties struct {
 	v1.BasicResourceProperties
 	ProvisioningState v1.ProvisioningState            `json:"provisioningState,omitempty"`
-	Application       string                          `json:"application,omitempty"`
 	Connections       map[string]ConnectionProperties `json:"connections,omitempty"`
 	Container         Container                       `json:"container,omitempty"`
 	Extensions        []Extension                     `json:"extensions,omitempty"`

--- a/pkg/corerp/datamodel/gateway.go
+++ b/pkg/corerp/datamodel/gateway.go
@@ -48,7 +48,6 @@ func (g *Gateway) OutputResources() []outputresource.OutputResource {
 type GatewayProperties struct {
 	v1.BasicResourceProperties
 	ProvisioningState v1.ProvisioningState       `json:"provisioningState,omitempty"`
-	Application       string                     `json:"application,omitempty"`
 	Internal          bool                       `json:"internal,omitempty"`
 	Hostname          *GatewayPropertiesHostname `json:"hostname,omitempty"`
 	Routes            []GatewayRoute             `json:"routes,omitempty"`

--- a/pkg/corerp/datamodel/httproute.go
+++ b/pkg/corerp/datamodel/httproute.go
@@ -58,7 +58,6 @@ func (h *HTTPRoute) OutputResources() []outputresource.OutputResource {
 type HTTPRouteProperties struct {
 	v1.BasicResourceProperties
 	ProvisioningState v1.ProvisioningState `json:"provisioningState,omitempty"`
-	Application       string               `json:"application,omitempty"`
 	Hostname          string               `json:"hostname,omitempty"`
 	Port              int32                `json:"port,omitempty"`
 	Scheme            string               `json:"scheme,omitempty"`

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -83,7 +83,9 @@ func Test_GetDependencyIDs_Success(t *testing.T) {
 	testResourceID := "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Microsoft.Storage/storageaccounts/testaccount/fileservices/default/shares/testShareName"
 	testAzureResourceID := makeResourceID(t, "Microsoft.ServiceBus/namespaces", "testAzureResource")
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: apiv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Connections: map[string]datamodel.ConnectionProperties{
 			"A": {
 				Source: makeResourceID(t, "HttpRoute", "A").String(),
@@ -223,7 +225,9 @@ func Test_GetDependencyIDs_InvalidAzureResourceId(t *testing.T) {
 // If you add minor features, add them here.
 func Test_Render_Basic(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: apiv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Env: map[string]string{
@@ -275,7 +279,9 @@ func Test_Render_Basic(t *testing.T) {
 
 func Test_Render_PortWithoutRoute(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: apiv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Ports: map[string]datamodel.ContainerPort{
@@ -317,7 +323,9 @@ func Test_Render_PortWithoutRoute(t *testing.T) {
 
 func Test_Render_PortConnectedToRoute(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: apiv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Ports: map[string]datamodel.ContainerPort{
@@ -370,7 +378,9 @@ func Test_Render_PortConnectedToRoute(t *testing.T) {
 
 func Test_Render_Connections(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: apiv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Connections: map[string]datamodel.ConnectionProperties{
 			"A": {
 				Source: makeResourceID(t, "ResourceType", "A").String(),
@@ -469,7 +479,9 @@ func Test_Render_Connections(t *testing.T) {
 
 func Test_RenderConnections_DisableDefaultEnvVars(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: apiv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Connections: map[string]datamodel.ConnectionProperties{
 			"A": {
 				Source:                makeResourceID(t, "ResourceType", "A").String(),
@@ -515,7 +527,9 @@ func Test_RenderConnections_DisableDefaultEnvVars(t *testing.T) {
 
 func Test_Render_ConnectionWithRoleAssignment(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: apiv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Connections: map[string]datamodel.ConnectionProperties{
 			"A": {
 				Source: makeResourceID(t, "ResourceType", "A").String(),
@@ -666,7 +680,9 @@ func Test_Render_AzureConnection(t *testing.T) {
 	testARMID := makeResourceID(t, "ResourceType", "test-azure-resource").String()
 	expectedRole := "administrator"
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: apiv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Connections: map[string]datamodel.ConnectionProperties{
 			"testAzureResourceConnection": {
 				Source: testARMID,
@@ -733,7 +749,9 @@ func Test_Render_AzureConnection(t *testing.T) {
 func Test_Render_AzureConnectionEmptyRoleAllowed(t *testing.T) {
 	testARMID := makeResourceID(t, "ResourceType", "test-azure-resource").String()
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: apiv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Connections: map[string]datamodel.ConnectionProperties{
 			"testAzureResourceConnection": {
 				Source: testARMID,
@@ -762,7 +780,9 @@ func Test_Render_EphemeralVolumes(t *testing.T) {
 	const tempVolName = "TempVolume"
 	const tempVolMountPath = "/tmpfs"
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: apiv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Env: map[string]string{
@@ -837,7 +857,9 @@ func Test_Render_PersistentAzureFileShareVolumes(t *testing.T) {
 	testResourceID := fmt.Sprintf("/subscriptions/%s/resourceGroups/test/providers/Microsoft.Storage/storageaccounts/testaccount/fileservices/default/share/%s", uuid.New(), testShareName)
 
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: apiv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Volumes: map[string]datamodel.VolumeProperties{
@@ -907,7 +929,10 @@ func Test_Render_PersistentAzureKeyVaultVolumes(t *testing.T) {
 	testResourceID := "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/azure-kv"
 
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: apiv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
+
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Volumes: map[string]datamodel.VolumeProperties{
@@ -1006,7 +1031,9 @@ func outputResourcesToKindMap(resources []outputresource.OutputResource) map[str
 
 func Test_Render_ReadinessProbeHttpGet(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: apiv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Env: map[string]string{
@@ -1081,7 +1108,9 @@ func Test_Render_ReadinessProbeHttpGet(t *testing.T) {
 
 func Test_Render_ReadinessProbeTcp(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: apiv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Env: map[string]string{
@@ -1147,7 +1176,9 @@ func Test_Render_ReadinessProbeTcp(t *testing.T) {
 
 func Test_Render_LivenessProbeExec(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: apiv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			Env: map[string]string{
@@ -1213,7 +1244,9 @@ func Test_Render_LivenessProbeExec(t *testing.T) {
 
 func Test_Render_LivenessProbeWithDefaults(t *testing.T) {
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: apiv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 			LivenessProbe: datamodel.HealthProbeProperties{

--- a/pkg/corerp/renderers/daprextension/renderer_test.go
+++ b/pkg/corerp/renderers/daprextension/renderer_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	apiv1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
 	"github.com/project-radius/radius/pkg/corerp/renderers"
 	"github.com/project-radius/radius/pkg/kubernetes"
@@ -54,7 +55,9 @@ func Test_Render_Success(t *testing.T) {
 	renderer := &Renderer{Inner: &noop{}}
 
 	ctnrProperties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 		},
@@ -94,7 +97,9 @@ func Test_Render_Success_AppID_FromRoute(t *testing.T) {
 	renderer := &Renderer{Inner: &noop{}}
 
 	ctnrProperties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 		},
@@ -140,7 +145,9 @@ func Test_Render_Fail_AppIDFromRouteConflict(t *testing.T) {
 	renderer := &Renderer{Inner: &noop{}}
 
 	ctnrProperties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 		},

--- a/pkg/corerp/renderers/gateway/render_test.go
+++ b/pkg/corerp/renderers/gateway/render_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-logr/logr"
 	apiv1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
 	"github.com/project-radius/radius/pkg/corerp/renderers"
 	"github.com/project-radius/radius/pkg/corerp/renderers/httproute"
@@ -74,7 +75,9 @@ func Test_Render_WithNoHostname(t *testing.T) {
 	r := &Renderer{}
 
 	properties, expectedIncludes := makeTestGateway(datamodel.GatewayProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		},
 	})
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -100,7 +103,9 @@ func Test_Render_WithPrefix(t *testing.T) {
 		Hostname: &datamodel.GatewayPropertiesHostname{
 			Prefix: prefix,
 		},
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		},
 	})
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -127,7 +132,9 @@ func Test_Render_WithFQHostname(t *testing.T) {
 		Hostname: &datamodel.GatewayPropertiesHostname{
 			FullyQualifiedHostname: expectedHostname,
 		},
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		},
 	})
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -153,7 +160,9 @@ func Test_Render_WithFQHostname_OverridesPrefix(t *testing.T) {
 			Prefix:                 prefix,
 			FullyQualifiedHostname: expectedHostname,
 		},
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		},
 	})
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -174,7 +183,9 @@ func Test_Render_DevEnvironment(t *testing.T) {
 	publicIP := "http://localhost:32323"
 	expectedFqdn := "localhost"
 	properties, expectedIncludes := makeTestGateway(datamodel.GatewayProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		},
 	})
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -201,7 +212,9 @@ func Test_Render_PublicEndpointOverride(t *testing.T) {
 	publicIP := "http://www.contoso.com:32323"
 	expectedFqdn := "www.contoso.com"
 	properties, expectedIncludes := makeTestGateway(datamodel.GatewayProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		},
 	})
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -226,7 +239,9 @@ func Test_Render_WithMissingPublicIP(t *testing.T) {
 	r := &Renderer{}
 
 	properties, expectedIncludes := makeTestGateway(datamodel.GatewayProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		},
 	})
 	resource := makeResource(t, properties)
 	appId, err := resources.Parse(resource.Properties.Application)
@@ -254,7 +269,9 @@ func Test_Render_Fails_WithNoRoute(t *testing.T) {
 	r := &Renderer{}
 
 	properties := datamodel.GatewayProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		},
 	}
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -272,8 +289,10 @@ func Test_Render_Fails_WithoutFQHostnameOrPrefix(t *testing.T) {
 	r := &Renderer{}
 
 	properties := datamodel.GatewayProperties{
-		Hostname:    &datamodel.GatewayPropertiesHostname{},
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		},
+		Hostname: &datamodel.GatewayPropertiesHostname{},
 	}
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -300,8 +319,10 @@ func Test_Render_Single_Route(t *testing.T) {
 	}
 	routes = append(routes, route)
 	properties := datamodel.GatewayProperties{
-		Routes:      routes,
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		},
+		Routes: routes,
 	}
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -351,8 +372,10 @@ func Test_Render_Multiple_Routes(t *testing.T) {
 	routes = append(routes, routeA)
 	routes = append(routes, routeB)
 	properties := datamodel.GatewayProperties{
-		Routes:      routes,
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		},
+		Routes: routes,
 	}
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -405,8 +428,10 @@ func Test_Render_Route_WithPrefixRewrite(t *testing.T) {
 	}
 	routes = append(routes, route)
 	properties := datamodel.GatewayProperties{
-		Routes:      routes,
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		},
+		Routes: routes,
 	}
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -480,8 +505,10 @@ func Test_Render_Route_WithMultiplePrefixRewrite(t *testing.T) {
 	routes = append(routes, routeC)
 	routes = append(routes, routeD)
 	properties := datamodel.GatewayProperties{
-		Routes:      routes,
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		},
+		Routes: routes,
 	}
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{}
@@ -565,8 +592,10 @@ func Test_Render_WithDependencies(t *testing.T) {
 	}
 	routes = append(routes, route)
 	properties := datamodel.GatewayProperties{
-		Routes:      routes,
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		},
+		Routes: routes,
 	}
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{
@@ -609,8 +638,10 @@ func renderHttpRoute(t *testing.T, port int32) renderers.RendererOutput {
 
 	dependencies := map[string]renderers.RendererDependency{}
 	properties := datamodel.HTTPRouteProperties{
-		Port:        port,
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		},
+		Port: port,
 	}
 	resource := makeDependentResource(t, properties)
 
@@ -740,11 +771,13 @@ func makeTestGateway(config datamodel.GatewayProperties) (datamodel.GatewayPrope
 	}
 
 	properties := datamodel.GatewayProperties{
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: config.Application,
+		},
 		Hostname: config.Hostname,
 		Routes: []datamodel.GatewayRoute{
 			defaultRoute,
 		},
-		Application: config.Application,
 	}
 
 	return properties, includes

--- a/pkg/corerp/renderers/manualscale/render_test.go
+++ b/pkg/corerp/renderers/manualscale/render_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	apiv1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
 	"github.com/project-radius/radius/pkg/kubernetes"
 	"github.com/project-radius/radius/pkg/radrp/outputresource"
@@ -85,7 +86,9 @@ func Test_Render_NoExtension(t *testing.T) {
 	renderer := &Renderer{Inner: &noop{}}
 
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 		},
@@ -118,7 +121,9 @@ func makeResource(t *testing.T, properties datamodel.ContainerProperties) *datam
 
 func makeProperties(t *testing.T, replicas *int32) datamodel.ContainerProperties {
 	properties := datamodel.ContainerProperties{
-		Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		BasicResourceProperties: v1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
+		},
 		Container: datamodel.Container{
 			Image: "someimage:latest",
 		},


### PR DESCRIPTION
# Description

Refactoring datamodels to move appid and envid to BasicResourceProviders before adding the check of the mismatch of envid and appid between existing resource and new resource.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

radius-project/core-team#758 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
