### PR TITLE
Automatically add new Issues to Core Team project

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -33,4 +33,13 @@ jobs:
               fi
             fi
           done
- 
+    
+  project:
+    name: Add Issue to Core Team project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Issue to Core Team project
+        uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/project-radius/projects/1
+          github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}


### PR DESCRIPTION
# Description

On creation of a new issue, add it to the [Core Team project](https://github.com/orgs/project-radius/projects/1).

Will ensure Issues aren't "orphaned" and left untriaged outside of the project.

## Issue reference

Closes #3004

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
