### PR TITLE
Adding `rad resource` types to error message

### DIFF
--- a/pkg/cli/clivalidation.go
+++ b/pkg/cli/clivalidation.go
@@ -154,15 +154,18 @@ func RequireResourceTypeAndName(args []string) (string, string, error) {
 // example of resource Type: Applications.Core/httpRoutes, Applications.Connector/redisCaches
 func RequireResourceType(args []string) (string, error) {
 	if len(args) < 1 {
-		return "", errors.New("No resource Type provided")
+		return "", errors.New("no resource Type provided")
 	}
 	resourceTypeName := args[0]
+	resources := []string{}
 	for _, resourceType := range ucp.ResourceTypesList {
+		resources = append(resources, strings.Split(resourceType, "/")[1])
 		if strings.EqualFold(strings.Split(resourceType, "/")[1], resourceTypeName) {
 			return resourceType, nil
 		}
 	}
-	return "", errors.New("Not a valid resource Type")
+	return "", fmt.Errorf("not a valid resource Type. available Types are: \n\n" +
+		strings.Join(resources, "\n") + "\n")
 }
 
 func RequireAzureResource(cmd *cobra.Command, args []string) (azureResource AzureResource, err error) {

--- a/pkg/cli/clivalidation.go
+++ b/pkg/cli/clivalidation.go
@@ -157,15 +157,16 @@ func RequireResourceType(args []string) (string, error) {
 		return "", errors.New("no resource Type provided")
 	}
 	resourceTypeName := args[0]
-	resources := []string{}
+	supportedTypes := []string{}
 	for _, resourceType := range ucp.ResourceTypesList {
-		resources = append(resources, strings.Split(resourceType, "/")[1])
-		if strings.EqualFold(strings.Split(resourceType, "/")[1], resourceTypeName) {
+		supportedType := strings.Split(resourceType, "/")[1]
+		supportedTypes = append(supportedTypes, supportedType)
+		if strings.EqualFold(supportedType, resourceTypeName) {
 			return resourceType, nil
 		}
 	}
-	return "", fmt.Errorf("not a valid resource Type. available Types are: \n\n" +
-		strings.Join(resources, "\n") + "\n")
+	return "", fmt.Errorf("%s is not a valid resource Type. available Types are: \n\n%s\n",
+		resourceTypeName, strings.Join(supportedTypes, "\n"))
 }
 
 func RequireAzureResource(cmd *cobra.Command, args []string) (azureResource AzureResource, err error) {

--- a/pkg/cli/clivalidation.go
+++ b/pkg/cli/clivalidation.go
@@ -165,7 +165,7 @@ func RequireResourceType(args []string) (string, error) {
 			return resourceType, nil
 		}
 	}
-	return "", fmt.Errorf("%s is not a valid resource Type. available Types are: \n\n%s\n",
+	return "", fmt.Errorf("'%s' is not a valid resource Type. Available Types are: \n\n%s\n",
 		resourceTypeName, strings.Join(supportedTypes, "\n"))
 }
 


### PR DESCRIPTION
Fixes #2927

# Description

Prints out available resource types as part of error message for `rad resource` commands. Example output (resource is "ghvghfvhkl" here):
![Screen Shot 2022-08-18 at 2 26 23 PM](https://user-images.githubusercontent.com/42750942/185498436-17bf92d9-74c1-44d2-82b2-86caed0a7eb2.png)

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #2927

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it


