### PR TITLE
Integrate Recipe based links with output resources

### DIFF
--- a/pkg/corerp/backend/deployment/deployment_test.go
+++ b/pkg/corerp/backend/deployment/deployment_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/project-radius/radius/pkg/ucp/store"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/cosmos-db/mgmt/documentdb"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -208,10 +209,9 @@ func buildMongoDBResourceDataWithRecipeAndSecrets() ResourceData {
 
 	secretValues := map[string]rp.SecretValueReference{}
 	secretValues[linkrp_r.ConnectionStringValue] = rp.SecretValueReference{
-		LocalID:              outputresource.LocalIDAzureCosmosAccount,
-		Action:               "listConnectionStrings", // https://docs.microsoft.com/en-us/rest/api/cosmos-db-resource-provider/2021-04-15/database-accounts/list-connection-strings
-		ValueSelector:        "/connectionStrings/0/connectionString",
-		ProviderResourceType: azresources.DocumentDBDatabaseAccounts,
+		LocalID:       outputresource.LocalIDAzureCosmosAccount,
+		Action:        "listConnectionStrings",
+		ValueSelector: "/connectionStrings/0/connectionString",
 		Transformer: resourcemodel.ResourceType{
 			Provider: resourcemodel.ProviderAzure,
 			Type:     resourcekinds.AzureCosmosDBMongo,
@@ -225,12 +225,58 @@ func buildMongoDBResourceDataWithRecipeAndSecrets() ResourceData {
 	testResource.ComputedValues = computedValues
 	testResource.SecretValues = secretValues
 
+	accountResourceType := resourcemodel.ResourceType{
+		Type:     resourcekinds.AzureCosmosAccount,
+		Provider: resourcemodel.ProviderAzure,
+	}
+	dbResourceType := resourcemodel.ResourceType{
+		Type:     resourcekinds.AzureCosmosDBMongo,
+		Provider: resourcemodel.ProviderAzure,
+	}
+	outputResources := []outputresource.OutputResource{
+		{
+			LocalID:              outputresource.LocalIDAzureCosmosAccount,
+			ResourceType:         accountResourceType,
+			ProviderResourceType: azresources.DocumentDBDatabaseAccounts,
+			Identity: resourcemodel.ResourceIdentity{
+				ResourceType: &accountResourceType,
+				Data: resourcemodel.ARMIdentity{
+					ID:         "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account",
+					APIVersion: clients.GetAPIVersionFromUserAgent(documentdb.UserAgent()),
+				},
+			},
+			RadiusManaged: to.BoolPtr(true),
+		},
+		{
+			LocalID:              outputresource.LocalIDAzureCosmosDBMongo,
+			ResourceType:         dbResourceType,
+			ProviderResourceType: azresources.DocumentDBDatabaseAccounts + "/" + azresources.DocumentDBDatabaseAccountsMongoDBDatabases,
+			Identity: resourcemodel.ResourceIdentity{
+				ResourceType: &dbResourceType,
+				Data: resourcemodel.ARMIdentity{
+					ID:         "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
+					APIVersion: clients.GetAPIVersionFromUserAgent(documentdb.UserAgent()),
+				},
+			},
+			Resource: map[string]interface{}{
+				"properties": map[string]interface{}{
+					"resource": map[string]string{
+						"id": "test-database",
+					},
+				},
+			},
+			RadiusManaged: to.BoolPtr(true),
+			Dependencies:  []outputresource.Dependency{{LocalID: outputresource.LocalIDAzureCosmosAccount}},
+		},
+	}
+
 	return ResourceData{
-		ID:             getTestResourceID(testResource.ID),
-		Resource:       testResource,
-		ComputedValues: computedValues,
-		SecretValues:   secretValues,
-		RecipeData:     testResource.RecipeData}
+		ID:              getTestResourceID(testResource.ID),
+		OutputResources: outputResources,
+		Resource:        testResource,
+		ComputedValues:  computedValues,
+		SecretValues:    secretValues,
+		RecipeData:      testResource.RecipeData}
 }
 
 func createContext(t *testing.T) context.Context {

--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -352,24 +352,6 @@ func (dp *deploymentProcessor) fetchSecret(ctx context.Context, dependency Resou
 		return reference.Value, nil
 	}
 
-	var recipeData = dependency.RecipeData
-
-	for _, id := range recipeData.Resources {
-		parsedID, err := resources.ParseResource(id)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse deployed recipe resource id %s: %w", id, err)
-		}
-		// Find resource that matches the expected Azure resource type
-		if strings.EqualFold(parsedID.Type(), reference.ProviderResourceType) {
-			identity := resourcemodel.NewARMIdentity(&reference.Transformer, id, recipeData.APIVersion)
-			return dp.secretClient.FetchSecret(ctx, identity, reference.Action, reference.ValueSelector)
-		}
-	}
-
-	if recipeData.Resources != nil {
-		return nil, fmt.Errorf("recipe %q resources do not match expected resource type for the link", recipeData.Name)
-	}
-
 	var match *outputresource.OutputResource
 	for _, outputResource := range dependency.OutputResources {
 		if outputResource.LocalID == reference.LocalID {

--- a/pkg/linkrp/frontend/deployment/deploymentprocessor_test.go
+++ b/pkg/linkrp/frontend/deployment/deploymentprocessor_test.go
@@ -37,47 +37,101 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildTestMongoResource() (resourceID resources.ID, testResource datamodel.MongoDatabase, rendererOutput renderers.RendererOutput) {
-	id := "/subscriptions/testSub/resourceGroups/testGroup/providers/applications.link/mongodatabases/mongo0"
-	resourceID = getResourceID(id)
+const (
+	applicationID = "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication"
+	envID         = "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0"
+
+	mongoLinkName = "mongo0"
+	mongoLinkID   = "/subscriptions/testSub/resourceGroups/testGroup/providers/applications.link/mongodatabases/mongo0"
+	mongoLinkType = "applications.link/mongodatabases"
+
+	cosmosAccountID = "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account"
+	cosmosMongoID   = "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database"
+
+	recipeName   = "testRecipe"
+	modeRecipe   = "recipe"
+	modeResource = "resource"
+)
+
+var (
+	mongoLinkResourceID = getResourceID(mongoLinkID)
+	recipeParams        = map[string]interface{}{
+		"throughput": 400,
+	}
+)
+
+func buildInputResourceMongo(mode string) (testResource datamodel.MongoDatabase) {
 	testResource = datamodel.MongoDatabase{
 		BaseResource: v1.BaseResource{
 			TrackedResource: v1.TrackedResource{
-				ID:   id,
-				Name: "mongo0",
-				Type: "applications.link/mongodatabases",
+				ID:   mongoLinkID,
+				Name: mongoLinkName,
+				Type: mongoLinkType,
 			},
 		},
 		Properties: datamodel.MongoDatabaseProperties{
 			MongoDatabaseResponseProperties: datamodel.MongoDatabaseResponseProperties{
 				BasicResourceProperties: rp.BasicResourceProperties{
-					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+					Application: applicationID,
+					Environment: envID,
 				},
-				Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
 			},
 		},
 	}
 
+	if mode == modeResource {
+		testResource.Properties.Resource = cosmosMongoID
+	} else if mode == modeRecipe {
+		testResource.Properties.Recipe = datamodel.LinkRecipe{
+			Name:       recipeName,
+			Parameters: recipeParams,
+		}
+	}
+
+	return
+}
+
+func buildRendererOutputMongo(mode string) (rendererOutput renderers.RendererOutput) {
+	accountResourceType := resourcemodel.ResourceType{
+		Type:     resourcekinds.AzureCosmosAccount,
+		Provider: resourcemodel.ProviderAzure,
+	}
+	dbResourceType := resourcemodel.ResourceType{
+		Type:     resourcekinds.AzureCosmosDBMongo,
+		Provider: resourcemodel.ProviderAzure,
+	}
 	azureMongoOutputResources := []outputresource.OutputResource{
 		{
-			LocalID: outputresource.LocalIDAzureCosmosAccount,
-			ResourceType: resourcemodel.ResourceType{
-				Type:     resourcekinds.AzureCosmosAccount,
-				Provider: resourcemodel.ProviderAzure,
+			LocalID:              outputresource.LocalIDAzureCosmosAccount,
+			ResourceType:         accountResourceType,
+			ProviderResourceType: azresources.DocumentDBDatabaseAccounts,
+			Identity: resourcemodel.ResourceIdentity{
+				ResourceType: &accountResourceType,
+				Data: resourcemodel.ARMIdentity{
+					ID:         cosmosAccountID,
+					APIVersion: clients.GetAPIVersionFromUserAgent(documentdb.UserAgent()),
+				},
 			},
 		},
 		{
-			LocalID: outputresource.LocalIDAzureCosmosDBMongo,
-			ResourceType: resourcemodel.ResourceType{
-				Type:     resourcekinds.AzureCosmosDBMongo,
-				Provider: resourcemodel.ProviderAzure,
-			},
-			Dependencies: []outputresource.Dependency{
-				{
-					LocalID: outputresource.LocalIDAzureCosmosAccount,
+			LocalID:              outputresource.LocalIDAzureCosmosDBMongo,
+			ResourceType:         dbResourceType,
+			ProviderResourceType: azresources.DocumentDBDatabaseAccounts + "/" + azresources.DocumentDBDatabaseAccountsMongoDBDatabases,
+			Identity: resourcemodel.ResourceIdentity{
+				ResourceType: &dbResourceType,
+				Data: resourcemodel.ARMIdentity{
+					ID:         cosmosMongoID,
+					APIVersion: clients.GetAPIVersionFromUserAgent(documentdb.UserAgent()),
 				},
 			},
+			Resource: map[string]interface{}{
+				"properties": map[string]interface{}{
+					"resource": map[string]string{
+						"id": "test-database",
+					},
+				},
+			},
+			Dependencies: []outputresource.Dependency{{LocalID: outputresource.LocalIDAzureCosmosAccount}},
 		},
 	}
 
@@ -89,58 +143,6 @@ func buildTestMongoResource() (resourceID resources.ID, testResource datamodel.M
 				// https://docs.microsoft.com/en-us/rest/api/cosmos-db-resource-provider/2021-04-15/database-accounts/list-connection-strings
 				Action:        "listConnectionStrings",
 				ValueSelector: "/connectionStrings/0/connectionString",
-				Transformer: resourcemodel.ResourceType{
-					Provider: resourcemodel.ProviderAzure,
-					Type:     resourcekinds.AzureCosmosDBMongo,
-				},
-			},
-		},
-		ComputedValues: map[string]renderers.ComputedValueReference{
-			renderers.DatabaseNameValue: {
-				Value: "test-database",
-			},
-		},
-	}
-
-	return
-}
-
-func buildTestMongoRecipe() (resourceID resources.ID, testResource datamodel.MongoDatabase, rendererOutput renderers.RendererOutput) {
-	id := "/subscriptions/testSub/resourceGroups/testGroup/providers/applications.link/mongodatabases/mongo0"
-	resourceID = getResourceID(id)
-	testResource = datamodel.MongoDatabase{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   id,
-				Name: "mongo0",
-				Type: "applications.link/mongodatabases",
-			},
-		},
-		Properties: datamodel.MongoDatabaseProperties{
-			MongoDatabaseResponseProperties: datamodel.MongoDatabaseResponseProperties{
-				BasicResourceProperties: rp.BasicResourceProperties{
-					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
-				},
-				Recipe: datamodel.LinkRecipe{
-					Name: "mongoDB",
-					Parameters: map[string]interface{}{
-						"ResourceGroup": "testRG",
-						"Subscription":  "Radius-Test",
-					},
-				},
-			},
-		},
-	}
-
-	rendererOutput = renderers.RendererOutput{
-		SecretValues: map[string]rp.SecretValueReference{
-			renderers.ConnectionStringValue: {
-				LocalID: outputresource.LocalIDAzureCosmosAccount,
-				// https://docs.microsoft.com/en-us/rest/api/cosmos-db-resource-provider/2021-04-15/database-accounts/list-connection-strings
-				Action:               "listConnectionStrings",
-				ValueSelector:        "/connectionStrings/0/connectionString",
-				ProviderResourceType: azresources.DocumentDBDatabaseAccounts,
 				Transformer: resourcemodel.ResourceType{
 					Provider: resourcemodel.ProviderAzure,
 					Type:     resourcekinds.AzureCosmosDBMongo,
@@ -153,99 +155,38 @@ func buildTestMongoRecipe() (resourceID resources.ID, testResource datamodel.Mon
 				ProviderResourceType: azresources.DocumentDBDatabaseAccounts + "/" + azresources.DocumentDBDatabaseAccountsMongoDBDatabases,
 				JSONPointer:          "/properties/resource/id",
 			},
+			renderers.Host: {
+				Value: 8080,
+			},
 		},
-		RecipeData: datamodel.RecipeData{
+	}
+
+	if mode == modeRecipe {
+		rendererOutput.RecipeData = datamodel.RecipeData{
 			RecipeProperties: datamodel.RecipeProperties{
 				LinkRecipe: datamodel.LinkRecipe{
-					Name:       testResource.Properties.Recipe.Name,
-					Parameters: testResource.Properties.Recipe.Parameters,
+					Name:       recipeName,
+					Parameters: recipeParams,
 				},
 				TemplatePath: "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
 			},
 			APIVersion: clients.GetAPIVersionFromUserAgent(documentdb.UserAgent()),
 			Provider:   resourcemodel.ProviderAzure,
-		},
+		}
 	}
 
 	return
 }
 
-func buildTestMongoResourceMixedCaseResourceType() (resourceID resources.ID, testResource datamodel.MongoDatabase, rendererOutput renderers.RendererOutput) {
-	id := "/subscriptions/testSub/resourceGroups/testGroup/providers/applications.link/mongodatabases/mongo0"
-	resourceID = getResourceID(id)
-	testResource = datamodel.MongoDatabase{
-		BaseResource: v1.BaseResource{
-			TrackedResource: v1.TrackedResource{
-				ID:   id,
-				Name: "mongo0",
-				Type: "Applications.Link/MongoDatabases",
-			},
-		},
-		Properties: datamodel.MongoDatabaseProperties{
-			MongoDatabaseResponseProperties: datamodel.MongoDatabaseResponseProperties{
-				BasicResourceProperties: rp.BasicResourceProperties{
-					Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-					Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
-				},
-				Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
-			},
-		},
-	}
-
-	azureMongoOutputResources := []outputresource.OutputResource{
-		{
-			LocalID: outputresource.LocalIDAzureCosmosAccount,
-			ResourceType: resourcemodel.ResourceType{
-				Type:     resourcekinds.AzureCosmosAccount,
-				Provider: resourcemodel.ProviderAzure,
-			},
-		},
-		{
-			LocalID: outputresource.LocalIDAzureCosmosDBMongo,
-			ResourceType: resourcemodel.ResourceType{
-				Type:     resourcekinds.AzureCosmosDBMongo,
-				Provider: resourcemodel.ProviderAzure,
-			},
-			Dependencies: []outputresource.Dependency{
-				{
-					LocalID: outputresource.LocalIDAzureCosmosAccount,
-				},
-			},
-		},
-	}
-
-	rendererOutput = renderers.RendererOutput{
-		Resources: azureMongoOutputResources,
-		SecretValues: map[string]rp.SecretValueReference{
-			renderers.ConnectionStringValue: {
-				LocalID: outputresource.LocalIDAzureCosmosAccount,
-				// https://docs.microsoft.com/en-us/rest/api/cosmos-db-resource-provider/2021-04-15/database-accounts/list-connection-strings
-				Action:        "listConnectionStrings",
-				ValueSelector: "/connectionStrings/0/connectionString",
-				Transformer: resourcemodel.ResourceType{
-					Provider: resourcemodel.ProviderAzure,
-					Type:     resourcekinds.AzureCosmosDBMongo,
-				},
-			},
-		},
-		ComputedValues: map[string]renderers.ComputedValueReference{
-			renderers.DatabaseNameValue: {
-				Value: "test-database",
-			},
-		},
-	}
-
-	return
-}
-
-func buildFetchSecretsInput(withRecipe bool) ResourceData {
-	var resourceID resources.ID
+func buildFetchSecretsInput(mode string) ResourceData {
 	var testResource datamodel.MongoDatabase
 	var rendererOutput renderers.RendererOutput
-	if withRecipe {
-		resourceID, testResource, rendererOutput = buildTestMongoRecipe()
-	} else {
-		resourceID, testResource, rendererOutput = buildTestMongoResource()
+	if mode == modeRecipe {
+		testResource = buildInputResourceMongo(modeRecipe)
+		rendererOutput = buildRendererOutputMongo(modeRecipe)
+	} else if mode == modeResource {
+		testResource = buildInputResourceMongo(modeResource)
+		rendererOutput = buildRendererOutputMongo(modeResource)
 	}
 	testResource.Properties.Secrets = datamodel.MongoDatabaseSecrets{
 		Username:         "testUser",
@@ -266,7 +207,7 @@ func buildFetchSecretsInput(withRecipe bool) ResourceData {
 	testResource.ComputedValues = computedValues
 	testResource.SecretValues = secretValues
 
-	return ResourceData{resourceID, testResource, rendererOutput.Resources, computedValues, secretValues, rendererOutput.RecipeData}
+	return ResourceData{mongoLinkResourceID, testResource, rendererOutput.Resources, computedValues, secretValues, rendererOutput.RecipeData}
 }
 
 func buildEnvironmentResource(recipeName string, providers *corerpDatamodel.Providers) store.Object {
@@ -389,54 +330,61 @@ func Test_Render(t *testing.T) {
 	mockRecipeHandler := handlers.NewMockRecipeHandler(ctrl)
 	dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil}
 	t.Run("verify render success", func(t *testing.T) {
-		resourceID, testResource, testRendererOutput := buildTestMongoResource()
+		testResource := buildInputResourceMongo(modeResource)
+		testRendererOutput := buildRendererOutputMongo(modeResource)
 
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
 		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
 		er := buildEnvironmentResource("", nil)
 		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
 
-		rendererOutput, err := dp.Render(ctx, resourceID, &testResource)
+		rendererOutput, err := dp.Render(ctx, mongoLinkResourceID, &testResource)
 		require.NoError(t, err)
 		require.Equal(t, len(testRendererOutput.Resources), len(rendererOutput.Resources))
+		require.Equal(t, testRendererOutput.ComputedValues, rendererOutput.ComputedValues)
+		require.Equal(t, testRendererOutput.SecretValues, rendererOutput.SecretValues)
 	})
 
 	t.Run("verify render success with recipe", func(t *testing.T) {
-		resourceID, testResource, testRendererOutput := buildTestMongoRecipe()
+		testResource := buildInputResourceMongo(modeRecipe)
+		testRendererOutput := buildRendererOutputMongo(modeRecipe)
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
 		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
-		er := buildEnvironmentResource("mongoDB", &corerpDatamodel.Providers{Azure: corerpDatamodel.ProvidersAzure{Scope: "/subscriptions/testSub/resourceGroups/testGroup"}})
+		er := buildEnvironmentResource(recipeName, &corerpDatamodel.Providers{Azure: corerpDatamodel.ProvidersAzure{Scope: "/subscriptions/testSub/resourceGroups/testGroup"}})
 		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
 
-		rendererOutput, err := dp.Render(ctx, resourceID, &testResource)
+		rendererOutput, err := dp.Render(ctx, mongoLinkResourceID, &testResource)
 		require.NoError(t, err)
+		require.Equal(t, testRendererOutput.Resources, rendererOutput.Resources)
+		require.Equal(t, testRendererOutput.ComputedValues, rendererOutput.ComputedValues)
+		require.Equal(t, testRendererOutput.SecretValues, rendererOutput.SecretValues)
 		require.Equal(t, testRendererOutput.RecipeData, rendererOutput.RecipeData)
 		require.Equal(t, testRendererOutput.EnvironmentProviders, rendererOutput.EnvironmentProviders)
 
 	})
 
 	t.Run("verify render success with mixedcase resourcetype", func(t *testing.T) {
-		resourceID, testResource, testRendererOutput := buildTestMongoResourceMixedCaseResourceType()
+		testResource := buildInputResourceMongo(modeResource)
+		testResource.Type = "Applications.Link/MongoDatabases"
+		testRendererOutput := buildRendererOutputMongo(modeResource)
 
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
 		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
 		er := buildEnvironmentResource("", nil)
 		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
 
-		rendererOutput, err := dp.Render(ctx, resourceID, &testResource)
+		rendererOutput, err := dp.Render(ctx, mongoLinkResourceID, &testResource)
 		require.NoError(t, err)
 		require.Equal(t, len(testRendererOutput.Resources), len(rendererOutput.Resources))
 	})
 
 	t.Run("verify render error: invalid environment id", func(t *testing.T) {
-		id := "/subscriptions/testSub/resourceGroups/testGroup/providers/applications.link/mongodatabases/mongo0"
-		resourceID := getResourceID(id)
 		resource := datamodel.MongoDatabase{
 			BaseResource: v1.BaseResource{
 				TrackedResource: v1.TrackedResource{
-					ID:   id,
-					Name: "mongo0",
-					Type: "Applications.Link/MongoDatabases",
+					ID:   mongoLinkID,
+					Name: mongoLinkName,
+					Type: mongoLinkType,
 				},
 			},
 			Properties: datamodel.MongoDatabaseProperties{
@@ -448,7 +396,7 @@ func Test_Render(t *testing.T) {
 			},
 		}
 
-		_, err := dp.Render(ctx, resourceID, &resource)
+		_, err := dp.Render(ctx, mongoLinkResourceID, &resource)
 		require.Error(t, err)
 		require.Equal(t, v1.CodeInvalid, err.(*conv.ErrClientRP).Code)
 		require.Equal(t, "provided environment id \"invalid-id\" is not a valid id.", err.(*conv.ErrClientRP).Message)
@@ -460,8 +408,9 @@ func Test_Render(t *testing.T) {
 		er := buildEnvironmentResource("", nil)
 		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
 
-		resourceID, testResource, _ := buildTestMongoResource()
-		_, err := dp.Render(ctx, resourceID, &testResource)
+		testResource := buildInputResourceMongo(modeResource)
+
+		_, err := dp.Render(ctx, mongoLinkResourceID, &testResource)
 		require.Error(t, err)
 		require.Equal(t, "failed to render the resource", err.Error())
 	})
@@ -480,10 +429,10 @@ func Test_Render(t *testing.T) {
 			Properties: datamodel.MongoDatabaseProperties{
 				MongoDatabaseResponseProperties: datamodel.MongoDatabaseResponseProperties{
 					BasicResourceProperties: rp.BasicResourceProperties{
-						Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
-						Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+						Application: applicationID,
+						Environment: envID,
 					},
-					Resource: "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
+					Resource: cosmosMongoID,
 				},
 			},
 		}
@@ -494,14 +443,12 @@ func Test_Render(t *testing.T) {
 	})
 
 	t.Run("Invalid environment type", func(t *testing.T) {
-		id := "/subscriptions/testSub/resourceGroups/testGroup/providers/applications.link/mongodatabases/mongo0"
-		resourceID := getResourceID(id)
 		resource := datamodel.MongoDatabase{
 			BaseResource: v1.BaseResource{
 				TrackedResource: v1.TrackedResource{
-					ID:   id,
-					Name: "mongo0",
-					Type: "Applications.Link/MongoDatabases",
+					ID:   mongoLinkID,
+					Name: mongoLinkName,
+					Type: mongoLinkType,
 				},
 			},
 			Properties: datamodel.MongoDatabaseProperties{
@@ -513,7 +460,7 @@ func Test_Render(t *testing.T) {
 			},
 		}
 
-		_, err := dp.Render(ctx, resourceID, &resource)
+		_, err := dp.Render(ctx, mongoLinkResourceID, &resource)
 		require.Error(t, err)
 		require.Equal(t, v1.CodeInvalid, err.(*conv.ErrClientRP).Code)
 		require.Equal(t, "provided environment id type \"Applications.Core/env\" is not a valid type.", err.(*conv.ErrClientRP).Message)
@@ -521,19 +468,20 @@ func Test_Render(t *testing.T) {
 	})
 
 	t.Run("Non existing environment", func(t *testing.T) {
-		resourceID, testResource, _ := buildTestMongoResource()
+		testResource := buildInputResourceMongo(modeResource)
 
 		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
 		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&store.Object{}, &store.ErrNotFound{})
 
-		_, err := dp.Render(ctx, resourceID, &testResource)
+		_, err := dp.Render(ctx, mongoLinkResourceID, &testResource)
 		require.Error(t, err)
 		require.Equal(t, v1.CodeInvalid, err.(*conv.ErrClientRP).Code)
 		require.Equal(t, "environment \"/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0\" does not exist", err.(*conv.ErrClientRP).Message)
 	})
 
 	t.Run("Missing output resource provider", func(t *testing.T) {
-		resourceID, testResource, testRendererOutput := buildTestMongoResource()
+		testResource := buildInputResourceMongo(modeResource)
+		testRendererOutput := buildRendererOutputMongo(modeResource)
 		testRendererOutput.Resources[0].ResourceType.Provider = ""
 
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
@@ -541,13 +489,13 @@ func Test_Render(t *testing.T) {
 		er := buildEnvironmentResource("", nil)
 		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
 
-		_, err := dp.Render(ctx, resourceID, &testResource)
+		_, err := dp.Render(ctx, mongoLinkResourceID, &testResource)
 		require.Error(t, err)
 		require.Equal(t, "output resource \"AzureCosmosAccount\" does not have a provider specified", err.Error())
 	})
 
 	t.Run("Unsupported output resource provider", func(t *testing.T) {
-		resourceID, testResource, _ := buildTestMongoResource()
+		testResource := buildInputResourceMongo(modeResource)
 		rendererOutput := renderers.RendererOutput{
 			Resources: []outputresource.OutputResource{
 				{
@@ -565,7 +513,7 @@ func Test_Render(t *testing.T) {
 		er := buildEnvironmentResource("", nil)
 		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
 
-		_, err := dp.Render(ctx, resourceID, &testResource)
+		_, err := dp.Render(ctx, mongoLinkResourceID, &testResource)
 		require.Error(t, err)
 		require.Equal(t, v1.CodeInvalid, err.(*conv.ErrClientRP).Code)
 		require.Equal(t, "provider unknown is not configured. Cannot support resource type azure.cosmosdb.account", err.(*conv.ErrClientRP).Message)
@@ -590,14 +538,15 @@ func Test_Render(t *testing.T) {
 		)
 
 		mockdp := deploymentProcessor{testModel, mocks.dbProvider, mocks.secretsValueClient, nil}
-		resourceID, testResource, testRendererOutput := buildTestMongoResource()
+		testResource := buildInputResourceMongo(modeResource)
+		testRendererOutput := buildRendererOutputMongo(modeResource)
 
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
 		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
 		er := buildEnvironmentResource("", nil)
 		mocks.db.EXPECT().Get(gomock.Any(), gomock.Any()).Times(1).Return(&er, nil)
 
-		_, err := mockdp.Render(ctx, resourceID, &testResource)
+		_, err := mockdp.Render(ctx, mongoLinkResourceID, &testResource)
 		require.Error(t, err)
 		require.Equal(t, v1.CodeInvalid, err.(*conv.ErrClientRP).Code)
 		require.Equal(t, "provider azure is not configured. Cannot support resource type azure.cosmosdb.account", err.(*conv.ErrClientRP).Message)
@@ -610,57 +559,29 @@ func Test_Deploy(t *testing.T) {
 	dp := deploymentProcessor{mocks.model, mocks.storageProvider, mocks.secretsValueClient, nil}
 
 	t.Run("Verify deploy success", func(t *testing.T) {
-		expectedCosmosMongoDBIdentity := resourcemodel.ResourceIdentity{
-			ResourceType: &resourcemodel.ResourceType{
-				Type:     resourcekinds.AzureCosmosDBMongo,
-				Provider: resourcemodel.ProviderAzure,
-			},
-			Data: resourcemodel.ARMIdentity{},
-		}
+		mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(2).Return(resourcemodel.ResourceIdentity{}, map[string]string{}, nil)
 
-		expectedCosmosMongoAccountIdentity := resourcemodel.ResourceIdentity{
-			ResourceType: &resourcemodel.ResourceType{
-				Type:     resourcekinds.AzureCosmosAccount,
-				Provider: resourcemodel.ProviderAzure,
-			},
-			Data: resourcemodel.ARMIdentity{},
-		}
+		testRendererOutput := buildRendererOutputMongo(modeResource)
 
-		mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(1).Return(expectedCosmosMongoAccountIdentity, map[string]string{}, nil)
-		mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(1).Return(expectedCosmosMongoDBIdentity, map[string]string{}, nil)
-
-		resourceID, _, testRendererOutput := buildTestMongoResource()
-		deploymentOutput, err := dp.Deploy(ctx, resourceID, testRendererOutput)
+		deploymentOutput, err := dp.Deploy(ctx, mongoLinkResourceID, testRendererOutput)
 		require.NoError(t, err)
 		require.Equal(t, len(testRendererOutput.Resources), len(deploymentOutput.Resources))
 		require.NotEqual(t, resourcemodel.ResourceIdentity{}, deploymentOutput.Resources[0].Identity)
 		require.NotEqual(t, resourcemodel.ResourceIdentity{}, deploymentOutput.Resources[1].Identity)
 		require.Equal(t, testRendererOutput.SecretValues, deploymentOutput.SecretValues)
-		require.Equal(t, map[string]interface{}{renderers.DatabaseNameValue: testRendererOutput.ComputedValues[renderers.DatabaseNameValue].Value}, deploymentOutput.ComputedValues)
+		require.Equal(t, map[string]interface{}{renderers.DatabaseNameValue: "test-database", renderers.Host: testRendererOutput.ComputedValues[renderers.Host].Value}, deploymentOutput.ComputedValues)
 	})
 
 	t.Run("Verify deploy success with recipe", func(t *testing.T) {
-		resources := []string{"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account",
-			"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database"}
-		resourceData := map[string]interface{}{
-			"id":   "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database",
-			"name": "test-database",
-			"properties": map[string]interface{}{
-				"resource": map[string]string{
-					"id": "test-database",
-				},
-			},
-			"resourceGroup": "kachawla-test-cs",
-			"type":          "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases",
-		}
+		resources := []string{cosmosAccountID, cosmosMongoID}
 		mocks.recipeHandler.EXPECT().DeployRecipe(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(resources, nil)
-		mocks.recipeHandler.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(resourceData, nil)
+		mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(2).Return(resourcemodel.ResourceIdentity{}, map[string]string{}, nil)
 
-		resourceID, _, testRendererOutput := buildTestMongoRecipe()
-		deploymentOutput, err := dp.Deploy(ctx, resourceID, testRendererOutput)
+		testRendererOutput := buildRendererOutputMongo(modeRecipe)
+		deploymentOutput, err := dp.Deploy(ctx, mongoLinkResourceID, testRendererOutput)
 		require.NoError(t, err)
 		require.Equal(t, testRendererOutput.SecretValues, deploymentOutput.SecretValues)
-		require.Equal(t, map[string]interface{}{renderers.DatabaseNameValue: "test-database"}, deploymentOutput.ComputedValues)
+		require.Equal(t, map[string]interface{}{renderers.DatabaseNameValue: "test-database", "host": 8080}, deploymentOutput.ComputedValues)
 		require.Equal(t, resources, deploymentOutput.RecipeData.Resources)
 	})
 
@@ -668,8 +589,8 @@ func Test_Deploy(t *testing.T) {
 		deploymentName := "recipe" + strconv.FormatInt(time.Now().UnixNano(), 10)
 		mocks.recipeHandler.EXPECT().DeployRecipe(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return([]string{}, fmt.Errorf("failed to deploy recipe - %s", deploymentName))
 
-		resourceID, _, testRendererOutput := buildTestMongoRecipe()
-		_, err := dp.Deploy(ctx, resourceID, testRendererOutput)
+		testRendererOutput := buildRendererOutputMongo(modeRecipe)
+		_, err := dp.Deploy(ctx, mongoLinkResourceID, testRendererOutput)
 		require.Error(t, err)
 		require.Equal(t, "failed to deploy recipe - "+deploymentName, err.Error())
 	})
@@ -677,8 +598,8 @@ func Test_Deploy(t *testing.T) {
 	t.Run("Verify deploy failure", func(t *testing.T) {
 		mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(1).Return(resourcemodel.ResourceIdentity{}, map[string]string{}, errors.New("failed to deploy the resource"))
 
-		resourceID, _, testRendererOutput := buildTestMongoResource()
-		_, err := dp.Deploy(ctx, resourceID, testRendererOutput)
+		testRendererOutput := buildRendererOutputMongo(modeResource)
+		_, err := dp.Deploy(ctx, mongoLinkResourceID, testRendererOutput)
 		require.Error(t, err)
 		require.Equal(t, "failed to deploy the resource", err.Error())
 	})
@@ -686,27 +607,27 @@ func Test_Deploy(t *testing.T) {
 	t.Run("Verify deploy failure - invalid request", func(t *testing.T) {
 		mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(1).Return(resourcemodel.ResourceIdentity{}, map[string]string{}, conv.NewClientErrInvalidRequest("failed to access connected Azure resource"))
 
-		resourceID, _, testRendererOutput := buildTestMongoResource()
-		_, err := dp.Deploy(ctx, resourceID, testRendererOutput)
+		testRendererOutput := buildRendererOutputMongo(modeResource)
+		_, err := dp.Deploy(ctx, mongoLinkResourceID, testRendererOutput)
 		require.Error(t, err)
 		require.Equal(t, v1.CodeInvalid, err.(*conv.ErrClientRP).Code)
 		require.Equal(t, "failed to access connected Azure resource", err.(*conv.ErrClientRP).Message)
 	})
 
 	t.Run("Output resource dependency missing local ID", func(t *testing.T) {
-		resourceID, _, testRendererOutput := buildTestMongoResource()
+		testRendererOutput := buildRendererOutputMongo(modeResource)
 		testRendererOutput.Resources[0].Dependencies = []outputresource.Dependency{
 			{LocalID: ""},
 		}
-		_, err := dp.Deploy(ctx, resourceID, testRendererOutput)
+		_, err := dp.Deploy(ctx, mongoLinkResourceID, testRendererOutput)
 		require.Error(t, err)
 		require.Equal(t, "missing localID for outputresource", err.Error())
 	})
 
 	t.Run("Invalid output resource type", func(t *testing.T) {
-		resourceID, _, testRendererOutput := buildTestMongoResource()
+		testRendererOutput := buildRendererOutputMongo(modeResource)
 		testRendererOutput.Resources[0].ResourceType.Type = "foo"
-		_, err := dp.Deploy(ctx, resourceID, testRendererOutput)
+		_, err := dp.Deploy(ctx, mongoLinkResourceID, testRendererOutput)
 		require.Error(t, err)
 		require.Equal(t, "output resource kind 'Provider: azure, Type: foo' is unsupported", err.Error())
 	})
@@ -714,10 +635,23 @@ func Test_Deploy(t *testing.T) {
 	t.Run("Missing output resource identity", func(t *testing.T) {
 		mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(1).Return(resourcemodel.ResourceIdentity{}, map[string]string{}, nil)
 
-		resourceID, _, testRendererOutput := buildTestMongoResource()
-		_, err := dp.Deploy(ctx, resourceID, testRendererOutput)
+		testRendererOutput := buildRendererOutputMongo(modeResource)
+		testRendererOutput.Resources[0].Identity = resourcemodel.ResourceIdentity{}
+		testRendererOutput.Resources[1].Identity = resourcemodel.ResourceIdentity{}
+		_, err := dp.Deploy(ctx, mongoLinkResourceID, testRendererOutput)
 		require.Error(t, err)
 		require.Equal(t, "output resource \"AzureCosmosAccount\" does not have an identity. This is a bug in the handler or renderer", err.Error())
+	})
+
+	t.Run("Recipe deployment - invalid resource id", func(t *testing.T) {
+		resources := []string{"invalid-id"}
+		mocks.recipeHandler.EXPECT().DeployRecipe(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(resources, nil)
+
+		testRendererOutput := buildRendererOutputMongo(modeRecipe)
+		_, err := dp.Deploy(ctx, mongoLinkResourceID, testRendererOutput)
+		require.Error(t, err)
+		require.Equal(t, "code BadRequest: err failed to parse id \"invalid-id\" of the resource deployed by recipe \"testRecipe\" for resource "+
+			"\"/subscriptions/testSub/resourceGroups/testGroup/providers/applications.link/mongodatabases/mongo0\": 'invalid-id' is not a valid resource id", err.Error())
 	})
 }
 
@@ -733,10 +667,6 @@ func Test_DeployRenderedResources_ComputedValues(t *testing.T) {
 	testOutputResource := outputresource.OutputResource{
 		LocalID:      outputresource.LocalIDAzureCosmosAccount,
 		ResourceType: testResourceType,
-		Identity: resourcemodel.ResourceIdentity{
-			ResourceType: &testResourceType,
-			Data:         resourcemodel.ARMIdentity{},
-		},
 		Resource: map[string]interface{}{
 			"some-data": "jsonpointer-value",
 		},
@@ -760,17 +690,13 @@ func Test_DeployRenderedResources_ComputedValues(t *testing.T) {
 	}
 
 	expectedCosmosAccountIdentity := resourcemodel.ResourceIdentity{
-		ResourceType: &resourcemodel.ResourceType{
-			Type:     resourcekinds.AzureCosmosAccount,
-			Provider: resourcemodel.ProviderAzure,
-		},
-		Data: resourcemodel.ARMIdentity{},
+		ResourceType: &testResourceType,
+		Data:         resourcemodel.ARMIdentity{},
 	}
 	properties := map[string]string{"property-key": "property-value"}
 	mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(1).Return(expectedCosmosAccountIdentity, properties, nil)
 
-	resourceID, _, _ := buildTestMongoResource()
-	deploymentOutput, err := dp.Deploy(ctx, resourceID, rendererOutput)
+	deploymentOutput, err := dp.Deploy(ctx, mongoLinkResourceID, rendererOutput)
 	require.NoError(t, err)
 
 	expected := map[string]interface{}{
@@ -779,6 +705,7 @@ func Test_DeployRenderedResources_ComputedValues(t *testing.T) {
 		"test-key3": "jsonpointer-value",
 	}
 	require.Equal(t, expected, deploymentOutput.ComputedValues)
+	require.Equal(t, expectedCosmosAccountIdentity, deploymentOutput.Resources[0].Identity)
 }
 
 func Test_Deploy_InvalidComputedValues(t *testing.T) {
@@ -809,10 +736,9 @@ func Test_Deploy_InvalidComputedValues(t *testing.T) {
 
 	mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(1).Return(resourcemodel.ResourceIdentity{}, map[string]string{}, nil)
 
-	resourceID, _, _ := buildTestMongoResource()
-	_, err := dp.Deploy(ctx, resourceID, rendererOutput)
+	_, err := dp.Deploy(ctx, mongoLinkResourceID, rendererOutput)
 	require.Error(t, err)
-	require.Equal(t, "failed to process JSON Pointer \".ddkfkdk\" for resource: JSON pointer must be empty or start with a \"/", err.Error())
+	require.Equal(t, "failed to parse JSON pointer \".ddkfkdk\" for computed value \"test-value\" for link \"/subscriptions/testSub/resourceGroups/testGroup/providers/applications.link/mongodatabases/mongo0\": JSON pointer must be empty or start with a \"/", err.Error())
 }
 
 func Test_Deploy_MissingJsonPointer(t *testing.T) {
@@ -829,6 +755,9 @@ func Test_Deploy_MissingJsonPointer(t *testing.T) {
 		ResourceType: resourceType,
 		Identity: resourcemodel.ResourceIdentity{
 			ResourceType: &resourceType,
+			Data: resourcemodel.ARMIdentity{
+				ID: "test",
+			},
 		},
 		Resource: map[string]interface{}{
 			"some-data": 3,
@@ -846,10 +775,10 @@ func Test_Deploy_MissingJsonPointer(t *testing.T) {
 
 	mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(1).Return(resourcemodel.ResourceIdentity{}, map[string]string{}, nil)
 
-	resourceID, _, _ := buildTestMongoResource()
-	_, err := dp.Deploy(ctx, resourceID, rendererOutput)
+	_, err := dp.Deploy(ctx, mongoLinkResourceID, rendererOutput)
 	require.Error(t, err)
-	require.Equal(t, "failed to process JSON Pointer \"/some-other-data\" for resource: object has no key \"some-other-data\"", err.Error())
+	require.Equal(t, "code BadRequest: err failed to process JSON pointer \"/some-other-data\" to fetch computed value \"test-value\". "+
+		"Output resource identity: {test }. Link id: \"/subscriptions/testSub/resourceGroups/testGroup/providers/applications.link/mongodatabases/mongo0\": object has no key \"some-other-data\"", err.Error())
 }
 
 func Test_Delete(t *testing.T) {
@@ -896,9 +825,8 @@ func Test_Delete(t *testing.T) {
 	t.Run("Verify delete success", func(t *testing.T) {
 		mocks.resourceHandler.EXPECT().Delete(gomock.Any(), gomock.Any()).Times(2).Return(nil)
 
-		resourceID, _, _ := buildTestMongoResource()
 		resourceData := ResourceData{
-			ID:              resourceID,
+			ID:              mongoLinkResourceID,
 			OutputResources: testOutputResources,
 		}
 		err := dp.Delete(ctx, resourceData)
@@ -907,14 +835,14 @@ func Test_Delete(t *testing.T) {
 
 	t.Run("Verify delete success with recipe resources", func(t *testing.T) {
 		mocks.recipeHandler.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(nil)
-		resourceID, _, rendererOutput := buildTestMongoRecipe()
+		rendererOutput := buildRendererOutputMongo(modeResource)
+
 		resourceData := ResourceData{
-			ID: resourceID,
+			ID: mongoLinkResourceID,
 			RecipeData: datamodel.RecipeData{
 				RecipeProperties: rendererOutput.RecipeData.RecipeProperties,
 				APIVersion:       rendererOutput.RecipeData.APIVersion,
-				Resources: []string{"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account",
-					"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account/mongodbDatabases/test-database"},
+				Resources:        []string{cosmosAccountID, cosmosMongoID},
 			},
 		}
 		err := dp.Delete(ctx, resourceData)
@@ -924,9 +852,8 @@ func Test_Delete(t *testing.T) {
 	t.Run("Verify delete failure", func(t *testing.T) {
 		mocks.resourceHandler.EXPECT().Delete(gomock.Any(), gomock.Any()).Times(1).Return(errors.New("failed to delete the resource"))
 
-		resourceID, _, _ := buildTestMongoResource()
 		resourceData := ResourceData{
-			ID:              resourceID,
+			ID:              mongoLinkResourceID,
 			OutputResources: testOutputResources,
 		}
 		err := dp.Delete(ctx, resourceData)
@@ -934,7 +861,6 @@ func Test_Delete(t *testing.T) {
 	})
 
 	t.Run("Output resource dependency missing local ID", func(t *testing.T) {
-		resourceID, _, _ := buildTestMongoResource()
 		outputResources := []outputresource.OutputResource{
 			{
 				LocalID: outputresource.LocalIDAzureCosmosDBMongo,
@@ -958,7 +884,7 @@ func Test_Delete(t *testing.T) {
 		}
 		resourceData := ResourceData{
 			OutputResources: outputResources,
-			ID:              resourceID,
+			ID:              mongoLinkResourceID,
 		}
 
 		err := dp.Delete(ctx, resourceData)
@@ -976,10 +902,9 @@ func Test_Delete(t *testing.T) {
 				},
 			},
 		}
-		resourceID, _, _ := buildTestMongoResource()
 		resourceData := ResourceData{
 			OutputResources: outputResources,
-			ID:              resourceID,
+			ID:              mongoLinkResourceID,
 		}
 		err := dp.Delete(ctx, resourceData)
 		require.Error(t, err)
@@ -992,7 +917,7 @@ func Test_FetchSecrets(t *testing.T) {
 	mocks := setup(t)
 	dp := deploymentProcessor{mocks.model, mocks.storageProvider, mocks.secretsValueClient, nil}
 
-	input := buildFetchSecretsInput(false)
+	input := buildFetchSecretsInput(modeResource)
 	secrets, err := dp.FetchSecrets(ctx, input)
 	require.NoError(t, err)
 	require.Equal(t, 3, len(secrets))
@@ -1003,7 +928,7 @@ func Test_FetchSecretsWithRecipe(t *testing.T) {
 	mocks := setup(t)
 	dp := deploymentProcessor{mocks.model, mocks.storageProvider, mocks.secretsValueClient, nil}
 
-	input := buildFetchSecretsInput(true)
+	input := buildFetchSecretsInput(modeRecipe)
 	secrets, err := dp.FetchSecrets(ctx, input)
 	require.NoError(t, err)
 	require.Equal(t, 3, len(secrets))

--- a/pkg/linkrp/frontend/deployment/deploymentprocessor_test.go
+++ b/pkg/linkrp/frontend/deployment/deploymentprocessor_test.go
@@ -159,9 +159,8 @@ func buildRendererOutputMongo(mode string) (rendererOutput renderers.RendererOut
 	if mode == modeResource || mode == modeRecipe {
 		computedValues = map[string]renderers.ComputedValueReference{
 			renderers.DatabaseNameValue: {
-				LocalID:              outputresource.LocalIDAzureCosmosDBMongo,
-				ProviderResourceType: azresources.DocumentDBDatabaseAccounts + "/" + azresources.DocumentDBDatabaseAccountsMongoDBDatabases,
-				JSONPointer:          "/properties/resource/id",
+				LocalID:     outputresource.LocalIDAzureCosmosDBMongo,
+				JSONPointer: "/properties/resource/id",
 			},
 			renderers.Host: {
 				Value: 8080,
@@ -170,8 +169,7 @@ func buildRendererOutputMongo(mode string) (rendererOutput renderers.RendererOut
 
 		secretValues = map[string]rp.SecretValueReference{
 			renderers.ConnectionStringValue: {
-				LocalID: outputresource.LocalIDAzureCosmosAccount,
-				// https://docs.microsoft.com/en-us/rest/api/cosmos-db-resource-provider/2021-04-15/database-accounts/list-connection-strings
+				LocalID:       outputresource.LocalIDAzureCosmosAccount,
 				Action:        "listConnectionStrings",
 				ValueSelector: "/connectionStrings/0/connectionString",
 				Transformer: resourcemodel.ResourceType{

--- a/pkg/linkrp/handlers/arm_handler.go
+++ b/pkg/linkrp/handlers/arm_handler.go
@@ -38,14 +38,14 @@ func (handler *armHandler) Put(ctx context.Context, resource *outputresource.Out
 	}
 
 	// Do a GET just to validate that the resource exists.
-	res, err := GetByID(ctx, handler.arm.Auth, id, apiVersion)
+	res, err := getByID(ctx, handler.arm.Auth, id, apiVersion)
 	if err != nil {
 		return resourcemodel.ResourceIdentity{}, nil, err
 	}
 
 	// Return the resource so renderers can use it for computed values.
 	// TODO: it may not require such serialization.
-	serialized, err := SerializeResource(*res)
+	serialized, err := serializeResource(*res)
 	if err != nil {
 		return resourcemodel.ResourceIdentity{}, nil, err
 	}
@@ -79,7 +79,7 @@ func (handler *armHandler) Delete(ctx context.Context, resource *outputresource.
 	return nil
 }
 
-func SerializeResource(resource resources.GenericResource) (map[string]interface{}, error) {
+func serializeResource(resource resources.GenericResource) (map[string]interface{}, error) {
 	// We turn the resource into a weakly-typed representation. This is needed because JSON Pointer
 	// will have trouble with the autorest embdedded types.
 	b, err := json.Marshal(&resource)
@@ -96,7 +96,7 @@ func SerializeResource(resource resources.GenericResource) (map[string]interface
 	return data, nil
 }
 
-func GetByID(ctx context.Context, auth autorest.Authorizer, id, apiVersion string) (*resources.GenericResource, error) {
+func getByID(ctx context.Context, auth autorest.Authorizer, id, apiVersion string) (*resources.GenericResource, error) {
 	parsed, err := ucpresources.ParseResource(id)
 	if err != nil {
 		return nil, err

--- a/pkg/linkrp/handlers/mock_recipe_handler.go
+++ b/pkg/linkrp/handlers/mock_recipe_handler.go
@@ -36,20 +36,6 @@ func (m *MockRecipeHandler) EXPECT() *MockRecipeHandlerMockRecorder {
 	return m.recorder
 }
 
-// Delete mocks base method.
-func (m *MockRecipeHandler) Delete(arg0 context.Context, arg1, arg2 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Delete indicates an expected call of Delete.
-func (mr *MockRecipeHandlerMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockRecipeHandler)(nil).Delete), arg0, arg1, arg2)
-}
-
 // DeployRecipe mocks base method.
 func (m *MockRecipeHandler) DeployRecipe(arg0 context.Context, arg1 datamodel0.RecipeProperties, arg2 datamodel.Providers) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -63,19 +49,4 @@ func (m *MockRecipeHandler) DeployRecipe(arg0 context.Context, arg1 datamodel0.R
 func (mr *MockRecipeHandlerMockRecorder) DeployRecipe(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployRecipe", reflect.TypeOf((*MockRecipeHandler)(nil).DeployRecipe), arg0, arg1, arg2)
-}
-
-// GetResource mocks base method.
-func (m *MockRecipeHandler) GetResource(arg0 context.Context, arg1, arg2, arg3 string) (map[string]interface{}, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetResource", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(map[string]interface{})
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetResource indicates an expected call of GetResource.
-func (mr *MockRecipeHandlerMockRecorder) GetResource(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResource", reflect.TypeOf((*MockRecipeHandler)(nil).GetResource), arg0, arg1, arg2, arg3)
 }

--- a/pkg/linkrp/renderers/mongodatabases/renderer.go
+++ b/pkg/linkrp/renderers/mongodatabases/renderer.go
@@ -84,9 +84,8 @@ func RenderAzureRecipe(resource *datamodel.MongoDatabase, options renderers.Rend
 
 	computedValues := map[string]renderers.ComputedValueReference{
 		renderers.DatabaseNameValue: {
-			LocalID:              outputresource.LocalIDAzureCosmosDBMongo,
-			ProviderResourceType: azresources.DocumentDBDatabaseAccounts + "/" + azresources.DocumentDBDatabaseAccountsMongoDBDatabases,
-			JSONPointer:          "/properties/resource/id", // response of "az resource show" for cosmos mongodb resource contains database name in this property
+			LocalID:     outputresource.LocalIDAzureCosmosDBMongo,
+			JSONPointer: "/properties/resource/id", // response of "az resource show" for cosmos mongodb resource contains database name in this property
 		},
 	}
 
@@ -200,10 +199,9 @@ func buildSecretValueReferenceForAzure(properties datamodel.MongoDatabasePropert
 	_, ok := secretValues[renderers.ConnectionStringValue]
 	if !ok {
 		secretValues[renderers.ConnectionStringValue] = rp.SecretValueReference{
-			LocalID:              outputresource.LocalIDAzureCosmosAccount,
-			Action:               "listConnectionStrings", // https://docs.microsoft.com/en-us/rest/api/cosmos-db-resource-provider/2021-04-15/database-accounts/list-connection-strings
-			ValueSelector:        "/connectionStrings/0/connectionString",
-			ProviderResourceType: azresources.DocumentDBDatabaseAccounts,
+			LocalID:       outputresource.LocalIDAzureCosmosAccount,
+			Action:        "listConnectionStrings", // https://docs.microsoft.com/en-us/rest/api/cosmos-db-resource-provider/2021-04-15/database-accounts/list-connection-strings
+			ValueSelector: "/connectionStrings/0/connectionString",
 			Transformer: resourcemodel.ResourceType{
 				Provider: resourcemodel.ProviderAzure,
 				Type:     resourcekinds.AzureCosmosDBMongo,

--- a/pkg/linkrp/renderers/mongodatabases/renderer.go
+++ b/pkg/linkrp/renderers/mongodatabases/renderer.go
@@ -89,9 +89,30 @@ func RenderAzureRecipe(resource *datamodel.MongoDatabase, options renderers.Rend
 		},
 	}
 
+	// Build expected output resources
+	expectedCosmosAccount := outputresource.OutputResource{
+		LocalID: outputresource.LocalIDAzureCosmosAccount,
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.AzureCosmosAccount,
+			Provider: resourcemodel.ProviderAzure,
+		},
+		ProviderResourceType: azresources.DocumentDBDatabaseAccounts,
+	}
+
+	expectedMongoDBResource := outputresource.OutputResource{
+		LocalID: outputresource.LocalIDAzureCosmosDBMongo,
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.AzureCosmosDBMongo,
+			Provider: resourcemodel.ProviderAzure,
+		},
+		ProviderResourceType: azresources.DocumentDBDatabaseAccounts + "/" + azresources.DocumentDBDatabaseAccountsMongoDBDatabases,
+		Dependencies:         []outputresource.Dependency{{LocalID: outputresource.LocalIDAzureCosmosAccount}},
+	}
+
 	return renderers.RendererOutput{
 		ComputedValues:       computedValues,
 		SecretValues:         secretValues,
+		Resources:            []outputresource.OutputResource{expectedCosmosAccount, expectedMongoDBResource},
 		RecipeData:           recipeData,
 		EnvironmentProviders: options.EnvironmentProviders,
 	}, nil

--- a/pkg/linkrp/renderers/mongodatabases/renderer.go
+++ b/pkg/linkrp/renderers/mongodatabases/renderer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/cosmos-db/mgmt/documentdb"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/azure/azresources"
 	"github.com/project-radius/radius/pkg/azure/clients"
@@ -97,6 +98,7 @@ func RenderAzureRecipe(resource *datamodel.MongoDatabase, options renderers.Rend
 			Provider: resourcemodel.ProviderAzure,
 		},
 		ProviderResourceType: azresources.DocumentDBDatabaseAccounts,
+		RadiusManaged:        to.BoolPtr(true),
 	}
 
 	expectedMongoDBResource := outputresource.OutputResource{
@@ -106,6 +108,7 @@ func RenderAzureRecipe(resource *datamodel.MongoDatabase, options renderers.Rend
 			Provider: resourcemodel.ProviderAzure,
 		},
 		ProviderResourceType: azresources.DocumentDBDatabaseAccounts + "/" + azresources.DocumentDBDatabaseAccountsMongoDBDatabases,
+		RadiusManaged:        to.BoolPtr(true),
 		Dependencies:         []outputresource.Dependency{{LocalID: outputresource.LocalIDAzureCosmosAccount}},
 	}
 
@@ -147,6 +150,7 @@ func RenderAzureResource(properties datamodel.MongoDatabaseProperties) (renderer
 			Type:     resourcekinds.AzureCosmosAccount,
 			Provider: resourcemodel.ProviderAzure,
 		},
+		RadiusManaged: to.BoolPtr(false),
 	}
 	cosmosAccountResource.Identity = resourcemodel.NewARMIdentity(&cosmosAccountResource.ResourceType, cosmosMongoAccountID.String(), clients.GetAPIVersionFromUserAgent(documentdb.UserAgent()))
 
@@ -156,6 +160,7 @@ func RenderAzureResource(properties datamodel.MongoDatabaseProperties) (renderer
 			Type:     resourcekinds.AzureCosmosDBMongo,
 			Provider: resourcemodel.ProviderAzure,
 		},
+		RadiusManaged: to.BoolPtr(false),
 		Dependencies: []outputresource.Dependency{
 			{
 				LocalID: outputresource.LocalIDAzureCosmosAccount,

--- a/pkg/linkrp/renderers/mongodatabases/renderer_test.go
+++ b/pkg/linkrp/renderers/mongodatabases/renderer_test.go
@@ -317,9 +317,8 @@ func Test_Render_Recipe_Success(t *testing.T) {
 
 	expectedComputedValues := map[string]renderers.ComputedValueReference{
 		renderers.DatabaseNameValue: {
-			LocalID:              outputresource.LocalIDAzureCosmosDBMongo,
-			JSONPointer:          "/properties/resource/id",
-			ProviderResourceType: "Microsoft.DocumentDB/databaseAccounts/mongodbDatabases",
+			LocalID:     outputresource.LocalIDAzureCosmosDBMongo,
+			JSONPointer: "/properties/resource/id",
 		},
 	}
 
@@ -364,7 +363,6 @@ func Test_Render_Recipe_Success(t *testing.T) {
 	require.Equal(t, outputresource.LocalIDAzureCosmosAccount, output.SecretValues[renderers.ConnectionStringValue].LocalID)
 	require.Equal(t, "/connectionStrings/0/connectionString", output.SecretValues[renderers.ConnectionStringValue].ValueSelector)
 	require.Equal(t, "listConnectionStrings", output.SecretValues[renderers.ConnectionStringValue].Action)
-	require.Equal(t, azresources.DocumentDBDatabaseAccounts, output.SecretValues[renderers.ConnectionStringValue].ProviderResourceType)
 
 	// Computed Values
 	require.Equal(t, expectedComputedValues, output.ComputedValues)

--- a/pkg/linkrp/renderers/mongodatabases/renderer_test.go
+++ b/pkg/linkrp/renderers/mongodatabases/renderer_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/cosmos-db/mgmt/documentdb"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/azure/azresources"
@@ -62,8 +63,9 @@ func Test_Render_Success(t *testing.T) {
 	}
 	expectedOutputResources := []outputresource.OutputResource{
 		{
-			LocalID:      outputresource.LocalIDAzureCosmosAccount,
-			ResourceType: accountResourceType,
+			LocalID:       outputresource.LocalIDAzureCosmosAccount,
+			ResourceType:  accountResourceType,
+			RadiusManaged: to.BoolPtr(false),
 			Identity: resourcemodel.ResourceIdentity{
 				ResourceType: &accountResourceType,
 				Data: resourcemodel.ARMIdentity{
@@ -73,8 +75,9 @@ func Test_Render_Success(t *testing.T) {
 			},
 		},
 		{
-			LocalID:      outputresource.LocalIDAzureCosmosDBMongo,
-			ResourceType: dbResourceType,
+			LocalID:       outputresource.LocalIDAzureCosmosDBMongo,
+			ResourceType:  dbResourceType,
+			RadiusManaged: to.BoolPtr(false),
 			Identity: resourcemodel.ResourceIdentity{
 				ResourceType: &dbResourceType,
 				Data: resourcemodel.ARMIdentity{
@@ -327,6 +330,7 @@ func Test_Render_Recipe_Success(t *testing.T) {
 				Type:     resourcekinds.AzureCosmosAccount,
 				Provider: resourcemodel.ProviderAzure,
 			},
+			RadiusManaged:        to.BoolPtr(true),
 			ProviderResourceType: azresources.DocumentDBDatabaseAccounts,
 		},
 		{
@@ -335,6 +339,7 @@ func Test_Render_Recipe_Success(t *testing.T) {
 				Type:     resourcekinds.AzureCosmosDBMongo,
 				Provider: resourcemodel.ProviderAzure,
 			},
+			RadiusManaged:        to.BoolPtr(true),
 			ProviderResourceType: azresources.DocumentDBDatabaseAccounts + "/" + azresources.DocumentDBDatabaseAccountsMongoDBDatabases,
 			Dependencies:         []outputresource.Dependency{{LocalID: outputresource.LocalIDAzureCosmosAccount}},
 		},

--- a/pkg/linkrp/renderers/types.go
+++ b/pkg/linkrp/renderers/types.go
@@ -74,7 +74,4 @@ type ComputedValueReference struct {
 
 	// JSONPointer specifies a JSON Pointer that can be used to look up the value in the resource's body.
 	JSONPointer string
-
-	// Resource type of the resource to look up the property from
-	ProviderResourceType string
 }

--- a/pkg/rp/outputresource/info.go
+++ b/pkg/rp/outputresource/info.go
@@ -28,10 +28,11 @@ type OutputResource struct {
 	// Resource type defined by the provider for this resource. Example for Azure, a resource type is of the format: Microsoft.DocumentDB/databaseAccounts
 	ProviderResourceType string
 
-	Deployed     bool                 `json:"deployed"`
-	Resource     interface{}          `json:"resource,omitempty"`
-	Dependencies []Dependency         // resources that are required to be deployed before this resource can be deployed - used for parent/child resources.
-	Status       OutputResourceStatus `json:"status,omitempty"`
+	RadiusManaged *bool                `json:"radiusManaged"`
+	Deployed      bool                 `json:"deployed"`
+	Resource      interface{}          `json:"resource,omitempty"`
+	Dependencies  []Dependency         // resources that are required to be deployed before this resource can be deployed - used for parent/child resources.
+	Status        OutputResourceStatus `json:"status,omitempty"`
 }
 
 type Dependency struct {
@@ -60,6 +61,14 @@ func (resource OutputResource) GetDependencies() ([]string, error) {
 		dependencies = append(dependencies, dependency.LocalID)
 	}
 	return dependencies, nil
+}
+
+func (resource OutputResource) IsRadiusManaged() bool {
+	if resource.RadiusManaged == nil {
+		return false
+	}
+
+	return *resource.RadiusManaged
 }
 
 // OrderOutputResources returns output resources ordered based on deployment order

--- a/pkg/rp/outputresource/info.go
+++ b/pkg/rp/outputresource/info.go
@@ -26,7 +26,7 @@ type OutputResource struct {
 	ResourceType resourcemodel.ResourceType `json:"resourceType"`
 
 	// Resource type defined by the provider for this resource. Example for Azure, a resource type is of the format: Microsoft.DocumentDB/databaseAccounts
-	ProviderResourceType string
+	ProviderResourceType string `json:"providerResourceType"`
 
 	RadiusManaged *bool                `json:"radiusManaged"`
 	Deployed      bool                 `json:"deployed"`

--- a/pkg/rp/outputresource/info.go
+++ b/pkg/rp/outputresource/info.go
@@ -25,9 +25,12 @@ type OutputResource struct {
 	// Resource type specifies the 'provider' and 'kind' used to look up the resource handler for processing
 	ResourceType resourcemodel.ResourceType `json:"resourceType"`
 
+	// Resource type defined by the provider for this resource. Example for Azure, a resource type is of the format: Microsoft.DocumentDB/databaseAccounts
+	ProviderResourceType string
+
 	Deployed     bool                 `json:"deployed"`
 	Resource     interface{}          `json:"resource,omitempty"`
-	Dependencies []Dependency         // resources that are required to be deployed before this resource can be deployed
+	Dependencies []Dependency         // resources that are required to be deployed before this resource can be deployed - used for parent/child resources.
 	Status       OutputResourceStatus `json:"status,omitempty"`
 }
 

--- a/pkg/rp/types.go
+++ b/pkg/rp/types.go
@@ -57,9 +57,6 @@ type SecretValueReference struct {
 	// no concept of 'action'. Will always be set for an ARM resource.
 	Action string
 
-	// Resource type this action can be performed on. Example for Azure a resource type is of the format: Microsoft.DocumentDB/databaseAccounts
-	ProviderResourceType string
-
 	// ValueSelector is a JSONPointer used to resolve the secret value.
 	ValueSelector string
 


### PR DESCRIPTION
# Description

For resource id based links we wrap underlying resources in output resources which users can view as a part of rad resource show. With recipe links, we currently don't provide users ability to view resources deployed by the recipe, so using same output resources framework to support this enable consistent experience and remove added complexity in the implementation, help using converge on some of the code between recipes and resource ids.

### Testing
Manually verified the changes locally. Existing end to end test is passing as well.

## Issue reference

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
