### PR TITLE
Add test target for cli test coverage

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -22,6 +22,10 @@ test: test-get-envtools ## Runs unit tests, excluding kubernetes controller test
 test-get-envtools:
 	$(call go-install-tool,$(ENV_SETUP),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
 
+.PHONY: test-validate-cli
+test-validate-cli: ## Run cli integration tests
+	CGO_ENABLED=1 go test -coverpkg= ./pkg/cli/cmd/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
+
 .PHONY: test-functional-azure
 test-functional-azure: ## Runs Azure functional tests
 	CGO_ENABLED=1 go test ./test/functional/azure/... -timeout ${TEST_TIMEOUT} -v -parallel 20 $(GOTEST_OPTS)

--- a/build/test.mk
+++ b/build/test.mk
@@ -24,7 +24,7 @@ test-get-envtools:
 
 .PHONY: test-validate-cli
 test-validate-cli: ## Run cli integration tests
-	CGO_ENABLED=1 go test -coverpkg= ./pkg/cli/cmd/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
+	CGO_ENABLED=1 go test -coverpkg= ./pkg/cli/cmd/... ./cmd/rad/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
 
 .PHONY: test-functional-azure
 test-functional-azure: ## Runs Azure functional tests

--- a/pkg/cli/cmd/README.md
+++ b/pkg/cli/cmd/README.md
@@ -8,6 +8,8 @@ Each command is its own page to discourage accidentally sharing code between com
 Any functionality that needs to be shared should be moved to another location outside of
 `pkg/cli/cmd`.
 
+Make sure to run `make test-validate-cli` to get the test coverage for the file you have added tests.
+
 ## Template
 
 Here's a useful template for a new (blank) command.


### PR DESCRIPTION
# Description
This change enables test coverage for cli integration tests. It is a separate target and isn't included in the test path

## Issue reference
NA, utility improvements

Fixes: NA

Output:
```sh
make test-validate-cli                      
CGO_ENABLED=1 go test -coverpkg= ./pkg/cli/cmd/... -timeout 1h -v -parallel 5 
=== RUN   Test_CommandValidation
--- PASS: Test_CommandValidation (0.00s)
=== RUN   Test_Validate
=== RUN   Test_Validate/Valid_Show_Command
=== RUN   Test_Validate/Show_Command_without_workspace
=== RUN   Test_Validate/Show_Command_with_invalid_resource_type
=== RUN   Test_Validate/Show_Command_with_in_sufficient_args
--- PASS: Test_Validate (0.00s)
    --- PASS: Test_Validate/Valid_Show_Command (0.00s)
    --- PASS: Test_Validate/Show_Command_without_workspace (0.00s)
    --- PASS: Test_Validate/Show_Command_with_invalid_resource_type (0.00s)
    --- PASS: Test_Validate/Show_Command_with_in_sufficient_args (0.00s)
=== RUN   Test_Run
=== RUN   Test_Run/Validate_rad_resource_show_valid_container_resource
--- PASS: Test_Run (0.00s)
    --- PASS: Test_Run/Validate_rad_resource_show_valid_container_resource (0.00s)
PASS
coverage: 87.9% of statements
ok      github.com/project-radius/radius/pkg/cli/cmd/resource/show      (cached)        coverage: 87.9% of statements
```

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
