### PR TITLE
Return the actionable error message for invalid environment and workspace names

### DIFF
--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -190,7 +190,7 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 
 	matched, msg, _ := prompt.ResourceName(workspaceName)
 	if !matched {
-		return fmt.Errorf("workspace %s. Use --workspace option to specify the valid name.", msg)
+		return fmt.Errorf("%s %s. Use --workspace option to specify the valid name.", workspaceName, msg)
 	}
 
 	// We're going to update the workspace in place if it's compatible. We only need to
@@ -449,7 +449,7 @@ func selectEnvironmentName(cmd *cobra.Command, defaultVal string, interactive bo
 		}
 		matched, msg, _ := prompt.ResourceName(envStr)
 		if !matched {
-			return "", fmt.Errorf("environment %s. Use --environment option to specify the valid name.", msg)
+			return "", fmt.Errorf("%s %s. Use --environment option to specify the valid name.", envStr, msg)
 		}
 	}
 

--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -188,6 +188,11 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 		workspaceName = environmentName
 	}
 
+	matched, msg, _ := prompt.ResourceName(workspaceName)
+	if !matched {
+		return fmt.Errorf("workspace %s. Use --workspace option to specify the valid name.", msg)
+	}
+
 	// We're going to update the workspace in place if it's compatible. We only need to
 	// report an error if it's not (eg: different connection type or different kubecontext.)
 	foundExistingWorkspace, err := cli.HasWorkspace(config, workspaceName)
@@ -432,7 +437,7 @@ func selectEnvironmentName(cmd *cobra.Command, defaultVal string, interactive bo
 	}
 	if interactive && envStr == "" {
 		promptMsg := fmt.Sprintf("Enter an environment name [%s]:", defaultVal)
-		envStr, err = prompt.TextWithDefault(promptMsg, &defaultVal, prompt.EmptyValidator)
+		envStr, err = prompt.TextWithDefault(promptMsg, &defaultVal, prompt.ResourceName)
 		if err != nil {
 			return "", err
 		}
@@ -442,7 +447,12 @@ func selectEnvironmentName(cmd *cobra.Command, defaultVal string, interactive bo
 			output.LogInfo("No environment name provided, using: %v", defaultVal)
 			envStr = defaultVal
 		}
+		matched, msg, _ := prompt.ResourceName(envStr)
+		if !matched {
+			return "", fmt.Errorf("environment %s. Use --environment option to specify the valid name.", msg)
+		}
 	}
+
 	return envStr, nil
 }
 

--- a/pkg/cli/prompt/prompt.go
+++ b/pkg/cli/prompt/prompt.go
@@ -19,7 +19,7 @@ const (
 	Yes     BinaryAnswer = iota
 	No
 
-	InvalidResourceNameMessage = "names must be made up of alphanumeric characters and hyphens, and must begin with an alphabetic character and end with an alphanumeric character"
+	InvalidResourceNameMessage = "name must be made up of alphanumeric characters and hyphens, and must begin with an alphabetic character and end with an alphanumeric character"
 )
 
 func MatchAll(validators ...func(string) (bool, string, error)) func(string) (bool, string, error) {


### PR DESCRIPTION
# Description

When user creates cluster context name with underscore or specifies invalid environment/workspace names, this change guides user to specify --workspace or --environment to the valid name. 

Examples

```
youngp@Youngs-MacBook-Pro radius % rad env init kubernetes --environment kind_under
Error: 'kind_under' name must be made up of alphanumeric characters and hyphens, and must begin with an alphabetic character and end with an alphanumeric character. Use --environment option to specify the valid name.
```

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: radius-project/core-team#763 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
