### PR TITLE
Add providers to environment metadata while rad env init

### DIFF
--- a/pkg/cli/cmd/env/create/create.go
+++ b/pkg/cli/cmd/env/create/create.go
@@ -141,7 +141,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	r.Output.LogInfo("Creating Environment...")
 	var providers corerp.ProviderProperties
 	if r.Workspace.ProviderConfig != (workspaces.ProviderConfig{}) && r.Workspace.ProviderConfig.Azure != nil &&
-		(r.Workspace.ProviderConfig.Azure.SubscriptionID != "" || r.Workspace.ProviderConfig.Azure.ResourceGroup != "") {
+		(r.Workspace.ProviderConfig.Azure.SubscriptionID != "" && r.Workspace.ProviderConfig.Azure.ResourceGroup != "") {
 		providers = cmd.CreateEnvAzureProvider(r.Workspace.ProviderConfig.Azure.SubscriptionID, r.Workspace.ProviderConfig.Azure.ResourceGroup)
 	}
 	isEnvCreated, err := r.AppManagementClient.CreateEnvironment(ctx, r.EnvironmentName, "global", r.Namespace, "Kubernetes", "", map[string]*corerp.EnvironmentRecipeProperties{}, &providers)

--- a/pkg/cli/cmd/env/create/create.go
+++ b/pkg/cli/cmd/env/create/create.go
@@ -140,7 +140,8 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 func (r *Runner) Run(ctx context.Context) error {
 	r.Output.LogInfo("Creating Environment...")
 	var providers corerp.ProviderProperties
-	if r.Workspace.ProviderConfig != (workspaces.ProviderConfig{}) && r.Workspace.ProviderConfig.Azure != nil {
+	if r.Workspace.ProviderConfig != (workspaces.ProviderConfig{}) && r.Workspace.ProviderConfig.Azure != nil &&
+		(r.Workspace.ProviderConfig.Azure.SubscriptionID != "" || r.Workspace.ProviderConfig.Azure.ResourceGroup != "") {
 		providers = cmd.CreateEnvAzureProvider(r.Workspace.ProviderConfig.Azure.SubscriptionID, r.Workspace.ProviderConfig.Azure.ResourceGroup)
 	}
 	isEnvCreated, err := r.AppManagementClient.CreateEnvironment(ctx, r.EnvironmentName, "global", r.Namespace, "Kubernetes", "", map[string]*corerp.EnvironmentRecipeProperties{}, &providers)


### PR DESCRIPTION
# Description

When providers are passed add the providers to the environment payload while creating the environment resource.

### Manual test result
1. rad env init with provider flags
```
pratiksm@Pratikshyas-MacBook-Pro radius % go run ./cmd/rad/main.go env init kubernetes —e test-envProvider chart ./deploy/Chart/ --force --provider-azure --provider-azure-resource-group RadiusTestRG --provider-azure-subscription 85716382-7362-45c3-ae03-2126e459a123    --provider-azure-client-id 725f4715-ceaf-4792-82cd-c93c8213f07e --provider-azure-client-secret  'xxxxxxxxx' --provider-azure-tenant-id 72f988bf-86f1-41af-91ab-2d7cd011db47 --appcore-image pratmishra.azurecr.io/appcore-rp --appcore-tag latest --ucp-image  pratmishra.azurecr.io/ucpd --ucp-tag latest
No environment name provided, using: kind-radius
Installing Radius version edge control plane...
Installing Radius version edge control plane to namespace: radius-system
Creating Workspace...
Successfully wrote configuration to /Users/pratiksm/.rad/config.yaml
Set "default" as current workspace
Creating Environment...
Successfully wrote configuration to /Users/pratiksm/.rad/config.yaml
Set "kind-radius" as current environment for workspace "default" 
pratiksm@Pratikshyas-MacBook-Pro radius % rad env list -o json
[
  {
    "id": "/planes/radius/local/resourcegroups/default/providers/applications.core/environments/kind-radius",
    "location": "global",
    "name": "kind-radius",
    "properties": {
      "compute": {
        "kind": "kubernetes",
        "namespace": "default",
        "resourceId": "self"
      },
      "providers": {
        "azure": {
          "scope": "/subscriptions/85716382-7362-45c3-ae03-2126e459a123/resourceGroup/RadiusTestRG"
        }
      },
      "provisioningState": "Succeeded"
    },
    "systemData": {
      "createdAt": "0001-01-01T00:00:00Z",
      "createdBy": "",
      "createdByType": "",
      "lastModifiedAt": "0001-01-01T00:00:00Z",
      "lastModifiedBy": "",
      "lastModifiedByType": ""
    },
    "tags": {},
    "type": "applications.core/environments"
  }
]
```

2. rad env init without provider flags
```
pratiksm@Pratikshyas-MacBook-Pro radius % go run cmd/rad/main.go env init kubernetes --chart deploy/Chart --appcore-image pratmishra.azurecr.io/appcore-rp pratmishra--appcore-tag latest --ucp-image pratmishra.azurecr.io/ucpd --ucp-tag latest
No environment name provided, using: kind-radius
Installing Radius version edge control plane...
Installing Radius version edge control plane to namespace: radius-system
Creating Workspace...
Successfully wrote configuration to /Users/pratiksm/.rad/config.yaml
Set "kind-radius" as current workspace
Creating Environment...
Successfully wrote configuration to /Users/pratiksm/.rad/config.yaml
Set "kind-radius" as current environment for workspace "kind-radius"
pratiksm@Pratikshyas-MacBook-Pro radius % rad env list -o json             
[
  {
    "id": "/planes/radius/local/resourcegroups/kind-radius/providers/applications.core/environments/kind-radius",
    "location": "global",
    "name": "kind-radius",
    "properties": {
      "compute": {
        "kind": "kubernetes",
        "namespace": "default",
        "resourceId": "self"
      },
      "provisioningState": "Succeeded"
    },
    "systemData": {
      "createdAt": "0001-01-01T00:00:00Z",
      "createdBy": "",
      "createdByType": "",
      "lastModifiedAt": "0001-01-01T00:00:00Z",
      "lastModifiedBy": "",
      "lastModifiedByType": ""
    },
    "tags": {},
    "type": "applications.core/environments"
  }
]
```

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #3971

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
