### PR TITLE
Update deployment processor to fetch the provider information from the environment metadata and pass it to recipe handler

### DIFF
--- a/pkg/connectorrp/frontend/deployment/deploymentprocessor.go
+++ b/pkg/connectorrp/frontend/deployment/deploymentprocessor.go
@@ -109,7 +109,7 @@ func (dp *deploymentProcessor) Render(ctx context.Context, id resources.ID, reso
 			ConnectorType:   envMetadata.RecipeConnectorType,
 			TemplatePath:    envMetadata.RecipeTemplatePath,
 		},
-		Providers: envMetadata.Providers,
+		EnvironmentProviders: envMetadata.Providers,
 	})
 	if err != nil {
 		return renderers.RendererOutput{}, err
@@ -171,7 +171,7 @@ func (dp *deploymentProcessor) Deploy(ctx context.Context, resourceID resources.
 	}
 
 	if rendererOutput.RecipeData.Name != "" {
-		deployedRecipeResources, err := dp.appmodel.GetRecipeModel().RecipeHandler.DeployRecipe(ctx, rendererOutput.RecipeData.RecipeProperties, rendererOutput.Providers)
+		deployedRecipeResources, err := dp.appmodel.GetRecipeModel().RecipeHandler.DeployRecipe(ctx, rendererOutput.RecipeData.RecipeProperties, rendererOutput.EnvironmentProviders)
 		if err != nil {
 			return DeploymentOutput{}, err
 		}

--- a/pkg/connectorrp/frontend/deployment/deploymentprocessor.go
+++ b/pkg/connectorrp/frontend/deployment/deploymentprocessor.go
@@ -492,10 +492,8 @@ func (dp *deploymentProcessor) getEnvironmentMetadata(ctx context.Context, envir
 		return envMetadata, fmt.Errorf("recipe with name %q does not exist in the environment %s", recipeName, environmentID)
 	}
 
-	// ger the providers metadata to deploy the recipe
-	if env.Properties.Providers != (coreDatamodel.ProviderProperties{}) && env.Properties.Providers.Azure != (coreDatamodel.ProviderPropertiesAzure{}) {
-		envMetadata.Providers = env.Properties.Providers
-	}
+	// get the providers metadata to deploy the recipe
+	envMetadata.Providers = env.Properties.Providers
 
 	return envMetadata, nil
 }

--- a/pkg/connectorrp/frontend/deployment/deploymentprocessor_test.go
+++ b/pkg/connectorrp/frontend/deployment/deploymentprocessor_test.go
@@ -678,7 +678,7 @@ func Test_Deploy(t *testing.T) {
 
 	t.Run("Verify deploy failure with recipe", func(t *testing.T) {
 		deploymentName := "recipe" + strconv.FormatInt(time.Now().UnixNano(), 10)
-		mocks.recipeHandler.EXPECT().DeployRecipe(gomock.Any(), gomock.Any()).Times(1).Return([]string{}, fmt.Errorf("failed to deploy recipe - %s", deploymentName))
+		mocks.recipeHandler.EXPECT().DeployRecipe(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return([]string{}, fmt.Errorf("failed to deploy recipe - %s", deploymentName))
 
 		resourceID, _, testRendererOutput := buildTestMongoRecipe()
 		_, err := dp.Deploy(ctx, resourceID, testRendererOutput)

--- a/pkg/connectorrp/frontend/deployment/deploymentprocessor_test.go
+++ b/pkg/connectorrp/frontend/deployment/deploymentprocessor_test.go
@@ -665,7 +665,7 @@ func Test_Deploy(t *testing.T) {
 			"resourceGroup": "kachawla-test-cs",
 			"type":          "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases",
 		}
-		mocks.recipeHandler.EXPECT().DeployRecipe(gomock.Any(), gomock.Any()).Times(1).Return(resources, nil)
+		mocks.recipeHandler.EXPECT().DeployRecipe(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(resources, nil)
 		mocks.recipeHandler.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(resourceData, nil)
 
 		resourceID, _, testRendererOutput := buildTestMongoRecipe()

--- a/pkg/connectorrp/handlers/mock_recipe_handler.go
+++ b/pkg/connectorrp/handlers/mock_recipe_handler.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	datamodel "github.com/project-radius/radius/pkg/connectorrp/datamodel"
+	datamodel0 "github.com/project-radius/radius/pkg/corerp/datamodel"
 )
 
 // MockRecipeHandler is a mock of RecipeHandler interface.
@@ -50,18 +51,18 @@ func (mr *MockRecipeHandlerMockRecorder) Delete(arg0, arg1, arg2 interface{}) *g
 }
 
 // DeployRecipe mocks base method.
-func (m *MockRecipeHandler) DeployRecipe(arg0 context.Context, arg1 datamodel.RecipeProperties) ([]string, error) {
+func (m *MockRecipeHandler) DeployRecipe(arg0 context.Context, arg1 datamodel.RecipeProperties, arg2 datamodel0.ProviderProperties) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeployRecipe", arg0, arg1)
+	ret := m.ctrl.Call(m, "DeployRecipe", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DeployRecipe indicates an expected call of DeployRecipe.
-func (mr *MockRecipeHandlerMockRecorder) DeployRecipe(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRecipeHandlerMockRecorder) DeployRecipe(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployRecipe", reflect.TypeOf((*MockRecipeHandler)(nil).DeployRecipe), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployRecipe", reflect.TypeOf((*MockRecipeHandler)(nil).DeployRecipe), arg0, arg1, arg2)
 }
 
 // GetResource mocks base method.

--- a/pkg/connectorrp/handlers/recipe_handler.go
+++ b/pkg/connectorrp/handlers/recipe_handler.go
@@ -59,7 +59,7 @@ func (handler *azureRecipeHandler) DeployRecipe(ctx context.Context, recipe data
 	}
 	subscriptionID, resourceGroup, err := parseAzureProvider(&providers)
 	if err != nil {
-		conv.NewClientErrInvalidRequest(fmt.Sprintf("failed to fetch azure provider %s", err.Error()))
+		return nil, conv.NewClientErrInvalidRequest(fmt.Sprintf("failed to fetch azure provider %s", err.Error()))
 	}
 
 	logger := radlogger.GetLogger(ctx).WithValues(

--- a/pkg/connectorrp/handlers/recipe_handler.go
+++ b/pkg/connectorrp/handlers/recipe_handler.go
@@ -16,9 +16,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/azure/armauth"
-	"github.com/project-radius/radius/pkg/azure/azresources"
 	"github.com/project-radius/radius/pkg/azure/clients"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
+	coreDatamodel "github.com/project-radius/radius/pkg/corerp/datamodel"
 	"github.com/project-radius/radius/pkg/radlogger"
 	"github.com/project-radius/radius/pkg/resourcemodel"
 	ucpresources "github.com/project-radius/radius/pkg/ucp/resources"
@@ -29,9 +29,10 @@ import (
 const deploymentPrefix = "recipe"
 
 // RecipeHandler is an interface to deploy and delete recipe resources
+//
 //go:generate mockgen -destination=./mock_recipe_handler.go -package=handlers -self_package github.com/project-radius/radius/pkg/connectorrp/handlers github.com/project-radius/radius/pkg/connectorrp/handlers RecipeHandler
 type RecipeHandler interface {
-	DeployRecipe(ctx context.Context, recipe datamodel.RecipeProperties) ([]string, error)
+	DeployRecipe(ctx context.Context, recipe datamodel.RecipeProperties, providers coreDatamodel.ProviderProperties) ([]string, error)
 	Delete(ctx context.Context, id string, apiVersion string) error
 	GetResource(ctx context.Context, provider, id, apiVersion string) (map[string]interface{}, error)
 }
@@ -49,21 +50,17 @@ type azureRecipeHandler struct {
 // DeployRecipe deploys the recipe template fetched from the provided recipe TemplatePath.
 // Currently the implementation assumes TemplatePath is location of an ARM JSON template in Azure Container Registry.
 // Returns resource IDs of the resources deployed by the template
-func (handler *azureRecipeHandler) DeployRecipe(ctx context.Context, recipe datamodel.RecipeProperties) (deployedResources []string, err error) {
+func (handler *azureRecipeHandler) DeployRecipe(ctx context.Context, recipe datamodel.RecipeProperties, providers coreDatamodel.ProviderProperties) (deployedResources []string, err error) {
 	if recipe.TemplatePath == "" {
 		return nil, fmt.Errorf("recipe template path cannot be empty")
 	}
-
-	if recipe.Parameters[azresources.SubscriptionIDKey] == "" {
-		return nil, conv.NewClientErrInvalidRequest("subscriptionID for recipe deployment must be provided in the recipe parameters")
+	if providers == (coreDatamodel.ProviderProperties{}) {
+		return nil, conv.NewClientErrInvalidRequest(fmt.Sprintf("failed to fetch scope for recipe %q", recipe.Name))
 	}
-
-	if recipe.Parameters[azresources.ResourceGroupKey] == "" {
-		return nil, conv.NewClientErrInvalidRequest("resourceGroup for recipe deployment must be provided in the recipe parameters")
+	subscriptionID, resourceGroup, err := parseAzureProvider(&providers)
+	if err != nil {
+		conv.NewClientErrInvalidRequest(fmt.Sprintf("failed to fetch azure provider %s", err.Error()))
 	}
-
-	subscriptionID := recipe.Parameters[azresources.SubscriptionIDKey].(string)
-	resourceGroup := recipe.Parameters[azresources.ResourceGroupKey].(string)
 
 	logger := radlogger.GetLogger(ctx).WithValues(
 		radlogger.LogFieldResourceGroup, resourceGroup,
@@ -189,6 +186,23 @@ func getRecipeBytes(ctx context.Context, repo *remote.Repository, layerDigest st
 		return nil, err
 	}
 	return pulledBlob, nil
+}
+
+// parseAzureProvider parses the scope to get the subscriptionID and resourceGroup
+func parseAzureProvider(providers *coreDatamodel.ProviderProperties) (string, string, error) {
+	if providers.Azure == (coreDatamodel.ProviderPropertiesAzure{}) {
+		return "", "", conv.NewClientErrInvalidRequest("azure provider is empty")
+	}
+	scope := strings.Split(providers.Azure.Scope, "/")
+	if len(scope) != 5 {
+		return "", "", conv.NewClientErrInvalidRequest("invalid azure scope")
+	}
+	subscriptionID := scope[2]
+	resourceGroup := scope[4]
+	if subscriptionID == "" || resourceGroup == "" {
+		return "", "", conv.NewClientErrInvalidRequest("subscriptionID or resourceGroup is invalid")
+	}
+	return subscriptionID, resourceGroup, nil
 }
 
 func (handler *azureRecipeHandler) Delete(ctx context.Context, id string, apiVersion string) error {

--- a/pkg/connectorrp/renderers/mongodatabases/renderer.go
+++ b/pkg/connectorrp/renderers/mongodatabases/renderer.go
@@ -91,10 +91,10 @@ func RenderAzureRecipe(resource *datamodel.MongoDatabase, options renderers.Rend
 	}
 
 	return renderers.RendererOutput{
-		ComputedValues: computedValues,
-		SecretValues:   secretValues,
-		RecipeData:     recipeData,
-		Providers:      options.Providers,
+		ComputedValues:       computedValues,
+		SecretValues:         secretValues,
+		RecipeData:           recipeData,
+		EnvironmentProviders: options.EnvironmentProviders,
 	}, nil
 }
 

--- a/pkg/connectorrp/renderers/mongodatabases/renderer.go
+++ b/pkg/connectorrp/renderers/mongodatabases/renderer.go
@@ -94,6 +94,7 @@ func RenderAzureRecipe(resource *datamodel.MongoDatabase, options renderers.Rend
 		ComputedValues: computedValues,
 		SecretValues:   secretValues,
 		RecipeData:     recipeData,
+		Providers:      options.Providers,
 	}, nil
 }
 

--- a/pkg/connectorrp/renderers/types.go
+++ b/pkg/connectorrp/renderers/types.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
+	coreDatamodel "github.com/project-radius/radius/pkg/corerp/datamodel"
 	"github.com/project-radius/radius/pkg/rp"
 	"github.com/project-radius/radius/pkg/rp/outputresource"
 )
@@ -37,6 +38,7 @@ type Renderer interface {
 type RenderOptions struct {
 	Namespace        string
 	RecipeProperties datamodel.RecipeProperties
+	Providers        coreDatamodel.ProviderProperties
 }
 
 type RendererOutput struct {
@@ -44,6 +46,7 @@ type RendererOutput struct {
 	ComputedValues map[string]ComputedValueReference
 	SecretValues   map[string]rp.SecretValueReference
 	RecipeData     datamodel.RecipeData
+	Providers      coreDatamodel.ProviderProperties
 }
 
 // ComputedValueReference represents a non-secret value that can accessed once the output resources

--- a/pkg/connectorrp/renderers/types.go
+++ b/pkg/connectorrp/renderers/types.go
@@ -46,7 +46,7 @@ type RendererOutput struct {
 	ComputedValues map[string]ComputedValueReference
 	SecretValues   map[string]rp.SecretValueReference
 	RecipeData     datamodel.RecipeData
-	Providers      coreDatamodel.ProviderProperties
+	Providers      coreDatamodel.ProviderProperties // providers are mapped to environment needed to deploy the recipe
 }
 
 // ComputedValueReference represents a non-secret value that can accessed once the output resources

--- a/pkg/connectorrp/renderers/types.go
+++ b/pkg/connectorrp/renderers/types.go
@@ -36,17 +36,17 @@ type Renderer interface {
 	Render(ctx context.Context, resource conv.DataModelInterface, options RenderOptions) (RendererOutput, error)
 }
 type RenderOptions struct {
-	Namespace        string
-	RecipeProperties datamodel.RecipeProperties
-	Providers        coreDatamodel.ProviderProperties
+	Namespace            string
+	RecipeProperties     datamodel.RecipeProperties
+	EnvironmentProviders coreDatamodel.ProviderProperties
 }
 
 type RendererOutput struct {
-	Resources      []outputresource.OutputResource
-	ComputedValues map[string]ComputedValueReference
-	SecretValues   map[string]rp.SecretValueReference
-	RecipeData     datamodel.RecipeData
-	Providers      coreDatamodel.ProviderProperties // providers are mapped to environment needed to deploy the recipe
+	Resources            []outputresource.OutputResource
+	ComputedValues       map[string]ComputedValueReference
+	SecretValues         map[string]rp.SecretValueReference
+	RecipeData           datamodel.RecipeData
+	EnvironmentProviders coreDatamodel.ProviderProperties // represents providers mapped to the linked environment needed to deploy the recipe
 }
 
 // ComputedValueReference represents a non-secret value that can accessed once the output resources

--- a/pkg/corerp/frontend/controller/environments/testdata/environment20220315privatepreview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environment20220315privatepreview_datamodel.json
@@ -19,6 +19,11 @@
                 "resourceId": "fakeid",
                 "namespace": "default"
             }
+        },
+        "providers": {
+            "azure": {
+                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+            }
         }
     },
     "tenantId": "00000000-0000-0000-0000-000000000000",

--- a/pkg/corerp/frontend/controller/environments/testdata/environment20220315privatepreview_input.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environment20220315privatepreview_input.json
@@ -5,6 +5,11 @@
             "kind": "kubernetes",
             "resourceId": "fakeid",
             "namespace": "default"
+        },
+        "providers": {
+            "azure": {
+                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+            }
         }
     }
 }

--- a/pkg/corerp/frontend/controller/environments/testdata/environment20220315privatepreview_output.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environment20220315privatepreview_output.json
@@ -8,6 +8,11 @@
             "resourceId": "fakeid",
             "namespace": "default"
         },
+        "providers": {
+            "azure": {
+                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+            }
+        },
         "provisioningState": "Succeeded"
     },
     "systemData": {


### PR DESCRIPTION
# Description

The PR implements the logic for connectorRP to fetch provider from environment and deploy recipe using the subscriptionID and resourceGroup from provider scope
In this PR:
1. ConnectorRP deploymentProcessor fetches the providers information from the saved environment metadata.
2. Passes the providers information to recipe_handler.
3. recipe_handler decodes the subscriptionId and resourceGroup from the providers scope and deploys the recipe.

Manually tested the E2E deployment with the changes.
Test Output:
```
Deploying template 'testBicep.bicep' into environment 'radiustestcluster' from workspace 'radius-testenv'...

Deployment In Progress...

Completed            recipes-env     Applications.Core/environments
Completed            recipe-resources-mongodb Applications.Core/applications
Completed            recipe-db       Applications.Connector/mongoDatabases

Deployment Complete

Resources:
    recipe-db       Applications.Connector/mongoDatabases
    recipe-resources-mongodb Applications.Core/applications
    recipes-env     Applications.Core/environments
```

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #3921 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
