### PR TITLE
rad env show should have default table format

### DIFF
--- a/cmd/rad/cmd/envShow.go
+++ b/cmd/rad/cmd/envShow.go
@@ -2,16 +2,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // ------------------------------------------------------------
-
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/connections"
+	"github.com/project-radius/radius/pkg/cli/objectformats"
+	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 // envShowCmd command returns properties of an environment
@@ -25,35 +23,31 @@ var envShowCmd = &cobra.Command{
 func init() {
 	envCmd.AddCommand(envShowCmd)
 }
-
 func showEnvironment(cmd *cobra.Command, args []string) error {
 	config := ConfigFromContext(cmd.Context())
+	format, err := cli.RequireOutput(cmd)
+	if err != nil {
+		return err
+	}
 	workspace, err := cli.RequireWorkspace(cmd, config)
 	if err != nil {
 		return err
 	}
-
 	environmentName, err := cli.RequireEnvironmentNameArgs(cmd, args, *workspace)
 	if err != nil {
 		return err
 	}
-
 	client, err := connections.DefaultFactory.CreateApplicationsManagementClient(cmd.Context(), *workspace)
 	if err != nil {
 		return err
 	}
-
 	envResource, err := client.GetEnvDetails(cmd.Context(), environmentName)
 	if err != nil {
 		return err
 	}
-
-	b, err := yaml.Marshal(envResource)
+	err = output.Write(format, envResource, cmd.OutOrStdout(), objectformats.GetGenericEnvironmentTableFormat())
 	if err != nil {
 		return err
 	}
-	fmt.Println(string(b))
-
 	return nil
-
 }


### PR DESCRIPTION
# Description
rad env show should output in table format by default for consistency.
In addition it should support -o json

## Issue reference
Fixes: #3234

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
