### PR TITLE
Validate Dapr install in Dapr links

### DIFF
--- a/pkg/corerp/frontend/controller/volumes/validator.go
+++ b/pkg/corerp/frontend/controller/volumes/validator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
 
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -37,8 +38,10 @@ func ValidateRequest(ctx context.Context, newResource *datamodel.VolumeResource,
 	if csiCRDValidationRequired {
 		crd := &apiextv1.CustomResourceDefinition{}
 		err := options.KubeClient.Get(ctx, client.ObjectKey{Name: secretProviderClassesCRD}, crd)
-		if err != nil {
+		if apierrors.IsNotFound(err) {
 			return rest.NewBadRequestResponse("Your volume requires secret store CSI driver. Please install it by following https://secrets-store-csi-driver.sigs.k8s.io/."), nil
+		} else if err != nil {
+			return nil, err
 		}
 	}
 

--- a/pkg/corerp/frontend/controller/volumes/validator_test.go
+++ b/pkg/corerp/frontend/controller/volumes/validator_test.go
@@ -56,7 +56,7 @@ func TestValidateRequest(t *testing.T) {
 	})
 
 	// Create default Kubernetes fake client.
-	defaultFakeClient := rptesting.NewFakeKubeClient(nil)
+	defaultFakeClient := rptesting.NewFakeKubeClient(crdScheme)
 
 	type args struct {
 		ctx         context.Context

--- a/pkg/linkrp/datamodel/daprdetector.go
+++ b/pkg/linkrp/datamodel/daprdetector.go
@@ -1,0 +1,38 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package datamodel
+
+import (
+	"context"
+
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	daprComponentCRD = "components.dapr.io"
+
+	// DaprMissingError is an error message that can be used when Dapr is not installed on the cluster.
+	DaprMissingError = "Dapr is not installed in your Kubernetes cluster. Please install Dapr by following the instructions at https://docs.dapr.io/operations/hosting/kubernetes/kubernetes-deploy/."
+)
+
+// IsDaprInstalled will check for Dapr to be installed in the deployment environment and return
+// and true if it is installed. Callers of this function can use DaprMissingError for a friendly error
+// message to send back to users.
+//
+// This check is based on the Dapr Component CRD, and only supports Kubernetes.
+func IsDaprInstalled(ctx context.Context, kubeClient client.Client) (bool, error) {
+	crd := &apiextv1.CustomResourceDefinition{}
+	err := kubeClient.Get(ctx, client.ObjectKey{Name: daprComponentCRD}, crd)
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/pkg/linkrp/frontend/controller/daprinvokehttproutes/createorupdatedaprinvokehttproute.go
+++ b/pkg/linkrp/frontend/controller/daprinvokehttproutes/createorupdatedaprinvokehttproute.go
@@ -36,6 +36,14 @@ func NewCreateOrUpdateDaprInvokeHttpRoute(opts ctrl.Options) (ctrl.Controller, e
 // Run executes CreateOrUpdateDaprInvokeHttpRoute operation.
 func (daprHttpRoute *CreateOrUpdateDaprInvokeHttpRoute) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (rest.Response, error) {
 	serviceCtx := v1.ARMRequestContextFromContext(ctx)
+
+	isSupported, err := datamodel.IsDaprInstalled(ctx, daprHttpRoute.KubeClient())
+	if err != nil {
+		return nil, err
+	} else if !isSupported {
+		return rest.NewBadRequestResponse(datamodel.DaprMissingError), nil
+	}
+
 	newResource, err := daprHttpRoute.Validate(ctx, req, serviceCtx.APIVersion)
 	if err != nil {
 		return nil, err
@@ -112,6 +120,7 @@ func (daprHttpRoute *CreateOrUpdateDaprInvokeHttpRoute) Run(ctx context.Context,
 // Validate extracts versioned resource from request and validates the properties.
 func (daprHttpRoute *CreateOrUpdateDaprInvokeHttpRoute) Validate(ctx context.Context, req *http.Request, apiVersion string) (*datamodel.DaprInvokeHttpRoute, error) {
 	serviceCtx := v1.ARMRequestContextFromContext(ctx)
+
 	content, err := ctrl.ReadJSONBody(req)
 	if err != nil {
 		return nil, err

--- a/pkg/linkrp/frontend/controller/daprinvokehttproutes/createorupdatedaprinvokehttproute_test.go
+++ b/pkg/linkrp/frontend/controller/daprinvokehttproutes/createorupdatedaprinvokehttproute_test.go
@@ -21,6 +21,9 @@ import (
 	"github.com/project-radius/radius/pkg/rp/outputresource"
 	"github.com/project-radius/radius/pkg/ucp/store"
 	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func getDeploymentProcessorOutputs() (renderers.RendererOutput, deployment.DeploymentOutput) {
@@ -40,11 +43,6 @@ func getDeploymentProcessorOutputs() (renderers.RendererOutput, deployment.Deplo
 }
 
 func TestCreateOrUpdateDaprInvokeHttpRoute_20220315PrivatePreview(t *testing.T) {
-	mctrl := gomock.NewController(t)
-	defer mctrl.Finish()
-
-	mStorageClient := store.NewMockStorageClient(mctrl)
-	mDeploymentProcessor := deployment.NewMockDeploymentProcessor(mctrl)
 	rendererOutput, deploymentOutput := getDeploymentProcessorOutputs()
 	ctx := context.Background()
 
@@ -53,13 +51,15 @@ func TestCreateOrUpdateDaprInvokeHttpRoute_20220315PrivatePreview(t *testing.T) 
 		headerKey          string
 		headerValue        string
 		resourceETag       string
+		daprMissing        bool
 		expectedStatusCode int
 		shouldFail         bool
 	}{
-		{"create-new-resource-no-if-match", "If-Match", "", "", http.StatusOK, false},
-		{"create-new-resource-*-if-match", "If-Match", "*", "", http.StatusPreconditionFailed, true},
-		{"create-new-resource-etag-if-match", "If-Match", "random-etag", "", http.StatusPreconditionFailed, true},
-		{"create-new-resource-*-if-none-match", "If-None-Match", "*", "", http.StatusOK, false},
+		{"create-new-resource-no-if-match", "If-Match", "", "", false, http.StatusOK, false},
+		{"create-new-resource-*-if-match", "If-Match", "*", "", false, http.StatusPreconditionFailed, true},
+		{"create-new-resource-etag-if-match", "If-Match", "random-etag", "", false, http.StatusPreconditionFailed, true},
+		{"create-new-resource-*-if-none-match", "If-None-Match", "*", "", false, http.StatusOK, false},
+		{"create-new-resource-without-dapr-installed", "If-Match", "", "", true, http.StatusBadRequest, true},
 	}
 
 	for _, testcase := range createNewResourceTestCases {
@@ -70,12 +70,18 @@ func TestCreateOrUpdateDaprInvokeHttpRoute_20220315PrivatePreview(t *testing.T) 
 			req.Header.Set(testcase.headerKey, testcase.headerValue)
 			ctx := radiustesting.ARMTestContextFromRequest(req)
 
-			mStorageClient.
-				EXPECT().
-				Get(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
-					return nil, &store.ErrNotFound{}
-				})
+			mctrl := gomock.NewController(t)
+			mStorageClient := store.NewMockStorageClient(mctrl)
+			mDeploymentProcessor := deployment.NewMockDeploymentProcessor(mctrl)
+
+			if !testcase.daprMissing {
+				mStorageClient.
+					EXPECT().
+					Get(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
+						return nil, &store.ErrNotFound{}
+					})
+			}
 
 			expectedOutput.SystemData.CreatedAt = expectedOutput.SystemData.LastModifiedAt
 			expectedOutput.SystemData.CreatedBy = expectedOutput.SystemData.LastModifiedBy
@@ -95,11 +101,30 @@ func TestCreateOrUpdateDaprInvokeHttpRoute_20220315PrivatePreview(t *testing.T) 
 					})
 			}
 
+			// Most tests will cover the case where Dapr is installed.
+			crdScheme := runtime.NewScheme()
+			err := apiextv1.AddToScheme(crdScheme)
+			require.NoError(t, err)
+
+			kubeClient := radiustesting.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apiextensions.k8s.io/v1",
+					Kind:       "CustomResourceDefinition",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "components.dapr.io",
+				},
+			})
+			if testcase.daprMissing {
+				kubeClient = radiustesting.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
+			}
+
 			opts := ctrl.Options{
 				StorageClient: mStorageClient,
 				GetDeploymentProcessor: func() deployment.DeploymentProcessor {
 					return mDeploymentProcessor
 				},
+				KubeClient: kubeClient,
 			}
 
 			ctl, err := NewCreateOrUpdateDaprInvokeHttpRoute(opts)
@@ -125,15 +150,17 @@ func TestCreateOrUpdateDaprInvokeHttpRoute_20220315PrivatePreview(t *testing.T) 
 		headerValue        string
 		inputFile          string
 		resourceETag       string
+		daprMissing        bool
 		expectedStatusCode int
 		shouldFail         bool
 	}{
-		{"update-resource-no-if-match", "If-Match", "", "", "resource-etag", http.StatusOK, false},
-		{"update-resource-with-diff-appid", "If-Match", "", "20220315privatepreview_input_appid.json", "resource-etag", http.StatusBadRequest, true},
-		{"update-resource-*-if-match", "If-Match", "*", "", "resource-etag", http.StatusOK, false},
-		{"update-resource-matching-if-match", "If-Match", "matching-etag", "", "matching-etag", http.StatusOK, false},
-		{"update-resource-not-matching-if-match", "If-Match", "not-matching-etag", "", "another-etag", http.StatusPreconditionFailed, true},
-		{"update-resource-*-if-none-match", "If-None-Match", "*", "", "another-etag", http.StatusPreconditionFailed, true},
+		{"update-resource-no-if-match", "If-Match", "", "", "resource-etag", false, http.StatusOK, false},
+		{"update-resource-with-diff-appid", "If-Match", "", "20220315privatepreview_input_appid.json", "resource-etag", false, http.StatusBadRequest, true},
+		{"update-resource-without-dapr-installed", "If-Match", "", "", "resource-etag", true, http.StatusBadRequest, true},
+		{"update-resource-*-if-match", "If-Match", "*", "", "resource-etag", false, http.StatusOK, false},
+		{"update-resource-matching-if-match", "If-Match", "matching-etag", "", "matching-etag", false, http.StatusOK, false},
+		{"update-resource-not-matching-if-match", "If-Match", "not-matching-etag", "", "another-etag", false, http.StatusPreconditionFailed, true},
+		{"update-resource-*-if-none-match", "If-None-Match", "*", "", "another-etag", false, http.StatusPreconditionFailed, true},
 	}
 
 	for _, testcase := range updateExistingResourceTestCases {
@@ -148,15 +175,21 @@ func TestCreateOrUpdateDaprInvokeHttpRoute_20220315PrivatePreview(t *testing.T) 
 			req.Header.Set(testcase.headerKey, testcase.headerValue)
 			ctx := radiustesting.ARMTestContextFromRequest(req)
 
-			mStorageClient.
-				EXPECT().
-				Get(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
-					return &store.Object{
-						Metadata: store.Metadata{ID: id, ETag: testcase.resourceETag},
-						Data:     dataModel,
-					}, nil
-				})
+			mctrl := gomock.NewController(t)
+			mStorageClient := store.NewMockStorageClient(mctrl)
+			mDeploymentProcessor := deployment.NewMockDeploymentProcessor(mctrl)
+
+			if !testcase.daprMissing {
+				mStorageClient.
+					EXPECT().
+					Get(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
+						return &store.Object{
+							Metadata: store.Metadata{ID: id, ETag: testcase.resourceETag},
+							Data:     dataModel,
+						}, nil
+					})
+			}
 
 			if !testcase.shouldFail {
 				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
@@ -173,11 +206,30 @@ func TestCreateOrUpdateDaprInvokeHttpRoute_20220315PrivatePreview(t *testing.T) 
 					})
 			}
 
+			// Most tests will cover the case where Dapr is installed.
+			crdScheme := runtime.NewScheme()
+			err := apiextv1.AddToScheme(crdScheme)
+			require.NoError(t, err)
+
+			kubeClient := radiustesting.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apiextensions.k8s.io/v1",
+					Kind:       "CustomResourceDefinition",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "components.dapr.io",
+				},
+			})
+			if testcase.daprMissing {
+				kubeClient = radiustesting.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
+			}
+
 			opts := ctrl.Options{
 				StorageClient: mStorageClient,
 				GetDeploymentProcessor: func() deployment.DeploymentProcessor {
 					return mDeploymentProcessor
 				},
+				KubeClient: kubeClient,
 			}
 
 			ctl, err := NewCreateOrUpdateDaprInvokeHttpRoute(opts)

--- a/pkg/linkrp/frontend/controller/daprpubsubbrokers/createorupdatedaprpubsubbroker.go
+++ b/pkg/linkrp/frontend/controller/daprpubsubbrokers/createorupdatedaprpubsubbroker.go
@@ -37,6 +37,14 @@ func NewCreateOrUpdateDaprPubSubBroker(opts ctrl.Options) (ctrl.Controller, erro
 // Run executes CreateOrUpdateDaprPubSubBroker operation.
 func (daprPubSub *CreateOrUpdateDaprPubSubBroker) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (rest.Response, error) {
 	serviceCtx := v1.ARMRequestContextFromContext(ctx)
+
+	isSupported, err := datamodel.IsDaprInstalled(ctx, daprPubSub.KubeClient())
+	if err != nil {
+		return nil, err
+	} else if !isSupported {
+		return rest.NewBadRequestResponse(datamodel.DaprMissingError), nil
+	}
+
 	newResource, err := daprPubSub.Validate(ctx, req, serviceCtx.APIVersion)
 	if err != nil {
 		return nil, err

--- a/pkg/linkrp/frontend/controller/daprpubsubbrokers/createorupdatedaprpubsubbroker_test.go
+++ b/pkg/linkrp/frontend/controller/daprpubsubbrokers/createorupdatedaprpubsubbroker_test.go
@@ -26,6 +26,9 @@ import (
 	"github.com/project-radius/radius/pkg/rp/outputresource"
 	"github.com/project-radius/radius/pkg/ucp/store"
 	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func getDeploymentProcessorOutputs() (renderers.RendererOutput, deployment.DeploymentOutput) {
@@ -89,12 +92,7 @@ func getDeploymentProcessorOutputs() (renderers.RendererOutput, deployment.Deplo
 }
 
 func TestCreateOrUpdateDaprPubSubBroker_20220315PrivatePreview(t *testing.T) {
-	mctrl := gomock.NewController(t)
-	defer mctrl.Finish()
-
-	mDeploymentProcessor := deployment.NewMockDeploymentProcessor(mctrl)
 	rendererOutput, deploymentOutput := getDeploymentProcessorOutputs()
-	mStorageClient := store.NewMockStorageClient(mctrl)
 	ctx := context.Background()
 
 	createNewResourceTestCases := []struct {
@@ -102,13 +100,15 @@ func TestCreateOrUpdateDaprPubSubBroker_20220315PrivatePreview(t *testing.T) {
 		headerKey          string
 		headerValue        string
 		resourceETag       string
+		daprMissing        bool
 		expectedStatusCode int
 		shouldFail         bool
 	}{
-		{"create-new-resource-no-if-match", "If-Match", "", "", http.StatusOK, false},
-		{"create-new-resource-*-if-match", "If-Match", "*", "", http.StatusPreconditionFailed, true},
-		{"create-new-resource-etag-if-match", "If-Match", "random-etag", "", http.StatusPreconditionFailed, true},
-		{"create-new-resource-*-if-none-match", "If-None-Match", "*", "", http.StatusOK, false},
+		{"create-new-resource-no-if-match", "If-Match", "", "", false, http.StatusOK, false},
+		{"create-new-resource-*-if-match", "If-Match", "*", "", false, http.StatusPreconditionFailed, true},
+		{"create-new-resource-etag-if-match", "If-Match", "random-etag", "", false, http.StatusPreconditionFailed, true},
+		{"create-new-resource-*-if-none-match", "If-None-Match", "*", "", false, http.StatusOK, false},
+		{"create-new-resource-without-dapr-installed", "If-Match", "", "", true, http.StatusBadRequest, true},
 	}
 
 	for _, testcase := range createNewResourceTestCases {
@@ -119,12 +119,18 @@ func TestCreateOrUpdateDaprPubSubBroker_20220315PrivatePreview(t *testing.T) {
 			req.Header.Set(testcase.headerKey, testcase.headerValue)
 			ctx := radiustesting.ARMTestContextFromRequest(req)
 
-			mStorageClient.
-				EXPECT().
-				Get(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
-					return nil, &store.ErrNotFound{}
-				})
+			mctrl := gomock.NewController(t)
+			mStorageClient := store.NewMockStorageClient(mctrl)
+			mDeploymentProcessor := deployment.NewMockDeploymentProcessor(mctrl)
+
+			if !testcase.daprMissing {
+				mStorageClient.
+					EXPECT().
+					Get(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
+						return nil, &store.ErrNotFound{}
+					})
+			}
 
 			expectedOutput.SystemData.CreatedAt = expectedOutput.SystemData.LastModifiedAt
 			expectedOutput.SystemData.CreatedBy = expectedOutput.SystemData.LastModifiedBy
@@ -144,11 +150,30 @@ func TestCreateOrUpdateDaprPubSubBroker_20220315PrivatePreview(t *testing.T) {
 					})
 			}
 
+			// Most tests will cover the case where Dapr is installed.
+			crdScheme := runtime.NewScheme()
+			err := apiextv1.AddToScheme(crdScheme)
+			require.NoError(t, err)
+
+			kubeClient := radiustesting.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apiextensions.k8s.io/v1",
+					Kind:       "CustomResourceDefinition",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "components.dapr.io",
+				},
+			})
+			if testcase.daprMissing {
+				kubeClient = radiustesting.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
+			}
+
 			opts := ctrl.Options{
 				StorageClient: mStorageClient,
 				GetDeploymentProcessor: func() deployment.DeploymentProcessor {
 					return mDeploymentProcessor
 				},
+				KubeClient: kubeClient,
 			}
 
 			ctl, err := NewCreateOrUpdateDaprPubSubBroker(opts)
@@ -174,15 +199,17 @@ func TestCreateOrUpdateDaprPubSubBroker_20220315PrivatePreview(t *testing.T) {
 		headerValue        string
 		inputFile          string
 		resourceETag       string
+		daprMissing        bool
 		expectedStatusCode int
 		shouldFail         bool
 	}{
-		{"update-resource-no-if-match", "If-Match", "", "", "resource-etag", http.StatusOK, false},
-		{"create-new-resource-with-diff-envid", "If-Match", "", "20220315privatepreview_input_diff_env.json", "", http.StatusBadRequest, true},
-		{"update-resource-*-if-match", "If-Match", "*", "", "resource-etag", http.StatusOK, false},
-		{"update-resource-matching-if-match", "If-Match", "matching-etag", "", "matching-etag", http.StatusOK, false},
-		{"update-resource-not-matching-if-match", "If-Match", "not-matching-etag", "", "another-etag", http.StatusPreconditionFailed, true},
-		{"update-resource-*-if-none-match", "If-None-Match", "*", "", "another-etag", http.StatusPreconditionFailed, true},
+		{"update-resource-no-if-match", "If-Match", "", "", "resource-etag", false, http.StatusOK, false},
+		{"create-new-resource-with-diff-envid", "If-Match", "", "20220315privatepreview_input_diff_env.json", "", false, http.StatusBadRequest, true},
+		{"update-resource-without-dapr-installed", "If-Match", "", "", "resource-etag", true, http.StatusBadRequest, true},
+		{"update-resource-*-if-match", "If-Match", "*", "", "resource-etag", false, http.StatusOK, false},
+		{"update-resource-matching-if-match", "If-Match", "matching-etag", "", "matching-etag", false, http.StatusOK, false},
+		{"update-resource-not-matching-if-match", "If-Match", "not-matching-etag", "", "another-etag", false, http.StatusPreconditionFailed, true},
+		{"update-resource-*-if-none-match", "If-None-Match", "*", "", "another-etag", false, http.StatusPreconditionFailed, true},
 	}
 
 	for _, testcase := range updateExistingResourceTestCases {
@@ -197,15 +224,21 @@ func TestCreateOrUpdateDaprPubSubBroker_20220315PrivatePreview(t *testing.T) {
 			req.Header.Set(testcase.headerKey, testcase.headerValue)
 			ctx := radiustesting.ARMTestContextFromRequest(req)
 
-			mStorageClient.
-				EXPECT().
-				Get(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
-					return &store.Object{
-						Metadata: store.Metadata{ID: id, ETag: testcase.resourceETag},
-						Data:     dataModel,
-					}, nil
-				})
+			mctrl := gomock.NewController(t)
+			mStorageClient := store.NewMockStorageClient(mctrl)
+			mDeploymentProcessor := deployment.NewMockDeploymentProcessor(mctrl)
+
+			if !testcase.daprMissing {
+				mStorageClient.
+					EXPECT().
+					Get(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
+						return &store.Object{
+							Metadata: store.Metadata{ID: id, ETag: testcase.resourceETag},
+							Data:     dataModel,
+						}, nil
+					})
+			}
 
 			if !testcase.shouldFail {
 				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
@@ -222,11 +255,30 @@ func TestCreateOrUpdateDaprPubSubBroker_20220315PrivatePreview(t *testing.T) {
 					})
 			}
 
+			// Most tests will cover the case where Dapr is installed.
+			crdScheme := runtime.NewScheme()
+			err := apiextv1.AddToScheme(crdScheme)
+			require.NoError(t, err)
+
+			kubeClient := radiustesting.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apiextensions.k8s.io/v1",
+					Kind:       "CustomResourceDefinition",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "components.dapr.io",
+				},
+			})
+			if testcase.daprMissing {
+				kubeClient = radiustesting.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
+			}
+
 			opts := ctrl.Options{
 				StorageClient: mStorageClient,
 				GetDeploymentProcessor: func() deployment.DeploymentProcessor {
 					return mDeploymentProcessor
 				},
+				KubeClient: kubeClient,
 			}
 
 			ctl, err := NewCreateOrUpdateDaprPubSubBroker(opts)

--- a/pkg/linkrp/frontend/controller/daprsecretstores/createorupdatedaprsecretstore.go
+++ b/pkg/linkrp/frontend/controller/daprsecretstores/createorupdatedaprsecretstore.go
@@ -36,6 +36,14 @@ func NewCreateOrUpdateDaprSecretStore(opts ctrl.Options) (ctrl.Controller, error
 // Run executes CreateOrUpdateDaprSecretStore operation.
 func (daprSecretStore *CreateOrUpdateDaprSecretStore) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (rest.Response, error) {
 	serviceCtx := v1.ARMRequestContextFromContext(ctx)
+
+	isSupported, err := datamodel.IsDaprInstalled(ctx, daprSecretStore.KubeClient())
+	if err != nil {
+		return nil, err
+	} else if !isSupported {
+		return rest.NewBadRequestResponse(datamodel.DaprMissingError), nil
+	}
+
 	newResource, err := daprSecretStore.Validate(ctx, req, serviceCtx.APIVersion)
 	if err != nil {
 		return nil, err

--- a/pkg/linkrp/frontend/controller/daprsecretstores/createorupdatedaprsecretstore_test.go
+++ b/pkg/linkrp/frontend/controller/daprsecretstores/createorupdatedaprsecretstore_test.go
@@ -24,6 +24,9 @@ import (
 	"github.com/project-radius/radius/pkg/rp/outputresource"
 	"github.com/project-radius/radius/pkg/ucp/store"
 	"github.com/stretchr/testify/require"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func getDeploymentProcessorOutputs() (renderers.RendererOutput, deployment.DeploymentOutput) {
@@ -65,11 +68,6 @@ func getDeploymentProcessorOutputs() (renderers.RendererOutput, deployment.Deplo
 }
 
 func TestCreateOrUpdateDaprSecretStore_20220315PrivatePreview(t *testing.T) {
-	mctrl := gomock.NewController(t)
-	defer mctrl.Finish()
-
-	mStorageClient := store.NewMockStorageClient(mctrl)
-	mDeploymentProcessor := deployment.NewMockDeploymentProcessor(mctrl)
 	rendererOutput, deploymentOutput := getDeploymentProcessorOutputs()
 	ctx := context.Background()
 
@@ -78,13 +76,15 @@ func TestCreateOrUpdateDaprSecretStore_20220315PrivatePreview(t *testing.T) {
 		headerKey          string
 		headerValue        string
 		resourceETag       string
+		daprMissing        bool
 		expectedStatusCode int
 		shouldFail         bool
 	}{
-		{"create-new-resource-no-if-match", "If-Match", "", "", http.StatusOK, false},
-		{"create-new-resource-*-if-match", "If-Match", "*", "", http.StatusPreconditionFailed, true},
-		{"create-new-resource-etag-if-match", "If-Match", "random-etag", "", http.StatusPreconditionFailed, true},
-		{"create-new-resource-*-if-none-match", "If-None-Match", "*", "", http.StatusOK, false},
+		{"create-new-resource-no-if-match", "If-Match", "", "", false, http.StatusOK, false},
+		{"create-new-resource-*-if-match", "If-Match", "*", "", false, http.StatusPreconditionFailed, true},
+		{"create-new-resource-etag-if-match", "If-Match", "random-etag", "", false, http.StatusPreconditionFailed, true},
+		{"create-new-resource-*-if-none-match", "If-None-Match", "*", "", false, http.StatusOK, false},
+		{"create-new-resource-without-dapr-installed", "If-Match", "", "", true, http.StatusBadRequest, true},
 	}
 
 	for _, testcase := range createNewResourceTestCases {
@@ -95,12 +95,18 @@ func TestCreateOrUpdateDaprSecretStore_20220315PrivatePreview(t *testing.T) {
 			req.Header.Set(testcase.headerKey, testcase.headerValue)
 			ctx := radiustesting.ARMTestContextFromRequest(req)
 
-			mStorageClient.
-				EXPECT().
-				Get(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
-					return nil, &store.ErrNotFound{}
-				})
+			mctrl := gomock.NewController(t)
+			mStorageClient := store.NewMockStorageClient(mctrl)
+			mDeploymentProcessor := deployment.NewMockDeploymentProcessor(mctrl)
+
+			if !testcase.daprMissing {
+				mStorageClient.
+					EXPECT().
+					Get(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
+						return nil, &store.ErrNotFound{}
+					})
+			}
 
 			expectedOutput.SystemData.CreatedAt = expectedOutput.SystemData.LastModifiedAt
 			expectedOutput.SystemData.CreatedBy = expectedOutput.SystemData.LastModifiedBy
@@ -120,11 +126,30 @@ func TestCreateOrUpdateDaprSecretStore_20220315PrivatePreview(t *testing.T) {
 					})
 			}
 
+			// Most tests will cover the case where Dapr is installed.
+			crdScheme := runtime.NewScheme()
+			err := apiextv1.AddToScheme(crdScheme)
+			require.NoError(t, err)
+
+			kubeClient := radiustesting.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apiextensions.k8s.io/v1",
+					Kind:       "CustomResourceDefinition",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "components.dapr.io",
+				},
+			})
+			if testcase.daprMissing {
+				kubeClient = radiustesting.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
+			}
+
 			opts := ctrl.Options{
 				StorageClient: mStorageClient,
 				GetDeploymentProcessor: func() deployment.DeploymentProcessor {
 					return mDeploymentProcessor
 				},
+				KubeClient: kubeClient,
 			}
 
 			ctl, err := NewCreateOrUpdateDaprSecretStore(opts)
@@ -150,15 +175,17 @@ func TestCreateOrUpdateDaprSecretStore_20220315PrivatePreview(t *testing.T) {
 		headerValue        string
 		inputFile          string
 		resourceETag       string
+		daprMissing        bool
 		expectedStatusCode int
 		shouldFail         bool
 	}{
-		{"update-resource-no-if-match", "If-Match", "", "", "resource-etag", http.StatusOK, false},
-		{"update-resource-with-diff-env-app", "If-Match", "", "20220315privatepreview_input_diffenvapp.json", "resource-etag", http.StatusBadRequest, true},
-		{"update-resource-*-if-match", "If-Match", "*", "", "resource-etag", http.StatusOK, false},
-		{"update-resource-matching-if-match", "If-Match", "matching-etag", "", "matching-etag", http.StatusOK, false},
-		{"update-resource-not-matching-if-match", "If-Match", "not-matching-etag", "", "another-etag", http.StatusPreconditionFailed, true},
-		{"update-resource-*-if-none-match", "If-None-Match", "*", "", "another-etag", http.StatusPreconditionFailed, true},
+		{"update-resource-no-if-match", "If-Match", "", "", "resource-etag", false, http.StatusOK, false},
+		{"update-resource-with-diff-env-app", "If-Match", "", "20220315privatepreview_input_diffenvapp.json", "resource-etag", false, http.StatusBadRequest, true},
+		{"update-resource-without-dapr-installed", "If-Match", "", "", "resource-etag", true, http.StatusBadRequest, true},
+		{"update-resource-*-if-match", "If-Match", "*", "", "resource-etag", false, http.StatusOK, false},
+		{"update-resource-matching-if-match", "If-Match", "matching-etag", "", "matching-etag", false, http.StatusOK, false},
+		{"update-resource-not-matching-if-match", "If-Match", "not-matching-etag", "", "another-etag", false, http.StatusPreconditionFailed, true},
+		{"update-resource-*-if-none-match", "If-None-Match", "*", "", "another-etag", false, http.StatusPreconditionFailed, true},
 	}
 
 	for _, testcase := range updateExistingResourceTestCases {
@@ -173,15 +200,21 @@ func TestCreateOrUpdateDaprSecretStore_20220315PrivatePreview(t *testing.T) {
 			req.Header.Set(testcase.headerKey, testcase.headerValue)
 			ctx := radiustesting.ARMTestContextFromRequest(req)
 
-			mStorageClient.
-				EXPECT().
-				Get(gomock.Any(), gomock.Any()).
-				DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
-					return &store.Object{
-						Metadata: store.Metadata{ID: id, ETag: testcase.resourceETag},
-						Data:     dataModel,
-					}, nil
-				})
+			mctrl := gomock.NewController(t)
+			mStorageClient := store.NewMockStorageClient(mctrl)
+			mDeploymentProcessor := deployment.NewMockDeploymentProcessor(mctrl)
+
+			if !testcase.daprMissing {
+				mStorageClient.
+					EXPECT().
+					Get(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
+						return &store.Object{
+							Metadata: store.Metadata{ID: id, ETag: testcase.resourceETag},
+							Data:     dataModel,
+						}, nil
+					})
+			}
 
 			if !testcase.shouldFail {
 				mDeploymentProcessor.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(rendererOutput, nil)
@@ -198,11 +231,30 @@ func TestCreateOrUpdateDaprSecretStore_20220315PrivatePreview(t *testing.T) {
 					})
 			}
 
+			// Most tests will cover the case where Dapr is installed.
+			crdScheme := runtime.NewScheme()
+			err := apiextv1.AddToScheme(crdScheme)
+			require.NoError(t, err)
+
+			kubeClient := radiustesting.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apiextensions.k8s.io/v1",
+					Kind:       "CustomResourceDefinition",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "components.dapr.io",
+				},
+			})
+			if testcase.daprMissing {
+				kubeClient = radiustesting.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
+			}
+
 			opts := ctrl.Options{
 				StorageClient: mStorageClient,
 				GetDeploymentProcessor: func() deployment.DeploymentProcessor {
 					return mDeploymentProcessor
 				},
+				KubeClient: kubeClient,
 			}
 
 			ctl, err := NewCreateOrUpdateDaprSecretStore(opts)

--- a/pkg/linkrp/frontend/controller/daprstatestores/createorupdatedaprstatestore.go
+++ b/pkg/linkrp/frontend/controller/daprstatestores/createorupdatedaprstatestore.go
@@ -36,6 +36,14 @@ func NewCreateOrUpdateDaprStateStore(opts ctrl.Options) (ctrl.Controller, error)
 // Run executes CreateOrUpdateDaprStateStore operation.
 func (daprStateStore *CreateOrUpdateDaprStateStore) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (rest.Response, error) {
 	serviceCtx := v1.ARMRequestContextFromContext(ctx)
+
+	isSupported, err := datamodel.IsDaprInstalled(ctx, daprStateStore.KubeClient())
+	if err != nil {
+		return nil, err
+	} else if !isSupported {
+		return rest.NewBadRequestResponse(datamodel.DaprMissingError), nil
+	}
+
 	newResource, err := daprStateStore.Validate(ctx, req, serviceCtx.APIVersion)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Part of: #2952

This change validates the installation status of Dapr inside links RP for Dapr resources. This is step one in removing Dapr from Radius' default installation. After we have a good experience with Dapr missing, we can remove it.

This validation is only applied on PUT calls to be more friendly to API consumers. We still allow clients to get and list dapr link resources without Dapr installed.

The pattern I followed is similar to the validation we perform for the AKV CSI driver.
