### PR TITLE
Fix container logs for pods running in default namespace

### DIFF
--- a/test/functional/corerp/corerptest.go
+++ b/test/functional/corerp/corerptest.go
@@ -197,15 +197,15 @@ func (ct CoreRPTest) Test(t *testing.T) {
 		if err != nil {
 			t.Errorf("failed to capture logs from radius controller: %v", err)
 		}
+
+		err = validation.SaveLogsForController(ctx, ct.Options.K8sClient, "default", logPrefix)
+		if err != nil {
+			t.Errorf("failed to capture logs from radius controller: %v", err)
+		}
 	})
 
-	err := validation.SaveLogsForApplication(ctx, ct.Options.K8sClient, ct.Name, logPrefix+"/"+ct.Name, ct.Name)
-	if err != nil {
-		t.Errorf("failed to capture logs from radius pods %v", err)
-	}
-
 	t.Logf("Creating secrets if provided")
-	err = ct.CreateSecrets(ctx)
+	err := ct.CreateSecrets(ctx)
 	if err != nil {
 		t.Errorf("failed to create secrets %v", err)
 	}

--- a/test/functional/corerp/corerptest.go
+++ b/test/functional/corerp/corerptest.go
@@ -198,6 +198,7 @@ func (ct CoreRPTest) Test(t *testing.T) {
 			t.Errorf("failed to capture logs from radius controller: %v", err)
 		}
 
+                // Getting logs from all pods in the default namespace as well, which is where all app pods run for calls to rad deploy
 		err = validation.SaveLogsForController(ctx, ct.Options.K8sClient, "default", logPrefix)
 		if err != nil {
 			t.Errorf("failed to capture logs from radius controller: %v", err)

--- a/test/validation/k8s.go
+++ b/test/validation/k8s.go
@@ -179,7 +179,7 @@ func watchForPods(ctx context.Context, k8s *kubernetes.Clientset, namespace stri
 
 			// Only start one log capture per pod
 			_, ok = pods[pod.Name]
-			if pod.Status.Phase != corev1.PodRunning || ok {
+			if ok {
 				continue
 			}
 			pods[pod.Name] = true


### PR DESCRIPTION
# Description

Logs from default namespace, which is where all of our pods are currently running for tests

## Issue reference

Fixes https://github.com/project-radius/radius/issues/3183

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
