### PR TITLE
Simplify Kubernetes auth for server

### DIFF
--- a/deploy/Chart/charts/appcore-rp/templates/appcore-rp.yaml
+++ b/deploy/Chart/charts/appcore-rp/templates/appcore-rp.yaml
@@ -118,9 +118,3 @@ stringData:
   # Skip ARM by default. Overwriting this secret will let you set this to false as well as configure credentials
   SKIP_ARM: 'true' 
 {{ end }}
-# Configuration for AKS integration
-{{ if .Values.global.rp.aks }}
-  K8S_SUBSCRIPTION_ID: {{ .Values.global.rp.aks.subscriptionId }}
-  K8S_RESOURCE_GROUP: {{ .Values.global.rp.aks.resourceGroup }}
-  K8S_CLUSTER_NAME: {{ .Values.global.rp.aks.clusterName }}
-{{ end }}

--- a/deploy/Chart/charts/de/templates/de.yaml
+++ b/deploy/Chart/charts/de/templates/de.yaml
@@ -70,13 +70,6 @@ stringData:
   # Skip ARM by default. Overwriting this secret will let you set this to false as well as configure credentials
   SKIP_ARM: 'true' 
 {{ end }}
-# Configuration for AKS integration. We only need this to be able to manipulate pod-identities via ARM.
-# This will move to the environment resource eventually.
-{{ if .Values.global.rp.aks }}
-  K8S_SUBSCRIPTION_ID: {{ .Values.global.rp.aks.subscriptionId }}
-  K8S_RESOURCE_GROUP: {{ .Values.global.rp.aks.resourceGroup }}
-  K8S_CLUSTER_NAME: {{ .Values.global.rp.aks.clusterName }}
-{{ end }}
 ---
 apiVersion: v1
 kind: Service

--- a/docs/contributing/contributing-code/contributing-code-azure/settings.md
+++ b/docs/contributing/contributing-code/contributing-code-azure/settings.md
@@ -36,11 +36,6 @@ Enum values are compared *case-insensitively*.
 | AZURE_CLIENT_SECRET            | no                         | string  | Configures the client secret of a service principal for ARM authentication.                                                                  |
 | AZURE_TENANT_ID                | no                         | string  | Configures the AAD tenant of a service principal for ARM authentication.                                                                     |
 | MSI_ENDPOINT/IDENTITY_ENDPOINT | no                         | string  | Used to detect whether the RP should use managed identity for ARM authentication.                                                            |
-| K8S_LOCAL                      | *see Kubernetes section*   | boolean | Configures the Kubernetes connection to use the local Kubernetes context.                                                                    |
-| K8S_CLUSTER                    | *see Kubernetes section*   | boolean | Configures the Kubernetes connection to use the Kubernetes in-cluster config.                                                                |
-| K8S_CLUSTER_NAME               | *see Kubernetes section*   | string  | Configures the resource name of an AKS cluster. Used to identify and connect to the Kubernetes cluster by retrieving credentials from ARM.   |
-| K8S_SUBSCRIPTION_ID            | *see Kubernetes section*   | string  | Configures the subscription id of an AKS cluster. Used to identify and connect to the Kubernetes cluster by retrieving credentials from ARM. |
-| K8S_RESOURCE_GROUP             | *see Kubernetes section*   | string  | Configures the resource group of an AKS cluster. Used to identify and connect to the Kubernetes cluster by retrieving credentials from ARM.  |
 | RADIUS_LOG_PROFILE                 | no (`development`)   | string  | Configures the log profile for Radius |
 | RADIUS_LOG_LEVEL                   | *see Logging section*   | string  | Configures the log level for Radius |
 
@@ -60,13 +55,10 @@ Our detection logic mirrors what the newer Azure Go SDKs do. Since we require th
 
 Authentication with Kubernetes can be disabled totally by setting `SKIP_K8S=true`. This will disable Kubernetes features like creation and management of containers/pods and ingresses.
 
-The RP can connect to Kubernetes using three different strategies to find the identity and credentials in order or priority:
+The RP connects to Kubernetes using two different strategies to find the identity and credentials in order or priority:
 
-- Using local Kubeconfig (used in local development)
-- Using in-cluster credentials
-- Using ARM to fetch credentials based on `K8S_CLUSTER_NAME`/`K8S_SUBSCRIPTION_ID`/`K8S_RESOURCE_GROUP` (used when deployed)
-
-Our detection logic treats `K8S_LOCAL` and `K8S_CLUSTER` as overrides. We will attempt to find the cluster using ARM by default.
+- Using in-cluster credentials (if present)
+- Using local Kubeconfig
 
 ## Logging
 

--- a/docs/contributing/contributing-code/running-radius-locally.md
+++ b/docs/contributing/contributing-code/running-radius-locally.md
@@ -27,7 +27,6 @@ Add the following to `configurations` in `.vscode/launch.json` in your Radius so
     "env": {
         "RADIUS_ENV": "self-hosted", // uses config from cmd/appcore-rp/radius-self-hosted.yaml
         "SKIP_AUTH": "true",
-        "K8S_LOCAL": "true",
         "SKIP_ARM": "false",
         "ARM_AUTH_METHOD": "ServicePrincipal",
         "ARM_SUBSCRIPTION_ID": "<your-subscription-id>",

--- a/pkg/rp/k8sauth/client.go
+++ b/pkg/rp/k8sauth/client.go
@@ -6,133 +6,29 @@
 package k8sauth
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"log"
-	"os"
-	"path/filepath"
-	"time"
 
-	"github.com/project-radius/radius/pkg/azure/armauth"
-	"github.com/project-radius/radius/pkg/azure/clients"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 // GetConfig gets the Kubernetes config
 func GetConfig() (*rest.Config, error) {
-	var config *rest.Config
-	var err error
-
-	useLocal := os.Getenv("K8S_LOCAL")
-	useCluster := os.Getenv("K8S_CLUSTER")
-	if useLocal == "true" {
-		config, err = createLocal()
-		if err != nil {
-			return nil, err
-		}
-	} else if useCluster == "true" {
-		config, err = createCluster()
-		if err != nil {
-			return nil, err
-		}
+	config, err := rest.InClusterConfig()
+	if errors.Is(err, rest.ErrNotInCluster) {
+		// Fall-back to kubeconfig
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to connect with in-cluster config: %w", err)
 	} else {
-		config, err = createRemote()
-		if err != nil {
-			return nil, err
-		}
+		return config, nil
+	}
+
+	// Not in a cluster, fall back to local kubeconfig
+	config, err = clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect with kubeconfig: %w", err)
 	}
 
 	return config, nil
-}
-
-func createLocal() (*rest.Config, error) {
-	log.Println("Creating Kubernetes client based on local context")
-
-	var kubeConfig string
-	if home := homeDir(); home != "" {
-		kubeConfig = filepath.Join(home, ".kube", "config")
-	} else {
-		return nil, errors.New("no HOME directory, cannot find kubeconfig")
-	}
-
-	log.Printf("Using %s for kube config", kubeConfig)
-	config, err := clientcmd.BuildConfigFromFlags("", kubeConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	log.Println("Created Kubernetes client config")
-	return config, nil
-}
-
-func createCluster() (*rest.Config, error) {
-	log.Println("Creating Kubernetes client based on cluster context")
-
-	config, err := clientcmd.BuildConfigFromFlags("", "")
-	if err != nil {
-		return nil, err
-	}
-
-	log.Println("Created Kubernetes client config")
-	return config, nil
-}
-
-func homeDir() string {
-	if h := os.Getenv("HOME"); h != "" {
-		return h
-	}
-	return os.Getenv("USERPROFILE") // windows
-}
-
-func createRemote() (*rest.Config, error) {
-	clusterName, ok := os.LookupEnv("K8S_CLUSTER_NAME")
-	if !ok {
-		return nil, errors.New("required env-var K8S_CLUSTER_NAME not found")
-	}
-
-	resourceGroup, ok := os.LookupEnv("K8S_RESOURCE_GROUP")
-	if !ok {
-		return nil, errors.New("required env-var K8S_RESOURCE_GROUP not found")
-	}
-
-	subscriptionID, ok := os.LookupEnv("K8S_SUBSCRIPTION_ID")
-	if !ok {
-		return nil, errors.New("required env-var K8S_SUBSCRIPTION_ID not found")
-	}
-
-	auth, err := armauth.GetArmAuthorizer()
-	if err != nil {
-		return nil, fmt.Errorf("cannot authorize with ARM: %w", err)
-	}
-
-	aks := clients.NewManagedClustersClient(subscriptionID, auth)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	log.Println("Listing cluster credentials")
-	res, err := aks.ListClusterAdminCredentials(ctx, resourceGroup, clusterName, "")
-	if err != nil {
-		return nil, err
-	}
-	log.Println("Listed cluster credentials")
-
-	if len(*res.Kubeconfigs) == 0 {
-		return nil, errors.New("no admin credentials found")
-	}
-
-	config, err := clientcmd.NewClientConfigFromBytes(*(*res.Kubeconfigs)[0].Value)
-	if err != nil {
-		return nil, err
-	}
-
-	clientconfig, err := config.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	log.Println("Created Kubernetes client config")
-	return clientconfig, nil
 }


### PR DESCRIPTION
I happened upon this (old) code while working on something else, and realized that it is still based on the CustomRP model. We have the capability to connect to ARM and download credentials from AKS, which we don't really need or want to do. The environment variables to configure this are still present in the helm chart, but nothing sets them.

I've also learned a lot about how kubernetes configuration model works since then, and this code can be simplified a lot. We don't really need environment variables for configuration. If we're running in a cluster then connecting to the cluster is the right thing (for now). So we can remove the setting and simplify everyone's life.
