### PR TITLE
Fix context name

### DIFF
--- a/pkg/cli/cmd/radInit/init.go
+++ b/pkg/cli/cmd/radInit/init.go
@@ -235,15 +235,15 @@ func installRadius(ctx context.Context, r *Runner) error {
 func selectKubeContext(currentContext string, kubeContexts map[string]*api.Context, interactive bool, prompter prompt.Interface) (string, error) {
 	values := []string{}
 	if interactive {
-		defaultValue := fmt.Sprintf("%s (current)", currentContext)
-		values = append(values, defaultValue)
+		// Ensure current context is at the top as the default
+		values = append(values, currentContext)
 		for k := range kubeContexts {
 			if k != currentContext {
 				values = append(values, k)
 			}
 		}
 		index, _, err := prompter.RunSelect(prompt.SelectionPrompter(
-			"Select the kubeconfig context to install Radius installation",
+			"Select the kubeconfig context to install Radius into",
 			values,
 		))
 		if err != nil {

--- a/pkg/cli/cmd/radInit/init.go
+++ b/pkg/cli/cmd/radInit/init.go
@@ -7,7 +7,6 @@ package radInit
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/manifoldco/promptui"


### PR DESCRIPTION
# Description

https://github.com/project-radius/radius/commit/b0cb333a69c0e1f4c42235950e80ac2a5ce54697 changed the prompt for selecting a kubeconfig context, and appended `(current)` to the name of the current context before inserting it into the context array.

The returned context is pulled from the context array, so now instead of returning the name of the default context, we're returning the appended string instead, which causes issues when the client tries to use the context.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
