### PR TITLE
Attempt to fix flaky test for AWS Multi Identifier resource

### DIFF
--- a/test/functional/corerp/resources/testdata/aws-multi-identifier.bicep
+++ b/test/functional/corerp/resources/testdata/aws-multi-identifier.bicep
@@ -6,7 +6,7 @@ param logGroupName string
 resource metricsFilter 'AWS.Logs/MetricFilter@default' = {
   properties: {
     FilterName: filterName
-    LogGroupName: logGroupName
+    LogGroupName: logGroup.properties.LogGroupName
     FilterPattern: '[ip, identity, user_id, timestamp, request, status_code = 404, size]'
     MetricTransformations: [
       {


### PR DESCRIPTION
# Description

The failure was always "The specified log group does not exist. (Service: CloudWatchLogs, Status Code: 400, Request ID: 7120cb10-b61d-4ddb-bd25-268e41674606)"

There was no dependency between the two resources specified in the bicep file. As a result, they could be deployed in parallel and potentially, the metrics filter before the logGroup where the metricsFilter actually depends on the log group.

Added a dependency which will fix the order in which the resources are deployed.

#4777 

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #4777 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
