### PR TITLE
TEMPORARILY disable sample test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,8 +84,9 @@ stages:
           targetName: corerp
         Ucp:
           targetName: ucp
-        Samples:
-          targetName: samples
+        # TEMPORARILY DISABLED WHILE WE UPDATE THE TUTORIAL AND TESTS
+        # Samples:
+        #   targetName: samples
     steps:
     ## Force the checkout directory of the radius repo to remain as if we had checked out only one Git repository, this work around the ADO behavior to checkout to a different directory breaking the assumptions of the test steps (for more info https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checkout-path)
     - checkout: self

--- a/test/functional/samples/tutorial_test.go
+++ b/test/functional/samples/tutorial_test.go
@@ -40,7 +40,11 @@ var samplesRepoAbsPath, samplesRepoEnvVarSet = os.LookupEnv("PROJECT_RADIUS_SAMP
 func Test_TutorialSampleMongoContainer(t *testing.T) {
 	if !samplesRepoEnvVarSet {
 		t.Skipf("Skip samples test execution, to enable you must set env var PROJECT_RADIUS_SAMPLES_REPO_ABS_PATH to the absolute path of the project-radius/samples repository")
+	} else {
+		// Workaround for go-lint. I just want to disable the test :(
+		t.Skip("This test is temporarily disabled while we're making updates to the tutorial. This will be fixed again by release time.", samplesRepoAbsPath, samplesRepoAbsPath)
 	}
+
 	cwd, _ := os.Getwd()
 	relPathSamplesRepo, _ := filepath.Rel(cwd, samplesRepoAbsPath)
 	template := filepath.Join(relPathSamplesRepo, "tutorial/app.bicep")


### PR DESCRIPTION
We're making changes to the tutorial for v0.17. This change will disable the functional test so it doesn't cause friction for others while it's under construction.
