### PR TITLE
Use matrix strategy to separate the functional tes jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,12 +72,20 @@ stages:
         make docker-build && make docker-push
       displayName: publish container
 
-- stage: FunctionalTest
+- stage: FunctionalTests
   dependsOn: ImageBuild
   jobs:
-  - job: ApplicationsCoreRP
+  - job: Test
     pool:
       vmImage: 'ubuntu-latest'
+    strategy:
+      matrix:
+        CoreRP:
+          targetName: corerp
+        Ucp:
+          targetName: ucp
+        Samples:
+          targetName: samples
     steps:
     ## Force the checkout directory of the radius repo to remain as if we had checked out only one Git repository, this work around the ADO behavior to checkout to a different directory breaking the assumptions of the test steps (for more info https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checkout-path)
     - checkout: self
@@ -210,29 +218,9 @@ stages:
     - script: |
         export PATH=$(Build.SourcesDirectory)/dist:$PATH
         export TEST_TIMEOUT=${{ variables.K8S_FUNCTIONALTEST_TIMEOUT }}
-        export RADIUS_CONTAINER_LOG_PATH=$(Build.SourcesDirectory)/${{ variables.RADIUS_CONTAINER_LOG_BASE }}/corerptest
-        make test-functional-corerp
-      env:
-        AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
-        AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
-        AWS_REGION: $(AWS_REGION)
-      displayName: run functional corerp tests
-    - script: |
-        export PATH=$(Build.SourcesDirectory)/dist:$PATH
-        export TEST_TIMEOUT=${{ variables.K8S_FUNCTIONALTEST_TIMEOUT }}
-        export RADIUS_CONTAINER_LOG_PATH=$(Build.SourcesDirectory)/${{ variables.RADIUS_CONTAINER_LOG_BASE }}/ucptest
-        make test-functional-ucp
-      env:
-        AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
-        AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
-        AWS_REGION: $(AWS_REGION)
-      displayName: run functional ucp tests
-    - script: |
-        export PATH=$(Build.SourcesDirectory)/dist:$PATH
-        export TEST_TIMEOUT=${{ variables.K8S_FUNCTIONALTEST_TIMEOUT }}
-        export RADIUS_CONTAINER_LOG_PATH=$(Build.SourcesDirectory)/${{ variables.RADIUS_CONTAINER_LOG_BASE }}/corerptest
-        make test-functional-samples
-      displayName: run sample tests
+        export RADIUS_CONTAINER_LOG_PATH=$(Build.SourcesDirectory)/${{ variables.RADIUS_CONTAINER_LOG_BASE }}$(targetName)test
+        make test-functional-$(targetName)
+      displayName: run functional $(targetName) tests
       env:
         AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
         AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -218,7 +218,7 @@ stages:
     - script: |
         export PATH=$(Build.SourcesDirectory)/dist:$PATH
         export TEST_TIMEOUT=${{ variables.K8S_FUNCTIONALTEST_TIMEOUT }}
-        export RADIUS_CONTAINER_LOG_PATH=$(Build.SourcesDirectory)/${{ variables.RADIUS_CONTAINER_LOG_BASE }}$(targetName)test
+        export RADIUS_CONTAINER_LOG_PATH=$(Build.SourcesDirectory)/${{ variables.RADIUS_CONTAINER_LOG_BASE }}/$(targetName)test
         make test-functional-$(targetName)
       displayName: run functional $(targetName) tests
       env:
@@ -228,7 +228,7 @@ stages:
         PROJECT_RADIUS_SAMPLES_REPO_ABS_PATH: $(Build.SourcesDirectory)/samples
     - publish: $(Build.SourcesDirectory)/dist/container_logs
       displayName: Publish container logs
-      artifact: FunctionalTest.ApplicationsCoreRPLogs.$(Build.BuildNumber)
+      artifact: $(targetName)FunctionalTest.$(Build.BuildNumber)
       condition: always()
     - script: |
         az group delete \

--- a/build/test.mk
+++ b/build/test.mk
@@ -26,18 +26,11 @@ test-get-envtools:
 test-validate-cli: ## Run cli integration tests
 	CGO_ENABLED=1 go test -coverpkg= ./pkg/cli/cmd/... ./cmd/rad/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
 
-.PHONY: test-functional-azure
-test-functional-azure: ## Runs Azure functional tests
-	CGO_ENABLED=1 go test ./test/functional/azure/... -timeout ${TEST_TIMEOUT} -v -parallel 20 $(GOTEST_OPTS)
-
-test-functional-localdev: ## Runs Local Dev functional tests
-	CGO_ENABLED=1 go test ./test/functional/localdev/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
-
 test-functional-kubernetes: ## Runs Kubernetes functional tests
 	CGO_ENABLED=1 go test ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
 
 test-functional-corerp: ## Runs Applications.Core functional tests
-	CGO_ENABLED=1 go test ./test/functional/corerp/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
+	CGO_ENABLED=1 go test ./test/functional/corerp/... -timeout ${TEST_TIMEOUT} -v -parallel 10 $(GOTEST_OPTS)
 
 test-functional-samples: ## Runs Samples functional tests
 	CGO_ENABLED=1 go test ./test/functional/samples/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)


### PR DESCRIPTION
# Description

Goal is to make it so that we can mark the samples validation optional while leaving corerp and ucp functional tests required.

## Issue reference
  
https://github.com/project-radius/radius/issues/4798