### PR TITLE
Add functional test for Azure Redis

### DIFF
--- a/pkg/connectorrp/frontend/controller/rediscaches/createorupdaterediscache.go
+++ b/pkg/connectorrp/frontend/controller/rediscaches/createorupdaterediscache.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strconv"
 
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	ctrl "github.com/project-radius/radius/pkg/armrpc/frontend/controller"
@@ -86,8 +87,16 @@ func (redis *CreateOrUpdateRedisCache) Run(ctx context.Context, req *http.Reques
 	if host, ok := deploymentOutput.ComputedValues[renderers.Host].(string); ok {
 		newResource.Properties.Host = host
 	}
-	if port, ok := deploymentOutput.ComputedValues[renderers.Port].(int32); ok {
-		newResource.Properties.Port = port
+	if port, ok := deploymentOutput.ComputedValues[renderers.Port]; ok {
+		if _, ok := port.(string); ok {
+			p, err := strconv.Atoi(port.(string))
+			if err != nil {
+				return nil, err
+			}
+			newResource.Properties.Port = int32(p)
+		} else {
+			newResource.Properties.Port = port.(int32)
+		}
 	}
 	if username, ok := deploymentOutput.ComputedValues[renderers.UsernameStringValue].(string); ok {
 		newResource.Properties.Username = username

--- a/pkg/connectorrp/frontend/controller/rediscaches/createorupdaterediscache_test.go
+++ b/pkg/connectorrp/frontend/controller/rediscaches/createorupdaterediscache_test.go
@@ -84,7 +84,7 @@ func getDeploymentProcessorOutputsAzureRedis() (renderers.RendererOutput, deploy
 				LocalID: outputresource.LocalIDAzureRedis,
 				ResourceType: resourcemodel.ResourceType{
 					Type:     resourcekinds.AzureRedis,
-					Provider: providers.ProviderAzure,
+					Provider: resourcemodel.ProviderAzure,
 				},
 				Identity: resourcemodel.ResourceIdentity{},
 			},
@@ -111,7 +111,7 @@ func getDeploymentProcessorOutputsAzureRedis() (renderers.RendererOutput, deploy
 				LocalID: outputresource.LocalIDAzureRedis,
 				ResourceType: resourcemodel.ResourceType{
 					Type:     resourcekinds.AzureRedis,
-					Provider: providers.ProviderAzure,
+					Provider: resourcemodel.ProviderAzure,
 				},
 			},
 		},

--- a/pkg/connectorrp/handlers/azure_redis.go
+++ b/pkg/connectorrp/handlers/azure_redis.go
@@ -45,7 +45,7 @@ func (handler *azureRedisHandler) Put(ctx context.Context, resource *outputresou
 	}
 	parsedID, err := resources.Parse(properties[RedisResourceIdKey])
 	if err != nil {
-		return resourcemodel.ResourceIdentity{}, nil, fmt.Errorf("failed to parse CosmosDB Mongo Database resource id: %w", err)
+		return resourcemodel.ResourceIdentity{}, nil, fmt.Errorf("failed to parse Azure Redis Cache resource id: %w", err)
 	}
 	redisClient := clients.NewRedisClient(parsedID.FindScope(resources.SubscriptionsSegment), handler.arm.Auth)
 	cache, err := redisClient.Get(ctx, parsedID.FindScope(resources.ResourceGroupsSegment), properties[RedisNameKey])

--- a/pkg/connectorrp/renderers/rediscaches/azuretransformer.go
+++ b/pkg/connectorrp/renderers/rediscaches/azuretransformer.go
@@ -27,12 +27,12 @@ func (t *AzureTransformer) Transform(ctx context.Context, computedValues map[str
 		return nil, errors.New("expected the access key to be a string")
 	}
 
-	hostname, ok := computedValues[handlers.RedisHostKey].(string)
+	hostname, ok := computedValues[renderers.Host].(string)
 	if !ok {
 		return nil, errors.New("hostname is required to build Redis connection string")
 	}
 
-	port, ok := computedValues[handlers.RedisPortKey].(string)
+	port, ok := computedValues[renderers.Port].(string)
 	if !ok {
 		return nil, errors.New("port is required to build Redis connection string")
 	}

--- a/pkg/connectorrp/renderers/rediscaches/azuretransformer.go
+++ b/pkg/connectorrp/renderers/rediscaches/azuretransformer.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/project-radius/radius/pkg/connectorrp/handlers"
 	"github.com/project-radius/radius/pkg/connectorrp/renderers"
 )
 

--- a/pkg/connectorrp/renderers/rediscaches/azuretransformer_test.go
+++ b/pkg/connectorrp/renderers/rediscaches/azuretransformer_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/project-radius/radius/pkg/connectorrp/handlers"
+	"github.com/project-radius/radius/pkg/connectorrp/renderers"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,8 +19,8 @@ func Test_Transform_Success(t *testing.T) {
 	redisTransformer := AzureTransformer{}
 
 	testComputedValues := map[string]interface{}{
-		handlers.RedisHostKey: "test-hostname",
-		handlers.RedisPortKey: "1234",
+		renderers.Host: "test-hostname",
+		renderers.Port: "1234",
 	}
 	testPrimaryKey := "test-password"
 	expectedConnectionString := "test-hostname:1234,password=test-password,ssl=True,abortConnect=False"
@@ -44,8 +44,8 @@ func Test_Transform_Error(t *testing.T) {
 			"Invalid primary key format",
 			1234,
 			map[string]interface{}{
-				handlers.RedisHostKey: "test-hostname",
-				handlers.RedisPortKey: "1234",
+				renderers.Host: "test-hostname",
+				renderers.Port: "1234",
 			},
 			"expected the access key to be a string",
 		},
@@ -53,7 +53,7 @@ func Test_Transform_Error(t *testing.T) {
 			"Missing hostname",
 			"test-password",
 			map[string]interface{}{
-				handlers.RedisPortKey: "1234",
+				renderers.Port: "1234",
 			},
 			"hostname is required to build Redis connection string",
 		},
@@ -61,7 +61,7 @@ func Test_Transform_Error(t *testing.T) {
 			"Missing port",
 			"test-password",
 			map[string]interface{}{
-				handlers.RedisHostKey: "test-hostname",
+				renderers.Host: "test-hostname",
 			},
 			"port is required to build Redis connection string",
 		},

--- a/test/functional/corerp/resources/redis_test.go
+++ b/test/functional/corerp/resources/redis_test.go
@@ -65,3 +65,41 @@ func Test_Redis(t *testing.T) {
 
 	test.Test(t)
 }
+
+func Test_RedisAzure(t *testing.T) {
+	template := "testdata/corerp-resources-redis-azure.bicep"
+	name := "corerp-resources-redis-azure"
+
+	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
+		{
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
+			CoreRPResources: &validation.CoreRPResourceSet{
+				Resources: []validation.CoreRPResource{
+					{
+						Name: name,
+						Type: validation.ApplicationsResource,
+					},
+					{
+						Name: "redis-azure-app-ctnr",
+						Type: validation.ContainersResource,
+						App:  name,
+					},
+					{
+						Name: "redis-connector",
+						Type: validation.RedisCachesResource,
+						App:  name,
+					},
+				},
+			},
+			K8sObjects: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					"default": {
+						validation.NewK8sPodForResource(name, "redis-azure-app-ctnr"),
+					},
+				},
+			},
+		},
+	}, nil)
+
+	test.Test(t)
+}

--- a/test/functional/corerp/resources/testdata/corerp-resources-redis-azure.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-redis-azure.bicep
@@ -1,0 +1,63 @@
+import radius as radius
+
+param magpieimage string
+param environment string
+
+param location string = resourceGroup().location
+param resourceIdentifier string = newGuid()
+
+resource app 'Applications.Core/applications@2022-03-15-privatepreview'  = {
+  name: 'corerp-resources-redis-azure'
+  location: 'global'
+  properties:{
+    environment: environment
+  }
+}
+
+resource webapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
+  name: 'redis-azure-app-ctnr'
+  location: 'global'
+  properties: {
+    application: app.id
+    container: {
+      image: magpieimage
+      env: {
+        DBCONNECTION: redis.connectionString()
+      }
+      readinessProbe:{
+        kind: 'httpGet'
+        containerPort: 3000
+        path: '/healthz'
+      }
+    }
+    connections: {
+      redis: {
+        source: redis.id
+      }
+    }
+  }
+}
+
+resource redis 'Applications.Connector/redisCaches@2022-03-15-privatepreview' = {
+  name: 'redis-connector'
+  location: 'global'
+  properties: {
+    environment: environment
+    application: app.id
+    resource: redisCache.id
+  }
+}
+
+resource redisCache 'Microsoft.Cache/redis@2020-12-01' = {
+  name: 'redis-${resourceIdentifier}'
+  location: location
+  properties: {
+    enableNonSslPort: false
+    minimumTlsVersion: '1.2'
+    sku: {
+      family: 'C'
+      capacity: 1
+      name: 'Basic'
+    }
+  }
+}

--- a/test/functional/corerp/resources/testdata/corerp-resources-redis-azure.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-redis-azure.bicep
@@ -3,9 +3,6 @@ import radius as radius
 param magpieimage string
 param environment string
 
-param location string = resourceGroup().location
-param resourceIdentifier string = newGuid()
-
 resource app 'Applications.Core/applications@2022-03-15-privatepreview'  = {
   name: 'corerp-resources-redis-azure'
   location: 'global'
@@ -30,11 +27,6 @@ resource webapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
         path: '/healthz'
       }
     }
-    connections: {
-      redis: {
-        source: redis.id
-      }
-    }
   }
 }
 
@@ -44,20 +36,6 @@ resource redis 'Applications.Connector/redisCaches@2022-03-15-privatepreview' = 
   properties: {
     environment: environment
     application: app.id
-    resource: redisCache.id
-  }
-}
-
-resource redisCache 'Microsoft.Cache/redis@2020-12-01' = {
-  name: 'redis-${resourceIdentifier}'
-  location: location
-  properties: {
-    enableNonSslPort: false
-    minimumTlsVersion: '1.2'
-    sku: {
-      family: 'C'
-      capacity: 1
-      name: 'Basic'
-    }
+    resource: '/subscriptions/85716382-7362-45c3-ae03-2126e459a123/resourceGroups/RadiusFunctionalTest/providers/Microsoft.Cache/Redis/redis-radiustest'
   }
 }


### PR DESCRIPTION
# Description
Follow up on https://github.com/project-radius/radius/pull/3403, found mismatched host/port keys being used between renderer and handler. Updated transformer to match keys stores in computed values.

Added test to validate call to fetch connection string succeeds.

Validated on localhost -
```
curl --location --request POST 'http://localhost:8080/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourceGroups/kachawla-test-cs/providers/applications.connector/rediscaches/redistest1/listsecrets?api-version=2022-03-15-privatepreview'
{
  "connectionString": "kachawla-redis-testcs.redis.cache.windows.net:6380,password=<removed>,ssl=True,abortConnect=False",
  "password": "<removed>"
}%                                     
```                       

## Issue reference

Fixes: https://github.com/project-radius/radius/issues/3406

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
