### PR TITLE
Enable fallback workspace for `rad resource ...`

### DIFF
--- a/cmd/rad/cmd/resourceExpose.go
+++ b/cmd/rad/cmd/resourceExpose.go
@@ -13,8 +13,8 @@ import (
 	"github.com/agnivade/levenshtein"
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/clients"
+	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
 	"github.com/project-radius/radius/pkg/cli/connections"
-	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/spf13/cobra"
 )
 
@@ -40,10 +40,11 @@ rad resource expose --application icecream-store containers orders --port 5000 -
 			return err
 		}
 
-		// TODO: support fallback workspace
-		if !workspace.IsNamedWorkspace() {
-			return workspaces.ErrNamedWorkspaceRequired
+		scope, err := cli.RequireScope(cmd, *workspace)
+		if err != nil {
+			return err
 		}
+		workspace.Scope = scope
 
 		// This gets the application name from the args provided
 		application, err := cli.RequireApplication(cmd, *workspace)
@@ -151,6 +152,7 @@ func init() {
 	resourceExposeCmd.Flags().IntP("remote-port", "", -1, "specify the remote port")
 	resourceExposeCmd.Flags().String("replica", "", "specify the replica to expose")
 	resourceExposeCmd.Flags().IntP("port", "p", -1, "specify the local port")
+	commonflags.AddResourceGroupFlag(resourceExposeCmd)
 	err := resourceExposeCmd.MarkFlagRequired("port")
 	if err != nil {
 		panic(err)

--- a/cmd/rad/cmd/resourceLogs.go
+++ b/cmd/rad/cmd/resourceLogs.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/clients"
+	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
 	"github.com/project-radius/radius/pkg/cli/connections"
-	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/spf13/cobra"
 )
 
@@ -48,10 +48,11 @@ rad resource logs containers orders --application icecream-store --container dap
 			return err
 		}
 
-		// TODO: support fallback workspace
-		if !workspace.IsNamedWorkspace() {
-			return workspaces.ErrNamedWorkspaceRequired
+		scope, err := cli.RequireScope(cmd, *workspace)
+		if err != nil {
+			return err
 		}
+		workspace.Scope = scope
 
 		application, err := cli.RequireApplication(cmd, *workspace)
 		if err != nil {
@@ -169,5 +170,6 @@ func init() {
 	resourceLogsCmd.Flags().String("container", "", "specify the container from which logs should be streamed")
 	resourceLogsCmd.Flags().BoolP("follow", "f", false, "specify that logs should be stream until the command is canceled")
 	resourceLogsCmd.Flags().String("replica", "", "specify the replica to collect logs from")
+	commonflags.AddResourceGroupFlag(resourceLogsCmd)
 	resourceCmd.AddCommand(resourceLogsCmd)
 }

--- a/pkg/cli/cmd/resource/delete/delete.go
+++ b/pkg/cli/cmd/resource/delete/delete.go
@@ -38,6 +38,7 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 
 	commonflags.AddOutputFlag(cmd)
 	commonflags.AddWorkspaceFlag(cmd)
+	commonflags.AddResourceGroupFlag(cmd)
 
 	return cmd, runner
 }
@@ -70,10 +71,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
-	// TODO: support fallback workspace
-	if !r.Workspace.IsNamedWorkspace() {
-		return workspaces.ErrNamedWorkspaceRequired
+	scope, err := cli.RequireScope(cmd, *r.Workspace)
+	if err != nil {
+		return err
 	}
+	r.Workspace.Scope = scope
 
 	resourceType, resourceName, err := cli.RequireResourceTypeAndName(args)
 	if err != nil {

--- a/pkg/cli/cmd/resource/delete/delete_test.go
+++ b/pkg/cli/cmd/resource/delete/delete_test.go
@@ -37,8 +37,8 @@ func Test_Validate(t *testing.T) {
 		},
 		{
 			Name:          "Delete Command with fallback workspace",
-			Input:         []string{"containers", "foo"},
-			ExpectedValid: false,
+			Input:         []string{"containers", "foo", "-g", "my-group"},
+			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
 				Config:         radcli.LoadEmptyConfig(t),

--- a/pkg/cli/cmd/resource/list/list.go
+++ b/pkg/cli/cmd/resource/list/list.go
@@ -48,6 +48,7 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	}
 
 	commonflags.AddApplicationNameFlag(cmd)
+	commonflags.AddResourceGroupFlag(cmd)
 	commonflags.AddOutputFlag(cmd)
 	commonflags.AddWorkspaceFlag(cmd)
 
@@ -83,10 +84,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
-	// TODO: support fallback workspace
-	if !r.Workspace.IsNamedWorkspace() {
-		return workspaces.ErrNamedWorkspaceRequired
+	scope, err := cli.RequireScope(cmd, *r.Workspace)
+	if err != nil {
+		return err
 	}
+	r.Workspace.Scope = scope
 
 	applicationName, err := cli.ReadApplicationName(cmd, *workspace)
 	if err != nil {

--- a/pkg/cli/cmd/resource/list/list_test.go
+++ b/pkg/cli/cmd/resource/list/list_test.go
@@ -51,8 +51,8 @@ func Test_Validate(t *testing.T) {
 		},
 		{
 			Name:          "List Command with fallback workspace",
-			Input:         []string{"containers"},
-			ExpectedValid: false,
+			Input:         []string{"containers", "-g", "my-group"},
+			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
 				Config:         radcli.LoadEmptyConfig(t),

--- a/pkg/cli/cmd/resource/show/show.go
+++ b/pkg/cli/cmd/resource/show/show.go
@@ -47,6 +47,7 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 
 	commonflags.AddOutputFlag(cmd)
 	commonflags.AddWorkspaceFlag(cmd)
+	commonflags.AddResourceGroupFlag(cmd)
 
 	return cmd, runner
 }
@@ -79,10 +80,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
-	// TODO: support fallback workspace
-	if !r.Workspace.IsNamedWorkspace() {
-		return workspaces.ErrNamedWorkspaceRequired
+	scope, err := cli.RequireScope(cmd, *r.Workspace)
+	if err != nil {
+		return err
 	}
+	r.Workspace.Scope = scope
 
 	resourceType, resourceName, err := cli.RequireResourceTypeAndName(args)
 	if err != nil {

--- a/pkg/cli/cmd/resource/show/show_test.go
+++ b/pkg/cli/cmd/resource/show/show_test.go
@@ -44,8 +44,8 @@ func Test_Validate(t *testing.T) {
 		},
 		{
 			Name:          "Show Command with fallback workspace",
-			Input:         []string{"containers", "foo"},
-			ExpectedValid: false,
+			Input:         []string{"containers", "foo", "-g", "my-group"},
+			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
 				Config:         radcli.LoadEmptyConfig(t),


### PR DESCRIPTION
Part of: #4401

This change enables the 'fallback workspace' for the `rad resource ...` family of commands. Since these commands are all based on resource groups, the user needs to specify a resource group for this case.
