### PR TITLE
Async worker client/server error handling

### DIFF
--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -239,8 +239,8 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 		// Such cases should not call w.completeOperation.
 		if !errors.Is(asyncReqCtx.Err(), context.Canceled) {
 			if err != nil {
-				code, msg := extractError(err)
-				result.SetFailed(armerrors.ErrorDetails{Code: code, Message: msg}, false)
+				armErr := extractError(err)
+				result.SetFailed(armErr, false)
 			}
 			w.completeOperation(ctx, message, result, asyncCtrl.StorageClient())
 		}
@@ -281,11 +281,11 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 	}
 }
 
-func extractError(err error) (errCode, errMessage string) {
+func extractError(err error) armerrors.ErrorDetails {
 	if clientErr, ok := err.(*conv.ErrClientRP); ok {
-		return clientErr.Code, clientErr.Message
+		return armerrors.ErrorDetails{Code: clientErr.Code, Message: clientErr.Message}
 	} else {
-		return armerrors.Internal, err.Error()
+		return armerrors.ErrorDetails{Code: armerrors.Internal, Message: err.Error()}
 	}
 }
 

--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
+	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	ctrl "github.com/project-radius/radius/pkg/armrpc/asyncoperation/controller"
 	manager "github.com/project-radius/radius/pkg/armrpc/asyncoperation/statusmanager"
@@ -238,7 +239,8 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 		// Such cases should not call w.completeOperation.
 		if !errors.Is(asyncReqCtx.Err(), context.Canceled) {
 			if err != nil {
-				result.SetFailed(armerrors.ErrorDetails{Code: armerrors.Internal, Message: err.Error()}, false)
+				code, msg := extractError(err)
+				result.SetFailed(armerrors.ErrorDetails{Code: code, Message: msg}, false)
 			}
 			w.completeOperation(ctx, message, result, asyncCtrl.StorageClient())
 		}
@@ -276,6 +278,14 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 			logger.Info("End processing operation.", "StartAt", opStartAt.UTC(), "EndAt", opEndAt.UTC(), "Duration", opEndAt.Sub(opStartAt))
 			return
 		}
+	}
+}
+
+func extractError(err error) (errCode, errMessage string) {
+	if clientErr, ok := err.(*conv.ErrClientRP); ok {
+		return clientErr.Code, clientErr.Message
+	} else {
+		return armerrors.Internal, err.Error()
 	}
 }
 

--- a/pkg/armrpc/asyncoperation/worker/worker_test.go
+++ b/pkg/armrpc/asyncoperation/worker/worker_test.go
@@ -143,25 +143,21 @@ func TestGetMessageExtendDuration(t *testing.T) {
 
 func TestErrorHandling(t *testing.T) {
 	tests := []struct {
-		err          error
-		expectedCode string
-		expectedMsg  string
+		err            error
+		expectedArmErr armerrors.ErrorDetails
 	}{
 		{
-			err:          conv.NewClientErrInvalidRequest("client error"),
-			expectedCode: armerrors.Invalid,
-			expectedMsg:  "client error",
+			err:            conv.NewClientErrInvalidRequest("client error"),
+			expectedArmErr: armerrors.ErrorDetails{Code: armerrors.Invalid, Message: "client error"},
 		},
 		{
-			err:          errors.New("internal error"),
-			expectedCode: armerrors.Internal,
-			expectedMsg:  "internal error",
+			err:            errors.New("internal error"),
+			expectedArmErr: armerrors.ErrorDetails{Code: armerrors.Internal, Message: "internal error"},
 		},
 	}
 
 	for _, tt := range tests {
-		code, msg := extractError(tt.err)
-		require.Equal(t, tt.expectedCode, code)
-		require.Equal(t, tt.expectedMsg, msg)
+		armErr := extractError(tt.err)
+		require.Equal(t, tt.expectedArmErr, armErr)
 	}
 }

--- a/pkg/armrpc/asyncoperation/worker/worker_test.go
+++ b/pkg/armrpc/asyncoperation/worker/worker_test.go
@@ -7,11 +7,14 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	"github.com/project-radius/radius/pkg/radrp/armerrors"
 	"github.com/project-radius/radius/pkg/ucp/store"
 	"github.com/stretchr/testify/require"
 )
@@ -135,5 +138,30 @@ func TestGetMessageExtendDuration(t *testing.T) {
 		worker := New(Options{}, nil, nil, nil)
 		d := worker.getMessageExtendDuration(tt.in)
 		require.Equal(t, tt.out, d.Round(time.Second))
+	}
+}
+
+func TestErrorHandling(t *testing.T) {
+	tests := []struct {
+		err          error
+		expectedCode string
+		expectedMsg  string
+	}{
+		{
+			err:          conv.NewClientErrInvalidRequest("client error"),
+			expectedCode: armerrors.Invalid,
+			expectedMsg:  "client error",
+		},
+		{
+			err:          errors.New("internal error"),
+			expectedCode: armerrors.Internal,
+			expectedMsg:  "internal error",
+		},
+	}
+
+	for _, tt := range tests {
+		code, msg := extractError(tt.err)
+		require.Equal(t, tt.expectedCode, code)
+		require.Equal(t, tt.expectedMsg, msg)
 	}
 }


### PR DESCRIPTION
# Description

Handle client/server errors in Async worker. It currently wraps any error returned as internal error resulting into responses like this:

```
{
"code": "Internal",
"message": "code BadRequest: err linked application ID \"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/default/providers/applications.core/environments/env\" for resource \"/planes/radius/local/resourcegroups/kind-radius/providers/applications.core/containers/invalid-ctnr\" has invalid application resource type."
}
```

## Issue reference

Please reference the issue this PR will close: https://github.com/project-radius/radius/issues/3288

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
