### PR TITLE
Add UCP functional test for DeleteAWS resource

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -170,6 +170,10 @@ stages:
         export TEST_TIMEOUT=${{ variables.K8S_FUNCTIONALTEST_TIMEOUT }}
         export RADIUS_CONTAINER_LOG_PATH=$(Build.SourcesDirectory)/${{ variables.RADIUS_CONTAINER_LOG_BASE }}/ucptest
         make test-functional-ucp
+      env:
+        AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+        AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+        AWS_REGION: $(AWS_REGION)
       displayName: run functional ucp tests
     - publish: $(Build.SourcesDirectory)/dist/container_logs
       displayName: Publish container logs

--- a/test/functional/corerp/resources/aws_kinesis_stream_test.go
+++ b/test/functional/corerp/resources/aws_kinesis_stream_test.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-func Test_KinesisStream(t *testing.T) {
+func Test_AWS_KinesisStream(t *testing.T) {
 	template := "testdata/aws-kinesis.bicep"
 	name := "ms" + uuid.New().String()
 

--- a/test/functional/ucp/aws_test.go
+++ b/test/functional/ucp/aws_test.go
@@ -1,0 +1,133 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package ucp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	awsgo "github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	"github.com/google/uuid"
+	"github.com/project-radius/radius/pkg/ucp/api/v20220901privatepreview"
+	"github.com/project-radius/radius/pkg/ucp/aws"
+	"github.com/project-radius/radius/test/validation"
+	"github.com/stretchr/testify/require"
+)
+
+func initializeAWS(t *testing.T, ctx context.Context) aws.AWSCloudControlClient {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	require.NoError(t, err)
+	var awsClient aws.AWSCloudControlClient = cloudcontrol.NewFromConfig(cfg)
+	return awsClient
+}
+
+func Test_AWS_DeleteResource(t *testing.T) {
+	ctx := context.Background()
+	resourceType := "AWS::Kinesis::Stream"
+	streamName := "my-stream" + uuid.NewString()
+
+	// Test setup - Create AWS resource using AWS APIs
+	awsClient := initializeAWS(t, ctx)
+
+	desiredState := map[string]interface{}{
+		"Name":                 streamName,
+		"RetentionPeriodHours": 180,
+		"ShardCount":           4,
+	}
+	desiredStateBytes, err := json.Marshal(desiredState)
+
+	response, err := awsClient.CreateResource(ctx, &cloudcontrol.CreateResourceInput{
+		TypeName:     &resourceType,
+		DesiredState: awsgo.String(string(desiredStateBytes)),
+	})
+	require.NoError(t, err)
+	// Wait till the create is complete
+	maxWaitTime := 300 * time.Second
+	waiter := cloudcontrol.NewResourceRequestSuccessWaiter(awsClient)
+	err = waiter.Wait(ctx, &cloudcontrol.GetResourceRequestStatusInput{
+		RequestToken: response.ProgressEvent.RequestToken,
+	}, maxWaitTime)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		// Just in case delete fails
+		deleteOutput, err := awsClient.DeleteResource(ctx, &cloudcontrol.DeleteResourceInput{
+			Identifier: &streamName,
+			TypeName:   to.Ptr("AWS::Kinesis::Stream"),
+		})
+		require.NoError(t, err)
+
+		// Wait till the delete is complete
+		maxWaitTime := 300 * time.Second
+		waiter := cloudcontrol.NewResourceRequestSuccessWaiter(awsClient)
+		err = waiter.Wait(ctx, &cloudcontrol.GetResourceRequestStatusInput{
+			RequestToken: deleteOutput.ProgressEvent.RequestToken,
+		}, maxWaitTime)
+	})
+	// End of test setup
+
+	test := NewUCPTest(t, "Test_AWS_DeleteResource", func(t *testing.T, url string, roundTripper http.RoundTripper) {
+		// Call UCP Delete AWS Resource API
+		resourceID := validation.GetResourceIdentifier(t, "AWS.Kinesis/Stream", streamName)
+
+		// Remove the stream name from the to form the post URL and add the stream name to the body
+		resourceIDParts := strings.Split(resourceID, "/")
+		resourceIDParts = resourceIDParts[:len(resourceIDParts)-1]
+		resourceID = strings.Join(resourceIDParts, "/")
+		deleteURL := fmt.Sprintf("%s%s/:delete?api-version=%s", url, resourceID, v20220901privatepreview.Version)
+		deleteRequestBody := map[string]interface{}{
+			"properties": map[string]interface{}{
+				"Name": streamName,
+			},
+		}
+		deleteBody, err := json.Marshal(deleteRequestBody)
+		require.NoError(t, err)
+
+		// Issue the Delete Request
+		deleteRequest, err := http.NewRequest(http.MethodPost, deleteURL, bytes.NewBuffer(deleteBody))
+		require.NoError(t, err)
+		deleteResponse, err := roundTripper.RoundTrip(deleteRequest)
+		require.Equal(t, http.StatusAccepted, deleteResponse.StatusCode)
+
+		// Get the operation status url from the Azure-Asyncoperation header
+		deleteResponseCompletionUrl := deleteResponse.Header["Azure-Asyncoperation"][0]
+		getRequest, err := http.NewRequest(http.MethodGet, deleteResponseCompletionUrl, nil)
+		require.NoError(t, err)
+		maxRetries := 100
+		deleteSucceeded := false
+		for i := 0; i < maxRetries; i++ {
+			getResponse, err := roundTripper.RoundTrip(getRequest)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, getResponse.StatusCode)
+
+			// Read the request status from the body
+			payload, err := io.ReadAll(getResponse.Body)
+			require.NoError(t, err)
+			body := map[string]interface{}{}
+			err = json.Unmarshal(payload, &body)
+			require.NoError(t, err)
+			if body["status"] == "Succeeded" {
+				deleteSucceeded = true
+				break
+			}
+			// Give it more time
+			time.Sleep(1 * time.Second)
+		}
+		require.True(t, deleteSucceeded)
+	})
+	test.Test(t)
+
+}

--- a/test/functional/ucp/aws_test.go
+++ b/test/functional/ucp/aws_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	awsgo "github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
@@ -27,57 +26,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func initializeAWS(t *testing.T, ctx context.Context) aws.AWSCloudControlClient {
-	cfg, err := awsconfig.LoadDefaultConfig(ctx)
-	require.NoError(t, err)
-	var awsClient aws.AWSCloudControlClient = cloudcontrol.NewFromConfig(cfg)
-	return awsClient
-}
+var streamName = "my-stream" + uuid.NewString()
+var resourceType = "AWS::Kinesis::Stream"
 
 func Test_AWS_DeleteResource(t *testing.T) {
 	ctx := context.Background()
-	resourceType := "AWS::Kinesis::Stream"
-	streamName := "my-stream" + uuid.NewString()
-
-	// Test setup - Create AWS resource using AWS APIs
-	awsClient := initializeAWS(t, ctx)
-
-	desiredState := map[string]interface{}{
-		"Name":                 streamName,
-		"RetentionPeriodHours": 180,
-		"ShardCount":           4,
-	}
-	desiredStateBytes, err := json.Marshal(desiredState)
-
-	response, err := awsClient.CreateResource(ctx, &cloudcontrol.CreateResourceInput{
-		TypeName:     &resourceType,
-		DesiredState: awsgo.String(string(desiredStateBytes)),
-	})
-	require.NoError(t, err)
-	// Wait till the create is complete
-	maxWaitTime := 300 * time.Second
-	waiter := cloudcontrol.NewResourceRequestSuccessWaiter(awsClient)
-	err = waiter.Wait(ctx, &cloudcontrol.GetResourceRequestStatusInput{
-		RequestToken: response.ProgressEvent.RequestToken,
-	}, maxWaitTime)
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		// Just in case delete fails
-		deleteOutput, err := awsClient.DeleteResource(ctx, &cloudcontrol.DeleteResourceInput{
-			Identifier: &streamName,
-			TypeName:   to.Ptr("AWS::Kinesis::Stream"),
-		})
-		require.NoError(t, err)
-
-		// Wait till the delete is complete
-		maxWaitTime := 300 * time.Second
-		waiter := cloudcontrol.NewResourceRequestSuccessWaiter(awsClient)
-		err = waiter.Wait(ctx, &cloudcontrol.GetResourceRequestStatusInput{
-			RequestToken: deleteOutput.ProgressEvent.RequestToken,
-		}, maxWaitTime)
-	})
-	// End of test setup
+	setupTestAWSResource(t, ctx)
 
 	test := NewUCPTest(t, "Test_AWS_DeleteResource", func(t *testing.T, url string, roundTripper http.RoundTripper) {
 		// Call UCP Delete AWS Resource API
@@ -100,6 +54,7 @@ func Test_AWS_DeleteResource(t *testing.T) {
 		deleteRequest, err := http.NewRequest(http.MethodPost, deleteURL, bytes.NewBuffer(deleteBody))
 		require.NoError(t, err)
 		deleteResponse, err := roundTripper.RoundTrip(deleteRequest)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusAccepted, deleteResponse.StatusCode)
 
 		// Get the operation status url from the Azure-Asyncoperation header
@@ -130,4 +85,57 @@ func Test_AWS_DeleteResource(t *testing.T) {
 	})
 	test.Test(t)
 
+}
+
+func setupTestAWSResource(t *testing.T, ctx context.Context) {
+	// Test setup - Create AWS resource using AWS APIs
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	require.NoError(t, err)
+	var awsClient aws.AWSCloudControlClient = cloudcontrol.NewFromConfig(cfg)
+	desiredState := map[string]interface{}{
+		"Name":                 streamName,
+		"RetentionPeriodHours": 180,
+		"ShardCount":           4,
+	}
+	desiredStateBytes, err := json.Marshal(desiredState)
+	require.NoError(t, err)
+
+	response, err := awsClient.CreateResource(ctx, &cloudcontrol.CreateResourceInput{
+		TypeName:     &resourceType,
+		DesiredState: awsgo.String(string(desiredStateBytes)),
+	})
+	require.NoError(t, err)
+	waitForSuccess(t, ctx, awsClient, response.ProgressEvent.RequestToken)
+
+	t.Cleanup(func() {
+		// Check if resource exists before issuing a delete because the AWS SDK async delete operation
+		// seems to fail if the resource does not exist
+		_, err := awsClient.GetResource(ctx, &cloudcontrol.GetResourceInput{
+			Identifier: &streamName,
+			TypeName:   &resourceType,
+		})
+		if aws.IsAWSResourceNotFound(err) {
+			return
+		}
+		// Just in case delete fails
+		deleteOutput, err := awsClient.DeleteResource(ctx, &cloudcontrol.DeleteResourceInput{
+			Identifier: &streamName,
+			TypeName:   &resourceType,
+		})
+		require.NoError(t, err)
+
+		// Ignoring status of delete since AWS command fails if the resource does not already exist
+		waitForSuccess(t, ctx, awsClient, deleteOutput.ProgressEvent.RequestToken)
+	})
+	// End of test setup
+}
+
+func waitForSuccess(t *testing.T, ctx context.Context, awsClient aws.AWSCloudControlClient, requestToken *string) {
+	// Wait till the create is complete
+	maxWaitTime := 300 * time.Second
+	waiter := cloudcontrol.NewResourceRequestSuccessWaiter(awsClient)
+	err := waiter.Wait(ctx, &cloudcontrol.GetResourceRequestStatusInput{
+		RequestToken: requestToken,
+	}, maxWaitTime)
+	require.NoError(t, err)
 }

--- a/test/validation/aws.go
+++ b/test/validation/aws.go
@@ -37,7 +37,7 @@ type AWSResourceSet struct {
 
 func ValidateAWSResources(ctx context.Context, t *testing.T, expected *AWSResourceSet, client aws.AWSCloudControlClient) {
 	for _, resource := range expected.Resources {
-		resourceType := getResourceTypeName(t, &resource)
+		resourceType := GetResourceTypeName(t, &resource)
 		_, err := client.GetResource(ctx, &cloudcontrol.GetResourceInput{
 			Identifier: to.StringPtr(resource.Name),
 			TypeName:   &resourceType,
@@ -47,7 +47,7 @@ func ValidateAWSResources(ctx context.Context, t *testing.T, expected *AWSResour
 }
 
 func DeleteAWSResource(ctx context.Context, t *testing.T, resource *AWSResource, client aws.AWSCloudControlClient) error {
-	resourceType := getResourceTypeName(t, resource)
+	resourceType := GetResourceTypeName(t, resource)
 	deleteOutput, err := client.DeleteResource(ctx, &cloudcontrol.DeleteResourceInput{
 		Identifier: to.StringPtr(resource.Name),
 		TypeName:   &resourceType,
@@ -66,7 +66,7 @@ func DeleteAWSResource(ctx context.Context, t *testing.T, resource *AWSResource,
 
 func ValidateNoAWSResource(ctx context.Context, t *testing.T, resource *AWSResource, client aws.AWSCloudControlClient) {
 	// Verify that the resource is indeed deleted
-	resourceType := getResourceTypeName(t, resource)
+	resourceType := GetResourceTypeName(t, resource)
 	_, err := client.GetResource(ctx, &cloudcontrol.GetResourceInput{
 		Identifier: to.StringPtr(resource.Name),
 		TypeName:   &resourceType,
@@ -76,7 +76,7 @@ func ValidateNoAWSResource(ctx context.Context, t *testing.T, resource *AWSResou
 	require.True(t, notFound)
 }
 
-func getResourceIdentifier(t *testing.T, resourceType string, name string) string {
+func GetResourceIdentifier(t *testing.T, resourceType string, name string) string {
 	creds := credentials.NewStaticCredentials(os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), "")
 	awsConfig := awsclient.NewConfig().WithCredentials(creds).WithMaxRetries(3)
 	mySession, err := session.NewSession(awsConfig)
@@ -88,8 +88,8 @@ func getResourceIdentifier(t *testing.T, resourceType string, name string) strin
 	return "/planes/aws/aws/accounts/" + *result.Account + "/regions/" + region + "/providers/" + resourceType + "/" + name
 }
 
-func getResourceTypeName(t *testing.T, resource *AWSResource) string {
-	id := getResourceIdentifier(t, resource.Type, resource.Name)
+func GetResourceTypeName(t *testing.T, resource *AWSResource) string {
+	id := GetResourceIdentifier(t, resource.Type, resource.Name)
 	resourceID, err := resources.Parse(id)
 	require.NoError(t, err)
 	resourceType := resources.ToAWSResourceType(resourceID)


### PR DESCRIPTION
# Description

Delete AWS resource UCP API cannot be tested using an e2e test. Adding a functional test to exercise this API and validate

#4209 

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #4209 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
