### PR TITLE
Add debug command that will capture all logs from the radius control plane as a zip

### DIFF
--- a/cmd/rad/cmd/debuglogs.go
+++ b/cmd/rad/cmd/debuglogs.go
@@ -55,7 +55,6 @@ func debugLogs(cmd *cobra.Command, args []string) error {
 
 	c := connection.(*workspaces.KubernetesConnection)
 
-	// k8sClient, err := // connections.DefaultFactory.CreateK8sClient(cmd.Context(), *workspace)
 	k8sClient, _, err := kubernetes.CreateTypedClient(c.Context)
 	if err != nil {
 		return err

--- a/cmd/rad/cmd/debuglogs.go
+++ b/cmd/rad/cmd/debuglogs.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 

--- a/cmd/rad/cmd/debuglogs.go
+++ b/cmd/rad/cmd/debuglogs.go
@@ -71,7 +71,11 @@ func debugLogs(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	tmpdir, _ := ioutil.TempDir("", "radius-debug-logs")
+	tmpdir, err := ioutil.TempDir("", "radius-debug-logs")
+
+	if err != nil {
+		return err
+	}
 
 	for _, pod := range pods.Items {
 		for _, container := range pod.Spec.Containers {

--- a/cmd/rad/cmd/debuglogs.go
+++ b/cmd/rad/cmd/debuglogs.go
@@ -25,22 +25,22 @@ import (
 )
 
 const (
-	feedbackFile = "feedback.zip"
+	debugLogsFile = "debug-logs.zip"
 )
 
-var feedbackCmd = &cobra.Command{
-	Use:   "feedback",
+var debugLogsCmd = &cobra.Command{
+	Use:   "debug-logs",
 	Short: "Captures information about the current Radius Workspace for debugging and diagnostics. Creates a ZIP file of logs in the current directory. WARNING Please inspect all logs before sending feedback to confirm no private information is included.",
 	Long:  `Captures information about the current Radius Workspace for debugging and diagnostics. Creates a ZIP file of logs in the current directory. WARNING Please inspect all logs before sending feedback to confirm no private information is included.`,
-	RunE:  feedback,
+	RunE:  debugLogs,
 }
 
 func init() {
-	RootCmd.AddCommand(feedbackCmd)
-	feedbackCmd.PersistentFlags().StringP("workspace", "w", "", "The workspace name")
+	RootCmd.AddCommand(debugLogsCmd)
+	debugLogsCmd.PersistentFlags().StringP("workspace", "w", "", "The workspace name")
 }
 
-func feedback(cmd *cobra.Command, args []string) error {
+func debugLogs(cmd *cobra.Command, args []string) error {
 	config := ConfigFromContext(cmd.Context())
 
 	w, err := cli.RequireWorkspace(cmd, config)
@@ -71,7 +71,7 @@ func feedback(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	tmpdir, _ := ioutil.TempDir("", "radius-feedback")
+	tmpdir, _ := ioutil.TempDir("", "radius-debug-logs")
 
 	for _, pod := range pods.Items {
 		for _, container := range pod.Spec.Containers {
@@ -89,7 +89,7 @@ func feedback(cmd *cobra.Command, args []string) error {
 
 	defer os.RemoveAll(tmpdir)
 
-	file, err := os.Create(feedbackFile)
+	file, err := os.Create(debugLogsFile)
 	if err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func feedback(cmd *cobra.Command, args []string) error {
 
 	err = filepath.Walk(tmpdir, walker)
 
-	fmt.Printf("Wrote zip file %s. Please inspect each log file and remove any private information before sharing feedback.\n", feedbackFile)
+	fmt.Printf("Wrote zip file %s. Please inspect each log file and remove any private information before sharing feedback.\n", debugLogsFile)
 
 	return err
 }

--- a/cmd/rad/cmd/debuglogs.go
+++ b/cmd/rad/cmd/debuglogs.go
@@ -70,7 +70,7 @@ func debugLogs(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	tmpdir, err := ioutil.TempDir("", "radius-debug-logs")
+	tmpdir, err := os.MkdirTemp("", "radius-debug-logs")
 
 	if err != nil {
 		return err

--- a/cmd/rad/cmd/feedback.go
+++ b/cmd/rad/cmd/feedback.go
@@ -1,0 +1,183 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cmd
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/project-radius/radius/pkg/cli"
+	"github.com/project-radius/radius/pkg/cli/kubernetes"
+	"github.com/project-radius/radius/pkg/cli/workspaces"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	feedbackFile = "feedback.zip"
+)
+
+var feedbackCmd = &cobra.Command{
+	Use:   "feedback",
+	Short: "Captures information about the current Radius Workspace for debugging and diagnostics. Creates a ZIP file of logs in the current directory.",
+	Long:  `Captures information about the current Radius Workspace for debugging and diagnostics. Creates a ZIP file of logs in the current directory.`,
+	RunE:  feedback,
+}
+
+func init() {
+	RootCmd.AddCommand(feedbackCmd)
+	feedbackCmd.PersistentFlags().StringP("workspace", "w", "", "The workspace name")
+}
+
+func feedback(cmd *cobra.Command, args []string) error {
+	config := ConfigFromContext(cmd.Context())
+
+	w, err := cli.RequireWorkspace(cmd, config)
+	if err != nil {
+		return err
+	}
+
+	connection, err := w.Connect()
+	if err != nil {
+		return err
+	}
+
+	c := connection.(*workspaces.KubernetesConnection)
+
+	// k8sClient, err := // connections.DefaultFactory.CreateK8sClient(cmd.Context(), *workspace)
+	k8sClient, _, err := kubernetes.CreateTypedClient(c.Context)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Capturing logs from the Radius workspace \"%s\"\n", w.Name)
+
+	pods, err := k8sClient.CoreV1().Pods("radius-system").List(cmd.Context(), v1.ListOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	tmpdir, _ := ioutil.TempDir("", "radius-feedback")
+
+	for _, pod := range pods.Items {
+		for _, container := range pod.Spec.Containers {
+			options := &corev1.PodLogOptions{
+				Container: container.Name,
+			}
+			request := k8sClient.CoreV1().Pods("radius-system").GetLogs(pod.Name, options)
+
+			filename := fmt.Sprintf("%s/%s.%s.log", tmpdir, pod.Name, container.Name)
+
+			// Ignore errors from this, always try to capture all logs.
+			captureIndividualLogs(cmd.Context(), request, cmd, filename)
+		}
+	}
+
+	defer os.RemoveAll(tmpdir)
+
+	file, err := os.Create(feedbackFile)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	zipWriter := zip.NewWriter(file)
+	defer zipWriter.Close()
+
+	walker := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+
+		header.Method = zip.Deflate
+
+		if info.IsDir() {
+			return nil
+		}
+
+		headerWriter, err := zipWriter.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		t, err := io.Copy(headerWriter, file)
+		if err != nil {
+			return err
+		}
+		fmt.Println(t)
+
+		return nil
+	}
+
+	err = filepath.Walk(tmpdir, walker)
+
+	fmt.Printf("Wrote zip file %s\n", feedbackFile)
+
+	return err
+}
+
+func captureIndividualLogs(ctx context.Context, request *rest.Request, cmd *cobra.Command, filename string) {
+	stream, err := request.Stream(cmd.Context())
+	if err != nil && err == ctx.Err() {
+		return
+	} else if err != nil {
+		fmt.Printf("Error reading log stream for %s. Error was %+v", filename, err)
+		return
+	}
+	defer stream.Close()
+
+	fh, err := os.Create(filename)
+	if err != nil {
+		return
+	}
+	defer fh.Close()
+
+	buf := make([]byte, 2000)
+
+	for {
+		numBytes, err := stream.Read(buf)
+
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil && err == ctx.Err() {
+			return
+		} else if err != nil {
+			fmt.Printf("Error reading log stream for %s. Error was %+v", filename, err)
+			return
+		}
+
+		if numBytes == 0 {
+			continue
+		}
+
+		_, err = fh.Write(buf[:numBytes])
+		if err != nil {
+			fmt.Printf("Error writing to %s. Error was %s", filename, err)
+			return
+		}
+	}
+}

--- a/deploy/Chart/charts/appcore-rp/templates/appcore-rp.yaml
+++ b/deploy/Chart/charts/appcore-rp/templates/appcore-rp.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   labels:
     control-plane: appcore-rp
+    app.kubernetes.io/part-of: radius-control-plane
   name: appcore-rp
   namespace: {{ .Release.Namespace }}
 spec:
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels:
         control-plane: appcore-rp
+        app.kubernetes.io/part-of: radius-control-plane
 {{ if .Values.global.rp.provider.azure.podidentity }}
         aadpodidbinding: {{ .Values.global.rp.provider.azure.podidentity }}
 {{ end }}

--- a/deploy/Chart/charts/de/templates/de.yaml
+++ b/deploy/Chart/charts/de/templates/de.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   labels:
     control-plane: de
+    app.kubernetes.io/part-of: radius-control-plane
   name: bicep-de
   namespace: {{ .Release.Namespace }}
 spec:
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels:
         control-plane: de
+        app.kubernetes.io/part-of: radius-control-plane
 {{ if .Values.global.rp.provider.azure.podidentity }}
         aadpodidbinding: {{ .Values.global.rp.provider.azure.podidentity }}
 {{ end }}

--- a/deploy/Chart/charts/ucp/templates/ucp.yaml
+++ b/deploy/Chart/charts/ucp/templates/ucp.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   labels:
     control-plane: ucp
+    app.kubernetes.io/part-of: radius-control-plane
   name: ucp
   namespace: "{{ .Release.Namespace }}"
 spec:
@@ -14,6 +15,7 @@ spec:
     metadata:
       labels:
         control-plane: ucp
+        app.kubernetes.io/part-of: radius-control-plane
 {{ if .Values.global.rp.provider.azure.podidentity }}
         aadpodidbinding: "{{ .Values.global.rp.provider.azure.podidentity }}"
 {{ end }}

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -26,6 +26,7 @@ const (
 
 	FieldManager      = "radius-rp"
 	AnnotationLocalID = "radius.dev/local-id"
+	ControlPlane      = "radius-control-plane"
 )
 
 // NOTE: the difference between descriptive labels and selector labels


### PR DESCRIPTION
# Description

Adds command called `rad feedback` (name pending) which will capture all logs from the radius control plane and put it in a zip folder. We can then update our bug instructions to mention "run `rad feedback` and upload logs to this issue".

## Issue reference

Part of https://github.com/project-radius/radius/issues/1324
Part of https://github.com/project-radius/docs/issues/226

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
