### PR TITLE
Add application scaffolding to rad init

### DIFF
--- a/cmd/rad/cmd/resourceExpose.go
+++ b/cmd/rad/cmd/resourceExpose.go
@@ -61,7 +61,7 @@ rad resource expose --application icecream-store containers orders --port 5000 -
 		//ignore applicationresource as we only check for existence of application
 		_, err = managementClient.ShowApplication(cmd.Context(), application)
 		if err != nil {
-			appNotFound := cli.Is404ErrorForAzureError(err)
+			appNotFound := clients.Is404Error(err)
 			//suggest an application only when an existing one is not found
 			if appNotFound {
 				//ignore errors as we are trying to suggest an application and don't care about the errors in the suggestion process

--- a/pkg/cli/clients/clients.go
+++ b/pkg/cli/clients/clients.go
@@ -130,8 +130,16 @@ type ApplicationsManagementClient interface {
 	DeleteResource(ctx context.Context, resourceType string, resourceName string) (bool, error)
 	ListApplications(ctx context.Context) ([]corerp.ApplicationResource, error)
 	ShowApplication(ctx context.Context, applicationName string) (corerp.ApplicationResource, error)
+
+	// CreateOrUpdateApplication creates or updates an application.
+	CreateOrUpdateApplication(ctx context.Context, applicationName string, resource corerp.ApplicationResource) error
+
+	// CreateApplicationIfNotFound creates an application if it does not exist.
+	CreateApplicationIfNotFound(ctx context.Context, applicationName string, resource corerp.ApplicationResource) error
+
 	DeleteApplication(ctx context.Context, applicationName string) (bool, error)
 	CreateEnvironment(ctx context.Context, envName, location, namespace, envKind, resourceId string, recipeProperties map[string]*corerp.EnvironmentRecipeProperties, providers *corerp.Providers, useDevRecipes bool) (bool, error)
+
 	// ListEnvironmentsInResourceGroup lists all environments in the configured scope (assumes configured scope is a resource group)
 	ListEnvironmentsInResourceGroup(ctx context.Context) ([]corerp.EnvironmentResource, error)
 

--- a/pkg/cli/clients/errors.go
+++ b/pkg/cli/clients/errors.go
@@ -1,0 +1,43 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package clients
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	"github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
+)
+
+// Is404Error returns true if the error is a 404 payload from an autorest operation.
+func Is404Error(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// The error might already be an ResponseError
+	responseError := &azcore.ResponseError{}
+	if errors.As(err, &responseError) && responseError.ErrorCode == v1.CodeNotFound {
+		return true
+	} else if errors.As(err, &responseError) {
+		return false
+	}
+
+	// OK so it's not an ResponseError, can we turn it into an ErrorResponse?
+	errorResponse := v20220315privatepreview.ErrorResponse{}
+	marshallErr := json.Unmarshal([]byte(err.Error()), &errorResponse)
+	if marshallErr != nil {
+		return false
+	}
+
+	if errorResponse.Error != nil && *errorResponse.Error.Code == v1.CodeNotFound {
+		return true
+	}
+
+	return false
+}

--- a/pkg/cli/clients/mock_applicationsclient.go
+++ b/pkg/cli/clients/mock_applicationsclient.go
@@ -37,6 +37,20 @@ func (m *MockApplicationsManagementClient) EXPECT() *MockApplicationsManagementC
 	return m.recorder
 }
 
+// CreateApplicationIfNotFound mocks base method.
+func (m *MockApplicationsManagementClient) CreateApplicationIfNotFound(arg0 context.Context, arg1 string, arg2 v20220315privatepreview.ApplicationResource) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateApplicationIfNotFound", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateApplicationIfNotFound indicates an expected call of CreateApplicationIfNotFound.
+func (mr *MockApplicationsManagementClientMockRecorder) CreateApplicationIfNotFound(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateApplicationIfNotFound", reflect.TypeOf((*MockApplicationsManagementClient)(nil).CreateApplicationIfNotFound), arg0, arg1, arg2)
+}
+
 // CreateEnvironment mocks base method.
 func (m *MockApplicationsManagementClient) CreateEnvironment(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string, arg6 map[string]*v20220315privatepreview.EnvironmentRecipeProperties, arg7 *v20220315privatepreview.Providers, arg8 bool) (bool, error) {
 	m.ctrl.T.Helper()
@@ -50,6 +64,20 @@ func (m *MockApplicationsManagementClient) CreateEnvironment(arg0 context.Contex
 func (mr *MockApplicationsManagementClientMockRecorder) CreateEnvironment(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEnvironment", reflect.TypeOf((*MockApplicationsManagementClient)(nil).CreateEnvironment), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+}
+
+// CreateOrUpdateApplication mocks base method.
+func (m *MockApplicationsManagementClient) CreateOrUpdateApplication(arg0 context.Context, arg1 string, arg2 v20220315privatepreview.ApplicationResource) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOrUpdateApplication", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateOrUpdateApplication indicates an expected call of CreateOrUpdateApplication.
+func (mr *MockApplicationsManagementClientMockRecorder) CreateOrUpdateApplication(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateApplication", reflect.TypeOf((*MockApplicationsManagementClient)(nil).CreateOrUpdateApplication), arg0, arg1, arg2)
 }
 
 // CreateUCPGroup mocks base method.

--- a/pkg/cli/clivalidation.go
+++ b/pkg/cli/clivalidation.go
@@ -6,17 +6,13 @@
 package cli
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"path"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/cli/ucp"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
-	"github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
 	"github.com/project-radius/radius/pkg/ucp/resources"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -369,32 +365,4 @@ func requiredMultiple(cmd *cobra.Command, args []string, names ...string) ([]str
 		args = args[1:]
 	}
 	return results, nil
-}
-
-// Is404Error returns true if the error is a 404 payload from an autorest operation.
-func Is404ErrorForAzureError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	// The error might already be an ResponseError
-	responseError := &azcore.ResponseError{}
-	if errors.As(err, &responseError) && responseError.ErrorCode == v1.CodeNotFound {
-		return true
-	} else if errors.As(err, &responseError) {
-		return false
-	}
-
-	// OK so it's not an ResponseError, can we turn it into an ErrorResponse?
-	errorResponse := v20220315privatepreview.ErrorResponse{}
-	marshallErr := json.Unmarshal([]byte(err.Error()), &errorResponse)
-	if marshallErr != nil {
-		return false
-	}
-
-	if errorResponse.Error != nil && *errorResponse.Error.Code == v1.CodeNotFound {
-		return true
-	}
-
-	return false
 }

--- a/pkg/cli/cmd/app/appswitch/switch.go
+++ b/pkg/cli/cmd/app/appswitch/switch.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/project-radius/radius/pkg/cli"
+	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/framework"
@@ -88,7 +89,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 
 	// Validate that the application exists
 	_, err = client.ShowApplication(cmd.Context(), r.ApplicationName)
-	if cli.Is404ErrorForAzureError(err) {
+	if clients.Is404Error(err) {
 		return &cli.FriendlyError{Message: fmt.Sprintf("Unable to switch applications as the requested application %s does not exist.\n", r.ApplicationName)}
 	} else if err != nil {
 		return err

--- a/pkg/cli/cmd/deploy/deploy.go
+++ b/pkg/cli/cmd/deploy/deploy.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/bicep"
+	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/deploy"
@@ -136,7 +137,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	_, err = client.GetEnvDetails(cmd.Context(), r.EnvironmentName)
-	if cli.Is404ErrorForAzureError(err) {
+	if clients.Is404Error(err) {
 		return &cli.FriendlyError{Message: fmt.Sprintf("environment %q does not exist in scope %q. Run `rad env create` try again \n", r.EnvironmentName, r.Workspace.Scope)}
 	} else if err != nil {
 		return err

--- a/pkg/cli/cmd/env/create/create.go
+++ b/pkg/cli/cmd/env/create/create.go
@@ -14,6 +14,7 @@ import (
 
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/cli"
+	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/cmd"
 	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
 	"github.com/project-radius/radius/pkg/cli/cmd/env/namespace"
@@ -137,7 +138,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 
 	_, err = client.ShowUCPGroup(cmd.Context(), "radius", "local", r.UCPResourceGroup)
-	if cli.Is404ErrorForAzureError(err) {
+	if clients.Is404Error(err) {
 		return &cli.FriendlyError{Message: fmt.Sprintf("Resource group %q could not be found.", r.UCPResourceGroup)}
 	} else if err != nil {
 		return err

--- a/pkg/cli/cmd/env/envswitch/switch.go
+++ b/pkg/cli/cmd/env/envswitch/switch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/project-radius/radius/pkg/cli"
+	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/framework"
@@ -102,7 +103,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 
 	// Validate that the environment exists
 	_, err = client.GetEnvDetails(cmd.Context(), r.EnvironmentName)
-	if cli.Is404ErrorForAzureError(err) {
+	if clients.Is404Error(err) {
 		return &cli.FriendlyError{Message: fmt.Sprintf("Unable to switch environments as requested environment %s does not exist.\n", r.EnvironmentName)}
 	} else if err != nil {
 		return err

--- a/pkg/cli/cmd/provider/show/show.go
+++ b/pkg/cli/cmd/provider/show/show.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/project-radius/radius/pkg/cli"
+	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
 	"github.com/project-radius/radius/pkg/cli/cmd/provider/common"
 	"github.com/project-radius/radius/pkg/cli/connections"
@@ -98,7 +99,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	providers, err := client.Get(ctx, r.Kind)
-	if cli.Is404ErrorForAzureError(err) {
+	if clients.Is404Error(err) {
 		return &cli.FriendlyError{Message: fmt.Sprintf("Cloud provider %q could not be found.", r.Kind)}
 	} else if err != nil {
 		return err

--- a/pkg/cli/cmd/resource/list/list.go
+++ b/pkg/cli/cmd/resource/list/list.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/project-radius/radius/pkg/cli"
+	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/framework"
@@ -128,7 +129,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		return nil
 	} else {
 		_, err = client.ShowApplication(ctx, r.ApplicationName)
-		if cli.Is404ErrorForAzureError(err) {
+		if clients.Is404Error(err) {
 			return &cli.FriendlyError{Message: fmt.Sprintf("Application %q could not be found in workspace %q.", r.ApplicationName, r.Workspace.Name)}
 		} else if err != nil {
 			return err

--- a/pkg/cli/setup/application.go
+++ b/pkg/cli/setup/application.go
@@ -1,0 +1,80 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package setup
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/project-radius/radius/pkg/cli/output"
+)
+
+const (
+	appBicepTemplate = `import radius as radius
+param application string
+
+resource demo 'Applications.Core/containers@2022-03-15-privatepreview' = {
+  name: 'demo'
+  location: 'global'
+  properties: {
+    application: application
+    container: {
+      image: 'radius.azurecr.io/tutorial/webapp:edge'
+      ports: {
+        web: {
+          containerPort: 3000
+        }
+      }
+    }
+  }
+}
+`  // Trailing newline intentional.
+
+	radYamlTemplate = `workspace:
+  application: %q
+`  // Trailing newline intentional.
+)
+
+// ScaffoldApplication creates a working sample application in the provided directory
+// along with configuration for the application name.
+func ScaffoldApplication(output output.Interface, directory string, name string) error {
+	// Create .rad in the working directory
+	err := os.Mkdir(filepath.Join(directory, ".rad"), 0755)
+	if os.IsExist(err) {
+		// This is fine
+	} else if err != nil {
+		return err
+	}
+
+	// We NEVER overwite app.bicep if it exists. We assume the user might have changed it, and don't
+	// want them to lose their content.
+	//
+	// On the other hand, we ALWAYS overwrite rad.yaml if it exists. We assume that the reason why
+	// the user is running `rad init` is to populate it.
+	appBicepFilepath := filepath.Join(directory, "app.bicep")
+	_, err = os.Stat(appBicepFilepath)
+	if os.IsNotExist(err) {
+		output.LogInfo("Created %q", "app.bicep")
+		err = os.WriteFile(appBicepFilepath, []byte(appBicepTemplate), 0644)
+		if err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	radYamlFilepath := filepath.Join(directory, ".rad", "rad.yaml")
+	err = os.WriteFile(radYamlFilepath, []byte(fmt.Sprintf(radYamlTemplate, name)), 0644)
+	if err != nil {
+		return err
+	}
+
+	// Printing the relative path here to avoid super long console output.
+	output.LogInfo("Created %q", filepath.Join(".rad", "rad.yaml"))
+
+	return nil
+}

--- a/pkg/cli/setup/application_test.go
+++ b/pkg/cli/setup/application_test.go
@@ -1,0 +1,102 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func Test_ScaffoldApplication_CreatesBothFiles(t *testing.T) {
+	directory := t.TempDir()
+	outputSink := &output.MockOutput{}
+
+	err := ScaffoldApplication(outputSink, directory, "cool-application")
+	require.NoError(t, err)
+
+	require.FileExists(t, filepath.Join(directory, ".rad", "rad.yaml"))
+	require.FileExists(t, filepath.Join(directory, "app.bicep"))
+
+	b, err := os.ReadFile(filepath.Join(directory, ".rad", "rad.yaml"))
+	require.NoError(t, err)
+
+	actualYaml := map[string]interface{}{}
+	err = yaml.Unmarshal(b, &actualYaml)
+	require.NoError(t, err)
+
+	expectedYaml := map[string]interface{}{
+		"workspace": map[string]interface{}{
+			"application": "cool-application",
+		},
+	}
+	require.Equal(t, expectedYaml, actualYaml)
+
+	b, err = os.ReadFile(filepath.Join(directory, "app.bicep"))
+	require.NoError(t, err)
+	require.Equal(t, appBicepTemplate, string(b))
+
+	expectedOutput := []interface{}{
+		output.LogOutput{
+			Format: "Created %q",
+			Params: []interface{}{"app.bicep"},
+		},
+		output.LogOutput{
+			Format: "Created %q",
+			Params: []interface{}{filepath.Join(".rad", "rad.yaml")},
+		},
+	}
+	require.Equal(t, expectedOutput, outputSink.Writes)
+}
+
+func Test_ScaffoldApplication_KeepsAppBicepButWritesRadYaml(t *testing.T) {
+	directory := t.TempDir()
+	outputSink := &output.MockOutput{}
+
+	// Pre-create files
+	err := os.Mkdir(filepath.Join(directory, ".rad"), 0755)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(directory, ".rad", "rad.yaml"), []byte("something else"), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(directory, "app.bicep"), []byte("something else"), 0644)
+	require.NoError(t, err)
+
+	err = ScaffoldApplication(outputSink, directory, "cool-application")
+	require.NoError(t, err)
+
+	require.FileExists(t, filepath.Join(directory, ".rad", "rad.yaml"))
+	require.FileExists(t, filepath.Join(directory, "app.bicep"))
+
+	b, err := os.ReadFile(filepath.Join(directory, ".rad", "rad.yaml"))
+	require.NoError(t, err)
+
+	actualYaml := map[string]interface{}{}
+	err = yaml.Unmarshal(b, &actualYaml)
+	require.NoError(t, err)
+
+	expectedYaml := map[string]interface{}{
+		"workspace": map[string]interface{}{
+			"application": "cool-application",
+		},
+	}
+	require.Equal(t, expectedYaml, actualYaml)
+
+	b, err = os.ReadFile(filepath.Join(directory, "app.bicep"))
+	require.NoError(t, err)
+	require.Equal(t, "something else", string(b))
+
+	expectedOutput := []interface{}{
+		output.LogOutput{
+			Format: "Created %q",
+			Params: []interface{}{filepath.Join(".rad", "rad.yaml")},
+		},
+	}
+	require.Equal(t, expectedOutput, outputSink.Writes)
+}

--- a/pkg/cli/ucp/ucp_management.go
+++ b/pkg/cli/ucp/ucp_management.go
@@ -258,6 +258,46 @@ func (amc *ARMApplicationsManagementClient) DeleteApplication(ctx context.Contex
 	return respFromCtx.StatusCode != 204, nil
 }
 
+// CreateOrUpdateApplication creates or updates an application.
+func (amc *ARMApplicationsManagementClient) CreateOrUpdateApplication(ctx context.Context, applicationName string, resource v20220315privatepreview.ApplicationResource) error {
+	client, err := v20220315privatepreview.NewApplicationsClient(amc.RootScope, &aztoken.AnonymousCredential{}, amc.ClientOptions)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.CreateOrUpdate(ctx, applicationName, resource, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateApplicationIfNotFound creates an application if it does not exist.
+func (amc *ARMApplicationsManagementClient) CreateApplicationIfNotFound(ctx context.Context, applicationName string, resource v20220315privatepreview.ApplicationResource) error {
+	client, err := v20220315privatepreview.NewApplicationsClient(amc.RootScope, &aztoken.AnonymousCredential{}, amc.ClientOptions)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Get(ctx, applicationName, nil)
+	if clients.Is404Error(err) {
+		// continue
+	} else if err != nil {
+		return err
+	} else {
+		// Application already exists, nothing to do.
+		return nil
+	}
+
+	_, err = client.CreateOrUpdate(ctx, applicationName, resource, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Creates a radius environment resource
 func (amc *ARMApplicationsManagementClient) CreateEnvironment(ctx context.Context, envName string, location string, namespace string, envKind string, resourceId string, recipeProperties map[string]*corerp.EnvironmentRecipeProperties, providers *corerp.Providers, useDevRecipes bool) (bool, error) {
 	client, err := corerp.NewEnvironmentsClient(amc.RootScope, &aztoken.AnonymousCredential{}, amc.ClientOptions)


### PR DESCRIPTION
Part of: radius-project/core-team#999

This change adds 'application' scaffolding to `rad init`. When running `rad init` the user has the option to treat the local directory as an application. Doing so will output a sample `app.bicep` as well as a configuration file that tells us the application name.

The intention is that this can be used in the root directory of a git repo to configure the behavior of the CLI for the repo. This also will support multiple applications per repo as well.

The next step here is that we'll integrate the CLI with the configuration file so that our commands become aware of the application name. We'll also pass the application id (when we know it) into Bicep as a parameter so it can be used in Bicep files like the one we created.
