### PR TITLE
Add support for scope collections to ID parser

### DIFF
--- a/pkg/connectorrp/renderers/mongodatabases/renderer_test.go
+++ b/pkg/connectorrp/renderers/mongodatabases/renderer_test.go
@@ -195,7 +195,7 @@ func Test_Render_InvalidSourceResourceIdentifier(t *testing.T) {
 					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
 					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
 				},
-				Resource: "/subscriptions/test-sub/resourceGroups/test-group/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
+				Resource: "//subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
 			},
 		},
 	}

--- a/pkg/connectorrp/renderers/rediscaches/renderer_test.go
+++ b/pkg/connectorrp/renderers/rediscaches/renderer_test.go
@@ -205,7 +205,7 @@ func Test_Render_InvalidSourceResourceIdentifier(t *testing.T) {
 					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
 					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
 				},
-				Resource: "/subscriptions/test-sub/resourceGroups/testGroup/Microsoft.Cache/Redis/testCache",
+				Resource: "//subscriptions/test-sub/resourceGroups/testGroup/providers/Microsoft.Cache/Redis/testCache",
 			},
 		},
 	}

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -178,7 +178,7 @@ func Test_GetDependencyIDs_InvalidAzureResourceId(t *testing.T) {
 		// Revert this once TODO: https://github.com/project-radius/core-team/issues/238 is done.
 		Connections: map[string]datamodel.ConnectionProperties{
 			"AzureResourceTest": {
-				Source: "/subscriptions/test-sub-id/Microsoft.ServiceBus/namespaces/testNamespace",
+				Source: "//subscriptions/test-sub-id/providers/Microsoft.ServiceBus/namespaces/testNamespace",
 				IAM: datamodel.IAMProperties{
 					Kind: datamodel.KindAzure,
 				},
@@ -194,7 +194,7 @@ func Test_GetDependencyIDs_InvalidAzureResourceId(t *testing.T) {
 	ids, azureIDs, err := renderer.GetDependencyIDs(createContext(t), resource)
 	require.Error(t, err)
 	require.Equal(t, err.(*conv.ErrClientRP).Code, apiv1.CodeInvalid)
-	require.Equal(t, err.(*conv.ErrClientRP).Message, "'subscriptions/test-sub-id/Microsoft.ServiceBus/namespaces/testNamespace' is not a valid resource id")
+	require.Equal(t, err.(*conv.ErrClientRP).Message, "'/subscriptions/test-sub-id/providers/Microsoft.ServiceBus/namespaces/testNamespace' is not a valid resource id")
 	require.Empty(t, ids)
 	require.Empty(t, azureIDs)
 }

--- a/pkg/ucp/resources/id_test.go
+++ b/pkg/ucp/resources/id_test.go
@@ -21,7 +21,6 @@ func Test_ParseInvalidIDs(t *testing.T) {
 		"//subscriptions/{%s}/resourceGroups/{%s}/providers/Microsoft.CustomProviders/resourceProviders",
 		"/subscriptions/{%s}/resourceGroups/{%s}/providers/Microsoft.CustomProviders/resourceProviders//",
 		"/subscriptions/{%s}/resourceGroups/{%s}/providers/Microsoft.CustomProviders//",
-		"/subscriptions/{%s}/resourceGroups/{%s}/ddproviders/Microsoft.CustomProviders/resourceProviders",
 		"/subscriptions/{%s}/resourceGroups//providers/Microsoft.CustomProviders/resourceProviders",
 		"/subscriptions/{%s}/resourceGroups/providers/Microsoft.CustomProviders/resourceProviders",
 		"/planes/radius",
@@ -262,6 +261,17 @@ func Test_ParseValidIDs(t *testing.T) {
 			provider: "",
 		},
 		{
+			id:       "/planes/radius/local/resourceGroups/r1/resources",
+			expected: "/planes/radius/local/resourceGroups/r1/resources",
+			scopes: []ScopeSegment{
+				{Type: "radius", Name: "local"},
+				{Type: "resourceGroups", Name: "r1"},
+				{Type: "resources", Name: ""},
+			},
+			types:    []TypeSegment{},
+			provider: "",
+		},
+		{
 			id:       "/planes/radius/local/resourceGroups/r1/providers/Applications.Core/environments/env",
 			expected: "/planes/radius/local/resourceGroups/r1/providers/Applications.Core/environments/env",
 			scopes: []ScopeSegment{
@@ -272,6 +282,20 @@ func Test_ParseValidIDs(t *testing.T) {
 				Type: "Applications.Core/environments", Name: "env"},
 			},
 			provider: "Applications.Core",
+		},
+
+		// NOTE: this is NOT actually invalid, just confusing.
+		{
+			id:       "/planes/radius/local/resourceGroups/r1/Applications.Core/environments/env",
+			expected: "/planes/radius/local/resourceGroups/r1/Applications.Core/environments/env",
+			scopes: []ScopeSegment{
+				{Type: "radius", Name: "local"},
+				{Type: "resourceGroups", Name: "r1"},
+				{Type: "Applications.Core", Name: "environments"},
+				{Type: "env", Name: ""},
+			},
+			types:    []TypeSegment{},
+			provider: "",
 		},
 	}
 


### PR DESCRIPTION
This change adds support for parsing resource ids like:

```txt
/planes/radius/local/resourceGroups/my-group/resources
```

This is needed to support some of the additional functionality resource groups provide, like listing the resources inside the group. We already have this support for collections on resource types, this extends it to cover scopes as well.

Unfortunately by adding support for this existing form, a bunch of our existing tests start failing because the *invalid* input they were using is no longer considered invalid.