### PR TITLE
Enabling Cosmos DB Storage Client test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,6 +79,8 @@ jobs:
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux'
         env:
           GOTEST_OPTS: '-race'
+          TEST_COSMOSDB_URL:  '${{ secrets.DEPLOY_TEST_COSMOS_URL }}'
+          TEST_COSMOSDB_MASTERKEY: '${{ secrets.DEPLOY_TEST_COSMOS_KEY }}'
         run: |
           make test
       - name: Upload CLI binary

--- a/pkg/ucp/store/cosmosdb/cosmosdbstorageclient_test.go
+++ b/pkg/ucp/store/cosmosdb/cosmosdbstorageclient_test.go
@@ -42,7 +42,7 @@ var (
 	dBUrl     = os.Getenv("TEST_COSMOSDB_URL")
 	masterKey = os.Getenv("TEST_COSMOSDB_MASTERKEY")
 
-	dbName           = "applicationscore"
+	dbName           = "functionaltest-mongodb"
 	dbCollectionName = "functional-test-environments"
 
 	testLocation            = "test-location"


### PR DESCRIPTION
# Description
Enabling Cosmos DB Storage Client test by adding Test Cosmos DB details as env variables. 

## Issue reference
Fixes: #2503 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
