### PR TITLE
Fix CLI argument validation

### DIFF
--- a/test/radcli/shared.go
+++ b/test/radcli/shared.go
@@ -66,15 +66,18 @@ func SharedValidateValidation(t *testing.T, factory func(framework framework.Fac
 			require.NoError(t, err, "flag parsing failed")
 
 			err = cmd.ValidateArgs(cmd.Flags().Args())
-			if !testcase.ExpectedValid && err != nil {
+			if err != nil && testcase.ExpectedValid {
+				require.NoError(t, err, "validation should have failed but it passed")
+			} else if err != nil {
+				// We expected this to fail, so it's OK if it does. No need to run Validate.
 				return
 			}
 
 			err = runner.Validate(cmd, cmd.Flags().Args())
-			if !testcase.ExpectedValid {
-				if err == nil {
-					require.Error(t, err, "validation should have failed but it passed")
-				}
+			if testcase.ExpectedValid {
+				require.NoError(t, err, "validation should have passed but it failed")
+			} else {
+				require.Error(t, err, "validation should have failed but it passed")
 			}
 		})
 	}


### PR DESCRIPTION
There were some gaps in how we were validating negative cases for CLI parsing. I found this while writing some new tests, and I was surprised when my negative tests didn't fail correctly.

Since the validation for the validation was invalid, it was possible for one of our negative tests to return a false-positive.

Fortunately NONE of our existing tests were affected. The new tests I was writing were the only ones hitting the validation problem.
