### PR TITLE
Updating UCP AWS Post handlers with new update logic

### DIFF
--- a/pkg/aws/operations/operations.go
+++ b/pkg/aws/operations/operations.go
@@ -25,18 +25,17 @@ type ResourceTypeSchema struct {
 // FlattenProperties flattens a state object.
 // For example:
 //
-//   "NumShards": 1
-//   "ClusterEndpoint": {
-//     "Address": "test-address"
-//     "Port": 3000
-//   }
+//	"NumShards": 1
+//	"ClusterEndpoint": {
+//	  "Address": "test-address"
+//	  "Port": 3000
+//	}
 //
 // Gets transformed to:
 //
-//   "NumShards": 1
-//   "ClusterEndpoint/Address": "test-address"
-//   "ClusterEndpoint/Port": 3000
-//
+//	"NumShards": 1
+//	"ClusterEndpoint/Address": "test-address"
+//	"ClusterEndpoint/Port": 3000
 func FlattenProperties(state map[string]interface{}) map[string]interface{} {
 	flattenedState := map[string]interface{}{}
 
@@ -60,19 +59,17 @@ func FlattenProperties(state map[string]interface{}) map[string]interface{} {
 // UnflattenProperties unflattens a flattened state object.
 // For example:
 //
-//   "NumShards": 1
-//   "ClusterEndpoint/Address": "test-address"
-//   "ClusterEndpoint/Port": 3000
-//
+//	"NumShards": 1
+//	"ClusterEndpoint/Address": "test-address"
+//	"ClusterEndpoint/Port": 3000
 //
 // Gets transformed to:
 //
-//   "NumShards": 1
-//   "ClusterEndpoint": {
-//     "Address": "test-address"
-//     "Port": 3000
-//   }
-//
+//	"NumShards": 1
+//	"ClusterEndpoint": {
+//	  "Address": "test-address"
+//	  "Port": 3000
+//	}
 func UnflattenProperties(state map[string]interface{}) map[string]interface{} {
 	unflattenedState := map[string]interface{}{}
 
@@ -167,4 +164,13 @@ func GeneratePatch(currentState []byte, desiredState []byte, schema []byte) (jso
 
 	// Calculate the patch based on the current state and the updated desired state
 	return jsondiff.CompareJSON(currentState, updatedDesiredState)
+}
+
+// ParsePropertyName transforms a propertyIdentifer of the form /properties/<propertyName> to <propertyName>
+func ParsePropertyName(propertyIdentifier string) (string, error) {
+	prefix := "/properties/"
+	if strings.HasPrefix(propertyIdentifier, prefix) {
+		return strings.Replace(propertyIdentifier, prefix, "", 1), nil
+	}
+	return "", fmt.Errorf("property identifier %s is not in the format /properties/<propertyName>", propertyIdentifier)
 }

--- a/pkg/aws/operations/operations.go
+++ b/pkg/aws/operations/operations.go
@@ -170,7 +170,7 @@ func GeneratePatch(currentState []byte, desiredState []byte, schema []byte) (jso
 func ParsePropertyName(propertyIdentifier string) (string, error) {
 	prefix := "/properties/"
 	if strings.HasPrefix(propertyIdentifier, prefix) {
-		return strings.Replace(propertyIdentifier, prefix, "", 1), nil
+		return strings.TrimPrefix(propertyIdentifier, prefix), nil
 	}
 	return "", fmt.Errorf("property identifier %s is not in the format /properties/<propertyName>", propertyIdentifier)
 }

--- a/pkg/aws/operations/operations_test.go
+++ b/pkg/aws/operations/operations_test.go
@@ -301,8 +301,8 @@ func Test_ParsePropertyName(t *testing.T) {
 		},
 		{
 			"ParsePropertyName successfully parses sub-properties",
-			"/properties/propertyName",
-			"propertyName",
+			"/properties/propertyName/subProperty/subSubProperty",
+			"propertyName/subProperty/subSubProperty",
 			nil,
 		},
 		{

--- a/pkg/aws/operations/operations_test.go
+++ b/pkg/aws/operations/operations_test.go
@@ -7,6 +7,7 @@ package operations
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -282,6 +283,41 @@ func Test_GeneratePatch(t *testing.T) {
 
 			require.Equal(t, testCase.expectedPatch, patch)
 		})
+	}
+}
 
+func Test_ParsePropertyName(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  string
+		output string
+		err    error
+	}{
+		{
+			"ParsePropertyName successfully parses single property",
+			"/properties/propertyName",
+			"propertyName",
+			nil,
+		},
+		{
+			"ParsePropertyName successfully parses sub-properties",
+			"/properties/propertyName",
+			"propertyName",
+			nil,
+		},
+		{
+			"ParsePropertyName returns an error if input is invalid",
+			"propertyName",
+			"",
+			fmt.Errorf("property identifier propertyName is not in the format /properties/<propertyName>"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual, err := ParsePropertyName(testCase.input)
+			require.Equal(t, testCase.output, actual)
+			require.Equal(t, err, testCase.err)
+		})
 	}
 }

--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
@@ -60,7 +60,15 @@ func getPrimaryIdentifiersFromSchema(ctx context.Context, schema string) ([]stri
 		return nil, err
 	}
 
-	primaryIdentifiers := schemaObject["primaryIdentifier"].([]interface{})
+	primaryIdentifiersObject, exists := schemaObject["primaryIdentifier"]
+	if !exists {
+		return nil, fmt.Errorf("primaryIdentifier not found in schema")
+	}
+
+	primaryIdentifiers, ok := primaryIdentifiersObject.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("primaryIdentifier is not an array")
+	}
 
 	primaryIdentifiersString := make([]string, len(primaryIdentifiers))
 	for i, primaryIdentifier := range primaryIdentifiers {

--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
@@ -70,15 +70,15 @@ func getPrimaryIdentifiersFromSchema(ctx context.Context, schema string) ([]stri
 		return nil, fmt.Errorf("primaryIdentifier is not an array")
 	}
 
-	primaryIdentifiersString := make([]string, len(primaryIdentifiers))
-	for i, primaryIdentifier := range primaryIdentifiers {
-		primaryIdentifiersString[i] = primaryIdentifier.(string)
+	var primaryIdentifiersString []string
+	for _, primaryIdentifier := range primaryIdentifiers {
+		primaryIdentifiersString = append(primaryIdentifiersString, primaryIdentifier.(string))
 	}
 
 	return primaryIdentifiersString, nil
 }
 
-func getResourceIDWithMultiIdentifiers(ctx context.Context, properties map[string]interface{}, schema string) (string, error) {
+func getPrimaryIdentifierFromMultiIdentifiers(ctx context.Context, properties map[string]interface{}, schema string) (string, error) {
 	primaryIdentifiers, err := getPrimaryIdentifiersFromSchema(ctx, schema)
 	if err != nil {
 		return "", err

--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
@@ -12,11 +12,10 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
-	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	awsoperations "github.com/project-radius/radius/pkg/aws/operations"
 	"github.com/project-radius/radius/pkg/middleware"
 	awsclient "github.com/project-radius/radius/pkg/ucp/aws"
 	ctrl "github.com/project-radius/radius/pkg/ucp/frontend/controller"
@@ -54,34 +53,36 @@ func ParseAWSRequest(ctx context.Context, opts ctrl.Options, r *http.Request) (a
 	return cloudControlClient, cloudFormationClient, resourceType, id, nil
 }
 
-func lookupAWSResourceSchema(ctx context.Context, cloudFormationClient awsclient.AWSCloudFormationClient, resourceType string) ([]interface{}, error) {
-	output, err := cloudFormationClient.DescribeType(ctx, &cloudformation.DescribeTypeInput{
-		Type:     types.RegistryTypeResource,
-		TypeName: aws.String(resourceType),
-	})
+func getPrimaryIdentifiersFromSchema(ctx context.Context, schema string) ([]string, error) {
+	schemaObject := map[string]interface{}{}
+	err := json.Unmarshal([]byte(schema), &schemaObject)
 	if err != nil {
 		return nil, err
 	}
 
-	description := map[string]interface{}{}
-	err = json.Unmarshal([]byte(*output.Schema), &description)
-	if err != nil {
-		return nil, err
+	primaryIdentifiers := schemaObject["primaryIdentifier"].([]interface{})
+
+	primaryIdentifiersString := make([]string, len(primaryIdentifiers))
+	for i, primaryIdentifier := range primaryIdentifiers {
+		primaryIdentifiersString[i] = primaryIdentifier.(string)
 	}
-	primaryIdentifier := description["primaryIdentifier"].([]interface{})
-	return primaryIdentifier, nil
+
+	return primaryIdentifiersString, nil
 }
 
-func getResourceIDWithMultiIdentifiers(ctx context.Context, cloudFormationClient awsclient.AWSCloudFormationClient, url string, resourceType string, properties map[string]interface{}) (string, error) {
-	primaryIdentifiers, err := lookupAWSResourceSchema(ctx, cloudFormationClient, resourceType)
+func getResourceIDWithMultiIdentifiers(ctx context.Context, properties map[string]interface{}, schema string) (string, error) {
+	primaryIdentifiers, err := getPrimaryIdentifiersFromSchema(ctx, schema)
 	if err != nil {
 		return "", err
 	}
 
 	var resourceID string
-	for _, pi := range primaryIdentifiers {
+	for _, primaryIdentifier := range primaryIdentifiers {
 		// Primary identifier is of the form /properties/<property-name>
-		propertyName := strings.Split(pi.(string), "/")[2]
+		propertyName, err := awsoperations.ParsePropertyName(primaryIdentifier)
+		if err != nil {
+			return "", err
+		}
 
 		if _, ok := properties[propertyName]; !ok {
 			// Mandatory property is missing

--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing_test.go
@@ -92,3 +92,35 @@ func TestGetPrimaryIdentifiersFromSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"/properties/GlobalNetworkId", "/properties/DeviceId"}, primaryIdentifiers)
 }
+
+func TestGetPrimaryIdentifiersFromSchema_PrimaryIdentifierMissing(t *testing.T) {
+	ctx := context.Background()
+
+	schemaObject := map[string]interface{}{}
+
+	schemaBytes, err := json.Marshal(schemaObject)
+	require.NoError(t, err)
+
+	schema := string(schemaBytes)
+
+	primaryIdentifiers, err := getPrimaryIdentifiersFromSchema(ctx, schema)
+	require.Nil(t, primaryIdentifiers)
+	require.EqualError(t, err, "primaryIdentifier not found in schema")
+}
+
+func TestGetPrimaryIdentifiersFromSchema_PrimaryIdentifierWrongDataType(t *testing.T) {
+	ctx := context.Background()
+
+	schemaObject := map[string]interface{}{
+		"primaryIdentifier": "/properties/GlobalNetworkId",
+	}
+
+	schemaBytes, err := json.Marshal(schemaObject)
+	require.NoError(t, err)
+
+	schema := string(schemaBytes)
+
+	primaryIdentifiers, err := getPrimaryIdentifiersFromSchema(ctx, schema)
+	require.Nil(t, primaryIdentifiers)
+	require.EqualError(t, err, "primaryIdentifier is not an array")
+}

--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestResourceIDWithMultiIdentifiers(t *testing.T) {
+func TestGetPrimaryIdentifierFromMultiIdentifiers(t *testing.T) {
 	ctx := context.Background()
 
 	schemaObject := map[string]interface{}{
@@ -34,12 +34,12 @@ func TestResourceIDWithMultiIdentifiers(t *testing.T) {
 		"DeviceId":        "device-id",
 	}
 
-	resourceID, err := getResourceIDWithMultiIdentifiers(ctx, properties, schema)
+	resourceID, err := getPrimaryIdentifierFromMultiIdentifiers(ctx, properties, schema)
 	require.NoError(t, err)
 	require.Equal(t, "global-network-id|device-id", resourceID)
 }
 
-func TestResourceIDWithMultiIdentifiers_MissingMandatoryParameters(t *testing.T) {
+func TestGetPrimaryIdentifierFromMultiIdentifiers_MissingMandatoryParameters(t *testing.T) {
 	ctx := context.Background()
 
 	schemaObject := map[string]interface{}{
@@ -58,7 +58,7 @@ func TestResourceIDWithMultiIdentifiers_MissingMandatoryParameters(t *testing.T)
 		"GlobalNetworkId": "global-network-id",
 	}
 
-	resourceID, err := getResourceIDWithMultiIdentifiers(ctx, properties, schema)
+	resourceID, err := getPrimaryIdentifierFromMultiIdentifiers(ctx, properties, schema)
 	require.Equal(t, resourceID, "")
 	require.Error(t, err)
 	require.EqualError(t, err, "mandatory property DeviceId is missing")

--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing_test.go
@@ -10,81 +10,58 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
-	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
-	"github.com/golang/mock/gomock"
-	awsclient "github.com/project-radius/radius/pkg/ucp/aws"
 	"github.com/project-radius/radius/pkg/ucp/resources"
 	"github.com/stretchr/testify/require"
 )
 
 func TestResourceIDWithMultiIdentifiers(t *testing.T) {
 	ctx := context.Background()
-	mockCtrl := gomock.NewController(t)
-	mockClient := awsclient.NewMockAWSCloudFormationClient(mockCtrl)
-	resourceType := "AWS::NetworkManager::Device"
 
-	primaryIdentifiers := map[string]interface{}{
+	schemaObject := map[string]interface{}{
 		"primaryIdentifier": []interface{}{
 			"/properties/GlobalNetworkId",
 			"/properties/DeviceId",
 		},
 	}
-	serialized, err := json.Marshal(primaryIdentifiers)
+
+	schemaBytes, err := json.Marshal(schemaObject)
 	require.NoError(t, err)
-	output := cloudformation.DescribeTypeOutput{
-		TypeName: aws.String(resourceType),
-		Schema:   to.Ptr(string(serialized)),
-	}
 
-	input := cloudformation.DescribeTypeInput{
-		TypeName: aws.String(resourceType),
-		Type:     types.RegistryTypeResource,
-	}
-	mockClient.EXPECT().DescribeType(ctx, &input).Return(&output, nil)
+	schema := string(schemaBytes)
 
-	url := "http://127.0.0.1:9000/apis/api.ucp.dev/v1alpha3/planes/aws/aws/accounts/841861948707/regions/us-west-2/providers/AWS.NetworkManager/Device/:put"
-	resourceID, err := getResourceIDWithMultiIdentifiers(ctx, mockClient, url, "AWS::NetworkManager::Device", map[string]interface{}{
+	properties := map[string]interface{}{
 		"GlobalNetworkId": "global-network-id",
 		"DeviceId":        "device-id",
-	})
+	}
+
+	resourceID, err := getResourceIDWithMultiIdentifiers(ctx, properties, schema)
 	require.NoError(t, err)
 	require.Equal(t, "global-network-id|device-id", resourceID)
 }
 
 func TestResourceIDWithMultiIdentifiers_MissingMandatoryParameters(t *testing.T) {
 	ctx := context.Background()
-	mockCtrl := gomock.NewController(t)
-	mockClient := awsclient.NewMockAWSCloudFormationClient(mockCtrl)
-	resourceType := "AWS::NetworkManager::Device"
 
-	primaryIdentifiers := map[string]interface{}{
+	schemaObject := map[string]interface{}{
 		"primaryIdentifier": []interface{}{
 			"/properties/GlobalNetworkId",
 			"/properties/DeviceId",
 		},
 	}
-	serialized, err := json.Marshal(primaryIdentifiers)
+
+	schemaBytes, err := json.Marshal(schemaObject)
 	require.NoError(t, err)
-	output := cloudformation.DescribeTypeOutput{
-		TypeName: aws.String(resourceType),
-		Schema:   to.Ptr(string(serialized)),
-	}
 
-	input := cloudformation.DescribeTypeInput{
-		TypeName: aws.String(resourceType),
-		Type:     types.RegistryTypeResource,
-	}
-	mockClient.EXPECT().DescribeType(ctx, &input).Return(&output, nil)
+	schema := string(schemaBytes)
 
-	url := "http://127.0.0.1:9000/apis/api.ucp.dev/v1alpha3/planes/aws/aws/accounts/841861948707/regions/us-west-2/providers/AWS.NetworkManager/Device/:put"
-	_, err = getResourceIDWithMultiIdentifiers(ctx, mockClient, url, "AWS::NetworkManager::Device", map[string]interface{}{
+	properties := map[string]interface{}{
 		"GlobalNetworkId": "global-network-id",
-	})
-	require.NotNil(t, err)
-	require.Equal(t, "mandatory property DeviceId is missing", err.Error())
+	}
+
+	resourceID, err := getResourceIDWithMultiIdentifiers(ctx, properties, schema)
+	require.Equal(t, resourceID, "")
+	require.Error(t, err)
+	require.EqualError(t, err, "mandatory property DeviceId is missing")
 }
 
 func TestComputeResourceID(t *testing.T) {
@@ -94,4 +71,24 @@ func TestComputeResourceID(t *testing.T) {
 	resourceID := "global-network-id|device-id"
 	computedID := computeResourceID(id, resourceID)
 	require.Equal(t, "/apis/api.ucp.dev/v1alpha3/planes/aws/aws/accounts/841861948707/regions/us-west-2/providers/AWS.NetworkManager/Device/global-network-id|device-id", computedID)
+}
+
+func TestGetPrimaryIdentifiersFromSchema(t *testing.T) {
+	ctx := context.Background()
+
+	schemaObject := map[string]interface{}{
+		"primaryIdentifier": []interface{}{
+			"/properties/GlobalNetworkId",
+			"/properties/DeviceId",
+		},
+	}
+
+	schemaBytes, err := json.Marshal(schemaObject)
+	require.NoError(t, err)
+
+	schema := string(schemaBytes)
+
+	primaryIdentifiers, err := getPrimaryIdentifiersFromSchema(ctx, schema)
+	require.NoError(t, err)
+	require.Equal(t, []string{"/properties/GlobalNetworkId", "/properties/DeviceId"}, primaryIdentifiers)
 }

--- a/pkg/ucp/frontend/controller/awsproxy/awsproxytest.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsproxytest.go
@@ -8,10 +8,7 @@ package awsproxy
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/project-radius/radius/pkg/ucp/store"
@@ -54,91 +51,66 @@ type AWSTestResource struct {
 	ResourceType          string
 	AWSResourceType       string
 	ResourceName          string
+	ARN                   string
 	CollectionPath        string
 	SingleResourcePath    string
 	OperationResultsPath  string
 	OperationStatusesPath string
 	LocationHeader        string
 	AzureAsyncOpHeader    string
-	TypeSchema            map[string]interface{}
-	SerializedTypeSchema  string
-	ARN                   string
+	Schema                string
 }
 
-func CreateAWSTestResource(resourceType string) *AWSTestResource {
-	var resourceName string
-	switch resourceType {
-	case AWSKinesisStreamResourceType:
-		resourceName = "test-stream"
-	case AWSMemoryDBClusterResourceType:
-		resourceName = "test-cluster"
-	case AWSRedShiftEndpointAuthorizationResourceType:
-		resourceName = "test-endpoint-authorization"
-	default:
-		return nil
-	}
+func CreateKinesisStreamTestResource(resourceName string) *AWSTestResource {
+	resourceType := AWSKinesisStreamResourceType
+	awsResourceType := AWSKinesisStreamAWSResourceType
+	provider := "AWS.Kinesis"
+	arn := fmt.Sprintf("arn:aws:kinesis:us-west-2:123456789012:stream:%s", resourceName)
+	typeSchema := getMockKinesisStreamResourceTypeSchema()
 
-	// Add some random characters to the end of the resource name
-	var suffixBuilder strings.Builder
-	rand.Seed(time.Now().UnixNano())
-	charset := "abcdefghijklmnopqrstuvwxyz"
-	for i := 0; i < 5; i++ {
-		suffixBuilder.WriteByte(charset[rand.Intn(len(charset))])
-	}
-	resourceNameSuffix := suffixBuilder.String()
-
-	return CreateAWSTestResourceWithName(resourceType, fmt.Sprintf("%s-%s", resourceName, resourceNameSuffix))
+	return CreateAWSTestResource(resourceType, awsResourceType, resourceName, provider, arn, typeSchema)
 }
 
-func CreateAWSTestResourceWithName(resourceType, resourceName string) *AWSTestResource {
-	var awsResourceType string
-	var typeSchema map[string]interface{}
-	var arn string
-	var provider string
-	switch resourceType {
-	case AWSKinesisStreamResourceType:
-		awsResourceType = AWSKinesisStreamAWSResourceType
-		typeSchema = getMockKinesisStreamResourceTypeSchema()
-		arn = fmt.Sprintf("arn:aws:kinesis:us-west-2:123456789012:stream:%s", resourceName)
-		provider = "AWS.Kinesis"
-	case AWSMemoryDBClusterResourceType:
-		awsResourceType = AWSMemoryDBClusterAWSResourceType
-		typeSchema = getMockMemoryDBClusterResourceTypeSchema()
-		arn = fmt.Sprintf("arn:aws:memorydb:us-west-2:123456789012:cluster:%s", resourceName)
-		provider = "AWS.MemoryDB"
-	case AWSRedShiftEndpointAuthorizationResourceType:
-		awsResourceType = AWSRedShiftEndpointAuthorizationAWSResourceType
-		typeSchema = getMockRedShiftEndpointAuthorizationResourceTypeSchema()
-		arn = fmt.Sprintf("arn:aws:redshift:us-west-2:123456789012:endpointauthorization:%s", resourceName)
-		provider = "AWS.RedShift"
-	default:
+func CreateMemoryDBClusterTestResource(resourceName string) *AWSTestResource {
+	resourceType := AWSMemoryDBClusterResourceType
+	awsResourceType := AWSMemoryDBClusterAWSResourceType
+	provider := "AWS.MemoryDB"
+	arn := fmt.Sprintf("arn:aws:memorydb:us-west-2:123456789012:cluster:%s", resourceName)
+	typeSchema := getMockMemoryDBClusterResourceTypeSchema()
+
+	return CreateAWSTestResource(resourceType, awsResourceType, resourceName, provider, arn, typeSchema)
+}
+
+func CreateRedshiftEndpointAuthorizationTestResource(resourceName string) *AWSTestResource {
+	resourceType := AWSRedShiftEndpointAuthorizationResourceType
+	awsResourceType := AWSRedShiftEndpointAuthorizationAWSResourceType
+	provider := "AWS.Redshift"
+	arn := fmt.Sprintf("arn:aws:redshift:us-west-2:123456789012:endpointauthorization:%s", resourceName)
+	typeSchema := getMockRedShiftEndpointAuthorizationResourceTypeSchema()
+
+	return CreateAWSTestResource(resourceType, awsResourceType, resourceName, provider, arn, typeSchema)
+}
+
+func CreateAWSTestResource(resourceType, awsResourceType, resourceName, provider, arn string, typeSchema map[string]interface{}) *AWSTestResource {
+	serialized, err := json.Marshal(typeSchema)
+	if err != nil {
 		return nil
 	}
-
-	serializedTypeSchema := serializeTypeSchema(typeSchema)
+	schema := string(serialized)
 
 	return &AWSTestResource{
 		ResourceType:          resourceType,
 		AWSResourceType:       awsResourceType,
 		ResourceName:          resourceName,
+		ARN:                   arn,
 		CollectionPath:        fmt.Sprintf("/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/%s", resourceType),
 		SingleResourcePath:    fmt.Sprintf("/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/%s/%s", resourceType, resourceName),
 		OperationResultsPath:  fmt.Sprintf("/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/%s/locations/us-west-2/operationResults/1234567", resourceType),
 		OperationStatusesPath: fmt.Sprintf("/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/%s/locations/us-west-2/operationStatuses/2345678", resourceType),
 		LocationHeader:        fmt.Sprintf("http://localhost:5000/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/%s/locations/global/operationResults/79b9f0da-4882-4dc8-a367-6fd3bc122ded", provider),
 		AzureAsyncOpHeader:    fmt.Sprintf("http://localhost:5000/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/%s/locations/global/operationStatuses/79b9f0da-4882-4dc8-a367-6fd3bc122ded", provider),
-		TypeSchema:            typeSchema,
-		SerializedTypeSchema:  serializedTypeSchema,
-		ARN:                   arn,
+		Schema:                schema,
 	}
-}
-
-func serializeTypeSchema(typeSchema map[string]interface{}) string {
-	serialized, err := json.Marshal(typeSchema)
-	if err != nil {
-		return ""
-	}
-	return string(serialized)
 }
 
 func getMockKinesisStreamResourceTypeSchema() map[string]interface{} {

--- a/pkg/ucp/frontend/controller/awsproxy/awsproxytest.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsproxytest.go
@@ -6,7 +6,12 @@
 package awsproxy
 
 import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/project-radius/radius/pkg/ucp/store"
@@ -15,20 +20,15 @@ import (
 )
 
 const (
-	testAWSResourceCollectionPath   = "/planes/aws/aws/accounts/1234567/regions/us-east-1/providers/AWS.Kinesis/Stream"
-	testAWSSingleResourcePath       = "/planes/aws/aws/accounts/1234567/regions/us-east-1/providers/AWS.Kinesis/Stream/stream-1"
-	testAWSOperationResultsPath     = "/planes/aws/aws/accounts/1234567/regions/us-east-1/providers/AWS.Kinesis/Stream/locations/us-west-2/operationResults/1234567"
-	testAWSOperationStatusesPath    = "/planes/aws/aws/accounts/1234567/regions/us-east-1/providers/AWS.Kinesis/Stream/locations/us-west-2/operationStatuses/2345678"
-	testAWSResourceName             = "stream-1"
-	testAWSResourceType             = "AWS.Kinesis/Stream"
-	testAWSRequestToken             = "79B9F0DA-4882-4DC8-A367-6FD3BC122DED" // Random UUID
-	testMultiIdentifierResourcePath = "/planes/aws/aws/accounts/841861948707/regions/us-west-2/providers/AWS.RedShift/EndpointAuthorization"
-	testPrimaryIdentifier1          = "abc"
-	testPrimaryIdentifier2          = "xyz"
-	testMultiIdentifierResourceType = "AWS.RedShift/EndpointAuthorization"
-	testHost                        = "localhost:5000"
-	testlocationHeader              = "http://localhost:5000/planes/aws/aws/accounts/1234567/regions/us-east-1/providers/AWS.Kinesis/locations/global/operationResults/79b9f0da-4882-4dc8-a367-6fd3bc122ded"
-	testazureAsyncOpHeader          = "http://localhost:5000/planes/aws/aws/accounts/1234567/regions/us-east-1/providers/AWS.Kinesis/locations/global/operationStatuses/79b9f0da-4882-4dc8-a367-6fd3bc122ded"
+	AWSKinesisStreamResourceType                    = "AWS.Kinesis/Stream"
+	AWSKinesisStreamAWSResourceType                 = "AWS::Kinesis::Stream"
+	AWSMemoryDBClusterResourceType                  = "AWS.MemoryDB/Cluster"
+	AWSMemoryDBClusterAWSResourceType               = "AWS::MemoryDB::Cluster"
+	AWSRedShiftEndpointAuthorizationResourceType    = "AWS.RedShift/EndpointAuthorization"
+	AWSRedShiftEndpointAuthorizationAWSResourceType = "AWS::RedShift::EndpointAuthorization"
+
+	testAWSRequestToken = "79B9F0DA-4882-4DC8-A367-6FD3BC122DED" // Random UUID
+	testHost            = "localhost:5000"
 )
 
 type TestOptions struct {
@@ -47,5 +47,136 @@ func setupTest(t *testing.T) TestOptions {
 		AWSCloudControlClient:   mockCloudControlClient,
 		AWSCloudFormationClient: mockCloudFormationClient,
 		StorageClient:           mockStorageClient,
+	}
+}
+
+type AWSTestResource struct {
+	ResourceType          string
+	AWSResourceType       string
+	ResourceName          string
+	CollectionPath        string
+	SingleResourcePath    string
+	OperationResultsPath  string
+	OperationStatusesPath string
+	LocationHeader        string
+	AzureAsyncOpHeader    string
+	TypeSchema            map[string]interface{}
+	SerializedTypeSchema  string
+	ARN                   string
+}
+
+func CreateAWSTestResource(resourceType string) *AWSTestResource {
+	var resourceName string
+	switch resourceType {
+	case AWSKinesisStreamResourceType:
+		resourceName = "test-stream"
+	case AWSMemoryDBClusterResourceType:
+		resourceName = "test-cluster"
+	case AWSRedShiftEndpointAuthorizationResourceType:
+		resourceName = "test-endpoint-authorization"
+	default:
+		return nil
+	}
+
+	// Add some random characters to the end of the resource name
+	var suffixBuilder strings.Builder
+	rand.Seed(time.Now().UnixNano())
+	charset := "abcdefghijklmnopqrstuvwxyz"
+	for i := 0; i < 5; i++ {
+		suffixBuilder.WriteByte(charset[rand.Intn(len(charset))])
+	}
+	resourceNameSuffix := suffixBuilder.String()
+
+	return CreateAWSTestResourceWithName(resourceType, fmt.Sprintf("%s-%s", resourceName, resourceNameSuffix))
+}
+
+func CreateAWSTestResourceWithName(resourceType, resourceName string) *AWSTestResource {
+	var awsResourceType string
+	var typeSchema map[string]interface{}
+	var arn string
+	var provider string
+	switch resourceType {
+	case AWSKinesisStreamResourceType:
+		awsResourceType = AWSKinesisStreamAWSResourceType
+		typeSchema = getMockKinesisStreamResourceTypeSchema()
+		arn = fmt.Sprintf("arn:aws:kinesis:us-west-2:123456789012:stream:%s", resourceName)
+		provider = "AWS.Kinesis"
+	case AWSMemoryDBClusterResourceType:
+		awsResourceType = AWSMemoryDBClusterAWSResourceType
+		typeSchema = getMockMemoryDBClusterResourceTypeSchema()
+		arn = fmt.Sprintf("arn:aws:memorydb:us-west-2:123456789012:cluster:%s", resourceName)
+		provider = "AWS.MemoryDB"
+	case AWSRedShiftEndpointAuthorizationResourceType:
+		awsResourceType = AWSRedShiftEndpointAuthorizationAWSResourceType
+		typeSchema = getMockRedShiftEndpointAuthorizationResourceTypeSchema()
+		arn = fmt.Sprintf("arn:aws:redshift:us-west-2:123456789012:endpointauthorization:%s", resourceName)
+		provider = "AWS.RedShift"
+	default:
+		return nil
+	}
+
+	serializedTypeSchema := serializeTypeSchema(typeSchema)
+
+	return &AWSTestResource{
+		ResourceType:          resourceType,
+		AWSResourceType:       awsResourceType,
+		ResourceName:          resourceName,
+		CollectionPath:        fmt.Sprintf("/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/%s", resourceType),
+		SingleResourcePath:    fmt.Sprintf("/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/%s/%s", resourceType, resourceName),
+		OperationResultsPath:  fmt.Sprintf("/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/%s/locations/us-west-2/operationResults/1234567", resourceType),
+		OperationStatusesPath: fmt.Sprintf("/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/%s/locations/us-west-2/operationStatuses/2345678", resourceType),
+		LocationHeader:        fmt.Sprintf("http://localhost:5000/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/%s/locations/global/operationResults/79b9f0da-4882-4dc8-a367-6fd3bc122ded", provider),
+		AzureAsyncOpHeader:    fmt.Sprintf("http://localhost:5000/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/%s/locations/global/operationStatuses/79b9f0da-4882-4dc8-a367-6fd3bc122ded", provider),
+		TypeSchema:            typeSchema,
+		SerializedTypeSchema:  serializedTypeSchema,
+		ARN:                   arn,
+	}
+}
+
+func serializeTypeSchema(typeSchema map[string]interface{}) string {
+	serialized, err := json.Marshal(typeSchema)
+	if err != nil {
+		return ""
+	}
+	return string(serialized)
+}
+
+func getMockKinesisStreamResourceTypeSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"primaryIdentifier": []interface{}{
+			"/properties/Name",
+		},
+		"readOnlyProperties": []interface{}{
+			"/properties/Arn",
+		},
+		"createOnlyProperties": []interface{}{
+			"/properties/Name",
+		},
+	}
+}
+
+func getMockMemoryDBClusterResourceTypeSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"primaryIdentifier": []interface{}{
+			"/properties/ClusterName",
+		},
+		"readOnlyProperties": []interface{}{
+			"/properties/ClusterEndpoint/Address",
+			"/properties/ClusterEndpoint/Port",
+			"/properties/ARN",
+		},
+		"createOnlyProperties": []interface{}{
+			"/properties/ClusterName",
+			"/properties/Port",
+		},
+	}
+}
+
+func getMockRedShiftEndpointAuthorizationResourceTypeSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"primaryIdentifier": []interface{}{
+			"/properties/ClusterIdentifier",
+			"/properties/Account",
+		},
 	}
 }

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource_test.go
@@ -27,6 +27,8 @@ func Test_CreateAWSResource(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
+	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		nil, &types.ResourceNotFoundException{
@@ -56,7 +58,7 @@ func Test_CreateAWSResource(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodPut, testAWSSingleResourcePath, bytes.NewBuffer(requestBodyBytes))
+	request, err := http.NewRequest(http.MethodPut, testResource.SingleResourcePath, bytes.NewBuffer(requestBodyBytes))
 	request.Host = testHost
 	require.NoError(t, err)
 
@@ -73,16 +75,16 @@ func Test_CreateAWSResource(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, res.Header.Get("Location"))
-	require.Equal(t, testlocationHeader, res.Header.Get("Location"))
+	require.Equal(t, testResource.LocationHeader, res.Header.Get("Location"))
 
 	require.NotNil(t, res.Header.Get("Azure-AsyncOperation"))
-	require.Equal(t, testazureAsyncOpHeader, res.Header.Get("Azure-AsyncOperation"))
+	require.Equal(t, testResource.AzureAsyncOpHeader, res.Header.Get("Azure-AsyncOperation"))
 	defer res.Body.Close()
 
 	expectedResponseObject := map[string]interface{}{
-		"id":   testAWSSingleResourcePath,
-		"name": testAWSResourceName,
-		"type": testAWSResourceType,
+		"id":   testResource.SingleResourcePath,
+		"name": testResource.ResourceName,
+		"type": testResource.ResourceType,
 		"properties": map[string]interface{}{
 			"RetentionPeriodHours": float64(178),
 			"ShardCount":           float64(3),
@@ -101,26 +103,12 @@ func Test_UpdateAWSResource(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	resourceTypeAWS := "AWS::MemoryDB::Cluster"
-	resourceId := "/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/AWS.MemoryDB/Cluster/mycluster"
-	resourceType := "AWS.MemoryDB/Cluster"
-	resourceName := "mycluster"
+	testResource := CreateAWSTestResource(AWSMemoryDBClusterResourceType)
 
-	typeSchema := map[string]interface{}{
-		"readOnlyProperties": []interface{}{
-			"/properties/ClusterEndpoint/Address",
-			"/properties/ClusterEndpoint/Port",
-			"/properties/ARN",
-		},
-		"createOnlyProperties": []interface{}{
-			"/properties/ClusterName",
-			"/properties/Port",
-		},
-	}
-	serialized, err := json.Marshal(typeSchema)
+	serialized, err := json.Marshal(testResource.TypeSchema)
 	require.NoError(t, err)
 	output := cloudformation.DescribeTypeOutput{
-		TypeName: aws.String(resourceTypeAWS),
+		TypeName: aws.String(testResource.AWSResourceType),
 		Schema:   aws.String(string(serialized)),
 	}
 
@@ -157,6 +145,7 @@ func Test_UpdateAWSResource(t *testing.T) {
 
 	requestBody := map[string]interface{}{
 		"properties": map[string]interface{}{
+			"Port":                6379,
 			"NumReplicasPerShard": 0,
 		},
 	}
@@ -170,7 +159,7 @@ func Test_UpdateAWSResource(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodPut, resourceId, bytes.NewBuffer(requestBodyBytes))
+	request, err := http.NewRequest(http.MethodPut, testResource.SingleResourcePath, bytes.NewBuffer(requestBodyBytes))
 	require.NoError(t, err)
 
 	actualResponse, err := awsController.Run(ctx, nil, request)
@@ -187,9 +176,9 @@ func Test_UpdateAWSResource(t *testing.T) {
 	defer res.Body.Close()
 
 	expectedResponseObject := map[string]interface{}{
-		"id":   resourceId,
-		"name": resourceName,
-		"type": resourceType,
+		"id":   testResource.SingleResourcePath,
+		"name": testResource.ResourceName,
+		"type": testResource.ResourceType,
 		"properties": map[string]interface{}{
 			"ClusterEndpoint": map[string]interface{}{
 				"Address": "test",
@@ -213,20 +202,11 @@ func Test_UpdateNoChangesDoesNotCallUpdate(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	resourceType := "AWS::Kinesis::Stream"
-	typeSchema := map[string]interface{}{
-		"readOnlyProperties": []interface{}{
-			"/properties/Arn",
-		},
-		"createOnlyProperties": []interface{}{
-			"/properties/Name",
-		},
-	}
-	serialized, err := json.Marshal(typeSchema)
-	require.NoError(t, err)
+	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+
 	output := cloudformation.DescribeTypeOutput{
-		TypeName: aws.String(resourceType),
-		Schema:   aws.String(string(serialized)),
+		TypeName: aws.String(testResource.AWSResourceType),
+		Schema:   aws.String(testResource.SerializedTypeSchema),
 	}
 
 	getResponseBody := map[string]interface{}{
@@ -263,7 +243,7 @@ func Test_UpdateNoChangesDoesNotCallUpdate(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodPut, testAWSSingleResourcePath, bytes.NewBuffer(requestBodyBytes))
+	request, err := http.NewRequest(http.MethodPut, testResource.SingleResourcePath, bytes.NewBuffer(requestBodyBytes))
 	require.NoError(t, err)
 
 	actualResponse, err := awsController.Run(ctx, nil, request)
@@ -280,9 +260,9 @@ func Test_UpdateNoChangesDoesNotCallUpdate(t *testing.T) {
 	defer res.Body.Close()
 
 	expectedResponseObject := map[string]interface{}{
-		"id":   testAWSSingleResourcePath,
-		"name": testAWSResourceName,
-		"type": testAWSResourceType,
+		"id":   testResource.SingleResourcePath,
+		"name": testResource.ResourceName,
+		"type": testResource.ResourceType,
 		"properties": map[string]interface{}{
 			"RetentionPeriodHours": float64(178),
 			"ShardCount":           float64(3),

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 	ctrl "github.com/project-radius/radius/pkg/ucp/frontend/controller"
 	"github.com/project-radius/radius/pkg/ucp/util/testcontext"
 	"github.com/stretchr/testify/require"
@@ -27,7 +28,7 @@ func Test_CreateAWSResource(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -103,13 +104,11 @@ func Test_UpdateAWSResource(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSMemoryDBClusterResourceType)
+	testResource := CreateMemoryDBClusterTestResource(uuid.NewString())
 
-	serialized, err := json.Marshal(testResource.TypeSchema)
-	require.NoError(t, err)
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
-		Schema:   aws.String(string(serialized)),
+		Schema:   aws.String(testResource.Schema),
 	}
 
 	getResponseBody := map[string]interface{}{
@@ -202,11 +201,11 @@ func Test_UpdateNoChangesDoesNotCallUpdate(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
-		Schema:   aws.String(testResource.SerializedTypeSchema),
+		Schema:   aws.String(testResource.Schema),
 	}
 
 	getResponseBody := map[string]interface{}{

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
@@ -61,7 +61,7 @@ func (p *CreateOrUpdateAWSResourceWithPost) Run(ctx context.Context, w http.Resp
 		return awserror.HandleAWSError(err)
 	}
 
-	awsResourceIdentifier, err := getResourceIDWithMultiIdentifiers(ctx, properties, *describeTypeOutput.Schema)
+	awsResourceIdentifier, err := getPrimaryIdentifierFromMultiIdentifiers(ctx, properties, *describeTypeOutput.Schema)
 	if err != nil {
 		e := v1.ErrorResponse{
 			Error: v1.ErrorDetails{

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost_test.go
@@ -23,498 +23,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_CreateAWSResourceWithPost(t *testing.T) {
-	ctx, cancel := testcontext.New(t)
-	defer cancel()
-
-	testOptions := setupTest(t)
-
-	primaryIdentifiers := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
-			"/properties/Name",
-		},
-	}
-	serialized, err := json.Marshal(primaryIdentifiers)
-	require.NoError(t, err)
-	output := cloudformation.DescribeTypeOutput{
-		TypeName: aws.String("AWS::Kinesis::Stream"),
-		Schema:   aws.String(string(serialized)),
-	}
-
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
-
-	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		nil, &types.ResourceNotFoundException{
-			Message: aws.String("Resource not found"),
-		})
-
-	testOptions.AWSCloudControlClient.EXPECT().CreateResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		&cloudcontrol.CreateResourceOutput{
-			ProgressEvent: &types.ProgressEvent{
-				OperationStatus: types.OperationStatusSuccess,
-				RequestToken:    aws.String(testAWSRequestToken),
-			},
-		}, nil)
-
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
-			"Name":                 testAWSResourceName,
-			"RetentionPeriodHours": 178,
-			"ShardCount":           3,
-		},
-	}
-	requestBodyBytes, err := json.Marshal(requestBody)
-	require.NoError(t, err)
-
-	awsController, err := NewCreateOrUpdateAWSResourceWithPost(ctrl.Options{
-		AWSCloudControlClient:   testOptions.AWSCloudControlClient,
-		AWSCloudFormationClient: testOptions.AWSCloudFormationClient,
-		DB:                      testOptions.StorageClient,
-	})
-	require.NoError(t, err)
-
-	request, err := http.NewRequest(http.MethodPost, testAWSResourceCollectionPath+"/:put", bytes.NewBuffer(requestBodyBytes))
-	require.NoError(t, err)
-
-	actualResponse, err := awsController.Run(ctx, nil, request)
-	require.NoError(t, err)
-
-	w := httptest.NewRecorder()
-	err = actualResponse.Apply(ctx, w, request)
-	require.NoError(t, err)
-
-	res := w.Result()
-	require.Equal(t, http.StatusCreated, res.StatusCode)
-	body, err := io.ReadAll(res.Body)
-	require.NoError(t, err)
-	defer res.Body.Close()
-
-	expectedResponseObject := map[string]interface{}{
-		"id":   testAWSSingleResourcePath,
-		"name": testAWSResourceName,
-		"type": testAWSResourceType,
-		"properties": map[string]interface{}{
-			"Name":                 testAWSResourceName,
-			"RetentionPeriodHours": float64(178),
-			"ShardCount":           float64(3),
-			"provisioningState":    "Provisioning",
-		},
-	}
-
-	actualResponseObject := map[string]interface{}{}
-	err = json.Unmarshal(body, &actualResponseObject)
-	require.NoError(t, err)
-
-	require.Equal(t, expectedResponseObject, actualResponseObject)
-}
-
 func Test_UpdateAWSResourceWithPost(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testOptions := setupTest(t)
-	primaryIdentifiers := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
-			"/properties/Name",
-		},
-	}
-	serialized, err := json.Marshal(primaryIdentifiers)
-	require.NoError(t, err)
+	testResource := CreateAWSTestResource(AWSMemoryDBClusterResourceType)
+
 	output := cloudformation.DescribeTypeOutput{
-		TypeName: aws.String("AWS::Kinesis::Stream"),
-		Schema:   aws.String(string(serialized)),
+		TypeName: aws.String(testResource.AWSResourceType),
+		Schema:   aws.String(testResource.SerializedTypeSchema),
 	}
 
+	testOptions := setupTest(t)
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	getResponseBody := map[string]interface{}{
-		"Name":                 testAWSResourceName,
-		"RetentionPeriodHours": 178,
-		"ShardCount":           3,
-	}
-	getResponseBodyBytes, err := json.Marshal(getResponseBody)
-	require.NoError(t, err)
-
-	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		&cloudcontrol.GetResourceOutput{
-			ResourceDescription: &types.ResourceDescription{
-				Properties: aws.String(string(getResponseBodyBytes)),
-			},
-		}, nil)
-
-	testOptions.AWSCloudControlClient.EXPECT().UpdateResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		&cloudcontrol.UpdateResourceOutput{
-			ProgressEvent: &types.ProgressEvent{
-				OperationStatus: types.OperationStatusSuccess,
-				RequestToken:    aws.String(testAWSRequestToken),
-			},
-		}, nil)
-
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
-			"Name":                 testAWSResourceName,
-			"RetentionPeriodHours": 180,
-			"ShardCount":           4,
-		},
-	}
-	requestBodyBytes, err := json.Marshal(requestBody)
-	require.NoError(t, err)
-
-	awsController, err := NewCreateOrUpdateAWSResourceWithPost(ctrl.Options{
-		AWSCloudControlClient:   testOptions.AWSCloudControlClient,
-		AWSCloudFormationClient: testOptions.AWSCloudFormationClient,
-		DB:                      testOptions.StorageClient,
-	})
-	require.NoError(t, err)
-
-	request, err := http.NewRequest(http.MethodPost, testAWSResourceCollectionPath, bytes.NewBuffer(requestBodyBytes))
-	require.NoError(t, err)
-
-	actualResponse, err := awsController.Run(ctx, nil, request)
-	require.NoError(t, err)
-
-	w := httptest.NewRecorder()
-	err = actualResponse.Apply(ctx, w, request)
-	require.NoError(t, err)
-
-	res := w.Result()
-	require.Equal(t, http.StatusCreated, res.StatusCode)
-	body, err := io.ReadAll(res.Body)
-	require.NoError(t, err)
-	defer res.Body.Close()
-
-	expectedResponseObject := map[string]interface{}{
-		"id":   testAWSSingleResourcePath,
-		"name": testAWSResourceName,
-		"type": testAWSResourceType,
-		"properties": map[string]interface{}{
-			"Name":                 testAWSResourceName,
-			"RetentionPeriodHours": float64(180),
-			"ShardCount":           float64(4),
-			"provisioningState":    "Provisioning",
-		},
-	}
-
-	actualResponseObject := map[string]interface{}{}
-	err = json.Unmarshal(body, &actualResponseObject)
-	require.NoError(t, err)
-
-	require.Equal(t, expectedResponseObject, actualResponseObject)
-}
-
-func Test_UpdateAWSResourceWithPost_NoChangesNoops(t *testing.T) {
-	ctx, cancel := testcontext.New(t)
-	defer cancel()
-
-	testOptions := setupTest(t)
-	primaryIdentifiers := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
-			"/properties/Name",
-		},
-	}
-	serialized, err := json.Marshal(primaryIdentifiers)
-	require.NoError(t, err)
-	output := cloudformation.DescribeTypeOutput{
-		TypeName: aws.String("AWS::Kinesis::Stream"),
-		Schema:   aws.String(string(serialized)),
-	}
-
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
-
-	getResponseBody := map[string]interface{}{
-		"Name":                 testAWSResourceName,
-		"RetentionPeriodHours": 178,
-		"ShardCount":           3,
-	}
-	getResponseBodyBytes, err := json.Marshal(getResponseBody)
-	require.NoError(t, err)
-
-	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		&cloudcontrol.GetResourceOutput{
-			ResourceDescription: &types.ResourceDescription{
-				Properties: aws.String(string(getResponseBodyBytes)),
-			},
-		}, nil)
-
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
-			"Name":                 testAWSResourceName,
-			"RetentionPeriodHours": 178,
-			"ShardCount":           3,
-		},
-	}
-	requestBodyBytes, err := json.Marshal(requestBody)
-	require.NoError(t, err)
-
-	awsController, err := NewCreateOrUpdateAWSResourceWithPost(ctrl.Options{
-		AWSCloudControlClient:   testOptions.AWSCloudControlClient,
-		AWSCloudFormationClient: testOptions.AWSCloudFormationClient,
-		DB:                      testOptions.StorageClient,
-	})
-	require.NoError(t, err)
-
-	request, err := http.NewRequest(http.MethodPost, testAWSResourceCollectionPath, bytes.NewBuffer(requestBodyBytes))
-	require.NoError(t, err)
-
-	actualResponse, err := awsController.Run(ctx, nil, request)
-	require.NoError(t, err)
-
-	w := httptest.NewRecorder()
-	err = actualResponse.Apply(ctx, w, request)
-	require.NoError(t, err)
-
-	res := w.Result()
-	require.Equal(t, http.StatusOK, res.StatusCode)
-	body, err := io.ReadAll(res.Body)
-	require.NoError(t, err)
-	defer res.Body.Close()
-
-	expectedResponseObject := map[string]interface{}{
-		"id":   testAWSSingleResourcePath,
-		"name": testAWSResourceName,
-		"type": testAWSResourceType,
-		"properties": map[string]interface{}{
-			"Name":                 testAWSResourceName,
-			"RetentionPeriodHours": float64(178),
-			"ShardCount":           float64(3),
-			"provisioningState":    "Succeeded",
-		},
-	}
-
-	actualResponseObject := map[string]interface{}{}
-	err = json.Unmarshal(body, &actualResponseObject)
-	require.NoError(t, err)
-
-	require.Equal(t, expectedResponseObject, actualResponseObject)
-}
-
-func Test_CreateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
-	ctx, cancel := testcontext.New(t)
-	defer cancel()
-
-	testOptions := setupTest(t)
-
-	primaryIdentifiers := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
-			"/properties/ClusterIdentifier",
-			"/properties/Account",
-		},
-	}
-	serialized, err := json.Marshal(primaryIdentifiers)
-	require.NoError(t, err)
-	output := cloudformation.DescribeTypeOutput{
-		TypeName: aws.String("AWS::RedShift::EndpointAuthorization"),
-		Schema:   aws.String(string(serialized)),
-	}
-
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
-
-	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		nil, &types.ResourceNotFoundException{
-			Message: aws.String("Resource not found"),
-		})
-
-	testOptions.AWSCloudControlClient.EXPECT().CreateResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		&cloudcontrol.CreateResourceOutput{
-			ProgressEvent: &types.ProgressEvent{
-				OperationStatus: types.OperationStatusSuccess,
-				RequestToken:    aws.String(testAWSRequestToken),
-			},
-		}, nil)
-
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
-			"ClusterIdentifier": testPrimaryIdentifier1,
-			"Account":           testPrimaryIdentifier2,
-		},
-	}
-	requestBodyBytes, err := json.Marshal(requestBody)
-	require.NoError(t, err)
-
-	awsController, err := NewCreateOrUpdateAWSResourceWithPost(ctrl.Options{
-		AWSCloudControlClient:   testOptions.AWSCloudControlClient,
-		AWSCloudFormationClient: testOptions.AWSCloudFormationClient,
-		DB:                      testOptions.StorageClient,
-	})
-	require.NoError(t, err)
-
-	request, err := http.NewRequest(http.MethodPost, testMultiIdentifierResourcePath+"/:put", bytes.NewBuffer(requestBodyBytes))
-	require.NoError(t, err)
-
-	actualResponse, err := awsController.Run(ctx, nil, request)
-	require.NoError(t, err)
-
-	w := httptest.NewRecorder()
-	err = actualResponse.Apply(ctx, w, request)
-	require.NoError(t, err)
-
-	res := w.Result()
-	require.Equal(t, http.StatusCreated, res.StatusCode)
-	body, err := io.ReadAll(res.Body)
-	require.NoError(t, err)
-	defer res.Body.Close()
-
-	id, err := resources.Parse(testMultiIdentifierResourcePath)
-	require.NoError(t, err)
-	multiIdentifierResourceID := testPrimaryIdentifier1 + "|" + testPrimaryIdentifier2
-	rID := computeResourceID(id, multiIdentifierResourceID)
-	expectedResponseObject := map[string]interface{}{
-		"id":   rID,
-		"name": multiIdentifierResourceID,
-		"type": testMultiIdentifierResourceType,
-		"properties": map[string]interface{}{
-			"ClusterIdentifier": "abc",
-			"Account":           "xyz",
-			"provisioningState": "Provisioning",
-		},
-	}
-
-	actualResponseObject := map[string]interface{}{}
-	err = json.Unmarshal(body, &actualResponseObject)
-	require.NoError(t, err)
-
-	require.Equal(t, expectedResponseObject, actualResponseObject)
-}
-
-func Test_UpdateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
-	ctx, cancel := testcontext.New(t)
-	defer cancel()
-
-	testOptions := setupTest(t)
-	primaryIdentifiers := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
-			"/properties/ClusterIdentifier",
-			"/properties/Account",
-		},
-	}
-	serialized, err := json.Marshal(primaryIdentifiers)
-	require.NoError(t, err)
-	output := cloudformation.DescribeTypeOutput{
-		TypeName: aws.String("AWS::RedShift::EndpointAuthorization"),
-		Schema:   aws.String(string(serialized)),
-	}
-
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
-
-	getResponseBody := map[string]interface{}{
-		"ClusterIdentifier": "abc",
-		"Account":           "xyz",
-	}
-	getResponseBodyBytes, err := json.Marshal(getResponseBody)
-	require.NoError(t, err)
-
-	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		&cloudcontrol.GetResourceOutput{
-			ResourceDescription: &types.ResourceDescription{
-				Properties: aws.String(string(getResponseBodyBytes)),
-			},
-		}, nil)
-
-	testOptions.AWSCloudControlClient.EXPECT().UpdateResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		&cloudcontrol.UpdateResourceOutput{
-			ProgressEvent: &types.ProgressEvent{
-				OperationStatus: types.OperationStatusSuccess,
-				RequestToken:    aws.String(testAWSRequestToken),
-			},
-		}, nil)
-
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
-			"ClusterIdentifier": "abc",
-			"Account":           "xyz",
-			"EndpointCount":     2,
-		},
-	}
-	requestBodyBytes, err := json.Marshal(requestBody)
-	require.NoError(t, err)
-
-	awsController, err := NewCreateOrUpdateAWSResourceWithPost(ctrl.Options{
-		AWSCloudControlClient:   testOptions.AWSCloudControlClient,
-		AWSCloudFormationClient: testOptions.AWSCloudFormationClient,
-		DB:                      testOptions.StorageClient,
-	})
-	require.NoError(t, err)
-
-	request, err := http.NewRequest(http.MethodPost, testMultiIdentifierResourcePath, bytes.NewBuffer(requestBodyBytes))
-	require.NoError(t, err)
-
-	actualResponse, err := awsController.Run(ctx, nil, request)
-	require.NoError(t, err)
-
-	w := httptest.NewRecorder()
-	err = actualResponse.Apply(ctx, w, request)
-	require.NoError(t, err)
-
-	res := w.Result()
-	require.Equal(t, http.StatusCreated, res.StatusCode)
-	body, err := io.ReadAll(res.Body)
-	require.NoError(t, err)
-	defer res.Body.Close()
-
-	id, err := resources.Parse(testMultiIdentifierResourcePath)
-	require.NoError(t, err)
-	multiIdentifierResourceID := testPrimaryIdentifier1 + "|" + testPrimaryIdentifier2
-	rID := computeResourceID(id, multiIdentifierResourceID)
-	expectedResponseObject := map[string]interface{}{
-		"id":   rID,
-		"name": multiIdentifierResourceID,
-		"type": testMultiIdentifierResourceType,
-		"properties": map[string]interface{}{
-			"ClusterIdentifier": "abc",
-			"Account":           "xyz",
-			"EndpointCount":     float64(2),
-			"provisioningState": "Provisioning",
-		},
-	}
-
-	actualResponseObject := map[string]interface{}{}
-	err = json.Unmarshal(body, &actualResponseObject)
-	require.NoError(t, err)
-
-	require.Equal(t, expectedResponseObject, actualResponseObject)
-}
-
-func Test_UpdateAWSResourceWithPost_WithSpecialProperties(t *testing.T) {
-	ctx, cancel := testcontext.New(t)
-	defer cancel()
-
-	resourceTypeAWS := "AWS::MemoryDB::Cluster"
-	resourceId := "/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/AWS.MemoryDB/Cluster/mycluster"
-	resourceType := "AWS.MemoryDB/Cluster"
-	resourceName := "mycluster"
-
-	testOptions := setupTest(t)
-	typeSchema := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
-			"/properties/ClusterName",
-		},
-		"readOnlyProperties": []interface{}{
-			"/properties/ClusterEndpoint/Address",
-			"/properties/ClusterEndpoint/Port",
-			"/properties/ARN",
-		},
-		"createOnlyProperties": []interface{}{
-			"/properties/ClusterName",
-			"/properties/Port",
-		},
-	}
-	serialized, err := json.Marshal(typeSchema)
-	require.NoError(t, err)
-	output := cloudformation.DescribeTypeOutput{
-		TypeName: aws.String(resourceTypeAWS),
-		Schema:   aws.String(string(serialized)),
-	}
-
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
-
-	getResponseBody := map[string]interface{}{
-		"ClusterName": resourceName,
+		"ClusterName": testResource.ResourceName,
 		"ClusterEndpoint": map[string]interface{}{
 			"Address": "test",
 			"Port":    6379,
 		},
 		"Port":                6379,
-		"ARN":                 "arn:aws:memorydb:us-west-2:123456789012:cluster:mycluster",
+		"ARN":                 testResource.ARN,
 		"NumReplicasPerShard": 1,
 	}
 	getResponseBodyBytes, err := json.Marshal(getResponseBody)
@@ -537,7 +67,7 @@ func Test_UpdateAWSResourceWithPost_WithSpecialProperties(t *testing.T) {
 
 	requestBody := map[string]interface{}{
 		"properties": map[string]interface{}{
-			"ClusterName":         resourceName,
+			"ClusterName":         testResource.ResourceName,
 			"Port":                6379,
 			"NumReplicasPerShard": 0,
 		},
@@ -552,7 +82,7 @@ func Test_UpdateAWSResourceWithPost_WithSpecialProperties(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodPost, "/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/AWS.MemoryDB/Cluster", bytes.NewBuffer(requestBodyBytes))
+	request, err := http.NewRequest(http.MethodPost, testResource.CollectionPath, bytes.NewBuffer(requestBodyBytes))
 	require.NoError(t, err)
 
 	actualResponse, err := awsController.Run(ctx, nil, request)
@@ -569,17 +99,17 @@ func Test_UpdateAWSResourceWithPost_WithSpecialProperties(t *testing.T) {
 	defer res.Body.Close()
 
 	expectedResponseObject := map[string]interface{}{
-		"id":   resourceId,
-		"name": resourceName,
-		"type": resourceType,
+		"id":   testResource.SingleResourcePath,
+		"name": testResource.ResourceName,
+		"type": testResource.ResourceType,
 		"properties": map[string]interface{}{
-			"ClusterName": resourceName,
+			"ClusterName": testResource.ResourceName,
 			"ClusterEndpoint": map[string]interface{}{
 				"Address": "test",
 				"Port":    float64(6379),
 			},
 			"Port":                float64(6379),
-			"ARN":                 "arn:aws:memorydb:us-west-2:123456789012:cluster:mycluster",
+			"ARN":                 testResource.ARN,
 			"NumReplicasPerShard": float64(0),
 			"provisioningState":   "Provisioning",
 		},
@@ -592,7 +122,7 @@ func Test_UpdateAWSResourceWithPost_WithSpecialProperties(t *testing.T) {
 	require.Equal(t, expectedResponseObject, actualResponseObject)
 }
 
-func Test_UpdateAWSResourceWithPost_WithSpecialProperties_NoChangesNoops(t *testing.T) {
+func Test_UpdateAWSResourceWithPost_NoChangesNoops(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
@@ -692,6 +222,183 @@ func Test_UpdateAWSResourceWithPost_WithSpecialProperties_NoChangesNoops(t *test
 			"ARN":                 "arn:aws:memorydb:us-west-2:123456789012:cluster:mycluster",
 			"NumReplicasPerShard": float64(1),
 			"provisioningState":   "Succeeded",
+		},
+	}
+
+	actualResponseObject := map[string]interface{}{}
+	err = json.Unmarshal(body, &actualResponseObject)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedResponseObject, actualResponseObject)
+}
+
+func Test_CreateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
+	ctx, cancel := testcontext.New(t)
+	defer cancel()
+
+	testResource := CreateAWSTestResource(AWSRedShiftEndpointAuthorizationResourceType)
+	clusterIdentifierValue := "abc"
+	accountValue := "xyz"
+
+	output := cloudformation.DescribeTypeOutput{
+		TypeName: aws.String(testResource.AWSResourceType),
+		Schema:   aws.String(testResource.SerializedTypeSchema),
+	}
+
+	testOptions := setupTest(t)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+
+	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		nil, &types.ResourceNotFoundException{
+			Message: aws.String("Resource not found"),
+		})
+
+	testOptions.AWSCloudControlClient.EXPECT().CreateResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&cloudcontrol.CreateResourceOutput{
+			ProgressEvent: &types.ProgressEvent{
+				OperationStatus: types.OperationStatusSuccess,
+				RequestToken:    aws.String(testAWSRequestToken),
+			},
+		}, nil)
+
+	requestBody := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"ClusterIdentifier": clusterIdentifierValue,
+			"Account":           accountValue,
+		},
+	}
+	requestBodyBytes, err := json.Marshal(requestBody)
+	require.NoError(t, err)
+
+	awsController, err := NewCreateOrUpdateAWSResourceWithPost(ctrl.Options{
+		AWSCloudControlClient:   testOptions.AWSCloudControlClient,
+		AWSCloudFormationClient: testOptions.AWSCloudFormationClient,
+		DB:                      testOptions.StorageClient,
+	})
+	require.NoError(t, err)
+
+	request, err := http.NewRequest(http.MethodPost, testResource.CollectionPath+"/:put", bytes.NewBuffer(requestBodyBytes))
+	require.NoError(t, err)
+
+	actualResponse, err := awsController.Run(ctx, nil, request)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	err = actualResponse.Apply(ctx, w, request)
+	require.NoError(t, err)
+
+	res := w.Result()
+	require.Equal(t, http.StatusCreated, res.StatusCode)
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	id, err := resources.Parse(testResource.CollectionPath)
+	require.NoError(t, err)
+	multiIdentifierResourceID := clusterIdentifierValue + "|" + accountValue
+	rID := computeResourceID(id, multiIdentifierResourceID)
+	expectedResponseObject := map[string]interface{}{
+		"id":   rID,
+		"name": multiIdentifierResourceID,
+		"type": testResource.ResourceType,
+		"properties": map[string]interface{}{
+			"ClusterIdentifier": clusterIdentifierValue,
+			"Account":           accountValue,
+			"provisioningState": "Provisioning",
+		},
+	}
+
+	actualResponseObject := map[string]interface{}{}
+	err = json.Unmarshal(body, &actualResponseObject)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedResponseObject, actualResponseObject)
+}
+
+func Test_UpdateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
+	ctx, cancel := testcontext.New(t)
+	defer cancel()
+
+	testResource := CreateAWSTestResource(AWSRedShiftEndpointAuthorizationResourceType)
+	clusterIdentifierValue := "abc"
+	accountValue := "xyz"
+
+	output := cloudformation.DescribeTypeOutput{
+		TypeName: aws.String(testResource.AWSResourceType),
+		Schema:   aws.String(testResource.SerializedTypeSchema),
+	}
+
+	testOptions := setupTest(t)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+
+	getResponseBody := map[string]interface{}{
+		"ClusterIdentifier": clusterIdentifierValue,
+		"Account":           accountValue,
+	}
+	getResponseBodyBytes, err := json.Marshal(getResponseBody)
+	require.NoError(t, err)
+
+	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&cloudcontrol.GetResourceOutput{
+			ResourceDescription: &types.ResourceDescription{
+				Properties: aws.String(string(getResponseBodyBytes)),
+			},
+		}, nil)
+
+	testOptions.AWSCloudControlClient.EXPECT().UpdateResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&cloudcontrol.UpdateResourceOutput{
+			ProgressEvent: &types.ProgressEvent{
+				OperationStatus: types.OperationStatusSuccess,
+				RequestToken:    aws.String(testAWSRequestToken),
+			},
+		}, nil)
+
+	requestBody := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"ClusterIdentifier": clusterIdentifierValue,
+			"Account":           accountValue,
+			"EndpointCount":     2,
+		},
+	}
+	requestBodyBytes, err := json.Marshal(requestBody)
+	require.NoError(t, err)
+
+	awsController, err := NewCreateOrUpdateAWSResourceWithPost(ctrl.Options{
+		AWSCloudControlClient:   testOptions.AWSCloudControlClient,
+		AWSCloudFormationClient: testOptions.AWSCloudFormationClient,
+		DB:                      testOptions.StorageClient,
+	})
+	require.NoError(t, err)
+
+	request, err := http.NewRequest(http.MethodPost, testResource.CollectionPath, bytes.NewBuffer(requestBodyBytes))
+	require.NoError(t, err)
+
+	actualResponse, err := awsController.Run(ctx, nil, request)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	err = actualResponse.Apply(ctx, w, request)
+	require.NoError(t, err)
+
+	res := w.Result()
+	require.Equal(t, http.StatusCreated, res.StatusCode)
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	id, err := resources.Parse(testResource.CollectionPath)
+	require.NoError(t, err)
+	multiIdentifierResourceID := clusterIdentifierValue + "|" + accountValue
+	rID := computeResourceID(id, multiIdentifierResourceID)
+	expectedResponseObject := map[string]interface{}{
+		"id":   rID,
+		"name": multiIdentifierResourceID,
+		"type": testResource.ResourceType,
+		"properties": map[string]interface{}{
+			"ClusterIdentifier": "abc",
+			"Account":           "xyz",
+			"EndpointCount":     float64(2),
+			"provisioningState": "Provisioning",
 		},
 	}
 

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
@@ -39,7 +38,7 @@ func Test_CreateAWSResourceWithPost(t *testing.T) {
 	require.NoError(t, err)
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String("AWS::Kinesis::Stream"),
-		Schema:   to.Ptr(string(serialized)),
+		Schema:   aws.String(string(serialized)),
 	}
 
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
@@ -53,7 +52,7 @@ func Test_CreateAWSResourceWithPost(t *testing.T) {
 		&cloudcontrol.CreateResourceOutput{
 			ProgressEvent: &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,
-				RequestToken:    to.Ptr(testAWSRequestToken),
+				RequestToken:    aws.String(testAWSRequestToken),
 			},
 		}, nil)
 
@@ -123,7 +122,7 @@ func Test_UpdateAWSResourceWithPost(t *testing.T) {
 	require.NoError(t, err)
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String("AWS::Kinesis::Stream"),
-		Schema:   to.Ptr(string(serialized)),
+		Schema:   aws.String(string(serialized)),
 	}
 
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
@@ -139,7 +138,7 @@ func Test_UpdateAWSResourceWithPost(t *testing.T) {
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&cloudcontrol.GetResourceOutput{
 			ResourceDescription: &types.ResourceDescription{
-				Properties: to.Ptr(string(getResponseBodyBytes)),
+				Properties: aws.String(string(getResponseBodyBytes)),
 			},
 		}, nil)
 
@@ -147,7 +146,7 @@ func Test_UpdateAWSResourceWithPost(t *testing.T) {
 		&cloudcontrol.UpdateResourceOutput{
 			ProgressEvent: &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,
-				RequestToken:    to.Ptr(testAWSRequestToken),
+				RequestToken:    aws.String(testAWSRequestToken),
 			},
 		}, nil)
 
@@ -203,7 +202,7 @@ func Test_UpdateAWSResourceWithPost(t *testing.T) {
 	require.Equal(t, expectedResponseObject, actualResponseObject)
 }
 
-func Test_UpdateNoChangesDoesNotCallUpdateWithPost(t *testing.T) {
+func Test_UpdateAWSResourceWithPost_NoChangesNoops(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
@@ -217,7 +216,7 @@ func Test_UpdateNoChangesDoesNotCallUpdateWithPost(t *testing.T) {
 	require.NoError(t, err)
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String("AWS::Kinesis::Stream"),
-		Schema:   to.Ptr(string(serialized)),
+		Schema:   aws.String(string(serialized)),
 	}
 
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
@@ -233,7 +232,7 @@ func Test_UpdateNoChangesDoesNotCallUpdateWithPost(t *testing.T) {
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&cloudcontrol.GetResourceOutput{
 			ResourceDescription: &types.ResourceDescription{
-				Properties: to.Ptr(string(getResponseBodyBytes)),
+				Properties: aws.String(string(getResponseBodyBytes)),
 			},
 		}, nil)
 
@@ -305,7 +304,7 @@ func Test_CreateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	require.NoError(t, err)
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String("AWS::RedShift::EndpointAuthorization"),
-		Schema:   to.Ptr(string(serialized)),
+		Schema:   aws.String(string(serialized)),
 	}
 
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
@@ -319,7 +318,7 @@ func Test_CreateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 		&cloudcontrol.CreateResourceOutput{
 			ProgressEvent: &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,
-				RequestToken:    to.Ptr(testAWSRequestToken),
+				RequestToken:    aws.String(testAWSRequestToken),
 			},
 		}, nil)
 
@@ -392,7 +391,7 @@ func Test_UpdateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	require.NoError(t, err)
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String("AWS::RedShift::EndpointAuthorization"),
-		Schema:   to.Ptr(string(serialized)),
+		Schema:   aws.String(string(serialized)),
 	}
 
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
@@ -407,7 +406,7 @@ func Test_UpdateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&cloudcontrol.GetResourceOutput{
 			ResourceDescription: &types.ResourceDescription{
-				Properties: to.Ptr(string(getResponseBodyBytes)),
+				Properties: aws.String(string(getResponseBodyBytes)),
 			},
 		}, nil)
 
@@ -415,7 +414,7 @@ func Test_UpdateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 		&cloudcontrol.UpdateResourceOutput{
 			ProgressEvent: &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,
-				RequestToken:    to.Ptr(testAWSRequestToken),
+				RequestToken:    aws.String(testAWSRequestToken),
 			},
 		}, nil)
 
@@ -465,6 +464,234 @@ func Test_UpdateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 			"Account":           "xyz",
 			"EndpointCount":     float64(2),
 			"provisioningState": "Provisioning",
+		},
+	}
+
+	actualResponseObject := map[string]interface{}{}
+	err = json.Unmarshal(body, &actualResponseObject)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedResponseObject, actualResponseObject)
+}
+
+func Test_UpdateAWSResourceWithPost_WithSpecialProperties(t *testing.T) {
+	ctx, cancel := testcontext.New(t)
+	defer cancel()
+
+	resourceTypeAWS := "AWS::MemoryDB::Cluster"
+	resourceId := "/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/AWS.MemoryDB/Cluster/mycluster"
+	resourceType := "AWS.MemoryDB/Cluster"
+	resourceName := "mycluster"
+
+	testOptions := setupTest(t)
+	typeSchema := map[string]interface{}{
+		"primaryIdentifier": []interface{}{
+			"/properties/ClusterName",
+		},
+		"readOnlyProperties": []interface{}{
+			"/properties/ClusterEndpoint/Address",
+			"/properties/ClusterEndpoint/Port",
+			"/properties/ARN",
+		},
+		"createOnlyProperties": []interface{}{
+			"/properties/ClusterName",
+			"/properties/Port",
+		},
+	}
+	serialized, err := json.Marshal(typeSchema)
+	require.NoError(t, err)
+	output := cloudformation.DescribeTypeOutput{
+		TypeName: aws.String(resourceTypeAWS),
+		Schema:   aws.String(string(serialized)),
+	}
+
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+
+	getResponseBody := map[string]interface{}{
+		"ClusterName": resourceName,
+		"ClusterEndpoint": map[string]interface{}{
+			"Address": "test",
+			"Port":    6379,
+		},
+		"Port":                6379,
+		"ARN":                 "arn:aws:memorydb:us-west-2:123456789012:cluster:mycluster",
+		"NumReplicasPerShard": 1,
+	}
+	getResponseBodyBytes, err := json.Marshal(getResponseBody)
+	require.NoError(t, err)
+
+	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&cloudcontrol.GetResourceOutput{
+			ResourceDescription: &types.ResourceDescription{
+				Properties: aws.String(string(getResponseBodyBytes)),
+			},
+		}, nil)
+
+	testOptions.AWSCloudControlClient.EXPECT().UpdateResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&cloudcontrol.UpdateResourceOutput{
+			ProgressEvent: &types.ProgressEvent{
+				OperationStatus: types.OperationStatusSuccess,
+				RequestToken:    aws.String(testAWSRequestToken),
+			},
+		}, nil)
+
+	requestBody := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"ClusterName":         resourceName,
+			"Port":                6379,
+			"NumReplicasPerShard": 0,
+		},
+	}
+	requestBodyBytes, err := json.Marshal(requestBody)
+	require.NoError(t, err)
+
+	awsController, err := NewCreateOrUpdateAWSResourceWithPost(ctrl.Options{
+		AWSCloudControlClient:   testOptions.AWSCloudControlClient,
+		AWSCloudFormationClient: testOptions.AWSCloudFormationClient,
+		DB:                      testOptions.StorageClient,
+	})
+	require.NoError(t, err)
+
+	request, err := http.NewRequest(http.MethodPost, "/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/AWS.MemoryDB/Cluster", bytes.NewBuffer(requestBodyBytes))
+	require.NoError(t, err)
+
+	actualResponse, err := awsController.Run(ctx, nil, request)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	err = actualResponse.Apply(ctx, w, request)
+	require.NoError(t, err)
+
+	res := w.Result()
+	require.Equal(t, http.StatusCreated, res.StatusCode)
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	expectedResponseObject := map[string]interface{}{
+		"id":   resourceId,
+		"name": resourceName,
+		"type": resourceType,
+		"properties": map[string]interface{}{
+			"ClusterName": resourceName,
+			"ClusterEndpoint": map[string]interface{}{
+				"Address": "test",
+				"Port":    float64(6379),
+			},
+			"Port":                float64(6379),
+			"ARN":                 "arn:aws:memorydb:us-west-2:123456789012:cluster:mycluster",
+			"NumReplicasPerShard": float64(0),
+			"provisioningState":   "Provisioning",
+		},
+	}
+
+	actualResponseObject := map[string]interface{}{}
+	err = json.Unmarshal(body, &actualResponseObject)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedResponseObject, actualResponseObject)
+}
+
+func Test_UpdateAWSResourceWithPost_WithSpecialProperties_NoChangesNoops(t *testing.T) {
+	ctx, cancel := testcontext.New(t)
+	defer cancel()
+
+	resourceTypeAWS := "AWS::MemoryDB::Cluster"
+	resourceId := "/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/AWS.MemoryDB/Cluster/mycluster"
+	resourceType := "AWS.MemoryDB/Cluster"
+	resourceName := "mycluster"
+
+	testOptions := setupTest(t)
+	typeSchema := map[string]interface{}{
+		"primaryIdentifier": []interface{}{
+			"/properties/ClusterName",
+		},
+		"readOnlyProperties": []interface{}{
+			"/properties/ClusterEndpoint/Address",
+			"/properties/ClusterEndpoint/Port",
+			"/properties/ARN",
+		},
+		"createOnlyProperties": []interface{}{
+			"/properties/ClusterName",
+			"/properties/Port",
+		},
+	}
+	serialized, err := json.Marshal(typeSchema)
+	require.NoError(t, err)
+	output := cloudformation.DescribeTypeOutput{
+		TypeName: aws.String(resourceTypeAWS),
+		Schema:   aws.String(string(serialized)),
+	}
+
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+
+	getResponseBody := map[string]interface{}{
+		"ClusterName": resourceName,
+		"ClusterEndpoint": map[string]interface{}{
+			"Address": "test",
+			"Port":    6379,
+		},
+		"Port":                6379,
+		"ARN":                 "arn:aws:memorydb:us-west-2:123456789012:cluster:mycluster",
+		"NumReplicasPerShard": 1,
+	}
+	getResponseBodyBytes, err := json.Marshal(getResponseBody)
+	require.NoError(t, err)
+
+	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&cloudcontrol.GetResourceOutput{
+			ResourceDescription: &types.ResourceDescription{
+				Properties: aws.String(string(getResponseBodyBytes)),
+			},
+		}, nil)
+
+	requestBody := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"ClusterName":         resourceName,
+			"Port":                6379,
+			"NumReplicasPerShard": 1,
+		},
+	}
+	requestBodyBytes, err := json.Marshal(requestBody)
+	require.NoError(t, err)
+
+	awsController, err := NewCreateOrUpdateAWSResourceWithPost(ctrl.Options{
+		AWSCloudControlClient:   testOptions.AWSCloudControlClient,
+		AWSCloudFormationClient: testOptions.AWSCloudFormationClient,
+		DB:                      testOptions.StorageClient,
+	})
+	require.NoError(t, err)
+
+	request, err := http.NewRequest(http.MethodPost, "/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/AWS.MemoryDB/Cluster", bytes.NewBuffer(requestBodyBytes))
+	require.NoError(t, err)
+
+	actualResponse, err := awsController.Run(ctx, nil, request)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	err = actualResponse.Apply(ctx, w, request)
+	require.NoError(t, err)
+
+	res := w.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	expectedResponseObject := map[string]interface{}{
+		"id":   resourceId,
+		"name": resourceName,
+		"type": resourceType,
+		"properties": map[string]interface{}{
+			"ClusterName": resourceName,
+			"ClusterEndpoint": map[string]interface{}{
+				"Address": "test",
+				"Port":    float64(6379),
+			},
+			"Port":                float64(6379),
+			"ARN":                 "arn:aws:memorydb:us-west-2:123456789012:cluster:mycluster",
+			"NumReplicasPerShard": float64(1),
+			"provisioningState":   "Succeeded",
 		},
 	}
 

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 	ctrl "github.com/project-radius/radius/pkg/ucp/frontend/controller"
 	"github.com/project-radius/radius/pkg/ucp/resources"
 	"github.com/project-radius/radius/pkg/ucp/util/testcontext"
@@ -27,11 +28,11 @@ func Test_UpdateAWSResourceWithPost(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSMemoryDBClusterResourceType)
+	testResource := CreateMemoryDBClusterTestResource(uuid.NewString())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
-		Schema:   aws.String(testResource.SerializedTypeSchema),
+		Schema:   aws.String(testResource.Schema),
 	}
 
 	testOptions := setupTest(t)
@@ -126,37 +127,18 @@ func Test_UpdateAWSResourceWithPost_NoChangesNoops(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	resourceTypeAWS := "AWS::MemoryDB::Cluster"
-	resourceId := "/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/AWS.MemoryDB/Cluster/mycluster"
-	resourceType := "AWS.MemoryDB/Cluster"
-	resourceName := "mycluster"
+	testResource := CreateMemoryDBClusterTestResource(uuid.NewString())
+
+	output := cloudformation.DescribeTypeOutput{
+		TypeName: aws.String(testResource.AWSResourceType),
+		Schema:   aws.String(testResource.Schema),
+	}
 
 	testOptions := setupTest(t)
-	typeSchema := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
-			"/properties/ClusterName",
-		},
-		"readOnlyProperties": []interface{}{
-			"/properties/ClusterEndpoint/Address",
-			"/properties/ClusterEndpoint/Port",
-			"/properties/ARN",
-		},
-		"createOnlyProperties": []interface{}{
-			"/properties/ClusterName",
-			"/properties/Port",
-		},
-	}
-	serialized, err := json.Marshal(typeSchema)
-	require.NoError(t, err)
-	output := cloudformation.DescribeTypeOutput{
-		TypeName: aws.String(resourceTypeAWS),
-		Schema:   aws.String(string(serialized)),
-	}
-
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	getResponseBody := map[string]interface{}{
-		"ClusterName": resourceName,
+		"ClusterName": testResource.ResourceName,
 		"ClusterEndpoint": map[string]interface{}{
 			"Address": "test",
 			"Port":    6379,
@@ -177,7 +159,7 @@ func Test_UpdateAWSResourceWithPost_NoChangesNoops(t *testing.T) {
 
 	requestBody := map[string]interface{}{
 		"properties": map[string]interface{}{
-			"ClusterName":         resourceName,
+			"ClusterName":         testResource.ResourceName,
 			"Port":                6379,
 			"NumReplicasPerShard": 1,
 		},
@@ -209,11 +191,11 @@ func Test_UpdateAWSResourceWithPost_NoChangesNoops(t *testing.T) {
 	defer res.Body.Close()
 
 	expectedResponseObject := map[string]interface{}{
-		"id":   resourceId,
-		"name": resourceName,
-		"type": resourceType,
+		"id":   testResource.SingleResourcePath,
+		"name": testResource.ResourceName,
+		"type": testResource.ResourceType,
 		"properties": map[string]interface{}{
-			"ClusterName": resourceName,
+			"ClusterName": testResource.ResourceName,
 			"ClusterEndpoint": map[string]interface{}{
 				"Address": "test",
 				"Port":    float64(6379),
@@ -236,13 +218,13 @@ func Test_CreateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSRedShiftEndpointAuthorizationResourceType)
+	testResource := CreateRedshiftEndpointAuthorizationTestResource(uuid.NewString())
 	clusterIdentifierValue := "abc"
 	accountValue := "xyz"
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
-		Schema:   aws.String(testResource.SerializedTypeSchema),
+		Schema:   aws.String(testResource.Schema),
 	}
 
 	testOptions := setupTest(t)
@@ -319,13 +301,13 @@ func Test_UpdateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSRedShiftEndpointAuthorizationResourceType)
+	testResource := CreateRedshiftEndpointAuthorizationTestResource(uuid.NewString())
 	clusterIdentifierValue := "abc"
 	accountValue := "xyz"
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
-		Schema:   aws.String(testResource.SerializedTypeSchema),
+		Schema:   aws.String(testResource.Schema),
 	}
 
 	testOptions := setupTest(t)

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresource_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresource_test.go
@@ -25,6 +25,8 @@ func Test_DeleteAWSResource(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
+	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+
 	getResponseBody := map[string]interface{}{
 		"RetentionPeriodHours": 178,
 		"ShardCount":           3,
@@ -36,7 +38,7 @@ func Test_DeleteAWSResource(t *testing.T) {
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&cloudcontrol.GetResourceOutput{
 			ResourceDescription: &types.ResourceDescription{
-				Identifier: aws.String(testAWSResourceName),
+				Identifier: aws.String(testResource.ResourceName),
 				Properties: aws.String(string(getResponseBodyBytes)),
 			},
 		}, nil)
@@ -55,7 +57,7 @@ func Test_DeleteAWSResource(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodDelete, testAWSSingleResourcePath, nil)
+	request, err := http.NewRequest(http.MethodDelete, testResource.SingleResourcePath, nil)
 	require.NoError(t, err)
 
 	actualResponse, err := awsController.Run(ctx, nil, request)
@@ -78,6 +80,8 @@ func Test_DeleteAWSResource_ResourceDoesNotExist(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
+	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		nil, &types.ResourceNotFoundException{
@@ -90,13 +94,13 @@ func Test_DeleteAWSResource_ResourceDoesNotExist(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodDelete, testAWSSingleResourcePath, nil)
+	request, err := http.NewRequest(http.MethodDelete, testResource.SingleResourcePath, nil)
 	require.NoError(t, err)
 
 	actualResponse, err := awsController.Run(ctx, nil, request)
 	require.NoError(t, err)
 
-	req := httptest.NewRequest("GET", testAWSSingleResourcePath, nil)
+	req := httptest.NewRequest("GET", testResource.SingleResourcePath, nil)
 	w := httptest.NewRecorder()
 	err = actualResponse.Apply(ctx, w, req)
 	require.NoError(t, err)

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresource_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresource_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 
 	ctrl "github.com/project-radius/radius/pkg/ucp/frontend/controller"
 	"github.com/project-radius/radius/pkg/ucp/util/testcontext"
@@ -25,7 +26,7 @@ func Test_DeleteAWSResource(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	getResponseBody := map[string]interface{}{
 		"RetentionPeriodHours": 178,
@@ -80,7 +81,7 @@ func Test_DeleteAWSResource_ResourceDoesNotExist(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost.go
@@ -60,7 +60,7 @@ func (p *DeleteAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWrit
 		return awserror.HandleAWSError(err)
 	}
 
-	awsResourceIdentifier, err := getResourceIDWithMultiIdentifiers(ctx, properties, *describeTypeOutput.Schema)
+	awsResourceIdentifier, err := getPrimaryIdentifierFromMultiIdentifiers(ctx, properties, *describeTypeOutput.Schema)
 	if err != nil {
 		e := v1.ErrorResponse{
 			Error: v1.ErrorDetails{

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
@@ -28,24 +27,18 @@ func Test_DeleteAWSResourceWithPost(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testOptions := setupTest(t)
+	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
 
-	primaryIdentifiers := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
-			"/properties/Name",
-		},
-	}
-	serialized, err := json.Marshal(primaryIdentifiers)
-	require.NoError(t, err)
 	output := cloudformation.DescribeTypeOutput{
-		TypeName: aws.String("AWS::Kinesis::Stream"),
-		Schema:   to.Ptr(string(serialized)),
+		TypeName: aws.String(testResource.AWSResourceType),
+		Schema:   aws.String(testResource.SerializedTypeSchema),
 	}
 
+	testOptions := setupTest(t)
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	getResponseBody := map[string]interface{}{
-		"Name":                 testAWSResourceName,
+		"Name":                 testResource.ResourceName,
 		"RetentionPeriodHours": 178,
 		"ShardCount":           3,
 	}
@@ -55,7 +48,7 @@ func Test_DeleteAWSResourceWithPost(t *testing.T) {
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&cloudcontrol.GetResourceOutput{
 			ResourceDescription: &types.ResourceDescription{
-				Identifier: aws.String(testAWSResourceName),
+				Identifier: aws.String(testResource.ResourceName),
 				Properties: aws.String(string(getResponseBodyBytes)),
 			},
 		}, nil)
@@ -77,13 +70,13 @@ func Test_DeleteAWSResourceWithPost(t *testing.T) {
 
 	requestBody := map[string]interface{}{
 		"properties": map[string]interface{}{
-			"Name": testAWSResourceName,
+			"Name": testResource.ResourceName,
 		},
 	}
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodPost, testAWSResourceCollectionPath+"/:delete", bytes.NewBuffer(body))
+	request, err := http.NewRequest(http.MethodPost, testResource.CollectionPath+"/:delete", bytes.NewBuffer(body))
 	require.NoError(t, err)
 
 	actualResponse, err := awsController.Run(ctx, nil, request)
@@ -106,20 +99,14 @@ func Test_DeleteAWSResourceWithPost_ResourceDoesNotExist(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testOptions := setupTest(t)
+	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
 
-	primaryIdentifiers := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
-			"/properties/Name",
-		},
-	}
-	serialized, err := json.Marshal(primaryIdentifiers)
-	require.NoError(t, err)
 	output := cloudformation.DescribeTypeOutput{
-		TypeName: aws.String("AWS::Kinesis::Stream"),
-		Schema:   to.Ptr(string(serialized)),
+		TypeName: aws.String(testResource.AWSResourceType),
+		Schema:   aws.String(testResource.SerializedTypeSchema),
 	}
 
+	testOptions := setupTest(t)
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -136,19 +123,19 @@ func Test_DeleteAWSResourceWithPost_ResourceDoesNotExist(t *testing.T) {
 
 	requestBody := map[string]interface{}{
 		"properties": map[string]interface{}{
-			"Name": testAWSResourceName,
+			"Name": testResource.ResourceName,
 		},
 	}
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodPost, testAWSResourceCollectionPath+"/:delete", bytes.NewBuffer(body))
+	request, err := http.NewRequest(http.MethodPost, testResource.CollectionPath+"/:delete", bytes.NewBuffer(body))
 	require.NoError(t, err)
 
 	actualResponse, err := awsController.Run(ctx, nil, request)
 	require.NoError(t, err)
 
-	req := httptest.NewRequest("GET", testAWSSingleResourcePath, nil)
+	req := httptest.NewRequest("GET", testResource.SingleResourcePath, nil)
 	w := httptest.NewRecorder()
 	err = actualResponse.Apply(ctx, w, req)
 	require.NoError(t, err)
@@ -160,4 +147,80 @@ func Test_DeleteAWSResourceWithPost_ResourceDoesNotExist(t *testing.T) {
 	defer res.Body.Close()
 
 	require.Equal(t, []byte(""), body)
+}
+
+func Test_DeleteAWSResourceWithPost_MultiIdentifier(t *testing.T) {
+	ctx, cancel := testcontext.New(t)
+	defer cancel()
+
+	testResource := CreateAWSTestResource(AWSRedShiftEndpointAuthorizationResourceType)
+	clusterIdentifierValue := "abc"
+	accountValue := "xyz"
+
+	output := cloudformation.DescribeTypeOutput{
+		TypeName: aws.String(testResource.AWSResourceType),
+		Schema:   aws.String(testResource.SerializedTypeSchema),
+	}
+
+	testOptions := setupTest(t)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+
+	getResponseBody := map[string]interface{}{
+		"ClusterIdentifier": clusterIdentifierValue,
+		"Account":           accountValue,
+	}
+	getResponseBodyBytes, err := json.Marshal(getResponseBody)
+	require.NoError(t, err)
+
+	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+		&cloudcontrol.GetResourceOutput{
+			ResourceDescription: &types.ResourceDescription{
+				Properties: aws.String(string(getResponseBodyBytes)),
+			},
+		}, nil)
+
+	testOptions.AWSCloudControlClient.EXPECT().DeleteResource(ctx, &cloudcontrol.DeleteResourceInput{
+		TypeName:   aws.String(testResource.AWSResourceType),
+		Identifier: aws.String("abc|xyz"),
+	}).Return(
+		&cloudcontrol.DeleteResourceOutput{
+			ProgressEvent: &types.ProgressEvent{
+				OperationStatus: types.OperationStatusSuccess,
+				RequestToken:    aws.String(testAWSRequestToken),
+			},
+		}, nil)
+
+	requestBody := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"ClusterIdentifier": clusterIdentifierValue,
+			"Account":           accountValue,
+		},
+	}
+	requestBodyBytes, err := json.Marshal(requestBody)
+	require.NoError(t, err)
+
+	awsController, err := NewDeleteAWSResourceWithPost(ctrl.Options{
+		AWSCloudControlClient:   testOptions.AWSCloudControlClient,
+		AWSCloudFormationClient: testOptions.AWSCloudFormationClient,
+		DB:                      testOptions.StorageClient,
+	})
+	require.NoError(t, err)
+
+	request, err := http.NewRequest(http.MethodPost, testResource.CollectionPath+"/:delete", bytes.NewBuffer(requestBodyBytes))
+	require.NoError(t, err)
+
+	actualResponse, err := awsController.Run(ctx, nil, request)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	err = actualResponse.Apply(ctx, w, request)
+	require.NoError(t, err)
+
+	res := w.Result()
+	require.Equal(t, http.StatusAccepted, res.StatusCode)
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	require.Equal(t, []byte("{}"), body)
 }

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 
 	ctrl "github.com/project-radius/radius/pkg/ucp/frontend/controller"
 	"github.com/project-radius/radius/pkg/ucp/util/testcontext"
@@ -27,11 +28,11 @@ func Test_DeleteAWSResourceWithPost(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
-		Schema:   aws.String(testResource.SerializedTypeSchema),
+		Schema:   aws.String(testResource.Schema),
 	}
 
 	testOptions := setupTest(t)
@@ -99,11 +100,11 @@ func Test_DeleteAWSResourceWithPost_ResourceDoesNotExist(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
-		Schema:   aws.String(testResource.SerializedTypeSchema),
+		Schema:   aws.String(testResource.Schema),
 	}
 
 	testOptions := setupTest(t)
@@ -153,13 +154,13 @@ func Test_DeleteAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSRedShiftEndpointAuthorizationResourceType)
+	testResource := CreateRedshiftEndpointAuthorizationTestResource(uuid.NewString())
 	clusterIdentifierValue := "abc"
 	accountValue := "xyz"
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
-		Schema:   aws.String(testResource.SerializedTypeSchema),
+		Schema:   aws.String(testResource.Schema),
 	}
 
 	testOptions := setupTest(t)

--- a/pkg/ucp/frontend/controller/awsproxy/getawsoperationresults_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsoperationresults_test.go
@@ -24,6 +24,8 @@ func Test_GetAWSOperationResults_TerminalStatus(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
+	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResourceRequestStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&cloudcontrol.GetResourceRequestStatusOutput{
@@ -39,7 +41,7 @@ func Test_GetAWSOperationResults_TerminalStatus(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodGet, testAWSOperationResultsPath, nil)
+	request, err := http.NewRequest(http.MethodGet, testResource.OperationResultsPath, nil)
 
 	require.NoError(t, err)
 	actualResponse, err := awsController.Run(ctx, nil, request)
@@ -54,6 +56,8 @@ func Test_GetAWSOperationResults_NonTerminalStatus(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
+	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResourceRequestStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&cloudcontrol.GetResourceRequestStatusOutput{
@@ -69,7 +73,7 @@ func Test_GetAWSOperationResults_NonTerminalStatus(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodGet, testAWSOperationResultsPath, nil)
+	request, err := http.NewRequest(http.MethodGet, testResource.OperationResultsPath, nil)
 
 	require.NoError(t, err)
 	actualResponse, err := awsController.Run(ctx, nil, request)

--- a/pkg/ucp/frontend/controller/awsproxy/getawsoperationresults_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsoperationresults_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 
 	armrpc_rest "github.com/project-radius/radius/pkg/armrpc/rest"
 	ctrl "github.com/project-radius/radius/pkg/ucp/frontend/controller"
@@ -24,7 +25,7 @@ func Test_GetAWSOperationResults_TerminalStatus(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResourceRequestStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -56,7 +57,7 @@ func Test_GetAWSOperationResults_NonTerminalStatus(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResourceRequestStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(

--- a/pkg/ucp/frontend/controller/awsproxy/getawsoperationstatuses_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsoperationstatuses_test.go
@@ -25,8 +25,9 @@ func Test_GetAWSOperationStatuses(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	eventTime := time.Now()
+	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
 
+	eventTime := time.Now()
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResourceRequestStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&cloudcontrol.GetResourceRequestStatusOutput{
@@ -43,7 +44,7 @@ func Test_GetAWSOperationStatuses(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodGet, testAWSOperationStatusesPath, nil)
+	request, err := http.NewRequest(http.MethodGet, testResource.OperationStatusesPath, nil)
 	require.NoError(t, err)
 
 	actualResponse, err := awsController.Run(ctx, nil, request)
@@ -60,6 +61,8 @@ func Test_GetAWSOperationStatuses(t *testing.T) {
 func Test_GetAWSOperationStatuses_Failed(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
+
+	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
 
 	eventTime := time.Now()
 	errorCode := types.HandlerErrorCodeInternalFailure
@@ -83,7 +86,7 @@ func Test_GetAWSOperationStatuses_Failed(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodGet, testAWSOperationStatusesPath, nil)
+	request, err := http.NewRequest(http.MethodGet, testResource.OperationStatusesPath, nil)
 	require.NoError(t, err)
 
 	actualResponse, err := awsController.Run(ctx, nil, request)

--- a/pkg/ucp/frontend/controller/awsproxy/getawsoperationstatuses_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsoperationstatuses_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	armrpc_rest "github.com/project-radius/radius/pkg/armrpc/rest"
@@ -25,7 +26,7 @@ func Test_GetAWSOperationStatuses(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	eventTime := time.Now()
 	testOptions := setupTest(t)
@@ -62,7 +63,7 @@ func Test_GetAWSOperationStatuses_Failed(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	eventTime := time.Now()
 	errorCode := types.HandlerErrorCodeInternalFailure

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresource_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresource_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 
 	armrpc_v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	armrpc_rest "github.com/project-radius/radius/pkg/armrpc/rest"
@@ -29,7 +30,7 @@ func Test_GetAWSResource(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	getResponseBody := map[string]interface{}{
 		"RetentionPeriodHours": 178,
@@ -76,7 +77,7 @@ func Test_GetAWSResource_NotFound(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -107,7 +108,7 @@ func Test_GetAWSResource_UnknownError(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any()).Return(nil, errors.New("something bad happened"))
@@ -132,7 +133,7 @@ func Test_GetAWSResource_SmithyError(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any()).Return(nil, &smithy.OperationError{

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost.go
@@ -13,10 +13,13 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	armrpc_controller "github.com/project-radius/radius/pkg/armrpc/frontend/controller"
 	armrpc_rest "github.com/project-radius/radius/pkg/armrpc/rest"
 	awsclient "github.com/project-radius/radius/pkg/ucp/aws"
+	awserror "github.com/project-radius/radius/pkg/ucp/aws"
 	ctrl "github.com/project-radius/radius/pkg/ucp/frontend/controller"
 	"github.com/project-radius/radius/pkg/ucp/ucplog"
 )
@@ -52,7 +55,15 @@ func (p *GetAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWriter,
 		return armrpc_rest.NewBadRequestARMResponse(e), nil
 	}
 
-	awsResourceIdentifier, err := getResourceIDWithMultiIdentifiers(ctx, cloudFormationClient, req.URL.Path, resourceType, properties)
+	describeTypeOutput, err := cloudFormationClient.DescribeType(ctx, &cloudformation.DescribeTypeInput{
+		Type:     types.RegistryTypeResource,
+		TypeName: aws.String(resourceType),
+	})
+	if err != nil {
+		return awserror.HandleAWSError(err)
+	}
+
+	awsResourceIdentifier, err := getResourceIDWithMultiIdentifiers(ctx, properties, *describeTypeOutput.Schema)
 	if err != nil {
 		e := v1.ErrorResponse{
 			Error: v1.ErrorDetails{

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost.go
@@ -63,7 +63,7 @@ func (p *GetAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWriter,
 		return awserror.HandleAWSError(err)
 	}
 
-	awsResourceIdentifier, err := getResourceIDWithMultiIdentifiers(ctx, properties, *describeTypeOutput.Schema)
+	awsResourceIdentifier, err := getPrimaryIdentifierFromMultiIdentifiers(ctx, properties, *describeTypeOutput.Schema)
 	if err != nil {
 		e := v1.ErrorResponse{
 			Error: v1.ErrorDetails{

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 	"gotest.tools/assert"
 
 	armrpc_v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
@@ -35,11 +36,11 @@ func Test_GetAWSResourceWithPost(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
-		Schema:   aws.String(testResource.SerializedTypeSchema),
+		Schema:   aws.String(testResource.Schema),
 	}
 
 	testOptions := setupTest(t)
@@ -100,11 +101,11 @@ func Test_GetAWSResourceWithPost_NotFound(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
-		Schema:   aws.String(testResource.SerializedTypeSchema),
+		Schema:   aws.String(testResource.Schema),
 	}
 
 	testOptions := setupTest(t)
@@ -144,11 +145,11 @@ func Test_GetAWSResourceWithPost_UnknownError(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
-		Schema:   aws.String(testResource.SerializedTypeSchema),
+		Schema:   aws.String(testResource.Schema),
 	}
 
 	testOptions := setupTest(t)
@@ -185,11 +186,11 @@ func Test_GetAWSResourceWithPost_SmithyError(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
-		Schema:   aws.String(testResource.SerializedTypeSchema),
+		Schema:   aws.String(testResource.Schema),
 	}
 
 	testOptions := setupTest(t)
@@ -239,13 +240,13 @@ func Test_GetAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSRedShiftEndpointAuthorizationResourceType)
+	testResource := CreateRedshiftEndpointAuthorizationTestResource(uuid.NewString())
 	clusterIdentifierValue := "abc"
 	accountValue := "xyz"
 
 	output := cloudformation.DescribeTypeOutput{
 		TypeName: aws.String(testResource.AWSResourceType),
-		Schema:   aws.String(testResource.SerializedTypeSchema),
+		Schema:   aws.String(testResource.Schema),
 	}
 
 	testOptions := setupTest(t)

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost_test.go
@@ -9,10 +9,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
@@ -25,6 +26,7 @@ import (
 	armrpc_v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	armrpc_rest "github.com/project-radius/radius/pkg/armrpc/rest"
 	ctrl "github.com/project-radius/radius/pkg/ucp/frontend/controller"
+	"github.com/project-radius/radius/pkg/ucp/resources"
 	"github.com/project-radius/radius/pkg/ucp/util/testcontext"
 	"github.com/stretchr/testify/require"
 )
@@ -33,24 +35,18 @@ func Test_GetAWSResourceWithPost(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testOptions := setupTest(t)
+	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
 
-	primaryIdentifiers := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
-			"/properties/Name",
-		},
-	}
-	serialized, err := json.Marshal(primaryIdentifiers)
-	require.NoError(t, err)
 	output := cloudformation.DescribeTypeOutput{
-		TypeName: aws.String("AWS::Kinesis::Stream"),
-		Schema:   to.Ptr(string(serialized)),
+		TypeName: aws.String(testResource.AWSResourceType),
+		Schema:   aws.String(testResource.SerializedTypeSchema),
 	}
 
+	testOptions := setupTest(t)
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	getResponseBody := map[string]interface{}{
-		"Name":                 testAWSResourceName,
+		"Name":                 testResource.ResourceName,
 		"RetentionPeriodHours": 178,
 		"ShardCount":           3,
 	}
@@ -60,7 +56,7 @@ func Test_GetAWSResourceWithPost(t *testing.T) {
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&cloudcontrol.GetResourceOutput{
 			ResourceDescription: &types.ResourceDescription{
-				Identifier: aws.String(testAWSResourceName),
+				Identifier: aws.String(testResource.ResourceName),
 				Properties: aws.String(string(getResponseBodyBytes)),
 			},
 		}, nil)
@@ -74,23 +70,23 @@ func Test_GetAWSResourceWithPost(t *testing.T) {
 
 	requestBody := map[string]interface{}{
 		"properties": map[string]interface{}{
-			"Name": testAWSResourceName,
+			"Name": testResource.ResourceName,
 		},
 	}
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodPost, testAWSResourceCollectionPath+"/:get", bytes.NewBuffer(body))
+	request, err := http.NewRequest(http.MethodPost, testResource.CollectionPath+"/:get", bytes.NewBuffer(body))
 
 	require.NoError(t, err)
 	actualResponse, err := awsController.Run(ctx, nil, request)
 
 	expectedResponse := armrpc_rest.NewOKResponse(map[string]interface{}{
-		"id":   testAWSSingleResourcePath,
-		"type": testAWSResourceType,
-		"name": to.Ptr(testAWSResourceName),
+		"id":   testResource.SingleResourcePath,
+		"type": testResource.ResourceType,
+		"name": aws.String(testResource.ResourceName),
 		"properties": map[string]interface{}{
-			"Name":                 testAWSResourceName,
+			"Name":                 testResource.ResourceName,
 			"RetentionPeriodHours": float64(178),
 			"ShardCount":           float64(3),
 		},
@@ -104,20 +100,14 @@ func Test_GetAWSResourceWithPost_NotFound(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testOptions := setupTest(t)
+	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
 
-	primaryIdentifiers := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
-			"/properties/Name",
-		},
-	}
-	serialized, err := json.Marshal(primaryIdentifiers)
-	require.NoError(t, err)
 	output := cloudformation.DescribeTypeOutput{
-		TypeName: aws.String("AWS::Kinesis::Stream"),
-		Schema:   to.Ptr(string(serialized)),
+		TypeName: aws.String(testResource.AWSResourceType),
+		Schema:   aws.String(testResource.SerializedTypeSchema),
 	}
 
+	testOptions := setupTest(t)
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
@@ -134,19 +124,19 @@ func Test_GetAWSResourceWithPost_NotFound(t *testing.T) {
 
 	requestBody := map[string]interface{}{
 		"properties": map[string]interface{}{
-			"Name": testAWSResourceName,
+			"Name": testResource.ResourceName,
 		},
 	}
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodPost, testAWSResourceCollectionPath+"/:get", bytes.NewBuffer(body))
+	request, err := http.NewRequest(http.MethodPost, testResource.CollectionPath+"/:get", bytes.NewBuffer(body))
 
 	require.NoError(t, err)
 	actualResponse, err := awsController.Run(ctx, nil, request)
 	require.NoError(t, err)
 
-	expectedResponse := armrpc_rest.NewNotFoundMessageResponse(fmt.Sprintf("Resource %s with primary identifiers %s not found", testAWSResourceCollectionPath, testAWSResourceName))
+	expectedResponse := armrpc_rest.NewNotFoundMessageResponse(fmt.Sprintf("Resource %s with primary identifiers %s not found", testResource.CollectionPath, testResource.ResourceName))
 	require.Equal(t, expectedResponse, actualResponse)
 }
 
@@ -154,20 +144,14 @@ func Test_GetAWSResourceWithPost_UnknownError(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testOptions := setupTest(t)
+	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
 
-	primaryIdentifiers := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
-			"/properties/Name",
-		},
-	}
-	serialized, err := json.Marshal(primaryIdentifiers)
-	require.NoError(t, err)
 	output := cloudformation.DescribeTypeOutput{
-		TypeName: aws.String("AWS::Kinesis::Stream"),
-		Schema:   to.Ptr(string(serialized)),
+		TypeName: aws.String(testResource.AWSResourceType),
+		Schema:   aws.String(testResource.SerializedTypeSchema),
 	}
 
+	testOptions := setupTest(t)
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any()).Return(nil, errors.New("something bad happened"))
@@ -181,13 +165,13 @@ func Test_GetAWSResourceWithPost_UnknownError(t *testing.T) {
 
 	requestBody := map[string]interface{}{
 		"properties": map[string]interface{}{
-			"Name": testAWSResourceName,
+			"Name": testResource.ResourceName,
 		},
 	}
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodPost, testAWSResourceCollectionPath+"/:get", bytes.NewBuffer(body))
+	request, err := http.NewRequest(http.MethodPost, testResource.CollectionPath+"/:get", bytes.NewBuffer(body))
 	require.NoError(t, err)
 
 	actualResponse, err := awsController.Run(ctx, nil, request)
@@ -201,20 +185,14 @@ func Test_GetAWSResourceWithPost_SmithyError(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testOptions := setupTest(t)
+	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
 
-	primaryIdentifiers := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
-			"/properties/Name",
-		},
-	}
-	serialized, err := json.Marshal(primaryIdentifiers)
-	require.NoError(t, err)
 	output := cloudformation.DescribeTypeOutput{
-		TypeName: aws.String("AWS::Kinesis::Stream"),
-		Schema:   to.Ptr(string(serialized)),
+		TypeName: aws.String(testResource.AWSResourceType),
+		Schema:   aws.String(testResource.SerializedTypeSchema),
 	}
 
+	testOptions := setupTest(t)
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any()).Return(nil, &smithy.OperationError{
@@ -235,13 +213,13 @@ func Test_GetAWSResourceWithPost_SmithyError(t *testing.T) {
 
 	requestBody := map[string]interface{}{
 		"properties": map[string]interface{}{
-			"Name": testAWSResourceName,
+			"Name": testResource.ResourceName,
 		},
 	}
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodPost, testAWSResourceCollectionPath+"/:get", bytes.NewBuffer(body))
+	request, err := http.NewRequest(http.MethodPost, testResource.CollectionPath+"/:get", bytes.NewBuffer(body))
 	require.NoError(t, err)
 
 	actualResponse, err := awsController.Run(ctx, nil, request)
@@ -255,4 +233,91 @@ func Test_GetAWSResourceWithPost_SmithyError(t *testing.T) {
 	})
 
 	require.Equal(t, expectedResponse, actualResponse)
+}
+
+func Test_GetAWSResourceWithPost_MultiIdentifier(t *testing.T) {
+	ctx, cancel := testcontext.New(t)
+	defer cancel()
+
+	testResource := CreateAWSTestResource(AWSRedShiftEndpointAuthorizationResourceType)
+	clusterIdentifierValue := "abc"
+	accountValue := "xyz"
+
+	output := cloudformation.DescribeTypeOutput{
+		TypeName: aws.String(testResource.AWSResourceType),
+		Schema:   aws.String(testResource.SerializedTypeSchema),
+	}
+
+	testOptions := setupTest(t)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+
+	getResponseBody := map[string]interface{}{
+		"ClusterIdentifier": clusterIdentifierValue,
+		"Account":           accountValue,
+	}
+	getResponseBodyBytes, err := json.Marshal(getResponseBody)
+	require.NoError(t, err)
+
+	testOptions.AWSCloudControlClient.EXPECT().GetResource(ctx, &cloudcontrol.GetResourceInput{
+		TypeName:   aws.String(testResource.AWSResourceType),
+		Identifier: aws.String("abc|xyz"),
+	}).Return(
+		&cloudcontrol.GetResourceOutput{
+			ResourceDescription: &types.ResourceDescription{
+				Identifier: aws.String(testResource.ResourceName),
+				Properties: aws.String(string(getResponseBodyBytes)),
+			},
+		}, nil)
+
+	requestBody := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"ClusterIdentifier": clusterIdentifierValue,
+			"Account":           accountValue,
+		},
+	}
+	requestBodyBytes, err := json.Marshal(requestBody)
+	require.NoError(t, err)
+
+	awsController, err := NewGetAWSResourceWithPost(ctrl.Options{
+		AWSCloudControlClient:   testOptions.AWSCloudControlClient,
+		AWSCloudFormationClient: testOptions.AWSCloudFormationClient,
+		DB:                      testOptions.StorageClient,
+	})
+	require.NoError(t, err)
+
+	request, err := http.NewRequest(http.MethodPost, testResource.CollectionPath+"/:get", bytes.NewBuffer(requestBodyBytes))
+	require.NoError(t, err)
+
+	actualResponse, err := awsController.Run(ctx, nil, request)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	err = actualResponse.Apply(ctx, w, request)
+	require.NoError(t, err)
+
+	res := w.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	id, err := resources.Parse(testResource.CollectionPath)
+	require.NoError(t, err)
+	multiIdentifierResourceID := clusterIdentifierValue + "|" + accountValue
+	rID := computeResourceID(id, multiIdentifierResourceID)
+	expectedResponseObject := map[string]interface{}{
+		"id":   rID,
+		"name": testResource.ResourceName,
+		"type": testResource.ResourceType,
+		"properties": map[string]interface{}{
+			"ClusterIdentifier": "abc",
+			"Account":           "xyz",
+		},
+	}
+
+	actualResponseObject := map[string]interface{}{}
+	err = json.Unmarshal(body, &actualResponseObject)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedResponseObject, actualResponseObject)
 }

--- a/pkg/ucp/frontend/controller/awsproxy/listawsresources_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/listawsresources_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 
 	armrpc_v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	armrpc_rest "github.com/project-radius/radius/pkg/armrpc/rest"
@@ -28,8 +29,8 @@ func Test_ListAWSResources(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	firstTestResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
-	secondTestResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	firstTestResource := CreateKinesisStreamTestResource(uuid.NewString())
+	secondTestResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	firstTestResourceResponseBody := map[string]interface{}{
 		"RetentionPeriodHours": 178,
@@ -102,7 +103,7 @@ func Test_ListAWSResourcesEmpty(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().ListResources(gomock.Any(), gomock.Any()).Return(&cloudcontrol.ListResourcesOutput{}, nil)
@@ -130,7 +131,7 @@ func Test_ListAWSResource_UnknownError(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().ListResources(gomock.Any(), gomock.Any()).Return(nil, errors.New("something bad happened"))
@@ -155,7 +156,7 @@ func Test_ListAWSResource_SmithyError(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().ListResources(gomock.Any(), gomock.Any()).Return(nil, &smithy.OperationError{

--- a/pkg/ucp/frontend/controller/awsproxy/listawsresources_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/listawsresources_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"path"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -29,20 +28,21 @@ func Test_ListAWSResources(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
-	streamOneResourceName := "streamone"
-	streamOneResponseBody := map[string]interface{}{
+	firstTestResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+	secondTestResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+
+	firstTestResourceResponseBody := map[string]interface{}{
 		"RetentionPeriodHours": 178,
 		"ShardCount":           3,
 	}
-	streamOneResponseBodyBytes, err := json.Marshal(streamOneResponseBody)
+	firstTestResourceResponseBodyBytes, err := json.Marshal(firstTestResourceResponseBody)
 	require.NoError(t, err)
 
-	streamTwoResourceName := "streamtwo"
-	streamTwoResponseBody := map[string]interface{}{
-		"RetentionPeriodHours": 178,
-		"ShardCount":           3,
+	secondTestResourceResponseBody := map[string]interface{}{
+		"RetentionPeriodHours": 180,
+		"ShardCount":           2,
 	}
-	streamTwoResponseBodyBytes, err := json.Marshal(streamTwoResponseBody)
+	secondTestResourceResponseBodyBytes, err := json.Marshal(secondTestResourceResponseBody)
 	require.NoError(t, err)
 
 	testOptions := setupTest(t)
@@ -50,12 +50,12 @@ func Test_ListAWSResources(t *testing.T) {
 		&cloudcontrol.ListResourcesOutput{
 			ResourceDescriptions: []types.ResourceDescription{
 				{
-					Identifier: aws.String(streamOneResourceName),
-					Properties: aws.String(string(streamOneResponseBodyBytes)),
+					Identifier: aws.String(firstTestResource.ResourceName),
+					Properties: aws.String(string(firstTestResourceResponseBodyBytes)),
 				},
 				{
-					Identifier: aws.String(streamTwoResourceName),
-					Properties: aws.String(string(streamTwoResponseBodyBytes)),
+					Identifier: aws.String(secondTestResource.ResourceName),
+					Properties: aws.String(string(secondTestResourceResponseBodyBytes)),
 				},
 			},
 		}, nil)
@@ -66,7 +66,7 @@ func Test_ListAWSResources(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodGet, testAWSResourceCollectionPath, nil)
+	request, err := http.NewRequest(http.MethodGet, firstTestResource.CollectionPath, nil)
 	require.NoError(t, err)
 
 	actualResponse, err := awsController.Run(ctx, nil, request)
@@ -75,21 +75,21 @@ func Test_ListAWSResources(t *testing.T) {
 	expectedResponse := armrpc_rest.NewOKResponse(map[string]interface{}{
 		"value": []interface{}{
 			map[string]interface{}{
-				"id":   path.Join(testAWSResourceCollectionPath, streamOneResourceName),
-				"name": aws.String(streamOneResourceName),
-				"type": testAWSResourceType,
+				"id":   firstTestResource.SingleResourcePath,
+				"name": aws.String(firstTestResource.ResourceName),
+				"type": firstTestResource.ResourceType,
 				"properties": map[string]interface{}{
 					"RetentionPeriodHours": float64(178),
 					"ShardCount":           float64(3),
 				},
 			},
 			map[string]interface{}{
-				"id":   path.Join(testAWSResourceCollectionPath, streamTwoResourceName),
-				"name": aws.String(streamTwoResourceName),
-				"type": testAWSResourceType,
+				"id":   secondTestResource.SingleResourcePath,
+				"name": aws.String(secondTestResource.ResourceName),
+				"type": secondTestResource.ResourceType,
 				"properties": map[string]interface{}{
-					"RetentionPeriodHours": float64(178),
-					"ShardCount":           float64(3),
+					"RetentionPeriodHours": float64(180),
+					"ShardCount":           float64(2),
 				},
 			},
 		},
@@ -102,6 +102,8 @@ func Test_ListAWSResourcesEmpty(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
+	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().ListResources(gomock.Any(), gomock.Any()).Return(&cloudcontrol.ListResourcesOutput{}, nil)
 
@@ -111,7 +113,7 @@ func Test_ListAWSResourcesEmpty(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodGet, testAWSResourceCollectionPath, nil)
+	request, err := http.NewRequest(http.MethodGet, testResource.CollectionPath, nil)
 	require.NoError(t, err)
 
 	actualResponse, err := awsController.Run(ctx, nil, request)
@@ -128,6 +130,8 @@ func Test_ListAWSResource_UnknownError(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
 
+	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
+
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().ListResources(gomock.Any(), gomock.Any()).Return(nil, errors.New("something bad happened"))
 
@@ -137,7 +141,7 @@ func Test_ListAWSResource_UnknownError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodGet, testAWSResourceCollectionPath, nil)
+	request, err := http.NewRequest(http.MethodGet, testResource.CollectionPath, nil)
 	require.NoError(t, err)
 
 	actualResponse, err := awsController.Run(ctx, nil, request)
@@ -150,6 +154,8 @@ func Test_ListAWSResource_UnknownError(t *testing.T) {
 func Test_ListAWSResource_SmithyError(t *testing.T) {
 	ctx, cancel := testcontext.New(t)
 	defer cancel()
+
+	testResource := CreateAWSTestResource(AWSKinesisStreamResourceType)
 
 	testOptions := setupTest(t)
 	testOptions.AWSCloudControlClient.EXPECT().ListResources(gomock.Any(), gomock.Any()).Return(nil, &smithy.OperationError{
@@ -167,7 +173,7 @@ func Test_ListAWSResource_SmithyError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	request, err := http.NewRequest(http.MethodGet, testAWSResourceCollectionPath, nil)
+	request, err := http.NewRequest(http.MethodGet, testResource.CollectionPath, nil)
 	require.NoError(t, err)
 
 	actualResponse, err := awsController.Run(ctx, nil, request)


### PR DESCRIPTION
# Description

* Updated `createorupdateawsresourcewithpost` handler with patch logic
* Added unit tests for `createorupdateawsresourcewithpost` handler
* Refactored some functions in `awsparsing.go`
* Updated `getawsresourcewithpost` and `deleteawsresourcewithpost` handlers with refactored code

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #4577
Fixes: #4591
Fixes: #4592
Fixes: #4593
Fixes: #4594


## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
