### PR TITLE
Normalize resource name for CRD store

### DIFF
--- a/pkg/ucp/store/apiserverstore/apiserverclient.go
+++ b/pkg/ucp/store/apiserverstore/apiserverclient.go
@@ -372,10 +372,11 @@ func (c *APIServerClient) synchronize() {
 func normalizeName(name string) string {
 	sb := strings.Builder{}
 	for _, ch := range name {
+		// Since this store uses . (dot) as a separator of the key, it converts dot character to hex code.
 		if unicode.IsDigit(ch) || unicode.IsLetter(ch) || ch == '-' {
 			sb.WriteRune(unicode.ToLower(ch))
 		} else {
-			sb.WriteString(fmt.Sprintf("0%02x", ch))
+			sb.WriteString(fmt.Sprintf("x%02x", ch))
 		}
 	}
 

--- a/pkg/ucp/store/apiserverstore/apiserverclient_test.go
+++ b/pkg/ucp/store/apiserverstore/apiserverclient_test.go
@@ -40,17 +40,17 @@ func Test_ResourceName_Normalize(t *testing.T) {
 		{
 			"ucp_resourcegroup_with_underscore",
 			"/planes/radius/local/resourceGroups/test_group",
-			"scope.test05fgroup.0fb96a9aa19f9c2e101405b80929ecc5cae090d0",
+			"scope.testx5fgroup.0fb96a9aa19f9c2e101405b80929ecc5cae090d0",
 		},
 		{
 			"ucp_resourcegroup_with_colon",
 			"/planes/radius/local/resourceGroups/test:group",
-			"scope.test03agroup.a01f2550797ca2e5d80b6032f361dea167e6c1f5",
+			"scope.testx3agroup.a01f2550797ca2e5d80b6032f361dea167e6c1f5",
 		},
 		{
 			"ucp_resourcegroup_with_undercore_char_code",
-			"/planes/radius/local/resourceGroups/test05fgroup",
-			"scope.test05fgroup.345a38402eb702848d9e7986b0d05462f66770e3",
+			"/planes/radius/local/resourceGroups/testx5fgroup",
+			"scope.testx5fgroup.38e1d2520da9c33fb1f82e7c697ebfb7ec28da2e",
 		},
 		{
 			"ucp_resourcegroup_with_long_resourcegroup_name",
@@ -60,12 +60,12 @@ func Test_ResourceName_Normalize(t *testing.T) {
 		{
 			"ucp_id_with_underscore",
 			"/planes/radius/local/resourceGroups/test_group/providers/Applications.Core/environments/cool_test",
-			"resource.cool05ftest.d42a57ad9f2f44521a1b0a63626fb9da20a31f45",
+			"resource.coolx5ftest.d42a57ad9f2f44521a1b0a63626fb9da20a31f45",
 		},
 		{
 			"ucp_id_with_dot",
 			"/planes/radius/local/resourceGroups/test_group/providers/Applications.Core/environments/cool.test",
-			"resource.cool02etest.abdff8cc92a10c748a2f8907b0b187cff1f9de14",
+			"resource.coolx2etest.abdff8cc92a10c748a2f8907b0b187cff1f9de14",
 		},
 		{
 			"ucp_id_with_hyphen",


### PR DESCRIPTION
# Description

When Radius/UCP store resource group and resource in self host mode, we generates crd resource name before storing the resource data in CRD. However, Kubernetes object name follows [RFC1123](https://datatracker.ietf.org/doc/html/rfc1123) for resource object name as below. Thus, if a user uses disallowed characters in its radius resource group or resource name, Radius cannot save it in CRD store.

- contain no more than 253 characters
- contain only lowercase alphanumeric characters, '-' or '.'
- start with an alphanumeric character
- end with an alphanumeric character

This PR is to normalize the resource name by converting disallowed char to hex code with the hash value of original resource id.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: radius-project/core-team#763

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
