### PR TITLE
Removing hardcoded DE image and tag from Azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,10 +24,6 @@ variables:
   value: edge
 - name: REL_VERSION
   value: pr-ado-$(Build.BuildNumber)
-- name: DE_IMAGE
-  value: radius.azurecr.io/deployment-engine
-- name: DE_TAG
-  value: latest
 - name: INTEGRATION_TEST_LOGANALYTICS_WORKSPACEID
   value: "/subscriptions/85716382-7362-45c3-ae03-2126e459a123/resourcegroups/radiusrplogs/providers/microsoft.operationalinsights/workspaces/rplogs"
 - name: INTEGRATION_TEST_SUBSCRIPTION_ID

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,7 +151,7 @@ stages:
       displayName: rad env init kubernetes
     - script: |
         kubectl set image deployment/bicep-de -n radius-system de=$(DE_IMAGE):$(DE_TAG)
-      condition: always()
+      condition: and(ne($(DE_IMAGE), ""), ne($(DE_TAG), ""))
     - script: |
         kubectl get pods -n radius-system
         kubectl describe pods -n radius-system

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,7 +151,7 @@ stages:
       displayName: rad env init kubernetes
     - script: |
         kubectl set image deployment/bicep-de -n radius-system de=$(DE_IMAGE):$(DE_TAG)
-      condition: and(variables['DE_IMAGE'], ''), ne(variables['DE_TAG'], ''))
+      condition: and(ne(variables['DE_IMAGE'], ''), ne(variables['DE_TAG'], ''))
     - script: |
         kubectl get pods -n radius-system
         kubectl describe pods -n radius-system

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,7 +151,7 @@ stages:
       displayName: rad env init kubernetes
     - script: |
         kubectl set image deployment/bicep-de -n radius-system de=$(DE_IMAGE):$(DE_TAG)
-      condition: and(ne($(DE_IMAGE), ""), ne($(DE_TAG), ""))
+      condition: and(variables['DE_IMAGE'], ''), ne(variables['DE_TAG'], ''))
     - script: |
         kubectl get pods -n radius-system
         kubectl describe pods -n radius-system


### PR DESCRIPTION
# Description

* Removes hardcoded DE image from azure pipelines file. The step to edit the DE image will only be run if the DE_IMAGE and DE_TAG variables are set.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
