### PR TITLE
Using injected magpiego image instead of latest

### DIFF
--- a/test/functional/corerp/cli/cli_test.go
+++ b/test/functional/corerp/cli/cli_test.go
@@ -76,7 +76,7 @@ func Test_CLI_DeploymentParameters(t *testing.T) {
 	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
-		{Executor: step.NewDeployExecutor(template, "@"+parameterFilePath, functional.GetMagpieImage()),
+		{Executor: step.NewDeployExecutor(template, "@"+parameterFilePath),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{

--- a/test/functional/corerp/cli/cli_test.go
+++ b/test/functional/corerp/cli/cli_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/bicep"
 	"github.com/project-radius/radius/pkg/cli/objectformats"
 	"github.com/project-radius/radius/test"
+	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/corerp"
 	"github.com/project-radius/radius/test/radcli"
 	"github.com/project-radius/radius/test/step"
@@ -30,7 +31,7 @@ func Test_CLI(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{
@@ -75,7 +76,7 @@ func Test_CLI_DeploymentParameters(t *testing.T) {
 	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
-		{Executor: step.NewDeployExecutor(template, "@"+parameterFilePath),
+		{Executor: step.NewDeployExecutor(template, "@"+parameterFilePath, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{

--- a/test/functional/corerp/cli/testdata/corerp-kubernetes-cli-parameters.bicep
+++ b/test/functional/corerp/cli/testdata/corerp-kubernetes-cli-parameters.bicep
@@ -9,6 +9,8 @@ param environment string = 'test'
 @description('Specifies the tag of the image to be deployed.')
 param magpietag string = 'latest'
 
+
+
 @description('Specifies the registry of the image to be deployed.')
 param registry string
 

--- a/test/functional/corerp/cli/testdata/corerp-kubernetes-cli-parameters.bicep
+++ b/test/functional/corerp/cli/testdata/corerp-kubernetes-cli-parameters.bicep
@@ -9,8 +9,6 @@ param environment string = 'test'
 @description('Specifies the tag of the image to be deployed.')
 param magpietag string = 'latest'
 
-
-
 @description('Specifies the registry of the image to be deployed.')
 param registry string
 

--- a/test/functional/corerp/cli/testdata/corerp-kubernetes-cli.bicep
+++ b/test/functional/corerp/cli/testdata/corerp-kubernetes-cli.bicep
@@ -7,7 +7,7 @@ param location string = 'global'
 param environment string = 'test'
 
 @description('Specifies the image to be deployed.')
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
   name: 'kubernetes-cli'

--- a/test/functional/corerp/mechanics/mechanics_test.go
+++ b/test/functional/corerp/mechanics/mechanics_test.go
@@ -307,7 +307,7 @@ func Test_InvalidResourceIDs(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployErrorExecutor(template),
+			Executor: step.NewDeployErrorExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{

--- a/test/functional/corerp/mechanics/testdata/corerp-mechanics-communication-cycle.bicep
+++ b/test/functional/corerp/mechanics/testdata/corerp-mechanics-communication-cycle.bicep
@@ -7,7 +7,7 @@ param location string = 'global'
 param environment string = 'test'
 
 @description('Specifies the image to be deployed.')
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
   name: 'corerp-mechanics-communication-cycle'

--- a/test/functional/corerp/mechanics/testdata/corerp-mechanics-invalid-resourceids.bicep
+++ b/test/functional/corerp/mechanics/testdata/corerp-mechanics-invalid-resourceids.bicep
@@ -7,7 +7,7 @@ param location string = 'global'
 param environment string = 'test'
 
 @description('Specifies the image to be deployed.')
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
   name: 'corerp-mechanics-invalid-resourceids'

--- a/test/functional/corerp/mechanics/testdata/corerp-mechanics-redeploy-withanotherresource.step1.bicep
+++ b/test/functional/corerp/mechanics/testdata/corerp-mechanics-redeploy-withanotherresource.step1.bicep
@@ -7,7 +7,7 @@ param location string = 'global'
 param environment string = 'test'
 
 @description('Specifies the image to be deployed.')
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
   name: 'corerp-mechanics-redeploy-with-another-resource'

--- a/test/functional/corerp/mechanics/testdata/corerp-mechanics-redeploy-withanotherresource.step2.bicep
+++ b/test/functional/corerp/mechanics/testdata/corerp-mechanics-redeploy-withanotherresource.step2.bicep
@@ -7,7 +7,7 @@ param location string = 'global'
 param environment string = 'test'
 
 @description('Specifies the image to be deployed.')
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
   name: 'corerp-mechanics-redeploy-with-another-resource'

--- a/test/functional/corerp/mechanics/testdata/corerp-mechanics-redeploy-withtwoseparateresource.step1.bicep
+++ b/test/functional/corerp/mechanics/testdata/corerp-mechanics-redeploy-withtwoseparateresource.step1.bicep
@@ -7,7 +7,7 @@ param location string = 'global'
 param environment string = 'test'
 
 @description('Specifies the image to be deployed.')
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
   name: 'corerp-mechanics-redeploy-withtwoseparateresource'

--- a/test/functional/corerp/mechanics/testdata/corerp-mechanics-redeploy-withtwoseparateresource.step2.bicep
+++ b/test/functional/corerp/mechanics/testdata/corerp-mechanics-redeploy-withtwoseparateresource.step2.bicep
@@ -7,7 +7,7 @@ param location string = 'global'
 param environment string = 'test'
 
 @description('Specifies the image to be deployed.')
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
   name: 'corerp-mechanics-redeploy-withtwoseparateresource'

--- a/test/functional/corerp/mechanics/testdata/corerp-mechanics-redeploy-withupdatedresource.step1.bicep
+++ b/test/functional/corerp/mechanics/testdata/corerp-mechanics-redeploy-withupdatedresource.step1.bicep
@@ -7,7 +7,7 @@ param location string = 'global'
 param environment string = 'test'
 
 @description('Specifies the image to be deployed.')
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
   name: 'corerp-mechanics-redeploy-withupdatedresource'

--- a/test/functional/corerp/mechanics/testdata/corerp-mechanics-redeploy-withupdatedresource.step2.bicep
+++ b/test/functional/corerp/mechanics/testdata/corerp-mechanics-redeploy-withupdatedresource.step2.bicep
@@ -7,7 +7,7 @@ param location string = 'global'
 param environment string = 'test'
 
 @description('Specifies the image to be deployed.')
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
   name: 'corerp-mechanics-redeploy-withupdatedresource'

--- a/test/functional/corerp/resources/azure_connections_test.go
+++ b/test/functional/corerp/resources/azure_connections_test.go
@@ -8,6 +8,7 @@ package resource_test
 import (
 	"testing"
 
+	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/corerp"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
@@ -23,7 +24,7 @@ func Test_AzureConnections(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{

--- a/test/functional/corerp/resources/container_test.go
+++ b/test/functional/corerp/resources/container_test.go
@@ -8,6 +8,7 @@ package resource_test
 import (
 	"testing"
 
+	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/corerp"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
@@ -21,7 +22,7 @@ func Test_Container(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{
@@ -55,7 +56,7 @@ func Test_ContainerHttpRoute(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{

--- a/test/functional/corerp/resources/dapr_invokehttproute_test.go
+++ b/test/functional/corerp/resources/dapr_invokehttproute_test.go
@@ -8,6 +8,7 @@ package resource_test
 import (
 	"testing"
 
+	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/corerp"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
@@ -22,8 +23,7 @@ func Test_DaprInvokeHttpRoute(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
-
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{

--- a/test/functional/corerp/resources/dapr_pubsub_test.go
+++ b/test/functional/corerp/resources/dapr_pubsub_test.go
@@ -8,6 +8,7 @@ package resource_test
 import (
 	"testing"
 
+	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/corerp"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
@@ -22,7 +23,7 @@ func Test_DaprPubSubGeneric(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{
@@ -62,7 +63,7 @@ func Test_DaprPubSubServiceBus(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{

--- a/test/functional/corerp/resources/dapr_secretstore_test.go
+++ b/test/functional/corerp/resources/dapr_secretstore_test.go
@@ -8,6 +8,7 @@ package resource_test
 import (
 	"testing"
 
+	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/corerp"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
@@ -27,7 +28,7 @@ func Test_DaprSecretStoreGeneric(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{

--- a/test/functional/corerp/resources/dapr_statestore_test.go
+++ b/test/functional/corerp/resources/dapr_statestore_test.go
@@ -8,6 +8,7 @@ package resource_test
 import (
 	"testing"
 
+	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/corerp"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
@@ -23,7 +24,7 @@ func Test_DaprStateStoreGeneric(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{
@@ -63,7 +64,7 @@ func Test_DaprStateStoreTableStorage(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{

--- a/test/functional/corerp/resources/extender_test.go
+++ b/test/functional/corerp/resources/extender_test.go
@@ -8,6 +8,7 @@ package resource_test
 import (
 	"testing"
 
+	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/corerp"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
@@ -21,7 +22,7 @@ func Test_Extender(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{

--- a/test/functional/corerp/resources/gateway_test.go
+++ b/test/functional/corerp/resources/gateway_test.go
@@ -8,6 +8,7 @@ package resource_test
 import (
 	"testing"
 
+	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/corerp"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
@@ -24,7 +25,7 @@ func Test_Gateway(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{

--- a/test/functional/corerp/resources/microsoftsql_test.go
+++ b/test/functional/corerp/resources/microsoftsql_test.go
@@ -8,6 +8,7 @@ package resource_test
 import (
 	"testing"
 
+	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/corerp"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
@@ -23,7 +24,7 @@ func Test_MicrosoftSQL(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{

--- a/test/functional/corerp/resources/mongodb_test.go
+++ b/test/functional/corerp/resources/mongodb_test.go
@@ -8,6 +8,7 @@ package resource_test
 import (
 	"testing"
 
+	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/corerp"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
@@ -33,7 +34,7 @@ func Test_MongoDB(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{
@@ -73,7 +74,7 @@ func Test_MongoDBUserSecrets(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{

--- a/test/functional/corerp/resources/rabbitmq_test.go
+++ b/test/functional/corerp/resources/rabbitmq_test.go
@@ -8,6 +8,7 @@ package resource_test
 import (
 	"testing"
 
+	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/corerp"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
@@ -24,7 +25,7 @@ func Test_RabbitMQ(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{

--- a/test/functional/corerp/resources/redis_test.go
+++ b/test/functional/corerp/resources/redis_test.go
@@ -8,6 +8,7 @@ package resource_test
 import (
 	"testing"
 
+	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/corerp"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
@@ -24,7 +25,7 @@ func Test_Redis(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{

--- a/test/functional/corerp/resources/sql_test.go
+++ b/test/functional/corerp/resources/sql_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/corerp"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
@@ -26,7 +27,7 @@ func Test_SQL(t *testing.T) {
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{

--- a/test/functional/corerp/resources/testdata/corerp-azure-connection-database-service.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-azure-connection-database-service.bicep
@@ -1,6 +1,6 @@
 import radius as radius
 
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 
 param environment string
 

--- a/test/functional/corerp/resources/testdata/corerp-resources-container-httproute.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-container-httproute.bicep
@@ -4,7 +4,7 @@ import radius as radius
 param location string = 'global'
 
 @description('Specifies the image of the container resource.')
-param image string = 'radiusdev.azurecr.io/magpiego:latest'
+param image string
 
 @description('Specifies the port of the container resource.')
 param port int = 3000

--- a/test/functional/corerp/resources/testdata/corerp-resources-container-httproute.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-container-httproute.bicep
@@ -4,7 +4,7 @@ import radius as radius
 param location string = 'global'
 
 @description('Specifies the image of the container resource.')
-param image string
+param magpieimage string
 
 @description('Specifies the port of the container resource.')
 param port int = 3000
@@ -26,7 +26,7 @@ resource container 'Applications.Core/containers@2022-03-15-privatepreview' = {
   properties: {
     application: app.id
     container: {
-      image: image
+      image: magpieimage
       ports: {
         web: {
           containerPort: port

--- a/test/functional/corerp/resources/testdata/corerp-resources-container.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-container.bicep
@@ -4,7 +4,7 @@ import radius as radius
 param location string = 'global'
 
 @description('Specifies the image of the container resource.')
-param image string = 'radiusdev.azurecr.io/magpiego:latest'
+param image string
 
 @description('Specifies the port of the container resource.')
 param port int = 3000

--- a/test/functional/corerp/resources/testdata/corerp-resources-container.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-container.bicep
@@ -4,7 +4,7 @@ import radius as radius
 param location string = 'global'
 
 @description('Specifies the image of the container resource.')
-param image string
+param magpieimage string
 
 @description('Specifies the port of the container resource.')
 param port int = 3000
@@ -26,7 +26,7 @@ resource container 'Applications.Core/containers@2022-03-15-privatepreview' = {
   properties: {
     application: app.id
     container: {
-      image: image
+      image: magpieimage
       ports: {
         web: {
           containerPort: port

--- a/test/functional/corerp/resources/testdata/corerp-resources-dapr-httproute.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-dapr-httproute.bicep
@@ -2,7 +2,7 @@ import radius as radius
 
 param location string = resourceGroup().location
 param environment string
-param image string
+param magpieimage string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
   name: 'dapr-invokehttproute'
@@ -18,7 +18,7 @@ resource frontend 'Applications.Core/containers@2022-03-15-privatepreview' = {
   properties: {
     application: app.id
     container: {
-      image: image
+      image: magpieimage
       readinessProbe:{
         kind:'httpGet'
         containerPort:3000
@@ -45,7 +45,7 @@ resource backend 'Applications.Core/containers@2022-03-15-privatepreview' = {
   properties: {
     application: app.id
     container: {
-      image: image
+      image: magpieimage
       ports: {
         orders: {
           containerPort: 3000

--- a/test/functional/corerp/resources/testdata/corerp-resources-dapr-httproute.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-dapr-httproute.bicep
@@ -2,7 +2,7 @@ import radius as radius
 
 param location string = resourceGroup().location
 param environment string
-param image string = 'pratmishra.azurecr.io/magpiego:latest'
+param image string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
   name: 'dapr-invokehttproute'

--- a/test/functional/corerp/resources/testdata/corerp-resources-dapr-pubsub-generic.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-dapr-pubsub-generic.bicep
@@ -1,6 +1,6 @@
 import radius as radius
 
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 
 param environment string
 

--- a/test/functional/corerp/resources/testdata/corerp-resources-dapr-pubsub-servicebus.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-dapr-pubsub-servicebus.bicep
@@ -1,6 +1,6 @@
 import radius as radius
 
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 
 param environment string
 

--- a/test/functional/corerp/resources/testdata/corerp-resources-dapr-secretstore-generic.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-dapr-secretstore-generic.bicep
@@ -1,6 +1,6 @@
 import radius as radius
 
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 
 param environment string
 

--- a/test/functional/corerp/resources/testdata/corerp-resources-dapr-statestore-generic.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-dapr-statestore-generic.bicep
@@ -1,6 +1,6 @@
 import radius as radius
 
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 
 param environment string
 

--- a/test/functional/corerp/resources/testdata/corerp-resources-dapr-statestore-tablestorage.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-dapr-statestore-tablestorage.bicep
@@ -1,6 +1,6 @@
 import radius as radius
 
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 
 param environment string
 

--- a/test/functional/corerp/resources/testdata/corerp-resources-extender.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-extender.bicep
@@ -1,6 +1,6 @@
 import radius as radius
 
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 param environment string 
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {

--- a/test/functional/corerp/resources/testdata/corerp-resources-gateway.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-gateway.bicep
@@ -10,7 +10,7 @@ param environment string
 param port int = 3000
 
 @description('Specifies the image for the container resource.')
-param image string
+param magpieimage string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
   name: 'corerp-resources-gateway'
@@ -60,7 +60,7 @@ resource frontendContainer 'Applications.Core/containers@2022-03-15-privateprevi
   properties: {
     application: app.id
     container: {
-      image: image
+      image: magpieimage
       ports: {
         web: {
           containerPort: port
@@ -95,7 +95,7 @@ resource backendContainer 'Applications.Core/containers@2022-03-15-privateprevie
   properties: {
     application: app.id
     container: {
-      image: image
+      image: magpieimage
       ports: {
         web: {
           containerPort: port

--- a/test/functional/corerp/resources/testdata/corerp-resources-gateway.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-gateway.bicep
@@ -10,7 +10,7 @@ param environment string
 param port int = 3000
 
 @description('Specifies the image for the container resource.')
-param image string = 'radiusdev.azurecr.io/magpiego:latest'
+param image string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
   name: 'corerp-resources-gateway'

--- a/test/functional/corerp/resources/testdata/corerp-resources-microsoft-sql.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-microsoft-sql.bicep
@@ -4,7 +4,7 @@ import radius as radius
 param location string = 'East US'
 
 @description('Specifies the image for the container resource.')
-param magpieImage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieImage string
 
 @description('Specifies the port for the container resource.')
 param magpiePort int = 3000

--- a/test/functional/corerp/resources/testdata/corerp-resources-mongodb-user-secrets.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-mongodb-user-secrets.bicep
@@ -9,7 +9,7 @@ param password string = newGuid()
 
 param environment string
 
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
   name: 'corerp-resources-mongodb-user-secrets'

--- a/test/functional/corerp/resources/testdata/corerp-resources-mongodb.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-mongodb.bicep
@@ -1,6 +1,6 @@
 import radius as radius
 
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieimage string
 
 param environment string
 

--- a/test/functional/corerp/resources/testdata/corerp-resources-rabbitmq.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-rabbitmq.bicep
@@ -4,7 +4,7 @@ import radius as radius
 param location string = 'global'
 
 @description('Specifies the image for the container resource.')
-param magpieImage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieImage string
 
 @description('Specifies the port for the container resource.')
 param magpiePort int = 3000

--- a/test/functional/corerp/resources/testdata/corerp-resources-redis-user-secrets.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-redis-user-secrets.bicep
@@ -1,7 +1,6 @@
 import radius as radius
 
-param magpieimage string = 'radiusdev.azurecr.io/magpiego:latest' 
-
+param magpieimage string
 param environment string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview'  = {

--- a/test/functional/corerp/resources/testdata/corerp-resources-sql.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-sql.bicep
@@ -12,7 +12,7 @@ param magpiePort int = 3000
 @description('Specifies the environment for resources.')
 param environment string = 'test'
 
-@description('Specifies the image for the container resource.')
+@description('Specifies the image for the sql container resource.')
 param sqlImage string = 'mcr.microsoft.com/mssql/server:2019-latest'
 
 @description('Specifies the port for the container resource.')

--- a/test/functional/corerp/resources/testdata/corerp-resources-sql.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-sql.bicep
@@ -4,7 +4,7 @@ import radius as radius
 param location string = 'global'
 
 @description('Specifies the image for the container resource.')
-param magpieImage string = 'radiusdev.azurecr.io/magpiego:latest'
+param magpieImage string
 
 @description('Specifies the port for the container resource.')
 param magpiePort int = 3000


### PR DESCRIPTION
# Description

* Updates corerp test files to use `functional.GetMagpieImage()` instead of default image from bicep file

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
