### PR TITLE
Check if Service Error conversion results in nil

### DIFF
--- a/pkg/azure/clients/unfold.go
+++ b/pkg/azure/clients/unfold.go
@@ -88,9 +88,44 @@ func UnfoldErrorDetails(d *radclient.ErrorDetail) *radclient.ErrorDetail {
 	if new.Message == nil {
 		return &new
 	}
+
+	// Try to unmarshal as both ErrorResponse and ErrorDetail.
+	// There seems to be some inconsistency in the error format returned from RPs
+	// here. We will try to unmarshal as ErrorResponse first, and if it fails,
+	// we will try to unmarshal as ErrorDetail.
+	// Note, the difference between ErrorResponse and ErrorDetail is that ErrorResponse has an extra level of wrapping with `error`.
+
+	// For example, Cosmos DB is returning an ErrorDetails in response to a 400 for this bicep:
+	// resource cosmosDb 'mongodbDatabases' = {
+	// 	name: 'db'
+	// 	properties: {
+	// 	  resource: {
+	// 		id: 'db2'
+	// 	  }
+	// 	  options: {
+	// 		throughput: 400
+	// 	  }
+	// 	}
+	// }
+	// "details":[{"code":"BadRequest","message":"{\r\n  \"code\": \"BadRequest\",\r\n  \"message\": \"Resource name db in request-uri does not match Resource name db2 in request-body.\\r\\nActivityId: 2c1f5342-0e09-450d-a414-196e02e16085, Microsoft.Azure.Documents.Common/2.14.0\"\r\n}"}]
+	// Counter example, Cosmos DB is returning an ErrorResponse in response to a 400 when the name/id are too long
+	// "details":[{"code":"BadRequest","message":"{\r\n  \"error\": {\r\n    \"code\": \"BadRequest\",\r\n    \"message\": \"<!DOCTYPE HTML PUBLIC \\\"-//W3C//DTD HTML 4.01//EN\\\"\\\"http://www.w3.org/TR/html4/strict.dtd\\\">\\r\\n<HTML><HEAD><TITLE>Bad Request</TITLE>\\r\\n<META HTTP-EQUIV=\\\"Content-Type\\\" Content=\\\"text/html; charset=us-ascii\\\"></HEAD>\\r\\n<BODY><h2>Bad Request - Invalid URL</h2>\\r\\n<hr><p>HTTP Error 400. The request URL is invalid.</p>\\r\\n</BODY></HTML>\\r\\n\"\r\n  }\r\n}"}]
+	// In radius, we always return ErrorResponse for these calls.
 	resp := radclient.ErrorResponse{}
 	err := json.Unmarshal([]byte(*d.Message), &resp)
-	if err != nil || cmp.Equal(resp.InnerError, radclient.ErrorDetail{}) {
+	if err != nil || resp.InnerError == nil || cmp.Equal(resp.InnerError, radclient.ErrorDetail{}) {
+		// Try as ErrorDetail directly rather than ErrorResponse
+		details := radclient.ErrorDetail{}
+		err := json.Unmarshal([]byte(*d.Message), &details)
+
+		if err != nil || cmp.Equal(details, radclient.ErrorDetail{}) {
+			return &new
+		}
+
+		// We successfully parse an armerrors.ErrorDetails from the message.
+		// Let's move that information into the structured details.
+		new.Message = nil
+		new.Details = append(new.Details, &details)
 		return &new
 	}
 	// We successfully parse an armerrors.ErrorResponse from the message.

--- a/pkg/azure/clients/unfold_test.go
+++ b/pkg/azure/clients/unfold_test.go
@@ -130,6 +130,37 @@ func TestUnfoldServiceError(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "message containing just error details works",
+		input: azure.ServiceError{
+			Details: []map[string]interface{}{{
+				"code":    to.StringPtr("BadRequest"),
+				"message": `{ "code": "BadRequest", "message": "Resource name db in request-uri does not match Resource name db2 in request-body.\\r\\nActivityId: 1ca0e394-3e49-4498-ba93-5a7785f6dc0b, Microsoft.Azure.Documents.Common/2.14.0"}`,
+			}},
+		},
+		expect: ServiceError{
+			Details: []*radclient.ErrorDetail{{
+				Code: to.StringPtr("BadRequest"),
+				Details: []*radclient.ErrorDetail{{
+					Code:    to.StringPtr("BadRequest"),
+					Message: to.StringPtr(`Resource name db in request-uri does not match Resource name db2 in request-body.\r\nActivityId: 1ca0e394-3e49-4498-ba93-5a7785f6dc0b, Microsoft.Azure.Documents.Common/2.14.0`),
+				}},
+			}},
+		},
+	}, {
+		name: "message without json still persists message",
+		input: azure.ServiceError{
+			Details: []map[string]interface{}{{
+				"code":    to.StringPtr("BadRequest"),
+				"message": "test",
+			}},
+		},
+		expect: ServiceError{
+			Details: []*radclient.ErrorDetail{{
+				Code:    to.StringPtr("BadRequest"),
+				Message: to.StringPtr("test"),
+			}},
+		},
+	}, {
 		name: "nested once, but can't parse using roundTripJSON",
 		input: azure.ServiceError{
 			Details: []map[string]interface{}{{

--- a/pkg/azure/clients/unfold_test.go
+++ b/pkg/azure/clients/unfold_test.go
@@ -130,7 +130,7 @@ func TestUnfoldServiceError(t *testing.T) {
 			}},
 		},
 	}, {
-		name: "message containing just error details works",
+		name: "message with invalid json format persists message",
 		input: azure.ServiceError{
 			Details: []map[string]interface{}{{
 				"code":    to.StringPtr("BadRequest"),
@@ -139,11 +139,8 @@ func TestUnfoldServiceError(t *testing.T) {
 		},
 		expect: ServiceError{
 			Details: []*radclient.ErrorDetail{{
-				Code: to.StringPtr("BadRequest"),
-				Details: []*radclient.ErrorDetail{{
-					Code:    to.StringPtr("BadRequest"),
-					Message: to.StringPtr(`Resource name db in request-uri does not match Resource name db2 in request-body.\r\nActivityId: 1ca0e394-3e49-4498-ba93-5a7785f6dc0b, Microsoft.Azure.Documents.Common/2.14.0`),
-				}},
+				Code:    to.StringPtr("BadRequest"),
+				Message: to.StringPtr(`{ "code": "BadRequest", "message": "Resource name db in request-uri does not match Resource name db2 in request-body.\\r\\nActivityId: 1ca0e394-3e49-4498-ba93-5a7785f6dc0b, Microsoft.Azure.Documents.Common/2.14.0"}`),
 			}},
 		},
 	}, {

--- a/pkg/cli/azure/deploy.go
+++ b/pkg/cli/azure/deploy.go
@@ -177,15 +177,12 @@ func (dc *ResouceDeploymentClient) waitForCompletion(ctx context.Context, future
 
 	err = future.WaitForCompletionRef(ctx, dc.Client.Client)
 	if err != nil {
-		fmt.Println(err.Error())
-
 		return clients.DeploymentResult{}, err
 	}
 
 	deployment, err = future.Result(dc.Client.DeploymentsClient)
 
 	if err != nil {
-		fmt.Println(err.Error())
 		return clients.DeploymentResult{}, err
 	}
 

--- a/pkg/cli/azure/deploy.go
+++ b/pkg/cli/azure/deploy.go
@@ -177,12 +177,15 @@ func (dc *ResouceDeploymentClient) waitForCompletion(ctx context.Context, future
 
 	err = future.WaitForCompletionRef(ctx, dc.Client.Client)
 	if err != nil {
+		fmt.Println(err.Error())
+
 		return clients.DeploymentResult{}, err
 	}
 
 	deployment, err = future.Result(dc.Client.DeploymentsClient)
 
 	if err != nil {
+		fmt.Println(err.Error())
 		return clients.DeploymentResult{}, err
 	}
 


### PR DESCRIPTION
# Description

This fixes two bugs with our error presentation logic for presenting ARM errors to the user:

- The unfold logic didn't handle cases where Unmarshal returned nil for the details, which was happening in original issue's case. With the nil check, we would have at a minimum seen at least an error saying an unformatted error.
- Adds logic to Unmarshal both ErrorResponse and ErrorDetails. I added an in-depth description for why this logic was added in code-comments as it's a bit nuanced.

## Issue reference

Fixes: https://github.com/project-radius/radius/issues/3391

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
