### PR TITLE
Set lint timeout to 30 minutes

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ jobs:
   linter_check:
     name: Lint
     runs-on: self-hosted
-    timeout-minutes: 12
+    timeout-minutes: 30
     env:
       GOVER: '^1.18'
       GOPROXY: https://proxy.golang.org


### PR DESCRIPTION
I've been seeing the linter workflow timeout be hit in my own PRs. Here's an example https://github.com/project-radius/radius/actions/runs/3576474166/workflow

Timeouts should be set such that we only hit them when something is really going wrong. It looks like right now our linter runs can take anywhere from 10-15 mins so the timeout is way too short.
