### PR TITLE
Get Identifier after calling create for AWS resources

### DIFF
--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
-	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/project-radius/radius/pkg/middleware"
 	awsclient "github.com/project-radius/radius/pkg/ucp/aws"
 	ctrl "github.com/project-radius/radius/pkg/ucp/frontend/controller"
@@ -54,20 +54,9 @@ func ParseAWSRequest(ctx context.Context, opts ctrl.Options, r *http.Request) (a
 	return cloudControlClient, cloudFormationClient, resourceType, id, nil
 }
 
-func lookupPrimaryIdentifiersForResourceType(opts ctrl.Options, resourceType string) ([]interface{}, error) {
-	sess, err := session.NewSession()
-	if err != nil {
-		return nil, err
-	}
-
-	var svc awsclient.AWSCloudFormationClient
-	if opts.AWSCloudFormationClient == nil {
-		svc = cloudformation.New(sess, aws.NewConfig())
-	} else {
-		svc = opts.AWSCloudFormationClient
-	}
-
-	output, err := svc.DescribeType(&cloudformation.DescribeTypeInput{
+func lookupPrimaryIdentifiersForResourceType(ctx context.Context, opts ctrl.Options, cloudFormationClient awsclient.AWSCloudControlClient, resourceType string) ([]interface{}, error) {
+	output, err := cloudFormationClient.DescribeType(ctx, &cloudformation.DescribeTypeInput{
+		Type:     types.RegistryTypeResource,
 		TypeName: aws.String(resourceType),
 	})
 	if err != nil {

--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
@@ -54,8 +54,8 @@ func ParseAWSRequest(ctx context.Context, opts ctrl.Options, r *http.Request) (a
 	return cloudControlClient, cloudFormationClient, resourceType, id, nil
 }
 
-func lookupPrimaryIdentifiersForResourceType(ctx context.Context, opts ctrl.Options, cloudFormationClient awsclient.AWSCloudControlClient, resourceType string) ([]interface{}, error) {
-	output, err := cloudFormationClient.DescribeType(ctx, &cloudformation.DescribeTypeInput{
+func lookupPrimaryIdentifiersForResourceType(ctx context.Context, client awsclient.AWSCloudFormationClient, resourceType string) ([]interface{}, error) {
+	output, err := client.DescribeType(ctx, &cloudformation.DescribeTypeInput{
 		Type:     types.RegistryTypeResource,
 		TypeName: aws.String(resourceType),
 	})

--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing_test.go
@@ -45,11 +45,8 @@ func TestResourceIDWithMultiIdentifiers(t *testing.T) {
 	}
 	mockClient.EXPECT().DescribeType(ctx, &input).Return(&output, nil)
 
-	opts := ctrl.Options{
-		AWSCloudFormationClient: mockClient,
-	}
-
-	actualPrimaryIdentifiers, err := lookupPrimaryIdentifiersForResourceType(opts, "AWS::NetworkManager::Device")
+	actualPrimaryIdentifiers, err := lookupPrimaryIdentifiersForResourceType(ctx, mockClient, "AWS::NetworkManager::Device")
+	require.NoError(t, err)
 
 	resourceID, err := getResourceIDFromPrimaryIdentifiers(actualPrimaryIdentifiers, map[string]interface{}{
 		"GlobalNetworkId": "global-network-id",
@@ -85,17 +82,10 @@ func TestResourceIDWithMultiIdentifiers_MissingMandatoryParameters(t *testing.T)
 	}
 	mockClient.EXPECT().DescribeType(ctx, &input).Return(&output, nil)
 
-<<<<<<< HEAD
-	url := "http://127.0.0.1:9000/apis/api.ucp.dev/v1alpha3/planes/aws/aws/accounts/841861948707/regions/us-west-2/providers/AWS.NetworkManager/Device/:put"
-	_, err = getResourceIDWithMultiIdentifiers(ctx, mockClient, url, "AWS::NetworkManager::Device", map[string]interface{}{
-=======
-	opts := ctrl.Options{
-		AWSCloudFormationClient: mockClient,
-	}
-	actualPrimaryIdentifiers, err := lookupPrimaryIdentifiersForResourceType(opts, "AWS::NetworkManager::Device")
+	actualPrimaryIdentifiers, err := lookupPrimaryIdentifiersForResourceType(ctx, mockClient, "AWS::NetworkManager::Device")
+	require.NoError(t, err)
 
 	_, err = getResourceIDFromPrimaryIdentifiers(actualPrimaryIdentifiers, map[string]interface{}{
->>>>>>> 825c2930 (Getting ID after creating resource)
 		"GlobalNetworkId": "global-network-id",
 	})
 	require.NotNil(t, err)

--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing_test.go
@@ -45,11 +45,17 @@ func TestResourceIDWithMultiIdentifiers(t *testing.T) {
 	}
 	mockClient.EXPECT().DescribeType(ctx, &input).Return(&output, nil)
 
-	url := "http://127.0.0.1:9000/apis/api.ucp.dev/v1alpha3/planes/aws/aws/accounts/841861948707/regions/us-west-2/providers/AWS.NetworkManager/Device/:put"
-	resourceID, err := getResourceIDWithMultiIdentifiers(ctx, mockClient, url, "AWS::NetworkManager::Device", map[string]interface{}{
+	opts := ctrl.Options{
+		AWSCloudFormationClient: mockClient,
+	}
+
+	actualPrimaryIdentifiers, err := lookupPrimaryIdentifiersForResourceType(opts, "AWS::NetworkManager::Device")
+
+	resourceID, err := getResourceIDFromPrimaryIdentifiers(actualPrimaryIdentifiers, map[string]interface{}{
 		"GlobalNetworkId": "global-network-id",
 		"DeviceId":        "device-id",
 	})
+
 	require.NoError(t, err)
 	require.Equal(t, "global-network-id|device-id", resourceID)
 }
@@ -79,8 +85,17 @@ func TestResourceIDWithMultiIdentifiers_MissingMandatoryParameters(t *testing.T)
 	}
 	mockClient.EXPECT().DescribeType(ctx, &input).Return(&output, nil)
 
+<<<<<<< HEAD
 	url := "http://127.0.0.1:9000/apis/api.ucp.dev/v1alpha3/planes/aws/aws/accounts/841861948707/regions/us-west-2/providers/AWS.NetworkManager/Device/:put"
 	_, err = getResourceIDWithMultiIdentifiers(ctx, mockClient, url, "AWS::NetworkManager::Device", map[string]interface{}{
+=======
+	opts := ctrl.Options{
+		AWSCloudFormationClient: mockClient,
+	}
+	actualPrimaryIdentifiers, err := lookupPrimaryIdentifiersForResourceType(opts, "AWS::NetworkManager::Device")
+
+	_, err = getResourceIDFromPrimaryIdentifiers(actualPrimaryIdentifiers, map[string]interface{}{
+>>>>>>> 825c2930 (Getting ID after creating resource)
 		"GlobalNetworkId": "global-network-id",
 	})
 	require.NotNil(t, err)

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
@@ -53,7 +53,7 @@ func (p *CreateOrUpdateAWSResourceWithPost) Run(ctx context.Context, w http.Resp
 		return armrpc_rest.NewBadRequestARMResponse(e), nil
 	}
 
-	primaryIdentifers, err := lookupPrimaryIdentifiersForResourceType(p.Options, resourceType)
+	primaryIdentifers, err := lookupPrimaryIdentifiersForResourceType(ctx, cloudFormationClient, resourceType)
 	if err != nil {
 		e := v1.ErrorResponse{
 			Error: v1.ErrorDetails{
@@ -87,7 +87,7 @@ func (p *CreateOrUpdateAWSResourceWithPost) Run(ctx context.Context, w http.Resp
 		// Create and update work differently for AWS - we need to know if the resource
 		// we're working on exists already.
 
-		getResponse, err = client.GetResource(ctx, &cloudcontrol.GetResourceInput{
+		getResponse, err = cloudControlClient.GetResource(ctx, &cloudcontrol.GetResourceInput{
 			TypeName:   &resourceType,
 			Identifier: aws.String(awsResourceIdentifier),
 		})
@@ -180,7 +180,7 @@ func (p *CreateOrUpdateAWSResourceWithPost) Run(ctx context.Context, w http.Resp
 			return awserror.HandleAWSError(err)
 		}
 
-		awsResourceIdentifier := *response.ProgressEvent.Identifier
+		awsResourceIdentifier = *response.ProgressEvent.Identifier
 
 		computedResourceID = computeResourceID(id, awsResourceIdentifier)
 	}

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
@@ -53,11 +53,6 @@ func (p *CreateOrUpdateAWSResourceWithPost) Run(ctx context.Context, w http.Resp
 		return armrpc_rest.NewBadRequestARMResponse(e), nil
 	}
 
-	// TODO
-	// 1. Split this method up into two calls
-	// 2. If we can't create the multi-identifier resource
-	// create the id afterwards and assume create
-
 	primaryIdentifers, err := lookupPrimaryIdentifiersForResourceType(p.Options, resourceType)
 	if err != nil {
 		e := v1.ErrorResponse{

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost_test.go
@@ -54,6 +54,7 @@ func Test_CreateAWSResourceWithPost(t *testing.T) {
 			ProgressEvent: &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,
 				RequestToken:    to.Ptr(testAWSRequestToken),
+				Identifier:      to.Ptr(testAWSResourceName),
 			},
 		}, nil)
 
@@ -148,6 +149,7 @@ func Test_UpdateAWSResourceWithPost(t *testing.T) {
 			ProgressEvent: &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,
 				RequestToken:    to.Ptr(testAWSRequestToken),
+				Identifier:      to.Ptr(testAWSResourceName),
 			},
 		}, nil)
 
@@ -307,6 +309,7 @@ func Test_CreateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 		TypeName: aws.String("AWS::RedShift::EndpointAuthorization"),
 		Schema:   to.Ptr(string(serialized)),
 	}
+	multiIdentifierResourceID := testPrimaryIdentifier1 + "|" + testPrimaryIdentifier2
 
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
@@ -320,6 +323,7 @@ func Test_CreateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 			ProgressEvent: &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,
 				RequestToken:    to.Ptr(testAWSRequestToken),
+				Identifier:      to.Ptr(multiIdentifierResourceID),
 			},
 		}, nil)
 
@@ -357,7 +361,6 @@ func Test_CreateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 
 	id, err := resources.Parse(testMultiIdentifierResourcePath)
 	require.NoError(t, err)
-	multiIdentifierResourceID := testPrimaryIdentifier1 + "|" + testPrimaryIdentifier2
 	rID := computeResourceID(id, multiIdentifierResourceID)
 	expectedResponseObject := map[string]interface{}{
 		"id":   rID,
@@ -388,6 +391,9 @@ func Test_UpdateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 			"/properties/Account",
 		},
 	}
+
+	multiIdentifierResourceID := testPrimaryIdentifier1 + "|" + testPrimaryIdentifier2
+
 	serialized, err := json.Marshal(primaryIdentifiers)
 	require.NoError(t, err)
 	output := cloudformation.DescribeTypeOutput{
@@ -416,6 +422,7 @@ func Test_UpdateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 			ProgressEvent: &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,
 				RequestToken:    to.Ptr(testAWSRequestToken),
+				Identifier:      to.Ptr(multiIdentifierResourceID),
 			},
 		}, nil)
 
@@ -454,7 +461,6 @@ func Test_UpdateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 
 	id, err := resources.Parse(testMultiIdentifierResourcePath)
 	require.NoError(t, err)
-	multiIdentifierResourceID := testPrimaryIdentifier1 + "|" + testPrimaryIdentifier2
 	rID := computeResourceID(id, multiIdentifierResourceID)
 	expectedResponseObject := map[string]interface{}{
 		"id":   rID,

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost.go
@@ -49,7 +49,7 @@ func (p *DeleteAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWrit
 		return armrpc_rest.NewBadRequestARMResponse(e), nil
 	}
 
-	primaryIdentifiers, err := lookupPrimaryIdentifiersForResourceType(p.Options, resourceType)
+	primaryIdentifiers, err := lookupPrimaryIdentifiersForResourceType(ctx, cloudFormationClient, resourceType)
 	if err != nil {
 		e := v1.ErrorResponse{
 			Error: v1.ErrorDetails{

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost.go
@@ -49,7 +49,20 @@ func (p *DeleteAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWrit
 		return armrpc_rest.NewBadRequestARMResponse(e), nil
 	}
 
-	awsResourceIdentifier, err := getResourceIDWithMultiIdentifiers(ctx, cloudFormationClient, req.URL.Path, resourceType, properties)
+	primaryIdentifiers, err := lookupPrimaryIdentifiersForResourceType(p.Options, resourceType)
+	if err != nil {
+		e := v1.ErrorResponse{
+			Error: v1.ErrorDetails{
+				Code:    v1.CodeInvalid,
+				Message: err.Error(),
+			},
+		}
+
+		return armrpc_rest.NewBadRequestARMResponse(e), nil
+	}
+
+	awsResourceIdentifier, err := getResourceIDFromPrimaryIdentifiers(primaryIdentifiers, properties)
+
 	if err != nil {
 		e := v1.ErrorResponse{
 			Error: v1.ErrorDetails{

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost.go
@@ -52,7 +52,7 @@ func (p *GetAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWriter,
 		return armrpc_rest.NewBadRequestARMResponse(e), nil
 	}
 
-	primaryIdentifiers, err := lookupPrimaryIdentifiersForResourceType(p.Options, resourceType)
+	primaryIdentifiers, err := lookupPrimaryIdentifiersForResourceType(ctx, cloudFormationClient, resourceType)
 	if err != nil {
 		e := v1.ErrorResponse{
 			Error: v1.ErrorDetails{

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost.go
@@ -52,7 +52,20 @@ func (p *GetAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWriter,
 		return armrpc_rest.NewBadRequestARMResponse(e), nil
 	}
 
-	awsResourceIdentifier, err := getResourceIDWithMultiIdentifiers(ctx, cloudFormationClient, req.URL.Path, resourceType, properties)
+	primaryIdentifiers, err := lookupPrimaryIdentifiersForResourceType(p.Options, resourceType)
+	if err != nil {
+		e := v1.ErrorResponse{
+			Error: v1.ErrorDetails{
+				Code:    v1.CodeInvalid,
+				Message: err.Error(),
+			},
+		}
+
+		return armrpc_rest.NewBadRequestARMResponse(e), nil
+	}
+
+	awsResourceIdentifier, err := getResourceIDFromPrimaryIdentifiers(primaryIdentifiers, properties)
+
 	if err != nil {
 		e := v1.ErrorResponse{
 			Error: v1.ErrorDetails{

--- a/pkg/ucp/integrationtests/aws/createresourcewithpost_test.go
+++ b/pkg/ucp/integrationtests/aws/createresourcewithpost_test.go
@@ -53,6 +53,7 @@ func Test_CreateAWSResourceWithPost(t *testing.T) {
 			ProgressEvent: &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,
 				RequestToken:    to.Ptr(testAWSRequestToken),
+				Identifier:      to.Ptr("testStream"),
 			},
 		}
 		return &output, nil

--- a/test/functional/corerp/resources/testdata/aws-kinesis-existing.bicep
+++ b/test/functional/corerp/resources/testdata/aws-kinesis-existing.bicep
@@ -17,7 +17,9 @@ param port int = 3000
 param environment string
 
 resource stream 'AWS.Kinesis/Stream@default' existing = {
-  name: streamName
+  properties: {
+    Name: streamName
+  }
 }
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {

--- a/test/functional/corerp/resources/testdata/aws-kinesis.bicep
+++ b/test/functional/corerp/resources/testdata/aws-kinesis.bicep
@@ -3,7 +3,6 @@ import aws as aws
 param streamName string
 
 resource stream 'AWS.Kinesis/Stream@default' = {
-  // name: streamName
   properties: {
     Name: streamName
     RetentionPeriodHours: 168

--- a/test/functional/corerp/resources/testdata/aws-kinesis.bicep
+++ b/test/functional/corerp/resources/testdata/aws-kinesis.bicep
@@ -3,7 +3,7 @@ import aws as aws
 param streamName string
 
 resource stream 'AWS.Kinesis/Stream@default' = {
-  name: streamName
+  // name: streamName
   properties: {
     Name: streamName
     RetentionPeriodHours: 168


### PR DESCRIPTION
Discovered when investigating https://github.com/project-radius/radius/issues/4590

This is to prevent regressions of existing behavior with SQS being able to be deployed. This change makes it so if we can't calculate the primary identifier for a resource, assume we need to create it first and obtain the primary identifier from the call to create.