### PR TITLE
Testing the deletion of orphaned output resources between same resource versions

### DIFF
--- a/test/functional/corerp/corerptest.go
+++ b/test/functional/corerp/corerptest.go
@@ -46,6 +46,7 @@ type TestStep struct {
 	PostStepVerify         func(ctx context.Context, t *testing.T, ct CoreRPTest)
 	SkipResourceValidation bool
 	SkipObjectValidation   bool
+	SkipResourceDeletion   bool
 }
 
 type CoreRPTest struct {
@@ -198,7 +199,7 @@ func (ct CoreRPTest) Test(t *testing.T) {
 			t.Errorf("failed to capture logs from radius controller: %v", err)
 		}
 
-                // Getting logs from all pods in the default namespace as well, which is where all app pods run for calls to rad deploy
+		// Getting logs from all pods in the default namespace as well, which is where all app pods run for calls to rad deploy
 		err = validation.SaveLogsForController(ctx, ct.Options.K8sClient, "default", logPrefix)
 		if err != nil {
 			t.Errorf("failed to capture logs from radius controller: %v", err)
@@ -268,7 +269,7 @@ func (ct CoreRPTest) Test(t *testing.T) {
 
 	// Cleanup code here will run regardless of pass/fail of subtests
 	for _, step := range ct.Steps {
-		if step.CoreRPResources == nil && step.SkipResourceValidation {
+		if (step.CoreRPResources == nil && step.SkipResourceValidation) || step.SkipResourceDeletion {
 			continue
 		}
 		for _, resource := range step.CoreRPResources.Resources {

--- a/test/functional/corerp/resources/container_versioning_test.go
+++ b/test/functional/corerp/resources/container_versioning_test.go
@@ -7,6 +7,7 @@ package resource_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/project-radius/radius/test/functional"
@@ -50,7 +51,10 @@ func Test_ContainerVersioning(t *testing.T) {
 			},
 			SkipResourceDeletion: true,
 			PostStepVerify: func(ctx context.Context, t *testing.T, test corerp.CoreRPTest) {
-				secrets, err := test.Options.K8sClient.CoreV1().Secrets("default").List(ctx, metav1.ListOptions{})
+				label := fmt.Sprintf("radius.dev/application=%s", name)
+				secrets, err := test.Options.K8sClient.CoreV1().Secrets("default").List(ctx, metav1.ListOptions{
+					LabelSelector: label,
+				})
 				require.NoError(t, err)
 				require.Len(t, secrets.Items, 1)
 			},
@@ -77,7 +81,10 @@ func Test_ContainerVersioning(t *testing.T) {
 				},
 			},
 			PostStepVerify: func(ctx context.Context, t *testing.T, test corerp.CoreRPTest) {
-				secrets, err := test.Options.K8sClient.CoreV1().Secrets("default").List(ctx, metav1.ListOptions{})
+				label := fmt.Sprintf("radius.dev/application=%s", name)
+				secrets, err := test.Options.K8sClient.CoreV1().Secrets("default").List(ctx, metav1.ListOptions{
+					LabelSelector: label,
+				})
 				require.NoError(t, err)
 				require.Len(t, secrets.Items, 0)
 			},

--- a/test/functional/corerp/resources/container_versioning_test.go
+++ b/test/functional/corerp/resources/container_versioning_test.go
@@ -1,0 +1,88 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package resource_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/project-radius/radius/test/functional"
+	"github.com/project-radius/radius/test/functional/corerp"
+	"github.com/project-radius/radius/test/step"
+	"github.com/project-radius/radius/test/validation"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_ContainerVersioning(t *testing.T) {
+	containerV1 := "testdata/containers/corerp-resources-friendly-container-version-1.bicep"
+	containerV2 := "testdata/containers/corerp-resources-friendly-container-version-2.bicep"
+
+	name := "corerp-resources-container-versioning"
+
+	requiredSecrets := map[string]map[string]string{}
+
+	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
+		{
+			Executor: step.NewDeployExecutor(containerV1, functional.GetMagpieImage()),
+			CoreRPResources: &validation.CoreRPResourceSet{
+				Resources: []validation.CoreRPResource{
+					{
+						Name: name,
+						Type: validation.ApplicationsResource,
+					},
+					{
+						Name: "friendly-ctnr",
+						Type: validation.ContainersResource,
+					},
+				},
+			},
+			K8sObjects: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					"default": {
+						validation.NewK8sPodForResource(name, "friendly-ctnr"),
+					},
+				},
+			},
+			SkipResourceDeletion: true,
+			PostStepVerify: func(ctx context.Context, t *testing.T, test corerp.CoreRPTest) {
+				secrets, err := test.Options.K8sClient.CoreV1().Secrets("default").List(ctx, metav1.ListOptions{})
+				require.NoError(t, err)
+				require.Len(t, secrets.Items, 1)
+			},
+		},
+		{
+			Executor: step.NewDeployExecutor(containerV2, functional.GetMagpieImage()),
+			CoreRPResources: &validation.CoreRPResourceSet{
+				Resources: []validation.CoreRPResource{
+					{
+						Name: name,
+						Type: validation.ApplicationsResource,
+					},
+					{
+						Name: "friendly-ctnr",
+						Type: validation.ContainersResource,
+					},
+				},
+			},
+			K8sObjects: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					"default": {
+						validation.NewK8sPodForResource(name, "friendly-ctnr"),
+					},
+				},
+			},
+			PostStepVerify: func(ctx context.Context, t *testing.T, test corerp.CoreRPTest) {
+				secrets, err := test.Options.K8sClient.CoreV1().Secrets("default").List(ctx, metav1.ListOptions{})
+				require.NoError(t, err)
+				require.Len(t, secrets.Items, 0)
+			},
+		},
+	}, requiredSecrets)
+
+	test.Test(t)
+}

--- a/test/functional/corerp/resources/testdata/containers/corerp-resources-friendly-container-version-1.bicep
+++ b/test/functional/corerp/resources/testdata/containers/corerp-resources-friendly-container-version-1.bicep
@@ -1,0 +1,77 @@
+import radius as radius
+
+param magpieimage string
+param environment string
+
+resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
+  name: 'corerp-resources-container-versioning'
+  location: 'global'
+  properties: {
+    environment: environment
+  }
+}
+
+resource webapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
+  name: 'friendly-ctnr'
+  location: 'global'
+  properties: {
+    application: app.id
+    container: {
+      image: magpieimage
+      env: {
+        DBCONNECTION: redis.connectionString()
+      }
+      readinessProbe: {
+        kind: 'httpGet'
+        containerPort: 3000
+        path: '/healthz'
+      }
+    }
+    connections: {
+      redis: {
+        source: redis.id
+      }
+    }
+  }
+}
+
+resource redisContainer 'Applications.Core/containers@2022-03-15-privatepreview' = {
+  name: 'friendly-rds-ctnr'
+  location: 'global'
+  properties: {
+    application: app.id
+    container: {
+      image: 'redis:6.2'
+      ports: {
+        redis: {
+          containerPort: 6379
+          provides: redisRoute.id
+        }
+      }
+    }
+    connections: {}
+  }
+}
+
+resource redisRoute 'Applications.Core/httproutes@2022-03-15-privatepreview' = {
+  name: 'friendly-rds-rte'
+  location: 'global'
+  properties: {
+    application: app.id
+  }
+}
+
+resource redis 'Applications.Connector/redisCaches@2022-03-15-privatepreview' = {
+  name: 'friendly-rds-rds'
+  location: 'global'
+  properties: {
+    environment: environment
+    application: app.id
+    host: redisRoute.properties.hostname
+    port: redisRoute.properties.port
+    secrets: {
+      connectionString: '${redisRoute.properties.hostname}:${redisRoute.properties.port}'
+      password: ''
+    }
+  }
+}

--- a/test/functional/corerp/resources/testdata/containers/corerp-resources-friendly-container-version-2.bicep
+++ b/test/functional/corerp/resources/testdata/containers/corerp-resources-friendly-container-version-2.bicep
@@ -1,0 +1,30 @@
+import radius as radius
+
+param magpieimage string
+param environment string
+
+resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
+  name: 'corerp-resources-container-versioning'
+  location: 'global'
+  properties: {
+    environment: environment
+  }
+}
+
+resource webapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
+  name: 'friendly-ctnr'
+  location: 'global'
+  properties: {
+    application: app.id
+    container: {
+      image: magpieimage
+      env: {}
+      readinessProbe: {
+        kind: 'httpGet'
+        containerPort: 3000
+        path: '/healthz'
+      }
+    }
+    connections: {}
+  }
+}


### PR DESCRIPTION
# Description
We added the capability to delete the orphaned resources between different versions of the same resource. This adds a functional test to this feature.

## Issue reference
Please reference the issue this PR will close: #3298 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
