### PR TITLE
Add diagnostics for fallback, non-named workspaces

### DIFF
--- a/pkg/cli/workspaces/err.go
+++ b/pkg/cli/workspaces/err.go
@@ -1,0 +1,32 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package workspaces
+
+var _ error = (*NamedWorkspaceRequiredError)(nil)
+
+// ErrNamedWorkspaceRequired is a value of NamedWorkspaceRequiredError.
+var ErrNamedWorkspaceRequired error = &NamedWorkspaceRequiredError{}
+
+// NamedWorkspaceRequiredError is an error used when a named workspace must be specified by the user.
+type NamedWorkspaceRequiredError struct {
+}
+
+func (*NamedWorkspaceRequiredError) Error() string {
+	return "This operation requires a named workspace. Specify a named workspace using the `--workspace` command line flag."
+}
+
+var _ error = (*EditableWorkspaceRequiredError)(nil)
+
+// ErrNamedWorkspaceRequired is a value of EditableWorkspaceRequiredError.
+var ErrEditableWorkspaceRequired error = &EditableWorkspaceRequiredError{}
+
+// EditableWorkspaceRequiredError is an error used when an editable workspace must be specified by the user.
+type EditableWorkspaceRequiredError struct {
+}
+
+func (*EditableWorkspaceRequiredError) Error() string {
+	return "This operation requires a workspace. Use `rad init` to scaffold a workspace in the local directory, or specify a named workspace using the `--workspace` command line flag."
+}

--- a/pkg/cli/workspaces/types.go
+++ b/pkg/cli/workspaces/types.go
@@ -5,10 +5,23 @@
 
 package workspaces
 
-// Workspace represents a single workspace entry in config.
+// Workspace represents configuration for the rad CLI.
+//
+// Workspaces may:
+//
+// - be stored in per-user config (~/.rad/config.yaml) OR
+//
+// - be stored in the user's working directory `$pwd/.rad/rad.yaml` OR
+//
+// - may represent the rad CLI's fallback configuration when no configuration is present
 type Workspace struct {
+	// Source indicates how the workspace was loaded.
+	Source Source `json:"-" mapstructure:"-" yaml:"-"`
+
 	// Name is the name of the workspace. The name is not stored as part of the workspace entry but is populated
 	// by the configuration APIs in this package.
+	//
+	// Will be set if the Source == SourceUserConfig, otherwise will be empty.
 	Name string `json:"-" mapstructure:"-" yaml:"-"`
 
 	// Connection represents the connection to the workspace. The details required by the connection are different
@@ -31,6 +44,32 @@ type Workspace struct {
 	// ProviderConfig represents the configuration for IAC providers used during deployment. This field is optional.
 	ProviderConfig ProviderConfig `json:"providerConfig,omitempty" mapstructure:"providerConfig" yaml:"providerConfig,omitempty" validate:"dive"`
 }
+
+// IsNamedWorkspace returns true for workspaces stored in per-user configuration. These workspaces have names that can
+// be referenced in commands with the `--workspace` flag.
+func (w Workspace) IsNamedWorkspace() bool {
+	return w.Source == SourceUserConfig
+}
+
+// IsEditableWorkspace returns true for workspaces stored in per-user or directory-based configuration. These workspaces
+// have configuration files and thus can have their settings updated.
+func (w Workspace) IsEditableWorkspace() bool {
+	return w.Source != SourceFallback
+}
+
+// Source specifies how a workspace was loaded.
+type Source string
+
+const (
+	// SourceFallback indicates that the workspace was not loaded from config, and is using default settings.
+	SourceFallback = "fallback"
+
+	// SourceLocalDirectory indicates that the workspace was loaded from the users working directory.
+	SourceLocalDirectory = "localdirectory"
+
+	// SourceUserConfig indicates that the workspace was loaded from per-user config.
+	SourceUserConfig = "userconfig"
+)
 
 // ProviderConfig represents the configuration for IAC providers used during deployment.
 type ProviderConfig struct {


### PR DESCRIPTION
We're removing the dependency on workspaces that are stored in per-user config in most commands to make the CLI more flexible. This is all tracked as part of radius-project/core-team#999.

This change adds errors and error messages for these cases as well as the ability to detect them. My strategy is to start with named-workspaces as a requirement for all of our commands and then gradually roll out support for the more flexible cases. This way the PRs stay incremental and reviewable.

The next PR will update the configuration system to work with the fallback workspace, and update commands and tests to report good errors until they support for the fallback.
