### PR TITLE
Fix tests for required flags

### DIFF
--- a/pkg/cli/cmd/env/create/create_test.go
+++ b/pkg/cli/cmd/env/create/create_test.go
@@ -29,7 +29,6 @@ func Test_CommandValidation(t *testing.T) {
 
 func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
-	configWithoutWorkspace := radcli.LoadConfigWithoutWorkspace(t)
 
 	ctrl := gomock.NewController(t)
 	appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
@@ -83,7 +82,7 @@ func Test_Validate(t *testing.T) {
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithoutWorkspace,
+				Config:         radcli.LoadConfigWithoutWorkspace(t),
 			},
 			ConnectionFactory:  &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
 			NamespaceInterface: namespaceClient,

--- a/pkg/cli/cmd/group/create/create_test.go
+++ b/pkg/cli/cmd/group/create/create_test.go
@@ -25,7 +25,6 @@ func Test_CommandValidation(t *testing.T) {
 
 func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
-	configWithoutWorkspace := radcli.LoadConfigWithoutWorkspace(t)
 	testcases := []radcli.ValidateInput{
 		{
 			Name:          "Create Command with incorrect args",
@@ -42,7 +41,7 @@ func Test_Validate(t *testing.T) {
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithoutWorkspace,
+				Config:         radcli.LoadConfigWithoutWorkspace(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/group/list/list_test.go
+++ b/pkg/cli/cmd/group/list/list_test.go
@@ -26,7 +26,6 @@ func Test_CommandValidation(t *testing.T) {
 
 func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
-	configWithoutWorkspace := radcli.LoadConfigWithWorkspace(t)
 
 	testcases := []radcli.ValidateInput{
 		{
@@ -44,12 +43,12 @@ func Test_Validate(t *testing.T) {
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithoutWorkspace,
+				Config:         configWithWorkspace,
 			},
 		},
 		{
 			Name:          "List Command with valid workspace specified",
-			Input:         []string{},
+			Input:         []string{"-w", radcli.TestWorkspaceName},
 			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",

--- a/pkg/cli/cmd/provider/create/azure/azure_test.go
+++ b/pkg/cli/cmd/provider/create/azure/azure_test.go
@@ -28,7 +28,6 @@ func Test_CommandValidation(t *testing.T) {
 
 func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
-	configWithoutWorkspace := radcli.LoadConfigWithoutWorkspace(t)
 	testcases := []radcli.ValidateInput{
 		{
 			Name: "Valid Azure command",
@@ -52,7 +51,7 @@ func Test_Validate(t *testing.T) {
 				"--resource-group", "cool-group",
 			},
 			ExpectedValid: false,
-			ConfigHolder:  framework.ConfigHolder{Config: configWithoutWorkspace},
+			ConfigHolder:  framework.ConfigHolder{Config: radcli.LoadConfigWithoutWorkspace(t)},
 		},
 		{
 			Name: "Azure command with too many positional args",
@@ -65,7 +64,7 @@ func Test_Validate(t *testing.T) {
 				"--resource-group", "cool-group",
 			},
 			ExpectedValid: false,
-			ConfigHolder:  framework.ConfigHolder{Config: configWithoutWorkspace},
+			ConfigHolder:  framework.ConfigHolder{Config: configWithWorkspace},
 		},
 		{
 			Name: "Azure command without client-id",
@@ -76,7 +75,7 @@ func Test_Validate(t *testing.T) {
 				"--resource-group", "cool-group",
 			},
 			ExpectedValid: false,
-			ConfigHolder:  framework.ConfigHolder{Config: configWithoutWorkspace},
+			ConfigHolder:  framework.ConfigHolder{Config: configWithWorkspace},
 		},
 		{
 			Name: "Azure command without client-secret",
@@ -87,7 +86,7 @@ func Test_Validate(t *testing.T) {
 				"--resource-group", "cool-group",
 			},
 			ExpectedValid: false,
-			ConfigHolder:  framework.ConfigHolder{Config: configWithoutWorkspace},
+			ConfigHolder:  framework.ConfigHolder{Config: configWithWorkspace},
 		},
 		{
 			Name: "Azure command without tenant-id",
@@ -98,7 +97,7 @@ func Test_Validate(t *testing.T) {
 				"--resource-group", "cool-group",
 			},
 			ExpectedValid: false,
-			ConfigHolder:  framework.ConfigHolder{Config: configWithoutWorkspace},
+			ConfigHolder:  framework.ConfigHolder{Config: configWithWorkspace},
 		},
 		{
 			Name: "Azure command without subscription",
@@ -109,7 +108,7 @@ func Test_Validate(t *testing.T) {
 				"--resource-group", "cool-group",
 			},
 			ExpectedValid: false,
-			ConfigHolder:  framework.ConfigHolder{Config: configWithoutWorkspace},
+			ConfigHolder:  framework.ConfigHolder{Config: configWithWorkspace},
 		},
 		{
 			Name: "Azure command without resource group",
@@ -121,7 +120,7 @@ func Test_Validate(t *testing.T) {
 				"--subscription", "E3955194-FC78-40A8-8143-C5D8DCDC45C5",
 			},
 			ExpectedValid: false,
-			ConfigHolder:  framework.ConfigHolder{Config: configWithoutWorkspace},
+			ConfigHolder:  framework.ConfigHolder{Config: configWithWorkspace},
 		},
 		{
 			Name: "Azure command with invalid subscription id",
@@ -133,7 +132,7 @@ func Test_Validate(t *testing.T) {
 				"--resource-group", "cool-group",
 			},
 			ExpectedValid: false,
-			ConfigHolder:  framework.ConfigHolder{Config: configWithoutWorkspace},
+			ConfigHolder:  framework.ConfigHolder{Config: configWithWorkspace},
 		},
 	}
 	radcli.SharedValidateValidation(t, NewCommand, testcases)

--- a/pkg/cli/cmd/provider/delete/delete_test.go
+++ b/pkg/cli/cmd/provider/delete/delete_test.go
@@ -25,7 +25,6 @@ func Test_CommandValidation(t *testing.T) {
 
 func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
-	configWithoutWorkspace := radcli.LoadConfigWithoutWorkspace(t)
 	testcases := []radcli.ValidateInput{
 		{
 			Name:          "Valid Delete Command",
@@ -42,7 +41,7 @@ func Test_Validate(t *testing.T) {
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithoutWorkspace,
+				Config:         radcli.LoadConfigWithoutWorkspace(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/provider/list/list_test.go
+++ b/pkg/cli/cmd/provider/list/list_test.go
@@ -26,7 +26,6 @@ func Test_CommandValidation(t *testing.T) {
 
 func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
-	configWithoutWorkspace := radcli.LoadConfigWithoutWorkspace(t)
 	testcases := []radcli.ValidateInput{
 		{
 			Name:          "Valid List Command",
@@ -43,7 +42,7 @@ func Test_Validate(t *testing.T) {
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithoutWorkspace,
+				Config:         radcli.LoadConfigWithoutWorkspace(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/provider/show/show_test.go
+++ b/pkg/cli/cmd/provider/show/show_test.go
@@ -26,7 +26,6 @@ func Test_CommandValidation(t *testing.T) {
 
 func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
-	configWithoutWorkspace := radcli.LoadConfigWithoutWorkspace(t)
 	testcases := []radcli.ValidateInput{
 		{
 			Name:          "Valid Show Command",
@@ -43,7 +42,7 @@ func Test_Validate(t *testing.T) {
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithoutWorkspace,
+				Config:         radcli.LoadConfigWithoutWorkspace(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/recipe/create/create.go
+++ b/pkg/cli/cmd/recipe/create/create.go
@@ -37,8 +37,11 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	commonflags.AddWorkspaceFlag(cmd)
 	commonflags.AddEnvironmentNameFlag(cmd)
 	cmd.Flags().String("template-path", "", "specify the path to the template provided by the recipe.")
+	_ = cmd.MarkFlagRequired("template-path")
 	cmd.Flags().String("link-type", "", "specify the type of the link this recipe can be consumed by")
+	_ = cmd.MarkFlagRequired("link-type")
 	cmd.Flags().String("name", "", "specify the name of the recipe")
+	_ = cmd.MarkFlagRequired("name")
 
 	return cmd, runner
 }

--- a/pkg/cli/cmd/recipe/create/create_test.go
+++ b/pkg/cli/cmd/recipe/create/create_test.go
@@ -27,7 +27,6 @@ func Test_CommandValidation(t *testing.T) {
 
 func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
-	configWithoutWorkspace := radcli.LoadConfigWithoutWorkspace(t)
 	testcases := []radcli.ValidateInput{
 		{
 			Name:          "Valid Create Command",
@@ -39,21 +38,30 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
+			Name:          "Create Command without workspace",
+			Input:         []string{"--name", "test_recipe", "--template-path", "test_template", "--link-type", "Applications.Link/mongoDatabases"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         radcli.LoadConfigWithoutWorkspace(t),
+			},
+		},
+		{
 			Name:          "Create Command without name",
 			Input:         []string{"--template-path", "test_template", "--link-type", "Applications.Link/mongoDatabases"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithoutWorkspace,
+				Config:         configWithWorkspace,
 			},
 		},
 		{
-			Name:          "Create Command without link-type",
+			Name:          "Create Command without template path",
 			Input:         []string{"--name", "test_recipe", "--link-type", "Applications.Link/mongoDatabases"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithoutWorkspace,
+				Config:         configWithWorkspace,
 			},
 		},
 		{
@@ -62,7 +70,7 @@ func Test_Validate(t *testing.T) {
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithoutWorkspace,
+				Config:         configWithWorkspace,
 			},
 		},
 		{

--- a/pkg/cli/cmd/recipe/delete/delete.go
+++ b/pkg/cli/cmd/recipe/delete/delete.go
@@ -35,6 +35,7 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	commonflags.AddWorkspaceFlag(cmd)
 	commonflags.AddEnvironmentNameFlag(cmd)
 	cmd.Flags().String("name", "", "specify the name of the recipe")
+	_ = cmd.MarkFlagRequired("name")
 
 	return cmd, runner
 }

--- a/pkg/cli/cmd/recipe/delete/delete_test.go
+++ b/pkg/cli/cmd/recipe/delete/delete_test.go
@@ -27,7 +27,6 @@ func Test_CommandValidation(t *testing.T) {
 
 func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
-	configWithoutWorkspace := radcli.LoadConfigWithoutWorkspace(t)
 	testcases := []radcli.ValidateInput{
 		{
 			Name:          "Valid Delete Command",
@@ -39,17 +38,26 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
+			Name:          "Delete Command without workspace",
+			Input:         []string{"--name", "test_recipe"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         radcli.LoadConfigWithoutWorkspace(t),
+			},
+		},
+		{
 			Name:          "Delete Command without name",
 			Input:         []string{},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithoutWorkspace,
+				Config:         configWithWorkspace,
 			},
 		},
 		{
 			Name:          "Delete Command with too many args",
-			Input:         []string{"foo", "bar", "foo1"},
+			Input:         []string{"--name", "foo", "bar", "foo1"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",

--- a/pkg/cli/cmd/recipe/list/list_test.go
+++ b/pkg/cli/cmd/recipe/list/list_test.go
@@ -28,7 +28,6 @@ func Test_CommandValidation(t *testing.T) {
 
 func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
-	configWithoutWorkspace := radcli.LoadConfigWithoutWorkspace(t)
 	testcases := []radcli.ValidateInput{
 		{
 			Name:          "Valid List Command",
@@ -45,7 +44,7 @@ func Test_Validate(t *testing.T) {
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithoutWorkspace,
+				Config:         radcli.LoadConfigWithoutWorkspace(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/resource/delete/delete_test.go
+++ b/pkg/cli/cmd/resource/delete/delete_test.go
@@ -25,7 +25,6 @@ func Test_CommandValidation(t *testing.T) {
 
 func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
-	configWithoutWorkspace := radcli.LoadConfigWithoutWorkspace(t)
 	testcases := []radcli.ValidateInput{
 		{
 			Name:          "Valid Delete Command",
@@ -42,7 +41,7 @@ func Test_Validate(t *testing.T) {
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithoutWorkspace,
+				Config:         radcli.LoadConfigWithoutWorkspace(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/resource/list/list_test.go
+++ b/pkg/cli/cmd/resource/list/list_test.go
@@ -30,7 +30,6 @@ func Test_CommandValidation(t *testing.T) {
 
 func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
-	configWithoutWorkspace := radcli.LoadConfigWithoutWorkspace(t)
 	testcases := []radcli.ValidateInput{
 		{
 			Name:          "Valid List Command",
@@ -56,7 +55,7 @@ func Test_Validate(t *testing.T) {
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithoutWorkspace,
+				Config:         radcli.LoadConfigWithoutWorkspace(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/resource/show/show_test.go
+++ b/pkg/cli/cmd/resource/show/show_test.go
@@ -33,7 +33,6 @@ func Test_CommandValidation(t *testing.T) {
 
 func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
-	configWithoutWorkspace := radcli.LoadConfigWithoutWorkspace(t)
 	testcases := []radcli.ValidateInput{
 		{
 			Name:          "Valid Show Command",
@@ -50,7 +49,7 @@ func Test_Validate(t *testing.T) {
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithoutWorkspace,
+				Config:         radcli.LoadConfigWithoutWorkspace(t),
 			},
 		},
 		{


### PR DESCRIPTION
While I was making some other CLI changes I found more missing validation in our CLI tests. Many of our tests use the "no workspace" configuration when they are testing other kinds of argument validation. This leads to false-negatives, something that needs to fail due to argument validation is actually failing for other reasons.

When I dug deeper here, there's yet another issue with testing cobra's behaviors. There's no good way to test required flags without running some of their logic. I had to transcribe some of their functionality into our framework, but the good news is that its now possible to test required args.

This change fixes the places where this validation was missing, and limits the scope of our "no workspace" testing to just the tests focused on that use case.
