### PR TITLE
Introduce TestSecretResource helper in corerp e2e test

### DIFF
--- a/test/functional/corerp/cli/cli_test.go
+++ b/test/functional/corerp/cli/cli_test.go
@@ -342,8 +342,6 @@ func Test_CLI(t *testing.T) {
 	template := "testdata/corerp-kubernetes-cli.bicep"
 	name := "kubernetes-cli"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
@@ -375,7 +373,7 @@ func Test_CLI(t *testing.T) {
 			},
 			PostStepVerify: verifyCLIBasics,
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -383,7 +381,6 @@ func Test_CLI(t *testing.T) {
 func Test_CLI_JSON(t *testing.T) {
 	template := "testdata/corerp-kubernetes-cli.json"
 	name := "kubernetes-cli-json"
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -416,7 +413,7 @@ func Test_CLI_JSON(t *testing.T) {
 			},
 			PostStepVerify: verifyCLIBasics,
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -518,8 +515,6 @@ func Test_CLI_DeploymentParameters(t *testing.T) {
 	name := "kubernetes-cli-params"
 	parameterFilePath := filepath.Join(cwd, parameterFile)
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{Executor: step.NewDeployExecutor(template, "@"+parameterFilePath),
 			CoreRPResources: &validation.CoreRPResourceSet{
@@ -549,7 +544,7 @@ func Test_CLI_DeploymentParameters(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -597,8 +592,6 @@ func Test_RecipeCommands(t *testing.T) {
 	template := "testdata/corerp-resources-environment.bicep"
 	name := "corerp-resources-environment"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template),
@@ -614,7 +607,7 @@ func Test_RecipeCommands(t *testing.T) {
 			K8sObjects:     &validation.K8sObjectSet{},
 			PostStepVerify: verifyRecipeCLI,
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/mechanics/aws_mechanics_test.go
+++ b/test/functional/corerp/mechanics/aws_mechanics_test.go
@@ -19,8 +19,6 @@ func Test_AWSRedeployWithUpdatedResourceUpdatesResource(t *testing.T) {
 	templateFmt := "testdata/aws-mechanics-redeploy-withupdatedresource.step%d.bicep"
 	name := "ms" + uuid.New().String()
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor:                               step.NewDeployExecutor(fmt.Sprintf(templateFmt, 1), "streamName="+name),
@@ -60,7 +58,7 @@ func Test_AWSRedeployWithUpdatedResourceUpdatesResource(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 	test.Test(t)
 }
 
@@ -68,8 +66,6 @@ func Test_AWSRedeployWithCreateAndWriteOnlyPropertyUpdate(t *testing.T) {
 	t.Skip("This test will fail because step 2 is updating a create-and-write-only property.")
 	name := "my-db"
 	templateFmt := "testdata/aws-mechanics-redeploy-withcreateandwriteonlypropertyupdate.step%d.bicep"
-
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -110,6 +106,6 @@ func Test_AWSRedeployWithCreateAndWriteOnlyPropertyUpdate(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 	test.Test(t)
 }

--- a/test/functional/corerp/mechanics/k8s_extensibility_test.go
+++ b/test/functional/corerp/mechanics/k8s_extensibility_test.go
@@ -22,8 +22,6 @@ func Test_Kubernetes_Extensibility(t *testing.T) {
 	template := "testdata/k8s-extensibility/connection-string.bicep"
 	name := "corerp-mechanics-k8s-extensibility"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor:           step.NewDeployExecutor(template),
@@ -32,7 +30,7 @@ func Test_Kubernetes_Extensibility(t *testing.T) {
 			// No output resources are expected
 			SkipKubernetesOutputResourceValidation: true,
 		},
-	}, requiredSecrets, loadResources("testdata/k8s-extensibility", ".input.yaml")...)
+	}, loadResources("testdata/k8s-extensibility", ".input.yaml")...)
 
 	test.Test(t)
 }

--- a/test/functional/corerp/mechanics/mechanics_test.go
+++ b/test/functional/corerp/mechanics/mechanics_test.go
@@ -26,8 +26,6 @@ func Test_NestedModules(t *testing.T) {
 	template := "testdata/corerp-mechanics-nestedmodules.bicep"
 	name := "corerp-mechanics-nestedmodules"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template),
@@ -45,7 +43,7 @@ func Test_NestedModules(t *testing.T) {
 			},
 			K8sObjects: &validation.K8sObjectSet{},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -54,8 +52,6 @@ func Test_RedeployWithAnotherResource(t *testing.T) {
 	name := "corerp-mechanics-redeploy-with-another-resource"
 	appNamespace := "default-corerp-mechanics-redeploy-with-another-resource"
 	templateFmt := "testdata/corerp-mechanics-redeploy-withanotherresource.step%d.bicep"
-
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -110,7 +106,7 @@ func Test_RedeployWithAnotherResource(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -119,8 +115,6 @@ func Test_RedeployWithUpdatedResourceUpdatesResource(t *testing.T) {
 	name := "corerp-mechanics-redeploy-withupdatedresource"
 	appNamespace := "default-corerp-mechanics-redeploy-withupdatedresource"
 	templateFmt := "testdata/corerp-mechanics-redeploy-withupdatedresource.step%d.bicep"
-
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -183,7 +177,7 @@ func Test_RedeployWithUpdatedResourceUpdatesResource(t *testing.T) {
 				require.Equal(t, "updated", envVar.Value, "expected env var to be updated")
 			},
 		},
-	}, requiredSecrets)
+	})
 	test.Test(t)
 }
 
@@ -191,8 +185,6 @@ func Test_RedeployWithTwoSeparateResourcesKeepsResource(t *testing.T) {
 	name := "corerp-mechanics-redeploy-withtwoseparateresource"
 	appNamespace := "default-corerp-mechanics-redeploy-withtwoseparateresource"
 	templateFmt := "testdata/corerp-mechanics-redeploy-withtwoseparateresource.step%d.bicep"
-
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -247,7 +239,7 @@ func Test_RedeployWithTwoSeparateResourcesKeepsResource(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -256,8 +248,6 @@ func Test_CommunicationCycle(t *testing.T) {
 	name := "corerp-mechanics-communication-cycle"
 	appNamespace := "default-corerp-mechanics-communication-cycle"
 	template := "testdata/corerp-mechanics-communication-cycle.bicep"
-
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -299,7 +289,7 @@ func Test_CommunicationCycle(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -307,8 +297,6 @@ func Test_CommunicationCycle(t *testing.T) {
 func Test_InvalidResourceIDs(t *testing.T) {
 	name := "corerp-mechanics-invalid-resourceids"
 	template := "testdata/corerp-mechanics-invalid-resourceids.bicep"
-
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -323,7 +311,7 @@ func Test_InvalidResourceIDs(t *testing.T) {
 			},
 			K8sObjects: &validation.K8sObjectSet{},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/application_environment_test.go
+++ b/test/functional/corerp/resources/application_environment_test.go
@@ -20,8 +20,6 @@ func Test_ApplicationAndEnvironment(t *testing.T) {
 	template := "testdata/corerp-resources-app-env.bicep"
 	name := "corerp-resources-app-env"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template),
@@ -50,7 +48,7 @@ func Test_ApplicationAndEnvironment(t *testing.T) {
 				}
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/application_test.go
+++ b/test/functional/corerp/resources/application_test.go
@@ -22,8 +22,6 @@ func Test_Application(t *testing.T) {
 	name := "corerp-resources-application"
 	appNamespace := "corerp-resources-application-app"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template),
@@ -42,6 +40,6 @@ func Test_Application(t *testing.T) {
 				require.NoErrorf(t, err, "%s must be created", appNamespace)
 			},
 		},
-	}, requiredSecrets)
+	})
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/aws_kinesis_stream_test.go
+++ b/test/functional/corerp/resources/aws_kinesis_stream_test.go
@@ -24,8 +24,6 @@ func Test_AWS_KinesisStream(t *testing.T) {
 	template := "testdata/aws-kinesis.bicep"
 	name := "ms" + uuid.New().String()
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor:                               step.NewDeployExecutor(template, "streamName="+name),
@@ -41,7 +39,7 @@ func Test_AWS_KinesisStream(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -51,8 +49,6 @@ func Test_KinesisStreamExisting(t *testing.T) {
 	templateExisting := "testdata/aws-kinesis-existing.bicep"
 	name := "ms" + uuid.New().String()
 	appNamespace := "default-aws-kinesis-existing-app"
-
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -105,7 +101,7 @@ func Test_KinesisStreamExisting(t *testing.T) {
 				require.Equal(t, name, envVar.Value, "expected env var to be updated")
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 

--- a/test/functional/corerp/resources/aws_multi_identifier_resource_test.go
+++ b/test/functional/corerp/resources/aws_multi_identifier_resource_test.go
@@ -20,8 +20,6 @@ func Test_AWS_MultiIdentifier_Resource(t *testing.T) {
 	logGroupName := "ms" + uuid.New().String()
 	testName := "ms" + uuid.New().String()
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, testName, []corerp.TestStep{
 		{
 			Executor:                               step.NewDeployExecutor(template, "filterName="+filterName, "logGroupName="+logGroupName),
@@ -42,7 +40,7 @@ func Test_AWS_MultiIdentifier_Resource(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/azure_connections_test.go
+++ b/test/functional/corerp/resources/azure_connections_test.go
@@ -20,8 +20,6 @@ func Test_AzureConnections(t *testing.T) {
 	template := "testdata/corerp-azure-connection-database-service.bicep"
 	appNamespace := "default-corerp-azure-connection-database-service"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
@@ -46,7 +44,7 @@ func Test_AzureConnections(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/container_test.go
+++ b/test/functional/corerp/resources/container_test.go
@@ -23,8 +23,6 @@ func Test_Container(t *testing.T) {
 	name := "corerp-resources-container"
 	appNamespace := "corerp-resources-container-app"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
@@ -49,7 +47,7 @@ func Test_Container(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -58,8 +56,6 @@ func Test_ContainerHttpRoute(t *testing.T) {
 	template := "testdata/corerp-resources-container-httproute.bicep"
 	name := "corerp-resources-container-httproute"
 	appNamespace := "corerp-resources-container-httproute-app"
-
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -91,7 +87,7 @@ func Test_ContainerHttpRoute(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -100,8 +96,6 @@ func Test_ContainerReadinessLiveness(t *testing.T) {
 	template := "testdata/corerp-resources-container-liveness-readiness.bicep"
 	name := "corerp-resources-container-live-ready"
 	appNamespace := "corerp-resources-container-live-ready-app"
-
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -127,7 +121,7 @@ func Test_ContainerReadinessLiveness(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -136,8 +130,6 @@ func Test_ContainerManualScale(t *testing.T) {
 	template := "testdata/corerp-azure-container-manualscale.bicep"
 	name := "corerp-resources-container-manualscale"
 	appNamespace := "corerp-resources-container-manualscale-app"
-
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -163,7 +155,7 @@ func Test_ContainerManualScale(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -172,8 +164,6 @@ func Test_ContainerWithCommandAndArgs(t *testing.T) {
 	container := "testdata/corerp-resources-container-cmd-args.bicep"
 	name := "corerp-resources-container-cmd-args"
 	appNamespace := "corerp-resources-container-cmd-args-app"
-
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -216,7 +206,7 @@ func Test_ContainerWithCommandAndArgs(t *testing.T) {
 				t.Logf("validated command and args of pod: %s", pod.Name)
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/container_versioning_test.go
+++ b/test/functional/corerp/resources/container_versioning_test.go
@@ -26,8 +26,6 @@ func Test_ContainerVersioning(t *testing.T) {
 	name := "corerp-resources-container-versioning"
 	appNamespace := "default-corerp-resources-container-versioning"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(containerV1, functional.GetMagpieImage()),
@@ -92,7 +90,7 @@ func Test_ContainerVersioning(t *testing.T) {
 				require.Len(t, secrets.Items, 0)
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/dapr_component_name_conflict_test.go
+++ b/test/functional/corerp/resources/dapr_component_name_conflict_test.go
@@ -18,8 +18,6 @@ func Test_DaprComponentNameConflict(t *testing.T) {
 	template := "testdata/corerp-resources-dapr-component-name-conflict.bicep"
 	name := "corerp-resources-dapr-component-name-conflict"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployErrorExecutor(template, v1.CodeInternal),
@@ -33,7 +31,7 @@ func Test_DaprComponentNameConflict(t *testing.T) {
 			},
 			K8sObjects: &validation.K8sObjectSet{},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/dapr_invokehttproute_test.go
+++ b/test/functional/corerp/resources/dapr_invokehttproute_test.go
@@ -19,8 +19,6 @@ func Test_DaprInvokeHttpRoute(t *testing.T) {
 	name := "dapr-invokehttproute"
 	appNamespace := "default-dapr-invokehttproute"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
@@ -56,7 +54,7 @@ func Test_DaprInvokeHttpRoute(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/dapr_pubsub_test.go
+++ b/test/functional/corerp/resources/dapr_pubsub_test.go
@@ -20,8 +20,6 @@ func Test_DaprPubSubGeneric(t *testing.T) {
 	name := "corerp-resources-dapr-pubsub-generic"
 	appNamespace := "default-corerp-resources-dapr-pubsub-generic"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
@@ -51,7 +49,7 @@ func Test_DaprPubSubGeneric(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -60,8 +58,6 @@ func Test_DaprPubSubServiceBus(t *testing.T) {
 	template := "testdata/corerp-resources-dapr-pubsub-servicebus.bicep"
 	name := "corerp-resources-dapr-pubsub-servicebus"
 	appNamespace := "default-corerp-resources-dapr-pubsub-servicebus"
-
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -92,7 +88,7 @@ func Test_DaprPubSubServiceBus(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -100,8 +96,6 @@ func Test_DaprPubSubServiceBus(t *testing.T) {
 func Test_DaprPubSubServiceInvalid(t *testing.T) {
 	template := "testdata/corerp-resources-dapr-pubsub-servicebus-invalid.bicep"
 	name := "corerp-resources-dapr-pubsub-servicebus-invalid"
-
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -116,7 +110,7 @@ func Test_DaprPubSubServiceInvalid(t *testing.T) {
 			},
 			K8sObjects: &validation.K8sObjectSet{},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/dapr_secretstore_test.go
+++ b/test/functional/corerp/resources/dapr_secretstore_test.go
@@ -12,32 +12,12 @@ import (
 	"github.com/project-radius/radius/test/functional/corerp"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func Test_DaprSecretStoreGeneric(t *testing.T) {
 	template := "testdata/corerp-resources-dapr-secretstore-generic.bicep"
 	name := "corerp-resources-dapr-secretstore-generic"
 	appNamespace := "default-corerp-resources-dapr-secretstore-generic"
-
-	requiredSecrets := map[string]map[string]string{}
-
-	// TODO: remove requiredSecrets, but instead use the below initialResource approach.
-	resources := []unstructured.Unstructured{
-		{
-			Object: map[string]any{
-				"apiVersion": "v1",
-				"kind":       "Secret",
-				"metadata": map[string]any{
-					"name":      "mysecret",
-					"namespace": appNamespace,
-				},
-				"data": map[string]any{
-					"mysecret": []byte("mysecret"),
-				},
-			},
-		},
-	}
 
 	test := corerp.NewCoreRPTest(t, appNamespace, []corerp.TestStep{
 		{
@@ -68,7 +48,7 @@ func Test_DaprSecretStoreGeneric(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets, resources...)
+	}, corerp.TestSecretResource(appNamespace, "mysecret", []byte("mysecret")))
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/dapr_statestore_test.go
+++ b/test/functional/corerp/resources/dapr_statestore_test.go
@@ -19,8 +19,6 @@ func Test_DaprStateStoreGeneric(t *testing.T) {
 	name := "corerp-resources-dapr-statestore-generic"
 	appNamespace := "default-corerp-resources-dapr-statestore-generic"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
@@ -50,7 +48,7 @@ func Test_DaprStateStoreGeneric(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -59,8 +57,6 @@ func Test_DaprStateStoreTableStorage(t *testing.T) {
 	template := "testdata/corerp-resources-dapr-statestore-tablestorage.bicep"
 	name := "corerp-resources-dapr-statestore-tablestorage"
 	appNamespace := "default-corerp-resources-dapr-statestore-tablestorage"
-
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -91,7 +87,7 @@ func Test_DaprStateStoreTableStorage(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/environment_test.go
+++ b/test/functional/corerp/resources/environment_test.go
@@ -17,8 +17,6 @@ func Test_Environment(t *testing.T) {
 	template := "testdata/corerp-resources-environment.bicep"
 	name := "corerp-resources-environment"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template),
@@ -33,7 +31,7 @@ func Test_Environment(t *testing.T) {
 			// Environment should not render any K8s Objects directly
 			K8sObjects: &validation.K8sObjectSet{},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/extender_test.go
+++ b/test/functional/corerp/resources/extender_test.go
@@ -19,8 +19,6 @@ func Test_Extender(t *testing.T) {
 	name := "corerp-resources-extender"
 	appNamespace := "default-corerp-resources-extender"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
@@ -49,7 +47,7 @@ func Test_Extender(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/gateway_test.go
+++ b/test/functional/corerp/resources/gateway_test.go
@@ -34,8 +34,6 @@ func Test_Gateway(t *testing.T) {
 	name := "corerp-resources-gateway"
 	appNamespace := "default-corerp-resources-gateway"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
@@ -105,7 +103,7 @@ func Test_Gateway(t *testing.T) {
 				require.Fail(t, "Gateway tests failed")
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -166,8 +164,6 @@ func Test_HTTPSGateway(t *testing.T) {
 	name := "corerp-resources-gateways"
 	appNamespace := "default-corerp-resources-gateways"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
@@ -223,7 +219,7 @@ func Test_HTTPSGateway(t *testing.T) {
 				require.Fail(t, "Gateway tests failed")
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/kubemetadata_container_test.go
+++ b/test/functional/corerp/resources/kubemetadata_container_test.go
@@ -23,8 +23,6 @@ func Test_KubeMetadataContainer(t *testing.T) {
 	name := "corerp-kmd-app"
 	appNamespace := "corerp-kmd-ns-corerp-kmd-app"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	expectedAnnotations := map[string]string{
 		"user.cntr.ann.1": "user.cntr.ann.val.1",
 		"user.cntr.ann.2": "user.cntr.ann.val.2",
@@ -86,7 +84,7 @@ func Test_KubeMetadataContainer(t *testing.T) {
 				require.True(t, isMapSubSet(expectedLabels, deployment.Labels))
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/kubmetadata_cascade_test.go
+++ b/test/functional/corerp/resources/kubmetadata_cascade_test.go
@@ -24,8 +24,6 @@ func Test_KubeMetadataCascade(t *testing.T) {
 	name := "corerp-kmd-cascade-app"
 	appNamespace := "corerp-kmd-cascade-ns-corerp-kmd-cascade-app"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	expectedAnnotations := map[string]string{
 		"user.env.ann.1":          "user.env.ann.val.1",
 		"user.env.ann.2":          "user.env.ann.val.2",
@@ -115,7 +113,7 @@ func Test_KubeMetadataCascade(t *testing.T) {
 				require.True(t, isMapNonIntersecting(notExpectedLabels, pod.Labels))
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/microsoftsql_test.go
+++ b/test/functional/corerp/resources/microsoftsql_test.go
@@ -19,8 +19,6 @@ func Test_MicrosoftSQL(t *testing.T) {
 	name := "corerp-resources-microsoft-sql"
 	appNamespace := "default-corerp-resources-microsoft-sql"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
@@ -45,7 +43,7 @@ func Test_MicrosoftSQL(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/mongodb_test.go
+++ b/test/functional/corerp/resources/mongodb_test.go
@@ -20,8 +20,6 @@ func Test_MongoDB(t *testing.T) {
 	name := "corerp-resources-mongodb"
 	appNamespace := "default-corerp-resources-mongodb"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
@@ -51,7 +49,7 @@ func Test_MongoDB(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -60,8 +58,6 @@ func Test_MongoDBUserSecrets(t *testing.T) {
 	template := "testdata/corerp-resources-mongodb-user-secrets.bicep"
 	name := "corerp-resources-mongodb-user-secrets"
 	appNamespace := "default-corerp-resources-mongodb-user-secrets"
-
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -104,7 +100,7 @@ func Test_MongoDBUserSecrets(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -116,8 +112,6 @@ func Test_MongoDB_Recipe(t *testing.T) {
 	template := "testdata/corerp-resources-mongodb-recipe.bicep"
 	name := "corerp-resources-mongodb-recipe"
 	appNamespace := "corerp-resources-mongodb-recipe-app"
-
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -153,7 +147,7 @@ func Test_MongoDB_Recipe(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -166,8 +160,6 @@ func Test_MongoDB_DevRecipe(t *testing.T) {
 	template := "testdata/corerp-resources-mongodb-devrecipe.bicep"
 	name := "corerp-resources-mongodb-devrecipe"
 	appNamespace := "corerp-resources-mongodb-devrecipe-app"
-
-	requiredSecrets := map[string]map[string]string{}
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
@@ -203,7 +195,7 @@ func Test_MongoDB_DevRecipe(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/persistent_volume_test.go
+++ b/test/functional/corerp/resources/persistent_volume_test.go
@@ -19,8 +19,6 @@ func Test_PersistentVolume(t *testing.T) {
 	name := "corerp-resources-volume-azure-keyvault"
 	appNamespace := "corerp-resources-volume-azure-keyvault-app"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
@@ -54,7 +52,7 @@ func Test_PersistentVolume(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/rabbitmq_test.go
+++ b/test/functional/corerp/resources/rabbitmq_test.go
@@ -19,8 +19,6 @@ func Test_RabbitMQ(t *testing.T) {
 	name := "corerp-resources-rabbitmq"
 	appNamespace := "default-corerp-resources-rabbitmq"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), "password=guest"),
@@ -62,7 +60,7 @@ func Test_RabbitMQ(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/redis_test.go
+++ b/test/functional/corerp/resources/redis_test.go
@@ -19,8 +19,6 @@ func Test_Redis(t *testing.T) {
 	name := "corerp-resources-redis-user-secrets"
 	appNamespace := "default-corerp-resources-redis-user-secrets"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
@@ -62,7 +60,7 @@ func Test_Redis(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }
@@ -94,7 +92,7 @@ func Test_RedisAzure(t *testing.T) {
 			},
 			SkipObjectValidation: true,
 		},
-	}, nil)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/sql_test.go
+++ b/test/functional/corerp/resources/sql_test.go
@@ -24,8 +24,6 @@ func Test_SQL(t *testing.T) {
 	name := "corerp-resources-sql"
 	appNamespace := "default-corerp-resources-sql"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
@@ -67,7 +65,7 @@ func Test_SQL(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/storage_test.go
+++ b/test/functional/corerp/resources/storage_test.go
@@ -20,8 +20,6 @@ func Test_Storage(t *testing.T) {
 	name := "corerp-resources-container-workload"
 	appNamespace := "azstorage-workload-app"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
@@ -46,7 +44,7 @@ func Test_Storage(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }

--- a/test/functional/samples/tutorial_test.go
+++ b/test/functional/samples/tutorial_test.go
@@ -47,8 +47,6 @@ func Test_TutorialSampleMongoContainer(t *testing.T) {
 	appName := "webapp"
 	appNamespace := "default-webapp"
 
-	requiredSecrets := map[string]map[string]string{}
-
 	test := corerp.NewCoreRPTest(t, appName, []corerp.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template),
@@ -111,7 +109,7 @@ func Test_TutorialSampleMongoContainer(t *testing.T) {
 				},
 			},
 		},
-	}, requiredSecrets)
+	})
 
 	test.Test(t)
 }


### PR DESCRIPTION
# Description

The old test secret injection is designed only for `default` namespace. Since we support app-scoped namespace, we need to have a way to specify target namespace.

This change introduces TestSecretResource helper for initialResources arg of NewCoreRPTest() to set up the test secret instead of having additional code and arguments to handle test secret.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #4839 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
