### PR TITLE
Add api version parameter to UCP credential resource

### DIFF
--- a/pkg/ucp/api/v20220901privatepreview/zz_generated_awscredential_client.go
+++ b/pkg/ucp/api/v20220901privatepreview/zz_generated_awscredential_client.go
@@ -95,6 +95,9 @@ func (client *AWSCredentialClient) createOrUpdateCreateRequest(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2022-09-01-privatepreview")
+	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, runtime.MarshalAsJSON(req, credential)
 }

--- a/pkg/ucp/api/v20220901privatepreview/zz_generated_awscredentials_client.go
+++ b/pkg/ucp/api/v20220901privatepreview/zz_generated_awscredentials_client.go
@@ -93,6 +93,9 @@ func (client *AWSCredentialsClient) deleteCreateRequest(ctx context.Context, pla
 	if err != nil {
 		return nil, err
 	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2022-09-01-privatepreview")
+	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
 }
@@ -138,6 +141,9 @@ func (client *AWSCredentialsClient) getCreateRequest(ctx context.Context, planeT
 	if err != nil {
 		return nil, err
 	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2022-09-01-privatepreview")
+	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
 }
@@ -187,6 +193,9 @@ func (client *AWSCredentialsClient) listCreateRequest(ctx context.Context, plane
 	if err != nil {
 		return nil, err
 	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2022-09-01-privatepreview")
+	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
 }

--- a/pkg/ucp/api/v20220901privatepreview/zz_generated_azurecredential_client.go
+++ b/pkg/ucp/api/v20220901privatepreview/zz_generated_azurecredential_client.go
@@ -95,6 +95,9 @@ func (client *AzureCredentialClient) createOrUpdateCreateRequest(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2022-09-01-privatepreview")
+	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, runtime.MarshalAsJSON(req, credential)
 }

--- a/pkg/ucp/api/v20220901privatepreview/zz_generated_azurecredentials_client.go
+++ b/pkg/ucp/api/v20220901privatepreview/zz_generated_azurecredentials_client.go
@@ -93,6 +93,9 @@ func (client *AzureCredentialsClient) deleteCreateRequest(ctx context.Context, p
 	if err != nil {
 		return nil, err
 	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2022-09-01-privatepreview")
+	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
 }
@@ -138,6 +141,9 @@ func (client *AzureCredentialsClient) getCreateRequest(ctx context.Context, plan
 	if err != nil {
 		return nil, err
 	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2022-09-01-privatepreview")
+	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
 }
@@ -187,6 +193,9 @@ func (client *AzureCredentialsClient) listCreateRequest(ctx context.Context, pla
 	if err != nil {
 		return nil, err
 	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2022-09-01-privatepreview")
+	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
 	return req, nil
 }

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/CredentialsDelete.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/CredentialsDelete.json
@@ -1,5 +1,6 @@
 {
     "parameters": {
+        "api-version": "2022-09-01-privatepreview",
         "PlaneType": "azure",
         "PlaneName": "azurecloud",
         "CredentialName": "default"

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/CredentialsGet.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/CredentialsGet.json
@@ -1,5 +1,6 @@
 {
     "parameters": {
+      "api-version": "2022-09-01-privatepreview",
       "PlaneType": "azure",
       "PlaneName": "azurecloud",
       "CredentialName": "default"

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/CredentialsList.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/CredentialsList.json
@@ -1,5 +1,6 @@
 {
     "parameters": {
+        "api-version": "2022-09-01-privatepreview",
         "PlaneType": "azure",
         "PlaneName": "azurecloud"
     },

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/CredentialsPut.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/CredentialsPut.json
@@ -1,5 +1,6 @@
 {
     "parameters": {
+      "api-version": "2022-09-01-privatepreview",
       "PlaneType": "azure",
       "PlaneName": "azurecloud",
       "CredentialResource": {

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/PlanesDeletePlaneLocal.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/PlanesDeletePlaneLocal.json
@@ -1,7 +1,8 @@
 {
   "parameters": {
-    "rootScope": "/planes/radius/local",
-    "planeName": "local"
+    "api-version": "2022-09-01-privatepreview",
+    "PlaneType": "radius",
+    "PlaneName": "local"
   },
   "responses": {
     "200": {},

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/PlanesGetPlaneLocal.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/PlanesGetPlaneLocal.json
@@ -1,7 +1,8 @@
 {
   "parameters": {
-    "rootScope": "/planes/radius/local",
-    "planeName": "local"
+    "api-version": "2022-09-01-privatepreview",
+    "PlaneType": "radius",
+    "PlaneName": "local"
   },
   "responses": {
     "200": {

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/PlanesList.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/PlanesList.json
@@ -1,6 +1,6 @@
 {
   "parameters": {
-    "rootScope": "/planes/radius/local"
+    "api-version": "2022-09-01-privatepreview"
   },
   "responses": {
     "200": {

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/PlanesPutPlaneLocal.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/PlanesPutPlaneLocal.json
@@ -1,8 +1,10 @@
 {
   "parameters": {
-    "rootScope": "/planes/radius/local",
-    "environmentName": "local",
+    "api-version": "2022-09-01-privatepreview",
+    "PlaneType": "radius",
+    "PlaneName": "local",
     "PlaneResource": {
+      "location": "global",
       "properties": {
         "resourceProviders": {
             "Applications.Core": "http://localhost:7443"

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/ResourceGroupsDeleteResourceGroupRG1.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/ResourceGroupsDeleteResourceGroupRG1.json
@@ -1,7 +1,9 @@
 {
   "parameters": {
-    "rootScope": "/planes/radius/local/resourcegroups/rg1",
-    "resourceGroupName": "rg1"
+    "api-version": "2022-09-01-privatepreview",
+    "PlaneType": "radius",
+    "PlaneName": "local",
+    "ResourceGroup": "rg1"
   },
   "responses": {
     "200": {},

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/ResourceGroupsGetResourceGroupRG1.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/ResourceGroupsGetResourceGroupRG1.json
@@ -1,7 +1,9 @@
 {
   "parameters": {
-    "rootScope": "/planes/radius/local/resourcegroups/rg1",
-    "resourceGroupName": "rg1"
+    "api-version": "2022-09-01-privatepreview",
+    "PlaneType": "radius",
+    "PlaneName": "local",
+    "ResourceGroup": "rg1"
   },
   "responses": {
     "200": {

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/ResourceGroupsList.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/ResourceGroupsList.json
@@ -1,6 +1,8 @@
 {
   "parameters": {
-    "rootScope": "/planes/radius/local/resourcegroups"
+    "api-version": "2022-09-01-privatepreview",
+    "PlaneType": "radius",
+    "PlaneName": "local"
   },
   "responses": {
     "200": {

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/ResourceGroupsPutResourceGroupRG1.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/examples/ResourceGroupsPutResourceGroupRG1.json
@@ -1,8 +1,11 @@
 {
   "parameters": {
-    "rootScope": "/planes/radius/local/resourcegroups/rg1",
-    "resourceGroupName": "rg1",
+    "api-version": "2022-09-01-privatepreview",
+    "PlaneType": "radius",
+    "PlaneName": "local",
+    "ResourceGroup": "rg1",
     "ResourceGroupResource": {
+      "location": "global"
     }
   },
   "responses": {

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/ucp.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/ucp.json
@@ -413,6 +413,9 @@
           },
           {
             "$ref": "#/parameters/CredentialNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v2/types.json#/parameters/ApiVersionParameter"
           }
         ],
         "responses": {
@@ -463,6 +466,9 @@
             "schema": {
               "$ref": "#/definitions/CredentialResource"
             }
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v2/types.json#/parameters/ApiVersionParameter"
           }
         ],
         "responses": {
@@ -509,6 +515,9 @@
           },
           {
             "$ref": "#/parameters/CredentialNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v2/types.json#/parameters/ApiVersionParameter"
           }
         ],
         "responses": {
@@ -551,6 +560,9 @@
           },
           {
             "$ref": "#/parameters/PlaneNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v2/types.json#/parameters/ApiVersionParameter"
           }
         ],
         "responses": {
@@ -594,6 +606,9 @@
           },
           {
             "$ref": "#/parameters/CredentialNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v2/types.json#/parameters/ApiVersionParameter"
           }
         ],
         "responses": {
@@ -644,6 +659,9 @@
             "schema": {
               "$ref": "#/definitions/CredentialResource"
             }
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v2/types.json#/parameters/ApiVersionParameter"
           }
         ],
         "responses": {
@@ -690,6 +708,9 @@
           },
           {
             "$ref": "#/parameters/CredentialNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v2/types.json#/parameters/ApiVersionParameter"
           }
         ],
         "responses": {
@@ -732,6 +753,9 @@
           },
           {
             "$ref": "#/parameters/PlaneNameParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v2/types.json#/parameters/ApiVersionParameter"
           }
         ],
         "responses": {


### PR DESCRIPTION
# Description

UCP has now added API versioning support. This parameter is missing in the swagger for the UCP credentials resource. Adding it.

#4609 

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #4609 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
