### PR TITLE
Adding current version of rad cli to install output

### DIFF
--- a/cmd/rad/cmd/version.go
+++ b/cmd/rad/cmd/version.go
@@ -18,8 +18,17 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Prints the versions of the rad cli",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		outFormat, _ := cmd.Flags().GetString("output")
-		writeVersionString(outFormat, cmd.OutOrStdout())
+		cli, err := cmd.Flags().GetBool("cli")
+		if err != nil {
+			return err
+		}
+
+		if !cli {
+			outFormat, _ := cmd.Flags().GetString("output")
+			writeVersionString(outFormat, cmd.OutOrStdout())
+		} else {
+			output.LogInfo(version.Version())
+		}
 		return nil
 	},
 }
@@ -58,4 +67,5 @@ func writeVersionString(format string, w io.Writer) {
 
 func init() {
 	RootCmd.AddCommand(versionCmd)
+	versionCmd.Flags().Bool("cli", false, "Use this flag to only show the rad CLI version")
 }

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -88,7 +88,7 @@ checkHttpRequestCLI() {
 
 checkExistingRadius() {
     if [ -f "$RADIUS_CLI_FILE" ]; then
-        version=$(rad version --cli)
+        version=$($RADIUS_CLI_FILE version --cli)
         echo -e "\nRadius CLI is detected. Current version: ${version}"
         #TODO $RADIUS_CLI_FILE --version
         echo -e "Reinstalling Radius CLI - ${RADIUS_CLI_FILE}...\n"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -88,7 +88,8 @@ checkHttpRequestCLI() {
 
 checkExistingRadius() {
     if [ -f "$RADIUS_CLI_FILE" ]; then
-        echo -e "\nRadius CLI is detected:"
+        version=$(rad version --cli)
+        echo -e "\nRadius CLI is detected. Current version: ${version}"
         #TODO $RADIUS_CLI_FILE --version
         echo -e "Reinstalling Radius CLI - ${RADIUS_CLI_FILE}...\n"
     else
@@ -195,7 +196,7 @@ cleanup() {
 }
 
 installCompleted() {
-    echo -e "\nTo get started with Radius, please visit https://docs.radapp.dev/getting-started/"
+    echo -e "\nTo get started with Radius, please visit https://radapp.dev/getting-started/"
 }
 
 # -----------------------------------------------------------------------------

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -90,7 +90,6 @@ checkExistingRadius() {
     if [ -f "$RADIUS_CLI_FILE" ]; then
         version=$($RADIUS_CLI_FILE version --cli)
         echo -e "\nRadius CLI is detected. Current version: ${version}"
-        #TODO $RADIUS_CLI_FILE --version
         echo -e "Reinstalling Radius CLI - ${RADIUS_CLI_FILE}...\n"
     else
         echo -e "Installing Radius CLI...\n"

--- a/test/functional/corerp/cli/cli_test.go
+++ b/test/functional/corerp/cli/cli_test.go
@@ -328,6 +328,24 @@ func Test_CLI_version(t *testing.T) {
 	require.Regexp(t, expected, objectformats.TrimSpaceMulti(output))
 }
 
+func Test_CLI_Only_version(t *testing.T) {
+	ctx, cancel := test.GetContext(t)
+	defer cancel()
+
+	options := corerp.NewTestOptions(t)
+	cli := radcli.NewCLI(t, options.ConfigFilePath)
+
+	output, err := cli.CliVersion(ctx)
+	require.NoError(t, err)
+
+	// Matching logic:
+	//
+	// Version: any work or number characters or hyphen or dot
+	matcher := `([a-zA-Z0-9-\.]+)`
+	expected := regexp.MustCompile(matcher)
+	require.Regexp(t, expected, objectformats.TrimSpaceMulti(output))
+}
+
 func GetAvailablePort() (int, error) {
 	address, err := net.ResolveTCPAddr("tcp", "localhost:0")
 	if err != nil {

--- a/test/radcli/cli.go
+++ b/test/radcli/cli.go
@@ -196,6 +196,14 @@ func (cli *CLI) Version(ctx context.Context) (string, error) {
 	return cli.RunCommand(ctx, args)
 }
 
+func (cli *CLI) CliVersion(ctx context.Context) (string, error) {
+	args := []string{
+		"version",
+		"--cli",
+	}
+	return cli.RunCommand(ctx, args)
+}
+
 func (cli *CLI) RunCommand(ctx context.Context, args []string) (string, error) {
 	description := "rad " + strings.Join(args, " ")
 	args = cli.appendStandardArgs(args)


### PR DESCRIPTION
# Description

Adding version name info to line about detecting existing version. Example:
`Radius CLI is detected. Current version: some-version`

Also updated the Radius docs link 

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: radius-project/core-team#734

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
