### PR TITLE
fix async headers in test

### DIFF
--- a/pkg/ucp/frontend/controller/awsproxy/awsproxytest.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsproxytest.go
@@ -26,8 +26,9 @@ const (
 	testPrimaryIdentifier1          = "abc"
 	testPrimaryIdentifier2          = "xyz"
 	testMultiIdentifierResourceType = "AWS.RedShift/EndpointAuthorization"
-	testlocationHeader              = "http:///planes/aws/aws/accounts/1234567/regions/us-east-1/providers/AWS.Kinesis/locations/global/operationResults/79b9f0da-4882-4dc8-a367-6fd3bc122ded"
-	testazureAsyncOpHeader          = "http:///planes/aws/aws/accounts/1234567/regions/us-east-1/providers/AWS.Kinesis/locations/global/operationStatuses/79b9f0da-4882-4dc8-a367-6fd3bc122ded"
+	testHost                        = "localhost:5000"
+	testlocationHeader              = "http://localhost:5000/planes/aws/aws/accounts/1234567/regions/us-east-1/providers/AWS.Kinesis/locations/global/operationResults/79b9f0da-4882-4dc8-a367-6fd3bc122ded"
+	testazureAsyncOpHeader          = "http://localhost:5000/planes/aws/aws/accounts/1234567/regions/us-east-1/providers/AWS.Kinesis/locations/global/operationStatuses/79b9f0da-4882-4dc8-a367-6fd3bc122ded"
 )
 
 type TestOptions struct {

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource_test.go
@@ -56,6 +56,7 @@ func Test_CreateAWSResource(t *testing.T) {
 	require.NoError(t, err)
 
 	request, err := http.NewRequest(http.MethodPut, testAWSSingleResourcePath, bytes.NewBuffer(requestBodyBytes))
+	request.Host = testHost
 	require.NoError(t, err)
 
 	actualResponse, err := awsController.Run(ctx, nil, request)


### PR DESCRIPTION
# Description

Test did not have host field set in the http request. As a result, the async headers showed http:/// in the resulting header. Fixing the test.

#4439 

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #4439 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
