### PR TITLE
Check Radius resource namespace for container dependencies

### DIFF
--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -44,10 +44,6 @@ import (
 	controller_runtime "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	ConnectorRPNamespace = "Applications.Connector"
-)
-
 //go:generate mockgen -destination=./mock_deploymentprocessor.go -package=deployment -self_package github.com/project-radius/radius/pkg/corerp/backend/deployment github.com/project-radius/radius/pkg/corerp/backend/deployment DeploymentProcessor
 type DeploymentProcessor interface {
 	Render(ctx context.Context, id resources.ID, resource conv.DataModelInterface) (renderers.RendererOutput, error)
@@ -514,7 +510,7 @@ func (dp *deploymentProcessor) buildResourceDependency(resourceID resources.ID, 
 			return ResourceData{}, conv.NewClientErrInvalidRequest(fmt.Sprintf("application ID %q for the resource %q is not a valid id. Error: %s", applicationID, resourceID.String(), err.Error()))
 		}
 		appID = parsedID
-	} else if strings.EqualFold(resourceID.ProviderNamespace(), ConnectorRPNamespace) {
+	} else if strings.EqualFold(resourceID.ProviderNamespace(), resources.ConnectorRPNamespace) {
 		// Application id is optional for connector resource types
 		appID = resources.ID{}
 	} else {

--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -75,7 +75,10 @@ func (r Renderer) GetDependencyIDs(ctx context.Context, dm conv.DataModelInterfa
 			continue
 		}
 
-		radiusResourceIDs = append(radiusResourceIDs, resourceID)
+		if resourceID.IsRadiusRPResource() {
+			radiusResourceIDs = append(radiusResourceIDs, resourceID)
+			continue
+		}
 	}
 
 	for _, port := range properties.Container.Ports {
@@ -88,7 +91,11 @@ func (r Renderer) GetDependencyIDs(ctx context.Context, dm conv.DataModelInterfa
 		if err != nil {
 			return nil, nil, conv.NewClientErrInvalidRequest(err.Error())
 		}
-		radiusResourceIDs = append(radiusResourceIDs, resourceID)
+
+		if resourceID.IsRadiusRPResource() {
+			radiusResourceIDs = append(radiusResourceIDs, resourceID)
+			continue
+		}
 	}
 
 	for _, volume := range properties.Container.Volumes {
@@ -98,7 +105,11 @@ func (r Renderer) GetDependencyIDs(ctx context.Context, dm conv.DataModelInterfa
 			if err != nil {
 				return nil, nil, conv.NewClientErrInvalidRequest(err.Error())
 			}
-			radiusResourceIDs = append(radiusResourceIDs, resourceID)
+
+			if resourceID.IsRadiusRPResource() {
+				radiusResourceIDs = append(radiusResourceIDs, resourceID)
+				continue
+			}
 		}
 	}
 

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -111,7 +111,7 @@ func Test_GetDependencyIDs_Success(t *testing.T) {
 			Ports: map[string]datamodel.ContainerPort{
 				"web": {
 					ContainerPort: 5000,
-					Provides:      makeResourceID(t, "Applications.Core/HttpRoutes", "C").String(),
+					Provides:      makeResourceID(t, "Applications.Core/httpRoutes", "C").String(),
 				},
 			},
 			Volumes: map[string]datamodel.VolumeProperties{

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -136,9 +136,9 @@ func Test_GetDependencyIDs_Success(t *testing.T) {
 	require.Len(t, azureResourceIDs, 1)
 
 	expectedRadiusResourceIDs := []resources.ID{
-		makeResourceID(t, "Applications.Core/HttpRoutes", "A"),
-		makeResourceID(t, "Applications.Core/HttpRoutes", "B"),
-		makeResourceID(t, "Applications.Core/HttpRoutes", "C"),
+		makeResourceID(t, "Applications.Core/httpRoutes", "A"),
+		makeResourceID(t, "Applications.Core/httpRoutes", "B"),
+		makeResourceID(t, "Applications.Core/httpRoutes", "C"),
 	}
 	require.ElementsMatch(t, expectedRadiusResourceIDs, radiusResourceIDs)
 

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -89,7 +89,7 @@ func Test_GetDependencyIDs_Success(t *testing.T) {
 				Source: makeResourceID(t, "Applications.Core/HttpRoutes", "A").String(),
 			},
 			"B": {
-				Source: makeResourceID(t, "Applications.Core/HttpRoutes", "B").String(),
+				Source: makeResourceID(t, "Applications.Core/httpRoutes", "B").String(),
 				IAM: datamodel.IAMProperties{
 					Kind:  datamodel.KindHTTP,
 					Roles: []string{"administrator"},

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -86,7 +86,7 @@ func Test_GetDependencyIDs_Success(t *testing.T) {
 		},
 		Connections: map[string]datamodel.ConnectionProperties{
 			"A": {
-				Source: makeResourceID(t, "Applications.Core/HttpRoutes", "A").String(),
+				Source: makeResourceID(t, "Applications.Core/httpRoutes", "A").String(),
 			},
 			"B": {
 				Source: makeResourceID(t, "Applications.Core/httpRoutes", "B").String(),

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -343,7 +343,7 @@ func Test_Render_PortConnectedToRoute(t *testing.T) {
 		require.Len(t, container.Ports, 1)
 		port := container.Ports[0]
 
-		routeID := makeResourceID(t, "Applications.Core/HttpRoutes", "A")
+		routeID := makeResourceID(t, "Applications.Core/httpRoutes", "A")
 
 		expected := v1.ContainerPort{
 			Name:          kubernetes.GetShortenedTargetPortName(applicationName + "httpRoutes" + routeID.Name()),

--- a/pkg/ucp/resources/id.go
+++ b/pkg/ucp/resources/id.go
@@ -18,6 +18,9 @@ const (
 	ResourceGroupsSegment = "resourcegroups"
 	SubscriptionsSegment  = "subscriptions"
 	LocationsSegment      = "locations"
+
+	CoreRPNamespace      = "Applications.Core"
+	ConnectorRPNamespace = "Applications.Connector"
 )
 
 // ID represents an ARM or UCP resource id. ID is immutable once created. Use Parse() to create IDs and use
@@ -162,6 +165,11 @@ func (ri ID) ProviderNamespace() string {
 	}
 	segments := strings.Split(ri.typeSegments[0].Type, SegmentSeparator)
 	return segments[0]
+}
+
+func (ri ID) IsRadiusRPResource() bool {
+	return strings.EqualFold(ri.ProviderNamespace(), CoreRPNamespace) ||
+		strings.EqualFold(ri.ProviderNamespace(), ConnectorRPNamespace)
 }
 
 // PlaneNamespace returns the plane part of the UCP ID

--- a/pkg/ucp/resources/id_test.go
+++ b/pkg/ucp/resources/id_test.go
@@ -842,3 +842,57 @@ func Test_ParseByMethod(t *testing.T) {
 		})
 	}
 }
+
+func Test_RadiusRPResource(t *testing.T) {
+	values := []struct {
+		testID   ID
+		expected bool
+	}{
+		{
+			testID: ID{
+				id: "/subscriptions/s1/resourceGroups/r1/providers/Applications.Core/containers/test-container",
+				scopeSegments: []ScopeSegment{
+					{Type: "subscriptions", Name: "s1"},
+					{Type: "resourceGroups", Name: "r1"},
+				},
+				typeSegments: []TypeSegment{
+					{Type: "Applications.Core/containers", Name: "test-container"},
+				},
+			},
+			expected: true,
+		},
+		{
+			testID: ID{
+				id: "/subscriptions/s1/resourceGroups/r1/providers/Applications.Connector/mongoDatabases/test-mongo",
+				scopeSegments: []ScopeSegment{
+					{Type: "subscriptions", Name: "s1"},
+					{Type: "resourceGroups", Name: "r1"},
+				},
+				typeSegments: []TypeSegment{
+					{Type: "Applications.Connector/mongoDatabases", Name: "test-mongo"},
+				},
+			},
+			expected: true,
+		},
+		{
+			testID: ID{
+				id: "/subscriptions/s1/resourceGroups/r1/providers/Applications.foo/containers/test-container",
+				scopeSegments: []ScopeSegment{
+					{Type: "subscriptions", Name: "s1"},
+					{Type: "resourceGroups", Name: "r1"},
+				},
+				typeSegments: []TypeSegment{
+					{Type: "Applications.foo/containers", Name: "test-container"},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for i, v := range values {
+		t.Run(fmt.Sprintf("%d: %v", i, v.testID.id), func(t *testing.T) {
+			radiusResource := v.testID.IsRadiusRPResource()
+			require.Equal(t, v.expected, radiusResource)
+		})
+	}
+}

--- a/test/functional/corerp/resources/testdata/corerp-azure-connection-database-service.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-azure-connection-database-service.bicep
@@ -28,9 +28,6 @@ resource store 'Applications.Core/containers@2022-03-15-privatepreview' = {
     connections: {
       databaseresource: {
         source: databaseAccount.id
-        iam: {
-          kind: 'azure'
-        }
       }
     }
   }


### PR DESCRIPTION
# Description

`GetDependencyIDs` is consumed by core RP deployment processor with the expectation that the dependent radius resource is already deployed and exists in the data store: https://github.com/project-radius/radius/blob/main/pkg/corerp/backend/deployment/deploymentprocessor.go#L111. So anything that isn't a Radius RP (Core/Connector) resource shouldn't be returned as radius resource.

https://github.com/project-radius/radius/issues/3241

## Issue reference

Please reference the issue this PR will close: https://github.com/project-radius/radius/issues/3241

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
