### PR TITLE
Enable value-based recipes

### DIFF
--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -234,6 +234,7 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 			if err != nil {
 				armErr := extractError(err)
 				result.SetFailed(armErr, false)
+				logger.Error(err, "Operation Failed")
 			}
 			w.completeOperation(ctx, message, result, asyncCtrl.StorageClient())
 		}

--- a/pkg/linkrp/frontend/deployment/deploymentprocessor_test.go
+++ b/pkg/linkrp/frontend/deployment/deploymentprocessor_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/azure/azresources"
 	"github.com/project-radius/radius/pkg/azure/clientv2"
@@ -52,8 +53,8 @@ const (
 	daprLinkName        = "test-state-store"
 	daprLinkID          = "/subscriptions/testSub/resourceGroups/testGroup/providers/Applications.Link/daprStateStores/test-state-store"
 	azureTableStorageID = "/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.Storage/storageAccounts/test-account/tableServices/default/tables/mytable"
-
-	recipeName = "testRecipe"
+	redisId             = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Microsoft.Cache/Redis/testCache"
+	recipeName          = "testRecipe"
 
 	modeRecipe   = "recipe"
 	modeResource = "resource"
@@ -62,6 +63,7 @@ const (
 
 var (
 	mongoLinkResourceID = getResourceID(mongoLinkID)
+	redisLinkResourceId = getResourceID(redisId)
 	recipeParams        = map[string]any{
 		"throughput": 400,
 	}
@@ -155,6 +157,71 @@ func buildOutputResourcesMongo(mode string) []rpv1.OutputResource {
 	}
 }
 
+func buildRendererOutputRedis() renderers.RendererOutput {
+	// Note: all of these computed values and secrets will be ignored
+	// unless the recipe output contains an Azure redis.
+	computedValues := map[string]renderers.ComputedValueReference{
+		renderers.Host: {
+			LocalID:     rpv1.LocalIDAzureRedis,
+			JSONPointer: "/properties/hostName",
+		},
+		renderers.Port: {
+			LocalID:     rpv1.LocalIDAzureRedis,
+			JSONPointer: "/properties/sslPort",
+		},
+	}
+	secretValues := map[string]rpv1.SecretValueReference{
+		renderers.PasswordStringHolder: {
+			LocalID:       rpv1.LocalIDAzureRedis,
+			Action:        "listKeys",
+			ValueSelector: "/primaryKey",
+		},
+		renderers.ConnectionStringValue: {
+			LocalID:       rpv1.LocalIDAzureRedis,
+			Action:        "listKeys",
+			ValueSelector: "/primaryKey",
+			Transformer: resourcemodel.ResourceType{
+				Provider: resourcemodel.ProviderAzure,
+				Type:     resourcekinds.AzureRedis,
+			},
+		},
+	}
+	recipeData := linkrp.RecipeData{
+		RecipeProperties: linkrp.RecipeProperties{
+			LinkRecipe: linkrp.LinkRecipe{
+				Name: "redis",
+			},
+			TemplatePath: "testpublicrecipe.azurecr.io/bicep/modules/redis:v1",
+		},
+		APIVersion: clientv2.RedisManagementClientAPIVersion,
+	}
+
+	outputResource := rpv1.OutputResource{
+		LocalID: rpv1.LocalIDAzureRedis,
+		ResourceType: resourcemodel.ResourceType{
+			Provider: resourcemodel.ProviderAzure,
+			Type:     resourcekinds.AzureRedis,
+		},
+		Resource: map[string]any{
+			"properties": map[string]any{
+				"hostName": "myrediscache.redis.cache.windows.net",
+				"sslPort":  6379,
+			},
+		},
+		ProviderResourceType: azresources.CacheRedis,
+		RadiusManaged:        to.Ptr(true),
+	}
+
+	rendererOutput := renderers.RendererOutput{
+		Resources:      []rpv1.OutputResource{outputResource},
+		SecretValues:   secretValues,
+		ComputedValues: computedValues,
+		RecipeData:     recipeData,
+	}
+
+	return rendererOutput
+}
+
 func buildRendererOutputMongo(mode string) (rendererOutput renderers.RendererOutput) {
 	computedValues := map[string]renderers.ComputedValueReference{}
 	secretValues := map[string]rpv1.SecretValueReference{}
@@ -208,7 +275,6 @@ func buildRendererOutputMongo(mode string) (rendererOutput renderers.RendererOut
 				},
 			},
 			APIVersion: clientv2.DocumentDBManagementClientAPIVersion,
-			Provider:   resourcemodel.ProviderAzure,
 		}
 	}
 
@@ -364,10 +430,34 @@ func setup(t *testing.T) SharedMocks {
 				},
 				ResourceHandler: mockResourceHandler,
 			},
+			{
+				ResourceType: resourcemodel.ResourceType{
+					Type:     resourcekinds.AzureRedis,
+					Provider: resourcemodel.ProviderAzure,
+				},
+				ResourceHandler: mockResourceHandler,
+			},
+			{
+				// Handles all AWS types
+				ResourceType: resourcemodel.ResourceType{
+					Type:     resourcekinds.Wildcard,
+					Provider: resourcemodel.ProviderAWS,
+				},
+				ResourceHandler: mockResourceHandler,
+			},
+			{
+				// Handles all Kubernetes types
+				ResourceType: resourcemodel.ResourceType{
+					Type:     resourcekinds.Wildcard,
+					Provider: resourcemodel.ProviderKubernetes,
+				},
+				ResourceHandler: mockResourceHandler,
+			},
 		},
 		map[string]bool{
 			resourcemodel.ProviderKubernetes: true,
 			resourcemodel.ProviderAzure:      true,
+			resourcemodel.ProviderAWS:        true,
 		})
 
 	return SharedMocks{
@@ -401,12 +491,11 @@ func createContext(t *testing.T) context.Context {
 
 func Test_Render(t *testing.T) {
 	ctx := createContext(t)
-	mocks := setup(t)
-	ctrl := gomock.NewController(t)
-	mockRecipeHandler := handlers.NewMockRecipeHandler(ctrl)
-	dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil}
 
 	t.Run("verify render success", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil}
+
 		testResource := buildInputResourceMongo(modeResource)
 		testRendererOutput := buildRendererOutputMongo(modeResource)
 		app, err := resources.ParseResource(testResource.Properties.Application)
@@ -453,6 +542,9 @@ func Test_Render(t *testing.T) {
 	})
 
 	t.Run("verify render success with environment scoped link", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil}
+
 		testResource := buildInputResourceMongo(modeResource)
 		testResource.Properties.Application = ""
 		testRendererOutput := buildRendererOutputMongo(modeResource)
@@ -493,6 +585,9 @@ func Test_Render(t *testing.T) {
 	})
 
 	t.Run("verify render success with recipe", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil}
+
 		testResource := buildInputResourceMongo(modeRecipe)
 		testRendererOutput := buildRendererOutputMongo(modeRecipe)
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(testRendererOutput, nil)
@@ -511,6 +606,9 @@ func Test_Render(t *testing.T) {
 	})
 
 	t.Run("verify render success with mixedcase resourcetype", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil}
+
 		testResource := buildInputResourceMongo(modeResource)
 		testResource.Type = "Applications.Link/MongoDatabases"
 		testRendererOutput := buildRendererOutputMongo(modeResource)
@@ -527,6 +625,9 @@ func Test_Render(t *testing.T) {
 	})
 
 	t.Run("verify render error: invalid environment id", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil}
+
 		resource := datamodel.MongoDatabase{
 			BaseResource: v1.BaseResource{
 				TrackedResource: v1.TrackedResource{
@@ -549,6 +650,9 @@ func Test_Render(t *testing.T) {
 	})
 
 	t.Run("verify render error", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil}
+
 		mocks.renderer.EXPECT().Render(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(renderers.RendererOutput{}, errors.New("failed to render the resource"))
 		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(2).Return(mocks.db, nil)
 		er := buildEnvironmentResource("", nil)
@@ -563,6 +667,9 @@ func Test_Render(t *testing.T) {
 	})
 
 	t.Run("Invalid resource type", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil}
+
 		testInvalidResourceID := "/subscriptions/testSub/resourceGroups/testGroup/providers/Applications.foo/foo/mongo0"
 		parsedID := getResourceID(testInvalidResourceID)
 		testInvalidResource := datamodel.MongoDatabase{
@@ -590,6 +697,9 @@ func Test_Render(t *testing.T) {
 	})
 
 	t.Run("Invalid environment type", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil}
+
 		resource := datamodel.MongoDatabase{
 			BaseResource: v1.BaseResource{
 				TrackedResource: v1.TrackedResource{
@@ -613,6 +723,9 @@ func Test_Render(t *testing.T) {
 	})
 
 	t.Run("Non existing environment", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil}
+
 		testResource := buildInputResourceMongo(modeResource)
 
 		mocks.dbProvider.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Times(1).Return(mocks.db, nil)
@@ -625,6 +738,9 @@ func Test_Render(t *testing.T) {
 	})
 
 	t.Run("Missing output resource provider", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil}
+
 		testResource := buildInputResourceMongo(modeResource)
 		testRendererOutput := buildRendererOutputMongo(modeResource)
 		testRendererOutput.Resources[0].ResourceType.Provider = ""
@@ -641,6 +757,9 @@ func Test_Render(t *testing.T) {
 	})
 
 	t.Run("Unsupported output resource provider", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.dbProvider, mocks.secretsValueClient, nil}
+
 		testResource := buildInputResourceMongo(modeResource)
 		rendererOutput := renderers.RendererOutput{
 			Resources: []rpv1.OutputResource{
@@ -667,6 +786,10 @@ func Test_Render(t *testing.T) {
 	})
 
 	t.Run("Azure provider unsupported", func(t *testing.T) {
+		mocks := setup(t)
+		ctrl := gomock.NewController(t)
+		mockRecipeHandler := handlers.NewMockRecipeHandler(ctrl)
+
 		testModel := model.NewModel(
 			model.RecipeModel{
 				RecipeHandler: mockRecipeHandler,
@@ -703,10 +826,11 @@ func Test_Render(t *testing.T) {
 
 func Test_Deploy(t *testing.T) {
 	ctx := createContext(t)
-	mocks := setup(t)
-	dp := deploymentProcessor{mocks.model, mocks.storageProvider, mocks.secretsValueClient, nil}
 
 	t.Run("Verify deploy success", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.storageProvider, mocks.secretsValueClient, nil}
+
 		mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(2).Return(resourcemodel.ResourceIdentity{}, map[string]string{}, nil)
 
 		testRendererOutput := buildRendererOutputMongo(modeResource)
@@ -720,9 +844,14 @@ func Test_Deploy(t *testing.T) {
 		require.Equal(t, map[string]any{renderers.DatabaseNameValue: "test-database", renderers.Host: testRendererOutput.ComputedValues[renderers.Host].Value}, deploymentOutput.ComputedValues)
 	})
 
-	t.Run("Verify deploy success with recipe", func(t *testing.T) {
-		resources := []string{cosmosAccountID, cosmosMongoID}
-		mocks.recipeHandler.EXPECT().DeployRecipe(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(resources, nil)
+	t.Run("Verify deploy success with mongo recipe", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.storageProvider, mocks.secretsValueClient, nil}
+
+		resources := handlers.RecipeResponse{
+			Resources: []string{cosmosAccountID, cosmosMongoID},
+		}
+		mocks.recipeHandler.EXPECT().DeployRecipe(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&resources, nil)
 		mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(2).Return(resourcemodel.ResourceIdentity{}, map[string]string{}, nil)
 
 		testRendererOutput := buildRendererOutputMongo(modeRecipe)
@@ -730,12 +859,91 @@ func Test_Deploy(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, testRendererOutput.SecretValues, deploymentOutput.SecretValues)
 		require.Equal(t, map[string]any{renderers.DatabaseNameValue: "test-database", "host": 8080}, deploymentOutput.ComputedValues)
-		require.Equal(t, resources, deploymentOutput.RecipeData.Resources)
+		require.Equal(t, resources.Resources, deploymentOutput.RecipeData.Resources)
+	})
+	t.Run("Verify deploy success with redis recipe (azure resource binding)", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.storageProvider, mocks.secretsValueClient, nil}
+
+		resources := handlers.RecipeResponse{
+			Resources: []string{"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Microsoft.Cache/Redis/testCache"},
+			Secrets:   map[string]any{},
+			Values:    map[string]any{},
+		}
+		mocks.recipeHandler.EXPECT().DeployRecipe(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&resources, nil)
+		mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(1).Return(resourcemodel.ResourceIdentity{}, map[string]string{}, nil)
+
+		testRendererOutput := buildRendererOutputRedis()
+		deploymentOutput, err := dp.Deploy(ctx, redisLinkResourceId, testRendererOutput)
+		require.NoError(t, err)
+		require.Equal(t, testRendererOutput.SecretValues, deploymentOutput.SecretValues)
+		require.Equal(t, map[string]any{renderers.Port: 6379, renderers.Host: "myrediscache.redis.cache.windows.net"}, deploymentOutput.ComputedValues)
+		require.Equal(t, resources.Resources, deploymentOutput.RecipeData.Resources)
+	})
+
+	t.Run("Verify deploy success with redis recipe (kubernetes value-based)", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.storageProvider, mocks.secretsValueClient, nil}
+
+		resources := handlers.RecipeResponse{
+			Resources: []string{
+				"/planes/kubernetes/local/namespaces/my-namespace/providers/core/Service/redis",
+				"/planes/kubernetes/local/namespaces/my-namespace/providers/apps/Deployment/redis",
+			},
+			Secrets: map[string]any{
+				"username":         "testUser",
+				"password":         "testPassword",
+				"connectionString": "test-connection-string",
+			},
+			Values: map[string]any{
+				"host": "redis.mynamespace.svc.cluster.local",
+				"port": 6379,
+			},
+		}
+		mocks.recipeHandler.EXPECT().DeployRecipe(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&resources, nil)
+		mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(2).Return(resourcemodel.ResourceIdentity{}, map[string]string{}, nil)
+
+		testRendererOutput := buildRendererOutputRedis()
+		deploymentOutput, err := dp.Deploy(ctx, redisLinkResourceId, testRendererOutput)
+		require.NoError(t, err)
+		require.Equal(t, testRendererOutput.SecretValues, deploymentOutput.SecretValues)
+		require.Equal(t, map[string]any{renderers.Port: 6379, renderers.Host: "redis.mynamespace.svc.cluster.local"}, deploymentOutput.ComputedValues)
+		require.Equal(t, resources.Resources, deploymentOutput.RecipeData.Resources)
+	})
+
+	t.Run("Verify deploy success with redis recipe (aws value-based)", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.storageProvider, mocks.secretsValueClient, nil}
+
+		resources := handlers.RecipeResponse{
+			Resources: []string{"/planes/aws/aws/accounts/00000000/regions/us-west-2/providers/AWS.MemoryDB/Cluster/mycluster"},
+			Secrets: map[string]any{
+				"username":         "testUser",
+				"password":         "testPassword",
+				"connectionString": "test-connection-string",
+			},
+			Values: map[string]any{
+				"host": "mycluster.us-west-2.amazonaws.com",
+				"port": 6379,
+			},
+		}
+		mocks.recipeHandler.EXPECT().DeployRecipe(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&resources, nil)
+		mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(1).Return(resourcemodel.ResourceIdentity{}, map[string]string{}, nil)
+
+		testRendererOutput := buildRendererOutputRedis()
+		deploymentOutput, err := dp.Deploy(ctx, redisLinkResourceId, testRendererOutput)
+		require.NoError(t, err)
+		require.Equal(t, testRendererOutput.SecretValues, deploymentOutput.SecretValues)
+		require.Equal(t, map[string]any{renderers.Port: 6379, renderers.Host: "mycluster.us-west-2.amazonaws.com"}, deploymentOutput.ComputedValues)
+		require.Equal(t, resources.Resources, deploymentOutput.RecipeData.Resources)
 	})
 
 	t.Run("Verify deploy failure with recipe", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.storageProvider, mocks.secretsValueClient, nil}
+
 		deploymentName := "recipe" + strconv.FormatInt(time.Now().UnixNano(), 10)
-		mocks.recipeHandler.EXPECT().DeployRecipe(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return([]string{}, fmt.Errorf("failed to deploy recipe - %s", deploymentName))
+		mocks.recipeHandler.EXPECT().DeployRecipe(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&handlers.RecipeResponse{}, fmt.Errorf("failed to deploy recipe - %s", deploymentName))
 
 		testRendererOutput := buildRendererOutputMongo(modeRecipe)
 		_, err := dp.Deploy(ctx, mongoLinkResourceID, testRendererOutput)
@@ -744,6 +952,9 @@ func Test_Deploy(t *testing.T) {
 	})
 
 	t.Run("Verify deploy failure", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.storageProvider, mocks.secretsValueClient, nil}
+
 		mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(1).Return(resourcemodel.ResourceIdentity{}, map[string]string{}, errors.New("failed to deploy the resource"))
 
 		testRendererOutput := buildRendererOutputMongo(modeResource)
@@ -753,6 +964,9 @@ func Test_Deploy(t *testing.T) {
 	})
 
 	t.Run("Verify deploy failure - invalid request", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.storageProvider, mocks.secretsValueClient, nil}
+
 		mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(1).Return(resourcemodel.ResourceIdentity{}, map[string]string{}, v1.NewClientErrInvalidRequest("failed to access connected Azure resource"))
 
 		testRendererOutput := buildRendererOutputMongo(modeResource)
@@ -763,6 +977,9 @@ func Test_Deploy(t *testing.T) {
 	})
 
 	t.Run("Output resource dependency missing local ID", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.storageProvider, mocks.secretsValueClient, nil}
+
 		testRendererOutput := buildRendererOutputMongo(modeResource)
 		testRendererOutput.Resources[0].Dependencies = []rpv1.Dependency{
 			{LocalID: ""},
@@ -773,6 +990,9 @@ func Test_Deploy(t *testing.T) {
 	})
 
 	t.Run("Invalid output resource type", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.storageProvider, mocks.secretsValueClient, nil}
+
 		testRendererOutput := buildRendererOutputMongo(modeResource)
 		testRendererOutput.Resources[0].ResourceType.Type = "foo"
 		_, err := dp.Deploy(ctx, mongoLinkResourceID, testRendererOutput)
@@ -781,6 +1001,9 @@ func Test_Deploy(t *testing.T) {
 	})
 
 	t.Run("Missing output resource identity", func(t *testing.T) {
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.storageProvider, mocks.secretsValueClient, nil}
+
 		mocks.resourceHandler.EXPECT().Put(gomock.Any(), gomock.Any()).Times(1).Return(resourcemodel.ResourceIdentity{}, map[string]string{}, nil)
 
 		testRendererOutput := buildRendererOutputMongo(modeResource)
@@ -792,10 +1015,15 @@ func Test_Deploy(t *testing.T) {
 	})
 
 	t.Run("Recipe deployment - invalid resource id", func(t *testing.T) {
-		resources := []string{"invalid-id"}
-		mocks.recipeHandler.EXPECT().DeployRecipe(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(resources, nil)
+		mocks := setup(t)
+		dp := deploymentProcessor{mocks.model, mocks.storageProvider, mocks.secretsValueClient, nil}
 
-		expectedErr := v1.NewClientErrInvalidRequest(fmt.Sprintf("failed to parse id \"%s\" of the resource deployed by recipe \"testRecipe\" for resource \"%s\": 'invalid-id' is not a valid resource id", resources[0], mongoLinkResourceID))
+		resources := handlers.RecipeResponse{
+			Resources: []string{"invalid-id"},
+		}
+		mocks.recipeHandler.EXPECT().DeployRecipe(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&resources, nil)
+
+		expectedErr := v1.NewClientErrInvalidRequest(fmt.Sprintf("failed to parse id \"%s\" of the resource deployed by recipe \"testRecipe\" for resource \"%s\": 'invalid-id' is not a valid resource id", resources.Resources[0], mongoLinkResourceID))
 		testRendererOutput := buildRendererOutputMongo(modeRecipe)
 		_, err := dp.Deploy(ctx, mongoLinkResourceID, testRendererOutput)
 		require.Error(t, err)

--- a/pkg/linkrp/handlers/aws_handler.go
+++ b/pkg/linkrp/handlers/aws_handler.go
@@ -1,0 +1,100 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+
+	aztoken "github.com/project-radius/radius/pkg/azure/tokencredentials"
+	"github.com/project-radius/radius/pkg/cli/clients_new/generated"
+	"github.com/project-radius/radius/pkg/resourcemodel"
+	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
+	"github.com/project-radius/radius/pkg/sdk"
+	"github.com/project-radius/radius/pkg/ucp/resources"
+)
+
+// NewAWSHandler creates a new ResourceHandler for AWS resources.
+func NewAWSHandler(connection sdk.Connection) ResourceHandler {
+	return &awsHandler{connection: connection}
+}
+
+type awsHandler struct {
+	connection sdk.Connection
+}
+
+// Put implements Put for AWS resources.
+func (handler *awsHandler) Put(ctx context.Context, resource *rpv1.OutputResource) (resourcemodel.ResourceIdentity, map[string]string, error) {
+	id, err := resource.Identity.RequireAWS()
+	if err != nil {
+		return resourcemodel.ResourceIdentity{}, nil, err
+	}
+
+	parsed, err := resources.ParseResource(id)
+	if err != nil {
+		return resourcemodel.ResourceIdentity{}, nil, err
+	}
+
+	client, err := generated.NewGenericResourcesClient(parsed.RootScope(), parsed.Type(), &aztoken.AnonymousCredential{}, sdk.NewClientOptions(handler.connection))
+	if err != nil {
+		return resourcemodel.ResourceIdentity{}, nil, err
+	}
+
+	response, err := client.Get(ctx, parsed.Name(), nil)
+	if err != nil {
+		return resourcemodel.ResourceIdentity{}, nil, err
+	}
+
+	// Serialize to map format since that's what the JSON-pointer library expects
+	b, err := response.MarshalJSON()
+	if err != nil {
+		return resourcemodel.ResourceIdentity{}, nil, err
+	}
+
+	data := map[string]any{}
+	err = json.Unmarshal(b, &data)
+	if err != nil {
+		return resourcemodel.ResourceIdentity{}, nil, err
+	}
+
+	resource.Resource = data
+
+	return resource.Identity, map[string]string{}, nil
+}
+
+// Delete implementes Delete for AWS resources.
+func (handler *awsHandler) Delete(ctx context.Context, resource *rpv1.OutputResource) error {
+	if !resource.IsRadiusManaged() {
+		return nil
+	}
+
+	id, err := resource.Identity.RequireAWS()
+	if err != nil {
+		return err
+	}
+
+	parsed, err := resources.ParseResource(id)
+	if err != nil {
+		return err
+	}
+
+	client, err := generated.NewGenericResourcesClient(parsed.RootScope(), parsed.Type(), &aztoken.AnonymousCredential{}, sdk.NewClientOptions(handler.connection))
+	if err != nil {
+		return err
+	}
+
+	poller, err := client.BeginDelete(ctx, parsed.Name(), nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/linkrp/handlers/kubernetes_handler.go
+++ b/pkg/linkrp/handlers/kubernetes_handler.go
@@ -1,0 +1,105 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/project-radius/radius/pkg/resourcemodel"
+	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewKubernetesHandler creates a new ResourceHandler for Kubernetes resources.
+func NewKubernetesHandler(client client.Client) ResourceHandler {
+	return &kubernetesHandler{client: client}
+}
+
+type kubernetesHandler struct {
+	client client.Client
+}
+
+// Put implements Put for Kubernetes resources.
+func (handler *kubernetesHandler) Put(ctx context.Context, resource *rpv1.OutputResource) (resourcemodel.ResourceIdentity, map[string]string, error) {
+	gvk, namespace, name, err := resource.Identity.RequireKubernetes()
+	if err != nil {
+		return resourcemodel.ResourceIdentity{}, nil, err
+	}
+
+	gvk, err = handler.SelectVersion(gvk)
+	if err != nil {
+		return resourcemodel.ResourceIdentity{}, nil, err
+	}
+
+	item := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": gvk.GroupVersion().String(),
+			"kind":       gvk.Kind,
+			"metadata": map[string]any{
+				"namespace": namespace,
+				"name":      name,
+			},
+		},
+	}
+
+	err = handler.client.Get(ctx, client.ObjectKeyFromObject(&item), &item)
+	if err != nil {
+		return resourcemodel.ResourceIdentity{}, nil, err
+	}
+
+	resource.Resource = item.Object
+	return resource.Identity, map[string]string{}, nil
+}
+
+// Delete implementes Delete for Kubernetes resources.
+func (handler *kubernetesHandler) Delete(ctx context.Context, resource *rpv1.OutputResource) error {
+	if !resource.IsRadiusManaged() {
+		return nil
+	}
+
+	gvk, namespace, name, err := resource.Identity.RequireKubernetes()
+	if err != nil {
+		return err
+	}
+
+	gvk, err = handler.SelectVersion(gvk)
+	if err != nil {
+		return err
+	}
+
+	item := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": gvk.GroupVersion().String(),
+			"kind":       gvk.Kind,
+			"metadata": map[string]any{
+				"namespace": namespace,
+				"name":      name,
+			},
+		},
+	}
+
+	return client.IgnoreNotFound(handler.client.Delete(ctx, &item))
+}
+
+// SelectVersion can find the preferred API version for a Kubernetes resource. The resource IDs we get back from
+// UCP don't contain a version. In the event that we don't care about the version we're using, this function
+// helps us stay uncoupled.
+func (handler *kubernetesHandler) SelectVersion(gvk schema.GroupVersionKind) (schema.GroupVersionKind, error) {
+	if gvk.Version != resourcemodel.APIVersionUnknown {
+		return gvk, nil
+	}
+
+	mapping, err := handler.client.RESTMapper().RESTMapping(gvk.GroupKind())
+	if err != nil {
+		return schema.GroupVersionKind{}, fmt.Errorf("unable to determine version for %s: %w", gvk.GroupKind().String(), err)
+	}
+
+	return mapping.GroupVersionKind, nil
+}

--- a/pkg/linkrp/handlers/mock_recipe_handler.go
+++ b/pkg/linkrp/handlers/mock_recipe_handler.go
@@ -37,10 +37,10 @@ func (m *MockRecipeHandler) EXPECT() *MockRecipeHandlerMockRecorder {
 }
 
 // DeployRecipe mocks base method.
-func (m *MockRecipeHandler) DeployRecipe(arg0 context.Context, arg1 linkrp.RecipeProperties, arg2 datamodel.Providers, arg3 linkrp.RecipeContext) ([]string, error) {
+func (m *MockRecipeHandler) DeployRecipe(arg0 context.Context, arg1 linkrp.RecipeProperties, arg2 datamodel.Providers, arg3 linkrp.RecipeContext) (*RecipeResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeployRecipe", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].(*RecipeResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/linkrp/handlers/recipe_handler.go
+++ b/pkg/linkrp/handlers/recipe_handler.go
@@ -151,15 +151,7 @@ func (handler *recipeHandler) DeployRecipe(ctx context.Context, recipe linkrp.Re
 		return nil, fmt.Errorf("failed to deploy the recipe %q, template path: %q, deployment: %q", recipe.Name, recipe.TemplatePath, deploymentID.Name())
 	}
 
-	recipeResponse := RecipeResponse{}
-	recipeResponse.Secrets = map[string]any{}
-	recipeResponse.Values = map[string]any{}
-
-	for _, id := range resp.Properties.OutputResources {
-		recipeResponse.Resources = append(recipeResponse.Resources, *id.ID)
-	}
-
-	err = prepareRecipeResponse(resp.Properties.Outputs, &recipeResponse)
+	recipeResponse, err := prepareRecipeResponse(resp.Properties.Outputs, resp.Properties.OutputResources)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read the recipe output %q: %w", ResultPropertyName, err)
 	}

--- a/pkg/linkrp/handlers/recipe_handler.go
+++ b/pkg/linkrp/handlers/recipe_handler.go
@@ -159,7 +159,10 @@ func (handler *recipeHandler) DeployRecipe(ctx context.Context, recipe linkrp.Re
 		recipeResponse.Resources = append(recipeResponse.Resources, *id.ID)
 	}
 
-	prepareRecipeResponse(resp.Properties.Outputs, &recipeResponse)
+	err = prepareRecipeResponse(resp.Properties.Outputs, &recipeResponse)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the recipe output %q: %w", ResultPropertyName, err)
+	}
 
 	return &recipeResponse, nil
 }

--- a/pkg/linkrp/handlers/recipe_handler.go
+++ b/pkg/linkrp/handlers/recipe_handler.go
@@ -42,7 +42,7 @@ const (
 //
 //go:generate mockgen -destination=./mock_recipe_handler.go -package=handlers -self_package github.com/project-radius/radius/pkg/linkrp/handlers github.com/project-radius/radius/pkg/linkrp/handlers RecipeHandler
 type RecipeHandler interface {
-	DeployRecipe(ctx context.Context, recipe linkrp.RecipeProperties, envProviders coreDatamodel.Providers, recipeContext linkrp.RecipeContext) ([]string, error)
+	DeployRecipe(ctx context.Context, recipe linkrp.RecipeProperties, envProviders coreDatamodel.Providers, recipeContext linkrp.RecipeContext) (*RecipeResponse, error)
 }
 
 func NewRecipeHandler(connection sdk.Connection) RecipeHandler {
@@ -58,7 +58,7 @@ type recipeHandler struct {
 // DeployRecipe deploys the recipe template fetched from the provided recipe TemplatePath using the providers scope.
 // Currently the implementation assumes TemplatePath is location of an ARM JSON template in Azure Container Registry.
 // Returns resource IDs of the resources deployed by the template
-func (handler *recipeHandler) DeployRecipe(ctx context.Context, recipe linkrp.RecipeProperties, envProviders coreDatamodel.Providers, recipeContext linkrp.RecipeContext) (deployedResources []string, err error) {
+func (handler *recipeHandler) DeployRecipe(ctx context.Context, recipe linkrp.RecipeProperties, envProviders coreDatamodel.Providers, recipeContext linkrp.RecipeContext) (*RecipeResponse, error) {
 	if recipe.TemplatePath == "" {
 		return nil, fmt.Errorf("recipe template path cannot be empty")
 	}
@@ -151,11 +151,17 @@ func (handler *recipeHandler) DeployRecipe(ctx context.Context, recipe linkrp.Re
 		return nil, fmt.Errorf("failed to deploy the recipe %q, template path: %q, deployment: %q", recipe.Name, recipe.TemplatePath, deploymentID.Name())
 	}
 
+	recipeResponse := RecipeResponse{}
+	recipeResponse.Secrets = map[string]any{}
+	recipeResponse.Values = map[string]any{}
+
 	for _, id := range resp.Properties.OutputResources {
-		deployedResources = append(deployedResources, *id.ID)
+		recipeResponse.Resources = append(recipeResponse.Resources, *id.ID)
 	}
 
-	return deployedResources, nil
+	prepareRecipeResponse(resp.Properties.Outputs, &recipeResponse)
+
+	return &recipeResponse, nil
 }
 
 // getDigestFromManifest gets the layers digest from the manifest

--- a/pkg/linkrp/handlers/recipe_handler_test.go
+++ b/pkg/linkrp/handlers/recipe_handler_test.go
@@ -214,7 +214,8 @@ func Test_RecipeResponseSuccess(t *testing.T) {
 		Secrets:   map[string]any{},
 		Values:    map[string]any{},
 	}
-	prepareRecipeResponse(response, &actualResp)
+	err := prepareRecipeResponse(response, &actualResp)
+	require.NoError(t, err)
 	require.Equal(t, expectedResponse, actualResp)
 }
 
@@ -242,7 +243,8 @@ func Test_RecipeResponseWithoutSecret(t *testing.T) {
 		Secrets:   map[string]any{},
 		Values:    map[string]any{},
 	}
-	prepareRecipeResponse(response, &actualResp)
+	err := prepareRecipeResponse(response, &actualResp)
+	require.NoError(t, err)
 	require.Equal(t, expectedResponse, actualResp)
 }
 
@@ -258,6 +260,7 @@ func Test_RecipeResponseWithoutResult(t *testing.T) {
 		Secrets:   map[string]any{},
 		Values:    map[string]any{},
 	}
-	prepareRecipeResponse(response, &actualResp)
+	err := prepareRecipeResponse(response, &actualResp)
+	require.NoError(t, err)
 	require.Equal(t, expectedResponse, actualResp)
 }

--- a/pkg/linkrp/handlers/recipe_handler_test.go
+++ b/pkg/linkrp/handlers/recipe_handler_test.go
@@ -180,3 +180,84 @@ func Test_createProviderConfig_hasProviders(t *testing.T) {
 	actual := createProviderConfig("test-rg", providers)
 	require.Equal(t, expected, actual)
 }
+
+func Test_RecipeResponseSuccess(t *testing.T) {
+	response := map[string]any{}
+	value := map[string]any{}
+	value["resources"] = []any{"testId1", "testId2"}
+	value["secrets"] = map[string]any{
+		"username":         "testUser",
+		"password":         "testPassword",
+		"connectionString": "test-connection-string",
+	}
+	value["values"] = map[string]any{
+		"host": "myrediscache.redis.cache.windows.net",
+		"port": 6379,
+	}
+	response["result"] = map[string]any{
+		"value": value,
+	}
+	expectedResponse := RecipeResponse{
+		Resources: []string{"outputResourceId", "testId1", "testId2"},
+		Secrets: map[string]any{
+			"username":         "testUser",
+			"password":         "testPassword",
+			"connectionString": "test-connection-string",
+		},
+		Values: map[string]any{
+			"host": "myrediscache.redis.cache.windows.net",
+			"port": 6379,
+		},
+	}
+	actualResp := RecipeResponse{
+		Resources: []string{"outputResourceId"},
+		Secrets:   map[string]any{},
+		Values:    map[string]any{},
+	}
+	prepareRecipeResponse(response, &actualResp)
+	require.Equal(t, expectedResponse, actualResp)
+}
+
+func Test_RecipeResponseWithoutSecret(t *testing.T) {
+	response := map[string]any{}
+	value := map[string]any{}
+	value["resources"] = []any{"testId1", "testId2"}
+	value["values"] = map[string]any{
+		"host": "myrediscache.redis.cache.windows.net",
+		"port": 6379,
+	}
+	response["result"] = map[string]any{
+		"value": value,
+	}
+	expectedResponse := RecipeResponse{
+		Resources: []string{"outputResourceId", "testId1", "testId2"},
+		Secrets:   map[string]any{},
+		Values: map[string]any{
+			"host": "myrediscache.redis.cache.windows.net",
+			"port": 6379,
+		},
+	}
+	actualResp := RecipeResponse{
+		Resources: []string{"outputResourceId"},
+		Secrets:   map[string]any{},
+		Values:    map[string]any{},
+	}
+	prepareRecipeResponse(response, &actualResp)
+	require.Equal(t, expectedResponse, actualResp)
+}
+
+func Test_RecipeResponseWithoutResult(t *testing.T) {
+	response := map[string]any{}
+	expectedResponse := RecipeResponse{
+		Resources: []string{"outputResourceId"},
+		Secrets:   map[string]any{},
+		Values:    map[string]any{},
+	}
+	actualResp := RecipeResponse{
+		Resources: []string{"outputResourceId"},
+		Secrets:   map[string]any{},
+		Values:    map[string]any{},
+	}
+	prepareRecipeResponse(response, &actualResp)
+	require.Equal(t, expectedResponse, actualResp)
+}

--- a/pkg/linkrp/handlers/recipe_handler_test.go
+++ b/pkg/linkrp/handlers/recipe_handler_test.go
@@ -8,6 +8,8 @@ package handlers
 import (
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	corerp_datamodel "github.com/project-radius/radius/pkg/corerp/datamodel"
 	"github.com/project-radius/radius/pkg/linkrp"
 	"github.com/project-radius/radius/pkg/sdk/clients"
@@ -182,6 +184,12 @@ func Test_createProviderConfig_hasProviders(t *testing.T) {
 }
 
 func Test_RecipeResponseSuccess(t *testing.T) {
+	resources := []*armresources.ResourceReference{
+		{
+			ID: to.Ptr("outputResourceId"),
+		},
+	}
+
 	response := map[string]any{}
 	value := map[string]any{}
 	value["resources"] = []any{"testId1", "testId2"}
@@ -192,13 +200,13 @@ func Test_RecipeResponseSuccess(t *testing.T) {
 	}
 	value["values"] = map[string]any{
 		"host": "myrediscache.redis.cache.windows.net",
-		"port": 6379,
+		"port": float64(6379), // This will be a float64 not an int in real scenarios, it's read from JSON.
 	}
 	response["result"] = map[string]any{
 		"value": value,
 	}
 	expectedResponse := RecipeResponse{
-		Resources: []string{"outputResourceId", "testId1", "testId2"},
+		Resources: []string{"testId1", "testId2", "outputResourceId"},
 		Secrets: map[string]any{
 			"username":         "testUser",
 			"password":         "testPassword",
@@ -206,61 +214,60 @@ func Test_RecipeResponseSuccess(t *testing.T) {
 		},
 		Values: map[string]any{
 			"host": "myrediscache.redis.cache.windows.net",
-			"port": 6379,
+			"port": float64(6379),
 		},
 	}
-	actualResp := RecipeResponse{
-		Resources: []string{"outputResourceId"},
-		Secrets:   map[string]any{},
-		Values:    map[string]any{},
-	}
-	err := prepareRecipeResponse(response, &actualResp)
+
+	actualResponse, err := prepareRecipeResponse(response, resources)
 	require.NoError(t, err)
-	require.Equal(t, expectedResponse, actualResp)
+	require.Equal(t, expectedResponse, actualResponse)
 }
 
 func Test_RecipeResponseWithoutSecret(t *testing.T) {
+	resources := []*armresources.ResourceReference{
+		{
+			ID: to.Ptr("outputResourceId"),
+		},
+	}
+
 	response := map[string]any{}
 	value := map[string]any{}
 	value["resources"] = []any{"testId1", "testId2"}
 	value["values"] = map[string]any{
 		"host": "myrediscache.redis.cache.windows.net",
-		"port": 6379,
+		"port": float64(6379), // This will be a float64 not an int in real scenarios, it's read from JSON.
 	}
 	response["result"] = map[string]any{
 		"value": value,
 	}
 	expectedResponse := RecipeResponse{
-		Resources: []string{"outputResourceId", "testId1", "testId2"},
+		Resources: []string{"testId1", "testId2", "outputResourceId"},
 		Secrets:   map[string]any{},
 		Values: map[string]any{
 			"host": "myrediscache.redis.cache.windows.net",
-			"port": 6379,
+			"port": float64(6379),
 		},
 	}
-	actualResp := RecipeResponse{
-		Resources: []string{"outputResourceId"},
-		Secrets:   map[string]any{},
-		Values:    map[string]any{},
-	}
-	err := prepareRecipeResponse(response, &actualResp)
+
+	actualResponse, err := prepareRecipeResponse(response, resources)
 	require.NoError(t, err)
-	require.Equal(t, expectedResponse, actualResp)
+	require.Equal(t, expectedResponse, actualResponse)
 }
 
 func Test_RecipeResponseWithoutResult(t *testing.T) {
+	resources := []*armresources.ResourceReference{
+		{
+			ID: to.Ptr("outputResourceId"),
+		},
+	}
 	response := map[string]any{}
 	expectedResponse := RecipeResponse{
 		Resources: []string{"outputResourceId"},
 		Secrets:   map[string]any{},
 		Values:    map[string]any{},
 	}
-	actualResp := RecipeResponse{
-		Resources: []string{"outputResourceId"},
-		Secrets:   map[string]any{},
-		Values:    map[string]any{},
-	}
-	err := prepareRecipeResponse(response, &actualResp)
+
+	actualResponse, err := prepareRecipeResponse(response, resources)
 	require.NoError(t, err)
-	require.Equal(t, expectedResponse, actualResp)
+	require.Equal(t, expectedResponse, actualResponse)
 }

--- a/pkg/linkrp/handlers/recipe_helper.go
+++ b/pkg/linkrp/handlers/recipe_helper.go
@@ -13,6 +13,14 @@ import (
 	"github.com/project-radius/radius/pkg/ucp/resources"
 )
 
+// RecipeResponse is the response from deplying the recipe.
+// It has the list of resourceId's that out deployed and the secrets ant output value
+type RecipeResponse struct {
+	Resources []string
+	Secrets   map[string]any
+	Values    map[string]any
+}
+
 // CreateRecipeContextParameter creates the context parameter for the recipe with the link, environment and application info
 func CreateRecipeContextParameter(resourceID, environmentID, environmentNamespace, applicationID, applicationNamespace string) (*linkrp.RecipeContext, error) {
 	recipeContext := linkrp.RecipeContext{}
@@ -76,4 +84,35 @@ func parseTemplatePath(templatePath string) (repository string, tag string, err 
 	repository = reference.Repository()
 	tag = reference.Tag()
 	return
+}
+
+// the function populates the recipe response from parsing the output result object
+func prepareRecipeResponse(outputs any, recipeResp *RecipeResponse) {
+	out, ok := outputs.(map[string]any)
+	if ok {
+		recipeOutput, ok := out["result"].(map[string]any)
+		if ok {
+			output, ok := recipeOutput["value"].(map[string]any)
+			if ok {
+				resources, ok := output["resources"].([]any)
+				if ok {
+					for _, resource := range resources {
+						recipeResp.Resources = append(recipeResp.Resources, resource.(string))
+					}
+				}
+				secrets, ok := output["secrets"].(map[string]any)
+				if ok {
+					for key, value := range secrets {
+						recipeResp.Secrets[key] = value
+					}
+				}
+				values, ok := output["values"].(map[string]any)
+				if ok {
+					for key, value := range values {
+						recipeResp.Values[key] = value
+					}
+				}
+			}
+		}
+	}
 }

--- a/pkg/linkrp/model/application_model.go
+++ b/pkg/linkrp/model/application_model.go
@@ -31,6 +31,7 @@ func NewApplicationModel(arm *armauth.ArmConfig, k8s client.Client, connection s
 	// Configure the providers supported by the appmodel
 	supportedProviders := map[string]bool{
 		resourcemodel.ProviderKubernetes: true,
+		resourcemodel.ProviderAWS:        true,
 	}
 	if arm != nil {
 		supportedProviders[resourcemodel.ProviderAzure] = true
@@ -95,6 +96,24 @@ func NewApplicationModel(arm *armauth.ArmConfig, k8s client.Client, connection s
 				Provider: resourcemodel.ProviderKubernetes,
 			},
 			ResourceHandler: handlers.NewDaprComponentHandler(k8s),
+		},
+
+		{
+			// Handles any Kubernetes resource type
+			ResourceType: resourcemodel.ResourceType{
+				Type:     resourcekinds.Wildcard,
+				Provider: resourcemodel.ProviderKubernetes,
+			},
+			ResourceHandler: handlers.NewKubernetesHandler(k8s),
+		},
+
+		{
+			// Handles any AWS resource type
+			ResourceType: resourcemodel.ResourceType{
+				Type:     resourcekinds.Wildcard,
+				Provider: resourcemodel.ProviderAWS,
+			},
+			ResourceHandler: handlers.NewAWSHandler(connection),
 		},
 	}
 

--- a/pkg/linkrp/model/application_model.go
+++ b/pkg/linkrp/model/application_model.go
@@ -101,7 +101,7 @@ func NewApplicationModel(arm *armauth.ArmConfig, k8s client.Client, connection s
 		{
 			// Handles any Kubernetes resource type
 			ResourceType: resourcemodel.ResourceType{
-				Type:     resourcekinds.Wildcard,
+				Type:     resourcekinds.AnyResourceType,
 				Provider: resourcemodel.ProviderKubernetes,
 			},
 			ResourceHandler: handlers.NewKubernetesHandler(k8s),
@@ -110,7 +110,7 @@ func NewApplicationModel(arm *armauth.ArmConfig, k8s client.Client, connection s
 		{
 			// Handles any AWS resource type
 			ResourceType: resourcemodel.ResourceType{
-				Type:     resourcekinds.Wildcard,
+				Type:     resourcekinds.AnyResourceType,
 				Provider: resourcemodel.ProviderAWS,
 			},
 			ResourceHandler: handlers.NewAWSHandler(connection),

--- a/pkg/linkrp/model/types.go
+++ b/pkg/linkrp/model/types.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/project-radius/radius/pkg/linkrp/handlers"
 	"github.com/project-radius/radius/pkg/linkrp/renderers"
+	"github.com/project-radius/radius/pkg/resourcekinds"
 	"github.com/project-radius/radius/pkg/resourcemodel"
 	sv "github.com/project-radius/radius/pkg/rp/secretvalue"
 )
@@ -50,6 +51,14 @@ func (m ApplicationModel) LookupRadiusResourceModel(resourceType string) (*Radiu
 func (m ApplicationModel) LookupOutputResourceModel(resourceType resourcemodel.ResourceType) (*OutputResourceModel, error) {
 	resource, ok := m.outputResourceLookup[resourceType]
 	if !ok {
+		wildcard, ok := m.outputResourceLookup[resourcemodel.ResourceType{Type: resourcekinds.Wildcard, Provider: resourceType.Provider}]
+		if ok {
+			return &OutputResourceModel{
+				ResourceType:    resourceType,
+				ResourceHandler: wildcard.ResourceHandler,
+			}, nil
+		}
+
 		return nil, fmt.Errorf("output resource kind '%s' is unsupported", resourceType)
 	}
 

--- a/pkg/linkrp/model/types.go
+++ b/pkg/linkrp/model/types.go
@@ -51,7 +51,7 @@ func (m ApplicationModel) LookupRadiusResourceModel(resourceType string) (*Radiu
 func (m ApplicationModel) LookupOutputResourceModel(resourceType resourcemodel.ResourceType) (*OutputResourceModel, error) {
 	resource, ok := m.outputResourceLookup[resourceType]
 	if !ok {
-		wildcard, ok := m.outputResourceLookup[resourcemodel.ResourceType{Type: resourcekinds.Wildcard, Provider: resourceType.Provider}]
+		wildcard, ok := m.outputResourceLookup[resourcemodel.ResourceType{Type: resourcekinds.AnyResourceType, Provider: resourceType.Provider}]
 		if ok {
 			return &OutputResourceModel{
 				ResourceType:    resourceType,

--- a/pkg/linkrp/renderers/daprstatestores/recipe.go
+++ b/pkg/linkrp/renderers/daprstatestores/recipe.go
@@ -30,7 +30,6 @@ func GetDaprStateStoreRecipe(resource *datamodel.DaprStateStore, applicationName
 		return renderers.RendererOutput{}, err
 	}
 	recipeData := linkrp.RecipeData{
-		Provider:         resourcemodel.ProviderAzure,
 		RecipeProperties: options.RecipeProperties,
 		APIVersion:       clientv2.StateStoreClientAPIVersion,
 	}

--- a/pkg/linkrp/renderers/mongodatabases/renderer.go
+++ b/pkg/linkrp/renderers/mongodatabases/renderer.go
@@ -75,7 +75,6 @@ func RenderAzureRecipe(resource *datamodel.MongoDatabase, options renderers.Rend
 	}
 
 	recipeData := linkrp.RecipeData{
-		Provider:         resourcemodel.ProviderAzure,
 		RecipeProperties: options.RecipeProperties,
 		APIVersion:       clientv2.DocumentDBManagementClientAPIVersion,
 	}

--- a/pkg/linkrp/renderers/rediscaches/renderer.go
+++ b/pkg/linkrp/renderers/rediscaches/renderer.go
@@ -7,9 +7,13 @@ package rediscaches
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	"github.com/project-radius/radius/pkg/azure/azresources"
 	"github.com/project-radius/radius/pkg/azure/clientv2"
+	"github.com/project-radius/radius/pkg/linkrp"
 	"github.com/project-radius/radius/pkg/linkrp/datamodel"
 	"github.com/project-radius/radius/pkg/linkrp/renderers"
 	"github.com/project-radius/radius/pkg/resourcekinds"
@@ -38,21 +42,62 @@ func (r Renderer) Render(ctx context.Context, dm v1.ResourceDataModel, options r
 		return renderers.RendererOutput{}, err
 	}
 
-	if resource.Properties.Resource == "" {
-		return renderers.RendererOutput{
-			Resources:      []rpv1.OutputResource{},
-			ComputedValues: computedValues,
-			SecretValues:   secretValues,
-		}, nil
-	} else {
+	switch resource.Properties.Mode {
+
+	case datamodel.LinkModeRecipe:
+		rendererOutput, err := renderAzureRecipe(resource, options, secretValues, computedValues)
+		if err != nil {
+			return renderers.RendererOutput{}, err
+		}
+		return rendererOutput, nil
+	case datamodel.LinkModeResource:
 		// Source resource identifier is provided. Currently only Azure resources are expected with non empty resource id
 		rendererOutput, err := renderAzureResource(properties, secretValues, computedValues)
 		if err != nil {
 			return renderers.RendererOutput{}, err
 		}
-
 		return rendererOutput, nil
+	case datamodel.LinkModeValues:
+		return renderers.RendererOutput{
+			Resources:      []rpv1.OutputResource{},
+			ComputedValues: computedValues,
+			SecretValues:   secretValues,
+		}, nil
+	default:
+		return renderers.RendererOutput{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("unsupported mode %s", resource.Properties.Mode))
 	}
+
+}
+
+func renderAzureRecipe(resource *datamodel.RedisCache, options renderers.RenderOptions, secretValues map[string]rpv1.SecretValueReference, computedValues map[string]renderers.ComputedValueReference) (renderers.RendererOutput, error) {
+	if options.RecipeProperties.LinkType != resource.ResourceTypeName() {
+		return renderers.RendererOutput{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("link type %q of provided recipe %q is incompatible with %q resource type. Recipe link type must match link resource type.",
+			options.RecipeProperties.LinkType, options.RecipeProperties.Name, linkrp.RedisCachesResourceType))
+	}
+
+	recipeData := linkrp.RecipeData{
+		RecipeProperties: options.RecipeProperties,
+		APIVersion:       clientv2.RedisManagementClientAPIVersion,
+	}
+
+	// Build computedValues reference
+	buildComputedValuesReference(computedValues)
+	// Build secretValue reference
+	buildSecretValueReference(secretValues)
+
+	// Build output resources
+	redisCacheOutputResource := buildOutputResource()
+	redisCacheOutputResource.ProviderResourceType = azresources.CacheRedis
+	// Set the RadiusManaged to true for resources deployed by recipe
+	redisCacheOutputResource.RadiusManaged = to.Ptr(true)
+
+	return renderers.RendererOutput{
+		Resources:            []rpv1.OutputResource{redisCacheOutputResource},
+		ComputedValues:       computedValues,
+		SecretValues:         secretValues,
+		RecipeData:           recipeData,
+		EnvironmentProviders: options.EnvironmentProviders,
+	}, nil
 }
 
 func renderAzureResource(properties datamodel.RedisCacheProperties, secretValues map[string]rpv1.SecretValueReference, computedValues map[string]renderers.ComputedValueReference) (renderers.RendererOutput, error) {
@@ -67,48 +112,13 @@ func renderAzureResource(properties datamodel.RedisCacheProperties, secretValues
 		return renderers.RendererOutput{}, v1.NewClientErrInvalidRequest("the 'resource' field must refer to an Azure Redis Cache")
 	}
 
-	if _, ok := computedValues[renderers.Host]; !ok {
-		computedValues[renderers.Host] = renderers.ComputedValueReference{
-			LocalID:     rpv1.LocalIDAzureRedis,
-			JSONPointer: "/properties/hostName", // https://learn.microsoft.com/en-us/rest/api/redis/redis/get
-		}
-	}
-
-	if _, ok := computedValues[renderers.Port]; !ok {
-		computedValues[renderers.Port] = renderers.ComputedValueReference{
-			LocalID:     rpv1.LocalIDAzureRedis,
-			JSONPointer: "/properties/sslPort", // https://learn.microsoft.com/en-us/rest/api/redis/redis/get
-		}
-	}
-
-	if _, ok := secretValues[renderers.PasswordStringHolder]; !ok {
-		secretValues[renderers.PasswordStringHolder] = rpv1.SecretValueReference{
-			LocalID:       rpv1.LocalIDAzureRedis,
-			Action:        "listKeys",
-			ValueSelector: "/primaryKey",
-		}
-	}
-
-	if _, ok := secretValues[renderers.ConnectionStringValue]; !ok {
-		secretValues[renderers.ConnectionStringValue] = rpv1.SecretValueReference{
-			LocalID:       rpv1.LocalIDAzureRedis,
-			Action:        "listKeys",
-			ValueSelector: "/primaryKey",
-			Transformer: resourcemodel.ResourceType{
-				Provider: resourcemodel.ProviderAzure,
-				Type:     resourcekinds.AzureRedis,
-			},
-		}
-	}
+	// Build computedValues reference
+	buildComputedValuesReference(computedValues)
+	// Build secretValue reference
+	buildSecretValueReference(secretValues)
 
 	// Build output resources
-	redisCacheOutputResource := rpv1.OutputResource{
-		LocalID: rpv1.LocalIDAzureRedis,
-		ResourceType: resourcemodel.ResourceType{
-			Type:     resourcekinds.AzureRedis,
-			Provider: resourcemodel.ProviderAzure,
-		},
-	}
+	redisCacheOutputResource := buildOutputResource()
 	redisCacheOutputResource.Identity = resourcemodel.NewARMIdentity(&redisCacheOutputResource.ResourceType, redisCacheID.String(), clientv2.RedisManagementClientAPIVersion)
 
 	return renderers.RendererOutput{
@@ -142,4 +152,53 @@ func getProvidedComputedValues(properties datamodel.RedisCacheProperties) map[st
 	}
 
 	return computedValues
+}
+
+func buildSecretValueReference(secretValues map[string]rpv1.SecretValueReference) map[string]rpv1.SecretValueReference {
+	if _, ok := secretValues[renderers.PasswordStringHolder]; !ok {
+		secretValues[renderers.PasswordStringHolder] = rpv1.SecretValueReference{
+			LocalID:       rpv1.LocalIDAzureRedis,
+			Action:        "listKeys",
+			ValueSelector: "/primaryKey",
+		}
+	}
+
+	if _, ok := secretValues[renderers.ConnectionStringValue]; !ok {
+		secretValues[renderers.ConnectionStringValue] = rpv1.SecretValueReference{
+			LocalID:       rpv1.LocalIDAzureRedis,
+			Action:        "listKeys",
+			ValueSelector: "/primaryKey",
+			Transformer: resourcemodel.ResourceType{
+				Provider: resourcemodel.ProviderAzure,
+				Type:     resourcekinds.AzureRedis,
+			},
+		}
+	}
+	return secretValues
+}
+
+func buildComputedValuesReference(computedValues map[string]renderers.ComputedValueReference) {
+	if _, ok := computedValues[renderers.Host]; !ok {
+		computedValues[renderers.Host] = renderers.ComputedValueReference{
+			LocalID:     rpv1.LocalIDAzureRedis,
+			JSONPointer: "/properties/hostName", // https://learn.microsoft.com/en-us/rest/api/redis/redis/get
+		}
+	}
+
+	if _, ok := computedValues[renderers.Port]; !ok {
+		computedValues[renderers.Port] = renderers.ComputedValueReference{
+			LocalID:     rpv1.LocalIDAzureRedis,
+			JSONPointer: "/properties/sslPort", // https://learn.microsoft.com/en-us/rest/api/redis/redis/get
+		}
+	}
+}
+
+func buildOutputResource() rpv1.OutputResource {
+	return rpv1.OutputResource{
+		LocalID: rpv1.LocalIDAzureRedis,
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.AzureRedis,
+			Provider: resourcemodel.ProviderAzure,
+		},
+	}
 }

--- a/pkg/linkrp/renderers/rediscaches/renderer_test.go
+++ b/pkg/linkrp/renderers/rediscaches/renderer_test.go
@@ -9,7 +9,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	"github.com/project-radius/radius/pkg/azure/azresources"
 	"github.com/project-radius/radius/pkg/azure/clientv2"
 	"github.com/project-radius/radius/pkg/linkrp"
 	"github.com/project-radius/radius/pkg/linkrp/datamodel"
@@ -172,9 +174,13 @@ func Test_Render_NoResourceSpecified(t *testing.T) {
 			Mode: datamodel.LinkModeResource,
 		},
 	}
+	expectedErr := &v1.ErrClientRP{
+		Code:    "BadRequest",
+		Message: "the 'resource' field must be a valid resource id",
+	}
 
 	_, err := renderer.Render(ctx, &redisResource, renderers.RenderOptions{})
-	require.NoError(t, err)
+	require.Equal(t, expectedErr, err)
 }
 
 func Test_Render_InvalidResourceModel(t *testing.T) {
@@ -290,4 +296,142 @@ func Test_Render_InvalidApplicationID(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, v1.CodeInvalid, err.(*v1.ErrClientRP).Code)
 	require.Equal(t, "failed to parse application from the property: 'invalid-app-id' is not a valid resource id", err.(*v1.ErrClientRP).Message)
+}
+
+func Test_Render_Recipe_Success(t *testing.T) {
+	ctx := context.Background()
+	renderer := Renderer{}
+
+	redisResource := datamodel.RedisCache{
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:   "/subscriptions/testSub/resourceGroups/testGroup/providers/Applications.Link/redisCaches/redis0",
+				Name: "redis0",
+				Type: linkrp.RedisCachesResourceType,
+			},
+		},
+		Properties: datamodel.RedisCacheProperties{
+			BasicResourceProperties: rpv1.BasicResourceProperties{
+				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+			},
+			Mode: datamodel.LinkModeRecipe,
+			RedisRecipeProperties: datamodel.RedisRecipeProperties{
+				Recipe: linkrp.LinkRecipe{
+					Name: "redis",
+					Parameters: map[string]any{
+						"throughput": 400,
+					},
+				},
+			},
+		},
+	}
+	expectedOutputResource := rpv1.OutputResource{
+		LocalID: rpv1.LocalIDAzureRedis,
+		ResourceType: resourcemodel.ResourceType{
+			Type:     resourcekinds.AzureRedis,
+			Provider: resourcemodel.ProviderAzure,
+		},
+		ProviderResourceType: azresources.CacheRedis,
+		RadiusManaged:        to.Ptr(true),
+	}
+
+	expectedComputedValues := map[string]renderers.ComputedValueReference{
+		renderers.Host: {
+			LocalID:     rpv1.LocalIDAzureRedis,
+			JSONPointer: "/properties/hostName",
+		},
+		renderers.Port: {
+			LocalID:     rpv1.LocalIDAzureRedis,
+			JSONPointer: "/properties/sslPort",
+		},
+	}
+	expectedSecretValues := map[string]rpv1.SecretValueReference{
+		renderers.PasswordStringHolder: {
+			LocalID:       rpv1.LocalIDAzureRedis,
+			Action:        "listKeys",
+			ValueSelector: "/primaryKey",
+		},
+		renderers.ConnectionStringValue: {
+			LocalID:       rpv1.LocalIDAzureRedis,
+			Action:        "listKeys",
+			ValueSelector: "/primaryKey",
+			Transformer: resourcemodel.ResourceType{
+				Provider: resourcemodel.ProviderAzure,
+				Type:     resourcekinds.AzureRedis,
+			},
+		},
+	}
+
+	output, err := renderer.Render(ctx, &redisResource, renderers.RenderOptions{
+		RecipeProperties: linkrp.RecipeProperties{
+			LinkRecipe: linkrp.LinkRecipe{
+				Name: "redis",
+				Parameters: map[string]any{
+					"throughput": 400,
+				},
+			},
+			TemplatePath: "testpublicrecipe.azurecr.io/bicep/modules/redis:v1",
+			LinkType:     linkrp.RedisCachesResourceType,
+		}})
+
+	require.NoError(t, err)
+	// Recipe properties
+	require.Equal(t, redisResource.Properties.Recipe.Name, output.RecipeData.Name)
+	require.Equal(t, redisResource.Properties.Recipe.Parameters, output.RecipeData.Parameters)
+	require.Equal(t, "testpublicrecipe.azurecr.io/bicep/modules/redis:v1", output.RecipeData.TemplatePath)
+	require.Equal(t, clientv2.RedisManagementClientAPIVersion, output.RecipeData.APIVersion)
+
+	// secrets and computed values
+	require.Equal(t, expectedSecretValues, output.SecretValues)
+	require.Equal(t, expectedComputedValues, output.ComputedValues)
+
+	// output resources
+	require.Len(t, output.Resources, 1)
+	require.Equal(t, expectedOutputResource, output.Resources[0])
+}
+
+func Test_Render_Recipe_InvalidLinkType(t *testing.T) {
+	ctx := context.Background()
+	renderer := Renderer{}
+
+	redisResource := datamodel.RedisCache{
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:   "/subscriptions/testSub/resourceGroups/testGroup/providers/Applications.Link/redisCaches/redis0",
+				Name: "redis0",
+				Type: linkrp.RedisCachesResourceType,
+			},
+		},
+		Properties: datamodel.RedisCacheProperties{
+			BasicResourceProperties: rpv1.BasicResourceProperties{
+				Environment: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+				Application: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+			},
+			Mode: datamodel.LinkModeRecipe,
+			RedisRecipeProperties: datamodel.RedisRecipeProperties{
+				Recipe: linkrp.LinkRecipe{
+					Name: "redis",
+					Parameters: map[string]any{
+						"throughput": 400,
+					},
+				},
+			},
+		},
+	}
+
+	_, err := renderer.Render(ctx, &redisResource, renderers.RenderOptions{
+		RecipeProperties: linkrp.RecipeProperties{
+			LinkRecipe: linkrp.LinkRecipe{
+				Name: "redis",
+			},
+			TemplatePath: "testpublicrecipe.azurecr.io/bicep/modules/rediscaches:v1",
+			LinkType:     linkrp.MongoDatabasesResourceType,
+			EnvParameters: map[string]any{
+				"throughput": 400,
+			},
+		}})
+	require.Error(t, err)
+	require.Equal(t, v1.CodeInvalid, err.(*v1.ErrClientRP).Code)
+	require.Equal(t, "link type \"Applications.Link/mongoDatabases\" of provided recipe \"redis\" is incompatible with \"Applications.Link/redisCaches\" resource type. Recipe link type must match link resource type.", err.(*v1.ErrClientRP).Message)
 }

--- a/pkg/linkrp/types.go
+++ b/pkg/linkrp/types.go
@@ -8,9 +8,7 @@ package linkrp
 type RecipeData struct {
 	RecipeProperties
 
-	Provider string
-
-	// API version to use to perform operations on resources supported by the link.
+	// APIVersion is the API version to use to perform operations on resources supported by the link.
 	// For example for Azure resources, every service has different REST API version that must be specified in the request.
 	APIVersion string
 

--- a/pkg/resourcekinds/resource_kinds.go
+++ b/pkg/resourcekinds/resource_kinds.go
@@ -39,7 +39,7 @@ const (
 	AzureFileShare                   = "azure.fileshare"
 	AzureFileShareStorageAccount     = "azure.fileshare.account"
 
-	// Wildcard is used to designate a resource handler that can handle any type that belongs to a provider. Wildcard
+	// AnyResourceType is used to designate a resource handler that can handle any type that belongs to a provider. AnyResourceType
 	// should only be used to register handlers, and not as part of an output resource.
-	Wildcard = "*"
+	AnyResourceType = "*"
 )

--- a/pkg/resourcekinds/resource_kinds.go
+++ b/pkg/resourcekinds/resource_kinds.go
@@ -38,4 +38,8 @@ const (
 	AzureRedis                       = "azure.redis"
 	AzureFileShare                   = "azure.fileshare"
 	AzureFileShareStorageAccount     = "azure.fileshare.account"
+
+	// Wildcard is used to designate a resource handler that can handle any type that belongs to a provider. Wildcard
+	// should only be used to register handlers, and not as part of an output resource.
+	Wildcard = "*"
 )

--- a/pkg/resourcemodel/identity.go
+++ b/pkg/resourcemodel/identity.go
@@ -8,11 +8,13 @@ package resourcemodel
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/project-radius/radius/pkg/logging"
 	"github.com/project-radius/radius/pkg/resourcekinds"
 	"github.com/project-radius/radius/pkg/ucp/resources"
 	"github.com/project-radius/radius/pkg/ucp/store"
+	"github.com/project-radius/radius/pkg/ucp/ucplog"
 	"go.mongodb.org/mongo-driver/bson"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,7 +25,13 @@ import (
 // The RP will be able to support a resource only if the corresponding provider is configured with the RP
 const (
 	ProviderAzure      = "azure"
+	ProviderAWS        = "aws"
 	ProviderKubernetes = "kubernetes"
+
+	// APIVersionUnknown encodes an "unknown" API version. Including API version in resource identity is
+	// a design mistake because an API version is not part of the identity of a resource. We use this
+	// value as a sentinel for the cases where we don't have a preferred API version.
+	APIVersionUnknown = "unknown"
 )
 
 // ResourceType determines the type of the resource and the provider domain for the resource
@@ -54,6 +62,11 @@ var _ json.Unmarshaler = (*ResourceIdentity)(nil)
 type ARMIdentity struct {
 	ID         string `json:"id"`
 	APIVersion string `json:"apiVersion"`
+}
+
+// UCPIdentity uniquely identifies a UCP resource
+type UCPIdentity struct {
+	ID string `json:"id"`
 }
 
 // KubernetesIdentity uniquely identifies a Kubernetes resource
@@ -91,6 +104,18 @@ func NewARMIdentity(resourceType *ResourceType, id string, apiVersion string) Re
 	}
 }
 
+func NewUCPIdentity(resourceType *ResourceType, id string) ResourceIdentity {
+	return ResourceIdentity{
+		ResourceType: &ResourceType{
+			Type:     resourceType.Type,
+			Provider: resourceType.Provider,
+		},
+		Data: UCPIdentity{
+			ID: id,
+		},
+	}
+}
+
 func NewKubernetesIdentity(resourceType *ResourceType, obj runtime.Object, objectMeta metav1.ObjectMeta) ResourceIdentity {
 	return ResourceIdentity{
 		ResourceType: &ResourceType{
@@ -103,6 +128,31 @@ func NewKubernetesIdentity(resourceType *ResourceType, obj runtime.Object, objec
 			Name:       objectMeta.Name,
 			Namespace:  objectMeta.Namespace,
 		},
+	}
+}
+
+// GetID constructs a UCP resource ID from the ResourceIdentity.
+func (r ResourceIdentity) GetID() string {
+	switch r.ResourceType.Provider {
+	case ProviderAzure:
+		id, _, _ := r.RequireARM()
+		return id
+	case ProviderAWS:
+		id, _ := r.RequireAWS()
+		return id
+	case ProviderKubernetes:
+		gvk, namespace, name, _ := r.RequireKubernetes()
+		group := gvk.Group
+		if group == "" {
+			group = "core"
+		}
+		if namespace == "" {
+			return fmt.Sprintf("/planes/kubernetes/local/providers/%s/%s/%s", group, gvk.Kind, name)
+		} else {
+			return fmt.Sprintf("/planes/kubernetes/local/namespaces/%s/providers/%s/%s/%s", namespace, group, gvk.Kind, name)
+		}
+	default:
+		return ""
 	}
 }
 
@@ -119,6 +169,21 @@ func (r ResourceIdentity) RequireARM() (string, string, error) {
 	}
 
 	return "", "", fmt.Errorf("expected an %q provider, was %q", ProviderAzure, r.ResourceType.Provider)
+}
+
+func (r ResourceIdentity) RequireAWS() (string, error) {
+	if r.ResourceType.Provider == ProviderAWS {
+		data, ok := r.Data.(UCPIdentity)
+		if !ok {
+			data = UCPIdentity{}
+			if err := store.DecodeMap(r.Data, &data); err != nil {
+				return "", err
+			}
+		}
+		return data.ID, nil
+	}
+
+	return "", fmt.Errorf("expected an %q provider, was %q", ProviderAWS, r.ResourceType.Provider)
 }
 
 func (r ResourceIdentity) RequireKubernetes() (schema.GroupVersionKind, string, string, error) {
@@ -147,6 +212,11 @@ func (r ResourceIdentity) IsSameResource(other ResourceIdentity) bool {
 		b, _ := other.Data.(ARMIdentity)
 		return a == b
 
+	case ProviderAWS:
+		a, _ := r.Data.(UCPIdentity)
+		b, _ := other.Data.(UCPIdentity)
+		return a == b
+
 	case ProviderKubernetes:
 		a, _ := r.Data.(KubernetesIdentity)
 		b, _ := other.Data.(KubernetesIdentity)
@@ -158,7 +228,7 @@ func (r ResourceIdentity) IsSameResource(other ResourceIdentity) bool {
 }
 
 // AsLogValues returns log values as key-value pairs from this ResourceIdentifier.
-func (r ResourceIdentity) AsLogValues() []any {
+func (r ResourceIdentity) AsLogValues() []interface{} {
 	if r.ResourceType == nil {
 		return nil
 	}
@@ -168,10 +238,10 @@ func (r ResourceIdentity) AsLogValues() []any {
 		data := r.Data.(ARMIdentity)
 		id, err := resources.ParseResource(data.ID)
 		if err != nil {
-			return []any{logging.LogFieldResourceID, data.ID}
+			return []interface{}{ucplog.LogFieldResourceID, data.ID}
 		}
 
-		return []any{
+		return []interface{}{
 			logging.LogFieldResourceID, data.ID,
 			logging.LogFieldSubscriptionID, id.FindScope(resources.SubscriptionsSegment),
 			logging.LogFieldResourceGroup, id.FindScope(resources.ResourceGroupsSegment),
@@ -179,9 +249,23 @@ func (r ResourceIdentity) AsLogValues() []any {
 			logging.LogFieldResourceName, id.QualifiedName(),
 		}
 
+	case ProviderAWS:
+		// We can't report an error here so this is best-effort.
+		data := r.Data.(UCPIdentity)
+		id, err := resources.ParseResource(data.ID)
+		if err != nil {
+			return []interface{}{ucplog.LogFieldResourceID, data.ID}
+		}
+
+		return []interface{}{
+			logging.LogFieldResourceID, data.ID,
+			logging.LogFieldResourceType, id.Type(),
+			logging.LogFieldResourceName, id.QualifiedName(),
+		}
+
 	case ProviderKubernetes:
 		data := r.Data.(KubernetesIdentity)
-		return []any{
+		return []interface{}{
 			logging.LogFieldResourceName, data.Name,
 			logging.LogFieldNamespace, data.Namespace,
 			logging.LogFieldKind, data.Kind,
@@ -210,6 +294,15 @@ func (r *ResourceIdentity) UnmarshalJSON(b []byte) error {
 	switch r.ResourceType.Provider {
 	case ProviderAzure:
 		identity := ARMIdentity{}
+		err = json.Unmarshal(data.Data, &identity)
+		if err != nil {
+			return err
+		}
+		r.Data = identity
+		return nil
+
+	case ProviderAWS:
+		identity := UCPIdentity{}
 		err = json.Unmarshal(data.Data, &identity)
 		if err != nil {
 			return err
@@ -259,6 +352,15 @@ func (r *ResourceIdentity) UnmarshalBSON(b []byte) error {
 		r.Data = identity
 		return nil
 
+	case ProviderAWS:
+		identity := UCPIdentity{}
+		err = bson.Unmarshal(data.Data, &identity)
+		if err != nil {
+			return err
+		}
+		r.Data = identity
+		return nil
+
 	case ProviderKubernetes:
 		identity := KubernetesIdentity{}
 		err = bson.Unmarshal(data.Data, &identity)
@@ -271,4 +373,65 @@ func (r *ResourceIdentity) UnmarshalBSON(b []byte) error {
 	default:
 		return fmt.Errorf("unknown provider: %q", r.ResourceType.Provider)
 	}
+}
+
+// FromUCPID translates a UCP resource ID into a ResourceIdentity.
+//
+// TODO: This is transitional while we're refactoring to get rid of ResourceIdentity. UCP resource IDs are a more
+// complete and flexible way of identitying resources.
+func FromUCPID(id resources.ID, preferredAPIVersion string) ResourceIdentity {
+	// Blank resource id => blank identity
+	if len(id.ScopeSegments()) == 0 {
+		return ResourceIdentity{}
+	}
+
+	firstScope := id.ScopeSegments()[0].Type
+	if preferredAPIVersion == "" {
+		preferredAPIVersion = APIVersionUnknown
+	}
+
+	// If this starts with a subscription ID then it's an Azure resource
+	//
+	// case: /subscriptions/.../resourceGroups/.../......
+	if strings.EqualFold(resources.SubscriptionsSegment, firstScope) {
+		return NewARMIdentity(&ResourceType{Type: id.Type(), Provider: ProviderAzure}, id.String(), preferredAPIVersion)
+	}
+
+	// case: /planes/azure/azurecloud/subscriptions/.../resourceGroups/.../......
+	if strings.EqualFold("azure", firstScope) {
+		return NewARMIdentity(&ResourceType{Type: id.Type(), Provider: ProviderAzure}, id.String(), preferredAPIVersion)
+	}
+
+	// case: /planes/aws/aws/accounts/.../regions/.../......
+	if strings.EqualFold("aws", firstScope) {
+		return NewUCPIdentity(&ResourceType{Type: id.Type(), Provider: ProviderAWS}, id.String())
+	}
+
+	// case: /planes/kubernetes/local/namespaces/.../......
+	if strings.EqualFold("kubernetes", firstScope) {
+		// Kubernetes has some quirks because API groups were added after the initial release.
+		// We encode the "unnamed" group as "core".
+		group, kind, _ := strings.Cut(id.Type(), "/")
+		resourceType := id.Type()
+		apiVersion := group + "/" + preferredAPIVersion
+		if strings.EqualFold(group, "core") {
+			resourceType = kind
+			apiVersion = preferredAPIVersion
+		}
+
+		return ResourceIdentity{
+			ResourceType: &ResourceType{
+				Type:     resourceType,
+				Provider: ProviderKubernetes,
+			},
+			Data: KubernetesIdentity{
+				Kind:       kind,
+				APIVersion: apiVersion,
+				Namespace:  id.FindScope("namespaces"),
+				Name:       id.Name(),
+			},
+		}
+	}
+
+	return ResourceIdentity{}
 }

--- a/pkg/resourcemodel/identity.go
+++ b/pkg/resourcemodel/identity.go
@@ -228,7 +228,7 @@ func (r ResourceIdentity) IsSameResource(other ResourceIdentity) bool {
 }
 
 // AsLogValues returns log values as key-value pairs from this ResourceIdentifier.
-func (r ResourceIdentity) AsLogValues() []interface{} {
+func (r ResourceIdentity) AsLogValues() []any {
 	if r.ResourceType == nil {
 		return nil
 	}
@@ -238,10 +238,10 @@ func (r ResourceIdentity) AsLogValues() []interface{} {
 		data := r.Data.(ARMIdentity)
 		id, err := resources.ParseResource(data.ID)
 		if err != nil {
-			return []interface{}{ucplog.LogFieldResourceID, data.ID}
+			return []any{ucplog.LogFieldResourceID, data.ID}
 		}
 
-		return []interface{}{
+		return []any{
 			logging.LogFieldResourceID, data.ID,
 			logging.LogFieldSubscriptionID, id.FindScope(resources.SubscriptionsSegment),
 			logging.LogFieldResourceGroup, id.FindScope(resources.ResourceGroupsSegment),
@@ -254,10 +254,10 @@ func (r ResourceIdentity) AsLogValues() []interface{} {
 		data := r.Data.(UCPIdentity)
 		id, err := resources.ParseResource(data.ID)
 		if err != nil {
-			return []interface{}{ucplog.LogFieldResourceID, data.ID}
+			return []any{ucplog.LogFieldResourceID, data.ID}
 		}
 
-		return []interface{}{
+		return []any{
 			logging.LogFieldResourceID, data.ID,
 			logging.LogFieldResourceType, id.Type(),
 			logging.LogFieldResourceName, id.QualifiedName(),
@@ -265,7 +265,7 @@ func (r ResourceIdentity) AsLogValues() []interface{} {
 
 	case ProviderKubernetes:
 		data := r.Data.(KubernetesIdentity)
-		return []interface{}{
+		return []any{
 			logging.LogFieldResourceName, data.Name,
 			logging.LogFieldNamespace, data.Namespace,
 			logging.LogFieldKind, data.Kind,

--- a/pkg/resourcemodel/identity_test.go
+++ b/pkg/resourcemodel/identity_test.go
@@ -14,27 +14,80 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-var values = []ResourceIdentity{
+var values = []struct {
+	ExpectedID string
+	Identity   ResourceIdentity
+}{
 	{
-		ResourceType: &ResourceType{
-			Type:     resourcekinds.AzureCosmosAccount,
-			Provider: ProviderAzure,
-		},
-		Data: ARMIdentity{
-			ID:         "/some/id",
-			APIVersion: "2020-01-01",
+		ExpectedID: "/subscriptions/0000/resourceGroups/mygroup/providers/Microsoft.DocumentDB/accounts/someaccount",
+		Identity: ResourceIdentity{
+			ResourceType: &ResourceType{
+				Type:     resourcekinds.AzureCosmosAccount,
+				Provider: ProviderAzure,
+			},
+			Data: ARMIdentity{
+				ID:         "/subscriptions/0000/resourceGroups/mygroup/providers/Microsoft.DocumentDB/accounts/someaccount",
+				APIVersion: "2020-01-01",
+			},
 		},
 	},
 	{
-		ResourceType: &ResourceType{
-			Type:     resourcekinds.Deployment,
-			Provider: ProviderKubernetes,
+		// "core" group
+		ExpectedID: "/planes/kubernetes/local/namespaces/test-namespace/providers/core/Secret/test-name",
+		Identity: ResourceIdentity{
+			ResourceType: &ResourceType{
+				Type:     resourcekinds.Secret,
+				Provider: ProviderKubernetes,
+			},
+			Data: KubernetesIdentity{
+				Kind:       "Secret",
+				APIVersion: "v1",
+				Name:       "test-name",
+				Namespace:  "test-namespace",
+			},
 		},
-		Data: KubernetesIdentity{
-			Kind:       "Deployment",
-			APIVersion: "apps/v1",
-			Name:       "test-name",
-			Namespace:  "test-namespace",
+	},
+	{
+		// Cluster-scoped resource
+		ExpectedID: "/planes/kubernetes/local/providers/secrets/SecretProviderClass/test-name",
+		Identity: ResourceIdentity{
+			ResourceType: &ResourceType{
+				Type:     resourcekinds.SecretProviderClass,
+				Provider: ProviderKubernetes,
+			},
+			Data: KubernetesIdentity{
+				Kind:       "SecretProviderClass",
+				APIVersion: "secrets/v1",
+				Name:       "test-name",
+			},
+		},
+	},
+	{
+		// Namespaced non-core group
+		ExpectedID: "/planes/kubernetes/local/namespaces/test-namespace/providers/apps/Deployment/test-name",
+		Identity: ResourceIdentity{
+			ResourceType: &ResourceType{
+				Type:     resourcekinds.Deployment,
+				Provider: ProviderKubernetes,
+			},
+			Data: KubernetesIdentity{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+				Name:       "test-name",
+				Namespace:  "test-namespace",
+			},
+		},
+	},
+	{
+		ExpectedID: "/planes/aws/aws/accounts/0000/regions/us-west-2/providers/AWS.Kinesis/Stream/mystream",
+		Identity: ResourceIdentity{
+			ResourceType: &ResourceType{
+				Type:     "AWS.Kinesis/Stream",
+				Provider: ProviderAWS,
+			},
+			Data: UCPIdentity{
+				ID: "/planes/aws/aws/accounts/0000/regions/us-west-2/providers/AWS.Kinesis/Stream/mystream",
+			},
 		},
 	},
 }
@@ -42,15 +95,15 @@ var values = []ResourceIdentity{
 // Test that all formats of ResourceIdentifier round-trip with BSON
 func Test_ResourceIdentifier_BSONRoundTrip(t *testing.T) {
 	for _, input := range values {
-		t.Run(string(input.ResourceType.Type), func(t *testing.T) {
-			b, err := bson.Marshal(&input)
+		t.Run(string(input.Identity.ResourceType.Type), func(t *testing.T) {
+			b, err := bson.Marshal(&input.Identity)
 			require.NoError(t, err)
 
 			output := ResourceIdentity{}
 			err = bson.Unmarshal(b, &output)
 			require.NoError(t, err)
 
-			require.Equal(t, input, output)
+			require.Equal(t, input.Identity, output)
 		})
 	}
 }
@@ -58,15 +111,24 @@ func Test_ResourceIdentifier_BSONRoundTrip(t *testing.T) {
 // Test that all formats of ResourceIdentifier round-trip with JSON
 func Test_ResourceIdentifier_JSONRoundTrip(t *testing.T) {
 	for _, input := range values {
-		t.Run(string(input.ResourceType.Type), func(t *testing.T) {
-			b, err := json.Marshal(&input)
+		t.Run(string(input.Identity.ResourceType.Type), func(t *testing.T) {
+			b, err := json.Marshal(&input.Identity)
 			require.NoError(t, err)
 
 			output := ResourceIdentity{}
 			err = json.Unmarshal(b, &output)
 			require.NoError(t, err)
 
-			require.Equal(t, input, output)
+			require.Equal(t, input.Identity, output)
+		})
+	}
+}
+
+func Test_GetID(t *testing.T) {
+	for _, input := range values {
+		t.Run(string(input.Identity.ResourceType.Type), func(t *testing.T) {
+			id := input.Identity.GetID()
+			require.Equal(t, input.ExpectedID, id)
 		})
 	}
 }


### PR DESCRIPTION
This change enables value-based recipes. We originally set the goal of enabling value-based recipes for Redis, but due the nature of the deployment engine, they are now enabled for any of our links that support recipes.

The downside is that it's pretty complicated (see new comments in deployment processor). Since our existing recipe support is based on resource binding, all of the concepts get mixed together. There's no easy to way to one or the other.

There's also some significant new infrastructure needed to power this in the form of:

- A generic Kubernetes handler that supports any Kubernetes type
- A generic AWS handler (same store)
- Functionality for turning a resource ID into a resource identity

There are many impedance mismatches between the "world of UCP" and the "world of output resource" that we should close down in follow ups.

This PR also incorporates and supersedes radius-project/radius#5031 and radius-project/radius#5044.
