### PR TITLE
Set aws cloud provider options in init command

### DIFF
--- a/pkg/cli/cmd/radInit/init.go
+++ b/pkg/cli/cmd/radInit/init.go
@@ -476,6 +476,7 @@ func installRadius(ctx context.Context, r *Runner) error {
 		Radius: helm.RadiusOptions{
 			Reinstall:     r.Reinstall,
 			AzureProvider: r.AzureCloudProvider,
+			AWSProvider:   r.AwsCloudProvider,
 		},
 	}
 


### PR DESCRIPTION
# Description

Setting aws cloud provider while installing radius. Among others, needed to set aws region on helm installation

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: NA

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
