### PR TITLE
Add specialized ID parsing functions

### DIFF
--- a/cmd/rad/cmd/appStatus.go
+++ b/cmd/rad/cmd/appStatus.go
@@ -62,7 +62,7 @@ func showApplicationStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, resource := range resourceList {
-		resourceID, err := resources.Parse(*resource.ID)
+		resourceID, err := resources.ParseResource(*resource.ID)
 		if err != nil {
 			return err
 		}

--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -338,7 +338,7 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 
 	step = output.BeginStep("Creating Environment...")
 
-	scopeId, err := resources.Parse(workspace.Scope)
+	scopeId, err := resources.ParseScope(workspace.Scope)
 	if err != nil {
 		return err
 	}

--- a/cmd/rad/cmd/envSwitch.go
+++ b/cmd/rad/cmd/envSwitch.go
@@ -38,7 +38,7 @@ func switchEnv(cmd *cobra.Command, args []string) error {
 	}
 
 	// TODO: for right now we assume the environment is in the default resource group.
-	scope, err := resources.Parse(workspace.Scope)
+	scope, err := resources.ParseScope(workspace.Scope)
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func switchEnv(cmd *cobra.Command, args []string) error {
 		output.LogInfo("Switching default environment to %v", environmentName)
 	} else {
 		// Parse the environment ID to get the name
-		existing, err := resources.Parse(workspace.Environment)
+		existing, err := resources.ParseResource(workspace.Environment)
 		if err != nil {
 			return err
 		}

--- a/cmd/rad/cmd/recipeCreate.go
+++ b/cmd/rad/cmd/recipeCreate.go
@@ -58,7 +58,7 @@ func recipeCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	scopeId, err := resources.Parse(workspace.Scope)
+	scopeId, err := resources.ParseScope(workspace.Scope)
 	if err != nil {
 		return err
 	}

--- a/pkg/armrpc/asyncoperation/statusmanager/statusmanager_test.go
+++ b/pkg/armrpc/asyncoperation/statusmanager/statusmanager_test.go
@@ -89,7 +89,7 @@ func TestOperationStatusResourceID(t *testing.T) {
 
 	for _, tc := range resourceIDTests {
 		t.Run(tc.resourceID, func(t *testing.T) {
-			rid, err := resources.Parse(tc.resourceID)
+			rid, err := resources.ParseResource(tc.resourceID)
 			require.NoError(t, err)
 			url := sm.operationStatusResourceID(rid, tc.operationID)
 			require.Equal(t, tc.operationResourceID, url)
@@ -189,7 +189,7 @@ func TestDeleteAsyncOperationStatus(t *testing.T) {
 			defer mctrl.Finish()
 
 			aomTest.storeClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.DeleteErr)
-			rid, err := resources.Parse(azureEnvResourceID)
+			rid, err := resources.ParseResource(azureEnvResourceID)
 			require.NoError(t, err)
 			err = aomTest.manager.Delete(context.TODO(), rid, uuid.New())
 
@@ -233,7 +233,7 @@ func TestGetAsyncOperationStatus(t *testing.T) {
 				Get(gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(tt.Obj, tt.GetErr)
 
-			rid, err := resources.Parse(azureEnvResourceID)
+			rid, err := resources.ParseResource(azureEnvResourceID)
 			require.NoError(t, err)
 			aos, err := aomTest.manager.Get(context.TODO(), rid, uuid.New())
 
@@ -287,7 +287,7 @@ func TestUpdateAsyncOperationStatus(t *testing.T) {
 			}
 
 			testAos.Status = v1.ProvisioningStateSucceeded
-			rid, err := resources.Parse(azureEnvResourceID)
+			rid, err := resources.ParseResource(azureEnvResourceID)
 			require.NoError(t, err)
 			err = aomTest.manager.Update(context.TODO(), rid, opID, v1.ProvisioningStateAccepted, nil, nil)
 

--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -308,7 +308,7 @@ func (w *AsyncRequestProcessWorker) completeOperation(ctx context.Context, messa
 func (w *AsyncRequestProcessWorker) updateResourceAndOperationStatus(ctx context.Context, sc store.StorageClient, req *ctrl.Request, state v1.ProvisioningState, opErr *v1.ErrorDetails) error {
 	logger := logr.FromContextOrDiscard(ctx)
 
-	rID, err := resources.Parse(req.ResourceID)
+	rID, err := resources.ParseResource(req.ResourceID)
 	if err != nil {
 		logger.Error(err, "failed to parse resource ID")
 		return err
@@ -334,7 +334,7 @@ func (w *AsyncRequestProcessWorker) updateResourceAndOperationStatus(ctx context
 }
 
 func (w *AsyncRequestProcessWorker) isDuplicated(ctx context.Context, sc store.StorageClient, resourceID string, operationID uuid.UUID) (bool, error) {
-	rID, err := resources.Parse(resourceID)
+	rID, err := resources.ParseResource(resourceID)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/armrpc/frontend/defaultoperation/getoperationresult.go
+++ b/pkg/armrpc/frontend/defaultoperation/getoperationresult.go
@@ -60,7 +60,7 @@ func (e *GetOperationResult) Run(ctx context.Context, req *http.Request) (rest.R
 // getOperationStatusResourceID function gets the operationResults resourceID
 // and converts it to an operationStatuses resourceID.
 func getOperationStatusResourceID(resourceID string) (resources.ID, error) {
-	id, err := resources.Parse(resourceID)
+	id, err := resources.ParseResource(resourceID)
 	if err != nil {
 		return id, err
 	}

--- a/pkg/armrpc/rest/results.go
+++ b/pkg/armrpc/rest/results.go
@@ -326,7 +326,7 @@ func NewLinkedResourceUpdateErrorResponse(resourceID resources.ID, oldProp *rp.B
 	newAppEnv := ""
 	if newProp.Application != "" {
 		name := newProp.Application
-		if rid, err := resources.Parse(newProp.Application); err == nil {
+		if rid, err := resources.ParseResource(newProp.Application); err == nil {
 			name = rid.Name()
 		}
 		newAppEnv += fmt.Sprintf("'%s' application", name)
@@ -336,7 +336,7 @@ func NewLinkedResourceUpdateErrorResponse(resourceID resources.ID, oldProp *rp.B
 			newAppEnv += " and "
 		}
 		name := newProp.Environment
-		if rid, err := resources.Parse(newProp.Environment); err == nil {
+		if rid, err := resources.ParseResource(newProp.Environment); err == nil {
 			name = rid.Name()
 		}
 		newAppEnv += fmt.Sprintf("'%s' environment", name)

--- a/pkg/armrpc/rest/results_test.go
+++ b/pkg/armrpc/rest/results_test.go
@@ -69,7 +69,7 @@ func Test_NewLinkedResourceUpdateErrorResponse(t *testing.T) {
 		},
 	}
 
-	resource, err := resources.Parse("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/containers/test-container-0")
+	resource, err := resources.ParseResource("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/containers/test-container-0")
 	require.NoError(t, err)
 
 	for _, tt := range errTests {
@@ -181,7 +181,7 @@ func TestGetAsyncLocationPath(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.desc, func(t *testing.T) {
-			resourceID, err := resources.Parse(tt.rID)
+			resourceID, err := resources.ParseResource(tt.rID)
 			require.NoError(t, err)
 
 			body := &datamodel.ContainerResource{}

--- a/pkg/cli/clivalidation.go
+++ b/pkg/cli/clivalidation.go
@@ -37,7 +37,7 @@ func RequireEnvironmentNameArgs(cmd *cobra.Command, args []string, workspace wor
 
 	// We store the environment id in config, but most commands work with the environment name.
 	if environmentName == "" && workspace.Environment != "" {
-		id, err := resources.Parse(workspace.Environment)
+		id, err := resources.ParseResource(workspace.Environment)
 		if err != nil {
 			return "", err
 		}
@@ -61,7 +61,7 @@ func RequireEnvironmentName(cmd *cobra.Command, args []string, workspace workspa
 
 	// We store the environment id in config, but most commands work with the environment name.
 	if environmentName == "" && workspace.Environment != "" {
-		id, err := resources.Parse(workspace.Environment)
+		id, err := resources.ParseResource(workspace.Environment)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/cli/connections/factory.go
+++ b/pkg/cli/connections/factory.go
@@ -21,9 +21,9 @@ import (
 	azclients "github.com/project-radius/radius/pkg/azure/clients"
 	aztoken "github.com/project-radius/radius/pkg/azure/tokencredentials"
 	"github.com/project-radius/radius/pkg/cli"
-	"github.com/project-radius/radius/pkg/cli/deployment"
 	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/clients_new/generated"
+	"github.com/project-radius/radius/pkg/cli/deployment"
 	"github.com/project-radius/radius/pkg/cli/kubernetes"
 	"github.com/project-radius/radius/pkg/cli/ucp"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
@@ -73,7 +73,7 @@ func (*impl) CreateDeploymentClient(ctx context.Context, workspace workspaces.Wo
 		op.Sender = &sender{RoundTripper: roundTripper}
 
 		// This client wants a resource group name, but we store the ID instead, so compute that.
-		id, err := resources.Parse(workspace.Scope)
+		id, err := resources.ParseScope(workspace.Scope)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cli/deployment/deploy.go
+++ b/pkg/cli/deployment/deploy.go
@@ -164,6 +164,7 @@ func (dc *ResourceDeploymentClient) createSummary(deployment resources.Deploymen
 			continue
 		}
 
+		// We might see scopes here as well as resources, so using the general Parse function.
 		id, err := ucpresources.Parse(*resource.ID)
 		if err != nil {
 			return clients.DeploymentResult{}, err
@@ -240,6 +241,8 @@ func (dc *ResourceDeploymentClient) monitorProgress(ctx context.Context, name st
 			}
 
 			provisioningState := v1.ProvisioningState(*operation.Properties.ProvisioningState)
+
+			// We might see scopes here as well as resources, so using the general Parse function.
 			id, err := ucpresources.Parse(*operation.Properties.TargetResource.ID)
 			if err != nil {
 				return err

--- a/pkg/cli/deployment/diagnostics.go
+++ b/pkg/cli/deployment/diagnostics.go
@@ -148,7 +148,7 @@ func (dc *ARMDiagnosticsClient) findNamespaceOfContainer(ctx context.Context, re
 		return "", fmt.Errorf("could not find namespace for container %q", resourceName)
 	}
 
-	id, err := resources.Parse(application)
+	id, err := resources.ParseResource(application)
 	if err != nil {
 		return "", fmt.Errorf("could not namespace for container %q:%w", resourceName, err)
 	}
@@ -168,7 +168,7 @@ func (dc *ARMDiagnosticsClient) findNamespaceOfContainer(ctx context.Context, re
 		return "", fmt.Errorf("could not find namespace for container %q", resourceName)
 	}
 
-	id, err = resources.Parse(environment)
+	id, err = resources.ParseResource(environment)
 	if err != nil {
 		return "", fmt.Errorf("could not namespace for container %q:%w", resourceName, err)
 	}

--- a/pkg/cli/ucp/ucp_management.go
+++ b/pkg/cli/ucp/ucp_management.go
@@ -286,7 +286,7 @@ func isResourceInApplication(ctx context.Context, resource generated.GenericReso
 		return false
 	}
 
-	idParsed, err := resources.Parse(associatedAppId)
+	idParsed, err := resources.ParseResource(associatedAppId)
 	if err != nil {
 		return false
 	}
@@ -310,7 +310,7 @@ func isResourceInEnvironment(ctx context.Context, resource generated.GenericReso
 		return false
 	}
 
-	idParsed, err := resources.Parse(associatedEnvId)
+	idParsed, err := resources.ParseResource(associatedEnvId)
 	if err != nil {
 		return false
 	}

--- a/pkg/connectorrp/frontend/deployment/deploymentprocessor.go
+++ b/pkg/connectorrp/frontend/deployment/deploymentprocessor.go
@@ -323,7 +323,7 @@ func (dp *deploymentProcessor) fetchSecret(ctx context.Context, outputResources 
 	}
 
 	for _, id := range recipeData.Resources {
-		parsedID, err := resources.Parse(id)
+		parsedID, err := resources.ParseResource(id)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse deployed recipe resource id %s: %w", id, err)
 		}
@@ -415,7 +415,7 @@ func (dp *deploymentProcessor) getMetadataFromResource(ctx context.Context, reso
 
 // getEnvironmentMetadata fetches the environment resource from the db to retrieve namespace and recipe metadata required to deploy the connector and linked resources ```
 func (dp *deploymentProcessor) getEnvironmentMetadata(ctx context.Context, environmentID string, recipeName string) (envMetadata EnvironmentMetadata, err error) {
-	envId, err := resources.Parse(environmentID)
+	envId, err := resources.ParseResource(environmentID)
 	envMetadata = EnvironmentMetadata{}
 	if err != nil {
 		return envMetadata, conv.NewClientErrInvalidRequest(fmt.Sprintf("provided environment id %q is not a valid id.", environmentID))

--- a/pkg/connectorrp/frontend/deployment/deploymentprocessor_test.go
+++ b/pkg/connectorrp/frontend/deployment/deploymentprocessor_test.go
@@ -373,7 +373,7 @@ func setup(t *testing.T) SharedMocks {
 }
 
 func getResourceID(id string) resources.ID {
-	resourceID, err := resources.Parse(id)
+	resourceID, err := resources.ParseResource(id)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/connectorrp/handlers/arm_handler.go
+++ b/pkg/connectorrp/handlers/arm_handler.go
@@ -75,7 +75,7 @@ func getByID(ctx context.Context, auth autorest.Authorizer, identity resourcemod
 		return nil, err
 	}
 
-	parsed, err := ucpresources.Parse(id)
+	parsed, err := ucpresources.ParseResource(id)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connectorrp/handlers/azure_cosmosdb_base.go
+++ b/pkg/connectorrp/handlers/azure_cosmosdb_base.go
@@ -40,7 +40,7 @@ const (
 )
 
 func (handler *azureCosmosDBBaseHandler) GetCosmosDBAccountByID(ctx context.Context, accountID string) (*documentdb.DatabaseAccountGetResults, error) {
-	parsed, err := resources.Parse(accountID)
+	parsed, err := resources.ParseResource(accountID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse CosmosDB Account resource id: %w", err)
 	}

--- a/pkg/connectorrp/handlers/azure_cosmosdb_mongo.go
+++ b/pkg/connectorrp/handlers/azure_cosmosdb_mongo.go
@@ -39,7 +39,7 @@ func (handler *azureCosmosDBMongoHandler) Put(ctx context.Context, resource *out
 		return resourcemodel.ResourceIdentity{}, nil, fmt.Errorf("missing required properties for resource")
 	}
 
-	parsedID, err := resources.Parse(properties[CosmosDBDatabaseIDKey])
+	parsedID, err := resources.ParseResource(properties[CosmosDBDatabaseIDKey])
 	if err != nil {
 		return resourcemodel.ResourceIdentity{}, nil, fmt.Errorf("failed to parse CosmosDB Mongo Database resource id: %w", err)
 	}

--- a/pkg/connectorrp/handlers/azure_redis.go
+++ b/pkg/connectorrp/handlers/azure_redis.go
@@ -43,7 +43,7 @@ func (handler *azureRedisHandler) Put(ctx context.Context, resource *outputresou
 	if !ok {
 		return resourcemodel.ResourceIdentity{}, nil, fmt.Errorf("missing required properties for resource")
 	}
-	parsedID, err := resources.Parse(properties[RedisResourceIdKey])
+	parsedID, err := resources.ParseResource(properties[RedisResourceIdKey])
 	if err != nil {
 		return resourcemodel.ResourceIdentity{}, nil, fmt.Errorf("failed to parse Azure Redis Cache resource id: %w", err)
 	}

--- a/pkg/connectorrp/handlers/dapr_pubsub_servicebus.go
+++ b/pkg/connectorrp/handlers/dapr_pubsub_servicebus.go
@@ -150,7 +150,7 @@ func (handler *daprPubSubServiceBusHandler) DeleteDaprPubSub(ctx context.Context
 }
 
 func (handler *daprPubSubServiceBusBaseHandler) GetNamespaceByID(ctx context.Context, id string) (*servicebus.SBNamespace, error) {
-	parsed, err := resources.Parse(id)
+	parsed, err := resources.ParseResource(id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse servicebus queue resource id: '%s':%w", id, err)
 	}
@@ -170,7 +170,7 @@ func (handler *daprPubSubServiceBusBaseHandler) GetNamespaceByID(ctx context.Con
 }
 
 func (handler *daprPubSubServiceBusBaseHandler) GetConnectionString(ctx context.Context, id string) (*string, error) {
-	parsed, err := resources.Parse(id)
+	parsed, err := resources.ParseResource(id)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connectorrp/handlers/dapr_statestore_storage.go
+++ b/pkg/connectorrp/handlers/dapr_statestore_storage.go
@@ -52,7 +52,7 @@ func (handler *daprStateStoreAzureStorageHandler) Put(ctx context.Context, resou
 		return resourcemodel.ResourceIdentity{}, nil, fmt.Errorf("missing required property %s for the resource", ResourceIDKey)
 	}
 
-	parsedID, err := resources.Parse(id)
+	parsedID, err := resources.ParseResource(id)
 	if err != nil {
 		return resourcemodel.ResourceIdentity{}, nil, fmt.Errorf("failed to parse Storage Account resource id: %w", err)
 	}
@@ -137,7 +137,7 @@ func (handler *daprStateStoreAzureStorageHandler) createDaprStateStore(ctx conte
 }
 
 func (handler *daprStateStoreAzureStorageHandler) findStorageKey(ctx context.Context, id string) (*storage.AccountKey, error) {
-	parsed, err := resources.Parse(id)
+	parsed, err := resources.ParseResource(id)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connectorrp/handlers/recipe_handler.go
+++ b/pkg/connectorrp/handlers/recipe_handler.go
@@ -190,7 +190,7 @@ func getRecipeBytes(ctx context.Context, repo *remote.Repository, layerDigest st
 }
 
 func (handler *azureRecipeHandler) Delete(ctx context.Context, id string, apiVersion string) error {
-	parsed, err := ucpresources.Parse(id)
+	parsed, err := ucpresources.ParseResource(id)
 	if err != nil {
 		return err
 	}

--- a/pkg/connectorrp/renderers/daprpubsubbrokers/azure_servicebus.go
+++ b/pkg/connectorrp/renderers/daprpubsubbrokers/azure_servicebus.go
@@ -27,7 +27,7 @@ func GetDaprPubSubAzureServiceBus(resource datamodel.DaprPubSubBroker, applicati
 	}
 
 	//Validate fully qualified resource identifier of the source resource is supplied for this connector
-	azureServiceBusNamespaceID, err := resources.Parse(properties.Resource)
+	azureServiceBusNamespaceID, err := resources.ParseResource(properties.Resource)
 	if err != nil {
 		return renderers.RendererOutput{}, conv.NewClientErrInvalidRequest("the 'resource' field must be a valid resource id")
 	}

--- a/pkg/connectorrp/renderers/daprstatestores/azurestorage.go
+++ b/pkg/connectorrp/renderers/daprstatestores/azurestorage.go
@@ -24,7 +24,7 @@ func GetDaprStateStoreAzureStorage(resource datamodel.DaprStateStore, applicatio
 			return nil, conv.NewClientErrInvalidRequest(renderers.ErrResourceMissingForResource.Error())
 		}
 		//Validate fully qualified resource identifier of the source resource is supplied for this connector
-		azuretableStorageID, err = resources.Parse(properties.Resource)
+		azuretableStorageID, err = resources.ParseResource(properties.Resource)
 		if err != nil {
 			return []outputresource.OutputResource{}, conv.NewClientErrInvalidRequest("the 'resource' field must be a valid resource id")
 		}
@@ -36,7 +36,7 @@ func GetDaprStateStoreAzureStorage(resource datamodel.DaprStateStore, applicatio
 			return nil, conv.NewClientErrInvalidRequest(renderers.ErrResourceMissingForResource.Error())
 		}
 		//Validate fully qualified resource identifier of the source resource is supplied for this connector
-		azuretableStorageID, err = resources.Parse(properties.Resource)
+		azuretableStorageID, err = resources.ParseResource(properties.Resource)
 		if err != nil {
 			return []outputresource.OutputResource{}, conv.NewClientErrInvalidRequest("the 'resource' field must be a valid resource id")
 		}

--- a/pkg/connectorrp/renderers/mongodatabases/renderer.go
+++ b/pkg/connectorrp/renderers/mongodatabases/renderer.go
@@ -102,7 +102,7 @@ func RenderAzureRecipe(resource *datamodel.MongoDatabase, options renderers.Rend
 
 func RenderAzureResource(properties datamodel.MongoDatabaseProperties, secretValues map[string]rp.SecretValueReference) (renderers.RendererOutput, error) {
 	// Validate fully qualified resource identifier of the source resource is supplied for this connector
-	cosmosMongoDBID, err := resources.Parse(properties.Resource)
+	cosmosMongoDBID, err := resources.ParseResource(properties.Resource)
 	if err != nil {
 		return renderers.RendererOutput{}, conv.NewClientErrInvalidRequest("the 'resource' field must be a valid resource id")
 	}

--- a/pkg/connectorrp/renderers/rediscaches/renderer.go
+++ b/pkg/connectorrp/renderers/rediscaches/renderer.go
@@ -58,7 +58,7 @@ func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface, option
 
 func renderAzureResource(properties datamodel.RedisCacheProperties, secretValues map[string]rp.SecretValueReference, computedValues map[string]renderers.ComputedValueReference) (renderers.RendererOutput, error) {
 	// Validate fully qualified resource identifier of the source resource is supplied for this connector
-	redisCacheID, err := resources.Parse(properties.Resource)
+	redisCacheID, err := resources.ParseResource(properties.Resource)
 	if err != nil {
 		return renderers.RendererOutput{}, conv.NewClientErrInvalidRequest("the 'resource' field must be a valid resource id")
 	}

--- a/pkg/connectorrp/renderers/sqldatabases/renderer.go
+++ b/pkg/connectorrp/renderers/sqldatabases/renderer.go
@@ -72,7 +72,7 @@ func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface, option
 
 func renderAzureResource(properties datamodel.SqlDatabaseProperties) (renderers.RendererOutput, error) {
 	// Validate fully qualified resource identifier of the source resource is supplied for this connector
-	databaseID, err := resources.Parse(properties.Resource)
+	databaseID, err := resources.ParseResource(properties.Resource)
 	if err != nil {
 		return renderers.RendererOutput{}, conv.NewClientErrInvalidRequest("the 'resource' field must be a valid resource id")
 	}

--- a/pkg/connectorrp/renderers/sqldatabases/renderer_test.go
+++ b/pkg/connectorrp/renderers/sqldatabases/renderer_test.go
@@ -131,7 +131,7 @@ func Test_Render_InvalidResourceType(t *testing.T) {
 				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
 				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
 			},
-			Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.SomethingElse/servers/sqlDatabases/test-database",
+			Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.SomethingElse/servers/test-database",
 		},
 	}
 

--- a/pkg/connectorrp/renderers/util.go
+++ b/pkg/connectorrp/renderers/util.go
@@ -17,7 +17,7 @@ import (
 func ValidateApplicationID(application string) (resources.ID, error) {
 	app := &coreDatamodel.Application{}
 	if application != "" {
-		appId, err := resources.Parse(application)
+		appId, err := resources.ParseResource(application)
 		if err != nil {
 			return resources.ID{}, conv.NewClientErrInvalidRequest(fmt.Sprintf("failed to parse application from the property: %s", err.Error()))
 		}

--- a/pkg/corerp/backend/controller/createorupdateresource.go
+++ b/pkg/corerp/backend/controller/createorupdateresource.go
@@ -67,6 +67,7 @@ func (c *CreateOrUpdateResource) Run(ctx context.Context, request *ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
+	// This code is general and we might be processing an async job for a resource or a scope, so using the general Parse function.
 	id, err := resources.Parse(request.ResourceID)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/pkg/corerp/backend/controller/createorupdateresource_test.go
+++ b/pkg/corerp/backend/controller/createorupdateresource_test.go
@@ -164,6 +164,7 @@ func TestCreateOrUpdateResourceRun_20220315PrivatePreview(t *testing.T) {
 				OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
 			}
 
+			// This code is general and we might be processing an async job for a resource or a scope, so using the general Parse function.
 			parsedID, err := resources.Parse(tt.rId)
 			require.NoError(t, err)
 
@@ -360,6 +361,7 @@ func TestCreateOrUpdateResourceRun_20220315PrivatePreview(t *testing.T) {
 				OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
 			}
 
+			// This code is general and we might be processing an async job for a resource or a scope, so using the general Parse function.
 			parsedID, err := resources.Parse(tt.rId)
 			require.NoError(t, err)
 

--- a/pkg/corerp/backend/controller/deleteresource.go
+++ b/pkg/corerp/backend/controller/deleteresource.go
@@ -32,6 +32,7 @@ func (c *DeleteResource) Run(ctx context.Context, request *ctrl.Request) (ctrl.R
 		return ctrl.NewFailedResult(v1.ErrorDetails{Message: err.Error()}), err
 	}
 
+	// This code is general and we might be processing an async job for a resource or a scope, so using the general Parse function.
 	id, err := resources.Parse(request.ResourceID)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/pkg/corerp/backend/deployment/deployment_test.go
+++ b/pkg/corerp/backend/deployment/deployment_test.go
@@ -144,7 +144,7 @@ func getTestRendererOutput() renderers.RendererOutput {
 }
 
 func getTestResourceID(id string) resources.ID {
-	resourceID, err := resources.Parse(id)
+	resourceID, err := resources.ParseResource(id)
 	if err != nil {
 		panic(err)
 	}
@@ -171,8 +171,8 @@ func Test_Render(t *testing.T) {
 		testRendererOutput := getTestRendererOutput()
 		resourceID := getTestResourceID(testResource.ID)
 
-		depId1, _ := resources.Parse("/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A")
-		depId2, _ := resources.Parse("/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Connector/mongoDatabases/test-mongo")
+		depId1, _ := resources.ParseResource("/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A")
+		depId2, _ := resources.ParseResource("/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Connector/mongoDatabases/test-mongo")
 		requiredResources := []resources.ID{depId1, depId2}
 
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
@@ -278,7 +278,7 @@ func Test_Render(t *testing.T) {
 		testRendererOutput := getTestRendererOutput()
 		resourceID := getTestResourceID(testResource.ID)
 
-		depId1, _ := resources.Parse("/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A")
+		depId1, _ := resources.ParseResource("/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A")
 		requiredResources := []resources.ID{depId1}
 
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
@@ -362,7 +362,7 @@ func Test_Render(t *testing.T) {
 		testRendererOutput := getTestRendererOutput()
 		resourceID := getTestResourceID(testResource.ID)
 
-		depId1, _ := resources.Parse("/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A")
+		depId1, _ := resources.ParseResource("/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A")
 		requiredResources := []resources.ID{depId1}
 
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
@@ -444,7 +444,7 @@ func Test_Render(t *testing.T) {
 	t.Run("verify render error", func(t *testing.T) {
 		testResource := getTestResource()
 		resourceID := getTestResourceID(testResource.ID)
-		depId1, _ := resources.Parse("/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A")
+		depId1, _ := resources.ParseResource("/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A")
 		requiredResources := []resources.ID{depId1}
 
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return(requiredResources, nil, nil)
@@ -638,7 +638,7 @@ func Test_Render(t *testing.T) {
 		resourceID := getTestResourceID(testResource.ID)
 
 		testRendererOutput.Resources[0].ResourceType.Provider = ""
-		depId1, _ := resources.Parse("/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A")
+		depId1, _ := resources.ParseResource("/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A")
 		requiredResources := []resources.ID{depId1}
 
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
@@ -722,7 +722,7 @@ func Test_Render(t *testing.T) {
 		resourceID := getTestResourceID(testResource.ID)
 
 		testRendererOutput.Resources[0].ResourceType.Provider = "unknown"
-		depId1, _ := resources.Parse("/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A")
+		depId1, _ := resources.ParseResource("/subscriptions/test-subscription/resourceGroups/test-resource-group/providers/Applications.Core/httpRoutes/A")
 		requiredResources := []resources.ID{depId1}
 
 		mocks.renderer.EXPECT().GetDependencyIDs(gomock.Any(), gomock.Any()).Times(1).Return(requiredResources, nil, nil)

--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -510,7 +510,7 @@ func (dp *deploymentProcessor) getResourceDataByID(ctx context.Context, resource
 func (dp *deploymentProcessor) buildResourceDependency(resourceID resources.ID, applicationID string, resource conv.DataModelInterface, outputResources []outputresource.OutputResource, computedValues map[string]interface{}, secretValues map[string]rp.SecretValueReference) (ResourceData, error) {
 	var appID resources.ID
 	if applicationID != "" {
-		parsedID, err := resources.Parse(applicationID)
+		parsedID, err := resources.ParseResource(applicationID)
 		if err != nil {
 			return ResourceData{}, conv.NewClientErrInvalidRequest(fmt.Sprintf("application ID %q for the resource %q is not a valid id. Error: %s", applicationID, resourceID.String(), err.Error()))
 		}
@@ -598,7 +598,7 @@ func (dp *deploymentProcessor) getEnvironmentFromApplication(ctx context.Context
 
 // getEnvironmentNamespace fetches the environment resource from the db for getting the namespace to deploy the resources
 func (dp *deploymentProcessor) getEnvironmentNamespace(ctx context.Context, environmentID, resourceID string) (string, error) {
-	envId, err := resources.Parse(environmentID)
+	envId, err := resources.ParseResource(environmentID)
 	if err != nil {
 		return "", conv.NewClientErrInvalidRequest(fmt.Sprintf("environment id %q linked to the application for resource %q is not a valid id. Error: %s", environmentID, resourceID, err.Error()))
 	}

--- a/pkg/corerp/handlers/arm_handler.go
+++ b/pkg/corerp/handlers/arm_handler.go
@@ -81,7 +81,7 @@ func getByID(ctx context.Context, auth autorest.Authorizer, identity resourcemod
 		return nil, err
 	}
 
-	parsed, err := ucpresources.Parse(id)
+	parsed, err := ucpresources.ParseResource(id)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/corerp/handlers/azure_fileshare_storageaccount.go
+++ b/pkg/corerp/handlers/azure_fileshare_storageaccount.go
@@ -74,7 +74,7 @@ func (handler *azureFileShareStorageAccountHandler) GetResourceNativeIdentityKey
 }
 
 func getStorageAccountByID(ctx context.Context, arm armauth.ArmConfig, accountID string) (*storage.Account, error) {
-	parsed, err := resources.Parse(accountID)
+	parsed, err := resources.ParseResource(accountID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse Storage Account resource id: %w", err)
 	}

--- a/pkg/corerp/handlers/azure_podidentity.go
+++ b/pkg/corerp/handlers/azure_podidentity.go
@@ -263,7 +263,7 @@ func (handler *azurePodIdentityHandler) Delete(ctx context.Context, resource out
 }
 
 func (handler *azurePodIdentityHandler) deleteManagedIdentity(ctx context.Context, msiResourceID string) error {
-	parsed, err := resources.Parse(msiResourceID)
+	parsed, err := resources.ParseResource(msiResourceID)
 	if err != nil {
 		return err
 	}

--- a/pkg/corerp/handlers/azure_roleassignment.go
+++ b/pkg/corerp/handlers/azure_roleassignment.go
@@ -56,6 +56,7 @@ func (handler *azureRoleAssignmentHandler) Put(ctx context.Context, resource *ou
 		return errors.New("missing dependency: a user assigned identity is required to create role assignment")
 	}
 
+	// Scope may be a resource ID or an azure scope. We don't really need to know which so we're using the generic 'Parse' function.
 	parsedScope, err := resources.Parse(scope)
 	if err != nil {
 		return err
@@ -85,6 +86,8 @@ func (handler *azureRoleAssignmentHandler) GetResourceIdentity(ctx context.Conte
 	}
 	roleName := properties[RoleNameKey]
 	scope := properties[RoleAssignmentScope]
+
+	// Scope may be a resource ID or an azure scope. We don't really need to know which so we're using the generic 'Parse' function.
 	parsedScope, err := resources.Parse(scope)
 	if err != nil {
 		return resourcemodel.ResourceIdentity{}, err

--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -74,7 +74,7 @@ func (r Renderer) GetDependencyIDs(ctx context.Context, dm conv.DataModelInterfa
 	//
 	// Anywhere we accept a resource ID in the model should have its value returned from here
 	for _, connection := range properties.Connections {
-		resourceID, err := resources.Parse(connection.Source)
+		resourceID, err := resources.ParseResource(connection.Source)
 		if err != nil {
 			return nil, nil, conv.NewClientErrInvalidRequest(err.Error())
 		}
@@ -97,7 +97,7 @@ func (r Renderer) GetDependencyIDs(ctx context.Context, dm conv.DataModelInterfa
 			continue
 		}
 
-		resourceID, err := resources.Parse(provides)
+		resourceID, err := resources.ParseResource(provides)
 		if err != nil {
 			return nil, nil, conv.NewClientErrInvalidRequest(err.Error())
 		}
@@ -111,7 +111,7 @@ func (r Renderer) GetDependencyIDs(ctx context.Context, dm conv.DataModelInterfa
 	for _, volume := range properties.Container.Volumes {
 		switch volume.Kind {
 		case datamodel.Persistent:
-			resourceID, err := resources.Parse(volume.Persistent.Source)
+			resourceID, err := resources.ParseResource(volume.Persistent.Source)
 			if err != nil {
 				return nil, nil, conv.NewClientErrInvalidRequest(err.Error())
 			}
@@ -133,7 +133,7 @@ func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface, option
 		return renderers.RendererOutput{}, conv.ErrInvalidModelConversion
 	}
 
-	appId, err := resources.Parse(resource.Properties.Application)
+	appId, err := resources.ParseResource(resource.Properties.Application)
 	if err != nil {
 		return renderers.RendererOutput{}, conv.NewClientErrInvalidRequest(fmt.Sprintf("invalid application id: %s ", err.Error()))
 	}
@@ -199,7 +199,7 @@ func (r Renderer) makeDeployment(ctx context.Context, resource datamodel.Contain
 	ports := []corev1.ContainerPort{}
 	for _, port := range cc.Container.Ports {
 		if provides := port.Provides; provides != "" {
-			resourceId, err := resources.Parse(provides)
+			resourceId, err := resources.ParseResource(provides)
 			if err != nil {
 				return outputresource.OutputResource{}, []outputresource.OutputResource{}, nil, conv.NewClientErrInvalidRequest(err.Error())
 			}
@@ -349,7 +349,7 @@ func (r Renderer) makeDeployment(ctx context.Context, resource datamodel.Contain
 					// The storage account was not created when the computed value was rendered
 					// Lookup the actual storage account name from the local id
 					id := properties.OutputResources[value.(string)].Data.(resourcemodel.ARMIdentity).ID
-					r, err := resources.Parse(id)
+					r, err := resources.ParseResource(id)
 					if err != nil {
 						return outputresource.OutputResource{}, []outputresource.OutputResource{}, nil, conv.NewClientErrInvalidRequest(err.Error())
 					}
@@ -554,7 +554,7 @@ func (r Renderer) makeAzureFileSharePersistentVolume(volumeName string, persiste
 	volumeSpec.Name = volumeName
 	volumeSpec.VolumeSource.AzureFile = &corev1.AzureFileVolumeSource{}
 	volumeSpec.AzureFile.SecretName = applicationName
-	resourceID, err := resources.Parse(persistentVolume.Source)
+	resourceID, err := resources.ParseResource(persistentVolume.Source)
 	if err != nil {
 		return corev1.Volume{}, corev1.VolumeMount{}, err
 	}

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -64,7 +64,7 @@ func makeResource(t *testing.T, properties datamodel.ContainerProperties) *datam
 }
 
 func makeResourceID(t *testing.T, resourceType string, resourceName string) resources.ID {
-	id, err := resources.Parse(resources.MakeRelativeID(
+	id, err := resources.ParseResource(resources.MakeRelativeID(
 		[]resources.ScopeSegment{
 			{Type: "subscriptions", Name: "test-subscription"},
 			{Type: "resourceGroups", Name: "test-resourcegroup"},
@@ -363,7 +363,7 @@ func Test_Render_Connections(t *testing.T) {
 		},
 		Connections: map[string]datamodel.ConnectionProperties{
 			"A": {
-				Source: makeResourceID(t, "ResourceType", "A").String(),
+				Source: makeResourceID(t, "SomeProvider/ResourceType", "A").String(),
 				IAM: datamodel.IAMProperties{
 					Kind: datamodel.KindHTTP,
 				},
@@ -379,8 +379,8 @@ func Test_Render_Connections(t *testing.T) {
 	}
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{
-		(makeResourceID(t, "ResourceType", "A").String()): {
-			ResourceID: makeResourceID(t, "ResourceType", "A"),
+		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
+			ResourceID: makeResourceID(t, "SomeProvider/ResourceType", "A"),
 			Definition: map[string]interface{}{},
 			ComputedValues: map[string]interface{}{
 				"ComputedKey1": "ComputedValue1",
@@ -464,7 +464,7 @@ func Test_RenderConnections_DisableDefaultEnvVars(t *testing.T) {
 		},
 		Connections: map[string]datamodel.ConnectionProperties{
 			"A": {
-				Source:                makeResourceID(t, "ResourceType", "A").String(),
+				Source:                makeResourceID(t, "SomeProvider/ResourceType", "A").String(),
 				DisableDefaultEnvVars: to.Ptr(true),
 				IAM: datamodel.IAMProperties{
 					Kind: datamodel.KindHTTP,
@@ -477,8 +477,8 @@ func Test_RenderConnections_DisableDefaultEnvVars(t *testing.T) {
 	}
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{
-		(makeResourceID(t, "ResourceType", "A").String()): {
-			ResourceID: makeResourceID(t, "ResourceType", "A"),
+		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
+			ResourceID: makeResourceID(t, "SomeProvider/ResourceType", "A"),
 			Definition: map[string]interface{}{},
 			ComputedValues: map[string]interface{}{
 				"ComputedKey1": "ComputedValue1",
@@ -514,7 +514,7 @@ func Test_Render_Connections_SecretsGetHashed(t *testing.T) {
 		},
 		Connections: map[string]datamodel.ConnectionProperties{
 			"A": {
-				Source: makeResourceID(t, "ResourceType", "A").String(),
+				Source: makeResourceID(t, "SomeProvider/ResourceType", "A").String(),
 				IAM: datamodel.IAMProperties{
 					Kind: datamodel.KindHTTP,
 				},
@@ -530,8 +530,8 @@ func Test_Render_Connections_SecretsGetHashed(t *testing.T) {
 	}
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{
-		(makeResourceID(t, "ResourceType", "A").String()): {
-			ResourceID: makeResourceID(t, "ResourceType", "A"),
+		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
+			ResourceID: makeResourceID(t, "SomeProvider/ResourceType", "A"),
 			Definition: map[string]interface{}{},
 			ComputedValues: map[string]interface{}{
 				"ComputedKey1": "ComputedValue1",
@@ -553,7 +553,7 @@ func Test_Render_Connections_SecretsGetHashed(t *testing.T) {
 	hash1 := deployment.Spec.Template.Annotations[kubernetes.AnnotationSecretHash]
 
 	// Update and render again
-	dependencies[makeResourceID(t, "ResourceType", "A").String()].ComputedValues["ComputedKey1"] = "new value"
+	dependencies[makeResourceID(t, "SomeProvider/ResourceType", "A").String()].ComputedValues["ComputedKey1"] = "new value"
 
 	output, err = renderer.Render(createContext(t), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: renderers.EnvironmentOptions{Namespace: "default"}})
 	require.NoError(t, err)
@@ -573,7 +573,7 @@ func Test_Render_ConnectionWithRoleAssignment(t *testing.T) {
 		},
 		Connections: map[string]datamodel.ConnectionProperties{
 			"A": {
-				Source: makeResourceID(t, "ResourceType", "A").String(),
+				Source: makeResourceID(t, "SomeProvider/ResourceType", "A").String(),
 				IAM: datamodel.IAMProperties{
 					Kind: datamodel.KindHTTP,
 				},
@@ -585,8 +585,8 @@ func Test_Render_ConnectionWithRoleAssignment(t *testing.T) {
 	}
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{
-		(makeResourceID(t, "ResourceType", "A").String()): {
-			ResourceID: makeResourceID(t, "ResourceType", "A"),
+		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
+			ResourceID: makeResourceID(t, "SomeProvider/ResourceType", "A"),
 			Definition: map[string]interface{}{},
 			ComputedValues: map[string]interface{}{
 				"ComputedKey1": "ComputedValue1",
@@ -599,7 +599,7 @@ func Test_Render_ConnectionWithRoleAssignment(t *testing.T) {
 						Type:     "dummy",
 						Provider: resourcemodel.ProviderAzure,
 					},
-					makeResourceID(t, "TargetResourceType", "TargetResource").String(),
+					makeResourceID(t, "SomeProvider/TargetResourceType", "TargetResource").String(),
 					"2020-01-01"),
 			},
 		},
@@ -636,11 +636,11 @@ func Test_Render_ConnectionWithRoleAssignment(t *testing.T) {
 				Type:     resourcekinds.AzureRoleAssignment,
 				Provider: resourcemodel.ProviderAzure,
 			},
-			LocalID:  outputresource.GenerateLocalIDForRoleAssignment(makeResourceID(t, "TargetResourceType", "TargetResource").String(), "TestRole1"),
+			LocalID:  outputresource.GenerateLocalIDForRoleAssignment(makeResourceID(t, "SomeProvider/TargetResourceType", "TargetResource").String(), "TestRole1"),
 			Deployed: false,
 			Resource: map[string]string{
 				handlers.RoleNameKey:         "TestRole1",
-				handlers.RoleAssignmentScope: makeResourceID(t, "TargetResourceType", "TargetResource").String(),
+				handlers.RoleAssignmentScope: makeResourceID(t, "SomeProvider/TargetResourceType", "TargetResource").String(),
 			},
 			Dependencies: []outputresource.Dependency{
 				{
@@ -653,11 +653,11 @@ func Test_Render_ConnectionWithRoleAssignment(t *testing.T) {
 				Type:     resourcekinds.AzureRoleAssignment,
 				Provider: resourcemodel.ProviderAzure,
 			},
-			LocalID:  outputresource.GenerateLocalIDForRoleAssignment(makeResourceID(t, "TargetResourceType", "TargetResource").String(), "TestRole2"),
+			LocalID:  outputresource.GenerateLocalIDForRoleAssignment(makeResourceID(t, "SomeProvider/TargetResourceType", "TargetResource").String(), "TestRole2"),
 			Deployed: false,
 			Resource: map[string]string{
 				handlers.RoleNameKey:         "TestRole2",
-				handlers.RoleAssignmentScope: makeResourceID(t, "TargetResourceType", "TargetResource").String(),
+				handlers.RoleAssignmentScope: makeResourceID(t, "SomeProvider/TargetResourceType", "TargetResource").String(),
 			},
 			Dependencies: []outputresource.Dependency{
 				{
@@ -706,10 +706,10 @@ func Test_Render_ConnectionWithRoleAssignment(t *testing.T) {
 					LocalID: outputresource.LocalIDUserAssignedManagedIdentity,
 				},
 				{
-					LocalID: outputresource.GenerateLocalIDForRoleAssignment(makeResourceID(t, "TargetResourceType", "TargetResource").String(), "TestRole1"),
+					LocalID: outputresource.GenerateLocalIDForRoleAssignment(makeResourceID(t, "SomeProvider/TargetResourceType", "TargetResource").String(), "TestRole1"),
 				},
 				{
-					LocalID: outputresource.GenerateLocalIDForRoleAssignment(makeResourceID(t, "TargetResourceType", "TargetResource").String(), "TestRole2"),
+					LocalID: outputresource.GenerateLocalIDForRoleAssignment(makeResourceID(t, "SomeProvider/TargetResourceType", "TargetResource").String(), "TestRole2"),
 				},
 			},
 		},
@@ -718,7 +718,7 @@ func Test_Render_ConnectionWithRoleAssignment(t *testing.T) {
 }
 
 func Test_Render_AzureConnection(t *testing.T) {
-	testARMID := makeResourceID(t, "ResourceType", "test-azure-resource").String()
+	testARMID := makeResourceID(t, "SomeProvider/ResourceType", "test-azure-resource").String()
 	expectedRole := "administrator"
 	properties := datamodel.ContainerProperties{
 		BasicResourceProperties: rp.BasicResourceProperties{
@@ -788,7 +788,7 @@ func Test_Render_AzureConnection(t *testing.T) {
 }
 
 func Test_Render_AzureConnectionEmptyRoleAllowed(t *testing.T) {
-	testARMID := makeResourceID(t, "ResourceType", "test-azure-resource").String()
+	testARMID := makeResourceID(t, "SomeProvider/ResourceType", "test-azure-resource").String()
 	properties := datamodel.ContainerProperties{
 		BasicResourceProperties: rp.BasicResourceProperties{
 			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app",
@@ -845,8 +845,8 @@ func Test_Render_EphemeralVolumes(t *testing.T) {
 	}
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{
-		(makeResourceID(t, "ResourceType", "A").String()): {
-			ResourceID:     makeResourceID(t, "ResourceType", "A"),
+		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
+			ResourceID:     makeResourceID(t, "SomeProvider/ResourceType", "A"),
 			Definition:     map[string]interface{}{},
 			ComputedValues: map[string]interface{}{},
 		},
@@ -917,7 +917,7 @@ func Test_Render_PersistentAzureFileShareVolumes(t *testing.T) {
 		},
 	}
 	resource := makeResource(t, properties)
-	resourceID, _ := resources.Parse(testResourceID)
+	resourceID, _ := resources.ParseResource(testResourceID)
 	dependencies := map[string]renderers.RendererDependency{
 		testResourceID: {
 			ResourceID: resourceID,
@@ -990,7 +990,7 @@ func Test_Render_PersistentAzureKeyVaultVolumes(t *testing.T) {
 		},
 	}
 	resource := makeResource(t, properties)
-	resourceID, _ := resources.Parse(testResourceID)
+	resourceID, _ := resources.ParseResource(testResourceID)
 	dependencies := map[string]renderers.RendererDependency{
 		testResourceID: {
 			ResourceID: resourceID,
@@ -1098,8 +1098,8 @@ func Test_Render_ReadinessProbeHttpGet(t *testing.T) {
 	}
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{
-		(makeResourceID(t, "ResourceType", "A").String()): {
-			ResourceID: makeResourceID(t, "ResourceType", "A"),
+		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
+			ResourceID: makeResourceID(t, "SomeProvider/ResourceType", "A"),
 			Definition: map[string]interface{}{},
 			ComputedValues: map[string]interface{}{
 				"ComputedKey1": "ComputedValue1",
@@ -1173,8 +1173,8 @@ func Test_Render_ReadinessProbeTcp(t *testing.T) {
 	}
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{
-		(makeResourceID(t, "ResourceType", "A").String()): {
-			ResourceID: makeResourceID(t, "ResourceType", "A"),
+		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
+			ResourceID: makeResourceID(t, "SomeProvider/ResourceType", "A"),
 			Definition: map[string]interface{}{},
 			ComputedValues: map[string]interface{}{
 				"ComputedKey1": "ComputedValue1",
@@ -1241,8 +1241,8 @@ func Test_Render_LivenessProbeExec(t *testing.T) {
 	}
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{
-		(makeResourceID(t, "ResourceType", "A").String()): {
-			ResourceID: makeResourceID(t, "ResourceType", "A"),
+		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
+			ResourceID: makeResourceID(t, "SomeProvider/ResourceType", "A"),
 			Definition: map[string]interface{}{},
 			ComputedValues: map[string]interface{}{
 				"ComputedKey1": "ComputedValue1",
@@ -1300,8 +1300,8 @@ func Test_Render_LivenessProbeWithDefaults(t *testing.T) {
 	}
 	resource := makeResource(t, properties)
 	dependencies := map[string]renderers.RendererDependency{
-		(makeResourceID(t, "ResourceType", "A").String()): {
-			ResourceID: makeResourceID(t, "ResourceType", "A"),
+		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
+			ResourceID: makeResourceID(t, "SomeProvider/ResourceType", "A"),
 			Definition: map[string]interface{}{},
 			ComputedValues: map[string]interface{}{
 				"ComputedKey1": "ComputedValue1",

--- a/pkg/corerp/renderers/daprextension/renderer.go
+++ b/pkg/corerp/renderers/daprextension/renderer.go
@@ -47,7 +47,7 @@ func (r Renderer) GetDependencyIDs(ctx context.Context, dm conv.DataModelInterfa
 		return radiusDependencyIDs, azureDependencyIDs, nil
 	}
 
-	parsed, err := resources.Parse(extension.Provides)
+	parsed, err := resources.ParseResource(extension.Provides)
 	if err != nil {
 		return nil, nil, conv.NewClientErrInvalidRequest(err.Error())
 	}

--- a/pkg/corerp/renderers/gateway/render.go
+++ b/pkg/corerp/renderers/gateway/render.go
@@ -37,7 +37,7 @@ func (r Renderer) GetDependencyIDs(ctx context.Context, dm conv.DataModelInterfa
 	gtwyProperties := gateway.Properties
 	// Get all httproutes that are used by this gateway
 	for _, httpRoute := range gtwyProperties.Routes {
-		resourceID, err := resources.Parse(httpRoute.Destination)
+		resourceID, err := resources.ParseResource(httpRoute.Destination)
 		if err != nil {
 			return nil, nil, conv.NewClientErrInvalidRequest(err.Error())
 		}
@@ -55,7 +55,7 @@ func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface, option
 	if !ok {
 		return renderers.RendererOutput{}, conv.ErrInvalidModelConversion
 	}
-	appId, err := resources.Parse(gateway.Properties.Application)
+	appId, err := resources.ParseResource(gateway.Properties.Application)
 	if err != nil {
 		return renderers.RendererOutput{}, conv.NewClientErrInvalidRequest(fmt.Sprintf("invalid application id: %s. id: %s", err.Error(), gateway.Properties.Application))
 	}
@@ -249,7 +249,7 @@ func MakeHttpRoutes(options renderers.RenderOptions, resource datamodel.Gateway,
 }
 
 func getRouteName(route *datamodel.GatewayRoute) (string, error) {
-	resourceID, err := resources.Parse(route.Destination)
+	resourceID, err := resources.ParseResource(route.Destination)
 	if err != nil {
 		return "", conv.NewClientErrInvalidRequest(err.Error())
 	}

--- a/pkg/corerp/renderers/gateway/render_test.go
+++ b/pkg/corerp/renderers/gateway/render_test.go
@@ -381,7 +381,7 @@ func Test_Render_WithMissingPublicIP(t *testing.T) {
 		},
 	})
 	resource := makeResource(t, properties)
-	appId, err := resources.Parse(resource.Properties.Application)
+	appId, err := resources.ParseResource(resource.Properties.Application)
 	require.NoError(t, err)
 	appName := appId.Name()
 	dependencies := map[string]renderers.RendererDependency{}
@@ -903,7 +903,7 @@ func makeDependentResource(t *testing.T, properties datamodel.HTTPRoutePropertie
 	return &dm
 }
 func makeResourceID(t *testing.T, resourceID string) resources.ID {
-	id, err := resources.Parse(resourceID)
+	id, err := resources.ParseResource(resourceID)
 	require.NoError(t, err)
 
 	return id

--- a/pkg/corerp/renderers/httproute/render.go
+++ b/pkg/corerp/renderers/httproute/render.go
@@ -38,7 +38,7 @@ func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface, option
 		return renderers.RendererOutput{}, conv.ErrInvalidModelConversion
 	}
 	outputResources := []outputresource.OutputResource{}
-	appId, err := resources.Parse(route.Properties.Application)
+	appId, err := resources.ParseResource(route.Properties.Application)
 	if err != nil {
 		return renderers.RendererOutput{}, conv.NewClientErrInvalidRequest(fmt.Sprintf("invalid application id: %s. id: %s", err.Error(), route.Properties.Application))
 	}
@@ -77,7 +77,7 @@ func (r Renderer) Render(ctx context.Context, dm conv.DataModelInterface, option
 }
 
 func (r *Renderer) makeService(route *datamodel.HTTPRoute, options renderers.RenderOptions) (outputresource.OutputResource, error) {
-	appId, err := resources.Parse(route.Properties.Application)
+	appId, err := resources.ParseResource(route.Properties.Application)
 
 	if err != nil {
 		return outputresource.OutputResource{}, conv.NewClientErrInvalidRequest(fmt.Sprintf("invalid application id: %s. id: %s", err.Error(), route.Properties.Application))

--- a/pkg/resourcemodel/identity.go
+++ b/pkg/resourcemodel/identity.go
@@ -158,7 +158,7 @@ func (r ResourceIdentity) AsLogValues() []interface{} {
 	case ProviderAzure:
 		// We can't report an error here so this is best-effort.
 		data := r.Data.(ARMIdentity)
-		id, err := resources.Parse(data.ID)
+		id, err := resources.ParseResource(data.ID)
 		if err != nil {
 			return []interface{}{radlogger.LogFieldResourceID, data.ID}
 		}

--- a/pkg/rp/secretvalueclient.go
+++ b/pkg/rp/secretvalueclient.go
@@ -33,7 +33,7 @@ func (c *client) FetchSecret(ctx context.Context, identity resourcemodel.Resourc
 		return nil, fmt.Errorf("unsupported resource type: %+v. Currently only ARM resources are supported", identity)
 	}
 
-	parsed, err := resources.Parse(arm.ID)
+	parsed, err := resources.ParseResource(arm.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ucp/frontend/controller/planes/createorupdateplane.go
+++ b/pkg/ucp/frontend/controller/planes/createorupdateplane.go
@@ -53,7 +53,7 @@ func (p *CreateOrUpdatePlane) Run(ctx context.Context, w http.ResponseWriter, re
 
 	plane.Type = planes.PlaneTypePrefix + "/" + planeType
 	plane.Name = name
-	id, err := resources.Parse(plane.ID)
+	id, err := resources.ParseScope(plane.ID)
 	//cannot parse ID something wrong with request
 	if err != nil {
 		return rest.NewBadRequestResponse(err.Error()), nil

--- a/pkg/ucp/frontend/controller/planes/deleteplane.go
+++ b/pkg/ucp/frontend/controller/planes/deleteplane.go
@@ -33,7 +33,7 @@ func NewDeletePlane(opts ctrl.Options) (ctrl.Controller, error) {
 func (p *DeletePlane) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (rest.Response, error) {
 	path := middleware.GetRelativePath(p.Options.BasePath, req.URL.Path)
 	logger := ucplog.GetLogger(ctx)
-	resourceId, err := resources.Parse(path)
+	resourceId, err := resources.ParseScope(path)
 	if err != nil {
 		return rest.NewBadRequestResponse(err.Error()), nil
 	}

--- a/pkg/ucp/frontend/controller/planes/getplane.go
+++ b/pkg/ucp/frontend/controller/planes/getplane.go
@@ -33,7 +33,7 @@ func NewGetPlane(opts ctrl.Options) (ctrl.Controller, error) {
 func (p *GetPlane) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (rest.Response, error) {
 	path := middleware.GetRelativePath(p.Options.BasePath, req.URL.Path)
 	logger := ucplog.GetLogger(ctx)
-	resourceId, err := resources.Parse(path)
+	resourceId, err := resources.ParseScope(path)
 	if err != nil {
 		if err != nil {
 			return rest.NewBadRequestResponse(err.Error()), nil

--- a/pkg/ucp/frontend/controller/planes/proxyplane.go
+++ b/pkg/ucp/frontend/controller/planes/proxyplane.go
@@ -54,12 +54,11 @@ func (p *ProxyPlane) Run(ctx context.Context, w http.ResponseWriter, req *http.R
 
 	// Lookup the plane
 	planePath := PlanesPath + "/" + planeType + "/" + name
-	planeID, err := resources.Parse(planePath)
+	planeID, err := resources.ParseScope(planePath)
 	if err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
+
 	plane := rest.Plane{}
 	_, err = p.GetResource(ctx, planeID.String(), &plane)
 	if err != nil {
@@ -80,7 +79,7 @@ func (p *ProxyPlane) Run(ctx context.Context, w http.ResponseWriter, req *http.R
 			return nil, err
 		}
 		rgPath := id.RootScope()
-		rgID, err := resources.Parse(rgPath)
+		rgID, err := resources.ParseScope(rgPath)
 		if err != nil {
 			return nil, err
 		}
@@ -101,6 +100,7 @@ func (p *ProxyPlane) Run(ctx context.Context, w http.ResponseWriter, req *http.R
 		return nil, err
 	}
 
+	// We expect either a resource or resource collection.
 	if resourceID.ProviderNamespace() == "" {
 		err = fmt.Errorf("Invalid resourceID specified with no provider")
 		return rest.NewBadRequestResponse(err.Error()), err

--- a/pkg/ucp/frontend/controller/resourcegroups/createorupdateresourcegroup.go
+++ b/pkg/ucp/frontend/controller/resourcegroups/createorupdateresourcegroup.go
@@ -46,7 +46,7 @@ func (r *CreateOrUpdateResourceGroup) Run(ctx context.Context, w http.ResponseWr
 
 	rg.ID = path
 	rgExists := true
-	ID, err := resources.Parse(rg.ID)
+	ID, err := resources.ParseScope(rg.ID)
 	//cannot parse ID something wrong with request
 	if err != nil {
 		return rest.NewBadRequestResponse(err.Error()), nil

--- a/pkg/ucp/frontend/controller/resourcegroups/deleteresourcegroup.go
+++ b/pkg/ucp/frontend/controller/resourcegroups/deleteresourcegroup.go
@@ -33,7 +33,7 @@ func NewDeleteResourceGroup(opts ctrl.Options) (ctrl.Controller, error) {
 func (r *DeleteResourceGroup) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (rest.Response, error) {
 	path := middleware.GetRelativePath(r.Options.BasePath, req.URL.Path)
 	logger := ucplog.GetLogger(ctx)
-	resourceID, err := resources.Parse(path)
+	resourceID, err := resources.ParseScope(path)
 	if err != nil {
 		return rest.NewBadRequestResponse(err.Error()), nil
 	}

--- a/pkg/ucp/frontend/controller/resourcegroups/getresourcegroup.go
+++ b/pkg/ucp/frontend/controller/resourcegroups/getresourcegroup.go
@@ -35,7 +35,7 @@ func (r *GetResourceGroup) Run(ctx context.Context, w http.ResponseWriter, req *
 	path := middleware.GetRelativePath(r.Options.BasePath, req.URL.Path)
 	logger := ucplog.GetLogger(ctx)
 	id := strings.ToLower(path)
-	resourceID, err := resources.Parse(id)
+	resourceID, err := resources.ParseScope(id)
 	if err != nil {
 		if err != nil {
 			return rest.NewBadRequestResponse(err.Error()), nil

--- a/pkg/ucp/integrationtests/integration_test.go
+++ b/pkg/ucp/integrationtests/integration_test.go
@@ -316,7 +316,7 @@ func sendProxyRequest(t *testing.T, ucp *httptest.Server, ucpClient Client, db *
 		return &data, nil
 	})
 
-	rgID, err := resources.Parse("/planes/radius/local/resourceGroups/rg1")
+	rgID, err := resources.ParseScope("/planes/radius/local/resourceGroups/rg1")
 	require.NoError(t, err)
 	db.EXPECT().Get(gomock.Any(), rgID.String())
 
@@ -369,7 +369,7 @@ func sendProxyRequest_ResourceGroupDoesNotExist(t *testing.T, ucp *httptest.Serv
 		return &data, nil
 	})
 
-	rgID, err := resources.Parse("/planes/radius/local/resourceGroups/rg1")
+	rgID, err := resources.ParseScope("/planes/radius/local/resourceGroups/rg1")
 	require.NoError(t, err)
 
 	db.EXPECT().Get(gomock.Any(), rgID.String()).DoAndReturn(func(ctx context.Context, id string, options ...store.GetOptions) (*store.Object, error) {

--- a/pkg/ucp/resources/id_test.go
+++ b/pkg/ucp/resources/id_test.go
@@ -35,12 +35,23 @@ func Test_ParseInvalidIDs(t *testing.T) {
 	}
 }
 
+type idkind string
+
+const (
+	kindnone               idkind = "none"
+	kindscope              idkind = "scope"
+	kindscopecollection    idkind = "scopecollection"
+	kindresource           idkind = "resource"
+	kindresourcecollection idkind = "resourcecollection"
+)
+
 func Test_ParseValidIDs(t *testing.T) {
 	values := []struct {
 		id       string
 		expected string
 		scopes   []ScopeSegment
 		types    []TypeSegment
+		kind     idkind
 		provider string
 	}{
 		{
@@ -54,6 +65,7 @@ func Test_ParseValidIDs(t *testing.T) {
 				{Type: "Microsoft.CustomProviders/resourceProviders"},
 			},
 			provider: "Microsoft.CustomProviders/resourceProviders",
+			kind:     kindresourcecollection,
 		},
 		{
 			id:       "/planes",
@@ -61,6 +73,7 @@ func Test_ParseValidIDs(t *testing.T) {
 			scopes:   []ScopeSegment{},
 			types:    []TypeSegment{},
 			provider: "",
+			kind:     kindscope,
 		},
 		{
 			id:       "/planes/",
@@ -68,6 +81,7 @@ func Test_ParseValidIDs(t *testing.T) {
 			scopes:   []ScopeSegment{},
 			types:    []TypeSegment{},
 			provider: "",
+			kind:     kindscope,
 		},
 		{
 			id:       "/",
@@ -75,6 +89,7 @@ func Test_ParseValidIDs(t *testing.T) {
 			scopes:   []ScopeSegment{},
 			types:    []TypeSegment{},
 			provider: "",
+			kind:     kindscope,
 		},
 		{
 			id:       "/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/",
@@ -87,6 +102,7 @@ func Test_ParseValidIDs(t *testing.T) {
 				{Type: "Microsoft.CustomProviders/resourceProviders"},
 			},
 			provider: "Microsoft.CustomProviders/resourceProviders",
+			kind:     kindresourcecollection,
 		},
 		{
 			id:       "subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders",
@@ -99,6 +115,7 @@ func Test_ParseValidIDs(t *testing.T) {
 				{Type: "Microsoft.CustomProviders/resourceProviders"},
 			},
 			provider: "Microsoft.CustomProviders/resourceProviders",
+			kind:     kindresourcecollection,
 		},
 		{
 			id:       "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders",
@@ -111,6 +128,7 @@ func Test_ParseValidIDs(t *testing.T) {
 				{Type: "Microsoft.CustomProviders/resourceProviders"},
 			},
 			provider: "Microsoft.CustomProviders/resourceProviders",
+			kind:     kindresourcecollection,
 		},
 		{
 			id:       "/Subscriptions/s1/resourceGroups/r1/providers/foo/bar",
@@ -123,6 +141,7 @@ func Test_ParseValidIDs(t *testing.T) {
 				{Type: "foo/bar"},
 			},
 			provider: "foo",
+			kind:     kindresourcecollection,
 		},
 		{
 			id:       "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius",
@@ -135,6 +154,7 @@ func Test_ParseValidIDs(t *testing.T) {
 				{Type: "Microsoft.CustomProviders/resourceProviders", Name: "radius"},
 			},
 			provider: "Microsoft.CustomProviders/resourceProviders",
+			kind:     kindresource,
 		},
 		{
 			id:       "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/",
@@ -147,6 +167,7 @@ func Test_ParseValidIDs(t *testing.T) {
 				{Type: "Microsoft.CustomProviders/resourceProviders", Name: "radius"},
 			},
 			provider: "Microsoft.CustomProviders/resourceProviders",
+			kind:     kindresource,
 		},
 		{
 			id:       "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/",
@@ -159,6 +180,7 @@ func Test_ParseValidIDs(t *testing.T) {
 				{Type: "Microsoft.CustomProviders/resourceProviders", Name: "radius"},
 			},
 			provider: "Microsoft.CustomProviders/resourceProviders",
+			kind:     kindresource,
 		},
 		{
 			id:       "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications",
@@ -172,6 +194,7 @@ func Test_ParseValidIDs(t *testing.T) {
 				{Type: "Applications"},
 			},
 			provider: "Microsoft.CustomProviders/resourceProviders",
+			kind:     kindresourcecollection,
 		},
 		{
 			id:       "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app",
@@ -185,6 +208,7 @@ func Test_ParseValidIDs(t *testing.T) {
 				{Type: "Applications", Name: "test-app"},
 			},
 			provider: "Microsoft.CustomProviders/resourceProviders",
+			kind:     kindresource,
 		},
 		{
 			id:       "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app/Containers",
@@ -199,6 +223,7 @@ func Test_ParseValidIDs(t *testing.T) {
 				{Type: "Containers"},
 			},
 			provider: "Microsoft.CustomProviders/resourceProviders",
+			kind:     kindresourcecollection,
 		},
 		{
 			id:       "/Subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app/Containers/test",
@@ -213,6 +238,7 @@ func Test_ParseValidIDs(t *testing.T) {
 				{Type: "Containers", Name: "test"},
 			},
 			provider: "Microsoft.CustomProviders/resourceProviders",
+			kind:     kindresource,
 		},
 		{
 			id:       "/planes/azure/azurecloud/subscriptions/s1/resourceGroups/r1/providers/Microsoft.CustomProviders/resourceProviders/radius/Applications/test-app/Containers/test",
@@ -228,6 +254,7 @@ func Test_ParseValidIDs(t *testing.T) {
 				{Type: "Containers", Name: "test"},
 			},
 			provider: "Microsoft.CustomProviders/resourceProviders",
+			kind:     kindresource,
 		},
 		{
 			id:       "/planes/radius/local/resourceGroups/r1/providers/Applications.Core/applications/cool-app",
@@ -240,6 +267,7 @@ func Test_ParseValidIDs(t *testing.T) {
 				{Type: "Applications.Core/applications", Name: "cool-app"},
 			},
 			provider: "Applications.Core",
+			kind:     kindresource,
 		},
 		{
 			id:       "/planes/radius/local/",
@@ -249,6 +277,7 @@ func Test_ParseValidIDs(t *testing.T) {
 			},
 			types:    []TypeSegment{},
 			provider: "",
+			kind:     kindscope,
 		},
 		{
 			id:       "/planes/radius/local/resourceGroups/r1",
@@ -259,6 +288,7 @@ func Test_ParseValidIDs(t *testing.T) {
 			},
 			types:    []TypeSegment{},
 			provider: "",
+			kind:     kindscope,
 		},
 		{
 			id:       "/planes/radius/local/resourceGroups/r1/resources",
@@ -270,6 +300,7 @@ func Test_ParseValidIDs(t *testing.T) {
 			},
 			types:    []TypeSegment{},
 			provider: "",
+			kind:     kindscopecollection,
 		},
 		{
 			id:       "/planes/radius/local/resourceGroups/r1/providers/Applications.Core/environments/env",
@@ -282,6 +313,7 @@ func Test_ParseValidIDs(t *testing.T) {
 				Type: "Applications.Core/environments", Name: "env"},
 			},
 			provider: "Applications.Core",
+			kind:     kindresource,
 		},
 
 		// NOTE: this is NOT actually invalid, just confusing.
@@ -296,6 +328,7 @@ func Test_ParseValidIDs(t *testing.T) {
 			},
 			types:    []TypeSegment{},
 			provider: "",
+			kind:     kindscopecollection,
 		},
 	}
 
@@ -307,12 +340,54 @@ func Test_ParseValidIDs(t *testing.T) {
 			require.Equalf(t, v.expected, id.id, "id comparison failed for %s", v.id)
 			require.Equalf(t, v.scopes, id.scopeSegments, "scope comparison failed for %s", v.id)
 
+			require.NotEqual(t, kindnone, v.kind, "test must specify id kind")
+			require.Equal(t, v.kind == kindresource, id.IsResource(), "IsResource")
+			require.Equal(t, v.kind == kindscope, id.IsScope(), "IsScope")
+			require.Equal(t, v.kind == kindresourcecollection, id.IsResourceCollection(), "IsResourceCollection")
+			require.Equal(t, v.kind == kindscopecollection, id.IsScopeCollection(), "IsScopeCollection")
+
 			require.Lenf(t, id.typeSegments, len(v.types), "types comparison failed for %s", v.id)
 			for i := range id.typeSegments {
 				require.Equalf(t, v.types[i], id.typeSegments[i], "types comparison failed for %s", v.id)
 			}
 		})
 	}
+}
+
+func Test_ParseResource_Valid(t *testing.T) {
+	input := "/planes/radius/local/resourceGroups/r1/providers/Applications.Core/environments/env"
+	_, err := ParseResource(input)
+	require.NoError(t, err)
+}
+
+func Test_ParseResource_InvalidID(t *testing.T) {
+	input := "//planes/radius/local/resourceGroups/r1/providers/Applications.Core/environments/env"
+	_, err := ParseResource(input)
+	require.Error(t, err)
+}
+
+func Test_ParseResource_NotResource(t *testing.T) {
+	input := "/planes/radius/local/resourceGroups/r1/providers/Applications.Core/environments/env/listAction"
+	_, err := ParseResource(input)
+	require.Error(t, err)
+}
+
+func Test_ParseScope_Valid(t *testing.T) {
+	input := "/planes/radius/local/resourceGroups/r1"
+	_, err := ParseScope(input)
+	require.NoError(t, err)
+}
+
+func Test_ParseScope_InvalidID(t *testing.T) {
+	input := "//planes/radius/local/resourceGroups/r1/providers/Applications.Core/environments/env"
+	_, err := ParseScope(input)
+	require.Error(t, err)
+}
+
+func Test_ParseResource_NotScope(t *testing.T) {
+	input := "/planes/radius/local/resourceGroups/r1/listAction"
+	_, err := ParseScope(input)
+	require.Error(t, err)
 }
 
 func Test_MakeRelativeID(t *testing.T) {

--- a/pkg/ucp/store/apiserverstore/apiserverclient.go
+++ b/pkg/ucp/store/apiserverstore/apiserverclient.go
@@ -23,7 +23,7 @@
 //
 // The kubernetes resource names we use are built according to the following format:
 //
-// 		<resource name>.<id hash>
+//	<resource name>.<id hash>
 //
 // We also use a labeling scheme to attach each root scope segment and the resource type as a label to the
 // Kubernetes objects. This allows us to filter the number of objects we transact with using the labels as hints.
@@ -154,7 +154,7 @@ func (c *APIServerClient) Get(ctx context.Context, id string, options ...store.G
 	if parsed.IsEmpty() {
 		return nil, &store.ErrInvalid{Message: "invalid argument. 'id' must not be empty"}
 	}
-	if parsed.IsCollection() {
+	if parsed.IsResourceCollection() || parsed.IsScopeCollection() {
 		return nil, &store.ErrInvalid{Message: "invalid argument. 'id' must refer to a named resource, not a collection"}
 	}
 
@@ -189,7 +189,7 @@ func (c *APIServerClient) Delete(ctx context.Context, id string, options ...stor
 	if parsed.IsEmpty() {
 		return &store.ErrInvalid{Message: "invalid argument. 'id' must not be empty"}
 	}
-	if parsed.IsCollection() {
+	if parsed.IsResourceCollection() || parsed.IsScopeCollection() {
 		return &store.ErrInvalid{Message: "invalid argument. 'id' must refer to a named resource, not a collection"}
 	}
 

--- a/pkg/ucp/store/cosmosdb/cosmosdbstorageclient.go
+++ b/pkg/ucp/store/cosmosdb/cosmosdbstorageclient.go
@@ -230,7 +230,7 @@ func (c *CosmosDBStorageClient) Query(ctx context.Context, query store.Query, op
 
 	cfg := store.NewQueryConfig(opts...)
 
-	resourceID, err := resources.Parse(query.RootScope)
+	resourceID, err := resources.ParseScope(query.RootScope)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ucp/store/etcdstore/etcdclient.go
+++ b/pkg/ucp/store/etcdstore/etcdclient.go
@@ -15,8 +15,8 @@
 //
 // Keys are structured like the following example:
 //
-// 		scope|/planes/radius/local/|/resourceGroups/cool-group/
-// 		resource|/planes/radius/local/resourceGroups/cool-group/|/Applications.Core/applications/cool-app/
+//	scope|/planes/radius/local/|/resourceGroups/cool-group/
+//	resource|/planes/radius/local/resourceGroups/cool-group/|/Applications.Core/applications/cool-app/
 //
 // As a special case for scopes (like resource groups) we treat the last segment as the routing scope.
 //
@@ -27,7 +27,7 @@
 // For example, the following query will be commonly executed and we don't want it to list all resources in the
 // database:
 //
-//		scope|/planes/
+//	scope|/planes/
 //
 // This scheme allows a variety of flexibility for querying/filtering with different scopes. We prefer
 // query approaches that that involved client-side filtering to avoid the need for N+1 query strategies.
@@ -118,7 +118,7 @@ func (c *ETCDClient) Get(ctx context.Context, id string, options ...store.GetOpt
 	if parsed.IsEmpty() {
 		return nil, &store.ErrInvalid{Message: "invalid argument. 'id' must not be empty"}
 	}
-	if parsed.IsCollection() {
+	if parsed.IsResourceCollection() || parsed.IsScopeCollection() {
 		return nil, &store.ErrInvalid{Message: "invalid argument. 'id' must refer to a named resource, not a collection"}
 	}
 
@@ -154,7 +154,7 @@ func (c *ETCDClient) Delete(ctx context.Context, id string, options ...store.Del
 	if parsed.IsEmpty() {
 		return &store.ErrInvalid{Message: "invalid argument. 'id' must not be empty"}
 	}
-	if parsed.IsCollection() {
+	if parsed.IsResourceCollection() || parsed.IsScopeCollection() {
 		return &store.ErrInvalid{Message: "invalid argument. 'id' must refer to a named resource, not a collection"}
 	}
 


### PR DESCRIPTION
This change adds more functions for parsing different kinds of resource IDs as well as cleaning up the semantics for how we detect different kinds.

New code should use ParseResource or ParseScope if possible. Parse is very general and doesn't provide a lot of guardrails. Only very very general-purpose code should use Parse (eg: a lot of places in UCP, or middleware for logging/metrics). The vast majority of code should use ParseResource.

I've updated all of the existing callsites for Parse to use a more specialized function if possible. I've also added a comment as justification in the places that have a non-obvious reason to use Parse.
