### PR TITLE
ask for --reinstall only if  radius installation is found

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,8 +138,7 @@ stages:
           --provider-azure-client-secret $INTEGRATION_TEST_SP_PASSWORD \
           --provider-azure-tenant-id $INTEGRATION_TEST_TENANT_ID \
           --provider-azure-subscription ${{ variables.INTEGRATION_TEST_SUBSCRIPTION_ID }} \
-          --reinstall
-
+          
       env:
         INTEGRATION_TEST_SP_APP_ID: $(INTEGRATION_TEST_SP_APP_ID)
         INTEGRATION_TEST_TENANT_ID: $(INTEGRATION_TEST_TENANT_ID)

--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -190,10 +190,6 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 		return err
 	}
 
-	if (!isEmpty(chartArgs) || azureProvider != nil) && !chartArgs.Reinstall {
-		return fmt.Errorf("chart arg / provider config is not empty for existing workspace. Specify '--reinstall' for the new arguments to take effect")
-	}
-
 	var workspace *workspaces.Workspace
 	if foundExistingWorkspace {
 		workspace, err = cli.GetWorkspace(config, workspaceName)
@@ -215,6 +211,10 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 	foundExistingRadius, err := setup.Install(cmd.Context(), clusterOptions, contextName)
 	if err != nil {
 		return err
+	}
+
+	if (!isEmpty(chartArgs) || azureProvider != nil) && !chartArgs.Reinstall && foundExistingRadius {
+		return fmt.Errorf("chart arg / provider config is not empty for existing workspace. Specify '--reinstall' for the new arguments to take effect")
 	}
 
 	//If existing radius control plane, retrieve az provider subscription and resourcegroup, and use that unless a --reinstall is specified


### PR DESCRIPTION
# Description

rad env init should ask for --reinstall only when existing radius cp is found

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: Fixes https://github.com/project-radius/radius/issues/3175

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
