### PR TITLE
Auto-create app as part of deployment

### DIFF
--- a/pkg/cli/cmd/deploy/deploy_test.go
+++ b/pkg/cli/cmd/deploy/deploy_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/bicep"
 	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/config"
+	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/deploy"
 	"github.com/project-radius/radius/pkg/cli/framework"
 	"github.com/project-radius/radius/pkg/cli/output"
@@ -106,29 +107,6 @@ func Test_Validate(t *testing.T) {
 					GetEnvDetails(gomock.Any(), "prod").
 					Return(v20220315privatepreview.EnvironmentResource{}, nil).
 					Times(1)
-				mocks.ApplicationManagementClient.EXPECT().
-					ShowApplication(gomock.Any(), "my-app").
-					Return(v20220315privatepreview.ApplicationResource{}, nil).
-					Times(1)
-			},
-		},
-		{
-			Name:          "rad deploy - app does not exist invalid",
-			Input:         []string{"app.bicep", "-e", "prod", "-a", "my-app"},
-			ExpectedValid: false,
-			ConfigHolder: framework.ConfigHolder{
-				ConfigFilePath: "",
-				Config:         configWithWorkspace,
-			},
-			ConfigureMocks: func(mocks radcli.ValidateMocks) {
-				mocks.ApplicationManagementClient.EXPECT().
-					GetEnvDetails(gomock.Any(), "prod").
-					Return(v20220315privatepreview.EnvironmentResource{}, nil).
-					Times(1)
-				mocks.ApplicationManagementClient.EXPECT().
-					ShowApplication(gomock.Any(), "my-app").
-					Return(v20220315privatepreview.ApplicationResource{}, radcli.Create404Error()).
-					Times(1)
 			},
 		},
 		{
@@ -148,10 +126,6 @@ func Test_Validate(t *testing.T) {
 				mocks.ApplicationManagementClient.EXPECT().
 					GetEnvDetails(gomock.Any(), "prod").
 					Return(v20220315privatepreview.EnvironmentResource{}, nil).
-					Times(1)
-				mocks.ApplicationManagementClient.EXPECT().
-					ShowApplication(gomock.Any(), "my-app").
-					Return(v20220315privatepreview.ApplicationResource{}, nil).
 					Times(1)
 			},
 		},
@@ -254,6 +228,12 @@ func Test_Run(t *testing.T) {
 
 		options := deploy.Options{}
 
+		appManagmentMock := clients.NewMockApplicationsManagementClient(ctrl)
+		appManagmentMock.EXPECT().
+			CreateApplicationIfNotFound(gomock.Any(), "test-application", gomock.Any()).
+			Return(nil).
+			Times(1)
+
 		deployMock := deploy.NewMockInterface(ctrl)
 		deployMock.EXPECT().
 			DeployWithProgress(gomock.Any(), gomock.Any()).
@@ -273,9 +253,10 @@ func Test_Run(t *testing.T) {
 		}
 		outputSink := &output.MockOutput{}
 		runner := &Runner{
-			Bicep:  bicep,
-			Deploy: deployMock,
-			Output: outputSink,
+			Bicep:             bicep,
+			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagmentMock},
+			Deploy:            deployMock,
+			Output:            outputSink,
 
 			FilePath:        "app.bicep",
 			ApplicationID:   fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/applications.core/applications/%s", radcli.TestEnvironmentName, "test-application"),


### PR DESCRIPTION
Part of: radius-project/core-team#999

This change automatically creates the application resource during deployment when an application is specified by the deployment command.

The app resource is only created if it does not already exists. This means we'll never overwrite your app resource if you set it up in a non-default way. This also means if you create the app resource in Bicep, the default we set up will be immediately overwritten by your version.

As I've been playing with `rad deploy -a` and `rad run` this feels like a really necessary missing piece of the workflow. This way you can move across different environments without any bootstrapping.
