### PR TITLE
Adding wait-for-completion-timeout to the sample workflow

### DIFF
--- a/.github/workflows/triggersampleworkflow.yml
+++ b/.github/workflows/triggersampleworkflow.yml
@@ -33,6 +33,7 @@ jobs:
         uses: aurelien-baudet/workflow-dispatch@v2
         with:
           workflow: test.yaml
+          wait-for-completion-timeout: 15
           repo: project-radius/samples
           token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
           ref: ${{ env.REL_CHANNEL }}


### PR DESCRIPTION
# Description
Added "wait-for-completion-timeout" to the sample workflow: https://github.com/aurelien-baudet/workflow-dispatch#wait-for-completion-timeout

## Issue reference
Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
