### PR TITLE
Make application name optional for rad resource show

### DIFF
--- a/cmd/rad/cmd/resourceShow.go
+++ b/cmd/rad/cmd/resourceShow.go
@@ -54,7 +54,7 @@ func showResource(cmd *cobra.Command, args []string) error {
 
 	applicationName, err := cmd.Flags().GetString("application")
 	if err != nil {
-		return &cli.FriendlyError{Message: "Unable to parse command"}
+		return &cli.FriendlyError{Message: "Unable to parse application name"}
 	}
 
 	client, err := connections.DefaultFactory.CreateApplicationsManagementClient(cmd.Context(), *workspace)

--- a/cmd/rad/cmd/resourceShow.go
+++ b/cmd/rad/cmd/resourceShow.go
@@ -52,10 +52,12 @@ func showResource(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	applicationName, err := cmd.Flags().GetString("application")
-	if err != nil {
-		return &cli.FriendlyError{Message: "Unable to parse application name"}
-	}
+	// The application flag is redundant for show as resources are env scoped
+	// The flag is useful for future behaviors where resources might be rg or subId scoped
+	// applicationName, err := cmd.Flags().GetString("application")
+	// if err != nil {
+	// 	return &cli.FriendlyError{Message: "Unable to parse application name"}
+	// }
 
 	client, err := connections.DefaultFactory.CreateApplicationsManagementClient(cmd.Context(), *workspace)
 	if err != nil {
@@ -67,7 +69,7 @@ func showResource(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	resourceDetails, err := client.ShowResourceByApplication(cmd.Context(), applicationName, resourceType, resourceName)
+	resourceDetails, err := client.ShowResource(cmd.Context(), resourceType, resourceName)
 	if err != nil {
 		return err
 	}

--- a/cmd/rad/cmd/resourceShow.go
+++ b/cmd/rad/cmd/resourceShow.go
@@ -52,9 +52,9 @@ func showResource(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	applicationName, err := cli.RequireApplication(cmd, *workspace)
+	applicationName, err := cmd.Flags().GetString("application")
 	if err != nil {
-		return err
+		return &cli.FriendlyError{Message: "Unable to parse command"}
 	}
 
 	client, err := connections.DefaultFactory.CreateApplicationsManagementClient(cmd.Context(), *workspace)

--- a/cmd/rad/cmd/resourceShow.go
+++ b/cmd/rad/cmd/resourceShow.go
@@ -15,6 +15,8 @@ import (
 )
 
 // resourceShowCmd command to show details of a resource
+// The application flag is redundant for show as resources are env scoped
+// The flag is useful for future behaviors where resources might be rg or subId scoped
 var resourceShowCmd = &cobra.Command{
 	Use:     "show [resourceType] [resourceName]",
 	Short:   "Show RAD resource details",
@@ -51,13 +53,6 @@ func showResource(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	// The application flag is redundant for show as resources are env scoped
-	// The flag is useful for future behaviors where resources might be rg or subId scoped
-	// applicationName, err := cmd.Flags().GetString("application")
-	// if err != nil {
-	// 	return &cli.FriendlyError{Message: "Unable to parse application name"}
-	// }
 
 	client, err := connections.DefaultFactory.CreateApplicationsManagementClient(cmd.Context(), *workspace)
 	if err != nil {

--- a/pkg/cli/clients/clients.go
+++ b/pkg/cli/clients/clients.go
@@ -134,7 +134,7 @@ type ApplicationsManagementClient interface {
 	ListAllResourcesByType(ctx context.Context, resourceType string) ([]generated.GenericResource, error)
 	ListAllResourceOfTypeInApplication(ctx context.Context, applicationName string, resourceType string) ([]generated.GenericResource, error)
 	ListAllResourcesByApplication(ctx context.Context, applicationName string) ([]generated.GenericResource, error)
-	ShowResourceByApplication(ctx context.Context, applicationName string, resourceType string, resourceName string) (generated.GenericResource, error)
+	ShowResource(ctx context.Context, resourceType string, resourceName string) (generated.GenericResource, error)
 	DeleteResource(ctx context.Context, resourceType string, resourceName string) (generated.GenericResourcesDeleteResponse, error)
 	ListApplications(ctx context.Context) ([]v20220315privatepreview.ApplicationResource, error)
 	ShowApplication(ctx context.Context, applicationName string) (corerp.ApplicationResource, error)

--- a/pkg/cli/ucp/ucp_management.go
+++ b/pkg/cli/ucp/ucp_management.go
@@ -90,7 +90,7 @@ func (amc *ARMApplicationsManagementClient) ListAllResourcesByApplication(ctx co
 	return results, nil
 }
 
-func (amc *ARMApplicationsManagementClient) ShowResourceByApplication(ctx context.Context, applicationName string, resourceType string, resourceName string) (generated.GenericResource, error) {
+func (amc *ARMApplicationsManagementClient) ShowResource(ctx context.Context, resourceType string, resourceName string) (generated.GenericResource, error) {
 	client := generated.NewGenericResourcesClient(amc.Connection, amc.RootScope, resourceType)
 	getResponse, err := client.Get(ctx, resourceName, &generated.GenericResourcesGetOptions{})
 	if err != nil {

--- a/test/functional/corerp/cli/cli_test.go
+++ b/test/functional/corerp/cli/cli_test.go
@@ -57,18 +57,7 @@ func verifyCLIBasics(ctx context.Context, t *testing.T, test corerp.CoreRPTest) 
 	})
 
 	t.Run("Validate rad resource show", func(t *testing.T) {
-		output, err := cli.ResourceShow(ctx, appName, "containers", "containera")
-		require.NoError(t, err)
-		// We are more interested in the content and less about the formatting, which
-		// is already covered by unit tests. The spaces change depending on the input
-		// and it takes very long to get a feedback from CI.
-		expected := regexp.MustCompile(`RESOURCE    TYPE\ncontainera  applications.core/containers\n`)
-		match := expected.MatchString(output)
-		require.Equal(t, true, match)
-	})
-
-	t.Run("Validate rad resource show with no application mentioned", func(t *testing.T) {
-		output, err := cli.ResourceShowNoApplicationFlag(ctx, "containers", "containera")
+		output, err := cli.ResourceShow(ctx, "containers", "containera")
 		require.NoError(t, err)
 		// We are more interested in the content and less about the formatting, which
 		// is already covered by unit tests. The spaces change depending on the input

--- a/test/functional/corerp/cli/cli_test.go
+++ b/test/functional/corerp/cli/cli_test.go
@@ -67,6 +67,17 @@ func verifyCLIBasics(ctx context.Context, t *testing.T, test corerp.CoreRPTest) 
 		require.Equal(t, true, match)
 	})
 
+	t.Run("Validate rad resource show with no application mentioned", func(t *testing.T) {
+		output, err := cli.ResourceShowNoApplicationFlag(ctx, "containers", "containera")
+		require.NoError(t, err)
+		// We are more interested in the content and less about the formatting, which
+		// is already covered by unit tests. The spaces change depending on the input
+		// and it takes very long to get a feedback from CI.
+		expected := regexp.MustCompile(`RESOURCE    TYPE\ncontainera  applications.core/containers\n`)
+		match := expected.MatchString(output)
+		require.Equal(t, true, match)
+	})
+
 	t.Run("Validate rad resoure logs containers", func(t *testing.T) {
 		output, err := cli.ResourceLogs(ctx, appName, "containera")
 		require.NoError(t, err)

--- a/test/radcli/cli.go
+++ b/test/radcli/cli.go
@@ -144,21 +144,11 @@ func (cli *CLI) EnvDelete(ctx context.Context, environmentName string) error {
 	return err
 }
 
-func (cli *CLI) ResourceShow(ctx context.Context, applicationName string, resourceType string, resourceName string) (string, error) {
+func (cli *CLI) ResourceShow(ctx context.Context, resourceType string, resourceName string) (string, error) {
 	args := []string{
 		"resource",
 		"show",
-		"-a", applicationName,
-		resourceType,
-		resourceName,
-	}
-	return cli.RunCommand(ctx, args)
-}
-
-func (cli *CLI) ResourceShowNoApplicationFlag(ctx context.Context, resourceType string, resourceName string) (string, error) {
-	args := []string{
-		"resource",
-		"show",
+		//"-a", applicationName, TODO: apply when application flag (-a) is re-enabled for rad resource show
 		resourceType,
 		resourceName,
 	}

--- a/test/radcli/cli.go
+++ b/test/radcli/cli.go
@@ -155,6 +155,16 @@ func (cli *CLI) ResourceShow(ctx context.Context, applicationName string, resour
 	return cli.RunCommand(ctx, args)
 }
 
+func (cli *CLI) ResourceShowNoApplicationFlag(ctx context.Context, resourceType string, resourceName string) (string, error) {
+	args := []string{
+		"resource",
+		"show",
+		resourceType,
+		resourceName,
+	}
+	return cli.RunCommand(ctx, args)
+}
+
 func (cli *CLI) ResourceList(ctx context.Context, applicationName string) (string, error) {
 	args := []string{
 		"resource",


### PR DESCRIPTION
# Description
- Updated the example and made application name optional because right now resource is associated with a scope

## Issue reference
https://github.com/project-radius/radius/issues/3247

Please reference the issue this PR will close: #_[3247]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
