### PR TITLE
Add plumbing for UCP connection in RPs

### DIFF
--- a/cmd/appcore-async/radius-dev.yaml
+++ b/cmd/appcore-async/radius-dev.yaml
@@ -45,3 +45,5 @@ metricsProvider:
     port: 2222
 featureFlags:
   - "PLACEHOLDER"
+ucp:
+  kind: kubernetes

--- a/cmd/appcore-rp/link-dev.yaml
+++ b/cmd/appcore-rp/link-dev.yaml
@@ -22,3 +22,5 @@ server:
 workerServer:
   maxOperationConcurrency: 3
   maxOperationRetryCount: 2
+ucp:
+  kind: kubernetes

--- a/cmd/appcore-rp/link-self-hosted.yaml
+++ b/cmd/appcore-rp/link-self-hosted.yaml
@@ -22,3 +22,5 @@ server:
 workerServer:
   maxOperationConcurrency: 3
   maxOperationRetryCount: 2
+ucp:
+  kind: kubernetes

--- a/cmd/appcore-rp/radius-cloud.yaml
+++ b/cmd/appcore-rp/radius-cloud.yaml
@@ -35,3 +35,5 @@ metricsProvider:
     port: 2222
 featureFlags:
   - "PLACEHOLDER"
+ucp:
+  kind: kubernetes

--- a/cmd/appcore-rp/radius-dev.yaml
+++ b/cmd/appcore-rp/radius-dev.yaml
@@ -22,3 +22,5 @@ server:
 workerServer:
   maxOperationConcurrency: 3
   maxOperationRetryCount: 2
+ucp:
+  kind: kubernetes

--- a/cmd/appcore-rp/radius-self-hosted.yaml
+++ b/cmd/appcore-rp/radius-self-hosted.yaml
@@ -22,3 +22,5 @@ server:
 workerServer:
   maxOperationConcurrency: 3
   maxOperationRetryCount: 2
+ucp:
+  kind: kubernetes

--- a/deploy/Chart/charts/appcore-rp/link-self-host.yaml
+++ b/deploy/Chart/charts/appcore-rp/link-self-host.yaml
@@ -30,3 +30,5 @@ server:
 workerServer:
   maxOperationConcurrency: 3
   maxOperationRetryCount: 2
+ucp:
+  kind: kubernetes

--- a/deploy/Chart/charts/appcore-rp/radius-self-host.yaml
+++ b/deploy/Chart/charts/appcore-rp/radius-self-host.yaml
@@ -30,3 +30,5 @@ server:
 workerServer:
   maxOperationConcurrency: 3
   maxOperationRetryCount: 2
+ucp:
+  kind: kubernetes

--- a/deploy/Chart/charts/appcore-rp/templates/serviceaccount.yaml
+++ b/deploy/Chart/charts/appcore-rp/templates/serviceaccount.yaml
@@ -26,7 +26,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - api.radius.dev
+  - api.ucp.dev
   resources:
   - '*'
   verbs:

--- a/pkg/armrpc/hostoptions/providerconfig.go
+++ b/pkg/armrpc/hostoptions/providerconfig.go
@@ -20,6 +20,7 @@ type ProviderConfig struct {
 	Server          *ServerOptions                      `yaml:"server,omitempty"`
 	WorkerServer    *WorkerServerOptions                `yaml:"workerServer,omitempty"`
 	MetricsProvider provider.MetricsProviderOptions     `yaml:"metricsProvider"`
+	UCP             UCPConfig                           `yaml:"ucp"`
 
 	// FeatureFlags includes the list of feature flags.
 	FeatureFlags []string `yaml:"featureFlags"`

--- a/pkg/armrpc/hostoptions/ucp.go
+++ b/pkg/armrpc/hostoptions/ucp.go
@@ -1,0 +1,38 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package hostoptions
+
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+type UCPConnectionKind = string
+
+const (
+	// UCPConnectionKindDirect describes a direct connection to UCP. See pkg/sdk/NewDirectConnection.
+	UCPConnectionKindDirect UCPConnectionKind = "direct"
+
+	// KindKubernetes describes a Kubernetes connection to UCP. See pkg/sdk/NewKubernetesConnectionFromConfig.
+	UCPConnectionKindKubernetes UCPConnectionKind = "kubernetes"
+)
+
+// Config represents the configuration for a UCP connection inside our host
+// configuration file.
+type UCPConfig struct {
+	// Kind describes the kind of connection. Use UCPConnectionKindKubernetes for production and UCPConnectionKindDirect for testing with
+	// a standalone UCP process.
+	Kind UCPConnectionKind `yaml:"kind"`
+
+	// Direct describes the connection options for a direct connection.
+	Direct *UCPDirectConnectionConfig `yaml:"direct,omitempty"`
+}
+
+// DirectConnectionConfig describes the connection options for a direct connection.
+type UCPDirectConnectionConfig struct {
+	// Endpoint is the URL endpoint for the connection.
+	Endpoint string `yaml:"endpoint"`
+}

--- a/pkg/cli/kubernetes/kubernetes.go
+++ b/pkg/cli/kubernetes/kubernetes.go
@@ -35,19 +35,6 @@ import (
 	runtime_client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	LegacyAPIServerBasePath  = "/apis/api.radius.dev/v1alpha3"
-	DeploymentEngineBasePath = "/apis/api.bicep.dev/v1alpha3"
-	Location                 = "Location"
-	AzureAsyncOperation      = "Azure-AsyncOperation"
-	IngressServiceName       = "contour-envoy"
-	RadiusConfigName         = "radius-config"
-	RadiusSystemNamespace    = "radius-system"
-	UCPAPIServerBasePath     = "/apis/api.ucp.dev/v1alpha3"
-	UCPType                  = "api.ucp.dev"
-	BicepType                = "api.bicep.dev"
-)
-
 var (
 	Scheme = k8s_runtime.NewScheme()
 )

--- a/test/functional/corerp/resources/mongodb_test.go
+++ b/test/functional/corerp/resources/mongodb_test.go
@@ -111,8 +111,6 @@ func Test_MongoDBUserSecrets(t *testing.T) {
 // the creation of a mongoDB from recipe
 // container using the mongoDB link to connect to the mongoDB resource
 func Test_MongoDB_Recipe(t *testing.T) {
-	t.Skip("This test is flaky, see issue: https://github.com/project-radius/radius/issues/4992")
-
 	template := "testdata/corerp-resources-mongodb-recipe.bicep"
 	name := "corerp-resources-mongodb-recipe"
 	appNamespace := "corerp-resources-mongodb-recipe-app"
@@ -221,6 +219,8 @@ func Test_MongoDB_Recipe_Parameters(t *testing.T) {
 	template := "testdata/corerp-resources-mongodb-recipe-parameters.bicep"
 	name := "corerp-resources-mongodb-recipe-parameters"
 	appNamespace := "corerp-resources-mongodb-recipe-param-app"
+
+	t.Skip("This test is flaky, see issue: https://github.com/project-radius/radius/issues/4992")
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{


### PR DESCRIPTION
Fixes: AzDo Task 5779 5782

This change adds the settings for creating an sdk.Connection to the host configuration used by our backend services.

This change also fixes the ClusterRole which was using the wrong api group (api.radius.dev was used before we created UCP).

I found a group of constants that should been removed during the previous SDK pr, which was the source of the confusion about the api group. None of these constants are used because all of that code was deleted in the SDK PR.
