### PR TITLE
Initial commit for the fetching the values set as output in a recipe

### DIFF
--- a/pkg/linkrp/handlers/mock_recipe_handler.go
+++ b/pkg/linkrp/handlers/mock_recipe_handler.go
@@ -37,10 +37,10 @@ func (m *MockRecipeHandler) EXPECT() *MockRecipeHandlerMockRecorder {
 }
 
 // DeployRecipe mocks base method.
-func (m *MockRecipeHandler) DeployRecipe(arg0 context.Context, arg1 datamodel0.RecipeProperties, arg2 datamodel.Providers, arg3 datamodel0.RecipeContext) ([]string, error) {
+func (m *MockRecipeHandler) DeployRecipe(arg0 context.Context, arg1 datamodel0.RecipeProperties, arg2 datamodel.Providers, arg3 datamodel0.RecipeContext) (*RecipeResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeployRecipe", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].(*RecipeResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/linkrp/handlers/recipe_handler_test.go
+++ b/pkg/linkrp/handlers/recipe_handler_test.go
@@ -127,3 +127,84 @@ func Test_ContextParameterError(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, linkContext)
 }
+
+func Test_RecipeResponseSuccess(t *testing.T) {
+	response := map[string]any{}
+	value := map[string]any{}
+	value["resources"] = []any{"testId1", "testId2"}
+	value["secrets"] = map[string]any{
+		"username":         "testUser",
+		"password":         "testPassword",
+		"connectionString": "test-connection-string",
+	}
+	value["values"] = map[string]any{
+		"host": "myrediscache.redis.cache.windows.net",
+		"port": 6379,
+	}
+	response["result"] = map[string]any{
+		"value": value,
+	}
+	expectedResponse := RecipeResponse{
+		Resources: []string{"outputResourceId", "testId1", "testId2"},
+		Secrets: map[string]any{
+			"username":         "testUser",
+			"password":         "testPassword",
+			"connectionString": "test-connection-string",
+		},
+		Values: map[string]any{
+			"host": "myrediscache.redis.cache.windows.net",
+			"port": 6379,
+		},
+	}
+	actualResp := RecipeResponse{
+		Resources: []string{"outputResourceId"},
+		Secrets:   map[string]any{},
+		Values:    map[string]any{},
+	}
+	prepareRecipeResponse(response, &actualResp)
+	require.Equal(t, expectedResponse, actualResp)
+}
+
+func Test_RecipeResponseWithoutSecret(t *testing.T) {
+	response := map[string]any{}
+	value := map[string]any{}
+	value["resources"] = []any{"testId1", "testId2"}
+	value["values"] = map[string]any{
+		"host": "myrediscache.redis.cache.windows.net",
+		"port": 6379,
+	}
+	response["result"] = map[string]any{
+		"value": value,
+	}
+	expectedResponse := RecipeResponse{
+		Resources: []string{"outputResourceId", "testId1", "testId2"},
+		Secrets:   map[string]any{},
+		Values: map[string]any{
+			"host": "myrediscache.redis.cache.windows.net",
+			"port": 6379,
+		},
+	}
+	actualResp := RecipeResponse{
+		Resources: []string{"outputResourceId"},
+		Secrets:   map[string]any{},
+		Values:    map[string]any{},
+	}
+	prepareRecipeResponse(response, &actualResp)
+	require.Equal(t, expectedResponse, actualResp)
+}
+
+func Test_RecipeResponseWithoutResult(t *testing.T) {
+	response := map[string]any{}
+	expectedResponse := RecipeResponse{
+		Resources: []string{"outputResourceId"},
+		Secrets:   map[string]any{},
+		Values:    map[string]any{},
+	}
+	actualResp := RecipeResponse{
+		Resources: []string{"outputResourceId"},
+		Secrets:   map[string]any{},
+		Values:    map[string]any{},
+	}
+	prepareRecipeResponse(response, &actualResp)
+	require.Equal(t, expectedResponse, actualResp)
+}


### PR DESCRIPTION
This change is to support value backed/based recipe.
When a recipe with output values set are deployed, the values returned at applied to the link.

Added UT in the recipe handler
Added UT in the deployment Processor

_Please explain the changes you've made._

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [X] Unit tests passing
* [ ] Extended the documentation / Created issue for it
