### PR TITLE
Normalize k8s resource name and update functional test to validate upper case

### DIFF
--- a/pkg/corerp/renderers/container/azure/identity.go
+++ b/pkg/corerp/renderers/container/azure/identity.go
@@ -165,7 +165,7 @@ func MakeFederatedIdentitySA(appName, name, namespace string, resource *datamode
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      kubernetes.NormalizeResourceName(name),
 			Namespace: namespace,
 			Labels:    labels,
 			Annotations: map[string]string{

--- a/pkg/corerp/renderers/container/azure/keyvaultvolume.go
+++ b/pkg/corerp/renderers/container/azure/keyvaultvolume.go
@@ -107,7 +107,7 @@ func MakeKeyVaultSecretProviderClass(appName, name string, res *datamodel.Volume
 			APIVersion: "secrets-store.csi.x-k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      kubernetes.NormalizeResourceName(name),
 			Namespace: envOpt.Namespace,
 			Labels:    kubernetes.MakeDescriptiveLabels(appName, res.Name, res.Type),
 			Annotations: map[string]string{

--- a/pkg/corerp/renderers/container/azure/util.go
+++ b/pkg/corerp/renderers/container/azure/util.go
@@ -6,7 +6,7 @@
 package azure
 
 import (
-	"strings"
+	"github.com/project-radius/radius/pkg/kubernetes"
 )
 
 const (
@@ -27,5 +27,5 @@ func MakeResourceName(prefix, name, separator string) string {
 	if prefix != "" {
 		prefix += separator
 	}
-	return strings.ToLower(prefix + name)
+	return kubernetes.NormalizeResourceName(prefix + name)
 }

--- a/pkg/corerp/renderers/container/rbac.go
+++ b/pkg/corerp/renderers/container/rbac.go
@@ -24,7 +24,7 @@ func makeRBACRole(appName, name, namespace string, resource *datamodel.Container
 			APIVersion: "rbac.authorization.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      kubernetes.NormalizeResourceName(name),
 			Namespace: namespace,
 			Labels:    labels,
 		},
@@ -56,13 +56,13 @@ func makeRBACRoleBinding(appName, name, saName, namespace string, resource *data
 			APIVersion: "rbac.authorization.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      kubernetes.NormalizeResourceName(name),
 			Namespace: namespace,
 			Labels:    labels,
 		},
 		RoleRef: rbacv1.RoleRef{
 			Kind:     "Role",
-			Name:     name,
+			Name:     kubernetes.NormalizeResourceName(name),
 			APIGroup: "rbac.authorization.k8s.io",
 		},
 		Subjects: []rbacv1.Subject{

--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -198,16 +198,16 @@ func (r Renderer) makeDeployment(ctx context.Context, applicationName string, op
 	ports := []corev1.ContainerPort{}
 	for _, port := range cc.Container.Ports {
 		if provides := port.Provides; provides != "" {
-			resourceId, err := resources.ParseResource(strings.ToLower(provides))
+			resourceId, err := resources.ParseResource(provides)
 			if err != nil {
 				return []outputresource.OutputResource{}, nil, v1.NewClientErrInvalidRequest(err.Error())
 			}
 
-			routeName := resourceId.Name()
+			routeName := kubernetes.NormalizeResourceName(resourceId.Name())
 			routeType := resourceId.TypeSegments()[len(resourceId.TypeSegments())-1].Type
 			routeTypeParts := strings.Split(routeType, "/")
 
-			routeTypeSuffix := routeTypeParts[len(routeTypeParts)-1]
+			routeTypeSuffix := kubernetes.NormalizeResourceName(routeTypeParts[len(routeTypeParts)-1])
 
 			routes = append(routes, struct {
 				Name string

--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -198,7 +198,7 @@ func (r Renderer) makeDeployment(ctx context.Context, applicationName string, op
 	ports := []corev1.ContainerPort{}
 	for _, port := range cc.Container.Ports {
 		if provides := port.Provides; provides != "" {
-			resourceId, err := resources.ParseResource(kubernetes.NormalizeResourceName(provides))
+			resourceId, err := resources.ParseResource(strings.ToLower(provides))
 			if err != nil {
 				return []outputresource.OutputResource{}, nil, v1.NewClientErrInvalidRequest(err.Error())
 			}

--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -198,7 +198,7 @@ func (r Renderer) makeDeployment(ctx context.Context, applicationName string, op
 	ports := []corev1.ContainerPort{}
 	for _, port := range cc.Container.Ports {
 		if provides := port.Provides; provides != "" {
-			resourceId, err := resources.ParseResource(provides)
+			resourceId, err := resources.ParseResource(kubernetes.NormalizeResourceName(provides))
 			if err != nil {
 				return []outputresource.OutputResource{}, nil, v1.NewClientErrInvalidRequest(err.Error())
 			}
@@ -230,7 +230,7 @@ func (r Renderer) makeDeployment(ctx context.Context, applicationName string, op
 	}
 
 	container := corev1.Container{
-		Name:  resource.Name,
+		Name:  kubernetes.NormalizeResourceName(resource.Name),
 		Image: cc.Container.Image,
 		// TODO: use better policies than this when we have a good versioning story
 		ImagePullPolicy: corev1.PullPolicy("Always"),

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -108,7 +108,7 @@ func NormalizeResourceName(name string) string {
 
 	if !IsValidObjectName(normalized) {
 		// This should not happen.
-		panic(normalized + " is invalid name for Kuberentes")
+		panic(normalized + " is an invalid name.")
 	}
 	return normalized
 }

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -55,11 +55,11 @@ const (
 // The descriptive labels are a superset of the selector labels.
 func MakeDescriptiveLabels(application string, resource string, resourceType string) map[string]string {
 	return map[string]string{
-		LabelRadiusApplication:  application,
-		LabelRadiusResource:     resource,
-		LabelRadiusResourceType: strings.ToLower(ConvertResourceTypeToLabelValue(resourceType)),
-		LabelName:               resource,
-		LabelPartOf:             application,
+		LabelRadiusApplication:  NormalizeResourceName(application),
+		LabelRadiusResource:     NormalizeResourceName(resource),
+		LabelRadiusResourceType: NormalizeResourceName(ConvertResourceTypeToLabelValue(resourceType)),
+		LabelName:               NormalizeResourceName(resource),
+		LabelPartOf:             NormalizeResourceName(application),
 		LabelManagedBy:          LabelManagedByRadiusRP,
 	}
 }
@@ -72,8 +72,8 @@ func MakeDescriptiveLabels(application string, resource string, resourceType str
 func MakeSelectorLabels(application string, resource string) map[string]string {
 	if resource != "" {
 		return map[string]string{
-			LabelRadiusApplication: application,
-			LabelRadiusResource:    resource,
+			LabelRadiusApplication: NormalizeResourceName(application),
+			LabelRadiusResource:    NormalizeResourceName(resource),
 		}
 	}
 	return map[string]string{
@@ -88,11 +88,11 @@ func MakeSelectorLabels(application string, resource string) map[string]string {
 // an HttpRoute and the Deployment created by a Container.
 func MakeRouteSelectorLabels(application string, resourceType string, route string) map[string]string {
 	return map[string]string{
-		LabelRadiusApplication: application,
+		LabelRadiusApplication: NormalizeResourceName(application),
 
 		// NOTE: pods can serve multiple routes of different types. Therefore we need to encode the
 		// the route's type and name in the *key* to support multiple matches.
-		fmt.Sprintf(LabelRadiusRouteFmt, strings.ToLower(strings.TrimSuffix(resourceType, "Route")), strings.ToLower(route)): "true",
+		fmt.Sprintf(LabelRadiusRouteFmt, NormalizeResourceName(strings.TrimSuffix(resourceType, "Route")), NormalizeResourceName(route)): "true",
 	}
 }
 
@@ -104,18 +104,18 @@ func MakeRouteSelectorLabels(application string, resourceType string, route stri
 func MakeResourceCRDLabels(application string, resourceType string, resource string) map[string]string {
 	if resourceType != "" && resource != "" {
 		return map[string]string{
-			LabelRadiusApplication:  application,
-			LabelRadiusResourceType: resourceType,
-			LabelRadiusResource:     resource,
-			LabelName:               resource,
-			LabelPartOf:             application,
+			LabelRadiusApplication:  NormalizeResourceName(application),
+			LabelRadiusResourceType: NormalizeResourceName(resourceType),
+			LabelRadiusResource:     NormalizeResourceName(resource),
+			LabelName:               NormalizeResourceName(resource),
+			LabelPartOf:             NormalizeResourceName(application),
 			LabelManagedBy:          LabelManagedByRadiusRP,
 		}
 	}
 
 	return map[string]string{
-		LabelRadiusApplication: application,
-		LabelName:              application,
+		LabelRadiusApplication: NormalizeResourceName(application),
+		LabelName:              NormalizeResourceName(application),
 		LabelManagedBy:         LabelManagedByRadiusRP,
 	}
 }

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -123,13 +123,8 @@ func MakeResourceCRDLabels(application string, resourceType string, resource str
 // NormalizeResourceName normalizes resource name used for kubernetes resource name scoped in namespace.
 // All name will be validated by swagger validaiton so that it does not get non-RFC1035 compliant characters.
 // Therefore, this function will lowercase the name without allowed character validation.
-// If name is empty, it will panic.
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names
 func NormalizeResourceName(name string) string {
-	if name == "" {
-		// This should not happen.
-		panic("resource name is empty")
-	}
 	return strings.ToLower(name)
 }
 

--- a/pkg/kubernetes/labels_test.go
+++ b/pkg/kubernetes/labels_test.go
@@ -77,6 +77,10 @@ func TestNormalizeResoureName(t *testing.T) {
 			"resource",
 		},
 		{
+			"panic_",
+			"",
+		},
+		{
 			"",
 			"",
 		},
@@ -84,7 +88,13 @@ func TestNormalizeResoureName(t *testing.T) {
 
 	for _, tt := range nameTests {
 		t.Run(tt.in, func(t *testing.T) {
-			require.Equal(t, tt.out, NormalizeResourceName(tt.in))
+			if tt.in == "panic_" {
+				require.Panics(t, func() {
+					NormalizeResourceName(tt.in)
+				})
+			} else {
+				require.Equal(t, tt.out, NormalizeResourceName(tt.in))
+			}
 		})
 	}
 }

--- a/pkg/kubernetes/labels_test.go
+++ b/pkg/kubernetes/labels_test.go
@@ -65,30 +65,32 @@ func TestConvertLabelToResourceType(t *testing.T) {
 
 func TestNormalizeResoureName(t *testing.T) {
 	nameTests := []struct {
-		in  string
-		out string
+		in    string
+		out   string
+		panic bool
 	}{
 		{
-			"resource",
-			"resource",
+			in:  "resource",
+			out: "resource",
 		},
 		{
-			"Resource",
-			"resource",
+			in:  "Resource",
+			out: "resource",
 		},
 		{
-			"panic_",
-			"",
+			in:    "panic_",
+			out:   "",
+			panic: true,
 		},
 		{
-			"",
-			"",
+			in:  "",
+			out: "",
 		},
 	}
 
 	for _, tt := range nameTests {
 		t.Run(tt.in, func(t *testing.T) {
-			if tt.in == "panic_" {
+			if tt.panic {
 				require.Panics(t, func() {
 					NormalizeResourceName(tt.in)
 				})

--- a/pkg/kubernetes/labels_test.go
+++ b/pkg/kubernetes/labels_test.go
@@ -78,19 +78,13 @@ func TestNormalizeResoureName(t *testing.T) {
 		},
 		{
 			"",
-			"panic",
+			"",
 		},
 	}
 
 	for _, tt := range nameTests {
 		t.Run(tt.in, func(t *testing.T) {
-			if tt.in == "" {
-				require.Panics(t, func() {
-					NormalizeResourceName(tt.in)
-				})
-			} else {
-				require.Equal(t, tt.out, NormalizeResourceName(tt.in))
-			}
+			require.Equal(t, tt.out, NormalizeResourceName(tt.in))
 		})
 	}
 }

--- a/pkg/linkrp/renderers/daprpubsubbrokers/azure_servicebus.go
+++ b/pkg/linkrp/renderers/daprpubsubbrokers/azure_servicebus.go
@@ -54,7 +54,7 @@ func GetDaprPubSubAzureServiceBus(resource datamodel.DaprPubSubBroker, applicati
 		Resource: map[string]string{
 			handlers.ResourceName:            kubernetes.NormalizeResourceName(resource.Name),
 			handlers.KubernetesNamespaceKey:  namespace,
-			handlers.ApplicationName:         applicationName,
+			handlers.ApplicationName:         kubernetes.NormalizeResourceName(applicationName),
 			handlers.KubernetesAPIVersionKey: "dapr.io/v1alpha1",
 			handlers.KubernetesKindKey:       "Component",
 

--- a/pkg/linkrp/renderers/daprpubsubbrokers/azure_servicebus.go
+++ b/pkg/linkrp/renderers/daprpubsubbrokers/azure_servicebus.go
@@ -52,7 +52,7 @@ func GetDaprPubSubAzureServiceBus(resource datamodel.DaprPubSubBroker, applicati
 			Provider: resourcemodel.ProviderAzure,
 		},
 		Resource: map[string]string{
-			handlers.ResourceName:            resource.Name,
+			handlers.ResourceName:            kubernetes.NormalizeResourceName(resource.Name),
 			handlers.KubernetesNamespaceKey:  namespace,
 			handlers.ApplicationName:         applicationName,
 			handlers.KubernetesAPIVersionKey: "dapr.io/v1alpha1",

--- a/test/functional/corerp/cli/cli_test.go
+++ b/test/functional/corerp/cli/cli_test.go
@@ -406,8 +406,8 @@ func Test_CLI_JSON(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					"default-kubernetes-cli-json": {
-						validation.NewK8sPodForResource(name, "containerA-json"),
-						validation.NewK8sPodForResource(name, "containerB-json"),
+						validation.NewK8sPodForResource(name, "containera-json"),
+						validation.NewK8sPodForResource(name, "containerb-json"),
 					},
 				},
 			},

--- a/test/functional/corerp/cli/cli_test.go
+++ b/test/functional/corerp/cli/cli_test.go
@@ -70,11 +70,11 @@ func verifyCLIBasics(ctx context.Context, t *testing.T, test corerp.CoreRPTest) 
 	options := corerp.NewCoreRPTestOptions(t)
 	cli := radcli.NewCLI(t, options.ConfigFilePath)
 	appName := test.Name
-	containerName := "containera"
+	containerName := "containerA"
 	//spacing in output will change based on resource names
 	showSpacing := ""
 	if strings.EqualFold(appName, "kubernetes-cli-json") {
-		containerName = "containera-json"
+		containerName = "containerA-json"
 		showSpacing = "     "
 	}
 
@@ -92,11 +92,11 @@ func verifyCLIBasics(ctx context.Context, t *testing.T, test corerp.CoreRPTest) 
 
 		// Resource ordering can vary so we don't assert exact output.
 		if strings.EqualFold(appName, "kubernetes-cli") {
-			require.Regexp(t, `containera`, output)
-			require.Regexp(t, `containerb`, output)
+			require.Regexp(t, `containerA`, output)
+			require.Regexp(t, `containerB`, output)
 		} else {
-			require.Regexp(t, `containera-json`, output)
-			require.Regexp(t, `containerb-json`, output)
+			require.Regexp(t, `containerA-json`, output)
+			require.Regexp(t, `containerB-json`, output)
 		}
 	})
 
@@ -352,12 +352,12 @@ func Test_CLI(t *testing.T) {
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "containera",
+						Name: "containerA",
 						Type: validation.ContainersResource,
 						App:  "kubernetes-cli",
 					},
 					{
-						Name: "containerb",
+						Name: "containerB",
 						Type: validation.ContainersResource,
 						App:  "kubernetes-cli",
 					},
@@ -392,12 +392,12 @@ func Test_CLI_JSON(t *testing.T) {
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "containera-json",
+						Name: "containerA-json",
 						Type: validation.ContainersResource,
 						App:  "kubernetes-cli-json",
 					},
 					{
-						Name: "containerb-json",
+						Name: "containerB-json",
 						Type: validation.ContainersResource,
 						App:  "kubernetes-cli-json",
 					},
@@ -406,8 +406,8 @@ func Test_CLI_JSON(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					"default-kubernetes-cli-json": {
-						validation.NewK8sPodForResource(name, "containera-json"),
-						validation.NewK8sPodForResource(name, "containerb-json"),
+						validation.NewK8sPodForResource(name, "containerA-json"),
+						validation.NewK8sPodForResource(name, "containerB-json"),
 					},
 				},
 			},
@@ -524,12 +524,12 @@ func Test_CLI_DeploymentParameters(t *testing.T) {
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "containerc",
+						Name: "containerC",
 						Type: validation.ContainersResource,
 						App:  "kubernetes-cli-params",
 					},
 					{
-						Name: "containerd",
+						Name: "containerD",
 						Type: validation.ContainersResource,
 						App:  "kubernetes-cli-params",
 					},

--- a/test/functional/corerp/cli/testdata/corerp-kubernetes-cli-parameters.bicep
+++ b/test/functional/corerp/cli/testdata/corerp-kubernetes-cli-parameters.bicep
@@ -21,7 +21,7 @@ resource parametersApp 'Applications.Core/applications@2022-03-15-privatepreview
 }
 
 resource containerc 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'containerc'
+  name: 'containerC'
   location: location
   properties: {
     application: parametersApp.id
@@ -32,7 +32,7 @@ resource containerc 'Applications.Core/containers@2022-03-15-privatepreview' = {
 }
 
 resource containerd 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'containerd'
+  name: 'containerD'
   location: location
   properties: {
     application: parametersApp.id

--- a/test/functional/corerp/cli/testdata/corerp-kubernetes-cli.bicep
+++ b/test/functional/corerp/cli/testdata/corerp-kubernetes-cli.bicep
@@ -18,7 +18,7 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 }
 
 resource containera 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'containera'
+  name: 'containerA'
   location: location
   properties: {
     application: app.id
@@ -29,7 +29,7 @@ resource containera 'Applications.Core/containers@2022-03-15-privatepreview' = {
 }
 
 resource containerb 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'containerb'
+  name: 'containerB'
   location: location
   properties: {
     application: app.id

--- a/test/functional/corerp/cli/testdata/corerp-kubernetes-cli.json
+++ b/test/functional/corerp/cli/testdata/corerp-kubernetes-cli.json
@@ -53,7 +53,7 @@
       "import": "radius",
       "type": "Applications.Core/containers@2022-03-15-privatepreview",
       "properties": {
-        "name": "containera-json",
+        "name": "containerA-json",
         "location": "[parameters('location')]",
         "properties": {
           "application": "[reference('app').id]",
@@ -70,7 +70,7 @@
       "import": "radius",
       "type": "Applications.Core/containers@2022-03-15-privatepreview",
       "properties": {
-        "name": "containerb-json",
+        "name": "containerB-json",
         "location": "[parameters('location')]",
         "properties": {
           "application": "[reference('app').id]",

--- a/test/functional/ucp/resourcegroup_test.go
+++ b/test/functional/ucp/resourcegroup_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -23,7 +24,7 @@ import (
 func Test_ResourceGroup_Operations(t *testing.T) {
 	test := NewUCPTest(t, "Test_ResourceGroup_Operations", func(t *testing.T, url string, roundTripper http.RoundTripper) {
 		// Create resource groups
-		rgID := "/planes/radius/local/resourcegroups/test-rg"
+		rgID := "/planes/radius/local/resourcegroups/test-RG"
 		apiVersion := v20220901privatepreview.Version
 		rgURL := fmt.Sprintf("%s%s?api-version=%s", url, rgID, apiVersion)
 
@@ -39,11 +40,11 @@ func Test_ResourceGroup_Operations(t *testing.T) {
 		rgs := listResourceGroups(t, roundTripper, listRGsURL)
 		require.GreaterOrEqual(t, len(rgs.Value), 1)
 
-		// Get Resource Group
-		rg, statusCode := getResourceGroup(t, roundTripper, rgURL)
+		// Get Resource Group by lowercasing resource name.
+		rg, statusCode := getResourceGroup(t, roundTripper, strings.ToLower(rgURL))
 		expectedResourceGroup := v20220901privatepreview.ResourceGroupResource{
 			ID:       to.Ptr(rgID),
-			Name:     to.Ptr("test-rg"),
+			Name:     to.Ptr("test-RG"),
 			Tags:     map[string]*string{},
 			Type:     to.Ptr("System.Resources/resourceGroups"),
 			Location: to.Ptr(v1.LocationGlobal),

--- a/test/functional/ucp/resourcegroup_test.go
+++ b/test/functional/ucp/resourcegroup_test.go
@@ -40,7 +40,7 @@ func Test_ResourceGroup_Operations(t *testing.T) {
 		rgs := listResourceGroups(t, roundTripper, listRGsURL)
 		require.GreaterOrEqual(t, len(rgs.Value), 1)
 
-		// Get Resource Group by lowercasing resource name.
+		// Get Resource Group by calling lower case URL.
 		rg, statusCode := getResourceGroup(t, roundTripper, strings.ToLower(rgURL))
 		expectedResourceGroup := v20220901privatepreview.ResourceGroupResource{
 			ID:       to.Ptr(rgID),


### PR DESCRIPTION
# Description

* Normalize k8s resource name and labels - Applications.Core/container renderer doesn't normalize name whereas the other resources normalizes name for k8s resource.
* Update the existing functional tests to validate the upper case resource name. 

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #3582  #4647 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
