### PR TITLE
pass env provider in the createUpdate call by ucp

### DIFF
--- a/pkg/cli/ucp/ucp_management.go
+++ b/pkg/cli/ucp/ucp_management.go
@@ -266,7 +266,7 @@ func (amc *ARMApplicationsManagementClient) CreateEnvironment(ctx context.Contex
 	}
 
 	envCompute := corerp.KubernetesCompute{Kind: &envKind, Namespace: &namespace, ResourceID: &resourceId}
-	properties := corerp.EnvironmentProperties{Compute: &envCompute, Recipes: recipeProperties, UseDevRecipes: &useDevRecipes}
+	properties := corerp.EnvironmentProperties{Compute: &envCompute, Recipes: recipeProperties, Providers: providers, UseDevRecipes: &useDevRecipes}
 	_, err = client.CreateOrUpdate(ctx, envName, corerp.EnvironmentResource{Location: &location, Properties: &properties}, &corerp.EnvironmentsClientCreateOrUpdateOptions{})
 	if err != nil {
 		return false, err


### PR DESCRIPTION
# Description

The UCP_management client was not passing the provider to createUpdate environment call.

rad env list -o json has the provider when providers are configured using rad init.
```
pratiksm@Pratikshyas-MacBook-Pro radius % rad env list -o json
[
  {
    "id": "/planes/radius/local/resourcegroups/kind/providers/applications.core/environments/kind",
    "location": "global",
    "name": "kind",
    "properties": {
      "compute": {
        "kind": "kubernetes",
        "namespace": "kind",
        "resourceId": ""
      },
      "providers": {
        "azure": {
          "scope": "/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourceGroups/pratikshya9"
        }
      },
      "provisioningState": "Succeeded",
      "recipes": {
        "mongo-azure": {
          "linkType": "Applications.Link/mongoDatabases",
          "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"
        }
      },
      "useDevRecipes": true
    },
    "systemData": {
      "createdAt": "0001-01-01T00:00:00Z",
      "createdBy": "",
      "createdByType": "",
      "lastModifiedAt": "0001-01-01T00:00:00Z",
      "lastModifiedBy": "",
      "lastModifiedByType": ""
    },
    "tags": {},
    "type": "applications.core/environments"
  }
]
```
## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
