### PR TITLE
Fix for 409 conflict error during create and delete recipe commands

### DIFF
--- a/pkg/cli/cmd/recipe/create/create.go
+++ b/pkg/cli/cmd/recipe/create/create.go
@@ -121,8 +121,13 @@ func (r *Runner) Run(ctx context.Context) error {
 			},
 		}
 	}
+	namespace := ""
+	switch v := envResource.Properties.Compute.(type) {
+	case *coreRpApps.KubernetesCompute:
+		namespace = *v.Namespace
+	}
 
-	isEnvCreated, err := client.CreateEnvironment(ctx, r.Workspace.Environment, "global", "default", "Kubernetes", *envResource.ID, recipeProperties, envResource.Properties.Providers, *envResource.Properties.UseDevRecipes)
+	isEnvCreated, err := client.CreateEnvironment(ctx, r.Workspace.Environment, "global", namespace, "Kubernetes", *envResource.ID, recipeProperties, envResource.Properties.Providers, *envResource.Properties.UseDevRecipes)
 	if err != nil || !isEnvCreated {
 		return &cli.FriendlyError{Message: fmt.Sprintf("failed to update Applications.Core/environments resource %s with recipe: %s", *envResource.ID, err.Error())}
 	}

--- a/pkg/cli/cmd/recipe/create/create.go
+++ b/pkg/cli/cmd/recipe/create/create.go
@@ -107,7 +107,7 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	recipeProperties := envResource.Properties.Recipes
 	if recipeProperties[r.RecipeName] != nil {
-		return fmt.Errorf("recipe with name %q alredy exists in the environment %q", r.RecipeName, r.Workspace.Environment)
+		return &cli.FriendlyError{Message: fmt.Sprintf("recipe with name %q alredy exists in the environment %q", r.RecipeName, r.Workspace.Environment)}
 	}
 	if recipeProperties != nil {
 		recipeProperties[r.RecipeName] = &corerpapps.EnvironmentRecipeProperties{

--- a/pkg/cli/cmd/recipe/create/create_test.go
+++ b/pkg/cli/cmd/recipe/create/create_test.go
@@ -96,6 +96,9 @@ func Test_Run(t *testing.T) {
 							TemplatePath:  to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
 						},
 					},
+					Compute: &v20220315privatepreview.KubernetesCompute{
+						Namespace: to.Ptr("default"),
+					},
 				},
 			}
 

--- a/pkg/cli/cmd/recipe/delete/delete.go
+++ b/pkg/cli/cmd/recipe/delete/delete.go
@@ -10,12 +10,12 @@ import (
 	"fmt"
 
 	"github.com/project-radius/radius/pkg/cli"
+	"github.com/project-radius/radius/pkg/cli/cmd"
 	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/framework"
 	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
-	coreRpApps "github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
 	"github.com/spf13/cobra"
 )
 
@@ -92,11 +92,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	if recipeProperties[r.RecipeName] == nil {
 		return fmt.Errorf("recipe %q is not part of the environment %q ", r.RecipeName, r.Workspace.Environment)
 	}
-	namespace := ""
-	switch v := envResource.Properties.Compute.(type) {
-	case *coreRpApps.KubernetesCompute:
-		namespace = *v.Namespace
-	}
+	namespace := cmd.GetNamespace(envResource)
 	delete(recipeProperties, r.RecipeName)
 	isEnvCreated, err := client.CreateEnvironment(ctx, r.Workspace.Environment, "global", namespace, "Kubernetes", *envResource.ID, recipeProperties, envResource.Properties.Providers, *envResource.Properties.UseDevRecipes)
 	if err != nil || !isEnvCreated {

--- a/pkg/cli/cmd/recipe/delete/delete.go
+++ b/pkg/cli/cmd/recipe/delete/delete.go
@@ -90,7 +90,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	recipeProperties := envResource.Properties.Recipes
 
 	if recipeProperties[r.RecipeName] == nil {
-		return fmt.Errorf("recipe %q is not part of the environment %q ", r.RecipeName, r.Workspace.Environment)
+		return &cli.FriendlyError{Message: fmt.Sprintf("recipe %q is not part of the environment %q ", r.RecipeName, r.Workspace.Environment)}
 	}
 	namespace := cmd.GetNamespace(envResource)
 	delete(recipeProperties, r.RecipeName)

--- a/pkg/cli/cmd/recipe/delete/delete_test.go
+++ b/pkg/cli/cmd/recipe/delete/delete_test.go
@@ -104,6 +104,45 @@ func Test_Run(t *testing.T) {
 			err := runner.Run(context.Background())
 			require.NoError(t, err)
 		})
+		t.Run("No Namespace", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			envResource := v20220315privatepreview.EnvironmentResource{
+				ID:       to.Ptr("/planes/radius/local/resourcegroups/kind-kind/providers/applications.core/environments/kind-kind"),
+				Name:     to.Ptr("kind-kind"),
+				Type:     to.Ptr("applications.core/environments"),
+				Location: to.Ptr("global"),
+				Properties: &v20220315privatepreview.EnvironmentProperties{
+					UseDevRecipes: to.Ptr(true),
+					Recipes: map[string]*v20220315privatepreview.EnvironmentRecipeProperties{
+						"cosmosDB": {
+							ConnectorType: to.Ptr("Applications.Connector/mongoDatabases"),
+							TemplatePath:  to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+						},
+					},
+				},
+			}
+
+			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
+			appManagementClient.EXPECT().
+				GetEnvDetails(gomock.Any(), gomock.Any()).
+				Return(envResource, nil).Times(1)
+			appManagementClient.EXPECT().
+				CreateEnvironment(context.Background(), "kind-kind", "global", "", "Kubernetes", gomock.Any(), map[string]*v20220315privatepreview.EnvironmentRecipeProperties{}, gomock.Any(), gomock.Any()).
+				Return(true, nil).Times(1)
+
+			outputSink := &output.MockOutput{}
+
+			runner := &Runner{
+				ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+				Output:            outputSink,
+				Workspace:         &workspaces.Workspace{Environment: "kind-kind"},
+				RecipeName:        "cosmosDB",
+			}
+
+			err := runner.Run(context.Background())
+			require.NoError(t, err)
+		})
 		t.Run("Delete recipe that doesn't exist in the environment", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 

--- a/pkg/cli/cmd/recipe/delete/delete_test.go
+++ b/pkg/cli/cmd/recipe/delete/delete_test.go
@@ -78,6 +78,9 @@ func Test_Run(t *testing.T) {
 							TemplatePath:  to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
 						},
 					},
+					Compute: &v20220315privatepreview.KubernetesCompute{
+						Namespace: to.Ptr("default"),
+					},
 				},
 			}
 

--- a/pkg/cli/cmd/utils.go
+++ b/pkg/cli/cmd/utils.go
@@ -19,3 +19,11 @@ func CreateEnvAzureProvider(subscriptionID, resourceGroup string) corerp.Provide
 	}
 	return providers
 }
+
+func GetNamespace(envResource corerp.EnvironmentResource) string {
+	switch v := envResource.Properties.Compute.(type) {
+	case *corerp.KubernetesCompute:
+		return *v.Namespace
+	}
+	return ""
+}


### PR DESCRIPTION
# Description

Added a fix for the below error
<img width="1418" alt="image" src="https://user-images.githubusercontent.com/100623239/197903261-44568b7d-3e9d-4ed8-9921-c39d12d4f10e.png">

- added changes to pass the namespace of the env retrieved than passing the "default " while updating the environment in create and delete recipes.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
