### PR TITLE
Improve formatting of deployment errors

### DIFF
--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -30,15 +30,19 @@ var RootCmd = &cobra.Command{
 }
 
 func prettyPrintRPError(err error) string {
-	raw := err.Error()
 	if new := clients.TryUnfoldErrorResponse(err); new != nil {
 		m, err := prettyPrintJSON(new)
 		if err == nil {
 			return m
 		}
-		return raw
+	} else if new := clients.TryUnfoldServiceError(err); new != nil {
+		m, err := prettyPrintJSON(new)
+		if err == nil {
+			return m
+		}
 	}
-	return raw
+
+	return err.Error()
 }
 
 func prettyPrintJSON(o interface{}) (string, error) {


### PR DESCRIPTION
Fixes: radius-project/core-team#635

This change improves the formatting of errors from failed deployments
by unescaping nested JSON and pretty-printing the JSON.

Turns out we already had this code, but it wasn't active on this code
path.
