### PR TITLE
Add `rad run` command

### DIFF
--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -38,6 +38,7 @@ import (
 	resource_delete "github.com/project-radius/radius/pkg/cli/cmd/resource/delete"
 	resource_list "github.com/project-radius/radius/pkg/cli/cmd/resource/list"
 	resource_show "github.com/project-radius/radius/pkg/cli/cmd/resource/show"
+	"github.com/project-radius/radius/pkg/cli/cmd/run"
 	workspace_create "github.com/project-radius/radius/pkg/cli/cmd/workspace/create"
 	workspace_delete "github.com/project-radius/radius/pkg/cli/cmd/workspace/delete"
 	workspace_list "github.com/project-radius/radius/pkg/cli/cmd/workspace/list"
@@ -50,6 +51,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/helm"
 	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/project-radius/radius/pkg/cli/prompt"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -140,6 +142,9 @@ func initSubCommands() {
 
 	deployCmd, _ := cmddeploy.NewCommand(framework)
 	RootCmd.AddCommand(deployCmd)
+
+	runCmd, _ := run.NewCommand(framework)
+	RootCmd.AddCommand(runCmd)
 
 	showCmd, _ := resource_show.NewCommand(framework)
 	resourceCmd.AddCommand(showCmd)

--- a/pkg/cli/cmd/deploy/deploy_test.go
+++ b/pkg/cli/cmd/deploy/deploy_test.go
@@ -147,15 +147,6 @@ func Test_Validate(t *testing.T) {
 				Config:         radcli.LoadEmptyConfig(t),
 			},
 		},
-		{
-			Name:          "Create Command with too many args",
-			Input:         []string{"a", "b"},
-			ExpectedValid: false,
-			ConfigHolder: framework.ConfigHolder{
-				ConfigFilePath: "",
-				Config:         configWithWorkspace,
-			},
-		},
 	}
 
 	radcli.SharedValidateValidation(t, NewCommand, testcases)

--- a/pkg/cli/cmd/run/run.go
+++ b/pkg/cli/cmd/run/run.go
@@ -1,0 +1,143 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package run
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/project-radius/radius/pkg/cli"
+	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
+	deploycmd "github.com/project-radius/radius/pkg/cli/cmd/deploy"
+	"github.com/project-radius/radius/pkg/cli/framework"
+	"github.com/project-radius/radius/pkg/cli/kubernetes/logstream"
+	"github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
+	"github.com/spf13/cobra"
+)
+
+// NewCommand creates an instance of the command and runner for the `rad run` command.
+func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
+	runner := NewRunner(factory)
+
+	cmd := &cobra.Command{
+		Use:   "run [file]",
+		Short: "Run an application",
+		Long: `Run an application specified by a Bicep or ARM template
+	
+	The run command compiles a Bicep or ARM template and runs it in your default environment (unless otherwise specified).
+		
+	The run command accepts the same parameters as the 'rad deploy' command. See the 'rad deploy' help for more information.
+	`,
+		Example: `
+# Run app.bicep
+rad run app.bicep
+
+# Run in a specific environment
+rad run app.bicep --environment prod
+
+# Run app.bicep and specify a string parameter
+rad run app.bicep --parameters version=latest
+
+# Run app.bicep and specify parameters from multiple sources
+rad run app.bicep --parameters @myfile.json --parameters version=latest
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: framework.RunCommand(runner),
+	}
+
+	commonflags.AddWorkspaceFlag(cmd)
+	commonflags.AddEnvironmentNameFlag(cmd)
+	commonflags.AddApplicationNameFlag(cmd)
+	cmd.Flags().StringArrayP("parameters", "p", []string{}, "Specify parameters for the deployment")
+
+	return cmd, runner
+}
+
+// Runner is the runner implementation for the `rad run` command.
+type Runner struct {
+	deploycmd.Runner
+	Logstream logstream.Interface
+}
+
+// NewRunner creates a new instance of the `rad run` runner.
+func NewRunner(factory framework.Factory) *Runner {
+	return &Runner{
+		Runner:    *deploycmd.NewRunner(factory),
+		Logstream: factory.GetLogstream(),
+	}
+}
+
+// Validate runs validation for the `rad run` command.
+func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
+	err := r.Runner.Validate(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	// In addition to the deployment validations, this command requires an application name
+	if r.ApplicationName == "" {
+		return &cli.FriendlyError{Message: "No application was specified. Use --application to specify the application name."}
+	}
+
+	return nil
+}
+
+// Run runs the `rad run` command.
+func (r *Runner) Run(ctx context.Context) error {
+	// Call into base first to deploy, and then set up port-forwards and logs.
+	err := r.Runner.Run(ctx)
+	if err != nil {
+		return err
+	}
+
+	kubeContext, ok := r.Workspace.KubernetesContext()
+	if !ok {
+		return nil
+	}
+
+	r.Output.LogInfo("")
+	r.Output.LogInfo("Starting log stream...")
+	r.Output.LogInfo("")
+
+	client, err := r.ConnectionFactory.CreateApplicationsManagementClient(ctx, *r.Workspace)
+	if err != nil {
+		return nil
+	}
+
+	// We don't expect an error here because we already deployed to the environment
+	environment, err := client.GetEnvDetails(ctx, r.EnvironmentName)
+	if err != nil {
+		return err
+	}
+
+	namespace := ""
+	switch compute := environment.Properties.Compute.(type) {
+	case *v20220315privatepreview.KubernetesCompute:
+		namespace = *compute.Namespace
+	default:
+		return &cli.FriendlyError{Message: "Only kubernetes runtimes are supported."}
+	}
+
+	err = r.Logstream.Stream(ctx, logstream.Options{
+		ApplicationName: r.ApplicationName,
+		Namespace:       namespace,
+		KubeContext:     kubeContext,
+
+		// Right now we don't need an abstraction for this because we don't really
+		// run the streaming logs in unit tests.
+		Out: os.Stdout,
+	})
+
+	// context.Canceled here means the user canceled.
+	if errors.Is(err, context.Canceled) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cli/cmd/run/run_test.go
+++ b/pkg/cli/cmd/run/run_test.go
@@ -1,0 +1,246 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package run
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/golang/mock/gomock"
+	"github.com/project-radius/radius/pkg/cli/bicep"
+	"github.com/project-radius/radius/pkg/cli/clients"
+	deploycmd "github.com/project-radius/radius/pkg/cli/cmd/deploy"
+	"github.com/project-radius/radius/pkg/cli/config"
+	"github.com/project-radius/radius/pkg/cli/connections"
+	"github.com/project-radius/radius/pkg/cli/deploy"
+	"github.com/project-radius/radius/pkg/cli/framework"
+	"github.com/project-radius/radius/pkg/cli/kubernetes/logstream"
+	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/project-radius/radius/pkg/cli/workspaces"
+	"github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
+	"github.com/project-radius/radius/test/radcli"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CommandValidation(t *testing.T) {
+	radcli.SharedCommandValidation(t, NewCommand)
+}
+
+func Test_Validate(t *testing.T) {
+	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
+
+	// NOTE: most of the logic of this command is shared with the `rad deploy` command.
+	// We're using a few of the same tests here as a smoke test, but the bulk of the testing
+	// is part of the `rad deploy` tests.
+	//
+	// We should revisit the test strategy if the code paths deviate sigificantly.
+	testcases := []radcli.ValidateInput{
+		{
+			Name:          "rad run - valid with app and env",
+			Input:         []string{"app.bicep", "-e", "prod", "-a", "my-app"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				mocks.ApplicationManagementClient.EXPECT().
+					GetEnvDetails(gomock.Any(), "prod").
+					Return(v20220315privatepreview.EnvironmentResource{}, nil).
+					Times(1)
+			},
+		},
+		{
+			Name:          "rad run - app set by directory config",
+			Input:         []string{"app.bicep", "-e", "prod"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+				DirectoryConfig: &config.DirectoryConfig{
+					Workspace: config.DirectoryWorkspaceConfig{
+						Application: "my-app",
+					},
+				},
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				mocks.ApplicationManagementClient.EXPECT().
+					GetEnvDetails(gomock.Any(), "prod").
+					Return(v20220315privatepreview.EnvironmentResource{}, nil).
+					Times(1)
+			},
+		},
+		{
+			Name:          "rad run - app is required invalid",
+			Input:         []string{"app.bicep"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				mocks.ApplicationManagementClient.EXPECT().
+					GetEnvDetails(gomock.Any(), radcli.TestEnvironmentName).
+					Return(v20220315privatepreview.EnvironmentResource{}, nil).
+					Times(1)
+			},
+		},
+		{
+			Name:          "rad run - fallback workspace invalid",
+			Input:         []string{"app.bicep"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         radcli.LoadEmptyConfig(t),
+			},
+		},
+		{
+			Name:          "rad run - too many args",
+			Input:         []string{"app.bicep", "anotherfile.json"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         radcli.LoadEmptyConfig(t),
+			},
+		},
+	}
+
+	radcli.SharedValidateValidation(t, NewCommand, testcases)
+}
+
+func Test_Run(t *testing.T) {
+	// NOTE: most of the logic of this command is shared with the `rad deploy` command.
+	// We're using one of the same tests here as a smoke test, but the bulk of the testing
+	// is part of the `rad deploy` tests.
+	//
+	// We should revisit the test strategy if the code paths deviate sigificantly.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	bicep := bicep.NewMockInterface(ctrl)
+	bicep.EXPECT().
+		PrepareTemplate("app.bicep").
+		Return(map[string]interface{}{}, nil).
+		Times(1)
+
+	deployOptionsChan := make(chan deploy.Options, 1)
+	deployMock := deploy.NewMockInterface(ctrl)
+	deployMock.EXPECT().
+		DeployWithProgress(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, o deploy.Options) (clients.DeploymentResult, error) {
+			// Capture options for verification
+			deployOptionsChan <- o
+			close(deployOptionsChan)
+
+			return clients.DeploymentResult{}, nil
+		}).
+		Times(1)
+
+	logstreamOptionsChan := make(chan logstream.Options, 1)
+	logstreamMock := logstream.NewMockInterface(ctrl)
+	logstreamMock.EXPECT().
+		Stream(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, o logstream.Options) error {
+			// Capture options for verification
+			logstreamOptionsChan <- o
+			close(logstreamOptionsChan)
+
+			// Wait for context to be canceled
+			<-ctx.Done()
+			return ctx.Err()
+		}).
+		Times(1)
+
+	environment := v20220315privatepreview.EnvironmentResource{
+		Properties: &v20220315privatepreview.EnvironmentProperties{
+			Compute: &v20220315privatepreview.KubernetesCompute{
+				Kind:      to.Ptr(v20220315privatepreview.EnvironmentComputeKindKubernetes),
+				Namespace: to.Ptr("test-namespace"),
+			},
+		},
+	}
+
+	clientMock := clients.NewMockApplicationsManagementClient(ctrl)
+	clientMock.EXPECT().
+		GetEnvDetails(gomock.Any(), radcli.TestEnvironmentName).
+		Return(environment, nil).
+		Times(1)
+	clientMock.EXPECT().
+		CreateApplicationIfNotFound(gomock.Any(), "test-application", gomock.Any()).
+		Return(nil).
+		Times(1)
+
+	workspace := &workspaces.Workspace{
+		Connection: map[string]interface{}{
+			"kind":    "kubernetes",
+			"context": "kind-kind",
+		},
+		Name: "kind-kind",
+	}
+	outputSink := &output.MockOutput{}
+	runner := &Runner{
+		Runner: deploycmd.Runner{
+			Bicep:  bicep,
+			Deploy: deployMock,
+			Output: outputSink,
+			ConnectionFactory: &connections.MockFactory{
+				ApplicationsManagementClient: clientMock,
+			},
+
+			FilePath:        "app.bicep",
+			ApplicationID:   fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/applications.core/applications/%s", radcli.TestEnvironmentName, "test-application"),
+			ApplicationName: "test-application",
+			EnvironmentID:   fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/applications.core/environments/%s", radcli.TestEnvironmentName, radcli.TestEnvironmentName),
+			EnvironmentName: radcli.TestEnvironmentName,
+			Parameters:      map[string]map[string]interface{}{},
+			Workspace:       workspace,
+		},
+		Logstream: logstreamMock,
+	}
+
+	// We'll run the actual command in the background, and do cancellation and verification in
+	// the foreground.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // Cancel if any test validation values
+
+	resultErrChan := make(chan error, 1)
+	go func() {
+		resultErrChan <- runner.Run(ctx)
+	}()
+
+	deployOptions := <-deployOptionsChan
+	// Deployment is scoped to app and env
+	require.Equal(t, runner.ApplicationID, deployOptions.ApplicationID)
+	require.Equal(t, runner.EnvironmentID, deployOptions.EnvironmentID)
+
+	logStreamOptions := <-logstreamOptionsChan
+	// Logstream is scoped to application and namespace
+	require.Equal(t, runner.ApplicationName, logStreamOptions.ApplicationName)
+	require.Equal(t, "kind-kind", logStreamOptions.KubeContext)
+	require.Equal(t, "test-namespace", logStreamOptions.Namespace)
+
+	// Shut down the log stream and verify result
+	cancel()
+	err := <-resultErrChan
+	require.NoError(t, err)
+
+	// All of the output in this command is being done by functions that we mock for testing, so this
+	// is always empty except for some boilerplate.
+	expected := []interface{}{
+		output.LogOutput{
+			Format: "",
+		},
+		output.LogOutput{
+			Format: "Starting log stream...",
+		},
+		output.LogOutput{
+			Format: "",
+		},
+	}
+	require.Equal(t, expected, outputSink.Writes)
+}

--- a/test/functional/corerp/cli/testdata/corerp-kubernetes-cli-run.bicep
+++ b/test/functional/corerp/cli/testdata/corerp-kubernetes-cli-run.bicep
@@ -1,0 +1,18 @@
+import radius as radius
+
+param application string
+
+resource container 'Applications.Core/containers@2022-03-15-privatepreview' = {
+  name: 'k8s-cli-run-logger'
+  location: 'global'
+  properties: {
+    application: application
+    container: {
+      image: 'debian'
+      command: ['/bin/sh']
+
+      // The test looks for this specific output, keep in sync with the CLI run test!
+      args: ['-c', 'while true; do echo "hello from the streaming logs!"; sleep 10;done']
+    }
+  }
+}


### PR DESCRIPTION
Part of: radius-project/core-team#999

This change adds a `rad run` command. This is similar to `rad deploy` except it continues running after deployment and displays streaming logs for all of the application's pods.

`rad run` requires an application name to be passed in at the command line, or specified via `rad.yaml`. We need to know the name of the application in order to stream logs for it.

The implementation embeds and reuses `rad deploy`, and adds the unique `rad run` functionality after running `rad deploy`'s logic. This allows us to keep the two commands in sync.

Here's what it looks like:

![image](https://user-images.githubusercontent.com/1430011/203189929-7e668a77-c717-4f01-ba15-404533a9a24a.png)
