### PR TITLE
Update CLI docs to reflect change from "Container" to "containers"

### DIFF
--- a/cmd/rad/cmd/resourceExpose.go
+++ b/cmd/rad/cmd/resourceExpose.go
@@ -26,7 +26,7 @@ This command is useful for testing resources that accept network traffic but are
 Press CTRL+C to exit the command and terminate the tunnel.`,
 	Example: `# expose port 80 on the 'orders' resource of the 'icecream-store' application
 # on local port 5000
-rad resource expose --application icecream-store Container orders --port 5000 --remote-port 80`,
+rad resource expose --application icecream-store containers orders --port 5000 --remote-port 80`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		config := ConfigFromContext(cmd.Context())
 		workspace, err := cli.RequireWorkspace(cmd, config)

--- a/cmd/rad/cmd/resourceLogs.go
+++ b/cmd/rad/cmd/resourceLogs.go
@@ -22,8 +22,8 @@ import (
 
 var resourceLogsCmd = &cobra.Command{
 	Use:   "logs [resource]",
-	Short: "Read logs from a running Container resource",
-	Long: `Reads logs from a running resource. Currently only supports the resource type 'radius.dev/Container'.
+	Short: "Read logs from a running containers resource",
+	Long: `Reads logs from a running resource. Currently only supports the resource type 'Applications.Core/containers'.
 This command allows you to access logs of a deployed application and output those logs to the local console.
 
 'rad resource logs' will output all currently available logs for the resource and then exit.
@@ -32,16 +32,16 @@ This command allows you to access logs of a deployed application and output thos
 
 Specify the '--follow' option to stream additional logs as they are emitted by the resource. When following, press CTRL+C to exit the command and terminate the stream.`,
 	Example: `# read logs from the 'webapp' resource of the current default app
-rad resource logs Container webapp
+rad resource logs containers webapp
 
 # read logs from the 'orders' resource of the 'icecream-store' application
-rad resource logs Container orders --application icecream-store
+rad resource logs containers orders --application icecream-store
 
 # stream logs from the 'orders' resource of the 'icecream-store' application
-rad resource logs Container orders --application icecream-store --follow
+rad resource logs containers orders --application icecream-store --follow
 
 # read logs from the 'daprd' sidecar container of the 'orders' resource of the 'icecream-store' application
-rad resource logs Container orders --application icecream-store --container daprd`,
+rad resource logs containers orders --application icecream-store --container daprd`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		config := ConfigFromContext(cmd.Context())
 		workspace, err := cli.RequireWorkspace(cmd, config)


### PR DESCRIPTION
# Description

Based on https://github.com/project-radius/radius/pull/3201/files#diff-201dafbce4b1898d58153651f27250c637b4324fd3138087f869e070ac980017 we need to update all our CLI docs to use "containers" instead of "Container"
