### PR TITLE
Create Cadl models for Connector Resources with Secrets

### DIFF
--- a/cadl/Applications.Connector/cadl-output/extenders.json
+++ b/cadl/Applications.Connector/cadl-output/extenders.json
@@ -1,0 +1,630 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Applications.Connector Management APIs",
+    "version": "0000-00-00",
+    "description": "REST API for Applications.Connector Extender Resource",
+    "x-cadl-generated": [
+      {
+        "emitter": "@azure-tools/cadl-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": ""
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Extenders"
+    },
+    {
+      "name": "Operations"
+    }
+  ],
+  "paths": {
+    "/{rootScope}/providers/Applications.Connector/extenders": {
+      "get": {
+        "tags": [
+          "Extenders"
+        ],
+        "operationId": "Extenders_ListByResourceGroup",
+        "description": "List ExtenderResponseResource resources by resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExtenderResponseResourceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{rootScope}/providers/Applications.Connector/extenders/{extenderName}": {
+      "get": {
+        "tags": [
+          "Extenders"
+        ],
+        "operationId": "Extenders_Get",
+        "description": "Get a ExtenderResponseResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          },
+          {
+            "$ref": "#/parameters/ExtenderResponseResource.extenderName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExtenderResponseResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Extenders"
+        ],
+        "operationId": "Extenders_CreateOrUpdate",
+        "description": "Create a ExtenderResponseResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          },
+          {
+            "$ref": "#/parameters/ExtenderResponseResource.extenderName"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "required": true,
+            "description": "Resource create parameters.",
+            "schema": {
+              "$ref": "#/definitions/ExtenderResponseResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExtenderResponseResource"
+            }
+          },
+          "201": {
+            "description": "ARM create operation completed successfully.",
+            "headers": {
+              "Retry-After": {
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
+                "type": "integer",
+                "format": "int32"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/ExtenderResponseResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "Extenders"
+        ],
+        "operationId": "Extenders_Update",
+        "description": "Update a ExtenderResponseResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          },
+          {
+            "$ref": "#/parameters/ExtenderResponseResource.extenderName"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "required": true,
+            "description": "The resource properties to be updated.",
+            "schema": {
+              "$ref": "#/definitions/ExtenderResponseResourceUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExtenderResponseResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Extenders"
+        ],
+        "operationId": "Extenders_Delete",
+        "description": "Delete a ExtenderResponseResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          },
+          {
+            "$ref": "#/parameters/ExtenderResponseResource.extenderName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "204": {
+            "description": "Resource deleted successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/{rootScope}/providers/Applications.Connector/extenders/{extenderName}/listSecrets": {
+      "get": {
+        "operationId": "Post",
+        "description": "Lists secrets values for the specified Extender resource",
+        "parameters": [
+          {
+            "name": "rootScope",
+            "in": "path",
+            "required": true,
+            "description": "Custom root scope",
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "name": "extenderName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "schema": {
+                  "$ref": "#/definitions/ExtenderListSecretsResult"
+                }
+              },
+              "required": [
+                "schema"
+              ],
+              "x-cadl-name": "(anonymous model)"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Applications.Connector/operations": {
+      "get": {
+        "tags": [
+          "Operations"
+        ],
+        "operationId": "Operations_List",
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Application": {
+      "type": "string",
+      "description": "Fully qualified resource ID for the application that the connector is consumed by"
+    },
+    "BasicResourceProperties": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ResourceStatus",
+          "description": "Status of a resource."
+        }
+      },
+      "description": "Basic properties of a Radius resource.",
+      "required": [
+        "status"
+      ]
+    },
+    "ErrorAdditionalInfo": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The additional info type",
+          "readOnly": true
+        },
+        "info": {
+          "type": "string",
+          "description": "The additional info",
+          "readOnly": true
+        }
+      },
+      "description": "The resource management error additional info.",
+      "required": [
+        "type",
+        "info"
+      ]
+    },
+    "ErrorDetail": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The error code",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message",
+          "readOnly": true
+        },
+        "target": {
+          "type": "string",
+          "description": "The error target",
+          "readOnly": true
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ErrorDetail"
+          },
+          "x-ms-identifiers": [
+            "target",
+            "message"
+          ],
+          "x-cadl-name": "ErrorDetail[]",
+          "description": "The error details",
+          "readOnly": true
+        },
+        "additionalInfo": {
+          "$ref": "#/definitions/ErrorAdditionalInfo",
+          "description": "The error additional info",
+          "readOnly": true
+        }
+      },
+      "description": "The error detail",
+      "required": [
+        "code",
+        "message",
+        "target",
+        "details",
+        "additionalInfo"
+      ]
+    },
+    "ErrorResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/ErrorDetail",
+          "description": "The error object."
+        }
+      },
+      "description": "Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).",
+      "required": [
+        "error"
+      ]
+    },
+    "ExtenderListSecretsResult": {
+      "type": "object",
+      "properties": {},
+      "description": "The secret values for the given Extender resource"
+    },
+    "ExtenderProperties": {
+      "type": "object",
+      "properties": {
+        "secrets": {
+          "$ref": "#/definitions/ExtenderSecrets",
+          "description": "The secrets value for the resource"
+        }
+      },
+      "description": "Extender connector properties",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ExtenderResponseProperties"
+        }
+      ]
+    },
+    "ExtenderResponseProperties": {
+      "type": "object",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Provisioning state of the extender connector at the time the operation was called",
+          "readOnly": true
+        },
+        "environment": {
+          "type": "string",
+          "description": "Fully qualified resource ID for the environment that the connector is linked to"
+        },
+        "application": {
+          "$ref": "#/definitions/Application",
+          "description": "Fully qualified resource ID for the application that the connector is consumed by"
+        }
+      },
+      "description": "Extender connector properties",
+      "required": [
+        "environment"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BasicResourceProperties"
+        }
+      ]
+    },
+    "ExtenderResponseResource": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExtenderResponseProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ],
+          "x-ms-client-flatten": true
+        }
+      },
+      "description": "Extender connector",
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ExtenderResponseResourceListResult": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ExtenderResponseResource"
+          },
+          "x-cadl-name": "ExtenderResponseResource[]",
+          "description": "The ExtenderResponseResource items on this page"
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page of items",
+          "x-cadl-name": "Rest.ResourceLocation<ExtenderResponseResource>"
+        }
+      },
+      "description": "The response of a ExtenderResponseResource list operation.",
+      "required": [
+        "value"
+      ]
+    },
+    "ExtenderResponseResourceUpdate": {
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-cadl-name": "Record<string>",
+          "description": "Resource tags."
+        },
+        "properties": {
+          "$ref": "#/definitions/ExtenderResponseResourceUpdateProperties"
+        }
+      },
+      "description": "The type used for update operations of the ExtenderResponseResource."
+    },
+    "ExtenderResponseResourceUpdateProperties": {
+      "type": "object",
+      "properties": {
+        "environment": {
+          "type": "string",
+          "description": "Fully qualified resource ID for the environment that the connector is linked to"
+        },
+        "application": {
+          "$ref": "#/definitions/Application",
+          "description": "Fully qualified resource ID for the application that the connector is consumed by"
+        },
+        "status": {
+          "$ref": "#/definitions/ResourceStatus",
+          "description": "Status of a resource."
+        }
+      },
+      "description": "The updatable properties of the ExtenderResponseResource."
+    },
+    "ExtenderSecrets": {
+      "type": "object",
+      "properties": {},
+      "description": "The secret values for the given Extender resource"
+    },
+    "OutputResource": {
+      "type": "object",
+      "properties": {},
+      "description": "Properties of an output resource."
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Provisioning",
+        "Updating",
+        "Deleting",
+        "Accepted"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true
+      }
+    },
+    "ResourceStatus": {
+      "type": "object",
+      "properties": {
+        "outputResources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OutputResource"
+          },
+          "x-ms-identifiers": [],
+          "x-cadl-name": "OutputResource[]",
+          "description": "Properties of an output resource"
+        }
+      },
+      "description": "Status of a resource.",
+      "required": [
+        "outputResources"
+      ]
+    }
+  },
+  "parameters": {
+    "ExtenderResponseResource.extenderName": {
+      "name": "extenderName",
+      "in": "path",
+      "required": true,
+      "description": "Extender name",
+      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+      "maxLength": 63,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "RootScopeParam": {
+      "name": "rootScope",
+      "in": "path",
+      "required": true,
+      "description": "root scope path",
+      "minLength": 1,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/cadl/Applications.Connector/cadl-output/extenders.json
+++ b/cadl/Applications.Connector/cadl-output/extenders.json
@@ -347,7 +347,8 @@
       "properties": {
         "status": {
           "$ref": "#/definitions/ResourceStatus",
-          "description": "Status of a resource."
+          "description": "Status of a resource.",
+          "readOnly": true
         }
       },
       "description": "Basic properties of a Radius resource.",
@@ -553,10 +554,6 @@
         "application": {
           "$ref": "#/definitions/Application",
           "description": "Fully qualified resource ID for the application that the connector is consumed by"
-        },
-        "status": {
-          "$ref": "#/definitions/ResourceStatus",
-          "description": "Status of a resource."
         }
       },
       "description": "The updatable properties of the ExtenderResponseResource."

--- a/cadl/Applications.Connector/cadl-output/mongoDatabases.json
+++ b/cadl/Applications.Connector/cadl-output/mongoDatabases.json
@@ -1,0 +1,688 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Applications.Connector Management APIs",
+    "version": "0000-00-00",
+    "description": "REST API for Applications.Connector MongoDatabase Resource",
+    "x-cadl-generated": [
+      {
+        "emitter": "@azure-tools/cadl-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": ""
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "MongoDatabases"
+    },
+    {
+      "name": "Operations"
+    }
+  ],
+  "paths": {
+    "/{rootScope}/providers/Applications.Connector/mongoDatabases": {
+      "get": {
+        "tags": [
+          "MongoDatabases"
+        ],
+        "operationId": "MongoDatabases_ListByResourceGroup",
+        "description": "List MongoDatabaseResponseResource resources by resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MongoDatabaseResponseResourceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{rootScope}/providers/Applications.Connector/mongoDatabases/{mongoDatabaseName}": {
+      "get": {
+        "tags": [
+          "MongoDatabases"
+        ],
+        "operationId": "MongoDatabases_Get",
+        "description": "Get a MongoDatabaseResponseResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          },
+          {
+            "$ref": "#/parameters/MongoDatabaseResponseResource.mongoDatabaseName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MongoDatabaseResponseResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "MongoDatabases"
+        ],
+        "operationId": "MongoDatabases_CreateOrUpdate",
+        "description": "Create a MongoDatabaseResponseResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          },
+          {
+            "$ref": "#/parameters/MongoDatabaseResponseResource.mongoDatabaseName"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "required": true,
+            "description": "Resource create parameters.",
+            "schema": {
+              "$ref": "#/definitions/MongoDatabaseResponseResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MongoDatabaseResponseResource"
+            }
+          },
+          "201": {
+            "description": "ARM create operation completed successfully.",
+            "headers": {
+              "Retry-After": {
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
+                "type": "integer",
+                "format": "int32"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/MongoDatabaseResponseResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "MongoDatabases"
+        ],
+        "operationId": "MongoDatabases_Update",
+        "description": "Update a MongoDatabaseResponseResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          },
+          {
+            "$ref": "#/parameters/MongoDatabaseResponseResource.mongoDatabaseName"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "required": true,
+            "description": "The resource properties to be updated.",
+            "schema": {
+              "$ref": "#/definitions/MongoDatabaseResponseResourceUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MongoDatabaseResponseResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "MongoDatabases"
+        ],
+        "operationId": "MongoDatabases_Delete",
+        "description": "Delete a MongoDatabaseResponseResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          },
+          {
+            "$ref": "#/parameters/MongoDatabaseResponseResource.mongoDatabaseName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "204": {
+            "description": "Resource deleted successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/{rootScope}/providers/Applications.Connector/mongoDatabases/{mongoDatabaseName}/listSecrets": {
+      "get": {
+        "operationId": "Post",
+        "description": "Lists secrets values for the specified MongoDatabase resource",
+        "parameters": [
+          {
+            "name": "rootScope",
+            "in": "path",
+            "required": true,
+            "description": "Custom root scope",
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "name": "mongoDatabaseName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "schema": {
+                  "$ref": "#/definitions/MongoDatabaseListSecretsResult"
+                }
+              },
+              "required": [
+                "schema"
+              ],
+              "x-cadl-name": "(anonymous model)"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Applications.Connector/operations": {
+      "get": {
+        "tags": [
+          "Operations"
+        ],
+        "operationId": "Operations_List",
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Application": {
+      "type": "string",
+      "description": "Fully qualified resource ID for the application that the connector is consumed by"
+    },
+    "BasicResourceProperties": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ResourceStatus",
+          "description": "Status of a resource."
+        }
+      },
+      "description": "Basic properties of a Radius resource.",
+      "required": [
+        "status"
+      ]
+    },
+    "ErrorAdditionalInfo": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The additional info type",
+          "readOnly": true
+        },
+        "info": {
+          "type": "string",
+          "description": "The additional info",
+          "readOnly": true
+        }
+      },
+      "description": "The resource management error additional info.",
+      "required": [
+        "type",
+        "info"
+      ]
+    },
+    "ErrorDetail": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The error code",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message",
+          "readOnly": true
+        },
+        "target": {
+          "type": "string",
+          "description": "The error target",
+          "readOnly": true
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ErrorDetail"
+          },
+          "x-ms-identifiers": [
+            "target",
+            "message"
+          ],
+          "x-cadl-name": "ErrorDetail[]",
+          "description": "The error details",
+          "readOnly": true
+        },
+        "additionalInfo": {
+          "$ref": "#/definitions/ErrorAdditionalInfo",
+          "description": "The error additional info",
+          "readOnly": true
+        }
+      },
+      "description": "The error detail",
+      "required": [
+        "code",
+        "message",
+        "target",
+        "details",
+        "additionalInfo"
+      ]
+    },
+    "ErrorResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/ErrorDetail",
+          "description": "The error object."
+        }
+      },
+      "description": "Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).",
+      "required": [
+        "error"
+      ]
+    },
+    "MongoDatabaseListSecretsResult": {
+      "type": "object",
+      "properties": {
+        "username": {
+          "type": "string",
+          "description": "Username to use when connecting to the target Mongo database"
+        },
+        "password": {
+          "type": "string",
+          "description": "Password to use when connecting to the target Mongo database"
+        },
+        "connectionString": {
+          "type": "string",
+          "description": "Connection string used to connect to the target Mongo database"
+        }
+      },
+      "description": "The secret values for the given MongoDatabase resource"
+    },
+    "MongoDatabaseProperties": {
+      "type": "object",
+      "properties": {
+        "secrets": {
+          "$ref": "#/definitions/MongoDatabaseSecrets",
+          "description": "Secrets values provided for the resource"
+        }
+      },
+      "description": "MongoDatabase connector properties",
+      "allOf": [
+        {
+          "$ref": "#/definitions/MongoDatabaseResponseProperties"
+        }
+      ]
+    },
+    "MongoDatabaseResponseProperties": {
+      "type": "object",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Provisioning state of the mongo database connector at the time the operation was called",
+          "readOnly": true
+        },
+        "environment": {
+          "type": "string",
+          "description": "Fully qualified resource ID for the environment that the connector is linked to"
+        },
+        "application": {
+          "$ref": "#/definitions/Application",
+          "description": "Fully qualified resource ID for the application that the connector is consumed by"
+        },
+        "resource": {
+          "type": "string",
+          "description": "Fully qualified resource ID of a supported resource with Mongo API to use for this connector"
+        },
+        "host": {
+          "type": "string",
+          "description": "Host name of the target Mongo database"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Port value of the target Mongo database"
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name of the target Mongo database",
+          "readOnly": true
+        }
+      },
+      "description": "MongoDatabase connector properties",
+      "required": [
+        "environment",
+        "database"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BasicResourceProperties"
+        }
+      ]
+    },
+    "MongoDatabaseResponseResource": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/MongoDatabaseResponseProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ],
+          "x-ms-client-flatten": true
+        }
+      },
+      "description": "MongoDatabase connector",
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "MongoDatabaseResponseResourceListResult": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MongoDatabaseResponseResource"
+          },
+          "x-cadl-name": "MongoDatabaseResponseResource[]",
+          "description": "The MongoDatabaseResponseResource items on this page"
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page of items",
+          "x-cadl-name": "Rest.ResourceLocation<MongoDatabaseResponseResource>"
+        }
+      },
+      "description": "The response of a MongoDatabaseResponseResource list operation.",
+      "required": [
+        "value"
+      ]
+    },
+    "MongoDatabaseResponseResourceUpdate": {
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-cadl-name": "Record<string>",
+          "description": "Resource tags."
+        },
+        "properties": {
+          "$ref": "#/definitions/MongoDatabaseResponseResourceUpdateProperties"
+        }
+      },
+      "description": "The type used for update operations of the MongoDatabaseResponseResource."
+    },
+    "MongoDatabaseResponseResourceUpdateProperties": {
+      "type": "object",
+      "properties": {
+        "environment": {
+          "type": "string",
+          "description": "Fully qualified resource ID for the environment that the connector is linked to"
+        },
+        "application": {
+          "$ref": "#/definitions/Application",
+          "description": "Fully qualified resource ID for the application that the connector is consumed by"
+        },
+        "resource": {
+          "type": "string",
+          "description": "Fully qualified resource ID of a supported resource with Mongo API to use for this connector"
+        },
+        "host": {
+          "type": "string",
+          "description": "Host name of the target Mongo database"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Port value of the target Mongo database"
+        },
+        "status": {
+          "$ref": "#/definitions/ResourceStatus",
+          "description": "Status of a resource."
+        }
+      },
+      "description": "The updatable properties of the MongoDatabaseResponseResource."
+    },
+    "MongoDatabaseSecrets": {
+      "type": "object",
+      "properties": {
+        "username": {
+          "type": "string",
+          "description": "Username to use when connecting to the target Mongo database"
+        },
+        "password": {
+          "type": "string",
+          "description": "Password to use when connecting to the target Mongo database"
+        },
+        "connectionString": {
+          "type": "string",
+          "description": "Connection string used to connect to the target Mongo database"
+        }
+      },
+      "description": "The secret values for the given MongoDatabase resource"
+    },
+    "OutputResource": {
+      "type": "object",
+      "properties": {},
+      "description": "Properties of an output resource."
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Provisioning",
+        "Updating",
+        "Deleting",
+        "Accepted"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true
+      }
+    },
+    "ResourceStatus": {
+      "type": "object",
+      "properties": {
+        "outputResources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OutputResource"
+          },
+          "x-ms-identifiers": [],
+          "x-cadl-name": "OutputResource[]",
+          "description": "Properties of an output resource"
+        }
+      },
+      "description": "Status of a resource.",
+      "required": [
+        "outputResources"
+      ]
+    }
+  },
+  "parameters": {
+    "MongoDatabaseResponseResource.mongoDatabaseName": {
+      "name": "mongoDatabaseName",
+      "in": "path",
+      "required": true,
+      "description": "The name of the MongoDatabase connector resource",
+      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+      "maxLength": 63,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "RootScopeParam": {
+      "name": "rootScope",
+      "in": "path",
+      "required": true,
+      "description": "root scope path",
+      "minLength": 1,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/cadl/Applications.Connector/cadl-output/mongoDatabases.json
+++ b/cadl/Applications.Connector/cadl-output/mongoDatabases.json
@@ -347,7 +347,8 @@
       "properties": {
         "status": {
           "$ref": "#/definitions/ResourceStatus",
-          "description": "Status of a resource."
+          "description": "Status of a resource.",
+          "readOnly": true
         }
       },
       "description": "Basic properties of a Radius resource.",
@@ -598,10 +599,6 @@
           "type": "integer",
           "format": "int32",
           "description": "Port value of the target Mongo database"
-        },
-        "status": {
-          "$ref": "#/definitions/ResourceStatus",
-          "description": "Status of a resource."
         }
       },
       "description": "The updatable properties of the MongoDatabaseResponseResource."

--- a/cadl/Applications.Connector/cadl-output/rabbitMQMessageQueues.json
+++ b/cadl/Applications.Connector/cadl-output/rabbitMQMessageQueues.json
@@ -347,7 +347,8 @@
       "properties": {
         "status": {
           "$ref": "#/definitions/ResourceStatus",
-          "description": "Status of a resource."
+          "description": "Status of a resource.",
+          "readOnly": true
         }
       },
       "description": "Basic properties of a Radius resource.",
@@ -588,10 +589,6 @@
         "queue": {
           "type": "string",
           "description": "The name of the queue"
-        },
-        "status": {
-          "$ref": "#/definitions/ResourceStatus",
-          "description": "Status of a resource."
         }
       },
       "description": "The updatable properties of the RabbitMQMessageQueueResponseResource."

--- a/cadl/Applications.Connector/cadl-output/rabbitMQMessageQueues.json
+++ b/cadl/Applications.Connector/cadl-output/rabbitMQMessageQueues.json
@@ -1,0 +1,649 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Applications.Connector Management APIs",
+    "version": "0000-00-00",
+    "description": "REST API for Applications.Connector RabbitMQMessageQueue Resource",
+    "x-cadl-generated": [
+      {
+        "emitter": "@azure-tools/cadl-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": ""
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "RabbitMQMessageQueues"
+    },
+    {
+      "name": "Operations"
+    }
+  ],
+  "paths": {
+    "/{rootScope}/providers/Applications.Connector/rabbitMQMessageQueues": {
+      "get": {
+        "tags": [
+          "RabbitMQMessageQueues"
+        ],
+        "operationId": "RabbitMqMessageQueues_ListByResourceGroup",
+        "description": "List RabbitMQMessageQueueResponseResource resources by resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RabbitMQMessageQueueResponseResourceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{rootScope}/providers/Applications.Connector/rabbitMQMessageQueues/{rabbitMQMessageQueueName}": {
+      "get": {
+        "tags": [
+          "RabbitMQMessageQueues"
+        ],
+        "operationId": "RabbitMqMessageQueues_Get",
+        "description": "Get a RabbitMQMessageQueueResponseResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          },
+          {
+            "$ref": "#/parameters/RabbitMQMessageQueueResponseResource.rabbitMQMessageQueueName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RabbitMQMessageQueueResponseResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "RabbitMQMessageQueues"
+        ],
+        "operationId": "RabbitMqMessageQueues_CreateOrUpdate",
+        "description": "Create a RabbitMQMessageQueueResponseResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          },
+          {
+            "$ref": "#/parameters/RabbitMQMessageQueueResponseResource.rabbitMQMessageQueueName"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "required": true,
+            "description": "Resource create parameters.",
+            "schema": {
+              "$ref": "#/definitions/RabbitMQMessageQueueResponseResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RabbitMQMessageQueueResponseResource"
+            }
+          },
+          "201": {
+            "description": "ARM create operation completed successfully.",
+            "headers": {
+              "Retry-After": {
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
+                "type": "integer",
+                "format": "int32"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/RabbitMQMessageQueueResponseResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "RabbitMQMessageQueues"
+        ],
+        "operationId": "RabbitMqMessageQueues_Update",
+        "description": "Update a RabbitMQMessageQueueResponseResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          },
+          {
+            "$ref": "#/parameters/RabbitMQMessageQueueResponseResource.rabbitMQMessageQueueName"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "required": true,
+            "description": "The resource properties to be updated.",
+            "schema": {
+              "$ref": "#/definitions/RabbitMQMessageQueueResponseResourceUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RabbitMQMessageQueueResponseResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "RabbitMQMessageQueues"
+        ],
+        "operationId": "RabbitMqMessageQueues_Delete",
+        "description": "Delete a RabbitMQMessageQueueResponseResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          },
+          {
+            "$ref": "#/parameters/RabbitMQMessageQueueResponseResource.rabbitMQMessageQueueName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "204": {
+            "description": "Resource deleted successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/{rootScope}/providers/Applications.Connector/rabbitMQMessageQueues/{rabbitMQMessageQueueName}/listSecrets": {
+      "get": {
+        "operationId": "Post",
+        "description": "Lists secrets values for the specified RabbitMQMessageQueue resource",
+        "parameters": [
+          {
+            "name": "rootScope",
+            "in": "path",
+            "required": true,
+            "description": "Custom root scope",
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "name": "rabbitMQMessageQueueName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "schema": {
+                  "$ref": "#/definitions/RabbitMQListSecretsResult"
+                }
+              },
+              "required": [
+                "schema"
+              ],
+              "x-cadl-name": "(anonymous model)"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Applications.Connector/operations": {
+      "get": {
+        "tags": [
+          "Operations"
+        ],
+        "operationId": "Operations_List",
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Application": {
+      "type": "string",
+      "description": "Fully qualified resource ID for the application that the connector is consumed by"
+    },
+    "BasicResourceProperties": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ResourceStatus",
+          "description": "Status of a resource."
+        }
+      },
+      "description": "Basic properties of a Radius resource.",
+      "required": [
+        "status"
+      ]
+    },
+    "ErrorAdditionalInfo": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The additional info type",
+          "readOnly": true
+        },
+        "info": {
+          "type": "string",
+          "description": "The additional info",
+          "readOnly": true
+        }
+      },
+      "description": "The resource management error additional info.",
+      "required": [
+        "type",
+        "info"
+      ]
+    },
+    "ErrorDetail": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The error code",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message",
+          "readOnly": true
+        },
+        "target": {
+          "type": "string",
+          "description": "The error target",
+          "readOnly": true
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ErrorDetail"
+          },
+          "x-ms-identifiers": [
+            "target",
+            "message"
+          ],
+          "x-cadl-name": "ErrorDetail[]",
+          "description": "The error details",
+          "readOnly": true
+        },
+        "additionalInfo": {
+          "$ref": "#/definitions/ErrorAdditionalInfo",
+          "description": "The error additional info",
+          "readOnly": true
+        }
+      },
+      "description": "The error detail",
+      "required": [
+        "code",
+        "message",
+        "target",
+        "details",
+        "additionalInfo"
+      ]
+    },
+    "ErrorResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/ErrorDetail",
+          "description": "The error object."
+        }
+      },
+      "description": "Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).",
+      "required": [
+        "error"
+      ]
+    },
+    "OutputResource": {
+      "type": "object",
+      "properties": {},
+      "description": "Properties of an output resource."
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Provisioning",
+        "Updating",
+        "Deleting",
+        "Accepted"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true
+      }
+    },
+    "RabbitMQListSecretsResult": {
+      "type": "object",
+      "properties": {
+        "connectionString": {
+          "type": "string",
+          "description": "The connection string used to connect to this RabbitMQ instance"
+        }
+      },
+      "description": "The secret values for the given RabbitMQMessageQueue resource"
+    },
+    "RabbitMQMessageQueueProperties": {
+      "type": "object",
+      "properties": {
+        "secrets": {
+          "$ref": "#/definitions/RabbitMQSecrets",
+          "description": "Secrets provided by resources,"
+        }
+      },
+      "description": "RabbitMQMessageQueue connector response properties",
+      "allOf": [
+        {
+          "$ref": "#/definitions/RabbitMQMessageQueueResponseProperties"
+        }
+      ]
+    },
+    "RabbitMQMessageQueueResponseProperties": {
+      "type": "object",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Provisioning state of the rabbitMQ message queue connector at the time the operation was called",
+          "readOnly": true
+        },
+        "environment": {
+          "type": "string",
+          "description": "Fully qualified resource ID for the environment that the connector is linked to"
+        },
+        "application": {
+          "$ref": "#/definitions/Application",
+          "description": "Fully qualified resource ID for the application that the connector is consumed by"
+        },
+        "queue": {
+          "type": "string",
+          "description": "The name of the queue"
+        }
+      },
+      "description": "RabbitMQMessageQueue connector response properties",
+      "required": [
+        "environment",
+        "queue"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BasicResourceProperties"
+        }
+      ]
+    },
+    "RabbitMQMessageQueueResponseResource": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RabbitMQMessageQueueResponseProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ],
+          "x-ms-client-flatten": true
+        }
+      },
+      "description": "RabbitMQMessageQueue connector",
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "RabbitMQMessageQueueResponseResourceListResult": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RabbitMQMessageQueueResponseResource"
+          },
+          "x-cadl-name": "RabbitMQMessageQueueResponseResource[]",
+          "description": "The RabbitMQMessageQueueResponseResource items on this page"
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page of items",
+          "x-cadl-name": "Rest.ResourceLocation<RabbitMQMessageQueueResponseResource>"
+        }
+      },
+      "description": "The response of a RabbitMQMessageQueueResponseResource list operation.",
+      "required": [
+        "value"
+      ]
+    },
+    "RabbitMQMessageQueueResponseResourceUpdate": {
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-cadl-name": "Record<string>",
+          "description": "Resource tags."
+        },
+        "properties": {
+          "$ref": "#/definitions/RabbitMQMessageQueueResponseResourceUpdateProperties"
+        }
+      },
+      "description": "The type used for update operations of the RabbitMQMessageQueueResponseResource."
+    },
+    "RabbitMQMessageQueueResponseResourceUpdateProperties": {
+      "type": "object",
+      "properties": {
+        "environment": {
+          "type": "string",
+          "description": "Fully qualified resource ID for the environment that the connector is linked to"
+        },
+        "application": {
+          "$ref": "#/definitions/Application",
+          "description": "Fully qualified resource ID for the application that the connector is consumed by"
+        },
+        "queue": {
+          "type": "string",
+          "description": "The name of the queue"
+        },
+        "status": {
+          "$ref": "#/definitions/ResourceStatus",
+          "description": "Status of a resource."
+        }
+      },
+      "description": "The updatable properties of the RabbitMQMessageQueueResponseResource."
+    },
+    "RabbitMQSecrets": {
+      "type": "object",
+      "properties": {
+        "connectionString": {
+          "type": "string",
+          "description": "The connection string used to connect to this RabbitMQ instance"
+        }
+      },
+      "description": "The secret values for the given RabbitMQMessageQueue resource"
+    },
+    "ResourceStatus": {
+      "type": "object",
+      "properties": {
+        "outputResources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OutputResource"
+          },
+          "x-ms-identifiers": [],
+          "x-cadl-name": "OutputResource[]",
+          "description": "Properties of an output resource"
+        }
+      },
+      "description": "Status of a resource.",
+      "required": [
+        "outputResources"
+      ]
+    }
+  },
+  "parameters": {
+    "RabbitMQMessageQueueResponseResource.rabbitMQMessageQueueName": {
+      "name": "rabbitMQMessageQueueName",
+      "in": "path",
+      "required": true,
+      "description": "The name of the RabbitMQMessageQueue connector resource",
+      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+      "maxLength": 63,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "RootScopeParam": {
+      "name": "rootScope",
+      "in": "path",
+      "required": true,
+      "description": "root scope path",
+      "minLength": 1,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/cadl/Applications.Connector/cadl-output/redisCaches.json
+++ b/cadl/Applications.Connector/cadl-output/redisCaches.json
@@ -347,7 +347,8 @@
       "properties": {
         "status": {
           "$ref": "#/definitions/ResourceStatus",
-          "description": "Status of a resource."
+          "description": "Status of a resource.",
+          "readOnly": true
         }
       },
       "description": "Basic properties of a Radius resource.",
@@ -617,10 +618,6 @@
         "username": {
           "type": "string",
           "description": "The username for redis"
-        },
-        "status": {
-          "$ref": "#/definitions/ResourceStatus",
-          "description": "Status of a resource."
         }
       },
       "description": "The updatable properties of the RedisCacheResponseResource."

--- a/cadl/Applications.Connector/cadl-output/redisCaches.json
+++ b/cadl/Applications.Connector/cadl-output/redisCaches.json
@@ -1,0 +1,682 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Applications.Connector Management APIs",
+    "version": "0000-00-00",
+    "description": "REST API for Applications.Connector RedisCache Resource",
+    "x-cadl-generated": [
+      {
+        "emitter": "@azure-tools/cadl-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": ""
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "RedisCaches"
+    },
+    {
+      "name": "Operations"
+    }
+  ],
+  "paths": {
+    "/{rootScope}/providers/Applications.Connector/redisCaches": {
+      "get": {
+        "tags": [
+          "RedisCaches"
+        ],
+        "operationId": "RedisCaches_ListByResourceGroup",
+        "description": "List RedisCacheResponseResource resources by resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RedisCacheResponseResourceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{rootScope}/providers/Applications.Connector/redisCaches/{redisCacheName}": {
+      "get": {
+        "tags": [
+          "RedisCaches"
+        ],
+        "operationId": "RedisCaches_Get",
+        "description": "Get a RedisCacheResponseResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          },
+          {
+            "$ref": "#/parameters/RedisCacheResponseResource.redisCacheName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RedisCacheResponseResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "RedisCaches"
+        ],
+        "operationId": "RedisCaches_CreateOrUpdate",
+        "description": "Create a RedisCacheResponseResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          },
+          {
+            "$ref": "#/parameters/RedisCacheResponseResource.redisCacheName"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "required": true,
+            "description": "Resource create parameters.",
+            "schema": {
+              "$ref": "#/definitions/RedisCacheResponseResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RedisCacheResponseResource"
+            }
+          },
+          "201": {
+            "description": "ARM create operation completed successfully.",
+            "headers": {
+              "Retry-After": {
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
+                "type": "integer",
+                "format": "int32"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/RedisCacheResponseResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "tags": [
+          "RedisCaches"
+        ],
+        "operationId": "RedisCaches_Update",
+        "description": "Update a RedisCacheResponseResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          },
+          {
+            "$ref": "#/parameters/RedisCacheResponseResource.redisCacheName"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "required": true,
+            "description": "The resource properties to be updated.",
+            "schema": {
+              "$ref": "#/definitions/RedisCacheResponseResourceUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RedisCacheResponseResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "RedisCaches"
+        ],
+        "operationId": "RedisCaches_Delete",
+        "description": "Delete a RedisCacheResponseResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParam"
+          },
+          {
+            "$ref": "#/parameters/RedisCacheResponseResource.redisCacheName"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "204": {
+            "description": "Resource deleted successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/{rootScope}/providers/Applications.Connector/redisCaches/{redisCacheName}/listSecrets": {
+      "get": {
+        "operationId": "Post",
+        "description": "Lists secrets values for the specified RedisCache resource",
+        "parameters": [
+          {
+            "name": "rootScope",
+            "in": "path",
+            "required": true,
+            "description": "Custom root scope",
+            "type": "object",
+            "properties": {}
+          },
+          {
+            "name": "redisCacheName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "schema": {
+                  "$ref": "#/definitions/RedisCacheListSecretsResult"
+                }
+              },
+              "required": [
+                "schema"
+              ],
+              "x-cadl-name": "(anonymous model)"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Applications.Connector/operations": {
+      "get": {
+        "tags": [
+          "Operations"
+        ],
+        "operationId": "Operations_List",
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Application": {
+      "type": "string",
+      "description": "Fully qualified resource ID for the application that the connector is consumed by"
+    },
+    "BasicResourceProperties": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ResourceStatus",
+          "description": "Status of a resource."
+        }
+      },
+      "description": "Basic properties of a Radius resource.",
+      "required": [
+        "status"
+      ]
+    },
+    "ErrorAdditionalInfo": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The additional info type",
+          "readOnly": true
+        },
+        "info": {
+          "type": "string",
+          "description": "The additional info",
+          "readOnly": true
+        }
+      },
+      "description": "The resource management error additional info.",
+      "required": [
+        "type",
+        "info"
+      ]
+    },
+    "ErrorDetail": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The error code",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message",
+          "readOnly": true
+        },
+        "target": {
+          "type": "string",
+          "description": "The error target",
+          "readOnly": true
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ErrorDetail"
+          },
+          "x-ms-identifiers": [
+            "target",
+            "message"
+          ],
+          "x-cadl-name": "ErrorDetail[]",
+          "description": "The error details",
+          "readOnly": true
+        },
+        "additionalInfo": {
+          "$ref": "#/definitions/ErrorAdditionalInfo",
+          "description": "The error additional info",
+          "readOnly": true
+        }
+      },
+      "description": "The error detail",
+      "required": [
+        "code",
+        "message",
+        "target",
+        "details",
+        "additionalInfo"
+      ]
+    },
+    "ErrorResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/ErrorDetail",
+          "description": "The error object."
+        }
+      },
+      "description": "Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).",
+      "required": [
+        "error"
+      ]
+    },
+    "OutputResource": {
+      "type": "object",
+      "properties": {},
+      "description": "Properties of an output resource."
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Provisioning",
+        "Updating",
+        "Deleting",
+        "Accepted"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true
+      }
+    },
+    "RedisCacheListSecretsResult": {
+      "type": "object",
+      "properties": {
+        "connectionString": {
+          "type": "string",
+          "description": "The connection string used to connect to the redis cache"
+        },
+        "password": {
+          "type": "string",
+          "description": "The password for this Redis instance"
+        }
+      },
+      "description": "The secret values for the given RedisCache resource"
+    },
+    "RedisCacheProperties": {
+      "type": "object",
+      "properties": {
+        "secrets": {
+          "$ref": "#/definitions/RedisCacheSecrets",
+          "description": "Secrets provided by resource"
+        }
+      },
+      "description": "RedisCache connector properties",
+      "allOf": [
+        {
+          "$ref": "#/definitions/RedisCacheResponseProperties"
+        }
+      ]
+    },
+    "RedisCacheResponseProperties": {
+      "type": "object",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Provisioning state of the redis cache connector at the time the operation was called",
+          "readOnly": true
+        },
+        "environment": {
+          "type": "string",
+          "description": "Fully qualified resource ID for the environment that the connector is linked to"
+        },
+        "application": {
+          "$ref": "#/definitions/Application",
+          "description": "Fully qualified resource ID for the application that the connector is consumed by"
+        },
+        "resource": {
+          "type": "string",
+          "description": "Fully qualified resource ID of a supported resource with Redis API to use for this connector"
+        },
+        "host": {
+          "type": "string",
+          "description": "The host name of the target redis cache"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port value of the target redis cache"
+        },
+        "username": {
+          "type": "string",
+          "description": "The username for redis"
+        }
+      },
+      "description": "RedisCache connector properties",
+      "required": [
+        "environment"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/BasicResourceProperties"
+        }
+      ]
+    },
+    "RedisCacheResponseResource": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RedisCacheResponseProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ],
+          "x-ms-client-flatten": true
+        }
+      },
+      "description": "RedisCache connecter",
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "RedisCacheResponseResourceListResult": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RedisCacheResponseResource"
+          },
+          "x-cadl-name": "RedisCacheResponseResource[]",
+          "description": "The RedisCacheResponseResource items on this page"
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page of items",
+          "x-cadl-name": "Rest.ResourceLocation<RedisCacheResponseResource>"
+        }
+      },
+      "description": "The response of a RedisCacheResponseResource list operation.",
+      "required": [
+        "value"
+      ]
+    },
+    "RedisCacheResponseResourceUpdate": {
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-cadl-name": "Record<string>",
+          "description": "Resource tags."
+        },
+        "properties": {
+          "$ref": "#/definitions/RedisCacheResponseResourceUpdateProperties"
+        }
+      },
+      "description": "The type used for update operations of the RedisCacheResponseResource."
+    },
+    "RedisCacheResponseResourceUpdateProperties": {
+      "type": "object",
+      "properties": {
+        "environment": {
+          "type": "string",
+          "description": "Fully qualified resource ID for the environment that the connector is linked to"
+        },
+        "application": {
+          "$ref": "#/definitions/Application",
+          "description": "Fully qualified resource ID for the application that the connector is consumed by"
+        },
+        "resource": {
+          "type": "string",
+          "description": "Fully qualified resource ID of a supported resource with Redis API to use for this connector"
+        },
+        "host": {
+          "type": "string",
+          "description": "The host name of the target redis cache"
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port value of the target redis cache"
+        },
+        "username": {
+          "type": "string",
+          "description": "The username for redis"
+        },
+        "status": {
+          "$ref": "#/definitions/ResourceStatus",
+          "description": "Status of a resource."
+        }
+      },
+      "description": "The updatable properties of the RedisCacheResponseResource."
+    },
+    "RedisCacheSecrets": {
+      "type": "object",
+      "properties": {
+        "connectionString": {
+          "type": "string",
+          "description": "The connection string used to connect to the redis cache"
+        },
+        "password": {
+          "type": "string",
+          "description": "The password for this Redis instance"
+        }
+      },
+      "description": "The secret values for the given RedisCache resource"
+    },
+    "ResourceStatus": {
+      "type": "object",
+      "properties": {
+        "outputResources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OutputResource"
+          },
+          "x-ms-identifiers": [],
+          "x-cadl-name": "OutputResource[]",
+          "description": "Properties of an output resource"
+        }
+      },
+      "description": "Status of a resource.",
+      "required": [
+        "outputResources"
+      ]
+    }
+  },
+  "parameters": {
+    "RedisCacheResponseResource.redisCacheName": {
+      "name": "redisCacheName",
+      "in": "path",
+      "required": true,
+      "description": "The name of the RedisCache connector resource",
+      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+      "maxLength": 63,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "RootScopeParam": {
+      "name": "rootScope",
+      "in": "path",
+      "required": true,
+      "description": "root scope path",
+      "minLength": 1,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/cadl/Applications.Connector/extenders.cadl
+++ b/cadl/Applications.Connector/extenders.cadl
@@ -1,0 +1,90 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+import "@cadl-lang/rest";
+import "@cadl-lang/versioning";
+import "@azure-tools/cadl-providerhub";
+import "@azure-tools/cadl-azure-core";
+import "@azure-tools/cadl-azure-resource-manager";
+
+// These files allow the use of {rootScope} in the generated paths with a custom resourceOperations object
+import "../customRootScope.cadl";
+import "../aksrootscope.cadl";
+
+import "./global.cadl";
+
+using Cadl.Http;
+using Cadl.Rest;
+using Cadl.Versioning;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Radius;
+
+@armNamespace
+@serviceTitle("Applications.Connector Management APIs")
+@doc("REST API for Applications.Connector Extender Resource")
+@versionedDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
+namespace Applications.Connector;
+
+@doc("Extender connector")
+model ExtenderResource is TrackedResource<ExtenderProperties> {
+  @doc("Extender name")
+  @maxLength(63)
+  @pattern("^[a-z]([-a-z0-9]*[a-z0-9])?$")
+  @key("extenderName")
+  @path
+  @segment("extenders")
+  name: string;
+}
+
+@doc("Extender connector")
+model ExtenderResponseResource is TrackedResource<ExtenderResponseProperties> {
+  @doc("Extender name")
+  @maxLength(63)
+  @pattern("^[a-z]([-a-z0-9]*[a-z0-9])?$")
+  @key("extenderName")
+  @path
+  @segment("extenders")
+  name: string;
+}
+
+@doc("The secret values for the given Extender resource")
+model ExtenderListSecretsResult is ExtenderSecrets;
+
+@doc("The secret values for the given Extender resource")
+model ExtenderSecrets {}
+
+@doc("Extender connector properties")
+model ExtenderResponseProperties extends BasicResourceProperties {
+  @doc("Provisioning state of the extender connector at the time the operation was called")
+  @visibility("read")
+  provisioningState?: ProvisioningState;
+
+  @doc("Fully qualified resource ID for the environment that the connector is linked to")
+  environment: string;
+
+  @doc("Fully qualified resource ID for the application that the connector is consumed by")
+  application?: Application;
+}
+
+@doc("Extender connector properties")
+model ExtenderProperties extends ExtenderResponseProperties {
+  @doc("The secrets value for the resource")
+  secrets?: ExtenderSecrets;
+}
+
+@doc("Lists secrets values for the specified Extender resource")
+@route("/{rootScope}/providers/Applications.Connector/extenders/{extenderName}/listSecrets")
+op post(@path rootScope: RootScopeParam, @path extenderName: string): {
+  @statusCode statusCode: 200;
+  schema: ExtenderListSecretsResult;
+} | ErrorResponse;
+
+@armResourceOperations
+interface Extenders
+  extends Radius.RootScopeResourceOperations<
+      ExtenderResponseResource,
+      ExtenderResponseProperties,
+      RootScopeParam
+    > {}

--- a/cadl/Applications.Connector/global.cadl
+++ b/cadl/Applications.Connector/global.cadl
@@ -5,6 +5,7 @@ using OpenAPI;
 @doc("Basic properties of a Radius resource.")
 model BasicResourceProperties {
   @doc("Status of a resource.")
+  @visibility("read")
   status: ResourceStatus;
 }
 

--- a/cadl/Applications.Connector/global.cadl
+++ b/cadl/Applications.Connector/global.cadl
@@ -1,0 +1,76 @@
+import "@cadl-lang/openapi";
+
+using OpenAPI;
+
+@doc("Basic properties of a Radius resource.")
+model BasicResourceProperties {
+  @doc("Status of a resource.")
+  status: ResourceStatus;
+}
+
+@doc("Status of a resource.")
+model ResourceStatus {
+  @doc("Properties of an output resource")
+  @extension("x-ms-identifiers", [])
+  outputResources: OutputResource[];
+}
+
+@doc("Properties of an output resource.")
+model OutputResource {}
+
+@doc("Fully qualified resource ID for the application that the connector is consumed by")
+model Application is string;
+
+@knownValues(ProvisioningStateKV)
+model ProvisioningState is string;
+enum ProvisioningStateKV {
+  Succeeded,
+  Failed,
+  Canceled,
+  Provisioning,
+  Updating,
+  Deleting,
+  Accepted,
+}
+
+@doc("Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).")
+@error
+model ErrorResponse {
+  @doc("The error object.")
+  error: ErrorDetail;
+}
+
+@doc("The error detail")
+model ErrorDetail {
+  @doc("The error code")
+  @visibility("read")
+  code: string;
+
+  @doc("The error message")
+  @visibility("read")
+  message: string;
+
+  @doc("The error target")
+  @visibility("read")
+  target: string;
+
+  @doc("The error details")
+  @visibility("read")
+  @extension("x-ms-identifiers", ["target", "message"])
+  details: ErrorDetail[];
+
+  @doc("The error additional info")
+  @visibility("read")
+  additionalInfo: ErrorAdditionalInfo;
+}
+
+@doc("The resource management error additional info.")
+model ErrorAdditionalInfo {
+  @doc("The additional info type")
+  @visibility("read")
+  type: string;
+
+  @doc("The additional info")
+  @visibility("read")
+  info: string;
+}

--- a/cadl/Applications.Connector/mongoDatabases.cadl
+++ b/cadl/Applications.Connector/mongoDatabases.cadl
@@ -1,0 +1,113 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+import "@cadl-lang/rest";
+import "@cadl-lang/versioning";
+import "@azure-tools/cadl-azure-core";
+import "@azure-tools/cadl-azure-resource-manager";
+import "@azure-tools/cadl-providerhub";
+
+// These files allow the use of {rootScope} in the generated paths with a custom resourceOperations object
+import "../customRootScope.cadl";
+import "../aksrootscope.cadl";
+
+import "./global.cadl";
+
+using Cadl.Http;
+using Cadl.Rest;
+using Cadl.Versioning;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Radius;
+
+@armNamespace
+@serviceTitle("Applications.Connector Management APIs")
+@doc("REST API for Applications.Connector MongoDatabase Resource")
+@versionedDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
+namespace Applications.Connector;
+
+@doc("MongoDatabase connector")
+model MongoDatabaseResource is TrackedResource<MongoDatabaseProperties> {
+  @doc("The name of the MongoDatabase connector resource")
+  @maxLength(63)
+  @pattern("^[a-z]([-a-z0-9]*[a-z0-9])?$")
+  @key("mongoDatabaseName")
+  @path
+  @segment("mongoDatabases")
+  name: string;
+}
+
+@doc("MongoDatabase connector")
+model MongoDatabaseResponseResource
+  is TrackedResource<MongoDatabaseResponseProperties> {
+  @doc("The name of the MongoDatabase connector resource")
+  @maxLength(63)
+  @pattern("^[a-z]([-a-z0-9]*[a-z0-9])?$")
+  @key("mongoDatabaseName")
+  @path
+  @segment("mongoDatabases")
+  name: string;
+}
+
+@doc("The secret values for the given MongoDatabase resource")
+model MongoDatabaseListSecretsResult is MongoDatabaseSecrets;
+
+@doc("The secret values for the given MongoDatabase resource")
+model MongoDatabaseSecrets {
+  @doc("Username to use when connecting to the target Mongo database")
+  username?: string;
+
+  @doc("Password to use when connecting to the target Mongo database")
+  password?: string;
+
+  @doc("Connection string used to connect to the target Mongo database")
+  connectionString?: string;
+}
+
+@doc("MongoDatabase connector properties")
+model MongoDatabaseResponseProperties extends BasicResourceProperties {
+  @doc("Provisioning state of the mongo database connector at the time the operation was called")
+  @visibility("read")
+  provisioningState?: ProvisioningState;
+
+  @doc("Fully qualified resource ID for the environment that the connector is linked to")
+  environment: string;
+
+  @doc("Fully qualified resource ID for the application that the connector is consumed by")
+  application?: Application;
+
+  @doc("Fully qualified resource ID of a supported resource with Mongo API to use for this connector")
+  resource?: string;
+
+  @doc("Host name of the target Mongo database")
+  host?: string;
+
+  @doc("Port value of the target Mongo database")
+  port?: int32;
+
+  @doc("Database name of the target Mongo database")
+  @visibility("read")
+  database: string;
+}
+
+@doc("MongoDatabase connector properties")
+model MongoDatabaseProperties extends MongoDatabaseResponseProperties {
+  @doc("Secrets values provided for the resource")
+  secrets?: MongoDatabaseSecrets;
+}
+
+@doc("Lists secrets values for the specified MongoDatabase resource")
+@route("/{rootScope}/providers/Applications.Connector/mongoDatabases/{mongoDatabaseName}/listSecrets")
+op post(@path rootScope: RootScopeParam, @path mongoDatabaseName: string): {
+  @statusCode statusCode: 200;
+  schema: MongoDatabaseListSecretsResult;
+} | ErrorResponse;
+
+@armResourceOperations
+interface MongoDatabases
+  extends Radius.RootScopeResourceOperations<
+      MongoDatabaseResponseResource,
+      MongoDatabaseResponseProperties,
+      RootScopeParam
+    > {}

--- a/cadl/Applications.Connector/rabbitMQMessageQueues.cadl
+++ b/cadl/Applications.Connector/rabbitMQMessageQueues.cadl
@@ -1,0 +1,102 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+import "@cadl-lang/rest";
+import "@cadl-lang/versioning";
+import "@azure-tools/cadl-azure-core";
+import "@azure-tools/cadl-azure-resource-manager";
+import "@azure-tools/cadl-providerhub";
+
+// These files allow the use of {rootScope} in the generated paths with a custom resourceOperations object
+import "../customRootScope.cadl";
+import "../aksrootscope.cadl";
+
+import "./global.cadl";
+
+using Cadl.Http;
+using Cadl.Rest;
+using Cadl.Versioning;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Radius;
+
+@armNamespace
+@serviceTitle("Applications.Connector Management APIs")
+@doc("REST API for Applications.Connector RabbitMQMessageQueue Resource")
+@versionedDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
+namespace Applications.Connector;
+
+@doc("RabbitMQMessageQueue connector")
+model RabbitMQMessageQueueResource
+  is TrackedResource<RabbitMQMessageQueueProperties> {
+  @doc("The name of the RabbitMQMessageQueue connector resource")
+  @maxLength(63)
+  @pattern("^[a-z]([-a-z0-9]*[a-z0-9])?$")
+  @key("rabbitMQMessageQueueName")
+  @path
+  @segment("rabbitMQMessageQueues")
+  name: string;
+}
+
+@doc("RabbitMQMessageQueue connector")
+model RabbitMQMessageQueueResponseResource
+  is TrackedResource<RabbitMQMessageQueueResponseProperties> {
+  @doc("The name of the RabbitMQMessageQueue connector resource")
+  @maxLength(63)
+  @pattern("^[a-z]([-a-z0-9]*[a-z0-9])?$")
+  @key("rabbitMQMessageQueueName")
+  @path
+  @segment("rabbitMQMessageQueues")
+  name: string;
+}
+
+@doc("The secret values for the given RabbitMQMessageQueue resource")
+model RabbitMQListSecretsResult is RabbitMQSecrets;
+
+@doc("The secret values for the given RabbitMQMessageQueue resource")
+model RabbitMQSecrets {
+  @doc("The connection string used to connect to this RabbitMQ instance")
+  connectionString?: string;
+}
+
+@doc("RabbitMQMessageQueue connector response properties")
+model RabbitMQMessageQueueResponseProperties extends BasicResourceProperties {
+  @doc("Provisioning state of the rabbitMQ message queue connector at the time the operation was called")
+  @visibility("read")
+  provisioningState?: ProvisioningState;
+
+  @doc("Fully qualified resource ID for the environment that the connector is linked to")
+  environment: string;
+
+  @doc("Fully qualified resource ID for the application that the connector is consumed by")
+  application?: Application;
+
+  @doc("The name of the queue")
+  queue: string;
+}
+
+@doc("RabbitMQMessageQueue connector response properties")
+model RabbitMQMessageQueueProperties
+  extends RabbitMQMessageQueueResponseProperties {
+  @doc("Secrets provided by resources,")
+  secrets?: RabbitMQSecrets;
+}
+
+@doc("Lists secrets values for the specified RabbitMQMessageQueue resource")
+@route("/{rootScope}/providers/Applications.Connector/rabbitMQMessageQueues/{rabbitMQMessageQueueName}/listSecrets")
+op post(
+  @path rootScope: RootScopeParam,
+  @path rabbitMQMessageQueueName: string
+): {
+  @statusCode statusCode: 200;
+  schema: RabbitMQListSecretsResult;
+} | ErrorResponse;
+
+@armResourceOperations
+interface RabbitMQMessageQueues
+  extends Radius.RootScopeResourceOperations<
+      RabbitMQMessageQueueResponseResource,
+      RabbitMQMessageQueueResponseProperties,
+      RootScopeParam
+    > {}

--- a/cadl/Applications.Connector/redisCaches.cadl
+++ b/cadl/Applications.Connector/redisCaches.cadl
@@ -1,0 +1,109 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+import "@cadl-lang/rest";
+import "@cadl-lang/versioning";
+import "@azure-tools/cadl-azure-core";
+import "@azure-tools/cadl-azure-resource-manager";
+import "@azure-tools/cadl-providerhub";
+
+// These files allow the use of {rootScope} in the generated paths with a custom resourceOperations object
+import "../customRootScope.cadl";
+import "../aksrootscope.cadl";
+
+import "./global.cadl";
+
+using Cadl.Http;
+using Cadl.Rest;
+using Cadl.Versioning;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Radius;
+
+@armNamespace
+@serviceTitle("Applications.Connector Management APIs")
+@doc("REST API for Applications.Connector RedisCache Resource")
+@versionedDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
+namespace Applications.Connector;
+
+@doc("RedisCache connector")
+model RedisCacheResource is TrackedResource<RedisCacheProperties> {
+  @doc("The name of the RedisCache connector resource")
+  @maxLength(63)
+  @pattern("^[a-z]([-a-z0-9]*[a-z0-9])?$")
+  @key("redisCacheName")
+  @path
+  @segment("redisCaches")
+  name: string;
+}
+
+@doc("RedisCache connecter")
+model RedisCacheResponseResource
+  is TrackedResource<RedisCacheResponseProperties> {
+  @doc("The name of the RedisCache connector resource")
+  @maxLength(63)
+  @pattern("^[a-z]([-a-z0-9]*[a-z0-9])?$")
+  @key("redisCacheName")
+  @path
+  @segment("redisCaches")
+  name: string;
+}
+
+@doc("The secret values for the given RedisCache resource")
+model RedisCacheListSecretsResult is RedisCacheSecrets;
+
+@doc("The secret values for the given RedisCache resource")
+model RedisCacheSecrets {
+  @doc("The connection string used to connect to the redis cache")
+  connectionString?: string;
+
+  @doc("The password for this Redis instance")
+  password?: string;
+}
+
+@doc("RedisCache connector properties")
+model RedisCacheResponseProperties extends BasicResourceProperties {
+  @doc("Provisioning state of the redis cache connector at the time the operation was called")
+  @visibility("read")
+  provisioningState?: ProvisioningState;
+
+  @doc("Fully qualified resource ID for the environment that the connector is linked to")
+  environment: string;
+
+  @doc("Fully qualified resource ID for the application that the connector is consumed by")
+  application?: Application;
+
+  @doc("Fully qualified resource ID of a supported resource with Redis API to use for this connector")
+  resource?: string;
+
+  @doc("The host name of the target redis cache")
+  host?: string;
+
+  @doc("The port value of the target redis cache")
+  port?: int32;
+
+  @doc("The username for redis")
+  username?: string;
+}
+
+@doc("RedisCache connector properties")
+model RedisCacheProperties extends RedisCacheResponseProperties {
+  @doc("Secrets provided by resource")
+  secrets?: RedisCacheSecrets;
+}
+
+@doc("Lists secrets values for the specified RedisCache resource")
+@route("/{rootScope}/providers/Applications.Connector/redisCaches/{redisCacheName}/listSecrets")
+op post(@path rootScope: RootScopeParam, @path redisCacheName: string): {
+  @statusCode statusCode: 200;
+  schema: RedisCacheListSecretsResult;
+} | ErrorResponse;
+
+@armResourceOperations
+interface RedisCaches
+  extends Radius.RootScopeResourceOperations<
+      RedisCacheResponseResource,
+      RedisCacheResponseProperties,
+      RootScopeParam
+    > {}

--- a/cadl/README.md
+++ b/cadl/README.md
@@ -40,7 +40,7 @@ There may be more or less depending on the  resource being modeled
 At the time of writing this, the Radius team's spec has not been approved by ARM. As a result, the Cadl team has created a custom `RootScopeResourceOperations` object. This makes it so that the paths generated for resources are prepended by `{rootScope}` as required in Project Radius.
 
 To utilize this object, do the following:
-1. Import `"./customRootScope.cadl` into the resource file.
+1. Import `customRootScope.cadl` into the resource file.
 2. When creating the `@armResourceOperations` use the `RootScopeResourceOperations` object under the Radius namespace instead of the standard `ResourceOperations` object:
 ```TypeScript
 @armResourceOperations
@@ -49,16 +49,16 @@ interface InterfaceName
 ```
 
 ## Emitting and Compiling
-In the `cadl-project.yaml` the emitter is set to `"@azure-tools/cadl-autorest": true`. This means that we compile to swagger instead of OpenApi3. If you want to compile to OpenApi3, set the emitter to `"@cadl-lang/openapi3": true`.
+In the `cadl-project.yaml` the emitter is set to `"@azure-tools/cadl-autorest": true`. This means that it compiles to swagger instead of OpenApi3. If you want to compile to OpenApi3, set the emitter to `"@cadl-lang/openapi3": true`.
 
-To compile with {rootScope} to a custom file, run the following command in the terminal:
+To compile with {rootScope} to a custom file, import `aksrootscope.cadl` into the resource file and run the following command in the terminal:
 ```TypeScript
-cadl compile {fileName}.cadl --import "./aksrootscope.cadl" --option "@azure-tools/cadl-autorest.output-file={fileName}.json"
+cadl compile {fileName}.cadl --option "@azure-tools/cadl-autorest.output-file={fileName}.json"
 ```
 
-To compile with the ARM compliant spec to a custom file, run the following command in the terminal:
+To compile with the ARM compliant spec to a custom file, import `armrootscope.cadl` into the resource file and run the following command in the terminal:
 ```TypeScript
-cadl compile {fileName}.cadl --import "./armrootscope.cadl" --option "@azure-tools/cadl-autorest.output-file={fileName}.json"
+cadl compile {fileName}.cadl --option "@azure-tools/cadl-autorest.output-file={fileName}.json"
 ```
 
 In both cases replace {fileName} with the file you want to compile.

--- a/cadl/README.md
+++ b/cadl/README.md
@@ -1,14 +1,12 @@
 # Cadl-fying Radius
-Cadl is a language for describing cloud service APIs and generating other API description languages, client and service code, documentation, and other assets. Cadl provides highly extensible core language primitives that can describe API shapes common among REST, GraphQL, gRPC, and other protocols.
-
-You can try a work-in-progress build of the compiler by following the steps in the Getting Started section in the Cadl repository. If you have more in depth questions about Cadl, Brian Terlson, Mark Colishaw and the Cadl Discussion channel on Teams as a whole are a great resource.
+Cadl is a modeling language based on typescript that can be used to generate OpenAPI and swagger specs. Follow the tutorial to install and get the environment set up.
 
 ## Important Resources
 - [Cadl Repository](https://github.com/microsoft/cadl "Cadl Repository")
 - [Cadl Tutorial](https://github.com/microsoft/cadl/blob/main/docs/tutorial.md)
 - [Cadl for the OpenAPI developer](https://github.com/microsoft/cadl/blob/34eaea96bb2e355d4df5bed0b3a1eeeee34a03bf/docs/cadl-for-openapi-dev.md)
 - [Cadl Azure Playground](https://cadlplayground.z22.web.core.windows.net/cadl-azure/ "Cadl Azure Playground")
-- [Cadl Discussion Teams Channel](https://teams.microsoft.com/l/channel/19%3a906c1efbbec54dc8949ac736633e6bdf%40thread.skype/Cadl%2520Discussion%2520%25F0%259F%2590%25AE?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47) (Note: After clicking into this link you may need to request access to the channel by following the prompts in Teams)
+- [Cadl Discussion Teams Channel](https://teams.microsoft.com/l/channel/19%3a906c1efbbec54dc8949ac736633e6bdf%40thread.skype/Cadl%2520Discussion%2520%25F0%259F%2590%25AE?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47) (Note: You may need to ask someone for access)
 
 ## Recommended Dependencies
 - @azure-tools/cadl-autorest
@@ -37,11 +35,11 @@ interface InterfaceName
 There may be more or less depending on the  resource being modeled
 
 ## {rootScope}
-At the time of writing this, the Radius team's spec has not been approved by ARM. As a result, the Cadl team has created a custom `RootScopeResourceOperations` object. This makes it so that the paths generated for resources are prepended by `{rootScope}` as required in Project Radius.
+At the time of writing this, the Radius team's spec has not been approved by ARM. As a result, the Cadl team has created a custom `RootScopeResourceOperations` object for us to use.
 
-To utilize this object, do the following:
-1. Import `customRootScope.cadl` into the resource file.
-2. When creating the `@armResourceOperations` use the `RootScopeResourceOperations` object under the Radius namespace instead of the standard `ResourceOperations` object:
+To utilize this, we need to do the following:
+1. Import `"./customRootScope.cadl` into our resource file.
+2. When creating the `@armResourceOperations` we use the `RootScopeResourceOperations` object under the Radius namespace instead of the standard `ResourceOperations` object:
 ```TypeScript
 @armResourceOperations
 interface InterfaceName 
@@ -49,16 +47,16 @@ interface InterfaceName
 ```
 
 ## Emitting and Compiling
-In the `cadl-project.yaml` the emitter is set to `"@azure-tools/cadl-autorest": true`. This means that it compiles to swagger instead of OpenApi3. If you want to compile to OpenApi3, set the emitter to `"@cadl-lang/openapi3": true`.
+In the `cadl-project.yaml` the emitter is set to `"@azure-tools/cadl-autorest": true`. This means that we compile to swagger instead of OpenApi3. If you want to compile to OpenApi3, set the emitter to `"@cadl-lang/openapi3": true`.
 
-To compile with {rootScope} to a custom file, import `aksrootscope.cadl` into the resource file and run the following command in the terminal:
+To compile with {rootScope} to a custom file, run the following command in the terminal:
 ```TypeScript
-cadl compile {fileName}.cadl --option "@azure-tools/cadl-autorest.output-file={fileName}.json"
+cadl compile {fileName}.cadl --import "./aksrootscope.cadl" --option "@azure-tools/cadl-autorest.output-file={fileName}.json"
 ```
 
-To compile with the ARM compliant spec to a custom file, import `armrootscope.cadl` into the resource file and run the following command in the terminal:
+To compile with the ARM compliant spec to a custom file, run the following command in the terminal:
 ```TypeScript
-cadl compile {fileName}.cadl --option "@azure-tools/cadl-autorest.output-file={fileName}.json"
+cadl compile {fileName}.cadl --import "./armrootscope.cadl" --option "@azure-tools/cadl-autorest.output-file={fileName}.json"
 ```
 
 In both cases replace {fileName} with the file you want to compile.

--- a/cadl/README.md
+++ b/cadl/README.md
@@ -1,12 +1,14 @@
 # Cadl-fying Radius
-Cadl is a modeling language based on typescript that can be used to generate OpenAPI and swagger specs. Follow the tutorial to install and get the environment set up.
+Cadl is a language for describing cloud service APIs and generating other API description languages, client and service code, documentation, and other assets. Cadl provides highly extensible core language primitives that can describe API shapes common among REST, GraphQL, gRPC, and other protocols.
+
+You can try a work-in-progress build of the compiler by following the steps in the Getting Started section in the Cadl repository. If you have more in depth questions about Cadl, Brian Terlson, Mark Colishaw and the Cadl Discussion channel on Teams as a whole are a great resource.
 
 ## Important Resources
 - [Cadl Repository](https://github.com/microsoft/cadl "Cadl Repository")
 - [Cadl Tutorial](https://github.com/microsoft/cadl/blob/main/docs/tutorial.md)
 - [Cadl for the OpenAPI developer](https://github.com/microsoft/cadl/blob/34eaea96bb2e355d4df5bed0b3a1eeeee34a03bf/docs/cadl-for-openapi-dev.md)
 - [Cadl Azure Playground](https://cadlplayground.z22.web.core.windows.net/cadl-azure/ "Cadl Azure Playground")
-- [Cadl Discussion Teams Channel](https://teams.microsoft.com/l/channel/19%3a906c1efbbec54dc8949ac736633e6bdf%40thread.skype/Cadl%2520Discussion%2520%25F0%259F%2590%25AE?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47) (Note: You may need to ask someone for access)
+- [Cadl Discussion Teams Channel](https://teams.microsoft.com/l/channel/19%3a906c1efbbec54dc8949ac736633e6bdf%40thread.skype/Cadl%2520Discussion%2520%25F0%259F%2590%25AE?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47) (Note: After clicking into this link you may need to request access to the channel by following the prompts in Teams)
 
 ## Recommended Dependencies
 - @azure-tools/cadl-autorest
@@ -35,11 +37,11 @@ interface InterfaceName
 There may be more or less depending on the  resource being modeled
 
 ## {rootScope}
-At the time of writing this, the Radius team's spec has not been approved by ARM. As a result, the Cadl team has created a custom `RootScopeResourceOperations` object for us to use.
+At the time of writing this, the Radius team's spec has not been approved by ARM. As a result, the Cadl team has created a custom `RootScopeResourceOperations` object. This makes it so that the paths generated for resources are prepended by `{rootScope}` as required in Project Radius.
 
-To utilize this, we need to do the following:
-1. Import `"./customRootScope.cadl` into our resource file.
-2. When creating the `@armResourceOperations` we use the `RootScopeResourceOperations` object under the Radius namespace instead of the standard `ResourceOperations` object:
+To utilize this object, do the following:
+1. Import `"./customRootScope.cadl` into the resource file.
+2. When creating the `@armResourceOperations` use the `RootScopeResourceOperations` object under the Radius namespace instead of the standard `ResourceOperations` object:
 ```TypeScript
 @armResourceOperations
 interface InterfaceName 


### PR DESCRIPTION
# Description

This models the following Connector resources in Cadl:

- Extenders
- Mongo Databases
- Rabbit MQ Message Queues
- Redis Caches

...as all of them have secrets. I'm grouping them together in one PR in the interest of time efficiency.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: https://github.com/project-radius/core-team/issues/311
https://github.com/project-radius/core-team/issues/312
https://github.com/project-radius/core-team/issues/313
https://github.com/project-radius/core-team/issues/314

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
