### PR TITLE
Fix regression for rad init command

### DIFF
--- a/pkg/cli/cmd/env/create/create.go
+++ b/pkg/cli/cmd/env/create/create.go
@@ -140,7 +140,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 func (r *Runner) Run(ctx context.Context) error {
 	r.Output.LogInfo("Creating Environment...")
 	var providers corerp.ProviderProperties
-	if r.Workspace.ProviderConfig != (workspaces.ProviderConfig{}) {
+	if r.Workspace.ProviderConfig != (workspaces.ProviderConfig{}) && r.Workspace.ProviderConfig.Azure != nil {
 		providers = cmd.CreateEnvAzureProvider(r.Workspace.ProviderConfig.Azure.SubscriptionID, r.Workspace.ProviderConfig.Azure.ResourceGroup)
 	}
 	isEnvCreated, err := r.AppManagementClient.CreateEnvironment(ctx, r.EnvironmentName, "global", r.Namespace, "Kubernetes", "", map[string]*corerp.EnvironmentRecipeProperties{}, &providers)

--- a/pkg/cli/cmd/env/create/create.go
+++ b/pkg/cli/cmd/env/create/create.go
@@ -139,7 +139,10 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 
 func (r *Runner) Run(ctx context.Context) error {
 	r.Output.LogInfo("Creating Environment...")
-	providers := cmd.CreateEnvAzureProvider(r.Workspace.ProviderConfig.Azure.SubscriptionID, r.Workspace.ProviderConfig.Azure.ResourceGroup)
+	var providers corerp.ProviderProperties
+	if r.Workspace.ProviderConfig != (workspaces.ProviderConfig{}) {
+		providers = cmd.CreateEnvAzureProvider(r.Workspace.ProviderConfig.Azure.SubscriptionID, r.Workspace.ProviderConfig.Azure.ResourceGroup)
+	}
 	isEnvCreated, err := r.AppManagementClient.CreateEnvironment(ctx, r.EnvironmentName, "global", r.Namespace, "Kubernetes", "", map[string]*corerp.EnvironmentRecipeProperties{}, &providers)
 	if err != nil || !isEnvCreated {
 		return err

--- a/pkg/cli/cmd/radInit/init.go
+++ b/pkg/cli/cmd/radInit/init.go
@@ -231,7 +231,10 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	// create the providers scope from the AzureCloudProvider properties for creating the environment
-	providers := cmd.CreateEnvAzureProvider(r.AzureCloudProvider.SubscriptionID, r.AzureCloudProvider.ResourceGroup)
+	var providers corerp.ProviderProperties
+	if r.AzureCloudProvider != nil {
+		providers = cmd.CreateEnvAzureProvider(r.AzureCloudProvider.SubscriptionID, r.AzureCloudProvider.ResourceGroup)
+	}
 	isEnvCreated, err := client.CreateEnvironment(ctx, r.EnvName, "global", r.NameSpace, "kubernetes", "", map[string]*corerp.EnvironmentRecipeProperties{}, &providers)
 	if err != nil || !isEnvCreated {
 		return &cli.FriendlyError{Message: "Failed to create radius environment"}


### PR DESCRIPTION
# Description

Fixes the regression for rad init without providing any cloud provider.

rad init response without provider
```
pratiksm@Pratikshyas-MacBook-Pro radius % rad init                      
✔ kind-radius
✔ Enter an environment name: default█
Enter a namespace name to deploy apps into: default
✔ Enter a namespace name to deploy apps into: default█

Installing Radius version v0.13.0-88-gba9196f-dirty control plane to namespace: radius-system
Successfully wrote configuration to /Users/pratiksm/.rad/config.yaml
```
## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #4086 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [X] Unit tests passing
* [x] Extended the documentation / Created issue for it
