### PR TITLE
Remove coupling to one subscription/resourceGroup

### DIFF
--- a/deploy/Chart/charts/appcore-rp/templates/appcore-rp.yaml
+++ b/deploy/Chart/charts/appcore-rp/templates/appcore-rp.yaml
@@ -107,8 +107,6 @@ stringData:
   # Enable ARM without explicit credentials
   SKIP_ARM: 'false'
   ARM_AUTH_METHOD: 'ManagedIdentity'
-  ARM_SUBSCRIPTION_ID: {{ .Values.global.rp.provider.azure.subscriptionId }}
-  ARM_RESOURCE_GROUP: {{ .Values.global.rp.provider.azure.resourceGroup }}
 {{ else if .Values.global.rp.provider.azure.servicePrincipal }}
   # Enable ARM with explicit credentials
   SKIP_ARM: 'false' 
@@ -116,8 +114,6 @@ stringData:
   AZURE_CLIENT_ID: {{ .Values.global.rp.provider.azure.servicePrincipal.clientId }}
   AZURE_CLIENT_SECRET: {{ .Values.global.rp.provider.azure.servicePrincipal.clientSecret }}
   AZURE_TENANT_ID: {{ .Values.global.rp.provider.azure.servicePrincipal.tenantId }}
-  ARM_SUBSCRIPTION_ID: {{ .Values.global.rp.provider.azure.subscriptionId }}
-  ARM_RESOURCE_GROUP: {{ .Values.global.rp.provider.azure.resourceGroup }}
 {{ else }}
   # Skip ARM by default. Overwriting this secret will let you set this to false as well as configure credentials
   SKIP_ARM: 'true' 

--- a/deploy/Chart/charts/de/templates/de.yaml
+++ b/deploy/Chart/charts/de/templates/de.yaml
@@ -59,8 +59,6 @@ stringData:
   # Enable ARM but without explicit credentials, pod identity will handle it
   SKIP_ARM: 'false'
   ARM_AUTH_METHOD: 'ManagedIdentity'
-  ARM_SUBSCRIPTION_ID: {{ .Values.global.rp.provider.azure.subscriptionId }}
-  ARM_RESOURCE_GROUP: {{ .Values.global.rp.provider.azure.resourceGroup }}
 {{ else if .Values.global.rp.provider.azure.servicePrincipal }}
   # Enable ARM with explicit credentials
   SKIP_ARM: 'false' 
@@ -68,8 +66,6 @@ stringData:
   AZURE_CLIENT_ID: {{ .Values.global.rp.provider.azure.servicePrincipal.clientId }}
   AZURE_CLIENT_SECRET: {{ .Values.global.rp.provider.azure.servicePrincipal.clientSecret }}
   AZURE_TENANT_ID: {{ .Values.global.rp.provider.azure.servicePrincipal.tenantId }}
-  ARM_SUBSCRIPTION_ID: {{ .Values.global.rp.provider.azure.subscriptionId }}
-  ARM_RESOURCE_GROUP: {{ .Values.global.rp.provider.azure.resourceGroup }}
 {{ else }}
   # Skip ARM by default. Overwriting this secret will let you set this to false as well as configure credentials
   SKIP_ARM: 'true' 

--- a/pkg/azure/armauth/auth.go
+++ b/pkg/azure/armauth/auth.go
@@ -6,7 +6,6 @@
 package armauth
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -23,12 +22,7 @@ const (
 
 // ArmConfig is the configuration we use for managing ARM resources
 type ArmConfig struct {
-	Auth              autorest.Authorizer
-	SubscriptionID    string
-	ResourceGroup     string
-	K8sSubscriptionID string
-	K8sResourceGroup  string
-	K8sClusterName    string
+	Auth autorest.Authorizer
 }
 
 // GetArmConfig gets the configuration we use for managing ARM resources
@@ -38,24 +32,8 @@ func GetArmConfig() (*ArmConfig, error) {
 		return &ArmConfig{}, err
 	}
 
-	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
-	if subscriptionID == "" {
-		return &ArmConfig{}, errors.New("required env-var ARM_SUBSCRIPTION_ID is missing")
-	}
-
-	resourceGroup := os.Getenv("ARM_RESOURCE_GROUP")
-	if resourceGroup == "" {
-		return &ArmConfig{}, errors.New("required env-var ARM_RESOURCE_GROUP is missing")
-	}
-
 	return &ArmConfig{
-		Auth:           auth,
-		SubscriptionID: subscriptionID,
-		ResourceGroup:  resourceGroup,
-
-		K8sSubscriptionID: os.Getenv("K8S_SUBSCRIPTION_ID"),
-		K8sResourceGroup:  os.Getenv("K8S_RESOURCE_GROUP"),
-		K8sClusterName:    os.Getenv("K8S_CLUSTER_NAME"),
+		Auth: auth,
 	}, nil
 }
 

--- a/pkg/azure/clients/common.go
+++ b/pkg/azure/clients/common.go
@@ -43,10 +43,10 @@ func GetDefaultAPIVersion(ctx context.Context, subscriptionId string, authorizer
 	return "", nil // unreachable
 }
 
-func GetResourceGroupLocation(ctx context.Context, armConfig armauth.ArmConfig) (*string, error) {
-	rgc := NewGroupsClient(armConfig.SubscriptionID, armConfig.Auth)
+func GetResourceGroupLocation(ctx context.Context, armConfig armauth.ArmConfig, subscriptionID string, resourceGroupName string) (*string, error) {
+	rgc := NewGroupsClient(subscriptionID, armConfig.Auth)
 
-	resourceGroup, err := rgc.Get(ctx, armConfig.ResourceGroup)
+	resourceGroup, err := rgc.Get(ctx, resourceGroupName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get resource group location: %w", err)
 	}

--- a/pkg/cli/helm/radiusclient.go
+++ b/pkg/cli/helm/radiusclient.go
@@ -309,9 +309,6 @@ func addAzureProviderValues(helmChart *chart.Chart, azureProvider *azure.Provide
 
 	azure := provider["azure"].(map[string]interface{})
 
-	azure["subscriptionId"] = azureProvider.SubscriptionID
-	azure["resourceGroup"] = azureProvider.ResourceGroup
-
 	if azureProvider.ServicePrincipal != nil {
 		_, ok = azure["servicePrincipal"]
 		if !ok {

--- a/pkg/connectorrp/handlers/arm_handler.go
+++ b/pkg/connectorrp/handlers/arm_handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/project-radius/radius/pkg/azure/clients"
 	"github.com/project-radius/radius/pkg/resourcemodel"
 	"github.com/project-radius/radius/pkg/rp/outputresource"
+	ucpresources "github.com/project-radius/radius/pkg/ucp/resources"
 )
 
 // NewARMHandler creates a ResourceHandler for 'generic' ARM resources.
@@ -31,7 +32,7 @@ type armHandler struct {
 
 func (handler *armHandler) Put(ctx context.Context, resource *outputresource.OutputResource) (outputResourceIdentity resourcemodel.ResourceIdentity, properties map[string]string, err error) {
 	// Do a GET just to validate that the resource exists.
-	res, err := getByID(ctx, handler.arm.SubscriptionID, handler.arm.Auth, resource.Identity)
+	res, err := getByID(ctx, handler.arm.Auth, resource.Identity)
 	if err != nil {
 		return resourcemodel.ResourceIdentity{}, nil, err
 	}
@@ -68,12 +69,18 @@ func (handler *armHandler) serializeResource(resource resources.GenericResource)
 	return data, nil
 }
 
-func getByID(ctx context.Context, subscriptionID string, auth autorest.Authorizer, identity resourcemodel.ResourceIdentity) (*resources.GenericResource, error) {
+func getByID(ctx context.Context, auth autorest.Authorizer, identity resourcemodel.ResourceIdentity) (*resources.GenericResource, error) {
 	id, apiVersion, err := identity.RequireARM()
 	if err != nil {
 		return nil, err
 	}
-	rc := clients.NewGenericResourceClient(subscriptionID, auth)
+
+	parsed, err := ucpresources.Parse(id)
+	if err != nil {
+		return nil, err
+	}
+
+	rc := clients.NewGenericResourceClient(parsed.FindScope(ucpresources.SubscriptionsSegment), auth)
 	resource, err := rc.GetByID(ctx, id, apiVersion)
 	if err != nil {
 		if clients.Is404Error(err) {

--- a/pkg/corerp/handlers/azure_roleassignment.go
+++ b/pkg/corerp/handlers/azure_roleassignment.go
@@ -17,6 +17,7 @@ import (
 	"github.com/project-radius/radius/pkg/radlogger"
 	"github.com/project-radius/radius/pkg/resourcemodel"
 	"github.com/project-radius/radius/pkg/rp/outputresource"
+	"github.com/project-radius/radius/pkg/ucp/resources"
 )
 
 const (
@@ -55,9 +56,14 @@ func (handler *azureRoleAssignmentHandler) Put(ctx context.Context, resource *ou
 		return errors.New("missing dependency: a user assigned identity is required to create role assignment")
 	}
 
+	parsedScope, err := resources.Parse(scope)
+	if err != nil {
+		return err
+	}
+
 	// Assign Key Vault Secrets User role to grant managed identity read-only access to the keyvault for secrets.
 	// Assign Key Vault Crypto User role to grant managed identity permissions to perform operations using encryption keys.
-	roleAssignment, err := roleassignment.Create(ctx, handler.arm.Auth, handler.arm.SubscriptionID, managedIdentityProperties[UserAssignedIdentityPrincipalIDKey], scope, roleName)
+	roleAssignment, err := roleassignment.Create(ctx, handler.arm.Auth, parsedScope.FindScope(resources.SubscriptionsSegment), managedIdentityProperties[UserAssignedIdentityPrincipalIDKey], scope, roleName)
 	if err != nil {
 		return fmt.Errorf(
 			"failed to assign '%s' role to the managed identity '%s' within resource '%s' scope : %w",
@@ -79,7 +85,12 @@ func (handler *azureRoleAssignmentHandler) GetResourceIdentity(ctx context.Conte
 	}
 	roleName := properties[RoleNameKey]
 	scope := properties[RoleAssignmentScope]
-	roleDefinitionID, err := roleassignment.GetRoleDefinitionID(ctx, handler.arm.Auth, handler.arm.SubscriptionID, scope, roleName)
+	parsedScope, err := resources.Parse(scope)
+	if err != nil {
+		return resourcemodel.ResourceIdentity{}, err
+	}
+
+	roleDefinitionID, err := roleassignment.GetRoleDefinitionID(ctx, handler.arm.Auth, parsedScope.FindScope(resources.SubscriptionsSegment), scope, roleName)
 	if err != nil {
 		return resourcemodel.ResourceIdentity{}, err
 	}

--- a/pkg/corerp/renderers/secretvalueclient.go
+++ b/pkg/corerp/renderers/secretvalueclient.go
@@ -13,6 +13,7 @@ import (
 	"github.com/project-radius/radius/pkg/azure/armauth"
 	"github.com/project-radius/radius/pkg/azure/clients"
 	"github.com/project-radius/radius/pkg/resourcemodel"
+	resources "github.com/project-radius/radius/pkg/ucp/resources"
 	"github.com/project-radius/radius/pkg/ucp/store"
 )
 
@@ -32,7 +33,12 @@ func (c *client) FetchSecret(ctx context.Context, identity resourcemodel.Resourc
 		return nil, fmt.Errorf("unsupported resource type: %+v. Currently only ARM resources are supported", identity)
 	}
 
-	custom := clients.NewCustomActionClient(c.ARM.SubscriptionID, c.ARM.Auth)
+	parsed, err := resources.Parse(arm.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	custom := clients.NewCustomActionClient(parsed.FindScope(resources.SubscriptionsSegment), c.ARM.Auth)
 	response, err := custom.InvokeCustomAction(ctx, arm.ID, arm.APIVersion, action, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change makes our use of Azure SDKs more flexible for a variety of
Azure scenarios. In old CustomRP model for Radius, we configured the
control plane with a single 'destination' resource group to use for
resources. This limitation was mostly to keep things simple while we
were running Radius as a 'user-mode-PaaS' in the user's subscription.
This choice leaked into all the code, where we ignore the actual
subscription/resourceGroup on the resources we were working with in
favor of our single value for each.

There's no good reason for this coupling, and the correct thing to do in
every case is parse the resource IDs of the resources we work with so we
can correct scopes. For code hygiene we should run, not walk, away from
the old model :).

This change fixes the way we handle scopes to be data-driven by the
actual resources, and removes the settings from the Helm chart that we
used to rely on.

The one part of the code that can't easily be updated is the handling of
managed identity and pod identity. Getting these functional again (they
aren't currently supported or working) will require the *user* to
provide this information as part of the environment configuration. For
now I've left a hefty comment in place to make it clear what to do if we
resurrect this code.
