### PR TITLE
Add port-forwarding to `rad run`

### DIFF
--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	env_show "github.com/project-radius/radius/pkg/cli/cmd/env/show"
 	"github.com/project-radius/radius/pkg/cli/kubernetes"
 	"github.com/project-radius/radius/pkg/cli/kubernetes/logstream"
+	"github.com/project-radius/radius/pkg/cli/kubernetes/portforward"
 	"github.com/project-radius/radius/pkg/cli/setup"
 
 	"github.com/project-radius/radius/pkg/cli/bicep"
@@ -132,6 +133,7 @@ func initSubCommands() {
 		Output: &output.OutputWriter{
 			Writer: RootCmd.OutOrStdout(),
 		},
+		Portforward:         &portforward.Impl{},
 		Prompter:            &prompt.Impl{},
 		ConfigFileInterface: &framework.ConfigFileInterfaceImpl{},
 		KubernetesInterface: &kubernetes.Impl{},

--- a/pkg/cli/framework/framework.go
+++ b/pkg/cli/framework/framework.go
@@ -15,6 +15,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/helm"
 	"github.com/project-radius/radius/pkg/cli/kubernetes"
 	"github.com/project-radius/radius/pkg/cli/kubernetes/logstream"
+	"github.com/project-radius/radius/pkg/cli/kubernetes/portforward"
 	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/project-radius/radius/pkg/cli/prompt"
 	"github.com/project-radius/radius/pkg/cli/setup"
@@ -29,6 +30,9 @@ type Factory interface {
 	GetDeploy() deploy.Interface
 	GetLogstream() logstream.Interface
 	GetOutput() output.Interface
+
+	// GetPortforward fetches the portforward interface.
+	GetPortforward() portforward.Interface
 	GetPrompter() prompt.Interface
 	GetConfigFileInterface() ConfigFileInterface
 	GetKubernetesInterface() kubernetes.Interface
@@ -44,6 +48,7 @@ type Impl struct {
 	Deploy              deploy.Interface
 	Logstream           logstream.Interface
 	Output              output.Interface
+	Portforward         portforward.Interface
 	Prompter            prompt.Interface
 	ConfigFileInterface ConfigFileInterface
 	KubernetesInterface kubernetes.Interface
@@ -76,27 +81,32 @@ func (i *Impl) GetOutput() output.Interface {
 	return i.Output
 }
 
-// Fetches the interface to prompt user for values
+// GetPortforward fetches the portforward interface.
+func (i *Impl) GetPortforward() portforward.Interface {
+	return i.Portforward
+}
+
+// GetPrompter fetches the interface to prompt user for values
 func (i *Impl) GetPrompter() prompt.Interface {
 	return i.Prompter
 }
 
-// Fetches the interface to interace with radius config file
+// GetConfigFileInterface fetches the interface to interace with radius config file
 func (i *Impl) GetConfigFileInterface() ConfigFileInterface {
 	return i.ConfigFileInterface
 }
 
-// Fetches the interface to get info related to the kubernetes cluster
+// GetKubernetesInterface fetches the interface to get info related to the kubernetes cluster
 func (i *Impl) GetKubernetesInterface() kubernetes.Interface {
 	return i.KubernetesInterface
 }
 
-// Fetches the interface for operations related to radius installation
+// GetHelmInterface fetches the interface for operations related to radius installation
 func (i *Impl) GetHelmInterface() helm.Interface {
 	return i.HelmInterface
 }
 
-// Fetches the interface for operations related to radius installation
+// GetNamespaceInterface fetches the interface for operations related to radius installation
 func (i *Impl) GetNamespaceInterface() namespace.Interface {
 	return i.NamespaceInterface
 }

--- a/pkg/cli/kubernetes/portforward/impl.go
+++ b/pkg/cli/kubernetes/portforward/impl.go
@@ -7,6 +7,8 @@ package portforward
 
 import (
 	"context"
+
+	"github.com/project-radius/radius/pkg/cli/kubernetes"
 )
 
 var _ Interface = (*Impl)(nil)
@@ -17,6 +19,18 @@ type Impl struct {
 func (i *Impl) Run(ctx context.Context, options Options) error {
 	if options.StatusChan != nil {
 		defer close(options.StatusChan)
+	}
+
+	// We allow initialization of other context, or the client + config. This is the
+	// most flexible for tests.
+	if options.Client == nil && options.RESTConfig == nil {
+		client, restConfig, err := kubernetes.CreateTypedClient(options.KubeContext)
+		if err != nil {
+			return err
+		}
+
+		options.Client = client
+		options.RESTConfig = restConfig
 	}
 
 	// The overall algorithm we're going to follow works like this:

--- a/pkg/cli/kubernetes/portforward/pod_watcher.go
+++ b/pkg/cli/kubernetes/portforward/pod_watcher.go
@@ -141,9 +141,9 @@ func (pw *podWatcher) sendPortNotifications(forwarder forwarder, kind StatusKind
 		containerName := pw.Pod.Labels[kubernetes.LabelRadiusResource]
 		replicaName := pw.Pod.Name
 
-		// Based on kubernetes naming conventions, trim to just the replica name
-		if containerName != "" && strings.Contains(replicaName, containerName+"-") {
-			replicaName = replicaName[(strings.LastIndex(replicaName, containerName+"-") + len(containerName) + 1):]
+		// If this is not a Radius resource then use a hueristic to get the deployment name.
+		if containerName == "" {
+			containerName, _, _ = strings.Cut(replicaName, "-")
 		}
 
 		ports := pw.forwarder.GetPorts()

--- a/pkg/cli/kubernetes/portforward/pod_watcher_test.go
+++ b/pkg/cli/kubernetes/portforward/pod_watcher_test.go
@@ -59,14 +59,14 @@ func Test_podWatcher_CanShutdownGracefully(t *testing.T) {
 		StatusMessage{
 			Kind:          KindConnected,
 			ContainerName: "test-container",
-			ReplicaName:   "abcd-efghij",
+			ReplicaName:   "test-app-test-container-abcd-efghij",
 			LocalPort:     3000,
 			RemotePort:    3000,
 		},
 		StatusMessage{
 			Kind:          KindDisconnected,
 			ContainerName: "test-container",
-			ReplicaName:   "abcd-efghij",
+			ReplicaName:   "test-app-test-container-abcd-efghij",
 			LocalPort:     3000,
 			RemotePort:    3000,
 		},
@@ -122,14 +122,14 @@ func Test_podWatcher_CanStartWhenPodIsReady(t *testing.T) {
 		StatusMessage{
 			Kind:          KindConnected,
 			ContainerName: "test-container",
-			ReplicaName:   "abcd-efghij",
+			ReplicaName:   "test-app-test-container-abcd-efghij",
 			LocalPort:     3000,
 			RemotePort:    3000,
 		},
 		StatusMessage{
 			Kind:          KindDisconnected,
 			ContainerName: "test-container",
-			ReplicaName:   "abcd-efghij",
+			ReplicaName:   "test-app-test-container-abcd-efghij",
 			LocalPort:     3000,
 			RemotePort:    3000,
 		},

--- a/pkg/cli/kubernetes/portforward/types.go
+++ b/pkg/cli/kubernetes/portforward/types.go
@@ -21,7 +21,12 @@ type Options struct {
 	// Namespace is the kubernetes namespace of the application.
 	Namespace string
 
-	// Client is the Kubernetes client used to access the cluster.
+	// KubeContext is the kubernetes context to use. If Client or RESTConfig is unset, this will be
+	// used to initialize those fields.
+	KubeContext string
+
+	// Client is the Kubernetes client used to access the cluster. If this is set then RESTConfig
+	// must also be set.
 	//
 	// We are using client-go here because the fake client from client-go has
 	// better support for watch.
@@ -30,7 +35,8 @@ type Options struct {
 	// Out is where output will be written.
 	Out io.Writer
 
-	// RESTConfig is the Kubernetes configuration for connecting to the server.
+	// RESTConfig is the Kubernetes configuration for connecting to the server. If this is set then
+	// Client must also be set.
 	RESTConfig *rest.Config
 
 	// Status chan will recieve StatusMessage updates if provided.

--- a/test/functional/corerp/cli/testdata/corerp-kubernetes-cli-run-portforward.bicep
+++ b/test/functional/corerp/cli/testdata/corerp-kubernetes-cli-run-portforward.bicep
@@ -1,0 +1,22 @@
+import radius as radius
+
+param application string
+
+@description('Specifies the image to be deployed.')
+param magpieimage string
+
+resource container 'Applications.Core/containers@2022-03-15-privatepreview' = {
+  name: 'k8s-cli-run-portforward'
+  location: 'global'
+  properties: {
+    application: application
+    container: {
+      image: magpieimage
+      ports: {
+        web: {
+          containerPort: 3000
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Part of: radius-project/core-team#999

This change adds support for port-forwarding to `rad run`. The previous PR in this series added the port-forward infra and this change wires it up to our command.

Since port-forwarding requires networking, I've added a new functional test to cover the new functionality.

There's one cosmetic change here to the display based on feedback I got from others. We want to show the pod name both for consistency with stern and also so it can be copy-pasted if needed into kubectl commands.

# Description

_Please explain the changes you've made._

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
