### PR TITLE
Use prompt interface in delete group

### DIFF
--- a/pkg/cli/cmd/group/delete/delete.go
+++ b/pkg/cli/cmd/group/delete/delete.go
@@ -44,6 +44,7 @@ type Runner struct {
 	ConfigHolder         *framework.ConfigHolder
 	ConnectionFactory    connections.Factory
 	Output               output.Interface
+	Prompter             prompt.Interface
 	Workspace            *workspaces.Workspace
 	UCPResourceGroupName string
 	Confirmation         bool
@@ -54,6 +55,7 @@ func NewRunner(factory framework.Factory) *Runner {
 		ConnectionFactory: factory.GetConnectionFactory(),
 		ConfigHolder:      factory.GetConfigHolder(),
 		Output:            factory.GetOutput(),
+		Prompter:          factory.GetPrompter(),
 	}
 }
 
@@ -86,7 +88,7 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	// Prompt user to confirm deletion
 	if !r.Confirmation {
-		confirmed, err := prompt.ConfirmWithDefault(fmt.Sprintf("Are you sure you want to delete the resource group '%v'? A resource group can be deleted only when empty", r.UCPResourceGroupName), prompt.No)
+		confirmed, err := r.Prompter.ConfirmWithDefault(fmt.Sprintf("Are you sure you want to delete the resource group '%v'? A resource group can be deleted only when empty", r.UCPResourceGroupName), prompt.No)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/cmd/group/delete/delete_test.go
+++ b/pkg/cli/cmd/group/delete/delete_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/framework"
 	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/project-radius/radius/pkg/cli/prompt"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/project-radius/radius/test/radcli"
 	"github.com/stretchr/testify/require"
@@ -42,6 +43,15 @@ func Test_Validate(t *testing.T) {
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
 				Config:         configWithWorkspace,
+			},
+		},
+		{
+			Name:          "Delete Command with no workspace",
+			Input:         []string{"groupname"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         radcli.LoadConfigWithoutWorkspace(t),
 			},
 		},
 	}
@@ -120,11 +130,19 @@ func Test_Run(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
 			outputSink := &output.MockOutput{}
+
+			prompter := prompt.NewMockInterface(ctrl)
+			prompter.EXPECT().
+				ConfirmWithDefault("Are you sure you want to delete the resource group 'testrg'? A resource group can be deleted only when empty", prompt.No).
+				Return(false, nil).
+				Times(1)
+
 			runner := &Runner{
 				ConnectionFactory:    &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
 				Workspace:            &workspaces.Workspace{},
 				UCPResourceGroupName: "testrg",
 				Confirmation:         false,
+				Prompter:             prompter,
 				Output:               outputSink,
 			}
 


### PR DESCRIPTION
This change updates the group delete command to use the prompt interface. This test appears to have different behaviors depending on how the test is run, because it's trying to interact directly with stdin. We want to avoid this anyway.
