### PR TITLE
Fixing app/env deletion error bug

### DIFF
--- a/cmd/rad/cmd/appDelete.go
+++ b/cmd/rad/cmd/appDelete.go
@@ -74,10 +74,12 @@ func DeleteApplication(ctx context.Context, workspace workspaces.Workspace, appl
 	}
 
 	appResp, err := client.DeleteApplication(ctx, applicationName)
-	if appResp.RawResponse.StatusCode == 204 {
-		output.LogInfo("Application '%s' does not exist or has already been deleted.", applicationName)
-	} else if err == nil {
-		output.LogInfo("Application deleted")
+	if err == nil {
+		if appResp.RawResponse.StatusCode == 204 {
+			output.LogInfo("Application '%s' does not exist or has already been deleted.", applicationName)
+		} else {
+			output.LogInfo("Application deleted")
+		}
 	}
 
 	return err

--- a/cmd/rad/cmd/envDelete.go
+++ b/cmd/rad/cmd/envDelete.go
@@ -63,10 +63,12 @@ func deleteEnvResource(cmd *cobra.Command, args []string) error {
 	}
 
 	envResp, err := client.DeleteEnv(cmd.Context(), environmentName)
-	if envResp.RawResponse.StatusCode == 204 {
-		output.LogInfo("Environment '%s' does not exist or has already been deleted.", environmentName)
-	} else if err == nil {
-		output.LogInfo("Environment deleted")
+	if err == nil {
+		if envResp.RawResponse.StatusCode == 204 {
+			output.LogInfo("Environment '%s' does not exist or has already been deleted.", environmentName)
+		} else {
+			output.LogInfo("Environment deleted")
+		}
 	}
 	return err
 

--- a/test/validation/corerp.go
+++ b/test/validation/corerp.go
@@ -49,7 +49,7 @@ func DeleteCoreRPResource(ctx context.Context, t *testing.T, cli *radcli.CLI, cl
 	if resource.Type == EnvironmentsResource {
 		t.Logf("deleting environment: %s", resource.Name)
 		envResp, err := client.DeleteEnv(ctx, resource.Name)
-		if envResp.RawResponse.StatusCode == 204 {
+		if err == nil && envResp.RawResponse.StatusCode == 204 {
 			output.LogInfo("Environment '%s' does not exist or has already been deleted.", resource.Name)
 		}
 		return err


### PR DESCRIPTION
# Description

App/env delete logic had a bug where if there was an error with deletion, a nil app/env http response was returned. Updated the logic to first check for errors and then parse the http response. See discussion [here](https://github.com/project-radius/radius/pull/3377#discussion_r956446293) for the specific bug


## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #3442

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
