### PR TITLE
Fix regressions in helm chart

### DIFF
--- a/deploy/Chart/charts/de/templates/serviceaccount.yaml
+++ b/deploy/Chart/charts/de/templates/serviceaccount.yaml
@@ -3,13 +3,6 @@ kind: ServiceAccount
 metadata:
   name: de-manager
   namespace: {{ .Release.Namespace }}
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/Chart/charts/ucp/templates/ucp.yaml
+++ b/deploy/Chart/charts/ucp/templates/ucp.yaml
@@ -35,8 +35,10 @@ spec:
           value: '/var/tls/cert'
         - name: PORT
           value: '9443'
+{{ if .Values.global.rp.provider.aws }}
         - name: AWS_REGION
           value: {{ .Values.global.rp.provider.aws.region }}
+{{ end }}
         name: ucp
         ports:
         - containerPort: 9443


### PR DESCRIPTION
Fixes: #5083

There were regressions in the helm chart that prevent it from installing when using `rad install kubernetes`. This PR fixes those issues.

- We need the nil check for the AWS provider, as it is usually not set, and trying to access `.region` will crash.
- Remove `rules` from `ServiceAccount`. `rules` are part of a `Role` or `ClusterRole` not a `ServiceAccount`. In this case the DE already has the cluster admin role, so the rules were redundant.
