### PR TITLE
Emptying the secrets map in extenders

### DIFF
--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_extenders_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_extenders_client.go
@@ -75,7 +75,7 @@ func (client *ExtendersClient) createOrUpdateCreateRequest(ctx context.Context, 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *ExtendersClient) createOrUpdateHandleResponse(resp *http.Response) (ExtendersCreateOrUpdateResponse, error) {
 	result := ExtendersCreateOrUpdateResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.ExtenderResource); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.ExtenderResponseResource); err != nil {
 		return ExtendersCreateOrUpdateResponse{}, err
 	}
 	return result, nil

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_mongodatabases_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_mongodatabases_client.go
@@ -75,7 +75,7 @@ func (client *MongoDatabasesClient) createOrUpdateCreateRequest(ctx context.Cont
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *MongoDatabasesClient) createOrUpdateHandleResponse(resp *http.Response) (MongoDatabasesCreateOrUpdateResponse, error) {
 	result := MongoDatabasesCreateOrUpdateResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.MongoDatabaseResource); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.MongoDatabaseResponseResource); err != nil {
 		return MongoDatabasesCreateOrUpdateResponse{}, err
 	}
 	return result, nil

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_rabbitmqmessagequeues_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_rabbitmqmessagequeues_client.go
@@ -75,7 +75,7 @@ func (client *RabbitMQMessageQueuesClient) createOrUpdateCreateRequest(ctx conte
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *RabbitMQMessageQueuesClient) createOrUpdateHandleResponse(resp *http.Response) (RabbitMQMessageQueuesCreateOrUpdateResponse, error) {
 	result := RabbitMQMessageQueuesCreateOrUpdateResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.RabbitMQMessageQueueResource); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.RabbitMQMessageQueueResponseResource); err != nil {
 		return RabbitMQMessageQueuesCreateOrUpdateResponse{}, err
 	}
 	return result, nil

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_rediscaches_client.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_rediscaches_client.go
@@ -75,7 +75,7 @@ func (client *RedisCachesClient) createOrUpdateCreateRequest(ctx context.Context
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client *RedisCachesClient) createOrUpdateHandleResponse(resp *http.Response) (RedisCachesCreateOrUpdateResponse, error) {
 	result := RedisCachesCreateOrUpdateResponse{RawResponse: resp}
-	if err := runtime.UnmarshalAsJSON(resp, &result.RedisCacheResource); err != nil {
+	if err := runtime.UnmarshalAsJSON(resp, &result.RedisCacheResponseResource); err != nil {
 		return RedisCachesCreateOrUpdateResponse{}, err
 	}
 	return result, nil

--- a/pkg/connectorrp/api/v20220315privatepreview/zz_generated_response_types.go
+++ b/pkg/connectorrp/api/v20220315privatepreview/zz_generated_response_types.go
@@ -187,7 +187,7 @@ type ExtendersCreateOrUpdateResponse struct {
 
 // ExtendersCreateOrUpdateResult contains the result from method Extenders.CreateOrUpdate.
 type ExtendersCreateOrUpdateResult struct {
-	ExtenderResource
+	ExtenderResponseResource
 }
 
 // ExtendersDeleteResponse contains the response from method Extenders.Delete.
@@ -242,7 +242,7 @@ type MongoDatabasesCreateOrUpdateResponse struct {
 
 // MongoDatabasesCreateOrUpdateResult contains the result from method MongoDatabases.CreateOrUpdate.
 type MongoDatabasesCreateOrUpdateResult struct {
-	MongoDatabaseResource
+	MongoDatabaseResponseResource
 }
 
 // MongoDatabasesDeleteResponse contains the response from method MongoDatabases.Delete.
@@ -296,7 +296,7 @@ type RabbitMQMessageQueuesCreateOrUpdateResponse struct {
 
 // RabbitMQMessageQueuesCreateOrUpdateResult contains the result from method RabbitMQMessageQueues.CreateOrUpdate.
 type RabbitMQMessageQueuesCreateOrUpdateResult struct {
-	RabbitMQMessageQueueResource
+	RabbitMQMessageQueueResponseResource
 }
 
 // RabbitMQMessageQueuesDeleteResponse contains the response from method RabbitMQMessageQueues.Delete.
@@ -350,7 +350,7 @@ type RedisCachesCreateOrUpdateResponse struct {
 
 // RedisCachesCreateOrUpdateResult contains the result from method RedisCaches.CreateOrUpdate.
 type RedisCachesCreateOrUpdateResult struct {
-	RedisCacheResource
+	RedisCacheResponseResource
 }
 
 // RedisCachesDeleteResponse contains the response from method RedisCaches.Delete.

--- a/pkg/connectorrp/frontend/controller/extenders/createorupdateextender.go
+++ b/pkg/connectorrp/frontend/controller/extenders/createorupdateextender.go
@@ -87,7 +87,13 @@ func (extender *CreateOrUpdateExtender) Run(ctx context.Context, req *http.Reque
 		return nil, err
 	}
 
-	versioned, err := converter.ExtenderDataModelToVersioned(newResource, serviceCtx.APIVersion, true)
+	extenderResponse := &datamodel.ExtenderResponse{}
+	err = savedResource.As(extenderResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	versioned, err := converter.ExtenderDataModelToVersioned(extenderResponse, serviceCtx.APIVersion, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connectorrp/frontend/controller/extenders/createorupdateextender_test.go
+++ b/pkg/connectorrp/frontend/controller/extenders/createorupdateextender_test.go
@@ -77,7 +77,7 @@ func TestCreateOrUpdateExtender_20220315PrivatePreview(t *testing.T) {
 			teardownTest, mds, msm, mDeploymentProcessor, rendererOutput, deploymentOutput := setupTest(t)
 			defer teardownTest(t)
 
-			input, dataModel, expectedOutput := getTestModels20220315privatepreview()
+			input, dataModel, expectedOutput := getTestModelsForGetAndListApis20220315privatepreview()
 			w := httptest.NewRecorder()
 			req, _ := radiustesting.GetARMTestHTTPRequest(context.Background(), http.MethodGet, testHeaderfile, input)
 			req.Header.Set(testcase.headerKey, testcase.headerValue)
@@ -122,7 +122,7 @@ func TestCreateOrUpdateExtender_20220315PrivatePreview(t *testing.T) {
 			require.Equal(t, testcase.expectedStatusCode, w.Result().StatusCode)
 
 			if !testcase.shouldFail {
-				actualOutput := &v20220315privatepreview.ExtenderResource{}
+				actualOutput := &v20220315privatepreview.ExtenderResponseResource{}
 				_ = json.Unmarshal(w.Body.Bytes(), actualOutput)
 				require.Equal(t, expectedOutput, actualOutput)
 
@@ -153,7 +153,7 @@ func TestCreateOrUpdateExtender_20220315PrivatePreview(t *testing.T) {
 			teardownTest, mds, msm, mDeploymentProcessor, rendererOutput, deploymentOutput := setupTest(t)
 			defer teardownTest(t)
 
-			input, dataModel, expectedOutput := getTestModels20220315privatepreview()
+			input, dataModel, expectedOutput := getTestModelsForGetAndListApis20220315privatepreview()
 			if testcase.inputFile != "" {
 				input = &v20220315privatepreview.ExtenderResource{}
 				_ = json.Unmarshal(radiustesting.ReadFixture(testcase.inputFile), input)
@@ -203,7 +203,7 @@ func TestCreateOrUpdateExtender_20220315PrivatePreview(t *testing.T) {
 			require.Equal(t, testcase.expectedStatusCode, w.Result().StatusCode)
 
 			if !testcase.shouldFail {
-				actualOutput := &v20220315privatepreview.ExtenderResource{}
+				actualOutput := &v20220315privatepreview.ExtenderResponseResource{}
 				_ = json.Unmarshal(w.Body.Bytes(), actualOutput)
 				require.Equal(t, expectedOutput, actualOutput)
 

--- a/pkg/connectorrp/frontend/controller/extenders/createorupdateextender_test.go
+++ b/pkg/connectorrp/frontend/controller/extenders/createorupdateextender_test.go
@@ -91,6 +91,7 @@ func TestCreateOrUpdateExtender_20220315PrivatePreview(t *testing.T) {
 				})
 			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
 			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+
 			expectedOutput.SystemData.CreatedAt = expectedOutput.SystemData.LastModifiedAt
 			expectedOutput.SystemData.CreatedBy = expectedOutput.SystemData.LastModifiedBy
 			expectedOutput.SystemData.CreatedByType = expectedOutput.SystemData.LastModifiedByType
@@ -100,6 +101,8 @@ func TestCreateOrUpdateExtender_20220315PrivatePreview(t *testing.T) {
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).
 					DoAndReturn(func(ctx context.Context, obj *store.Object, opts ...store.SaveOptions) error {
+						// First time created objects should have the same lastModifiedAt and createdAt
+						dataModel.SystemData.CreatedAt = dataModel.SystemData.LastModifiedAt
 						obj.ETag = "new-resource-etag"
 						obj.Data = dataModel
 						return nil

--- a/pkg/connectorrp/frontend/controller/mongodatabases/createorupdatemongodatabase.go
+++ b/pkg/connectorrp/frontend/controller/mongodatabases/createorupdatemongodatabase.go
@@ -92,7 +92,13 @@ func (mongo *CreateOrUpdateMongoDatabase) Run(ctx context.Context, req *http.Req
 		return nil, err
 	}
 
-	versioned, err := converter.MongoDatabaseDataModelToVersioned(newResource, serviceCtx.APIVersion, true)
+	mongoResponse := &datamodel.MongoDatabaseResponse{}
+	err = savedResource.As(mongoResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	versioned, err := converter.MongoDatabaseDataModelToVersioned(mongoResponse, serviceCtx.APIVersion, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connectorrp/frontend/controller/mongodatabases/createorupdatemongodatabase_test.go
+++ b/pkg/connectorrp/frontend/controller/mongodatabases/createorupdatemongodatabase_test.go
@@ -51,7 +51,7 @@ func TestCreateOrUpdateMongoDatabase_20220315PrivatePreview(t *testing.T) {
 
 	for _, testcase := range createNewResourceTestCases {
 		t.Run(testcase.desc, func(t *testing.T) {
-			input, dataModel, expectedOutput := getTestModels20220315privatepreview()
+			input, dataModel, expectedOutput := getTestModelsForGetAndListApis20220315privatepreview()
 			rendererOutput, deploymentOutput := getDeploymentProcessorOutputs()
 			w := httptest.NewRecorder()
 			req, _ := radiustesting.GetARMTestHTTPRequest(ctx, http.MethodGet, testHeaderfile, input)
@@ -98,7 +98,7 @@ func TestCreateOrUpdateMongoDatabase_20220315PrivatePreview(t *testing.T) {
 			require.Equal(t, testcase.expectedStatusCode, w.Result().StatusCode)
 
 			if !testcase.shouldFail {
-				actualOutput := &v20220315privatepreview.MongoDatabaseResource{}
+				actualOutput := &v20220315privatepreview.MongoDatabaseResponseResource{}
 				_ = json.Unmarshal(w.Body.Bytes(), actualOutput)
 				require.Equal(t, expectedOutput, actualOutput)
 
@@ -126,7 +126,7 @@ func TestCreateOrUpdateMongoDatabase_20220315PrivatePreview(t *testing.T) {
 
 	for _, testcase := range updateExistingResourceTestCases {
 		t.Run(testcase.desc, func(t *testing.T) {
-			input, dataModel, expectedOutput := getTestModels20220315privatepreview()
+			input, dataModel, expectedOutput := getTestModelsForGetAndListApis20220315privatepreview()
 			if testcase.inputFile != "" {
 				input = &v20220315privatepreview.MongoDatabaseResource{}
 				_ = json.Unmarshal(radiustesting.ReadFixture(testcase.inputFile), input)
@@ -175,7 +175,7 @@ func TestCreateOrUpdateMongoDatabase_20220315PrivatePreview(t *testing.T) {
 			require.Equal(t, testcase.expectedStatusCode, w.Result().StatusCode)
 
 			if !testcase.shouldFail {
-				actualOutput := &v20220315privatepreview.MongoDatabaseResource{}
+				actualOutput := &v20220315privatepreview.MongoDatabaseResponseResource{}
 				_ = json.Unmarshal(w.Body.Bytes(), actualOutput)
 				require.Equal(t, expectedOutput, actualOutput)
 

--- a/pkg/connectorrp/frontend/controller/mongodatabases/createorupdatemongodatabase_test.go
+++ b/pkg/connectorrp/frontend/controller/mongodatabases/createorupdatemongodatabase_test.go
@@ -77,6 +77,8 @@ func TestCreateOrUpdateMongoDatabase_20220315PrivatePreview(t *testing.T) {
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).
 					DoAndReturn(func(ctx context.Context, obj *store.Object, opts ...store.SaveOptions) error {
+						// First time created objects should have the same lastModifiedAt and createdAt
+						dataModel.SystemData.CreatedAt = dataModel.SystemData.LastModifiedAt
 						obj.ETag = "new-resource-etag"
 						obj.Data = dataModel
 						return nil

--- a/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/createorupdaterabbitmq.go
+++ b/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/createorupdaterabbitmq.go
@@ -91,7 +91,13 @@ func (rabbitmq *CreateOrUpdateRabbitMQMessageQueue) Run(ctx context.Context, req
 		return nil, err
 	}
 
-	versioned, err := converter.RabbitMQMessageQueueDataModelToVersioned(newResource, serviceCtx.APIVersion, true)
+	rmqResponse := &datamodel.RabbitMQMessageQueueResponse{}
+	err = savedResource.As(rmqResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	versioned, err := converter.RabbitMQMessageQueueDataModelToVersioned(rmqResponse, serviceCtx.APIVersion, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/createorupdaterabbitmq_test.go
+++ b/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/createorupdaterabbitmq_test.go
@@ -70,7 +70,7 @@ func TestCreateOrUpdateRabbitMQ_20220315PrivatePreview(t *testing.T) {
 
 	for _, testcase := range createNewResourceTestCases {
 		t.Run(testcase.desc, func(t *testing.T) {
-			input, dataModel, expectedOutput := getTestModels20220315privatepreview()
+			input, dataModel, expectedOutput := getTestModelsForGetAndListApis20220315privatepreview()
 			w := httptest.NewRecorder()
 			req, _ := radiustesting.GetARMTestHTTPRequest(ctx, http.MethodGet, testHeaderfile, input)
 			req.Header.Set(testcase.headerKey, testcase.headerValue)
@@ -116,7 +116,7 @@ func TestCreateOrUpdateRabbitMQ_20220315PrivatePreview(t *testing.T) {
 			require.Equal(t, testcase.expectedStatusCode, w.Result().StatusCode)
 
 			if !testcase.shouldFail {
-				actualOutput := &v20220315privatepreview.RabbitMQMessageQueueResource{}
+				actualOutput := &v20220315privatepreview.RabbitMQMessageQueueResponseResource{}
 				_ = json.Unmarshal(w.Body.Bytes(), actualOutput)
 				require.Equal(t, expectedOutput, actualOutput)
 
@@ -144,7 +144,7 @@ func TestCreateOrUpdateRabbitMQ_20220315PrivatePreview(t *testing.T) {
 
 	for _, testcase := range updateExistingResourceTestCases {
 		t.Run(testcase.desc, func(t *testing.T) {
-			input, dataModel, expectedOutput := getTestModels20220315privatepreview()
+			input, dataModel, expectedOutput := getTestModelsForGetAndListApis20220315privatepreview()
 			if testcase.inputFile != "" {
 				input = &v20220315privatepreview.RabbitMQMessageQueueResource{}
 				_ = json.Unmarshal(radiustesting.ReadFixture(testcase.inputFile), input)
@@ -193,7 +193,7 @@ func TestCreateOrUpdateRabbitMQ_20220315PrivatePreview(t *testing.T) {
 			require.Equal(t, testcase.expectedStatusCode, w.Result().StatusCode)
 
 			if !testcase.shouldFail {
-				actualOutput := &v20220315privatepreview.RabbitMQMessageQueueResource{}
+				actualOutput := &v20220315privatepreview.RabbitMQMessageQueueResponseResource{}
 				_ = json.Unmarshal(w.Body.Bytes(), actualOutput)
 				require.Equal(t, expectedOutput, actualOutput)
 

--- a/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/createorupdaterabbitmq_test.go
+++ b/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/createorupdaterabbitmq_test.go
@@ -95,6 +95,8 @@ func TestCreateOrUpdateRabbitMQ_20220315PrivatePreview(t *testing.T) {
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).
 					DoAndReturn(func(ctx context.Context, obj *store.Object, opts ...store.SaveOptions) error {
+						// First time created objects should have the same lastModifiedAt and createdAt
+						dataModel.SystemData.CreatedAt = dataModel.SystemData.LastModifiedAt
 						obj.ETag = "new-resource-etag"
 						obj.Data = dataModel
 						return nil

--- a/pkg/connectorrp/frontend/controller/rediscaches/createorupdaterediscache.go
+++ b/pkg/connectorrp/frontend/controller/rediscaches/createorupdaterediscache.go
@@ -98,7 +98,13 @@ func (redis *CreateOrUpdateRedisCache) Run(ctx context.Context, req *http.Reques
 		return nil, err
 	}
 
-	versioned, err := converter.RedisCacheDataModelToVersioned(newResource, serviceCtx.APIVersion, true)
+	redisResponse := &datamodel.RedisCacheResponse{}
+	err = savedResource.As(redisResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	versioned, err := converter.RedisCacheDataModelToVersioned(redisResponse, serviceCtx.APIVersion, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connectorrp/frontend/controller/rediscaches/createorupdaterediscache_test.go
+++ b/pkg/connectorrp/frontend/controller/rediscaches/createorupdaterediscache_test.go
@@ -102,7 +102,7 @@ func TestCreateOrUpdateRedisCache_20220315PrivatePreview(t *testing.T) {
 
 	for _, testcase := range createNewResourceTestCases {
 		t.Run(testcase.desc, func(t *testing.T) {
-			input, dataModel, expectedOutput := getTestModels20220315privatepreview()
+			input, dataModel, expectedOutput := getTestModelsForGetAndListApis20220315privatepreview()
 			w := httptest.NewRecorder()
 			req, _ := radiustesting.GetARMTestHTTPRequest(ctx, http.MethodGet, testHeaderfile, input)
 			req.Header.Set(testcase.headerKey, testcase.headerValue)
@@ -145,7 +145,7 @@ func TestCreateOrUpdateRedisCache_20220315PrivatePreview(t *testing.T) {
 			_ = resp.Apply(ctx, w, req)
 			require.Equal(t, testcase.expectedStatusCode, w.Result().StatusCode)
 			if !testcase.shouldFail {
-				actualOutput := &v20220315privatepreview.RedisCacheResource{}
+				actualOutput := &v20220315privatepreview.RedisCacheResponseResource{}
 				_ = json.Unmarshal(w.Body.Bytes(), actualOutput)
 				require.Equal(t, expectedOutput, actualOutput)
 
@@ -173,7 +173,7 @@ func TestCreateOrUpdateRedisCache_20220315PrivatePreview(t *testing.T) {
 
 	for _, testcase := range updateExistingResourceTestCases {
 		t.Run(testcase.desc, func(t *testing.T) {
-			input, dataModel, expectedOutput := getTestModels20220315privatepreview()
+			input, dataModel, expectedOutput := getTestModelsForGetAndListApis20220315privatepreview()
 			if testcase.inputFile != "" {
 				input = &v20220315privatepreview.RedisCacheResource{}
 				_ = json.Unmarshal(radiustesting.ReadFixture(testcase.inputFile), input)
@@ -220,7 +220,7 @@ func TestCreateOrUpdateRedisCache_20220315PrivatePreview(t *testing.T) {
 			require.Equal(t, testcase.expectedStatusCode, w.Result().StatusCode)
 
 			if !testcase.shouldFail {
-				actualOutput := &v20220315privatepreview.RedisCacheResource{}
+				actualOutput := &v20220315privatepreview.RedisCacheResponseResource{}
 				_ = json.Unmarshal(w.Body.Bytes(), actualOutput)
 				require.Equal(t, expectedOutput, actualOutput)
 

--- a/pkg/connectorrp/frontend/controller/rediscaches/createorupdaterediscache_test.go
+++ b/pkg/connectorrp/frontend/controller/rediscaches/createorupdaterediscache_test.go
@@ -125,6 +125,8 @@ func TestCreateOrUpdateRedisCache_20220315PrivatePreview(t *testing.T) {
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).
 					DoAndReturn(func(ctx context.Context, obj *store.Object, opts ...store.SaveOptions) error {
+						// First time created objects should have the same lastModifiedAt and createdAt
+						dataModel.SystemData.CreatedAt = dataModel.SystemData.LastModifiedAt
 						obj.ETag = "new-resource-etag"
 						obj.Data = dataModel
 						return nil

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/extenders.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/extenders.json
@@ -156,13 +156,13 @@
             "200": {
               "description": "The request was successful; response contains the extender resource",
               "schema": {
-                "$ref": "#/definitions/ExtenderResource"
+                "$ref": "#/definitions/ExtenderResponseResource"
               }
             },
             "201": {
               "description": "The request was successful, resource will be updated asynchronously",
               "schema": {
-                "$ref": "#/definitions/ExtenderResource"
+                "$ref": "#/definitions/ExtenderResponseResource"
               }
             },
             "default": {

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/mongoDatabases.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/mongoDatabases.json
@@ -156,13 +156,13 @@
           "200": {
             "description": "The request was successful; response contains the mongoDatabase resource",
             "schema": {
-              "$ref": "#/definitions/MongoDatabaseResource"
+              "$ref": "#/definitions/MongoDatabaseResponseResource"
             }
           },
           "201": {
             "description": "The request was successful, resource will be updated asynchronously",
             "schema": {
-              "$ref": "#/definitions/MongoDatabaseResource"
+              "$ref": "#/definitions/MongoDatabaseResponseResource"
             }
           },
           "default": {

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/rabbitMQMessageQueues.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/rabbitMQMessageQueues.json
@@ -156,13 +156,13 @@
           "200": {
             "description": "The request was successful; response contains the rabbitMQMessageQueue resource",
             "schema": {
-              "$ref": "#/definitions/RabbitMQMessageQueueResource"
+              "$ref": "#/definitions/RabbitMQMessageQueueResponseResource"
             }
           },
           "201": {
             "description": "The request was successful, resource will be updated asynchronously",
             "schema": {
-              "$ref": "#/definitions/RabbitMQMessageQueueResource"
+              "$ref": "#/definitions/RabbitMQMessageQueueResponseResource"
             }
           },
           "default": {

--- a/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/redisCaches.json
+++ b/swagger/specification/applications/resource-manager/Applications.Connector/preview/2022-03-15-privatepreview/redisCaches.json
@@ -156,13 +156,13 @@
           "200": {
             "description": "The request was successful; response contains the redisCache resource",
             "schema": {
-              "$ref": "#/definitions/RedisCacheResource"
+              "$ref": "#/definitions/RedisCacheResponseResource"
             }
           },
           "201": {
             "description": "The request was successful, resource will be updated asynchronously",
             "schema": {
-              "$ref": "#/definitions/RedisCacheResource"
+              "$ref": "#/definitions/RedisCacheResponseResource"
             }
           },
           "default": {


### PR DESCRIPTION
Details about whether we should empty the map or make it nil will be discussed and PR will be updated accordingly.

# Description
Secret properties of an extender are reachable right now without calling a function. This PR attempts to solve this issue. rad deploy with `extenderContainer.secrets('secret')` works successfully. Here is the bicep:

```
import radius as radius

param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
param environment string

resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
  name: 'corerp-resources-extender'
  location: 'global'
  properties: {
    environment: environment
  }
}

resource twilio 'Applications.Connector/extenders@2022-03-15-privatepreview' = {
  name: 'extr-twilio'
  location: 'global'
  properties: {
    environment: environment
    fromNumber: '222-222-2222'
    secrets: {
      accountSid: 'sid'
      authToken: 'token'
    }
  }
}

resource container 'Applications.Core/containers@2022-03-15-privatepreview' = {
  name: 'extr-ctnr'
  location: 'global'
  properties: {
    application: app.id
    container: {
      image: magpieimage
      env: {
        TWILIO_NUMBER: twilio.properties.fromNumber
        TWILIO_SID: twilio.secrets('accountSid')
        TWILIO_ACCOUNT: twilio.secrets('authToken')
      }
    }
    connections: {}
  }
}
```

## Issue reference
Please reference the issue this PR will close: #3156 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
