### PR TITLE
fix rad init to ask for providers even for 1st time install

### DIFF
--- a/pkg/cli/cmd/radInit/init.go
+++ b/pkg/cli/cmd/radInit/init.go
@@ -154,35 +154,22 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		Scope:       fmt.Sprintf("/planes/radius/local/resourceGroups/%s", r.EnvName),
 	}
 
-	// This loop is required for adding multiple cloud providers
-	// addingAnotherProvider tracks whether a user wants to add multiple cloud provider or not at the time of prompt
-	addingAnotherProvider := "y"
-	for strings.ToLower(addingAnotherProvider) == "y" && r.Reinstall {
-		var cloudProvider int
-		// This loop is required to move up a level when the user selects [back] as an option
-		// addingCloudProvider tracks whether a user wants to add a new cloud provider at the time of prompt
-		addingCloudProvider := true
-		for addingCloudProvider {
-			cloudProviderPrompter, err := prompt.YesOrNoPrompter("Add cloud providers for cloud resources [y/N]?", "N", r.Prompter)
-			if err != nil {
-				return &cli.FriendlyError{Message: "Error reading cloud provider"}
-			}
-			if strings.ToLower(cloudProviderPrompter) == "n" {
-				cloudProvider = -1
-				break
-			}
-			cloudProvider, err = selectCloudProvider(r.Output, r.Prompter)
-			if err != nil {
-				return &cli.FriendlyError{Message: "Error reading cloud provider"}
-			}
-			// cloudProvider being -1 represents the user doesn't wants to add one
-			if cloudProvider != -1 {
-				addingCloudProvider = false
-			}
+	var cloudProvider int
+	// This loop is required to move up a level when the user selects [back] as an option
+	// addingCloudProvider tracks whether a user wants to add a new cloud provider at the time of prompt
+	addingCloudProvider := true
+	for addingCloudProvider {
+		cloudProviderPrompter, err := prompt.YesOrNoPrompter("Add cloud providers for cloud resources [y/N]?", "N", r.Prompter)
+		if err != nil {
+			return &cli.FriendlyError{Message: "Error reading cloud provider"}
 		}
-		// if the user doesn't want to add a cloud provider, then break out of the adding provider prompt block
-		if cloudProvider == -1 {
+		if strings.ToLower(cloudProviderPrompter) == "n" {
+			cloudProvider = -1
 			break
+		}
+		cloudProvider, err = selectCloudProvider(r.Output, r.Prompter)
+		if err != nil {
+			return &cli.FriendlyError{Message: "Error reading cloud provider"}
 		}
 		switch cloudProvider {
 		case Azure:
@@ -192,6 +179,10 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 			}
 		case AWS:
 			r.Output.LogInfo("AWS is not supported")
+		}
+		// cloudProvider being -1 represents the user doesn't wants to add one
+		if cloudProvider != -1 {
+			addingCloudProvider = false
 		}
 	}
 

--- a/pkg/cli/cmd/radInit/init_test.go
+++ b/pkg/cli/cmd/radInit/init_test.go
@@ -246,7 +246,6 @@ func initMocksWithCloudProvider(kubernetesMock *kubernetes.MockInterface, prompt
 	initPromptYes(prompterMock)
 	initSelectCloudProvider(prompterMock)
 	initParseCloudProvider(azureMock, prompterMock)
-	initAddCloudProviderPromptNo(prompterMock) // N dont add another cloud provider
 }
 
 func initParseCloudProvider(azureMock *setup.MockInterface, prompterMock *prompt.MockInterface) {


### PR DESCRIPTION
# Description

`rad init` doesn't allow users to input provider information on initial install

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: radius-project/core-team#994

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
