### PR TITLE
Fix API validation for UCP

### DIFF
--- a/pkg/middleware/normalizepath.go
+++ b/pkg/middleware/normalizepath.go
@@ -1,0 +1,36 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package middleware
+
+import (
+	"net/http"
+	"strings"
+)
+
+const (
+	PlanesSegment         = "/planes"
+	ResourceGroupsSegment = "/resourcegroups"
+)
+
+// NormalizePath is the middelware to normalize the case in planes and resourcegroups segments and preserve the case
+// for the rest of the URL
+// For example, the user could specify the url as /Planes/radius/local/resourceGroups/abc and this
+// will translate it to: /planes/radius/local/resourcegroups/abc
+func NormalizePath(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		newURL := r.URL.Path
+		if planesIndex := strings.Index(strings.ToLower(newURL), PlanesSegment); planesIndex >= 0 {
+			newURL = strings.Replace(newURL, newURL[planesIndex:planesIndex+len(PlanesSegment)], PlanesSegment, 1)
+		}
+
+		if resourcegroupsIndex := strings.Index(strings.ToLower(newURL), ResourceGroupsSegment); resourcegroupsIndex >= 0 {
+			newURL = strings.Replace(newURL, newURL[resourcegroupsIndex:resourcegroupsIndex+len(ResourceGroupsSegment)], ResourceGroupsSegment, 1)
+		}
+		r.URL.Path = newURL
+		next.ServeHTTP(w, r)
+	}
+	return http.HandlerFunc(fn)
+}

--- a/pkg/middleware/normalizepath_test.go
+++ b/pkg/middleware/normalizepath_test.go
@@ -1,0 +1,70 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizePath(t *testing.T) {
+	tests := []struct {
+		armid    string
+		expected string
+	}{
+		{
+			"/Planes",
+			"/planes",
+		},
+		{
+			"/Planes/radius/Local/resourceGroups",
+			"/planes/radius/Local/resourcegroups",
+		},
+		{
+			// Tests when /planes is not in the beginning
+			"/apis/api.ucp.dev/v1alpha3/Planes/Radius/Local",
+			"/apis/api.ucp.dev/v1alpha3/planes/Radius/Local",
+		},
+		{
+			"/Planes/radius/local/ResourceGroups/abc/providers/Applications.Core/environments/Default",
+			"/planes/radius/local/resourcegroups/abc/providers/Applications.Core/environments/Default",
+		},
+	}
+
+	for _, tt := range tests {
+		w := httptest.NewRecorder()
+		r := mux.NewRouter()
+		r.Path("/planes/{planeType}/{planeName}/resourcegroups/{resourceGroup}/providers/Applications.Core/{resourceType}/{resourceName}").Methods(http.MethodPost).HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(r.URL.Path))
+			})
+		r.Path("/planes").Methods(http.MethodPost).HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(r.URL.Path))
+			})
+		r.Path("/planes/{planeType}/{planeName}/resourcegroups").Methods(http.MethodPost).HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(r.URL.Path))
+			})
+		r.Path("/apis/api.ucp.dev/v1alpha3/planes/{planeType}/{planeName}").Methods(http.MethodPost).HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(r.URL.Path))
+			})
+
+		handler := NormalizePath(r)
+
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, tt.armid, nil)
+		handler.ServeHTTP(w, req)
+
+		parsed := w.Body.String()
+		assert.Equal(t, tt.expected, parsed)
+	}
+}

--- a/pkg/ucp/api/v20220901privatepreview/zz_generated_awscredential_client.go
+++ b/pkg/ucp/api/v20220901privatepreview/zz_generated_awscredential_client.go
@@ -78,15 +78,15 @@ func (client *AWSCredentialClient) CreateOrUpdate(ctx context.Context, planeType
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *AWSCredentialClient) createOrUpdateCreateRequest(ctx context.Context, planeType string, planeName string, credentialName string, credential CredentialResource, options *AWSCredentialClientCreateOrUpdateOptions) (*policy.Request, error) {
-	urlPath := "/planes/{planeType}/{planeName}/providers/System.AWS/credentials/{credentialName}"
+	urlPath := "/planes/{PlaneType}/{PlaneName}/providers/System.AWS/credentials/{credentialName}"
 	if planeType == "" {
 		return nil, errors.New("parameter planeType cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeType}", url.PathEscape(planeType))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneType}", url.PathEscape(planeType))
 	if planeName == "" {
 		return nil, errors.New("parameter planeName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneName}", url.PathEscape(planeName))
 	if credentialName == "" {
 		return nil, errors.New("parameter credentialName cannot be empty")
 	}

--- a/pkg/ucp/api/v20220901privatepreview/zz_generated_awscredentials_client.go
+++ b/pkg/ucp/api/v20220901privatepreview/zz_generated_awscredentials_client.go
@@ -76,15 +76,15 @@ func (client *AWSCredentialsClient) Delete(ctx context.Context, planeType string
 
 // deleteCreateRequest creates the Delete request.
 func (client *AWSCredentialsClient) deleteCreateRequest(ctx context.Context, planeType string, planeName string, credentialName string, options *AWSCredentialsClientDeleteOptions) (*policy.Request, error) {
-	urlPath := "/planes/{planeType}/{planeName}/providers/System.AWS/credentials/{credentialName}"
+	urlPath := "/planes/{PlaneType}/{PlaneName}/providers/System.AWS/credentials/{credentialName}"
 	if planeType == "" {
 		return nil, errors.New("parameter planeType cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeType}", url.PathEscape(planeType))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneType}", url.PathEscape(planeType))
 	if planeName == "" {
 		return nil, errors.New("parameter planeName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneName}", url.PathEscape(planeName))
 	if credentialName == "" {
 		return nil, errors.New("parameter credentialName cannot be empty")
 	}
@@ -124,15 +124,15 @@ func (client *AWSCredentialsClient) Get(ctx context.Context, planeType string, p
 
 // getCreateRequest creates the Get request.
 func (client *AWSCredentialsClient) getCreateRequest(ctx context.Context, planeType string, planeName string, credentialName string, options *AWSCredentialsClientGetOptions) (*policy.Request, error) {
-	urlPath := "/planes/{planeType}/{planeName}/providers/System.AWS/credentials/{credentialName}"
+	urlPath := "/planes/{PlaneType}/{PlaneName}/providers/System.AWS/credentials/{credentialName}"
 	if planeType == "" {
 		return nil, errors.New("parameter planeType cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeType}", url.PathEscape(planeType))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneType}", url.PathEscape(planeType))
 	if planeName == "" {
 		return nil, errors.New("parameter planeName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneName}", url.PathEscape(planeName))
 	if credentialName == "" {
 		return nil, errors.New("parameter credentialName cannot be empty")
 	}
@@ -180,15 +180,15 @@ func (client *AWSCredentialsClient) List(ctx context.Context, planeType string, 
 
 // listCreateRequest creates the List request.
 func (client *AWSCredentialsClient) listCreateRequest(ctx context.Context, planeType string, planeName string, options *AWSCredentialsClientListOptions) (*policy.Request, error) {
-	urlPath := "/planes/{planeType}/{planeName}/providers/System.AWS/credentials"
+	urlPath := "/planes/{PlaneType}/{PlaneName}/providers/System.AWS/credentials"
 	if planeType == "" {
 		return nil, errors.New("parameter planeType cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeType}", url.PathEscape(planeType))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneType}", url.PathEscape(planeType))
 	if planeName == "" {
 		return nil, errors.New("parameter planeName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneName}", url.PathEscape(planeName))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err

--- a/pkg/ucp/api/v20220901privatepreview/zz_generated_azurecredential_client.go
+++ b/pkg/ucp/api/v20220901privatepreview/zz_generated_azurecredential_client.go
@@ -78,15 +78,15 @@ func (client *AzureCredentialClient) CreateOrUpdate(ctx context.Context, planeTy
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *AzureCredentialClient) createOrUpdateCreateRequest(ctx context.Context, planeType string, planeName string, credentialName string, credential CredentialResource, options *AzureCredentialClientCreateOrUpdateOptions) (*policy.Request, error) {
-	urlPath := "/planes/{planeType}/{planeName}/providers/System.Azure/credentials/{credentialName}"
+	urlPath := "/planes/{PlaneType}/{PlaneName}/providers/System.Azure/credentials/{credentialName}"
 	if planeType == "" {
 		return nil, errors.New("parameter planeType cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeType}", url.PathEscape(planeType))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneType}", url.PathEscape(planeType))
 	if planeName == "" {
 		return nil, errors.New("parameter planeName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneName}", url.PathEscape(planeName))
 	if credentialName == "" {
 		return nil, errors.New("parameter credentialName cannot be empty")
 	}

--- a/pkg/ucp/api/v20220901privatepreview/zz_generated_azurecredentials_client.go
+++ b/pkg/ucp/api/v20220901privatepreview/zz_generated_azurecredentials_client.go
@@ -76,15 +76,15 @@ func (client *AzureCredentialsClient) Delete(ctx context.Context, planeType stri
 
 // deleteCreateRequest creates the Delete request.
 func (client *AzureCredentialsClient) deleteCreateRequest(ctx context.Context, planeType string, planeName string, credentialName string, options *AzureCredentialsClientDeleteOptions) (*policy.Request, error) {
-	urlPath := "/planes/{planeType}/{planeName}/providers/System.Azure/credentials/{credentialName}"
+	urlPath := "/planes/{PlaneType}/{PlaneName}/providers/System.Azure/credentials/{credentialName}"
 	if planeType == "" {
 		return nil, errors.New("parameter planeType cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeType}", url.PathEscape(planeType))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneType}", url.PathEscape(planeType))
 	if planeName == "" {
 		return nil, errors.New("parameter planeName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneName}", url.PathEscape(planeName))
 	if credentialName == "" {
 		return nil, errors.New("parameter credentialName cannot be empty")
 	}
@@ -124,15 +124,15 @@ func (client *AzureCredentialsClient) Get(ctx context.Context, planeType string,
 
 // getCreateRequest creates the Get request.
 func (client *AzureCredentialsClient) getCreateRequest(ctx context.Context, planeType string, planeName string, credentialName string, options *AzureCredentialsClientGetOptions) (*policy.Request, error) {
-	urlPath := "/planes/{planeType}/{planeName}/providers/System.Azure/credentials/{credentialName}"
+	urlPath := "/planes/{PlaneType}/{PlaneName}/providers/System.Azure/credentials/{credentialName}"
 	if planeType == "" {
 		return nil, errors.New("parameter planeType cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeType}", url.PathEscape(planeType))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneType}", url.PathEscape(planeType))
 	if planeName == "" {
 		return nil, errors.New("parameter planeName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneName}", url.PathEscape(planeName))
 	if credentialName == "" {
 		return nil, errors.New("parameter credentialName cannot be empty")
 	}
@@ -180,15 +180,15 @@ func (client *AzureCredentialsClient) List(ctx context.Context, planeType string
 
 // listCreateRequest creates the List request.
 func (client *AzureCredentialsClient) listCreateRequest(ctx context.Context, planeType string, planeName string, options *AzureCredentialsClientListOptions) (*policy.Request, error) {
-	urlPath := "/planes/{planeType}/{planeName}/providers/System.Azure/credentials"
+	urlPath := "/planes/{PlaneType}/{PlaneName}/providers/System.Azure/credentials"
 	if planeType == "" {
 		return nil, errors.New("parameter planeType cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeType}", url.PathEscape(planeType))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneType}", url.PathEscape(planeType))
 	if planeName == "" {
 		return nil, errors.New("parameter planeName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneName}", url.PathEscape(planeName))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err

--- a/pkg/ucp/api/v20220901privatepreview/zz_generated_planes_client.go
+++ b/pkg/ucp/api/v20220901privatepreview/zz_generated_planes_client.go
@@ -76,15 +76,15 @@ func (client *PlanesClient) CreateOrUpdate(ctx context.Context, planeType string
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
 func (client *PlanesClient) createOrUpdateCreateRequest(ctx context.Context, planeType string, planeName string, plane PlaneResource, options *PlanesClientCreateOrUpdateOptions) (*policy.Request, error) {
-	urlPath := "/planes/{planeType}/{planeName}"
+	urlPath := "/planes/{PlaneType}/{PlaneName}"
 	if planeType == "" {
 		return nil, errors.New("parameter planeType cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeType}", url.PathEscape(planeType))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneType}", url.PathEscape(planeType))
 	if planeName == "" {
 		return nil, errors.New("parameter planeName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneName}", url.PathEscape(planeName))
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
@@ -128,15 +128,15 @@ func (client *PlanesClient) Delete(ctx context.Context, planeType string, planeN
 
 // deleteCreateRequest creates the Delete request.
 func (client *PlanesClient) deleteCreateRequest(ctx context.Context, planeType string, planeName string, options *PlanesClientDeleteOptions) (*policy.Request, error) {
-	urlPath := "/planes/{planeType}/{planeName}"
+	urlPath := "/planes/{PlaneType}/{PlaneName}"
 	if planeType == "" {
 		return nil, errors.New("parameter planeType cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeType}", url.PathEscape(planeType))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneType}", url.PathEscape(planeType))
 	if planeName == "" {
 		return nil, errors.New("parameter planeName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneName}", url.PathEscape(planeName))
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
@@ -171,15 +171,15 @@ func (client *PlanesClient) Get(ctx context.Context, planeType string, planeName
 
 // getCreateRequest creates the Get request.
 func (client *PlanesClient) getCreateRequest(ctx context.Context, planeType string, planeName string, options *PlanesClientGetOptions) (*policy.Request, error) {
-	urlPath := "/planes/{planeType}/{planeName}"
+	urlPath := "/planes/{PlaneType}/{PlaneName}"
 	if planeType == "" {
 		return nil, errors.New("parameter planeType cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeType}", url.PathEscape(planeType))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneType}", url.PathEscape(planeType))
 	if planeName == "" {
 		return nil, errors.New("parameter planeName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneName}", url.PathEscape(planeName))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err

--- a/pkg/ucp/api/v20220901privatepreview/zz_generated_resourcegroups_client.go
+++ b/pkg/ucp/api/v20220901privatepreview/zz_generated_resourcegroups_client.go
@@ -57,12 +57,12 @@ pl: pl,
 // Generated from API version 2022-09-01-privatepreview
 // planeType - The type of the plane
 // planeName - The name of the plane
-// resourceGroupName - The name of the resource group
-// resourceGroup - ResourceGroup details
+// resourceGroup - The name of the resource group
+// resourceGroup1 - ResourceGroup details
 // options - ResourceGroupsClientCreateOrUpdateOptions contains the optional parameters for the ResourceGroupsClient.CreateOrUpdate
 // method.
-func (client *ResourceGroupsClient) CreateOrUpdate(ctx context.Context, planeType string, planeName string, resourceGroupName string, resourceGroup ResourceGroupResource, options *ResourceGroupsClientCreateOrUpdateOptions) (ResourceGroupsClientCreateOrUpdateResponse, error) {
-	req, err := client.createOrUpdateCreateRequest(ctx, planeType, planeName, resourceGroupName, resourceGroup, options)
+func (client *ResourceGroupsClient) CreateOrUpdate(ctx context.Context, planeType string, planeName string, resourceGroup string, resourceGroup1 ResourceGroupResource, options *ResourceGroupsClientCreateOrUpdateOptions) (ResourceGroupsClientCreateOrUpdateResponse, error) {
+	req, err := client.createOrUpdateCreateRequest(ctx, planeType, planeName, resourceGroup, resourceGroup1, options)
 	if err != nil {
 		return ResourceGroupsClientCreateOrUpdateResponse{}, err
 	}
@@ -77,20 +77,20 @@ func (client *ResourceGroupsClient) CreateOrUpdate(ctx context.Context, planeTyp
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ResourceGroupsClient) createOrUpdateCreateRequest(ctx context.Context, planeType string, planeName string, resourceGroupName string, resourceGroup ResourceGroupResource, options *ResourceGroupsClientCreateOrUpdateOptions) (*policy.Request, error) {
-	urlPath := "/planes/{planeType}/{planeName}/resourcegroups/{resourceGroupName}"
+func (client *ResourceGroupsClient) createOrUpdateCreateRequest(ctx context.Context, planeType string, planeName string, resourceGroup string, resourceGroup1 ResourceGroupResource, options *ResourceGroupsClientCreateOrUpdateOptions) (*policy.Request, error) {
+	urlPath := "/planes/{PlaneType}/{PlaneName}/resourcegroups/{ResourceGroup}"
 	if planeType == "" {
 		return nil, errors.New("parameter planeType cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeType}", url.PathEscape(planeType))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneType}", url.PathEscape(planeType))
 	if planeName == "" {
 		return nil, errors.New("parameter planeName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
-	if resourceGroupName == "" {
-		return nil, errors.New("parameter resourceGroupName cannot be empty")
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneName}", url.PathEscape(planeName))
+	if resourceGroup == "" {
+		return nil, errors.New("parameter resourceGroup cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
+	urlPath = strings.ReplaceAll(urlPath, "{ResourceGroup}", url.PathEscape(resourceGroup))
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func (client *ResourceGroupsClient) createOrUpdateCreateRequest(ctx context.Cont
 	reqQP.Set("api-version", "2022-09-01-privatepreview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	return req, runtime.MarshalAsJSON(req, resourceGroup)
+	return req, runtime.MarshalAsJSON(req, resourceGroup1)
 }
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
@@ -116,10 +116,10 @@ func (client *ResourceGroupsClient) createOrUpdateHandleResponse(resp *http.Resp
 // Generated from API version 2022-09-01-privatepreview
 // planeType - The type of the plane
 // planeName - The name of the plane
-// resourceGroupName - The name of the resource group
+// resourceGroup - The name of the resource group
 // options - ResourceGroupsClientDeleteOptions contains the optional parameters for the ResourceGroupsClient.Delete method.
-func (client *ResourceGroupsClient) Delete(ctx context.Context, planeType string, planeName string, resourceGroupName string, options *ResourceGroupsClientDeleteOptions) (ResourceGroupsClientDeleteResponse, error) {
-	req, err := client.deleteCreateRequest(ctx, planeType, planeName, resourceGroupName, options)
+func (client *ResourceGroupsClient) Delete(ctx context.Context, planeType string, planeName string, resourceGroup string, options *ResourceGroupsClientDeleteOptions) (ResourceGroupsClientDeleteResponse, error) {
+	req, err := client.deleteCreateRequest(ctx, planeType, planeName, resourceGroup, options)
 	if err != nil {
 		return ResourceGroupsClientDeleteResponse{}, err
 	}
@@ -134,20 +134,20 @@ func (client *ResourceGroupsClient) Delete(ctx context.Context, planeType string
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *ResourceGroupsClient) deleteCreateRequest(ctx context.Context, planeType string, planeName string, resourceGroupName string, options *ResourceGroupsClientDeleteOptions) (*policy.Request, error) {
-	urlPath := "/planes/{planeType}/{planeName}/resourcegroups/{resourceGroupName}"
+func (client *ResourceGroupsClient) deleteCreateRequest(ctx context.Context, planeType string, planeName string, resourceGroup string, options *ResourceGroupsClientDeleteOptions) (*policy.Request, error) {
+	urlPath := "/planes/{PlaneType}/{PlaneName}/resourcegroups/{ResourceGroup}"
 	if planeType == "" {
 		return nil, errors.New("parameter planeType cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeType}", url.PathEscape(planeType))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneType}", url.PathEscape(planeType))
 	if planeName == "" {
 		return nil, errors.New("parameter planeName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
-	if resourceGroupName == "" {
-		return nil, errors.New("parameter resourceGroupName cannot be empty")
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneName}", url.PathEscape(planeName))
+	if resourceGroup == "" {
+		return nil, errors.New("parameter resourceGroup cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
+	urlPath = strings.ReplaceAll(urlPath, "{ResourceGroup}", url.PathEscape(resourceGroup))
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
@@ -164,10 +164,10 @@ func (client *ResourceGroupsClient) deleteCreateRequest(ctx context.Context, pla
 // Generated from API version 2022-09-01-privatepreview
 // planeType - The type of the plane
 // planeName - The name of the plane
-// resourceGroupName - The name of the resource group
+// resourceGroup - The name of the resource group
 // options - ResourceGroupsClientGetOptions contains the optional parameters for the ResourceGroupsClient.Get method.
-func (client *ResourceGroupsClient) Get(ctx context.Context, planeType string, planeName string, resourceGroupName string, options *ResourceGroupsClientGetOptions) (ResourceGroupsClientGetResponse, error) {
-	req, err := client.getCreateRequest(ctx, planeType, planeName, resourceGroupName, options)
+func (client *ResourceGroupsClient) Get(ctx context.Context, planeType string, planeName string, resourceGroup string, options *ResourceGroupsClientGetOptions) (ResourceGroupsClientGetResponse, error) {
+	req, err := client.getCreateRequest(ctx, planeType, planeName, resourceGroup, options)
 	if err != nil {
 		return ResourceGroupsClientGetResponse{}, err
 	}
@@ -182,20 +182,20 @@ func (client *ResourceGroupsClient) Get(ctx context.Context, planeType string, p
 }
 
 // getCreateRequest creates the Get request.
-func (client *ResourceGroupsClient) getCreateRequest(ctx context.Context, planeType string, planeName string, resourceGroupName string, options *ResourceGroupsClientGetOptions) (*policy.Request, error) {
-	urlPath := "/planes/{planeType}/{planeName}/resourcegroups/{resourceGroupName}"
+func (client *ResourceGroupsClient) getCreateRequest(ctx context.Context, planeType string, planeName string, resourceGroup string, options *ResourceGroupsClientGetOptions) (*policy.Request, error) {
+	urlPath := "/planes/{PlaneType}/{PlaneName}/resourcegroups/{ResourceGroup}"
 	if planeType == "" {
 		return nil, errors.New("parameter planeType cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeType}", url.PathEscape(planeType))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneType}", url.PathEscape(planeType))
 	if planeName == "" {
 		return nil, errors.New("parameter planeName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
-	if resourceGroupName == "" {
-		return nil, errors.New("parameter resourceGroupName cannot be empty")
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneName}", url.PathEscape(planeName))
+	if resourceGroup == "" {
+		return nil, errors.New("parameter resourceGroup cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
+	urlPath = strings.ReplaceAll(urlPath, "{ResourceGroup}", url.PathEscape(resourceGroup))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err
@@ -239,15 +239,15 @@ func (client *ResourceGroupsClient) List(ctx context.Context, planeType string, 
 
 // listCreateRequest creates the List request.
 func (client *ResourceGroupsClient) listCreateRequest(ctx context.Context, planeType string, planeName string, options *ResourceGroupsClientListOptions) (*policy.Request, error) {
-	urlPath := "/planes/{planeType}/{planeName}/resourcegroups"
+	urlPath := "/planes/{PlaneType}/{PlaneName}/resourcegroups"
 	if planeType == "" {
 		return nil, errors.New("parameter planeType cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeType}", url.PathEscape(planeType))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneType}", url.PathEscape(planeType))
 	if planeName == "" {
 		return nil, errors.New("parameter planeName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{planeName}", url.PathEscape(planeName))
+	urlPath = strings.ReplaceAll(urlPath, "{PlaneName}", url.PathEscape(planeName))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
 	if err != nil {
 		return nil, err

--- a/pkg/ucp/frontend/api/routes.go
+++ b/pkg/ucp/frontend/api/routes.go
@@ -25,7 +25,7 @@ import (
 const (
 	planeCollectionPath       = "/planes"
 	awsPlaneType              = "/planes/aws"
-	planeItemPath             = "/planes/{PlaneType}/{PlaneID}"
+	planeItemPath             = "/planes/{PlaneType}/{PlaneName}"
 	planeCollectionByType     = "/planes/{PlaneType}"
 	awsOperationResultsPath   = "/{AWSPlaneName}/accounts/{AccountID}/regions/{Region}/providers/{Provider}/locations/{Location}/operationResults/{operationID}"
 	awsOperationStatusesPath  = "/{AWSPlaneName}/accounts/{AccountID}/regions/{Region}/providers/{Provider}/locations/{Location}/operationStatuses/{operationID}"
@@ -80,7 +80,7 @@ func Register(ctx context.Context, router *mux.Router, ctrlOpts ctrl.Options) er
 	planeCollectionByTypeSubRouter := rootScopeRouter.Path(planeCollectionByType).Subrouter()
 	planeSubRouter := rootScopeRouter.Path(planeItemPath).Subrouter()
 
-	var resourceGroupCollectionPath = fmt.Sprintf("%s/%s", planeItemPath, "resource{[gG]}roups")
+	var resourceGroupCollectionPath = fmt.Sprintf("%s/%s", planeItemPath, "resourcegroups")
 	var resourceGroupItemPath = fmt.Sprintf("%s/%s", resourceGroupCollectionPath, "{ResourceGroup}")
 	resourceGroupCollectionSubRouter := rootScopeRouter.Path(resourceGroupCollectionPath).Subrouter()
 	resourceGroupSubRouter := rootScopeRouter.Path(resourceGroupItemPath).Subrouter()
@@ -192,6 +192,7 @@ func Register(ctx context.Context, router *mux.Router, ctrlOpts ctrl.Options) er
 
 		// Proxy request should take the least priority in routing and should therefore be last
 		{
+			// Note that the API validation is not applied to the router used for proxying
 			ParentRouter:   router,
 			Path:           fmt.Sprintf("%s%s", baseURL, planeItemPath),
 			HandlerFactory: planes_ctrl.NewProxyPlane,

--- a/pkg/ucp/integrationtests/integration_test.go
+++ b/pkg/ucp/integrationtests/integration_test.go
@@ -106,7 +106,7 @@ var testAzurePlane = v20220901privatepreview.PlaneResource{
 }
 
 var testResourceGroup = v20220901privatepreview.ResourceGroupResource{
-	ID:       to.Ptr(testUCPNativePlaneID + "/resourceGroups/rg1"),
+	ID:       to.Ptr(testUCPNativePlaneID + "/resourcegroups/rg1"),
 	Name:     to.Ptr("rg1"),
 	Type:     to.Ptr(resourcegroups.ResourceGroupType),
 	Location: to.Ptr(v1.LocationGlobal),
@@ -342,7 +342,7 @@ func createResourceGroup(t *testing.T, ucp *httptest.Server, ucpClient Client, d
 		return nil, &store.ErrNotFound{}
 	})
 	db.EXPECT().Save(gomock.Any(), gomock.Any(), gomock.Any())
-	createResourceGroupRequest, err := http.NewRequest("PUT", ucp.URL+basePath+"/planes/radius/local/resourceGroups/rg1?api-version=2022-09-01-privatepreview", bytes.NewBuffer(body))
+	createResourceGroupRequest, err := http.NewRequest("PUT", ucp.URL+basePath+"/planes/radius/local/resourcegroups/rg1?api-version=2022-09-01-privatepreview", bytes.NewBuffer(body))
 	require.NoError(t, err)
 	createResourceGroupResponse, err := ucpClient.httpClient.Do(createResourceGroupRequest)
 	require.NoError(t, err)

--- a/pkg/ucp/integrationtests/integration_test.go
+++ b/pkg/ucp/integrationtests/integration_test.go
@@ -223,6 +223,23 @@ func Test_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, response.StatusCode)
 }
 
+func Test_APIValidationIsApplied(t *testing.T) {
+	ucp, ucpClient, _ := initialize(t)
+	// Send a request that will be proxied to the RP
+	requestBody := v20220901privatepreview.ResourceGroupResource{
+		Tags: map[string]*string{},
+		// Missing location
+	}
+	body, err := json.Marshal(requestBody)
+	require.NoError(t, err)
+
+	createResourceGroupRequest, err := http.NewRequest("PUT", ucp.URL+basePath+"/planes/radius/local/resourcegroups/rg1?api-version=2022-09-01-privatepreview", bytes.NewBuffer(body))
+	require.NoError(t, err)
+	response, err := ucpClient.httpClient.Do(createResourceGroupRequest)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, response.StatusCode)
+}
+
 func initialize(t *testing.T) (*httptest.Server, Client, *store.MockStorageClient) {
 	body, err := json.Marshal(applicationList)
 	require.NoError(t, err)

--- a/pkg/validator/apivalidator.go
+++ b/pkg/validator/apivalidator.go
@@ -40,7 +40,7 @@ func APIValidator(loader *Loader) func(h http.Handler) http.Handler {
 			}
 
 			apiVersion := r.URL.Query().Get(APIVersionQueryKey)
-			v, ok := loader.GetValidator(rID.Type(), apiVersion, false)
+			v, ok := loader.GetValidator(rID.Type(), apiVersion)
 			if !ok {
 				resp := unsupportedAPIVersionResponse(apiVersion, rID.Type(), loader.SupportedVersions(rID.Type()))
 				if err := resp.Apply(r.Context(), w, r); err != nil {
@@ -70,7 +70,7 @@ func APIValidatorUCP(loader *Loader) func(h http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
 			endpointType := UCPEndpointType
 			apiVersion := r.URL.Query().Get(APIVersionQueryKey)
-			v, ok := loader.GetValidator(endpointType, apiVersion, true)
+			v, ok := loader.GetValidator(endpointType, apiVersion)
 			if !ok {
 				resp := unsupportedAPIVersionResponse(apiVersion, endpointType, loader.SupportedVersions(endpointType))
 				if err := resp.Apply(r.Context(), w, r); err != nil {

--- a/pkg/validator/loader.go
+++ b/pkg/validator/loader.go
@@ -49,10 +49,9 @@ func (l *Loader) SupportedVersions(resourceType string) []string {
 }
 
 // GetValidator returns the cached validator.
-func (l *Loader) GetValidator(resourceType, version string, ignoreUndefinedPath bool) (Validator, bool) {
+func (l *Loader) GetValidator(resourceType, version string) (Validator, bool) {
 	// ARM types are compared case-insensitively
 	v, ok := l.validators[getValidatorKey(resourceType, version)]
-	v.ignoreUndefinedPath = ignoreUndefinedPath
 	if ok {
 		return &v, true
 	}

--- a/pkg/validator/loader_test.go
+++ b/pkg/validator/loader_test.go
@@ -64,7 +64,7 @@ func TestParseSpecFilePath(t *testing.T) {
 func TestLoader(t *testing.T) {
 	l, err := LoadSpec(context.Background(), "applications.core", swagger.SpecFiles, "{rootScope:.*}", "rootScope")
 	require.NoError(t, err)
-	v, ok := l.GetValidator("applications.core/environments", "2022-03-15-privatepreview", false)
+	v, ok := l.GetValidator("applications.core/environments", "2022-03-15-privatepreview")
 	require.True(t, ok)
 	require.NotNil(t, v)
 }

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -52,12 +52,11 @@ type validator struct {
 	TypeName   string
 	APIVersion string
 
-	rootScopePrefix     string
-	rootScopeParam      string
-	specDoc             *loads.Document
-	paramCache          map[string]map[string]spec.Parameter
-	paramCacheMu        *sync.RWMutex
-	ignoreUndefinedPath bool
+	rootScopePrefix string
+	rootScopeParam  string
+	specDoc         *loads.Document
+	paramCache      map[string]map[string]spec.Parameter
+	paramCacheMu    *sync.RWMutex
 }
 
 // findParam looks up the correct spec.Parameter which a unique parameter is defined by a combination
@@ -136,7 +135,7 @@ func (v *validator) ValidateRequest(req *http.Request) []ValidationError {
 	routeParams := v.toRouteParams(req)
 	params, err := v.findParam(req)
 	if err != nil {
-		if errors.Is(err, ErrUndefinedRoute) && !v.ignoreUndefinedPath {
+		if errors.Is(err, ErrUndefinedRoute) {
 			return []ValidationError{{
 				Code:    v1.CodeInvalidRequestContent,
 				Message: "failed to parse route: " + err.Error(),

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -19,7 +19,7 @@ import (
 func TestFindParam(t *testing.T) {
 	l, err := LoadSpec(context.Background(), "applications.core", swagger.SpecFiles, "/{rootScope:.*}", "rootScope")
 	require.NoError(t, err)
-	v, ok := l.GetValidator("applications.core/environments", "2022-03-15-privatepreview", false)
+	v, ok := l.GetValidator("applications.core/environments", "2022-03-15-privatepreview")
 	require.True(t, ok)
 	validator := v.(*validator)
 

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/ucp.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/ucp.json
@@ -63,7 +63,7 @@
           "deprecated": false
         }
       },
-      "/planes/{planeType}/{planeName}": {
+      "/planes/{PlaneType}/{PlaneName}": {
         "get": {
           "description": "Gets the properties of a UCP Plane.",
           "operationId": "Planes_Get",
@@ -200,7 +200,7 @@
           }
         }
       },
-      "/planes/{planeType}/{planeName}/resourcegroups": {
+      "/planes/{PlaneType}/{PlaneName}/resourcegroups": {
         "get": {
           "description": "List all resource groups.",
           "operationId": "ResourceGroups_List",
@@ -243,7 +243,7 @@
           "deprecated": false
         }
       },
-      "/planes/{planeType}/{planeName}/resourcegroups/{resourceGroupName}": {
+      "/planes/{PlaneType}/{PlaneName}/resourcegroups/{ResourceGroup}": {
         "get": {
           "description": "Gets the properties of a UCP ResourceGroup.",
           "operationId": "ResourceGroups_Get",
@@ -389,7 +389,7 @@
           }
         }
       },
-    "/planes/{planeType}/{planeName}/providers/System.Azure/credentials/{credentialName}": {
+    "/planes/{PlaneType}/{PlaneName}/providers/System.Azure/credentials/{credentialName}": {
       "get": {
         "description": "Get name of the secret that is holding credentials for the plane instance",
         "operationId": "AzureCredentials_Get",
@@ -539,7 +539,7 @@
 
     },
 
-    "/planes/{planeType}/{planeName}/providers/System.Azure/credentials": {
+    "/planes/{PlaneType}/{PlaneName}/providers/System.Azure/credentials": {
       "get": {
         "description": "List the credentials for this plane instance",
         "operationId": "AzureCredentials_List",
@@ -582,7 +582,7 @@
         "deprecated": false
       }
     },
-    "/planes/{planeType}/{planeName}/providers/System.AWS/credentials/{credentialName}": {
+    "/planes/{PlaneType}/{PlaneName}/providers/System.AWS/credentials/{credentialName}": {
       "get": {
         "description": "Get name of the secret that is holding credentials for the plane instance",
         "operationId": "AWSCredentials_Get",
@@ -732,7 +732,7 @@
 
     },
 
-    "/planes/{planeType}/{planeName}/providers/System.AWS/credentials": {
+    "/planes/{PlaneType}/{PlaneName}/providers/System.AWS/credentials": {
       "get": {
         "description": "List the credentials for this plane instance",
         "operationId": "AWSCredentials_List",
@@ -1051,7 +1051,7 @@
     },
     "parameters": {
       "PlaneTypeParameter": {
-        "name": "planeType",
+        "name": "PlaneType",
         "in": "path",
         "required": true,
         "type": "string",
@@ -1061,7 +1061,7 @@
         "x-ms-parameter-location": "method"
       },
       "PlaneNameParameter": {
-          "name": "planeName",
+          "name": "PlaneName",
           "in": "path",
           "required": true,
           "type": "string",
@@ -1071,7 +1071,7 @@
           "x-ms-parameter-location": "method"
       },
       "ResourceGroupNameParameter": {
-        "name": "resourceGroupName",
+        "name": "ResourceGroup",
         "in": "path",
         "required": true,
         "type": "string",

--- a/test/functional/ucp/proxy_test.go
+++ b/test/functional/ucp/proxy_test.go
@@ -73,9 +73,10 @@ func Test_ProxyOperations(t *testing.T) {
 		nativePlaneID := "/planes/testnativetype/testnativeplane"
 		nativeplaneURL := fmt.Sprintf("%s%s?api-version=%s", url, nativePlaneID, apiVersion)
 		nativePlane := v20220901privatepreview.PlaneResource{
-			ID:   to.Ptr(nonNativePlaneID),
-			Type: to.Ptr("System.Planes/testnativetype"),
-			Name: to.Ptr("testnativeplane"),
+			ID:       to.Ptr(nonNativePlaneID),
+			Type:     to.Ptr("System.Planes/testnativetype"),
+			Name:     to.Ptr("testnativeplane"),
+			Location: to.Ptr(v1.LocationGlobal),
 			Properties: &v20220901privatepreview.PlaneResourceProperties{
 				Kind: to.Ptr(v20220901privatepreview.PlaneKindUCPNative),
 				ResourceProviders: map[string]*string{

--- a/test/functional/ucp/resourcegroup_test.go
+++ b/test/functional/ucp/resourcegroup_test.go
@@ -23,7 +23,7 @@ import (
 func Test_ResourceGroup_Operations(t *testing.T) {
 	test := NewUCPTest(t, "Test_ResourceGroup_Operations", func(t *testing.T, url string, roundTripper http.RoundTripper) {
 		// Create resource groups
-		rgID := "/planes/radius/local/resourceGroups/test-rg"
+		rgID := "/planes/radius/local/resourcegroups/test-rg"
 		apiVersion := v20220901privatepreview.Version
 		rgURL := fmt.Sprintf("%s%s?api-version=%s", url, rgID, apiVersion)
 


### PR DESCRIPTION
# Description

API Validation for UCP was broken. Remove ignoreUndefinedPath that bypassed validation. Apply API validation only to non-proxy paths.
#4429 

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #4429 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
