### PR TITLE
Add logic to `rad init` for existing environments

### DIFF
--- a/cmd/rad/cmd/envList.go
+++ b/cmd/rad/cmd/envList.go
@@ -32,7 +32,7 @@ func getEnvConfigs(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	envList, err := client.ListEnv(cmd.Context())
+	envList, err := client.ListEnvironmentsInResourceGroup(cmd.Context())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/clients/clients.go
+++ b/pkg/cli/clients/clients.go
@@ -132,7 +132,11 @@ type ApplicationsManagementClient interface {
 	ShowApplication(ctx context.Context, applicationName string) (corerp.ApplicationResource, error)
 	DeleteApplication(ctx context.Context, applicationName string) (bool, error)
 	CreateEnvironment(ctx context.Context, envName, location, namespace, envKind, resourceId string, recipeProperties map[string]*corerp.EnvironmentRecipeProperties, providers *corerp.Providers, useDevRecipes bool) (bool, error)
-	ListEnv(ctx context.Context) ([]corerp.EnvironmentResource, error)
+	// ListEnvironmentsInResourceGroup lists all environments in the configured scope (assumes configured scope is a resource group)
+	ListEnvironmentsInResourceGroup(ctx context.Context) ([]corerp.EnvironmentResource, error)
+
+	// ListEnvironmentsAll lists all environments across resource groups.
+	ListEnvironmentsAll(ctx context.Context) ([]corerp.EnvironmentResource, error)
 	GetEnvDetails(ctx context.Context, envName string) (corerp.EnvironmentResource, error)
 	DeleteEnv(ctx context.Context, envName string) (bool, error)
 	CreateUCPGroup(ctx context.Context, planeType string, planeName string, resourceGroupName string, resourceGroup ucp_v20220901privatepreview.ResourceGroupResource) (bool, error)

--- a/pkg/cli/clients/mock_applicationsclient.go
+++ b/pkg/cli/clients/mock_applicationsclient.go
@@ -232,19 +232,34 @@ func (mr *MockApplicationsManagementClientMockRecorder) ListApplications(arg0 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListApplications", reflect.TypeOf((*MockApplicationsManagementClient)(nil).ListApplications), arg0)
 }
 
-// ListEnv mocks base method.
-func (m *MockApplicationsManagementClient) ListEnv(arg0 context.Context) ([]v20220315privatepreview.EnvironmentResource, error) {
+// ListEnvironmentsAll mocks base method.
+func (m *MockApplicationsManagementClient) ListEnvironmentsAll(arg0 context.Context) ([]v20220315privatepreview.EnvironmentResource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEnv", arg0)
+	ret := m.ctrl.Call(m, "ListEnvironmentsAll", arg0)
 	ret0, _ := ret[0].([]v20220315privatepreview.EnvironmentResource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListEnv indicates an expected call of ListEnv.
-func (mr *MockApplicationsManagementClientMockRecorder) ListEnv(arg0 interface{}) *gomock.Call {
+// ListEnvironmentsAll indicates an expected call of ListEnvironmentsAll.
+func (mr *MockApplicationsManagementClientMockRecorder) ListEnvironmentsAll(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEnv", reflect.TypeOf((*MockApplicationsManagementClient)(nil).ListEnv), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEnvironmentsAll", reflect.TypeOf((*MockApplicationsManagementClient)(nil).ListEnvironmentsAll), arg0)
+}
+
+// ListEnvironmentsInResourceGroup mocks base method.
+func (m *MockApplicationsManagementClient) ListEnvironmentsInResourceGroup(arg0 context.Context) ([]v20220315privatepreview.EnvironmentResource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListEnvironmentsInResourceGroup", arg0)
+	ret0, _ := ret[0].([]v20220315privatepreview.EnvironmentResource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListEnvironmentsInResourceGroup indicates an expected call of ListEnvironmentsInResourceGroup.
+func (mr *MockApplicationsManagementClientMockRecorder) ListEnvironmentsInResourceGroup(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEnvironmentsInResourceGroup", reflect.TypeOf((*MockApplicationsManagementClient)(nil).ListEnvironmentsInResourceGroup), arg0)
 }
 
 // ListUCPGroup mocks base method.

--- a/pkg/cli/cmd/app/appswitch/switch.go
+++ b/pkg/cli/cmd/app/appswitch/switch.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/project-radius/radius/pkg/cli"
-	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/framework"
@@ -38,20 +37,18 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 }
 
 type Runner struct {
-	ConfigHolder        *framework.ConfigHolder
-	Output              output.Interface
-	Workspace           *workspaces.Workspace
-	ApplicationName     string
-	ConnectionFactory   connections.Factory
-	AppManagementClient clients.ApplicationsManagementClient
+	ConfigHolder      *framework.ConfigHolder
+	Output            output.Interface
+	Workspace         *workspaces.Workspace
+	ApplicationName   string
+	ConnectionFactory connections.Factory
 }
 
 func NewRunner(factory framework.Factory) *Runner {
 	return &Runner{
-		ConfigHolder:        factory.GetConfigHolder(),
-		Output:              factory.GetOutput(),
-		ConnectionFactory:   factory.GetConnectionFactory(),
-		AppManagementClient: factory.GetAppManagementClient(),
+		ConfigHolder:      factory.GetConfigHolder(),
+		Output:            factory.GetOutput(),
+		ConnectionFactory: factory.GetConnectionFactory(),
 	}
 }
 
@@ -75,13 +72,13 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	r.AppManagementClient, err = r.ConnectionFactory.CreateApplicationsManagementClient(cmd.Context(), *r.Workspace)
+	client, err := r.ConnectionFactory.CreateApplicationsManagementClient(cmd.Context(), *r.Workspace)
 	if err != nil {
 		return err
 	}
 
 	// Validate that the application exists
-	_, err = r.AppManagementClient.ShowApplication(cmd.Context(), r.ApplicationName)
+	_, err = client.ShowApplication(cmd.Context(), r.ApplicationName)
 	if cli.Is404ErrorForAzureError(err) {
 		return &cli.FriendlyError{Message: fmt.Sprintf("Unable to switch applications as the requested application %s does not exist.\n", r.ApplicationName)}
 	} else if err != nil {

--- a/pkg/cli/cmd/app/appswitch/switch_test.go
+++ b/pkg/cli/cmd/app/appswitch/switch_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/golang/mock/gomock"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/cli/clients"
-	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/framework"
 	corerp "github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
 	"github.com/project-radius/radius/test/radcli"
@@ -25,13 +24,6 @@ func Test_CommandValidation(t *testing.T) {
 func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
 
-	ctrl := gomock.NewController(t)
-	appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
-
-	createShowApplicationSuccess(appManagementClient)
-	// Non-existing application
-	createShowApplicationError(appManagementClient)
-
 	testcases := []radcli.ValidateInput{
 		{
 			Name:          "Switch Command with valid command",
@@ -41,7 +33,9 @@ func Test_Validate(t *testing.T) {
 				ConfigFilePath: "",
 				Config:         configWithWorkspace,
 			},
-			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				createShowApplicationSuccess(mocks.ApplicationManagementClient)
+			},
 		},
 		{
 			Name:          "Switch Command with non-existent app",
@@ -51,9 +45,12 @@ func Test_Validate(t *testing.T) {
 				ConfigFilePath: "",
 				Config:         configWithWorkspace,
 			},
-			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				createShowApplicationError(mocks.ApplicationManagementClient)
+			},
 		},
 	}
+
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
 }
 

--- a/pkg/cli/cmd/env/envswitch/switch.go
+++ b/pkg/cli/cmd/env/envswitch/switch.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/project-radius/radius/pkg/cli"
-	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/framework"
@@ -41,23 +40,21 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 }
 
 type Runner struct {
-	ConfigHolder        *framework.ConfigHolder
-	Output              output.Interface
-	Workspace           *workspaces.Workspace
-	ApplicationName     string
-	EnvironmentId       resources.ID
-	EnvironmentName     string
-	Scope               resources.ID
-	ConnectionFactory   connections.Factory
-	AppManagementClient clients.ApplicationsManagementClient
+	ConfigHolder      *framework.ConfigHolder
+	Output            output.Interface
+	Workspace         *workspaces.Workspace
+	ApplicationName   string
+	EnvironmentId     resources.ID
+	EnvironmentName   string
+	Scope             resources.ID
+	ConnectionFactory connections.Factory
 }
 
 func NewRunner(factory framework.Factory) *Runner {
 	return &Runner{
-		ConfigHolder:        factory.GetConfigHolder(),
-		Output:              factory.GetOutput(),
-		ConnectionFactory:   factory.GetConnectionFactory(),
-		AppManagementClient: factory.GetAppManagementClient(),
+		ConfigHolder:      factory.GetConfigHolder(),
+		Output:            factory.GetOutput(),
+		ConnectionFactory: factory.GetConnectionFactory(),
 	}
 }
 
@@ -89,14 +86,13 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	r.AppManagementClient, err = r.ConnectionFactory.CreateApplicationsManagementClient(cmd.Context(), *r.Workspace)
+	client, err := r.ConnectionFactory.CreateApplicationsManagementClient(cmd.Context(), *r.Workspace)
 	if err != nil {
 		return err
 	}
 
 	// Validate that the environment exists
-	_, err = r.AppManagementClient.GetEnvDetails(cmd.Context(), r.EnvironmentName)
-
+	_, err = client.GetEnvDetails(cmd.Context(), r.EnvironmentName)
 	if cli.Is404ErrorForAzureError(err) {
 		return &cli.FriendlyError{Message: fmt.Sprintf("Unable to switch environments as requested environment %s does not exist.\n", r.EnvironmentName)}
 	} else if err != nil {

--- a/pkg/cli/cmd/env/envswitch/switch_test.go
+++ b/pkg/cli/cmd/env/envswitch/switch_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/golang/mock/gomock"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/cli/clients"
-	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/framework"
 	corerp "github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
 	"github.com/project-radius/radius/test/radcli"
@@ -25,13 +24,6 @@ func Test_CommandValidation(t *testing.T) {
 func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
 
-	ctrl := gomock.NewController(t)
-	appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
-
-	createGetEnvDetailsSuccess(appManagementClient)
-	// Non-existing environment
-	createGetEnvDetailsError(appManagementClient)
-
 	testcases := []radcli.ValidateInput{
 		{
 			Name:          "Switch Command with valid arguments",
@@ -41,7 +33,9 @@ func Test_Validate(t *testing.T) {
 				ConfigFilePath: "",
 				Config:         configWithWorkspace,
 			},
-			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				createGetEnvDetailsSuccess(mocks.ApplicationManagementClient)
+			},
 		},
 		{
 			Name:          "Switch Command with non-existent env",
@@ -51,7 +45,9 @@ func Test_Validate(t *testing.T) {
 				ConfigFilePath: "",
 				Config:         configWithWorkspace,
 			},
-			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				createGetEnvDetailsError(mocks.ApplicationManagementClient)
+			},
 		},
 	}
 	radcli.SharedValidateValidation(t, NewCommand, testcases)

--- a/pkg/cli/cmd/provider/common/validation.go
+++ b/pkg/cli/cmd/provider/common/validation.go
@@ -14,7 +14,16 @@ import (
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/project-radius/radius/pkg/cli/prompt"
+	corerp "github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
 	"github.com/spf13/cobra"
+)
+
+// Used in tests
+const (
+	SelectExistingEnvironmentPrompt         = "Select an existing environment or create a new one"
+	SelectExistingEnvironmentCreateSentinel = "[create new]"
+	EnterEnvironmentNamePrompt              = "Enter an environment name"
+	EnterNamespacePrompt                    = "Enter a namespace name to deploy apps into"
 )
 
 func ValidateCloudProviderName(name string) error {
@@ -23,6 +32,63 @@ func ValidateCloudProviderName(name string) error {
 	}
 
 	return &cli.FriendlyError{Message: fmt.Sprintf("Cloud provider type %q is not supported. Supported types: azure.", name)}
+}
+
+// SelectExistingEnvironment prompts the user to select from existing environments (with the option to create a new one).
+// We also expect the the existing environments to be a non-empty list, callers should check that.
+//
+// If the name returned is empty, it means that that either no environment was found or that the user opted to create a new one.
+func SelectExistingEnvironment(cmd *cobra.Command, defaultVal string, prompter prompt.Interface, existing []corerp.EnvironmentResource) (string, error) {
+	selectedName, err := cmd.Flags().GetString("environment")
+	if err != nil {
+		return "", err
+	}
+
+	// If the user provided a name, let's use that if possible.
+	if selectedName != "" {
+		for _, env := range existing {
+			if strings.EqualFold(selectedName, *env.Name) {
+				return selectedName, nil
+			}
+		}
+
+		// Returing empty tells the caller to create a new one.
+		return "", nil
+	}
+
+	// On this code path, we're going to prompt for input.
+	//
+	// Build the list of items in the following way:
+	//
+	// - default environment (if it exists)
+	// - (all other existing environments)
+	// - [create new]
+	items := []string{}
+	for _, env := range existing {
+		if strings.EqualFold(defaultVal, *env.Name) {
+			items = append(items, defaultVal)
+			break
+		}
+	}
+	for _, env := range existing {
+		// The default is already in the list
+		if !strings.EqualFold(defaultVal, *env.Name) {
+			items = append(items, *env.Name)
+		}
+	}
+	items = append(items, SelectExistingEnvironmentCreateSentinel)
+
+	_, choice, err := prompter.RunSelect(prompt.SelectionPrompter(SelectExistingEnvironmentPrompt, items))
+	if err != nil {
+		return "", err
+	}
+
+	if choice == SelectExistingEnvironmentCreateSentinel {
+		// Returing empty tells the caller to create a new one.
+		return "", nil
+	}
+
+	return choice, nil
 }
 
 // Selects the environment flag name from user if interactive or sets it from flags or to the default value otherwise
@@ -35,7 +101,7 @@ func SelectEnvironmentName(cmd *cobra.Command, defaultVal string, interactive bo
 		return "", err
 	}
 	if interactive && envStr == "" {
-		envStr, err = prompter.RunPrompt(prompt.TextPromptWithDefault("Enter an environment name", defaultVal, prompt.ResourceName))
+		envStr, err = prompter.RunPrompt(prompt.TextPromptWithDefault(EnterEnvironmentNamePrompt, defaultVal, prompt.ResourceName))
 		if err != nil {
 			return "", err
 		}
@@ -59,7 +125,7 @@ func SelectNamespace(cmd *cobra.Command, defaultVal string, interactive bool, pr
 	var err error
 	if interactive {
 		namespaceSelector := promptui.Prompt{
-			Label:   "Enter a namespace name to deploy apps into",
+			Label:   EnterNamespacePrompt,
 			Default: defaultVal,
 			Validate: func(s string) error {
 				valid, msg, err := prompt.EmptyValidator(s)

--- a/pkg/cli/cmd/radInit/init.go
+++ b/pkg/cli/cmd/radInit/init.go
@@ -28,6 +28,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/workspaces"
 	corerp "github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
 	"github.com/project-radius/radius/pkg/ucp/api/v20220901privatepreview"
+	"github.com/project-radius/radius/pkg/ucp/resources"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
@@ -35,6 +36,11 @@ import (
 const (
 	Azure int = iota
 	AWS
+
+	confirmCloudProviderPrompt   = "Add cloud providers for cloud resources [y/N]?"
+	confirmReinstallRadiusPrompt = "Would you like to reinstall Radius control plane and configure cloud providers [N/y]?"
+	selectKubeContextPrompt      = "Select the kubeconfig context to install Radius into"
+	selectCloudProviderPrompt    = "Select your cloud provider"
 )
 
 const (
@@ -63,25 +69,25 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 }
 
 type Runner struct {
-	ConfigHolder           *framework.ConfigHolder
-	Output                 output.Interface
-	Format                 string
-	Workspace              *workspaces.Workspace
-	ServicePrincipal       *azure.ServicePrincipal
-	ConnectionFactory      connections.Factory
-	KubeContext            string
-	EnvName                string
-	NameSpace              string
-	AzureCloudProvider     *azure.Provider
-	CreateNewResourceGroup bool
-	RadiusInstalled        bool
-	Reinstall              bool
-	Prompter               prompt.Interface
-	ConfigFileInterface    framework.ConfigFileInterface
-	KubernetesInterface    kubernetes.Interface
-	HelmInterface          helm.Interface
-	SkipDevRecipes         bool
-	SetupInterface         setup.Interface
+	ConfigHolder        *framework.ConfigHolder
+	Output              output.Interface
+	Format              string
+	Workspace           *workspaces.Workspace
+	ServicePrincipal    *azure.ServicePrincipal
+	ConnectionFactory   connections.Factory
+	KubeContext         string
+	ExistingEnvironment bool
+	EnvName             string
+	Namespace           string
+	AzureCloudProvider  *azure.Provider
+	RadiusInstalled     bool
+	Reinstall           bool
+	Prompter            prompt.Interface
+	ConfigFileInterface framework.ConfigFileInterface
+	KubernetesInterface kubernetes.Interface
+	HelmInterface       helm.Interface
+	SkipDevRecipes      bool
+	SetupInterface      setup.Interface
 }
 
 func NewRunner(factory framework.Factory) *Runner {
@@ -127,7 +133,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 
 	if r.RadiusInstalled {
 		output.LogInfo(fmt.Sprintf("Radius control plane is already installed to context '%s'...", r.KubeContext))
-		y, err := prompt.YesOrNoPrompter("Would you like to reinstall Radius control plane and configure cloud providers [N/y]?", "N", r.Prompter)
+		y, err := prompt.YesOrNoPrompter(confirmReinstallRadiusPrompt, "N", r.Prompter)
 		if err != nil {
 			return &cli.FriendlyError{Message: "Unable to read reinstall prompt"}
 		}
@@ -136,73 +142,135 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	r.EnvName, err = common.SelectEnvironmentName(cmd, "default", true, r.Prompter)
-	if err != nil {
-		return &cli.FriendlyError{Message: "Failed to read env name"}
-	}
-
-	r.NameSpace, err = common.SelectNamespace(cmd, "default", true, r.Prompter)
-	if err != nil {
-		return &cli.FriendlyError{Message: "Namespace not specified"}
-	}
-
+	// Set up a connection so we can list environments
 	r.Workspace = &workspaces.Workspace{
-		Name: r.EnvName,
 		Connection: map[string]interface{}{
 			"context": r.KubeContext,
-			"kind":    kubernetesKind, // we support only kubernetes for now
+			"kind":    kubernetesKind,
 		},
-		Environment: fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Applications.Core/environments/%s", r.EnvName, r.EnvName),
-		Scope:       fmt.Sprintf("/planes/radius/local/resourceGroups/%s", r.EnvName),
+
+		// We can't know the scope yet. Setting it up likes this ensures that any code
+		// that needs a resource group will fail. After we know the env name we will
+		// update this value.
+		Scope: "/planes/radius/local",
 	}
 
-	// This loop is required for adding multiple cloud providers
-	// addingAnotherProvider tracks whether a user wants to add multiple cloud provider or not at the time of prompt
-	addingAnotherProvider := "y"
-	for strings.ToLower(addingAnotherProvider) == "y" && r.Reinstall {
-		var cloudProvider int
-		// This loop is required to move up a level when the user selects [back] as an option
-		// addingCloudProvider tracks whether a user wants to add a new cloud provider at the time of prompt
-		addingCloudProvider := true
-		for addingCloudProvider {
-			cloudProviderPrompter, err := prompt.YesOrNoPrompter("Add cloud providers for cloud resources [y/N]?", "N", r.Prompter)
-			if err != nil {
-				return &cli.FriendlyError{Message: "Error reading cloud provider"}
-			}
-			if strings.ToLower(cloudProviderPrompter) == "n" {
-				cloudProvider = -1
-				break
-			}
-			cloudProvider, err = selectCloudProvider(r.Output, r.Prompter)
-			if err != nil {
-				return &cli.FriendlyError{Message: "Error reading cloud provider"}
-			}
-			// cloudProvider being -1 represents the user doesn't wants to add one
-			if cloudProvider != -1 {
-				addingCloudProvider = false
-			}
+	environments := []corerp.EnvironmentResource{}
+	if r.RadiusInstalled {
+		client, err := r.ConnectionFactory.CreateApplicationsManagementClient(cmd.Context(), *r.Workspace)
+		if err != nil {
+			return err
 		}
-		// if the user doesn't want to add a cloud provider, then break out of the adding provider prompt block
-		if cloudProvider == -1 {
-			break
-		}
-		switch cloudProvider {
-		case Azure:
-			r.AzureCloudProvider, err = r.SetupInterface.ParseAzureProviderArgs(cmd, true, r.Prompter)
-			if err != nil {
-				return err
-			}
-		case AWS:
-			r.Output.LogInfo("AWS is not supported")
+
+		environments, err = client.ListEnvironmentsAll(cmd.Context())
+		if err != nil {
+			return err
 		}
 	}
+
+	// If there are any existing environments and we're not reinstalling, ask to use
+	// one of those first.
+	//
+	// "reinstall" repreresents the the user-intent to reconfigure cloud providers,
+	// we also need to force re-creation of the envionment to do that, so we don't want
+	// to reuse an existing one.
+	if len(environments) > 0 && !r.Reinstall {
+		r.EnvName, err = common.SelectExistingEnvironment(cmd, "default", r.Prompter, environments)
+		if err != nil {
+			return err
+		}
+
+		// User choose an existing environment, grab any settings we need from it.
+		if r.EnvName != "" {
+			r.ExistingEnvironment = true
+
+			// Grab any provider info we found on the environment resource so we can store it locally.
+			for _, env := range environments {
+				if strings.EqualFold(r.EnvName, *env.Name) {
+					if env.Properties != nil &&
+						env.Properties.Providers != nil &&
+						env.Properties.Providers.Azure != nil &&
+						env.Properties.Providers.Azure.Scope != nil {
+						scope, err := resources.ParseScope(*env.Properties.Providers.Azure.Scope)
+						if err != nil {
+							return err
+						}
+
+						r.AzureCloudProvider = &azure.Provider{
+							SubscriptionID: scope.FindScope(resources.SubscriptionsSegment),
+							ResourceGroup:  scope.FindScope(resources.ResourceGroupsSegment),
+						}
+					}
+					break
+				}
+			}
+		}
+	}
+
+	// If we're going to create an environment, then prompt for the name now.
+	if !r.ExistingEnvironment {
+		r.EnvName, err = common.SelectEnvironmentName(cmd, "default", true, r.Prompter)
+		if err != nil {
+			return &cli.FriendlyError{Message: "Failed to read env name"}
+		}
+
+		r.Namespace, err = common.SelectNamespace(cmd, "default", true, r.Prompter)
+		if err != nil {
+			return &cli.FriendlyError{Message: "Namespace not specified"}
+		}
+
+		// This loop is required for adding multiple cloud providers
+		// addingAnotherProvider tracks whether a user wants to add multiple cloud provider or not at the time of prompt
+		addingAnotherProvider := "y"
+		for strings.ToLower(addingAnotherProvider) == "y" {
+			var cloudProvider int
+			// This loop is required to move up a level when the user selects [back] as an option
+			// addingCloudProvider tracks whether a user wants to add a new cloud provider at the time of prompt
+			addingCloudProvider := true
+			for addingCloudProvider {
+				cloudProviderPrompter, err := prompt.YesOrNoPrompter(confirmCloudProviderPrompt, "N", r.Prompter)
+				if err != nil {
+					return &cli.FriendlyError{Message: "Error reading cloud provider"}
+				}
+				if strings.ToLower(cloudProviderPrompter) == "n" {
+					cloudProvider = -1
+					break
+				}
+				cloudProvider, err = selectCloudProvider(r.Output, r.Prompter)
+				if err != nil {
+					return &cli.FriendlyError{Message: "Error reading cloud provider"}
+				}
+				// cloudProvider being -1 represents the user doesn't wants to add one
+				if cloudProvider != -1 {
+					addingCloudProvider = false
+				}
+			}
+			// if the user doesn't want to add a cloud provider, then break out of the adding provider prompt block
+			if cloudProvider == -1 {
+				break
+			}
+			switch cloudProvider {
+			case Azure:
+				r.AzureCloudProvider, err = r.SetupInterface.ParseAzureProviderArgs(cmd, true, r.Prompter)
+				if err != nil {
+					return err
+				}
+			case AWS:
+				r.Output.LogInfo("AWS is not supported")
+			}
+		}
+	}
+
+	// Update the workspace with the information we captured about the environment.
+	r.Workspace.Name = r.EnvName
+	r.Workspace.Environment = fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Applications.Core/environments/%s", r.EnvName, r.EnvName)
+	r.Workspace.Scope = fmt.Sprintf("/planes/radius/local/resourceGroups/%s", r.EnvName)
 
 	return nil
 }
 
 // Creates radius resources, azure resources if required based on the user input, command flags
 func (r *Runner) Run(ctx context.Context) error {
-
 	config := r.ConfigFileInterface.ConfigFromContext(ctx)
 	//TODO: Initialize cloud providers separately once providers commands are in
 	// If the user prompts for re-install, re-install and init providers
@@ -215,38 +283,43 @@ func (r *Runner) Run(ctx context.Context) error {
 			return &cli.FriendlyError{Message: "Failed to install radius"}
 		}
 	}
-	client, err := r.ConnectionFactory.CreateApplicationsManagementClient(ctx, *r.Workspace)
-	if err != nil {
-		return err
-	}
-	//ignore the id of the resource group created
-	isGroupCreated, err := client.CreateUCPGroup(ctx, "radius", "local", r.EnvName, v20220901privatepreview.ResourceGroupResource{
-		Location: to.Ptr(v1.LocationGlobal),
-	})
-	if err != nil || !isGroupCreated {
-		return &cli.FriendlyError{Message: "Failed to create ucp resource group"}
+
+	if !r.ExistingEnvironment {
+		client, err := r.ConnectionFactory.CreateApplicationsManagementClient(ctx, *r.Workspace)
+		if err != nil {
+			return err
+		}
+
+		//ignore the id of the resource group created
+		isGroupCreated, err := client.CreateUCPGroup(ctx, "radius", "local", r.EnvName, v20220901privatepreview.ResourceGroupResource{
+			Location: to.Ptr(v1.LocationGlobal),
+		})
+		if err != nil || !isGroupCreated {
+			return &cli.FriendlyError{Message: "Failed to create ucp resource group"}
+		}
+
+		// TODO: we TEMPORARILY create a resource group in the deployments plane because the deployments RP requires it.
+		// We'll remove this in the future.
+		_, err = client.CreateUCPGroup(ctx, "deployments", "local", r.EnvName, v20220901privatepreview.ResourceGroupResource{
+			Location: to.Ptr(v1.LocationGlobal),
+		})
+		if err != nil {
+			return err
+		}
+
+		// create the providers scope from the AzureCloudProvider properties for creating the environment
+		var providers corerp.Providers
+		if r.AzureCloudProvider != nil {
+			providers = cmd.CreateEnvAzureProvider(r.AzureCloudProvider.SubscriptionID, r.AzureCloudProvider.ResourceGroup)
+		}
+
+		isEnvCreated, err := client.CreateEnvironment(ctx, r.EnvName, v1.LocationGlobal, r.Namespace, "kubernetes", "", map[string]*corerp.EnvironmentRecipeProperties{}, &providers, !r.SkipDevRecipes)
+		if err != nil || !isEnvCreated {
+			return &cli.FriendlyError{Message: "Failed to create radius environment"}
+		}
 	}
 
-	// TODO: we TEMPORARILY create a resource group in the deployments plane because the deployments RP requires it.
-	// We'll remove this in the future.
-	_, err = client.CreateUCPGroup(ctx, "deployments", "local", r.EnvName, v20220901privatepreview.ResourceGroupResource{
-		Location: to.Ptr(v1.LocationGlobal),
-	})
-	if err != nil {
-		return err
-	}
-
-	// create the providers scope from the AzureCloudProvider properties for creating the environment
-	var providers corerp.Providers
-	if r.AzureCloudProvider != nil {
-		providers = cmd.CreateEnvAzureProvider(r.AzureCloudProvider.SubscriptionID, r.AzureCloudProvider.ResourceGroup)
-	}
-	isEnvCreated, err := client.CreateEnvironment(ctx, r.EnvName, v1.LocationGlobal, r.NameSpace, "kubernetes", "", map[string]*corerp.EnvironmentRecipeProperties{}, &providers, !r.SkipDevRecipes)
-	if err != nil || !isEnvCreated {
-		return &cli.FriendlyError{Message: "Failed to create radius environment"}
-	}
-
-	err = r.ConfigFileInterface.EditWorkspaces(ctx, config, r.Workspace, r.AzureCloudProvider)
+	err := r.ConfigFileInterface.EditWorkspaces(ctx, config, r.Workspace, r.AzureCloudProvider)
 	if err != nil {
 		return err
 	}
@@ -284,7 +357,7 @@ func selectKubeContext(currentContext string, kubeContexts map[string]*api.Conte
 			}
 		}
 		index, _, err := prompter.RunSelect(prompt.SelectionPrompter(
-			"Select the kubeconfig context to install Radius into",
+			selectKubeContextPrompt,
 			values,
 		))
 		if err != nil {
@@ -303,7 +376,7 @@ func selectKubeContext(currentContext string, kubeContexts map[string]*api.Conte
 func selectCloudProvider(output output.Interface, prompter prompt.Interface) (int, error) {
 	values := []string{"Azure", "AWS", "[back]"}
 	cloudProviderSelector := promptui.Select{
-		Label: "Select your cloud provider",
+		Label: selectCloudProviderPrompt,
 		Items: values,
 	}
 	index, _, err := prompter.RunSelect(cloudProviderSelector)

--- a/pkg/cli/cmd/radInit/init_test.go
+++ b/pkg/cli/cmd/radInit/init_test.go
@@ -8,12 +8,16 @@ package radInit
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
+	"github.com/manifoldco/promptui"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/cli/azure"
 	"github.com/project-radius/radius/pkg/cli/clients"
+	"github.com/project-radius/radius/pkg/cli/cmd/provider/common"
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/framework"
 	"github.com/project-radius/radius/pkg/cli/helm"
@@ -22,6 +26,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/prompt"
 	"github.com/project-radius/radius/pkg/cli/setup"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
+	corerp "github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
 	"github.com/project-radius/radius/test/radcli"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -32,26 +37,8 @@ func Test_CommandValidation(t *testing.T) {
 }
 
 func Test_Validate(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
+	config := radcli.LoadConfigWithWorkspace(t)
 
-	// Scenario with no cloud provider
-	kubernetesMock := kubernetes.NewMockInterface(ctrl)
-	prompter := prompt.NewMockInterface(ctrl)
-	helmMock := helm.NewMockInterface(ctrl)
-	setupMock := setup.NewMockInterface(ctrl)
-
-	initMocksWithoutCloudProvider(kubernetesMock, prompter, helmMock)
-	// Scenario with error kubeContext read
-	initMocksWithKubeContextReadError(kubernetesMock)
-	// Scenario with error kubeContext selection
-	initMocksWithKubeContextSelectionError(kubernetesMock, prompter)
-	// Scenario with error env name read
-	initMocksWithErrorEnvNameRead(kubernetesMock, prompter, helmMock)
-	// Scenario with error name space read
-	initMocksWithErrorNamespaceRead(kubernetesMock, prompter, helmMock)
-	// Scenario with cloud provider configured
-	initMocksWithCloudProvider(kubernetesMock, prompter, helmMock, setupMock)
 	testcases := []radcli.ValidateInput{
 		{
 			Name:          "Valid Init Command",
@@ -59,11 +46,141 @@ func Test_Validate(t *testing.T) {
 			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithWorkspace,
+				Config:         config,
 			},
-			KubernetesInterface: kubernetesMock,
-			Prompter:            prompter,
-			HelmInterface:       helmMock,
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				// Radius is already installed, no reinstall
+				initGetKubeContextSuccess(mocks.Kubernetes)
+				initKubeContextWithKind(mocks.Prompter)
+				initHelmMockRadiusInstalled(mocks.Helm)
+				initRadiusReinstallNo(mocks.Prompter)
+
+				// No existing environment, users will be prompted to create a new one
+				setExistingEnvironments(mocks.ApplicationManagementClient, []corerp.EnvironmentResource{})
+
+				// Use default env name and namespace
+				initEnvNamePrompt(mocks.Prompter)
+				initNamespacePrompt(mocks.Prompter)
+
+				// No cloud providers
+				initAddCloudProviderPromptNo(mocks.Prompter)
+			},
+		},
+		{
+			Name:          "Valid Init Command Without Radius installed",
+			Input:         []string{},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         config,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				// Radius is already installed, no reinstall
+				initGetKubeContextSuccess(mocks.Kubernetes)
+				initKubeContextWithKind(mocks.Prompter)
+				initHelmMockRadiusNotInstalled(mocks.Helm)
+
+				// We do not prompt for reinstall if Radius is not yet installed
+
+				// We do not check for existing environments if Radius is not installed
+
+				// Use default env name and namespace
+				initEnvNamePrompt(mocks.Prompter)
+				initNamespacePrompt(mocks.Prompter)
+
+				// No cloud providers
+				initAddCloudProviderPromptNo(mocks.Prompter)
+			},
+		},
+		{
+			Name:          "Initialize with existing environment, choose to create new",
+			Input:         []string{},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         config,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				// Radius is already installed, no reinstall
+				initGetKubeContextSuccess(mocks.Kubernetes)
+				initKubeContextWithKind(mocks.Prompter)
+				initHelmMockRadiusInstalled(mocks.Helm)
+				initRadiusReinstallNo(mocks.Prompter)
+
+				// Configure an existing environment - but then choose to create a new one
+				setExistingEnvironments(mocks.ApplicationManagementClient, []corerp.EnvironmentResource{
+					{
+						Name: to.StringPtr("cool-existing-env"),
+					},
+				})
+				initExistingEnvironmentSelection(mocks.Prompter, common.SelectExistingEnvironmentCreateSentinel)
+
+				// Use default env name and namespace
+				initEnvNamePrompt(mocks.Prompter)
+				initNamespacePrompt(mocks.Prompter)
+
+				// No cloud providers
+				initAddCloudProviderPromptNo(mocks.Prompter)
+			},
+		},
+		{
+			Name:          "Initialize with existing environment, choose existing",
+			Input:         []string{},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         config,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				// Radius is already installed, no reinstall
+				initGetKubeContextSuccess(mocks.Kubernetes)
+				initKubeContextWithKind(mocks.Prompter)
+				initHelmMockRadiusInstalled(mocks.Helm)
+				initRadiusReinstallNo(mocks.Prompter)
+
+				// Configure an existing environment - but then choose to create a new one
+				setExistingEnvironments(mocks.ApplicationManagementClient, []corerp.EnvironmentResource{
+					{
+						Name: to.StringPtr("cool-existing-env"),
+					},
+				})
+				initExistingEnvironmentSelection(mocks.Prompter, "cool-existing-env")
+
+				// No need to choose env settings since we're using existing
+			},
+		},
+		{
+			Name:          "Init Command With Cloud Provider (Reinstall))",
+			Input:         []string{},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         config,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				// Radius is already installed
+				initGetKubeContextSuccess(mocks.Kubernetes)
+				initKubeContextWithKind(mocks.Prompter)
+				initHelmMockRadiusInstalled(mocks.Helm)
+
+				// Reinstall
+				initRadiusReinstallYes(mocks.Prompter)
+
+				// No existing environment, users will be prompted to create a new one
+				setExistingEnvironments(mocks.ApplicationManagementClient, []corerp.EnvironmentResource{})
+
+				// Choose default name and namespace
+				initEnvNamePrompt(mocks.Prompter)
+				initNamespacePrompt(mocks.Prompter)
+
+				// Add azure provider
+				initAddCloudProviderPromptYes(mocks.Prompter)
+				initSelectCloudProvider(mocks.Prompter)
+				initParseCloudProvider(mocks.Setup, mocks.Prompter)
+
+				// Don't add any other cloud providers
+				initAddCloudProviderPromptNo(mocks.Prompter)
+			},
 		},
 		{
 			Name:          "Init Command With Error KubeContext Read",
@@ -71,9 +188,12 @@ func Test_Validate(t *testing.T) {
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithWorkspace,
+				Config:         config,
 			},
-			KubernetesInterface: kubernetesMock,
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				// Fail to read Kubernetes context
+				initGetKubeContextError(mocks.Kubernetes)
+			},
 		},
 		{
 			Name:          "Init Command With Error KubeContext Selection",
@@ -81,10 +201,13 @@ func Test_Validate(t *testing.T) {
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithWorkspace,
+				Config:         config,
 			},
-			KubernetesInterface: kubernetesMock,
-			Prompter:            prompter,
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				// Cancel instead of choosing kubernetes context
+				initGetKubeContextSuccess(mocks.Kubernetes)
+				initKubeContextSelectionError(mocks.Prompter)
+			},
 		},
 		{
 			Name:          "Init Command With Error EnvName Read",
@@ -92,11 +215,21 @@ func Test_Validate(t *testing.T) {
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithWorkspace,
+				Config:         config,
 			},
-			KubernetesInterface: kubernetesMock,
-			Prompter:            prompter,
-			HelmInterface:       helmMock,
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				// Radius is already installed, no reinstall
+				initGetKubeContextSuccess(mocks.Kubernetes)
+				initKubeContextWithKind(mocks.Prompter)
+				initHelmMockRadiusInstalled(mocks.Helm)
+				initRadiusReinstallNo(mocks.Prompter)
+
+				// No existing environment, users will be prompted to create a new one
+				setExistingEnvironments(mocks.ApplicationManagementClient, []corerp.EnvironmentResource{})
+
+				// User cancels from environment name prompt
+				initEnvNamePromptError(mocks.Prompter)
+			},
 		},
 		{
 			Name:          "Init Command With Error Namespace Read",
@@ -104,24 +237,22 @@ func Test_Validate(t *testing.T) {
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
-				Config:         configWithWorkspace,
+				Config:         config,
 			},
-			KubernetesInterface: kubernetesMock,
-			Prompter:            prompter,
-			HelmInterface:       helmMock,
-		},
-		{
-			Name:          "Init Command With Cloud Provider Read",
-			Input:         []string{},
-			ExpectedValid: true,
-			ConfigHolder: framework.ConfigHolder{
-				ConfigFilePath: "",
-				Config:         configWithWorkspace,
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				// Radius is already installed, no reinstall
+				initGetKubeContextSuccess(mocks.Kubernetes)
+				initKubeContextWithKind(mocks.Prompter)
+				initHelmMockRadiusInstalled(mocks.Helm)
+				initRadiusReinstallNo(mocks.Prompter)
+
+				// No existing environment, users will be prompted to create a new one
+				setExistingEnvironments(mocks.ApplicationManagementClient, []corerp.EnvironmentResource{})
+
+				// Choose default name and cancel out of namespace prompt
+				initEnvNamePrompt(mocks.Prompter)
+				initNamespacePromptError(mocks.Prompter)
 			},
-			KubernetesInterface: kubernetesMock,
-			Prompter:            prompter,
-			HelmInterface:       helmMock,
-			SetupInterface:      setupMock,
 		},
 	}
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
@@ -143,7 +274,7 @@ func Test_Run(t *testing.T) {
 			CreateUCPGroup(context.Background(), "deployments", "local", "default", gomock.Any()).
 			Return(true, nil).Times(1)
 		appManagementClient.EXPECT().
-			CreateEnvironment(context.Background(), "default", v1.LocationGlobal, "defaultNameSpace", "kubernetes", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			CreateEnvironment(context.Background(), "default", v1.LocationGlobal, "defaultNamespace", "kubernetes", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(true, nil).Times(1)
 
 		configFileInterface.EXPECT().
@@ -166,7 +297,7 @@ func Test_Run(t *testing.T) {
 			Workspace:           &workspaces.Workspace{Name: "defaultWorkspace"},
 			KubeContext:         "kind-kind",
 			EnvName:             "default",
-			NameSpace:           "defaultNameSpace",
+			Namespace:           "defaultNamespace",
 			Reinstall:           true,
 			AzureCloudProvider: &azure.Provider{
 				SubscriptionID: "test-subscription",
@@ -195,7 +326,7 @@ func Test_Run_WithoutAzureProvider(t *testing.T) {
 			CreateUCPGroup(context.Background(), "deployments", "local", "default", gomock.Any()).
 			Return(true, nil).Times(1)
 		appManagementClient.EXPECT().
-			CreateEnvironment(context.Background(), "default", v1.LocationGlobal, "defaultNameSpace", "kubernetes", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			CreateEnvironment(context.Background(), "default", v1.LocationGlobal, "defaultNamespace", "kubernetes", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(true, nil).Times(1)
 
 		configFileInterface.EXPECT().
@@ -218,7 +349,7 @@ func Test_Run_WithoutAzureProvider(t *testing.T) {
 			Workspace:           &workspaces.Workspace{Name: "defaultWorkspace"},
 			KubeContext:         "kind-kind",
 			EnvName:             "default",
-			NameSpace:           "defaultNameSpace",
+			Namespace:           "defaultNamespace",
 			Reinstall:           true,
 		}
 
@@ -227,31 +358,8 @@ func Test_Run_WithoutAzureProvider(t *testing.T) {
 	})
 }
 
-func initMocksWithoutCloudProvider(kubernetesMock *kubernetes.MockInterface, prompterMock *prompt.MockInterface, helmMock *helm.MockInterface) {
-	initGetKubeContextSuccess(kubernetesMock)
-	initKubeContextWithKind(prompterMock)
-	initHelmMockRadiusInstalled(helmMock)
-	initRadiusReInstallNo(prompterMock)
-	initEnvNamePrompt(prompterMock)
-	initNameSpacePrompt(prompterMock)
-	initAddCloudProviderPromptNo(prompterMock)
-}
-
-func initMocksWithCloudProvider(kubernetesMock *kubernetes.MockInterface, prompterMock *prompt.MockInterface, helmMock *helm.MockInterface, azureMock *setup.MockInterface) {
-	initGetKubeContextSuccess(kubernetesMock)
-	initKubeContextWithKind(prompterMock)
-	initHelmMockRadiusInstalled(helmMock)
-	initPromptYes(prompterMock)
-	initEnvNamePrompt(prompterMock)
-	initNameSpacePrompt(prompterMock)
-	initPromptYes(prompterMock)
-	initSelectCloudProvider(prompterMock)
-	initParseCloudProvider(azureMock, prompterMock)
-	initAddCloudProviderPromptNo(prompterMock) // N dont add another cloud provider
-}
-
-func initParseCloudProvider(azureMock *setup.MockInterface, prompterMock *prompt.MockInterface) {
-	azureMock.EXPECT().ParseAzureProviderArgs(gomock.Any(), true, prompterMock).Return(&azure.Provider{
+func initParseCloudProvider(setup *setup.MockInterface, promper *prompt.MockInterface) {
+	setup.EXPECT().ParseAzureProviderArgs(gomock.Any(), true, promper).Return(&azure.Provider{
 		SubscriptionID: "test-subscription",
 		ResourceGroup:  "test-rg",
 		ServicePrincipal: &azure.ServicePrincipal{
@@ -260,32 +368,6 @@ func initParseCloudProvider(azureMock *setup.MockInterface, prompterMock *prompt
 			TenantID:     gomock.Any().String(),
 		},
 	}, nil)
-}
-
-func initMocksWithKubeContextReadError(kubernetesMock *kubernetes.MockInterface) {
-	initGetKubeContextError(kubernetesMock)
-}
-
-func initMocksWithKubeContextSelectionError(kubernetesMock *kubernetes.MockInterface, prompterMock *prompt.MockInterface) {
-	initGetKubeContextSuccess(kubernetesMock)
-	initKubeContextSelectionError(prompterMock)
-}
-
-func initMocksWithErrorEnvNameRead(kubernetesMock *kubernetes.MockInterface, prompterMock *prompt.MockInterface, helmMock *helm.MockInterface) {
-	initGetKubeContextSuccess(kubernetesMock)
-	initKubeContextWithKind(prompterMock)
-	initHelmMockRadiusInstalled(helmMock)
-	initRadiusReInstallNo(prompterMock)
-	initEnvNamePromptError(prompterMock)
-}
-
-func initMocksWithErrorNamespaceRead(kubernetesMock *kubernetes.MockInterface, prompterMock *prompt.MockInterface, helmMock *helm.MockInterface) {
-	initGetKubeContextSuccess(kubernetesMock)
-	initKubeContextWithKind(prompterMock)
-	initHelmMockRadiusInstalled(helmMock)
-	initRadiusReInstallNo(prompterMock)
-	initEnvNamePrompt(prompterMock)
-	initNameSpacePromptError(prompterMock)
 }
 
 func initGetKubeContextSuccess(kubernestesMock *kubernetes.MockInterface) {
@@ -314,65 +396,136 @@ func getTestKubeConfig() *api.Config {
 
 func initKubeContextWithKind(prompter *prompt.MockInterface) {
 	prompter.EXPECT().
-		RunSelect(gomock.Any()).
+		RunSelect(matchesSelect(selectKubeContextPrompt)).
 		Return(2, "", nil).Times(1)
 }
 
 func initKubeContextSelectionError(prompter *prompt.MockInterface) {
 	prompter.EXPECT().
-		RunSelect(gomock.Any()).
+		RunSelect(matchesSelect(selectKubeContextPrompt)).
 		Return(-1, "", errors.New("cannot read selection")).Times(1)
 }
 
-func initRadiusReInstallNo(prompter *prompt.MockInterface) {
+func initRadiusReinstallNo(prompter *prompt.MockInterface) {
 	prompter.EXPECT().
-		RunPrompt(gomock.Any()).
+		RunPrompt(matchesPrompt(confirmReinstallRadiusPrompt)).
 		Return("N", nil).Times(1)
+}
+
+func initRadiusReinstallYes(prompter *prompt.MockInterface) {
+	prompter.EXPECT().
+		RunPrompt(matchesPrompt(confirmReinstallRadiusPrompt)).
+		Return("Y", nil).Times(1)
 }
 
 func initEnvNamePrompt(prompter *prompt.MockInterface) {
 	prompter.EXPECT().
-		RunPrompt(gomock.Any()).
+		RunPrompt(matchesPrompt(common.EnterEnvironmentNamePrompt)).
 		Return("default", nil).Times(1)
 }
 
 func initEnvNamePromptError(prompter *prompt.MockInterface) {
 	prompter.EXPECT().
-		RunPrompt(gomock.Any()).
+		RunPrompt(matchesPrompt(common.EnterEnvironmentNamePrompt)).
 		Return("", errors.New("unable to read prompt")).Times(1)
 }
 
-func initNameSpacePrompt(prompter *prompt.MockInterface) {
+func initNamespacePrompt(prompter *prompt.MockInterface) {
 	prompter.EXPECT().
-		RunPrompt(gomock.Any()).
+		RunPrompt(matchesPrompt(common.EnterNamespacePrompt)).
 		Return("default", nil).Times(1)
 }
 
-func initNameSpacePromptError(prompter *prompt.MockInterface) {
+func initNamespacePromptError(prompter *prompt.MockInterface) {
 	prompter.EXPECT().
-		RunPrompt(gomock.Any()).
+		RunPrompt(matchesPrompt(common.EnterNamespacePrompt)).
 		Return("", errors.New("Unable to read namespace")).Times(1)
 }
 
 func initAddCloudProviderPromptNo(prompter *prompt.MockInterface) {
 	prompter.EXPECT().
-		RunPrompt(gomock.Any()).
+		RunPrompt(matchesPrompt(confirmCloudProviderPrompt)).
 		Return("N", nil).Times(1)
 }
 
-func initPromptYes(prompter *prompt.MockInterface) {
+func initAddCloudProviderPromptYes(prompter *prompt.MockInterface) {
 	prompter.EXPECT().
-		RunPrompt(gomock.Any()).
+		RunPrompt(matchesPrompt(confirmCloudProviderPrompt)).
 		Return("Y", nil).Times(1)
+
 }
 
 func initSelectCloudProvider(prompter *prompt.MockInterface) {
 	prompter.EXPECT().
-		RunSelect(gomock.Any()).Return(0, "", nil).Times(1)
+		RunSelect(matchesSelect(selectCloudProviderPrompt)).Return(0, "", nil).Times(1)
 }
 
 func initHelmMockRadiusInstalled(helmMock *helm.MockInterface) {
 	helmMock.EXPECT().
 		CheckRadiusInstall(gomock.Any()).
 		Return(true, nil).Times(1)
+}
+
+func initHelmMockRadiusNotInstalled(helmMock *helm.MockInterface) {
+	helmMock.EXPECT().
+		CheckRadiusInstall(gomock.Any()).
+		Return(false, nil).Times(1)
+}
+
+func setExistingEnvironments(clientMock *clients.MockApplicationsManagementClient, environments []corerp.EnvironmentResource) {
+	clientMock.EXPECT().
+		ListEnvironmentsAll(gomock.Any()).
+		Return(environments, nil).Times(1)
+}
+
+func initExistingEnvironmentSelection(prompter *prompt.MockInterface, choice string) {
+	prompter.EXPECT().
+		RunSelect(matchesSelect(common.SelectExistingEnvironmentPrompt)).
+		Return(-1, choice, nil).Times(1) // We ignore the index, so this is ok.
+}
+
+var _ gomock.Matcher = (*PromptMatcher)(nil)
+
+func matchesPrompt(message string) *PromptMatcher {
+	return &PromptMatcher{Message: message}
+}
+
+type PromptMatcher struct {
+	Message string
+}
+
+func (m *PromptMatcher) Matches(x interface{}) bool {
+	p, ok := x.(promptui.Prompt)
+	if !ok {
+		return false
+	}
+
+	return p.Label == m.Message
+}
+
+func (m *PromptMatcher) String() string {
+	return fmt.Sprintf("promptui.Prompt { Label: \"%s\"}", m.Message)
+}
+
+var _ gomock.Matcher = (*SelectMatcher)(nil)
+
+func matchesSelect(message string) *SelectMatcher {
+	return &SelectMatcher{Message: message}
+}
+
+type SelectMatcher struct {
+	Message string
+}
+
+func (m *SelectMatcher) Matches(x interface{}) bool {
+	p, ok := x.(promptui.Select)
+	if !ok {
+		return false
+	}
+
+	return p.Label == m.Message
+}
+
+func (m *SelectMatcher) String() string {
+	return fmt.Sprintf("promptui.Select { Label: \"%s\"}", m.Message)
 }

--- a/pkg/cli/framework/framework.go
+++ b/pkg/cli/framework/framework.go
@@ -8,7 +8,6 @@ package framework
 import (
 	"context"
 
-	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/cmd/env/namespace"
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/helm"
@@ -29,7 +28,6 @@ type Factory interface {
 	GetKubernetesInterface() kubernetes.Interface
 	GetHelmInterface() helm.Interface
 	GetNamespaceInterface() namespace.Interface
-	GetAppManagementClient() clients.ApplicationsManagementClient
 	GetSetupInterface() setup.Interface
 }
 
@@ -42,7 +40,6 @@ type Impl struct {
 	KubernetesInterface kubernetes.Interface
 	HelmInterface       helm.Interface
 	NamespaceInterface  namespace.Interface
-	AppManagementClient clients.ApplicationsManagementClient
 	SetupInterface      setup.Interface
 }
 
@@ -81,10 +78,6 @@ func (i *Impl) GetHelmInterface() helm.Interface {
 // Fetches the interface for operations related to radius installation
 func (i *Impl) GetNamespaceInterface() namespace.Interface {
 	return i.NamespaceInterface
-}
-
-func (i *Impl) GetAppManagementClient() clients.ApplicationsManagementClient {
-	return i.AppManagementClient
 }
 
 func (i *Impl) GetSetupInterface() setup.Interface {

--- a/test/radcli/shared.go
+++ b/test/radcli/shared.go
@@ -13,8 +13,10 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/golang/mock/gomock"
 	armrpcv1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/clients_new/generated"
 	"github.com/project-radius/radius/pkg/cli/cmd/env/namespace"
 	"github.com/project-radius/radius/pkg/cli/connections"
@@ -32,16 +34,20 @@ import (
 )
 
 type ValidateInput struct {
-	Name                string
-	Input               []string
-	ExpectedValid       bool
-	ConfigHolder        framework.ConfigHolder
-	KubernetesInterface kubernetes.Interface
-	Prompter            prompt.Interface
-	HelmInterface       helm.Interface
-	ConnectionFactory   *connections.MockFactory
-	NamespaceInterface  namespace.Interface
-	SetupInterface      setup.Interface
+	Name           string
+	Input          []string
+	ExpectedValid  bool
+	ConfigHolder   framework.ConfigHolder
+	ConfigureMocks func(mocks ValidateMocks)
+}
+
+type ValidateMocks struct {
+	Kubernetes                  *kubernetes.MockInterface
+	Namespace                   *namespace.MockInterface
+	Prompter                    *prompt.MockInterface
+	Helm                        *helm.MockInterface
+	Setup                       *setup.MockInterface
+	ApplicationManagementClient *clients.MockApplicationsManagementClient
 }
 
 func SharedCommandValidation(t *testing.T, factory func(framework framework.Factory) (*cobra.Command, framework.Runner)) {
@@ -57,16 +63,35 @@ func SharedCommandValidation(t *testing.T, factory func(framework framework.Fact
 func SharedValidateValidation(t *testing.T, factory func(framework framework.Factory) (*cobra.Command, framework.Runner), testcases []ValidateInput) {
 	for _, testcase := range testcases {
 		t.Run(testcase.Name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
 			framework := &framework.Impl{
-				ConnectionFactory:   testcase.ConnectionFactory,
-				ConfigHolder:        &testcase.ConfigHolder,
-				Output:              &output.MockOutput{},
-				KubernetesInterface: testcase.KubernetesInterface,
-				Prompter:            testcase.Prompter,
-				HelmInterface:       testcase.HelmInterface,
-				NamespaceInterface:  testcase.NamespaceInterface,
-				SetupInterface:      testcase.SetupInterface,
+				ConfigHolder: &testcase.ConfigHolder,
+				Output:       &output.MockOutput{},
 			}
+
+			if testcase.ConfigureMocks != nil {
+				mocks := ValidateMocks{
+					Kubernetes:                  kubernetes.NewMockInterface(ctrl),
+					Namespace:                   namespace.NewMockInterface(ctrl),
+					Prompter:                    prompt.NewMockInterface(ctrl),
+					Helm:                        helm.NewMockInterface(ctrl),
+					Setup:                       setup.NewMockInterface(ctrl),
+					ApplicationManagementClient: clients.NewMockApplicationsManagementClient(ctrl),
+				}
+
+				testcase.ConfigureMocks(mocks)
+
+				framework.KubernetesInterface = mocks.Kubernetes
+				framework.NamespaceInterface = mocks.Namespace
+				framework.Prompter = mocks.Prompter
+				framework.HelmInterface = mocks.Helm
+				framework.SetupInterface = mocks.Setup
+				framework.ConnectionFactory = &connections.MockFactory{
+					ApplicationsManagementClient: mocks.ApplicationManagementClient,
+				}
+			}
+
 			cmd, runner := factory(framework)
 			cmd.SetArgs(testcase.Input)
 			cmd.SetContext(context.Background())

--- a/test/validation/corerp.go
+++ b/test/validation/corerp.go
@@ -78,7 +78,7 @@ func DeleteCoreRPResource(ctx context.Context, t *testing.T, cli *radcli.CLI, cl
 func ValidateCoreRPResources(ctx context.Context, t *testing.T, expected *CoreRPResourceSet, client clients.ApplicationsManagementClient) {
 	for _, resource := range expected.Resources {
 		if resource.Type == EnvironmentsResource {
-			envs, err := client.ListEnv(ctx)
+			envs, err := client.ListEnvironmentsInResourceGroup(ctx)
 			require.NoError(t, err)
 			require.NotEmpty(t, envs)
 


### PR DESCRIPTION
Part of: https://github.com/project-radius/radius/issues/4303

This change adds support to `rad init` to work with existing environments. Currently `rad init` assumes that you will always be creating a new environment which isn't usual in practice. The common cases are:

- Setting up a cluster for the first time
- Connecting to an existing environment 

If users select 'reinstall to update cloud providers' we will not ask about existing environments. We need to modify/create an environment to do that.

If there are no existing environments we will also not ask about it.