### PR TITLE
Add nightly test for latest release

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,25 @@
+name: Nightly Tests
+
+on:
+  # Run at 00:00 UTC every day
+  schedule:
+    - cron: '0 0 * * *'
+  # Add manual trigger
+  workflow_dispatch:
+
+jobs:
+  install-latest:
+    name: Install and initialize latest release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create KinD Cluster
+        uses: helm/kind-action@v1.5.0
+        with:
+          cluster_name: radius
+      - name: Install latest rad
+        run: |
+          wget -q "https://get.radapp.dev/tools/rad/install.sh" -O - | /bin/bash
+      - name: Initialize Radius
+        run: |
+          rad env init kubernetes
+          cat ~/.rad/config.yaml

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -23,3 +23,7 @@ jobs:
         run: |
           rad env init kubernetes
           cat ~/.rad/config.yaml
+      - name: Make test
+        run: make test
+
+      

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,13 @@ resources:
 
 trigger: none
 
+schedules:
+- cron: "0 0 * * *"
+  displayName: Daily midnight build
+  branches:
+    include:
+    - release/0.16
+
 pr: [ main, features/*]
 
 variables:


### PR DESCRIPTION
# Description

Adds a nightly test that checks if the latest Radius release can be installed. This ensures customers can install the rad CLI and initialize a Radius environment

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
