### PR TITLE
Handling deletion for non-existent envs/apps

### DIFF
--- a/cmd/rad/cmd/appDelete.go
+++ b/cmd/rad/cmd/appDelete.go
@@ -75,8 +75,7 @@ func DeleteApplication(ctx context.Context, workspace workspaces.Workspace, appl
 
 	appResp, err := client.DeleteApplication(ctx, applicationName)
 	if appResp.RawResponse.StatusCode == 204 {
-		return &cli.FriendlyError{Message: fmt.Sprintf("Application '%s' does not exist or has already been deleted.", applicationName)}
-		// output.LogInfo("Application '%s' does not exist or has already been deleted. Error Status Code: %d", applicationName, appResp.RawResponse.StatusCode)
+		output.LogInfo("Application '%s' does not exist or has already been deleted.", applicationName)
 	} else if err == nil {
 		output.LogInfo("Application deleted")
 	}

--- a/cmd/rad/cmd/appDelete.go
+++ b/cmd/rad/cmd/appDelete.go
@@ -75,7 +75,8 @@ func DeleteApplication(ctx context.Context, workspace workspaces.Workspace, appl
 
 	appResp, err := client.DeleteApplication(ctx, applicationName)
 	if appResp.RawResponse.StatusCode == 204 {
-		output.LogInfo("Application '%s' does not exist or has already been deleted. Error Status Code: %d", applicationName, appResp.RawResponse.StatusCode)
+		return &cli.FriendlyError{Message: fmt.Sprintf("Application '%s' does not exist or has already been deleted.", applicationName)}
+		// output.LogInfo("Application '%s' does not exist or has already been deleted. Error Status Code: %d", applicationName, appResp.RawResponse.StatusCode)
 	} else if err == nil {
 		output.LogInfo("Application deleted")
 	}

--- a/cmd/rad/cmd/appDelete.go
+++ b/cmd/rad/cmd/appDelete.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/connections"
+	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/project-radius/radius/pkg/cli/prompt"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/spf13/cobra"
@@ -72,10 +73,12 @@ func DeleteApplication(ctx context.Context, workspace workspaces.Workspace, appl
 		return err
 	}
 
-	_, err = client.DeleteApplication(ctx, applicationName)
-	if err != nil {
-		return err
+	appResp, err := client.DeleteApplication(ctx, applicationName)
+	if appResp.RawResponse.StatusCode == 204 {
+		output.LogInfo("Application '%s' does not exist or has already been deleted. Error Status Code: %d", applicationName, appResp.RawResponse.StatusCode)
+	} else if err == nil {
+		output.LogInfo("Application deleted")
 	}
 
-	return nil
+	return err
 }

--- a/cmd/rad/cmd/envDelete.go
+++ b/cmd/rad/cmd/envDelete.go
@@ -62,8 +62,10 @@ func deleteEnvResource(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = client.DeleteEnv(cmd.Context(), environmentName)
-	if err == nil {
+	envResp, err := client.DeleteEnv(cmd.Context(), environmentName)
+	if envResp.RawResponse.StatusCode == 204 {
+		output.LogInfo("Environment '%s' does not exist or has already been deleted. Error Status Code: %d", environmentName, envResp.RawResponse.StatusCode)
+	} else if err == nil {
 		output.LogInfo("Environment deleted")
 	}
 	return err

--- a/cmd/rad/cmd/envDelete.go
+++ b/cmd/rad/cmd/envDelete.go
@@ -64,8 +64,7 @@ func deleteEnvResource(cmd *cobra.Command, args []string) error {
 
 	envResp, err := client.DeleteEnv(cmd.Context(), environmentName)
 	if envResp.RawResponse.StatusCode == 204 {
-		return &cli.FriendlyError{Message: fmt.Sprintf("Environment '%s' does not exist or has already been deleted.", environmentName)}
-		// output.LogInfo("Environment '%s' does not exist or has already been deleted. Error Status Code: %d", environmentName, envResp.RawResponse.StatusCode)
+		output.LogInfo("Environment '%s' does not exist or has already been deleted.", environmentName)
 	} else if err == nil {
 		output.LogInfo("Environment deleted")
 	}

--- a/cmd/rad/cmd/envDelete.go
+++ b/cmd/rad/cmd/envDelete.go
@@ -64,7 +64,8 @@ func deleteEnvResource(cmd *cobra.Command, args []string) error {
 
 	envResp, err := client.DeleteEnv(cmd.Context(), environmentName)
 	if envResp.RawResponse.StatusCode == 204 {
-		output.LogInfo("Environment '%s' does not exist or has already been deleted. Error Status Code: %d", environmentName, envResp.RawResponse.StatusCode)
+		return &cli.FriendlyError{Message: fmt.Sprintf("Environment '%s' does not exist or has already been deleted.", environmentName)}
+		// output.LogInfo("Environment '%s' does not exist or has already been deleted. Error Status Code: %d", environmentName, envResp.RawResponse.StatusCode)
 	} else if err == nil {
 		output.LogInfo("Environment deleted")
 	}

--- a/pkg/cli/clients/clients.go
+++ b/pkg/cli/clients/clients.go
@@ -143,7 +143,7 @@ type ApplicationsManagementClient interface {
 	DeleteApplication(ctx context.Context, applicationName string) (v20220315privatepreview.ApplicationsDeleteResponse, error)
 	ListEnv(ctx context.Context) ([]corerp.EnvironmentResource, error)
 	GetEnvDetails(ctx context.Context, envName string) (corerp.EnvironmentResource, error)
-	DeleteEnv(ctx context.Context, envName string) error
+	DeleteEnv(ctx context.Context, envName string) (v20220315privatepreview.EnvironmentsDeleteResponse, error)
 }
 
 func ShallowCopy(params DeploymentParameters) DeploymentParameters {

--- a/pkg/cli/ucp/ucp_management.go
+++ b/pkg/cli/ucp/ucp_management.go
@@ -278,24 +278,24 @@ func (amc *ARMApplicationsManagementClient) GetEnvDetails(ctx context.Context, e
 
 }
 
-func (amc *ARMApplicationsManagementClient) DeleteEnv(ctx context.Context, envName string) error {
+func (amc *ARMApplicationsManagementClient) DeleteEnv(ctx context.Context, envName string) (corerp.EnvironmentsDeleteResponse, error) {
 	applicationsWithEnv, err := amc.ListApplicationsByEnv(ctx, envName)
 	if err != nil {
-		return err
+		return corerp.EnvironmentsDeleteResponse{}, err
 	}
 	for _, application := range applicationsWithEnv {
 		_, err := amc.DeleteApplication(ctx, *application.Name)
 		if err != nil {
-			return err
+			return corerp.EnvironmentsDeleteResponse{}, err
 		}
 	}
 	envClient := corerp.NewEnvironmentsClient(amc.Connection, amc.RootScope)
 
-	_, err = envClient.Delete(ctx, envName, &corerp.EnvironmentsDeleteOptions{})
+	envResp, err := envClient.Delete(ctx, envName, &corerp.EnvironmentsDeleteOptions{})
 	if err != nil {
-		return err
+		return corerp.EnvironmentsDeleteResponse{}, err
 	}
 
-	return nil
+	return envResp, err
 
 }

--- a/test/validation/corerp.go
+++ b/test/validation/corerp.go
@@ -47,7 +47,8 @@ type CoreRPResourceSet struct {
 func DeleteCoreRPResource(ctx context.Context, t *testing.T, cli *radcli.CLI, client clients.ApplicationsManagementClient, resource CoreRPResource) error {
 	if resource.Type == EnvironmentsResource {
 		t.Logf("deleting environment: %s", resource.Name)
-		return client.DeleteEnv(ctx, resource.Name)
+		_, err := client.DeleteEnv(ctx, resource.Name)
+		return err
 
 		// TODO: this should probably call the CLI, but if you create an
 		// environment via bicep deployment, it will not be reflected in the

--- a/test/validation/corerp.go
+++ b/test/validation/corerp.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/project-radius/radius/pkg/cli/clients"
+	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/stretchr/testify/require"
 
 	"github.com/project-radius/radius/test/radcli"
@@ -47,7 +48,10 @@ type CoreRPResourceSet struct {
 func DeleteCoreRPResource(ctx context.Context, t *testing.T, cli *radcli.CLI, client clients.ApplicationsManagementClient, resource CoreRPResource) error {
 	if resource.Type == EnvironmentsResource {
 		t.Logf("deleting environment: %s", resource.Name)
-		_, err := client.DeleteEnv(ctx, resource.Name)
+		envResp, err := client.DeleteEnv(ctx, resource.Name)
+		if envResp.RawResponse.StatusCode == 204 {
+			output.LogInfo("Environment '%s' does not exist or has already been deleted.", resource.Name)
+		}
 		return err
 
 		// TODO: this should probably call the CLI, but if you create an


### PR DESCRIPTION
# Description

Environments and applications can be deleted multiple times or deleted if they don't currently exist. Updated code to return output log saying env/app has already been deleted/doesn't exist if user tries to delete them. Addresses radius-project/core-team#850

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: radius-project/core-team#850

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [X ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
