### PR TITLE
MAINT: Improvements to UCP OpenAPI Specs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v2
       - name: Set up Go ${{ env.GOVER }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GOVER }}
       - name: Setup npm
@@ -44,10 +44,9 @@ jobs:
       - name: Setup Azure CLI
         run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
       - name: Run linter
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: 'latest'
-          skip-go-installation: true
           args: --timeout=10m
       - name: Run make generate
         run: make generate

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/ucp.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/ucp.json
@@ -256,7 +256,7 @@
             }
           },
           "tags": [
-            "Planes"
+            "ResourceGroups"
           ],
           "parameters": [
             {
@@ -299,7 +299,7 @@
             }
           },
           "tags": [
-            "ResourceGroup"
+            "ResourceGroups"
           ],
           "parameters": [
             {
@@ -357,7 +357,7 @@
             }
           },
           "tags": [
-            "ResourceGroup"
+            "ResourceGroups"
           ],
           "parameters": [
             {


### PR DESCRIPTION
# Description

I tried rendering the OpenAPI Specs of UCP in [SwaggerEditor](https://editor.swagger.io/) to explore the API and noticed the following issues (see below image of rendered spec):

* PUT and DELETE on `/planes/{planeType}/{planeName}/resourcegroups/{resourceGroupName}` are using a singular value in the OpenAPI `tag` `ResourceGroup` instead of the REST convention of a plural resource name. 
* GET on `/planes/{planeType}/{planeName}/resourcegroups/{resourceGroupName}` is tagged as a Planes operation instead of being tagged as an operation on `ResourceGroups`

![image](https://user-images.githubusercontent.com/9611108/195693775-3531b4d3-187b-4e6c-8a3d-85c9dc2e47e3.png)

The changes made on the spec render as seen below:

![image](https://user-images.githubusercontent.com/9611108/195694415-dfb9a244-7dcf-41a0-aa7e-9564209186d6.png)
