### PR TITLE
Introduce 'required features' on functional test

### DIFF
--- a/pkg/cli/kubernetes/kubernetes.go
+++ b/pkg/cli/kubernetes/kubernetes.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,6 +69,7 @@ func init() {
 	// Any time we add a new type to to radius,
 	// we need to add it here.
 	// TODO centralize these calls.
+	_ = apiextv1.AddToScheme(Scheme)
 	_ = clientgoscheme.AddToScheme(Scheme)
 	_ = contourv1.AddToScheme(Scheme)
 }

--- a/test/functional/corerp/resources/dapr_component_name_conflict_test.go
+++ b/test/functional/corerp/resources/dapr_component_name_conflict_test.go
@@ -32,6 +32,7 @@ func Test_DaprComponentNameConflict(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{},
 		},
 	})
+	test.RequiredFeatures = []corerp.RequiredFeature{corerp.FeatureDapr}
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/dapr_invokehttproute_test.go
+++ b/test/functional/corerp/resources/dapr_invokehttproute_test.go
@@ -55,6 +55,7 @@ func Test_DaprInvokeHttpRoute(t *testing.T) {
 			},
 		},
 	})
+	test.RequiredFeatures = []corerp.RequiredFeature{corerp.FeatureDapr}
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/dapr_pubsub_test.go
+++ b/test/functional/corerp/resources/dapr_pubsub_test.go
@@ -50,6 +50,7 @@ func Test_DaprPubSubGeneric(t *testing.T) {
 			},
 		},
 	})
+	test.RequiredFeatures = []corerp.RequiredFeature{corerp.FeatureDapr}
 
 	test.Test(t)
 }
@@ -89,6 +90,7 @@ func Test_DaprPubSubServiceBus(t *testing.T) {
 			},
 		},
 	})
+	test.RequiredFeatures = []corerp.RequiredFeature{corerp.FeatureDapr}
 
 	test.Test(t)
 }
@@ -111,6 +113,7 @@ func Test_DaprPubSubServiceInvalid(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{},
 		},
 	})
+	test.RequiredFeatures = []corerp.RequiredFeature{corerp.FeatureDapr}
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/dapr_secretstore_test.go
+++ b/test/functional/corerp/resources/dapr_secretstore_test.go
@@ -49,6 +49,7 @@ func Test_DaprSecretStoreGeneric(t *testing.T) {
 			},
 		},
 	}, corerp.TestSecretResource(appNamespace, "mysecret", []byte("mysecret")))
-
+	test.RequiredFeatures = []corerp.RequiredFeature{corerp.FeatureDapr}
+	
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/dapr_statestore_test.go
+++ b/test/functional/corerp/resources/dapr_statestore_test.go
@@ -49,6 +49,7 @@ func Test_DaprStateStoreGeneric(t *testing.T) {
 			},
 		},
 	})
+	test.RequiredFeatures = []corerp.RequiredFeature{corerp.FeatureDapr}
 
 	test.Test(t)
 }
@@ -88,6 +89,7 @@ func Test_DaprStateStoreTableStorage(t *testing.T) {
 			},
 		},
 	})
+	test.RequiredFeatures = []corerp.RequiredFeature{corerp.FeatureDapr}
 
 	test.Test(t)
 }

--- a/test/functional/corerp/resources/persistent_volume_test.go
+++ b/test/functional/corerp/resources/persistent_volume_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func Test_PersistentVolume(t *testing.T) {
+
 	template := "testdata/corerp-resources-volume-azure-keyvault.bicep"
 	name := "corerp-resources-volume-azure-keyvault"
 	appNamespace := "corerp-resources-volume-azure-keyvault-app"
@@ -53,6 +54,7 @@ func Test_PersistentVolume(t *testing.T) {
 			},
 		},
 	})
+	test.RequiredFeatures = []corerp.RequiredFeature{corerp.FeatureCSIDriver}
 
 	test.Test(t)
 }


### PR DESCRIPTION
This change adds the ability for a functional test to declare "required features" like a CSI driver or Dapr. Then the test will detect the installation of those features and skip itself if appropriate.

I've applied to the existing tests that have a dependency on either CSI drivers or Dapr.
