### PR TITLE
Adding rp.provider and rp.publicEndpointOverride back to the Helm Chart values.yaml

### DIFF
--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -16,4 +16,8 @@ global:
   radius:
     container: radius.azurecr.io/radius-controller
     tag: latest # Tag for radius-controller image.
+  rp:
+    provider:
+      azure: {}
+    publicEndpointOverride: ''
     


### PR DESCRIPTION
# Description
The two values that were deleted with this PR https://github.com/project-radius/radius/pull/3369 are put back in this PR.

## Issue reference
Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
