### PR TITLE
Removing unused output resources of the same resource

### DIFF
--- a/pkg/armrpc/api/v1/types.go
+++ b/pkg/armrpc/api/v1/types.go
@@ -160,6 +160,10 @@ type ResourceStatus struct {
 	OutputResources []outputresource.OutputResource `json:"outputResources,omitempty"`
 }
 
+func (in *ResourceStatus) DeepCopy(out *ResourceStatus) {
+	in.OutputResources = out.OutputResources
+}
+
 // OutputResource contains some internal fields like resources/dependencies that shouldn't be inlcuded in the user response
 func BuildExternalOutputResources(outputResources []outputresource.OutputResource) []map[string]interface{} {
 	var externalOutputResources []map[string]interface{}

--- a/pkg/connectorrp/frontend/controller/daprinvokehttproutes/createorupdatedaprinvokehttproute.go
+++ b/pkg/connectorrp/frontend/controller/daprinvokehttproutes/createorupdatedaprinvokehttproute.go
@@ -16,6 +16,7 @@ import (
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel/converter"
 	"github.com/project-radius/radius/pkg/connectorrp/renderers/daprinvokehttproutes"
+	"github.com/project-radius/radius/pkg/radrp/outputresource"
 	"github.com/project-radius/radius/pkg/radrp/rest"
 	"github.com/project-radius/radius/pkg/ucp/store"
 )
@@ -40,23 +41,6 @@ func (daprHttpRoute *CreateOrUpdateDaprInvokeHttpRoute) Run(ctx context.Context,
 		return nil, err
 	}
 
-	rendererOutput, err := daprHttpRoute.DeploymentProcessor().Render(ctx, serviceCtx.ResourceID, newResource)
-	if err != nil {
-		return nil, err
-	}
-	deploymentOutput, err := daprHttpRoute.DeploymentProcessor().Deploy(ctx, serviceCtx.ResourceID, rendererOutput)
-	if err != nil {
-		return nil, err
-	}
-
-	newResource.Properties.BasicResourceProperties.Status.OutputResources = deploymentOutput.Resources
-	newResource.InternalMetadata.ComputedValues = deploymentOutput.ComputedValues
-	newResource.InternalMetadata.SecretValues = deploymentOutput.SecretValues
-	if appId, ok := deploymentOutput.ComputedValues[daprinvokehttproutes.AppIDKey].(string); ok {
-		newResource.Properties.AppId = appId
-	}
-
-	// Read existing resource info from the data store
 	old := &datamodel.DaprInvokeHttpRoute{}
 	isNewResource := false
 	etag, err := daprHttpRoute.GetResource(ctx, serviceCtx.ResourceID.String(), old)
@@ -67,6 +51,7 @@ func (daprHttpRoute *CreateOrUpdateDaprInvokeHttpRoute) Run(ctx context.Context,
 			return nil, err
 		}
 	}
+
 	if req.Method == http.MethodPatch && isNewResource {
 		return rest.NewNotFoundResponse(serviceCtx.ResourceID), nil
 	}
@@ -85,7 +70,30 @@ func (daprHttpRoute *CreateOrUpdateDaprInvokeHttpRoute) Run(ctx context.Context,
 		}
 	}
 
-	// Add/update resource in the data store
+	rendererOutput, err := daprHttpRoute.DeploymentProcessor().Render(ctx, serviceCtx.ResourceID, newResource)
+	if err != nil {
+		return nil, err
+	}
+	deploymentOutput, err := daprHttpRoute.DeploymentProcessor().Deploy(ctx, serviceCtx.ResourceID, rendererOutput)
+	if err != nil {
+		return nil, err
+	}
+
+	newResource.Properties.BasicResourceProperties.Status.OutputResources = deploymentOutput.Resources
+	newResource.InternalMetadata.ComputedValues = deploymentOutput.ComputedValues
+	newResource.InternalMetadata.SecretValues = deploymentOutput.SecretValues
+	if appId, ok := deploymentOutput.ComputedValues[daprinvokehttproutes.AppIDKey].(string); ok {
+		newResource.Properties.AppId = appId
+	}
+
+	if !isNewResource {
+		diff := outputresource.GetGCOutputResources(newResource.Properties.Status.OutputResources, old.Properties.Status.OutputResources)
+		err = daprHttpRoute.DeploymentProcessor().Delete(ctx, serviceCtx.ResourceID, diff)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	savedResource, err := daprHttpRoute.SaveResource(ctx, serviceCtx.ResourceID.String(), newResource, etag)
 	if err != nil {
 		return nil, err

--- a/pkg/connectorrp/frontend/controller/daprinvokehttproutes/createorupdatedaprinvokehttproute_test.go
+++ b/pkg/connectorrp/frontend/controller/daprinvokehttproutes/createorupdatedaprinvokehttproute_test.go
@@ -77,14 +77,14 @@ func TestCreateOrUpdateDaprInvokeHttpRoute_20220315PrivatePreview(t *testing.T) 
 					return nil, &store.ErrNotFound{}
 				})
 
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
-
 			expectedOutput.SystemData.CreatedAt = expectedOutput.SystemData.LastModifiedAt
 			expectedOutput.SystemData.CreatedBy = expectedOutput.SystemData.LastModifiedBy
 			expectedOutput.SystemData.CreatedByType = expectedOutput.SystemData.LastModifiedByType
 
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+
 				mStorageClient.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -158,10 +158,11 @@ func TestCreateOrUpdateDaprInvokeHttpRoute_20220315PrivatePreview(t *testing.T) 
 					}, nil
 				})
 
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
-
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+				mDeploymentProcessor.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+
 				mStorageClient.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).

--- a/pkg/connectorrp/frontend/controller/daprpubsubbrokers/createorupdatedaprpubsubbroker_test.go
+++ b/pkg/connectorrp/frontend/controller/daprpubsubbrokers/createorupdatedaprpubsubbroker_test.go
@@ -123,14 +123,14 @@ func TestCreateOrUpdateDaprPubSubBroker_20220315PrivatePreview(t *testing.T) {
 					return nil, &store.ErrNotFound{}
 				})
 
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
-
 			expectedOutput.SystemData.CreatedAt = expectedOutput.SystemData.LastModifiedAt
 			expectedOutput.SystemData.CreatedBy = expectedOutput.SystemData.LastModifiedBy
 			expectedOutput.SystemData.CreatedByType = expectedOutput.SystemData.LastModifiedByType
 
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+
 				mStorageClient.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -204,10 +204,11 @@ func TestCreateOrUpdateDaprPubSubBroker_20220315PrivatePreview(t *testing.T) {
 					}, nil
 				})
 
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
-
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+				mDeploymentProcessor.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+
 				mStorageClient.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).

--- a/pkg/connectorrp/frontend/controller/daprsecretstores/createorupdatedaprsecretstore_test.go
+++ b/pkg/connectorrp/frontend/controller/daprsecretstores/createorupdatedaprsecretstore_test.go
@@ -102,13 +102,15 @@ func TestCreateOrUpdateDaprSecretStore_20220315PrivatePreview(t *testing.T) {
 				DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
 					return nil, &store.ErrNotFound{}
 				})
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+
 			expectedOutput.SystemData.CreatedAt = expectedOutput.SystemData.LastModifiedAt
 			expectedOutput.SystemData.CreatedBy = expectedOutput.SystemData.LastModifiedBy
 			expectedOutput.SystemData.CreatedByType = expectedOutput.SystemData.LastModifiedByType
 
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+
 				mStorageClient.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -182,10 +184,11 @@ func TestCreateOrUpdateDaprSecretStore_20220315PrivatePreview(t *testing.T) {
 					}, nil
 				})
 
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
-
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+				mDeploymentProcessor.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+
 				mStorageClient.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).

--- a/pkg/connectorrp/frontend/controller/daprstatestores/createorupdatedaprstatestore_test.go
+++ b/pkg/connectorrp/frontend/controller/daprstatestores/createorupdatedaprstatestore_test.go
@@ -65,14 +65,14 @@ func TestCreateOrUpdateDaprStateStore_20220315PrivatePreview(t *testing.T) {
 					return nil, &store.ErrNotFound{}
 				})
 
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
-
 			expectedOutput.SystemData.CreatedAt = expectedOutput.SystemData.LastModifiedAt
 			expectedOutput.SystemData.CreatedBy = expectedOutput.SystemData.LastModifiedBy
 			expectedOutput.SystemData.CreatedByType = expectedOutput.SystemData.LastModifiedByType
 
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+
 				mStorageClient.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -146,10 +146,12 @@ func TestCreateOrUpdateDaprStateStore_20220315PrivatePreview(t *testing.T) {
 						Data:     dataModel,
 					}, nil
 				})
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
 
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+				mDeploymentProcessor.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+
 				mStorageClient.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).

--- a/pkg/connectorrp/frontend/controller/extenders/createorupdateextender_test.go
+++ b/pkg/connectorrp/frontend/controller/extenders/createorupdateextender_test.go
@@ -89,14 +89,15 @@ func TestCreateOrUpdateExtender_20220315PrivatePreview(t *testing.T) {
 				DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
 					return nil, &store.ErrNotFound{}
 				})
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
 
 			expectedOutput.SystemData.CreatedAt = expectedOutput.SystemData.LastModifiedAt
 			expectedOutput.SystemData.CreatedBy = expectedOutput.SystemData.LastModifiedBy
 			expectedOutput.SystemData.CreatedByType = expectedOutput.SystemData.LastModifiedByType
 
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+
 				mds.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -176,10 +177,11 @@ func TestCreateOrUpdateExtender_20220315PrivatePreview(t *testing.T) {
 					}, nil
 				})
 
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
-
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+				mDeploymentProcessor.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+
 				mds.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).

--- a/pkg/connectorrp/frontend/controller/mongodatabases/createorupdatemongodatabase_test.go
+++ b/pkg/connectorrp/frontend/controller/mongodatabases/createorupdatemongodatabase_test.go
@@ -65,14 +65,14 @@ func TestCreateOrUpdateMongoDatabase_20220315PrivatePreview(t *testing.T) {
 					return nil, &store.ErrNotFound{}
 				})
 
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
-
 			expectedOutput.SystemData.CreatedAt = expectedOutput.SystemData.LastModifiedAt
 			expectedOutput.SystemData.CreatedBy = expectedOutput.SystemData.LastModifiedBy
 			expectedOutput.SystemData.CreatedByType = expectedOutput.SystemData.LastModifiedByType
 
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+
 				mStorageClient.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -148,10 +148,12 @@ func TestCreateOrUpdateMongoDatabase_20220315PrivatePreview(t *testing.T) {
 						Data:     dataModel,
 					}, nil
 				})
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
 
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+				mDeploymentProcessor.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+
 				mStorageClient.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).

--- a/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/createorupdaterabbitmq.go
+++ b/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/createorupdaterabbitmq.go
@@ -16,6 +16,7 @@ import (
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel/converter"
 	"github.com/project-radius/radius/pkg/connectorrp/renderers/rabbitmqmessagequeues"
+	"github.com/project-radius/radius/pkg/radrp/outputresource"
 	"github.com/project-radius/radius/pkg/radrp/rest"
 	"github.com/project-radius/radius/pkg/ucp/store"
 )
@@ -40,23 +41,6 @@ func (rabbitmq *CreateOrUpdateRabbitMQMessageQueue) Run(ctx context.Context, req
 		return nil, err
 	}
 
-	rendererOutput, err := rabbitmq.DeploymentProcessor().Render(ctx, serviceCtx.ResourceID, newResource)
-	if err != nil {
-		return nil, err
-	}
-	deploymentOutput, err := rabbitmq.DeploymentProcessor().Deploy(ctx, serviceCtx.ResourceID, rendererOutput)
-	if err != nil {
-		return nil, err
-	}
-
-	newResource.Properties.BasicResourceProperties.Status.OutputResources = deploymentOutput.Resources
-	newResource.InternalMetadata.ComputedValues = deploymentOutput.ComputedValues
-	newResource.InternalMetadata.SecretValues = deploymentOutput.SecretValues
-	if queue, ok := deploymentOutput.ComputedValues[rabbitmqmessagequeues.QueueNameKey].(string); ok {
-		newResource.Properties.Queue = queue
-	}
-
-	// Read existing resource info from the data store
 	old := &datamodel.RabbitMQMessageQueue{}
 	isNewResource := false
 	etag, err := rabbitmq.GetResource(ctx, serviceCtx.ResourceID.String(), old)
@@ -67,6 +51,7 @@ func (rabbitmq *CreateOrUpdateRabbitMQMessageQueue) Run(ctx context.Context, req
 			return nil, err
 		}
 	}
+
 	if req.Method == http.MethodPatch && isNewResource {
 		return rest.NewNotFoundResponse(serviceCtx.ResourceID), nil
 	}
@@ -85,7 +70,30 @@ func (rabbitmq *CreateOrUpdateRabbitMQMessageQueue) Run(ctx context.Context, req
 		}
 	}
 
-	// Add/update resource in the data store
+	rendererOutput, err := rabbitmq.DeploymentProcessor().Render(ctx, serviceCtx.ResourceID, newResource)
+	if err != nil {
+		return nil, err
+	}
+	deploymentOutput, err := rabbitmq.DeploymentProcessor().Deploy(ctx, serviceCtx.ResourceID, rendererOutput)
+	if err != nil {
+		return nil, err
+	}
+
+	newResource.Properties.BasicResourceProperties.Status.OutputResources = deploymentOutput.Resources
+	newResource.InternalMetadata.ComputedValues = deploymentOutput.ComputedValues
+	newResource.InternalMetadata.SecretValues = deploymentOutput.SecretValues
+	if queue, ok := deploymentOutput.ComputedValues[rabbitmqmessagequeues.QueueNameKey].(string); ok {
+		newResource.Properties.Queue = queue
+	}
+
+	if !isNewResource {
+		diff := outputresource.GetGCOutputResources(newResource.Properties.Status.OutputResources, old.Properties.Status.OutputResources)
+		err = rabbitmq.DeploymentProcessor().Delete(ctx, serviceCtx.ResourceID, diff)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	savedResource, err := rabbitmq.SaveResource(ctx, serviceCtx.ResourceID.String(), newResource, etag)
 	if err != nil {
 		return nil, err

--- a/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/createorupdaterabbitmq_test.go
+++ b/pkg/connectorrp/frontend/controller/rabbitmqmessagequeues/createorupdaterabbitmq_test.go
@@ -83,14 +83,14 @@ func TestCreateOrUpdateRabbitMQ_20220315PrivatePreview(t *testing.T) {
 					return nil, &store.ErrNotFound{}
 				})
 
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
-
 			expectedOutput.SystemData.CreatedAt = expectedOutput.SystemData.LastModifiedAt
 			expectedOutput.SystemData.CreatedBy = expectedOutput.SystemData.LastModifiedBy
 			expectedOutput.SystemData.CreatedByType = expectedOutput.SystemData.LastModifiedByType
 
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+
 				mStorageClient.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -166,10 +166,11 @@ func TestCreateOrUpdateRabbitMQ_20220315PrivatePreview(t *testing.T) {
 					}, nil
 				})
 
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
-
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+				mDeploymentProcessor.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+
 				mStorageClient.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).

--- a/pkg/connectorrp/frontend/controller/rediscaches/createorupdaterediscache.go
+++ b/pkg/connectorrp/frontend/controller/rediscaches/createorupdaterediscache.go
@@ -16,6 +16,7 @@ import (
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel/converter"
 	"github.com/project-radius/radius/pkg/connectorrp/renderers"
+	"github.com/project-radius/radius/pkg/radrp/outputresource"
 	"github.com/project-radius/radius/pkg/radrp/rest"
 	"github.com/project-radius/radius/pkg/ucp/store"
 )
@@ -38,6 +39,35 @@ func (redis *CreateOrUpdateRedisCache) Run(ctx context.Context, req *http.Reques
 	newResource, err := redis.Validate(ctx, req, serviceCtx.APIVersion)
 	if err != nil {
 		return nil, err
+	}
+
+	old := &datamodel.RedisCache{}
+	isNewResource := false
+	etag, err := redis.GetResource(ctx, serviceCtx.ResourceID.String(), old)
+	if err != nil {
+		if errors.Is(&store.ErrNotFound{}, err) {
+			isNewResource = true
+		} else {
+			return nil, err
+		}
+	}
+
+	if req.Method == http.MethodPatch && isNewResource {
+		return rest.NewNotFoundResponse(serviceCtx.ResourceID), nil
+	}
+
+	err = ctrl.ValidateETag(*serviceCtx, etag)
+	if err != nil {
+		return rest.NewPreconditionFailedResponse(serviceCtx.ResourceID.String(), err.Error()), nil
+	}
+
+	newResource.SystemData = ctrl.UpdateSystemData(old.SystemData, *serviceCtx.SystemData())
+	if !isNewResource {
+		newResource.CreatedAPIVersion = old.CreatedAPIVersion
+		prop := newResource.Properties.BasicResourceProperties
+		if !old.Properties.BasicResourceProperties.EqualLinkedResource(prop) {
+			return rest.NewLinkedResourceUpdateErrorResponse(serviceCtx.ResourceID.String(), &old.Properties.BasicResourceProperties), nil
+		}
 	}
 
 	rendererOutput, err := redis.DeploymentProcessor().Render(ctx, serviceCtx.ResourceID, newResource)
@@ -63,36 +93,14 @@ func (redis *CreateOrUpdateRedisCache) Run(ctx context.Context, req *http.Reques
 		newResource.Properties.Username = username
 	}
 
-	// Read existing resource info from the data store
-	old := &datamodel.RedisCache{}
-	isNewResource := false
-	etag, err := redis.GetResource(ctx, serviceCtx.ResourceID.String(), old)
-	if err != nil {
-		if errors.Is(&store.ErrNotFound{}, err) {
-			isNewResource = true
-		} else {
+	if !isNewResource {
+		diff := outputresource.GetGCOutputResources(newResource.Properties.Status.OutputResources, old.Properties.Status.OutputResources)
+		err = redis.DeploymentProcessor().Delete(ctx, serviceCtx.ResourceID, diff)
+		if err != nil {
 			return nil, err
 		}
 	}
-	if req.Method == http.MethodPatch && isNewResource {
-		return rest.NewNotFoundResponse(serviceCtx.ResourceID), nil
-	}
 
-	err = ctrl.ValidateETag(*serviceCtx, etag)
-	if err != nil {
-		return rest.NewPreconditionFailedResponse(serviceCtx.ResourceID.String(), err.Error()), nil
-	}
-
-	newResource.SystemData = ctrl.UpdateSystemData(old.SystemData, *serviceCtx.SystemData())
-	if !isNewResource {
-		newResource.CreatedAPIVersion = old.CreatedAPIVersion
-		prop := newResource.Properties.BasicResourceProperties
-		if !old.Properties.BasicResourceProperties.EqualLinkedResource(prop) {
-			return rest.NewLinkedResourceUpdateErrorResponse(serviceCtx.ResourceID.String(), &old.Properties.BasicResourceProperties), nil
-		}
-	}
-
-	// Add/update resource in the data store
 	savedResource, err := redis.SaveResource(ctx, serviceCtx.ResourceID.String(), newResource, etag)
 	if err != nil {
 		return nil, err

--- a/pkg/connectorrp/frontend/controller/rediscaches/createorupdaterediscache_test.go
+++ b/pkg/connectorrp/frontend/controller/rediscaches/createorupdaterediscache_test.go
@@ -114,13 +114,15 @@ func TestCreateOrUpdateRedisCache_20220315PrivatePreview(t *testing.T) {
 				DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
 					return nil, &store.ErrNotFound{}
 				})
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+
 			expectedOutput.SystemData.CreatedAt = expectedOutput.SystemData.LastModifiedAt
 			expectedOutput.SystemData.CreatedBy = expectedOutput.SystemData.LastModifiedBy
 			expectedOutput.SystemData.CreatedByType = expectedOutput.SystemData.LastModifiedByType
 
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+
 				mStorageClient.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -194,9 +196,12 @@ func TestCreateOrUpdateRedisCache_20220315PrivatePreview(t *testing.T) {
 						Data:     dataModel,
 					}, nil
 				})
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+				mDeploymentProcessor.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+
 				mStorageClient.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).

--- a/pkg/connectorrp/frontend/controller/sqldatabases/createorupdatesqldatabase_test.go
+++ b/pkg/connectorrp/frontend/controller/sqldatabases/createorupdatesqldatabase_test.go
@@ -104,14 +104,14 @@ func TestCreateOrUpdateSqlDatabase_20220315PrivatePreview(t *testing.T) {
 					return nil, &store.ErrNotFound{}
 				})
 
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
-
 			expectedOutput.SystemData.CreatedAt = expectedOutput.SystemData.LastModifiedAt
 			expectedOutput.SystemData.CreatedBy = expectedOutput.SystemData.LastModifiedBy
 			expectedOutput.SystemData.CreatedByType = expectedOutput.SystemData.LastModifiedByType
 
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+
 				mStorageClient.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -185,10 +185,11 @@ func TestCreateOrUpdateSqlDatabase_20220315PrivatePreview(t *testing.T) {
 					}, nil
 				})
 
-			mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
-			mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
-
 			if !testcase.shouldFail {
+				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
+				mDeploymentProcessor.EXPECT().Deploy(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(deploymentOutput, nil)
+				mDeploymentProcessor.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+
 				mStorageClient.
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).

--- a/pkg/corerp/backend/controller/createorupdateresource_test.go
+++ b/pkg/corerp/backend/controller/createorupdateresource_test.go
@@ -193,6 +193,14 @@ func TestCreateOrUpdateResourceRun_20220315PrivatePreview(t *testing.T) {
 						After(renderCall).
 						Times(1)
 
+					if !errors.Is(&store.ErrNotFound{}, tt.getErr) {
+						mdp.EXPECT().
+							Delete(gomock.Any(), gomock.Any(), gomock.Any()).
+							Return(nil).
+							After(deployCall).
+							Times(1)
+					}
+
 					if tt.deployErr == nil {
 						msc.EXPECT().
 							Save(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -381,11 +389,18 @@ func TestCreateOrUpdateResourceRun_20220315PrivatePreview(t *testing.T) {
 						After(renderCall).
 						Times(1)
 
+					deleteCall := mdp.EXPECT().
+						Delete(gomock.Any(), gomock.Any(), gomock.Any()).
+						Return(nil).
+						After(deployCall).
+						Times(1)
+
 					if tt.deployErr == nil {
 						msc.EXPECT().
 							Save(gomock.Any(), gomock.Any(), gomock.Any()).
 							Return(tt.saveErr).
 							After(deployCall).
+							After(deleteCall).
 							Times(1)
 					}
 				}

--- a/pkg/corerp/frontend/controller/containers/createorupdatecontainer.go
+++ b/pkg/corerp/frontend/controller/containers/createorupdatecontainer.go
@@ -88,7 +88,7 @@ func (e *CreateOrUpdateContainer) Run(ctx context.Context, req *http.Request) (r
 		// because it is wiped from the DB when we are saving the newResource.
 		// Container X - v2 needs to be deployed and because we don't know the outputResources
 		// of v1, we don't know which one to delete.
-		newResource.Properties.BasicResourceProperties = old.Properties.BasicResourceProperties
+		newResource.Properties.Status.DeepCopy(&old.Properties.Status)
 	}
 
 	obj, err := e.SaveResource(ctx, serviceCtx.ResourceID.String(), newResource, etag)

--- a/pkg/corerp/frontend/controller/containers/createorupdatecontainer.go
+++ b/pkg/corerp/frontend/controller/containers/createorupdatecontainer.go
@@ -77,6 +77,18 @@ func (e *CreateOrUpdateContainer) Run(ctx context.Context, req *http.Request) (r
 		if !old.Properties.BasicResourceProperties.EqualLinkedResource(prop) {
 			return rest.NewLinkedResourceUpdateErrorResponse(serviceCtx.ResourceID.String(), &old.Properties.BasicResourceProperties), nil
 		}
+		// Container is a resource that is asyncly processed. Here, in createOrUpdateContainer, we
+		// don't do the rendering and the deployment. newResource is collected from the request and
+		// that is why newResource doesn't have outputResources. It is wiped in the save call 2
+		// lines below. Because we are saving newResource and newResource doesn't have the output
+		// resources array. When we don't know the outputResources of a resource, we can't delete
+		// the ones that are not needed when we are deploying a new version of that resource.
+		// Container X - v1 => OutputResources[Y,Z]
+		// During the createOrUpdateContainer call Container X loses the OutputResources array
+		// because it is wiped from the DB when we are saving the newResource.
+		// Container X - v2 needs to be deployed and because we don't know the outputResources
+		// of v1, we don't know which one to delete.
+		newResource.Properties.BasicResourceProperties = old.Properties.BasicResourceProperties
 	}
 
 	obj, err := e.SaveResource(ctx, serviceCtx.ResourceID.String(), newResource, etag)

--- a/pkg/corerp/frontend/controller/gateway/createorupdategateway.go
+++ b/pkg/corerp/frontend/controller/gateway/createorupdategateway.go
@@ -85,7 +85,7 @@ func (e *CreateOrUpdateGateway) Run(ctx context.Context, req *http.Request) (res
 		// because it is wiped from the DB when we are saving the newResource.
 		// Gateway X - v2 needs to be deployed and because we don't know the outputResources
 		// of v1, we don't know which one to delete.
-		newResource.Properties.BasicResourceProperties = old.Properties.BasicResourceProperties
+		newResource.Properties.Status.DeepCopy(&old.Properties.Status)
 	}
 
 	obj, err := e.SaveResource(ctx, serviceCtx.ResourceID.String(), newResource, etag)

--- a/pkg/corerp/frontend/controller/gateway/createorupdategateway.go
+++ b/pkg/corerp/frontend/controller/gateway/createorupdategateway.go
@@ -74,6 +74,18 @@ func (e *CreateOrUpdateGateway) Run(ctx context.Context, req *http.Request) (res
 		if !old.Properties.BasicResourceProperties.EqualLinkedResource(prop) {
 			return rest.NewLinkedResourceUpdateErrorResponse(serviceCtx.ResourceID.String(), &old.Properties.BasicResourceProperties), nil
 		}
+		// Gateway is a resource that is asyncly processed. Here, in createOrUpdateGateway, we
+		// don't do the rendering and the deployment. newResource is collected from the request and
+		// that is why newResource doesn't have outputResources. It is wiped in the save call 2
+		// lines below. Because we are saving newResource and newResource doesn't have the output
+		// resources array. When we don't know the outputResources of a resource, we can't delete
+		// the ones that are not needed when we are deploying a new version of that resource.
+		// Gateway X - v1 => OutputResources[Y,Z]
+		// During the createOrUpdateGateway call Gateway X loses the OutputResources array
+		// because it is wiped from the DB when we are saving the newResource.
+		// Gateway X - v2 needs to be deployed and because we don't know the outputResources
+		// of v1, we don't know which one to delete.
+		newResource.Properties.BasicResourceProperties = old.Properties.BasicResourceProperties
 	}
 
 	obj, err := e.SaveResource(ctx, serviceCtx.ResourceID.String(), newResource, etag)

--- a/pkg/corerp/frontend/controller/httproutes/createorupdatehttproute.go
+++ b/pkg/corerp/frontend/controller/httproutes/createorupdatehttproute.go
@@ -86,7 +86,7 @@ func (e *CreateOrUpdateHTTPRoute) Run(ctx context.Context, req *http.Request) (r
 		// because it is wiped from the DB when we are saving the newResource.
 		// HttpRoute X - v2 needs to be deployed and because we don't know the outputResources
 		// of v1, we don't know which one to delete.
-		newResource.Properties.BasicResourceProperties = old.Properties.BasicResourceProperties
+		newResource.Properties.Status.DeepCopy(&old.Properties.Status)
 	}
 
 	nr, err := e.SaveResource(ctx, serviceCtx.ResourceID.String(), newResource, etag)

--- a/pkg/corerp/frontend/controller/httproutes/createorupdatehttproute.go
+++ b/pkg/corerp/frontend/controller/httproutes/createorupdatehttproute.go
@@ -75,6 +75,18 @@ func (e *CreateOrUpdateHTTPRoute) Run(ctx context.Context, req *http.Request) (r
 		if !old.Properties.BasicResourceProperties.EqualLinkedResource(prop) {
 			return rest.NewLinkedResourceUpdateErrorResponse(serviceCtx.ResourceID.String(), &old.Properties.BasicResourceProperties), nil
 		}
+		// HttpRoute is a resource that is asyncly processed. Here, in createOrUpdateHttpRoute, we
+		// don't do the rendering and the deployment. newResource is collected from the request and
+		// that is why newResource doesn't have outputResources. It is wiped in the save call 2
+		// lines below. Because we are saving newResource and newResource doesn't have the output
+		// resources array. When we don't know the outputResources of a resource, we can't delete
+		// the ones that are not needed when we are deploying a new version of that resource.
+		// HttpRoute X - v1 => OutputResources[Y,Z]
+		// During the createOrUpdateHttpRoute call HttpRoute X loses the OutputResources array
+		// because it is wiped from the DB when we are saving the newResource.
+		// HttpRoute X - v2 needs to be deployed and because we don't know the outputResources
+		// of v1, we don't know which one to delete.
+		newResource.Properties.BasicResourceProperties = old.Properties.BasicResourceProperties
 	}
 
 	nr, err := e.SaveResource(ctx, serviceCtx.ResourceID.String(), newResource, etag)

--- a/pkg/radrp/outputresource/info_test.go
+++ b/pkg/radrp/outputresource/info_test.go
@@ -1,0 +1,252 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package outputresource
+
+import (
+	"testing"
+
+	"github.com/project-radius/radius/pkg/providers"
+	"github.com/project-radius/radius/pkg/resourcekinds"
+	"github.com/project-radius/radius/pkg/resourcemodel"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetGCOutputResources_Same(t *testing.T) {
+	after := []OutputResource{}
+	before := []OutputResource{}
+
+	managedIdentity := OutputResource{
+		LocalID: LocalIDUserAssignedManagedIdentity,
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.AzureUserAssignedManagedIdentity,
+			Provider: providers.ProviderAzure,
+		},
+	}
+
+	roleAssignmentKeys := OutputResource{
+		LocalID: LocalIDRoleAssignmentKVKeys,
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.AzureRoleAssignment,
+			Provider: providers.ProviderAzure,
+		},
+		Dependencies: []Dependency{{LocalID: managedIdentity.LocalID}},
+	}
+
+	aadPodIdentity := OutputResource{
+		LocalID: LocalIDAADPodIdentity,
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.AzurePodIdentity,
+			Provider: providers.ProviderAzureKubernetesService,
+		},
+		Dependencies: []Dependency{
+			{LocalID: managedIdentity.LocalID},
+			{LocalID: roleAssignmentKeys.LocalID},
+		},
+	}
+
+	after = append(after, managedIdentity)
+	after = append(after, roleAssignmentKeys)
+	after = append(after, aadPodIdentity)
+
+	before = append(before, managedIdentity)
+	before = append(before, roleAssignmentKeys)
+	before = append(before, aadPodIdentity)
+
+	diff := GetGCOutputResources(after, before)
+
+	require.Equal(t, []OutputResource{}, diff)
+}
+
+func TestGetGCOutputResources_SameWithAdditionalOutputResource(t *testing.T) {
+	after := []OutputResource{}
+	before := []OutputResource{}
+
+	managedIdentity := OutputResource{
+		LocalID: LocalIDUserAssignedManagedIdentity,
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.AzureUserAssignedManagedIdentity,
+			Provider: providers.ProviderAzure,
+		},
+	}
+
+	roleAssignmentKeys := OutputResource{
+		LocalID: LocalIDRoleAssignmentKVKeys,
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.AzureRoleAssignment,
+			Provider: providers.ProviderAzure,
+		},
+		Dependencies: []Dependency{{LocalID: managedIdentity.LocalID}},
+	}
+
+	aadPodIdentity := OutputResource{
+		LocalID: LocalIDAADPodIdentity,
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.AzurePodIdentity,
+			Provider: providers.ProviderAzureKubernetesService,
+		},
+		Dependencies: []Dependency{
+			{LocalID: managedIdentity.LocalID},
+			{LocalID: roleAssignmentKeys.LocalID},
+		},
+	}
+
+	after = append(after, managedIdentity)
+	after = append(after, roleAssignmentKeys)
+	after = append(after, aadPodIdentity)
+
+	before = append(before, roleAssignmentKeys)
+	before = append(before, aadPodIdentity)
+
+	diff := GetGCOutputResources(after, before)
+
+	require.Equal(t, []OutputResource{}, diff)
+}
+
+func TestGetGCOutputResources_ManagedIdentityShouldBeDeleted(t *testing.T) {
+	after := []OutputResource{}
+	before := []OutputResource{}
+
+	managedIdentity := OutputResource{
+		LocalID: LocalIDUserAssignedManagedIdentity,
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.AzureUserAssignedManagedIdentity,
+			Provider: providers.ProviderAzure,
+		},
+	}
+
+	roleAssignmentKeys := OutputResource{
+		LocalID: LocalIDRoleAssignmentKVKeys,
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.AzureRoleAssignment,
+			Provider: providers.ProviderAzure,
+		},
+		Dependencies: []Dependency{{LocalID: managedIdentity.LocalID}},
+	}
+
+	aadPodIdentity := OutputResource{
+		LocalID: LocalIDAADPodIdentity,
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.AzurePodIdentity,
+			Provider: providers.ProviderAzureKubernetesService,
+		},
+		Dependencies: []Dependency{
+			{LocalID: managedIdentity.LocalID},
+			{LocalID: roleAssignmentKeys.LocalID},
+		},
+	}
+
+	after = append(after, roleAssignmentKeys)
+	after = append(after, aadPodIdentity)
+
+	before = append(before, managedIdentity)
+	before = append(before, roleAssignmentKeys)
+	before = append(before, aadPodIdentity)
+
+	diff := GetGCOutputResources(after, before)
+
+	require.Equal(t, []OutputResource{managedIdentity}, diff)
+}
+
+func TestGetGCOutputResources_ALotOfResources(t *testing.T) {
+	after := []OutputResource{}
+	before := []OutputResource{}
+
+	managedIdentity1 := OutputResource{
+		LocalID: LocalIDUserAssignedManagedIdentity,
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.AzureUserAssignedManagedIdentity,
+			Provider: providers.ProviderAzure,
+		},
+	}
+
+	managedIdentity2 := OutputResource{
+		LocalID: LocalIDUserAssignedManagedIdentity,
+		ResourceType: resourcemodel.ResourceType{
+			Type: resourcekinds.AzureUserAssignedManagedIdentity,
+			// Fixme: Kubernetes is not possible?
+			Provider: providers.ProviderKubernetes,
+		},
+	}
+
+	roleAssignmentKeys := OutputResource{
+		LocalID: LocalIDRoleAssignmentKVKeys,
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.AzureRoleAssignment,
+			Provider: providers.ProviderAzure,
+		},
+		Dependencies: []Dependency{{LocalID: managedIdentity1.LocalID}},
+	}
+
+	aadPodIdentity := OutputResource{
+		LocalID: LocalIDAADPodIdentity,
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.AzurePodIdentity,
+			Provider: providers.ProviderAzureKubernetesService,
+		},
+		Dependencies: []Dependency{
+			{LocalID: managedIdentity1.LocalID},
+			{LocalID: roleAssignmentKeys.LocalID},
+		},
+	}
+
+	after = append(after, managedIdentity1)
+	after = append(after, roleAssignmentKeys)
+	after = append(after, aadPodIdentity)
+
+	before = append(before, managedIdentity1)
+	before = append(before, managedIdentity2)
+	before = append(before, roleAssignmentKeys)
+	before = append(before, aadPodIdentity)
+
+	diff := GetGCOutputResources(after, before)
+
+	require.Equal(t, []OutputResource{managedIdentity2}, diff)
+}
+
+func TestGetGCOutputResources_Secret(t *testing.T) {
+	after := []OutputResource{}
+	before := []OutputResource{}
+
+	deployment := OutputResource{
+		LocalID: LocalIDDeployment,
+		Identity: resourcemodel.ResourceIdentity{
+			ResourceType: &resourcemodel.ResourceType{
+				Type:     resourcekinds.Deployment,
+				Provider: providers.ProviderKubernetes,
+			},
+		},
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.Deployment,
+			Provider: providers.ProviderKubernetes,
+		},
+		Dependencies: nil,
+	}
+
+	secret := OutputResource{
+		LocalID: LocalIDSecret,
+		Identity: resourcemodel.ResourceIdentity{
+			ResourceType: &resourcemodel.ResourceType{
+				Type:     resourcekinds.Secret,
+				Provider: providers.ProviderKubernetes,
+			},
+		},
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.Secret,
+			Provider: providers.ProviderKubernetes,
+		},
+		Dependencies: nil,
+	}
+
+	after = append(after, deployment)
+
+	before = append(before, secret)
+	before = append(before, deployment)
+
+	diff := GetGCOutputResources(after, before)
+
+	require.Equal(t, []OutputResource{secret}, diff)
+
+}


### PR DESCRIPTION
# Description
Imagine deploying the same resource twice with different properties. We have to delete the old output resources that are not used by the new version of the resource.

What if the same output resource is being used by two different resources and one ends up deleting that output resource?

~~Note: This doesn't remove the secrets. Will continue investigating.~~ It removes all resources that are not used by the new version of the main resource.

## Issue reference
Please reference the issue this PR will close: radius-project/core-team#756 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
