### PR TITLE
Fix UCP panic

### DIFF
--- a/pkg/ucp/frontend/api/handler.go
+++ b/pkg/ucp/frontend/api/handler.go
@@ -168,11 +168,14 @@ func (h *Handler) ProxyPlaneRequest(w http.ResponseWriter, r *http.Request) {
 	newURL.Path = h.getRelativePath(r.URL.Path)
 	response, err := h.ucp.Planes.ProxyRequest(ctx, h.db, w, r, &newURL)
 	if err != nil {
-		err := response.Apply(ctx, w, r)
-		if err != nil {
-			internalServerError(ctx, w, r, err)
-			return
-		}
+		internalServerError(ctx, w, r, err)
+		return
+	}
+
+	err = response.Apply(ctx, w, r)
+	if err != nil {
+		internalServerError(ctx, w, r, err)
+		return
 	}
 }
 func (h *Handler) DefaultHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/ucp/frontend/api/handler.go
+++ b/pkg/ucp/frontend/api/handler.go
@@ -106,6 +106,7 @@ func (h *Handler) CreateOrUpdatePlane(w http.ResponseWriter, r *http.Request) {
 		internalServerError(ctx, w, r, err)
 		return
 	}
+
 	err = response.Apply(ctx, w, r)
 	if err != nil {
 		internalServerError(ctx, w, r, err)
@@ -172,10 +173,12 @@ func (h *Handler) ProxyPlaneRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = response.Apply(ctx, w, r)
-	if err != nil {
-		internalServerError(ctx, w, r, err)
-		return
+	if response != nil {
+		err = response.Apply(ctx, w, r)
+		if err != nil {
+			internalServerError(ctx, w, r, err)
+			return
+		}
 	}
 }
 func (h *Handler) DefaultHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/ucp/frontend/ucphandler/planes/planes.go
+++ b/pkg/ucp/frontend/ucphandler/planes/planes.go
@@ -301,5 +301,6 @@ func (ucp *ucpHandler) ProxyRequest(ctx context.Context, db store.StorageClient,
 	logger.Info(fmt.Sprintf("Proxying request to target %s", proxyURL))
 	sender.ServeHTTP(w, r.WithContext(ctx))
 
-	return rest.NewNoContentResponse(), nil
+	// The upstream response has already been sent at this point. Therefore, return nil response here
+	return nil, nil
 }


### PR DESCRIPTION
# Description

The root cause was that the handler code was this:-
response, err := h.ucp.Planes.ProxyRequest(ctx, h.db, w, r, &newURL)
if err != nil {
err := response.Apply(ctx, w, r)
if err != nil {
When the err is not nil, response was nil and response.Apply caused the panic

I checked the CI/CD logs for random PRs and I see this panic in all ucp logs. So that way it's reproducible. I added some logs and looks like the error is coming from a context getting canceled but not sure what is causing that.

#3048 

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #3048 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
