### PR TITLE
secrets created in container should be prefixed with appname

### DIFF
--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -236,7 +236,7 @@ func (r Renderer) makeDeployment(ctx context.Context, resource datamodel.Contain
 	// We build the environment variable list in a stable order for testability
 	// For the values that come from connections we back them with secretData. We'll extract the values
 	// and return them.
-	env, secretData := getEnvVarsAndSecretData(resource, applicationName, dependencies)
+	env, secretData := getEnvVarsAndSecretData(resource, dependencies)
 
 	for k, v := range cc.Container.Env {
 		env[k] = corev1.EnvVar{Name: k, Value: v}
@@ -378,7 +378,7 @@ func (r Renderer) makeDeployment(ctx context.Context, resource datamodel.Contain
 	return deploymentOutput, outputResources, secretData, nil
 }
 
-func getEnvVarsAndSecretData(resource datamodel.ContainerResource, applicationName string, dependencies map[string]renderers.RendererDependency) (map[string]corev1.EnvVar, map[string][]byte) {
+func getEnvVarsAndSecretData(resource datamodel.ContainerResource, dependencies map[string]renderers.RendererDependency) (map[string]corev1.EnvVar, map[string][]byte) {
 	env := map[string]corev1.EnvVar{}
 	secretData := map[string][]byte{}
 	cc := resource.Properties

--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -391,7 +391,7 @@ func getEnvVarsAndSecretData(resource datamodel.ContainerResource, applicationNa
 		properties := dependencies[con.Source]
 		if !con.GetDisableDefaultEnvVars() {
 			for key, value := range properties.ComputedValues {
-				name := fmt.Sprintf("%s_%s_%s", "CONNECTION", strings.ToUpper(applicationName+"-"+name), strings.ToUpper(key))
+				name := fmt.Sprintf("%s_%s_%s", "CONNECTION", strings.ToUpper(name), strings.ToUpper(key))
 
 				source := corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
@@ -567,7 +567,7 @@ func (r Renderer) makeSecret(ctx context.Context, resource datamodel.ContainerRe
 			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      applicationName + "-" + resource.Name,
+			Name:      kubernetes.MakeResourceName(applicationName, resource.Name),
 			Namespace: options.Environment.Namespace,
 			Labels:    kubernetes.MakeDescriptiveLabels(applicationName, resource.Name),
 		},

--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -391,7 +391,7 @@ func getEnvVarsAndSecretData(resource datamodel.ContainerResource, applicationNa
 		properties := dependencies[con.Source]
 		if !con.GetDisableDefaultEnvVars() {
 			for key, value := range properties.ComputedValues {
-				name := fmt.Sprintf("%s_%s_%s", "CONNECTION", strings.ToUpper(applicationName+"_"+name), strings.ToUpper(key))
+				name := fmt.Sprintf("%s_%s_%s", "CONNECTION", strings.ToUpper(applicationName+"-"+name), strings.ToUpper(key))
 
 				source := corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
@@ -567,7 +567,7 @@ func (r Renderer) makeSecret(ctx context.Context, resource datamodel.ContainerRe
 			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      applicationName + "_" + resource.Name,
+			Name:      applicationName + "-" + resource.Name,
 			Namespace: options.Environment.Namespace,
 			Labels:    kubernetes.MakeDescriptiveLabels(applicationName, resource.Name),
 		},

--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -236,7 +236,7 @@ func (r Renderer) makeDeployment(ctx context.Context, resource datamodel.Contain
 	// We build the environment variable list in a stable order for testability
 	// For the values that come from connections we back them with secretData. We'll extract the values
 	// and return them.
-	env, secretData := getEnvVarsAndSecretData(resource, dependencies)
+	env, secretData := getEnvVarsAndSecretData(resource, applicationName, dependencies)
 
 	for k, v := range cc.Container.Env {
 		env[k] = corev1.EnvVar{Name: k, Value: v}
@@ -378,7 +378,7 @@ func (r Renderer) makeDeployment(ctx context.Context, resource datamodel.Contain
 	return deploymentOutput, outputResources, secretData, nil
 }
 
-func getEnvVarsAndSecretData(resource datamodel.ContainerResource, dependencies map[string]renderers.RendererDependency) (map[string]corev1.EnvVar, map[string][]byte) {
+func getEnvVarsAndSecretData(resource datamodel.ContainerResource, applicationName string, dependencies map[string]renderers.RendererDependency) (map[string]corev1.EnvVar, map[string][]byte) {
 	env := map[string]corev1.EnvVar{}
 	secretData := map[string][]byte{}
 	cc := resource.Properties
@@ -396,7 +396,7 @@ func getEnvVarsAndSecretData(resource datamodel.ContainerResource, dependencies 
 				source := corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: resource.Name,
+							Name: kubernetes.MakeResourceName(applicationName, resource.Name),
 						},
 						Key: name,
 					},

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -438,7 +438,7 @@ func Test_Render_Connections(t *testing.T) {
 				ValueFrom: &v1.EnvVarSource{
 					SecretKeyRef: &v1.SecretKeySelector{
 						LocalObjectReference: v1.LocalObjectReference{
-							Name: resource.Name,
+							Name: secretName,
 						},
 						Key: "CONNECTION_A_COMPUTEDKEY1",
 					},
@@ -449,7 +449,7 @@ func Test_Render_Connections(t *testing.T) {
 				ValueFrom: &v1.EnvVarSource{
 					SecretKeyRef: &v1.SecretKeySelector{
 						LocalObjectReference: v1.LocalObjectReference{
-							Name: resource.Name,
+							Name: secretName,
 						},
 						Key: "CONNECTION_A_COMPUTEDKEY2",
 					},

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -434,24 +434,24 @@ func Test_Render_Connections(t *testing.T) {
 
 		expectedEnv := []v1.EnvVar{
 			{
-				Name: "CONNECTION_TEST-APP-A_COMPUTEDKEY1",
+				Name: "CONNECTION_A_COMPUTEDKEY1",
 				ValueFrom: &v1.EnvVarSource{
 					SecretKeyRef: &v1.SecretKeySelector{
 						LocalObjectReference: v1.LocalObjectReference{
 							Name: resource.Name,
 						},
-						Key: "CONNECTION_TEST-APP-A_COMPUTEDKEY1",
+						Key: "CONNECTION_A_COMPUTEDKEY1",
 					},
 				},
 			},
 			{
-				Name: "CONNECTION_TEST-APP-A_COMPUTEDKEY2",
+				Name: "CONNECTION_A_COMPUTEDKEY2",
 				ValueFrom: &v1.EnvVarSource{
 					SecretKeyRef: &v1.SecretKeySelector{
 						LocalObjectReference: v1.LocalObjectReference{
 							Name: resource.Name,
 						},
-						Key: "CONNECTION_TEST-APP-A_COMPUTEDKEY2",
+						Key: "CONNECTION_A_COMPUTEDKEY2",
 					},
 				},
 			},
@@ -475,8 +475,8 @@ func Test_Render_Connections(t *testing.T) {
 
 		require.Equal(t, outputResource.LocalID, outputresource.LocalIDSecret)
 		require.Len(t, secret.Data, 2)
-		require.Equal(t, "ComputedValue1", string(secret.Data["CONNECTION_TEST-APP-A_COMPUTEDKEY1"]))
-		require.Equal(t, "82", string(secret.Data["CONNECTION_TEST-APP-A_COMPUTEDKEY2"]))
+		require.Equal(t, "ComputedValue1", string(secret.Data["CONNECTION_A_COMPUTEDKEY1"]))
+		require.Equal(t, "82", string(secret.Data["CONNECTION_A_COMPUTEDKEY2"]))
 	})
 	require.Len(t, output.Resources, 2)
 }

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -40,7 +40,7 @@ const envVarName1 = "TEST_VAR_1"
 const envVarValue1 = "TEST_VALUE_1"
 const envVarName2 = "TEST_VAR_2"
 const envVarValue2 = "81"
-const secretName = "test-app_test-container"
+const secretName = "test-app-test-container"
 
 func createContext(t *testing.T) context.Context {
 	logger, err := radlogger.NewTestLogger(t)
@@ -434,24 +434,24 @@ func Test_Render_Connections(t *testing.T) {
 
 		expectedEnv := []v1.EnvVar{
 			{
-				Name: "CONNECTION_TEST-APP_A_COMPUTEDKEY1",
+				Name: "CONNECTION_TEST-APP-A_COMPUTEDKEY1",
 				ValueFrom: &v1.EnvVarSource{
 					SecretKeyRef: &v1.SecretKeySelector{
 						LocalObjectReference: v1.LocalObjectReference{
 							Name: resource.Name,
 						},
-						Key: "CONNECTION_TEST-APP_A_COMPUTEDKEY1",
+						Key: "CONNECTION_TEST-APP-A_COMPUTEDKEY1",
 					},
 				},
 			},
 			{
-				Name: "CONNECTION_TEST-APP_A_COMPUTEDKEY2",
+				Name: "CONNECTION_TEST-APP-A_COMPUTEDKEY2",
 				ValueFrom: &v1.EnvVarSource{
 					SecretKeyRef: &v1.SecretKeySelector{
 						LocalObjectReference: v1.LocalObjectReference{
 							Name: resource.Name,
 						},
-						Key: "CONNECTION_TEST-APP_A_COMPUTEDKEY2",
+						Key: "CONNECTION_TEST-APP-A_COMPUTEDKEY2",
 					},
 				},
 			},
@@ -475,8 +475,8 @@ func Test_Render_Connections(t *testing.T) {
 
 		require.Equal(t, outputResource.LocalID, outputresource.LocalIDSecret)
 		require.Len(t, secret.Data, 2)
-		require.Equal(t, "ComputedValue1", string(secret.Data["CONNECTION_TEST-APP_A_COMPUTEDKEY1"]))
-		require.Equal(t, "82", string(secret.Data["CONNECTION_TEST-APP_A_COMPUTEDKEY2"]))
+		require.Equal(t, "ComputedValue1", string(secret.Data["CONNECTION_TEST-APP-A_COMPUTEDKEY1"]))
+		require.Equal(t, "82", string(secret.Data["CONNECTION_TEST-APP-A_COMPUTEDKEY2"]))
 	})
 	require.Len(t, output.Resources, 2)
 }

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -40,6 +40,7 @@ const envVarName1 = "TEST_VAR_1"
 const envVarValue1 = "TEST_VALUE_1"
 const envVarName2 = "TEST_VAR_2"
 const envVarValue2 = "81"
+const secretName = "test-app_test-container"
 
 func createContext(t *testing.T) context.Context {
 	logger, err := radlogger.NewTestLogger(t)
@@ -433,24 +434,24 @@ func Test_Render_Connections(t *testing.T) {
 
 		expectedEnv := []v1.EnvVar{
 			{
-				Name: "CONNECTION_A_COMPUTEDKEY1",
+				Name: "CONNECTION_TEST-APP_A_COMPUTEDKEY1",
 				ValueFrom: &v1.EnvVarSource{
 					SecretKeyRef: &v1.SecretKeySelector{
 						LocalObjectReference: v1.LocalObjectReference{
 							Name: resource.Name,
 						},
-						Key: "CONNECTION_A_COMPUTEDKEY1",
+						Key: "CONNECTION_TEST-APP_A_COMPUTEDKEY1",
 					},
 				},
 			},
 			{
-				Name: "CONNECTION_A_COMPUTEDKEY2",
+				Name: "CONNECTION_TEST-APP_A_COMPUTEDKEY2",
 				ValueFrom: &v1.EnvVarSource{
 					SecretKeyRef: &v1.SecretKeySelector{
 						LocalObjectReference: v1.LocalObjectReference{
 							Name: resource.Name,
 						},
-						Key: "CONNECTION_A_COMPUTEDKEY2",
+						Key: "CONNECTION_TEST-APP_A_COMPUTEDKEY2",
 					},
 				},
 			},
@@ -467,15 +468,15 @@ func Test_Render_Connections(t *testing.T) {
 		expectedOutputResource := outputresource.NewKubernetesOutputResource(resourcekinds.Secret, outputresource.LocalIDSecret, secret, secret.ObjectMeta)
 		require.Equal(t, outputResource, expectedOutputResource)
 
-		require.Equal(t, resourceName, secret.Name)
+		require.Equal(t, secretName, secret.Name)
 		require.Equal(t, "default", secret.Namespace)
 		require.Equal(t, labels, secret.Labels)
 		require.Empty(t, secret.Annotations)
 
 		require.Equal(t, outputResource.LocalID, outputresource.LocalIDSecret)
 		require.Len(t, secret.Data, 2)
-		require.Equal(t, "ComputedValue1", string(secret.Data["CONNECTION_A_COMPUTEDKEY1"]))
-		require.Equal(t, "82", string(secret.Data["CONNECTION_A_COMPUTEDKEY2"]))
+		require.Equal(t, "ComputedValue1", string(secret.Data["CONNECTION_TEST-APP_A_COMPUTEDKEY1"]))
+		require.Equal(t, "82", string(secret.Data["CONNECTION_TEST-APP_A_COMPUTEDKEY2"]))
 	})
 	require.Len(t, output.Resources, 2)
 }


### PR DESCRIPTION
# Description

Prefix the secrets created in the container with the application name to make it unique for the application.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: Fixes #2986

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
