### PR TITLE
Use UCP deployment client for recipes

### DIFF
--- a/pkg/azure/clientv2/apiversion.go
+++ b/pkg/azure/clientv2/apiversion.go
@@ -6,12 +6,11 @@
 package clientv2
 
 var (
-	StateStoreClientAPIVersion           = "2022-09-01"
-	ServiceBusClientAPIVersion           = "2022-01-01-preview"
-	MSIClientAPIVersion                  = "2022-01-31-preview"
-	RoleAssignmentClientAPIVersion       = "2022-04-01"
-	DeploymentsClientAPIVersion          = "2020-10-01"
-	DeploymentOperationsClientAPIVersion = "2020-10-01"
+	AccountsClientAPIVersion       = "2022-09-01"
+	StateStoreClientAPIVersion     = "2022-09-01"
+	ServiceBusClientAPIVersion     = "2022-01-01-preview"
+	MSIClientAPIVersion            = "2022-01-31-preview"
+	RoleAssignmentClientAPIVersion = "2022-04-01"
 
 	// https://github.com/Azure/azure-rest-api-specs/blob/main/specification/sql/resource-manager/readme.md
 	SQLManagementClientAPIVersion = "2021-11-01"

--- a/pkg/cli/deployment/deploy.go
+++ b/pkg/cli/deployment/deploy.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/google/uuid"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
-	"github.com/project-radius/radius/pkg/azure/clientv2"
 	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
 	sdkclients "github.com/project-radius/radius/pkg/sdk/clients"
@@ -111,7 +110,7 @@ func (dc *ResourceDeploymentClient) startDeployment(ctx context.Context, name st
 			},
 		},
 		resourceId,
-		clientv2.DeploymentsClientAPIVersion)
+		sdkclients.DeploymentsClientAPIVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -120,12 +119,13 @@ func (dc *ResourceDeploymentClient) startDeployment(ctx context.Context, name st
 }
 
 func (dc *ResourceDeploymentClient) GetProviderConfigs() sdkclients.ProviderConfig {
-	var providerConfigs sdkclients.ProviderConfig
+	providerConfig := sdkclients.NewDefaultProviderConfig(dc.RadiusResourceGroup)
+
 	if dc.AzProvider != nil {
 		if dc.AzProvider.SubscriptionID != "" && dc.AzProvider.ResourceGroup != "" {
 			scope := "/subscriptions/" + dc.AzProvider.SubscriptionID + "/resourceGroups/" + dc.AzProvider.ResourceGroup
-			providerConfigs.Az = &sdkclients.Az{
-				Type: "AzureResourceManager",
+			providerConfig.Az = &sdkclients.Az{
+				Type: sdkclients.ProviderTypeAzure,
 				Value: sdkclients.Value{
 					Scope: scope,
 				},
@@ -135,33 +135,15 @@ func (dc *ResourceDeploymentClient) GetProviderConfigs() sdkclients.ProviderConf
 
 	if dc.AWSProvider != nil {
 		scope := "/planes/aws/aws/accounts/" + dc.AWSProvider.AccountId + "/regions/" + dc.AWSProvider.Region
-		providerConfigs.AWS = &sdkclients.AWS{
-			Type: "AWS",
+		providerConfig.AWS = &sdkclients.AWS{
+			Type: sdkclients.ProviderTypeAWS,
 			Value: sdkclients.Value{
 				Scope: scope,
 			},
 		}
 	}
 
-	if dc.RadiusResourceGroup != "" {
-		scope := "/planes/radius/local/resourceGroups/" + dc.RadiusResourceGroup
-		providerConfigs.Radius = &sdkclients.Radius{
-			Type: "Radius",
-			Value: sdkclients.Value{
-				Scope: scope,
-			},
-		}
-
-		scope = "/planes/deployments/local/resourceGroups/" + dc.RadiusResourceGroup
-		providerConfigs.Deployments = &sdkclients.Deployments{
-			Type: "Microsoft.Resources",
-			Value: sdkclients.Value{
-				Scope: scope,
-			},
-		}
-	}
-
-	return providerConfigs
+	return providerConfig
 }
 
 func (dc *ResourceDeploymentClient) createSummary(deployment *armresources.DeploymentExtended) (clients.DeploymentResult, error) {
@@ -298,7 +280,7 @@ func (dc *ResourceDeploymentClient) listOperations(ctx context.Context, name str
 
 	resourceId = ucpresources.MakeUCPID(scopes, types)
 
-	ops, err := dc.OperationsClient.List(ctx, dc.RadiusResourceGroup, name, resourceId, clientv2.DeploymentOperationsClientAPIVersion, nil)
+	ops, err := dc.OperationsClient.List(ctx, dc.RadiusResourceGroup, name, resourceId, sdkclients.DeploymentOperationsClientAPIVersion, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/linkrp/backend/service.go
+++ b/pkg/linkrp/backend/service.go
@@ -54,7 +54,7 @@ func (s *Service) Run(ctx context.Context) error {
 		return err
 	}
 
-	linkAppModel, err := model.NewApplicationModel(s.Options.Arm, s.KubeClient)
+	linkAppModel, err := model.NewApplicationModel(s.Options.Arm, s.KubeClient, s.Options.UCPConnection)
 	if err != nil {
 		return fmt.Errorf("failed to initialize application model: %w", err)
 	}

--- a/pkg/linkrp/frontend/service.go
+++ b/pkg/linkrp/frontend/service.go
@@ -42,7 +42,7 @@ func (s *Service) Run(ctx context.Context) error {
 		return err
 	}
 
-	linkAppModel, err := model.NewApplicationModel(s.Options.Arm, s.KubeClient)
+	linkAppModel, err := model.NewApplicationModel(s.Options.Arm, s.KubeClient, s.Options.UCPConnection)
 	if err != nil {
 		return fmt.Errorf("failed to initialize application model: %w", err)
 	}

--- a/pkg/linkrp/handlers/recipe_handler.go
+++ b/pkg/linkrp/handlers/recipe_handler.go
@@ -10,24 +10,33 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/go-logr/logr"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
-	"github.com/project-radius/radius/pkg/azure/armauth"
-	"github.com/project-radius/radius/pkg/azure/clientv2"
+	aztoken "github.com/project-radius/radius/pkg/azure/tokencredentials"
 	coreDatamodel "github.com/project-radius/radius/pkg/corerp/datamodel"
 	"github.com/project-radius/radius/pkg/linkrp"
 	"github.com/project-radius/radius/pkg/linkrp/datamodel"
-	"github.com/project-radius/radius/pkg/logging"
+	"github.com/project-radius/radius/pkg/sdk"
+	"github.com/project-radius/radius/pkg/sdk/clients"
+	"github.com/project-radius/radius/pkg/ucp/resources"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/registry/remote"
 )
 
-const deploymentPrefix = "recipe"
+const (
+	deploymentPrefix = "recipe"
+
+	// pollFrequency is the polling frequency of the deployment client.
+	// This is set to a relatively low number because we're using the UCP deployment engine
+	// inside the cluster. This is a good balance to feel responsible for quick operations
+	// like deploying Kubernetes resources without generating a wasteful amount of traffic.
+	// The default would be 30 seconds.
+	pollFrequency = time.Second * 5
+)
 
 // RecipeHandler is an interface to deploy and delete recipe resources
 //
@@ -36,35 +45,25 @@ type RecipeHandler interface {
 	DeployRecipe(ctx context.Context, recipe linkrp.RecipeProperties, envProviders coreDatamodel.Providers, recipeContext linkrp.RecipeContext) ([]string, error)
 }
 
-func NewRecipeHandler(arm *armauth.ArmConfig) RecipeHandler {
-	return &azureRecipeHandler{
-		arm: arm,
+func NewRecipeHandler(connection sdk.Connection) RecipeHandler {
+	return &recipeHandler{
+		connection: connection,
 	}
 }
 
-type azureRecipeHandler struct {
-	arm *armauth.ArmConfig
+type recipeHandler struct {
+	connection sdk.Connection
 }
 
 // DeployRecipe deploys the recipe template fetched from the provided recipe TemplatePath using the providers scope.
 // Currently the implementation assumes TemplatePath is location of an ARM JSON template in Azure Container Registry.
 // Returns resource IDs of the resources deployed by the template
-func (handler *azureRecipeHandler) DeployRecipe(ctx context.Context, recipe linkrp.RecipeProperties, envProviders coreDatamodel.Providers, recipeContext linkrp.RecipeContext) (deployedResources []string, err error) {
+func (handler *recipeHandler) DeployRecipe(ctx context.Context, recipe linkrp.RecipeProperties, envProviders coreDatamodel.Providers, recipeContext linkrp.RecipeContext) (deployedResources []string, err error) {
 	if recipe.TemplatePath == "" {
 		return nil, fmt.Errorf("recipe template path cannot be empty")
 	}
-	if envProviders == (coreDatamodel.Providers{}) {
-		return nil, v1.NewClientErrInvalidRequest(fmt.Sprintf("failed to deploy recipe %q. Environment provider scope is required to deploy link recipes.", recipe.Name))
-	}
-	subscriptionID, resourceGroup, err := parseAzureProvider(&envProviders)
-	if err != nil {
-		return nil, err
-	}
 
-	logger := logr.FromContextOrDiscard(ctx).WithValues(
-		logging.LogFieldResourceGroup, resourceGroup,
-		logging.LogFieldSubscriptionID, subscriptionID,
-	)
+	logger := logr.FromContextOrDiscard(ctx)
 	logger.Info(fmt.Sprintf("Deploying recipe: %q, template: %q", recipe.Name, recipe.TemplatePath))
 
 	registryRepo, tag, err := parseTemplatePath(recipe.TemplatePath)
@@ -101,36 +100,55 @@ func (handler *azureRecipeHandler) DeployRecipe(ctx context.Context, recipe link
 	parameters := createRecipeParameters(recipe.Parameters, recipe.EnvParameters, isContextParameterDefined, &recipeContext)
 
 	// Using ARM deployment client to deploy ARM JSON template fetched from ACR
-	client, err := clientv2.NewDeploymentsClient(subscriptionID, &handler.arm.ClientOptions)
+	client, err := clients.NewResourceDeploymentsClient(&clients.Options{
+		ARMClientOptions: sdk.NewClientOptions(handler.connection),
+		BaseURI:          handler.connection.Endpoint(),
+		Cred:             &aztoken.AnonymousCredential{},
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	deploymentName := deploymentPrefix + strconv.FormatInt(time.Now().UnixNano(), 10)
-	poller, err := client.BeginCreateOrUpdate(
-		ctx,
-		resourceGroup,
-		deploymentName,
-		armresources.Deployment{
-			Properties: &armresources.DeploymentProperties{
-				Template:   recipeData,
-				Parameters: parameters,
-				Mode:       to.Ptr(armresources.DeploymentModeIncremental),
-			},
-		},
-		&armresources.DeploymentsClientBeginCreateOrUpdateOptions{},
-	)
+	deploymentID, err := createDeploymentID(recipeContext.Resource.ID, deploymentName)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := poller.PollUntilDone(ctx, nil)
+	// Provider config will specify the Azure and AWS scopes (if provided).
+	providerConfig := createProviderConfig(deploymentID.FindScope(resources.ResourceGroupsSegment), envProviders)
+
+	logger.Info("deploying bicep template for recipe", "deploymentID", deploymentID)
+	if providerConfig.AWS != nil {
+		logger.Info("using AWS provider", "deploymentID", deploymentID, "scope", providerConfig.AWS.Value.Scope)
+	}
+	if providerConfig.Az != nil {
+		logger.Info("using Azure provider", "deploymentID", deploymentID, "scope", providerConfig.Az.Value.Scope)
+	}
+
+	poller, err := client.CreateOrUpdate(
+		ctx,
+		clients.Deployment{
+			Properties: &clients.DeploymentProperties{
+				Template:       recipeData,
+				Parameters:     parameters,
+				ProviderConfig: providerConfig,
+				Mode:           armresources.DeploymentModeIncremental,
+			},
+		},
+		deploymentID.String(),
+		clients.DeploymentsClientAPIVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: pollFrequency})
 	if err != nil {
 		return nil, err
 	}
 
 	if *resp.Properties.ProvisioningState != armresources.ProvisioningStateSucceeded {
-		return nil, fmt.Errorf("failed to deploy the recipe %q, template path: %q, deployment: %q", recipe.Name, recipe.TemplatePath, deploymentName)
+		return nil, fmt.Errorf("failed to deploy the recipe %q, template path: %q, deployment: %q", recipe.Name, recipe.TemplatePath, deploymentID.Name())
 	}
 
 	for _, id := range resp.Properties.OutputResources {
@@ -195,20 +213,37 @@ func getRecipeBytes(ctx context.Context, repo *remote.Repository, layerDigest st
 	return pulledBlob, nil
 }
 
-// parseAzureProvider parses the scope to get the subscriptionID and resourceGroup
-func parseAzureProvider(providers *coreDatamodel.Providers) (subscriptionID string, resourceGroup string, err error) {
-	if providers.Azure == (coreDatamodel.ProvidersAzure{}) {
-		return "", "", v1.NewClientErrInvalidRequest("environment does not contain Azure provider scope required to deploy recipes on Azure")
+func createDeploymentID(resourceID string, deploymentName string) (resources.ID, error) {
+	parsed, err := resources.ParseResource(resourceID)
+	if err != nil {
+		return resources.ID{}, err
 	}
-	// valid scope: "/subscriptions/test-sub/resourceGroups/test-group"
-	scope := strings.Split(providers.Azure.Scope, "/")
-	if len(scope) != 5 {
-		return "", "", v1.NewClientErrInvalidRequest(fmt.Sprintf("invalid azure scope. Valid scope eg: %q", "/subscriptions/<subscriptionID>/resourceGroups/<resourceGroup>"))
+
+	resourceGroup := parsed.FindScope(resources.ResourceGroupsSegment)
+	raw := fmt.Sprintf("/planes/deployments/local/resourceGroups/%s/providers/Microsoft.Resources/deployments/%s", resourceGroup, deploymentName)
+	return resources.ParseResource(raw)
+}
+
+func createProviderConfig(resourceGroup string, envProviders coreDatamodel.Providers) clients.ProviderConfig {
+	config := clients.NewDefaultProviderConfig(resourceGroup)
+
+	if envProviders.Azure != (coreDatamodel.ProvidersAzure{}) {
+		config.Az = &clients.Az{
+			Type: clients.ProviderTypeAzure,
+			Value: clients.Value{
+				Scope: envProviders.Azure.Scope,
+			},
+		}
 	}
-	subscriptionID = scope[2]
-	resourceGroup = scope[4]
-	if subscriptionID == "" || resourceGroup == "" {
-		return "", "", v1.NewClientErrInvalidRequest("subscriptionID and resourceGroup must be provided to deploy link recipes to Azure")
+
+	if envProviders.AWS != (coreDatamodel.ProvidersAWS{}) {
+		config.AWS = &clients.AWS{
+			Type: clients.ProviderTypeAWS,
+			Value: clients.Value{
+				Scope: envProviders.AWS.Scope,
+			},
+		}
 	}
-	return
+
+	return config
 }

--- a/pkg/linkrp/model/application_model.go
+++ b/pkg/linkrp/model/application_model.go
@@ -21,12 +21,13 @@ import (
 	"github.com/project-radius/radius/pkg/linkrp/renderers/rediscaches"
 	"github.com/project-radius/radius/pkg/linkrp/renderers/sqldatabases"
 	"github.com/project-radius/radius/pkg/resourcemodel"
+	"github.com/project-radius/radius/pkg/sdk"
 
 	"github.com/project-radius/radius/pkg/resourcekinds"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func NewApplicationModel(arm *armauth.ArmConfig, k8s client.Client) (ApplicationModel, error) {
+func NewApplicationModel(arm *armauth.ArmConfig, k8s client.Client, connection sdk.Connection) (ApplicationModel, error) {
 	// Configure the providers supported by the appmodel
 	supportedProviders := map[string]bool{
 		resourcemodel.ProviderKubernetes: true,
@@ -152,7 +153,7 @@ func NewApplicationModel(arm *armauth.ArmConfig, k8s client.Client) (Application
 	}
 
 	recipeModel := RecipeModel{
-		RecipeHandler: handlers.NewRecipeHandler(arm),
+		RecipeHandler: handlers.NewRecipeHandler(connection),
 	}
 
 	err := checkForDuplicateRegistrations(radiusResourceModel, outputResourceModel)

--- a/pkg/sdk/clients/apiversion.go
+++ b/pkg/sdk/clients/apiversion.go
@@ -1,0 +1,14 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package clients
+
+var (
+	// DeploymentsClientAPIVersion is the API version of the UCP deployment client.
+	DeploymentsClientAPIVersion = "2020-10-01"
+
+	// DeploymentOperationsClientAPIVersion is the API version of the UCP deployment operations client.
+	DeploymentOperationsClientAPIVersion = "2020-10-01"
+)

--- a/pkg/sdk/clients/providerconfig.go
+++ b/pkg/sdk/clients/providerconfig.go
@@ -1,0 +1,40 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package clients
+
+const (
+	// ProviderTypeAzure is used to specify the provider configuration for Azure resources.
+	ProviderTypeAzure = "AzureResourceManager"
+	// ProviderTypeAWS is used to specify the provider configuration for AWS resources.
+	ProviderTypeAWS = "AWS"
+	// ProviderTypeDeployments is used to specify the provider configuration for Bicep modules.
+	ProviderTypeDeployments = "Microsoft.Resources"
+	// ProviderTypeRadius is used to specify the provider configuration for Radius resources.
+	ProviderTypeRadius = "Radius"
+)
+
+// NewDefaultProviderConfig creates a new ProviderConfig for use with ResourceDeploymentsClient.
+//
+// The default config will include configuration for Radius resources, Kuberenetes resources, and Bicep modules.
+// AWS and Azure resources must be added separately.
+func NewDefaultProviderConfig(resourceGroup string) ProviderConfig {
+	config := ProviderConfig{
+		Deployments: &Deployments{
+			Type: "Microsoft.Resources",
+			Value: Value{
+				Scope: "/planes/deployments/local/resourceGroups/" + resourceGroup,
+			},
+		},
+		Radius: &Radius{
+			Type: "Radius",
+			Value: Value{
+				Scope: "/planes/radius/local/resourceGroups/" + resourceGroup,
+			},
+		},
+	}
+
+	return config
+}

--- a/pkg/sdk/clients/providerconfig_test.go
+++ b/pkg/sdk/clients/providerconfig_test.go
@@ -1,0 +1,32 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package clients
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GetProviderConfigs(t *testing.T) {
+	expectedConfig := ProviderConfig{
+		Deployments: &Deployments{
+			Type: ProviderTypeDeployments,
+			Value: Value{
+				Scope: "/planes/deployments/local/resourceGroups/" + "testrg",
+			},
+		},
+		Radius: &Radius{
+			Type: ProviderTypeRadius,
+			Value: Value{
+				Scope: "/planes/radius/local/resourceGroups/" + "testrg",
+			},
+		},
+	}
+
+	providerConfig := NewDefaultProviderConfig("testrg")
+	require.Equal(t, providerConfig, expectedConfig)
+}

--- a/test/functional/corerp/resources/testdata/corerp-resources-dapr-statestore-recipe.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-dapr-statestore-recipe.bicep
@@ -17,7 +17,7 @@ resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
     }
     providers: {
       azure: {
-        scope: '/subcriptions/${sub}/resourceGroup/${rg}'
+        scope: '/subscriptions/${sub}/resourceGroups/${rg}'
       }
     }
     recipes: {

--- a/test/functional/corerp/resources/testdata/corerp-resources-mongodb-devrecipe.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-mongodb-devrecipe.bicep
@@ -17,7 +17,7 @@ resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
     }
     providers: {
       azure: {
-        scope: '/subcriptions/${sub}/resourceGroup/${rg}'
+        scope: '/subscriptions/${sub}/resourceGroups/${rg}'
       }
     }
     useDevRecipes: true

--- a/test/functional/corerp/resources/testdata/corerp-resources-mongodb-recipe-context.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-mongodb-recipe-context.bicep
@@ -17,7 +17,7 @@ resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
     }
     providers: {
       azure: {
-        scope: '/subcriptions/${sub}/resourceGroup/${rg}'
+        scope: '/subscriptions/${sub}/resourceGroups/${rg}'
       }
     }
     recipes: {

--- a/test/functional/corerp/resources/testdata/corerp-resources-mongodb-recipe-parameters.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-mongodb-recipe-parameters.bicep
@@ -17,7 +17,7 @@ resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
     }
     providers: {
       azure: {
-        scope: '/subcriptions/${sub}/resourceGroup/${rg}'
+        scope: '/subscriptions/${sub}/resourceGroups/${rg}'
       }
     }
     recipes: {

--- a/test/functional/corerp/resources/testdata/corerp-resources-mongodb-recipe.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-mongodb-recipe.bicep
@@ -17,7 +17,7 @@ resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
     }
     providers: {
       azure: {
-        scope: '/subcriptions/${sub}/resourceGroup/${rg}'
+        scope: '/subscriptions/${sub}/resourceGroups/${rg}'
       }
     }
     recipes: {


### PR DESCRIPTION
This change enables the UCP deployment client for recipes (instead of the Azure deployment client). This means we'll be deploying Bicep templates in recipes to the local deployment engine instead of to Azure. This enables us to use Kubernetes and AWS resources in recipes (almost).
