### PR TITLE
Changing Generic Resource Client Delete api to async

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -198,7 +198,7 @@ jobs:
     runs-on: self-hosted
     env:
       # Timeout used for Kubernetes functional tests
-      K8S_FUNCTIONALTEST_TIMEOUT: 20m
+      K8S_FUNCTIONALTEST_TIMEOUT: 30m
       RADIUS_CONTAINER_LOG_BASE: dist/container_logs
       RADIUS_CHART_LOCATION: deploy/Chart/
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,9 +27,9 @@ variables:
 - name: DOCKER_REGISTRY
   value: radiusdev.azurecr.io
 - name: K8S_FUNCTIONALTEST_TIMEOUT
-  value: 20m
+  value: 30m
 - name: AZURE_FUNCTIONALTEST_TIMEOUT
-  value: 20m
+  value: 30m
 - name: REL_CHANNEL
   value: edge
 - name: REL_VERSION

--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -14,24 +14,19 @@ import (
 	"strings"
 
 	"github.com/project-radius/radius/pkg/azure/clients"
+	"github.com/project-radius/radius/pkg/azure/clientv2"
 	"github.com/project-radius/radius/pkg/cli"
-
+	"github.com/project-radius/radius/pkg/cli/bicep"
+	appSwitch "github.com/project-radius/radius/pkg/cli/cmd/app/appswitch"
+	credential "github.com/project-radius/radius/pkg/cli/cmd/credential"
+	cmddeploy "github.com/project-radius/radius/pkg/cli/cmd/deploy"
 	env_create "github.com/project-radius/radius/pkg/cli/cmd/env/create"
 	env_delete "github.com/project-radius/radius/pkg/cli/cmd/env/delete"
+	envSwitch "github.com/project-radius/radius/pkg/cli/cmd/env/envswitch"
 	env_list "github.com/project-radius/radius/pkg/cli/cmd/env/list"
 	"github.com/project-radius/radius/pkg/cli/cmd/env/namespace"
 	env_show "github.com/project-radius/radius/pkg/cli/cmd/env/show"
-	"github.com/project-radius/radius/pkg/cli/kubernetes"
-	"github.com/project-radius/radius/pkg/cli/kubernetes/logstream"
-	"github.com/project-radius/radius/pkg/cli/kubernetes/portforward"
-	"github.com/project-radius/radius/pkg/cli/setup"
-
-	"github.com/project-radius/radius/pkg/cli/bicep"
-	appSwitch "github.com/project-radius/radius/pkg/cli/cmd/app/appswitch"
-	cmddeploy "github.com/project-radius/radius/pkg/cli/cmd/deploy"
-	envSwitch "github.com/project-radius/radius/pkg/cli/cmd/env/envswitch"
 	group "github.com/project-radius/radius/pkg/cli/cmd/group"
-	credential "github.com/project-radius/radius/pkg/cli/cmd/credential"
 	"github.com/project-radius/radius/pkg/cli/cmd/radInit"
 	recipe_list "github.com/project-radius/radius/pkg/cli/cmd/recipe/list"
 	recipe_register "github.com/project-radius/radius/pkg/cli/cmd/recipe/register"
@@ -50,8 +45,12 @@ import (
 	"github.com/project-radius/radius/pkg/cli/deploy"
 	"github.com/project-radius/radius/pkg/cli/framework"
 	"github.com/project-radius/radius/pkg/cli/helm"
+	"github.com/project-radius/radius/pkg/cli/kubernetes"
+	"github.com/project-radius/radius/pkg/cli/kubernetes/logstream"
+	"github.com/project-radius/radius/pkg/cli/kubernetes/portforward"
 	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/project-radius/radius/pkg/cli/prompt"
+	"github.com/project-radius/radius/pkg/cli/setup"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -82,6 +81,11 @@ func prettyPrintRPError(err error) string {
 			return m
 		}
 	} else if new := clients.TryUnfoldServiceError(err); new != nil {
+		m, err := prettyPrintJSON(new)
+		if err == nil {
+			return m
+		}
+	} else if new := clientv2.TryUnfoldResponseError(err); new != nil {
 		m, err := prettyPrintJSON(new)
 		if err == nil {
 			return m

--- a/pkg/azure/clientv2/unfold_test.go
+++ b/pkg/azure/clientv2/unfold_test.go
@@ -1,0 +1,133 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package clientv2
+
+import (
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	baseURI            = "https://127.0.0.1:49176/apis/api.ucp.dev/v1alpha3"
+	deploymentPlane    = "/planes/deployments/local"
+	resourceID         = "/resourceGroups/kind-radius-wi/providers/Microsoft.Resources/deployments/rad-deploy-test"
+	operationsEndpoint = "/operations"
+)
+
+func TestTryUnfoldResponseError(t *testing.T) {
+	type args struct {
+		resp *http.Response
+	}
+	tests := []struct {
+		name string
+		args args
+		want *v1.ErrorDetails
+	}{
+		{
+			name: "nil",
+			args: args{
+				resp: &http.Response{
+					Status:     "404 Not Found",
+					StatusCode: http.StatusNotFound,
+					Body:       http.NoBody,
+					Request: &http.Request{
+						Method: http.MethodGet,
+						URL:    parseURL(t, roleAssignmentBaseURL+"/"+roleAssigmentName+"?api-version="+apiVersion),
+					},
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			respErr := runtime.NewResponseError(tt.args.resp)
+			_ = TryUnfoldResponseError(respErr)
+		})
+	}
+}
+
+func TestUnfoldResponseError(t *testing.T) {
+	type args struct {
+		resp *http.Response
+	}
+	tests := []struct {
+		name string
+		args args
+		code string
+	}{
+		{
+			name: "deployment-failed",
+			args: args{
+				resp: &http.Response{
+					Status:     "200 OK",
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{ "id": null, "error": { "code": "DeploymentFailed", "target": null, "message": "At least one resource deployment operation failed." } }`)),
+					Request: &http.Request{
+						Method: http.MethodGet,
+						URL:    parseURL(t, baseURI+deploymentPlane+resourceID+operationsEndpoint+"?api-version="+apiVersion),
+					},
+				},
+			},
+			code: "DeploymentFailed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			respErr := runtime.NewResponseError(tt.args.resp)
+			errorDetails := TryUnfoldResponseError(respErr)
+			require.Equal(t, tt.code, errorDetails.Code)
+		})
+	}
+}
+
+func Test_readResponseBody(t *testing.T) {
+	type args struct {
+		resp *http.Response
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "nil-body",
+			args: args{
+				resp: &http.Response{
+					Status:     "200 OK",
+					StatusCode: http.StatusOK,
+					Body:       nil,
+					Request: &http.Request{
+						Method: http.MethodGet,
+						URL:    parseURL(t, baseURI+deploymentPlane+resourceID+operationsEndpoint+"?api-version="+apiVersion),
+					},
+				},
+			},
+			want:    []byte{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := readResponseBody(tt.args.resp)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("readResponseBody() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("readResponseBody() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cli/clients_new/generated/zz_generated_genericresources_client.go
+++ b/pkg/cli/clients_new/generated/zz_generated_genericresources_client.go
@@ -109,28 +109,46 @@ func (client *GenericResourcesClient) createOrUpdateHandleResponse(resp *http.Re
 	return result, nil
 }
 
-// Delete - Deletes an existing Generic resource
+// BeginDelete - Deletes an existing Generic resource
 // If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2022-03-15-privatepreview
 // resourceName - The name of the generic resource
-// options - GenericResourcesClientDeleteOptions contains the optional parameters for the GenericResourcesClient.Delete method.
-func (client *GenericResourcesClient) Delete(ctx context.Context, resourceName string, options *GenericResourcesClientDeleteOptions) (GenericResourcesClientDeleteResponse, error) {
+// options - GenericResourcesClientBeginDeleteOptions contains the optional parameters for the GenericResourcesClient.BeginDelete
+// method.
+func (client *GenericResourcesClient) BeginDelete(ctx context.Context, resourceName string, options *GenericResourcesClientBeginDeleteOptions) (*runtime.Poller[GenericResourcesClientDeleteResponse], error) {
+	if options == nil || options.ResumeToken == "" {
+		resp, err := client.deleteOperation(ctx, resourceName, options)
+		if err != nil {
+			return nil, err
+		}
+		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[GenericResourcesClientDeleteResponse]{
+			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
+		})
+	} else {
+		return runtime.NewPollerFromResumeToken[GenericResourcesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+	}
+}
+
+// Delete - Deletes an existing Generic resource
+// If the operation fails it returns an *azcore.ResponseError type.
+// Generated from API version 2022-03-15-privatepreview
+func (client *GenericResourcesClient) deleteOperation(ctx context.Context, resourceName string, options *GenericResourcesClientBeginDeleteOptions) (*http.Response, error) {
 	req, err := client.deleteCreateRequest(ctx, resourceName, options)
 	if err != nil {
-		return GenericResourcesClientDeleteResponse{}, err
+		return nil, err
 	}
 	resp, err := client.pl.Do(req)
 	if err != nil {
-		return GenericResourcesClientDeleteResponse{}, err
+		return nil, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
-		return GenericResourcesClientDeleteResponse{}, runtime.NewResponseError(resp)
+		return nil, runtime.NewResponseError(resp)
 	}
-	return GenericResourcesClientDeleteResponse{}, nil
+	 return resp, nil
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *GenericResourcesClient) deleteCreateRequest(ctx context.Context, resourceName string, options *GenericResourcesClientDeleteOptions) (*policy.Request, error) {
+func (client *GenericResourcesClient) deleteCreateRequest(ctx context.Context, resourceName string, options *GenericResourcesClientBeginDeleteOptions) (*policy.Request, error) {
 	urlPath := "/{rootScope}/providers/{resourceType}/{resourceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
 	urlPath = strings.ReplaceAll(urlPath, "{resourceType}", client.resourceType)

--- a/pkg/cli/clients_new/generated/zz_generated_models.go
+++ b/pkg/cli/clients_new/generated/zz_generated_models.go
@@ -76,14 +76,15 @@ type GenericResourceProperties struct {
 	PropertyValue map[string]interface{} `json:"propertyValue,omitempty"`
 }
 
+// GenericResourcesClientBeginDeleteOptions contains the optional parameters for the GenericResourcesClient.BeginDelete method.
+type GenericResourcesClientBeginDeleteOptions struct {
+	// Resumes the LRO from the provided token.
+	ResumeToken string
+}
+
 // GenericResourcesClientCreateOrUpdateOptions contains the optional parameters for the GenericResourcesClient.CreateOrUpdate
 // method.
 type GenericResourcesClientCreateOrUpdateOptions struct {
-	// placeholder for future optional parameters
-}
-
-// GenericResourcesClientDeleteOptions contains the optional parameters for the GenericResourcesClient.Delete method.
-type GenericResourcesClientDeleteOptions struct {
 	// placeholder for future optional parameters
 }
 

--- a/pkg/cli/swagger/genericResource.json
+++ b/pkg/cli/swagger/genericResource.json
@@ -211,7 +211,11 @@
                 "$ref": "#/definitions/ErrorResponse"
               }
             }
-          }
+          },
+          "x-ms-long-running-operation-options": {
+            "final-state-via": "azure-async-operation"
+          },
+          "x-ms-long-running-operation": true
         }
       }
     },

--- a/pkg/cli/ucp/ucp_management.go
+++ b/pkg/cli/ucp/ucp_management.go
@@ -157,7 +157,12 @@ func (amc *ARMApplicationsManagementClient) DeleteResource(ctx context.Context, 
 	var respFromCtx *http.Response
 	ctxWithResp := runtime.WithCaptureResponse(ctx, &respFromCtx)
 
-	_, err = client.Delete(ctxWithResp, resourceName, nil)
+	poller, err := client.BeginDelete(ctxWithResp, resourceName, nil)
+	if err != nil {
+		return false, err
+	}
+
+	_, err = poller.PollUntilDone(ctx, nil)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/linkrp/frontend/controller/mongodatabases/deletemongodatabase.go
+++ b/pkg/linkrp/frontend/controller/mongodatabases/deletemongodatabase.go
@@ -22,7 +22,7 @@ var _ ctrl.Controller = (*DeleteMongoDatabase)(nil)
 
 var (
 	// AsyncDeleteMongoDatabaseOperationTimeout is the default timeout duration of async delete container operation.
-	AsyncDeleteMongoDatabaseOperationTimeout = time.Duration(300) * time.Second
+	AsyncDeleteMongoDatabaseOperationTimeout = time.Duration(900) * time.Second
 )
 
 // DeleteMongoDatabase is the controller implementation to delete mongoDatabase link resource.

--- a/pkg/linkrp/handlers/arm_handler.go
+++ b/pkg/linkrp/handlers/arm_handler.go
@@ -71,16 +71,6 @@ func (handler *armHandler) Delete(ctx context.Context, resource *outputresource.
 		return err
 	}
 
-	resp, err := client.CheckExistenceByID(ctx, id, apiVersion, &armresources.ClientCheckExistenceByIDOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to check existence of resource %q: %w", id, err)
-	}
-
-	if !resp.Success {
-		logger.Info(fmt.Sprintf("Resource %s does not exist", id))
-		return nil
-	}
-
 	poller, err := client.BeginDeleteByID(ctx, id, apiVersion, &armresources.ClientBeginDeleteByIDOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to delete resource %q: %w", id, err)

--- a/test/functional/corerp/resources/mongodb_test.go
+++ b/test/functional/corerp/resources/mongodb_test.go
@@ -169,7 +169,6 @@ func Test_MongoDB_Recipe(t *testing.T) {
 // the creation of a mongoDB from a devrecipe that is linked to the environment when created with useDevRecipes = true
 // the container using the mongoDB link to connect to the mongoDB resource
 func Test_MongoDB_DevRecipe(t *testing.T) {
-
 	template := "testdata/corerp-resources-mongodb-devrecipe.bicep"
 	name := "corerp-resources-mongodb-devrecipe"
 	appNamespace := "corerp-resources-mongodb-devrecipe-app"

--- a/test/functional/corerp/resources/testdata/corerp-resources-mongodb-recipe.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-mongodb-recipe.bicep
@@ -23,7 +23,7 @@ resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
     recipes: {
       mongodb: {
           linkType: 'Applications.Link/mongoDatabases' 
-          templatePath: 'radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0' 
+          templatePath: 'radiusdev.azurecr.io/recipes/functionaltest/basic/mongodatabases/azure:1.0' 
       }
     }
   }


### PR DESCRIPTION
# Description

Making Generic Resource Client Delete api async
Added swagger changes to declare the delete operation async and generated the client code.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
