### PR TITLE
Hide `rad init` command

### DIFF
--- a/pkg/cli/cmd/radInit/init.go
+++ b/pkg/cli/cmd/radInit/init.go
@@ -42,6 +42,7 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	runner := NewRunner(factory)
 
 	cmd := &cobra.Command{
+		Hidden:  true,
 		Use:     "init",
 		Short:   "Initialize Radius",
 		Long:    "Interactively initialize the Radius control-plane, create an environment, and configure a workspace",


### PR DESCRIPTION
# Description

Until the following Features/Bugs are addressed, we should hide `rad init`:

- [x] https://github.com/project-radius/radius/issues/3822
- [x] https://github.com/project-radius/radius/issues/3750
- [x] https://github.com/project-radius/radius/issues/4018
- [x] https://github.com/project-radius/radius/issues/3712

This ensures there is a single, consistent experience between environments on Azure and AWS

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
