### PR TITLE
Add provisioning state to PUT calls

### DIFF
--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/google/uuid"
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	radrprest "github.com/project-radius/radius/pkg/armrpc/rest"
 	awserror "github.com/project-radius/radius/pkg/ucp/aws"
 	ctrl "github.com/project-radius/radius/pkg/ucp/frontend/controller"
@@ -80,27 +81,6 @@ func (p *CreateOrUpdateAWSResource) Run(ctx context.Context, w http.ResponseWrit
 		return awserror.HandleAWSError(err)
 	}
 
-	// AWS doesn't return the resource state as part of the cloud-control operation. Let's
-	// simulate that here.
-	responseProperties := map[string]interface{}{}
-	if getResponse != nil {
-		err = json.Unmarshal([]byte(*getResponse.ResourceDescription.Properties), &responseProperties)
-		if err != nil {
-			return awserror.HandleAWSError(err)
-		}
-	}
-
-	// Properties specified by users take precedence
-	for k, v := range properties {
-		responseProperties[k] = v
-	}
-
-	responseBody := map[string]interface{}{
-		"id":         id.String(),
-		"name":       id.Name(),
-		"type":       id.Type(),
-		"properties": responseProperties,
-	}
 	var operation uuid.UUID
 	desiredState, err := json.Marshal(properties)
 	if err != nil {
@@ -161,6 +141,32 @@ func (p *CreateOrUpdateAWSResource) Run(ctx context.Context, w http.ResponseWrit
 		}
 	}
 
+	// AWS doesn't return the resource state as part of the cloud-control operation. Let's
+	// simulate that here.
+	responseProperties := map[string]interface{}{}
+	if getResponse != nil {
+		err = json.Unmarshal([]byte(*getResponse.ResourceDescription.Properties), &responseProperties)
+		if err != nil {
+			return awserror.HandleAWSError(err)
+		}
+	}
+
+	// Properties specified by users take precedence
+	for k, v := range properties {
+		responseProperties[k] = v
+	}
+
+	responseProperties["provisioningState"] = v1.ProvisioningStateProvisioning
+
+	responseBody := map[string]interface{}{
+		"id":         id.String(),
+		"name":       id.Name(),
+		"type":       id.Type(),
+		"properties": responseProperties,
+	}
+
 	resp := radrprest.NewAsyncOperationResponse(responseBody, "global", 201, id, operation, "", id.RootScope(), p.Options.BasePath)
+	resp.(*radrprest.AsyncOperationResponse).RootScope = id.RootScope()
+	resp.(*radrprest.AsyncOperationResponse).PathBase = p.Options.BasePath
 	return resp, nil
 }

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource.go
@@ -166,7 +166,5 @@ func (p *CreateOrUpdateAWSResource) Run(ctx context.Context, w http.ResponseWrit
 	}
 
 	resp := radrprest.NewAsyncOperationResponse(responseBody, "global", 201, id, operation, "", id.RootScope(), p.Options.BasePath)
-	resp.(*radrprest.AsyncOperationResponse).RootScope = id.RootScope()
-	resp.(*radrprest.AsyncOperationResponse).PathBase = p.Options.BasePath
 	return resp, nil
 }

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource_test.go
@@ -78,6 +78,7 @@ func Test_CreateAWSResource(t *testing.T) {
 		"properties": map[string]interface{}{
 			"RetentionPeriodHours": float64(178),
 			"ShardCount":           float64(3),
+			"provisioningState":    "Provisioning",
 		},
 	}
 
@@ -153,6 +154,7 @@ func Test_UpdateAWSResource(t *testing.T) {
 		"properties": map[string]interface{}{
 			"RetentionPeriodHours": float64(180),
 			"ShardCount":           float64(4),
+			"provisioningState":    "Provisioning",
 		},
 	}
 
@@ -208,7 +210,7 @@ func Test_UpdateNoChangesDoesNotCallUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	res := w.Result()
-	require.Equal(t, http.StatusCreated, res.StatusCode)
+	require.Equal(t, http.StatusOK, res.StatusCode)
 	body, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	defer res.Body.Close()
@@ -220,6 +222,7 @@ func Test_UpdateNoChangesDoesNotCallUpdate(t *testing.T) {
 		"properties": map[string]interface{}{
 			"RetentionPeriodHours": float64(178),
 			"ShardCount":           float64(3),
+			"provisioningState":    "Succeeded",
 		},
 	}
 


### PR DESCRIPTION
# Description

We need to set provisioningState to a value when calling CreateOrUpdate, otherwise the deployment engine will assume that a provisioning state of empty leads to the deployment being considered "completed".

I do have a quick question though on this.

## Issue reference

Fixes https://github.com/project-radius/radius/issues/3780

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
