### PR TITLE
Support case insensitive resource id for cosmosdb store

### DIFF
--- a/pkg/ucp/store/cosmosdb/cosmosdbstorageclient.go
+++ b/pkg/ucp/store/cosmosdb/cosmosdbstorageclient.go
@@ -176,13 +176,13 @@ func constructCosmosDBQuery(query store.Query) (*cosmosapi.Query, error) {
 		whereParam = whereParam + "STARTSWITH(c.rootScope, @rootScope, true)"
 		queryParams = append(queryParams, cosmosapi.QueryParam{
 			Name:  "@rootScope",
-			Value: query.RootScope,
+			Value: strings.ToLower(query.RootScope),
 		})
 	} else {
 		whereParam = whereParam + "c.rootScope = @rootScope"
 		queryParams = append(queryParams, cosmosapi.QueryParam{
 			Name:  "@rootScope",
-			Value: query.RootScope,
+			Value: strings.ToLower(query.RootScope),
 		})
 	}
 
@@ -387,8 +387,8 @@ func (c *CosmosDBStorageClient) Save(ctx context.Context, obj *store.Object, opt
 
 	entity := &ResourceEntity{
 		ID:           docID,
-		ResourceID:   parsed.String(),
-		RootScope:    parsed.RootScope(),
+		ResourceID:   strings.ToLower(parsed.String()),
+		RootScope:    strings.ToLower(parsed.RootScope()),
 		PartitionKey: partitionKey,
 		Entity:       obj.Data,
 	}

--- a/pkg/ucp/store/cosmosdb/cosmosdbstorageclient_test.go
+++ b/pkg/ucp/store/cosmosdb/cosmosdbstorageclient_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -140,11 +141,11 @@ func TestConstructCosmosDBQuery(t *testing.T) {
 		},
 		{
 			desc:        "root-scope-subscription-id-and-resource-group",
-			storeQuery:  store.Query{RootScope: "/subscriptions/00000000-0000-0000-1000-000000000001/resourceGroups/testGroup", ScopeRecursive: false},
+			storeQuery:  store.Query{RootScope: "/subscriptions/00000000-0000-0000-1000-000000000001/resourcegroups/testgroup", ScopeRecursive: false},
 			queryString: "SELECT * FROM c WHERE c.rootScope = @rootScope",
 			params: []cosmosapi.QueryParam{{
 				Name:  "@rootScope",
-				Value: "/subscriptions/00000000-0000-0000-1000-000000000001/resourceGroups/testGroup",
+				Value: "/subscriptions/00000000-0000-0000-1000-000000000001/resourcegroups/testgroup",
 			}},
 			err: nil,
 		},
@@ -229,10 +230,10 @@ func TestSave(t *testing.T) {
 	client := mustGetTestClient(t)
 
 	ucpRootScope := fmt.Sprintf("/planes/radius/local/resourcegroups/%s", randomResourceGroups[0])
-	ucpResource := getTestEnvironmentModel(ucpRootScope, "test-ucp-resource")
+	ucpResource := getTestEnvironmentModel(ucpRootScope, "test-UCP-resource")
 
 	armResourceRootScope := fmt.Sprintf("/subscriptions/%s/resourcegroups/%s", randomSubscriptionIDs[0], randomResourceGroups[0])
-	armResource := getTestEnvironmentModel(armResourceRootScope, "test-resource")
+	armResource := getTestEnvironmentModel(armResourceRootScope, "test-Resource")
 
 	setupTest := func(tb testing.TB, resource *datamodel.Environment) (func(tb testing.TB), *store.Object) {
 		// Prepare DB object
@@ -601,8 +602,8 @@ func TestPaginationTokenAndQueryItemCount(t *testing.T) {
 	ucpResources := []string{}
 	armResources := []string{}
 
-	ucpRootScope := "/planes/radius/local/resourcegroups/test-rg"
-	armResourceRootScope := "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg"
+	ucpRootScope := "/planes/radius/local/resourcegroups/test-RG"
+	armResourceRootScope := "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-RG"
 
 	setupTest := func(tb testing.TB) func(tb testing.TB) {
 		// 50 UCP - 50 ARM
@@ -610,7 +611,7 @@ func TestPaginationTokenAndQueryItemCount(t *testing.T) {
 			ucpEnv := buildAndSaveTestModel(ctx, t, ucpRootScope, fmt.Sprintf("ucp-env-%d", i))
 			ucpResources = append(ucpResources, ucpEnv.ID)
 
-			armEnv := buildAndSaveTestModel(ctx, t, armResourceRootScope, fmt.Sprintf("test-env-%d", i))
+			armEnv := buildAndSaveTestModel(ctx, t, armResourceRootScope, fmt.Sprintf("test-ENV-%d", i))
 			armResources = append(armResources, armEnv.ID)
 		}
 
@@ -641,7 +642,7 @@ func TestPaginationTokenAndQueryItemCount(t *testing.T) {
 			itemCount: "",
 		},
 		"ucp-resource-10-query-item-count": {
-			rootScope: ucpRootScope,
+			rootScope: strings.ToLower(ucpRootScope), // case-insensitive query
 			itemCount: "10",
 		},
 		"arm-resource-10-query-item-count": {


### PR DESCRIPTION
# Description

This is to support case insensitive query to preserve the case of resource group and resource name. 

note: the other store implementations support case-insensitive query.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

#3582 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
