### PR TITLE
Remove provider configuration from rad install kubernetes

### DIFF
--- a/cmd/rad/cmd/installKubernetes.go
+++ b/cmd/rad/cmd/installKubernetes.go
@@ -12,7 +12,6 @@ import (
 	"github.com/project-radius/radius/pkg/cli/azure"
 	"github.com/project-radius/radius/pkg/cli/helm"
 	"github.com/project-radius/radius/pkg/cli/kubernetes"
-	"github.com/project-radius/radius/pkg/cli/prompt"
 	"github.com/project-radius/radius/pkg/cli/setup"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/spf13/cobra"
@@ -34,11 +33,6 @@ func init() {
 }
 
 func installKubernetes(cmd *cobra.Command, args []string) error {
-	interactive, err := cmd.Flags().GetBool("interactive")
-	if err != nil {
-		return err
-	}
-
 	// It's ok if this is blank.
 	kubeContext, err := cmd.Flags().GetString("kubecontext")
 	if err != nil {
@@ -46,12 +40,6 @@ func installKubernetes(cmd *cobra.Command, args []string) error {
 	}
 
 	chartArgs, err := setup.ParseChartArgs(cmd)
-	if err != nil {
-		return err
-	}
-
-	// Configure Azure provider for cloud resources if specified
-	azureProvider, err := setup.ParseAzureProviderArgs(cmd, interactive, &prompt.Impl{})
 	if err != nil {
 		return err
 	}
@@ -65,7 +53,6 @@ func installKubernetes(cmd *cobra.Command, args []string) error {
 			AppCoreImage:           chartArgs.AppCoreImage,
 			AppCoreTag:             chartArgs.AppCoreTag,
 			PublicEndpointOverride: chartArgs.PublicEndpointOverride,
-			AzureProvider:          azureProvider,
 		},
 	}
 
@@ -78,7 +65,8 @@ func installKubernetes(cmd *cobra.Command, args []string) error {
 
 	//installation completed. update workspaces, if any.
 	if !alreadyInstalled {
-		err = updateWorkspaces(cmd.Context(), azureProvider)
+		// install doesn't configure providers, user init to configure providers.
+		err = updateWorkspaces(cmd.Context(), nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/rad/cmd/installKubernetes.go
+++ b/cmd/rad/cmd/installKubernetes.go
@@ -29,7 +29,6 @@ func init() {
 	installKubernetesCmd.PersistentFlags().BoolP("interactive", "i", false, "Collect values for required command arguments through command line interface prompts")
 	installKubernetesCmd.Flags().String("kubecontext", "", "the Kubernetes context to use, will use the default if unset")
 	setup.RegisterPersistentChartArgs(installKubernetesCmd)
-	setup.RegisterPersistentAzureProviderArgs(installKubernetesCmd)
 }
 
 func installKubernetes(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
# Description

rad init should be used while configuring providers and installing radius at the same time. 

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #5101

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
