### PR TITLE
Adds fallback workspace but block its use

### DIFF
--- a/cmd/rad/cmd/appDelete.go
+++ b/cmd/rad/cmd/appDelete.go
@@ -43,6 +43,11 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// TODO: support fallback workspace
+	if !workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
 	applicationName, err := cli.RequireApplicationArgs(cmd, args, *workspace)
 	if err != nil {
 		return err

--- a/cmd/rad/cmd/appList.go
+++ b/cmd/rad/cmd/appList.go
@@ -10,6 +10,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/objectformats"
 	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/spf13/cobra"
 )
 
@@ -31,6 +32,11 @@ func listApplications(cmd *cobra.Command, args []string) error {
 	workspace, err := cli.RequireWorkspace(cmd, config)
 	if err != nil {
 		return err
+	}
+
+	// TODO: support fallback workspace
+	if !workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
 	}
 
 	client, err := connections.DefaultFactory.CreateApplicationsManagementClient(cmd.Context(), *workspace)

--- a/cmd/rad/cmd/appShow.go
+++ b/cmd/rad/cmd/appShow.go
@@ -32,6 +32,11 @@ func showApplication(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// TODO: support fallback workspace
+	if !workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
 	applicationName, err := cli.RequireApplicationArgs(cmd, args, *workspace)
 	if err != nil {
 		return err

--- a/cmd/rad/cmd/appStatus.go
+++ b/cmd/rad/cmd/appStatus.go
@@ -13,6 +13,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/objectformats"
 	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/project-radius/radius/pkg/ucp/resources"
 	"github.com/spf13/cobra"
 )
@@ -34,6 +35,11 @@ func showApplicationStatus(cmd *cobra.Command, args []string) error {
 	workspace, err := cli.RequireWorkspace(cmd, config)
 	if err != nil {
 		return err
+	}
+
+	// TODO: support fallback workspace
+	if !workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
 	}
 
 	application, err := cli.RequireApplicationArgs(cmd, args, *workspace)

--- a/cmd/rad/cmd/deploy.go
+++ b/cmd/rad/cmd/deploy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/deploy"
 	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/project-radius/radius/pkg/version"
 	"github.com/spf13/cobra"
 )
@@ -109,6 +110,11 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	workspace, err := cli.RequireWorkspace(cmd, config)
 	if err != nil {
 		return err
+	}
+
+	// TODO: support fallback workspace
+	if !workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
 	}
 
 	environmentName, err := cli.RequireEnvironmentName(cmd, args, *workspace)

--- a/cmd/rad/cmd/envDelete.go
+++ b/cmd/rad/cmd/envDelete.go
@@ -14,6 +14,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/project-radius/radius/pkg/cli/prompt"
+	"github.com/project-radius/radius/pkg/cli/workspaces"
 )
 
 var envDeleteCmd = &cobra.Command{
@@ -34,6 +35,11 @@ func deleteEnvResource(cmd *cobra.Command, args []string) error {
 	workspace, err := cli.RequireWorkspace(cmd, config)
 	if err != nil {
 		return err
+	}
+
+	// TODO: support fallback workspace
+	if !workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
 	}
 
 	environmentName, err := cli.RequireEnvironmentNameArgs(cmd, args, *workspace)

--- a/cmd/rad/cmd/envList.go
+++ b/cmd/rad/cmd/envList.go
@@ -10,6 +10,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/objectformats"
 	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
 	"github.com/spf13/cobra"
 )
@@ -26,6 +27,11 @@ func getEnvConfigs(cmd *cobra.Command, args []string) error {
 	workspace, err := cli.RequireWorkspace(cmd, config)
 	if err != nil {
 		return err
+	}
+
+	// TODO: support fallback workspace
+	if !workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
 	}
 
 	client, err := connections.DefaultFactory.CreateApplicationsManagementClient(cmd.Context(), *workspace)

--- a/cmd/rad/cmd/envShow.go
+++ b/cmd/rad/cmd/envShow.go
@@ -9,6 +9,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/objectformats"
 	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/spf13/cobra"
 )
 
@@ -33,6 +34,11 @@ func showEnvironment(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	// TODO: support fallback workspace
+	if !workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
 	environmentName, err := cli.RequireEnvironmentNameArgs(cmd, args, *workspace)
 	if err != nil {
 		return err

--- a/cmd/rad/cmd/resourceExpose.go
+++ b/cmd/rad/cmd/resourceExpose.go
@@ -14,6 +14,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/connections"
+	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/spf13/cobra"
 )
 
@@ -38,6 +39,11 @@ rad resource expose --application icecream-store containers orders --port 5000 -
 		workspace, err := cli.RequireWorkspace(cmd, config)
 		if err != nil {
 			return err
+		}
+
+		// TODO: support fallback workspace
+		if !workspace.IsNamedWorkspace() {
+			return workspaces.ErrNamedWorkspaceRequired
 		}
 
 		// This gets the application name from the args provided

--- a/cmd/rad/cmd/resourceLogs.go
+++ b/cmd/rad/cmd/resourceLogs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/connections"
+	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/spf13/cobra"
 )
 
@@ -46,6 +47,11 @@ rad resource logs containers orders --application icecream-store --container dap
 		workspace, err := cli.RequireWorkspace(cmd, config)
 		if err != nil {
 			return err
+		}
+
+		// TODO: support fallback workspace
+		if !workspace.IsNamedWorkspace() {
+			return workspaces.ErrNamedWorkspaceRequired
 		}
 
 		application, err := cli.RequireApplication(cmd, *workspace)

--- a/pkg/cli/cmd/app/appswitch/switch.go
+++ b/pkg/cli/cmd/app/appswitch/switch.go
@@ -61,6 +61,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
+	if !r.Workspace.IsEditableWorkspace() {
+		// Only workspaces stored in configuration can be modified.
+		return workspaces.ErrEditableWorkspaceRequired
+	}
+
 	r.ApplicationName, err = cli.ReadApplicationNameArgs(cmd, args)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/app/appswitch/switch_test.go
+++ b/pkg/cli/cmd/app/appswitch/switch_test.go
@@ -38,6 +38,12 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
+			Name:          "Switch Command with non-editable workspace invalid",
+			Input:         []string{},
+			ExpectedValid: false,
+			ConfigHolder:  framework.ConfigHolder{Config: radcli.LoadEmptyConfig(t)},
+		},
+		{
 			Name:          "Switch Command with non-existent app",
 			Input:         []string{"nonExistentApp"},
 			ExpectedValid: false,

--- a/pkg/cli/cmd/env/create/create.go
+++ b/pkg/cli/cmd/env/create/create.go
@@ -82,6 +82,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
+	// TODO: support fallback workspace
+	if !r.Workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
 	r.EnvironmentName, err = cli.RequireEnvironmentNameArgs(cmd, args, *workspace)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/env/create/create_test.go
+++ b/pkg/cli/cmd/env/create/create_test.go
@@ -73,12 +73,12 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "Create command without workspace",
+			Name:          "Create command with fallback workspace",
 			Input:         []string{"testingenv"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         radcli.LoadConfigWithoutWorkspace(t),
+				Config:         radcli.LoadEmptyConfig(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/env/envswitch/switch.go
+++ b/pkg/cli/cmd/env/envswitch/switch.go
@@ -67,6 +67,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
+	if !r.Workspace.IsEditableWorkspace() {
+		// Only workspaces stored in configuration can be modified.
+		return workspaces.ErrEditableWorkspaceRequired
+	}
+
 	r.EnvironmentName, err = cli.RequireEnvironmentNameArgs(cmd, args, *r.Workspace)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/env/envswitch/switch_test.go
+++ b/pkg/cli/cmd/env/envswitch/switch_test.go
@@ -49,6 +49,12 @@ func Test_Validate(t *testing.T) {
 				createGetEnvDetailsError(mocks.ApplicationManagementClient)
 			},
 		},
+		{
+			Name:          "Switch Command with non-editable workspace invalid",
+			Input:         []string{},
+			ExpectedValid: false,
+			ConfigHolder:  framework.ConfigHolder{Config: radcli.LoadEmptyConfig(t)},
+		},
 	}
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
 }

--- a/pkg/cli/cmd/group/create/create.go
+++ b/pkg/cli/cmd/group/create/create.go
@@ -70,6 +70,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// TODO: support fallback workspace
+	if !workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
 	resourceGroup, err := cli.RequireUCPResourceGroup(cmd, args)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/group/create/create_test.go
+++ b/pkg/cli/cmd/group/create/create_test.go
@@ -36,12 +36,12 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "Create Command with  valid args but no workspace",
+			Name:          "Create Command with valid args and fallback workspace",
 			Input:         []string{"rg"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         radcli.LoadConfigWithoutWorkspace(t),
+				Config:         radcli.LoadEmptyConfig(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/group/delete/delete.go
+++ b/pkg/cli/cmd/group/delete/delete.go
@@ -67,6 +67,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// TODO: support fallback workspace
+	if !workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
 	resourceGroup, err := cli.RequireUCPResourceGroup(cmd, args)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/group/delete/delete_test.go
+++ b/pkg/cli/cmd/group/delete/delete_test.go
@@ -46,12 +46,12 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "Delete Command with no workspace",
+			Name:          "Delete Command with fallback workspace",
 			Input:         []string{"groupname"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         radcli.LoadConfigWithoutWorkspace(t),
+				Config:         radcli.LoadEmptyConfig(t),
 			},
 		},
 	}

--- a/pkg/cli/cmd/group/groupswitch/switch.go
+++ b/pkg/cli/cmd/group/groupswitch/switch.go
@@ -62,6 +62,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if !workspace.IsEditableWorkspace() {
+		// Only workspaces stored in configuration can be modified.
+		return workspaces.ErrEditableWorkspaceRequired
+	}
+
 	resourceGroup, err := cli.RequireUCPResourceGroup(cmd, args)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/group/groupswitch/switch_test.go
+++ b/pkg/cli/cmd/group/groupswitch/switch_test.go
@@ -50,6 +50,15 @@ func Test_Validate(t *testing.T) {
 				Config:         configWithWorkspace,
 			},
 		},
+		{
+			Name:          "Switch command with non-editable workspace invalid",
+			Input:         []string{"groupname"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         radcli.LoadEmptyConfig(t),
+			},
+		},
 	}
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
 }
@@ -68,14 +77,16 @@ func Test_Run(t *testing.T) {
 								"kind":    workspaces.KindKubernetes,
 								"context": "my-context",
 							},
-							Scope: "/planes/radius/local/resourceGroups/a",
+							Source: workspaces.SourceUserConfig,
+							Scope:  "/planes/radius/local/resourceGroups/a",
 						},
 						"b": {
 							Connection: map[string]interface{}{
 								"kind":    workspaces.KindKubernetes,
 								"context": "my-context",
 							},
-							Scope: "/planes/radius/local/resourceGroups/b",
+							Source: workspaces.SourceUserConfig,
+							Scope:  "/planes/radius/local/resourceGroups/b",
 						},
 					},
 				},
@@ -94,7 +105,8 @@ func Test_Run(t *testing.T) {
 							"kind":    workspaces.KindKubernetes,
 							"context": "my-context",
 						},
-						Scope: "/planes/radius/local/resourceGroups/a",
+						Source: workspaces.SourceUserConfig,
+						Scope:  "/planes/radius/local/resourceGroups/a",
 					},
 					"b": {
 						Name: "b",
@@ -102,7 +114,8 @@ func Test_Run(t *testing.T) {
 							"kind":    workspaces.KindKubernetes,
 							"context": "my-context",
 						},
-						Scope: "/planes/radius/local/resourceGroups/a",
+						Source: workspaces.SourceUserConfig,
+						Scope:  "/planes/radius/local/resourceGroups/a",
 					},
 				},
 			}
@@ -155,7 +168,8 @@ func Test_Run(t *testing.T) {
 								"kind":    workspaces.KindKubernetes,
 								"context": "my-context",
 							},
-							Scope: "/planes/radius/local/resourceGroups/b",
+							Source: workspaces.SourceUserConfig,
+							Scope:  "/planes/radius/local/resourceGroups/b",
 						},
 					},
 				},
@@ -179,7 +193,8 @@ func Test_Run(t *testing.T) {
 					"kind":    workspaces.KindKubernetes,
 					"context": "my-context",
 				},
-				Scope: "/planes/radius/local/resourceGroups/b",
+				Source: workspaces.SourceUserConfig,
+				Scope:  "/planes/radius/local/resourceGroups/b",
 			}
 
 			runner := &Runner{

--- a/pkg/cli/cmd/group/list/list.go
+++ b/pkg/cli/cmd/group/list/list.go
@@ -68,6 +68,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// TODO: support fallback workspace
+	if !workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
 	format, err := cmd.Flags().GetString("output")
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/group/list/list_test.go
+++ b/pkg/cli/cmd/group/list/list_test.go
@@ -55,6 +55,15 @@ func Test_Validate(t *testing.T) {
 				Config:         configWithWorkspace,
 			},
 		},
+		{
+			Name:          "List Command with fallback workspace",
+			Input:         []string{},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         radcli.LoadEmptyConfig(t),
+			},
+		},
 	}
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
 }

--- a/pkg/cli/cmd/group/show/show.go
+++ b/pkg/cli/cmd/group/show/show.go
@@ -69,6 +69,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// TODO: support fallback workspace
+	if !workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
 	format, err := cli.RequireOutput(cmd)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/group/show/show_test.go
+++ b/pkg/cli/cmd/group/show/show_test.go
@@ -49,6 +49,15 @@ func Test_Validate(t *testing.T) {
 				Config:         configWithWorkspace,
 			},
 		},
+		{
+			Name:          "Show Command with fallback workspace",
+			Input:         []string{"groupname"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         radcli.LoadEmptyConfig(t),
+			},
+		},
 	}
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
 }

--- a/pkg/cli/cmd/provider/create/azure/azure.go
+++ b/pkg/cli/cmd/provider/create/azure/azure.go
@@ -99,6 +99,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
+	// TODO: support fallback workspace
+	if !r.Workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
 	format, err := cli.RequireOutput(cmd)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/provider/create/azure/azure_test.go
+++ b/pkg/cli/cmd/provider/create/azure/azure_test.go
@@ -42,7 +42,7 @@ func Test_Validate(t *testing.T) {
 			ConfigHolder:  framework.ConfigHolder{Config: configWithWorkspace},
 		},
 		{
-			Name: "Azure command without workspace",
+			Name: "Azure command with fallback workspace",
 			Input: []string{
 				"--client-id", "abcd",
 				"--client-secret", "efgh",
@@ -51,7 +51,7 @@ func Test_Validate(t *testing.T) {
 				"--resource-group", "cool-group",
 			},
 			ExpectedValid: false,
-			ConfigHolder:  framework.ConfigHolder{Config: radcli.LoadConfigWithoutWorkspace(t)},
+			ConfigHolder:  framework.ConfigHolder{Config: radcli.LoadEmptyConfig(t)},
 		},
 		{
 			Name: "Azure command with too many positional args",
@@ -155,6 +155,7 @@ func Test_Run(t *testing.T) {
 								"kind":    workspaces.KindKubernetes,
 								"context": "my-context",
 							},
+							Source: workspaces.SourceUserConfig,
 
 							// Will have provider info added
 						},
@@ -163,6 +164,7 @@ func Test_Run(t *testing.T) {
 								"kind":    workspaces.KindKubernetes,
 								"context": "my-context",
 							},
+							Source: workspaces.SourceUserConfig,
 
 							// Will be over-written
 							ProviderConfig: workspaces.ProviderConfig{
@@ -177,6 +179,7 @@ func Test_Run(t *testing.T) {
 								"kind":    workspaces.KindKubernetes,
 								"context": "my-other-context",
 							},
+							Source: workspaces.SourceUserConfig,
 
 							// Will be left-alone
 							ProviderConfig: workspaces.ProviderConfig{
@@ -226,6 +229,7 @@ func Test_Run(t *testing.T) {
 						"kind":    workspaces.KindKubernetes,
 						"context": "my-context",
 					},
+					Source: workspaces.SourceUserConfig,
 				},
 				Format: "table",
 
@@ -257,6 +261,7 @@ func Test_Run(t *testing.T) {
 							"kind":    workspaces.KindKubernetes,
 							"context": "my-context",
 						},
+						Source: workspaces.SourceUserConfig,
 						ProviderConfig: workspaces.ProviderConfig{
 							Azure: &workspaces.AzureProvider{
 								SubscriptionID: "E3955194-FC78-40A8-8143-C5D8DCDC45C5",
@@ -270,6 +275,7 @@ func Test_Run(t *testing.T) {
 							"kind":    workspaces.KindKubernetes,
 							"context": "my-context",
 						},
+						Source: workspaces.SourceUserConfig,
 						ProviderConfig: workspaces.ProviderConfig{
 							Azure: &workspaces.AzureProvider{
 								SubscriptionID: "E3955194-FC78-40A8-8143-C5D8DCDC45C5",
@@ -283,6 +289,7 @@ func Test_Run(t *testing.T) {
 							"kind":    workspaces.KindKubernetes,
 							"context": "my-other-context",
 						},
+						Source: workspaces.SourceUserConfig,
 						ProviderConfig: workspaces.ProviderConfig{
 							Azure: &workspaces.AzureProvider{
 								SubscriptionID: "FE3955194-FC78-40A8-8143-C5D8DCDC45C5",

--- a/pkg/cli/cmd/provider/delete/delete.go
+++ b/pkg/cli/cmd/provider/delete/delete.go
@@ -64,6 +64,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
+	// TODO: support fallback workspace
+	if !r.Workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
 	format, err := cli.RequireOutput(cmd)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/provider/delete/delete_test.go
+++ b/pkg/cli/cmd/provider/delete/delete_test.go
@@ -36,12 +36,12 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "Delete Command without workspace",
+			Name:          "Delete Command with fallback workspace",
 			Input:         []string{"Azure"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         radcli.LoadConfigWithoutWorkspace(t),
+				Config:         radcli.LoadEmptyConfig(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/provider/list/list.go
+++ b/pkg/cli/cmd/provider/list/list.go
@@ -63,6 +63,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
+	// TODO: support fallback workspace
+	if !r.Workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
 	format, err := cli.RequireOutput(cmd)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/provider/list/list_test.go
+++ b/pkg/cli/cmd/provider/list/list_test.go
@@ -37,12 +37,12 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "List Command without workspace",
+			Name:          "List Command with fallback workspace",
 			Input:         []string{},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         radcli.LoadConfigWithoutWorkspace(t),
+				Config:         radcli.LoadEmptyConfig(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/provider/show/show.go
+++ b/pkg/cli/cmd/provider/show/show.go
@@ -65,6 +65,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
+	// TODO: support fallback workspace
+	if !r.Workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
 	format, err := cli.RequireOutput(cmd)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/provider/show/show_test.go
+++ b/pkg/cli/cmd/provider/show/show_test.go
@@ -37,12 +37,12 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "Show Command without workspace",
+			Name:          "Show Command with fallback workspace",
 			Input:         []string{"Azure"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         radcli.LoadConfigWithoutWorkspace(t),
+				Config:         radcli.LoadEmptyConfig(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/recipe/create/create.go
+++ b/pkg/cli/cmd/recipe/create/create.go
@@ -36,6 +36,7 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 
 	commonflags.AddOutputFlag(cmd)
 	commonflags.AddWorkspaceFlag(cmd)
+	commonflags.AddResourceGroupFlag(cmd)
 	commonflags.AddEnvironmentNameFlag(cmd)
 	cmd.Flags().String("template-path", "", "specify the path to the template provided by the recipe.")
 	_ = cmd.MarkFlagRequired("template-path")
@@ -73,11 +74,16 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
-	environmentName, err := cli.RequireEnvironmentName(cmd, args, *workspace)
+	// TODO: support fallback workspace
+	if !r.Workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
+	environment, err := cli.RequireEnvironmentName(cmd, args, *workspace)
 	if err != nil {
 		return err
 	}
-	r.Workspace.Environment = environmentName
+	r.Workspace.Environment = environment
 
 	templatePath, err := requireTemplatePath(cmd)
 	if err != nil {

--- a/pkg/cli/cmd/recipe/create/create_test.go
+++ b/pkg/cli/cmd/recipe/create/create_test.go
@@ -39,12 +39,12 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "Create Command without workspace",
+			Name:          "Create Command with fallback workspace",
 			Input:         []string{"--name", "test_recipe", "--template-path", "test_template", "--link-type", "Applications.Link/mongoDatabases"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         radcli.LoadConfigWithoutWorkspace(t),
+				Config:         radcli.LoadEmptyConfig(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/recipe/delete/delete.go
+++ b/pkg/cli/cmd/recipe/delete/delete.go
@@ -34,6 +34,7 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 
 	commonflags.AddOutputFlag(cmd)
 	commonflags.AddWorkspaceFlag(cmd)
+	commonflags.AddResourceGroupFlag(cmd)
 	commonflags.AddEnvironmentNameFlag(cmd)
 	cmd.Flags().String("name", "", "specify the name of the recipe")
 	_ = cmd.MarkFlagRequired("name")
@@ -65,11 +66,16 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
-	environmentName, err := cli.RequireEnvironmentName(cmd, args, *workspace)
+	// TODO: support fallback workspace
+	if !r.Workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
+	environment, err := cli.RequireEnvironmentName(cmd, args, *workspace)
 	if err != nil {
 		return err
 	}
-	r.Workspace.Environment = environmentName
+	r.Workspace.Environment = environment
 
 	recipeName, err := requireRecipeName(cmd)
 	if err != nil {

--- a/pkg/cli/cmd/recipe/delete/delete_test.go
+++ b/pkg/cli/cmd/recipe/delete/delete_test.go
@@ -39,12 +39,12 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "Delete Command without workspace",
+			Name:          "Delete Command with fallback workspace",
 			Input:         []string{"--name", "test_recipe"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         radcli.LoadConfigWithoutWorkspace(t),
+				Config:         radcli.LoadEmptyConfig(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/recipe/list/list.go
+++ b/pkg/cli/cmd/recipe/list/list.go
@@ -32,6 +32,7 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 
 	commonflags.AddOutputFlag(cmd)
 	commonflags.AddWorkspaceFlag(cmd)
+	commonflags.AddResourceGroupFlag(cmd)
 	commonflags.AddEnvironmentNameFlag(cmd)
 
 	return cmd, runner
@@ -61,11 +62,16 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
-	environmentName, err := cli.RequireEnvironmentName(cmd, args, *workspace)
+	// TODO: support fallback workspace
+	if !r.Workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
+	environment, err := cli.RequireEnvironmentName(cmd, args, *workspace)
 	if err != nil {
 		return err
 	}
-	r.Workspace.Environment = environmentName
+	r.Workspace.Environment = environment
 
 	format, err := cli.RequireOutput(cmd)
 	if err != nil {

--- a/pkg/cli/cmd/recipe/list/list_test.go
+++ b/pkg/cli/cmd/recipe/list/list_test.go
@@ -40,12 +40,12 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "List Command without workspace",
-			Input:         []string{},
+			Name:          "List Command with fallback workspace",
+			Input:         []string{"-e", "my-env", "-g", "my-env"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         radcli.LoadConfigWithoutWorkspace(t),
+				Config:         radcli.LoadEmptyConfig(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/resource/delete/delete.go
+++ b/pkg/cli/cmd/resource/delete/delete.go
@@ -66,6 +66,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
+	// TODO: support fallback workspace
+	if !r.Workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
 	resourceType, resourceName, err := cli.RequireResourceTypeAndName(args)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/resource/delete/delete_test.go
+++ b/pkg/cli/cmd/resource/delete/delete_test.go
@@ -36,12 +36,12 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "Delete Command without workspace",
+			Name:          "Delete Command with fallback workspace",
 			Input:         []string{"containers", "foo"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         radcli.LoadConfigWithoutWorkspace(t),
+				Config:         radcli.LoadEmptyConfig(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/resource/list/list.go
+++ b/pkg/cli/cmd/resource/list/list.go
@@ -78,6 +78,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
+	// TODO: support fallback workspace
+	if !r.Workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
 	applicationName, err := cli.ReadApplicationName(cmd, *workspace)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/resource/list/list_test.go
+++ b/pkg/cli/cmd/resource/list/list_test.go
@@ -50,12 +50,12 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "List Command without workspace",
+			Name:          "List Command with fallback workspace",
 			Input:         []string{"containers"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         radcli.LoadConfigWithoutWorkspace(t),
+				Config:         radcli.LoadEmptyConfig(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/resource/show/show.go
+++ b/pkg/cli/cmd/resource/show/show.go
@@ -75,6 +75,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
+	// TODO: support fallback workspace
+	if !r.Workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
 	resourceType, resourceName, err := cli.RequireResourceTypeAndName(args)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/resource/show/show_test.go
+++ b/pkg/cli/cmd/resource/show/show_test.go
@@ -43,12 +43,12 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "Show Command without workspace",
+			Name:          "Show Command with fallback workspace",
 			Input:         []string{"containers", "foo"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         radcli.LoadConfigWithoutWorkspace(t),
+				Config:         radcli.LoadEmptyConfig(t),
 			},
 		},
 		{

--- a/pkg/cli/cmd/workspace/delete/delete.go
+++ b/pkg/cli/cmd/workspace/delete/delete.go
@@ -76,6 +76,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	r.Workspace = workspace
 	r.Confirm = yes
 
+	if !r.Workspace.IsNamedWorkspace() {
+		// Only workspaces stored in configuration can be deleted.
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
 	return nil
 }
 

--- a/pkg/cli/cmd/workspace/delete/delete_test.go
+++ b/pkg/cli/cmd/workspace/delete/delete_test.go
@@ -46,10 +46,10 @@ func Test_Validate(t *testing.T) {
 			ConfigHolder:  framework.ConfigHolder{Config: config},
 		},
 		{
-			Name:          "delete workspace no-workspace invalid",
+			Name:          "delete workspace with non-named workspace invalid",
 			Input:         []string{},
 			ExpectedValid: false,
-			ConfigHolder:  framework.ConfigHolder{Config: radcli.LoadConfigWithoutWorkspace(t)},
+			ConfigHolder:  framework.ConfigHolder{Config: radcli.LoadEmptyConfig(t)},
 		},
 		{
 			Name:          "delete workspace not-found invalid",

--- a/pkg/cli/cmd/workspace/list/list_test.go
+++ b/pkg/cli/cmd/workspace/list/list_test.go
@@ -57,10 +57,12 @@ func Test_Run(t *testing.T) {
 				// Intentionally NOT in alphabetical order
 				"workspace-b": {
 					Environment: "b",
+					Source:      workspaces.SourceUserConfig,
 					Connection:  map[string]interface{}{},
 				},
 				"workspace-a": {
 					Environment: "a",
+					Source:      workspaces.SourceUserConfig,
 					Connection:  map[string]interface{}{},
 				},
 			},
@@ -85,11 +87,13 @@ func Test_Run(t *testing.T) {
 					{
 						Name:        "workspace-a",
 						Environment: "a",
+						Source:      workspaces.SourceUserConfig,
 						Connection:  map[string]interface{}{},
 					},
 					{
 						Name:        "workspace-b",
 						Environment: "b",
+						Source:      workspaces.SourceUserConfig,
 						Connection:  map[string]interface{}{},
 					},
 				},

--- a/pkg/cli/cmd/workspace/show/show.go
+++ b/pkg/cli/cmd/workspace/show/show.go
@@ -59,6 +59,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// TODO: support fallback workspace
+	if !workspace.IsNamedWorkspace() {
+		return workspaces.ErrNamedWorkspaceRequired
+	}
+
 	format, err := cli.RequireOutput(cmd)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/workspace/show/show_test.go
+++ b/pkg/cli/cmd/workspace/show/show_test.go
@@ -32,6 +32,12 @@ func Test_Validate(t *testing.T) {
 			ConfigHolder:  framework.ConfigHolder{Config: config},
 		},
 		{
+			Name:          "show fallback workspace",
+			Input:         []string{},
+			ExpectedValid: false,
+			ConfigHolder:  framework.ConfigHolder{Config: radcli.LoadEmptyConfig(t)},
+		},
+		{
 			Name:          "show explicit workspace flag valid",
 			Input:         []string{"-w", radcli.TestWorkspaceName},
 			ExpectedValid: true,
@@ -42,12 +48,6 @@ func Test_Validate(t *testing.T) {
 			Input:         []string{radcli.TestWorkspaceName},
 			ExpectedValid: true,
 			ConfigHolder:  framework.ConfigHolder{Config: config},
-		},
-		{
-			Name:          "show workspace no-workspace invalid",
-			Input:         []string{},
-			ExpectedValid: false,
-			ConfigHolder:  framework.ConfigHolder{Config: radcli.LoadConfigWithoutWorkspace(t)},
 		},
 		{
 			Name:          "show workspace not-found invalid",
@@ -72,7 +72,7 @@ func Test_Validate(t *testing.T) {
 }
 
 func Test_Run(t *testing.T) {
-	t.Run("Show workspace", func(t *testing.T) {
+	t.Run("Show named workspace", func(t *testing.T) {
 		outputSink := &output.MockOutput{}
 
 		runner := &Runner{
@@ -96,6 +96,29 @@ func Test_Run(t *testing.T) {
 					Environment: "test-environment",
 					Connection:  map[string]interface{}{},
 				},
+				Options: objectformats.GetWorkspaceTableFormat(),
+			},
+		}
+
+		require.Equal(t, expected, outputSink.Writes)
+	})
+
+	t.Run("Show fallback workspace", func(t *testing.T) {
+		outputSink := &output.MockOutput{}
+
+		runner := &Runner{
+			ConfigHolder: &framework.ConfigHolder{},
+			Output:       outputSink,
+			Workspace:    workspaces.MakeFallbackWorkspace(),
+		}
+
+		err := runner.Run(context.Background())
+		require.NoError(t, err)
+
+		expected := []interface{}{
+			output.FormattedOutput{
+				Format:  "",
+				Obj:     runner.Workspace,
 				Options: objectformats.GetWorkspaceTableFormat(),
 			},
 		}

--- a/pkg/cli/cmd/workspace/switch/switch_test.go
+++ b/pkg/cli/cmd/workspace/switch/switch_test.go
@@ -28,12 +28,6 @@ func Test_Validate(t *testing.T) {
 
 	testcases := []radcli.ValidateInput{
 		{
-			Name:          "switch current workspace valid",
-			Input:         []string{radcli.TestWorkspaceName},
-			ExpectedValid: true,
-			ConfigHolder:  framework.ConfigHolder{Config: config},
-		},
-		{
 			Name:          "switch explicit workspace flag valid",
 			Input:         []string{"-w", radcli.TestWorkspaceName},
 			ExpectedValid: true,
@@ -43,6 +37,12 @@ func Test_Validate(t *testing.T) {
 			Name:          "switch explicit workspace positional valid",
 			Input:         []string{radcli.TestWorkspaceName},
 			ExpectedValid: true,
+			ConfigHolder:  framework.ConfigHolder{Config: config},
+		},
+		{
+			Name:          "switch workspace no-workspace-specified invalid",
+			Input:         []string{},
+			ExpectedValid: false,
 			ConfigHolder:  framework.ConfigHolder{Config: config},
 		},
 		{

--- a/pkg/cli/config_test.go
+++ b/pkg/cli/config_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
@@ -64,9 +65,31 @@ workspaces:
 	require.Error(t, err)
 }
 
+func Test_GetWorkspace_Nil_NoDefault(t *testing.T) {
+	var yaml = `
+workspaces:
+  items:
+    test:
+      connection:
+        kind: kubernetes
+      scope: /a/b/c
+`
+
+	v, err := makeConfig(yaml)
+	require.NoError(t, err)
+
+	section, err := ReadWorkspaceSection(v)
+	require.NoError(t, err)
+
+	ws, err := section.GetWorkspace("")
+	require.Nil(t, ws)
+	require.NoError(t, err)
+}
+
 func Test_GetWorkspace_Invalid_NotFound(t *testing.T) {
 	var yaml = `
 workspaces:
+  default: test2
   items:
     test:
       connection:
@@ -84,7 +107,7 @@ workspaces:
 	require.Error(t, err)
 }
 
-func Test_GetWorkspace_Valid(t *testing.T) {
+func Test_GetWorkspace_Default_Valid(t *testing.T) {
 	var yaml = `
 workspaces:
   default: test
@@ -107,6 +130,35 @@ workspaces:
 	require.NoError(t, err)
 
 	require.Equal(t, "test", ws.Name)
+	require.Equal(t, workspaces.Source(workspaces.SourceUserConfig), ws.Source)
+	require.Equal(t, "/a/b/c", ws.Scope)
+	require.Equal(t, "/a/b/c/providers/Applications.Core/environments/ice-cold", ws.Environment)
+	require.Equal(t, map[string]interface{}{"kind": "kubernetes", "context": "cool-beans"}, ws.Connection)
+}
+
+func Test_GetWorkspace_Named_Valid(t *testing.T) {
+	var yaml = `
+workspaces:
+  items:
+    test:
+      connection:
+        kind: kubernetes
+        context: cool-beans
+      scope: /a/b/c
+      environment: /a/b/c/providers/Applications.Core/environments/ice-cold
+`
+
+	v, err := makeConfig(yaml)
+	require.NoError(t, err)
+
+	es, err := ReadWorkspaceSection(v)
+	require.NoError(t, err)
+
+	ws, err := es.GetWorkspace("test")
+	require.NoError(t, err)
+
+	require.Equal(t, "test", ws.Name)
+	require.Equal(t, workspaces.Source(workspaces.SourceUserConfig), ws.Source)
 	require.Equal(t, "/a/b/c", ws.Scope)
 	require.Equal(t, "/a/b/c/providers/Applications.Core/environments/ice-cold", ws.Environment)
 	require.Equal(t, map[string]interface{}{"kind": "kubernetes", "context": "cool-beans"}, ws.Connection)

--- a/pkg/cli/workspaces/connection.go
+++ b/pkg/cli/workspaces/connection.go
@@ -3,9 +3,6 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-// workspaces contains functionality for using the workspace concept of the CLI to connect and interact
-// with the remote endpoints that are described by the workspace concept
-// (Radius control plane, environment, et al).
 package workspaces
 
 import (
@@ -15,6 +12,18 @@ import (
 )
 
 const KindKubernetes string = "kubernetes"
+
+// MakeFallbackWorkspace creates an un-named workspace that will use the current KubeContext.
+// This is is used in fallback cases where the user has no config.
+func MakeFallbackWorkspace() *Workspace {
+	return &Workspace{
+		Source: SourceFallback,
+		Connection: map[string]interface{}{
+			"kind":    KindKubernetes,
+			"context": "", // Default Kubernetes context
+		},
+	}
+}
 
 type Connection interface {
 	fmt.Stringer

--- a/test/radcli/shared.go
+++ b/test/radcli/shared.go
@@ -176,7 +176,7 @@ workspaces:
 	return LoadConfig(t, yamlData)
 }
 
-func LoadConfigWithoutWorkspace(t *testing.T) *viper.Viper {
+func LoadEmptyConfig(t *testing.T) *viper.Viper {
 
 	var yamlData = `
 workspaces: 


### PR DESCRIPTION

This change adds the 'fallback workspace' concept to our configuration
system, but prevents its use in all of our commands. I'm taking this
strategy so that I can incrementally enable CLI functionality without
the need for a 'big bang' that touches all commands. I also realize that
this commit is a 'big bang' :) -- but I think that's justified because
each individual change is simple.

This change should have minimal impact on the UX for a Radius user, the
error message they will see if they have no workspace has changed
slightly, but no new functionality is enabled.

The commands that can be considered 'done' in this PR are the ones that
will **never** support fallback workspace for obvious reasons. For
instance `rad env switch` is a command that edits configuration, it will
never function without a configuration.