### PR TITLE
Changing check on Recipe.Name to checking mode type.

### DIFF
--- a/pkg/linkrp/api/v20220315privatepreview/daprsecretstore_conversion.go
+++ b/pkg/linkrp/api/v20220315privatepreview/daprsecretstore_conversion.go
@@ -95,9 +95,7 @@ func (dst *DaprSecretStoreResource) ConvertFrom(src conv.DataModelInterface) err
 	case datamodel.LinkModeRecipe:
 		mode := DaprSecretStorePropertiesModeRecipe
 		var recipe *Recipe
-		if daprSecretStore.Properties.Recipe.Name != "" {
-			recipe = fromRecipeDataModel(daprSecretStore.Properties.Recipe)
-		}
+		recipe = fromRecipeDataModel(daprSecretStore.Properties.Recipe)
 		dst.Properties = &RecipeDaprSecretStoreProperties{
 			Status: &ResourceStatus{
 				OutputResources: rp.BuildExternalOutputResources(daprSecretStore.Properties.Status.OutputResources),

--- a/pkg/linkrp/api/v20220315privatepreview/rabbitmq_conversion.go
+++ b/pkg/linkrp/api/v20220315privatepreview/rabbitmq_conversion.go
@@ -91,9 +91,7 @@ func (dst *RabbitMQMessageQueueResource) ConvertFrom(src conv.DataModelInterface
 	case datamodel.LinkModeRecipe:
 		mode := RabbitMQMessageQueuePropertiesModeRecipe
 		var recipe *Recipe
-		if rabbitmq.Properties.Recipe.Name != "" {
-			recipe = fromRecipeDataModel(rabbitmq.Properties.Recipe)
-		}
+		recipe = fromRecipeDataModel(rabbitmq.Properties.Recipe)
 		dst.Properties = &RecipeRabbitMQMessageQueueProperties{
 			Status: &ResourceStatus{
 				OutputResources: rp.BuildExternalOutputResources(rabbitmq.Properties.Status.OutputResources),

--- a/pkg/linkrp/api/v20220315privatepreview/sqldatabase_conversion.go
+++ b/pkg/linkrp/api/v20220315privatepreview/sqldatabase_conversion.go
@@ -112,9 +112,7 @@ func (dst *SQLDatabaseResource) ConvertFrom(src conv.DataModelInterface) error {
 	case datamodel.LinkModeRecipe:
 		mode := SQLDatabasePropertiesModeRecipe
 		var recipe *Recipe
-		if sql.Properties.Recipe.Name != "" {
-			recipe = fromRecipeDataModel(sql.Properties.Recipe)
-		}
+		recipe = fromRecipeDataModel(sql.Properties.Recipe)
 		dst.Properties = &RecipeSQLDatabaseProperties{
 			Status: &ResourceStatus{
 				OutputResources: rp.BuildExternalOutputResources(sql.Properties.Status.OutputResources),

--- a/pkg/linkrp/frontend/deployment/deploymentprocessor.go
+++ b/pkg/linkrp/frontend/deployment/deploymentprocessor.go
@@ -351,28 +351,28 @@ func (dp *deploymentProcessor) getMetadataFromResource(ctx context.Context, reso
 	case strings.ToLower(mongodatabases.ResourceType):
 		obj := resource.(*datamodel.MongoDatabase)
 		envId = obj.Properties.Environment
-		if obj.Properties.Recipe.Name != "" {
+		if obj.Properties.Mode == datamodel.LinkModeRecipe {
 			recipe.Name = obj.Properties.Recipe.Name
 			recipe.Parameters = obj.Properties.Recipe.Parameters
 		}
 	case strings.ToLower(sqldatabases.ResourceType):
 		obj := resource.(*datamodel.SqlDatabase)
 		envId = obj.Properties.Environment
-		if obj.Properties.Recipe.Name != "" {
+		if obj.Properties.Mode == datamodel.LinkModeRecipe {
 			recipe.Name = obj.Properties.Recipe.Name
 			recipe.Parameters = obj.Properties.Recipe.Parameters
 		}
 	case strings.ToLower(rediscaches.ResourceType):
 		obj := resource.(*datamodel.RedisCache)
 		envId = obj.Properties.Environment
-		if obj.Properties.Recipe.Name != "" {
+		if obj.Properties.Mode == datamodel.LinkModeRecipe {
 			recipe.Name = obj.Properties.Recipe.Name
 			recipe.Parameters = obj.Properties.Recipe.Parameters
 		}
 	case strings.ToLower(rabbitmqmessagequeues.ResourceType):
 		obj := resource.(*datamodel.RabbitMQMessageQueue)
 		envId = obj.Properties.Environment
-		if obj.Properties.Recipe.Name != "" {
+		if obj.Properties.Mode == datamodel.LinkModeRecipe {
 			recipe.Name = obj.Properties.Recipe.Name
 			recipe.Parameters = obj.Properties.Recipe.Parameters
 		}
@@ -389,7 +389,7 @@ func (dp *deploymentProcessor) getMetadataFromResource(ctx context.Context, reso
 	case strings.ToLower(daprsecretstores.ResourceType):
 		obj := resource.(*datamodel.DaprSecretStore)
 		envId = obj.Properties.Environment
-		if obj.Properties.Recipe.Name != "" {
+		if obj.Properties.Mode == datamodel.LinkModeRecipe {
 			recipe.Name = obj.Properties.Recipe.Name
 			recipe.Parameters = obj.Properties.Recipe.Parameters
 		}


### PR DESCRIPTION
# Description

After adding in the property 'mode', we can now check whether a Recipe is present on a datamodel by checking 'mode' instead of Properties.Recipe.Name != "".

## Issue reference

Fixes: #4569 [AB#4932](https://dev.azure.com/azure-octo/Incubations/_workitems/edit/4932)

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
