### PR TITLE
Recipe handler/renderer updates

### DIFF
--- a/pkg/connectorrp/datamodel/connectormetadata.go
+++ b/pkg/connectorrp/datamodel/connectormetadata.go
@@ -19,14 +19,20 @@ type ConnectorMetadata struct {
 	// Stores action to retrieve secret values. For Azure, connectionstring is accessed through cosmos listConnectionString operation, if secrets are not provided as input
 	SecretValues map[string]rp.SecretValueReference `json:"secretValues,omitempty"`
 
-	RecipeData RecipeData
+	RecipeData RecipeData `json:"recipeData,omitempty"`
 }
 
 type RecipeData struct {
-	RecipeProperty    RecipeProperty
+	RecipeProperties
 	APIVersion        string
 	AzureResourceType resources.KnownType
 	Resources         []string // Resource ids of the resources deployed by the recipe
+}
+
+type RecipeProperties struct {
+	ConnectorRecipe
+	ConnectorType string
+	TemplatePath  string
 }
 
 // ConnectorRecipe is the recipe details used to automatically deploy underlying infrastructure for a connector
@@ -35,9 +41,4 @@ type ConnectorRecipe struct {
 	Name string `json:"name,omitempty"`
 	// Parameters are key/value parameters to pass into the recipe at deployment
 	Parameters map[string]interface{} `json:"parameters,omitempty"`
-}
-
-type RecipeProperty struct {
-	Recipe             ConnectorRecipe
-	RecipeTemplatePath string
 }

--- a/pkg/connectorrp/datamodel/connectormetadata.go
+++ b/pkg/connectorrp/datamodel/connectormetadata.go
@@ -7,7 +7,6 @@ package datamodel
 
 import (
 	"github.com/project-radius/radius/pkg/rp"
-	"github.com/project-radius/radius/pkg/ucp/resources"
 )
 
 // ConnectorMetadata represents internal DataModel properties common to all connector types.
@@ -24,9 +23,8 @@ type ConnectorMetadata struct {
 
 type RecipeData struct {
 	RecipeProperties
-	APIVersion        string
-	AzureResourceType resources.KnownType
-	Resources         []string // Resource ids of the resources deployed by the recipe
+	APIVersion string
+	Resources  []string // Resource ids of the resources deployed by the recipe
 }
 
 type RecipeProperties struct {

--- a/pkg/connectorrp/datamodel/connectormetadata.go
+++ b/pkg/connectorrp/datamodel/connectormetadata.go
@@ -23,8 +23,13 @@ type ConnectorMetadata struct {
 
 type RecipeData struct {
 	RecipeProperties
+
+	// API version to use to perform operations on resources supported by the connector.
+	// For example for Azure resources, every service has different REST API version that must be specified in the request.
 	APIVersion string
-	Resources  []string // Resource ids of the resources deployed by the recipe
+
+	// Resource ids of the resources deployed by the recipe
+	Resources []string
 }
 
 type RecipeProperties struct {

--- a/pkg/connectorrp/frontend/deployment/deploymentprocessor.go
+++ b/pkg/connectorrp/frontend/deployment/deploymentprocessor.go
@@ -102,11 +102,11 @@ func (dp *deploymentProcessor) Render(ctx context.Context, id resources.ID, reso
 	}
 
 	rendererOutput, err := renderer.Render(ctx, resource, renderers.RenderOptions{
-		Namespace:           envMetadata.Namespace,
-		RecipeConnectorType: envMetadata.RecipeConnectorType,
-		RecipeProperty: datamodel.RecipeProperty{
-			Recipe:             recipe,
-			RecipeTemplatePath: envMetadata.RecipeTemplatePath,
+		Namespace: envMetadata.Namespace,
+		RecipeProperties: datamodel.RecipeProperties{
+			ConnectorRecipe: recipe,
+			ConnectorType:   envMetadata.RecipeConnectorType,
+			TemplatePath:    envMetadata.RecipeTemplatePath,
 		}})
 	if err != nil {
 		return renderers.RendererOutput{}, err
@@ -152,8 +152,8 @@ func (dp *deploymentProcessor) Deploy(ctx context.Context, id resources.ID, rend
 	updatedOutputResources := []outputresource.OutputResource{}
 	computedValues := make(map[string]interface{})
 
-	if rendererOutput.RecipeData.RecipeProperty.Recipe.Name != "" {
-		deployedRecipeResources, err := dp.appmodel.GetRecipeModel().RecipeHandler.DeployRecipe(ctx, rendererOutput.RecipeData.RecipeProperty)
+	if rendererOutput.RecipeData.Name != "" {
+		deployedRecipeResources, err := dp.appmodel.GetRecipeModel().RecipeHandler.DeployRecipe(ctx, rendererOutput.RecipeData.RecipeProperties)
 		if err != nil {
 			return DeploymentOutput{}, err
 		}
@@ -188,6 +188,7 @@ func (dp *deploymentProcessor) Deploy(ctx context.Context, id resources.ID, rend
 		RecipeData:     rendererOutput.RecipeData,
 	}, nil
 }
+
 func (dp *deploymentProcessor) deployOutputResource(ctx context.Context, id resources.ID, outputResource *outputresource.OutputResource, rendererOutput renderers.RendererOutput) (computedValues map[string]interface{}, err error) {
 	logger := radlogger.GetLogger(ctx)
 	logger.Info(fmt.Sprintf("Deploying output resource: LocalID: %s, resource type: %q\n", outputResource.LocalID, outputResource.ResourceType))
@@ -262,16 +263,16 @@ func (dp *deploymentProcessor) Delete(ctx context.Context, resourceData Resource
 			return err
 		}
 	}
-	resourceIds := resourceData.RecipeData.Resources
-	for i := len(resourceIds) - 1; i >= 0; i-- {
-		id := resourceIds[i]
-		logger.Info(fmt.Sprintf("Deleting resource: %s", id))
+
+	// Delete resources deployed as part of recipe deployment
+	for _, id := range resourceData.RecipeData.Resources {
+		logger.Info(fmt.Sprintf("Deleting recipe resource: %s", id))
 		err = dp.appmodel.GetRecipeModel().RecipeHandler.Delete(ctx, id, resourceData.RecipeData.APIVersion)
 		if err != nil {
 			return err
 		}
-
 	}
+
 	return nil
 }
 
@@ -336,7 +337,7 @@ func (dp *deploymentProcessor) fetchSecret(ctx context.Context, outputResources 
 	}
 
 	if recipeData.Resources != nil {
-		return nil, fmt.Errorf("recipe %q resources do not match expected resource type for the connector", recipeData.RecipeProperty.Recipe.Name)
+		return nil, fmt.Errorf("recipe %q resources do not match expected resource type for the connector", recipeData.Name)
 	}
 
 	return nil, fmt.Errorf("cannot find an output resource matching LocalID %s", reference.LocalID)

--- a/pkg/connectorrp/frontend/deployment/deploymentprocessor_test.go
+++ b/pkg/connectorrp/frontend/deployment/deploymentprocessor_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	"github.com/project-radius/radius/pkg/azure/azresources"
 	"github.com/project-radius/radius/pkg/azure/clients"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
 	"github.com/project-radius/radius/pkg/connectorrp/handlers"
@@ -133,8 +134,9 @@ func buildTestMongoRecipe() (resourceID resources.ID, testResource datamodel.Mon
 			renderers.ConnectionStringValue: {
 				LocalID: outputresource.LocalIDAzureCosmosAccount,
 				// https://docs.microsoft.com/en-us/rest/api/cosmos-db-resource-provider/2021-04-15/database-accounts/list-connection-strings
-				Action:        "listConnectionStrings",
-				ValueSelector: "/connectionStrings/0/connectionString",
+				Action:               "listConnectionStrings",
+				ValueSelector:        "/connectionStrings/0/connectionString",
+				ProviderResourceType: azresources.DocumentDBDatabaseAccounts,
 				Transformer: resourcemodel.ResourceType{
 					Provider: resourcemodel.ProviderAzure,
 					Type:     resourcekinds.AzureCosmosDBMongo,
@@ -147,15 +149,14 @@ func buildTestMongoRecipe() (resourceID resources.ID, testResource datamodel.Mon
 			},
 		},
 		RecipeData: datamodel.RecipeData{
-			RecipeProperty: datamodel.RecipeProperty{
-				Recipe: datamodel.ConnectorRecipe{
+			RecipeProperties: datamodel.RecipeProperties{
+				ConnectorRecipe: datamodel.ConnectorRecipe{
 					Name:       testResource.Properties.Recipe.Name,
 					Parameters: testResource.Properties.Recipe.Parameters,
 				},
-				RecipeTemplatePath: "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
+				TemplatePath: "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
 			},
-			APIVersion:        clients.GetAPIVersionFromUserAgent(documentdb.UserAgent()),
-			AzureResourceType: mongodatabases.AzureCosmosMongoResourceType,
+			APIVersion: clients.GetAPIVersionFromUserAgent(documentdb.UserAgent()),
 		},
 	}
 
@@ -905,10 +906,9 @@ func Test_Delete(t *testing.T) {
 		resourceData := ResourceData{
 			ID: resourceID,
 			RecipeData: datamodel.RecipeData{
-				RecipeProperty:    rendererOutput.RecipeData.RecipeProperty,
-				APIVersion:        rendererOutput.RecipeData.APIVersion,
-				Resources:         []string{"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database"},
-				AzureResourceType: rendererOutput.RecipeData.AzureResourceType,
+				RecipeProperties: rendererOutput.RecipeData.RecipeProperties,
+				APIVersion:       rendererOutput.RecipeData.APIVersion,
+				Resources:        []string{"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database"},
 			},
 		}
 		err := dp.Delete(ctx, resourceData)

--- a/pkg/connectorrp/frontend/deployment/deploymentprocessor_test.go
+++ b/pkg/connectorrp/frontend/deployment/deploymentprocessor_test.go
@@ -648,7 +648,8 @@ func Test_Deploy(t *testing.T) {
 	})
 
 	t.Run("Verify deploy success with recipe", func(t *testing.T) {
-		resources := []string{"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database"}
+		resources := []string{"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account",
+			"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database"}
 		mocks.recipeHandler.EXPECT().DeployRecipe(gomock.Any(), gomock.Any()).Times(1).Return(resources, nil)
 
 		resourceID, _, testRendererOutput := buildTestMongoRecipe()
@@ -901,14 +902,15 @@ func Test_Delete(t *testing.T) {
 	})
 
 	t.Run("Verify delete success with recipe resources", func(t *testing.T) {
-		mocks.recipeHandler.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+		mocks.recipeHandler.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(nil)
 		resourceID, _, rendererOutput := buildTestMongoRecipe()
 		resourceData := ResourceData{
 			ID: resourceID,
 			RecipeData: datamodel.RecipeData{
 				RecipeProperties: rendererOutput.RecipeData.RecipeProperties,
 				APIVersion:       rendererOutput.RecipeData.APIVersion,
-				Resources:        []string{"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database"},
+				Resources: []string{"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account",
+					"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database"},
 			},
 		}
 		err := dp.Delete(ctx, resourceData)

--- a/pkg/connectorrp/handlers/mock_recipe_handler.go
+++ b/pkg/connectorrp/handlers/mock_recipe_handler.go
@@ -50,7 +50,7 @@ func (mr *MockRecipeHandlerMockRecorder) Delete(arg0, arg1, arg2 interface{}) *g
 }
 
 // DeployRecipe mocks base method.
-func (m *MockRecipeHandler) DeployRecipe(arg0 context.Context, arg1 datamodel.RecipeProperty) ([]string, error) {
+func (m *MockRecipeHandler) DeployRecipe(arg0 context.Context, arg1 datamodel.RecipeProperties) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeployRecipe", arg0, arg1)
 	ret0, _ := ret[0].([]string)

--- a/pkg/connectorrp/renderers/mongodatabases/renderer.go
+++ b/pkg/connectorrp/renderers/mongodatabases/renderer.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/cosmos-db/mgmt/documentdb"
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
+	"github.com/project-radius/radius/pkg/azure/azresources"
 	"github.com/project-radius/radius/pkg/azure/clients"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
 	"github.com/project-radius/radius/pkg/connectorrp/handlers"
@@ -78,9 +79,8 @@ func RenderAzureRecipe(resource *datamodel.MongoDatabase, options renderers.Rend
 	}
 
 	recipeData := datamodel.RecipeData{
-		RecipeProperties:  options.RecipeProperties,
-		APIVersion:        clients.GetAPIVersionFromUserAgent(documentdb.UserAgent()),
-		AzureResourceType: AzureCosmosMongoResourceType,
+		RecipeProperties: options.RecipeProperties,
+		APIVersion:       clients.GetAPIVersionFromUserAgent(documentdb.UserAgent()),
 	}
 
 	secretValues := buildSecretValueReferenceForAzure(resource.Properties)
@@ -173,9 +173,10 @@ func buildSecretValueReferenceForAzure(properties datamodel.MongoDatabasePropert
 	_, ok := secretValues[renderers.ConnectionStringValue]
 	if !ok {
 		secretValues[renderers.ConnectionStringValue] = rp.SecretValueReference{
-			LocalID:       cosmosAccountDependency.LocalID,
-			Action:        "listConnectionStrings", // https://docs.microsoft.com/en-us/rest/api/cosmos-db-resource-provider/2021-04-15/database-accounts/list-connection-strings
-			ValueSelector: "/connectionStrings/0/connectionString",
+			LocalID:              cosmosAccountDependency.LocalID,
+			Action:               "listConnectionStrings", // https://docs.microsoft.com/en-us/rest/api/cosmos-db-resource-provider/2021-04-15/database-accounts/list-connection-strings
+			ValueSelector:        "/connectionStrings/0/connectionString",
+			ProviderResourceType: azresources.DocumentDBDatabaseAccounts,
 			Transformer: resourcemodel.ResourceType{
 				Provider: resourcemodel.ProviderAzure,
 				Type:     resourcekinds.AzureCosmosDBMongo,

--- a/pkg/connectorrp/renderers/mongodatabases/renderer_test.go
+++ b/pkg/connectorrp/renderers/mongodatabases/renderer_test.go
@@ -285,16 +285,16 @@ func Test_Render_Recipe_Success(t *testing.T) {
 	}
 
 	output, err := renderer.Render(ctx, &mongoDBResource, renderers.RenderOptions{
-		RecipeConnectorType: "Applications.Connector/mongoDatabases",
-		RecipeProperty: datamodel.RecipeProperty{
-			Recipe: datamodel.ConnectorRecipe{
+		RecipeProperties: datamodel.RecipeProperties{
+			ConnectorRecipe: datamodel.ConnectorRecipe{
 				Name: "mongodb",
 			},
-			RecipeTemplatePath: "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
+			TemplatePath:  "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
+			ConnectorType: ResourceType,
 		}})
 	require.NoError(t, err)
-	require.Equal(t, mongoDBResource.Properties.Recipe.Name, output.RecipeData.RecipeProperty.Recipe.Name)
-	require.Equal(t, "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1", output.RecipeData.RecipeProperty.RecipeTemplatePath)
+	require.Equal(t, mongoDBResource.Properties.Recipe.Name, output.RecipeData.Name)
+	require.Equal(t, "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1", output.RecipeData.TemplatePath)
 	require.Equal(t, clients.GetAPIVersionFromUserAgent(documentdb.UserAgent()), output.RecipeData.APIVersion)
 	require.Equal(t, "/connectionStrings/0/connectionString", output.SecretValues[renderers.ConnectionStringValue].ValueSelector)
 	require.Equal(t, "listConnectionStrings", output.SecretValues[renderers.ConnectionStringValue].Action)
@@ -324,14 +324,14 @@ func Test_Render_Recipe_InvalidConnectorType(t *testing.T) {
 	}
 
 	_, err := renderer.Render(ctx, &mongoDBResource, renderers.RenderOptions{
-		RecipeConnectorType: "Applications.Connector/redisCaches",
-		RecipeProperty: datamodel.RecipeProperty{
-			Recipe: datamodel.ConnectorRecipe{
+		RecipeProperties: datamodel.RecipeProperties{
+			ConnectorRecipe: datamodel.ConnectorRecipe{
 				Name: "mongodb",
 			},
-			RecipeTemplatePath: "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
+			TemplatePath:  "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
+			ConnectorType: "Applications.Connector/redisCaches",
 		}})
 	require.Error(t, err)
 	require.Equal(t, v1.CodeInvalid, err.(*conv.ErrClientRP).Code)
-	require.Equal(t, "the connector resource type must match the Recipe Connector type.", err.(*conv.ErrClientRP).Message)
+	require.Equal(t, "connector type \"Applications.Connector/redisCaches\" of provided recipe \"mongodb\" is incompatible with \"Applications.Connector/mongoDatabases\" resource type. Recipe connector type must match connector resource type.", err.(*conv.ErrClientRP).Message)
 }

--- a/pkg/connectorrp/renderers/types.go
+++ b/pkg/connectorrp/renderers/types.go
@@ -36,9 +36,8 @@ type Renderer interface {
 	Render(ctx context.Context, resource conv.DataModelInterface, options RenderOptions) (RendererOutput, error)
 }
 type RenderOptions struct {
-	Namespace           string
-	RecipeConnectorType string
-	RecipeProperty      datamodel.RecipeProperty
+	Namespace        string
+	RecipeProperties datamodel.RecipeProperties
 }
 
 type RendererOutput struct {

--- a/pkg/rp/types.go
+++ b/pkg/rp/types.go
@@ -54,6 +54,9 @@ type SecretValueReference struct {
 	// no concept of 'action'. Will always be set for an ARM resource.
 	Action string
 
+	// Resource type this action can be performed on. Example for Azure a resource type is of the format: Microsoft.DocumentDB/databaseAccounts
+	ProviderResourceType string
+
 	// ValueSelector is a JSONPointer used to resolve the secret value.
 	ValueSelector string
 


### PR DESCRIPTION
# Description

* Server/client error separation; logging; consolidating duplicated code
* Move Azure resource type to secrets reference closer to map it to secrets action - recipe output can contain multiple resources but secrets action can only be performed only on one specific resource type. For example for Cosmos DB based Mongo connector, listConnectionString is allowed on Azure Cosmos Account instead of Cosmos DB resource type.

## Issue reference

https://github.com/project-radius/radius/issues/3957

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
