### PR TITLE
Add cli flags to support AWS Provider

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -163,6 +163,7 @@ stages:
       displayName: run functional ucp tests
     - publish: $(Build.SourcesDirectory)/dist/container_logs
       displayName: Publish container logs
+      artifact: container_logs_$(Build.BuildNumber)
       condition: always()
     - script: |
         az group delete \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -163,7 +163,7 @@ stages:
       displayName: run functional ucp tests
     - publish: $(Build.SourcesDirectory)/dist/container_logs
       displayName: Publish container logs
-      artifact: container_logs_$(Build.BuildNumber)
+      artifact: FunctionalTest.ApplicationsCoreRPLogs.$(Build.BuildNumber)
       condition: always()
     - script: |
         az group delete \

--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -46,7 +46,7 @@ func init() {
 
 	setup.RegisterPersistentChartArgs(envInitCmd)
 	setup.RegisterPersistentAzureProviderArgs(envInitCmd)
-	setup.RegisterPersistentAwsProviderArgs(envInitCmd)
+	setup.RegisterPersistentAWSProviderArgs(envInitCmd)
 }
 
 type EnvKind int
@@ -89,8 +89,8 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 		return err
 	}
 
-	// Configure Aws provider for cloud resources if specified
-	awsProvider, err := setup.ParseAwsProviderFromArgs(cmd, interactive)
+	// Configure AWS provider for cloud resources if specified
+	awsProvider, err := setup.ParseAWSProviderFromArgs(cmd, interactive)
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 		Name: environmentName,
 		Providers: &environments.Providers{
 			AzureProvider: azureProvider,
-			AwsProvider:   awsProvider},
+			AWSProvider:   awsProvider},
 	}
 
 	cliOptions := helm.CLIClusterOptions{
@@ -133,7 +133,7 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 			AppCoreTag:             chartArgs.AppCoreTag,
 			PublicEndpointOverride: chartArgs.PublicEndpointOverride,
 			AzureProvider:          azureProvider,
-			AwsProvider:            awsProvider,
+			AWSProvider:            awsProvider,
 		},
 	}
 

--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -294,7 +294,7 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 	//if reinstall is specified then use azprovider if provided, or if not, this is an install with no azProviderConfig yet.
 	//if no reinstall, then make sure to preserve the azProviderConfig from existing installation
 	var azProviderConfig workspaces.AzureProvider
-	if azProvider != nil && azProvider.SubscriptionID != "" && azProvider.ResourceGroup != "" {
+	if azProvider != nil {
 		azProviderConfig = workspaces.AzureProvider{
 			SubscriptionID: azProvider.SubscriptionID,
 			ResourceGroup:  azProvider.ResourceGroup,
@@ -308,7 +308,7 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 	}
 
 	var awsProviderConfig workspaces.AWSProvider
-	if awsProvider != nil && awsProvider.TargetRegion != "" && awsProvider.AccountId != "" {
+	if awsProvider != nil {
 		awsProviderConfig = workspaces.AWSProvider{
 			Region:    awsProvider.TargetRegion,
 			AccountId: awsProvider.AccountId,

--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -44,8 +44,9 @@ func init() {
 	envInitCmd.PersistentFlags().StringP("namespace", "n", "default", "Specify the namespace to use for the environment into which application resources are deployed")
 	envInitCmd.PersistentFlags().BoolP("force", "f", false, "Overwrite existing workspace if present")
 
-	setup.RegisterPersistantChartArgs(envInitCmd)
-	setup.RegistePersistantAzureProviderArgs(envInitCmd)
+	setup.RegisterPersistentChartArgs(envInitCmd)
+	setup.RegisterPersistentAzureProviderArgs(envInitCmd)
+	setup.RegisterPersistentAwsProviderArgs(envInitCmd)
 }
 
 type EnvKind int
@@ -88,6 +89,12 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 		return err
 	}
 
+	// Configure Aws provider for cloud resources if specified
+	awsProvider, err := setup.ParseAwsProviderFromArgs(cmd, interactive)
+	if err != nil {
+		return err
+	}
+
 	var defaultEnvName string
 
 	switch kind {
@@ -110,8 +117,10 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 	}
 
 	params := &EnvironmentParams{
-		Name:      environmentName,
-		Providers: &environments.Providers{AzureProvider: azureProvider},
+		Name: environmentName,
+		Providers: &environments.Providers{
+			AzureProvider: azureProvider,
+			AwsProvider:   awsProvider},
 	}
 
 	cliOptions := helm.CLIClusterOptions{
@@ -124,6 +133,7 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 			AppCoreTag:             chartArgs.AppCoreTag,
 			PublicEndpointOverride: chartArgs.PublicEndpointOverride,
 			AzureProvider:          azureProvider,
+			AwsProvider:            awsProvider,
 		},
 	}
 

--- a/cmd/rad/cmd/installKubernetes.go
+++ b/cmd/rad/cmd/installKubernetes.go
@@ -28,8 +28,8 @@ func init() {
 	installCmd.AddCommand(installKubernetesCmd)
 	installKubernetesCmd.PersistentFlags().BoolP("interactive", "i", false, "Collect values for required command arguments through command line interface prompts")
 	installKubernetesCmd.Flags().String("kubecontext", "", "the Kubernetes context to use, will use the default if unset")
-	setup.RegisterPersistantChartArgs(installKubernetesCmd)
-	setup.RegistePersistantAzureProviderArgs(installKubernetesCmd)
+	setup.RegisterPersistentChartArgs(installKubernetesCmd)
+	setup.RegisterPersistentAzureProviderArgs(installKubernetesCmd)
 }
 
 func installKubernetes(cmd *cobra.Command, args []string) error {

--- a/cmd/rad/cmd/workspaceInitKubernetes.go
+++ b/cmd/rad/cmd/workspaceInitKubernetes.go
@@ -33,7 +33,7 @@ func init() {
 	workspaceInitKubernetesCmd.Flags().BoolP("force", "f", false, "Overwrite existing workspace if present")
 	workspaceInitKubernetesCmd.Flags().String("kubecontext", "", "the Kubernetes context to use, will use the default if unset")
 
-	setup.RegistePersistantAzureProviderArgs(workspaceInitKubernetesCmd)
+	setup.RegisterPersistentAzureProviderArgs(workspaceInitKubernetesCmd)
 }
 
 func initWorkspaceKubernetes(cmd *cobra.Command, args []string) error {

--- a/deploy/Chart/charts/ucp/templates/ucp.yaml
+++ b/deploy/Chart/charts/ucp/templates/ucp.yaml
@@ -97,7 +97,7 @@ metadata:
 stringData:
 # Configuration for 'AWS' provider functionality
 {{ if .Values.global.rp.provider.aws }}
-  AWS_ACCESS_KEY_ID: {{ .Values.global.rp.provider.aws.principalKeyId }} 
-  AWS_SECRET_ACCESS_KEY: {{ .Values.global.rp.provider.aws.principalAccessKey }}
+  AWS_ACCESS_KEY_ID: {{ .Values.global.rp.provider.aws.accessKeyId }} 
+  AWS_SECRET_ACCESS_KEY: {{ .Values.global.rp.provider.aws.secretAccessKey }}
   AWS_DEFAULT_REGION: {{ .Values.global.rp.provider.aws.region }}
 {{ end }}

--- a/deploy/Chart/charts/ucp/templates/ucp.yaml
+++ b/deploy/Chart/charts/ucp/templates/ucp.yaml
@@ -23,6 +23,9 @@ spec:
       serviceAccountName: ucp
       containers:
       - image: "{{ .Values.global.ucp.image }}:{{ .Values.global.ucp.tag }}"
+        envFrom:
+        - secretRef: 
+            name: ucp-aws-provider-credentials
         env:
         - name: UCP_CONFIG
           value: /etc/config/ucp-config.yaml
@@ -83,3 +86,18 @@ metadata:
 data:
   ucp-config.yaml: |-
 {{ .Files.Get "ucp-config.yaml" | indent 4}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ucp-aws-provider-credentials
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app: ucp
+stringData:
+# Configuration for 'AWS' provider functionality
+{{ if .Values.global.rp.provider.aws }}
+  AWS_ACCESS_KEY_ID: {{ .Values.global.rp.provider.aws.principalKeyId }} 
+  AWS_SECRET_ACCESS_KEY: {{ .Values.global.rp.provider.aws.principalAccessKey }}
+  AWS_DEFAULT_REGION: {{ .Values.global.rp.provider.aws.region }}
+{{ end }}

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
 	github.com/Masterminds/squirrel v1.5.2 // indirect
+	github.com/aws/aws-sdk-go v1.44.98 // indirect
 	github.com/benbjohnson/clock v1.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
@@ -115,6 +116,7 @@ require (
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jmoiron/sqlx v1.3.4 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.30.27/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.34.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.40.14/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+github.com/aws/aws-sdk-go v1.44.98 h1:fX+NxebSdO/9T6DTNOLhpC+Vv6RNkKRfsMg0a7o/yBo=
+github.com/aws/aws-sdk-go v1.44.98/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -964,6 +966,7 @@ github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.3.1/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=

--- a/pkg/cli/aws/provider.go
+++ b/pkg/cli/aws/provider.go
@@ -10,4 +10,5 @@ type Provider struct {
 	AccessKeyId     string
 	SecretAccessKey string
 	TargetRegion    string
+	AccountId       string
 }

--- a/pkg/cli/aws/provider.go
+++ b/pkg/cli/aws/provider.go
@@ -7,7 +7,7 @@ package aws
 
 // Provider specifies the properties required to configure Azure provider for cloud resources
 type Provider struct {
-	PrincipalKeyId string
-	PrincipalAccessKey string
-	TargetRegion string
+	AccessKeyId     string
+	SecretAccessKey string
+	TargetRegion    string
 }

--- a/pkg/cli/aws/provider.go
+++ b/pkg/cli/aws/provider.go
@@ -1,0 +1,13 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package aws
+
+// Provider specifies the properties required to configure Azure provider for cloud resources
+type Provider struct {
+	PrincipalKeyId string
+	PrincipalAccessKey string
+	TargetRegion string
+}

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -257,9 +257,6 @@ func GetConfigFilePath(v *viper.Viper) string {
 }
 
 func UpdateAzProvider(section *WorkspaceSection, provider workspaces.AzureProvider, contextName string) {
-	if provider.ResourceGroup == "" || provider.SubscriptionID == "" {
-		return
-	}
 	for _, workspaceItem := range section.Items {
 		if workspaceItem.IsSameKubernetesContext(contextName) {
 			workspaceName := workspaceItem.Name
@@ -273,9 +270,6 @@ func UpdateAzProvider(section *WorkspaceSection, provider workspaces.AzureProvid
 }
 
 func UpdateAWSProvider(section *WorkspaceSection, provider workspaces.AWSProvider, contextName string) {
-	if provider.AccountId == "" || provider.Region == "" {
-		return
-	}
 	for _, workspaceItem := range section.Items {
 		if workspaceItem.IsSameKubernetesContext(contextName) {
 			workspaceName := workspaceItem.Name

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -20,10 +20,11 @@ import (
 	en_translations "github.com/go-playground/validator/v10/translations/en"
 	"github.com/gofrs/flock"
 	"github.com/mitchellh/go-homedir"
-	"github.com/project-radius/radius/pkg/cli/output"
-	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/spf13/viper"
 	"golang.org/x/text/cases"
+
+	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/project-radius/radius/pkg/cli/workspaces"
 )
 
 // EnvironmentKey is the key used for the environment section
@@ -256,10 +257,32 @@ func GetConfigFilePath(v *viper.Viper) string {
 }
 
 func UpdateAzProvider(section *WorkspaceSection, provider workspaces.AzureProvider, contextName string) {
+	if provider.ResourceGroup == "" || provider.SubscriptionID == "" {
+		return
+	}
 	for _, workspaceItem := range section.Items {
 		if workspaceItem.IsSameKubernetesContext(contextName) {
 			workspaceName := workspaceItem.Name
-			workspaceItem.ProviderConfig.Azure = &workspaces.AzureProvider{ResourceGroup: provider.ResourceGroup, SubscriptionID: provider.SubscriptionID}
+			workspaceItem.ProviderConfig.Azure = &workspaces.AzureProvider{
+				ResourceGroup:  provider.ResourceGroup,
+				SubscriptionID: provider.SubscriptionID,
+			}
+			section.Items[workspaceName] = workspaceItem
+		}
+	}
+}
+
+func UpdateAWSProvider(section *WorkspaceSection, provider workspaces.AWSProvider, contextName string) {
+	if provider.AccountId == "" || provider.Region == "" {
+		return
+	}
+	for _, workspaceItem := range section.Items {
+		if workspaceItem.IsSameKubernetesContext(contextName) {
+			workspaceName := workspaceItem.Name
+			workspaceItem.ProviderConfig.AWS = &workspaces.AWSProvider{
+				AccountId: provider.AccountId,
+				Region:    provider.Region,
+			}
 			section.Items[workspaceName] = workspaceItem
 		}
 	}

--- a/pkg/cli/environments/types.go
+++ b/pkg/cli/environments/types.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/project-radius/radius/pkg/cli/aws"
 	"github.com/project-radius/radius/pkg/cli/azure"
 	"github.com/project-radius/radius/pkg/cli/clients"
 )
@@ -52,6 +53,7 @@ type Registry struct {
 
 type Providers struct {
 	AzureProvider *azure.Provider `mapstructure:"azure,omitempty"`
+	AwsProvider   *aws.Provider   `mapstructure:"aws,omitempty"`
 }
 
 type DeploymentEnvironment interface {

--- a/pkg/cli/environments/types.go
+++ b/pkg/cli/environments/types.go
@@ -53,7 +53,7 @@ type Registry struct {
 
 type Providers struct {
 	AzureProvider *azure.Provider `mapstructure:"azure,omitempty"`
-	AwsProvider   *aws.Provider   `mapstructure:"aws,omitempty"`
+	AWSProvider   *aws.Provider   `mapstructure:"aws,omitempty"`
 }
 
 type DeploymentEnvironment interface {

--- a/pkg/cli/helm/cluster.go
+++ b/pkg/cli/helm/cluster.go
@@ -11,11 +11,11 @@ import (
 	"fmt"
 	"strings"
 
+	helm "helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/storage/driver"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/project-radius/radius/pkg/version"
-	helm "helm.sh/helm/v3/pkg/action"
-	"helm.sh/helm/v3/pkg/storage/driver"
 )
 
 const (
@@ -105,6 +105,9 @@ func PopulateDefaultClusterOptions(cliOptions CLIClusterOptions) ClusterOptions 
 
 	if cliOptions.Radius.AzureProvider != nil {
 		options.Radius.AzureProvider = cliOptions.Radius.AzureProvider
+	}
+	if cliOptions.Radius.AwsProvider != nil {
+		options.Radius.AwsProvider = cliOptions.Radius.AwsProvider
 	}
 
 	return options

--- a/pkg/cli/helm/cluster.go
+++ b/pkg/cli/helm/cluster.go
@@ -106,8 +106,8 @@ func PopulateDefaultClusterOptions(cliOptions CLIClusterOptions) ClusterOptions 
 	if cliOptions.Radius.AzureProvider != nil {
 		options.Radius.AzureProvider = cliOptions.Radius.AzureProvider
 	}
-	if cliOptions.Radius.AwsProvider != nil {
-		options.Radius.AwsProvider = cliOptions.Radius.AwsProvider
+	if cliOptions.Radius.AWSProvider != nil {
+		options.Radius.AWSProvider = cliOptions.Radius.AWSProvider
 	}
 
 	return options

--- a/pkg/cli/helm/radiusclient.go
+++ b/pkg/cli/helm/radiusclient.go
@@ -312,9 +312,9 @@ func addAwsProviderValues(helmChart *chart.Chart, awsProvider *aws.Provider) err
 	provider := rp["provider"].(map[string]interface{})
 
 	provider["aws"] = map[string]interface{}{
-		"principalKeyId":     awsProvider.PrincipalKeyId,
-		"principalAccessKey": awsProvider.PrincipalAccessKey,
-		"region":             awsProvider.TargetRegion,
+		"accessKeyId":     awsProvider.AccessKeyId,
+		"secretAccessKey": awsProvider.SecretAccessKey,
+		"region":          awsProvider.TargetRegion,
 	}
 
 	return nil

--- a/pkg/cli/helm/radiusclient.go
+++ b/pkg/cli/helm/radiusclient.go
@@ -43,7 +43,7 @@ type RadiusOptions struct {
 	DETag                  string
 	PublicEndpointOverride string
 	AzureProvider          *azure.Provider
-	AwsProvider            *aws.Provider
+	AWSProvider            *aws.Provider
 }
 
 func ApplyRadiusHelmChart(options RadiusOptions, kubeContext string) (bool, error) {
@@ -84,8 +84,8 @@ func ApplyRadiusHelmChart(options RadiusOptions, kubeContext string) (bool, erro
 		}
 	}
 
-	if options.AwsProvider != nil {
-		err = addAwsProviderValues(helmChart, options.AwsProvider)
+	if options.AWSProvider != nil {
+		err = addAWSProviderValues(helmChart, options.AWSProvider)
 		if err != nil {
 			return false, fmt.Errorf("failed to add aws provider values, err: %w, helm output: %s", err, helmOutput.String())
 		}
@@ -287,7 +287,7 @@ func addRadiusValues(helmChart *chart.Chart, options *RadiusOptions) error {
 	return nil
 }
 
-func addAwsProviderValues(helmChart *chart.Chart, awsProvider *aws.Provider) error {
+func addAWSProviderValues(helmChart *chart.Chart, awsProvider *aws.Provider) error {
 	if awsProvider == nil {
 		return nil
 	}

--- a/pkg/cli/prompt/prompt.go
+++ b/pkg/cli/prompt/prompt.go
@@ -65,7 +65,7 @@ func ConfirmWithDefault(prompt string, defaultAns BinaryAnswer) (bool, error) {
 		if count == 0 && defaultAns != unknown {
 			return defaultAns == Yes, nil
 		} else if err != nil {
-			return false, errors.New("nothing enterted")
+			return false, errors.New("nothing entered")
 		}
 
 		if strings.EqualFold("y", input) {

--- a/pkg/cli/setup/aws.go
+++ b/pkg/cli/setup/aws.go
@@ -83,8 +83,10 @@ func parseAWSProviderNonInteractive(cmd *cobra.Command) (*radAWS.Provider, error
 
 	creds := credentials.NewStaticCredentials(keyId, secretAccessKey, "")
 	awsConfig := aws.NewConfig().WithCredentials(creds).WithMaxRetries(3)
-	mySession := session.Must(session.NewSession(awsConfig))
-
+	mySession, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize a AWS session object: %w", err)
+	}
 	client := sts.New(mySession)
 	result, err := client.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 	awsError := awserr.New("", "", errors.New("")) //placeholder error to be filled by errors.As() below

--- a/pkg/cli/setup/aws.go
+++ b/pkg/cli/setup/aws.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	AwsProviderFlagName                = "provider-aws"
-	AwsProviderAccessKeyIdFlagName     = "provider-aFws-access-key-id"
+	AwsProviderAccessKeyIdFlagName     = "provider-aws-access-key-id"
 	AwsProviderSecretAccessKeyFlagName = "provider-aws-secret-access-key"
 	AwsProviderRegionFlagName          = "provider-aws-region"
 )

--- a/pkg/cli/setup/aws.go
+++ b/pkg/cli/setup/aws.go
@@ -1,0 +1,81 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package setup
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/project-radius/radius/pkg/cli/aws"
+)
+
+const (
+	AWS_PROVIDER_FLAG_NAME        = "provider-aws"
+	AWS_PROVIDER_KEY_ID_FLAG_NAME = "provider-aws-access-key-id"
+	AWS_PROVIDER_SECRET_FLAG_NAME = "provider-aws-secret-access-key"
+	AWS_PROVIDER_REGION_FLAG_NAME = "provider-aws-region"
+)
+
+func RegisterPersistentAwsProviderArgs(cmd *cobra.Command) {
+	cmd.PersistentFlags().BoolP(
+		AWS_PROVIDER_FLAG_NAME,
+		"",
+		false,
+		"Add AWS provider for cloud resources",
+	)
+	cmd.PersistentFlags().String(
+		AWS_PROVIDER_KEY_ID_FLAG_NAME,
+		"",
+		"Specifies an AWS access key associated with an IAM user or role",
+	)
+	cmd.PersistentFlags().String(
+		AWS_PROVIDER_SECRET_FLAG_NAME,
+		"",
+		"Specifies the secret key associated with the access key. This is essentially the \"password\" for the access key",
+	)
+	cmd.PersistentFlags().String(
+		AWS_PROVIDER_REGION_FLAG_NAME,
+		"",
+		"Specifies the region to be used for resources deployed by this provider",
+	)
+}
+
+func ParseAwsProviderFromArgs(cmd *cobra.Command, interactive bool) (*aws.Provider, error) {
+	if interactive {
+		panic("Not implemented, see https://github.com/project-radius/radius/issues/3655")
+	}
+	return parseAwsProviderNonInteractive(cmd)
+
+}
+
+func parseAwsProviderNonInteractive(cmd *cobra.Command) (*aws.Provider, error) {
+	addAwsProvider, err := cmd.Flags().GetBool(AWS_PROVIDER_FLAG_NAME)
+	if err != nil {
+		return nil, err
+	}
+	if !addAwsProvider {
+		return nil, nil
+	}
+
+	principalKeyId, err := cmd.Flags().GetString(AWS_PROVIDER_KEY_ID_FLAG_NAME)
+	if err != nil {
+		return nil, err
+	}
+	principalSecret, err := cmd.Flags().GetString(AWS_PROVIDER_SECRET_FLAG_NAME)
+	if err != nil {
+		return nil, err
+	}
+
+	region, err := cmd.Flags().GetString(AWS_PROVIDER_REGION_FLAG_NAME)
+	if err != nil {
+		return nil, err
+	}
+
+	return &aws.Provider{
+		PrincipalKeyId:     principalKeyId,
+		PrincipalAccessKey: principalSecret,
+		TargetRegion:       region,
+	}, nil
+}

--- a/pkg/cli/setup/aws.go
+++ b/pkg/cli/setup/aws.go
@@ -74,8 +74,8 @@ func parseAwsProviderNonInteractive(cmd *cobra.Command) (*aws.Provider, error) {
 	}
 
 	return &aws.Provider{
-		PrincipalKeyId:     principalKeyId,
-		PrincipalAccessKey: principalSecret,
-		TargetRegion:       region,
+		AccessKeyId:     principalKeyId,
+		SecretAccessKey: principalSecret,
+		TargetRegion:    region,
 	}, nil
 }

--- a/pkg/cli/setup/aws.go
+++ b/pkg/cli/setup/aws.go
@@ -12,31 +12,31 @@ import (
 )
 
 const (
-	AWS_PROVIDER_FLAG_NAME        = "provider-aws"
-	AWS_PROVIDER_KEY_ID_FLAG_NAME = "provider-aws-access-key-id"
-	AWS_PROVIDER_SECRET_FLAG_NAME = "provider-aws-secret-access-key"
-	AWS_PROVIDER_REGION_FLAG_NAME = "provider-aws-region"
+	AwsProviderFlagName                = "provider-aws"
+	AwsProviderAccessKeyIdFlagName     = "provider-aFws-access-key-id"
+	AwsProviderSecretAccessKeyFlagName = "provider-aws-secret-access-key"
+	AwsProviderRegionFlagName          = "provider-aws-region"
 )
 
 func RegisterPersistentAwsProviderArgs(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolP(
-		AWS_PROVIDER_FLAG_NAME,
+		AwsProviderFlagName,
 		"",
 		false,
 		"Add AWS provider for cloud resources",
 	)
 	cmd.PersistentFlags().String(
-		AWS_PROVIDER_KEY_ID_FLAG_NAME,
+		AwsProviderAccessKeyIdFlagName,
 		"",
 		"Specifies an AWS access key associated with an IAM user or role",
 	)
 	cmd.PersistentFlags().String(
-		AWS_PROVIDER_SECRET_FLAG_NAME,
+		AwsProviderSecretAccessKeyFlagName,
 		"",
 		"Specifies the secret key associated with the access key. This is essentially the \"password\" for the access key",
 	)
 	cmd.PersistentFlags().String(
-		AWS_PROVIDER_REGION_FLAG_NAME,
+		AwsProviderRegionFlagName,
 		"",
 		"Specifies the region to be used for resources deployed by this provider",
 	)
@@ -51,7 +51,7 @@ func ParseAwsProviderFromArgs(cmd *cobra.Command, interactive bool) (*aws.Provid
 }
 
 func parseAwsProviderNonInteractive(cmd *cobra.Command) (*aws.Provider, error) {
-	addAwsProvider, err := cmd.Flags().GetBool(AWS_PROVIDER_FLAG_NAME)
+	addAwsProvider, err := cmd.Flags().GetBool(AwsProviderFlagName)
 	if err != nil {
 		return nil, err
 	}
@@ -59,16 +59,16 @@ func parseAwsProviderNonInteractive(cmd *cobra.Command) (*aws.Provider, error) {
 		return nil, nil
 	}
 
-	principalKeyId, err := cmd.Flags().GetString(AWS_PROVIDER_KEY_ID_FLAG_NAME)
+	principalKeyId, err := cmd.Flags().GetString(AwsProviderAccessKeyIdFlagName)
 	if err != nil {
 		return nil, err
 	}
-	principalSecret, err := cmd.Flags().GetString(AWS_PROVIDER_SECRET_FLAG_NAME)
+	principalSecret, err := cmd.Flags().GetString(AwsProviderSecretAccessKeyFlagName)
 	if err != nil {
 		return nil, err
 	}
 
-	region, err := cmd.Flags().GetString(AWS_PROVIDER_REGION_FLAG_NAME)
+	region, err := cmd.Flags().GetString(AwsProviderRegionFlagName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/setup/aws.go
+++ b/pkg/cli/setup/aws.go
@@ -12,63 +12,63 @@ import (
 )
 
 const (
-	AwsProviderFlagName                = "provider-aws"
-	AwsProviderAccessKeyIdFlagName     = "provider-aws-access-key-id"
-	AwsProviderSecretAccessKeyFlagName = "provider-aws-secret-access-key"
-	AwsProviderRegionFlagName          = "provider-aws-region"
+	AWSProviderFlagName                = "provider-aws"
+	AWSProviderAccessKeyIdFlagName     = "provider-aws-access-key-id"
+	AWSProviderSecretAccessKeyFlagName = "provider-aws-secret-access-key"
+	AWSProviderRegionFlagName          = "provider-aws-region"
 )
 
-func RegisterPersistentAwsProviderArgs(cmd *cobra.Command) {
+func RegisterPersistentAWSProviderArgs(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolP(
-		AwsProviderFlagName,
+		AWSProviderFlagName,
 		"",
 		false,
 		"Add AWS provider for cloud resources",
 	)
 	cmd.PersistentFlags().String(
-		AwsProviderAccessKeyIdFlagName,
+		AWSProviderAccessKeyIdFlagName,
 		"",
 		"Specifies an AWS access key associated with an IAM user or role",
 	)
 	cmd.PersistentFlags().String(
-		AwsProviderSecretAccessKeyFlagName,
+		AWSProviderSecretAccessKeyFlagName,
 		"",
 		"Specifies the secret key associated with the access key. This is essentially the \"password\" for the access key",
 	)
 	cmd.PersistentFlags().String(
-		AwsProviderRegionFlagName,
+		AWSProviderRegionFlagName,
 		"",
 		"Specifies the region to be used for resources deployed by this provider",
 	)
 }
 
-func ParseAwsProviderFromArgs(cmd *cobra.Command, interactive bool) (*aws.Provider, error) {
+func ParseAWSProviderFromArgs(cmd *cobra.Command, interactive bool) (*aws.Provider, error) {
 	if interactive {
 		panic("Not implemented, see https://github.com/project-radius/radius/issues/3655")
 	}
-	return parseAwsProviderNonInteractive(cmd)
+	return parseAWSProviderNonInteractive(cmd)
 
 }
 
-func parseAwsProviderNonInteractive(cmd *cobra.Command) (*aws.Provider, error) {
-	addAwsProvider, err := cmd.Flags().GetBool(AwsProviderFlagName)
+func parseAWSProviderNonInteractive(cmd *cobra.Command) (*aws.Provider, error) {
+	addAWSProvider, err := cmd.Flags().GetBool(AWSProviderFlagName)
 	if err != nil {
 		return nil, err
 	}
-	if !addAwsProvider {
+	if !addAWSProvider {
 		return nil, nil
 	}
 
-	principalKeyId, err := cmd.Flags().GetString(AwsProviderAccessKeyIdFlagName)
+	principalKeyId, err := cmd.Flags().GetString(AWSProviderAccessKeyIdFlagName)
 	if err != nil {
 		return nil, err
 	}
-	principalSecret, err := cmd.Flags().GetString(AwsProviderSecretAccessKeyFlagName)
+	principalSecret, err := cmd.Flags().GetString(AWSProviderSecretAccessKeyFlagName)
 	if err != nil {
 		return nil, err
 	}
 
-	region, err := cmd.Flags().GetString(AwsProviderRegionFlagName)
+	region, err := cmd.Flags().GetString(AWSProviderRegionFlagName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/setup/azure.go
+++ b/pkg/cli/setup/azure.go
@@ -19,16 +19,17 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/marstr/randname"
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
+
 	"github.com/project-radius/radius/pkg/azure/clients"
 	"github.com/project-radius/radius/pkg/cli/azure"
 	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/project-radius/radius/pkg/cli/prompt"
-	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 )
 
 // RegisterAzureProviderArgs adds flags to configure Azure provider for cloud resources.
-func RegistePersistantAzureProviderArgs(cmd *cobra.Command) {
+func RegisterPersistentAzureProviderArgs(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolP("provider-azure", "", false, "Add Azure provider for cloud resources")
 	cmd.PersistentFlags().String("provider-azure-subscription", "", "Azure subscription for cloud resources")
 	cmd.PersistentFlags().String("provider-azure-resource-group", "", "Azure resource-group for cloud resources")

--- a/pkg/cli/setup/chart.go
+++ b/pkg/cli/setup/chart.go
@@ -26,8 +26,8 @@ type ChartArgs struct {
 	PublicEndpointOverride string
 }
 
-// RegisterPersistantChartArgs registers the CLI arguments used for our Helm chart.
-func RegisterPersistantChartArgs(cmd *cobra.Command) {
+// RegisterPersistentChartArgs registers the CLI arguments used for our Helm chart.
+func RegisterPersistentChartArgs(cmd *cobra.Command) {
 	cmd.PersistentFlags().Bool("reinstall", false, "Specify to force reinstallation of Radius")
 	cmd.PersistentFlags().String("chart", "", "Specify a file path to a helm chart to install Radius from")
 	cmd.PersistentFlags().String("image", "", "Specify the radius controller image to use")

--- a/pkg/cli/workspaces/types.go
+++ b/pkg/cli/workspaces/types.go
@@ -36,17 +36,11 @@ type Workspace struct {
 type ProviderConfig struct {
 	// Azure represents the configuration for the Azure IAC provider used during deployment. This field is optional.
 	Azure *AzureProvider `json:"azure,omitempty" mapstructure:"azure" yaml:"azure,omitempty"`
-	// AWS represents the configuration for the AWS IAC provider used during deployment. This field is optional.
-	AWS *AwsProvider `json:"aws,omitempty" mapstructure:"aws" yaml:"aws,omitempty"`
 }
 
 type AzureProvider struct {
 	SubscriptionID string
 	ResourceGroup  string
-}
-
-type AwsProvider struct {
-	Scope string
 }
 
 // Registry represent the configuration for a container registry.

--- a/pkg/cli/workspaces/types.go
+++ b/pkg/cli/workspaces/types.go
@@ -36,11 +36,17 @@ type Workspace struct {
 type ProviderConfig struct {
 	// Azure represents the configuration for the Azure IAC provider used during deployment. This field is optional.
 	Azure *AzureProvider `json:"azure,omitempty" mapstructure:"azure" yaml:"azure,omitempty"`
+	// AWS represents the configuration for the AWS IAC provider used during deployment. This field is optional.
+	AWS *AwsProvider `json:"aws,omitempty" mapstructure:"aws" yaml:"aws,omitempty"`
 }
 
 type AzureProvider struct {
 	SubscriptionID string
 	ResourceGroup  string
+}
+
+type AwsProvider struct {
+	Scope string
 }
 
 // Registry represent the configuration for a container registry.

--- a/pkg/cli/workspaces/types.go
+++ b/pkg/cli/workspaces/types.go
@@ -36,26 +36,27 @@ type Workspace struct {
 type ProviderConfig struct {
 	// Azure represents the configuration for the Azure IAC provider used during deployment. This field is optional.
 	Azure *AzureProvider `json:"azure,omitempty" mapstructure:"azure" yaml:"azure,omitempty"`
-	AWS *AWSProvider `json:"aws,omitempty" mapstructure:"aws" yaml:"aws,omitempty"`
+	AWS   *AWSProvider   `json:"aws,omitempty" mapstructure:"aws" yaml:"aws,omitempty"`
 }
 
 type AzureProvider struct {
-	SubscriptionID string
-	ResourceGroup  string
+	SubscriptionID string `json:"subscriptionId,omitempty" mapstructure:"subscriptionId" yaml:"subscriptionId,omitempty"`
+	ResourceGroup  string `json:"resourceGroup,omitempty" mapstructure:"resourceGroup" yaml:"resourceGroup,omitempty"`
 }
 
 type AWSProvider struct {
-	Region string
-	AccountId string
+	Region    string `json:"region,omitempty" mapstructure:"region" yaml:"region,omitempty"`
+	AccountId string `json:"accountId,omitempty" mapstructure:"accountId" yaml:"accountId,omitempty"`
 }
+
 // Registry represent the configuration for a container registry.
 type Registry struct {
 	// PushEndpoint is the endpoint used for push commands. For a local container registry this hostname
 	// is expected to be accessible from the host machine.
-	PushEndpoint string `mapstructure:"pushendpoint" validate:"required"`
+	PushEndpoint string `json:"pushEndpoint,omitempty" mapstructure:"pushEndpoint" validate:"required" yaml:"pushEndpoint,omitempty"`
 
 	// PullEndpoint is the endpoing used to pull by the runtime. For a local container registry this hostname
 	// is expected to be accessible by the runtime. Can be the same as PushEndpoint if the registry has a routable
 	// address.
-	PullEndpoint string `mapstructure:"pullendpoint" validate:"required"`
+	PullEndpoint string `json:"pullEndpoint,omitempty" mapstructure:"pullEndpoint" validate:"required" yaml:"pullEndpoint,omitempty"`
 }

--- a/pkg/cli/workspaces/types.go
+++ b/pkg/cli/workspaces/types.go
@@ -36,6 +36,7 @@ type Workspace struct {
 type ProviderConfig struct {
 	// Azure represents the configuration for the Azure IAC provider used during deployment. This field is optional.
 	Azure *AzureProvider `json:"azure,omitempty" mapstructure:"azure" yaml:"azure,omitempty"`
+	AWS *AWSProvider `json:"aws,omitempty" mapstructure:"aws" yaml:"aws,omitempty"`
 }
 
 type AzureProvider struct {
@@ -43,6 +44,10 @@ type AzureProvider struct {
 	ResourceGroup  string
 }
 
+type AWSProvider struct {
+	Region string
+	AccountId string
+}
 // Registry represent the configuration for a container registry.
 type Registry struct {
 	// PushEndpoint is the endpoint used for push commands. For a local container registry this hostname


### PR DESCRIPTION
# Description

* Added support for provisioning an AWS resource provider. The user is now able to specify the AWS credentials and region using cli flags and these will be propagated to the execution context of UCP as environment variables.
* Validates user input credentials and gets AccountId value
* Persists AWS `AccountId` and `Region` to `~/.rad/config.yaml` for use by rad during deploy action
* Fixed minor spelling errors in cli code variable names.
* Fix a defect in azure-pipelines where the CI/CD build fails on re-try because of a naming collision on publish container_logs 
* Fixes https://github.com/project-radius/radius/issues/3708


You may validate manually on a kind cluster by running the following commands
```bash
make build-rad
kind create cluster --name t
rad env init kubernetes --provider-aws --provider-aws-access-key-id myUserId --provider-aws-secret-access-key mySecretIsVeryLong --provider-aws-region west-us-2 --chart deploy/Chart
docker exec tt-control-plane crictl ps | grep ucp ## to get the ucp container id
docker exec tt-control-plane crictl inspect <container_id_here>| jq '.[].runtimeSpec.process.env' | grep AWS ## to see the values have been set
```
## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: radius-project/radius#3647 