### PR TITLE
Update interface{} -> any

### DIFF
--- a/cmd/appcore-async/main.go
+++ b/cmd/appcore-async/main.go
@@ -64,7 +64,7 @@ func main() {
 		services = append(services, data.NewEmbeddedETCDService(data.EmbeddedETCDServiceOptions{ClientConfigSink: client}))
 	}
 
-	loggerValues := []interface{}{}
+	loggerValues := []any{}
 	host := &hosting.Host{
 		Services: services,
 

--- a/cmd/appcore-rp/main.go
+++ b/cmd/appcore-rp/main.go
@@ -108,7 +108,7 @@ func main() {
 		hostingSvc = append(hostingSvc, data.NewEmbeddedETCDService(data.EmbeddedETCDServiceOptions{ClientConfigSink: client}))
 	}
 
-	loggerValues := []interface{}{}
+	loggerValues := []any{}
 	host := &hosting.Host{
 		Services: hostingSvc,
 

--- a/cmd/applink-rp/main.go
+++ b/cmd/applink-rp/main.go
@@ -70,7 +70,7 @@ func main() {
 		hostingSvc = append(hostingSvc, data.NewEmbeddedETCDService(data.EmbeddedETCDServiceOptions{ClientConfigSink: client}))
 	}
 
-	loggerValues := []interface{}{}
+	loggerValues := []any{}
 	host := &hosting.Host{
 		Services: hostingSvc,
 

--- a/cmd/rad/cmd/appList.go
+++ b/cmd/rad/cmd/appList.go
@@ -50,7 +50,7 @@ func listApplications(cmd *cobra.Command, args []string) error {
 	return printOutput(cmd, applicationList, false)
 }
 
-func printOutput(cmd *cobra.Command, obj interface{}, isLegacy bool) error {
+func printOutput(cmd *cobra.Command, obj any, isLegacy bool) error {
 	format, err := cli.RequireOutput(cmd)
 	if err != nil {
 		return err

--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -260,7 +260,7 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 	}
 
 	workspace = &workspaces.Workspace{
-		Connection: map[string]interface{}{
+		Connection: map[string]any{
 			"kind":    "kubernetes",
 			"context": contextName,
 		},

--- a/cmd/rad/cmd/resource.go
+++ b/cmd/rad/cmd/resource.go
@@ -15,7 +15,7 @@ func init() {
 	resourceCmd.PersistentFlags().StringP("workspace", "w", "", "The workspace name")
 }
 
-func NewResourceCommand() *cobra.Command{
+func NewResourceCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "resource",
 		Short: "Manage resources",

--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -91,7 +91,7 @@ func prettyPrintRPError(err error) string {
 	return err.Error()
 }
 
-func prettyPrintJSON(o interface{}) (string, error) {
+func prettyPrintJSON(o any) (string, error) {
 	b, err := json.MarshalIndent(o, "", "  ")
 	if err != nil {
 		return "", err

--- a/pkg/armrpc/api/v1/errorresponse.go
+++ b/pkg/armrpc/api/v1/errorresponse.go
@@ -23,6 +23,6 @@ type ErrorDetails struct {
 
 // ErrorAdditionalInfo represents abritrary additional information as part of an error as defined by the ARM API.
 type ErrorAdditionalInfo struct {
-	Type string                 `json:"type"`
-	Info map[string]interface{} `json:"info"`
+	Type string         `json:"type"`
+	Info map[string]any `json:"info"`
 }

--- a/pkg/armrpc/api/v1/paginatedlist.go
+++ b/pkg/armrpc/api/v1/paginatedlist.go
@@ -7,6 +7,6 @@ package v1
 
 // PaginatedList represents the object for resource list pagination.
 type PaginatedList struct {
-	Value    []interface{} `json:"value"`
-	NextLink string        `json:"nextLink,omitempty"`
+	Value    []any  `json:"value"`
+	NextLink string `json:"nextLink,omitempty"`
 }

--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -366,7 +366,7 @@ func updateResourceState(ctx context.Context, sc store.StorageClient, id string,
 		return err
 	}
 
-	objmap := obj.Data.(map[string]interface{})
+	objmap := obj.Data.(map[string]any)
 	pState, ok := objmap["provisioningState"].(string)
 	if ok && strings.EqualFold(pState, string(state)) {
 		// Do not update it if provisioning state is already the target state.

--- a/pkg/armrpc/asyncoperation/worker/worker_runoperation_test.go
+++ b/pkg/armrpc/asyncoperation/worker/worker_runoperation_test.go
@@ -73,7 +73,7 @@ func newTestResourceObject() *store.Object {
 		Data: map[string]any{
 			"name":              "env0",
 			"provisioningState": "Accepted",
-			"properties":        map[string]interface{}{},
+			"properties":        map[string]any{},
 		},
 	}
 }

--- a/pkg/armrpc/asyncoperation/worker/worker_test.go
+++ b/pkg/armrpc/asyncoperation/worker/worker_test.go
@@ -30,16 +30,16 @@ func TestDefaultOptions(t *testing.T) {
 func TestUpdateResourceState(t *testing.T) {
 	updateStates := []struct {
 		tc          string
-		in          map[string]interface{}
+		in          map[string]any
 		updateState v1.ProvisioningState
 		outErr      error
 		callSave    bool
 	}{
 		{
 			tc: "not found provisioningState",
-			in: map[string]interface{}{
+			in: map[string]any{
 				"name":       "env0",
-				"properties": map[string]interface{}{},
+				"properties": map[string]any{},
 			},
 			updateState: v1.ProvisioningStateAccepted,
 			outErr:      nil,
@@ -47,10 +47,10 @@ func TestUpdateResourceState(t *testing.T) {
 		},
 		{
 			tc: "not update state",
-			in: map[string]interface{}{
+			in: map[string]any{
 				"name":              "env0",
 				"provisioningState": "Accepted",
-				"properties":        map[string]interface{}{},
+				"properties":        map[string]any{},
 			},
 			updateState: v1.ProvisioningStateAccepted,
 			outErr:      nil,
@@ -58,10 +58,10 @@ func TestUpdateResourceState(t *testing.T) {
 		},
 		{
 			tc: "update state",
-			in: map[string]interface{}{
+			in: map[string]any{
 				"name":              "env0",
 				"provisioningState": "Updating",
-				"properties":        map[string]interface{}{},
+				"properties":        map[string]any{},
 			},
 			updateState: v1.ProvisioningStateAccepted,
 			outErr:      nil,
@@ -91,7 +91,7 @@ func TestUpdateResourceState(t *testing.T) {
 					EXPECT().
 					Save(gomock.Any(), gomock.Any(), gomock.Any()).
 					DoAndReturn(func(ctx context.Context, obj *store.Object, options ...store.SaveOptions) error {
-						k := obj.Data.(map[string]interface{})
+						k := obj.Data.(map[string]any)
 						require.Equal(t, k["provisioningState"].(string), string(tt.updateState))
 						return nil
 					})

--- a/pkg/armrpc/authentication/arm_cert_manager.go
+++ b/pkg/armrpc/authentication/arm_cert_manager.go
@@ -71,7 +71,8 @@ func IsValidThumbprint(thumbprint string) bool {
 }
 
 // Start fetching the client certificates from the arm metadata endpoint during service start up
-//  and runs in the background the periodic certificate refresher.
+//
+//	and runs in the background the periodic certificate refresher.
 func (acm *ArmCertManager) Start(ctx context.Context) error {
 	certs, err := acm.refreshCert()
 	if err != nil {

--- a/pkg/armrpc/authentication/arm_cert_store.go
+++ b/pkg/armrpc/authentication/arm_cert_store.go
@@ -23,7 +23,7 @@ func storeCertificates(certificates []Certificate) {
 func getValidCertificates() []Certificate {
 	purgeOldCertificates()
 	var validCertificates []Certificate
-	ArmCertStore.Range(func(k, v interface{}) bool {
+	ArmCertStore.Range(func(k, v any) bool {
 		valid := v.(Certificate).isValid()
 		if valid {
 			validCertificates = append(validCertificates, v.(Certificate))
@@ -36,7 +36,7 @@ func getValidCertificates() []Certificate {
 // purgeOldCertificates updates the cert store with active thumbprints
 func purgeOldCertificates() {
 	var certificates []Certificate
-	ArmCertStore.Range(func(k, v interface{}) bool {
+	ArmCertStore.Range(func(k, v any) bool {
 		expired := v.(Certificate).isExpired()
 		if expired {
 			certificates = append(certificates, v.(Certificate))

--- a/pkg/armrpc/frontend/controller/controller.go
+++ b/pkg/armrpc/frontend/controller/controller.go
@@ -113,7 +113,7 @@ func (b *BaseController) StatusManager() sm.StatusManager {
 }
 
 // GetResource is the helper to get the resource via storage client.
-func (c *BaseController) GetResource(ctx context.Context, id string, out interface{}) (etag string, err error) {
+func (c *BaseController) GetResource(ctx context.Context, id string, out any) (etag string, err error) {
 	etag = ""
 	var res *store.Object
 	if res, err = c.StorageClient().Get(ctx, id); err == nil {
@@ -126,7 +126,7 @@ func (c *BaseController) GetResource(ctx context.Context, id string, out interfa
 }
 
 // SaveResource is the helper to save the resource via storage client.
-func (c *BaseController) SaveResource(ctx context.Context, id string, in interface{}, etag string) (*store.Object, error) {
+func (c *BaseController) SaveResource(ctx context.Context, id string, in any, etag string) (*store.Object, error) {
 	nr := &store.Object{
 		Metadata: store.Metadata{
 			ID: id,

--- a/pkg/armrpc/frontend/defaultoperation/listresources.go
+++ b/pkg/armrpc/frontend/defaultoperation/listresources.go
@@ -56,7 +56,7 @@ func (e *ListResources[P, T]) Run(ctx context.Context, w http.ResponseWriter, re
 func (e *ListResources[P, T]) createPaginationResponse(ctx context.Context, req *http.Request, result *store.ObjectQueryResult) (*v1.PaginatedList, error) {
 	serviceCtx := v1.ARMRequestContextFromContext(ctx)
 
-	items := []interface{}{}
+	items := []any{}
 	for _, item := range result.Items {
 		resource := new(T)
 		if err := item.As(resource); err != nil {

--- a/pkg/armrpc/rest/results.go
+++ b/pkg/armrpc/rest/results.go
@@ -35,19 +35,19 @@ type Response interface {
 //
 // This is used when modification to an existing resource is processed synchronously.
 type OKResponse struct {
-	Body    interface{}
+	Body    any
 	Headers map[string]string
 }
 
 // NewOKResponse creates an OKResponse that will write a 200 OK with the provided body as JSON.
 // Set the body to nil to write an empty 200 OK.
-func NewOKResponse(body interface{}) Response {
+func NewOKResponse(body any) Response {
 	return &OKResponse{Body: body}
 }
 
 // NewOKResponseWithHeaders creates an OKResponse that will write a 200 OK with the provided body as JSON.
 // Set the body to nil to write an empty 200 OK.
-func NewOKResponseWithHeaders(body interface{}, headers map[string]string) Response {
+func NewOKResponseWithHeaders(body any, headers map[string]string) Response {
 	return &OKResponse{
 		Body:    body,
 		Headers: headers,
@@ -85,10 +85,10 @@ func (r *OKResponse) Apply(ctx context.Context, w http.ResponseWriter, req *http
 //
 // This is used when a request to create a new resource is processed synchronously.
 type CreatedResponse struct {
-	Body interface{}
+	Body any
 }
 
-func NewCreatedResponse(body interface{}) Response {
+func NewCreatedResponse(body any) Response {
 	response := &CreatedResponse{Body: body}
 	return response
 }
@@ -116,12 +116,12 @@ func (r *CreatedResponse) Apply(ctx context.Context, w http.ResponseWriter, req 
 //
 // This is used when a request to create a new resource is processed asynchronously.
 type CreatedAsyncResponse struct {
-	Body     interface{}
+	Body     any
 	Location string
 	Scheme   string
 }
 
-func NewCreatedAsyncResponse(body interface{}, location string, scheme string) Response {
+func NewCreatedAsyncResponse(body any, location string, scheme string) Response {
 	return &CreatedAsyncResponse{Body: body, Location: location, Scheme: scheme}
 }
 
@@ -165,13 +165,13 @@ func (r *CreatedAsyncResponse) Apply(ctx context.Context, w http.ResponseWriter,
 //
 // This is used when a request to create an existing resource is processed asynchronously.
 type AcceptedAsyncResponse struct {
-	Body     interface{}
+	Body     any
 	Location string
 	Scheme   string
 }
 
 // NewAcceptedAsyncResponse creates an AcceptedAsyncResponse
-func NewAcceptedAsyncResponse(body interface{}, location string, scheme string) Response {
+func NewAcceptedAsyncResponse(body any, location string, scheme string) Response {
 	return &AcceptedAsyncResponse{Body: body, Location: location, Scheme: scheme}
 }
 
@@ -215,7 +215,7 @@ func (r *AcceptedAsyncResponse) Apply(ctx context.Context, w http.ResponseWriter
 
 // AsyncOperationResponse represents the response for an async operation request.
 type AsyncOperationResponse struct {
-	Body        interface{}
+	Body        any
 	Location    string
 	Code        int
 	ResourceID  resources.ID
@@ -226,7 +226,7 @@ type AsyncOperationResponse struct {
 }
 
 // NewAsyncOperationResponse creates an AsyncOperationResponse
-func NewAsyncOperationResponse(body interface{}, location string, code int, resourceID resources.ID, operationID uuid.UUID, apiVersion string, rootScope string, pathBase string) Response {
+func NewAsyncOperationResponse(body any, location string, code int, resourceID resources.ID, operationID uuid.UUID, apiVersion string, rootScope string, pathBase string) Response {
 	return &AsyncOperationResponse{
 		Body:        body,
 		Location:    location,

--- a/pkg/armrpc/rest/results_test.go
+++ b/pkg/armrpc/rest/results_test.go
@@ -100,8 +100,8 @@ func Test_NewLinkedResourceUpdateErrorResponse(t *testing.T) {
 
 func Test_NewNoResourceMatchResponse(t *testing.T) {
 	response := NewNoResourceMatchResponse("/some/url")
-	payload := map[string]interface{}{
-		"error": map[string]interface{}{
+	payload := map[string]any{
+		"error": map[string]any{
 			"code":    v1.CodeNotFound,
 			"message": "the specified path \"/some/url\" did not match any resource",
 			"target":  "/some/url",

--- a/pkg/aws/operations/operations.go
+++ b/pkg/aws/operations/operations.go
@@ -16,10 +16,10 @@ import (
 )
 
 type ResourceTypeSchema struct {
-	Properties           map[string]interface{} `json:"properties,omitempty"`
-	ReadOnlyProperties   []string               `json:"readOnlyProperties,omitempty"`
-	CreateOnlyProperties []string               `json:"createOnlyProperties,omitempty"`
-	WriteOnlyProperties  []string               `json:"writeOnlyProperties,omitempty"`
+	Properties           map[string]any `json:"properties,omitempty"`
+	ReadOnlyProperties   []string       `json:"readOnlyProperties,omitempty"`
+	CreateOnlyProperties []string       `json:"createOnlyProperties,omitempty"`
+	WriteOnlyProperties  []string       `json:"writeOnlyProperties,omitempty"`
 }
 
 // FlattenProperties flattens a state object.
@@ -36,13 +36,13 @@ type ResourceTypeSchema struct {
 //	"NumShards": 1
 //	"ClusterEndpoint/Address": "test-address"
 //	"ClusterEndpoint/Port": 3000
-func FlattenProperties(state map[string]interface{}) map[string]interface{} {
-	flattenedState := map[string]interface{}{}
+func FlattenProperties(state map[string]any) map[string]any {
+	flattenedState := map[string]any{}
 
 	for k, v := range state {
 		// If the value is a map, flatten it
 		if reflect.TypeOf(v).Kind() == reflect.Map {
-			flattenedSubState := FlattenProperties(v.(map[string]interface{}))
+			flattenedSubState := FlattenProperties(v.(map[string]any))
 
 			for subK, subV := range flattenedSubState {
 				key := k + "/" + subK
@@ -70,8 +70,8 @@ func FlattenProperties(state map[string]interface{}) map[string]interface{} {
 //	  "Address": "test-address"
 //	  "Port": 3000
 //	}
-func UnflattenProperties(state map[string]interface{}) map[string]interface{} {
-	unflattenedState := map[string]interface{}{}
+func UnflattenProperties(state map[string]any) map[string]any {
+	unflattenedState := map[string]any{}
 
 	for k, v := range state {
 		splitPath := strings.Split(k, "/")
@@ -80,17 +80,17 @@ func UnflattenProperties(state map[string]interface{}) map[string]interface{} {
 		if len(splitPath) == 1 {
 			unflattenedState[rootKey] = v
 		} else {
-			var currentState interface{} = unflattenedState
+			var currentState any = unflattenedState
 			for i := 0; i < len(splitPath); i++ {
 				subKey := splitPath[i]
 				if i == len(splitPath)-1 {
-					if currentStateMap, ok := currentState.(map[string]interface{}); ok {
+					if currentStateMap, ok := currentState.(map[string]any); ok {
 						currentStateMap[subKey] = v
 					}
 				} else {
-					if currentStateMap, ok := currentState.(map[string]interface{}); ok {
+					if currentStateMap, ok := currentState.(map[string]any); ok {
 						if _, exists := currentStateMap[subKey]; !exists {
-							currentStateMap[subKey] = map[string]interface{}{}
+							currentStateMap[subKey] = map[string]any{}
 						}
 
 						currentState = currentStateMap[subKey]
@@ -116,7 +116,7 @@ func GeneratePatch(currentState []byte, desiredState []byte, schema []byte) (jso
 	}
 
 	// Get the current state of the resource
-	var currentStateObject map[string]interface{}
+	var currentStateObject map[string]any
 	err = json.Unmarshal(currentState, &currentStateObject)
 	if err != nil {
 		return nil, err
@@ -124,7 +124,7 @@ func GeneratePatch(currentState []byte, desiredState []byte, schema []byte) (jso
 	flattenedCurrentStateObject := FlattenProperties(currentStateObject)
 
 	// Get the desired state of the resource
-	var desiredStateObject map[string]interface{}
+	var desiredStateObject map[string]any
 	err = json.Unmarshal(desiredState, &desiredStateObject)
 	if err != nil {
 		return nil, err

--- a/pkg/aws/operations/operations_test.go
+++ b/pkg/aws/operations/operations_test.go
@@ -15,9 +15,9 @@ import (
 )
 
 func TestFlattenProperties(t *testing.T) {
-	properties := map[string]interface{}{
-		"A": map[string]interface{}{
-			"B": map[string]interface{}{
+	properties := map[string]any{
+		"A": map[string]any{
+			"B": map[string]any{
 				"C": "D",
 			},
 			"E": "F",
@@ -26,7 +26,7 @@ func TestFlattenProperties(t *testing.T) {
 	}
 
 	flattened := FlattenProperties(properties)
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"A/B/C": "D",
 		"A/E":   "F",
 		"G":     "H",
@@ -34,16 +34,16 @@ func TestFlattenProperties(t *testing.T) {
 }
 
 func TestUnflattenProperties(t *testing.T) {
-	properties := map[string]interface{}{
+	properties := map[string]any{
 		"A/B/C": "D",
 		"A/E":   "F",
 		"G":     "H",
 	}
 
 	unflattened := UnflattenProperties(properties)
-	require.Equal(t, map[string]interface{}{
-		"A": map[string]interface{}{
-			"B": map[string]interface{}{
+	require.Equal(t, map[string]any{
+		"A": map[string]any{
+			"B": map[string]any{
 				"C": "D",
 			},
 			"E": "F",
@@ -53,9 +53,9 @@ func TestUnflattenProperties(t *testing.T) {
 }
 
 func TestFlattenUnflattenInverses(t *testing.T) {
-	properties := map[string]interface{}{
-		"A": map[string]interface{}{
-			"B": map[string]interface{}{
+	properties := map[string]any{
+		"A": map[string]any{
+			"B": map[string]any{
 				"C": "D",
 			},
 			"E": "F",
@@ -69,8 +69,8 @@ func TestFlattenUnflattenInverses(t *testing.T) {
 }
 
 func TestFlattenUnflattenRealData(t *testing.T) {
-	properties := map[string]interface{}{
-		"ClusterEndpoint:": map[string]interface{}{
+	properties := map[string]any{
+		"ClusterEndpoint:": map[string]any{
 			"Address": "https://A1B2C3D4E5F6.gr7.us-west-2.eks.amazonaws.com",
 			"Port":    443,
 		},
@@ -85,42 +85,42 @@ func TestFlattenUnflattenRealData(t *testing.T) {
 func Test_GeneratePatch(t *testing.T) {
 	testCases := []struct {
 		name          string
-		currentState  map[string]interface{}
-		desiredState  map[string]interface{}
-		schema        map[string]interface{}
+		currentState  map[string]any
+		desiredState  map[string]any
+		schema        map[string]any
 		expectedPatch jsondiff.Patch
 	}{
 		{
 			"No updates creates empty patch",
-			map[string]interface{}{
+			map[string]any{
 				"A": "B",
-				"C": map[string]interface{}{
-					"D": map[string]interface{}{
+				"C": map[string]any{
+					"D": map[string]any{
 						"E": "F",
 					},
-					"G": map[string]interface{}{
+					"G": map[string]any{
 						"I": "J",
 					},
 					"K": "L",
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"A": "B",
-				"C": map[string]interface{}{
-					"G": map[string]interface{}{
+				"C": map[string]any{
+					"G": map[string]any{
 						"I": "J",
 					},
 				},
 			},
-			map[string]interface{}{
-				"properties": map[string]interface{}{
-					"A": map[string]interface{}{},
-					"C": map[string]interface{}{},
+			map[string]any{
+				"properties": map[string]any{
+					"A": map[string]any{},
+					"C": map[string]any{},
 				},
-				"readOnlyProperties": []interface{}{
+				"readOnlyProperties": []any{
 					"/properties/C/D/E",
 				},
-				"createOnlyProperties": []interface{}{
+				"createOnlyProperties": []any{
 					"/properties/C/K",
 				},
 			},
@@ -128,35 +128,35 @@ func Test_GeneratePatch(t *testing.T) {
 		},
 		{
 			"Update creates patch",
-			map[string]interface{}{
+			map[string]any{
 				"A": "B",
-				"C": map[string]interface{}{
-					"D": map[string]interface{}{
+				"C": map[string]any{
+					"D": map[string]any{
 						"E": "F",
 					},
-					"G": map[string]interface{}{
+					"G": map[string]any{
 						"I": "J",
 					},
 					"K": "L",
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"A": "Test",
-				"C": map[string]interface{}{
-					"G": map[string]interface{}{
+				"C": map[string]any{
+					"G": map[string]any{
 						"I": "Test2",
 					},
 				},
 			},
-			map[string]interface{}{
-				"properties": map[string]interface{}{
-					"A": map[string]interface{}{},
-					"C": map[string]interface{}{},
+			map[string]any{
+				"properties": map[string]any{
+					"A": map[string]any{},
+					"C": map[string]any{},
 				},
-				"readOnlyProperties": []interface{}{
+				"readOnlyProperties": []any{
 					"/properties/C/D/E",
 				},
-				"createOnlyProperties": []interface{}{
+				"createOnlyProperties": []any{
 					"/properties/C/K",
 				},
 			},
@@ -177,27 +177,27 @@ func Test_GeneratePatch(t *testing.T) {
 		},
 		{
 			"Specify create-only properties",
-			map[string]interface{}{
-				"A": map[string]interface{}{
-					"B": map[string]interface{}{
+			map[string]any{
+				"A": map[string]any{
+					"B": map[string]any{
 						"C": "D",
 						"E": "F",
 					},
 				},
 			},
-			map[string]interface{}{
-				"A": map[string]interface{}{
-					"B": map[string]interface{}{
+			map[string]any{
+				"A": map[string]any{
+					"B": map[string]any{
 						"C": "D",
 						"E": "Test",
 					},
 				},
 			},
-			map[string]interface{}{
-				"properties": map[string]interface{}{
-					"A": map[string]interface{}{},
+			map[string]any{
+				"properties": map[string]any{
+					"A": map[string]any{},
 				},
-				"createOnlyProperties": []interface{}{
+				"createOnlyProperties": []any{
 					"/properties/A/B/C",
 				},
 			},
@@ -212,30 +212,30 @@ func Test_GeneratePatch(t *testing.T) {
 		},
 		{
 			"Remove object",
-			map[string]interface{}{
-				"A": map[string]interface{}{
-					"B": map[string]interface{}{
+			map[string]any{
+				"A": map[string]any{
+					"B": map[string]any{
 						"C": "D",
 						"E": "F",
 					},
 				},
 				"G": "H",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"G": "H",
 			},
-			map[string]interface{}{
-				"properties": map[string]interface{}{
-					"A": map[string]interface{}{},
-					"G": map[string]interface{}{},
+			map[string]any{
+				"properties": map[string]any{
+					"A": map[string]any{},
+					"G": map[string]any{},
 				},
 			},
 			jsondiff.Patch{
 				{
 					Type: "remove",
 					Path: "/A",
-					OldValue: map[string]interface{}{
-						"B": map[string]interface{}{
+					OldValue: map[string]any{
+						"B": map[string]any{
 							"C": "D",
 							"E": "F",
 						},
@@ -246,20 +246,20 @@ func Test_GeneratePatch(t *testing.T) {
 		},
 		{
 			"Updating create-and-write-only property noops",
-			map[string]interface{}{
+			map[string]any{
 				"A": "B",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"A": "C",
 			},
-			map[string]interface{}{
-				"properties": map[string]interface{}{
-					"A": map[string]interface{}{},
+			map[string]any{
+				"properties": map[string]any{
+					"A": map[string]any{},
 				},
-				"createOnlyProperties": []interface{}{
+				"createOnlyProperties": []any{
 					"/properties/A",
 				},
-				"writeOnlyProperties": []interface{}{
+				"writeOnlyProperties": []any{
 					"/properties/A",
 				},
 			},

--- a/pkg/azure/clients/customaction.go
+++ b/pkg/azure/clients/customaction.go
@@ -19,11 +19,11 @@ type CustomActionClient struct {
 }
 
 type CustomActionResponse struct {
-	Body     map[string]interface{}
+	Body     map[string]any
 	Response autorest.Response
 }
 
-func (client CustomActionClient) InvokeCustomAction(ctx context.Context, id string, apiVersion string, action string, body interface{}) (result CustomActionResponse, err error) {
+func (client CustomActionClient) InvokeCustomAction(ctx context.Context, id string, apiVersion string, action string, body any) (result CustomActionResponse, err error) {
 	req, err := client.InvokeCustomActionPreparer(ctx, id, apiVersion, action, body)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "CustomActionClient", "InvokeCustomAction", nil, "Failure preparing request")
@@ -45,13 +45,13 @@ func (client CustomActionClient) InvokeCustomAction(ctx context.Context, id stri
 	return
 }
 
-func (client CustomActionClient) InvokeCustomActionPreparer(ctx context.Context, id string, apiVersion string, action string, body interface{}) (*http.Request, error) {
-	pathParameters := map[string]interface{}{
+func (client CustomActionClient) InvokeCustomActionPreparer(ctx context.Context, id string, apiVersion string, action string, body any) (*http.Request, error) {
+	pathParameters := map[string]any{
 		"id":     autorest.Encode("none", id),
 		"action": autorest.Encode("path", action),
 	}
 
-	queryParameters := map[string]interface{}{
+	queryParameters := map[string]any{
 		"api-version": apiVersion,
 	}
 
@@ -73,7 +73,7 @@ func (client CustomActionClient) InvokeCustomActionSender(req *http.Request) (*h
 }
 
 func (client CustomActionClient) InvokeCustomActionResponder(resp *http.Response) (result CustomActionResponse, err error) {
-	body := map[string]interface{}{}
+	body := map[string]any{}
 	err = autorest.Respond(
 		resp,
 		azure.WithErrorUnlessStatusCode(http.StatusOK),

--- a/pkg/azure/clients/resourcedeploymentclient.go
+++ b/pkg/azure/clients/resourcedeploymentclient.go
@@ -27,13 +27,13 @@ type Deployment struct {
 // DeploymentProperties deployment properties.
 type DeploymentProperties struct {
 	// Template - The template content. You use this element when you want to pass the template syntax directly in the request rather than link to an existing template. It can be a JObject or well-formed JSON string. Use either the templateLink property or the template property, but not both.
-	Template interface{} `json:"template,omitempty"`
+	Template any `json:"template,omitempty"`
 	// TemplateLink - The URI of the template. Use either the templateLink property or the template property, but not both.
 	TemplateLink *resources.TemplateLink `json:"templateLink,omitempty"`
 	//ProviderConfig specifies the scope for resources
-	ProviderConfig interface{} `json:"providerconfig,omitempty"`
+	ProviderConfig any `json:"providerconfig,omitempty"`
 	// Parameters - Name and value pairs that define the deployment parameters for the template. You use this element when you want to provide the parameter values directly in the request rather than link to an existing parameter file. Use either the parametersLink property or the parameters property, but not both. It can be a JObject or a well formed JSON string.
-	Parameters interface{} `json:"parameters,omitempty"`
+	Parameters any `json:"parameters,omitempty"`
 	// ParametersLink - The URI of parameters file. You use this element to link to an existing parameters file. Use either the parametersLink property or the parameters property, but not both.
 	ParametersLink *resources.ParametersLink `json:"parametersLink,omitempty"`
 	// Mode - The mode that is used to deploy resources. This value can be either Incremental or Complete. In Incremental mode, resources are deployed without deleting existing resources that are not included in the template. In Complete mode, resources are deployed and existing resources in the resource group that are not included in the template are deleted. Be careful when using Complete mode as you may unintentionally delete resources. Possible values include: 'DeploymentModeIncremental', 'DeploymentModeComplete'
@@ -114,7 +114,7 @@ func (client ResourceDeploymentClient) CreateOrUpdate(ctx context.Context, resou
 // CreateOrUpdatePreparer prepares the CreateOrUpdate request.
 func (client ResourceDeploymentClient) ResourceCreateOrUpdatePreparer(ctx context.Context, resourceID string, parameters Deployment) (*http.Request, error) {
 	const APIVersion = "2020-10-01"
-	queryParameters := map[string]interface{}{
+	queryParameters := map[string]any{
 		"api-version": APIVersion,
 	}
 

--- a/pkg/azure/clients/resourcedeploymentoperationsclient.go
+++ b/pkg/azure/clients/resourcedeploymentoperationsclient.go
@@ -73,7 +73,7 @@ func (client ResourceDeploymentOperationsClient) List(ctx context.Context, resou
 // ListPreparer prepares the List request.
 func (client ResourceDeploymentOperationsClient) ListPreparer(ctx context.Context, resourceId string, top *int32) (*http.Request, error) {
 	const APIVersion = "2020-10-01"
-	queryParameters := map[string]interface{}{
+	queryParameters := map[string]any{
 		"api-version": APIVersion,
 	}
 	if top != nil {

--- a/pkg/azure/clients/unfold.go
+++ b/pkg/azure/clients/unfold.go
@@ -23,12 +23,12 @@ import (
 // being the Details field having more structure.  We need that structure to unfold the
 // error messages.
 type ServiceError struct {
-	Code           string                   `json:"code,omitempty" yaml:"code,omitempty"`
-	Message        string                   `json:"message,omitempty" yaml:"message,omitempty"`
-	Target         *string                  `json:"target,omitempty" yaml:"target,omitempty"`
-	Details        []*v1.ErrorDetails       `json:"details,omitempty" yaml:"details,omitempty"`
-	InnerError     map[string]interface{}   `json:"innererror,omitempty" yaml:"innererror,omitempty"`
-	AdditionalInfo []map[string]interface{} `json:"additionalInfo,omitempty" yaml:"additionalInfo,omitempty"`
+	Code           string             `json:"code,omitempty" yaml:"code,omitempty"`
+	Message        string             `json:"message,omitempty" yaml:"message,omitempty"`
+	Target         *string            `json:"target,omitempty" yaml:"target,omitempty"`
+	Details        []*v1.ErrorDetails `json:"details,omitempty" yaml:"details,omitempty"`
+	InnerError     map[string]any     `json:"innererror,omitempty" yaml:"innererror,omitempty"`
+	AdditionalInfo []map[string]any   `json:"additionalInfo,omitempty" yaml:"additionalInfo,omitempty"`
 }
 
 // UnfoldServiceError unfolds the Details field in the given azure.ServiceError,
@@ -138,7 +138,7 @@ func TryUnfoldServiceError(err error) *ServiceError {
 	return UnfoldServiceError(svcError)
 }
 
-func roundTripJSON(input interface{}, output interface{}) error {
+func roundTripJSON(input any, output any) error {
 	b, err := json.Marshal(input)
 	if err != nil {
 		return err
@@ -146,7 +146,7 @@ func roundTripJSON(input interface{}, output interface{}) error {
 	return json.Unmarshal(b, output)
 }
 
-func extractString(o interface{}) *string {
+func extractString(o any) *string {
 	if o == nil {
 		return nil
 	}

--- a/pkg/azure/clients/unfold_test.go
+++ b/pkg/azure/clients/unfold_test.go
@@ -124,7 +124,7 @@ func TestUnfoldServiceError(t *testing.T) {
 		{
 			name: "nested once",
 			input: azure.ServiceError{
-				Details: []map[string]interface{}{{
+				Details: []map[string]any{{
 					"code":    to.Ptr("DownstreamEndpointError"),
 					"message": `{"error": { "code": "BadRequest" }}`,
 				}},
@@ -217,7 +217,7 @@ func TestTryUnfoldServiceError(t *testing.T) {
 		{
 			name: "nested once",
 			input: &azure.ServiceError{
-				Details: []map[string]interface{}{{
+				Details: []map[string]any{{
 					"code":    to.Ptr("DownstreamEndpointError"),
 					"message": `{"error": { "code": "BadRequest" }}`,
 				}},

--- a/pkg/azure/clientv2/resourcedeploymentclient.go
+++ b/pkg/azure/clientv2/resourcedeploymentclient.go
@@ -32,13 +32,13 @@ type Deployment struct {
 // DeploymentProperties deployment properties.
 type DeploymentProperties struct {
 	// Template - The template content. You use this element when you want to pass the template syntax directly in the request rather than link to an existing template. It can be a JObject or well-formed JSON string. Use either the templateLink property or the template property, but not both.
-	Template interface{} `json:"template,omitempty"`
+	Template any `json:"template,omitempty"`
 	// TemplateLink - The URI of the template. Use either the templateLink property or the template property, but not both.
 	TemplateLink *armresources.TemplateLink `json:"templateLink,omitempty"`
 	//ProviderConfig specifies the scope for resources
-	ProviderConfig interface{} `json:"providerconfig,omitempty"`
+	ProviderConfig any `json:"providerconfig,omitempty"`
 	// Parameters - Name and value pairs that define the deployment parameters for the template. You use this element when you want to provide the parameter values directly in the request rather than link to an existing parameter file. Use either the parametersLink property or the parameters property, but not both. It can be a JObject or a well formed JSON string.
-	Parameters interface{} `json:"parameters,omitempty"`
+	Parameters any `json:"parameters,omitempty"`
 	// ParametersLink - The URI of parameters file. You use this element to link to an existing parameters file. Use either the parametersLink property or the parameters property, but not both.
 	ParametersLink *armresources.ParametersLink `json:"parametersLink,omitempty"`
 	// Mode - The mode that is used to deploy resources. This value can be either Incremental or Complete. In Incremental mode, resources are deployed without deleting existing resources that are not included in the template. In Complete mode, resources are deployed and existing resources in the resource group that are not included in the template are deleted. Be careful when using Complete mode as you may unintentionally delete resources. Possible values include: 'DeploymentModeIncremental', 'DeploymentModeComplete'

--- a/pkg/azure/clientv2/unfold.go
+++ b/pkg/azure/clientv2/unfold.go
@@ -131,7 +131,7 @@ func TryUnfoldErrorResponse(err error) *generated.ErrorDetail {
 	return &errDetails
 }
 
-func roundTripJSON(input interface{}, output interface{}) error {
+func roundTripJSON(input any, output any) error {
 	b, err := json.Marshal(input)
 	if err != nil {
 		return err
@@ -139,7 +139,7 @@ func roundTripJSON(input interface{}, output interface{}) error {
 	return json.Unmarshal(b, output)
 }
 
-func extractString(o interface{}) *string {
+func extractString(o any) *string {
 	if o == nil {
 		return nil
 	}

--- a/pkg/cli/bicep/build.go
+++ b/pkg/cli/bicep/build.go
@@ -70,13 +70,13 @@ func runBicepRaw(args ...string) ([]byte, error) {
 	return bytes, nil
 }
 
-func runBicepJson(args ...string) (map[string]interface{}, error) {
+func runBicepJson(args ...string) (map[string]any, error) {
 	bytes, err := runBicepRaw(args...)
 	if err != nil {
 		return nil, err
 	}
 
-	template := map[string]interface{}{}
+	template := map[string]any{}
 	err = json.Unmarshal(bytes, &template)
 	if err != nil {
 		return nil, err
@@ -86,7 +86,7 @@ func runBicepJson(args ...string) (map[string]interface{}, error) {
 }
 
 // Build the provided `.bicep` file and returns the deployment template.
-func Build(filePath string) (map[string]interface{}, error) {
+func Build(filePath string) (map[string]any, error) {
 	// rad-bicep is being told to output the template to stdout and we will capture it
 	// rad-bicep will output compilation errors to stderr which will go to the user's console
 	return runBicepJson("build", "--stdout", filePath)

--- a/pkg/cli/bicep/convert_test.go
+++ b/pkg/cli/bicep/convert_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func Test_ConvertMapStringInterface(t *testing.T) {
-	in := make(map[string]map[string]interface{})
-	in["throughput"] = map[string]interface{}{"value": 400}
-	expected := map[string]interface{}{"throughput": 400}
+	in := make(map[string]map[string]any)
+	in["throughput"] = map[string]any{"value": 400}
+	expected := map[string]any{"throughput": 400}
 	result := ConvertToMapStringInterface(in)
 	require.Equal(t, result, expected)
 }

--- a/pkg/cli/bicep/deployment_parameters.go
+++ b/pkg/cli/bicep/deployment_parameters.go
@@ -32,7 +32,7 @@ func (OSFileSystem) Open(name string) (fs.File, error) {
 	return os.Open(name)
 }
 
-func (pp ParameterParser) ParseFileContents(input map[string]interface{}) (clients.DeploymentParameters, error) {
+func (pp ParameterParser) ParseFileContents(input map[string]any) (clients.DeploymentParameters, error) {
 	output := clients.DeploymentParameters{}
 
 	b, err := json.Marshal(input)
@@ -98,7 +98,7 @@ func (pp ParameterParser) parseSingle(input string, output clients.DeploymentPar
 			return err
 		}
 
-		var data interface{}
+		var data any
 		err = json.Unmarshal(b, &data)
 		if err != nil {
 			return err
@@ -132,13 +132,13 @@ func (pp ParameterParser) mergeParameters(output clients.DeploymentParameters, i
 	}
 }
 
-func (pp ParameterParser) mergeSingleParameter(output clients.DeploymentParameters, name string, input interface{}) {
+func (pp ParameterParser) mergeSingleParameter(output clients.DeploymentParameters, name string, input any) {
 	// We intentionally overwrite duplicates.
 	output[name] = NewParameter(input)
 }
 
-func NewParameter(value interface{}) map[string]interface{} {
-	return map[string]interface{}{
+func NewParameter(value any) map[string]any {
+	return map[string]any{
 		"value": value,
 	}
 }

--- a/pkg/cli/bicep/deployment_parameters_test.go
+++ b/pkg/cli/bicep/deployment_parameters_test.go
@@ -60,17 +60,17 @@ func Test_ParseParameters_Overwrite(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := clients.DeploymentParameters{
-		"key1": map[string]interface{}{
-			"value": map[string]interface{}{
+		"key1": map[string]any{
+			"value": map[string]any{
 				"someValue": true,
 			},
 		},
-		"key2": map[string]interface{}{
-			"value": map[string]interface{}{
+		"key2": map[string]any{
+			"value": map[string]any{
 				"someValue": "another-value",
 			},
 		},
-		"key3": map[string]interface{}{
+		"key3": map[string]any{
 			"value": "value3",
 		},
 	}
@@ -86,7 +86,7 @@ func Test_ParseParameters_File(t *testing.T) {
 	input, err := os.ReadFile(filepath.Join("testdata", "test-parameters.json"))
 	require.NoError(t, err)
 
-	template := map[string]interface{}{}
+	template := map[string]any{}
 	err = json.Unmarshal(input, &template)
 	require.NoError(t, err)
 
@@ -94,10 +94,10 @@ func Test_ParseParameters_File(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := clients.DeploymentParameters{
-		"param1": map[string]interface{}{
+		"param1": map[string]any{
 			"value": "value1",
 		},
-		"param2": map[string]interface{}{
+		"param2": map[string]any{
 			"value": "value2",
 		},
 	}

--- a/pkg/cli/bicep/envinject.go
+++ b/pkg/cli/bicep/envinject.go
@@ -10,7 +10,7 @@ package bicep
 // - parameters.environment exists && param not passed in -> inject environmentId
 // - parameters.environment does not exist -> noop
 // - input parameters already include environment -> noop.
-func InjectEnvironmentParam(deploymentTemplate map[string]interface{}, parameters map[string]map[string]interface{}, environmentId string) error {
+func InjectEnvironmentParam(deploymentTemplate map[string]any, parameters map[string]map[string]any, environmentId string) error {
 	return injectParam(deploymentTemplate, parameters, "environment", environmentId)
 }
 
@@ -19,16 +19,16 @@ func InjectEnvironmentParam(deploymentTemplate map[string]interface{}, parameter
 // - parameters.application exists && param not passed in -> inject environmentId
 // - parameters.application does not exist -> noop
 // - input parameters already include application -> noop.
-func InjectApplicationParam(deploymentTemplate map[string]interface{}, parameters map[string]map[string]interface{}, applicationId string) error {
+func InjectApplicationParam(deploymentTemplate map[string]any, parameters map[string]map[string]any, applicationId string) error {
 	return injectParam(deploymentTemplate, parameters, "application", applicationId)
 }
 
-func injectParam(deploymentTemplate map[string]interface{}, parameters map[string]map[string]interface{}, parameter string, value string) error {
+func injectParam(deploymentTemplate map[string]any, parameters map[string]map[string]any, parameter string, value string) error {
 	if deploymentTemplate["parameters"] == nil {
 		return nil
 	}
 
-	innerParameters := deploymentTemplate["parameters"].(map[string]interface{})
+	innerParameters := deploymentTemplate["parameters"].(map[string]any)
 	if innerParameters[parameter] == nil {
 		return nil
 	}
@@ -37,7 +37,7 @@ func injectParam(deploymentTemplate map[string]interface{}, parameters map[strin
 
 	// Set the value if it wasn't set at the command line by the user.
 	if _, ok := parameters[parameter]; !ok {
-		parameters[parameter] = map[string]interface{}{
+		parameters[parameter] = map[string]any{
 			"value": value,
 		}
 	}

--- a/pkg/cli/bicep/envinject_test.go
+++ b/pkg/cli/bicep/envinject_test.go
@@ -17,12 +17,12 @@ import (
 func Test_InjectEnvironmentParam_InjectedIfParamAvailable(t *testing.T) {
 	input, err := os.ReadFile(filepath.Join("testdata", "test-injectenvid.json"))
 	require.NoError(t, err)
-	template := map[string]interface{}{}
+	template := map[string]any{}
 
 	err = json.Unmarshal(input, &template)
 	require.NoError(t, err)
 
-	params := map[string]map[string]interface{}{}
+	params := map[string]map[string]any{}
 
 	err = InjectEnvironmentParam(template, params, "/planes/radius/local/resourceGroups/my-rg/providers/Application.Core/environments/my")
 	require.NoError(t, err)
@@ -33,12 +33,12 @@ func Test_InjectEnvironmentParam_InjectedIfParamAvailable(t *testing.T) {
 func Test_InjectApplicationParam_InjectedIfParamAvailable(t *testing.T) {
 	input, err := os.ReadFile(filepath.Join("testdata", "test-injectappid.json"))
 	require.NoError(t, err)
-	template := map[string]interface{}{}
+	template := map[string]any{}
 
 	err = json.Unmarshal(input, &template)
 	require.NoError(t, err)
 
-	params := map[string]map[string]interface{}{}
+	params := map[string]map[string]any{}
 
 	err = InjectApplicationParam(template, params, "/planes/radius/local/resourceGroups/my-rg/providers/Application.Core/applications/my")
 	require.NoError(t, err)
@@ -49,12 +49,12 @@ func Test_InjectApplicationParam_InjectedIfParamAvailable(t *testing.T) {
 func Test_injectParam_InjectedIfParamAvailable(t *testing.T) {
 	input, err := os.ReadFile(filepath.Join("testdata", "test-injectenvid.json"))
 	require.NoError(t, err)
-	template := map[string]interface{}{}
+	template := map[string]any{}
 
 	err = json.Unmarshal(input, &template)
 	require.NoError(t, err)
 
-	params := map[string]map[string]interface{}{}
+	params := map[string]map[string]any{}
 
 	err = injectParam(template, params, "environment", "/planes/radius/local/resourceGroups/my-rg/providers/Application.Core/environments/my")
 	require.NoError(t, err)
@@ -65,12 +65,12 @@ func Test_injectParam_InjectedIfParamAvailable(t *testing.T) {
 func Test_injectParam_NotInjectedIfNoParamAvailable(t *testing.T) {
 	input, err := os.ReadFile(filepath.Join("testdata", "test-noenv.json"))
 	require.NoError(t, err)
-	template := map[string]interface{}{}
+	template := map[string]any{}
 
 	err = json.Unmarshal(input, &template)
 	require.NoError(t, err)
 
-	params := map[string]map[string]interface{}{}
+	params := map[string]map[string]any{}
 
 	err = injectParam(template, params, "environment", "/planes/radius/local/resourceGroups/my-rg/providers/Application.Core/environments/my")
 	require.NoError(t, err)
@@ -81,12 +81,12 @@ func Test_injectParam_NotInjectedIfNoParamAvailable(t *testing.T) {
 func Test_injectParam_NotInjectedIfParamAlreadySet(t *testing.T) {
 	input, err := os.ReadFile(filepath.Join("testdata", "test-injectenvid.json"))
 	require.NoError(t, err)
-	template := map[string]interface{}{}
+	template := map[string]any{}
 
 	err = json.Unmarshal(input, &template)
 	require.NoError(t, err)
 
-	params := map[string]map[string]interface{}{
+	params := map[string]map[string]any{
 		"environment": {
 			"value": "ANOTHERENV",
 		},

--- a/pkg/cli/bicep/files.go
+++ b/pkg/cli/bicep/files.go
@@ -11,13 +11,13 @@ import (
 	"os"
 )
 
-func ReadARMJSON(filePath string) (map[string]interface{}, error) {
+func ReadARMJSON(filePath string) (map[string]any, error) {
 	bytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("could not read json file: %w", err)
 	}
 
-	var template map[string]interface{}
+	var template map[string]any
 	err = json.Unmarshal(bytes, &template)
 	if err != nil {
 		return nil, fmt.Errorf("could not unmarshal json file: %w", err)

--- a/pkg/cli/bicep/types.go
+++ b/pkg/cli/bicep/types.go
@@ -18,7 +18,7 @@ import (
 // Interface is the interface for preparing Bicep or ARM-JSON templates for deployment. This interface
 // is designed to be called from the CLI and will print output to the console.
 type Interface interface {
-	PrepareTemplate(filePath string) (map[string]interface{}, error)
+	PrepareTemplate(filePath string) (map[string]any, error)
 }
 
 var _ Interface = (*Impl)(nil)
@@ -29,7 +29,7 @@ var _ Interface = (*Impl)(nil)
 type Impl struct {
 }
 
-func (*Impl) PrepareTemplate(filePath string) (map[string]interface{}, error) {
+func (*Impl) PrepareTemplate(filePath string) (map[string]any, error) {
 	if strings.EqualFold(path.Ext(filePath), ".json") {
 		return ReadARMJSON(filePath)
 	} else if !strings.EqualFold(path.Ext(filePath), ".bicep") {
@@ -65,8 +65,8 @@ func (*Impl) PrepareTemplate(filePath string) (map[string]interface{}, error) {
 	return template, nil
 }
 
-func ConvertToMapStringInterface(in map[string]map[string]interface{}) map[string]interface{} {
-	result := make(map[string]interface{})
+func ConvertToMapStringInterface(in map[string]map[string]any) map[string]any {
+	result := make(map[string]any)
 	for k, v := range in {
 		result[k] = v["value"]
 	}

--- a/pkg/cli/clients/clients.go
+++ b/pkg/cli/clients/clients.go
@@ -31,12 +31,12 @@ import (
 // The full format is documented here: https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/parameter-files
 //
 // Note that we're only storing the 'parameters' node of the format described above.
-type DeploymentParameters = map[string]map[string]interface{}
+type DeploymentParameters = map[string]map[string]any
 
 // DeploymentOptions is the options passed when deploying an ARM-JSON template.
 type DeploymentOptions struct {
 	// Template is the text of the ARM-JSON template in string form.
-	Template map[string]interface{}
+	Template map[string]any
 
 	// Parameters is the set of parameters passed to the deployment.
 	Parameters DeploymentParameters
@@ -60,8 +60,8 @@ type ResourceProgress struct {
 }
 
 type DeploymentOutput struct {
-	Type  string      `json:"type"`
-	Value interface{} `json:"value"`
+	Type  string `json:"type"`
+	Value any    `json:"value"`
 }
 
 type DeploymentResult struct {

--- a/pkg/cli/cmd/deploy/deploy.go
+++ b/pkg/cli/cmd/deploy/deploy.go
@@ -102,7 +102,7 @@ type Runner struct {
 	EnvironmentID   string
 	EnvironmentName string
 	FilePath        string
-	Parameters      map[string]map[string]interface{}
+	Parameters      map[string]map[string]any
 	Workspace       *workspaces.Workspace
 }
 

--- a/pkg/cli/cmd/deploy/deploy_test.go
+++ b/pkg/cli/cmd/deploy/deploy_test.go
@@ -160,7 +160,7 @@ func Test_Run(t *testing.T) {
 		bicep := bicep.NewMockInterface(ctrl)
 		bicep.EXPECT().
 			PrepareTemplate("app.bicep").
-			Return(map[string]interface{}{}, nil).
+			Return(map[string]any{}, nil).
 			Times(1)
 
 		options := deploy.Options{}
@@ -176,7 +176,7 @@ func Test_Run(t *testing.T) {
 			Times(1)
 
 		workspace := &workspaces.Workspace{
-			Connection: map[string]interface{}{
+			Connection: map[string]any{
 				"kind":    "kubernetes",
 				"context": "kind-kind",
 			},
@@ -191,7 +191,7 @@ func Test_Run(t *testing.T) {
 			FilePath:        "app.bicep",
 			EnvironmentID:   fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/applications.core/environments/%s", radcli.TestEnvironmentName, radcli.TestEnvironmentName),
 			EnvironmentName: radcli.TestEnvironmentName,
-			Parameters:      map[string]map[string]interface{}{},
+			Parameters:      map[string]map[string]any{},
 			Workspace:       workspace,
 		}
 
@@ -214,7 +214,7 @@ func Test_Run(t *testing.T) {
 		bicep := bicep.NewMockInterface(ctrl)
 		bicep.EXPECT().
 			PrepareTemplate("app.bicep").
-			Return(map[string]interface{}{}, nil).
+			Return(map[string]any{}, nil).
 			Times(1)
 
 		options := deploy.Options{}
@@ -236,7 +236,7 @@ func Test_Run(t *testing.T) {
 			Times(1)
 
 		workspace := &workspaces.Workspace{
-			Connection: map[string]interface{}{
+			Connection: map[string]any{
 				"kind":    "kubernetes",
 				"context": "kind-kind",
 			},
@@ -254,7 +254,7 @@ func Test_Run(t *testing.T) {
 			ApplicationName: "test-application",
 			EnvironmentID:   fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/applications.core/environments/%s", radcli.TestEnvironmentName, radcli.TestEnvironmentName),
 			EnvironmentName: radcli.TestEnvironmentName,
-			Parameters:      map[string]map[string]interface{}{},
+			Parameters:      map[string]map[string]any{},
 			Workspace:       workspace,
 		}
 

--- a/pkg/cli/cmd/env/create/create_test.go
+++ b/pkg/cli/cmd/env/create/create_test.go
@@ -122,7 +122,7 @@ func Test_Run(t *testing.T) {
 			awsProvider := &workspaces.AWSProvider{}
 			providerConfig := workspaces.ProviderConfig{Azure: azureProvider, AWS: awsProvider}
 			workspace := &workspaces.Workspace{
-				Connection: map[string]interface{}{
+				Connection: map[string]any{
 					"kind":    "kubernetes",
 					"context": "kind-kind",
 				},
@@ -166,7 +166,7 @@ func Test_RunWithoutAzureProvider(t *testing.T) {
 			awsProvider := &workspaces.AWSProvider{}
 			providerConfig := workspaces.ProviderConfig{AWS: awsProvider}
 			workspace := &workspaces.Workspace{
-				Connection: map[string]interface{}{
+				Connection: map[string]any{
 					"kind":    "kubernetes",
 					"context": "kind-kind",
 				},
@@ -206,7 +206,7 @@ func Test_Run_WithoutProvider(t *testing.T) {
 			configFileInterface := framework.NewMockConfigFileInterface(ctrl)
 			outputSink := &output.MockOutput{}
 			workspace := &workspaces.Workspace{
-				Connection: map[string]interface{}{
+				Connection: map[string]any{
 					"kind":    "kubernetes",
 					"context": "kind-kind",
 				},
@@ -245,7 +245,7 @@ func Test_Run_SkipDevRecipes(t *testing.T) {
 			configFileInterface := framework.NewMockConfigFileInterface(ctrl)
 			outputSink := &output.MockOutput{}
 			workspace := &workspaces.Workspace{
-				Connection: map[string]interface{}{
+				Connection: map[string]any{
 					"kind":    "kubernetes",
 					"context": "kind-kind",
 				},
@@ -281,7 +281,7 @@ func Test_Run_SkipDevRecipes(t *testing.T) {
 			configFileInterface := framework.NewMockConfigFileInterface(ctrl)
 			outputSink := &output.MockOutput{}
 			workspace := &workspaces.Workspace{
-				Connection: map[string]interface{}{
+				Connection: map[string]any{
 					"kind":    "kubernetes",
 					"context": "kind-kind",
 				},

--- a/pkg/cli/cmd/env/delete/delete_test.go
+++ b/pkg/cli/cmd/env/delete/delete_test.go
@@ -99,7 +99,7 @@ func Test_Show(t *testing.T) {
 			Times(1)
 
 		workspace := &workspaces.Workspace{
-			Connection: map[string]interface{}{
+			Connection: map[string]any{
 				"kind":    "kubernetes",
 				"context": "kind-kind",
 			},
@@ -119,7 +119,7 @@ func Test_Show(t *testing.T) {
 		err := runner.Run(context.Background())
 		require.NoError(t, err)
 
-		expected := []interface{}{
+		expected := []any{
 			output.LogOutput{
 				Format: "Environment deleted",
 			},
@@ -145,7 +145,7 @@ func Test_Show(t *testing.T) {
 			Times(1)
 
 		workspace := &workspaces.Workspace{
-			Connection: map[string]interface{}{
+			Connection: map[string]any{
 				"kind":    "kubernetes",
 				"context": "kind-kind",
 			},
@@ -165,7 +165,7 @@ func Test_Show(t *testing.T) {
 		err := runner.Run(context.Background())
 		require.NoError(t, err)
 
-		expected := []interface{}{
+		expected := []any{
 			output.LogOutput{
 				Format: "Environment deleted",
 			},
@@ -185,7 +185,7 @@ func Test_Show(t *testing.T) {
 			Times(1)
 
 		workspace := &workspaces.Workspace{
-			Connection: map[string]interface{}{
+			Connection: map[string]any{
 				"kind":    "kubernetes",
 				"context": "kind-kind",
 			},
@@ -221,7 +221,7 @@ func Test_Show(t *testing.T) {
 			Times(1)
 
 		workspace := &workspaces.Workspace{
-			Connection: map[string]interface{}{
+			Connection: map[string]any{
 				"kind":    "kubernetes",
 				"context": "kind-kind",
 			},
@@ -241,10 +241,10 @@ func Test_Show(t *testing.T) {
 		err := runner.Run(context.Background())
 		require.NoError(t, err)
 
-		expected := []interface{}{
+		expected := []any{
 			output.LogOutput{
 				Format: "Environment '%s' does not exist or has already been deleted.",
-				Params: []interface{}{"test-env"},
+				Params: []any{"test-env"},
 			},
 		}
 

--- a/pkg/cli/cmd/env/list/list_test.go
+++ b/pkg/cli/cmd/env/list/list_test.go
@@ -90,7 +90,7 @@ func Test_Run(t *testing.T) {
 		Times(1)
 
 	workspace := &workspaces.Workspace{
-		Connection: map[string]interface{}{
+		Connection: map[string]any{
 			"kind":    "kubernetes",
 			"context": "kind-kind",
 		},
@@ -108,7 +108,7 @@ func Test_Run(t *testing.T) {
 	err := runner.Run(context.Background())
 	require.NoError(t, err)
 
-	expected := []interface{}{
+	expected := []any{
 		output.FormattedOutput{
 			Format:  "table",
 			Obj:     environments,

--- a/pkg/cli/cmd/env/show/show_test.go
+++ b/pkg/cli/cmd/env/show/show_test.go
@@ -96,7 +96,7 @@ func Test_Show(t *testing.T) {
 			Times(1)
 
 		workspace := &workspaces.Workspace{
-			Connection: map[string]interface{}{
+			Connection: map[string]any{
 				"kind":    "kubernetes",
 				"context": "kind-kind",
 			},
@@ -115,7 +115,7 @@ func Test_Show(t *testing.T) {
 		err := runner.Run(context.Background())
 		require.NoError(t, err)
 
-		expected := []interface{}{
+		expected := []any{
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     environment,
@@ -137,7 +137,7 @@ func Test_Show(t *testing.T) {
 			Times(1)
 
 		workspace := &workspaces.Workspace{
-			Connection: map[string]interface{}{
+			Connection: map[string]any{
 				"kind":    "kubernetes",
 				"context": "kind-kind",
 			},

--- a/pkg/cli/cmd/group/create/create_test.go
+++ b/pkg/cli/cmd/group/create/create_test.go
@@ -85,7 +85,7 @@ func Test_Run(t *testing.T) {
 		appManagementClient.EXPECT().CreateUCPGroup(gomock.Any(), gomock.Any(), gomock.Any(), "testrg", gomock.Any()).Return(true, nil).Times(2)
 
 		workspace := &workspaces.Workspace{
-			Connection: map[string]interface{}{
+			Connection: map[string]any{
 				"kind":    "kubernetes",
 				"context": "kind-kind",
 			},
@@ -103,14 +103,14 @@ func Test_Run(t *testing.T) {
 		err := runner.Run(context.Background())
 		require.NoError(t, err)
 
-		expected := []interface{}{
+		expected := []any{
 			output.LogOutput{
 				Format: "creating resource group %q in workspace %q...\n",
-				Params: []interface{}{"testrg", "kind-kind"},
+				Params: []any{"testrg", "kind-kind"},
 			},
 			output.LogOutput{
 				Format: "resource group %q created",
-				Params: []interface{}{"testrg"},
+				Params: []any{"testrg"},
 			},
 		}
 		require.Equal(t, expected, outputSink.Writes)

--- a/pkg/cli/cmd/group/delete/delete_test.go
+++ b/pkg/cli/cmd/group/delete/delete_test.go
@@ -80,14 +80,14 @@ func Test_Run(t *testing.T) {
 			err := runner.Run(context.Background())
 			require.NoError(t, err)
 
-			expected := []interface{}{
+			expected := []any{
 				output.LogOutput{
 					Format: "deleting resource group %q ...\n",
-					Params: []interface{}{"testrg"},
+					Params: []any{"testrg"},
 				},
 				output.LogOutput{
 					Format: "resource group %q deleted",
-					Params: []interface{}{"testrg"},
+					Params: []any{"testrg"},
 				},
 			}
 			require.Equal(t, expected, outputSink.Writes)
@@ -112,14 +112,14 @@ func Test_Run(t *testing.T) {
 			err := runner.Run(context.Background())
 			require.NoError(t, err)
 
-			expected := []interface{}{
+			expected := []any{
 				output.LogOutput{
 					Format: "deleting resource group %q ...\n",
-					Params: []interface{}{"testrg"},
+					Params: []any{"testrg"},
 				},
 				output.LogOutput{
 					Format: "resource group %q does not exist or has already been deleted",
-					Params: []interface{}{"testrg"},
+					Params: []any{"testrg"},
 				},
 			}
 			require.Equal(t, expected, outputSink.Writes)
@@ -149,10 +149,10 @@ func Test_Run(t *testing.T) {
 			err := runner.Run(context.Background())
 			require.NoError(t, err)
 
-			expected := []interface{}{
+			expected := []any{
 				output.LogOutput{
 					Format: "resource group %q NOT deleted",
-					Params: []interface{}{"testrg"},
+					Params: []any{"testrg"},
 				},
 			}
 			require.Equal(t, expected, outputSink.Writes)

--- a/pkg/cli/cmd/group/groupswitch/switch_test.go
+++ b/pkg/cli/cmd/group/groupswitch/switch_test.go
@@ -68,12 +68,12 @@ func Test_Run(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
 			configPath := path.Join(t.TempDir(), "config.yaml")
 
-			yamlData, err := yaml.Marshal(map[string]interface{}{
+			yamlData, err := yaml.Marshal(map[string]any{
 				"workspaces": cli.WorkspaceSection{
 					Default: "b",
 					Items: map[string]workspaces.Workspace{
 						"a": {
-							Connection: map[string]interface{}{
+							Connection: map[string]any{
 								"kind":    workspaces.KindKubernetes,
 								"context": "my-context",
 							},
@@ -81,7 +81,7 @@ func Test_Run(t *testing.T) {
 							Scope:  "/planes/radius/local/resourceGroups/a",
 						},
 						"b": {
-							Connection: map[string]interface{}{
+							Connection: map[string]any{
 								"kind":    workspaces.KindKubernetes,
 								"context": "my-context",
 							},
@@ -101,7 +101,7 @@ func Test_Run(t *testing.T) {
 				Items: map[string]workspaces.Workspace{
 					"a": {
 						Name: "a",
-						Connection: map[string]interface{}{
+						Connection: map[string]any{
 							"kind":    workspaces.KindKubernetes,
 							"context": "my-context",
 						},
@@ -110,7 +110,7 @@ func Test_Run(t *testing.T) {
 					},
 					"b": {
 						Name: "b",
-						Connection: map[string]interface{}{
+						Connection: map[string]any{
 							"kind":    workspaces.KindKubernetes,
 							"context": "my-context",
 						},
@@ -130,7 +130,7 @@ func Test_Run(t *testing.T) {
 
 			workspace := &workspaces.Workspace{
 				Name: "b",
-				Connection: map[string]interface{}{
+				Connection: map[string]any{
 					"kind":    workspaces.KindKubernetes,
 					"context": "my-context",
 				},
@@ -158,13 +158,13 @@ func Test_Run(t *testing.T) {
 		t.Run("Switch (not existant)", func(t *testing.T) {
 			configPath := path.Join(t.TempDir(), "config.yaml")
 
-			yamlData, err := yaml.Marshal(map[string]interface{}{
+			yamlData, err := yaml.Marshal(map[string]any{
 				"workspaces": cli.WorkspaceSection{
 					Default: "b",
 					Items: map[string]workspaces.Workspace{
 
 						"b": {
-							Connection: map[string]interface{}{
+							Connection: map[string]any{
 								"kind":    workspaces.KindKubernetes,
 								"context": "my-context",
 							},
@@ -189,7 +189,7 @@ func Test_Run(t *testing.T) {
 
 			workspace := &workspaces.Workspace{
 				Name: "b",
-				Connection: map[string]interface{}{
+				Connection: map[string]any{
 					"kind":    workspaces.KindKubernetes,
 					"context": "my-context",
 				},

--- a/pkg/cli/cmd/group/list/list_test.go
+++ b/pkg/cli/cmd/group/list/list_test.go
@@ -84,7 +84,7 @@ func Test_Run(t *testing.T) {
 		appManagementClient.EXPECT().ListUCPGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(resourceGroups, nil).Times(1)
 
 		workspace := &workspaces.Workspace{
-			Connection: map[string]interface{}{
+			Connection: map[string]any{
 				"kind":    "kubernetes",
 				"context": "kind-kind",
 			},

--- a/pkg/cli/cmd/group/show/show_test.go
+++ b/pkg/cli/cmd/group/show/show_test.go
@@ -80,7 +80,7 @@ func Test_Run(t *testing.T) {
 		appManagementClient.EXPECT().ShowUCPGroup(gomock.Any(), gomock.Any(), gomock.Any(), "testrg").Return(testResourceGroup, nil)
 
 		workspace := &workspaces.Workspace{
-			Connection: map[string]interface{}{
+			Connection: map[string]any{
 				"kind":    "kubernetes",
 				"context": "kind-kind",
 			},
@@ -103,7 +103,7 @@ func Test_Run(t *testing.T) {
 			ID:   &id,
 			Name: &runner.UCPResourceGroupName,
 		}
-		expected := []interface{}{
+		expected := []any{
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     resourceGroup,

--- a/pkg/cli/cmd/provider/create/azure/azure_test.go
+++ b/pkg/cli/cmd/provider/create/azure/azure_test.go
@@ -146,12 +146,12 @@ func Test_Run(t *testing.T) {
 			// We need to isolate the configuration because we're going to make edits
 			configPath := path.Join(t.TempDir(), "config.yaml")
 
-			yamlData, err := yaml.Marshal(map[string]interface{}{
+			yamlData, err := yaml.Marshal(map[string]any{
 				"workspaces": cli.WorkspaceSection{
 					Default: "a",
 					Items: map[string]workspaces.Workspace{
 						"a": {
-							Connection: map[string]interface{}{
+							Connection: map[string]any{
 								"kind":    workspaces.KindKubernetes,
 								"context": "my-context",
 							},
@@ -160,7 +160,7 @@ func Test_Run(t *testing.T) {
 							// Will have provider info added
 						},
 						"b": {
-							Connection: map[string]interface{}{
+							Connection: map[string]any{
 								"kind":    workspaces.KindKubernetes,
 								"context": "my-context",
 							},
@@ -175,7 +175,7 @@ func Test_Run(t *testing.T) {
 							},
 						},
 						"c": {
-							Connection: map[string]interface{}{
+							Connection: map[string]any{
 								"kind":    workspaces.KindKubernetes,
 								"context": "my-other-context",
 							},
@@ -225,7 +225,7 @@ func Test_Run(t *testing.T) {
 				ConnectionFactory: &connections.MockFactory{CloudProviderManagementClient: client},
 				Output:            outputSink,
 				Workspace: &workspaces.Workspace{
-					Connection: map[string]interface{}{
+					Connection: map[string]any{
 						"kind":    workspaces.KindKubernetes,
 						"context": "my-context",
 					},
@@ -244,10 +244,10 @@ func Test_Run(t *testing.T) {
 			err = runner.Run(context.Background())
 			require.NoError(t, err)
 
-			expected := []interface{}{
+			expected := []any{
 				output.LogOutput{
 					Format: "Setting cloud provider %q for Radius installation %q...",
-					Params: []interface{}{"azure", "Kubernetes (context=my-context)"},
+					Params: []any{"azure", "Kubernetes (context=my-context)"},
 				},
 			}
 			require.Equal(t, expected, outputSink.Writes)
@@ -257,7 +257,7 @@ func Test_Run(t *testing.T) {
 				Items: map[string]workspaces.Workspace{
 					"a": {
 						Name: "a",
-						Connection: map[string]interface{}{
+						Connection: map[string]any{
 							"kind":    workspaces.KindKubernetes,
 							"context": "my-context",
 						},
@@ -271,7 +271,7 @@ func Test_Run(t *testing.T) {
 					},
 					"b": {
 						Name: "b",
-						Connection: map[string]interface{}{
+						Connection: map[string]any{
 							"kind":    workspaces.KindKubernetes,
 							"context": "my-context",
 						},
@@ -285,7 +285,7 @@ func Test_Run(t *testing.T) {
 					},
 					"c": {
 						Name: "c",
-						Connection: map[string]interface{}{
+						Connection: map[string]any{
 							"kind":    workspaces.KindKubernetes,
 							"context": "my-other-context",
 						},

--- a/pkg/cli/cmd/provider/delete/delete_test.go
+++ b/pkg/cli/cmd/provider/delete/delete_test.go
@@ -76,7 +76,7 @@ func Test_Validate(t *testing.T) {
 }
 
 func Test_Run(t *testing.T) {
-	connection := map[string]interface{}{
+	connection := map[string]any{
 		"kind":    workspaces.KindKubernetes,
 		"context": "my-context",
 	}
@@ -104,10 +104,10 @@ func Test_Run(t *testing.T) {
 			err := runner.Run(context.Background())
 			require.NoError(t, err)
 
-			expected := []interface{}{
+			expected := []any{
 				output.LogOutput{
 					Format: "Deleting cloud provider %q for Radius installation %q...",
-					Params: []interface{}{"azure", "Kubernetes (context=my-context)"},
+					Params: []any{"azure", "Kubernetes (context=my-context)"},
 				},
 				output.LogOutput{
 					Format: "Cloud provider deleted.",
@@ -137,14 +137,14 @@ func Test_Run(t *testing.T) {
 			err := runner.Run(context.Background())
 			require.NoError(t, err)
 
-			expected := []interface{}{
+			expected := []any{
 				output.LogOutput{
 					Format: "Deleting cloud provider %q for Radius installation %q...",
-					Params: []interface{}{"azure", "Kubernetes (context=my-context)"},
+					Params: []any{"azure", "Kubernetes (context=my-context)"},
 				},
 				output.LogOutput{
 					Format: "Cloud provider %q was not found or has been already deleted.",
-					Params: []interface{}{"azure"},
+					Params: []any{"azure"},
 				},
 			}
 			require.Equal(t, expected, outputSink.Writes)

--- a/pkg/cli/cmd/provider/list/list_test.go
+++ b/pkg/cli/cmd/provider/list/list_test.go
@@ -59,7 +59,7 @@ func Test_Validate(t *testing.T) {
 }
 
 func Test_Run(t *testing.T) {
-	connection := map[string]interface{}{
+	connection := map[string]any{
 		"kind":    workspaces.KindKubernetes,
 		"context": "my-context",
 	}
@@ -93,10 +93,10 @@ func Test_Run(t *testing.T) {
 			err := runner.Run(context.Background())
 			require.NoError(t, err)
 
-			expected := []interface{}{
+			expected := []any{
 				output.LogOutput{
 					Format: "Listing all cloud providers for Radius installation %q...",
-					Params: []interface{}{"Kubernetes (context=my-context)"},
+					Params: []any{"Kubernetes (context=my-context)"},
 				},
 				output.FormattedOutput{
 					Format:  "table",

--- a/pkg/cli/cmd/provider/show/show_test.go
+++ b/pkg/cli/cmd/provider/show/show_test.go
@@ -77,7 +77,7 @@ func Test_Validate(t *testing.T) {
 }
 
 func Test_Run(t *testing.T) {
-	connection := map[string]interface{}{
+	connection := map[string]any{
 		"kind":    workspaces.KindKubernetes,
 		"context": "my-context",
 	}
@@ -110,10 +110,10 @@ func Test_Run(t *testing.T) {
 			err := runner.Run(context.Background())
 			require.NoError(t, err)
 
-			expected := []interface{}{
+			expected := []any{
 				output.LogOutput{
 					Format: "Showing cloud provider %q for Radius installation %q...",
-					Params: []interface{}{"azure", "Kubernetes (context=my-context)"},
+					Params: []any{"azure", "Kubernetes (context=my-context)"},
 				},
 				output.FormattedOutput{
 					Format:  "table",

--- a/pkg/cli/cmd/radInit/init.go
+++ b/pkg/cli/cmd/radInit/init.go
@@ -164,7 +164,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 
 	// Set up a connection so we can list environments
 	r.Workspace = &workspaces.Workspace{
-		Connection: map[string]interface{}{
+		Connection: map[string]any{
 			"context": r.KubeContext,
 			"kind":    kubernetesKind,
 		},

--- a/pkg/cli/cmd/radInit/init_test.go
+++ b/pkg/cli/cmd/radInit/init_test.go
@@ -758,7 +758,7 @@ type PromptMatcher struct {
 	Message string
 }
 
-func (m *PromptMatcher) Matches(x interface{}) bool {
+func (m *PromptMatcher) Matches(x any) bool {
 	p, ok := x.(promptui.Prompt)
 	if !ok {
 		return false
@@ -781,7 +781,7 @@ type SelectMatcher struct {
 	Message string
 }
 
-func (m *SelectMatcher) Matches(x interface{}) bool {
+func (m *SelectMatcher) Matches(x any) bool {
 	p, ok := x.(promptui.Select)
 	if !ok {
 		return false

--- a/pkg/cli/cmd/recipe/create/create.go
+++ b/pkg/cli/cmd/recipe/create/create.go
@@ -74,7 +74,7 @@ type Runner struct {
 	TemplatePath      string
 	LinkType          string
 	RecipeName        string
-	Parameters        map[string]map[string]interface{}
+	Parameters        map[string]map[string]any
 }
 
 // NewRunner creates a new instance of the `rad recipe create` runner.

--- a/pkg/cli/cmd/recipe/create/create_test.go
+++ b/pkg/cli/cmd/recipe/create/create_test.go
@@ -156,7 +156,7 @@ func Test_Run(t *testing.T) {
 						"cosmosDB": {
 							LinkType:     to.Ptr("Applications.Link/mongoDatabases"),
 							TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
-							Parameters:   map[string]interface{}{"throughput": 400},
+							Parameters:   map[string]any{"throughput": 400},
 						},
 					},
 					Compute: &v20220315privatepreview.KubernetesCompute{
@@ -182,7 +182,7 @@ func Test_Run(t *testing.T) {
 				TemplatePath:      "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
 				LinkType:          "Applications.Link/mongoDatabases",
 				RecipeName:        "cosmosDB_new",
-				Parameters:        map[string]map[string]interface{}{},
+				Parameters:        map[string]map[string]any{},
 			}
 
 			err := runner.Run(context.Background())

--- a/pkg/cli/cmd/recipe/list/list_test.go
+++ b/pkg/cli/cmd/recipe/list/list_test.go
@@ -105,7 +105,7 @@ func Test_Run(t *testing.T) {
 			err := runner.Run(context.Background())
 			require.NoError(t, err)
 
-			expected := []interface{}{
+			expected := []any{
 				output.FormattedOutput{
 					Format:  "table",
 					Obj:     recipes,

--- a/pkg/cli/cmd/resource/delete/delete_test.go
+++ b/pkg/cli/cmd/resource/delete/delete_test.go
@@ -100,10 +100,10 @@ func Test_Run(t *testing.T) {
 			err := runner.Run(context.Background())
 			require.NoError(t, err)
 
-			expected := []interface{}{
+			expected := []any{
 				output.LogOutput{
 					Format: "Resource '%s' of type '%s' does not exist or has already been deleted",
-					Params: []interface{}{"test-container", "containers"},
+					Params: []any{"test-container", "containers"},
 				},
 			}
 			require.Equal(t, expected, outputSink.Writes)
@@ -132,7 +132,7 @@ func Test_Run(t *testing.T) {
 			err := runner.Run(context.Background())
 			require.NoError(t, err)
 
-			expected := []interface{}{
+			expected := []any{
 				output.LogOutput{
 					Format: "Resource deleted",
 				},

--- a/pkg/cli/cmd/resource/list/list_test.go
+++ b/pkg/cli/cmd/resource/list/list_test.go
@@ -146,7 +146,7 @@ func Test_Run(t *testing.T) {
 			err := runner.Run(context.Background())
 			require.NoError(t, err)
 
-			expected := []interface{}{
+			expected := []any{
 				output.FormattedOutput{
 					Format:  "table",
 					Obj:     resources,
@@ -184,7 +184,7 @@ func Test_Run(t *testing.T) {
 			err := runner.Run(context.Background())
 			require.NoError(t, err)
 
-			expected := []interface{}{
+			expected := []any{
 				output.FormattedOutput{
 					Format:  "table",
 					Obj:     resources,

--- a/pkg/cli/cmd/resource/show/show_test.go
+++ b/pkg/cli/cmd/resource/show/show_test.go
@@ -107,7 +107,7 @@ func Test_Run(t *testing.T) {
 		err := runner.Run(context.Background())
 		require.NoError(t, err)
 
-		expected := []interface{}{
+		expected := []any{
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     resource,

--- a/pkg/cli/cmd/run/run_test.go
+++ b/pkg/cli/cmd/run/run_test.go
@@ -126,7 +126,7 @@ func Test_Run(t *testing.T) {
 	bicep := bicep.NewMockInterface(ctrl)
 	bicep.EXPECT().
 		PrepareTemplate("app.bicep").
-		Return(map[string]interface{}{}, nil).
+		Return(map[string]any{}, nil).
 		Times(1)
 
 	deployOptionsChan := make(chan deploy.Options, 1)
@@ -197,7 +197,7 @@ func Test_Run(t *testing.T) {
 		Times(1)
 
 	workspace := &workspaces.Workspace{
-		Connection: map[string]interface{}{
+		Connection: map[string]any{
 			"kind":    "kubernetes",
 			"context": "kind-kind",
 		},
@@ -218,7 +218,7 @@ func Test_Run(t *testing.T) {
 			ApplicationName: "test-application",
 			EnvironmentID:   fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/applications.core/environments/%s", radcli.TestEnvironmentName, radcli.TestEnvironmentName),
 			EnvironmentName: radcli.TestEnvironmentName,
-			Parameters:      map[string]map[string]interface{}{},
+			Parameters:      map[string]map[string]any{},
 			Workspace:       workspace,
 		},
 		Logstream:   logstreamMock,
@@ -259,7 +259,7 @@ func Test_Run(t *testing.T) {
 
 	// All of the output in this command is being done by functions that we mock for testing, so this
 	// is always empty except for some boilerplate.
-	expected := []interface{}{
+	expected := []any{
 		output.LogOutput{
 			Format: "",
 		},

--- a/pkg/cli/cmd/workspace/create/create.go
+++ b/pkg/cli/cmd/workspace/create/create.go
@@ -134,7 +134,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		r.Workspace = &workspaces.Workspace{}
 		r.Workspace.Name = workspaceName
 	}
-	r.Workspace.Connection = map[string]interface{}{}
+	r.Workspace.Connection = map[string]any{}
 	r.Workspace.Connection["context"] = context
 	r.Workspace.Connection["kind"] = args[0]
 

--- a/pkg/cli/cmd/workspace/create/create_test.go
+++ b/pkg/cli/cmd/workspace/create/create_test.go
@@ -128,7 +128,7 @@ func Test_Run(t *testing.T) {
 		outputSink := &output.MockOutput{}
 		workspace := &workspaces.Workspace{
 			Name: "defaultWorkspace",
-			Connection: map[string]interface{}{
+			Connection: map[string]any{
 				"kind":    "kubernetes",
 				"context": "kind-kind",
 			},

--- a/pkg/cli/cmd/workspace/list/list_test.go
+++ b/pkg/cli/cmd/workspace/list/list_test.go
@@ -58,12 +58,12 @@ func Test_Run(t *testing.T) {
 				"workspace-b": {
 					Environment: "b",
 					Source:      workspaces.SourceUserConfig,
-					Connection:  map[string]interface{}{},
+					Connection:  map[string]any{},
 				},
 				"workspace-a": {
 					Environment: "a",
 					Source:      workspaces.SourceUserConfig,
-					Connection:  map[string]interface{}{},
+					Connection:  map[string]any{},
 				},
 			},
 		})
@@ -80,7 +80,7 @@ func Test_Run(t *testing.T) {
 		err := runner.Run(context.Background())
 		require.NoError(t, err)
 
-		expected := []interface{}{
+		expected := []any{
 			output.FormattedOutput{
 				Format: "",
 				Obj: []workspaces.Workspace{
@@ -88,13 +88,13 @@ func Test_Run(t *testing.T) {
 						Name:        "workspace-a",
 						Environment: "a",
 						Source:      workspaces.SourceUserConfig,
-						Connection:  map[string]interface{}{},
+						Connection:  map[string]any{},
 					},
 					{
 						Name:        "workspace-b",
 						Environment: "b",
 						Source:      workspaces.SourceUserConfig,
-						Connection:  map[string]interface{}{},
+						Connection:  map[string]any{},
 					},
 				},
 				Options: objectformats.GetWorkspaceTableFormat(),

--- a/pkg/cli/cmd/workspace/show/show_test.go
+++ b/pkg/cli/cmd/workspace/show/show_test.go
@@ -81,20 +81,20 @@ func Test_Run(t *testing.T) {
 			Workspace: &workspaces.Workspace{
 				Name:        "test-workspace",
 				Environment: "test-environment",
-				Connection:  map[string]interface{}{},
+				Connection:  map[string]any{},
 			},
 		}
 
 		err := runner.Run(context.Background())
 		require.NoError(t, err)
 
-		expected := []interface{}{
+		expected := []any{
 			output.FormattedOutput{
 				Format: "",
 				Obj: &workspaces.Workspace{
 					Name:        "test-workspace",
 					Environment: "test-environment",
-					Connection:  map[string]interface{}{},
+					Connection:  map[string]any{},
 				},
 				Options: objectformats.GetWorkspaceTableFormat(),
 			},
@@ -115,7 +115,7 @@ func Test_Run(t *testing.T) {
 		err := runner.Run(context.Background())
 		require.NoError(t, err)
 
-		expected := []interface{}{
+		expected := []any{
 			output.FormattedOutput{
 				Format:  "",
 				Obj:     runner.Workspace,

--- a/pkg/cli/cmd/workspace/switch/switch_test.go
+++ b/pkg/cli/cmd/workspace/switch/switch_test.go
@@ -78,7 +78,7 @@ func Test_Run(t *testing.T) {
 			Items: map[string]workspaces.Workspace{
 				"current-workspace": {
 					Environment: "test-env",
-					Connection:  map[string]interface{}{},
+					Connection:  map[string]any{},
 				},
 			},
 		})
@@ -96,10 +96,10 @@ func Test_Run(t *testing.T) {
 		err := runner.Run(context.Background())
 		require.NoError(t, err)
 
-		expected := []interface{}{
+		expected := []any{
 			output.LogOutput{
 				Format: "Default environment is already set to %v",
-				Params: []interface{}{"current-workspace"},
+				Params: []any{"current-workspace"},
 			},
 		}
 		require.Equal(t, expected, outputSink.Writes)
@@ -115,7 +115,7 @@ func Test_Run(t *testing.T) {
 			Items: map[string]workspaces.Workspace{
 				"new-workspace": {
 					Environment: "test-env",
-					Connection:  map[string]interface{}{},
+					Connection:  map[string]any{},
 				},
 			},
 		})
@@ -137,10 +137,10 @@ func Test_Run(t *testing.T) {
 		err := runner.Run(context.Background())
 		require.NoError(t, err)
 
-		expected := []interface{}{
+		expected := []any{
 			output.LogOutput{
 				Format: "Switching default workspace to %v",
-				Params: []interface{}{"new-workspace"},
+				Params: []any{"new-workspace"},
 			},
 		}
 		require.Equal(t, expected, outputSink.Writes)
@@ -156,11 +156,11 @@ func Test_Run(t *testing.T) {
 			Items: map[string]workspaces.Workspace{
 				"current-workspace": {
 					Environment: "test-env",
-					Connection:  map[string]interface{}{},
+					Connection:  map[string]any{},
 				},
 				"new-workspace": {
 					Environment: "test-env",
-					Connection:  map[string]interface{}{},
+					Connection:  map[string]any{},
 				},
 			},
 		})
@@ -182,10 +182,10 @@ func Test_Run(t *testing.T) {
 		err := runner.Run(context.Background())
 		require.NoError(t, err)
 
-		expected := []interface{}{
+		expected := []any{
 			output.LogOutput{
 				Format: "Switching default workspace from %v to %v",
-				Params: []interface{}{"current-workspace", "new-workspace"},
+				Params: []any{"current-workspace", "new-workspace"},
 			},
 		}
 		require.Equal(t, expected, outputSink.Writes)

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -351,7 +351,7 @@ func SaveConfig(v *viper.Viper) error {
 	return nil
 }
 
-func validate(value interface{}) error {
+func validate(value any) error {
 	english := en.New()
 	uni := ut.New(english, english)
 	trans, _ := uni.GetTranslator("en")

--- a/pkg/cli/config_test.go
+++ b/pkg/cli/config_test.go
@@ -133,7 +133,7 @@ workspaces:
 	require.Equal(t, workspaces.Source(workspaces.SourceUserConfig), ws.Source)
 	require.Equal(t, "/a/b/c", ws.Scope)
 	require.Equal(t, "/a/b/c/providers/Applications.Core/environments/ice-cold", ws.Environment)
-	require.Equal(t, map[string]interface{}{"kind": "kubernetes", "context": "cool-beans"}, ws.Connection)
+	require.Equal(t, map[string]any{"kind": "kubernetes", "context": "cool-beans"}, ws.Connection)
 }
 
 func Test_GetWorkspace_Named_Valid(t *testing.T) {
@@ -161,7 +161,7 @@ workspaces:
 	require.Equal(t, workspaces.Source(workspaces.SourceUserConfig), ws.Source)
 	require.Equal(t, "/a/b/c", ws.Scope)
 	require.Equal(t, "/a/b/c/providers/Applications.Core/environments/ice-cold", ws.Environment)
-	require.Equal(t, map[string]interface{}{"kind": "kubernetes", "context": "cool-beans"}, ws.Connection)
+	require.Equal(t, map[string]any{"kind": "kubernetes", "context": "cool-beans"}, ws.Connection)
 }
 
 func makeConfig(yaml string) (*viper.Viper, error) {

--- a/pkg/cli/deploy/types.go
+++ b/pkg/cli/deploy/types.go
@@ -29,7 +29,7 @@ type Options struct {
 	Parameters clients.DeploymentParameters
 
 	// Template should contain a parsed ARM-JSON template.
-	Template map[string]interface{}
+	Template map[string]any
 
 	// ApplicationID is the resource ID of the application. If provided, will be used as configuration for the Radius provider.
 	ApplicationID string

--- a/pkg/cli/helm/contourclient.go
+++ b/pkg/cli/helm/contourclient.go
@@ -80,7 +80,7 @@ func AddContourValues(helmChart *chart.Chart, options ContourOptions) error {
 	if options.HostNetwork {
 		// https://projectcontour.io/docs/main/deploy-options/#host-networking
 		// https://github.com/bitnami/charts/blob/7550513a4f491bb999f95027a7bfcc35ff076c33/bitnami/contour/values.yaml#L605
-		envoyNode := helmChart.Values["envoy"].(map[string]interface{})
+		envoyNode := helmChart.Values["envoy"].(map[string]any)
 		if envoyNode == nil {
 			return fmt.Errorf("envoy node not found in chart values")
 		}
@@ -88,7 +88,7 @@ func AddContourValues(helmChart *chart.Chart, options ContourOptions) error {
 		envoyNode["hostNetwork"] = true
 		envoyNode["dnsPolicy"] = "ClusterFirstWithHostNet"
 
-		containerPortsNode := envoyNode["containerPorts"].(map[string]interface{})
+		containerPortsNode := envoyNode["containerPorts"].(map[string]any)
 		if containerPortsNode == nil {
 			return fmt.Errorf("envoy.containerPorts node not found in chart values")
 		}
@@ -98,12 +98,12 @@ func AddContourValues(helmChart *chart.Chart, options ContourOptions) error {
 		containerPortsNode["http"] = 80
 		containerPortsNode["https"] = 443
 
-		serviceNode := envoyNode["service"].(map[string]interface{})
+		serviceNode := envoyNode["service"].(map[string]any)
 		if serviceNode == nil {
 			return fmt.Errorf("envoy.service node not found in chart values")
 		}
 
-		servicePortsNode := serviceNode["ports"].(map[string]interface{})
+		servicePortsNode := serviceNode["ports"].(map[string]any)
 		if serviceNode == nil {
 			return fmt.Errorf("envoy.service.ports node not found in chart values")
 		}

--- a/pkg/cli/helm/helm.go
+++ b/pkg/cli/helm/helm.go
@@ -33,7 +33,7 @@ func HelmConfig(builder *strings.Builder, flags *genericclioptions.ConfigFlags) 
 	hc := helm.Configuration{}
 	// helmDriver is "secret" to make the backend storage driver
 	// use kubernetes secrets.
-	err := hc.Init(flags, *flags.Namespace, helmDriverSecret, func(format string, v ...interface{}) {
+	err := hc.Init(flags, *flags.Namespace, helmDriverSecret, func(format string, v ...any) {
 		builder.WriteString(fmt.Sprintf(format, v...))
 		builder.WriteRune('\n')
 	})

--- a/pkg/cli/helm/radiusclient.go
+++ b/pkg/cli/helm/radiusclient.go
@@ -157,25 +157,25 @@ func GetAzProvider(options RadiusOptions, kubeContext string) (*azure.Provider, 
 	if !ok {
 		return nil, nil
 	}
-	global := cfg["global"].(map[string]interface{})
+	global := cfg["global"].(map[string]any)
 
 	_, ok = global["rp"]
 	if !ok {
 		return nil, nil
 	}
-	rp := global["rp"].(map[string]interface{})
+	rp := global["rp"].(map[string]any)
 
 	_, ok = rp["provider"]
 	if !ok {
 		return nil, nil
 	}
-	provider := rp["provider"].(map[string]interface{})
+	provider := rp["provider"].(map[string]any)
 
 	_, ok = provider["azure"]
 	if !ok {
 		return nil, nil
 	}
-	azureProvider := provider["azure"].(map[string]interface{})
+	azureProvider := provider["azure"].(map[string]any)
 
 	var azProvider azure.Provider
 
@@ -218,21 +218,21 @@ func addRadiusValues(helmChart *chart.Chart, options *RadiusOptions) error {
 
 	_, ok := values["global"]
 	if !ok {
-		values["global"] = make(map[string]interface{})
+		values["global"] = make(map[string]any)
 	}
-	global := values["global"].(map[string]interface{})
+	global := values["global"].(map[string]any)
 
 	_, ok = global["radius"]
 	if !ok {
-		global["radius"] = make(map[string]interface{})
+		global["radius"] = make(map[string]any)
 	}
-	radius := global["radius"].(map[string]interface{})
+	radius := global["radius"].(map[string]any)
 
 	_, ok = global["rp"]
 	if !ok {
-		global["rp"] = make(map[string]interface{})
+		global["rp"] = make(map[string]any)
 	}
-	rp := global["rp"].(map[string]interface{})
+	rp := global["rp"].(map[string]any)
 
 	if options.Image != "" {
 		rp["container"] = options.Image
@@ -248,9 +248,9 @@ func addRadiusValues(helmChart *chart.Chart, options *RadiusOptions) error {
 
 	_, ok = global["appcorerp"]
 	if !ok {
-		global["appcorerp"] = make(map[string]interface{})
+		global["appcorerp"] = make(map[string]any)
 	}
-	appcorerp := global["appcorerp"].(map[string]interface{})
+	appcorerp := global["appcorerp"].(map[string]any)
 
 	if options.AppCoreImage != "" {
 		appcorerp["image"] = options.AppCoreImage
@@ -261,9 +261,9 @@ func addRadiusValues(helmChart *chart.Chart, options *RadiusOptions) error {
 
 	_, ok = global["ucp"]
 	if !ok {
-		global["ucp"] = make(map[string]interface{})
+		global["ucp"] = make(map[string]any)
 	}
-	ucp := global["ucp"].(map[string]interface{})
+	ucp := global["ucp"].(map[string]any)
 	if options.UCPImage != "" {
 		ucp["image"] = options.UCPImage
 	}
@@ -273,10 +273,10 @@ func addRadiusValues(helmChart *chart.Chart, options *RadiusOptions) error {
 
 	_, ok = global["engine"]
 	if !ok {
-		global["engine"] = make(map[string]interface{})
+		global["engine"] = make(map[string]any)
 	}
 
-	de := global["engine"].(map[string]interface{})
+	de := global["engine"].(map[string]any)
 	if options.DEImage != "" {
 		de["image"] = options.DEImage
 	}
@@ -295,23 +295,23 @@ func addAWSProviderValues(helmChart *chart.Chart, awsProvider *aws.Provider) err
 
 	_, ok := values["global"]
 	if !ok {
-		values["global"] = make(map[string]interface{})
+		values["global"] = make(map[string]any)
 	}
-	global := values["global"].(map[string]interface{})
+	global := values["global"].(map[string]any)
 
 	_, ok = global["rp"]
 	if !ok {
-		global["rp"] = make(map[string]interface{})
+		global["rp"] = make(map[string]any)
 	}
-	rp := global["rp"].(map[string]interface{})
+	rp := global["rp"].(map[string]any)
 
 	_, ok = rp["provider"]
 	if !ok {
-		rp["provider"] = make(map[string]interface{})
+		rp["provider"] = make(map[string]any)
 	}
-	provider := rp["provider"].(map[string]interface{})
+	provider := rp["provider"].(map[string]any)
 
-	provider["aws"] = map[string]interface{}{
+	provider["aws"] = map[string]any{
 		"accessKeyId":     awsProvider.AccessKeyId,
 		"secretAccessKey": awsProvider.SecretAccessKey,
 		"region":          awsProvider.TargetRegion,
@@ -328,35 +328,35 @@ func addAzureProviderValues(helmChart *chart.Chart, azureProvider *azure.Provide
 
 	_, ok := values["global"]
 	if !ok {
-		values["global"] = make(map[string]interface{})
+		values["global"] = make(map[string]any)
 	}
-	global := values["global"].(map[string]interface{})
+	global := values["global"].(map[string]any)
 
 	_, ok = global["rp"]
 	if !ok {
-		global["rp"] = make(map[string]interface{})
+		global["rp"] = make(map[string]any)
 	}
-	rp := global["rp"].(map[string]interface{})
+	rp := global["rp"].(map[string]any)
 
 	_, ok = rp["provider"]
 	if !ok {
-		rp["provider"] = make(map[string]interface{})
+		rp["provider"] = make(map[string]any)
 	}
-	provider := rp["provider"].(map[string]interface{})
+	provider := rp["provider"].(map[string]any)
 
 	_, ok = provider["azure"]
 	if !ok {
-		provider["azure"] = make(map[string]interface{})
+		provider["azure"] = make(map[string]any)
 	}
 
-	azure := provider["azure"].(map[string]interface{})
+	azure := provider["azure"].(map[string]any)
 
 	if azureProvider.ServicePrincipal != nil {
 		_, ok = azure["servicePrincipal"]
 		if !ok {
-			azure["servicePrincipal"] = make(map[string]interface{})
+			azure["servicePrincipal"] = make(map[string]any)
 		}
-		azure["servicePrincipal"] = map[string]interface{}{
+		azure["servicePrincipal"] = map[string]any{
 			"clientId":     azureProvider.ServicePrincipal.ClientID,
 			"clientSecret": azureProvider.ServicePrincipal.ClientSecret,
 			"tenantId":     azureProvider.ServicePrincipal.TenantID,

--- a/pkg/cli/kubernetes/logstream/stern.go
+++ b/pkg/cli/kubernetes/logstream/stern.go
@@ -88,8 +88,8 @@ func (i *Impl) Stream(ctx context.Context, options Options) error {
 }
 
 // functionTable sets the functions available to the text template.
-func functionTable() map[string]interface{} {
-	return map[string]interface{}{
+func functionTable() map[string]any {
+	return map[string]any{
 		"color": func(color color.Color, text string) string {
 			// Use the provided color to add ascii escapes.
 			return color.SprintFunc()(text)

--- a/pkg/cli/output/formatter.go
+++ b/pkg/cli/output/formatter.go
@@ -24,7 +24,7 @@ type Column struct {
 }
 
 type Formatter interface {
-	Format(obj interface{}, writer io.Writer, options FormatterOptions) error
+	Format(obj any, writer io.Writer, options FormatterOptions) error
 }
 
 func NewFormatter(format string) (Formatter, error) {
@@ -41,10 +41,10 @@ func NewFormatter(format string) (Formatter, error) {
 	}
 }
 
-func convertToSlice(obj interface{}) ([]interface{}, error) {
+func convertToSlice(obj any) ([]any, error) {
 	// We use reflection here because we're building a table and thus need to handle both scalars (structs)
 	// and slices/arrays of structs.
-	var vv []interface{}
+	var vv []any
 	v := reflect.ValueOf(obj)
 
 	// Follow pointers at the top level

--- a/pkg/cli/output/json.go
+++ b/pkg/cli/output/json.go
@@ -13,7 +13,7 @@ import (
 type JSONFormatter struct {
 }
 
-func (f *JSONFormatter) Format(obj interface{}, writer io.Writer, options FormatterOptions) error {
+func (f *JSONFormatter) Format(obj any, writer io.Writer, options FormatterOptions) error {
 	b, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {
 		return err

--- a/pkg/cli/output/json_test.go
+++ b/pkg/cli/output/json_test.go
@@ -38,7 +38,7 @@ func Test_JSON_Scalar(t *testing.T) {
 }
 
 func Test_JSON_Slice(t *testing.T) {
-	obj := []interface{}{
+	obj := []any{
 		jsonInput{
 			Size:   "mega",
 			IsCool: true,

--- a/pkg/cli/output/list.go
+++ b/pkg/cli/output/list.go
@@ -15,7 +15,7 @@ type ListFormatter struct{}
 
 var _ Formatter = (*ListFormatter)(nil)
 
-func (f *ListFormatter) Format(obj interface{}, writer io.Writer, options FormatterOptions) error {
+func (f *ListFormatter) Format(obj any, writer io.Writer, options FormatterOptions) error {
 
 	items, err := convertToSlice(obj)
 	if err != nil {

--- a/pkg/cli/output/list_test.go
+++ b/pkg/cli/output/list_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
 var formatter = &ListFormatter{}
 
 func Test_List_Scalar(t *testing.T) {
@@ -22,7 +23,6 @@ func Test_List_Scalar(t *testing.T) {
 		IsCool: true,
 	}
 
-	
 	buffer := &bytes.Buffer{}
 	err := formatter.Format(obj, buffer, FormatterOptions{})
 	require.NoError(t, err)

--- a/pkg/cli/output/logger.go
+++ b/pkg/cli/output/logger.go
@@ -12,13 +12,13 @@ type Step struct {
 }
 
 // LogInfo logs a message that is displayed to the user by default.
-func LogInfo(format string, v ...interface{}) {
+func LogInfo(format string, v ...any) {
 	fmt.Printf(format, v...)
 	fmt.Println()
 }
 
 // BeginStep starts execution of a step
-func BeginStep(format string, v ...interface{}) Step {
+func BeginStep(format string, v ...any) Step {
 	LogInfo(format, v...)
 	return Step{}
 }

--- a/pkg/cli/output/mock_writer.go
+++ b/pkg/cli/output/mock_writer.go
@@ -34,7 +34,7 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // Write mocks base method.
-func (m *MockInterface) Write(arg0 string, arg1 interface{}, arg2 FormatterOptions) error {
+func (m *MockInterface) Write(arg0 string, arg1 any, arg2 FormatterOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Write", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -42,7 +42,7 @@ func (m *MockInterface) Write(arg0 string, arg1 interface{}, arg2 FormatterOptio
 }
 
 // Write indicates an expected call of Write.
-func (mr *MockInterfaceMockRecorder) Write(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) Write(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockInterface)(nil).Write), arg0, arg1, arg2)
 }

--- a/pkg/cli/output/output_mock.go
+++ b/pkg/cli/output/output_mock.go
@@ -8,25 +8,25 @@ package output
 var _ Interface = (*MockOutput)(nil)
 
 type MockOutput struct {
-	Writes []interface{}
+	Writes []any
 }
 
 type LogOutput struct {
 	Format string
-	Params []interface{}
+	Params []any
 }
 
 type FormattedOutput struct {
 	Format  string
-	Obj     interface{}
+	Obj     any
 	Options FormatterOptions
 }
 
-func (o *MockOutput) LogInfo(format string, v ...interface{}) {
+func (o *MockOutput) LogInfo(format string, v ...any) {
 	o.Writes = append(o.Writes, LogOutput{Format: format, Params: v})
 }
 
-func (o *MockOutput) WriteFormatted(format string, obj interface{}, options FormatterOptions) error {
+func (o *MockOutput) WriteFormatted(format string, obj any, options FormatterOptions) error {
 	o.Writes = append(o.Writes, FormattedOutput{Format: format, Obj: obj, Options: options})
 	return nil
 }

--- a/pkg/cli/output/table.go
+++ b/pkg/cli/output/table.go
@@ -27,7 +27,7 @@ const (
 type TableFormatter struct {
 }
 
-func (f *TableFormatter) Format(obj interface{}, writer io.Writer, options FormatterOptions) error {
+func (f *TableFormatter) Format(obj any, writer io.Writer, options FormatterOptions) error {
 	if len(options.Columns) == 0 {
 		return errors.New("no columns were defined, table format is not supported for this command")
 	}

--- a/pkg/cli/output/table_test.go
+++ b/pkg/cli/output/table_test.go
@@ -75,7 +75,7 @@ mega      true                Some-Value  some-value
 }
 
 func Test_Table_Slice(t *testing.T) {
-	obj := []interface{}{
+	obj := []any{
 		tableInput{
 			Size:   "mega",
 			IsCool: true,
@@ -123,7 +123,7 @@ func Test_convertToStruct(t *testing.T) {
 			Name:    "struct",
 			Input:   aStruct,
 			Success: true,
-			Expected: []interface{}{
+			Expected: []any{
 				aStruct,
 			},
 		},
@@ -131,18 +131,18 @@ func Test_convertToStruct(t *testing.T) {
 			Name:    "struct pointer",
 			Input:   &aStruct,
 			Success: true,
-			Expected: []interface{}{
+			Expected: []any{
 				aStruct,
 			},
 		},
 		{
 			Name: "slice",
-			Input: []interface{}{
-				aStruct, &aStruct, "test", []interface{}{},
+			Input: []any{
+				aStruct, &aStruct, "test", []any{},
 			},
 			Success: true,
-			Expected: []interface{}{
-				aStruct, &aStruct, "test", []interface{}{},
+			Expected: []any{
+				aStruct, &aStruct, "test", []any{},
 			},
 		},
 	}
@@ -162,7 +162,7 @@ func Test_convertToStruct(t *testing.T) {
 
 type convertInput struct {
 	Name     string
-	Input    interface{}
+	Input    any
 	Success  bool
-	Expected []interface{}
+	Expected []any
 }

--- a/pkg/cli/output/writer.go
+++ b/pkg/cli/output/writer.go
@@ -13,26 +13,26 @@ import (
 // Interface is a mockable interface for writing cli output
 type Interface interface {
 	// LogInfo logs a message that is displayed to the user by default.
-	LogInfo(format string, v ...interface{})
+	LogInfo(format string, v ...any)
 
 	// Write
-	WriteFormatted(format string, obj interface{}, options FormatterOptions) error
+	WriteFormatted(format string, obj any, options FormatterOptions) error
 }
 
 type OutputWriter struct {
 	Writer io.Writer
 }
 
-func (o *OutputWriter) LogInfo(format string, v ...interface{}) {
+func (o *OutputWriter) LogInfo(format string, v ...any) {
 	fmt.Fprintf(o.Writer, format, v...)
 	fmt.Fprintln(o.Writer)
 }
 
-func (o *OutputWriter) WriteFormatted(format string, obj interface{}, options FormatterOptions) error {
+func (o *OutputWriter) WriteFormatted(format string, obj any, options FormatterOptions) error {
 	return Write(format, obj, o.Writer, options)
 }
 
-func Write(format string, obj interface{}, writer io.Writer, options FormatterOptions) error {
+func Write(format string, obj any, writer io.Writer, options FormatterOptions) error {
 	formatter, err := NewFormatter(format)
 	if err != nil {
 		return err

--- a/pkg/cli/setup/application_test.go
+++ b/pkg/cli/setup/application_test.go
@@ -28,12 +28,12 @@ func Test_ScaffoldApplication_CreatesBothFiles(t *testing.T) {
 	b, err := os.ReadFile(filepath.Join(directory, ".rad", "rad.yaml"))
 	require.NoError(t, err)
 
-	actualYaml := map[string]interface{}{}
+	actualYaml := map[string]any{}
 	err = yaml.Unmarshal(b, &actualYaml)
 	require.NoError(t, err)
 
-	expectedYaml := map[string]interface{}{
-		"workspace": map[string]interface{}{
+	expectedYaml := map[string]any{
+		"workspace": map[string]any{
 			"application": "cool-application",
 		},
 	}
@@ -43,14 +43,14 @@ func Test_ScaffoldApplication_CreatesBothFiles(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, appBicepTemplate, string(b))
 
-	expectedOutput := []interface{}{
+	expectedOutput := []any{
 		output.LogOutput{
 			Format: "Created %q",
-			Params: []interface{}{"app.bicep"},
+			Params: []any{"app.bicep"},
 		},
 		output.LogOutput{
 			Format: "Created %q",
-			Params: []interface{}{filepath.Join(".rad", "rad.yaml")},
+			Params: []any{filepath.Join(".rad", "rad.yaml")},
 		},
 	}
 	require.Equal(t, expectedOutput, outputSink.Writes)
@@ -77,12 +77,12 @@ func Test_ScaffoldApplication_KeepsAppBicepButWritesRadYaml(t *testing.T) {
 	b, err := os.ReadFile(filepath.Join(directory, ".rad", "rad.yaml"))
 	require.NoError(t, err)
 
-	actualYaml := map[string]interface{}{}
+	actualYaml := map[string]any{}
 	err = yaml.Unmarshal(b, &actualYaml)
 	require.NoError(t, err)
 
-	expectedYaml := map[string]interface{}{
-		"workspace": map[string]interface{}{
+	expectedYaml := map[string]any{
+		"workspace": map[string]any{
 			"application": "cool-application",
 		},
 	}
@@ -92,10 +92,10 @@ func Test_ScaffoldApplication_KeepsAppBicepButWritesRadYaml(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "something else", string(b))
 
-	expectedOutput := []interface{}{
+	expectedOutput := []any{
 		output.LogOutput{
 			Format: "Created %q",
-			Params: []interface{}{filepath.Join(".rad", "rad.yaml")},
+			Params: []any{filepath.Join(".rad", "rad.yaml")},
 		},
 	}
 	require.Equal(t, expectedOutput, outputSink.Writes)

--- a/pkg/cli/setup/resourcegroups.go
+++ b/pkg/cli/setup/resourcegroups.go
@@ -83,7 +83,7 @@ func createUCPResourceGroup(ctx context.Context, connection workspaces.Connectio
 	}
 
 	defer resp.Body.Close()
-	var jsonBody map[string]interface{}
+	var jsonBody map[string]any
 	if json.NewDecoder(resp.Body).Decode(&jsonBody) != nil {
 		return "", nil
 	}

--- a/pkg/cli/workspaces/connection.go
+++ b/pkg/cli/workspaces/connection.go
@@ -18,7 +18,7 @@ const KindKubernetes string = "kubernetes"
 func MakeFallbackWorkspace() *Workspace {
 	return &Workspace{
 		Source: SourceFallback,
-		Connection: map[string]interface{}{
+		Connection: map[string]any{
 			"kind":    KindKubernetes,
 			"context": "", // Default Kubernetes context
 		},

--- a/pkg/cli/workspaces/connection_test.go
+++ b/pkg/cli/workspaces/connection_test.go
@@ -18,7 +18,7 @@ func Test_IsSameKubernetesContext(t *testing.T) {
 	ctx := "kind-kind"
 	ws := Workspace{
 		Name: "my_workspace",
-		Connection: map[string]interface{}{
+		Connection: map[string]any{
 			"kind":    "kubernetes",
 			"context": "kind-kind",
 		},

--- a/pkg/cli/workspaces/types.go
+++ b/pkg/cli/workspaces/types.go
@@ -33,7 +33,7 @@ type Workspace struct {
 	// Connection represents the connection to the workspace. The details required by the connection are different
 	// depending on the kind of connection. For example a Kubernetes connection requires a valid kubeconfig context
 	// entry and a namespace.
-	Connection map[string]interface{} `json:"connection" mapstructure:"connection" yaml:"connection" validate:"required"`
+	Connection map[string]any `json:"connection" mapstructure:"connection" yaml:"connection" validate:"required"`
 
 	// Environment represents the default environment used for deployments of applications. This field is optional.
 	Environment string `json:"environment,omitempty" mapstructure:"environment" yaml:"environment,omitempty"`

--- a/pkg/corerp/api/generated/zz_generated_applications_client.go
+++ b/pkg/corerp/api/generated/zz_generated_applications_client.go
@@ -26,9 +26,9 @@ import (
 // ApplicationsClient contains the methods for the Applications group.
 // Don't use this type directly, use NewApplicationsClient() instead.
 type ApplicationsClient struct {
-	host string
+	host      string
 	rootScope string
-	pl runtime.Pipeline
+	pl        runtime.Pipeline
 }
 
 // NewApplicationsClient creates a new instance of ApplicationsClient with the specified values.
@@ -49,8 +49,8 @@ func NewApplicationsClient(rootScope string, credential azcore.TokenCredential, 
 	}
 	client := &ApplicationsClient{
 		rootScope: rootScope,
-		host: ep,
-pl: pl,
+		host:      ep,
+		pl:        pl,
 	}
 	return client, nil
 }
@@ -196,7 +196,7 @@ func (client *ApplicationsClient) getHandleResponse(resp *http.Response) (Applic
 // Generated from API version 2022-03-15-privatepreview
 // options - ApplicationsClientListByScopeOptions contains the optional parameters for the ApplicationsClient.ListByScope
 // method.
-func (client *ApplicationsClient) NewListByScopePager(options *ApplicationsClientListByScopeOptions) (*runtime.Pager[ApplicationsClientListByScopeResponse]) {
+func (client *ApplicationsClient) NewListByScopePager(options *ApplicationsClientListByScopeOptions) *runtime.Pager[ApplicationsClientListByScopeResponse] {
 	return runtime.NewPager(runtime.PagingHandler[ApplicationsClientListByScopeResponse]{
 		More: func(page ApplicationsClientListByScopeResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -296,4 +296,3 @@ func (client *ApplicationsClient) updateHandleResponse(resp *http.Response) (App
 	}
 	return result, nil
 }
-

--- a/pkg/corerp/api/generated/zz_generated_constants.go
+++ b/pkg/corerp/api/generated/zz_generated_constants.go
@@ -10,7 +10,7 @@
 package generated
 
 const (
-	moduleName = "generated"
+	moduleName    = "generated"
 	moduleVersion = "v0.0.1"
 )
 
@@ -18,13 +18,13 @@ const (
 type AzureIdentityKind string
 
 const (
-	AzureIdentityKindWorkload AzureIdentityKind = "Workload"
+	AzureIdentityKindWorkload       AzureIdentityKind = "Workload"
 	AzureIdentityKindSystemAssigned AzureIdentityKind = "SystemAssigned"
 )
 
 // PossibleAzureIdentityKindValues returns the possible values for the AzureIdentityKind const type.
 func PossibleAzureIdentityKindValues() []AzureIdentityKind {
-	return []AzureIdentityKind{	
+	return []AzureIdentityKind{
 		AzureIdentityKindWorkload,
 		AzureIdentityKindSystemAssigned,
 	}
@@ -35,13 +35,13 @@ type CertType string
 
 const (
 	CertTypeCertificate CertType = "certificate"
-	CertTypePublickey CertType = "publickey"
-	CertTypePrivatekey CertType = "privatekey"
+	CertTypePublickey   CertType = "publickey"
+	CertTypePrivatekey  CertType = "privatekey"
 )
 
 // PossibleCertTypeValues returns the possible values for the CertType const type.
 func PossibleCertTypeValues() []CertType {
-	return []CertType{	
+	return []CertType{
 		CertTypeCertificate,
 		CertTypePublickey,
 		CertTypePrivatekey,
@@ -52,15 +52,15 @@ func PossibleCertTypeValues() []CertType {
 type CreatedByType string
 
 const (
-	CreatedByTypeApplication CreatedByType = "Application"
-	CreatedByTypeKey CreatedByType = "Key"
+	CreatedByTypeApplication     CreatedByType = "Application"
+	CreatedByTypeKey             CreatedByType = "Key"
 	CreatedByTypeManagedIdentity CreatedByType = "ManagedIdentity"
-	CreatedByTypeUser CreatedByType = "User"
+	CreatedByTypeUser            CreatedByType = "User"
 )
 
 // PossibleCreatedByTypeValues returns the possible values for the CreatedByType const type.
 func PossibleCreatedByTypeValues() []CreatedByType {
-	return []CreatedByType{	
+	return []CreatedByType{
 		CreatedByTypeApplication,
 		CreatedByTypeKey,
 		CreatedByTypeManagedIdentity,
@@ -72,14 +72,14 @@ func PossibleCreatedByTypeValues() []CreatedByType {
 type Encoding string
 
 const (
-	EncodingUTF8 Encoding = "utf-8"
-	EncodingHex Encoding = "hex"
+	EncodingUTF8   Encoding = "utf-8"
+	EncodingHex    Encoding = "hex"
 	EncodingBase64 Encoding = "base64"
 )
 
 // PossibleEncodingValues returns the possible values for the Encoding const type.
 func PossibleEncodingValues() []Encoding {
-	return []Encoding{	
+	return []Encoding{
 		EncodingUTF8,
 		EncodingHex,
 		EncodingBase64,
@@ -96,7 +96,7 @@ const (
 
 // PossibleFormatValues returns the possible values for the Format const type.
 func PossibleFormatValues() []Format {
-	return []Format{	
+	return []Format{
 		FormatPem,
 		FormatPfx,
 	}
@@ -111,7 +111,7 @@ const (
 
 // PossibleKindValues returns the possible values for the Kind const type.
 func PossibleKindValues() []Kind {
-	return []Kind{	
+	return []Kind{
 		KindAzure,
 	}
 }
@@ -120,13 +120,13 @@ func PossibleKindValues() []Kind {
 type ManagedStore string
 
 const (
-	ManagedStoreDisk ManagedStore = "disk"
+	ManagedStoreDisk   ManagedStore = "disk"
 	ManagedStoreMemory ManagedStore = "memory"
 )
 
 // PossibleManagedStoreValues returns the possible values for the ManagedStore const type.
 func PossibleManagedStoreValues() []ManagedStore {
-	return []ManagedStore{	
+	return []ManagedStore{
 		ManagedStoreDisk,
 		ManagedStoreMemory,
 	}
@@ -138,13 +138,13 @@ type Protocol string
 const (
 	ProtocolGrpc Protocol = "grpc"
 	ProtocolHTTP Protocol = "http"
-	ProtocolTCP Protocol = "TCP"
-	ProtocolUDP Protocol = "UDP"
+	ProtocolTCP  Protocol = "TCP"
+	ProtocolUDP  Protocol = "UDP"
 )
 
 // PossibleProtocolValues returns the possible values for the Protocol const type.
 func PossibleProtocolValues() []Protocol {
-	return []Protocol{	
+	return []Protocol{
 		ProtocolGrpc,
 		ProtocolHTTP,
 		ProtocolTCP,
@@ -156,18 +156,18 @@ func PossibleProtocolValues() []Protocol {
 type ProvisioningState string
 
 const (
-	ProvisioningStateAccepted ProvisioningState = "Accepted"
-	ProvisioningStateCanceled ProvisioningState = "Canceled"
-	ProvisioningStateDeleting ProvisioningState = "Deleting"
-	ProvisioningStateFailed ProvisioningState = "Failed"
+	ProvisioningStateAccepted     ProvisioningState = "Accepted"
+	ProvisioningStateCanceled     ProvisioningState = "Canceled"
+	ProvisioningStateDeleting     ProvisioningState = "Deleting"
+	ProvisioningStateFailed       ProvisioningState = "Failed"
 	ProvisioningStateProvisioning ProvisioningState = "Provisioning"
-	ProvisioningStateSucceeded ProvisioningState = "Succeeded"
-	ProvisioningStateUpdating ProvisioningState = "Updating"
+	ProvisioningStateSucceeded    ProvisioningState = "Succeeded"
+	ProvisioningStateUpdating     ProvisioningState = "Updating"
 )
 
 // PossibleProvisioningStateValues returns the possible values for the ProvisioningState const type.
 func PossibleProvisioningStateValues() []ProvisioningState {
-	return []ProvisioningState{	
+	return []ProvisioningState{
 		ProvisioningStateAccepted,
 		ProvisioningStateCanceled,
 		ProvisioningStateDeleting,
@@ -182,15 +182,14 @@ func PossibleProvisioningStateValues() []ProvisioningState {
 type VolumePermission string
 
 const (
-	VolumePermissionRead VolumePermission = "read"
+	VolumePermissionRead  VolumePermission = "read"
 	VolumePermissionWrite VolumePermission = "write"
 )
 
 // PossibleVolumePermissionValues returns the possible values for the VolumePermission const type.
 func PossibleVolumePermissionValues() []VolumePermission {
-	return []VolumePermission{	
+	return []VolumePermission{
 		VolumePermissionRead,
 		VolumePermissionWrite,
 	}
 }
-

--- a/pkg/corerp/api/generated/zz_generated_containers_client.go
+++ b/pkg/corerp/api/generated/zz_generated_containers_client.go
@@ -26,9 +26,9 @@ import (
 // ContainersClient contains the methods for the Containers group.
 // Don't use this type directly, use NewContainersClient() instead.
 type ContainersClient struct {
-	host string
+	host      string
 	rootScope string
-	pl runtime.Pipeline
+	pl        runtime.Pipeline
 }
 
 // NewContainersClient creates a new instance of ContainersClient with the specified values.
@@ -49,8 +49,8 @@ func NewContainersClient(rootScope string, credential azcore.TokenCredential, op
 	}
 	client := &ContainersClient{
 		rootScope: rootScope,
-		host: ep,
-pl: pl,
+		host:      ep,
+		pl:        pl,
 	}
 	return client, nil
 }
@@ -195,7 +195,7 @@ func (client *ContainersClient) getHandleResponse(resp *http.Response) (Containe
 // NewListByScopePager - List all containers in the given scope.
 // Generated from API version 2022-03-15-privatepreview
 // options - ContainersClientListByScopeOptions contains the optional parameters for the ContainersClient.ListByScope method.
-func (client *ContainersClient) NewListByScopePager(options *ContainersClientListByScopeOptions) (*runtime.Pager[ContainersClientListByScopeResponse]) {
+func (client *ContainersClient) NewListByScopePager(options *ContainersClientListByScopeOptions) *runtime.Pager[ContainersClientListByScopeResponse] {
 	return runtime.NewPager(runtime.PagingHandler[ContainersClientListByScopeResponse]{
 		More: func(page ContainersClientListByScopeResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -295,4 +295,3 @@ func (client *ContainersClient) updateHandleResponse(resp *http.Response) (Conta
 	}
 	return result, nil
 }
-

--- a/pkg/corerp/api/generated/zz_generated_environments_client.go
+++ b/pkg/corerp/api/generated/zz_generated_environments_client.go
@@ -26,9 +26,9 @@ import (
 // EnvironmentsClient contains the methods for the Environments group.
 // Don't use this type directly, use NewEnvironmentsClient() instead.
 type EnvironmentsClient struct {
-	host string
+	host      string
 	rootScope string
-	pl runtime.Pipeline
+	pl        runtime.Pipeline
 }
 
 // NewEnvironmentsClient creates a new instance of EnvironmentsClient with the specified values.
@@ -49,8 +49,8 @@ func NewEnvironmentsClient(rootScope string, credential azcore.TokenCredential, 
 	}
 	client := &EnvironmentsClient{
 		rootScope: rootScope,
-		host: ep,
-pl: pl,
+		host:      ep,
+		pl:        pl,
 	}
 	return client, nil
 }
@@ -196,7 +196,7 @@ func (client *EnvironmentsClient) getHandleResponse(resp *http.Response) (Enviro
 // Generated from API version 2022-03-15-privatepreview
 // options - EnvironmentsClientListByScopeOptions contains the optional parameters for the EnvironmentsClient.ListByScope
 // method.
-func (client *EnvironmentsClient) NewListByScopePager(options *EnvironmentsClientListByScopeOptions) (*runtime.Pager[EnvironmentsClientListByScopeResponse]) {
+func (client *EnvironmentsClient) NewListByScopePager(options *EnvironmentsClientListByScopeOptions) *runtime.Pager[EnvironmentsClientListByScopeResponse] {
 	return runtime.NewPager(runtime.PagingHandler[EnvironmentsClientListByScopeResponse]{
 		More: func(page EnvironmentsClientListByScopeResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -296,4 +296,3 @@ func (client *EnvironmentsClient) updateHandleResponse(resp *http.Response) (Env
 	}
 	return result, nil
 }
-

--- a/pkg/corerp/api/generated/zz_generated_gateways_client.go
+++ b/pkg/corerp/api/generated/zz_generated_gateways_client.go
@@ -26,9 +26,9 @@ import (
 // GatewaysClient contains the methods for the Gateways group.
 // Don't use this type directly, use NewGatewaysClient() instead.
 type GatewaysClient struct {
-	host string
+	host      string
 	rootScope string
-	pl runtime.Pipeline
+	pl        runtime.Pipeline
 }
 
 // NewGatewaysClient creates a new instance of GatewaysClient with the specified values.
@@ -49,8 +49,8 @@ func NewGatewaysClient(rootScope string, credential azcore.TokenCredential, opti
 	}
 	client := &GatewaysClient{
 		rootScope: rootScope,
-		host: ep,
-pl: pl,
+		host:      ep,
+		pl:        pl,
 	}
 	return client, nil
 }
@@ -194,7 +194,7 @@ func (client *GatewaysClient) getHandleResponse(resp *http.Response) (GatewaysCl
 // NewListByScopePager - List all Gateways in the given scope.
 // Generated from API version 2022-03-15-privatepreview
 // options - GatewaysClientListByScopeOptions contains the optional parameters for the GatewaysClient.ListByScope method.
-func (client *GatewaysClient) NewListByScopePager(options *GatewaysClientListByScopeOptions) (*runtime.Pager[GatewaysClientListByScopeResponse]) {
+func (client *GatewaysClient) NewListByScopePager(options *GatewaysClientListByScopeOptions) *runtime.Pager[GatewaysClientListByScopeResponse] {
 	return runtime.NewPager(runtime.PagingHandler[GatewaysClientListByScopeResponse]{
 		More: func(page GatewaysClientListByScopeResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -294,4 +294,3 @@ func (client *GatewaysClient) updateHandleResponse(resp *http.Response) (Gateway
 	}
 	return result, nil
 }
-

--- a/pkg/corerp/api/generated/zz_generated_httproutes_client.go
+++ b/pkg/corerp/api/generated/zz_generated_httproutes_client.go
@@ -26,9 +26,9 @@ import (
 // HTTPRoutesClient contains the methods for the HTTPRoutes group.
 // Don't use this type directly, use NewHTTPRoutesClient() instead.
 type HTTPRoutesClient struct {
-	host string
+	host      string
 	rootScope string
-	pl runtime.Pipeline
+	pl        runtime.Pipeline
 }
 
 // NewHTTPRoutesClient creates a new instance of HTTPRoutesClient with the specified values.
@@ -49,8 +49,8 @@ func NewHTTPRoutesClient(rootScope string, credential azcore.TokenCredential, op
 	}
 	client := &HTTPRoutesClient{
 		rootScope: rootScope,
-		host: ep,
-pl: pl,
+		host:      ep,
+		pl:        pl,
 	}
 	return client, nil
 }
@@ -195,7 +195,7 @@ func (client *HTTPRoutesClient) getHandleResponse(resp *http.Response) (HTTPRout
 // NewListByScopePager - List all HTTP Routes in the given scope.
 // Generated from API version 2022-03-15-privatepreview
 // options - HTTPRoutesClientListByScopeOptions contains the optional parameters for the HTTPRoutesClient.ListByScope method.
-func (client *HTTPRoutesClient) NewListByScopePager(options *HTTPRoutesClientListByScopeOptions) (*runtime.Pager[HTTPRoutesClientListByScopeResponse]) {
+func (client *HTTPRoutesClient) NewListByScopePager(options *HTTPRoutesClientListByScopeOptions) *runtime.Pager[HTTPRoutesClientListByScopeResponse] {
 	return runtime.NewPager(runtime.PagingHandler[HTTPRoutesClientListByScopeResponse]{
 		More: func(page HTTPRoutesClientListByScopeResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -295,4 +295,3 @@ func (client *HTTPRoutesClient) updateHandleResponse(resp *http.Response) (HTTPR
 	}
 	return result, nil
 }
-

--- a/pkg/corerp/api/generated/zz_generated_models.go
+++ b/pkg/corerp/api/generated/zz_generated_models.go
@@ -121,10 +121,10 @@ type AzureKeyVaultVolumeProperties struct {
 // GetVolumeProperties implements the VolumePropertiesClassification interface for type AzureKeyVaultVolumeProperties.
 func (a *AzureKeyVaultVolumeProperties) GetVolumeProperties() *VolumeProperties {
 	return &VolumeProperties{
-		Kind: a.Kind,
+		Kind:              a.Kind,
 		ProvisioningState: a.ProvisioningState,
-		Application: a.Application,
-		Status: a.Status,
+		Application:       a.Application,
+		Status:            a.Status,
 	}
 }
 
@@ -156,9 +156,9 @@ type CertificateObjectProperties struct {
 
 type ConnectionProperties struct {
 	// REQUIRED; The source of the connection
-	Source *string `json:"source,omitempty"`
-	DisableDefaultEnvVars *bool `json:"disableDefaultEnvVars,omitempty"`
-	Iam *IamProperties `json:"iam,omitempty"`
+	Source                *string        `json:"source,omitempty"`
+	DisableDefaultEnvVars *bool          `json:"disableDefaultEnvVars,omitempty"`
+	Iam                   *IamProperties `json:"iam,omitempty"`
 }
 
 // Container - Definition of a container.
@@ -419,7 +419,7 @@ type EphemeralVolume struct {
 // GetVolume implements the VolumeClassification interface for type EphemeralVolume.
 func (e *EphemeralVolume) GetVolume() *Volume {
 	return &Volume{
-		Kind: e.Kind,
+		Kind:      e.Kind,
 		MountPath: e.MountPath,
 	}
 }
@@ -427,7 +427,7 @@ func (e *EphemeralVolume) GetVolume() *Volume {
 // ErrorAdditionalInfo - The resource management error additional info.
 type ErrorAdditionalInfo struct {
 	// READ-ONLY; The additional info.
-	Info map[string]interface{} `json:"info,omitempty" azure:"ro"`
+	Info map[string]any `json:"info,omitempty" azure:"ro"`
 
 	// READ-ONLY; The additional info type.
 	Type *string `json:"type,omitempty" azure:"ro"`
@@ -479,10 +479,10 @@ type ExecHealthProbeProperties struct {
 // GetHealthProbeProperties implements the HealthProbePropertiesClassification interface for type ExecHealthProbeProperties.
 func (e *ExecHealthProbeProperties) GetHealthProbeProperties() *HealthProbeProperties {
 	return &HealthProbeProperties{
-		Kind: e.Kind,
+		Kind:                e.Kind,
 		InitialDelaySeconds: e.InitialDelaySeconds,
-		FailureThreshold: e.FailureThreshold,
-		PeriodSeconds: e.PeriodSeconds,
+		FailureThreshold:    e.FailureThreshold,
+		PeriodSeconds:       e.PeriodSeconds,
 	}
 }
 
@@ -532,11 +532,11 @@ type GatewayProperties struct {
 // mygateway.myapp.PUBLICHOSTNAMEORIP.nip.io.
 type GatewayPropertiesHostname struct {
 	// Specify a fully-qualified domain name: myapp.mydomain.com. Mutually exclusive with 'prefix' and will take priority if both
-// are defined.
+	// are defined.
 	FullyQualifiedHostname *string `json:"fullyQualifiedHostname,omitempty"`
 
 	// Specify a prefix for the hostname: myhostname.myapp.PUBLICHOSTNAMEORIP.nip.io. Mutually exclusive with 'fullyQualifiedHostname'
-// and will be overridden if both are defined.
+	// and will be overridden if both are defined.
 	Prefix *string `json:"prefix,omitempty"`
 }
 
@@ -581,7 +581,7 @@ type GatewayRoute struct {
 	Path *string `json:"path,omitempty"`
 
 	// Optionally update the prefix when sending the request to the service. Ex - replacePrefix: '/' and path: '/myservice' will
-// transform '/myservice/myroute' to '/myroute'
+	// transform '/myservice/myroute' to '/myroute'
 	ReplacePrefix *string `json:"replacePrefix,omitempty"`
 }
 
@@ -637,10 +637,10 @@ type HTTPGetHealthProbeProperties struct {
 // GetHealthProbeProperties implements the HealthProbePropertiesClassification interface for type HTTPGetHealthProbeProperties.
 func (h *HTTPGetHealthProbeProperties) GetHealthProbeProperties() *HealthProbeProperties {
 	return &HealthProbeProperties{
-		Kind: h.Kind,
+		Kind:                h.Kind,
 		InitialDelaySeconds: h.InitialDelaySeconds,
-		FailureThreshold: h.FailureThreshold,
-		PeriodSeconds: h.PeriodSeconds,
+		FailureThreshold:    h.FailureThreshold,
+		PeriodSeconds:       h.PeriodSeconds,
 	}
 }
 
@@ -787,7 +787,7 @@ type KubernetesCompute struct {
 // GetEnvironmentCompute implements the EnvironmentComputeClassification interface for type KubernetesCompute.
 func (k *KubernetesCompute) GetEnvironmentCompute() *EnvironmentCompute {
 	return &EnvironmentCompute{
-		Kind: k.Kind,
+		Kind:       k.Kind,
 		ResourceID: k.ResourceID,
 	}
 }
@@ -826,7 +826,7 @@ type PersistentVolume struct {
 // GetVolume implements the VolumeClassification interface for type PersistentVolume.
 func (p *PersistentVolume) GetVolume() *Volume {
 	return &Volume{
-		Kind: p.Kind,
+		Kind:      p.Kind,
 		MountPath: p.MountPath,
 	}
 }
@@ -857,7 +857,7 @@ type Resource struct {
 
 // ResourceStatus - Status of a resource.
 type ResourceStatus struct {
-	OutputResources []map[string]interface{} `json:"outputResources,omitempty"`
+	OutputResources []map[string]any `json:"outputResources,omitempty"`
 }
 
 type SecretObjectProperties struct {
@@ -916,10 +916,10 @@ type TCPHealthProbeProperties struct {
 // GetHealthProbeProperties implements the HealthProbePropertiesClassification interface for type TCPHealthProbeProperties.
 func (t *TCPHealthProbeProperties) GetHealthProbeProperties() *HealthProbeProperties {
 	return &HealthProbeProperties{
-		Kind: t.Kind,
+		Kind:                t.Kind,
 		InitialDelaySeconds: t.InitialDelaySeconds,
-		FailureThreshold: t.FailureThreshold,
-		PeriodSeconds: t.PeriodSeconds,
+		FailureThreshold:    t.FailureThreshold,
+		PeriodSeconds:       t.PeriodSeconds,
 	}
 }
 
@@ -1046,4 +1046,3 @@ type VolumesClientListByScopeOptions struct {
 type VolumesClientUpdateOptions struct {
 	// placeholder for future optional parameters
 }
-

--- a/pkg/corerp/api/generated/zz_generated_models_serde.go
+++ b/pkg/corerp/api/generated/zz_generated_models_serde.go
@@ -18,7 +18,7 @@ import (
 
 // MarshalJSON implements the json.Marshaller interface for type ApplicationProperties.
 func (a ApplicationProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "environment", a.Environment)
 	populate(objectMap, "provisioningState", a.ProvisioningState)
 	return json.Marshal(objectMap)
@@ -34,11 +34,11 @@ func (a *ApplicationProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "environment":
-				err = unpopulate(val, "Environment", &a.Environment)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Environment", &a.Environment)
+			delete(rawMsg, key)
 		case "provisioningState":
-				err = unpopulate(val, "ProvisioningState", &a.ProvisioningState)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ProvisioningState", &a.ProvisioningState)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", a, err)
@@ -49,7 +49,7 @@ func (a *ApplicationProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type ApplicationResource.
 func (a ApplicationResource) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "id", a.ID)
 	populate(objectMap, "location", a.Location)
 	populate(objectMap, "name", a.Name)
@@ -70,26 +70,26 @@ func (a *ApplicationResource) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "id":
-				err = unpopulate(val, "ID", &a.ID)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ID", &a.ID)
+			delete(rawMsg, key)
 		case "location":
-				err = unpopulate(val, "Location", &a.Location)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Location", &a.Location)
+			delete(rawMsg, key)
 		case "name":
-				err = unpopulate(val, "Name", &a.Name)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Name", &a.Name)
+			delete(rawMsg, key)
 		case "properties":
-				err = unpopulate(val, "Properties", &a.Properties)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Properties", &a.Properties)
+			delete(rawMsg, key)
 		case "systemData":
-				err = unpopulate(val, "SystemData", &a.SystemData)
-				delete(rawMsg, key)
+			err = unpopulate(val, "SystemData", &a.SystemData)
+			delete(rawMsg, key)
 		case "tags":
-				err = unpopulate(val, "Tags", &a.Tags)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Tags", &a.Tags)
+			delete(rawMsg, key)
 		case "type":
-				err = unpopulate(val, "Type", &a.Type)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Type", &a.Type)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", a, err)
@@ -100,7 +100,7 @@ func (a *ApplicationResource) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type ApplicationResourceList.
 func (a ApplicationResourceList) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "nextLink", a.NextLink)
 	populate(objectMap, "value", a.Value)
 	return json.Marshal(objectMap)
@@ -116,11 +116,11 @@ func (a *ApplicationResourceList) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "nextLink":
-				err = unpopulate(val, "NextLink", &a.NextLink)
-				delete(rawMsg, key)
+			err = unpopulate(val, "NextLink", &a.NextLink)
+			delete(rawMsg, key)
 		case "value":
-				err = unpopulate(val, "Value", &a.Value)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Value", &a.Value)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", a, err)
@@ -131,7 +131,7 @@ func (a *ApplicationResourceList) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type AzureIdentity.
 func (a AzureIdentity) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "clientId", a.ClientID)
 	populate(objectMap, "kind", a.Kind)
 	populate(objectMap, "tenantId", a.TenantID)
@@ -148,14 +148,14 @@ func (a *AzureIdentity) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "clientId":
-				err = unpopulate(val, "ClientID", &a.ClientID)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ClientID", &a.ClientID)
+			delete(rawMsg, key)
 		case "kind":
-				err = unpopulate(val, "Kind", &a.Kind)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Kind", &a.Kind)
+			delete(rawMsg, key)
 		case "tenantId":
-				err = unpopulate(val, "TenantID", &a.TenantID)
-				delete(rawMsg, key)
+			err = unpopulate(val, "TenantID", &a.TenantID)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", a, err)
@@ -166,7 +166,7 @@ func (a *AzureIdentity) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type AzureKeyVaultVolumeProperties.
 func (a AzureKeyVaultVolumeProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "application", a.Application)
 	populate(objectMap, "certificates", a.Certificates)
 	populate(objectMap, "identity", a.Identity)
@@ -189,32 +189,32 @@ func (a *AzureKeyVaultVolumeProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "application":
-				err = unpopulate(val, "Application", &a.Application)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Application", &a.Application)
+			delete(rawMsg, key)
 		case "certificates":
-				err = unpopulate(val, "Certificates", &a.Certificates)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Certificates", &a.Certificates)
+			delete(rawMsg, key)
 		case "identity":
-				err = unpopulate(val, "Identity", &a.Identity)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Identity", &a.Identity)
+			delete(rawMsg, key)
 		case "keys":
-				err = unpopulate(val, "Keys", &a.Keys)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Keys", &a.Keys)
+			delete(rawMsg, key)
 		case "kind":
-				err = unpopulate(val, "Kind", &a.Kind)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Kind", &a.Kind)
+			delete(rawMsg, key)
 		case "provisioningState":
-				err = unpopulate(val, "ProvisioningState", &a.ProvisioningState)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ProvisioningState", &a.ProvisioningState)
+			delete(rawMsg, key)
 		case "resource":
-				err = unpopulate(val, "Resource", &a.Resource)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Resource", &a.Resource)
+			delete(rawMsg, key)
 		case "secrets":
-				err = unpopulate(val, "Secrets", &a.Secrets)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Secrets", &a.Secrets)
+			delete(rawMsg, key)
 		case "status":
-				err = unpopulate(val, "Status", &a.Status)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Status", &a.Status)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", a, err)
@@ -225,7 +225,7 @@ func (a *AzureKeyVaultVolumeProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type BasicResourceProperties.
 func (b BasicResourceProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "status", b.Status)
 	return json.Marshal(objectMap)
 }
@@ -240,8 +240,8 @@ func (b *BasicResourceProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "status":
-				err = unpopulate(val, "Status", &b.Status)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Status", &b.Status)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", b, err)
@@ -252,7 +252,7 @@ func (b *BasicResourceProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type CertificateObjectProperties.
 func (c CertificateObjectProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "alias", c.Alias)
 	populate(objectMap, "certType", c.CertType)
 	populate(objectMap, "encoding", c.Encoding)
@@ -272,23 +272,23 @@ func (c *CertificateObjectProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "alias":
-				err = unpopulate(val, "Alias", &c.Alias)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Alias", &c.Alias)
+			delete(rawMsg, key)
 		case "certType":
-				err = unpopulate(val, "CertType", &c.CertType)
-				delete(rawMsg, key)
+			err = unpopulate(val, "CertType", &c.CertType)
+			delete(rawMsg, key)
 		case "encoding":
-				err = unpopulate(val, "Encoding", &c.Encoding)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Encoding", &c.Encoding)
+			delete(rawMsg, key)
 		case "format":
-				err = unpopulate(val, "Format", &c.Format)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Format", &c.Format)
+			delete(rawMsg, key)
 		case "name":
-				err = unpopulate(val, "Name", &c.Name)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Name", &c.Name)
+			delete(rawMsg, key)
 		case "version":
-				err = unpopulate(val, "Version", &c.Version)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Version", &c.Version)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", c, err)
@@ -299,7 +299,7 @@ func (c *CertificateObjectProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type ConnectionProperties.
 func (c ConnectionProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "disableDefaultEnvVars", c.DisableDefaultEnvVars)
 	populate(objectMap, "iam", c.Iam)
 	populate(objectMap, "source", c.Source)
@@ -316,14 +316,14 @@ func (c *ConnectionProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "disableDefaultEnvVars":
-				err = unpopulate(val, "DisableDefaultEnvVars", &c.DisableDefaultEnvVars)
-				delete(rawMsg, key)
+			err = unpopulate(val, "DisableDefaultEnvVars", &c.DisableDefaultEnvVars)
+			delete(rawMsg, key)
 		case "iam":
-				err = unpopulate(val, "Iam", &c.Iam)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Iam", &c.Iam)
+			delete(rawMsg, key)
 		case "source":
-				err = unpopulate(val, "Source", &c.Source)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Source", &c.Source)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", c, err)
@@ -334,7 +334,7 @@ func (c *ConnectionProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type Container.
 func (c Container) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "env", c.Env)
 	populate(objectMap, "image", c.Image)
 	populate(objectMap, "livenessProbe", c.LivenessProbe)
@@ -354,23 +354,23 @@ func (c *Container) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "env":
-				err = unpopulate(val, "Env", &c.Env)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Env", &c.Env)
+			delete(rawMsg, key)
 		case "image":
-				err = unpopulate(val, "Image", &c.Image)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Image", &c.Image)
+			delete(rawMsg, key)
 		case "livenessProbe":
-				c.LivenessProbe, err = unmarshalHealthProbePropertiesClassification(val)
-				delete(rawMsg, key)
+			c.LivenessProbe, err = unmarshalHealthProbePropertiesClassification(val)
+			delete(rawMsg, key)
 		case "ports":
-				err = unpopulate(val, "Ports", &c.Ports)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Ports", &c.Ports)
+			delete(rawMsg, key)
 		case "readinessProbe":
-				c.ReadinessProbe, err = unmarshalHealthProbePropertiesClassification(val)
-				delete(rawMsg, key)
+			c.ReadinessProbe, err = unmarshalHealthProbePropertiesClassification(val)
+			delete(rawMsg, key)
 		case "volumes":
-				c.Volumes, err = unmarshalVolumeClassificationMap(val)
-				delete(rawMsg, key)
+			c.Volumes, err = unmarshalVolumeClassificationMap(val)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", c, err)
@@ -381,7 +381,7 @@ func (c *Container) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type ContainerPort.
 func (c ContainerPort) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "containerPort", c.ContainerPort)
 	populate(objectMap, "protocol", c.Protocol)
 	populate(objectMap, "provides", c.Provides)
@@ -398,14 +398,14 @@ func (c *ContainerPort) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "containerPort":
-				err = unpopulate(val, "ContainerPort", &c.ContainerPort)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ContainerPort", &c.ContainerPort)
+			delete(rawMsg, key)
 		case "protocol":
-				err = unpopulate(val, "Protocol", &c.Protocol)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Protocol", &c.Protocol)
+			delete(rawMsg, key)
 		case "provides":
-				err = unpopulate(val, "Provides", &c.Provides)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Provides", &c.Provides)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", c, err)
@@ -416,7 +416,7 @@ func (c *ContainerPort) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type ContainerProperties.
 func (c ContainerProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "application", c.Application)
 	populate(objectMap, "connections", c.Connections)
 	populate(objectMap, "container", c.Container)
@@ -436,23 +436,23 @@ func (c *ContainerProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "application":
-				err = unpopulate(val, "Application", &c.Application)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Application", &c.Application)
+			delete(rawMsg, key)
 		case "connections":
-				err = unpopulate(val, "Connections", &c.Connections)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Connections", &c.Connections)
+			delete(rawMsg, key)
 		case "container":
-				err = unpopulate(val, "Container", &c.Container)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Container", &c.Container)
+			delete(rawMsg, key)
 		case "extensions":
-				c.Extensions, err = unmarshalExtensionClassificationArray(val)
-				delete(rawMsg, key)
+			c.Extensions, err = unmarshalExtensionClassificationArray(val)
+			delete(rawMsg, key)
 		case "provisioningState":
-				err = unpopulate(val, "ProvisioningState", &c.ProvisioningState)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ProvisioningState", &c.ProvisioningState)
+			delete(rawMsg, key)
 		case "status":
-				err = unpopulate(val, "Status", &c.Status)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Status", &c.Status)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", c, err)
@@ -463,7 +463,7 @@ func (c *ContainerProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type ContainerResource.
 func (c ContainerResource) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "id", c.ID)
 	populate(objectMap, "location", c.Location)
 	populate(objectMap, "name", c.Name)
@@ -484,26 +484,26 @@ func (c *ContainerResource) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "id":
-				err = unpopulate(val, "ID", &c.ID)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ID", &c.ID)
+			delete(rawMsg, key)
 		case "location":
-				err = unpopulate(val, "Location", &c.Location)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Location", &c.Location)
+			delete(rawMsg, key)
 		case "name":
-				err = unpopulate(val, "Name", &c.Name)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Name", &c.Name)
+			delete(rawMsg, key)
 		case "properties":
-				err = unpopulate(val, "Properties", &c.Properties)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Properties", &c.Properties)
+			delete(rawMsg, key)
 		case "systemData":
-				err = unpopulate(val, "SystemData", &c.SystemData)
-				delete(rawMsg, key)
+			err = unpopulate(val, "SystemData", &c.SystemData)
+			delete(rawMsg, key)
 		case "tags":
-				err = unpopulate(val, "Tags", &c.Tags)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Tags", &c.Tags)
+			delete(rawMsg, key)
 		case "type":
-				err = unpopulate(val, "Type", &c.Type)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Type", &c.Type)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", c, err)
@@ -514,7 +514,7 @@ func (c *ContainerResource) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type ContainerResourceList.
 func (c ContainerResourceList) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "nextLink", c.NextLink)
 	populate(objectMap, "value", c.Value)
 	return json.Marshal(objectMap)
@@ -530,11 +530,11 @@ func (c *ContainerResourceList) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "nextLink":
-				err = unpopulate(val, "NextLink", &c.NextLink)
-				delete(rawMsg, key)
+			err = unpopulate(val, "NextLink", &c.NextLink)
+			delete(rawMsg, key)
 		case "value":
-				err = unpopulate(val, "Value", &c.Value)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Value", &c.Value)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", c, err)
@@ -545,7 +545,7 @@ func (c *ContainerResourceList) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type DaprSidecarExtension.
 func (d DaprSidecarExtension) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "appId", d.AppID)
 	populate(objectMap, "appPort", d.AppPort)
 	populate(objectMap, "config", d.Config)
@@ -565,23 +565,23 @@ func (d *DaprSidecarExtension) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "appId":
-				err = unpopulate(val, "AppID", &d.AppID)
-				delete(rawMsg, key)
+			err = unpopulate(val, "AppID", &d.AppID)
+			delete(rawMsg, key)
 		case "appPort":
-				err = unpopulate(val, "AppPort", &d.AppPort)
-				delete(rawMsg, key)
+			err = unpopulate(val, "AppPort", &d.AppPort)
+			delete(rawMsg, key)
 		case "config":
-				err = unpopulate(val, "Config", &d.Config)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Config", &d.Config)
+			delete(rawMsg, key)
 		case "kind":
-				err = unpopulate(val, "Kind", &d.Kind)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Kind", &d.Kind)
+			delete(rawMsg, key)
 		case "protocol":
-				err = unpopulate(val, "Protocol", &d.Protocol)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Protocol", &d.Protocol)
+			delete(rawMsg, key)
 		case "provides":
-				err = unpopulate(val, "Provides", &d.Provides)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Provides", &d.Provides)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", d, err)
@@ -592,7 +592,7 @@ func (d *DaprSidecarExtension) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type EnvironmentCompute.
 func (e EnvironmentCompute) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	objectMap["kind"] = e.Kind
 	populate(objectMap, "resourceId", e.ResourceID)
 	return json.Marshal(objectMap)
@@ -608,11 +608,11 @@ func (e *EnvironmentCompute) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "kind":
-				err = unpopulate(val, "Kind", &e.Kind)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Kind", &e.Kind)
+			delete(rawMsg, key)
 		case "resourceId":
-				err = unpopulate(val, "ResourceID", &e.ResourceID)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ResourceID", &e.ResourceID)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", e, err)
@@ -623,7 +623,7 @@ func (e *EnvironmentCompute) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type EnvironmentProperties.
 func (e EnvironmentProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "compute", e.Compute)
 	populate(objectMap, "providers", e.Providers)
 	populate(objectMap, "provisioningState", e.ProvisioningState)
@@ -641,17 +641,17 @@ func (e *EnvironmentProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "compute":
-				e.Compute, err = unmarshalEnvironmentComputeClassification(val)
-				delete(rawMsg, key)
+			e.Compute, err = unmarshalEnvironmentComputeClassification(val)
+			delete(rawMsg, key)
 		case "providers":
-				err = unpopulate(val, "Providers", &e.Providers)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Providers", &e.Providers)
+			delete(rawMsg, key)
 		case "provisioningState":
-				err = unpopulate(val, "ProvisioningState", &e.ProvisioningState)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ProvisioningState", &e.ProvisioningState)
+			delete(rawMsg, key)
 		case "recipes":
-				err = unpopulate(val, "Recipes", &e.Recipes)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Recipes", &e.Recipes)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", e, err)
@@ -662,7 +662,7 @@ func (e *EnvironmentProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type EnvironmentRecipeProperties.
 func (e EnvironmentRecipeProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "linkType", e.LinkType)
 	populate(objectMap, "templatePath", e.TemplatePath)
 	return json.Marshal(objectMap)
@@ -678,11 +678,11 @@ func (e *EnvironmentRecipeProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "linkType":
-				err = unpopulate(val, "LinkType", &e.LinkType)
-				delete(rawMsg, key)
+			err = unpopulate(val, "LinkType", &e.LinkType)
+			delete(rawMsg, key)
 		case "templatePath":
-				err = unpopulate(val, "TemplatePath", &e.TemplatePath)
-				delete(rawMsg, key)
+			err = unpopulate(val, "TemplatePath", &e.TemplatePath)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", e, err)
@@ -693,7 +693,7 @@ func (e *EnvironmentRecipeProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type EnvironmentResource.
 func (e EnvironmentResource) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "id", e.ID)
 	populate(objectMap, "location", e.Location)
 	populate(objectMap, "name", e.Name)
@@ -714,26 +714,26 @@ func (e *EnvironmentResource) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "id":
-				err = unpopulate(val, "ID", &e.ID)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ID", &e.ID)
+			delete(rawMsg, key)
 		case "location":
-				err = unpopulate(val, "Location", &e.Location)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Location", &e.Location)
+			delete(rawMsg, key)
 		case "name":
-				err = unpopulate(val, "Name", &e.Name)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Name", &e.Name)
+			delete(rawMsg, key)
 		case "properties":
-				err = unpopulate(val, "Properties", &e.Properties)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Properties", &e.Properties)
+			delete(rawMsg, key)
 		case "systemData":
-				err = unpopulate(val, "SystemData", &e.SystemData)
-				delete(rawMsg, key)
+			err = unpopulate(val, "SystemData", &e.SystemData)
+			delete(rawMsg, key)
 		case "tags":
-				err = unpopulate(val, "Tags", &e.Tags)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Tags", &e.Tags)
+			delete(rawMsg, key)
 		case "type":
-				err = unpopulate(val, "Type", &e.Type)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Type", &e.Type)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", e, err)
@@ -744,7 +744,7 @@ func (e *EnvironmentResource) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type EnvironmentResourceList.
 func (e EnvironmentResourceList) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "nextLink", e.NextLink)
 	populate(objectMap, "value", e.Value)
 	return json.Marshal(objectMap)
@@ -760,11 +760,11 @@ func (e *EnvironmentResourceList) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "nextLink":
-				err = unpopulate(val, "NextLink", &e.NextLink)
-				delete(rawMsg, key)
+			err = unpopulate(val, "NextLink", &e.NextLink)
+			delete(rawMsg, key)
 		case "value":
-				err = unpopulate(val, "Value", &e.Value)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Value", &e.Value)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", e, err)
@@ -775,7 +775,7 @@ func (e *EnvironmentResourceList) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type EphemeralVolume.
 func (e EphemeralVolume) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	objectMap["kind"] = "ephemeral"
 	populate(objectMap, "managedStore", e.ManagedStore)
 	populate(objectMap, "mountPath", e.MountPath)
@@ -792,14 +792,14 @@ func (e *EphemeralVolume) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "kind":
-				err = unpopulate(val, "Kind", &e.Kind)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Kind", &e.Kind)
+			delete(rawMsg, key)
 		case "managedStore":
-				err = unpopulate(val, "ManagedStore", &e.ManagedStore)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ManagedStore", &e.ManagedStore)
+			delete(rawMsg, key)
 		case "mountPath":
-				err = unpopulate(val, "MountPath", &e.MountPath)
-				delete(rawMsg, key)
+			err = unpopulate(val, "MountPath", &e.MountPath)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", e, err)
@@ -810,7 +810,7 @@ func (e *EphemeralVolume) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type ErrorAdditionalInfo.
 func (e ErrorAdditionalInfo) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "info", e.Info)
 	populate(objectMap, "type", e.Type)
 	return json.Marshal(objectMap)
@@ -826,11 +826,11 @@ func (e *ErrorAdditionalInfo) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "info":
-				err = unpopulate(val, "Info", &e.Info)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Info", &e.Info)
+			delete(rawMsg, key)
 		case "type":
-				err = unpopulate(val, "Type", &e.Type)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Type", &e.Type)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", e, err)
@@ -841,7 +841,7 @@ func (e *ErrorAdditionalInfo) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type ErrorDetail.
 func (e ErrorDetail) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "additionalInfo", e.AdditionalInfo)
 	populate(objectMap, "code", e.Code)
 	populate(objectMap, "details", e.Details)
@@ -860,20 +860,20 @@ func (e *ErrorDetail) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "additionalInfo":
-				err = unpopulate(val, "AdditionalInfo", &e.AdditionalInfo)
-				delete(rawMsg, key)
+			err = unpopulate(val, "AdditionalInfo", &e.AdditionalInfo)
+			delete(rawMsg, key)
 		case "code":
-				err = unpopulate(val, "Code", &e.Code)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Code", &e.Code)
+			delete(rawMsg, key)
 		case "details":
-				err = unpopulate(val, "Details", &e.Details)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Details", &e.Details)
+			delete(rawMsg, key)
 		case "message":
-				err = unpopulate(val, "Message", &e.Message)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Message", &e.Message)
+			delete(rawMsg, key)
 		case "target":
-				err = unpopulate(val, "Target", &e.Target)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Target", &e.Target)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", e, err)
@@ -884,7 +884,7 @@ func (e *ErrorDetail) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type ErrorResponse.
 func (e ErrorResponse) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "error", e.Error)
 	return json.Marshal(objectMap)
 }
@@ -899,8 +899,8 @@ func (e *ErrorResponse) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "error":
-				err = unpopulate(val, "Error", &e.Error)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Error", &e.Error)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", e, err)
@@ -911,7 +911,7 @@ func (e *ErrorResponse) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type ExecHealthProbeProperties.
 func (e ExecHealthProbeProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "command", e.Command)
 	populate(objectMap, "failureThreshold", e.FailureThreshold)
 	populate(objectMap, "initialDelaySeconds", e.InitialDelaySeconds)
@@ -930,20 +930,20 @@ func (e *ExecHealthProbeProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "command":
-				err = unpopulate(val, "Command", &e.Command)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Command", &e.Command)
+			delete(rawMsg, key)
 		case "failureThreshold":
-				err = unpopulate(val, "FailureThreshold", &e.FailureThreshold)
-				delete(rawMsg, key)
+			err = unpopulate(val, "FailureThreshold", &e.FailureThreshold)
+			delete(rawMsg, key)
 		case "initialDelaySeconds":
-				err = unpopulate(val, "InitialDelaySeconds", &e.InitialDelaySeconds)
-				delete(rawMsg, key)
+			err = unpopulate(val, "InitialDelaySeconds", &e.InitialDelaySeconds)
+			delete(rawMsg, key)
 		case "kind":
-				err = unpopulate(val, "Kind", &e.Kind)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Kind", &e.Kind)
+			delete(rawMsg, key)
 		case "periodSeconds":
-				err = unpopulate(val, "PeriodSeconds", &e.PeriodSeconds)
-				delete(rawMsg, key)
+			err = unpopulate(val, "PeriodSeconds", &e.PeriodSeconds)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", e, err)
@@ -954,7 +954,7 @@ func (e *ExecHealthProbeProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type Extension.
 func (e Extension) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	objectMap["kind"] = e.Kind
 	return json.Marshal(objectMap)
 }
@@ -969,8 +969,8 @@ func (e *Extension) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "kind":
-				err = unpopulate(val, "Kind", &e.Kind)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Kind", &e.Kind)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", e, err)
@@ -981,7 +981,7 @@ func (e *Extension) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type GatewayProperties.
 func (g GatewayProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "application", g.Application)
 	populate(objectMap, "hostname", g.Hostname)
 	populate(objectMap, "internal", g.Internal)
@@ -1002,26 +1002,26 @@ func (g *GatewayProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "application":
-				err = unpopulate(val, "Application", &g.Application)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Application", &g.Application)
+			delete(rawMsg, key)
 		case "hostname":
-				err = unpopulate(val, "Hostname", &g.Hostname)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Hostname", &g.Hostname)
+			delete(rawMsg, key)
 		case "internal":
-				err = unpopulate(val, "Internal", &g.Internal)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Internal", &g.Internal)
+			delete(rawMsg, key)
 		case "provisioningState":
-				err = unpopulate(val, "ProvisioningState", &g.ProvisioningState)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ProvisioningState", &g.ProvisioningState)
+			delete(rawMsg, key)
 		case "routes":
-				err = unpopulate(val, "Routes", &g.Routes)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Routes", &g.Routes)
+			delete(rawMsg, key)
 		case "status":
-				err = unpopulate(val, "Status", &g.Status)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Status", &g.Status)
+			delete(rawMsg, key)
 		case "url":
-				err = unpopulate(val, "URL", &g.URL)
-				delete(rawMsg, key)
+			err = unpopulate(val, "URL", &g.URL)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", g, err)
@@ -1032,7 +1032,7 @@ func (g *GatewayProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type GatewayPropertiesHostname.
 func (g GatewayPropertiesHostname) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "fullyQualifiedHostname", g.FullyQualifiedHostname)
 	populate(objectMap, "prefix", g.Prefix)
 	return json.Marshal(objectMap)
@@ -1048,11 +1048,11 @@ func (g *GatewayPropertiesHostname) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "fullyQualifiedHostname":
-				err = unpopulate(val, "FullyQualifiedHostname", &g.FullyQualifiedHostname)
-				delete(rawMsg, key)
+			err = unpopulate(val, "FullyQualifiedHostname", &g.FullyQualifiedHostname)
+			delete(rawMsg, key)
 		case "prefix":
-				err = unpopulate(val, "Prefix", &g.Prefix)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Prefix", &g.Prefix)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", g, err)
@@ -1063,7 +1063,7 @@ func (g *GatewayPropertiesHostname) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type GatewayResource.
 func (g GatewayResource) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "id", g.ID)
 	populate(objectMap, "location", g.Location)
 	populate(objectMap, "name", g.Name)
@@ -1084,26 +1084,26 @@ func (g *GatewayResource) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "id":
-				err = unpopulate(val, "ID", &g.ID)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ID", &g.ID)
+			delete(rawMsg, key)
 		case "location":
-				err = unpopulate(val, "Location", &g.Location)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Location", &g.Location)
+			delete(rawMsg, key)
 		case "name":
-				err = unpopulate(val, "Name", &g.Name)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Name", &g.Name)
+			delete(rawMsg, key)
 		case "properties":
-				err = unpopulate(val, "Properties", &g.Properties)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Properties", &g.Properties)
+			delete(rawMsg, key)
 		case "systemData":
-				err = unpopulate(val, "SystemData", &g.SystemData)
-				delete(rawMsg, key)
+			err = unpopulate(val, "SystemData", &g.SystemData)
+			delete(rawMsg, key)
 		case "tags":
-				err = unpopulate(val, "Tags", &g.Tags)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Tags", &g.Tags)
+			delete(rawMsg, key)
 		case "type":
-				err = unpopulate(val, "Type", &g.Type)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Type", &g.Type)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", g, err)
@@ -1114,7 +1114,7 @@ func (g *GatewayResource) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type GatewayResourceList.
 func (g GatewayResourceList) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "nextLink", g.NextLink)
 	populate(objectMap, "value", g.Value)
 	return json.Marshal(objectMap)
@@ -1130,11 +1130,11 @@ func (g *GatewayResourceList) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "nextLink":
-				err = unpopulate(val, "NextLink", &g.NextLink)
-				delete(rawMsg, key)
+			err = unpopulate(val, "NextLink", &g.NextLink)
+			delete(rawMsg, key)
 		case "value":
-				err = unpopulate(val, "Value", &g.Value)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Value", &g.Value)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", g, err)
@@ -1145,7 +1145,7 @@ func (g *GatewayResourceList) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type GatewayRoute.
 func (g GatewayRoute) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "destination", g.Destination)
 	populate(objectMap, "path", g.Path)
 	populate(objectMap, "replacePrefix", g.ReplacePrefix)
@@ -1162,14 +1162,14 @@ func (g *GatewayRoute) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "destination":
-				err = unpopulate(val, "Destination", &g.Destination)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Destination", &g.Destination)
+			delete(rawMsg, key)
 		case "path":
-				err = unpopulate(val, "Path", &g.Path)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Path", &g.Path)
+			delete(rawMsg, key)
 		case "replacePrefix":
-				err = unpopulate(val, "ReplacePrefix", &g.ReplacePrefix)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ReplacePrefix", &g.ReplacePrefix)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", g, err)
@@ -1180,7 +1180,7 @@ func (g *GatewayRoute) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type HTTPGetHealthProbeProperties.
 func (h HTTPGetHealthProbeProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "containerPort", h.ContainerPort)
 	populate(objectMap, "failureThreshold", h.FailureThreshold)
 	populate(objectMap, "headers", h.Headers)
@@ -1201,26 +1201,26 @@ func (h *HTTPGetHealthProbeProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "containerPort":
-				err = unpopulate(val, "ContainerPort", &h.ContainerPort)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ContainerPort", &h.ContainerPort)
+			delete(rawMsg, key)
 		case "failureThreshold":
-				err = unpopulate(val, "FailureThreshold", &h.FailureThreshold)
-				delete(rawMsg, key)
+			err = unpopulate(val, "FailureThreshold", &h.FailureThreshold)
+			delete(rawMsg, key)
 		case "headers":
-				err = unpopulate(val, "Headers", &h.Headers)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Headers", &h.Headers)
+			delete(rawMsg, key)
 		case "initialDelaySeconds":
-				err = unpopulate(val, "InitialDelaySeconds", &h.InitialDelaySeconds)
-				delete(rawMsg, key)
+			err = unpopulate(val, "InitialDelaySeconds", &h.InitialDelaySeconds)
+			delete(rawMsg, key)
 		case "kind":
-				err = unpopulate(val, "Kind", &h.Kind)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Kind", &h.Kind)
+			delete(rawMsg, key)
 		case "path":
-				err = unpopulate(val, "Path", &h.Path)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Path", &h.Path)
+			delete(rawMsg, key)
 		case "periodSeconds":
-				err = unpopulate(val, "PeriodSeconds", &h.PeriodSeconds)
-				delete(rawMsg, key)
+			err = unpopulate(val, "PeriodSeconds", &h.PeriodSeconds)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", h, err)
@@ -1231,7 +1231,7 @@ func (h *HTTPGetHealthProbeProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type HTTPRouteProperties.
 func (h HTTPRouteProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "application", h.Application)
 	populate(objectMap, "hostname", h.Hostname)
 	populate(objectMap, "port", h.Port)
@@ -1252,26 +1252,26 @@ func (h *HTTPRouteProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "application":
-				err = unpopulate(val, "Application", &h.Application)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Application", &h.Application)
+			delete(rawMsg, key)
 		case "hostname":
-				err = unpopulate(val, "Hostname", &h.Hostname)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Hostname", &h.Hostname)
+			delete(rawMsg, key)
 		case "port":
-				err = unpopulate(val, "Port", &h.Port)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Port", &h.Port)
+			delete(rawMsg, key)
 		case "provisioningState":
-				err = unpopulate(val, "ProvisioningState", &h.ProvisioningState)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ProvisioningState", &h.ProvisioningState)
+			delete(rawMsg, key)
 		case "scheme":
-				err = unpopulate(val, "Scheme", &h.Scheme)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Scheme", &h.Scheme)
+			delete(rawMsg, key)
 		case "status":
-				err = unpopulate(val, "Status", &h.Status)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Status", &h.Status)
+			delete(rawMsg, key)
 		case "url":
-				err = unpopulate(val, "URL", &h.URL)
-				delete(rawMsg, key)
+			err = unpopulate(val, "URL", &h.URL)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", h, err)
@@ -1282,7 +1282,7 @@ func (h *HTTPRouteProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type HTTPRouteResource.
 func (h HTTPRouteResource) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "id", h.ID)
 	populate(objectMap, "location", h.Location)
 	populate(objectMap, "name", h.Name)
@@ -1303,26 +1303,26 @@ func (h *HTTPRouteResource) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "id":
-				err = unpopulate(val, "ID", &h.ID)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ID", &h.ID)
+			delete(rawMsg, key)
 		case "location":
-				err = unpopulate(val, "Location", &h.Location)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Location", &h.Location)
+			delete(rawMsg, key)
 		case "name":
-				err = unpopulate(val, "Name", &h.Name)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Name", &h.Name)
+			delete(rawMsg, key)
 		case "properties":
-				err = unpopulate(val, "Properties", &h.Properties)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Properties", &h.Properties)
+			delete(rawMsg, key)
 		case "systemData":
-				err = unpopulate(val, "SystemData", &h.SystemData)
-				delete(rawMsg, key)
+			err = unpopulate(val, "SystemData", &h.SystemData)
+			delete(rawMsg, key)
 		case "tags":
-				err = unpopulate(val, "Tags", &h.Tags)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Tags", &h.Tags)
+			delete(rawMsg, key)
 		case "type":
-				err = unpopulate(val, "Type", &h.Type)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Type", &h.Type)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", h, err)
@@ -1333,7 +1333,7 @@ func (h *HTTPRouteResource) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type HTTPRouteResourceList.
 func (h HTTPRouteResourceList) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "nextLink", h.NextLink)
 	populate(objectMap, "value", h.Value)
 	return json.Marshal(objectMap)
@@ -1349,11 +1349,11 @@ func (h *HTTPRouteResourceList) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "nextLink":
-				err = unpopulate(val, "NextLink", &h.NextLink)
-				delete(rawMsg, key)
+			err = unpopulate(val, "NextLink", &h.NextLink)
+			delete(rawMsg, key)
 		case "value":
-				err = unpopulate(val, "Value", &h.Value)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Value", &h.Value)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", h, err)
@@ -1364,7 +1364,7 @@ func (h *HTTPRouteResourceList) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type HealthProbeProperties.
 func (h HealthProbeProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "failureThreshold", h.FailureThreshold)
 	populate(objectMap, "initialDelaySeconds", h.InitialDelaySeconds)
 	objectMap["kind"] = h.Kind
@@ -1382,17 +1382,17 @@ func (h *HealthProbeProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "failureThreshold":
-				err = unpopulate(val, "FailureThreshold", &h.FailureThreshold)
-				delete(rawMsg, key)
+			err = unpopulate(val, "FailureThreshold", &h.FailureThreshold)
+			delete(rawMsg, key)
 		case "initialDelaySeconds":
-				err = unpopulate(val, "InitialDelaySeconds", &h.InitialDelaySeconds)
-				delete(rawMsg, key)
+			err = unpopulate(val, "InitialDelaySeconds", &h.InitialDelaySeconds)
+			delete(rawMsg, key)
 		case "kind":
-				err = unpopulate(val, "Kind", &h.Kind)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Kind", &h.Kind)
+			delete(rawMsg, key)
 		case "periodSeconds":
-				err = unpopulate(val, "PeriodSeconds", &h.PeriodSeconds)
-				delete(rawMsg, key)
+			err = unpopulate(val, "PeriodSeconds", &h.PeriodSeconds)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", h, err)
@@ -1403,7 +1403,7 @@ func (h *HealthProbeProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type IamProperties.
 func (i IamProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "kind", i.Kind)
 	populate(objectMap, "roles", i.Roles)
 	return json.Marshal(objectMap)
@@ -1419,11 +1419,11 @@ func (i *IamProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "kind":
-				err = unpopulate(val, "Kind", &i.Kind)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Kind", &i.Kind)
+			delete(rawMsg, key)
 		case "roles":
-				err = unpopulate(val, "Roles", &i.Roles)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Roles", &i.Roles)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", i, err)
@@ -1434,7 +1434,7 @@ func (i *IamProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type KeyObjectProperties.
 func (k KeyObjectProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "alias", k.Alias)
 	populate(objectMap, "name", k.Name)
 	populate(objectMap, "version", k.Version)
@@ -1451,14 +1451,14 @@ func (k *KeyObjectProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "alias":
-				err = unpopulate(val, "Alias", &k.Alias)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Alias", &k.Alias)
+			delete(rawMsg, key)
 		case "name":
-				err = unpopulate(val, "Name", &k.Name)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Name", &k.Name)
+			delete(rawMsg, key)
 		case "version":
-				err = unpopulate(val, "Version", &k.Version)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Version", &k.Version)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", k, err)
@@ -1469,7 +1469,7 @@ func (k *KeyObjectProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type KubernetesCompute.
 func (k KubernetesCompute) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	objectMap["kind"] = "kubernetes"
 	populate(objectMap, "namespace", k.Namespace)
 	populate(objectMap, "resourceId", k.ResourceID)
@@ -1486,14 +1486,14 @@ func (k *KubernetesCompute) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "kind":
-				err = unpopulate(val, "Kind", &k.Kind)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Kind", &k.Kind)
+			delete(rawMsg, key)
 		case "namespace":
-				err = unpopulate(val, "Namespace", &k.Namespace)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Namespace", &k.Namespace)
+			delete(rawMsg, key)
 		case "resourceId":
-				err = unpopulate(val, "ResourceID", &k.ResourceID)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ResourceID", &k.ResourceID)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", k, err)
@@ -1504,7 +1504,7 @@ func (k *KubernetesCompute) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type ManualScalingExtension.
 func (m ManualScalingExtension) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	objectMap["kind"] = "manualScaling"
 	populate(objectMap, "replicas", m.Replicas)
 	return json.Marshal(objectMap)
@@ -1520,11 +1520,11 @@ func (m *ManualScalingExtension) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "kind":
-				err = unpopulate(val, "Kind", &m.Kind)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Kind", &m.Kind)
+			delete(rawMsg, key)
 		case "replicas":
-				err = unpopulate(val, "Replicas", &m.Replicas)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Replicas", &m.Replicas)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", m, err)
@@ -1535,7 +1535,7 @@ func (m *ManualScalingExtension) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type PersistentVolume.
 func (p PersistentVolume) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	objectMap["kind"] = "persistent"
 	populate(objectMap, "mountPath", p.MountPath)
 	populate(objectMap, "permission", p.Permission)
@@ -1553,17 +1553,17 @@ func (p *PersistentVolume) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "kind":
-				err = unpopulate(val, "Kind", &p.Kind)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Kind", &p.Kind)
+			delete(rawMsg, key)
 		case "mountPath":
-				err = unpopulate(val, "MountPath", &p.MountPath)
-				delete(rawMsg, key)
+			err = unpopulate(val, "MountPath", &p.MountPath)
+			delete(rawMsg, key)
 		case "permission":
-				err = unpopulate(val, "Permission", &p.Permission)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Permission", &p.Permission)
+			delete(rawMsg, key)
 		case "source":
-				err = unpopulate(val, "Source", &p.Source)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Source", &p.Source)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", p, err)
@@ -1574,7 +1574,7 @@ func (p *PersistentVolume) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type ProviderProperties.
 func (p ProviderProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "azure", p.Azure)
 	return json.Marshal(objectMap)
 }
@@ -1589,8 +1589,8 @@ func (p *ProviderProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "azure":
-				err = unpopulate(val, "Azure", &p.Azure)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Azure", &p.Azure)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", p, err)
@@ -1601,7 +1601,7 @@ func (p *ProviderProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type ProviderPropertiesAzure.
 func (p ProviderPropertiesAzure) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "scope", p.Scope)
 	return json.Marshal(objectMap)
 }
@@ -1616,8 +1616,8 @@ func (p *ProviderPropertiesAzure) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "scope":
-				err = unpopulate(val, "Scope", &p.Scope)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Scope", &p.Scope)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", p, err)
@@ -1628,7 +1628,7 @@ func (p *ProviderPropertiesAzure) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type Resource.
 func (r Resource) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "id", r.ID)
 	populate(objectMap, "name", r.Name)
 	populate(objectMap, "type", r.Type)
@@ -1645,14 +1645,14 @@ func (r *Resource) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "id":
-				err = unpopulate(val, "ID", &r.ID)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ID", &r.ID)
+			delete(rawMsg, key)
 		case "name":
-				err = unpopulate(val, "Name", &r.Name)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Name", &r.Name)
+			delete(rawMsg, key)
 		case "type":
-				err = unpopulate(val, "Type", &r.Type)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Type", &r.Type)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", r, err)
@@ -1663,7 +1663,7 @@ func (r *Resource) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type ResourceStatus.
 func (r ResourceStatus) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "outputResources", r.OutputResources)
 	return json.Marshal(objectMap)
 }
@@ -1678,8 +1678,8 @@ func (r *ResourceStatus) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "outputResources":
-				err = unpopulate(val, "OutputResources", &r.OutputResources)
-				delete(rawMsg, key)
+			err = unpopulate(val, "OutputResources", &r.OutputResources)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", r, err)
@@ -1690,7 +1690,7 @@ func (r *ResourceStatus) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type SecretObjectProperties.
 func (s SecretObjectProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "alias", s.Alias)
 	populate(objectMap, "encoding", s.Encoding)
 	populate(objectMap, "name", s.Name)
@@ -1708,17 +1708,17 @@ func (s *SecretObjectProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "alias":
-				err = unpopulate(val, "Alias", &s.Alias)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Alias", &s.Alias)
+			delete(rawMsg, key)
 		case "encoding":
-				err = unpopulate(val, "Encoding", &s.Encoding)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Encoding", &s.Encoding)
+			delete(rawMsg, key)
 		case "name":
-				err = unpopulate(val, "Name", &s.Name)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Name", &s.Name)
+			delete(rawMsg, key)
 		case "version":
-				err = unpopulate(val, "Version", &s.Version)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Version", &s.Version)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", s, err)
@@ -1729,7 +1729,7 @@ func (s *SecretObjectProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type SystemData.
 func (s SystemData) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populateTimeRFC3339(objectMap, "createdAt", s.CreatedAt)
 	populate(objectMap, "createdBy", s.CreatedBy)
 	populate(objectMap, "createdByType", s.CreatedByType)
@@ -1749,23 +1749,23 @@ func (s *SystemData) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "createdAt":
-				err = unpopulateTimeRFC3339(val, "CreatedAt", &s.CreatedAt)
-				delete(rawMsg, key)
+			err = unpopulateTimeRFC3339(val, "CreatedAt", &s.CreatedAt)
+			delete(rawMsg, key)
 		case "createdBy":
-				err = unpopulate(val, "CreatedBy", &s.CreatedBy)
-				delete(rawMsg, key)
+			err = unpopulate(val, "CreatedBy", &s.CreatedBy)
+			delete(rawMsg, key)
 		case "createdByType":
-				err = unpopulate(val, "CreatedByType", &s.CreatedByType)
-				delete(rawMsg, key)
+			err = unpopulate(val, "CreatedByType", &s.CreatedByType)
+			delete(rawMsg, key)
 		case "lastModifiedAt":
-				err = unpopulateTimeRFC3339(val, "LastModifiedAt", &s.LastModifiedAt)
-				delete(rawMsg, key)
+			err = unpopulateTimeRFC3339(val, "LastModifiedAt", &s.LastModifiedAt)
+			delete(rawMsg, key)
 		case "lastModifiedBy":
-				err = unpopulate(val, "LastModifiedBy", &s.LastModifiedBy)
-				delete(rawMsg, key)
+			err = unpopulate(val, "LastModifiedBy", &s.LastModifiedBy)
+			delete(rawMsg, key)
 		case "lastModifiedByType":
-				err = unpopulate(val, "LastModifiedByType", &s.LastModifiedByType)
-				delete(rawMsg, key)
+			err = unpopulate(val, "LastModifiedByType", &s.LastModifiedByType)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", s, err)
@@ -1776,7 +1776,7 @@ func (s *SystemData) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type TCPHealthProbeProperties.
 func (t TCPHealthProbeProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "containerPort", t.ContainerPort)
 	populate(objectMap, "failureThreshold", t.FailureThreshold)
 	populate(objectMap, "initialDelaySeconds", t.InitialDelaySeconds)
@@ -1795,20 +1795,20 @@ func (t *TCPHealthProbeProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "containerPort":
-				err = unpopulate(val, "ContainerPort", &t.ContainerPort)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ContainerPort", &t.ContainerPort)
+			delete(rawMsg, key)
 		case "failureThreshold":
-				err = unpopulate(val, "FailureThreshold", &t.FailureThreshold)
-				delete(rawMsg, key)
+			err = unpopulate(val, "FailureThreshold", &t.FailureThreshold)
+			delete(rawMsg, key)
 		case "initialDelaySeconds":
-				err = unpopulate(val, "InitialDelaySeconds", &t.InitialDelaySeconds)
-				delete(rawMsg, key)
+			err = unpopulate(val, "InitialDelaySeconds", &t.InitialDelaySeconds)
+			delete(rawMsg, key)
 		case "kind":
-				err = unpopulate(val, "Kind", &t.Kind)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Kind", &t.Kind)
+			delete(rawMsg, key)
 		case "periodSeconds":
-				err = unpopulate(val, "PeriodSeconds", &t.PeriodSeconds)
-				delete(rawMsg, key)
+			err = unpopulate(val, "PeriodSeconds", &t.PeriodSeconds)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", t, err)
@@ -1819,7 +1819,7 @@ func (t *TCPHealthProbeProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type TrackedResource.
 func (t TrackedResource) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "id", t.ID)
 	populate(objectMap, "location", t.Location)
 	populate(objectMap, "name", t.Name)
@@ -1838,20 +1838,20 @@ func (t *TrackedResource) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "id":
-				err = unpopulate(val, "ID", &t.ID)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ID", &t.ID)
+			delete(rawMsg, key)
 		case "location":
-				err = unpopulate(val, "Location", &t.Location)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Location", &t.Location)
+			delete(rawMsg, key)
 		case "name":
-				err = unpopulate(val, "Name", &t.Name)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Name", &t.Name)
+			delete(rawMsg, key)
 		case "tags":
-				err = unpopulate(val, "Tags", &t.Tags)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Tags", &t.Tags)
+			delete(rawMsg, key)
 		case "type":
-				err = unpopulate(val, "Type", &t.Type)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Type", &t.Type)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", t, err)
@@ -1862,7 +1862,7 @@ func (t *TrackedResource) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type Volume.
 func (v Volume) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	objectMap["kind"] = v.Kind
 	populate(objectMap, "mountPath", v.MountPath)
 	return json.Marshal(objectMap)
@@ -1878,11 +1878,11 @@ func (v *Volume) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "kind":
-				err = unpopulate(val, "Kind", &v.Kind)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Kind", &v.Kind)
+			delete(rawMsg, key)
 		case "mountPath":
-				err = unpopulate(val, "MountPath", &v.MountPath)
-				delete(rawMsg, key)
+			err = unpopulate(val, "MountPath", &v.MountPath)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", v, err)
@@ -1893,7 +1893,7 @@ func (v *Volume) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type VolumeProperties.
 func (v VolumeProperties) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "application", v.Application)
 	objectMap["kind"] = v.Kind
 	populate(objectMap, "provisioningState", v.ProvisioningState)
@@ -1911,17 +1911,17 @@ func (v *VolumeProperties) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "application":
-				err = unpopulate(val, "Application", &v.Application)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Application", &v.Application)
+			delete(rawMsg, key)
 		case "kind":
-				err = unpopulate(val, "Kind", &v.Kind)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Kind", &v.Kind)
+			delete(rawMsg, key)
 		case "provisioningState":
-				err = unpopulate(val, "ProvisioningState", &v.ProvisioningState)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ProvisioningState", &v.ProvisioningState)
+			delete(rawMsg, key)
 		case "status":
-				err = unpopulate(val, "Status", &v.Status)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Status", &v.Status)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", v, err)
@@ -1932,7 +1932,7 @@ func (v *VolumeProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type VolumeResource.
 func (v VolumeResource) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "id", v.ID)
 	populate(objectMap, "location", v.Location)
 	populate(objectMap, "name", v.Name)
@@ -1953,26 +1953,26 @@ func (v *VolumeResource) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "id":
-				err = unpopulate(val, "ID", &v.ID)
-				delete(rawMsg, key)
+			err = unpopulate(val, "ID", &v.ID)
+			delete(rawMsg, key)
 		case "location":
-				err = unpopulate(val, "Location", &v.Location)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Location", &v.Location)
+			delete(rawMsg, key)
 		case "name":
-				err = unpopulate(val, "Name", &v.Name)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Name", &v.Name)
+			delete(rawMsg, key)
 		case "properties":
-				v.Properties, err = unmarshalVolumePropertiesClassification(val)
-				delete(rawMsg, key)
+			v.Properties, err = unmarshalVolumePropertiesClassification(val)
+			delete(rawMsg, key)
 		case "systemData":
-				err = unpopulate(val, "SystemData", &v.SystemData)
-				delete(rawMsg, key)
+			err = unpopulate(val, "SystemData", &v.SystemData)
+			delete(rawMsg, key)
 		case "tags":
-				err = unpopulate(val, "Tags", &v.Tags)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Tags", &v.Tags)
+			delete(rawMsg, key)
 		case "type":
-				err = unpopulate(val, "Type", &v.Type)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Type", &v.Type)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", v, err)
@@ -1983,7 +1983,7 @@ func (v *VolumeResource) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface for type VolumeResourceList.
 func (v VolumeResourceList) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]interface{})
+	objectMap := make(map[string]any)
 	populate(objectMap, "nextLink", v.NextLink)
 	populate(objectMap, "value", v.Value)
 	return json.Marshal(objectMap)
@@ -1999,11 +1999,11 @@ func (v *VolumeResourceList) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "nextLink":
-				err = unpopulate(val, "NextLink", &v.NextLink)
-				delete(rawMsg, key)
+			err = unpopulate(val, "NextLink", &v.NextLink)
+			delete(rawMsg, key)
 		case "value":
-				err = unpopulate(val, "Value", &v.Value)
-				delete(rawMsg, key)
+			err = unpopulate(val, "Value", &v.Value)
+			delete(rawMsg, key)
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", v, err)
@@ -2012,7 +2012,7 @@ func (v *VolumeResourceList) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func populate(m map[string]interface{}, k string, v interface{}) {
+func populate(m map[string]any, k string, v any) {
 	if v == nil {
 		return
 	} else if azcore.IsNullValue(v) {
@@ -2022,7 +2022,7 @@ func populate(m map[string]interface{}, k string, v interface{}) {
 	}
 }
 
-func unpopulate(data json.RawMessage, fn string, v interface{}) error {
+func unpopulate(data json.RawMessage, fn string, v any) error {
 	if data == nil {
 		return nil
 	}
@@ -2031,4 +2031,3 @@ func unpopulate(data json.RawMessage, fn string, v interface{}) error {
 	}
 	return nil
 }
-

--- a/pkg/corerp/api/generated/zz_generated_polymorphic_helpers.go
+++ b/pkg/corerp/api/generated/zz_generated_polymorphic_helpers.go
@@ -15,7 +15,7 @@ func unmarshalEnvironmentComputeClassification(rawMsg json.RawMessage) (Environm
 	if rawMsg == nil {
 		return nil, nil
 	}
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(rawMsg, &m); err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func unmarshalExtensionClassification(rawMsg json.RawMessage) (ExtensionClassifi
 	if rawMsg == nil {
 		return nil, nil
 	}
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(rawMsg, &m); err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func unmarshalHealthProbePropertiesClassification(rawMsg json.RawMessage) (Healt
 	if rawMsg == nil {
 		return nil, nil
 	}
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(rawMsg, &m); err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func unmarshalVolumeClassification(rawMsg json.RawMessage) (VolumeClassification
 	if rawMsg == nil {
 		return nil, nil
 	}
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(rawMsg, &m); err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func unmarshalVolumePropertiesClassification(rawMsg json.RawMessage) (VolumeProp
 	if rawMsg == nil {
 		return nil, nil
 	}
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(rawMsg, &m); err != nil {
 		return nil, err
 	}
@@ -146,4 +146,3 @@ func unmarshalVolumePropertiesClassification(rawMsg json.RawMessage) (VolumeProp
 	}
 	return b, json.Unmarshal(rawMsg, b)
 }
-

--- a/pkg/corerp/api/generated/zz_generated_response_types.go
+++ b/pkg/corerp/api/generated/zz_generated_response_types.go
@@ -158,4 +158,3 @@ type VolumesClientListByScopeResponse struct {
 type VolumesClientUpdateResponse struct {
 	VolumeResource
 }
-

--- a/pkg/corerp/api/generated/zz_generated_time_rfc3339.go
+++ b/pkg/corerp/api/generated/zz_generated_time_rfc3339.go
@@ -9,8 +9,6 @@
 
 package generated
 
-
-
 import (
 	"encoding/json"
 	"fmt"
@@ -20,8 +18,6 @@ import (
 	"strings"
 	"time"
 )
-
-
 
 const (
 	utcLayoutJSON = `"2006-01-02T15:04:05.999999999"`
@@ -66,8 +62,7 @@ func (t *timeRFC3339) Parse(layout, value string) error {
 	return err
 }
 
-
-func populateTimeRFC3339(m map[string]interface{}, k string, t *time.Time) {
+func populateTimeRFC3339(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return
 	} else if azcore.IsNullValue(t) {

--- a/pkg/corerp/api/generated/zz_generated_volumes_client.go
+++ b/pkg/corerp/api/generated/zz_generated_volumes_client.go
@@ -26,9 +26,9 @@ import (
 // VolumesClient contains the methods for the Volumes group.
 // Don't use this type directly, use NewVolumesClient() instead.
 type VolumesClient struct {
-	host string
+	host      string
 	rootScope string
-	pl runtime.Pipeline
+	pl        runtime.Pipeline
 }
 
 // NewVolumesClient creates a new instance of VolumesClient with the specified values.
@@ -49,8 +49,8 @@ func NewVolumesClient(rootScope string, credential azcore.TokenCredential, optio
 	}
 	client := &VolumesClient{
 		rootScope: rootScope,
-		host: ep,
-pl: pl,
+		host:      ep,
+		pl:        pl,
 	}
 	return client, nil
 }
@@ -194,7 +194,7 @@ func (client *VolumesClient) getHandleResponse(resp *http.Response) (VolumesClie
 // NewListByScopePager - List all volumes in the given scope.
 // Generated from API version 2022-03-15-privatepreview
 // options - VolumesClientListByScopeOptions contains the optional parameters for the VolumesClient.ListByScope method.
-func (client *VolumesClient) NewListByScopePager(options *VolumesClientListByScopeOptions) (*runtime.Pager[VolumesClientListByScopeResponse]) {
+func (client *VolumesClient) NewListByScopePager(options *VolumesClientListByScopeOptions) *runtime.Pager[VolumesClientListByScopeResponse] {
 	return runtime.NewPager(runtime.PagingHandler[VolumesClientListByScopeResponse]{
 		More: func(page VolumesClientListByScopeResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -294,4 +294,3 @@ func (client *VolumesClient) updateHandleResponse(resp *http.Response) (VolumesC
 	}
 	return result, nil
 }
-

--- a/pkg/corerp/api/v20220315privatepreview/environment_conversion_test.go
+++ b/pkg/corerp/api/v20220315privatepreview/environment_conversion_test.go
@@ -101,7 +101,7 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 						"cosmos-recipe": {
 							LinkType:     "Applications.Link/mongoDatabases",
 							TemplatePath: "br:sampleregistry.azureacr.io/radius/recipes/mongodatabases",
-							Parameters: map[string]interface{}{
+							Parameters: map[string]any{
 								"throughput": float64(400),
 							},
 						},
@@ -264,7 +264,7 @@ func TestConvertDataModelToVersioned(t *testing.T) {
 				require.Equal(t, 1, len(r.Properties.Recipes))
 				require.Equal(t, "Applications.Link/mongoDatabases", r.Properties.Recipes["cosmos-recipe"].LinkType)
 				require.Equal(t, "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb", r.Properties.Recipes["cosmos-recipe"].TemplatePath)
-				require.Equal(t, map[string]interface{}{"throughput": float64(400)}, r.Properties.Recipes["cosmos-recipe"].Parameters)
+				require.Equal(t, map[string]any{"throughput": float64(400)}, r.Properties.Recipes["cosmos-recipe"].Parameters)
 				require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup", r.Properties.Providers.Azure.Scope)
 				require.Equal(t, "kubernetesMetadata", *versioned.Properties.Extensions[0].GetExtension().Kind)
 				require.Equal(t, 1, len(versioned.Properties.Extensions))

--- a/pkg/corerp/backend/controller/createorupdateresource_test.go
+++ b/pkg/corerp/backend/controller/createorupdateresource_test.go
@@ -171,9 +171,9 @@ func TestCreateOrUpdateResourceRun_20220315PrivatePreview(t *testing.T) {
 			getCall := msc.EXPECT().
 				Get(gomock.Any(), gomock.Any()).
 				Return(&store.Object{
-					Data: map[string]interface{}{
+					Data: map[string]any{
 						"name": "env0",
-						"properties": map[string]interface{}{
+						"properties": map[string]any{
 							"provisioningState": "Accepted",
 						},
 					},
@@ -368,9 +368,9 @@ func TestCreateOrUpdateResourceRun_20220315PrivatePreview(t *testing.T) {
 			getCall := msc.EXPECT().
 				Get(gomock.Any(), gomock.Any()).
 				Return(&store.Object{
-					Data: map[string]interface{}{
+					Data: map[string]any{
 						"name": "env0",
-						"properties": map[string]interface{}{
+						"properties": map[string]any{
 							"provisioningState": "Accepted",
 						},
 					},

--- a/pkg/corerp/backend/deployment/deployment_test.go
+++ b/pkg/corerp/backend/deployment/deployment_test.go
@@ -189,7 +189,7 @@ func buildMongoDBLinkWithRecipe() linkrp_dm.MongoDatabase {
 				RecipeProperties: linkrp_dm.RecipeProperties{
 					LinkRecipe: linkrp_dm.LinkRecipe{
 						Name: "mongoDB",
-						Parameters: map[string]interface{}{
+						Parameters: map[string]any{
 							"ResourceGroup": "testRG",
 							"Subscription":  "Radius-Test",
 						},
@@ -218,7 +218,7 @@ func buildMongoDBResourceDataWithRecipeAndSecrets() ResourceData {
 		},
 	}
 
-	computedValues := map[string]interface{}{
+	computedValues := map[string]any{
 		linkrp_r.DatabaseNameValue: "db",
 	}
 
@@ -258,8 +258,8 @@ func buildMongoDBResourceDataWithRecipeAndSecrets() ResourceData {
 					APIVersion: clients.GetAPIVersionFromUserAgent(documentdb.UserAgent()),
 				},
 			},
-			Resource: map[string]interface{}{
-				"properties": map[string]interface{}{
+			Resource: map[string]any{
+				"properties": map[string]any{
 					"resource": map[string]string{
 						"id": "test-database",
 					},
@@ -903,7 +903,7 @@ func Test_Deploy(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, len(testRendererOutput.Resources), len(deploymentOutput.DeployedOutputResources))
 		require.NotEqual(t, resourcemodel.ResourceIdentity{}, deploymentOutput.DeployedOutputResources[0].Identity)
-		require.Equal(t, map[string]interface{}{"url": testRendererOutput.ComputedValues["url"].Value}, deploymentOutput.ComputedValues)
+		require.Equal(t, map[string]any{"url": testRendererOutput.ComputedValues["url"].Value}, deploymentOutput.ComputedValues)
 	})
 
 	t.Run("Verify deploy failure", func(t *testing.T) {

--- a/pkg/corerp/datamodel/converter/application_converter_test.go
+++ b/pkg/corerp/datamodel/converter/application_converter_test.go
@@ -22,7 +22,7 @@ func TestApplicationDataModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{

--- a/pkg/corerp/datamodel/converter/container_converter_test.go
+++ b/pkg/corerp/datamodel/converter/container_converter_test.go
@@ -22,7 +22,7 @@ func TestContainerDataModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{

--- a/pkg/corerp/datamodel/converter/environment_converter_test.go
+++ b/pkg/corerp/datamodel/converter/environment_converter_test.go
@@ -31,7 +31,7 @@ func TestEnvironmentDataModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{

--- a/pkg/corerp/datamodel/converter/gateway_converter_test.go
+++ b/pkg/corerp/datamodel/converter/gateway_converter_test.go
@@ -22,7 +22,7 @@ func TestGatewayDataModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{

--- a/pkg/corerp/datamodel/converter/httproute_converter_test.go
+++ b/pkg/corerp/datamodel/converter/httproute_converter_test.go
@@ -22,7 +22,7 @@ func TestHTTPRouteDataModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{

--- a/pkg/corerp/datamodel/converter/volume_converter_test.go
+++ b/pkg/corerp/datamodel/converter/volume_converter_test.go
@@ -22,7 +22,7 @@ func TestVolumeResourceModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{

--- a/pkg/corerp/datamodel/environment.go
+++ b/pkg/corerp/datamodel/environment.go
@@ -33,9 +33,9 @@ type EnvironmentProperties struct {
 
 // EnvironmentRecipeProperties represents the properties of environment's recipe.
 type EnvironmentRecipeProperties struct {
-	LinkType     string                 `json:"linkType,omitempty"`
-	TemplatePath string                 `json:"templatePath,omitempty"`
-	Parameters   map[string]interface{} `json:"parameters,omitempty"`
+	LinkType     string         `json:"linkType,omitempty"`
+	TemplatePath string         `json:"templatePath,omitempty"`
+	Parameters   map[string]any `json:"parameters,omitempty"`
 }
 
 // Providers represents configs for providers for the environment, eg azure

--- a/pkg/corerp/datamodel/linkmetadata.go
+++ b/pkg/corerp/datamodel/linkmetadata.go
@@ -13,7 +13,7 @@ type LinkMetadata struct {
 
 	// ComputedValues map is any resource values that will be needed for more operations.
 	// For example; database name to generate secrets for cosmos DB.
-	ComputedValues map[string]interface{} `json:"computedValues,omitempty"`
+	ComputedValues map[string]any `json:"computedValues,omitempty"`
 
 	// Stores action to retrieve secret values. For Azure, connectionstring is accessed through cosmos listConnectionString operation, if secrets are not provided as input
 	SecretValues map[string]rp.SecretValueReference `json:"secretValues,omitempty"`

--- a/pkg/corerp/frontend/handler/getoperations.go
+++ b/pkg/corerp/frontend/handler/getoperations.go
@@ -42,7 +42,7 @@ func (opctrl *GetOperations) Run(ctx context.Context, w http.ResponseWriter, req
 
 func (opctrl *GetOperations) availableOperationsV1() *v1.PaginatedList {
 	return &v1.PaginatedList{
-		Value: []interface{}{
+		Value: []any{
 			&v1.Operation{
 				Name: "Applications.Core/operations/read",
 				Display: &v1.OperationDisplayProperties{

--- a/pkg/corerp/handlers/arm_handler.go
+++ b/pkg/corerp/handlers/arm_handler.go
@@ -49,7 +49,7 @@ func (handler *armHandler) Delete(ctx context.Context, options *DeleteOptions) e
 	return nil
 }
 
-func (handler *armHandler) serializeResource(resource resources.GenericResource) (map[string]interface{}, error) {
+func (handler *armHandler) serializeResource(resource resources.GenericResource) (map[string]any, error) {
 	// We turn the resource into a weakly-typed representation. This is needed because JSON Pointer
 	// will have trouble with the autorest embdedded types.
 	b, err := json.Marshal(&resource)
@@ -57,7 +57,7 @@ func (handler *armHandler) serializeResource(resource resources.GenericResource)
 		return nil, fmt.Errorf("failed to marshal %T", resource)
 	}
 
-	data := map[string]interface{}{}
+	data := map[string]any{}
 	err = json.Unmarshal(b, &data)
 	if err != nil {
 		return nil, errors.New("failed to umarshal resource data")

--- a/pkg/corerp/handlers/kubernetes.go
+++ b/pkg/corerp/handlers/kubernetes.go
@@ -131,12 +131,12 @@ func (handler *kubernetesHandler) Put(ctx context.Context, options *PutOptions) 
 func (handler *kubernetesHandler) PatchNamespace(ctx context.Context, namespace string) error {
 	// Ensure that the namespace exists that we're able to operate upon.
 	ns := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Namespace",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": namespace,
-				"labels": map[string]interface{}{
+				"labels": map[string]any{
 					kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
 				},
 			},
@@ -159,10 +159,10 @@ func (handler *kubernetesHandler) Delete(ctx context.Context, options *DeleteOpt
 	}
 
 	item := unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": identity.APIVersion,
 			"kind":       identity.Kind,
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"namespace": identity.Namespace,
 				"name":      identity.Name,
 			},
@@ -195,7 +195,7 @@ func (handler *kubernetesHandler) watchUntilReady(ctx context.Context, item clie
 
 	deploymentInformer := informerFactory.Apps().V1().Deployments().Informer()
 	handlers := cache.ResourceEventHandlerFuncs{
-		AddFunc: func(new_obj interface{}) {
+		AddFunc: func(new_obj any) {
 			obj, ok := new_obj.(*v1.Deployment)
 			if !ok {
 				watchErrorCh <- errors.New("deployment object is not of appsv1.Deployment type")
@@ -203,7 +203,7 @@ func (handler *kubernetesHandler) watchUntilReady(ctx context.Context, item clie
 
 			handler.watchUntilDeploymentReady(ctx, obj, readinessCh)
 		},
-		UpdateFunc: func(old_obj, new_obj interface{}) {
+		UpdateFunc: func(old_obj, new_obj any) {
 			old, ok := old_obj.(*v1.Deployment)
 			if !ok {
 				watchErrorCh <- errors.New("old deployment object is not of appsv1.Deployment type")
@@ -216,7 +216,7 @@ func (handler *kubernetesHandler) watchUntilReady(ctx context.Context, item clie
 				handler.watchUntilDeploymentReady(ctx, new, readinessCh)
 			}
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			// no-op here
 		},
 	}

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -492,7 +492,7 @@ func Test_Render_Connections(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{
 		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
 			ResourceID: makeResourceID(t, "SomeProvider/ResourceType", "A"),
-			ComputedValues: map[string]interface{}{
+			ComputedValues: map[string]any{
 				"ComputedKey1": "ComputedValue1",
 				"ComputedKey2": 82,
 			},
@@ -589,7 +589,7 @@ func Test_RenderConnections_DisableDefaultEnvVars(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{
 		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
 			ResourceID: makeResourceID(t, "SomeProvider/ResourceType", "A"),
-			ComputedValues: map[string]interface{}{
+			ComputedValues: map[string]any{
 				"ComputedKey1": "ComputedValue1",
 				"ComputedKey2": 82,
 			},
@@ -641,7 +641,7 @@ func Test_Render_Connections_SecretsGetHashed(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{
 		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
 			ResourceID: makeResourceID(t, "SomeProvider/ResourceType", "A"),
-			ComputedValues: map[string]interface{}{
+			ComputedValues: map[string]any{
 				"ComputedKey1": "ComputedValue1",
 				"ComputedKey2": 82,
 			},
@@ -695,7 +695,7 @@ func Test_Render_ConnectionWithRoleAssignment(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{
 		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
 			ResourceID: makeResourceID(t, "SomeProvider/ResourceType", "A"),
-			ComputedValues: map[string]interface{}{
+			ComputedValues: map[string]any{
 				"ComputedKey1": "ComputedValue1",
 				"ComputedKey2": 82,
 			},
@@ -958,7 +958,7 @@ func Test_Render_EphemeralVolumes(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{
 		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
 			ResourceID:     makeResourceID(t, "SomeProvider/ResourceType", "A"),
-			ComputedValues: map[string]interface{}{},
+			ComputedValues: map[string]any{},
 		},
 	}
 	renderer := Renderer{}
@@ -1033,7 +1033,7 @@ func Test_Render_PersistentAzureFileShareVolumes(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{
 		testResourceID: {
 			ResourceID: resourceID,
-			ComputedValues: map[string]interface{}{
+			ComputedValues: map[string]any{
 				"azurestorageaccountname": "accountname",
 				"azurestorageaccountkey":  "storagekey",
 			},
@@ -1217,7 +1217,7 @@ func Test_Render_ReadinessProbeHttpGet(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{
 		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
 			ResourceID: makeResourceID(t, "SomeProvider/ResourceType", "A"),
-			ComputedValues: map[string]interface{}{
+			ComputedValues: map[string]any{
 				"ComputedKey1": "ComputedValue1",
 				"ComputedKey2": 82,
 			},
@@ -1293,7 +1293,7 @@ func Test_Render_ReadinessProbeTcp(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{
 		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
 			ResourceID: makeResourceID(t, "SomeProvider/ResourceType", "A"),
-			ComputedValues: map[string]interface{}{
+			ComputedValues: map[string]any{
 				"ComputedKey1": "ComputedValue1",
 				"ComputedKey2": 82,
 			},
@@ -1362,7 +1362,7 @@ func Test_Render_LivenessProbeExec(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{
 		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
 			ResourceID: makeResourceID(t, "SomeProvider/ResourceType", "A"),
-			ComputedValues: map[string]interface{}{
+			ComputedValues: map[string]any{
 				"ComputedKey1": "ComputedValue1",
 				"ComputedKey2": 82,
 			},
@@ -1421,7 +1421,7 @@ func Test_Render_LivenessProbeWithDefaults(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{
 		(makeResourceID(t, "SomeProvider/ResourceType", "A").String()): {
 			ResourceID: makeResourceID(t, "SomeProvider/ResourceType", "A"),
-			ComputedValues: map[string]interface{}{
+			ComputedValues: map[string]any{
 				"ComputedKey1": "ComputedValue1",
 				"ComputedKey2": 82,
 			},

--- a/pkg/corerp/renderers/gateway/render_test.go
+++ b/pkg/corerp/renderers/gateway/render_test.go
@@ -925,7 +925,7 @@ func Test_Render_WithDependencies(t *testing.T) {
 	dependencies := map[string]renderers.RendererDependency{
 		(makeResourceID(t, routeDestination).String()): {
 			ResourceID: makeResourceID(t, routeDestination),
-			ComputedValues: map[string]interface{}{
+			ComputedValues: map[string]any{
 				"port": port,
 			},
 		},

--- a/pkg/corerp/renderers/types.go
+++ b/pkg/corerp/renderers/types.go
@@ -45,7 +45,7 @@ type RendererDependency struct {
 	Resource conv.DataModelInterface
 
 	// ComputedValues is a map of the computed values and secrets of the dependency.
-	ComputedValues map[string]interface{}
+	ComputedValues map[string]any
 
 	// OutputResources is a map of the output resource identities of the dependency. The map is keyed on the LocalID of the output resource.
 	OutputResources map[string]resourcemodel.ResourceIdentity

--- a/pkg/corerp/testing/armtest.go
+++ b/pkg/corerp/testing/armtest.go
@@ -16,7 +16,7 @@ import (
 	"github.com/project-radius/radius/pkg/armrpc/hostoptions"
 )
 
-func GetARMTestHTTPRequest(ctx context.Context, method string, headerFixtureJSONFile string, body interface{}) (*http.Request, error) {
+func GetARMTestHTTPRequest(ctx context.Context, method string, headerFixtureJSONFile string, body any) (*http.Request, error) {
 	jsonData, err := os.ReadFile("./testdata/" + headerFixtureJSONFile)
 	if err != nil {
 		return nil, err

--- a/pkg/linkrp/api/v20220315privatepreview/daprpubsubbroker_conversion_test.go
+++ b/pkg/linkrp/api/v20220315privatepreview/daprpubsubbroker_conversion_test.go
@@ -51,7 +51,7 @@ func TestDaprPubSubBroker_ConvertVersionedToDataModel(t *testing.T) {
 			require.Equal(t, []outputresource.OutputResource(nil), convertedResource.Properties.Status.OutputResources)
 		case *RecipeDaprPubSubProperties:
 			if payload == "daprpubsubbrokerresource_recipe2.json" {
-				parameters := map[string]interface{}{"port": float64(6081)}
+				parameters := map[string]any{"port": float64(6081)}
 				require.Equal(t, parameters, convertedResource.Properties.Recipe.Parameters)
 			} else {
 				require.Equal(t, "redis-test", convertedResource.Properties.Recipe.Name)
@@ -97,7 +97,7 @@ func TestDaprPubSubBroker_ConvertDataModelToVersioned(t *testing.T) {
 			require.Equal(t, "bar", v.Metadata["foo"])
 		case *RecipeDaprPubSubProperties:
 			if payload == "daprpubsubbrokerresourcedatamodel_recipe2" {
-				parameters := map[string]interface{}{"port": float64(6081)}
+				parameters := map[string]any{"port": float64(6081)}
 				require.Equal(t, parameters, resource.Properties.Recipe.Parameters)
 			} else {
 				require.Equal(t, "redis-test", resource.Properties.Recipe.Name)

--- a/pkg/linkrp/api/v20220315privatepreview/daprstatestore_conversion_test.go
+++ b/pkg/linkrp/api/v20220315privatepreview/daprstatestore_conversion_test.go
@@ -57,7 +57,7 @@ func TestDaprStateStore_ConvertVersionedToDataModel(t *testing.T) {
 			require.Equal(t, []outputresource.OutputResource(nil), convertedResource.Properties.Status.OutputResources)
 		case *RecipeDaprStateStoreProperties:
 			if payload == "daprstatestoreresource_recipe2.json" {
-				parameters := map[string]interface{}{"port": float64(6081)}
+				parameters := map[string]any{"port": float64(6081)}
 				require.Equal(t, parameters, convertedResource.Properties.Recipe.Parameters)
 			} else {
 				require.Equal(t, "recipe-test", convertedResource.Properties.Recipe.Name)
@@ -110,7 +110,7 @@ func TestDaprStateStore_ConvertDataModelToVersioned(t *testing.T) {
 			require.Equal(t, "kubernetes", v.GetDaprStateStoreProperties().Status.OutputResources[0]["Provider"])
 		case *RecipeDaprStateStoreProperties:
 			if payload == "daprstatestoreresourcedatamodel_recipe2.json" {
-				parameters := map[string]interface{}{"port": float64(6081)}
+				parameters := map[string]any{"port": float64(6081)}
 				require.Equal(t, parameters, resource.Properties.Recipe.Parameters)
 			} else {
 				require.Equal(t, "recipe-test", resource.Properties.Recipe.Name)

--- a/pkg/linkrp/api/v20220315privatepreview/extender_conversion_test.go
+++ b/pkg/linkrp/api/v20220315privatepreview/extender_conversion_test.go
@@ -36,10 +36,10 @@ func TestExtender_ConvertVersionedToDataModel(t *testing.T) {
 		require.Equal(t, "Applications.Link/extenders", convertedResource.Type)
 		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication", convertedResource.Properties.Application)
 		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", convertedResource.Properties.Environment)
-		require.Equal(t, map[string]interface{}{"fromNumber": "222-222-2222"}, convertedResource.Properties.AdditionalProperties)
+		require.Equal(t, map[string]any{"fromNumber": "222-222-2222"}, convertedResource.Properties.AdditionalProperties)
 
 		if payload == "extenderresource.json" {
-			require.Equal(t, map[string]interface{}{"accountSid": "sid", "authToken:": "token"}, convertedResource.Properties.Secrets)
+			require.Equal(t, map[string]any{"accountSid": "sid", "authToken:": "token"}, convertedResource.Properties.Secrets)
 			require.Equal(t, []outputresource.OutputResource(nil), convertedResource.Properties.Status.OutputResources)
 		} else {
 			require.Empty(t, convertedResource.Properties.Secrets)
@@ -69,7 +69,7 @@ func TestExtender_ConvertDataModelToVersioned(t *testing.T) {
 		require.Equal(t, "Applications.Link/extenders", *versionedResource.Type)
 		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/applications/testApplication", *versionedResource.Properties.Application)
 		require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", *versionedResource.Properties.Environment)
-		require.Equal(t, map[string]interface{}{"fromNumber": "222-222-2222"}, versionedResource.Properties.AdditionalProperties)
+		require.Equal(t, map[string]any{"fromNumber": "222-222-2222"}, versionedResource.Properties.AdditionalProperties)
 		require.Empty(t, versionedResource.Properties.Secrets) // Secrets are omitted from the versioned data model.
 
 		if payload == "extenderresourcedatamodel.json" {

--- a/pkg/linkrp/api/v20220315privatepreview/rediscache_conversion_test.go
+++ b/pkg/linkrp/api/v20220315privatepreview/rediscache_conversion_test.go
@@ -50,7 +50,7 @@ func TestRedisCache_ConvertVersionedToDataModel(t *testing.T) {
 		case *RecipeRedisCacheProperties:
 			require.Equal(t, "redis-test", convertedResource.Properties.Recipe.Name)
 			if payload == "rediscacheresource_recipe2.json" {
-				parameters := map[string]interface{}{"port": float64(6081)}
+				parameters := map[string]any{"port": float64(6081)}
 				require.Equal(t, parameters, convertedResource.Properties.Recipe.Parameters)
 				require.Equal(t, "myrediscache.redis.cache.windows.net", convertedResource.Properties.Host)
 				require.Equal(t, int32(10255), convertedResource.Properties.Port)
@@ -99,7 +99,7 @@ func TestRedisCache_ConvertDataModelToVersioned(t *testing.T) {
 		case *RecipeRedisCacheProperties:
 			require.Equal(t, "redis-test", *v.Recipe.Name)
 			if payload == "rediscacheresourcedatamodel_recipe2.json" {
-				parameters := map[string]interface{}{"port": float64(6081)}
+				parameters := map[string]any{"port": float64(6081)}
 				require.Equal(t, parameters, v.Recipe.Parameters)
 			}
 		case *ValuesRedisCacheProperties:

--- a/pkg/linkrp/datamodel/converter/daprinvokehttproute_converter_test.go
+++ b/pkg/linkrp/datamodel/converter/daprinvokehttproute_converter_test.go
@@ -21,7 +21,7 @@ func TestDaprInvokeHttpRouteDataModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{

--- a/pkg/linkrp/datamodel/converter/daprpubsubbroker_converter_test.go
+++ b/pkg/linkrp/datamodel/converter/daprpubsubbroker_converter_test.go
@@ -21,7 +21,7 @@ func TestDaprPubSubBrokerDataModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{

--- a/pkg/linkrp/datamodel/converter/daprsecretstore_converter_test.go
+++ b/pkg/linkrp/datamodel/converter/daprsecretstore_converter_test.go
@@ -21,7 +21,7 @@ func TestDaprSecretStoreDataModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{

--- a/pkg/linkrp/datamodel/converter/daprstatestore_converter_test.go
+++ b/pkg/linkrp/datamodel/converter/daprstatestore_converter_test.go
@@ -21,7 +21,7 @@ func TestDaprStateStoreDataModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{

--- a/pkg/linkrp/datamodel/converter/extender_converter_test.go
+++ b/pkg/linkrp/datamodel/converter/extender_converter_test.go
@@ -21,7 +21,7 @@ func TestExtenderDataModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{

--- a/pkg/linkrp/datamodel/converter/mongodatabase_converter_test.go
+++ b/pkg/linkrp/datamodel/converter/mongodatabase_converter_test.go
@@ -30,7 +30,7 @@ func TestMongoDatabaseDataModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{
@@ -104,7 +104,7 @@ func TestMongoDatabaseSecretsDataModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{

--- a/pkg/linkrp/datamodel/converter/rabbitmq_converter_test.go
+++ b/pkg/linkrp/datamodel/converter/rabbitmq_converter_test.go
@@ -21,7 +21,7 @@ func TestRabbitMQMessageQueueDataModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{
@@ -95,7 +95,7 @@ func TestRabbitMQSecretsDataModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{

--- a/pkg/linkrp/datamodel/converter/rediscache_converter_test.go
+++ b/pkg/linkrp/datamodel/converter/rediscache_converter_test.go
@@ -21,7 +21,7 @@ func TestRedisCacheDataModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{
@@ -95,7 +95,7 @@ func TestRedisCacheSecretsDataModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{

--- a/pkg/linkrp/datamodel/converter/sqldatabase_converter_test.go
+++ b/pkg/linkrp/datamodel/converter/sqldatabase_converter_test.go
@@ -21,7 +21,7 @@ func TestSqlDatabaseDataModelToVersioned(t *testing.T) {
 	testset := []struct {
 		dataModelFile string
 		apiVersion    string
-		apiModelType  interface{}
+		apiModelType  any
 		err           error
 	}{
 		{

--- a/pkg/linkrp/datamodel/daprpubsubbroker.go
+++ b/pkg/linkrp/datamodel/daprpubsubbroker.go
@@ -29,12 +29,12 @@ func (daprPubSub *DaprPubSubBroker) ResourceTypeName() string {
 type DaprPubSubBrokerProperties struct {
 	rp.BasicResourceProperties
 	rp.BasicDaprResourceProperties
-	ProvisioningState v1.ProvisioningState   `json:"provisioningState,omitempty"`
-	Topic             string                 `json:"topic,omitempty"` // Topic name of the Azure ServiceBus resource. Provided by the user.
-	Mode              LinkMode               `json:"mode"`
-	Metadata          map[string]interface{} `json:"metadata,omitempty"`
-	Recipe            LinkRecipe             `json:"recipe"`
-	Resource          string                 `json:"resource,omitempty"`
-	Type              string                 `json:"type,omitempty"`
-	Version           string                 `json:"version,omitempty"`
+	ProvisioningState v1.ProvisioningState `json:"provisioningState,omitempty"`
+	Topic             string               `json:"topic,omitempty"` // Topic name of the Azure ServiceBus resource. Provided by the user.
+	Mode              LinkMode             `json:"mode"`
+	Metadata          map[string]any       `json:"metadata,omitempty"`
+	Recipe            LinkRecipe           `json:"recipe"`
+	Resource          string               `json:"resource,omitempty"`
+	Type              string               `json:"type,omitempty"`
+	Version           string               `json:"version,omitempty"`
 }

--- a/pkg/linkrp/datamodel/daprsecretstore.go
+++ b/pkg/linkrp/datamodel/daprsecretstore.go
@@ -29,10 +29,10 @@ func (daprSecretStore DaprSecretStore) ResourceTypeName() string {
 type DaprSecretStoreProperties struct {
 	rp.BasicResourceProperties
 	rp.BasicDaprResourceProperties
-	ProvisioningState v1.ProvisioningState   `json:"provisioningState,omitempty"`
-	Mode              LinkMode               `json:"mode"`
-	Type              string                 `json:"type"`
-	Version           string                 `json:"version"`
-	Metadata          map[string]interface{} `json:"metadata"`
-	Recipe            LinkRecipe             `json:"recipe,omitempty"`
+	ProvisioningState v1.ProvisioningState `json:"provisioningState,omitempty"`
+	Mode              LinkMode             `json:"mode"`
+	Type              string               `json:"type"`
+	Version           string               `json:"version"`
+	Metadata          map[string]any       `json:"metadata"`
+	Recipe            LinkRecipe           `json:"recipe,omitempty"`
 }

--- a/pkg/linkrp/datamodel/daprstatestore.go
+++ b/pkg/linkrp/datamodel/daprstatestore.go
@@ -29,11 +29,11 @@ func (daprStateStore DaprStateStore) ResourceTypeName() string {
 type DaprStateStoreProperties struct {
 	rp.BasicResourceProperties
 	rp.BasicDaprResourceProperties
-	ProvisioningState v1.ProvisioningState   `json:"provisioningState,omitempty"`
-	Mode              LinkMode               `json:"mode,omitempty"`
-	Metadata          map[string]interface{} `json:"metadata,omitempty"`
-	Recipe            LinkRecipe             `json:"recipe,omitempty"`
-	Resource          string                 `json:"resource,omitempty"`
-	Type              string                 `json:"type,omitempty"`
-	Version           string                 `json:"version,omitempty"`
+	ProvisioningState v1.ProvisioningState `json:"provisioningState,omitempty"`
+	Mode              LinkMode             `json:"mode,omitempty"`
+	Metadata          map[string]any       `json:"metadata,omitempty"`
+	Recipe            LinkRecipe           `json:"recipe,omitempty"`
+	Resource          string               `json:"resource,omitempty"`
+	Type              string               `json:"type,omitempty"`
+	Version           string               `json:"version,omitempty"`
 }

--- a/pkg/linkrp/datamodel/extender.go
+++ b/pkg/linkrp/datamodel/extender.go
@@ -28,7 +28,7 @@ func (extender Extender) ResourceTypeName() string {
 // ExtenderProperties represents the properties of Extender resource.
 type ExtenderProperties struct {
 	rp.BasicResourceProperties
-	AdditionalProperties map[string]interface{} `json:"additionalProperties,omitempty"`
-	ProvisioningState    v1.ProvisioningState   `json:"provisioningState,omitempty"`
-	Secrets              map[string]interface{} `json:"secrets,omitempty"`
+	AdditionalProperties map[string]any       `json:"additionalProperties,omitempty"`
+	ProvisioningState    v1.ProvisioningState `json:"provisioningState,omitempty"`
+	Secrets              map[string]any       `json:"secrets,omitempty"`
 }

--- a/pkg/linkrp/datamodel/linkmetadata.go
+++ b/pkg/linkrp/datamodel/linkmetadata.go
@@ -13,7 +13,7 @@ import (
 type LinkMetadata struct {
 	// ComputedValues map is any resource values that will be needed for more operations.
 	// For example; database name to generate secrets for cosmos DB.
-	ComputedValues map[string]interface{} `json:"computedValues,omitempty"`
+	ComputedValues map[string]any `json:"computedValues,omitempty"`
 
 	// Stores action to retrieve secret values. For Azure, connectionstring is accessed through cosmos listConnectionString operation, if secrets are not provided as input
 	SecretValues map[string]rp.SecretValueReference `json:"secretValues,omitempty"`
@@ -45,7 +45,7 @@ type LinkRecipe struct {
 	// Name of the recipe within the environment to use
 	Name string `json:"name,omitempty"`
 	// Parameters are key/value parameters to pass into the recipe at deployment
-	Parameters map[string]interface{} `json:"parameters,omitempty"`
+	Parameters map[string]any `json:"parameters,omitempty"`
 }
 
 type LinkMode string

--- a/pkg/linkrp/datamodel/reflection_test.go
+++ b/pkg/linkrp/datamodel/reflection_test.go
@@ -38,7 +38,7 @@ func Test_TestReflectionIsCool(t *testing.T) {
 	expected := &properties
 	require.Equal(t, expected, actual)
 
-	err := mapstructure.Decode(map[string]interface{}{"AppId": "B"}, actual)
+	err := mapstructure.Decode(map[string]any{"AppId": "B"}, actual)
 	require.NoError(t, err)
 
 	require.Equal(t, res.Resource.(*DaprInvokeHttpRoute).Properties.AppId, "B")

--- a/pkg/linkrp/frontend/controller/daprpubsubbrokers/createorupdatedaprpubsubbroker_test.go
+++ b/pkg/linkrp/frontend/controller/daprpubsubbrokers/createorupdatedaprpubsubbroker_test.go
@@ -82,7 +82,7 @@ func getDeploymentProcessorOutputs() (renderers.RendererOutput, deployment.Deplo
 				},
 			},
 		},
-		ComputedValues: map[string]interface{}{
+		ComputedValues: map[string]any{
 			daprpubsubbrokers.TopicNameKey: rendererOutput.ComputedValues[daprpubsubbrokers.TopicNameKey].Value,
 			renderers.ComponentNameKey:     rendererOutput.ComputedValues[renderers.ComponentNameKey].Value,
 		},

--- a/pkg/linkrp/frontend/controller/daprsecretstores/createorupdatedaprsecretstore_test.go
+++ b/pkg/linkrp/frontend/controller/daprsecretstores/createorupdatedaprsecretstore_test.go
@@ -59,7 +59,7 @@ func getDeploymentProcessorOutputs() (renderers.RendererOutput, deployment.Deplo
 				},
 			},
 		},
-		ComputedValues: map[string]interface{}{
+		ComputedValues: map[string]any{
 			"componentName": rendererOutput.ComputedValues["componentName"].Value,
 		},
 	}

--- a/pkg/linkrp/frontend/controller/daprstatestores/createorupdatedaprstatestore_test.go
+++ b/pkg/linkrp/frontend/controller/daprstatestores/createorupdatedaprstatestore_test.go
@@ -268,7 +268,7 @@ func getDeploymentProcessorOutputs() (renderers.RendererOutput, deployment.Deplo
 				},
 			},
 		},
-		ComputedValues: map[string]interface{}{
+		ComputedValues: map[string]any{
 			"componentName": rendererOutput.ComputedValues["componentName"].Value,
 		},
 	}

--- a/pkg/linkrp/frontend/controller/extenders/listsecretsextender_test.go
+++ b/pkg/linkrp/frontend/controller/extenders/listsecretsextender_test.go
@@ -37,7 +37,7 @@ func TestListSecrets_20220315PrivatePreview(t *testing.T) {
 	ctx := context.Background()
 
 	_, extenderDataModel, _ := getTestModels20220315privatepreview()
-	expectedSecrets := map[string]interface{}{
+	expectedSecrets := map[string]any{
 		"accountSid": "sid",
 		"authToken:": "token",
 	}
@@ -107,7 +107,7 @@ func TestListSecrets_20220315PrivatePreview(t *testing.T) {
 		_ = resp.Apply(ctx, w, req)
 		require.Equal(t, 200, w.Result().StatusCode)
 
-		actualOutput := &map[string]interface{}{}
+		actualOutput := &map[string]any{}
 		_ = json.Unmarshal(w.Body.Bytes(), actualOutput)
 
 		require.Equal(t, expectedSecrets["accountSid"], (*actualOutput)["accountSid"])

--- a/pkg/linkrp/frontend/controller/mongodatabases/createorupdatemongodatabase_test.go
+++ b/pkg/linkrp/frontend/controller/mongodatabases/createorupdatemongodatabase_test.go
@@ -222,7 +222,7 @@ func getDeploymentProcessorOutputs() (renderers.RendererOutput, deployment.Deplo
 				},
 			},
 		},
-		ComputedValues: map[string]interface{}{
+		ComputedValues: map[string]any{
 			"database": rendererOutput.ComputedValues["database"].Value,
 		},
 	}

--- a/pkg/linkrp/frontend/controller/mongodatabases/listsecretsmongodatabase_test.go
+++ b/pkg/linkrp/frontend/controller/mongodatabases/listsecretsmongodatabase_test.go
@@ -66,7 +66,7 @@ func TestListSecrets_20220315PrivatePreview(t *testing.T) {
 		w := httptest.NewRecorder()
 		req, _ := radiustesting.GetARMTestHTTPRequest(ctx, http.MethodGet, testHeaderfile, nil)
 		ctx := radiustesting.ARMTestContextFromRequest(req)
-		expectedSecrets := map[string]interface{}{
+		expectedSecrets := map[string]any{
 			renderers.UsernameStringValue:   "testUser",
 			renderers.PasswordStringHolder:  "testPassword",
 			renderers.ConnectionStringValue: "testConnectionString",
@@ -110,7 +110,7 @@ func TestListSecrets_20220315PrivatePreview(t *testing.T) {
 		w := httptest.NewRecorder()
 		req, _ := radiustesting.GetARMTestHTTPRequest(ctx, http.MethodGet, testHeaderfile, nil)
 		ctx := radiustesting.ARMTestContextFromRequest(req)
-		expectedSecrets := map[string]interface{}{
+		expectedSecrets := map[string]any{
 			renderers.UsernameStringValue:   "testUser",
 			renderers.ConnectionStringValue: "testConnectionString",
 		}

--- a/pkg/linkrp/frontend/controller/rabbitmqmessagequeues/listsecretsrabbitmq_test.go
+++ b/pkg/linkrp/frontend/controller/rabbitmqmessagequeues/listsecretsrabbitmq_test.go
@@ -66,7 +66,7 @@ func TestListSecrets_20220315PrivatePreview(t *testing.T) {
 		w := httptest.NewRecorder()
 		req, _ := radiustesting.GetARMTestHTTPRequest(ctx, http.MethodGet, testHeaderfile, nil)
 		ctx := radiustesting.ARMTestContextFromRequest(req)
-		expectedSecrets := map[string]interface{}{
+		expectedSecrets := map[string]any{
 			renderers.ConnectionStringValue: "connection://string",
 		}
 
@@ -106,7 +106,7 @@ func TestListSecrets_20220315PrivatePreview(t *testing.T) {
 		w := httptest.NewRecorder()
 		req, _ := radiustesting.GetARMTestHTTPRequest(ctx, http.MethodGet, testHeaderfile, nil)
 		ctx := radiustesting.ARMTestContextFromRequest(req)
-		expectedSecrets := map[string]interface{}{}
+		expectedSecrets := map[string]any{}
 
 		mStorageClient.
 			EXPECT().

--- a/pkg/linkrp/frontend/controller/rediscaches/createorupdaterediscache_test.go
+++ b/pkg/linkrp/frontend/controller/rediscaches/createorupdaterediscache_test.go
@@ -28,7 +28,7 @@ import (
 
 func getDeploymentProcessorOutputs(buildComputedValueReferences bool) (renderers.RendererOutput, deployment.DeploymentOutput) {
 	var computedValues map[string]renderers.ComputedValueReference
-	var portValue interface{}
+	var portValue any
 	if buildComputedValueReferences {
 		computedValues = map[string]renderers.ComputedValueReference{
 			renderers.Host: {
@@ -83,7 +83,7 @@ func getDeploymentProcessorOutputs(buildComputedValueReferences bool) (renderers
 				},
 			},
 		},
-		ComputedValues: map[string]interface{}{
+		ComputedValues: map[string]any{
 			renderers.Host: "myrediscache.redis.cache.windows.net",
 			renderers.Port: portValue,
 		},

--- a/pkg/linkrp/frontend/controller/rediscaches/listsecretsrediscache_test.go
+++ b/pkg/linkrp/frontend/controller/rediscaches/listsecretsrediscache_test.go
@@ -66,7 +66,7 @@ func TestListSecrets_20220315PrivatePreview(t *testing.T) {
 		w := httptest.NewRecorder()
 		req, _ := radiustesting.GetARMTestHTTPRequest(ctx, http.MethodGet, testHeaderfile, nil)
 		ctx := radiustesting.ARMTestContextFromRequest(req)
-		expectedSecrets := map[string]interface{}{
+		expectedSecrets := map[string]any{
 			renderers.PasswordStringHolder:  "testPassword",
 			renderers.ConnectionStringValue: "test-connection-string",
 		}
@@ -108,7 +108,7 @@ func TestListSecrets_20220315PrivatePreview(t *testing.T) {
 		w := httptest.NewRecorder()
 		req, _ := radiustesting.GetARMTestHTTPRequest(ctx, http.MethodGet, testHeaderfile, nil)
 		ctx := radiustesting.ARMTestContextFromRequest(req)
-		expectedSecrets := map[string]interface{}{
+		expectedSecrets := map[string]any{
 			renderers.PasswordStringHolder: "testPassword",
 		}
 

--- a/pkg/linkrp/frontend/deployment/deploymentprocessor_test.go
+++ b/pkg/linkrp/frontend/deployment/deploymentprocessor_test.go
@@ -62,7 +62,7 @@ const (
 
 var (
 	mongoLinkResourceID = getResourceID(mongoLinkID)
-	recipeParams        = map[string]interface{}{
+	recipeParams        = map[string]any{
 		"throughput": 400,
 	}
 )
@@ -142,8 +142,8 @@ func buildOutputResourcesMongo(mode string) []outputresource.OutputResource {
 					APIVersion: clients.GetAPIVersionFromUserAgent(documentdb.UserAgent()),
 				},
 			},
-			Resource: map[string]interface{}{
-				"properties": map[string]interface{}{
+			Resource: map[string]any{
+				"properties": map[string]any{
 					"resource": map[string]string{
 						"id": "test-database",
 					},
@@ -648,7 +648,7 @@ func Test_Deploy(t *testing.T) {
 		require.NotEqual(t, resourcemodel.ResourceIdentity{}, deploymentOutput.Resources[0].Identity)
 		require.NotEqual(t, resourcemodel.ResourceIdentity{}, deploymentOutput.Resources[1].Identity)
 		require.Equal(t, testRendererOutput.SecretValues, deploymentOutput.SecretValues)
-		require.Equal(t, map[string]interface{}{renderers.DatabaseNameValue: "test-database", renderers.Host: testRendererOutput.ComputedValues[renderers.Host].Value}, deploymentOutput.ComputedValues)
+		require.Equal(t, map[string]any{renderers.DatabaseNameValue: "test-database", renderers.Host: testRendererOutput.ComputedValues[renderers.Host].Value}, deploymentOutput.ComputedValues)
 	})
 
 	t.Run("Verify deploy success with recipe", func(t *testing.T) {
@@ -660,7 +660,7 @@ func Test_Deploy(t *testing.T) {
 		deploymentOutput, err := dp.Deploy(ctx, mongoLinkResourceID, testRendererOutput)
 		require.NoError(t, err)
 		require.Equal(t, testRendererOutput.SecretValues, deploymentOutput.SecretValues)
-		require.Equal(t, map[string]interface{}{renderers.DatabaseNameValue: "test-database", "host": 8080}, deploymentOutput.ComputedValues)
+		require.Equal(t, map[string]any{renderers.DatabaseNameValue: "test-database", "host": 8080}, deploymentOutput.ComputedValues)
 		require.Equal(t, resources, deploymentOutput.RecipeData.Resources)
 	})
 
@@ -746,7 +746,7 @@ func Test_DeployRenderedResources_ComputedValues(t *testing.T) {
 	testOutputResource := outputresource.OutputResource{
 		LocalID:      outputresource.LocalIDAzureCosmosAccount,
 		ResourceType: testResourceType,
-		Resource: map[string]interface{}{
+		Resource: map[string]any{
 			"some-data": "jsonpointer-value",
 		},
 	}
@@ -778,7 +778,7 @@ func Test_DeployRenderedResources_ComputedValues(t *testing.T) {
 	deploymentOutput, err := dp.Deploy(ctx, mongoLinkResourceID, rendererOutput)
 	require.NoError(t, err)
 
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"test-key1": "static-value",
 		"test-key2": "property-value",
 		"test-key3": "jsonpointer-value",
@@ -839,7 +839,7 @@ func Test_Deploy_MissingJsonPointer(t *testing.T) {
 				ID: "test",
 			},
 		},
-		Resource: map[string]interface{}{
+		Resource: map[string]any{
 			"some-data": 3,
 		},
 	}
@@ -982,7 +982,7 @@ func Test_FetchSecretsWithValues(t *testing.T) {
 	dp := deploymentProcessor{mocks.model, mocks.storageProvider, mocks.secretsValueClient, nil}
 
 	rendererOutput := buildRendererOutputMongo(modeValues)
-	computedValues := map[string]interface{}{
+	computedValues := map[string]any{
 		renderers.DatabaseNameValue: mongoLinkName,
 	}
 	resourceData := ResourceData{
@@ -1007,7 +1007,7 @@ func Test_FetchSecretsWithResource(t *testing.T) {
 
 	resource := buildInputResourceMongo(modeResource)
 	rendererOutput := buildRendererOutputMongo(modeResource)
-	computedValues := map[string]interface{}{
+	computedValues := map[string]any{
 		renderers.DatabaseNameValue: "test-database",
 	}
 
@@ -1021,7 +1021,7 @@ func Test_FetchSecretsWithResource(t *testing.T) {
 		ComputedValues:  computedValues,
 	}
 
-	expectedOutput := map[string]interface{}{
+	expectedOutput := map[string]any{
 		renderers.ConnectionStringValue: cosmosConnectionString + "/test-database",
 	}
 	secrets, err := dp.FetchSecrets(ctx, resourceData)
@@ -1037,7 +1037,7 @@ func Test_FetchSecretsWithRecipe(t *testing.T) {
 
 	resource := buildInputResourceMongo(modeRecipe)
 	rendererOutput := buildRendererOutputMongo(modeRecipe)
-	computedValues := map[string]interface{}{
+	computedValues := map[string]any{
 		renderers.DatabaseNameValue: "test-database",
 	}
 
@@ -1051,7 +1051,7 @@ func Test_FetchSecretsWithRecipe(t *testing.T) {
 		ComputedValues:  computedValues,
 	}
 
-	expectedOutput := map[string]interface{}{
+	expectedOutput := map[string]any{
 		renderers.ConnectionStringValue: cosmosConnectionString + "/test-database",
 	}
 	secrets, err := dp.FetchSecrets(ctx, resourceData)

--- a/pkg/linkrp/frontend/handler/getoperations.go
+++ b/pkg/linkrp/frontend/handler/getoperations.go
@@ -42,7 +42,7 @@ func (opctrl *GetOperations) Run(ctx context.Context, w http.ResponseWriter, req
 
 func (opctrl *GetOperations) availableOperationsV1() *v1.PaginatedList {
 	return &v1.PaginatedList{
-		Value: []interface{}{
+		Value: []any{
 			&v1.Operation{
 				Name: "Applications.Link/operations/read",
 				Display: &v1.OperationDisplayProperties{

--- a/pkg/linkrp/handlers/arm_handler.go
+++ b/pkg/linkrp/handlers/arm_handler.go
@@ -79,7 +79,7 @@ func (handler *armHandler) Delete(ctx context.Context, resource *outputresource.
 	return nil
 }
 
-func serializeResource(resource resources.GenericResource) (map[string]interface{}, error) {
+func serializeResource(resource resources.GenericResource) (map[string]any, error) {
 	// We turn the resource into a weakly-typed representation. This is needed because JSON Pointer
 	// will have trouble with the autorest embdedded types.
 	b, err := json.Marshal(&resource)
@@ -87,7 +87,7 @@ func serializeResource(resource resources.GenericResource) (map[string]interface
 		return nil, fmt.Errorf("failed to marshal %T", resource)
 	}
 
-	data := map[string]interface{}{}
+	data := map[string]any{}
 	err = json.Unmarshal(b, &data)
 	if err != nil {
 		return nil, errors.New("failed to umarshal resource data")

--- a/pkg/linkrp/handlers/dapr_component.go
+++ b/pkg/linkrp/handlers/dapr_component.go
@@ -79,12 +79,12 @@ func (handler *daprComponentHandler) Put(ctx context.Context, resource *outputre
 
 func (handler *daprComponentHandler) PatchNamespace(ctx context.Context, namespace string) error {
 	ns := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "v1",
 			"kind":       "Namespace",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": namespace,
-				"labels": map[string]interface{}{
+				"labels": map[string]any{
 					kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
 				},
 			},
@@ -106,10 +106,10 @@ func (handler *daprComponentHandler) Delete(ctx context.Context, resource *outpu
 	}
 
 	item := unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": identity.APIVersion,
 			"kind":       identity.Kind,
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"namespace": identity.Namespace,
 				"name":      identity.Name,
 			},

--- a/pkg/linkrp/handlers/dapr_pubsub_servicebus.go
+++ b/pkg/linkrp/handlers/dapr_pubsub_servicebus.go
@@ -93,7 +93,7 @@ func (handler *daprPubSubServiceBusHandler) Put(ctx context.Context, resource *o
 }
 
 func (handler *daprPubSubServiceBusHandler) Delete(ctx context.Context, resource *outputresource.OutputResource) error {
-	properties := resource.Resource.(map[string]interface{})
+	properties := resource.Resource.(map[string]any)
 
 	err := handler.DeleteDaprPubSub(ctx, properties)
 	if err != nil {
@@ -110,19 +110,19 @@ func (handler *daprPubSubServiceBusHandler) PatchDaprPubSub(ctx context.Context,
 	}
 
 	item := unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": properties[KubernetesAPIVersionKey],
 			"kind":       properties[KubernetesKindKey],
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"namespace": properties[KubernetesNamespaceKey],
 				"name":      kubernetes.NormalizeResourceName(properties[ResourceName]),
 				"labels":    kubernetes.MakeDescriptiveLabels(properties[ApplicationName], properties[ResourceName], DaprPubSubBrokerResourceType),
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"type":    "pubsub.azure.servicebus",
 				"version": "v1",
-				"metadata": []interface{}{
-					map[string]interface{}{
+				"metadata": []any{
+					map[string]any{
 						"name":  "connectionString",
 						"value": cs,
 					},
@@ -139,12 +139,12 @@ func (handler *daprPubSubServiceBusHandler) PatchDaprPubSub(ctx context.Context,
 	return nil
 }
 
-func (handler *daprPubSubServiceBusHandler) DeleteDaprPubSub(ctx context.Context, properties map[string]interface{}) error {
+func (handler *daprPubSubServiceBusHandler) DeleteDaprPubSub(ctx context.Context, properties map[string]any) error {
 	item := unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": properties[KubernetesAPIVersionKey],
 			"kind":       properties[KubernetesKindKey],
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"namespace": properties[KubernetesNamespaceKey],
 				"name":      kubernetes.NormalizeResourceName(properties[ResourceName].(string)),
 			},

--- a/pkg/linkrp/handlers/dapr_statestore_storage.go
+++ b/pkg/linkrp/handlers/dapr_statestore_storage.go
@@ -91,7 +91,7 @@ func (handler *daprStateStoreAzureStorageHandler) Put(ctx context.Context, resou
 }
 
 func (handler *daprStateStoreAzureStorageHandler) Delete(ctx context.Context, resource *outputresource.OutputResource) error {
-	properties := resource.Resource.(map[string]interface{})
+	properties := resource.Resource.(map[string]any)
 
 	err := handler.deleteDaprStateStore(ctx, properties)
 	if err != nil {
@@ -108,27 +108,27 @@ func (handler *daprStateStoreAzureStorageHandler) createDaprStateStore(ctx conte
 	}
 
 	item := unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": properties[KubernetesAPIVersionKey],
 			"kind":       properties[KubernetesKindKey],
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"namespace": properties[KubernetesNamespaceKey],
 				"name":      kubernetes.NormalizeResourceName(properties[ResourceName]),
 				"labels":    kubernetes.MakeDescriptiveLabels(properties[ApplicationName], properties[ResourceName], DaprStateStoreResourceType),
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"type":    "state.azure.tablestorage",
 				"version": "v1",
-				"metadata": []interface{}{
-					map[string]interface{}{
+				"metadata": []any{
+					map[string]any{
 						"name":  "accountName",
 						"value": accountName,
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":  "accountKey",
 						"value": accountKey,
 					},
-					map[string]interface{}{
+					map[string]any{
 						"name":  "tableName",
 						"value": "dapr",
 					},
@@ -177,12 +177,12 @@ func (handler *daprStateStoreAzureStorageHandler) findStorageKey(ctx context.Con
 	return nil, fmt.Errorf("listkeys contained keys, but none of them have full access")
 }
 
-func (handler *daprStateStoreAzureStorageHandler) deleteDaprStateStore(ctx context.Context, properties map[string]interface{}) error {
+func (handler *daprStateStoreAzureStorageHandler) deleteDaprStateStore(ctx context.Context, properties map[string]any) error {
 	item := unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": properties[KubernetesAPIVersionKey],
 			"kind":       properties[KubernetesKindKey],
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"namespace": properties[KubernetesNamespaceKey],
 				"name":      properties[ResourceName],
 			},

--- a/pkg/linkrp/handlers/recipe_handler.go
+++ b/pkg/linkrp/handlers/recipe_handler.go
@@ -82,7 +82,7 @@ func (handler *azureRecipeHandler) DeployRecipe(ctx context.Context, recipe data
 		return nil, conv.NewClientErrInvalidRequest(fmt.Sprintf("failed to fetch template from the path %q for recipe %q: %s", recipe.TemplatePath, recipe.Name, err.Error()))
 	}
 
-	recipeData := make(map[string]interface{})
+	recipeData := make(map[string]any)
 	err = json.Unmarshal(recipeBytes, &recipeData)
 	if err != nil {
 		return nil, err
@@ -147,13 +147,13 @@ func getDigestFromManifest(ctx context.Context, repo *remote.Repository, tag str
 		return "", err
 	}
 	// create the manifest map to get the digest of the layer
-	var manifest map[string]interface{}
+	var manifest map[string]any
 	err = json.Unmarshal(manifestBlob, &manifest)
 	if err != nil {
 		return "", err
 	}
 	// get the layers digest to fetch the blob
-	layer, ok := manifest["layers"].([]interface{})[0].(map[string]interface{})
+	layer, ok := manifest["layers"].([]any)[0].(map[string]any)
 	if !ok {
 		return "", fmt.Errorf("failed to decode the layers from manifest")
 	}

--- a/pkg/linkrp/renderers/dapr/generic.go
+++ b/pkg/linkrp/renderers/dapr/generic.go
@@ -16,7 +16,7 @@ import (
 type DaprGeneric struct {
 	Type     *string
 	Version  *string
-	Metadata map[string]interface{}
+	Metadata map[string]any
 }
 
 func (daprGeneric DaprGeneric) Validate() error {
@@ -38,9 +38,9 @@ func (daprGeneric DaprGeneric) Validate() error {
 func ConstructDaprGeneric(daprGeneric DaprGeneric, appName string, resourceName string, namespace string, resourceType string) (unstructured.Unstructured, error) {
 	// Convert the metadata map to a yaml list with keys name and value as per
 	// Dapr specs: https://docs.dapr.io/reference/components-reference/
-	yamlListItems := []map[string]interface{}{}
+	yamlListItems := []map[string]any{}
 	for k, v := range daprGeneric.Metadata {
-		yamlItem := map[string]interface{}{
+		yamlItem := map[string]any{
 			"name":  k,
 			"value": v,
 		}
@@ -49,15 +49,15 @@ func ConstructDaprGeneric(daprGeneric DaprGeneric, appName string, resourceName 
 
 	// Translate into Dapr State Store schema
 	item := unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "dapr.io/v1alpha1",
 			"kind":       "Component",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"namespace": namespace,
 				"name":      kubernetes.NormalizeResourceName(resourceName),
 				"labels":    kubernetes.MakeDescriptiveLabels(appName, resourceName, resourceType),
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"type":     *daprGeneric.Type,
 				"version":  *daprGeneric.Version,
 				"metadata": yamlListItems,

--- a/pkg/linkrp/renderers/daprpubsubbrokers/renderer_test.go
+++ b/pkg/linkrp/renderers/daprpubsubbrokers/renderer_test.go
@@ -57,7 +57,7 @@ func Test_Render_Generic_Success(t *testing.T) {
 			Mode:    datamodel.LinkModeValues,
 			Type:    "pubsub.kafka",
 			Version: "v1",
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"foo": "bar",
 			},
 		},
@@ -73,18 +73,18 @@ func Test_Render_Generic_Success(t *testing.T) {
 	require.Equal(t, kubernetes.NormalizeResourceName(resourceName), result.ComputedValues[renderers.ComponentNameKey].Value)
 
 	expected := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": daprVersion,
 			"kind":       k8sKind,
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"namespace": "radius-test",
 				"name":      kubernetes.NormalizeResourceName(resourceName),
 				"labels":    kubernetes.MakeDescriptiveLabels(applicationName, resourceName, ResourceType),
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"type":    pubsubType,
 				"version": daprPubSubVersion,
-				"metadata": []map[string]interface{}{
+				"metadata": []map[string]any{
 					{
 						"name":  "foo",
 						"value": "bar",
@@ -139,7 +139,7 @@ func Test_Render_Generic_MissingType(t *testing.T) {
 				Environment: environmentID,
 			},
 			Mode: datamodel.LinkModeValues,
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"foo": "bar",
 			},
 			Version: "v1",
@@ -168,7 +168,7 @@ func Test_Render_Generic_MissingVersion(t *testing.T) {
 				Environment: environmentID,
 			},
 			Mode: datamodel.LinkModeValues,
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"foo": "bar",
 			},
 			Type: "pubsub.kafka",
@@ -185,7 +185,7 @@ func Test_ConstructDaprPubSubGeneric(t *testing.T) {
 	properties := datamodel.DaprPubSubBrokerProperties{
 		Type:    "pubsub.kafka",
 		Version: "v1",
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"foo": "bar",
 		},
 	}
@@ -198,18 +198,18 @@ func Test_ConstructDaprPubSubGeneric(t *testing.T) {
 	require.NoError(t, err, "Unable to construct Pub/Sub resource spec")
 
 	expected := unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": daprVersion,
 			"kind":       k8sKind,
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"namespace": "radius-test",
 				"name":      kubernetes.NormalizeResourceName(resourceName),
 				"labels":    kubernetes.MakeDescriptiveLabels(applicationName, resourceName, ResourceType),
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"type":    pubsubType,
 				"version": daprPubSubVersion,
-				"metadata": []map[string]interface{}{
+				"metadata": []map[string]any{
 					{
 						"name":  "foo",
 						"value": "bar",
@@ -383,7 +383,7 @@ func Test_Render_InvalidApplicationID(t *testing.T) {
 			Mode:    datamodel.LinkModeValues,
 			Type:    "pubsub.kafka",
 			Version: "v1",
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"foo": "bar",
 			},
 		},
@@ -412,7 +412,7 @@ func Test_Render_EmptyApplicationID(t *testing.T) {
 			Mode:    datamodel.LinkModeValues,
 			Type:    "pubsub.kafka",
 			Version: "v1",
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"foo": "bar",
 			},
 		},

--- a/pkg/linkrp/renderers/daprsecretstores/renderer_test.go
+++ b/pkg/linkrp/renderers/daprsecretstores/renderer_test.go
@@ -90,7 +90,7 @@ func Test_Render_Generic_Success(t *testing.T) {
 			Type:    ResourceType,
 			Mode:    datamodel.LinkModeValues,
 			Version: daprSecretStoreVersion,
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"foo": "bar",
 			},
 		},
@@ -112,18 +112,18 @@ func Test_Render_Generic_Success(t *testing.T) {
 	require.Equal(t, expectedComputedValues, result.ComputedValues)
 
 	expected := unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": daprVersion,
 			"kind":       k8sKind,
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"namespace": "radius-test",
 				"name":      kubernetes.NormalizeResourceName(resourceName),
 				"labels":    kubernetes.MakeDescriptiveLabels(applicationName, resourceName, ResourceType),
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"type":    "Applications.Link/daprSecretStores",
 				"version": "v1",
-				"metadata": []map[string]interface{}{
+				"metadata": []map[string]any{
 					{
 						"name":  "foo",
 						"value": "bar",
@@ -180,7 +180,7 @@ func Test_Render_Generic_MissingType(t *testing.T) {
 			},
 			Mode:    datamodel.LinkModeValues,
 			Version: daprSecretStoreVersion,
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"foo": "bar",
 			},
 		},
@@ -210,7 +210,7 @@ func Test_Render_Generic_MissingVersion(t *testing.T) {
 			},
 			Mode: datamodel.LinkModeValues,
 			Type: "secretstores.kubernetes",
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"foo": "bar",
 			},
 		},
@@ -242,7 +242,7 @@ func Test_Render_InvalidApplicationID(t *testing.T) {
 			Mode:    datamodel.LinkModeValues,
 			Type:    ResourceType,
 			Version: daprSecretStoreVersion,
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"foo": "bar",
 			},
 		},
@@ -272,7 +272,7 @@ func Test_Render_EmptyApplicationID(t *testing.T) {
 			Mode:    datamodel.LinkModeValues,
 			Type:    ResourceType,
 			Version: daprSecretStoreVersion,
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"foo": "bar",
 			},
 		},

--- a/pkg/linkrp/renderers/daprstatestores/renderer_test.go
+++ b/pkg/linkrp/renderers/daprstatestores/renderer_test.go
@@ -171,7 +171,7 @@ func Test_Render_Generic_Success(t *testing.T) {
 			Mode:    datamodel.LinkModeValues,
 			Type:    stateStoreType,
 			Version: daprStateStoreVersion,
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"foo": "bar",
 			},
 		},
@@ -187,18 +187,18 @@ func Test_Render_Generic_Success(t *testing.T) {
 	require.Equal(t, kubernetes.NormalizeResourceName(resourceName), result.ComputedValues[renderers.ComponentNameKey].Value)
 
 	expected := unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": daprVersion,
 			"kind":       k8sKind,
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"namespace": "radius-test",
 				"name":      kubernetes.NormalizeResourceName(resourceName),
 				"labels":    kubernetes.MakeDescriptiveLabels(applicationName, resourceName, ResourceType),
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"type":    stateStoreType,
 				"version": daprStateStoreVersion,
-				"metadata": []map[string]interface{}{
+				"metadata": []map[string]any{
 					{
 						"name":  "foo",
 						"value": "bar",
@@ -253,7 +253,7 @@ func Test_Render_Generic_MissingType(t *testing.T) {
 				Environment: environmentID,
 			},
 			Mode: datamodel.LinkModeValues,
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"foo": "bar",
 			},
 			Version: daprStateStoreVersion,
@@ -282,7 +282,7 @@ func Test_Render_Generic_MissingVersion(t *testing.T) {
 				Environment: environmentID,
 			},
 			Mode: datamodel.LinkModeValues,
-			Metadata: map[string]interface{}{
+			Metadata: map[string]any{
 				"foo": "bar",
 			},
 			Type: stateStoreType,

--- a/pkg/linkrp/renderers/extenders/renderer_test.go
+++ b/pkg/linkrp/renderers/extenders/renderer_test.go
@@ -43,10 +43,10 @@ func Test_Render_Success(t *testing.T) {
 				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
 				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
 			},
-			AdditionalProperties: map[string]interface{}{
+			AdditionalProperties: map[string]any{
 				"foo": "bar",
 			},
-			Secrets: map[string]interface{}{
+			Secrets: map[string]any{
 				"secretname": "secretvalue",
 			},
 		},
@@ -85,10 +85,10 @@ func Test_Render_InvalidApplicationID(t *testing.T) {
 				Application: "invalid-app-id",
 				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
 			},
-			AdditionalProperties: map[string]interface{}{
+			AdditionalProperties: map[string]any{
 				"foo": "bar",
 			},
-			Secrets: map[string]interface{}{
+			Secrets: map[string]any{
 				"secretname": "secretvalue",
 			},
 		},

--- a/pkg/linkrp/renderers/mongodatabases/azuretransformer.go
+++ b/pkg/linkrp/renderers/mongodatabases/azuretransformer.go
@@ -20,7 +20,7 @@ var _ rp.SecretValueTransformer = (*AzureTransformer)(nil)
 type AzureTransformer struct {
 }
 
-func (t *AzureTransformer) Transform(ctx context.Context, computedValues map[string]interface{}, value interface{}) (interface{}, error) {
+func (t *AzureTransformer) Transform(ctx context.Context, computedValues map[string]any, value any) (any, error) {
 	// Mongo uses the following format for mongo: mongodb://{accountname}:{key}@{endpoint}:{port}/{database}?...{params}
 	//
 	// The connection strings that come back from CosmosDB don't include the database name.

--- a/pkg/linkrp/renderers/rediscaches/azuretransformer.go
+++ b/pkg/linkrp/renderers/rediscaches/azuretransformer.go
@@ -20,7 +20,7 @@ type AzureTransformer struct {
 }
 
 // Transform builds connection string using primary key for Azure Redis Cache resource
-func (t *AzureTransformer) Transform(ctx context.Context, computedValues map[string]interface{}, primaryKey interface{}) (interface{}, error) {
+func (t *AzureTransformer) Transform(ctx context.Context, computedValues map[string]any, primaryKey any) (any, error) {
 	// Redis connection string format: '{hostName}:{port},password={primaryKey},ssl=True,abortConnect=False'
 	password, ok := primaryKey.(string)
 	if !ok {

--- a/pkg/linkrp/renderers/rediscaches/azuretransformer_test.go
+++ b/pkg/linkrp/renderers/rediscaches/azuretransformer_test.go
@@ -18,7 +18,7 @@ func Test_Transform_Success(t *testing.T) {
 	ctx := context.Background()
 	redisTransformer := AzureTransformer{}
 
-	testComputedValues := map[string]interface{}{
+	testComputedValues := map[string]any{
 		renderers.Host: "test-hostname",
 		renderers.Port: "1234",
 	}
@@ -36,14 +36,14 @@ func Test_Transform_Error(t *testing.T) {
 
 	testCases := []struct {
 		description        string
-		primaryKey         interface{}
-		computedValues     map[string]interface{}
+		primaryKey         any
+		computedValues     map[string]any
 		expectedErrMessage string
 	}{
 		{
 			"Invalid primary key format",
 			1234,
-			map[string]interface{}{
+			map[string]any{
 				renderers.Host: "test-hostname",
 				renderers.Port: "1234",
 			},
@@ -52,7 +52,7 @@ func Test_Transform_Error(t *testing.T) {
 		{
 			"Missing hostname",
 			"test-password",
-			map[string]interface{}{
+			map[string]any{
 				renderers.Port: "1234",
 			},
 			"hostname is required to build Redis connection string",
@@ -60,7 +60,7 @@ func Test_Transform_Error(t *testing.T) {
 		{
 			"Missing port",
 			"test-password",
-			map[string]interface{}{
+			map[string]any{
 				renderers.Host: "test-hostname",
 			},
 			"port is required to build Redis connection string",

--- a/pkg/linkrp/renderers/types.go
+++ b/pkg/linkrp/renderers/types.go
@@ -67,7 +67,7 @@ type ComputedValueReference struct {
 	LocalID string
 
 	// Value specifies a static value to copy to computed values.
-	Value interface{}
+	Value any
 
 	// PropertyReference specifies a property key to look up in the resource's *persisted properties*.
 	PropertyReference string

--- a/pkg/middleware/appendlogger.go
+++ b/pkg/middleware/appendlogger.go
@@ -22,7 +22,7 @@ func AppendLogValues(h http.Handler) http.Handler {
 			return
 		}
 
-		values := []interface{}{}
+		values := []any{}
 		values = append(values, radlogger.LogFieldResourceID, id.String())
 
 		// TODO: populate correlation id and w3c trace parent id - https://github.com/project-radius/core-team/issues/53

--- a/pkg/middleware/metricsrecorder.go
+++ b/pkg/middleware/metricsrecorder.go
@@ -46,7 +46,7 @@ type responseWriterInterceptor struct {
 	statusCode int
 }
 
-//Customized response writer to fetch the response status in the middleware
+// Customized response writer to fetch the response status in the middleware
 func (w *responseWriterInterceptor) WriteHeader(statusCode int) {
 	w.statusCode = statusCode
 	w.ResponseWriter.WriteHeader(statusCode)

--- a/pkg/middleware/ucp_logging.go
+++ b/pkg/middleware/ucp_logging.go
@@ -16,7 +16,7 @@ import (
 // UseLogValues appends logging values to the context based on the request.
 func UseLogValues(h http.Handler, basePath string) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
-		values := []interface{}{}
+		values := []any{}
 		values = append(values,
 			ucplog.LogFieldHTTPMethod, r.Method,
 			ucplog.LogFieldRequestURL, r.URL.Path,

--- a/pkg/radlogger/radlogger.go
+++ b/pkg/radlogger/radlogger.go
@@ -117,7 +117,7 @@ func NewTestLogger(t *testing.T) (logr.Logger, error) {
 	return log, nil
 }
 
-func WrapLogContext(ctx context.Context, keyValues ...interface{}) context.Context {
+func WrapLogContext(ctx context.Context, keyValues ...any) context.Context {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	ctx = logr.NewContext(ctx, logger.WithValues(keyValues...))

--- a/pkg/resourcemodel/identity.go
+++ b/pkg/resourcemodel/identity.go
@@ -44,7 +44,7 @@ func (r ResourceType) String() string {
 type ResourceIdentity struct {
 	ResourceType *ResourceType `json:"resourceType"`
 	// A polymorphic payload. The fields in this data structure are determined by the provider field in the ResourceType
-	Data interface{} `json:"data"`
+	Data any `json:"data"`
 }
 
 // We just need custom Unmarshaling, default Marshaling is fine.
@@ -158,7 +158,7 @@ func (r ResourceIdentity) IsSameResource(other ResourceIdentity) bool {
 }
 
 // AsLogValues returns log values as key-value pairs from this ResourceIdentifier.
-func (r ResourceIdentity) AsLogValues() []interface{} {
+func (r ResourceIdentity) AsLogValues() []any {
 	if r.ResourceType == nil {
 		return nil
 	}
@@ -168,10 +168,10 @@ func (r ResourceIdentity) AsLogValues() []interface{} {
 		data := r.Data.(ARMIdentity)
 		id, err := resources.ParseResource(data.ID)
 		if err != nil {
-			return []interface{}{radlogger.LogFieldResourceID, data.ID}
+			return []any{radlogger.LogFieldResourceID, data.ID}
 		}
 
-		return []interface{}{
+		return []any{
 			radlogger.LogFieldResourceID, data.ID,
 			radlogger.LogFieldSubscriptionID, id.FindScope(resources.SubscriptionsSegment),
 			radlogger.LogFieldResourceGroup, id.FindScope(resources.ResourceGroupsSegment),
@@ -181,7 +181,7 @@ func (r ResourceIdentity) AsLogValues() []interface{} {
 
 	case ProviderKubernetes:
 		data := r.Data.(KubernetesIdentity)
-		return []interface{}{
+		return []any{
 			radlogger.LogFieldResourceName, data.Name,
 			radlogger.LogFieldNamespace, data.Namespace,
 			radlogger.LogFieldKind, data.Kind,

--- a/pkg/rp/frontend/resource_test.go
+++ b/pkg/rp/frontend/resource_test.go
@@ -89,7 +89,7 @@ type TestResourceProperties struct {
 
 // ResourceStatus - Status of a resource.
 type ResourceStatus struct {
-	OutputResources []map[string]interface{} `json:"outputResources,omitempty"`
+	OutputResources []map[string]any `json:"outputResources,omitempty"`
 }
 
 func (src *TestResource) ConvertTo() (conv.DataModelInterface, error) {

--- a/pkg/rp/outputresource/info.go
+++ b/pkg/rp/outputresource/info.go
@@ -30,7 +30,7 @@ type OutputResource struct {
 
 	RadiusManaged *bool                `json:"radiusManaged"`
 	Deployed      bool                 `json:"deployed"`
-	Resource      interface{}          `json:"resource,omitempty"`
+	Resource      any                  `json:"resource,omitempty"`
 	Dependencies  []Dependency         // resources that are required to be deployed before this resource can be deployed - used for parent/child resources.
 	Status        OutputResourceStatus `json:"status,omitempty"`
 }

--- a/pkg/rp/secretvalueclient.go
+++ b/pkg/rp/secretvalueclient.go
@@ -27,7 +27,7 @@ type client struct {
 	ARM armauth.ArmConfig
 }
 
-func (c *client) FetchSecret(ctx context.Context, identity resourcemodel.ResourceIdentity, action string, valueSelector string) (interface{}, error) {
+func (c *client) FetchSecret(ctx context.Context, identity resourcemodel.ResourceIdentity, action string, valueSelector string) (any, error) {
 	arm := &resourcemodel.ARMIdentity{}
 	if err := store.DecodeMap(identity.Data, arm); err != nil {
 		return nil, fmt.Errorf("unsupported resource type: %+v. Currently only ARM resources are supported", identity)

--- a/pkg/rp/types.go
+++ b/pkg/rp/types.go
@@ -42,7 +42,7 @@ type ComputedValueReference struct {
 	LocalID string
 
 	// Value specifies a static value to copy to computed values.
-	Value interface{}
+	Value any
 
 	// PropertyReference specifies a property key to look up in the resource's *persisted properties*.
 	PropertyReference string
@@ -90,18 +90,18 @@ type SecretValueReference struct {
 // string that application code consumes will include a database name or queue name, etc. Or the different
 // libraries involved might support different connection string formats, and the user has to choose on.
 type SecretValueTransformer interface {
-	Transform(ctx context.Context, resourceComputedValues map[string]interface{}, secretValue interface{}) (interface{}, error)
+	Transform(ctx context.Context, resourceComputedValues map[string]any, secretValue any) (any, error)
 }
 
 //go:generate mockgen -destination=./mock_secretvalueclient.go -package=rp -self_package github.com/project-radius/radius/pkg/rp github.com/project-radius/radius/pkg/rp SecretValueClient
 type SecretValueClient interface {
-	FetchSecret(ctx context.Context, identity resourcemodel.ResourceIdentity, action string, valueSelector string) (interface{}, error)
+	FetchSecret(ctx context.Context, identity resourcemodel.ResourceIdentity, action string, valueSelector string) (any, error)
 }
 
 // DeploymentOutput is the output details of a deployment.
 type DeploymentOutput struct {
 	DeployedOutputResources []outputresource.OutputResource
-	ComputedValues          map[string]interface{}
+	ComputedValues          map[string]any
 	SecretValues            map[string]SecretValueReference
 }
 
@@ -167,10 +167,10 @@ type KubernetesComputeProperties struct {
 }
 
 // OutputResource contains some internal fields like resources/dependencies that shouldn't be inlcuded in the user response
-func BuildExternalOutputResources(outputResources []outputresource.OutputResource) []map[string]interface{} {
-	var externalOutputResources []map[string]interface{}
+func BuildExternalOutputResources(outputResources []outputresource.OutputResource) []map[string]any {
+	var externalOutputResources []map[string]any
 	for _, or := range outputResources {
-		externalOutput := map[string]interface{}{
+		externalOutput := map[string]any{
 			"LocalID":  or.LocalID,
 			"Provider": or.ResourceType.Provider,
 			"Identity": or.Identity.Data,

--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
@@ -56,7 +56,7 @@ func ParseAWSRequest(ctx context.Context, opts ctrl.Options, r *http.Request) (a
 // getPrimaryIdentifiersFromSchema returns the primaryIdentifier field from the
 // provided AWS CloudFormation type schema
 func getPrimaryIdentifiersFromSchema(ctx context.Context, schema string) ([]string, error) {
-	schemaObject := map[string]interface{}{}
+	schemaObject := map[string]any{}
 	err := json.Unmarshal([]byte(schema), &schemaObject)
 	if err != nil {
 		return nil, err
@@ -67,7 +67,7 @@ func getPrimaryIdentifiersFromSchema(ctx context.Context, schema string) ([]stri
 		return nil, fmt.Errorf("primaryIdentifier not found in schema")
 	}
 
-	primaryIdentifiers, ok := primaryIdentifiersObject.([]interface{})
+	primaryIdentifiers, ok := primaryIdentifiersObject.([]any)
 	if !ok {
 		return nil, fmt.Errorf("primaryIdentifier is not an array")
 	}
@@ -82,7 +82,7 @@ func getPrimaryIdentifiersFromSchema(ctx context.Context, schema string) ([]stri
 
 // getPrimaryIdentifierFromMultiIdentifiers returns the primary identifier for the resource
 // when provided desired primary identifier values and the resource type schema
-func getPrimaryIdentifierFromMultiIdentifiers(ctx context.Context, properties map[string]interface{}, schema string) (string, error) {
+func getPrimaryIdentifierFromMultiIdentifiers(ctx context.Context, properties map[string]any, schema string) (string, error) {
 	primaryIdentifiers, err := getPrimaryIdentifiersFromSchema(ctx, schema)
 	if err != nil {
 		return "", err
@@ -110,20 +110,20 @@ func getPrimaryIdentifierFromMultiIdentifiers(ctx context.Context, properties ma
 	return resourceID, nil
 }
 
-func readPropertiesFromBody(req *http.Request) (map[string]interface{}, error) {
+func readPropertiesFromBody(req *http.Request) (map[string]any, error) {
 	decoder := json.NewDecoder(req.Body)
 	defer req.Body.Close()
 
-	body := map[string]interface{}{}
+	body := map[string]any{}
 	err := decoder.Decode(&body)
 	if err != nil {
 		return nil, err
 	}
 
-	properties := map[string]interface{}{}
+	properties := map[string]any{}
 	obj, ok := body["properties"]
 	if ok {
-		pp, ok := obj.(map[string]interface{})
+		pp, ok := obj.(map[string]any)
 		if ok {
 			properties = pp
 		}

--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing_test.go
@@ -17,8 +17,8 @@ import (
 func TestGetPrimaryIdentifierFromMultiIdentifiers(t *testing.T) {
 	ctx := context.Background()
 
-	schemaObject := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
+	schemaObject := map[string]any{
+		"primaryIdentifier": []any{
 			"/properties/GlobalNetworkId",
 			"/properties/DeviceId",
 		},
@@ -29,7 +29,7 @@ func TestGetPrimaryIdentifierFromMultiIdentifiers(t *testing.T) {
 
 	schema := string(schemaBytes)
 
-	properties := map[string]interface{}{
+	properties := map[string]any{
 		"GlobalNetworkId": "global-network-id",
 		"DeviceId":        "device-id",
 	}
@@ -42,8 +42,8 @@ func TestGetPrimaryIdentifierFromMultiIdentifiers(t *testing.T) {
 func TestGetPrimaryIdentifierFromMultiIdentifiers_MissingMandatoryParameters(t *testing.T) {
 	ctx := context.Background()
 
-	schemaObject := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
+	schemaObject := map[string]any{
+		"primaryIdentifier": []any{
 			"/properties/GlobalNetworkId",
 			"/properties/DeviceId",
 		},
@@ -54,7 +54,7 @@ func TestGetPrimaryIdentifierFromMultiIdentifiers_MissingMandatoryParameters(t *
 
 	schema := string(schemaBytes)
 
-	properties := map[string]interface{}{
+	properties := map[string]any{
 		"GlobalNetworkId": "global-network-id",
 	}
 
@@ -76,8 +76,8 @@ func TestComputeResourceID(t *testing.T) {
 func TestGetPrimaryIdentifiersFromSchema(t *testing.T) {
 	ctx := context.Background()
 
-	schemaObject := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
+	schemaObject := map[string]any{
+		"primaryIdentifier": []any{
 			"/properties/GlobalNetworkId",
 			"/properties/DeviceId",
 		},
@@ -96,7 +96,7 @@ func TestGetPrimaryIdentifiersFromSchema(t *testing.T) {
 func TestGetPrimaryIdentifiersFromSchema_PrimaryIdentifierMissing(t *testing.T) {
 	ctx := context.Background()
 
-	schemaObject := map[string]interface{}{}
+	schemaObject := map[string]any{}
 
 	schemaBytes, err := json.Marshal(schemaObject)
 	require.NoError(t, err)
@@ -111,7 +111,7 @@ func TestGetPrimaryIdentifiersFromSchema_PrimaryIdentifierMissing(t *testing.T) 
 func TestGetPrimaryIdentifiersFromSchema_PrimaryIdentifierWrongDataType(t *testing.T) {
 	ctx := context.Background()
 
-	schemaObject := map[string]interface{}{
+	schemaObject := map[string]any{
 		"primaryIdentifier": "/properties/GlobalNetworkId",
 	}
 

--- a/pkg/ucp/frontend/controller/awsproxy/awsproxytest.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsproxytest.go
@@ -91,7 +91,7 @@ func CreateRedshiftEndpointAuthorizationTestResource(resourceName string) *AWSTe
 	return CreateAWSTestResource(resourceType, awsResourceType, resourceName, provider, arn, typeSchema)
 }
 
-func CreateAWSTestResource(resourceType, awsResourceType, resourceName, provider, arn string, typeSchema map[string]interface{}) *AWSTestResource {
+func CreateAWSTestResource(resourceType, awsResourceType, resourceName, provider, arn string, typeSchema map[string]any) *AWSTestResource {
 	serialized, err := json.Marshal(typeSchema)
 	if err != nil {
 		return nil
@@ -113,40 +113,40 @@ func CreateAWSTestResource(resourceType, awsResourceType, resourceName, provider
 	}
 }
 
-func getMockKinesisStreamResourceTypeSchema() map[string]interface{} {
-	return map[string]interface{}{
-		"primaryIdentifier": []interface{}{
+func getMockKinesisStreamResourceTypeSchema() map[string]any {
+	return map[string]any{
+		"primaryIdentifier": []any{
 			"/properties/Name",
 		},
-		"readOnlyProperties": []interface{}{
+		"readOnlyProperties": []any{
 			"/properties/Arn",
 		},
-		"createOnlyProperties": []interface{}{
+		"createOnlyProperties": []any{
 			"/properties/Name",
 		},
 	}
 }
 
-func getMockMemoryDBClusterResourceTypeSchema() map[string]interface{} {
-	return map[string]interface{}{
-		"primaryIdentifier": []interface{}{
+func getMockMemoryDBClusterResourceTypeSchema() map[string]any {
+	return map[string]any{
+		"primaryIdentifier": []any{
 			"/properties/ClusterName",
 		},
-		"readOnlyProperties": []interface{}{
+		"readOnlyProperties": []any{
 			"/properties/ClusterEndpoint/Address",
 			"/properties/ClusterEndpoint/Port",
 			"/properties/ARN",
 		},
-		"createOnlyProperties": []interface{}{
+		"createOnlyProperties": []any{
 			"/properties/ClusterName",
 			"/properties/Port",
 		},
 	}
 }
 
-func getMockRedShiftEndpointAuthorizationResourceTypeSchema() map[string]interface{} {
-	return map[string]interface{}{
-		"primaryIdentifier": []interface{}{
+func getMockRedShiftEndpointAuthorizationResourceTypeSchema() map[string]any {
+	return map[string]any{
+		"primaryIdentifier": []any{
 			"/properties/ClusterIdentifier",
 			"/properties/Account",
 		},

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource.go
@@ -43,7 +43,7 @@ func (p *CreateOrUpdateAWSResource) Run(ctx context.Context, w http.ResponseWrit
 	decoder := json.NewDecoder(req.Body)
 	defer req.Body.Close()
 
-	body := map[string]interface{}{}
+	body := map[string]any{}
 	err = decoder.Decode(&body)
 	if err != nil {
 		e := v1.ErrorResponse{
@@ -60,10 +60,10 @@ func (p *CreateOrUpdateAWSResource) Run(ctx context.Context, w http.ResponseWrit
 		}
 	}
 
-	properties := map[string]interface{}{}
+	properties := map[string]any{}
 	obj, ok := body["properties"]
 	if ok {
-		pp, ok := obj.(map[string]interface{})
+		pp, ok := obj.(map[string]any)
 		if ok {
 			properties = pp
 		}
@@ -91,7 +91,7 @@ func (p *CreateOrUpdateAWSResource) Run(ctx context.Context, w http.ResponseWrit
 
 	// AWS doesn't return the resource state as part of the cloud-control operation. Let's
 	// simulate that here.
-	responseProperties := map[string]interface{}{}
+	responseProperties := map[string]any{}
 	if getResponse != nil {
 		err = json.Unmarshal([]byte(*getResponse.ResourceDescription.Properties), &responseProperties)
 		if err != nil {
@@ -146,7 +146,7 @@ func (p *CreateOrUpdateAWSResource) Run(ctx context.Context, w http.ResponseWrit
 			// mark provisioning state as succeeded here
 			// and return 200, telling the deployment engine that the resource has already been created
 			responseProperties["provisioningState"] = v1.ProvisioningStateSucceeded
-			responseBody := map[string]interface{}{
+			responseBody := map[string]any{
 				"id":         id.String(),
 				"name":       id.Name(),
 				"type":       id.Type(),
@@ -173,7 +173,7 @@ func (p *CreateOrUpdateAWSResource) Run(ctx context.Context, w http.ResponseWrit
 
 	responseProperties["provisioningState"] = v1.ProvisioningStateProvisioning
 
-	responseBody := map[string]interface{}{
+	responseBody := map[string]any{
 		"id":         id.String(),
 		"name":       id.Name(),
 		"type":       id.Type(),

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource_test.go
@@ -44,8 +44,8 @@ func Test_CreateAWSResource(t *testing.T) {
 			},
 		}, nil)
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"RetentionPeriodHours": 178,
 			"ShardCount":           3,
 		},
@@ -82,18 +82,18 @@ func Test_CreateAWSResource(t *testing.T) {
 	require.Equal(t, testResource.AzureAsyncOpHeader, res.Header.Get("Azure-AsyncOperation"))
 	defer res.Body.Close()
 
-	expectedResponseObject := map[string]interface{}{
+	expectedResponseObject := map[string]any{
 		"id":   testResource.SingleResourcePath,
 		"name": testResource.ResourceName,
 		"type": testResource.ResourceType,
-		"properties": map[string]interface{}{
+		"properties": map[string]any{
 			"RetentionPeriodHours": float64(178),
 			"ShardCount":           float64(3),
 			"provisioningState":    "Provisioning",
 		},
 	}
 
-	actualResponseObject := map[string]interface{}{}
+	actualResponseObject := map[string]any{}
 	err = json.Unmarshal(body, &actualResponseObject)
 	require.NoError(t, err)
 
@@ -111,8 +111,8 @@ func Test_UpdateAWSResource(t *testing.T) {
 		Schema:   aws.String(testResource.Schema),
 	}
 
-	getResponseBody := map[string]interface{}{
-		"ClusterEndpoint": map[string]interface{}{
+	getResponseBody := map[string]any{
+		"ClusterEndpoint": map[string]any{
 			"Address": "test",
 			"Port":    6379,
 		},
@@ -142,8 +142,8 @@ func Test_UpdateAWSResource(t *testing.T) {
 			},
 		}, nil)
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"Port":                6379,
 			"NumReplicasPerShard": 0,
 		},
@@ -174,12 +174,12 @@ func Test_UpdateAWSResource(t *testing.T) {
 	require.NoError(t, err)
 	defer res.Body.Close()
 
-	expectedResponseObject := map[string]interface{}{
+	expectedResponseObject := map[string]any{
 		"id":   testResource.SingleResourcePath,
 		"name": testResource.ResourceName,
 		"type": testResource.ResourceType,
-		"properties": map[string]interface{}{
-			"ClusterEndpoint": map[string]interface{}{
+		"properties": map[string]any{
+			"ClusterEndpoint": map[string]any{
 				"Address": "test",
 				"Port":    float64(6379),
 			},
@@ -190,7 +190,7 @@ func Test_UpdateAWSResource(t *testing.T) {
 		},
 	}
 
-	actualResponseObject := map[string]interface{}{}
+	actualResponseObject := map[string]any{}
 	err = json.Unmarshal(body, &actualResponseObject)
 	require.NoError(t, err)
 
@@ -208,7 +208,7 @@ func Test_UpdateNoChangesDoesNotCallUpdate(t *testing.T) {
 		Schema:   aws.String(testResource.Schema),
 	}
 
-	getResponseBody := map[string]interface{}{
+	getResponseBody := map[string]any{
 		"RetentionPeriodHours": 178,
 		"ShardCount":           3,
 	}
@@ -226,8 +226,8 @@ func Test_UpdateNoChangesDoesNotCallUpdate(t *testing.T) {
 			},
 		}, nil)
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"RetentionPeriodHours": 178,
 			"ShardCount":           3,
 		},
@@ -258,18 +258,18 @@ func Test_UpdateNoChangesDoesNotCallUpdate(t *testing.T) {
 	require.NoError(t, err)
 	defer res.Body.Close()
 
-	expectedResponseObject := map[string]interface{}{
+	expectedResponseObject := map[string]any{
 		"id":   testResource.SingleResourcePath,
 		"name": testResource.ResourceName,
 		"type": testResource.ResourceType,
-		"properties": map[string]interface{}{
+		"properties": map[string]any{
 			"RetentionPeriodHours": float64(178),
 			"ShardCount":           float64(3),
 			"provisioningState":    "Succeeded",
 		},
 	}
 
-	actualResponseObject := map[string]interface{}{}
+	actualResponseObject := map[string]any{}
 	err = json.Unmarshal(body, &actualResponseObject)
 	require.NoError(t, err)
 

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
@@ -71,7 +71,7 @@ func (p *CreateOrUpdateAWSResourceWithPost) Run(ctx context.Context, w http.Resp
 	existing := true
 	var getResponse *cloudcontrol.GetResourceOutput = nil
 	computedResourceID := ""
-	responseProperties := map[string]interface{}{}
+	responseProperties := map[string]any{}
 
 	awsResourceIdentifier, err := getPrimaryIdentifierFromMultiIdentifiers(ctx, properties, *describeTypeOutput.Schema)
 	if errors.Is(&awserror.AWSMissingPropertyError{}, err) {
@@ -140,7 +140,7 @@ func (p *CreateOrUpdateAWSResourceWithPost) Run(ctx context.Context, w http.Resp
 			// mark provisioning state as succeeded here
 			// and return 200, telling the deployment engine that the resource has already been created
 			responseProperties["provisioningState"] = v1.ProvisioningStateSucceeded
-			responseBody := map[string]interface{}{
+			responseBody := map[string]any{
 				"id":         computedResourceID,
 				"name":       awsResourceIdentifier,
 				"type":       id.Type(),
@@ -174,7 +174,7 @@ func (p *CreateOrUpdateAWSResourceWithPost) Run(ctx context.Context, w http.Resp
 
 	responseProperties["provisioningState"] = v1.ProvisioningStateProvisioning
 
-	responseBody := map[string]interface{}{
+	responseBody := map[string]any{
 		"type":       id.Type(),
 		"properties": responseProperties,
 	}

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost_test.go
@@ -51,8 +51,8 @@ func Test_CreateAWSResourceWithPost(t *testing.T) {
 			},
 		}, nil)
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"ClusterName":         testResource.ResourceName,
 			"Port":                6379,
 			"NumReplicasPerShard": 1,
@@ -84,11 +84,11 @@ func Test_CreateAWSResourceWithPost(t *testing.T) {
 	require.NoError(t, err)
 	defer res.Body.Close()
 
-	expectedResponseObject := map[string]interface{}{
+	expectedResponseObject := map[string]any{
 		"id":   testResource.SingleResourcePath,
 		"name": testResource.ResourceName,
 		"type": testResource.ResourceType,
-		"properties": map[string]interface{}{
+		"properties": map[string]any{
 			"ClusterName":         testResource.ResourceName,
 			"Port":                float64(6379),
 			"NumReplicasPerShard": float64(1),
@@ -96,7 +96,7 @@ func Test_CreateAWSResourceWithPost(t *testing.T) {
 		},
 	}
 
-	actualResponseObject := map[string]interface{}{}
+	actualResponseObject := map[string]any{}
 	err = json.Unmarshal(body, &actualResponseObject)
 	require.NoError(t, err)
 
@@ -117,9 +117,9 @@ func Test_UpdateAWSResourceWithPost(t *testing.T) {
 	testOptions := setupTest(t)
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	getResponseBody := map[string]interface{}{
+	getResponseBody := map[string]any{
 		"ClusterName": testResource.ResourceName,
-		"ClusterEndpoint": map[string]interface{}{
+		"ClusterEndpoint": map[string]any{
 			"Address": "test",
 			"Port":    6379,
 		},
@@ -146,8 +146,8 @@ func Test_UpdateAWSResourceWithPost(t *testing.T) {
 			},
 		}, nil)
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"ClusterName":         testResource.ResourceName,
 			"Port":                6379,
 			"NumReplicasPerShard": 0,
@@ -179,13 +179,13 @@ func Test_UpdateAWSResourceWithPost(t *testing.T) {
 	require.NoError(t, err)
 	defer res.Body.Close()
 
-	expectedResponseObject := map[string]interface{}{
+	expectedResponseObject := map[string]any{
 		"id":   testResource.SingleResourcePath,
 		"name": testResource.ResourceName,
 		"type": testResource.ResourceType,
-		"properties": map[string]interface{}{
+		"properties": map[string]any{
 			"ClusterName": testResource.ResourceName,
-			"ClusterEndpoint": map[string]interface{}{
+			"ClusterEndpoint": map[string]any{
 				"Address": "test",
 				"Port":    float64(6379),
 			},
@@ -196,7 +196,7 @@ func Test_UpdateAWSResourceWithPost(t *testing.T) {
 		},
 	}
 
-	actualResponseObject := map[string]interface{}{}
+	actualResponseObject := map[string]any{}
 	err = json.Unmarshal(body, &actualResponseObject)
 	require.NoError(t, err)
 
@@ -217,9 +217,9 @@ func Test_UpdateAWSResourceWithPost_NoChangesNoops(t *testing.T) {
 	testOptions := setupTest(t)
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	getResponseBody := map[string]interface{}{
+	getResponseBody := map[string]any{
 		"ClusterName": testResource.ResourceName,
-		"ClusterEndpoint": map[string]interface{}{
+		"ClusterEndpoint": map[string]any{
 			"Address": "test",
 			"Port":    6379,
 		},
@@ -237,8 +237,8 @@ func Test_UpdateAWSResourceWithPost_NoChangesNoops(t *testing.T) {
 			},
 		}, nil)
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"ClusterName":         testResource.ResourceName,
 			"Port":                6379,
 			"NumReplicasPerShard": 1,
@@ -270,13 +270,13 @@ func Test_UpdateAWSResourceWithPost_NoChangesNoops(t *testing.T) {
 	require.NoError(t, err)
 	defer res.Body.Close()
 
-	expectedResponseObject := map[string]interface{}{
+	expectedResponseObject := map[string]any{
 		"id":   testResource.SingleResourcePath,
 		"name": testResource.ResourceName,
 		"type": testResource.ResourceType,
-		"properties": map[string]interface{}{
+		"properties": map[string]any{
 			"ClusterName": testResource.ResourceName,
-			"ClusterEndpoint": map[string]interface{}{
+			"ClusterEndpoint": map[string]any{
 				"Address": "test",
 				"Port":    float64(6379),
 			},
@@ -287,7 +287,7 @@ func Test_UpdateAWSResourceWithPost_NoChangesNoops(t *testing.T) {
 		},
 	}
 
-	actualResponseObject := map[string]interface{}{}
+	actualResponseObject := map[string]any{}
 	err = json.Unmarshal(body, &actualResponseObject)
 	require.NoError(t, err)
 
@@ -320,8 +320,8 @@ func Test_CreateAWSResourceWithPost_NoPrimaryIdentifierAvailable(t *testing.T) {
 			},
 		}, nil)
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"ClusterIdentifier": clusterIdentifierValue,
 		},
 	}
@@ -354,17 +354,17 @@ func Test_CreateAWSResourceWithPost_NoPrimaryIdentifierAvailable(t *testing.T) {
 	id, err := resources.Parse(testResource.CollectionPath)
 	require.NoError(t, err)
 	rID := computeResourceID(id, multiIdentifierResourceID)
-	expectedResponseObject := map[string]interface{}{
+	expectedResponseObject := map[string]any{
 		"id":   rID,
 		"name": multiIdentifierResourceID,
 		"type": testResource.ResourceType,
-		"properties": map[string]interface{}{
+		"properties": map[string]any{
 			"ClusterIdentifier": clusterIdentifierValue,
 			"provisioningState": "Provisioning",
 		},
 	}
 
-	actualResponseObject := map[string]interface{}{}
+	actualResponseObject := map[string]any{}
 	err = json.Unmarshal(body, &actualResponseObject)
 	require.NoError(t, err)
 
@@ -402,8 +402,8 @@ func Test_CreateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 			},
 		}, nil)
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"ClusterIdentifier": clusterIdentifierValue,
 			"Account":           accountValue,
 		},
@@ -437,18 +437,18 @@ func Test_CreateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	id, err := resources.Parse(testResource.CollectionPath)
 	require.NoError(t, err)
 	rID := computeResourceID(id, multiIdentifierResourceID)
-	expectedResponseObject := map[string]interface{}{
+	expectedResponseObject := map[string]any{
 		"id":   rID,
 		"name": multiIdentifierResourceID,
 		"type": testResource.ResourceType,
-		"properties": map[string]interface{}{
+		"properties": map[string]any{
 			"ClusterIdentifier": clusterIdentifierValue,
 			"Account":           accountValue,
 			"provisioningState": "Provisioning",
 		},
 	}
 
-	actualResponseObject := map[string]interface{}{}
+	actualResponseObject := map[string]any{}
 	err = json.Unmarshal(body, &actualResponseObject)
 	require.NoError(t, err)
 
@@ -472,7 +472,7 @@ func Test_UpdateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	testOptions := setupTest(t)
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	getResponseBody := map[string]interface{}{
+	getResponseBody := map[string]any{
 		"ClusterIdentifier": clusterIdentifierValue,
 		"Account":           accountValue,
 	}
@@ -495,8 +495,8 @@ func Test_UpdateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 			},
 		}, nil)
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"ClusterIdentifier": clusterIdentifierValue,
 			"Account":           accountValue,
 			"EndpointCount":     2,
@@ -531,11 +531,11 @@ func Test_UpdateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	id, err := resources.Parse(testResource.CollectionPath)
 	require.NoError(t, err)
 	rID := computeResourceID(id, multiIdentifierResourceID)
-	expectedResponseObject := map[string]interface{}{
+	expectedResponseObject := map[string]any{
 		"id":   rID,
 		"name": multiIdentifierResourceID,
 		"type": testResource.ResourceType,
-		"properties": map[string]interface{}{
+		"properties": map[string]any{
 			"ClusterIdentifier": "abc",
 			"Account":           "xyz",
 			"EndpointCount":     float64(2),
@@ -543,7 +543,7 @@ func Test_UpdateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 		},
 	}
 
-	actualResponseObject := map[string]interface{}{}
+	actualResponseObject := map[string]any{}
 	err = json.Unmarshal(body, &actualResponseObject)
 	require.NoError(t, err)
 

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresource.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresource.go
@@ -59,6 +59,6 @@ func (p *DeleteAWSResource) Run(ctx context.Context, w http.ResponseWriter, req 
 		return nil, err
 	}
 
-	resp := armrpc_rest.NewAsyncOperationResponse(map[string]interface{}{}, v1.LocationGlobal, 202, id, operation, "", id.RootScope(), p.Options.BasePath)
+	resp := armrpc_rest.NewAsyncOperationResponse(map[string]any{}, v1.LocationGlobal, 202, id, operation, "", id.RootScope(), p.Options.BasePath)
 	return resp, nil
 }

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresource_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresource_test.go
@@ -28,7 +28,7 @@ func Test_DeleteAWSResource(t *testing.T) {
 
 	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
-	getResponseBody := map[string]interface{}{
+	getResponseBody := map[string]any{
 		"RetentionPeriodHours": 178,
 		"ShardCount":           3,
 	}

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost.go
@@ -96,6 +96,6 @@ func (p *DeleteAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWrit
 		return nil, err
 	}
 
-	resp := armrpc_rest.NewAsyncOperationResponse(map[string]interface{}{}, v1.LocationGlobal, 202, id, operation, "", id.RootScope(), p.Options.BasePath)
+	resp := armrpc_rest.NewAsyncOperationResponse(map[string]any{}, v1.LocationGlobal, 202, id, operation, "", id.RootScope(), p.Options.BasePath)
 	return resp, nil
 }

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost_test.go
@@ -38,7 +38,7 @@ func Test_DeleteAWSResourceWithPost(t *testing.T) {
 	testOptions := setupTest(t)
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	getResponseBody := map[string]interface{}{
+	getResponseBody := map[string]any{
 		"Name":                 testResource.ResourceName,
 		"RetentionPeriodHours": 178,
 		"ShardCount":           3,
@@ -69,8 +69,8 @@ func Test_DeleteAWSResourceWithPost(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"Name": testResource.ResourceName,
 		},
 	}
@@ -122,8 +122,8 @@ func Test_DeleteAWSResourceWithPost_ResourceDoesNotExist(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"Name": testResource.ResourceName,
 		},
 	}
@@ -166,7 +166,7 @@ func Test_DeleteAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	testOptions := setupTest(t)
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	getResponseBody := map[string]interface{}{
+	getResponseBody := map[string]any{
 		"ClusterIdentifier": clusterIdentifierValue,
 		"Account":           accountValue,
 	}
@@ -191,8 +191,8 @@ func Test_DeleteAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 			},
 		}, nil)
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"ClusterIdentifier": clusterIdentifierValue,
 			"Account":           accountValue,
 		},

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresource.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresource.go
@@ -45,7 +45,7 @@ func (p *GetAWSResource) Run(ctx context.Context, w http.ResponseWriter, req *ht
 		return awsclient.HandleAWSError(err)
 	}
 
-	properties := map[string]interface{}{}
+	properties := map[string]any{}
 	if response.ResourceDescription.Properties != nil {
 		err := json.Unmarshal([]byte(*response.ResourceDescription.Properties), &properties)
 		if err != nil {
@@ -53,7 +53,7 @@ func (p *GetAWSResource) Run(ctx context.Context, w http.ResponseWriter, req *ht
 		}
 	}
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"id":         id.String(),
 		"name":       response.ResourceDescription.Identifier,
 		"type":       id.Type(),

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresource_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresource_test.go
@@ -32,7 +32,7 @@ func Test_GetAWSResource(t *testing.T) {
 
 	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
-	getResponseBody := map[string]interface{}{
+	getResponseBody := map[string]any{
 		"RetentionPeriodHours": 178,
 		"ShardCount":           3,
 	}
@@ -59,11 +59,11 @@ func Test_GetAWSResource(t *testing.T) {
 	require.NoError(t, err)
 	actualResponse, err := awsController.Run(ctx, nil, request)
 
-	expectedResponse := armrpc_rest.NewOKResponse(map[string]interface{}{
+	expectedResponse := armrpc_rest.NewOKResponse(map[string]any{
 		"id":   testResource.SingleResourcePath,
 		"name": aws.String(testResource.ResourceName),
 		"type": testResource.ResourceType,
-		"properties": map[string]interface{}{
+		"properties": map[string]any{
 			"RetentionPeriodHours": float64(178),
 			"ShardCount":           float64(3),
 		},

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost.go
@@ -86,7 +86,7 @@ func (p *GetAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWriter,
 		return awsclient.HandleAWSError(err)
 	}
 
-	resourceProperties := map[string]interface{}{}
+	resourceProperties := map[string]any{}
 	if response.ResourceDescription.Properties != nil {
 		err := json.Unmarshal([]byte(*response.ResourceDescription.Properties), &resourceProperties)
 		if err != nil {
@@ -95,7 +95,7 @@ func (p *GetAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWriter,
 	}
 
 	computedResourceID := computeResourceID(id, awsResourceIdentifier)
-	body := map[string]interface{}{
+	body := map[string]any{
 		"id":         computedResourceID,
 		"name":       response.ResourceDescription.Identifier,
 		"type":       id.Type(),

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost_test.go
@@ -46,7 +46,7 @@ func Test_GetAWSResourceWithPost(t *testing.T) {
 	testOptions := setupTest(t)
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	getResponseBody := map[string]interface{}{
+	getResponseBody := map[string]any{
 		"Name":                 testResource.ResourceName,
 		"RetentionPeriodHours": 178,
 		"ShardCount":           3,
@@ -69,8 +69,8 @@ func Test_GetAWSResourceWithPost(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"Name": testResource.ResourceName,
 		},
 	}
@@ -82,11 +82,11 @@ func Test_GetAWSResourceWithPost(t *testing.T) {
 	require.NoError(t, err)
 	actualResponse, err := awsController.Run(ctx, nil, request)
 
-	expectedResponse := armrpc_rest.NewOKResponse(map[string]interface{}{
+	expectedResponse := armrpc_rest.NewOKResponse(map[string]any{
 		"id":   testResource.SingleResourcePath,
 		"type": testResource.ResourceType,
 		"name": aws.String(testResource.ResourceName),
-		"properties": map[string]interface{}{
+		"properties": map[string]any{
 			"Name":                 testResource.ResourceName,
 			"RetentionPeriodHours": float64(178),
 			"ShardCount":           float64(3),
@@ -123,8 +123,8 @@ func Test_GetAWSResourceWithPost_NotFound(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"Name": testResource.ResourceName,
 		},
 	}
@@ -164,8 +164,8 @@ func Test_GetAWSResourceWithPost_UnknownError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"Name": testResource.ResourceName,
 		},
 	}
@@ -212,8 +212,8 @@ func Test_GetAWSResourceWithPost_SmithyError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"Name": testResource.ResourceName,
 		},
 	}
@@ -252,7 +252,7 @@ func Test_GetAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	testOptions := setupTest(t)
 	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	getResponseBody := map[string]interface{}{
+	getResponseBody := map[string]any{
 		"ClusterIdentifier": clusterIdentifierValue,
 		"Account":           accountValue,
 	}
@@ -270,8 +270,8 @@ func Test_GetAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 			},
 		}, nil)
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"ClusterIdentifier": clusterIdentifierValue,
 			"Account":           accountValue,
 		},
@@ -306,17 +306,17 @@ func Test_GetAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	require.NoError(t, err)
 	multiIdentifierResourceID := clusterIdentifierValue + "|" + accountValue
 	rID := computeResourceID(id, multiIdentifierResourceID)
-	expectedResponseObject := map[string]interface{}{
+	expectedResponseObject := map[string]any{
 		"id":   rID,
 		"name": testResource.ResourceName,
 		"type": testResource.ResourceType,
-		"properties": map[string]interface{}{
+		"properties": map[string]any{
 			"ClusterIdentifier": "abc",
 			"Account":           "xyz",
 		},
 	}
 
-	actualResponseObject := map[string]interface{}{}
+	actualResponseObject := map[string]any{}
 	err = json.Unmarshal(body, &actualResponseObject)
 	require.NoError(t, err)
 

--- a/pkg/ucp/frontend/controller/awsproxy/listawsresources.go
+++ b/pkg/ucp/frontend/controller/awsproxy/listawsresources.go
@@ -47,9 +47,9 @@ func (p *ListAWSResources) Run(ctx context.Context, w http.ResponseWriter, req *
 	//
 	// https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/resource-operations-list.html
 
-	items := []interface{}{}
+	items := []any{}
 	for _, result := range response.ResourceDescriptions {
-		properties := map[string]interface{}{}
+		properties := map[string]any{}
 		if result.Properties != nil {
 			err := json.Unmarshal([]byte(*result.Properties), &properties)
 			if err != nil {
@@ -58,7 +58,7 @@ func (p *ListAWSResources) Run(ctx context.Context, w http.ResponseWriter, req *
 		}
 
 		resourceName := *result.Identifier
-		item := map[string]interface{}{
+		item := map[string]any{
 			"id":         path.Join(id.String(), resourceName),
 			"name":       result.Identifier,
 			"type":       id.Type(),
@@ -67,7 +67,7 @@ func (p *ListAWSResources) Run(ctx context.Context, w http.ResponseWriter, req *
 		items = append(items, item)
 	}
 
-	body := map[string]interface{}{
+	body := map[string]any{
 		"value": items,
 	}
 	return armrpc_rest.NewOKResponse(body), nil

--- a/pkg/ucp/frontend/controller/awsproxy/listawsresources_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/listawsresources_test.go
@@ -32,14 +32,14 @@ func Test_ListAWSResources(t *testing.T) {
 	firstTestResource := CreateKinesisStreamTestResource(uuid.NewString())
 	secondTestResource := CreateKinesisStreamTestResource(uuid.NewString())
 
-	firstTestResourceResponseBody := map[string]interface{}{
+	firstTestResourceResponseBody := map[string]any{
 		"RetentionPeriodHours": 178,
 		"ShardCount":           3,
 	}
 	firstTestResourceResponseBodyBytes, err := json.Marshal(firstTestResourceResponseBody)
 	require.NoError(t, err)
 
-	secondTestResourceResponseBody := map[string]interface{}{
+	secondTestResourceResponseBody := map[string]any{
 		"RetentionPeriodHours": 180,
 		"ShardCount":           2,
 	}
@@ -73,22 +73,22 @@ func Test_ListAWSResources(t *testing.T) {
 	actualResponse, err := awsController.Run(ctx, nil, request)
 	require.NoError(t, err)
 
-	expectedResponse := armrpc_rest.NewOKResponse(map[string]interface{}{
-		"value": []interface{}{
-			map[string]interface{}{
+	expectedResponse := armrpc_rest.NewOKResponse(map[string]any{
+		"value": []any{
+			map[string]any{
 				"id":   firstTestResource.SingleResourcePath,
 				"name": aws.String(firstTestResource.ResourceName),
 				"type": firstTestResource.ResourceType,
-				"properties": map[string]interface{}{
+				"properties": map[string]any{
 					"RetentionPeriodHours": float64(178),
 					"ShardCount":           float64(3),
 				},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"id":   secondTestResource.SingleResourcePath,
 				"name": aws.String(secondTestResource.ResourceName),
 				"type": secondTestResource.ResourceType,
-				"properties": map[string]interface{}{
+				"properties": map[string]any{
 					"RetentionPeriodHours": float64(180),
 					"ShardCount":           float64(2),
 				},
@@ -120,8 +120,8 @@ func Test_ListAWSResourcesEmpty(t *testing.T) {
 	actualResponse, err := awsController.Run(ctx, nil, request)
 	require.NoError(t, err)
 
-	expectedResponse := armrpc_rest.NewOKResponse(map[string]interface{}{
-		"value": []interface{}{},
+	expectedResponse := armrpc_rest.NewOKResponse(map[string]any{
+		"value": []any{},
 	})
 
 	require.Equal(t, expectedResponse, actualResponse)

--- a/pkg/ucp/frontend/controller/controller.go
+++ b/pkg/ucp/frontend/controller/controller.go
@@ -108,7 +108,7 @@ func (b *BaseController) StorageClient() store.StorageClient {
 }
 
 // GetResource is the helper to get the resource via storage client.
-func (c *BaseController) GetResource(ctx context.Context, id string, out interface{}) (etag string, err error) {
+func (c *BaseController) GetResource(ctx context.Context, id string, out any) (etag string, err error) {
 	etag = ""
 	var res *store.Object
 	if res, err = c.StorageClient().Get(ctx, id); err == nil && res != nil {
@@ -121,7 +121,7 @@ func (c *BaseController) GetResource(ctx context.Context, id string, out interfa
 }
 
 // SaveResource is the helper to save the resource via storage client.
-func (c *BaseController) SaveResource(ctx context.Context, id string, in interface{}, etag string) (*store.Object, error) {
+func (c *BaseController) SaveResource(ctx context.Context, id string, in any, etag string) (*store.Object, error) {
 	nr := &store.Object{
 		Metadata: store.Metadata{
 			ID: id,

--- a/pkg/ucp/frontend/controller/kubernetes/discoverydoc.go
+++ b/pkg/ucp/frontend/controller/kubernetes/discoverydoc.go
@@ -36,11 +36,11 @@ func (e *DiscoveryDoc) Run(ctx context.Context, w http.ResponseWriter, req *http
 
 	// We avoid using the rest package here so we can avoid logging every request.
 	// This endpoint is called ..... A ... LOT.
-	b, err := json.Marshal(map[string]interface{}{
+	b, err := json.Marshal(map[string]any{
 		"kind":         "APIResourceList",
 		"apiVersion":   "v1alpha3",
 		"groupVersion": "api.ucp.dev/v1alpha3",
-		"resources":    []interface{}{},
+		"resources":    []any{},
 	})
 	if err != nil {
 		controller.HandleError(ctx, w, req, err)

--- a/pkg/ucp/frontend/controller/kubernetes/openapiv2doc.go
+++ b/pkg/ucp/frontend/controller/kubernetes/openapiv2doc.go
@@ -36,13 +36,13 @@ func (e *OpenAPIv2Doc) Run(ctx context.Context, w http.ResponseWriter, req *http
 
 	// We avoid using the rest package here so we can avoid logging every request.
 	// This endpoint is called ..... A ... LOT.
-	b, err := json.Marshal(map[string]interface{}{
+	b, err := json.Marshal(map[string]any{
 		"swagger": "2.0",
-		"info": map[string]interface{}{
+		"info": map[string]any{
 			"title":   "Radius APIService",
 			"version": "v1alpha3",
 		},
-		"paths": map[string]interface{}{},
+		"paths": map[string]any{},
 	})
 	if err != nil {
 		controller.HandleError(ctx, w, req, err)

--- a/pkg/ucp/frontend/controller/planes/listplanes.go
+++ b/pkg/ucp/frontend/controller/planes/listplanes.go
@@ -52,9 +52,9 @@ func (e *ListPlanes) Run(ctx context.Context, w http.ResponseWriter, req *http.R
 	return ok, nil
 }
 
-func (p *ListPlanes) createResponse(ctx context.Context, req *http.Request, result *store.ObjectQueryResult) ([]interface{}, error) {
+func (p *ListPlanes) createResponse(ctx context.Context, req *http.Request, result *store.ObjectQueryResult) ([]any, error) {
 	apiVersion := ctrl.GetAPIVersion(req)
-	listOfPlanes := []interface{}{}
+	listOfPlanes := []any{}
 	if len(result.Items) > 0 {
 		for _, item := range result.Items {
 			var plane datamodel.Plane

--- a/pkg/ucp/frontend/controller/planes/listplanes_test.go
+++ b/pkg/ucp/frontend/controller/planes/listplanes_test.go
@@ -36,7 +36,7 @@ func Test_ListPlanes(t *testing.T) {
 	query.RootScope = rootScope
 	query.IsScopeQuery = true
 
-	expectedPlaneList := []interface{}{}
+	expectedPlaneList := []any{}
 	expectedResponse := armrpc_rest.NewOKResponse(expectedPlaneList)
 
 	mockStorageClient.EXPECT().Query(gomock.Any(), query).Return(&store.ObjectQueryResult{}, nil)

--- a/pkg/ucp/frontend/controller/resourcegroups/listresourcegroups_test.go
+++ b/pkg/ucp/frontend/controller/resourcegroups/listresourcegroups_test.go
@@ -78,7 +78,7 @@ func Test_ListResourceGroups(t *testing.T) {
 		Tags:     *to.Ptr(map[string]*string{}),
 	}
 	expectedResourceGroupList := &v1.PaginatedList{
-		Value: []interface{}{
+		Value: []any{
 			&resourceGroup,
 		},
 	}

--- a/pkg/ucp/hosting/hosting.go
+++ b/pkg/ucp/hosting/hosting.go
@@ -33,7 +33,7 @@ type Host struct {
 	Services []Service
 
 	// LoggerValues is key-value-pairs passed to .WithValues to initialize the logger for the host.
-	LoggerValues []interface{}
+	LoggerValues []any
 
 	// TimeoutFunc allows you to control the timeout behavior for testing
 	TimeoutFunc func()

--- a/pkg/ucp/integrationtests/aws/createresource_test.go
+++ b/pkg/ucp/integrationtests/aws/createresource_test.go
@@ -42,8 +42,8 @@ func Test_CreateAWSResource(t *testing.T) {
 		return &output, nil
 	})
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"RetentionPeriodHours": 178,
 			"ShardCount":           3,
 		},

--- a/pkg/ucp/integrationtests/aws/createresourcewithpost_test.go
+++ b/pkg/ucp/integrationtests/aws/createresourcewithpost_test.go
@@ -27,8 +27,8 @@ import (
 func Test_CreateAWSResourceWithPost(t *testing.T) {
 	ucp, ucpClient, cloudcontrolClient, cloudformationClient := initializeTest(t)
 
-	primaryIdentifiers := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
+	primaryIdentifiers := map[string]any{
+		"primaryIdentifier": []any{
 			"/properties/Name",
 		},
 	}
@@ -59,8 +59,8 @@ func Test_CreateAWSResourceWithPost(t *testing.T) {
 		return &output, nil
 	})
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"Name":                 "testStream",
 			"RetentionPeriodHours": 178,
 			"ShardCount":           3,

--- a/pkg/ucp/integrationtests/aws/deleteresource_test.go
+++ b/pkg/ucp/integrationtests/aws/deleteresource_test.go
@@ -24,7 +24,7 @@ import (
 func Test_DeleteAWSResource(t *testing.T) {
 	ucp, ucpClient, cloudcontrolClient, _ := initializeTest(t)
 
-	getResponseBody := map[string]interface{}{
+	getResponseBody := map[string]any{
 		"RetentionPeriodHours": 178,
 		"ShardCount":           3,
 	}

--- a/pkg/ucp/integrationtests/aws/deleteresourcewithpost_test.go
+++ b/pkg/ucp/integrationtests/aws/deleteresourcewithpost_test.go
@@ -27,8 +27,8 @@ import (
 func Test_DeleteAWSResourceWithPost(t *testing.T) {
 	ucp, ucpClient, cloudcontrolClient, cloudformationClient := initializeTest(t)
 
-	primaryIdentifiers := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
+	primaryIdentifiers := map[string]any{
+		"primaryIdentifier": []any{
 			"/properties/Name",
 		},
 	}
@@ -41,7 +41,7 @@ func Test_DeleteAWSResourceWithPost(t *testing.T) {
 
 	cloudformationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	getResponseBody := map[string]interface{}{
+	getResponseBody := map[string]any{
 		"RetentionPeriodHours": 178,
 		"ShardCount":           3,
 	}
@@ -68,8 +68,8 @@ func Test_DeleteAWSResourceWithPost(t *testing.T) {
 		return &output, nil
 	})
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"Name":                 "testStream",
 			"RetentionPeriodHours": 178,
 			"ShardCount":           3,

--- a/pkg/ucp/integrationtests/aws/getresource_test.go
+++ b/pkg/ucp/integrationtests/aws/getresource_test.go
@@ -24,7 +24,7 @@ import (
 func Test_GetAWSResource(t *testing.T) {
 	ucp, ucpClient, cloudcontrolClient, _ := initializeTest(t)
 
-	getResponseBody := map[string]interface{}{
+	getResponseBody := map[string]any{
 		"RetentionPeriodHours": 178,
 		"ShardCount":           3,
 	}

--- a/pkg/ucp/integrationtests/aws/getresourcewithpost_test.go
+++ b/pkg/ucp/integrationtests/aws/getresourcewithpost_test.go
@@ -27,8 +27,8 @@ import (
 func Test_GetAWSResourceWithPost(t *testing.T) {
 	ucp, ucpClient, cloudcontrolClient, cloudformationClient := initializeTest(t)
 
-	primaryIdentifiers := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
+	primaryIdentifiers := map[string]any{
+		"primaryIdentifier": []any{
 			"/properties/Name",
 		},
 	}
@@ -41,7 +41,7 @@ func Test_GetAWSResourceWithPost(t *testing.T) {
 
 	cloudformationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	getResponseBody := map[string]interface{}{
+	getResponseBody := map[string]any{
 		"RetentionPeriodHours": 178,
 		"ShardCount":           3,
 	}
@@ -58,8 +58,8 @@ func Test_GetAWSResourceWithPost(t *testing.T) {
 		return &output, nil
 	})
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"Name":                 "testStream",
 			"RetentionPeriodHours": 178,
 			"ShardCount":           3,

--- a/pkg/ucp/integrationtests/aws/listresources_test.go
+++ b/pkg/ucp/integrationtests/aws/listresources_test.go
@@ -26,7 +26,7 @@ const testProxyRequestAWSListPath = "/planes/aws/aws/accounts/1234567/regions/us
 func Test_ListAWSResources(t *testing.T) {
 	ucp, ucpClient, cloudcontrolClient, _ := initializeTest(t)
 
-	getResponseBody := map[string]interface{}{
+	getResponseBody := map[string]any{
 		"RetentionPeriodHours": 178,
 		"ShardCount":           3,
 	}

--- a/pkg/ucp/integrationtests/aws/updateresource_test.go
+++ b/pkg/ucp/integrationtests/aws/updateresource_test.go
@@ -29,7 +29,7 @@ const ZeroAWSRequestToken = "00000000-0000-0000-0000-000000000000"
 func Test_UpdateAWSResource(t *testing.T) {
 	ucp, ucpClient, cloudcontrolClient, cloudFormationClient := initializeTest(t)
 
-	getResponseBody := map[string]interface{}{
+	getResponseBody := map[string]any{
 		"RetentionPeriodHours": 178,
 		"ShardCount":           3,
 	}
@@ -37,11 +37,11 @@ func Test_UpdateAWSResource(t *testing.T) {
 	require.NoError(t, err)
 
 	resourceType := "AWS::Kinesis::Stream"
-	typeSchema := map[string]interface{}{
-		"readOnlyProperties": []interface{}{
+	typeSchema := map[string]any{
+		"readOnlyProperties": []any{
 			"/properties/Arn",
 		},
-		"createOnlyProperties": []interface{}{
+		"createOnlyProperties": []any{
 			"/properties/Name",
 		},
 	}
@@ -73,8 +73,8 @@ func Test_UpdateAWSResource(t *testing.T) {
 		return &output, nil
 	})
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"RetentionPeriodHours": 180,
 			"ShardCount":           4,
 		},

--- a/pkg/ucp/integrationtests/aws/updateresourcewithpost_test.go
+++ b/pkg/ucp/integrationtests/aws/updateresourcewithpost_test.go
@@ -27,8 +27,8 @@ import (
 func Test_UpdateAWSResourceWithPost(t *testing.T) {
 	ucp, ucpClient, cloudcontrolClient, cloudformationClient := initializeTest(t)
 
-	primaryIdentifiers := map[string]interface{}{
-		"primaryIdentifier": []interface{}{
+	primaryIdentifiers := map[string]any{
+		"primaryIdentifier": []any{
 			"/properties/Name",
 		},
 	}
@@ -41,7 +41,7 @@ func Test_UpdateAWSResourceWithPost(t *testing.T) {
 
 	cloudformationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	getResponseBody := map[string]interface{}{
+	getResponseBody := map[string]any{
 		"Name":                 "testStream",
 		"RetentionPeriodHours": 178,
 		"ShardCount":           3,
@@ -68,8 +68,8 @@ func Test_UpdateAWSResourceWithPost(t *testing.T) {
 		return &output, nil
 	})
 
-	requestBody := map[string]interface{}{
-		"properties": map[string]interface{}{
+	requestBody := map[string]any{
+		"properties": map[string]any{
 			"Name":                 "testStream",
 			"RetentionPeriodHours": 180,
 			"ShardCount":           4,

--- a/pkg/ucp/integrationtests/integration_test.go
+++ b/pkg/ucp/integrationtests/integration_test.go
@@ -62,7 +62,7 @@ const (
 )
 
 var planeKindAzure v20220901privatepreview.PlaneKind = v20220901privatepreview.PlaneKindAzure
-var applicationList = []map[string]interface{}{
+var applicationList = []map[string]any{
 	{
 		"Name": "app1",
 	},
@@ -305,11 +305,11 @@ func initialize(t *testing.T) (*httptest.Server, Client, *store.MockStorageClien
 }
 
 func registerRP(t *testing.T, ucp *httptest.Server, ucpClient Client, db *store.MockStorageClient, ucpNative bool) {
-	var requestBody map[string]interface{}
+	var requestBody map[string]any
 	if ucpNative {
-		requestBody = map[string]interface{}{
+		requestBody = map[string]any{
 			"location": v1.LocationGlobal,
-			"properties": map[string]interface{}{
+			"properties": map[string]any{
 				"resourceProviders": map[string]string{
 					"Applications.Core": "http://" + rpURL,
 				},
@@ -317,9 +317,9 @@ func registerRP(t *testing.T, ucp *httptest.Server, ucpClient Client, db *store.
 			},
 		}
 	} else {
-		requestBody = map[string]interface{}{
+		requestBody = map[string]any{
 			"location": v1.LocationGlobal,
-			"properties": map[string]interface{}{
+			"properties": map[string]any{
 				"kind": rest.PlaneKindAzure,
 				"url":  "http://" + azureURL,
 			},
@@ -405,7 +405,7 @@ func sendProxyRequest(t *testing.T, ucp *httptest.Server, ucpClient Client, db *
 
 	proxyRequestResponseBody, err := io.ReadAll(proxyRequestResponse.Body)
 	require.NoError(t, err)
-	responseAppList := []map[string]interface{}{}
+	responseAppList := []map[string]any{}
 	err = json.Unmarshal(proxyRequestResponseBody, &responseAppList)
 	require.NoError(t, err)
 	assert.DeepEqual(t, applicationList, responseAppList)
@@ -429,7 +429,7 @@ func sendProxyRequest_AzurePlane(t *testing.T, ucp *httptest.Server, ucpClient C
 
 	proxyRequestResponseBody, err := io.ReadAll(proxyRequestResponse.Body)
 	require.NoError(t, err)
-	responseAppList := []map[string]interface{}{}
+	responseAppList := []map[string]any{}
 	err = json.Unmarshal(proxyRequestResponseBody, &responseAppList)
 	require.NoError(t, err)
 	assert.DeepEqual(t, applicationList, responseAppList)
@@ -480,9 +480,9 @@ func Test_RequestWithBadAPIVersion(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	requestBody := map[string]interface{}{
+	requestBody := map[string]any{
 		"location": v1.LocationGlobal,
-		"properties": map[string]interface{}{
+		"properties": map[string]any{
 			"resourceProviders": map[string]string{
 				"Applications.Core": "http://" + rpURL,
 			},

--- a/pkg/ucp/integrationtests/testserver/testserver.go
+++ b/pkg/ucp/integrationtests/testserver/testserver.go
@@ -189,7 +189,7 @@ func (ts *TestServer) MakeRequest(method string, pathAndQuery string, body []byt
 		requestBuffer = bytes.NewBuffer(body)
 
 		// Pretty-print body for logs.
-		var data interface{}
+		var data any
 		err := json.Unmarshal(body, &data)
 		require.NoError(ts.t, err, "unmarshalling request failed")
 
@@ -214,7 +214,7 @@ func (ts *TestServer) MakeRequest(method string, pathAndQuery string, body []byt
 
 	// Pretty-print response for logs.
 	if len(responseBuffer.Bytes()) > 0 {
-		var data interface{}
+		var data any
 		err = json.Unmarshal(responseBuffer.Bytes(), &data)
 		require.NoError(ts.t, err, "unmarshalling response failed")
 
@@ -258,11 +258,11 @@ func (tr *TestResponse) EqualsResponse(statusCode int, body []byte) {
 		return
 	}
 
-	var expected interface{}
+	var expected any
 	err := json.Unmarshal(body, &expected)
 	require.NoError(tr.t, err, "unmarshalling expected response failed")
 
-	var actual interface{}
+	var actual any
 	err = json.Unmarshal(tr.Body.Bytes(), &actual)
 	require.NoError(tr.t, err, "unmarshalling actual response failed")
 

--- a/pkg/ucp/queue/apiserver/client.go
+++ b/pkg/ucp/queue/apiserver/client.go
@@ -202,7 +202,7 @@ func newMessageLabelSelector(now time.Time, name string) (labels.Selector, error
 }
 
 // getQueueMessage fetches the first item which is the message in the current queue. We can
-// determine whether the message is leased by another client by checking if `NextVisibleAt``
+// determine whether the message is leased by another client by checking if `NextVisibleAt“
 // value is less than `now`.
 func (c *Client) getQueueMessage(ctx context.Context, now time.Time) (*v1alpha1.QueueMessage, error) {
 	ql := &v1alpha1.QueueMessageList{}

--- a/pkg/ucp/queue/client/message.go
+++ b/pkg/ucp/queue/client/message.go
@@ -38,7 +38,7 @@ type Metadata struct {
 }
 
 // NewMessage creates Message.
-func NewMessage(data interface{}) *Message {
+func NewMessage(data any) *Message {
 	msg := &Message{
 		// Support only JSONContentType.
 		ContentType: JSONContentType,

--- a/pkg/ucp/secret/client.go
+++ b/pkg/ucp/secret/client.go
@@ -14,7 +14,7 @@ import (
 
 // Client is an interface to implement secret operations.
 type Client interface {
-	// Save creates or updates secret. 
+	// Save creates or updates secret.
 	// Returns ErrInvalid in case of invalid input.
 	Save(ctx context.Context, name string, value []byte) error
 
@@ -27,7 +27,7 @@ type Client interface {
 }
 
 // SaveSecret saves a generic secret value using secret client.
-func SaveSecret[T any](ctx context.Context, client Client,name string, value T) error {
+func SaveSecret[T any](ctx context.Context, client Client, name string, value T) error {
 	secretData, err := json.Marshal(value)
 	if err != nil {
 		return err

--- a/pkg/ucp/store/apiserverstore/api/ucp.dev/v1alpha1/groupversion_info.go
+++ b/pkg/ucp/store/apiserverstore/api/ucp.dev/v1alpha1/groupversion_info.go
@@ -4,8 +4,8 @@
 // ------------------------------------------------------------
 
 // Package v1alpha1 contains API Schema definitions for the ucp v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=ucp.dev
+// +kubebuilder:object:generate=true
+// +groupName=ucp.dev
 package v1alpha1
 
 import (

--- a/pkg/ucp/store/apiserverstore/apiserverclient.go
+++ b/pkg/ucp/store/apiserverstore/apiserverclient.go
@@ -511,7 +511,7 @@ func findIndex(resource *ucpv1alpha1.Resource, id resources.ID) *int {
 }
 
 func readEntry(entry *ucpv1alpha1.ResourceEntry) (*store.Object, error) {
-	var data interface{}
+	var data any
 	err := json.Unmarshal(entry.Data.Raw, &data)
 	if err != nil {
 		return nil, err

--- a/pkg/ucp/store/apiserverstore/apiserverclient_test.go
+++ b/pkg/ucp/store/apiserverstore/apiserverclient_test.go
@@ -92,7 +92,6 @@ func Test_ResourceName_Normalize(t *testing.T) {
 	}
 }
 
-//
 func Test_APIServer_Client(t *testing.T) {
 	// The APIServer tests require installation of the Kubernetes test environment binaries.
 	// Our Makefile knows how to download the the amd64 version of these on MacOS.

--- a/pkg/ucp/store/cosmosdb/cosmosdbstorageclient.go
+++ b/pkg/ucp/store/cosmosdb/cosmosdbstorageclient.go
@@ -52,7 +52,7 @@ type ResourceEntity struct {
 	// PartitionKey represents the key used for partitioning.
 	PartitionKey string `json:"partitionKey"`
 	// Entity represents the resource metadata.
-	Entity interface{} `json:"entity"`
+	Entity any `json:"entity"`
 }
 
 // CosmosDBStorageClient implements CosmosDB stroage client.

--- a/pkg/ucp/store/filter.go
+++ b/pkg/ucp/store/filter.go
@@ -19,12 +19,12 @@ func (o Object) MatchesFilters(filters []QueryFilter) (bool, error) {
 	data := o.Data
 	if data == nil {
 		// Treat nil as "empty" data
-		data = map[string]interface{}{}
+		data = map[string]any{}
 	} else if reflect.TypeOf(o.Data).Kind() != reflect.Map ||
 		reflect.TypeOf(o.Data).Key().Kind() != reflect.String {
 		// It's most likely for our use case that the data is a map[string]interface{}. However, if it's not
 		// then we need to convert This is basically just here for safety and completeness.
-		data = map[string]interface{}{}
+		data = map[string]any{}
 		err := o.As(&data)
 		if err != nil {
 			return false, err

--- a/pkg/ucp/store/filter_test.go
+++ b/pkg/ucp/store/filter_test.go
@@ -49,19 +49,19 @@ func Test_MatchesFilters(t *testing.T) {
 		// We can work with maps of different types
 		{
 			Description:   "map_string_interface_match",
-			Obj:           &Object{Data: map[string]interface{}{"value": "cool"}},
+			Obj:           &Object{Data: map[string]any{"value": "cool"}},
 			Filters:       []QueryFilter{{Field: "value", Value: "cool"}},
 			ExpectedMatch: true,
 		},
 		{
 			Description:   "map_string_interface_match_not_match",
-			Obj:           &Object{Data: map[string]interface{}{"value": "cool"}},
+			Obj:           &Object{Data: map[string]any{"value": "cool"}},
 			Filters:       []QueryFilter{{Field: "value", Value: "uncool"}},
 			ExpectedMatch: false,
 		},
 		{
 			Description:   "map_string_interface_match_not_match_wrong_type",
-			Obj:           &Object{Data: map[string]interface{}{"value": 3}},
+			Obj:           &Object{Data: map[string]any{"value": 3}},
 			Filters:       []QueryFilter{{Field: "value", Value: "uncool"}},
 			ExpectedMatch: false,
 		},
@@ -80,25 +80,25 @@ func Test_MatchesFilters(t *testing.T) {
 
 		{
 			Description:   "multi_match",
-			Obj:           &Object{Data: map[string]interface{}{"value": "cool", "another": "very-cool"}},
+			Obj:           &Object{Data: map[string]any{"value": "cool", "another": "very-cool"}},
 			Filters:       []QueryFilter{{Field: "value", Value: "cool"}, {Field: "another", Value: "very-cool"}},
 			ExpectedMatch: true,
 		},
 		{
 			Description:   "multi_not_match",
-			Obj:           &Object{Data: map[string]interface{}{"value": "cool", "another": "sub-zero"}},
+			Obj:           &Object{Data: map[string]any{"value": "cool", "another": "sub-zero"}},
 			Filters:       []QueryFilter{{Field: "value", Value: "cool"}, {Field: "another", Value: "very-cool"}},
 			ExpectedMatch: false,
 		},
 		{
 			Description:   "nested_match",
-			Obj:           &Object{Data: map[string]interface{}{"properties": map[string]interface{}{"value": "freezing"}}},
+			Obj:           &Object{Data: map[string]any{"properties": map[string]any{"value": "freezing"}}},
 			Filters:       []QueryFilter{{Field: "properties.value", Value: "freezing"}},
 			ExpectedMatch: true,
 		},
 		{
 			Description:   "nested_match",
-			Obj:           &Object{Data: map[string]interface{}{"properties": map[string]interface{}{"value": "freezing"}}},
+			Obj:           &Object{Data: map[string]any{"properties": map[string]any{"value": "freezing"}}},
 			Filters:       []QueryFilter{{Field: "properties.value", Value: "warm"}},
 			ExpectedMatch: false,
 		},

--- a/pkg/ucp/store/map.go
+++ b/pkg/ucp/store/map.go
@@ -13,7 +13,7 @@ import (
 )
 
 // DecodeMap decodes map[string]interface{} structure to the type of out.
-func DecodeMap(in interface{}, out interface{}) error {
+func DecodeMap(in any, out any) error {
 	cfg := &mapstructure.DecoderConfig{
 		TagName: "json", // Use the JSON config for conversions.
 		Result:  out,
@@ -31,7 +31,7 @@ func DecodeMap(in interface{}, out interface{}) error {
 
 // https://github.com/mitchellh/mapstructure/issues/159
 func toTimeHookFunc() mapstructure.DecodeHookFunc {
-	return func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+	return func(f reflect.Type, t reflect.Type, data any) (any, error) {
 		if t != reflect.TypeOf(time.Time{}) {
 			return data, nil
 		}

--- a/pkg/ucp/store/map_test.go
+++ b/pkg/ucp/store/map_test.go
@@ -21,7 +21,7 @@ type TestTime struct {
 
 type Test struct {
 	Flag int
-	Data interface{}
+	Data any
 }
 
 func TestDecodeMap_WithoutTimeDecodeHook(t *testing.T) {
@@ -36,7 +36,7 @@ func TestDecodeMap_WithoutTimeDecodeHook(t *testing.T) {
 	}
 
 	jsv, _ := json.Marshal(test)
-	i := make(map[string]interface{})
+	i := make(map[string]any)
 
 	err := json.Unmarshal(jsv, &i)
 	require.NoError(t, err)
@@ -63,25 +63,25 @@ func TestDecodeMap_WithTimeDecodeHook(t *testing.T) {
 
 	testCases := []struct {
 		desc string
-		obj  map[string]interface{}
+		obj  map[string]any
 	}{
 		{
 			"time-now",
-			map[string]interface{}{
+			map[string]any{
 				"name":      "time-string",
 				"createdAt": "2022-09-01T15:00:00Z",
 			},
 		},
 		{
 			"time-unix-float",
-			map[string]interface{}{
+			map[string]any{
 				"name":      "time-unix-float",
 				"createdAt": float64(now.UnixMilli()),
 			},
 		},
 		{
 			"time-unix-int",
-			map[string]interface{}{
+			map[string]any{
 				"name":      "time-unix-int",
 				"createdAt": int64(now.UnixMilli()),
 			},

--- a/pkg/ucp/store/object.go
+++ b/pkg/ucp/store/object.go
@@ -18,7 +18,7 @@ type Object struct {
 	Metadata
 
 	// Data is the payload of the object. It will be marshaled to and from JSON for storage.
-	Data interface{}
+	Data any
 }
 
 // ObjectQueryResult represents the result of Query().
@@ -29,6 +29,6 @@ type ObjectQueryResult struct {
 	Items []Object
 }
 
-func (o *Object) As(out interface{}) error {
+func (o *Object) As(out any) error {
 	return DecodeMap(o.Data, out)
 }

--- a/pkg/ucp/ucplog/const.go
+++ b/pkg/ucp/ucplog/const.go
@@ -9,4 +9,3 @@ package ucplog
 const (
 	LogHTTPStatusCode = "statusCode"
 )
-

--- a/pkg/ucp/ucplog/log.go
+++ b/pkg/ucp/ucplog/log.go
@@ -45,7 +45,7 @@ func GetLogger(ctx context.Context) logr.Logger {
 	return logr.FromContextOrDiscard(ctx)
 }
 
-func WrapLogContext(ctx context.Context, keyValues ...interface{}) context.Context {
+func WrapLogContext(ctx context.Context, keyValues ...any) context.Context {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	ctx = logr.NewContext(ctx, logger.WithValues(keyValues...))

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -161,11 +161,11 @@ func (v *validator) ValidateRequest(req *http.Request) []ValidationError {
 		req.ContentLength = (int64)(len(content))
 	}
 
-	bindData := make(map[string]interface{})
+	bindData := make(map[string]any)
 	result := binder.Bind(
 		req, middleware.RouteParams(routeParams),
 		// Pass content to the validator marshaler to prevent from reading body from buffer.
-		runtime.ConsumerFunc(func(reader io.Reader, data interface{}) error {
+		runtime.ConsumerFunc(func(reader io.Reader, data any) error {
 			return json.Unmarshal(content, data)
 		}), bindData)
 	if result != nil {

--- a/test/functional/corerp/mechanics/aws_mechanics_test.go
+++ b/test/functional/corerp/mechanics/aws_mechanics_test.go
@@ -30,7 +30,7 @@ func Test_AWSRedeployWithUpdatedResourceUpdatesResource(t *testing.T) {
 						Name:       name,
 						Type:       validation.KinesisResourceType,
 						Identifier: name,
-						Properties: map[string]interface{}{
+						Properties: map[string]any{
 							"Name":                 name,
 							"RetentionPeriodHours": float64(168),
 							"ShardCount":           float64(3),
@@ -49,7 +49,7 @@ func Test_AWSRedeployWithUpdatedResourceUpdatesResource(t *testing.T) {
 						Name:       name,
 						Type:       validation.KinesisResourceType,
 						Identifier: name,
-						Properties: map[string]interface{}{
+						Properties: map[string]any{
 							"Name":                 name,
 							"RetentionPeriodHours": float64(48),
 							"ShardCount":           float64(3),
@@ -78,8 +78,8 @@ func Test_AWSRedeployWithCreateAndWriteOnlyPropertyUpdate(t *testing.T) {
 						Name:       name,
 						Type:       validation.DBInstanceResourceType,
 						Identifier: name,
-						Properties: map[string]interface{}{
-							"Endpoint": map[string]interface{}{
+						Properties: map[string]any{
+							"Endpoint": map[string]any{
 								"Port": 1444,
 							},
 						},
@@ -97,8 +97,8 @@ func Test_AWSRedeployWithCreateAndWriteOnlyPropertyUpdate(t *testing.T) {
 						Name:       name,
 						Type:       validation.DBInstanceResourceType,
 						Identifier: name,
-						Properties: map[string]interface{}{
-							"Endpoint": map[string]interface{}{
+						Properties: map[string]any{
+							"Endpoint": map[string]any{
 								"Port": 1444,
 							},
 						},

--- a/test/functional/corerp/resources/dapr_secretstore_test.go
+++ b/test/functional/corerp/resources/dapr_secretstore_test.go
@@ -50,6 +50,6 @@ func Test_DaprSecretStoreGeneric(t *testing.T) {
 		},
 	}, corerp.TestSecretResource(appNamespace, "mysecret", []byte("mysecret")))
 	test.RequiredFeatures = []corerp.RequiredFeature{corerp.FeatureDapr}
-	
+
 	test.Test(t)
 }

--- a/test/functional/samples/tutorial_test.go
+++ b/test/functional/samples/tutorial_test.go
@@ -157,8 +157,8 @@ func testGatewayWithPortForward(t *testing.T, ctx context.Context, at corerp.Cor
 			return err
 		}
 
-		expectedListResponseBody := map[string]interface{}{
-			"items":   []interface{}{},
+		expectedListResponseBody := map[string]any{
+			"items":   []any{},
 			"message": nil,
 		}
 		require.Equal(t, expectedListResponseBody, actualListResponseBody)
@@ -182,7 +182,7 @@ func testGatewayWithPortForward(t *testing.T, ctx context.Context, at corerp.Cor
 			return err
 		}
 
-		var createdItem map[string]interface{}
+		var createdItem map[string]any
 		err = json.Unmarshal(createResponseBody, &createdItem)
 		if err != nil {
 			return err
@@ -209,8 +209,8 @@ func testGatewayWithPortForward(t *testing.T, ctx context.Context, at corerp.Cor
 			return err
 		}
 
-		expectedListResponseBody = map[string]interface{}{
-			"items": []interface{}{
+		expectedListResponseBody = map[string]any{
+			"items": []any{
 				createdItem,
 			},
 			"message": nil,
@@ -228,7 +228,7 @@ func testGatewayWithPortForward(t *testing.T, ctx context.Context, at corerp.Cor
 			return err
 		}
 
-		var actualGetResponseBody map[string]interface{}
+		var actualGetResponseBody map[string]any
 		err = json.Unmarshal(getResponseBody, &actualGetResponseBody)
 		if err != nil {
 			return err
@@ -238,7 +238,7 @@ func testGatewayWithPortForward(t *testing.T, ctx context.Context, at corerp.Cor
 		require.Equal(t, expectedGetResponseBody, actualGetResponseBody)
 
 		// Test PUT /api/todos/:id (update)
-		updateRequestBody := map[string]interface{}{
+		updateRequestBody := map[string]any{
 			"id":    createdItem["id"],
 			"_id":   createdItem["_id"],
 			"title": createdItem["title"],
@@ -276,8 +276,8 @@ func testGatewayWithPortForward(t *testing.T, ctx context.Context, at corerp.Cor
 			return err
 		}
 
-		expectedListResponseBody = map[string]interface{}{
-			"items":   []interface{}{},
+		expectedListResponseBody = map[string]any{
+			"items":   []any{},
 			"message": nil,
 		}
 		require.Equal(t, expectedListResponseBody, actualListResponseBody)

--- a/test/functional/ucp/aws_test.go
+++ b/test/functional/ucp/aws_test.go
@@ -44,8 +44,8 @@ func Test_AWS_DeleteResource(t *testing.T) {
 		resourceIDParts = resourceIDParts[:len(resourceIDParts)-1]
 		resourceID = strings.Join(resourceIDParts, "/")
 		deleteURL := fmt.Sprintf("%s%s/:delete?api-version=%s", url, resourceID, v20220901privatepreview.Version)
-		deleteRequestBody := map[string]interface{}{
-			"properties": map[string]interface{}{
+		deleteRequestBody := map[string]any{
+			"properties": map[string]any{
 				"Name": streamName,
 			},
 		}
@@ -73,7 +73,7 @@ func Test_AWS_DeleteResource(t *testing.T) {
 			// Read the request status from the body
 			payload, err := io.ReadAll(getResponse.Body)
 			require.NoError(t, err)
-			body := map[string]interface{}{}
+			body := map[string]any{}
 			err = json.Unmarshal(payload, &body)
 			require.NoError(t, err)
 			if body["status"] == "Succeeded" {
@@ -114,7 +114,7 @@ func Test_AWS_ListResources(t *testing.T) {
 
 		payload, err := io.ReadAll(listResponse.Body)
 		require.NoError(t, err)
-		body := map[string][]interface{}{}
+		body := map[string][]any{}
 		err = json.Unmarshal(payload, &body)
 		require.NoError(t, err)
 
@@ -131,7 +131,7 @@ func setupTestAWSResource(t *testing.T, ctx context.Context, resourceName string
 	cfg, err := awsconfig.LoadDefaultConfig(ctx)
 	require.NoError(t, err)
 	var awsClient aws.AWSCloudControlClient = cloudcontrol.NewFromConfig(cfg)
-	desiredState := map[string]interface{}{
+	desiredState := map[string]any{
 		"Name":                 resourceName,
 		"RetentionPeriodHours": 180,
 		"ShardCount":           4,

--- a/test/functional/ucp/plane_test.go
+++ b/test/functional/ucp/plane_test.go
@@ -117,7 +117,7 @@ func getPlane(t *testing.T, roundTripper http.RoundTripper, url string) (rest.Pl
 	return plane, result.StatusCode
 }
 
-func listPlanes(t *testing.T, roundTripper http.RoundTripper, url string) []interface{} {
+func listPlanes(t *testing.T, roundTripper http.RoundTripper, url string) []any {
 	listRequest, err := http.NewRequest(
 		http.MethodGet,
 		url,
@@ -133,7 +133,7 @@ func listPlanes(t *testing.T, roundTripper http.RoundTripper, url string) []inte
 	defer body.Close()
 	payload, err := io.ReadAll(body)
 	require.NoError(t, err)
-	var listOfPlanes []interface{}
+	var listOfPlanes []any
 	err = json.Unmarshal(payload, &listOfPlanes)
 	require.NoError(t, err)
 

--- a/test/ucp/storetest/shared.go
+++ b/test/ucp/storetest/shared.go
@@ -44,48 +44,48 @@ var NestedResource1ID = parseOrPanic(ResourceGroup1Scope + "/providers/" + Neste
 var ARMResourceID = parseOrPanic(ARMResourceScope + "/providers/" + ResourcePath1)
 var RadiusPlaneID = parseOrPanic(RadiusScope)
 
-var ResourceGroup1Data = map[string]interface{}{
+var ResourceGroup1Data = map[string]any{
 	"value": "1",
-	"properties": map[string]interface{}{
+	"properties": map[string]any{
 		"group": "1",
 	},
 }
 
-var ResourceGroup2Data = map[string]interface{}{
+var ResourceGroup2Data = map[string]any{
 	"value": "2",
-	"properties": map[string]interface{}{
+	"properties": map[string]any{
 		"group": "2",
 	},
 }
 
-var Data1 = map[string]interface{}{
+var Data1 = map[string]any{
 	"value": "1",
-	"properties": map[string]interface{}{
+	"properties": map[string]any{
 		"resource": "1",
 	},
 }
-var Data2 = map[string]interface{}{
+var Data2 = map[string]any{
 	"value": "2",
-	"properties": map[string]interface{}{
+	"properties": map[string]any{
 		"resource": "2",
 	},
 }
 
-var NestedData1 = map[string]interface{}{
+var NestedData1 = map[string]any{
 	"value": "3",
-	"properties": map[string]interface{}{
+	"properties": map[string]any{
 		"resource": "3",
 	},
 }
 
-var RadiusPlaneData = map[string]interface{}{
+var RadiusPlaneData = map[string]any{
 	"value:": "1",
-	"properties": map[string]interface{}{
+	"properties": map[string]any{
 		"plane": "1",
 	},
 }
 
-func MarshalOrPanic(in interface{}) []byte {
+func MarshalOrPanic(in any) []byte {
 	b, err := json.Marshal(in)
 	if err != nil {
 		panic(err)
@@ -103,7 +103,7 @@ func parseOrPanic(id string) resources.ID {
 	return parsed
 }
 
-func createObject(id resources.ID, data interface{}) store.Object {
+func createObject(id resources.ID, data any) store.Object {
 	return store.Object{
 		Metadata: store.Metadata{
 			ID:          id.String(),

--- a/test/validation/aws.go
+++ b/test/validation/aws.go
@@ -32,7 +32,7 @@ type AWSResource struct {
 	Type       string
 	Name       string
 	Identifier string
-	Properties map[string]interface{}
+	Properties map[string]any
 }
 
 type AWSResourceSet struct {
@@ -49,7 +49,7 @@ func ValidateAWSResources(ctx context.Context, t *testing.T, expected *AWSResour
 		require.NoError(t, err)
 
 		if resource.Properties != nil {
-			var resourceResponseProperties map[string]interface{}
+			var resourceResponseProperties map[string]any
 			err := json.Unmarshal([]byte(*resourceResponse.ResourceDescription.Properties), &resourceResponseProperties)
 			require.NoError(t, err)
 
@@ -127,10 +127,10 @@ func GetResourceTypeName(ctx context.Context, t *testing.T, resource *AWSResourc
 }
 
 // assertFieldsArePresent ensures that all fields in actual exist and are equivalent in expected
-func assertFieldsArePresent(t *testing.T, actual interface{}, expected interface{}) {
+func assertFieldsArePresent(t *testing.T, actual any, expected any) {
 	switch actual := actual.(type) {
-	case map[string]interface{}:
-		if expectedMap, ok := expected.(map[string]interface{}); ok {
+	case map[string]any:
+		if expectedMap, ok := expected.(map[string]any); ok {
 			for k := range actual {
 				assertFieldsArePresent(t, actual[k], expectedMap[k])
 			}


### PR DESCRIPTION
This is just a style change. In 2023 it's preferrable to use the new any keyword, which is much more clear than "empty interface".

Created with:

gofmt -w -r 'interface{} -> any' .
