### PR TITLE
Adding recursive call to monitorProgress to support nested modules

### DIFF
--- a/pkg/cli/azure/deploy.go
+++ b/pkg/cli/azure/deploy.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -233,7 +234,7 @@ func (dc *ResourceDeploymentClient) monitorProgress(ctx context.Context, name st
 				return err
 			}
 
-			if id.Type() == NestedModuleType {
+			if strings.EqualFold(id.Type(), NestedModuleType) {
 				// Recursively monitor progress for nested deployments in a new goroutine
 				wg.Add(1)
 				go func() {

--- a/pkg/cli/azure/deploy.go
+++ b/pkg/cli/azure/deploy.go
@@ -238,6 +238,8 @@ func (dc *ResourceDeploymentClient) monitorProgress(ctx context.Context, name st
 				// Recursively monitor progress for nested deployments in a new goroutine
 				wg.Add(1)
 				go func() {
+					// Bicep modules are themselves a resource, and so they only will show up after the deployment starts.
+					// When that happens we need to monitor them recursively so we can display the resources inside of them.
 					_ = dc.monitorProgress(ctx, id.Name(), progressChan, wg)
 					wg.Done()
 				}()

--- a/pkg/cli/azure/deploy.go
+++ b/pkg/cli/azure/deploy.go
@@ -22,10 +22,14 @@ import (
 	ucpresources "github.com/project-radius/radius/pkg/ucp/resources"
 )
 
-// OperationPollInterval is the interval used for polling of deployment operations for progress.
-const OperationPollInterval time.Duration = time.Second * 5
+const (
+	NestedModuleType string = "Microsoft.Resources/deployments"
 
-type ResouceDeploymentClient struct {
+	// OperationPollInterval is the interval used for polling of deployment operations for progress.
+	OperationPollInterval time.Duration = time.Second * 5
+)
+
+type ResourceDeploymentClient struct {
 	RadiusResourceGroup string
 	Client              azclients.ResourceDeploymentClient
 	OperationsClient    azclients.ResourceDeploymentOperationsClient
@@ -33,9 +37,9 @@ type ResouceDeploymentClient struct {
 	AzProvider          *workspaces.AzureProvider
 }
 
-var _ clients.DeploymentClient = (*ResouceDeploymentClient)(nil)
+var _ clients.DeploymentClient = (*ResourceDeploymentClient)(nil)
 
-func (dc *ResouceDeploymentClient) Deploy(ctx context.Context, options clients.DeploymentOptions) (clients.DeploymentResult, error) {
+func (dc *ResourceDeploymentClient) Deploy(ctx context.Context, options clients.DeploymentOptions) (clients.DeploymentResult, error) {
 	// Used for graceful shutdown of the polling listener.
 	wg := sync.WaitGroup{}
 	defer func() {
@@ -72,7 +76,7 @@ func (dc *ResouceDeploymentClient) Deploy(ctx context.Context, options clients.D
 	return summary, nil
 }
 
-func (dc *ResouceDeploymentClient) startDeployment(ctx context.Context, name string, options clients.DeploymentOptions) (*resources.DeploymentsCreateOrUpdateFuture, error) {
+func (dc *ResourceDeploymentClient) startDeployment(ctx context.Context, name string, options clients.DeploymentOptions) (*resources.DeploymentsCreateOrUpdateFuture, error) {
 	var resourceId string
 	scopes := []ucpresources.ScopeSegment{
 		{Type: "deployments", Name: "local"},
@@ -102,7 +106,7 @@ func (dc *ResouceDeploymentClient) startDeployment(ctx context.Context, name str
 	return &future, nil
 }
 
-func (dc *ResouceDeploymentClient) GetProviderConfigs() azclients.ProviderConfig {
+func (dc *ResourceDeploymentClient) GetProviderConfigs() azclients.ProviderConfig {
 	var providerConfigs azclients.ProviderConfig
 	if dc.AzProvider != nil {
 		if dc.AzProvider.SubscriptionID != "" && dc.AzProvider.ResourceGroup != "" {
@@ -137,7 +141,7 @@ func (dc *ResouceDeploymentClient) GetProviderConfigs() azclients.ProviderConfig
 	return providerConfigs
 }
 
-func (dc *ResouceDeploymentClient) createSummary(deployment resources.DeploymentExtended) (clients.DeploymentResult, error) {
+func (dc *ResourceDeploymentClient) createSummary(deployment resources.DeploymentExtended) (clients.DeploymentResult, error) {
 	if deployment.Properties == nil || deployment.Properties.OutputResources == nil {
 		return clients.DeploymentResult{}, nil
 	}
@@ -170,7 +174,7 @@ func (dc *ResouceDeploymentClient) createSummary(deployment resources.Deployment
 	return clients.DeploymentResult{Resources: resources, Outputs: outputs}, nil
 }
 
-func (dc *ResouceDeploymentClient) waitForCompletion(ctx context.Context, future resources.DeploymentsCreateOrUpdateFuture) (clients.DeploymentResult, error) {
+func (dc *ResourceDeploymentClient) waitForCompletion(ctx context.Context, future resources.DeploymentsCreateOrUpdateFuture) (clients.DeploymentResult, error) {
 	var err error
 	var deployment resources.DeploymentExtended
 
@@ -193,7 +197,7 @@ func (dc *ResouceDeploymentClient) waitForCompletion(ctx context.Context, future
 	return summary, nil
 }
 
-func (dc *ResouceDeploymentClient) monitorProgress(ctx context.Context, name string, progressChan chan<- clients.ResourceProgress) error {
+func (dc *ResourceDeploymentClient) monitorProgress(ctx context.Context, name string, progressChan chan<- clients.ResourceProgress) error {
 	// A note about this: since we're doing polling we might not see all of the operations
 	// complete before the overall deployment completes. That's fine, this will be handled
 	// by the presentation layer. In this code we just cancel when we're told to.
@@ -228,6 +232,12 @@ func (dc *ResouceDeploymentClient) monitorProgress(ctx context.Context, name str
 			if err != nil {
 				return err
 			}
+
+			if id.Type() == NestedModuleType {
+				// Recursively monitor progress for nested deployments in a new goroutine
+				go dc.monitorProgress(ctx, id.Name(), progressChan)
+			}
+
 			current := status[id.String()]
 
 			next := clients.StatusStarted
@@ -250,7 +260,7 @@ func (dc *ResouceDeploymentClient) monitorProgress(ctx context.Context, name str
 	return nil
 }
 
-func (dc *ResouceDeploymentClient) listOperations(ctx context.Context, name string) ([]resources.DeploymentOperation, error) {
+func (dc *ResourceDeploymentClient) listOperations(ctx context.Context, name string) ([]resources.DeploymentOperation, error) {
 	var resourceId string
 
 	// No providers section, hence all segments are part of scopes

--- a/pkg/cli/azure/deploy_test.go
+++ b/pkg/cli/azure/deploy_test.go
@@ -15,7 +15,7 @@ import (
 
 func Test_GetProviderConfigs(t *testing.T) {
 
-	resourceDeploymentClient := ResouceDeploymentClient{
+	resourceDeploymentClient := ResourceDeploymentClient{
 		RadiusResourceGroup: "testrg",
 		Client:              clients.ResourceDeploymentClient{},
 		OperationsClient:    clients.ResourceDeploymentOperationsClient{},
@@ -43,7 +43,7 @@ func Test_GetProviderConfigs(t *testing.T) {
 
 func Test_GetProviderConfigsWithAzProvider(t *testing.T) {
 
-	resourceDeploymentClient := ResouceDeploymentClient{
+	resourceDeploymentClient := ResourceDeploymentClient{
 		RadiusResourceGroup: "testrg",
 		Client:              clients.ResourceDeploymentClient{},
 		OperationsClient:    clients.ResourceDeploymentOperationsClient{},

--- a/pkg/cli/connections/factory.go
+++ b/pkg/cli/connections/factory.go
@@ -77,7 +77,7 @@ func (*impl) CreateDeploymentClient(ctx context.Context, workspace workspaces.Wo
 			return nil, err
 		}
 
-		return &azure.ResouceDeploymentClient{
+		return &azure.ResourceDeploymentClient{
 			Client:              dc,
 			OperationsClient:    op,
 			RadiusResourceGroup: id.FindScope(resources.ResourceGroupsSegment),

--- a/pkg/cli/localrp/deploy.go
+++ b/pkg/cli/localrp/deploy.go
@@ -25,7 +25,7 @@ var _ clients.DeploymentClient = (*LocalRPDeploymentClient)(nil)
 
 // Local RP Deployment Client to be used for local deployments to Azure environments
 type LocalRPDeploymentClient struct {
-	InnerClient azure.ResouceDeploymentClient
+	InnerClient azure.ResourceDeploymentClient
 	BindUrl     string
 	BackendUrl  string
 }


### PR DESCRIPTION
# Description

* Added recursive call to `dc.monitorProgress` to recurse into modules and provide deployment information
* Fixed typo: `ResourceDeploymentClient` -> `ResourceDeploymentClient`

## Example output

```
❯ rad deploy /Users/willsmith/dev/radius-sandbox/module/appwithmodule.bicep
Building /Users/willsmith/dev/radius-sandbox/module/appwithmodule.bicep...
Deploying template '/Users/willsmith/dev/radius-sandbox/module/appwithmodule.bicep' into environment 'kind-kind' from workspace 'kind-kind'...

Deployment In Progress...

Completed            module          Microsoft.Resources/deployments
Completed            containerwithmoduletwo Applications.Core/containers
Completed            appwithmodule   Applications.Core/applications
Completed            gatewaywithmodule Applications.Core/gateways
Completed            containerwithmodule Applications.Core/containers
Completed            routewithmodule Applications.Core/httpRoutes

Deployment Complete

Resources:
    appwithmodule   Applications.Core/applications
    containerwithmodule Applications.Core/containers
    containerwithmoduletwo Applications.Core/containers
    gatewaywithmodule Applications.Core/gateways
    routewithmodule Applications.Core/httpRoutes

Public Endpoints:
    gatewaywithmodule Applications.Core/gateways unknown
```

## Issue reference

Fixes: https://github.com/project-radius/radius/issues/3132

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
