### PR TITLE
Adding observed generation check in the deployment readiness check to avoid stale replicas

### DIFF
--- a/pkg/corerp/handlers/kubernetes.go
+++ b/pkg/corerp/handlers/kubernetes.go
@@ -250,7 +250,10 @@ func (handler *kubernetesHandler) watchUntilDeploymentReady(ctx context.Context,
 		// check for complete deployment condition
 		// Reference https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#complete-deployment
 		if c.Type == v1.DeploymentProgressing && c.Status == corev1.ConditionTrue && strings.EqualFold(c.Reason, "NewReplicaSetAvailable") {
-			readinessCh <- true
+			// ObservedGeneration should be updated to latest generation to avoid stale replicas
+			if obj.Status.ObservedGeneration >= obj.Generation {
+				readinessCh <- true
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Description

Adding observed generation to avoid stale replicas in the deployment readiness status conditions.

## Issue reference

Fixes: #3425 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
