### PR TITLE
Grant Bicep extensiblity permission on everything

### DIFF
--- a/deploy/Chart/charts/de/templates/serviceaccount.yaml
+++ b/deploy/Chart/charts/de/templates/serviceaccount.yaml
@@ -5,46 +5,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: de-manager-role
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-      - secrets
-      - services
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-      - statefulsets
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: de-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: de-manager-role
+  name: cluster-admin
 subjects:
   - kind: ServiceAccount
     name: de-manager


### PR DESCRIPTION
Fixes: radius-project/core-team#806

This change grants Bicep extensibility maximal permissions on the
cluster. Right now we have a more limited set of permissions set which
lead to spotty limitations and failures.

This is ultimately something we'd like to review and come up with a more
nuanced policy. I'm adding this to our design queue to review.
