### PR TITLE
Disable K8s Service Links

### DIFF
--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/project-radius/radius/pkg/armrpc/api/conv"
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
 	"github.com/project-radius/radius/pkg/corerp/handlers"
@@ -490,6 +491,13 @@ func (r Renderer) makeDeployment(ctx context.Context, applicationName string, op
 					Annotations: map[string]string{},
 				},
 				Spec: corev1.PodSpec{
+					// See: https://github.com/kubernetes/kubernetes/issues/92226 and
+					// 		https://github.com/project-radius/radius/issues/3002
+					//
+					// Service links are a flawed and Kubernetes-only feature that we don't
+					// want to leak into Radius containers.
+					EnableServiceLinks: to.Ptr(false),
+
 					ServiceAccountName: serviceAccountName,
 					Containers:         []corev1.Container{container},
 					Volumes:            volumes,

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -271,6 +271,12 @@ func Test_Render_Basic(t *testing.T) {
 		require.Equal(t, labels, deployment.Spec.Template.Labels)
 		require.Equal(t, matchLabels, deployment.Spec.Selector.MatchLabels)
 
+		// See https://github.com/project-radius/radius/issues/3002
+		//
+		// We disable service links and rely on Radius' connections feature instead.
+		require.NotNil(t, deployment.Spec.Template.Spec.EnableServiceLinks)
+		require.False(t, *deployment.Spec.Template.Spec.EnableServiceLinks)
+
 		require.Len(t, deployment.Spec.Template.Spec.Containers, 1)
 
 		container := deployment.Spec.Template.Spec.Containers[0]


### PR DESCRIPTION
Fixes: radius-project/core-team#749

This change disables Kubernetes service links, a feature that injects environment variables for each service into pods. We're disabling this feature because it has plenty of issues and it's platform-specific (kubernetes). See the issues mentioned in comments for context.

Radius provides its own service-discovery mechanism without the same problems (connections).
