### PR TITLE
Reserving dev recipe names when useDevRecipes is set to true

### DIFF
--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
@@ -177,7 +177,7 @@ func parseRepoPathForMetadata(repo string) (link, provider string) {
 	return link, provider
 }
 
-func ensureUserRecipesNamesAreNotReserved(userRecipes map[string]datamodel.EnvironmentRecipeProperties, devRecipes map[string]datamodel.EnvironmentRecipeProperties) error {
+func ensureUserRecipesNamesAreNotReserved(userRecipes, devRecipes map[string]datamodel.EnvironmentRecipeProperties) error {
 	overlap := map[string]datamodel.EnvironmentRecipeProperties{}
 	for k := range devRecipes {
 		if v, ok := userRecipes[k]; ok {
@@ -186,22 +186,17 @@ func ensureUserRecipesNamesAreNotReserved(userRecipes map[string]datamodel.Envir
 	}
 
 	if len(overlap) > 0 {
-		var errorString string
-
+		errorPrefix := "recipe name(s) reserved for devRecipes for: "
+		var errorRecipes string
 		for k, v := range overlap {
-			if errorString != "" {
-				errorString += ", "
+			if errorRecipes != "" {
+				errorRecipes += ", "
 			}
-			errorString += fmt.Sprintf("recipe with name %s (linkType %s and templatePath %s)", k, v.LinkType, v.TemplatePath)
+
+			errorRecipes += fmt.Sprintf("recipe with name %s (linkType %s and templatePath %s)", k, v.LinkType, v.TemplatePath)
 		}
 
-		if len(overlap) > 1 {
-			errorString += " have names that are reserved for devRecipes."
-		} else {
-			errorString += " has a name that is reserved for devRecipes."
-		}
-
-		return fmt.Errorf(errorString)
+		return fmt.Errorf(errorPrefix + errorPrefix)
 	}
 
 	return nil

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
@@ -66,7 +66,7 @@ func (e *CreateOrUpdateEnvironment) Run(ctx context.Context, w http.ResponseWrit
 			return nil, err
 		}
 
-		err = ensureUserRecipesHaveValidNames(newResource.Properties.Recipes, devRecipes)
+		err = ensureUserRecipesNamesAreNotReserved(newResource.Properties.Recipes, devRecipes)
 		if err != nil {
 			return nil, err
 		}
@@ -177,7 +177,7 @@ func parseRepoPathForMetadata(repo string) (link, provider string) {
 	return link, provider
 }
 
-func ensureUserRecipesHaveValidNames(userRecipes map[string]datamodel.EnvironmentRecipeProperties, devRecipes map[string]datamodel.EnvironmentRecipeProperties) error {
+func ensureUserRecipesNamesAreNotReserved(userRecipes map[string]datamodel.EnvironmentRecipeProperties, devRecipes map[string]datamodel.EnvironmentRecipeProperties) error {
 	overlap := map[string]datamodel.EnvironmentRecipeProperties{}
 	for k := range devRecipes {
 		if v, ok := userRecipes[k]; ok {

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
@@ -179,7 +179,7 @@ func parseRepoPathForMetadata(repo string) (link, provider string) {
 
 func ensureUserRecipesHaveValidNames(userRecipes map[string]datamodel.EnvironmentRecipeProperties, devRecipes map[string]datamodel.EnvironmentRecipeProperties) error {
 	overlap := map[string]datamodel.EnvironmentRecipeProperties{}
-	for k, _ := range devRecipes {
+	for k := range devRecipes {
 		if v, ok := userRecipes[k]; ok {
 			overlap[k] = v
 		}

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
@@ -686,7 +686,7 @@ func TestEnsureUserRecipesHaveValidNames(t *testing.T) {
 			},
 		}
 
-		err := ensureUserRecipesHaveValidNames(userRecipes, devRecipes)
+		err := ensureUserRecipesNamesAreNotReserved(userRecipes, devRecipes)
 		require.NoError(t, err)
 	})
 	t.Run("Single recipe overlap between user and dev recipes", func(t *testing.T) {
@@ -711,7 +711,7 @@ func TestEnsureUserRecipesHaveValidNames(t *testing.T) {
 			},
 		}
 
-		err := ensureUserRecipesHaveValidNames(userRecipes, devRecipes)
+		err := ensureUserRecipesNamesAreNotReserved(userRecipes, devRecipes)
 		require.Error(t, err, fmt.Sprintf(
 			"recipe with name %s (linkType %s and templatePath %s) has a name that is reserved for devRecipes.",
 			"mongo-azure",
@@ -740,7 +740,7 @@ func TestEnsureUserRecipesHaveValidNames(t *testing.T) {
 			},
 		}
 
-		err := ensureUserRecipesHaveValidNames(userRecipes, devRecipes)
+		err := ensureUserRecipesNamesAreNotReserved(userRecipes, devRecipes)
 		require.Error(t, err, fmt.Sprintf(
 			"recipe with name %s (linkType %s and templatePath %s), recipe with name %s (linkType %s and templatePath %s) have names that are reserved for devRecipes.",
 			"mongo-azure",

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
@@ -713,7 +713,7 @@ func TestEnsureUserRecipesHaveValidNames(t *testing.T) {
 
 		err := ensureUserRecipesNamesAreNotReserved(userRecipes, devRecipes)
 		require.Error(t, err, fmt.Sprintf(
-			"recipe with name %s (linkType %s and templatePath %s) has a name that is reserved for devRecipes.",
+			"recipe name(s) reserved for devRecipes for: recipe with name %s (linkType %s and templatePath %s)",
 			"mongo-azure",
 			userRecipes["mongo-azure"].LinkType,
 			userRecipes["mongo-azure"].TemplatePath))
@@ -742,7 +742,7 @@ func TestEnsureUserRecipesHaveValidNames(t *testing.T) {
 
 		err := ensureUserRecipesNamesAreNotReserved(userRecipes, devRecipes)
 		require.Error(t, err, fmt.Sprintf(
-			"recipe with name %s (linkType %s and templatePath %s), recipe with name %s (linkType %s and templatePath %s) have names that are reserved for devRecipes.",
+			"recipe name(s) reserved for devRecipes for: recipe with name %s (linkType %s and templatePath %s), recipe with name %s (linkType %s and templatePath %s)",
 			"mongo-azure",
 			userRecipes["mongo-azure"].LinkType,
 			userRecipes["mongo-azure"].TemplatePath,

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
@@ -606,7 +606,7 @@ func TestGetDevRecipes(t *testing.T) {
 		devRecipes, err := getDevRecipes(ctx)
 		require.NoError(t, err)
 		expectedRecipes := map[string]datamodel.EnvironmentRecipeProperties{
-			"mongo-azure": datamodel.EnvironmentRecipeProperties{
+			"mongo-azure": {
 				LinkType:     "Applications.Link/mongoDatabases",
 				TemplatePath: "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0",
 			},
@@ -666,21 +666,21 @@ func TestParseRepoPathForMetadata(t *testing.T) {
 func TestEnsureUserRecipesHaveValidNames(t *testing.T) {
 	t.Run("No overlap between user and dev recipes", func(t *testing.T) {
 		devRecipes := map[string]datamodel.EnvironmentRecipeProperties{
-			"mongo-azure": datamodel.EnvironmentRecipeProperties{
+			"mongo-azure": {
 				LinkType:     "Applications.Link/mongoDatabases",
 				TemplatePath: "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0",
 			},
-			"redis-azure": datamodel.EnvironmentRecipeProperties{
+			"redis-azure": {
 				LinkType:     "Applications.Link/redisCache",
 				TemplatePath: "radiusdev.azurecr.io/recipes/redis/azure:1.0",
 			},
 		}
 		userRecipes := map[string]datamodel.EnvironmentRecipeProperties{
-			"user-mongo-azure": datamodel.EnvironmentRecipeProperties{
+			"user-mongo-azure": {
 				LinkType:     "Applications.Link/mongoDatabases",
 				TemplatePath: "radiusdev.azurecr.io/mongo:1.0",
 			},
-			"user-redis-azure": datamodel.EnvironmentRecipeProperties{
+			"user-redis-azure": {
 				LinkType:     "Applications.Link/redisCache",
 				TemplatePath: "radiusdev.azurecr.io/redis:1.0",
 			},
@@ -691,21 +691,21 @@ func TestEnsureUserRecipesHaveValidNames(t *testing.T) {
 	})
 	t.Run("Single recipe overlap between user and dev recipes", func(t *testing.T) {
 		devRecipes := map[string]datamodel.EnvironmentRecipeProperties{
-			"mongo-azure": datamodel.EnvironmentRecipeProperties{
+			"mongo-azure": {
 				LinkType:     "Applications.Link/mongoDatabases",
 				TemplatePath: "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0",
 			},
-			"redis-azure": datamodel.EnvironmentRecipeProperties{
+			"redis-azure": {
 				LinkType:     "Applications.Link/redisCache",
 				TemplatePath: "radiusdev.azurecr.io/recipes/redis/azure:1.0",
 			},
 		}
 		userRecipes := map[string]datamodel.EnvironmentRecipeProperties{
-			"mongo-azure": datamodel.EnvironmentRecipeProperties{
+			"mongo-azure": {
 				LinkType:     "Applications.Link/mongoDatabases",
 				TemplatePath: "radiusdev.azurecr.io/mongo:1.0",
 			},
-			"user-redis-azure": datamodel.EnvironmentRecipeProperties{
+			"user-redis-azure": {
 				LinkType:     "Applications.Link/redisCache",
 				TemplatePath: "radiusdev.azurecr.io/redis:1.0",
 			},
@@ -720,21 +720,21 @@ func TestEnsureUserRecipesHaveValidNames(t *testing.T) {
 	})
 	t.Run("Multiple recipe overlap between user and dev recipes", func(t *testing.T) {
 		devRecipes := map[string]datamodel.EnvironmentRecipeProperties{
-			"mongo-azure": datamodel.EnvironmentRecipeProperties{
+			"mongo-azure": {
 				LinkType:     "Applications.Link/mongoDatabases",
 				TemplatePath: "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0",
 			},
-			"redis-azure": datamodel.EnvironmentRecipeProperties{
+			"redis-azure": {
 				LinkType:     "Applications.Link/redisCache",
 				TemplatePath: "radiusdev.azurecr.io/recipes/redis/azure:1.0",
 			},
 		}
 		userRecipes := map[string]datamodel.EnvironmentRecipeProperties{
-			"mongo-azure": datamodel.EnvironmentRecipeProperties{
+			"mongo-azure": {
 				LinkType:     "Applications.Link/mongoDatabases",
 				TemplatePath: "radiusdev.azurecr.io/mongo:1.0",
 			},
-			"redis-azure": datamodel.EnvironmentRecipeProperties{
+			"redis-azure": {
 				LinkType:     "Applications.Link/redisCache",
 				TemplatePath: "radiusdev.azurecr.io/redis:1.0",
 			},

--- a/pkg/corerp/frontend/controller/environments/testdata/environment20220315privatepreview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environment20220315privatepreview_datamodel.json
@@ -20,10 +20,10 @@
                 "namespace": "default"
             }
         },
-        "useDevRecipes":false,
+        "useDevRecipes": false,
         "providers": {
             "azure": {
-                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+                "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
             }
         }
     },

--- a/pkg/corerp/frontend/controller/environments/testdata/environment20220315privatepreview_input.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environment20220315privatepreview_input.json
@@ -6,10 +6,10 @@
             "resourceId": "fakeid",
             "namespace": "default"
         },
-        "useDevRecipes":false,
+        "useDevRecipes": false,
         "providers": {
             "azure": {
-                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+                "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
             }
         }
     }

--- a/pkg/corerp/frontend/controller/environments/testdata/environment20220315privatepreview_output.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environment20220315privatepreview_output.json
@@ -10,10 +10,10 @@
         },
         "providers": {
             "azure": {
-                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+                "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
             }
         },
-        "useDevRecipes":false,
+        "useDevRecipes": false,
         "provisioningState": "Succeeded"
     },
     "systemData": {

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipes20220315privatepreview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipes20220315privatepreview_datamodel.json
@@ -21,19 +21,19 @@
             }
         },
         "recipes": {
-          "mongo-azure": {
-            "linkType": "Applications.Link/mongoDatabases",
-            "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"
-          },
-          "redis": {
-            "linkType": "Applications.Link/redisCache",
-            "templatePath": "radiusdev.azurecr.io/redis:1.0"
-          }
+            "mongo-azure": {
+                "linkType": "Applications.Link/mongoDatabases",
+                "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"
+            },
+            "redis": {
+                "linkType": "Applications.Link/redisCache",
+                "templatePath": "radiusdev.azurecr.io/redis:1.0"
+            }
         },
-        "useDevRecipes":true,
+        "useDevRecipes": true,
         "providers": {
             "azure": {
-                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+                "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
             }
         }
     },

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipes20220315privatepreview_input.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipes20220315privatepreview_input.json
@@ -7,15 +7,15 @@
             "namespace": "default"
         },
         "recipes": {
-          "redis": {
-            "linkType": "Applications.Link/redisCache",
-            "templatePath": "radiusdev.azurecr.io/redis:1.0"
+            "redis": {
+                "linkType": "Applications.Link/redisCache",
+                "templatePath": "radiusdev.azurecr.io/redis:1.0"
             }
         },
-        "useDevRecipes":true,
+        "useDevRecipes": true,
         "providers": {
             "azure": {
-                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+                "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
             }
         }
     }

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipes20220315privatepreview_output.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipes20220315privatepreview_output.json
@@ -1,39 +1,39 @@
 {
-    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0",
-    "location": "West US",
-    "name": "env0",
-    "properties": {
-        "compute": {
-            "kind": "kubernetes",
-            "resourceId": "fakeid",
-            "namespace": "default"
-        },
-        "providers": {
-            "azure": {
-                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
-            }
-        },
-        "recipes": {
-          "mongo-azure": {
-            "linkType": "Applications.Link/mongoDatabases",
-            "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"
-          },
-          "redis": {
-            "linkType": "Applications.Link/redisCache",
-            "templatePath": "radiusdev.azurecr.io/redis:1.0"
-          }
-        },
-        "useDevRecipes":true,
-        "provisioningState": "Succeeded"
+  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0",
+  "location": "West US",
+  "name": "env0",
+  "properties": {
+    "compute": {
+      "kind": "kubernetes",
+      "resourceId": "fakeid",
+      "namespace": "default"
     },
-    "systemData": {
-        "createdAt": "2022-03-22T18:54:52.6857175Z",
-        "createdBy": "fake@hotmail.com",
-        "createdByType": "User",
-        "lastModifiedAt": "2022-03-22T18:57:52.6857175Z",
-        "lastModifiedBy": "fake@hotmail.com",
-        "lastModifiedByType": "User"
+    "providers": {
+      "azure": {
+        "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+      }
     },
-    "tags": {},
-    "type": "applications.core/environments"
+    "recipes": {
+      "mongo-azure": {
+        "linkType": "Applications.Link/mongoDatabases",
+        "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"
+      },
+      "redis": {
+        "linkType": "Applications.Link/redisCache",
+        "templatePath": "radiusdev.azurecr.io/redis:1.0"
+      }
+    },
+    "useDevRecipes": true,
+    "provisioningState": "Succeeded"
+  },
+  "systemData": {
+    "createdAt": "2022-03-22T18:54:52.6857175Z",
+    "createdBy": "fake@hotmail.com",
+    "createdByType": "User",
+    "lastModifiedAt": "2022-03-22T18:57:52.6857175Z",
+    "lastModifiedBy": "fake@hotmail.com",
+    "lastModifiedByType": "User"
+  },
+  "tags": {},
+  "type": "applications.core/environments"
 }

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipestoexisting20220315privatepreview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipestoexisting20220315privatepreview_datamodel.json
@@ -1,49 +1,49 @@
 {
-    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0",
-    "name": "env0",
-    "type": "applications.core/environments",
-    "location": "West US",
-    "systemData": {
-        "createdAt": "2022-03-22T18:54:52.6857175Z",
-        "createdBy": "fake@hotmail.com",
-        "createdByType": "User",
-        "lastModifiedAt": "2022-03-22T18:57:52.6857175Z",
-        "lastModifiedBy": "fake@hotmail.com",
-        "lastModifiedByType": "User"
+  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0",
+  "name": "env0",
+  "type": "applications.core/environments",
+  "location": "West US",
+  "systemData": {
+    "createdAt": "2022-03-22T18:54:52.6857175Z",
+    "createdBy": "fake@hotmail.com",
+    "createdByType": "User",
+    "lastModifiedAt": "2022-03-22T18:57:52.6857175Z",
+    "lastModifiedBy": "fake@hotmail.com",
+    "lastModifiedByType": "User"
+  },
+  "provisioningState": "Succeeded",
+  "properties": {
+    "compute": {
+      "kind": "kubernetes",
+      "kubernetes": {
+        "resourceId": "fakeid",
+        "namespace": "default"
+      }
     },
-    "provisioningState": "Succeeded",
-    "properties": {
-        "compute": {
-            "kind": "kubernetes",
-            "kubernetes": {
-                "resourceId": "fakeid",
-                "namespace": "default"
-            }
-        },
-        "recipes": {
-          "mongo-azure": {
-            "linkType": "Applications.Link/mongoDatabases",
-            "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"
-          },
-          "redis": {
-            "linkType": "Applications.Link/redisCache",
-            "templatePath": "radiusdev.azurecr.io/redis:1.0"
-          },
-          "sql": {
-            "linkType": "Applications.Link/sqlDatabases",
-            "templatePath": "radiusdev.azurecr.io/sql:1.0"
-          }
-        },
-        "useDevRecipes":true,
-        "providers": {
-            "azure": {
-                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
-            }
-        }
+    "recipes": {
+      "mongo-azure": {
+        "linkType": "Applications.Link/mongoDatabases",
+        "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"
+      },
+      "redis": {
+        "linkType": "Applications.Link/redisCache",
+        "templatePath": "radiusdev.azurecr.io/redis:1.0"
+      },
+      "sql": {
+        "linkType": "Applications.Link/sqlDatabases",
+        "templatePath": "radiusdev.azurecr.io/sql:1.0"
+      }
     },
-    "tenantId": "00000000-0000-0000-0000-000000000000",
-    "subscriptionId": "00000000-0000-0000-0000-000000000000",
-    "resourceGroup": "radius-test-rg",
-    "createdApiVersion": "2022-03-15-privatepreview",
-    "updatedApiVersion": "2022-03-15-privatepreview"
+    "useDevRecipes": true,
+    "providers": {
+      "azure": {
+        "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+      }
+    }
+  },
+  "tenantId": "00000000-0000-0000-0000-000000000000",
+  "subscriptionId": "00000000-0000-0000-0000-000000000000",
+  "resourceGroup": "radius-test-rg",
+  "createdApiVersion": "2022-03-15-privatepreview",
+  "updatedApiVersion": "2022-03-15-privatepreview"
 }

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipestoexisting20220315privatepreview_input.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipestoexisting20220315privatepreview_input.json
@@ -1,26 +1,26 @@
 {
-    "location": "West US",
-    "properties": {
-        "compute": {
-            "kind": "kubernetes",
-            "resourceId": "fakeid",
-            "namespace": "default"
-        },
-        "recipes": {
-          "redis": {
-            "linkType": "Applications.Link/redisCache",
-            "templatePath": "radiusdev.azurecr.io/redis:1.0"
-          },
-          "sql": {
-            "linkType": "Applications.Link/sqlDatabases",
-            "templatePath": "radiusdev.azurecr.io/sql:1.0"
-          }
-        },
-        "useDevRecipes":true,
-        "providers": {
-            "azure": {
-                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
-            }
-        }
+  "location": "West US",
+  "properties": {
+    "compute": {
+      "kind": "kubernetes",
+      "resourceId": "fakeid",
+      "namespace": "default"
+    },
+    "recipes": {
+      "redis": {
+        "linkType": "Applications.Link/redisCache",
+        "templatePath": "radiusdev.azurecr.io/redis:1.0"
+      },
+      "sql": {
+        "linkType": "Applications.Link/sqlDatabases",
+        "templatePath": "radiusdev.azurecr.io/sql:1.0"
+      }
+    },
+    "useDevRecipes": true,
+    "providers": {
+      "azure": {
+        "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+      }
     }
+  }
 }

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipestoexisting20220315privatepreview_output.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipestoexisting20220315privatepreview_output.json
@@ -1,43 +1,43 @@
 {
-    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0",
-    "location": "West US",
-    "name": "env0",
-    "properties": {
-        "compute": {
-            "kind": "kubernetes",
-            "resourceId": "fakeid",
-            "namespace": "default"
-        },
-        "providers": {
-            "azure": {
-                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
-            }
-        },
-        "recipes": {
-          "mongo-azure": {
-            "linkType": "Applications.Link/mongoDatabases",
-            "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"
-          },
-          "redis": {
-            "linkType": "Applications.Link/redisCache",
-            "templatePath": "radiusdev.azurecr.io/redis:1.0"
-          },
-          "sql": {
-            "linkType": "Applications.Link/sqlDatabases",
-            "templatePath": "radiusdev.azurecr.io/sql:1.0"
-          }
-        },
-        "useDevRecipes":true,
-        "provisioningState": "Succeeded"
+  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0",
+  "location": "West US",
+  "name": "env0",
+  "properties": {
+    "compute": {
+      "kind": "kubernetes",
+      "resourceId": "fakeid",
+      "namespace": "default"
     },
-    "systemData": {
-        "createdAt": "2022-03-22T18:54:52.6857175Z",
-        "createdBy": "fake@hotmail.com",
-        "createdByType": "User",
-        "lastModifiedAt": "2022-03-22T18:57:52.6857175Z",
-        "lastModifiedBy": "fake@hotmail.com",
-        "lastModifiedByType": "User"
+    "providers": {
+      "azure": {
+        "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+      }
     },
-    "tags": {},
-    "type": "applications.core/environments"
+    "recipes": {
+      "mongo-azure": {
+        "linkType": "Applications.Link/mongoDatabases",
+        "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"
+      },
+      "redis": {
+        "linkType": "Applications.Link/redisCache",
+        "templatePath": "radiusdev.azurecr.io/redis:1.0"
+      },
+      "sql": {
+        "linkType": "Applications.Link/sqlDatabases",
+        "templatePath": "radiusdev.azurecr.io/sql:1.0"
+      }
+    },
+    "useDevRecipes": true,
+    "provisioningState": "Succeeded"
+  },
+  "systemData": {
+    "createdAt": "2022-03-22T18:54:52.6857175Z",
+    "createdBy": "fake@hotmail.com",
+    "createdByType": "User",
+    "lastModifiedAt": "2022-03-22T18:57:52.6857175Z",
+    "lastModifiedBy": "fake@hotmail.com",
+    "lastModifiedByType": "User"
+  },
+  "tags": {},
+  "type": "applications.core/environments"
 }

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipestoexistingoriginal20220315privatepreview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipestoexistingoriginal20220315privatepreview_datamodel.json
@@ -21,15 +21,15 @@
             }
         },
         "recipes": {
-          "sql": {
-            "linkType": "Applications.Link/sqlDatabases",
-            "templatePath": "radiusdev.azurecr.io/sql:1.0"
-          }
+            "sql": {
+                "linkType": "Applications.Link/sqlDatabases",
+                "templatePath": "radiusdev.azurecr.io/sql:1.0"
+            }
         },
-        "useDevRecipes":false,
+        "useDevRecipes": false,
         "providers": {
             "azure": {
-                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+                "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
             }
         }
     },

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentuserrecipesconflictwithreservednames20220315privatepreview_input.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentuserrecipesconflictwithreservednames20220315privatepreview_input.json
@@ -8,14 +8,14 @@
         },
         "recipes": {
             "mongo-azure": {
-              "linkType": "Applications.Link/mongoDatabases",
-              "templatePath": "radiusdev.azurecr.io/mongo:1.0"
+                "linkType": "Applications.Link/mongoDatabases",
+                "templatePath": "radiusdev.azurecr.io/mongo:1.0"
             }
         },
-        "useDevRecipes":true,
+        "useDevRecipes": true,
         "providers": {
             "azure": {
-                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+                "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
             }
         }
     }

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentuserrecipesconflictwithreservednames20220315privatepreview_input.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentuserrecipesconflictwithreservednames20220315privatepreview_input.json
@@ -7,9 +7,9 @@
             "namespace": "default"
         },
         "recipes": {
-          "redis": {
-            "linkType": "Applications.Link/redisCache",
-            "templatePath": "radiusdev.azurecr.io/redis:1.0"
+            "mongo-azure": {
+              "linkType": "Applications.Link/mongoDatabases",
+              "templatePath": "radiusdev.azurecr.io/mongo:1.0"
             }
         },
         "useDevRecipes":true,

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentuserrecipesconflictwithreservednamesoriginal20220315privatepreview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentuserrecipesconflictwithreservednamesoriginal20220315privatepreview_datamodel.json
@@ -1,0 +1,41 @@
+{
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0",
+    "name": "env0",
+    "type": "applications.core/environments",
+    "location": "West US",
+    "systemData": {
+        "createdAt": "2022-03-22T18:54:52.6857175Z",
+        "createdBy": "fake@hotmail.com",
+        "createdByType": "User",
+        "lastModifiedAt": "2022-03-22T18:57:52.6857175Z",
+        "lastModifiedBy": "fake@hotmail.com",
+        "lastModifiedByType": "User"
+    },
+    "provisioningState": "Succeeded",
+    "properties": {
+        "compute": {
+            "kind": "kubernetes",
+            "kubernetes": {
+                "resourceId": "fakeid",
+                "namespace": "default"
+            }
+        },
+        "recipes": {
+            "mongo-azure": {
+                "linkType": "Applications.Link/mongoDatabases",
+                "templatePath": "radiusdev.azurecr.io/mongo:1.0"
+            }
+        },
+        "useDevRecipes":false,
+        "providers": {
+            "azure": {
+                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+            }
+        }
+    },
+    "tenantId": "00000000-0000-0000-0000-000000000000",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "resourceGroup": "radius-test-rg",
+    "createdApiVersion": "2022-03-15-privatepreview",
+    "updatedApiVersion": "2022-03-15-privatepreview"
+}

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentuserrecipesconflictwithreservednamesoriginal20220315privatepreview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentuserrecipesconflictwithreservednamesoriginal20220315privatepreview_datamodel.json
@@ -26,10 +26,10 @@
                 "templatePath": "radiusdev.azurecr.io/mongo:1.0"
             }
         },
-        "useDevRecipes":false,
+        "useDevRecipes": false,
         "providers": {
             "azure": {
-                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+                "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
             }
         }
     },

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentwithdevrecipes20220315privatepreview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentwithdevrecipes20220315privatepreview_datamodel.json
@@ -21,15 +21,15 @@
             }
         },
         "recipes": {
-          "mongo-azure": {
-            "linkType": "Applications.Link/mongoDatabases",
-            "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"
-          }
+            "mongo-azure": {
+                "linkType": "Applications.Link/mongoDatabases",
+                "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"
+            }
         },
-        "useDevRecipes":true,
+        "useDevRecipes": true,
         "providers": {
             "azure": {
-                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+                "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
             }
         }
     },

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentwithdevrecipes20220315privatepreview_input.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentwithdevrecipes20220315privatepreview_input.json
@@ -6,10 +6,10 @@
             "resourceId": "fakeid",
             "namespace": "default"
         },
-        "useDevRecipes":true,
+        "useDevRecipes": true,
         "providers": {
             "azure": {
-                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+                "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
             }
         }
     }

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentwithdevrecipes20220315privatepreview_output.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentwithdevrecipes20220315privatepreview_output.json
@@ -10,16 +10,16 @@
         },
         "providers": {
             "azure": {
-                "scope" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+                "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
             }
         },
         "recipes": {
-          "mongo-azure": {
-            "linkType": "Applications.Link/mongoDatabases",
-            "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"
-          }
+            "mongo-azure": {
+                "linkType": "Applications.Link/mongoDatabases",
+                "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"
+            }
         },
-        "useDevRecipes":true,
+        "useDevRecipes": true,
         "provisioningState": "Succeeded"
     },
     "systemData": {

--- a/pkg/corerp/frontend/controller/environments/v20220315privatepreview_test.go
+++ b/pkg/corerp/frontend/controller/environments/v20220315privatepreview_test.go
@@ -83,3 +83,24 @@ func getTestModelsAppendDevRecipesToExisting20220315privatepreview() (*datamodel
 
 	return envExistingDataModel, envInput, envDataModel, expectedOutput
 }
+
+func getTestModelsUserRecipesConflictWithReservedNames20220315privatepreview() *v20220315privatepreview.EnvironmentResource {
+	rawInput := radiustesting.ReadFixture("environmentuserrecipesconflictwithreservednames20220315privatepreview_input.json")
+	envInput := &v20220315privatepreview.EnvironmentResource{}
+	_ = json.Unmarshal(rawInput, envInput)
+
+	return envInput
+}
+
+func getTestModelsExistingUserRecipesConflictWithReservedNames20220315privatepreview() (*datamodel.Environment, *v20220315privatepreview.EnvironmentResource) {
+
+	rawExistingDataModel := radiustesting.ReadFixture("environmentuserrecipesconflictwithreservednamesoriginal20220315privatepreview_datamodel.json")
+	envExistingDataModel := &datamodel.Environment{}
+	_ = json.Unmarshal(rawExistingDataModel, envExistingDataModel)
+
+	rawInput := radiustesting.ReadFixture("environmentuserrecipesconflictwithreservednames20220315privatepreview_input.json")
+	envInput := &v20220315privatepreview.EnvironmentResource{}
+	_ = json.Unmarshal(rawInput, envInput)
+
+	return envExistingDataModel, envInput
+}


### PR DESCRIPTION
# Description

Reserve the dev recipe names when useDevRecipes is set to true. This will throw an error that specifies all the user recipes that have conflicting names.

## Issue reference

Fixes: #4159 #4165 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
