### PR TITLE
Add `rad init --dev`

### DIFF
--- a/pkg/cli/cmd/provider/common/validation.go
+++ b/pkg/cli/cmd/provider/common/validation.go
@@ -38,7 +38,7 @@ func ValidateCloudProviderName(name string) error {
 // We also expect the the existing environments to be a non-empty list, callers should check that.
 //
 // If the name returned is empty, it means that that either no environment was found or that the user opted to create a new one.
-func SelectExistingEnvironment(cmd *cobra.Command, defaultVal string, prompter prompt.Interface, existing []corerp.EnvironmentResource) (string, error) {
+func SelectExistingEnvironment(cmd *cobra.Command, defaultVal string, interactive bool, prompter prompt.Interface, existing []corerp.EnvironmentResource) (string, error) {
 	selectedName, err := cmd.Flags().GetString("environment")
 	if err != nil {
 		return "", err
@@ -52,7 +52,19 @@ func SelectExistingEnvironment(cmd *cobra.Command, defaultVal string, prompter p
 			}
 		}
 
-		// Returing empty tells the caller to create a new one.
+		// Returing empty tells the caller to create a new one, or to prompt or fail.
+		return "", nil
+	}
+
+	if !interactive {
+		// If an an environment exists that matches the default then choose that.
+		for _, env := range existing {
+			if strings.EqualFold(defaultVal, *env.Name) {
+				return defaultVal, nil
+			}
+		}
+
+		// Returing empty tells the caller to prompt or fail.
 		return "", nil
 	}
 

--- a/pkg/cli/cmd/radInit/init_test.go
+++ b/pkg/cli/cmd/radInit/init_test.go
@@ -183,6 +183,91 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
+			Name:          "rad init --dev create new environment",
+			Input:         []string{"--dev"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         config,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				// Radius is already installed, no reinstall
+				initGetKubeContextSuccess(mocks.Kubernetes)
+				initHelmMockRadiusInstalled(mocks.Helm)
+
+				// No existing environment, users will be prompted to create a new one
+				setExistingEnvironments(mocks.ApplicationManagementClient, []corerp.EnvironmentResource{})
+
+				// No prompts in this case
+			},
+		},
+		{
+			Name:          "rad init --dev without Radius installed",
+			Input:         []string{"--dev"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         config,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				// Radius is already installed
+				initGetKubeContextSuccess(mocks.Kubernetes)
+				initHelmMockRadiusNotInstalled(mocks.Helm)
+
+				// No prompts in this case
+			},
+		},
+		{
+			Name:          "rad init --dev chooses existing environment",
+			Input:         []string{"--dev"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         config,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				// Radius is already installed, no reinstall
+				initGetKubeContextSuccess(mocks.Kubernetes)
+				initHelmMockRadiusInstalled(mocks.Helm)
+
+				// Configure an existing environment - this will be chosen automatically
+				setExistingEnvironments(mocks.ApplicationManagementClient, []corerp.EnvironmentResource{
+					{
+						Name: to.StringPtr("default"),
+					},
+				})
+
+				// No prompts in this case
+			},
+		},
+		{
+			Name:          "rad init --dev prompts for existing environment",
+			Input:         []string{"--dev"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         config,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				// Radius is already installed, no reinstall
+				initGetKubeContextSuccess(mocks.Kubernetes)
+				initHelmMockRadiusInstalled(mocks.Helm)
+
+				// Configure an existing environment - user has to choose
+				setExistingEnvironments(mocks.ApplicationManagementClient, []corerp.EnvironmentResource{
+					{
+						Name: to.StringPtr("dev"),
+					},
+					{
+						Name: to.StringPtr("prod"),
+					},
+				})
+
+				// prompt the user since there's no 'default'
+				initExistingEnvironmentSelection(mocks.Prompter, "prod")
+			},
+		},
+		{
 			Name:          "Init Command With Error KubeContext Read",
 			Input:         []string{},
 			ExpectedValid: false,


### PR DESCRIPTION
Part of: radius-project/core-team#999

This change adds a `--dev` flag to `rad init` that is optimized for development setup. The goal is make it trivial for users to setup Radius for non-production use across a few scenarios:

- First time cluster setup
- Creating a new application for an existing cluster
- Accessing a cluster that's already setup by someone else

Passing `--dev` will short circuit **ALL** of the existing choices users are asked today by `rad init` unless they absolutely need to be asked. For example we'll choose the user's current KubeContext, default namespace, default environment, no cloud providers, etc. We only ask about these things if there's a conflict, for example if multiple environments exist but none of them are called 'default'.

We choosing an opt-in mechanism for this because we want to lean *heavily* into optimizing for developer scenarios. It feels better to provide a flexible option as the default and then have users opt-in to non-production use in an obvious way. For an example, we'll include the 'dev' recipe pack by default without the user have to know what a recipe pack is. To make this absolutely clear - it's not just that we're choosing defaults for some of our choices, it's that we're going to make those defaults **heavily** biased towards non-production use. If we were just choosing more defaults, we'd simplify further by baking it into `rad init`.
