### PR TITLE
Set location for Link RP service

### DIFF
--- a/pkg/armrpc/servicecontext/middleware.go
+++ b/pkg/armrpc/servicecontext/middleware.go
@@ -15,6 +15,16 @@ import (
 
 // ARMRequestCtx is the middleware to inject ARMRequestContext to the http request.
 func ARMRequestCtx(pathBase, location string) func(h http.Handler) http.Handler {
+	// We normally don't like to use panics like this, but this issue is NASTY to diagnose when it happens
+	// and it can regress based on changes to our configuration file format.
+	//
+	// The location field is used to the build the URL for an asynchronous operation. If you find that the
+	// URL for an asynchronous operation has a blank segment "someText//someOtherText" then a misconfigured
+	// location is probably the cause.
+	if location == "" {
+		panic("location is required. The location should be set in a configuration file and wired up to the middleware through the host options.")
+	}
+
 	return func(h http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
 			rpcContext, err := v1.FromARMRequest(r, pathBase, location)

--- a/pkg/armrpc/servicecontext/middleware_test.go
+++ b/pkg/armrpc/servicecontext/middleware_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gorilla/mux"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestARMRequestCtx(t *testing.T) {
@@ -93,4 +94,10 @@ func TestARMRequestCtx(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_ARMRequestCtx_with_empty_location_causes_panic(t *testing.T) {
+	require.Panics(t, func() {
+		ARMRequestCtx("/some/base/path", "") // Empty location
+	})
 }

--- a/pkg/linkrp/frontend/service.go
+++ b/pkg/linkrp/frontend/service.go
@@ -60,6 +60,7 @@ func (s *Service) Run(ctx context.Context) error {
 	err = s.Start(ctx, server.Options{
 		ProviderNamespace: s.ProviderName,
 		Address:           address,
+		Location:          s.Options.Config.Env.RoleLocation,
 		PathBase:          s.Options.Config.Server.PathBase,
 		// set the arm cert manager for managing client certificate
 		ArmCertMgr:    s.ARMCertManager,


### PR DESCRIPTION
Link RP has a bug where URLs for async operations are wrong because they are missing the location and output a blank URL segment. We've seen this bug in the past and it's NASTY to try and diagnose if you don't already know the cause.

The root cause is that we forgot to set a field. Lame.

The only async operation in Link RP right now is the DELETE for Mongo. I'm not 100% certain why we haven't found the bug before now. The deployment engine definitely chokes on it so when I changed a PUT operation to async it explodes. This kind of bug won't be caught by postman testing because we don't usually do polling when we do that.
