### PR TITLE
Shorten messages for `rad debug-logs`

### DIFF
--- a/cmd/rad/cmd/debuglogs.go
+++ b/cmd/rad/cmd/debuglogs.go
@@ -29,9 +29,14 @@ const (
 
 var debugLogsCmd = &cobra.Command{
 	Use:   "debug-logs",
-	Short: "Captures information about the current Radius Workspace for debugging and diagnostics. Creates a ZIP file of logs in the current directory. WARNING Please inspect all logs before sending feedback to confirm no private information is included.",
-	Long:  `Captures information about the current Radius Workspace for debugging and diagnostics. Creates a ZIP file of logs in the current directory. WARNING Please inspect all logs before sending feedback to confirm no private information is included.`,
-	RunE:  debugLogs,
+	Short: "Capture logs from Radius control plane for debugging and diagnostics.",
+	Long: `Capture logs from Radius control plane for debugging and diagnostics.
+	
+Creates a ZIP file of logs in the current directory.
+
+WARNING Please inspect all logs before sending feedback to confirm no private information is included.
+`,
+	RunE: debugLogs,
 }
 
 func init() {


### PR DESCRIPTION
# Description

Shortens short message to fix rendering in rad command:

<img width="1103" alt="image" src="https://user-images.githubusercontent.com/54363786/194657559-675eb490-8e80-4b23-85a0-7c1845b481c2.png">

New:

<img width="758" alt="image" src="https://user-images.githubusercontent.com/54363786/194657847-96a9ab27-be6c-48dd-85e2-0fbe96966a98.png">

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: https://github.com/project-radius/radius/issues/3770

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
