### PR TITLE
rad env changes

### DIFF
--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -213,8 +213,12 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 		return err
 	}
 
-	if (!isEmpty(chartArgs) || azureProvider != nil) && !chartArgs.Reinstall && foundExistingRadius {
-		return fmt.Errorf("chart arg / provider config is not empty for existing workspace. Specify '--reinstall' for the new arguments to take effect")
+	if (azureProvider != nil) && !chartArgs.Reinstall && foundExistingRadius {
+		return fmt.Errorf("error: adding a cloud provider requires a reinstall of the Radius services. Specify '--reinstall' for the new arguments to take effect")
+	}
+
+	if !isEmpty(chartArgs) && !chartArgs.Reinstall && foundExistingRadius {
+		return fmt.Errorf("error: arguments provided requires a reinstall of the Radius services. Specify '--reinstall' for the new arguments to take effect")
 	}
 
 	//If existing radius control plane, retrieve az provider subscription and resourcegroup, and use that unless a --reinstall is specified
@@ -390,27 +394,27 @@ func selectNamespace(cmd *cobra.Command, defaultVal string, interactive bool) (s
 }
 
 func selectEnvironmentName(cmd *cobra.Command, defaultVal string, interactive bool) (string, error) {
-	var val string
+	var envStr string
 	var err error
 
-	val, err = cmd.Flags().GetString("environment")
+	envStr, err = cmd.Flags().GetString("environment")
 	if err != nil {
 		return "", err
 	}
-	if interactive && val == "" {
+	if interactive && envStr == "" {
 		promptMsg := fmt.Sprintf("Enter an environment name [%s]:", defaultVal)
-		val, err = prompt.TextWithDefault(promptMsg, &defaultVal, prompt.EmptyValidator)
+		envStr, err = prompt.TextWithDefault(promptMsg, &defaultVal, prompt.EmptyValidator)
 		if err != nil {
 			return "", err
 		}
-		fmt.Printf("Using %s as environment name\n", val)
+		fmt.Printf("Using %s as environment name\n", envStr)
 	} else {
-		if val == "" {
+		if envStr == "" {
 			output.LogInfo("No environment name provided, using: %v", defaultVal)
-			val = defaultVal
+			envStr = defaultVal
 		}
 	}
-	return val, nil
+	return envStr, nil
 }
 
 func isEmpty(chartArgs *setup.ChartArgs) bool {

--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -392,7 +392,12 @@ func selectNamespace(cmd *cobra.Command, defaultVal string, interactive bool) (s
 func selectEnvironmentName(cmd *cobra.Command, defaultVal string, interactive bool) (string, error) {
 	var val string
 	var err error
-	if interactive {
+
+	val, err = cmd.Flags().GetString("environment")
+	if err != nil {
+		return "", err
+	}
+	if interactive && val == "" {
 		promptMsg := fmt.Sprintf("Enter an environment name [%s]:", defaultVal)
 		val, err = prompt.TextWithDefault(promptMsg, &defaultVal, prompt.EmptyValidator)
 		if err != nil {
@@ -400,7 +405,6 @@ func selectEnvironmentName(cmd *cobra.Command, defaultVal string, interactive bo
 		}
 		fmt.Printf("Using %s as environment name\n", val)
 	} else {
-		val, _ = cmd.Flags().GetString("environment")
 		if val == "" {
 			output.LogInfo("No environment name provided, using: %v", defaultVal)
 			val = defaultVal

--- a/pkg/cli/helm/radiusclient.go
+++ b/pkg/cli/helm/radiusclient.go
@@ -168,17 +168,17 @@ func GetAzProvider(options RadiusOptions, kubeContext string) (*azure.Provider, 
 
 	var azProvider azure.Provider
 
-	_, ok = azureProvider["subscriptionId"]
+	subscriptionId, ok := azureProvider["subscriptionId"]
 	if !ok {
 		return nil, nil
 	}
-	_, ok = azureProvider["resourceGroup"]
+	resourceGroup, ok := azureProvider["resourceGroup"]
 	if !ok {
 		return nil, nil
 	}
 
-	azProvider.SubscriptionID = azureProvider["subscriptionId"].(string)
-	azProvider.ResourceGroup = azureProvider["resourceGroup"].(string)
+	azProvider.SubscriptionID = subscriptionId.(string)
+	azProvider.ResourceGroup = resourceGroup.(string)
 	return &azProvider, nil
 
 }

--- a/pkg/cli/helm/radiusclient.go
+++ b/pkg/cli/helm/radiusclient.go
@@ -167,6 +167,16 @@ func GetAzProvider(options RadiusOptions, kubeContext string) (*azure.Provider, 
 	azureProvider := provider["azure"].(map[string]interface{})
 
 	var azProvider azure.Provider
+
+	_, ok = azureProvider["subscriptionId"]
+	if !ok {
+		return nil, nil
+	}
+	_, ok = azureProvider["resourceGroup"]
+	if !ok {
+		return nil, nil
+	}
+
 	azProvider.SubscriptionID = azureProvider["subscriptionId"].(string)
 	azProvider.ResourceGroup = azureProvider["resourceGroup"].(string)
 	return &azProvider, nil


### PR DESCRIPTION
# Description

few env fixes
- rad env -i should. not request a env name, if one is provided through -e
- reinstalls should not panic if the older install has not been configured with an az provider

## Issue reference
https://github.com/project-radius/radius/issues/3168
https://github.com/project-radius/radius/issues/3106

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
