### PR TITLE
Reject user provided label/annotation where key starts with reserved phrase

### DIFF
--- a/pkg/corerp/renderers/kubernetesmetadata/render.go
+++ b/pkg/corerp/renderers/kubernetesmetadata/render.go
@@ -12,14 +12,13 @@ import (
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
 	"github.com/project-radius/radius/pkg/corerp/renderers"
+	"github.com/project-radius/radius/pkg/kubernetes"
 	"github.com/project-radius/radius/pkg/radlogger"
 	"github.com/project-radius/radius/pkg/resourcemodel"
 	"github.com/project-radius/radius/pkg/ucp/resources"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
-
-const reservedRadiusDevPrefix = "radius.dev/"
 
 // Renderer is the renderers.Renderer implementation for the kubernetesmetadata extension.
 type Renderer struct {
@@ -206,7 +205,7 @@ func rejectReservedEntries(ctx context.Context, inputMap map[string]string) map[
 	logger := radlogger.GetLogger(ctx)
 
 	for k := range inputMap {
-		if strings.HasPrefix(k, reservedRadiusDevPrefix) {
+		if strings.HasPrefix(k, kubernetes.RadiusDevPrefix) {
 			logger.Info("User provided label/annotation key starts with 'radius.dev/' and is not being applied", "key", k)
 			delete(inputMap, k)
 		}

--- a/pkg/corerp/renderers/kubernetesmetadata/render.go
+++ b/pkg/corerp/renderers/kubernetesmetadata/render.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-const reservedKeyStart = "radius.dev/"
+const reservedRadiusDevPrefix = "radius.dev/"
 
 // Renderer is the renderers.Renderer implementation for the kubernetesmetadata extension.
 type Renderer struct {
@@ -206,7 +206,7 @@ func mergeMaps(mergeMap map[string]string, newInputMap map[string]string, existi
 // Reject custom user entries that would affect Radius reserved keys
 func rejectReservedEntries(inputMap map[string]string, logger logr.Logger) map[string]string {
 	for k := range inputMap {
-		if strings.HasPrefix(k, reservedKeyStart) {
+		if strings.HasPrefix(k, reservedRadiusDevPrefix) {
 			logger.Info("User provided label/annotation key starts with 'radius.dev/' and is not being applied", "key", k)
 			delete(inputMap, k)
 		}

--- a/pkg/corerp/renderers/kubernetesmetadata/render_test.go
+++ b/pkg/corerp/renderers/kubernetesmetadata/render_test.go
@@ -69,31 +69,37 @@ func TestApplicationDataModelToVersioned(t *testing.T) {
 			testName:     "Test_Render_Success",
 			expectedMaps: getTestResultMaps(),
 			setupMaps:    nil,
-			properties:   makeProperties(t, false),
+			properties:   makeProperties(t, false, false),
 		},
 		{
 			testName:     "Test_Render_CascadeKubeMetadata",
 			expectedMaps: getCascadeTestResultMaps(),
 			setupMaps:    getSetUpMaps(false, false),
-			properties:   makeProperties(t, false),
+			properties:   makeProperties(t, false, false),
 		},
 		{
 			testName:     "Test_Render_KubeMetadataCollision",
 			expectedMaps: getCascadeTestResultMaps(),
 			setupMaps:    getSetUpMaps(true, false),
-			properties:   makeProperties(t, false),
+			properties:   makeProperties(t, false, false),
 		},
 		{
 			testName:     "Test_Render_OnlyAppExtension",
 			expectedMaps: getOnlyAppTestResultMaps(),
 			setupMaps:    getSetUpMaps(false, true),
-			properties:   makeProperties(t, true),
+			properties:   makeProperties(t, true, false),
 		},
 		{
 			testName:     "Test_Render_NoExtension",
 			expectedMaps: getEmptyTestResultMaps(),
 			setupMaps:    nil,
-			properties:   makeProperties(t, true),
+			properties:   makeProperties(t, true, false),
+		},
+		{
+			testName:     "Test_ReserveKey_Collision",
+			expectedMaps: getTestResultMaps(),
+			setupMaps:    nil,
+			properties:   makeProperties(t, false, true),
 		},
 	}
 
@@ -153,7 +159,7 @@ func makeResource(t *testing.T, properties datamodel.ContainerProperties) *datam
 	return &resource
 }
 
-func makeProperties(t *testing.T, isEmpty bool) datamodel.ContainerProperties {
+func makeProperties(t *testing.T, isEmpty bool, hasReservedKey bool) datamodel.ContainerProperties {
 	if isEmpty {
 		return datamodel.ContainerProperties{
 			BasicResourceProperties: rp.BasicResourceProperties{
@@ -201,6 +207,12 @@ func makeProperties(t *testing.T, isEmpty bool) datamodel.ContainerProperties {
 			},
 		},
 	}
+
+	if hasReservedKey {
+		properties.Extensions[0].KubernetesMetadata.Annotations["radius.dev/testannkey"] = "radius.dev/testannval"
+		properties.Extensions[0].KubernetesMetadata.Labels["radius.dev/testlblkey"] = "radius.dev/testlblval"
+	}
+
 	return properties
 }
 

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -29,6 +29,7 @@ const (
 	ControlPlane = "radius-control-plane"
 
 	AnnotationSecretHash = "radius.dev/secret-hash"
+	RadiusDevPrefix      = "radius.dev/"
 
 	// AnnotationIdentityType is the annotation for supported identity.
 	AnnotationIdentityType = "radius.dev/identity-type"


### PR DESCRIPTION
Updated Kubernetes Metadata Extension implementation to block users if they override or customize Radius' use of radius.dev/... labels.

## 4709

Fixes: #4709 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
