### PR TITLE
Add workflow to alert on code-changes requiring docs updates

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - "swagger/**"
+      - ".github/workflows/docs.yaml"
 
 jobs:
   docs:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,6 +19,6 @@ jobs:
           body: |
             You are editing files which require a docs update. Please ensure you've made the appropriate changes to the docs and submitted a PR.
             - Swagger changes require reference edge docs to be updated [here](https://github.com/project-radius/docs/tree/edge/docs/content/reference/resource-schema)
-            - Make sure to branch off of and PR into the edge branch instead of the default latest branch, as the swagger changes will not be available until the next release.
+            - Make sure to create a branch and submit a PR into the edge branch instead of the default latest branch, as the swagger changes will not be available until the next release.
             
             For more information on contributing to docs please visit https://docs.radapp.dev/contributing/docs/.

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,6 +17,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             You are editing files which require a docs update. Please ensure you've made the appropriate changes to the docs and submitted a PR.
-               - Swagger changes require reference edge docs to be updated [here](https://github.com/project-radius/docs/tree/edge/docs/content/reference/resource-schema)
+            - Swagger changes require reference edge docs to be updated [here](https://github.com/project-radius/docs/tree/edge/docs/content/reference/resource-schema)
+            - Make sure to branch off of and PR into the edge branch instead of the default latest branch, as the swagger changes will not be available until the next release.
             
             For more information on contributing to docs please visit https://docs.radapp.dev/contributing/docs/.

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,22 @@
+name: Check for docs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "swagger/**"
+
+jobs:
+  docs:
+    name: Add docs comment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add comment requiring docs update
+        uses: peter-evans/create-or-update-comment@v2.1.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            You are editing files which require a docs update. Please ensure you've made the appropriate changes to the docs and submitted a PR.
+               - Swagger changes require reference edge docs to be updated [here](https://github.com/project-radius/docs/tree/edge/docs/content/reference/resource-schema)
+            
+            For more information on contributing to docs please visit https://docs.radapp.dev/contributing/docs/.


### PR DESCRIPTION
# Description

Today our reference docs aren't auto-generated. This means any changes to our Swagger specs require an accompanying docs PR.

This PR adds a workflow that adds a comment to a PR whenever a directory containing code that would require a docs change is updated.

It prints instructions on what to change and how to change it.

It only runs on PRs.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
