### PR TITLE
Add SDK package as home for client code

### DIFF
--- a/cmd/rad/cmd/debuglogs.go
+++ b/cmd/rad/cmd/debuglogs.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/kubernetes"
-	"github.com/project-radius/radius/pkg/cli/workspaces"
 	k8slabels "github.com/project-radius/radius/pkg/kubernetes"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -50,14 +49,12 @@ func debugLogs(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	connection, err := w.Connect()
-	if err != nil {
-		return err
+	context, ok := w.KubernetesContext()
+	if !ok {
+		return &cli.FriendlyError{Message: "a Kubernetes connection is required"}
 	}
 
-	c := connection.(*workspaces.KubernetesConnection)
-
-	k8sClient, _, err := kubernetes.CreateTypedClient(c.Context)
+	k8sClient, _, err := kubernetes.CreateTypedClient(context)
 	if err != nil {
 		return err
 	}

--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -19,7 +19,6 @@ import (
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/azure"
 	"github.com/project-radius/radius/pkg/cli/cmd/provider/common"
-	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/helm"
 	"github.com/project-radius/radius/pkg/cli/kubernetes"
 	"github.com/project-radius/radius/pkg/cli/output"
@@ -27,6 +26,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/setup"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
 	coreRpApps "github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
+	"github.com/project-radius/radius/pkg/sdk"
 	"github.com/project-radius/radius/pkg/ucp/resources"
 )
 
@@ -186,13 +186,13 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 		}
 	}
 
-	//If the user specifies a workspace name with -w and that workspace points to a different Kubernetes cluster, then --force is required
-	//If the user does not specify a workspace with -w and the current default workspace points to a different cluster, then create a new workspace
-	//If the user does not specify a workspace with -w and the current default workspace points to the same cluster, then update the existing workspace
+	// If the user specifies a workspace name with -w and that workspace points to a different Kubernetes cluster, then --force is required
+	// If the user does not specify a workspace with -w and the current default workspace points to a different cluster, then create a new workspace
+	// If the user does not specify a workspace with -w and the current default workspace points to the same cluster, then update the existing workspace
 
 	isSameConn := true
 	if foundExistingWorkspace {
-		isSameConn = workspace.ConnectionEquals(&workspaces.KubernetesConnection{Kind: workspaces.KindKubernetes, Context: contextName})
+		isSameConn = workspace.ConnectionConfigEquals(&workspaces.KubernetesConnectionConfig{Kind: workspaces.KindKubernetes, Context: contextName})
 	}
 
 	if foundExistingWorkspace {
@@ -244,14 +244,22 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 	// TODO: we TEMPORARILY create a resource group as part of creating the workspace.
 	//
 	// We'll flesh this out more when we add explicit commands for managing resource groups.
-	var connection workspaces.Connection
+	var connection sdk.Connection
 	if workspace != nil {
 		connection, err = workspace.Connect()
 		if err != nil {
 			return err
 		}
 	} else {
-		connection = &workspaces.KubernetesConnection{Context: contextName}
+		config, err := kubernetes.GetConfig(contextName)
+		if err != nil {
+			return err
+		}
+
+		connection, err = sdk.NewKubernetesConnectionFromConfig(config)
+		if err != nil {
+			return err
+		}
 	}
 
 	id, err := setup.CreateWorkspaceResourceGroup(cmd.Context(), connection, workspaceName)
@@ -342,9 +350,14 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 }
 
 func createEnvironmentResource(ctx context.Context, kubeCtxName, resourceGroupName, environmentName, namespace, subscriptionID, resourceGroup string) (string, error) {
-	baseURL, transporter, err := kubernetes.CreateAPIServerTransporter(kubeCtxName, "")
+	config, err := kubernetes.GetConfig(kubeCtxName)
 	if err != nil {
-		return "", fmt.Errorf("failed to create environment client: %w", err)
+		return "", err
+	}
+
+	connection, err := sdk.NewKubernetesConnectionFromConfig(config)
+	if err != nil {
+		return "", fmt.Errorf("failed to create connection: %w", err)
 	}
 
 	id := "self"
@@ -371,7 +384,7 @@ func createEnvironmentResource(ctx context.Context, kubeCtxName, resourceGroupNa
 
 	rootScope := fmt.Sprintf("planes/radius/local/resourceGroups/%s", resourceGroupName)
 
-	envClient, err := coreRpApps.NewEnvironmentsClient(rootScope, &aztoken.AnonymousCredential{}, connections.GetClientOptions(baseURL, transporter))
+	envClient, err := coreRpApps.NewEnvironmentsClient(rootScope, &aztoken.AnonymousCredential{}, sdk.NewClientOptions(connection))
 	if err != nil {
 		return "", fmt.Errorf("failed to create environment client: %w", err)
 	}

--- a/pkg/cli/connections/factory.go
+++ b/pkg/cli/connections/factory.go
@@ -9,15 +9,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/Azure/go-autorest/autorest"
 	azclients "github.com/project-radius/radius/pkg/azure/clients"
 	aztoken "github.com/project-radius/radius/pkg/azure/tokencredentials"
 	"github.com/project-radius/radius/pkg/cli"
@@ -27,6 +21,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/kubernetes"
 	"github.com/project-radius/radius/pkg/cli/ucp"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
+	"github.com/project-radius/radius/pkg/sdk"
 	"github.com/project-radius/radius/pkg/ucp/resources"
 )
 
@@ -46,57 +41,63 @@ var _ Factory = (*impl)(nil)
 type impl struct {
 }
 
-func (*impl) CreateDeploymentClient(ctx context.Context, workspace workspaces.Workspace) (clients.DeploymentClient, error) {
+func (i *impl) CreateDeploymentClient(ctx context.Context, workspace workspaces.Workspace) (clients.DeploymentClient, error) {
 	connection, err := workspace.Connect()
 	if err != nil {
 		return nil, err
 	}
 
-	switch c := connection.(type) {
-	case *workspaces.KubernetesConnection:
-		url, roundTripper, err := kubernetes.GetBaseUrlAndRoundTripperForDeploymentEngine(c.Overrides.UCP, c.Context)
-
-		if err != nil {
-			return nil, err
-		}
-
-		dc := azclients.NewResourceDeploymentClientWithBaseURI(url)
-
-		// Poll faster than the default, many deployments are quick
-		dc.PollingDelay = 5 * time.Second
-
-		dc.Sender = &sender{RoundTripper: roundTripper}
-
-		op := azclients.NewResourceDeploymentOperationsClientWithBaseURI(url)
-		op.PollingDelay = 5 * time.Second
-		op.Sender = &sender{RoundTripper: roundTripper}
-
-		// This client wants a resource group name, but we store the ID instead, so compute that.
-		id, err := resources.ParseScope(workspace.Scope)
-		if err != nil {
-			return nil, err
-		}
-
-		return &deployment.ResourceDeploymentClient{
-			Client:              dc,
-			OperationsClient:    op,
-			RadiusResourceGroup: id.FindScope(resources.ResourceGroupsSegment),
-			AzProvider:          workspace.ProviderConfig.Azure,
-			AWSProvider:         workspace.ProviderConfig.AWS,
-		}, nil
-	default:
-		return nil, fmt.Errorf("unsupported connection type: %+v", connection)
+	err = sdk.TestConnection(ctx, connection)
+	if errors.Is(err, &sdk.ErrRadiusNotInstalled{}) {
+		return nil, &cli.FriendlyError{Message: err.Error()}
+	} else if err != nil {
+		return nil, err
 	}
+
+	// Poll faster than the default, many deployments are quick
+	dc := azclients.NewResourceDeploymentClientWithBaseURI(connection.Endpoint())
+	dc.PollingDelay = 5 * time.Second
+	dc.Sender = connection.Client()
+
+	op := azclients.NewResourceDeploymentOperationsClientWithBaseURI(connection.Endpoint())
+	op.PollingDelay = 5 * time.Second
+	op.Sender = connection.Client()
+
+	// This client wants a resource group name, but we store the ID instead, so compute that.
+	id, err := resources.ParseScope(workspace.Scope)
+	if err != nil {
+		return nil, err
+	}
+
+	return &deployment.ResourceDeploymentClient{
+		Client:              dc,
+		OperationsClient:    op,
+		RadiusResourceGroup: id.FindScope(resources.ResourceGroupsSegment),
+		AzProvider:          workspace.ProviderConfig.Azure,
+		AWSProvider:         workspace.ProviderConfig.AWS,
+	}, nil
 }
 
-func (*impl) CreateDiagnosticsClient(ctx context.Context, workspace workspaces.Workspace) (clients.DiagnosticsClient, error) {
+func (i *impl) CreateDiagnosticsClient(ctx context.Context, workspace workspaces.Workspace) (clients.DiagnosticsClient, error) {
 	connection, err := workspace.Connect()
 	if err != nil {
 		return nil, err
 	}
 
-	switch c := connection.(type) {
-	case *workspaces.KubernetesConnection:
+	err = sdk.TestConnection(ctx, connection)
+	if errors.Is(err, &sdk.ErrRadiusNotInstalled{}) {
+		return nil, &cli.FriendlyError{Message: err.Error()}
+	} else if err != nil {
+		return nil, err
+	}
+
+	connectionConfig, err := workspace.ConnectionConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	switch c := connectionConfig.(type) {
+	case *workspaces.KubernetesConnectionConfig:
 		k8sClient, config, err := kubernetes.CreateTypedClient(c.Context)
 		if err != nil {
 			return nil, err
@@ -106,23 +107,7 @@ func (*impl) CreateDiagnosticsClient(ctx context.Context, workspace workspaces.W
 			return nil, err
 		}
 
-		baseURL, pipeline, err := kubernetes.CreateAPIServerPipeline(c.Context, c.Overrides.UCP)
-		if err != nil {
-			return nil, err
-		}
-
-		err = RadiusHealthCheck(ctx, workspace, pipeline, baseURL)
-		if err != nil {
-			return nil, err
-		}
-
-		baseURL, transporter, err := kubernetes.CreateAPIServerTransporter(c.Context, c.Overrides.UCP)
-		if err != nil {
-			return nil, err
-		}
-
-		clientOpts := GetClientOptions(baseURL, transporter)
-
+		clientOpts := sdk.NewClientOptions(connection)
 		appClient, err := generated.NewGenericResourcesClient(workspace.Scope, "Applications.Core/applications", &aztoken.AnonymousCredential{}, clientOpts)
 		if err != nil {
 			return nil, err
@@ -163,110 +148,21 @@ func (*impl) CreateApplicationsManagementClient(ctx context.Context, workspace w
 		return nil, err
 	}
 
-	switch c := connection.(type) {
-	case *workspaces.KubernetesConnection:
-		baseURL, pipeline, err := kubernetes.CreateAPIServerPipeline(c.Context, c.Overrides.UCP)
-		if err != nil {
-			return nil, err
-		}
-
-		err = RadiusHealthCheck(ctx, workspace, pipeline, baseURL)
-		if err != nil {
-			return nil, err
-		}
-
-		baseURL, transporter, err := kubernetes.CreateAPIServerTransporter(c.Context, c.Overrides.UCP)
-		if err != nil {
-			return nil, err
-		}
-
-		return &ucp.ARMApplicationsManagementClient{
-			// The client expects root scope without a leading /
-			RootScope:     strings.TrimPrefix(workspace.Scope, resources.SegmentSeparator),
-			ClientOptions: GetClientOptions(baseURL, transporter),
-		}, nil
-	default:
-		return nil, fmt.Errorf("unsupported connection type: %+v", connection)
+	err = sdk.TestConnection(ctx, connection)
+	if errors.Is(err, &sdk.ErrRadiusNotInstalled{}) {
+		return nil, &cli.FriendlyError{Message: err.Error()}
+	} else if err != nil {
+		return nil, err
 	}
+
+	return &ucp.ARMApplicationsManagementClient{
+		// The client expects root scope without a leading /
+		RootScope:     strings.TrimPrefix(workspace.Scope, resources.SegmentSeparator),
+		ClientOptions: sdk.NewClientOptions(connection),
+	}, nil
 }
 
 //nolint:all
 func (*impl) CreateCloudProviderManagementClient(ctx context.Context, workspace workspaces.Workspace) (clients.CloudProviderManagementClient, error) {
 	return nil, errors.New("this feature is currently not supported")
-}
-
-var _ autorest.Sender = (*sender)(nil)
-
-type sender struct {
-	RoundTripper http.RoundTripper
-}
-
-func (s *sender) Do(request *http.Request) (*http.Response, error) {
-	return s.RoundTripper.RoundTrip(request)
-}
-
-// HealthCheck function checks if there is a Radius installation for the given connection.
-func RadiusHealthCheck(ctx context.Context, workspace workspaces.Workspace, pipeline runtime.Pipeline, baseURL string) error {
-	req, err := createHealthCheckRequest(ctx, baseURL)
-	if err != nil {
-		return err
-	}
-
-	resp, err := pipeline.Do(req)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
-		return &cli.FriendlyError{
-			Message: fmt.Sprintf("A Radius installation could not be found for Kubernetes context %q. Use 'rad install kubernetes' to install.", workspace.Name),
-		}
-	}
-
-	return nil
-}
-
-func createHealthCheckRequest(ctx context.Context, basepath string) (*policy.Request, error) {
-	req, err := runtime.NewRequest(ctx, http.MethodGet, basepath)
-	if err != nil {
-		return nil, err
-	}
-	req.Raw().Header.Set("Accept", "application/json")
-	return req, nil
-}
-
-// GetClientOptions function returns ClientOptions with given BaseURL and Transporter.
-func GetClientOptions(baseURL string, transporter policy.Transporter) *arm.ClientOptions {
-	return &arm.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Cloud: cloud.Configuration{
-				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
-					cloud.ResourceManager: {
-						Endpoint: baseURL,
-						Audience: "https://management.core.windows.net",
-					},
-				},
-			},
-			PerRetryPolicies: []policy.Policy{
-				// Autorest will inject an empty bearer token, which conflicts with bearer auth
-				// when its used by Kubernetes. We don't *ever() need Autorest to handle auth for us
-				// so we just remove it.
-				//
-				// We'll solve this problem permanently by writing our own client.
-				&RemoveAuthorizationHeaderPolicy{},
-			},
-			Transport: transporter,
-		},
-		DisableRPRegistration: true,
-	}
-}
-
-var _ policy.Policy = (*RemoveAuthorizationHeaderPolicy)(nil)
-
-type RemoveAuthorizationHeaderPolicy struct {
-}
-
-func (p *RemoveAuthorizationHeaderPolicy) Do(req *policy.Request) (*http.Response, error) {
-	delete(req.Raw().Header, "Authorization")
-	return req.Next()
 }

--- a/pkg/cli/kubernetes/kubernetes.go
+++ b/pkg/cli/kubernetes/kubernetes.go
@@ -9,24 +9,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
-	"net/textproto"
-	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s_runtime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/discovery"
 	memory "k8s.io/client-go/discovery/cached"
@@ -37,7 +29,6 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/project-radius/radius/pkg/cli/output"
@@ -55,9 +46,6 @@ const (
 	UCPAPIServerBasePath     = "/apis/api.ucp.dev/v1alpha3"
 	UCPType                  = "api.ucp.dev"
 	BicepType                = "api.bicep.dev"
-
-	module  = "v20220315privatepreview"
-	version = "v0.0.1"
 )
 
 var (
@@ -102,110 +90,6 @@ func CreateExtensionClient(context string) (clientset.Interface, error) {
 	}
 
 	return client, err
-}
-
-func CreateRestRoundTripper(context string, group string, overrideURL string) (http.RoundTripper, error) {
-	if overrideURL != "" {
-		return http.DefaultTransport, nil
-	}
-
-	merged, err := GetConfig(context)
-	if err != nil {
-		return nil, err
-	}
-	gv := schema.GroupVersion{Group: group, Version: "v1alpha3"}
-	merged.GroupVersion = &gv
-	merged.APIPath = "/apis"
-	merged.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
-
-	client, err := rest.TransportFor(merged)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewLocationRewriteRoundTripper(merged.Host, client), err
-}
-
-func CreateAPIServerPipeline(context string, overrideURL string) (string, runtime.Pipeline, error) {
-	baseURL, transporter, err := CreateAPIServerTransporter(context, overrideURL)
-	if err != nil {
-		return baseURL, runtime.Pipeline{}, err
-	}
-
-	pipeline := runtime.NewPipeline(module, version, runtime.PipelineOptions{}, &policy.ClientOptions{
-		Cloud: cloud.Configuration{
-			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
-				cloud.ResourceManager: {
-					Endpoint: baseURL,
-					Audience: "https://management.core.windows.net",
-				},
-			},
-		},
-		Transport: transporter,
-	})
-
-	return baseURL, pipeline, nil
-}
-
-func GetBaseUrlForDeploymentEngine(overrideURL string) string {
-	return strings.TrimSuffix(overrideURL, "/") + UCPAPIServerBasePath
-}
-
-func GetBaseUrlAndRoundTripperForDeploymentEngine(ucpURL string, context string) (string, http.RoundTripper, error) {
-	var baseURL string
-	var roundTripper http.RoundTripper
-	basePath := UCPAPIServerBasePath
-
-	if ucpURL != "" {
-		baseURL = strings.TrimSuffix(ucpURL, "/") + basePath
-		roundTripper = NewLocationRewriteRoundTripper(ucpURL, http.DefaultTransport)
-	} else {
-		restConfig, err := GetConfig(context)
-		if err != nil {
-			return "", nil, err
-		}
-
-		k8sType := UCPType
-
-		roundTripper, err = CreateRestRoundTripper(context, k8sType, ucpURL)
-		if err != nil {
-			return "", nil, err
-		}
-
-		baseURL = strings.TrimSuffix(restConfig.Host+restConfig.APIPath, "/") + basePath
-		roundTripper = NewLocationRewriteRoundTripper(restConfig.Host, roundTripper)
-	}
-	return baseURL, roundTripper, nil
-}
-
-func GetBaseUrlAndRoundTripper(overrideURL string, group string, context string) (string, http.RoundTripper, error) {
-	var baseURL string
-	var roundTripper http.RoundTripper
-	if overrideURL != "" {
-		baseURL = strings.TrimSuffix(overrideURL, "/") + UCPAPIServerBasePath
-		roundTripper = NewLocationRewriteRoundTripper(overrideURL, http.DefaultTransport)
-	} else {
-		restConfig, err := GetConfig(context)
-		if err != nil {
-			return "", nil, err
-		}
-		roundTripper, err = CreateRestRoundTripper(context, group, overrideURL)
-		if err != nil {
-			return "", nil, err
-		}
-		baseURL = strings.TrimSuffix(restConfig.Host+restConfig.APIPath, "/") + UCPAPIServerBasePath
-		roundTripper = NewLocationRewriteRoundTripper(restConfig.Host, roundTripper)
-	}
-	return baseURL, roundTripper, nil
-}
-
-func CreateRestConfig(context string) (*rest.Config, error) {
-	merged, err := GetConfig(context)
-	if err != nil {
-		return nil, err
-	}
-
-	return merged, err
 }
 
 func CreateDynamicClient(context string) (dynamic.Interface, error) {
@@ -302,115 +186,6 @@ func homeDir() string {
 		return h
 	}
 	return os.Getenv("USERPROFILE") // windows
-}
-
-var _ policy.Transporter = &KubernetesTransporter{}
-
-type KubernetesTransporter struct {
-	Client http.RoundTripper
-}
-
-func (t *KubernetesTransporter) Do(req *http.Request) (*http.Response, error) {
-	resp, err := t.Client.RoundTrip(req)
-	return resp, err
-}
-
-var _ http.RoundTripper = (*LocationRewriteRoundTripper)(nil)
-
-// LocationRewriteRoundTripper rewrites the value of the HTTP Location header on responses
-// to match the expected Host/Scheme.
-//
-// There is a blocking behavior bug when combining the ARM-RPC protocol and a Kubernetes APIService.
-// Kubernetes does not forward the original hostname when proxying requests (we get the wrong value in
-// X-Forwarded-Host). See: https://github.com/kubernetes/kubernetes/issues/107435
-//
-// ARM-RPC requires the Location header to contain a fully-qualified absolute URL (it must start
-// with https://...). Combining this requirement with the broken behavior of APIService proxying means
-// that we generate the wrong URL.
-//
-// So this is a temporary solution, until we can solve this at the protocol level. We rewrite the Location
-// header on the client.
-type LocationRewriteRoundTripper struct {
-	Inner  http.RoundTripper
-	Host   string
-	Scheme string
-}
-
-func (t *LocationRewriteRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
-	res, err := t.Inner.RoundTrip(request)
-	if err != nil {
-		return nil, err
-	}
-
-	value, ok := res.Header[textproto.CanonicalMIMEHeaderKey(Location)]
-	if ok && len(value) > 0 {
-		u := GetFixedHeader(value, t.Scheme, t.Host)
-		if u != nil {
-			res.Header[textproto.CanonicalMIMEHeaderKey(Location)] = []string{u.String()}
-		}
-	}
-
-	valueAsync, ok := res.Header[textproto.CanonicalMIMEHeaderKey(AzureAsyncOperation)]
-	if ok && len(valueAsync) > 0 {
-		u := GetFixedHeader(valueAsync, t.Scheme, t.Host)
-		if u != nil {
-			res.Header[textproto.CanonicalMIMEHeaderKey(AzureAsyncOperation)] = []string{u.String()}
-		}
-	}
-
-	return res, nil
-}
-
-func GetFixedHeader(value []string, scheme string, host string) *url.URL {
-	// OK we have a location value, try to parse as a URL and then rewrite.
-	// Location is specified to contain a single value so just use the first one.
-	u, err := url.Parse(value[0])
-	if err != nil {
-		// If we fail to parse the location value just skip rewiting. Our usage of Location should always be valid.
-		return nil
-	}
-
-	if u.Scheme == "" {
-		// If we don't have a fully-qualified URL then just skip rewriting. Our usage of Location should always be fully-qualified.
-		return nil
-	}
-
-	if scheme != "" {
-		u.Scheme = scheme
-	}
-	u.Host = host
-
-	return u
-}
-
-func NewLocationRewriteRoundTripper(prefix string, inner http.RoundTripper) *LocationRewriteRoundTripper {
-	// NOTE: while we get the value from RESTConfig.Host - it's NOT always a host:port combo. Sometimes
-	// it is a URL including the scheme portion. JUST FOR FUN.
-	//
-	// We do our best to handle all of those cases here and degrade silently if we can't.
-	if strings.Contains(prefix, "://") {
-		// If we get here this is likely a fully-qualified URL.
-		u, err := url.Parse(prefix)
-		if err != nil {
-			// We failed to parse this as a URL, just treat it as a hostname then.
-			return &LocationRewriteRoundTripper{Inner: inner, Host: prefix}
-		}
-
-		// OK we have a URL
-		return &LocationRewriteRoundTripper{Inner: inner, Host: u.Host, Scheme: u.Scheme}
-	}
-
-	// If we get here it's likely not a fully-qualified URL. Treat it as a hostname.
-	return &LocationRewriteRoundTripper{Inner: inner, Host: prefix}
-}
-
-func CreateAPIServerTransporter(kubeContext string, overrideURL string) (string, policy.Transporter, error) {
-	baseURL, roundTripper, err := GetBaseUrlAndRoundTripper(overrideURL, "api.ucp.dev", kubeContext)
-	if err != nil {
-		return "", nil, err
-	}
-
-	return baseURL, &KubernetesTransporter{Client: roundTripper}, nil
 }
 
 // Creating a Kubernetes client

--- a/pkg/cli/setup/resourcegroups.go
+++ b/pkg/cli/setup/resourcegroups.go
@@ -8,14 +8,11 @@ package setup
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
-	"github.com/project-radius/radius/pkg/cli"
-	"github.com/project-radius/radius/pkg/cli/kubernetes"
-	"github.com/project-radius/radius/pkg/cli/workspaces"
+	"github.com/project-radius/radius/pkg/sdk"
 	"github.com/project-radius/radius/pkg/ucp/api/v20220901privatepreview"
 )
 
@@ -38,7 +35,7 @@ func (e *ErrUCPResourceGroupCreationFailed) Is(target error) bool {
 }
 
 // TODO remove this when envInit is removed. DO NOT add new uses of this function. Use the generated client.
-func CreateWorkspaceResourceGroup(ctx context.Context, connection workspaces.Connection, name string) (string, error) {
+func CreateWorkspaceResourceGroup(ctx context.Context, connection sdk.Connection, name string) (string, error) {
 	id, err := createUCPResourceGroup(ctx, connection, name, "/planes/radius/local")
 	if err != nil {
 		return "", err
@@ -54,20 +51,10 @@ func CreateWorkspaceResourceGroup(ctx context.Context, connection workspaces.Con
 	return id, nil
 }
 
-func createUCPResourceGroup(ctx context.Context, connection workspaces.Connection, resourceGroupName string, plane string) (string, error) {
-	kc, ok := connection.(*workspaces.KubernetesConnection)
-	if !ok {
-		return "", errors.New("only kubernetes connections are supported right now")
-	}
-
-	baseUrl, rt, err := kubernetes.GetBaseUrlAndRoundTripper(kc.Overrides.UCP, kubernetes.UCPType, kc.Context)
-	if err != nil {
-		return "", &cli.ClusterUnreachableError{Err: err}
-	}
-
+func createUCPResourceGroup(ctx context.Context, connection sdk.Connection, resourceGroupName string, plane string) (string, error) {
 	createRgRequest, err := http.NewRequest(
 		http.MethodPut,
-		fmt.Sprintf("%s%s/resourceGroups/%s?api-version=%s", baseUrl, plane, resourceGroupName, v20220901privatepreview.Version),
+		fmt.Sprintf("%s%s/resourceGroups/%s?api-version=%s", connection.Endpoint(), plane, resourceGroupName, v20220901privatepreview.Version),
 		strings.NewReader(`{
 			"location": "global"
 		}`))
@@ -77,7 +64,7 @@ func createUCPResourceGroup(ctx context.Context, connection workspaces.Connectio
 	}
 	createRgRequest = createRgRequest.WithContext(ctx)
 
-	resp, err := rt.RoundTrip(createRgRequest)
+	resp, err := connection.Client().Do(createRgRequest)
 	if err != nil || (resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK) {
 		return "", &ErrUCPResourceGroupCreationFailed{resp, err}
 	}

--- a/pkg/sdk/connection.go
+++ b/pkg/sdk/connection.go
@@ -1,0 +1,23 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package sdk
+
+import (
+	"net/http"
+)
+
+// Connection represents the configuration needed to connect to Radius. Use the functions
+// in this package to create a connection.
+type Connection interface {
+	// Client returns an http.Client for communicating with Radius. This satisfies both the
+	// autorest.Sender interface (autorest Track1 Go SDK) and policy.Transporter interface
+	// (autorest Track2 Go SDK).
+	Client() *http.Client
+
+	// Endpoint returns the endpoint (aka. base URL) of the Radius API. This definitely includes
+	// the URL scheme and authority, and may include path segments.
+	Endpoint() string
+}

--- a/pkg/sdk/connection_direct.go
+++ b/pkg/sdk/connection_direct.go
@@ -1,0 +1,49 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package sdk
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+var _ Connection = (*directConnection)(nil)
+
+// directConnection represents a connection to a Radius API endpoint with no authentication
+// or intermediate systems. This is mostly used for test scenarios.
+type directConnection struct {
+	endpoint string
+}
+
+// NewDirectConnection creates a connection from the given endpoint URL.
+func NewDirectConnection(endpoint string) (Connection, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse endpoint %q: %w", endpoint, err)
+	}
+
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("the endpoint must use the http or https scheme (got %q)", endpoint)
+	}
+
+	return &directConnection{
+		endpoint: endpoint,
+	}, nil
+}
+
+// Client returns an http.Client for communicating with Radius. This satisfies both the
+// autorest.Sender interface (autorest Track1 Go SDK) and policy.Transporter interface
+// (autorest Track2 Go SDK).
+func (c *directConnection) Client() *http.Client {
+	return http.DefaultClient
+}
+
+// Endpoint returns the endpoint (aka. base URL) of the Radius API. This definitely includes
+// the URL scheme and authority, and may include path segments.
+func (c *directConnection) Endpoint() string {
+	return c.endpoint
+}

--- a/pkg/sdk/connection_direct_test.go
+++ b/pkg/sdk/connection_direct_test.go
@@ -1,0 +1,47 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package sdk
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_NewDirectConnection_Valid(t *testing.T) {
+	endpoint := "http://some.endpoint.com/cool-path"
+
+	connection, err := NewDirectConnection(endpoint)
+	require.NoError(t, err)
+
+	require.IsType(t, &directConnection{}, connection)
+	require.Equal(t, endpoint, connection.(*directConnection).endpoint)
+
+	require.Equal(t, http.DefaultClient, connection.Client())
+	require.Equal(t, endpoint, connection.Endpoint())
+}
+
+func Test_NewDirectConnection_InvalidUrl(t *testing.T) {
+	// It's geniunely kinda hard to make Go's URL parser reject something :-|
+	endpoint := ":"
+
+	connection, err := NewDirectConnection(endpoint)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to parse endpoint")
+	require.Nil(t, connection)
+}
+
+func Test_NewDirectConnection_InvalidWithoutScheme(t *testing.T) {
+	// We require an absolute URL. Since Go's URL parser is so permissive, a lot
+	// of cases will end up here.
+	endpoint := "/just/a/path"
+
+	connection, err := NewDirectConnection(endpoint)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "the endpoint must use the http or https scheme")
+	require.Nil(t, connection)
+}

--- a/pkg/sdk/connection_kubernetes.go
+++ b/pkg/sdk/connection_kubernetes.go
@@ -1,0 +1,69 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package sdk
+
+import (
+	"net/http"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubectl/pkg/scheme"
+)
+
+const (
+	// ucpGroup is the Kubernetes API group of the UCP APIService extension. This is used to build
+	// URLs for communicating with UCP & Radius in Kubernetes.
+	ucpGroup = "api.ucp.dev"
+
+	// ucpVersion is the Kubernetes API version of the UCP APIService extension. This is used to build
+	// URLs for communicating with UCP & Radius in Kubernetes.
+	ucpVersion = "v1alpha3"
+)
+
+var _ Connection = (*kubernetesConnection)(nil)
+
+// kubernetesConnection represents a connection to Radius through the Kubernetes API server. This
+// connection type is most commonly used.
+type kubernetesConnection struct {
+	endpoint string
+
+	// roundTripper is the http.roundTripper used to send requests.
+	roundTripper http.RoundTripper
+}
+
+// NewKubernetesConnectionFromConfig creates a KubernetesConnection from the provided Kubernetes
+// configuration.
+func NewKubernetesConnectionFromConfig(config *rest.Config) (Connection, error) {
+	// Make a copy of the configuration because we are going to edit it.
+	copied := *config
+
+	copied.GroupVersion = &schema.GroupVersion{Group: ucpGroup, Version: ucpVersion}
+	copied.APIPath = "/apis"
+	copied.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+
+	roundTripper, err := rest.TransportFor(&copied)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := strings.TrimSuffix(copied.Host+copied.APIPath, "/") + "/" + ucpGroup + "/" + ucpVersion
+	roundTripper = newLocationRewriteRoundTripper(copied.Host, roundTripper)
+	return &kubernetesConnection{endpoint: endpoint, roundTripper: roundTripper}, nil
+}
+
+// Client returns an http.Client for communicating with Radius. This satisfies both the
+// autorest.Sender interface (autorest Track1 Go SDK) and policy.Transporter interface
+// (autorest Track2 Go SDK).
+func (c *kubernetesConnection) Client() *http.Client {
+	return &http.Client{Transport: c.roundTripper}
+}
+
+// Endpoint returns the endpoint (aka. base URL) of the Radius API. This definitely includes
+// the URL scheme and authority, and may include path segments.
+func (c *kubernetesConnection) Endpoint() string {
+	return c.endpoint
+}

--- a/pkg/sdk/connection_kubernetes_test.go
+++ b/pkg/sdk/connection_kubernetes_test.go
@@ -1,0 +1,46 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package sdk
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+// Note: we're not implementing our own validation of Kubernetes config, so we're
+// also not testing those cases in details. We assume the Kubernetes libraries do
+// a good enough job.
+
+func Test_NewKubernetesConnectionFromConfig_Valid(t *testing.T) {
+	// We're being fairly detailed with the verification of the roundtripper here
+	// because a regression will result in some really hard to understand error messages.
+
+	config := &rest.Config{
+		Host: "https://example.com",
+	}
+
+	expectedEndpoint := "https://example.com/apis/api.ucp.dev/v1alpha3"
+	expectedInnerRoundTripper, err := rest.TransportFor(config)
+	require.NoError(t, err)
+
+	expectedRoundTripper := newLocationRewriteRoundTripper(expectedEndpoint, expectedInnerRoundTripper)
+
+	connection, err := NewKubernetesConnectionFromConfig(config)
+	require.NoError(t, err)
+
+	require.IsType(t, &kubernetesConnection{}, connection)
+	kubernetesConnection := connection.(*kubernetesConnection)
+	require.Equal(t, expectedEndpoint, kubernetesConnection.endpoint)
+
+	roundTripper := kubernetesConnection.roundTripper
+	require.Equal(t, expectedRoundTripper, roundTripper)
+
+	require.Equal(t, &http.Client{Transport: expectedRoundTripper}, connection.Client())
+	require.Equal(t, expectedEndpoint, connection.Endpoint())
+}

--- a/pkg/sdk/connection_location.go
+++ b/pkg/sdk/connection_location.go
@@ -1,0 +1,111 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package sdk
+
+import (
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"strings"
+)
+
+const (
+	locationHeader            = "Location"
+	azureAsyncOperationHeader = "Azure-AsyncOperation"
+)
+
+// TODO: replace this with use of the HTTP Referrer header.
+
+var _ http.RoundTripper = (*locationRewriteRoundTripper)(nil)
+
+// locationRewriteRoundTripper rewrites the value of the HTTP Location and Azure-AsyncOperation header
+// on responses to match the expected externally routable URL scheme, host, and port.
+//
+// There is a blocking behavior bug when combining the ARM-RPC protocol and a Kubernetes APIService.
+// Kubernetes does not forward the original hostname when proxying requests (we get the wrong value in
+// X-Forwarded-Host). See: https://github.com/kubernetes/kubernetes/issues/107435
+//
+// ARM-RPC requires the Location header to contain a fully-qualified absolute URL (it must start
+// with http://... or https://...). Combining this requirement with the broken behavior of APIService
+// proxying means that we generate the wrong URL.
+//
+// So this is a temporary solution, until we can solve this at the protocol level. We rewrite the Location
+// header on the client.
+type locationRewriteRoundTripper struct {
+	// RoundTripper is the inner http.RoundTripper that sends the request.
+	RoundTripper http.RoundTripper
+
+	// Scheme is the externally routable scheme segment of the URL (usually https).
+	Scheme string
+
+	// Authority is the externally routable authority segment of the URL (host:port).
+	Authority string
+}
+
+// RoundTrip is the implementation of http.RoundTripper.
+func (t *locationRewriteRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	// Send the request and then rewrite response headers.
+	res, err := t.RoundTripper.RoundTrip(request)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, headerName := range []string{locationHeader, azureAsyncOperationHeader} {
+		values, ok := res.Header[textproto.CanonicalMIMEHeaderKey(headerName)]
+		if ok && len(values) > 0 {
+			// Headers can be multi-value but the cases we care about only have a single value.
+			rewritten := t.rewrite(values[0], t.Scheme, t.Authority)
+			if rewritten != nil {
+				res.Header[textproto.CanonicalMIMEHeaderKey(headerName)] = []string{rewritten.String()}
+			}
+		}
+	}
+
+	return res, nil
+}
+
+func (t *locationRewriteRoundTripper) rewrite(value string, scheme string, host string) *url.URL {
+	// OK we have a value, try to parse as a URL and then rewrite.
+	u, err := url.Parse(value)
+	if err != nil {
+		// If we fail to parse the value just skip rewiting. Our usage should always be valid.
+		return nil
+	}
+
+	if u.Scheme == "" {
+		// If we don't have a fully-qualified URL then just skip rewriting. Our usage should always be fully-qualified.
+		return nil
+	}
+
+	if scheme != "" {
+		u.Scheme = scheme
+	}
+	u.Host = host
+
+	return u
+}
+
+// newLocationRewriteRoundTripper creates a new roundtripper for the given URL or authority value.
+func newLocationRewriteRoundTripper(endpoint string, inner http.RoundTripper) *locationRewriteRoundTripper {
+	// NOTE: while we get the value from RESTConfig.Host - it's NOT always a host:port combo. Sometimes
+	// it is a URL including the scheme portion. JUST FOR FUN.
+	//
+	// We do our best to handle all of those cases here and degrade silently if we can't.
+	if strings.Contains(endpoint, "://") {
+		// If we get here this is likely a fully-qualified URL.
+		u, err := url.Parse(endpoint)
+		if err != nil {
+			// We failed to parse this as a URL, just treat it as a hostname then.
+			return &locationRewriteRoundTripper{RoundTripper: inner, Authority: endpoint}
+		}
+
+		// OK we have a URL
+		return &locationRewriteRoundTripper{RoundTripper: inner, Authority: u.Host, Scheme: u.Scheme}
+	}
+
+	// If we get here it's likely not a fully-qualified URL. Treat it as a hostname.
+	return &locationRewriteRoundTripper{RoundTripper: inner, Authority: endpoint}
+}

--- a/pkg/sdk/connection_location_test.go
+++ b/pkg/sdk/connection_location_test.go
@@ -1,0 +1,70 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package sdk
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_newLocationRewriteRoundTripper_Authority(t *testing.T) {
+	endpoint := "example.com"
+	innerRoundTripper := http.DefaultTransport
+
+	expected := &locationRewriteRoundTripper{
+		RoundTripper: innerRoundTripper,
+		Scheme:       "",
+		Authority:    "example.com",
+	}
+
+	actual := newLocationRewriteRoundTripper(endpoint, innerRoundTripper)
+	require.Equal(t, expected, actual)
+}
+
+func Test_newLocationRewriteRoundTripper_URL(t *testing.T) {
+	endpoint := "http://example.com/some/path"
+	innerRoundTripper := http.DefaultTransport
+
+	expected := &locationRewriteRoundTripper{
+		RoundTripper: innerRoundTripper,
+		Scheme:       "http",
+		Authority:    "example.com",
+	}
+
+	actual := newLocationRewriteRoundTripper(endpoint, innerRoundTripper)
+	require.Equal(t, expected, actual)
+}
+
+func Test_locationRewriteRoundTripper_RoundTrip(t *testing.T) {
+	mockRoundTripper := &MockTransport{
+		Response: &http.Response{
+			Header: http.Header{
+				http.CanonicalHeaderKey(locationHeader):            []string{"https://other-host.com/location"},
+				http.CanonicalHeaderKey(azureAsyncOperationHeader): []string{"https://other-host.com/async-operation"},
+			},
+		},
+	}
+
+	roundTripper := newLocationRewriteRoundTripper("http://example.com", mockRoundTripper)
+	response, err := roundTripper.RoundTrip(&http.Request{}) // Request doesn't matter
+	require.NoError(t, err)
+
+	require.Equal(t, "http://example.com/location", response.Header.Get(locationHeader))
+	require.Equal(t, "http://example.com/async-operation", response.Header.Get(azureAsyncOperationHeader))
+}
+
+var _ http.RoundTripper = (*MockTransport)(nil)
+
+type MockTransport struct {
+	Response *http.Response
+}
+
+// RoundTrip implements http.RoundTripper
+func (mt *MockTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return mt.Response, nil
+}

--- a/pkg/sdk/doc.go
+++ b/pkg/sdk/doc.go
@@ -1,0 +1,13 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+// sdk defines the functionality for interacting with Radius as a client. This includes
+// opening a connection to the Radius control plane for making API calls as well as client
+// APIs.
+//
+// The sdk package can be safely used from the CLI and RPs in Radius as well as external
+// packages. This means that the sdk package CANNOT reference other packages in the
+// Radius codebase as it will be used from basically everywhere.
+package sdk

--- a/pkg/sdk/health.go
+++ b/pkg/sdk/health.go
@@ -1,0 +1,63 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package sdk
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// ErrRadiusNotInstalled is the error reported when Radius is not installed for a connection.
+type ErrRadiusNotInstalled struct {
+}
+
+// Is determines whether the provided error is an ErrRadiusNotInstalled.
+func (*ErrRadiusNotInstalled) Is(other error) bool {
+	_, ok := other.(*ErrRadiusNotInstalled)
+	return ok
+}
+
+// Error is the Error() implementation.
+func (*ErrRadiusNotInstalled) Error() string {
+	return "a Radius installation could not be found. Use 'rad install kubernetes' to install"
+}
+
+// TestConnection tests the provided connection to determine if the Radius API is responding. This
+// will return ErrRadiusNotInstalled when it can be determined that Radius is not installed, and
+// a generic error for other failure conditions.
+//
+// Creating a new connection with the various New functions in this package does not call TestConnection
+// automatically. This allows a connection to be created before Radius has been installed.
+func TestConnection(ctx context.Context, connection Connection) error {
+	req, err := createHealthCheckRequest(ctx, connection.Endpoint())
+	if err != nil {
+		return err
+	}
+
+	resp, err := connection.Client().Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return &ErrRadiusNotInstalled{}
+	} else if resp.StatusCode >= 400 {
+		return fmt.Errorf("an unknown error occurred, status code was %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func createHealthCheckRequest(ctx context.Context, url string) (*http.Request, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}

--- a/pkg/sdk/pipeline.go
+++ b/pkg/sdk/pipeline.go
@@ -1,0 +1,68 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package sdk
+
+import (
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
+
+const (
+	// module is used to build a runtime.Pipeline. This is informational text about the client that
+	// is added as part of the User-Agent header.
+	module = "v20220315privatepreview"
+
+	// version is used to build a runtime.Pipeline. This is informational text about the client that
+	// is added as part of the User-Agent header.
+	version = "v0.0.1"
+)
+
+// NewPipeline builds a runtime.Pipeline from a Radius SDK connection. This is used to construct
+// autorest Track2 Go clients.
+func NewPipeline(connection Connection) runtime.Pipeline {
+	return runtime.NewPipeline(module, version, runtime.PipelineOptions{}, &NewClientOptions(connection).ClientOptions)
+}
+
+// NewClientOptions builds an arm.ClientOptions from a Radius SDK connection. This is used
+// to construct autorest Track2 Go clients.
+func NewClientOptions(connection Connection) *arm.ClientOptions {
+	return &arm.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Cloud: cloud.Configuration{
+				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+					cloud.ResourceManager: {
+						Endpoint: connection.Endpoint(),
+						Audience: "https://management.core.windows.net",
+					},
+				},
+			},
+			PerRetryPolicies: []policy.Policy{
+				// Autorest will inject an empty bearer token, which conflicts with bearer auth
+				// when its used by Kubernetes. We don't *ever* need Autorest to handle auth for us
+				// so we just remove it.
+				//
+				// We'll solve this problem permanently by writing our own client.
+				&removeAuthorizationHeaderPolicy{},
+			},
+			Transport: connection.Client(),
+		},
+		DisableRPRegistration: true,
+	}
+}
+
+var _ policy.Policy = (*removeAuthorizationHeaderPolicy)(nil)
+
+type removeAuthorizationHeaderPolicy struct {
+}
+
+func (p *removeAuthorizationHeaderPolicy) Do(req *policy.Request) (*http.Response, error) {
+	delete(req.Raw().Header, "Authorization")
+	return req.Next()
+}


### PR DESCRIPTION
This change introduces a new top-level package 'pkg/sdk' that contains client code for interacting with the UCP & Radius APIs. The reason for the new package is that we need to start calling into UCP from inside our server APIs. We have code today that accesses the database instead of calling the API (eg: link RP reading the database of core rp). We also need to call into the deployment engine from the link rp as part of the recipes work.

The problem is that all of our client code for interacting with the APIs today is part of pkg/cli. Rather than introducing cli references to our RP code, I chose to fix the layering. This is a refactor I've been wanting to do for a while now.

I also used this opportunity to clean up the proliferation of different options and APIs that have sprung up organically. Lots of our existing code futzes around with baseURLs and roundtrippers and other low level details due to the lack of abstraction.

Now there's one abstraction (sdk.Connection), two functions for creating a connection (one for testing and one for Kubernetes), and one way (per generation of SDK) to hook up a generated client to a connection.

This change introduces the new functionality, adds tests where they were missing before and refactors the client code to use the new types. My next step will be to introduce sdk.Connection on the server side and wire it up based on our server side configuration.
