### PR TITLE
Enable fallback workspace for group commands

### DIFF
--- a/pkg/cli/cmd/group/create/create.go
+++ b/pkg/cli/cmd/group/create/create.go
@@ -70,11 +70,6 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// TODO: support fallback workspace
-	if !workspace.IsNamedWorkspace() {
-		return workspaces.ErrNamedWorkspaceRequired
-	}
-
 	resourceGroup, err := cli.RequireUCPResourceGroup(cmd, args)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/group/create/create_test.go
+++ b/pkg/cli/cmd/group/create/create_test.go
@@ -38,7 +38,7 @@ func Test_Validate(t *testing.T) {
 		{
 			Name:          "Create Command with valid args and fallback workspace",
 			Input:         []string{"rg"},
-			ExpectedValid: false,
+			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
 				Config:         radcli.LoadEmptyConfig(t),

--- a/pkg/cli/cmd/group/delete/delete.go
+++ b/pkg/cli/cmd/group/delete/delete.go
@@ -67,11 +67,6 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// TODO: support fallback workspace
-	if !workspace.IsNamedWorkspace() {
-		return workspaces.ErrNamedWorkspaceRequired
-	}
-
 	resourceGroup, err := cli.RequireUCPResourceGroup(cmd, args)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/group/delete/delete_test.go
+++ b/pkg/cli/cmd/group/delete/delete_test.go
@@ -48,7 +48,7 @@ func Test_Validate(t *testing.T) {
 		{
 			Name:          "Delete Command with fallback workspace",
 			Input:         []string{"groupname"},
-			ExpectedValid: false,
+			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
 				Config:         radcli.LoadEmptyConfig(t),

--- a/pkg/cli/cmd/group/list/list.go
+++ b/pkg/cli/cmd/group/list/list.go
@@ -37,7 +37,7 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	}
 
 	commonflags.AddWorkspaceFlag(cmd)
-	cmd.Flags().StringP("output", "o", "", "The output format")
+	commonflags.AddOutputFlag(cmd)
 
 	return cmd, runner
 }
@@ -66,11 +66,6 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	workspace, err := cli.RequireWorkspace(cmd, config)
 	if err != nil {
 		return err
-	}
-
-	// TODO: support fallback workspace
-	if !workspace.IsNamedWorkspace() {
-		return workspaces.ErrNamedWorkspaceRequired
 	}
 
 	format, err := cmd.Flags().GetString("output")

--- a/pkg/cli/cmd/group/list/list_test.go
+++ b/pkg/cli/cmd/group/list/list_test.go
@@ -58,7 +58,7 @@ func Test_Validate(t *testing.T) {
 		{
 			Name:          "List Command with fallback workspace",
 			Input:         []string{},
-			ExpectedValid: false,
+			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
 				Config:         radcli.LoadEmptyConfig(t),

--- a/pkg/cli/cmd/group/show/show.go
+++ b/pkg/cli/cmd/group/show/show.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/project-radius/radius/pkg/cli"
+	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/framework"
 	"github.com/project-radius/radius/pkg/cli/objectformats"
@@ -36,9 +37,9 @@ Note that these resource groups are separate from the Azure cloud provider and A
 		RunE:    framework.RunCommand(runner),
 	}
 
-	cmd.Flags().StringP("group", "g", "", "The resource group name")
-	cmd.Flags().StringP("workspace", "w", "", "The workspace name")
-	cmd.Flags().StringP("output", "o", "", "The output format")
+	commonflags.AddResourceGroupFlag(cmd)
+	commonflags.AddWorkspaceFlag(cmd)
+	commonflags.AddOutputFlag(cmd)
 
 	return cmd, runner
 }
@@ -67,11 +68,6 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	workspace, err := cli.RequireWorkspace(cmd, config)
 	if err != nil {
 		return err
-	}
-
-	// TODO: support fallback workspace
-	if !workspace.IsNamedWorkspace() {
-		return workspaces.ErrNamedWorkspaceRequired
 	}
 
 	format, err := cli.RequireOutput(cmd)

--- a/pkg/cli/cmd/group/show/show_test.go
+++ b/pkg/cli/cmd/group/show/show_test.go
@@ -52,7 +52,7 @@ func Test_Validate(t *testing.T) {
 		{
 			Name:          "Show Command with fallback workspace",
 			Input:         []string{"groupname"},
-			ExpectedValid: false,
+			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
 				Config:         radcli.LoadEmptyConfig(t),


### PR DESCRIPTION
Part of: radius-project/core-team#999

This change enables the `rad group` family of commands to work without a config.yaml defined. No code changes were needed to make these commands function correctly except to move the guardrails. I cleaned up some code duplication I found with parameters.
