### PR TITLE
workspace behavior changes

### DIFF
--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -179,14 +179,13 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 		}
 
 		workspaceName = section.Default
-		workspaceSpecified = false
 	} else {
 		workspaceSpecified = true
 	}
 
+	// if user does not specify a workspace name and there is no default workspace, use environmentName as workspace name
 	if workspaceName == "" {
 		workspaceName = environmentName
-		workspaceSpecified = false
 	}
 
 	// We're going to update the workspace in place if it's compatible. We only need to
@@ -212,13 +211,15 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 	if foundExistingWorkspace {
 		isSameConn = workspace.ConnectionEquals(&workspaces.KubernetesConnection{Kind: workspaces.KindKubernetes, Context: contextName})
 	}
-	if foundExistingWorkspace && workspaceSpecified && !force && !isSameConn {
-		return fmt.Errorf("the specified workspace %q has a connection to Kubernetes context %q, which is different from context %q. Specify '--force' to overwrite", workspaceName, workspace.Connection["context"], contextName)
-	}
 
-	if foundExistingWorkspace && !workspaceSpecified && !isSameConn {
-		workspaceName = environmentName
-		workspace = nil
+	if foundExistingWorkspace {
+		if workspaceSpecified && !force && !isSameConn {
+			return fmt.Errorf("the specified workspace %q has a connection to Kubernetes context %q, which is different from context %q. Specify '--force' to overwrite", workspaceName, workspace.Connection["context"], contextName)
+		}
+		if !workspaceSpecified && !isSameConn {
+			workspaceName = environmentName
+			workspace = nil
+		}
 	}
 
 	// Make sure namespace for applications exists


### PR DESCRIPTION
- If the user specifies a workspace name with -w and that workspace points to a different Kubernetes cluster, then --force is required
- If the user does not specify a workspace with -w and the current default workspace points to a different cluster, then create a new workspace
- If the user does not specify a workspace with -w and the current default workspace points to the same cluster, then update the existing workspace

# Description

_Please explain the changes you've made._

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: radius-project/core-team#788

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
