### PR TITLE
Fix for DaprSecretStore creation failure with empty metadata.

### DIFF
--- a/pkg/connectorrp/renderers/dapr/generic.go
+++ b/pkg/connectorrp/renderers/dapr/generic.go
@@ -28,7 +28,7 @@ func (daprGeneric DaprGeneric) Validate() error {
 		return renderers.NewClientErrInvalidRequest("No Dapr component version specified for generic Dapr component")
 	}
 
-	if daprGeneric.Metadata == nil || len(daprGeneric.Metadata) == 0 {
+	if daprGeneric.Metadata == nil {
 		return renderers.NewClientErrInvalidRequest(fmt.Sprintf("No metadata specified for Dapr component of type %s", *daprGeneric.Type))
 	}
 

--- a/pkg/connectorrp/renderers/daprsecretstores/renderer_test.go
+++ b/pkg/connectorrp/renderers/daprsecretstores/renderer_test.go
@@ -144,10 +144,9 @@ func Test_Render_Generic_MissingMetadata(t *testing.T) {
 				Application: applicationID,
 				Environment: environmentID,
 			},
-			Type:     "secretstores.kubernetes",
-			Kind:     resourcekinds.DaprGeneric,
-			Version:  daprSecretStoreVersion,
-			Metadata: map[string]interface{}{},
+			Type:    "secretstores.kubernetes",
+			Kind:    resourcekinds.DaprGeneric,
+			Version: daprSecretStoreVersion,
 		},
 	}
 	_, err := renderer.Render(ctx, &resource, renderers.RenderOptions{Namespace: "radius-test"})

--- a/pkg/connectorrp/renderers/daprstatestores/renderer_test.go
+++ b/pkg/connectorrp/renderers/daprstatestores/renderer_test.go
@@ -223,9 +223,8 @@ func Test_Render_Generic_MissingMetadata(t *testing.T) {
 			},
 			Kind: "generic",
 			DaprStateStoreGeneric: datamodel.DaprStateStoreGenericResourceProperties{
-				Type:     stateStoreType,
-				Metadata: map[string]interface{}{},
-				Version:  daprStateStoreVersion,
+				Type:    stateStoreType,
+				Version: daprStateStoreVersion,
 			},
 		},
 	}


### PR DESCRIPTION
# Description

Fix for DaprSecretStore creation failure with empty metadata.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: radius-project/core-team#801 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
