### PR TITLE
dev-recipe support for redis link and aws/k8s

### DIFF
--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
@@ -128,10 +128,15 @@ func getDevRecipes(ctx context.Context) (map[string]datamodel.EnvironmentRecipeP
 				if slices.Contains(supportedProviders(), provider) {
 					var name string
 					var linkType string
+					// TODO: this needs to metadata driven per-recipe so we don't have to maintain a lookup
+					// table.
 					switch link {
 					case "mongodatabases":
 						name = "mongo" + "-" + provider
 						linkType = linkrp.MongoDatabasesResourceType
+					case "rediscaches":
+						name = "redis" + "-" + provider
+						linkType = linkrp.RedisCachesResourceType
 					default:
 						continue
 					}

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
@@ -612,6 +612,10 @@ func TestGetDevRecipes(t *testing.T) {
 				LinkType:     linkrp.MongoDatabasesResourceType,
 				TemplatePath: "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0",
 			},
+			"redis-kubernetes": {
+				LinkType:     linkrp.RedisCachesResourceType,
+				TemplatePath: "radiusdev.azurecr.io/recipes/rediscaches/kubernetes:1.0",
+			},
 		}
 		require.Equal(t, devRecipes, expectedRecipes)
 	})

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipes20220315privatepreview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipes20220315privatepreview_datamodel.json
@@ -28,6 +28,10 @@
             "redis": {
                 "linkType": "Applications.Link/redisCache",
                 "templatePath": "radiusdev.azurecr.io/redis:1.0"
+            },
+            "redis-kubernetes": {
+                "linkType": "Applications.Link/redisCaches",
+                "templatePath": "radiusdev.azurecr.io/recipes/rediscaches/kubernetes:1.0"
             }
         },
         "useDevRecipes": true,

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipes20220315privatepreview_output.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipes20220315privatepreview_output.json
@@ -21,6 +21,10 @@
       "redis": {
         "linkType": "Applications.Link/redisCache",
         "templatePath": "radiusdev.azurecr.io/redis:1.0"
+      },
+      "redis-kubernetes": {
+        "linkType": "Applications.Link/redisCaches",
+        "templatePath": "radiusdev.azurecr.io/recipes/rediscaches/kubernetes:1.0"
       }
     },
     "useDevRecipes": true,

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipestoexisting20220315privatepreview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipestoexisting20220315privatepreview_datamodel.json
@@ -29,6 +29,10 @@
         "linkType": "Applications.Link/redisCache",
         "templatePath": "radiusdev.azurecr.io/redis:1.0"
       },
+      "redis-kubernetes": {
+        "linkType": "Applications.Link/redisCaches",
+        "templatePath": "radiusdev.azurecr.io/recipes/rediscaches/kubernetes:1.0"
+      },
       "sql": {
         "linkType": "Applications.Link/sqlDatabases",
         "templatePath": "radiusdev.azurecr.io/sql:1.0"

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipestoexisting20220315privatepreview_output.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentappenddevrecipestoexisting20220315privatepreview_output.json
@@ -22,6 +22,10 @@
         "linkType": "Applications.Link/redisCache",
         "templatePath": "radiusdev.azurecr.io/redis:1.0"
       },
+      "redis-kubernetes": {
+        "linkType": "Applications.Link/redisCaches",
+        "templatePath": "radiusdev.azurecr.io/recipes/rediscaches/kubernetes:1.0"
+      },
       "sql": {
         "linkType": "Applications.Link/sqlDatabases",
         "templatePath": "radiusdev.azurecr.io/sql:1.0"

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentuserrecipesconflictwithreservednamesoriginal20220315privatepreview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentuserrecipesconflictwithreservednamesoriginal20220315privatepreview_datamodel.json
@@ -24,6 +24,10 @@
             "mongo-azure": {
                 "linkType": "Applications.Link/mongoDatabases",
                 "templatePath": "radiusdev.azurecr.io/mongo:1.0"
+            },
+            "redis-kubernetes": {
+                "linkType": "Applications.Link/redisCaches",
+                "templatePath": "radiusdev.azurecr.io/recipes/rediscaches/kubernetes:1.0"
             }
         },
         "useDevRecipes": false,

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentwithdevrecipes20220315privatepreview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentwithdevrecipes20220315privatepreview_datamodel.json
@@ -24,6 +24,10 @@
             "mongo-azure": {
                 "linkType": "Applications.Link/mongoDatabases",
                 "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"
+            }, 
+            "redis-kubernetes": {
+                "linkType": "Applications.Link/redisCaches",
+                "templatePath": "radiusdev.azurecr.io/recipes/rediscaches/kubernetes:1.0"
             }
         },
         "useDevRecipes": true,

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentwithdevrecipes20220315privatepreview_output.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentwithdevrecipes20220315privatepreview_output.json
@@ -17,6 +17,10 @@
             "mongo-azure": {
                 "linkType": "Applications.Link/mongoDatabases",
                 "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"
+            },
+            "redis-kubernetes": {
+                "linkType": "Applications.Link/redisCaches",
+                "templatePath": "radiusdev.azurecr.io/recipes/rediscaches/kubernetes:1.0"
             }
         },
         "useDevRecipes": true,

--- a/pkg/corerp/frontend/controller/environments/types.go
+++ b/pkg/corerp/frontend/controller/environments/types.go
@@ -10,6 +10,10 @@ const (
 	DevRecipesACRPath = "radiusdev.azurecr.io"
 )
 
+// supportedProviders returns the list of "known" providers we understand for dev recipes.
+// this is used as a filter to exclude non-matching repositories from the dev recipes registry.
+//
+// This is no effect on the execution of the recipe.
 func supportedProviders() []string {
-	return []string{"azure"}
+	return []string{"aws", "azure", "kubernetes"}
 }


### PR DESCRIPTION
This updates our existing logic to enable dev-recipes that leverage AWS and Kubernetes, as well as enabling the redis link. I've tested this manually to make sure the scenario we're going to use for the tutorial works.

I've also updated all of the existing dev recipes tests due to #5085
