### PR TITLE
Fixing AWS provider not showing up in interactive mode

### DIFF
--- a/cmd/rad/cmd/envInit.go
+++ b/cmd/rad/cmd/envInit.go
@@ -87,7 +87,7 @@ func initSelfHosted(cmd *cobra.Command, args []string, kind EnvKind) error {
 	}
 
 	// Configure AWS provider for cloud resources if specified
-	awsProvider, err := setup.ParseAWSProviderFromArgs(cmd, interactive)
+	awsProvider, err := setup.ParseAWSProviderFromArgs(cmd, interactive, &prompt.Impl{})
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/setup/aws.go
+++ b/pkg/cli/setup/aws.go
@@ -48,18 +48,18 @@ func RegisterPersistentAWSProviderArgs(cmd *cobra.Command) {
 	)
 }
 
-func ParseAWSProviderFromArgs(cmd *cobra.Command, interactive bool) (*radAWS.Provider, error) {
+func ParseAWSProviderFromArgs(cmd *cobra.Command, interactive bool, prompter prompt.Interface) (*radAWS.Provider, error) {
 	if interactive {
-		return parseAWSProviderInteractive(cmd)
+		return parseAWSProviderInteractive(cmd, prompter)
 	}
 	return parseAWSProviderNonInteractive(cmd)
 
 }
 
-func parseAWSProviderInteractive(cmd *cobra.Command) (*radAWS.Provider, error) {
+func parseAWSProviderInteractive(cmd *cobra.Command, prompter prompt.Interface) (*radAWS.Provider, error) {
 	ctx := cmd.Context()
 
-	addAWSCred, err := prompt.ConfirmWithDefault("Add AWS provider for cloud resources [y/N]?", prompt.No)
+	addAWSCred, err := prompt.YesOrNoPrompt("Add AWS provider for cloud resources?", "no", prompter)
 	if err != nil {
 		return nil, err
 	}
@@ -67,17 +67,26 @@ func parseAWSProviderInteractive(cmd *cobra.Command) (*radAWS.Provider, error) {
 		return nil, nil
 	}
 
-	region, err := prompt.Text("Enter the region you would like to use to deploy AWS resources:", prompt.EmptyValidator)
+	region, err := prompter.GetTextInput(
+		"Enter the region you would like to use to deploy AWS resources:",
+		"",
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	keyID, err := prompt.Text("Enter the IAM Access Key ID:", prompt.EmptyValidator)
+	keyID, err := prompter.GetTextInput(
+		"Enter the IAM Access Key ID:",
+		"",
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	secretAccessKey, err := prompt.Text("Enter your IAM Secret Access Keys:", prompt.EmptyValidator)
+	secretAccessKey, err := prompter.GetTextInput(
+		"Enter your IAM Secret Access Keys:",
+		"",
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

* Fixes issue where `rad env init kubernetes -i` would not show AWS provider:

<img width="382" alt="image" src="https://user-images.githubusercontent.com/32342549/214978167-e1f72f49-864c-4620-b144-cc4d19f9d686.png">


## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: radius-project/core-team#1088

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
