### PR TITLE
Update mongo connector renderer to use generic arm handler

### DIFF
--- a/pkg/connectorrp/model/application_model.go
+++ b/pkg/connectorrp/model/application_model.go
@@ -103,7 +103,7 @@ func NewApplicationModel(arm *armauth.ArmConfig, k8s client.Client) (Application
 				Type:     resourcekinds.AzureCosmosDBMongo,
 				Provider: resourcemodel.ProviderAzure,
 			},
-			ResourceHandler:        handlers.NewAzureCosmosDBMongoHandler(arm),
+			ResourceHandler:        handlers.NewARMHandler(arm),
 			SecretValueTransformer: &mongodatabases.AzureTransformer{},
 		},
 		{
@@ -111,7 +111,7 @@ func NewApplicationModel(arm *armauth.ArmConfig, k8s client.Client) (Application
 				Type:     resourcekinds.AzureCosmosAccount,
 				Provider: resourcemodel.ProviderAzure,
 			},
-			ResourceHandler: handlers.NewAzureCosmosAccountHandler(arm),
+			ResourceHandler: handlers.NewARMHandler(arm),
 		},
 		{
 			ResourceType: resourcemodel.ResourceType{

--- a/pkg/connectorrp/renderers/mongodatabases/renderer.go
+++ b/pkg/connectorrp/renderers/mongodatabases/renderer.go
@@ -14,7 +14,6 @@ import (
 	"github.com/project-radius/radius/pkg/azure/azresources"
 	"github.com/project-radius/radius/pkg/azure/clients"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
-	"github.com/project-radius/radius/pkg/connectorrp/handlers"
 	"github.com/project-radius/radius/pkg/connectorrp/renderers"
 	"github.com/project-radius/radius/pkg/resourcekinds"
 	"github.com/project-radius/radius/pkg/resourcemodel"
@@ -127,12 +126,8 @@ func RenderAzureResource(properties datamodel.MongoDatabaseProperties) (renderer
 			Type:     resourcekinds.AzureCosmosAccount,
 			Provider: resourcemodel.ProviderAzure,
 		},
-		Resource: map[string]string{
-			handlers.CosmosDBAccountIDKey:   cosmosMongoAccountID.String(),
-			handlers.CosmosDBAccountNameKey: cosmosMongoDBID.TypeSegments()[0].Name,
-			handlers.CosmosDBAccountKindKey: string(documentdb.DatabaseAccountKindMongoDB),
-		},
 	}
+	cosmosAccountResource.Identity = resourcemodel.NewARMIdentity(&cosmosAccountResource.ResourceType, cosmosMongoAccountID.String(), clients.GetAPIVersionFromUserAgent(documentdb.UserAgent()))
 
 	databaseResource := outputresource.OutputResource{
 		LocalID: outputresource.LocalIDAzureCosmosDBMongo,
@@ -140,18 +135,13 @@ func RenderAzureResource(properties datamodel.MongoDatabaseProperties) (renderer
 			Type:     resourcekinds.AzureCosmosDBMongo,
 			Provider: resourcemodel.ProviderAzure,
 		},
-		Resource: map[string]string{
-			handlers.CosmosDBAccountIDKey:    cosmosMongoAccountID.String(),
-			handlers.CosmosDBDatabaseIDKey:   cosmosMongoDBID.String(),
-			handlers.CosmosDBAccountNameKey:  cosmosMongoDBID.TypeSegments()[0].Name,
-			handlers.CosmosDBDatabaseNameKey: cosmosMongoDBID.TypeSegments()[1].Name,
-		},
 		Dependencies: []outputresource.Dependency{
 			{
 				LocalID: outputresource.LocalIDAzureCosmosAccount,
 			},
 		},
 	}
+	databaseResource.Identity = resourcemodel.NewARMIdentity(&databaseResource.ResourceType, cosmosMongoDBID.String(), clients.GetAPIVersionFromUserAgent(documentdb.UserAgent()))
 
 	return renderers.RendererOutput{
 		Resources:      []outputresource.OutputResource{cosmosAccountResource, databaseResource},

--- a/pkg/connectorrp/renderers/mongodatabases/renderer_test.go
+++ b/pkg/connectorrp/renderers/mongodatabases/renderer_test.go
@@ -14,9 +14,9 @@ import (
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/azure/clients"
 	"github.com/project-radius/radius/pkg/connectorrp/datamodel"
-	"github.com/project-radius/radius/pkg/connectorrp/handlers"
 	"github.com/project-radius/radius/pkg/connectorrp/renderers"
 	"github.com/project-radius/radius/pkg/resourcekinds"
+	"github.com/project-radius/radius/pkg/resourcemodel"
 	"github.com/project-radius/radius/pkg/rp"
 	"github.com/project-radius/radius/pkg/rp/outputresource"
 	"github.com/stretchr/testify/require"
@@ -49,39 +49,52 @@ func Test_Render_Success(t *testing.T) {
 		},
 	}
 
-	output, err := renderer.Render(ctx, &mongoDBResource, renderers.RenderOptions{})
-	require.NoError(t, err)
-
-	require.Len(t, output.Resources, 2)
-	accountResource := output.Resources[0]
-	databaseResource := output.Resources[1]
-
-	require.Equal(t, outputresource.LocalIDAzureCosmosAccount, accountResource.LocalID)
-	require.Equal(t, resourcekinds.AzureCosmosAccount, accountResource.ResourceType.Type)
-
-	require.Equal(t, outputresource.LocalIDAzureCosmosDBMongo, databaseResource.LocalID)
-	require.Equal(t, resourcekinds.AzureCosmosDBMongo, databaseResource.ResourceType.Type)
-
-	expectedAccount := map[string]string{
-		handlers.CosmosDBAccountIDKey:   "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account",
-		handlers.CosmosDBAccountNameKey: "test-account",
-		handlers.CosmosDBAccountKindKey: string(documentdb.DatabaseAccountKindMongoDB),
+	accountResourceType := resourcemodel.ResourceType{
+		Type:     resourcekinds.AzureCosmosAccount,
+		Provider: resourcemodel.ProviderAzure,
 	}
-	require.Equal(t, expectedAccount, accountResource.Resource)
-
-	expectedDatabase := map[string]string{
-		handlers.CosmosDBAccountIDKey:    "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account",
-		handlers.CosmosDBAccountNameKey:  "test-account",
-		handlers.CosmosDBDatabaseIDKey:   "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
-		handlers.CosmosDBDatabaseNameKey: "test-database",
+	dbResourceType := resourcemodel.ResourceType{
+		Type:     resourcekinds.AzureCosmosDBMongo,
+		Provider: resourcemodel.ProviderAzure,
 	}
-	require.Equal(t, expectedDatabase, databaseResource.Resource)
-
+	expectedOutputResources := []outputresource.OutputResource{
+		{
+			LocalID:      outputresource.LocalIDAzureCosmosAccount,
+			ResourceType: accountResourceType,
+			Identity: resourcemodel.ResourceIdentity{
+				ResourceType: &accountResourceType,
+				Data: resourcemodel.ARMIdentity{
+					ID:         "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account",
+					APIVersion: clients.GetAPIVersionFromUserAgent(documentdb.UserAgent()),
+				},
+			},
+		},
+		{
+			LocalID:      outputresource.LocalIDAzureCosmosDBMongo,
+			ResourceType: dbResourceType,
+			Identity: resourcemodel.ResourceIdentity{
+				ResourceType: &dbResourceType,
+				Data: resourcemodel.ARMIdentity{
+					ID:         "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
+					APIVersion: clients.GetAPIVersionFromUserAgent(documentdb.UserAgent()),
+				},
+			},
+			Dependencies: []outputresource.Dependency{
+				{
+					LocalID: outputresource.LocalIDAzureCosmosAccount,
+				},
+			},
+		},
+	}
 	expectedComputedValues := map[string]renderers.ComputedValueReference{
 		renderers.DatabaseNameValue: {
 			Value: "test-database",
 		},
 	}
+
+	output, err := renderer.Render(ctx, &mongoDBResource, renderers.RenderOptions{})
+	require.NoError(t, err)
+	require.Equal(t, expectedOutputResources, output.Resources)
 	require.Equal(t, expectedComputedValues, output.ComputedValues)
 	require.Equal(t, "/connectionStrings/0/connectionString", output.SecretValues[renderers.ConnectionStringValue].ValueSelector)
 	require.Equal(t, "listConnectionStrings", output.SecretValues[renderers.ConnectionStringValue].Action)


### PR DESCRIPTION
# Description

We implemented generic arm handler but didn't end up migrating existing connector implementation to use it. Trying to consolidate code between recipe and resource based connectors so cleaning this up now as well to minimize more refactoring in the future.
For reference for review, SQL connector uses arm handler today https://github.com/project-radius/radius/blob/main/pkg/connectorrp/renderers/sqldatabases/renderer.go

Verified locally that the computed value is getting populated correctly.

Will be updating rest of the connectors in separate PRs to keep the changes and impact isolated to each connector type.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
