### PR TITLE
Switch to CDN addresses for blob assets

### DIFF
--- a/.devcontainer/tutorials-codespace/Dockerfile
+++ b/.devcontainer/tutorials-codespace/Dockerfile
@@ -12,11 +12,11 @@ RUN bash /tmp/library-scripts/azcli-debian.sh \
 
 # Install rad CLI (Linux)
 #    TODO: change to make binary directly inside this Dockerfile? 
-RUN wget -O /usr/local/bin/rad https://radiuspublic.blob.core.windows.net/tools/rad/edge/linux-x64/rad 
+RUN wget -O /usr/local/bin/rad https://get.radapp.dev/tools/rad/edge/linux-x64/rad 
 RUN chmod +rx /usr/local/bin/rad
 
 # Download Radius VSCode extension
-RUN wget -O /home/rad-vscode-bicep.vsix https://radiuspublic.blob.core.windows.net/tools/vscode/edge/rad-vscode-bicep.vsix
+RUN wget -O /home/rad-vscode-bicep.vsix https://get.radapp.dev/tools/vscode/edge/rad-vscode-bicep.vsix
 
 USER vscode
 

--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -43,7 +43,7 @@ jobs:
       # a newer release
       - name: Download version marker file
         run: |
-          curl https://radiuspublic.blob.core.windows.net/version/stable.txt -o current-stable.txt
+          curl https://get.radapp.dev/version/stable.txt -o current-stable.txt
         if: ${{ success() && env.UPDATE_RELEASE == 'true' }}
       - name: Get version
         id: setcurrentversion

--- a/.github/workflows/validate-bicep.yaml
+++ b/.github/workflows/validate-bicep.yaml
@@ -33,7 +33,7 @@ jobs:
         run: python ./.github/scripts/get_release_version.py
       - name: Download rad-bicep-corerp
         run: |
-          ./.github/scripts/curl-with-retries.sh https://radiuspublic.blob.core.windows.net/tools/bicep-extensibility/${{ env.REL_CHANNEL }}/linux-x64/rad-bicep --output rad-bicep-corerp
+          ./.github/scripts/curl-with-retries.sh https://get.radapp.dev/tools/bicep-extensibility/${{ env.REL_CHANNEL }}/linux-x64/rad-bicep --output rad-bicep-corerp
           chmod +x rad-bicep-corerp
           ./rad-bicep-corerp --version
       - name: Verify Bicep files

--- a/docs/contributing/contributing-code/release-process.md
+++ b/docs/contributing/contributing-code/release-process.md
@@ -128,7 +128,7 @@ Do not start the release until the following scenarios are validated:
    
    If this is a new minor release - check the stable version marker.
    
-   The file https://radiuspublic.blob.core.windows.net/version/stable.txt should contain (in plain text) the channel you just created.
+   The file https://get.radapp.dev/version/stable.txt should contain (in plain text) the channel you just created.
    
    You can find this file in the storage account under `version/stable.txt`.
 
@@ -159,13 +159,13 @@ After creating a release, it's good to sanity check that the release works in so
 
    ```sh
    Windows:
-   $script=iwr -useb  https://radiuspublic.blob.core.windows.net/tools/rad/install.ps1; $block=[ScriptBlock]::Create($script); invoke-command -ScriptBlock $block -ArgumentList 0.12.0-rc3
+   $script=iwr -useb  https://get.radapp.dev/tools/rad/install.ps1; $block=[ScriptBlock]::Create($script); invoke-command -ScriptBlock $block -ArgumentList 0.12.0-rc3
 
    MacOS:
-   curl -fsSL "https://radiuspublic.blob.core.windows.net/tools/rad/install.sh" | /bin/bash -s 0.12.0-rc3
+   curl -fsSL "https://get.radapp.dev/tools/rad/install.sh" | /bin/bash -s 0.12.0-rc3
 
    Direct binary downloads
-   https://radiuspublic.blob.core.windows.net/tools/rad/<version>/<macos-x64 or windows-x64 or linux-x64>/rad
+   https://get.radapp.dev/tools/rad/<version>/<macos-x64 or windows-x64 or linux-x64>/rad
    ```
 
    Note: if you download the direct binary, execute `rad bicep download` to also download the corresponding bicep compiler binary. The scripts above will download the bicep compiler by default.

--- a/pkg/cli/bicep/bicep.go
+++ b/pkg/cli/bicep/bicep.go
@@ -52,7 +52,7 @@ func DeleteBicep() error {
 func DownloadBicep() error {
 	dirPrefix := "bicep-extensibility"
 	// Placeholders are for: channel, platform, filename
-	downloadURIFmt := fmt.Sprint("https://radiuspublic.blob.core.windows.net/tools/", dirPrefix, "/%s/%s/%s")
+	downloadURIFmt := fmt.Sprint("https://get.radapp.dev/tools/", dirPrefix, "/%s/%s/%s")
 
 	uri, err := tools.GetDownloadURI(downloadURIFmt, binaryName)
 	if err != nil {

--- a/pkg/cli/de/de.go
+++ b/pkg/cli/de/de.go
@@ -17,7 +17,7 @@ const radDEEnvVar = "RAD_DE"
 const binaryName = "arm-de"
 
 // Placeholders are for: channel, platform, filename
-const downloadURIFmt = "https://radiuspublic.blob.core.windows.net/tools/de/%s/%s/%s"
+const downloadURIFmt = "https://get.radapp.dev/tools/de/%s/%s/%s"
 
 // IsDEInstalled returns true if our local copy of arm-de is installed
 func IsDEInstalled() (bool, error) {


### PR DESCRIPTION
# Description

As of 09/08/2022, any GET with URL Path containing `/edge/` to `get.radapp.dev` will automatically bypass the cache. This ensures users don't pick up stale edge releases.

This PR updates any URLs which were hitting the blob store directly.

This will save on costs when the URL automatically switches between edge and versioned releases based upon a script, such as our build and release pipelines.

