### PR TITLE
Enabling Dapr test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,6 +147,7 @@ stages:
     - script: |
         kubectl get pods -n radius-system
         kubectl describe pods -n radius-system
+        kubectl create secret generic mysecret --from-literal=mysecret=mysecret
       condition: always()
       continueOnError: 'true'
     - script: |

--- a/test/functional/corerp/corerptest.go
+++ b/test/functional/corerp/corerptest.go
@@ -206,12 +206,6 @@ func (ct CoreRPTest) Test(t *testing.T) {
 		}
 	})
 
-	t.Logf("Creating secrets if provided")
-	err := ct.CreateSecrets(ctx)
-	if err != nil {
-		t.Errorf("failed to create secrets %v", err)
-	}
-
 	// Inside the integration test code we rely on the context for timeout/cancellation functionality.
 	// We expect the caller to wire this out to the test timeout system, or a stricter timeout if desired.
 
@@ -286,12 +280,6 @@ func (ct CoreRPTest) Test(t *testing.T) {
 				t.Logf("finished validation of deletion of pods for %s", ct.Description)
 			}
 		}
-	}
-
-	t.Logf("Deleting secrets")
-	err = ct.DeleteSecrets(ctx)
-	if err != nil {
-		t.Errorf("failed to delete secrets %v", err)
 	}
 
 	// Custom verification is expected to use `t` to trigger its own assertions

--- a/test/functional/corerp/corerptest.go
+++ b/test/functional/corerp/corerptest.go
@@ -211,7 +211,7 @@ func (ct CoreRPTest) Test(t *testing.T) {
 
 	require.GreaterOrEqual(t, len(ct.Steps), 1, "at least one step is required")
 	defer ct.CleanUpExtensionResources(ct.InitialResources)
-	err = ct.CreateInitialResources(ctx)
+	err := ct.CreateInitialResources(ctx)
 	require.NoError(t, err, "failed to create initial resources")
 
 	success := true

--- a/test/functional/corerp/resources/dapr_invokehttproute_test.go
+++ b/test/functional/corerp/resources/dapr_invokehttproute_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func Test_DaprInvokeHttpRoute(t *testing.T) {
-	t.Skip("https://github.com/project-radius/radius/issues/3182")
 	template := "testdata/corerp-resources-dapr-httproute.bicep"
 	name := "dapr-invokehttproute"
 

--- a/test/functional/corerp/resources/dapr_pubsub_test.go
+++ b/test/functional/corerp/resources/dapr_pubsub_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func Test_DaprPubSubGeneric(t *testing.T) {
-	t.Skip("https://github.com/project-radius/radius/issues/3182")
 	template := "testdata/corerp-resources-dapr-pubsub-generic.bicep"
 	name := "corerp-resources-dapr-pubsub-generic"
 

--- a/test/functional/corerp/resources/dapr_secretstore_test.go
+++ b/test/functional/corerp/resources/dapr_secretstore_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func Test_DaprSecretStoreGeneric(t *testing.T) {
-	t.Skip("https://github.com/project-radius/radius/issues/3182")
-
 	template := "testdata/corerp-resources-dapr-secretstore-generic.bicep"
 	name := "corerp-resources-dapr-secretstore-generic"
 

--- a/test/functional/corerp/resources/dapr_statestore_test.go
+++ b/test/functional/corerp/resources/dapr_statestore_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func Test_DaprStateStoreGeneric(t *testing.T) {
-	t.Skip("https://github.com/project-radius/radius/issues/3182")
-
 	template := "testdata/corerp-resources-dapr-statestore-generic.bicep"
 	name := "corerp-resources-dapr-statestore-generic"
 


### PR DESCRIPTION
# Description

Creating the secret during the starting of the pipeline so that the tests do not manage it. It helps with the tests failing to create the secrets for the Dapr secretstore functional test.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[#3182]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
