### PR TITLE
Support Azure RedisCache connection string with Redis connector

### DIFF
--- a/pkg/connectorrp/frontend/deployment/deploymentprocessor.go
+++ b/pkg/connectorrp/frontend/deployment/deploymentprocessor.go
@@ -246,16 +246,6 @@ func (dp *deploymentProcessor) Delete(ctx context.Context, resourceID resources.
 func (dp *deploymentProcessor) FetchSecrets(ctx context.Context, resourceData ResourceData) (map[string]interface{}, error) {
 	secretValues := map[string]interface{}{}
 
-	computedValues := map[string]interface{}{}
-	for k, v := range resourceData.ComputedValues {
-		computedValues[k] = v
-	}
-
-	rendererDependency := renderers.RendererDependency{
-		ResourceID:     resourceData.ID,
-		ComputedValues: computedValues,
-	}
-
 	for k, secretReference := range resourceData.SecretValues {
 		secret, err := dp.fetchSecret(ctx, resourceData.OutputResources, secretReference)
 		if err != nil {
@@ -270,7 +260,7 @@ func (dp *deploymentProcessor) FetchSecrets(ctx context.Context, resourceData Re
 				return nil, fmt.Errorf("could not find a secret transformer for %q", secretReference.Transformer)
 			}
 
-			secret, err = outputResourceModel.SecretValueTransformer.Transform(ctx, rendererDependency, secret)
+			secret, err = outputResourceModel.SecretValueTransformer.Transform(ctx, resourceData.ComputedValues, secret)
 			if err != nil {
 				return nil, fmt.Errorf("failed to transform secret %s for resource %s: %w", k, resourceData.ID.String(), err)
 			}

--- a/pkg/connectorrp/handlers/azure_redis.go
+++ b/pkg/connectorrp/handlers/azure_redis.go
@@ -19,14 +19,11 @@ import (
 )
 
 const (
-	RedisBaseName      = "azureredis"
-	RedisNameKey       = "redisname"
-	RedisResourceIdKey = "redisid"
-	RedisPortKey       = "redisport"
-	RedisHostKey       = "redishost"
-	RedisUsernameKey   = "redisusername"
-	// On Azure, RedisUsername is empty.
-	RedisUsername            = ""
+	RedisBaseName            = "azureredis"
+	RedisNameKey             = "redisname"
+	RedisResourceIdKey       = "redisid"
+	RedisPortKey             = "redisport"
+	RedisHostKey             = "redishost"
 	RedisConnectionStringKey = "redisconnectionstring"
 	RedisPasswordKey         = "redispassword"
 )
@@ -64,7 +61,6 @@ func (handler *azureRedisHandler) Put(ctx context.Context, resource *outputresou
 	properties[RedisNameKey] = *cache.Name
 	properties[RedisHostKey] = *cache.HostName
 	properties[RedisPortKey] = fmt.Sprintf("%d", *cache.Properties.SslPort)
-	properties[RedisUsernameKey] = RedisUsername
 
 	return outputResourceIdentity, properties, nil
 }

--- a/pkg/connectorrp/model/application_model.go
+++ b/pkg/connectorrp/model/application_model.go
@@ -147,7 +147,8 @@ func NewApplicationModel(arm *armauth.ArmConfig, k8s client.Client) (Application
 				Type:     resourcekinds.AzureRedis,
 				Provider: providers.ProviderAzure,
 			},
-			ResourceHandler: handlers.NewAzureRedisHandler(arm),
+			ResourceHandler:        handlers.NewAzureRedisHandler(arm),
+			SecretValueTransformer: &rediscaches.AzureTransformer{},
 		},
 	}
 

--- a/pkg/connectorrp/renderers/mongodatabases/azuretransformer.go
+++ b/pkg/connectorrp/renderers/mongodatabases/azuretransformer.go
@@ -19,7 +19,7 @@ var _ renderers.SecretValueTransformer = (*AzureTransformer)(nil)
 type AzureTransformer struct {
 }
 
-func (t *AzureTransformer) Transform(ctx context.Context, dependency renderers.RendererDependency, value interface{}) (interface{}, error) {
+func (t *AzureTransformer) Transform(ctx context.Context, computedValues map[string]interface{}, value interface{}) (interface{}, error) {
 	// Mongo uses the following format for mongo: mongodb://{accountname}:{key}@{endpoint}:{port}/{database}?...{params}
 	//
 	// The connection strings that come back from CosmosDB don't include the database name.
@@ -34,7 +34,7 @@ func (t *AzureTransformer) Transform(ctx context.Context, dependency renderers.R
 		return "", fmt.Errorf("failed to parse connection string as a URL: %w", err)
 	}
 
-	databaseName, ok := dependency.ComputedValues[renderers.DatabaseNameValue].(string)
+	databaseName, ok := computedValues[renderers.DatabaseNameValue].(string)
 	if !ok {
 		return nil, errors.New("expected the databaseName to be a string")
 	}

--- a/pkg/connectorrp/renderers/rediscaches/azuretransformer.go
+++ b/pkg/connectorrp/renderers/rediscaches/azuretransformer.go
@@ -19,7 +19,7 @@ var _ renderers.SecretValueTransformer = (*AzureTransformer)(nil)
 type AzureTransformer struct {
 }
 
-// Build connection string using primary key for Azure Redis Cache resource
+// Transform builds connection string using primary key for Azure Redis Cache resource
 func (t *AzureTransformer) Transform(ctx context.Context, computedValues map[string]interface{}, primaryKey interface{}) (interface{}, error) {
 	// Redis connection string format: '{hostName}:{port},password={primaryKey},ssl=True,abortConnect=False'
 	password, ok := primaryKey.(string)

--- a/pkg/connectorrp/renderers/rediscaches/azuretransformer.go
+++ b/pkg/connectorrp/renderers/rediscaches/azuretransformer.go
@@ -1,0 +1,43 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package rediscaches
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/project-radius/radius/pkg/connectorrp/renderers"
+	"github.com/project-radius/radius/pkg/handlers"
+)
+
+var _ renderers.SecretValueTransformer = (*AzureTransformer)(nil)
+
+type AzureTransformer struct {
+}
+
+// Build connection string using primary key for Azure Redis Cache resource
+func (t *AzureTransformer) Transform(ctx context.Context, computedValues map[string]interface{}, primaryKey interface{}) (interface{}, error) {
+	// Redis connection string format: '{hostName}:{port},password={primaryKey},ssl=True,abortConnect=False'
+	password, ok := primaryKey.(string)
+	if !ok {
+		return nil, errors.New("expected the access key to be a string")
+	}
+
+	hostname, ok := computedValues[handlers.RedisHostKey].(string)
+	if !ok {
+		return nil, errors.New("hostname is required to build Redis connection string")
+	}
+
+	port, ok := computedValues[handlers.RedisPortKey].(string)
+	if !ok {
+		return nil, errors.New("port is required to build Redis connection string")
+	}
+
+	connectionString := fmt.Sprintf("%s:%v,password=%s,ssl=True,abortConnect=False", hostname, port, password)
+
+	return connectionString, nil
+}

--- a/pkg/connectorrp/renderers/rediscaches/azuretransformer_test.go
+++ b/pkg/connectorrp/renderers/rediscaches/azuretransformer_test.go
@@ -1,0 +1,77 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package rediscaches
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/project-radius/radius/pkg/connectorrp/handlers"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Transform_Success(t *testing.T) {
+	ctx := context.Background()
+	redisTransformer := AzureTransformer{}
+
+	testComputedValues := map[string]interface{}{
+		handlers.RedisHostKey: "test-hostname",
+		handlers.RedisPortKey: "1234",
+	}
+	testPrimaryKey := "test-password"
+	expectedConnectionString := "test-hostname:1234,password=test-password,ssl=True,abortConnect=False"
+
+	connectionString, err := redisTransformer.Transform(ctx, testComputedValues, testPrimaryKey)
+	require.NoError(t, err)
+	require.Equal(t, expectedConnectionString, connectionString)
+}
+
+func Test_Transform_Error(t *testing.T) {
+	ctx := context.Background()
+	redisTransformer := AzureTransformer{}
+
+	testCases := []struct {
+		description        string
+		primaryKey         interface{}
+		computedValues     map[string]interface{}
+		expectedErrMessage string
+	}{
+		{
+			"Invalid primary key format",
+			1234,
+			map[string]interface{}{
+				handlers.RedisHostKey: "test-hostname",
+				handlers.RedisPortKey: "1234",
+			},
+			"expected the access key to be a string",
+		},
+		{
+			"Missing hostname",
+			"test-password",
+			map[string]interface{}{
+				handlers.RedisPortKey: "1234",
+			},
+			"hostname is required to build Redis connection string",
+		},
+		{
+			"Missing port",
+			"test-password",
+			map[string]interface{}{
+				handlers.RedisHostKey: "test-hostname",
+			},
+			"port is required to build Redis connection string",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprint(testCase.description), func(t *testing.T) {
+			_, err := redisTransformer.Transform(ctx, testCase.computedValues, testCase.primaryKey)
+			require.Error(t, err)
+			require.Equal(t, testCase.expectedErrMessage, err.Error())
+		})
+	}
+}

--- a/pkg/connectorrp/renderers/rediscaches/renderer_test.go
+++ b/pkg/connectorrp/renderers/rediscaches/renderer_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
 	"github.com/project-radius/radius/pkg/connectorrp/renderers"
 	"github.com/project-radius/radius/pkg/handlers"
+	"github.com/project-radius/radius/pkg/providers"
 	"github.com/project-radius/radius/pkg/resourcekinds"
+	"github.com/project-radius/radius/pkg/resourcemodel"
 	"github.com/project-radius/radius/pkg/rp"
 	"github.com/project-radius/radius/pkg/rp/armerrors"
 	"github.com/project-radius/radius/pkg/rp/outputresource"
@@ -43,8 +45,6 @@ func Test_Render_Success(t *testing.T) {
 					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
 				},
 				Resource: "/subscriptions/test-sub/resourceGroups/testGroup/providers/Microsoft.Cache/Redis/testCache",
-				Host:     "hello.com",
-				Port:     1234,
 			},
 		},
 	}
@@ -65,24 +65,37 @@ func Test_Render_Success(t *testing.T) {
 	require.Equal(t, expectedOutputResource, redisCacheOutputResource.Resource)
 
 	expectedComputedValues := map[string]renderers.ComputedValueReference{
-		renderers.UsernameStringValue: {
-			LocalID:           "AzureRedis",
-			PropertyReference: "redisusername",
-		},
 		renderers.Host: {
-			Value: "hello.com",
+			LocalID:           outputresource.LocalIDAzureRedis,
+			PropertyReference: handlers.RedisHostKey,
 		},
 		renderers.Port: {
-			Value: int32(1234),
+			LocalID:           outputresource.LocalIDAzureRedis,
+			PropertyReference: handlers.RedisPortKey,
+		},
+	}
+	expectedSecretValues := map[string]rp.SecretValueReference{
+		renderers.PasswordStringHolder: {
+			LocalID:       outputresource.LocalIDAzureRedis,
+			Action:        "listKeys",
+			ValueSelector: "/primaryKey",
+		},
+		renderers.ConnectionStringValue: {
+			LocalID:       outputresource.LocalIDAzureRedis,
+			Action:        "listKeys",
+			ValueSelector: "/primaryKey",
+			Transformer: resourcemodel.ResourceType{
+				Provider: providers.ProviderAzure,
+				Type:     resourcekinds.AzureRedis,
+			},
 		},
 	}
 
 	require.Equal(t, expectedComputedValues, output.ComputedValues)
-	require.Equal(t, "/primaryKey", output.SecretValues[renderers.PasswordStringHolder].ValueSelector)
-	require.Equal(t, "listKeys", output.SecretValues[renderers.PasswordStringHolder].Action)
+	require.Equal(t, expectedSecretValues, output.SecretValues)
 }
 
-func Test_Render_UserSpecifiedSecrets(t *testing.T) {
+func Test_Render_UserSpecifiedValuesAndSecrets(t *testing.T) {
 	ctx := context.Background()
 	renderer := Renderer{}
 
@@ -113,9 +126,6 @@ func Test_Render_UserSpecifiedSecrets(t *testing.T) {
 	require.Len(t, output.Resources, 0)
 
 	expectedComputedValues := map[string]renderers.ComputedValueReference{
-		renderers.UsernameStringValue: {
-			Value: "",
-		},
 		renderers.Host: {
 			Value: "hello.com",
 		},

--- a/pkg/connectorrp/renderers/types.go
+++ b/pkg/connectorrp/renderers/types.go
@@ -13,7 +13,6 @@ import (
 	"github.com/project-radius/radius/pkg/resourcemodel"
 	"github.com/project-radius/radius/pkg/rp"
 	"github.com/project-radius/radius/pkg/rp/outputresource"
-	"github.com/project-radius/radius/pkg/ucp/resources"
 )
 
 const (
@@ -74,21 +73,6 @@ type ComputedValueReference struct {
 	JSONPointer string
 }
 
-// Represents a dependency of the resource currently being rendered. Currently dependencies are always Radius resources.
-type RendererDependency struct {
-	// ResourceID is the resource ID of the Radius resource that is the dependency.
-	ResourceID resources.ID
-
-	// Definition is the definition (`properties` node) of the dependency.
-	Definition map[string]interface{}
-
-	// ComputedValues is a map of the computed values and secrets of the dependency.
-	ComputedValues map[string]interface{}
-
-	// OutputResources is a map of the output resource identities of the dependency. The map is keyed on the LocalID of the output resource.
-	OutputResources map[string]resourcemodel.ResourceIdentity
-}
-
 // SecretValueTransformer allows transforming a secret value before passing it on to a Resource
 // that wants to access it.
 //
@@ -97,7 +81,7 @@ type RendererDependency struct {
 // string that application code consumes will include a database name or queue name, etc. Or the different
 // libraries involved might support different connection string formats, and the user has to choose on.
 type SecretValueTransformer interface {
-	Transform(ctx context.Context, dependency RendererDependency, value interface{}) (interface{}, error)
+	Transform(ctx context.Context, resourceComputedValues map[string]interface{}, secretValue interface{}) (interface{}, error)
 }
 
 //go:generate mockgen -destination=./mock_secretvalueclient.go -package=renderers -self_package github.com/project-radius/radius/pkg/connectorrp/renderers github.com/project-radius/radius/pkg/connectorrp/renderers SecretValueClient


### PR DESCRIPTION
# Description

Build Azure Redis Cache connection string using fetched primary key.
For reference we use this format to build connection string in eshop tutorial today https://github.com/project-radius/samples/blob/edge/reference-apps/eshop/iac/app.azure.bicep#L1208

## Issue reference

Fixes: https://github.com/project-radius/radius/issues/3352

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change - will update eshop sample to use connectionString() function on the connector after https://github.com/project-radius/radius/issues/3354 is done.
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it - https://github.com/project-radius/docs/issues/295
