### PR TITLE
Update json pointer for database name

### DIFF
--- a/pkg/connectorrp/frontend/deployment/deploymentprocessor_test.go
+++ b/pkg/connectorrp/frontend/deployment/deploymentprocessor_test.go
@@ -147,7 +147,7 @@ func buildTestMongoRecipe() (resourceID resources.ID, testResource datamodel.Mon
 			renderers.DatabaseNameValue: {
 				LocalID:              outputresource.LocalIDAzureCosmosDBMongo,
 				ProviderResourceType: azresources.DocumentDBDatabaseAccounts + "/" + azresources.DocumentDBDatabaseAccountsMongoDBDatabases,
-				JSONPointer:          "/name",
+				JSONPointer:          "/properties/resource/id",
 			},
 		},
 		RecipeData: datamodel.RecipeData{

--- a/pkg/connectorrp/renderers/mongodatabases/renderer.go
+++ b/pkg/connectorrp/renderers/mongodatabases/renderer.go
@@ -86,7 +86,7 @@ func RenderAzureRecipe(resource *datamodel.MongoDatabase, options renderers.Rend
 		renderers.DatabaseNameValue: {
 			LocalID:              outputresource.LocalIDAzureCosmosDBMongo,
 			ProviderResourceType: azresources.DocumentDBDatabaseAccounts + "/" + azresources.DocumentDBDatabaseAccountsMongoDBDatabases,
-			JSONPointer:          "/name", // response of "az resource show" for cosmos mongodb resource contains database name in this property
+			JSONPointer:          "/properties/resource/id", // response of "az resource show" for cosmos mongodb resource contains database name in this property
 		},
 	}
 

--- a/pkg/connectorrp/renderers/mongodatabases/renderer_test.go
+++ b/pkg/connectorrp/renderers/mongodatabases/renderer_test.go
@@ -287,7 +287,7 @@ func Test_Render_Recipe_Success(t *testing.T) {
 	expectedComputedValues := map[string]renderers.ComputedValueReference{
 		renderers.DatabaseNameValue: {
 			LocalID:              outputresource.LocalIDAzureCosmosDBMongo,
-			JSONPointer:          "/name",
+			JSONPointer:          "/properties/resource/id",
 			ProviderResourceType: "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases",
 		},
 	}


### PR DESCRIPTION
# Description

GetResource is only fetching properties part of the resource for some reason, changing the pointer to read from id inside the property. Will look into why top level properties aren't being returned.

`Parsing json pointer \"/name\" from deployed recipe resource map[properties:map[resource:map[id:mongodb-1]]]`

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
