### PR TITLE
Update `rad recipe delete` to `rad recipe unregister`

### DIFF
--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -33,9 +33,9 @@ import (
 	group "github.com/project-radius/radius/pkg/cli/cmd/group"
 	provider "github.com/project-radius/radius/pkg/cli/cmd/provider"
 	"github.com/project-radius/radius/pkg/cli/cmd/radInit"
-	recipe_delete "github.com/project-radius/radius/pkg/cli/cmd/recipe/delete"
 	recipe_list "github.com/project-radius/radius/pkg/cli/cmd/recipe/list"
 	recipe_register "github.com/project-radius/radius/pkg/cli/cmd/recipe/register"
+	recipe_unregister "github.com/project-radius/radius/pkg/cli/cmd/recipe/unregister"
 	resource_delete "github.com/project-radius/radius/pkg/cli/cmd/resource/delete"
 	resource_list "github.com/project-radius/radius/pkg/cli/cmd/resource/list"
 	resource_show "github.com/project-radius/radius/pkg/cli/cmd/resource/show"
@@ -164,8 +164,8 @@ func initSubCommands() {
 	registerRecipeCmd, _ := recipe_register.NewCommand(framework)
 	recipeCmd.AddCommand(registerRecipeCmd)
 
-	deleteRecipeCmd, _ := recipe_delete.NewCommand(framework)
-	recipeCmd.AddCommand(deleteRecipeCmd)
+	unregisterRecipeCmd, _ := recipe_unregister.NewCommand(framework)
+	recipeCmd.AddCommand(unregisterRecipeCmd)
 
 	providerCmd := provider.NewCommand(framework)
 	RootCmd.AddCommand(providerCmd)

--- a/pkg/cli/cmd/recipe/register/register.go
+++ b/pkg/cli/cmd/recipe/register/register.go
@@ -166,7 +166,7 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	isEnvCreated, err := client.CreateEnvironment(ctx, r.Workspace.Environment, v1.LocationGlobal, namespace, "Kubernetes", *envResource.ID, recipeProperties, envResource.Properties.Providers, *envResource.Properties.UseDevRecipes)
 	if err != nil || !isEnvCreated {
-		return &cli.FriendlyError{Message: fmt.Sprintf("failed to update Applications.Core/environments resource %s with recipe: %s", *envResource.ID, err.Error())}
+		return &cli.FriendlyError{Message: fmt.Sprintf("failed to register the recipe %s to the environment %s: %s", r.RecipeName, *envResource.ID, err.Error())}
 	}
 
 	r.Output.LogInfo("Successfully linked recipe %q to environment %q ", r.RecipeName, r.Workspace.Environment)

--- a/pkg/cli/cmd/recipe/unregister/unregister.go
+++ b/pkg/cli/cmd/recipe/unregister/unregister.go
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-package delete
+package unregister
 
 import (
 	"context"
@@ -20,15 +20,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCommand creates an instance of the command and runner for the `rad recipe delete` command.
+// NewCommand creates an instance of the command and runner for the `rad recipe unregister` command.
 func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	runner := NewRunner(factory)
 
 	cmd := &cobra.Command{
-		Use:     "delete",
-		Short:   "Delete a link recipe from an environment",
-		Long:    `Delete a link recipe from an environment`,
-		Example: `rad recipe delete --name cosmosdb`,
+		Use:     "unregister",
+		Short:   "Unregister a link recipe from an environment",
+		Long:    `Unregister a link recipe from an environment`,
+		Example: `rad recipe unregister --name cosmosdb`,
 		Args:    cobra.ExactArgs(0),
 		RunE:    framework.RunCommand(runner),
 	}
@@ -43,7 +43,7 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	return cmd, runner
 }
 
-// Runner is the runner implementation for the `rad recipe delete` command.
+// Runner is the runner implementation for the `rad recipe unregister` command.
 type Runner struct {
 	ConfigHolder      *framework.ConfigHolder
 	ConnectionFactory connections.Factory
@@ -52,7 +52,7 @@ type Runner struct {
 	RecipeName        string
 }
 
-// NewRunner creates a new instance of the `rad recipe delete` runner.
+// NewRunner creates a new instance of the `rad recipe unregister` runner.
 func NewRunner(factory framework.Factory) *Runner {
 	return &Runner{
 		ConfigHolder:      factory.GetConfigHolder(),
@@ -61,7 +61,7 @@ func NewRunner(factory framework.Factory) *Runner {
 	}
 }
 
-// Validate runs validation for the `rad recipe delete` command.
+// Validate runs validation for the `rad recipe unregister` command.
 func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	// Validate command line args
 	workspace, err := cli.RequireWorkspace(cmd, r.ConfigHolder.Config, r.ConfigHolder.DirectoryConfig)
@@ -89,7 +89,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// Run runs the `rad recipe delete` command.
+// Run runs the `rad recipe unregister` command.
 func (r *Runner) Run(ctx context.Context) error {
 	client, err := r.ConnectionFactory.CreateApplicationsManagementClient(ctx, *r.Workspace)
 	if err != nil {
@@ -109,10 +109,10 @@ func (r *Runner) Run(ctx context.Context) error {
 	delete(recipeProperties, r.RecipeName)
 	isEnvCreated, err := client.CreateEnvironment(ctx, r.Workspace.Environment, v1.LocationGlobal, namespace, "Kubernetes", *envResource.ID, recipeProperties, envResource.Properties.Providers, *envResource.Properties.UseDevRecipes)
 	if err != nil || !isEnvCreated {
-		return &cli.FriendlyError{Message: fmt.Sprintf("failed to delete the recipe %s from the environment %s: %s", r.RecipeName, *envResource.ID, err.Error())}
+		return &cli.FriendlyError{Message: fmt.Sprintf("failed to unregister the recipe %s from the environment %s: %s", r.RecipeName, *envResource.ID, err.Error())}
 	}
 
-	r.Output.LogInfo("Successfully deleted recipe %q from environment %q ", r.RecipeName, r.Workspace.Environment)
+	r.Output.LogInfo("Successfully unregistered recipe %q from environment %q ", r.RecipeName, r.Workspace.Environment)
 	return nil
 }
 

--- a/pkg/cli/cmd/recipe/unregister/unregister_test.go
+++ b/pkg/cli/cmd/recipe/unregister/unregister_test.go
@@ -3,7 +3,7 @@
 // Licensed under the MIT License.
 // ------------------------------------------------------------
 
-package delete
+package unregister
 
 import (
 	"context"
@@ -30,7 +30,7 @@ func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
 	testcases := []radcli.ValidateInput{
 		{
-			Name:          "Valid Delete Command",
+			Name:          "Valid Unregister Command",
 			Input:         []string{"--name", "test_recipe"},
 			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
@@ -39,7 +39,7 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "Delete Command with fallback workspace",
+			Name:          "Unregister Command with fallback workspace",
 			Input:         []string{"--name", "test_recipe"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
@@ -48,7 +48,7 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "Delete Command without name",
+			Name:          "Unregister Command without name",
 			Input:         []string{},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
@@ -57,7 +57,7 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "Delete Command with too many args",
+			Name:          "Unregister Command with too many args",
 			Input:         []string{"--name", "foo", "bar", "foo1"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
@@ -70,7 +70,7 @@ func Test_Validate(t *testing.T) {
 }
 
 func Test_Run(t *testing.T) {
-	t.Run("Delete recipe from the environment", func(t *testing.T) {
+	t.Run("Unregister recipe from the environment", func(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
@@ -152,7 +152,7 @@ func Test_Run(t *testing.T) {
 			err := runner.Run(context.Background())
 			require.NoError(t, err)
 		})
-		t.Run("Delete recipe that doesn't exist in the environment", func(t *testing.T) {
+		t.Run("Unregister recipe that doesn't exist in the environment", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			envResource := v20220315privatepreview.EnvironmentResource{
@@ -188,7 +188,7 @@ func Test_Run(t *testing.T) {
 			err := runner.Run(context.Background())
 			require.Error(t, err)
 		})
-		t.Run("Delete recipe with no recipes added to the environment", func(t *testing.T) {
+		t.Run("Unregister recipe with no recipes added to the environment", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			envResource := v20220315privatepreview.EnvironmentResource{

--- a/test/functional/corerp/cli/cli_test.go
+++ b/test/functional/corerp/cli/cli_test.go
@@ -58,10 +58,10 @@ func verifyRecipeCLI(ctx context.Context, t *testing.T, test corerp.CoreRPTest) 
 		require.Regexp(t, linkType, output)
 		require.Regexp(t, recipeTemplate, output)
 	})
-	t.Run("Validate rad recipe delete", func(t *testing.T) {
-		output, err := cli.RecipeDelete(ctx, recipeName)
+	t.Run("Validate rad recipe unregister", func(t *testing.T) {
+		output, err := cli.RecipeUnregister(ctx, recipeName)
 		require.NoError(t, err)
-		require.Contains(t, output, "Successfully deleted recipe")
+		require.Contains(t, output, "Successfully unregistered recipe")
 
 	})
 }

--- a/test/radcli/cli.go
+++ b/test/radcli/cli.go
@@ -264,10 +264,10 @@ func (cli *CLI) RecipeRegister(ctx context.Context, recipeName, templatePath, li
 	return cli.RunCommand(ctx, args)
 }
 
-func (cli *CLI) RecipeDelete(ctx context.Context, recipeName string) (string, error) {
+func (cli *CLI) RecipeUnregister(ctx context.Context, recipeName string) (string, error) {
 	args := []string{
 		"recipe",
-		"delete",
+		"unregister",
 		"--name", recipeName,
 	}
 	return cli.RunCommand(ctx, args)


### PR DESCRIPTION
# Description

Update `rad recipe delete` to `rad recipe unregister` following Azure commands convention. `rad recipe create` was updated in https://github.com/project-radius/radius/pull/4913

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
