### PR TITLE
Add recipe support for redis cache

### DIFF
--- a/pkg/linkrp/renderers/rediscaches/renderer.go
+++ b/pkg/linkrp/renderers/rediscaches/renderer.go
@@ -69,9 +69,9 @@ func (r Renderer) Render(ctx context.Context, dm v1.ResourceDataModel, options r
 }
 
 func renderAzureRecipe(resource *datamodel.RedisCache, options renderers.RenderOptions, secretValues map[string]rpv1.SecretValueReference, computedValues map[string]renderers.ComputedValueReference) (renderers.RendererOutput, error) {
-	if options.RecipeProperties.LinkType != resource.ResourceTypeName() {
-		return renderers.RendererOutput{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("link type %q of provided recipe %q is incompatible with %q resource type. Recipe link type must match link resource type.",
-			options.RecipeProperties.LinkType, options.RecipeProperties.Name, linkrp.RedisCachesResourceType))
+	err := renderers.ValidateLinkType(resource, options)
+	if err != nil {
+		return renderers.RendererOutput{}, err
 	}
 
 	recipeData := linkrp.RecipeData{

--- a/pkg/linkrp/renderers/rediscaches/renderer.go
+++ b/pkg/linkrp/renderers/rediscaches/renderer.go
@@ -13,7 +13,6 @@ import (
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/azure/azresources"
 	"github.com/project-radius/radius/pkg/azure/clientv2"
-	"github.com/project-radius/radius/pkg/linkrp"
 	"github.com/project-radius/radius/pkg/linkrp/datamodel"
 	"github.com/project-radius/radius/pkg/linkrp/renderers"
 	"github.com/project-radius/radius/pkg/resourcekinds"
@@ -186,7 +185,7 @@ func getProvidedComputedValues(properties datamodel.RedisCacheProperties) map[st
 	return computedValues
 }
 
-func buildSecretValueReference(secretValues map[string]rpv1.SecretValueReference) map[string]rpv1.SecretValueReference {
+func buildSecretValueReference(secretValues map[string]rpv1.SecretValueReference) {
 	if _, ok := secretValues[renderers.PasswordStringHolder]; !ok {
 		secretValues[renderers.PasswordStringHolder] = rpv1.SecretValueReference{
 			LocalID:       rpv1.LocalIDAzureRedis,
@@ -206,7 +205,6 @@ func buildSecretValueReference(secretValues map[string]rpv1.SecretValueReference
 			},
 		}
 	}
-	return secretValues
 }
 
 func buildComputedValuesReference(computedValues map[string]renderers.ComputedValueReference) {

--- a/pkg/linkrp/renderers/rediscaches/renderer.go
+++ b/pkg/linkrp/renderers/rediscaches/renderer.go
@@ -13,6 +13,7 @@ import (
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/azure/azresources"
 	"github.com/project-radius/radius/pkg/azure/clientv2"
+	"github.com/project-radius/radius/pkg/linkrp"
 	"github.com/project-radius/radius/pkg/linkrp/datamodel"
 	"github.com/project-radius/radius/pkg/linkrp/renderers"
 	"github.com/project-radius/radius/pkg/resourcekinds"
@@ -41,13 +42,14 @@ func (r Renderer) Render(ctx context.Context, dm v1.ResourceDataModel, options r
 		return renderers.RendererOutput{}, err
 	}
 
-	if resource.Properties.Resource == "" {
-		return renderers.RendererOutput{
-			Resources:      []rpv1.OutputResource{},
-			ComputedValues: computedValues,
-			SecretValues:   secretValues,
-		}, nil
-	} else {
+	switch resource.Properties.Mode {
+	case datamodel.LinkModeRecipe:
+		rendererOutput, err := renderAzureRecipe(resource, options, secretValues, computedValues)
+		if err != nil {
+			return renderers.RendererOutput{}, err
+		}
+		return rendererOutput, nil
+	case datamodel.LinkModeResource:
 		// Source resource identifier is provided. Currently only Azure resources are expected with non empty resource id
 		rendererOutput, err := renderAzureResource(properties, secretValues, computedValues)
 		if err != nil {
@@ -56,7 +58,7 @@ func (r Renderer) Render(ctx context.Context, dm v1.ResourceDataModel, options r
 		return rendererOutput, nil
 	case datamodel.LinkModeValues:
 		return renderers.RendererOutput{
-			Resources:      []outputresource.OutputResource{},
+			Resources:      []rpv1.OutputResource{},
 			ComputedValues: computedValues,
 			SecretValues:   secretValues,
 		}, nil
@@ -66,64 +68,31 @@ func (r Renderer) Render(ctx context.Context, dm v1.ResourceDataModel, options r
 
 }
 
-func renderAzureRecipe(resource *datamodel.RedisCache, options renderers.RenderOptions, secretValues map[string]rp.SecretValueReference, computedValues map[string]renderers.ComputedValueReference) (renderers.RendererOutput, error) {
+func renderAzureRecipe(resource *datamodel.RedisCache, options renderers.RenderOptions, secretValues map[string]rpv1.SecretValueReference, computedValues map[string]renderers.ComputedValueReference) (renderers.RendererOutput, error) {
 	if options.RecipeProperties.LinkType != resource.ResourceTypeName() {
 		return renderers.RendererOutput{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("link type %q of provided recipe %q is incompatible with %q resource type. Recipe link type must match link resource type.",
 			options.RecipeProperties.LinkType, options.RecipeProperties.Name, linkrp.RedisCachesResourceType))
 	}
 
-	recipeData := datamodel.RecipeData{
+	recipeData := linkrp.RecipeData{
 		Provider:         resourcemodel.ProviderAzure,
 		RecipeProperties: options.RecipeProperties,
 		APIVersion:       clientv2.RedisManagementClientAPIVersion,
 	}
 
-	if _, ok := computedValues[renderers.Host]; !ok {
-		computedValues[renderers.Host] = renderers.ComputedValueReference{
-			LocalID:     outputresource.LocalIDAzureRedis,
-			JSONPointer: "/properties/hostName", // https://learn.microsoft.com/en-us/rest/api/redis/redis/get
-		}
-	}
+	// Build computedValues reference
+	buildComputedValuesReference(computedValues)
+	// Build secretValue reference
+	buildSecretValueReference(secretValues)
 
-	if _, ok := computedValues[renderers.Port]; !ok {
-		computedValues[renderers.Port] = renderers.ComputedValueReference{
-			LocalID:     outputresource.LocalIDAzureRedis,
-			JSONPointer: "/properties/sslPort", // https://learn.microsoft.com/en-us/rest/api/redis/redis/get
-		}
-	}
-
-	if _, ok := secretValues[renderers.PasswordStringHolder]; !ok {
-		secretValues[renderers.PasswordStringHolder] = rp.SecretValueReference{
-			LocalID:       outputresource.LocalIDAzureRedis,
-			Action:        "listKeys",
-			ValueSelector: "/primaryKey",
-		}
-	}
-
-	if _, ok := secretValues[renderers.ConnectionStringValue]; !ok {
-		secretValues[renderers.ConnectionStringValue] = rp.SecretValueReference{
-			LocalID:       outputresource.LocalIDAzureRedis,
-			Action:        "listKeys",
-			ValueSelector: "/primaryKey",
-			Transformer: resourcemodel.ResourceType{
-				Provider: resourcemodel.ProviderAzure,
-				Type:     resourcekinds.AzureRedis,
-			},
-		}
-	}
 	// Build output resources
-	redisCacheOutputResource := outputresource.OutputResource{
-		LocalID: outputresource.LocalIDAzureRedis,
-		ResourceType: resourcemodel.ResourceType{
-			Type:     resourcekinds.AzureRedis,
-			Provider: resourcemodel.ProviderAzure,
-		},
-		ProviderResourceType: azresources.CacheRedis,
-		RadiusManaged:        to.Ptr(true),
-	}
+	redisCacheOutputResource := buildOutputResource()
+	redisCacheOutputResource.ProviderResourceType = azresources.CacheRedis
+	// Set the RadiusManaged to true for resources deployed by recipe
+	redisCacheOutputResource.RadiusManaged = to.Ptr(true)
 
 	return renderers.RendererOutput{
-		Resources:            []outputresource.OutputResource{redisCacheOutputResource},
+		Resources:            []rpv1.OutputResource{redisCacheOutputResource},
 		ComputedValues:       computedValues,
 		SecretValues:         secretValues,
 		RecipeData:           recipeData,

--- a/pkg/linkrp/renderers/rediscaches/renderer_test.go
+++ b/pkg/linkrp/renderers/rediscaches/renderer_test.go
@@ -311,7 +311,7 @@ func Test_Render_Recipe_Success(t *testing.T) {
 			},
 		},
 		Properties: datamodel.RedisCacheProperties{
-			BasicResourceProperties: rp.BasicResourceProperties{
+			BasicResourceProperties: rpv1.BasicResourceProperties{
 				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
 				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
 			},
@@ -326,8 +326,8 @@ func Test_Render_Recipe_Success(t *testing.T) {
 			},
 		},
 	}
-	expectedOutputResource := outputresource.OutputResource{
-		LocalID: outputresource.LocalIDAzureRedis,
+	expectedOutputResource := rpv1.OutputResource{
+		LocalID: rpv1.LocalIDAzureRedis,
 		ResourceType: resourcemodel.ResourceType{
 			Type:     resourcekinds.AzureRedis,
 			Provider: resourcemodel.ProviderAzure,
@@ -338,22 +338,22 @@ func Test_Render_Recipe_Success(t *testing.T) {
 
 	expectedComputedValues := map[string]renderers.ComputedValueReference{
 		renderers.Host: {
-			LocalID:     outputresource.LocalIDAzureRedis,
+			LocalID:     rpv1.LocalIDAzureRedis,
 			JSONPointer: "/properties/hostName",
 		},
 		renderers.Port: {
-			LocalID:     outputresource.LocalIDAzureRedis,
+			LocalID:     rpv1.LocalIDAzureRedis,
 			JSONPointer: "/properties/sslPort",
 		},
 	}
-	expectedSecretValues := map[string]rp.SecretValueReference{
+	expectedSecretValues := map[string]rpv1.SecretValueReference{
 		renderers.PasswordStringHolder: {
-			LocalID:       outputresource.LocalIDAzureRedis,
+			LocalID:       rpv1.LocalIDAzureRedis,
 			Action:        "listKeys",
 			ValueSelector: "/primaryKey",
 		},
 		renderers.ConnectionStringValue: {
-			LocalID:       outputresource.LocalIDAzureRedis,
+			LocalID:       rpv1.LocalIDAzureRedis,
 			Action:        "listKeys",
 			ValueSelector: "/primaryKey",
 			Transformer: resourcemodel.ResourceType{
@@ -404,7 +404,7 @@ func Test_Render_Recipe_InvalidLinkType(t *testing.T) {
 			},
 		},
 		Properties: datamodel.RedisCacheProperties{
-			BasicResourceProperties: rp.BasicResourceProperties{
+			BasicResourceProperties: rpv1.BasicResourceProperties{
 				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
 				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
 			},

--- a/pkg/linkrp/renderers/rediscaches/renderer_test.go
+++ b/pkg/linkrp/renderers/rediscaches/renderer_test.go
@@ -317,7 +317,7 @@ func Test_Render_Recipe_Success(t *testing.T) {
 			},
 			Mode: datamodel.LinkModeRecipe,
 			RedisRecipeProperties: datamodel.RedisRecipeProperties{
-				Recipe: datamodel.LinkRecipe{
+				Recipe: linkrp.LinkRecipe{
 					Name: "redis",
 					Parameters: map[string]any{
 						"throughput": 400,
@@ -364,8 +364,8 @@ func Test_Render_Recipe_Success(t *testing.T) {
 	}
 
 	output, err := renderer.Render(ctx, &redisResource, renderers.RenderOptions{
-		RecipeProperties: datamodel.RecipeProperties{
-			LinkRecipe: datamodel.LinkRecipe{
+		RecipeProperties: linkrp.RecipeProperties{
+			LinkRecipe: linkrp.LinkRecipe{
 				Name: "redis",
 				Parameters: map[string]any{
 					"throughput": 400,
@@ -410,7 +410,7 @@ func Test_Render_Recipe_InvalidLinkType(t *testing.T) {
 			},
 			Mode: datamodel.LinkModeRecipe,
 			RedisRecipeProperties: datamodel.RedisRecipeProperties{
-				Recipe: datamodel.LinkRecipe{
+				Recipe: linkrp.LinkRecipe{
 					Name: "redis",
 					Parameters: map[string]any{
 						"throughput": 400,
@@ -421,8 +421,8 @@ func Test_Render_Recipe_InvalidLinkType(t *testing.T) {
 	}
 
 	_, err := renderer.Render(ctx, &redisResource, renderers.RenderOptions{
-		RecipeProperties: datamodel.RecipeProperties{
-			LinkRecipe: datamodel.LinkRecipe{
+		RecipeProperties: linkrp.RecipeProperties{
+			LinkRecipe: linkrp.LinkRecipe{
 				Name: "redis",
 			},
 			TemplatePath: "testpublicrecipe.azurecr.io/bicep/modules/rediscaches:v1",

--- a/pkg/linkrp/renderers/rediscaches/renderer_test.go
+++ b/pkg/linkrp/renderers/rediscaches/renderer_test.go
@@ -380,7 +380,7 @@ func Test_Render_Recipe_Success(t *testing.T) {
 	require.Equal(t, redisResource.Properties.Recipe.Name, output.RecipeData.Name)
 	require.Equal(t, redisResource.Properties.Recipe.Parameters, output.RecipeData.Parameters)
 	require.Equal(t, "testpublicrecipe.azurecr.io/bicep/modules/redis:v1", output.RecipeData.TemplatePath)
-	require.Equal(t, clientv2.DocumentDBManagementClientAPIVersion, output.RecipeData.APIVersion)
+	require.Equal(t, clientv2.RedisManagementClientAPIVersion, output.RecipeData.APIVersion)
 
 	// secrets and computed values
 	require.Equal(t, expectedSecretValues, output.SecretValues)


### PR DESCRIPTION
# Description

Added the recipe support for redis cache.
Updated the renderer
Added UT's

Log's from manual testing.
```
Deploying recipe: "redis", template: "radiusdev.azurecr.io/recipes/functionaltest/basic/rediscaches/azure:1.0"	{"resourceID": "/planes/radius/local/resourcegroups/kind-radius/providers/applications.link/rediscaches/redis-recipe", "resourceGroup": "pratmishra-01", "subscriptionID": "66d1209e-1382-45d3-99bb-650e6bf63fc0"}
2023-01-26T17:44:27.932Z	INFO	applications.core.Applications.Link	Recipe resource [/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourceGroups/pratmishra-01/providers/Microsoft.Cache/redis/pratmishra]	{"resourceID": "/planes/radius/local/resourcegroups/kind-radius/providers/applications.link/rediscaches/redis-recipe", "resourceID": "/planes/radius/local/resourcegroups/kind-radius/providers/Applications.Link/redisCaches/redis-recipe"}
```
## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [X] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
