### PR TITLE
Add GitHub issues automation

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -1,0 +1,36 @@
+name: Issues Automation
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  customer:
+    name: Add a label if Isssue created by customer
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+    steps:
+      - name: Add label if author in preview team
+        env:
+          ISSUE: ${{ github.event.issue.html_url }}
+          AUTHOR: ${{ github.actor }}
+        run: |
+          MEMBERS=$(gh api orgs/project-radius/teams/Radius-Preview/members | jq -r '.[] | .login')
+          ADMINS=$(gh api orgs/project-radius/teams/Radius-Admin/members | jq -r '.[] | .login')
+          for USER in $MEMBERS; do
+            if [[ "$USER" == "$AUTHOR" ]]; then
+              ISADMIN=false
+              for ADMIN in $ADMINS; do
+                if [[ "$USER" == "$ADMIN" ]]; then
+                  echo "$USER is an admin, skipping"
+                  ISADMIN=true
+                fi
+              done
+              if [[ "$ISADMIN" == "false" ]]; then
+                echo "Adding label for issue $ISSUE"
+                gh issue edit $ISSUE --add-label "customer-issue"
+              fi
+            fi
+          done
+ 

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   customer:
-    name: Add a label if Isssue created by customer
+    name: Add a label if Issue created by customer
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT }}


### PR DESCRIPTION
# Description

We need to be able to know what Issues are being opened by customers so we can prioritize accordingly and triage into backlogs.

This PR:
  - Is triggered anytime a new Issue is opened
  - Checks if the author is in the `project-radius/Radius-Preview` team
  - Checks if the author is in the `project-radius/Radius-Admin` team
  - If in preview and not an admin, add the https://github.com/project-radius/radius/labels/customer-issue label

Now we can query customer issues at https://github.com/project-radius/radius/labels/customer-issue