### PR TITLE
Initial commit of `to` helper

### DIFF
--- a/pkg/to/ptr.go
+++ b/pkg/to/ptr.go
@@ -1,0 +1,31 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+// https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azcore/to
+
+package to
+
+// Ptr returns a pointer to the provided value.
+func Ptr[T any](v T) *T {
+	return &v
+}
+
+// SliceOfPtrs returns a slice of *T from the specified values.
+func SliceOfPtrs[T any](vv ...T) []*T {
+	slc := make([]*T, len(vv))
+	for i := range vv {
+		slc[i] = Ptr(vv[i])
+	}
+	return slc
+}
+
+// StringMapPtr returns a pointer to a map of string pointers built from the passed map of strings.
+func StringMapPtr(ms map[string]string) *map[string]*string {
+	msp := make(map[string]*string, len(ms))
+	for k, s := range ms {
+		msp[k] = Ptr(s)
+	}
+	return &msp
+}

--- a/pkg/to/ptr_test.go
+++ b/pkg/to/ptr_test.go
@@ -1,0 +1,32 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+// https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azcore/to
+
+package to
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPtr(t *testing.T) {
+	b := true
+	pb := Ptr(b)
+
+	require.NotNil(t, pb, "unexpected nil conversion")
+	require.Equal(t, b, *pb)
+}
+
+func TestSliceOfPtrs(t *testing.T) {
+	arr := SliceOfPtrs[int]()
+	require.Len(t, arr, 0, "expected zero length")
+
+	arr = SliceOfPtrs(1, 2, 3, 4, 5)
+	for i, v := range arr {
+		require.Equal(t, i+1, *v)
+	}
+}

--- a/pkg/to/ptr_test.go
+++ b/pkg/to/ptr_test.go
@@ -18,7 +18,7 @@ func TestPtr(t *testing.T) {
 	pb := Ptr(b)
 
 	require.NotNil(t, pb, "unexpected nil conversion")
-	require.Equal(t, b, *pb)
+	require.Exactly(t, b, *pb)
 }
 
 func TestSliceOfPtrs(t *testing.T) {
@@ -27,6 +27,6 @@ func TestSliceOfPtrs(t *testing.T) {
 
 	arr = SliceOfPtrs(1, 2, 3, 4, 5)
 	for i, v := range arr {
-		require.Equal(t, i+1, *v)
+		require.Exactly(t, i+1, *v)
 	}
 }

--- a/pkg/to/value.go
+++ b/pkg/to/value.go
@@ -1,0 +1,88 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+// Package to provides helpers to ease working with pointer values of marshalled structures.
+
+package to
+
+// String returns a string value for the passed string pointer. It returns the empty string if the
+// pointer is nil.
+func String(s *string) string {
+	if s != nil {
+		return *s
+	}
+	return ""
+}
+
+// StringSlice returns a string slice value for the passed string slice pointer. It returns a nil
+// slice if the pointer is nil.
+func StringSlice(s *[]string) []string {
+	if s != nil {
+		return *s
+	}
+	return nil
+}
+
+// StringMap returns a map of strings built from the map of string pointers. The empty string is
+// used for nil pointers.
+func StringMap(msp map[string]*string) map[string]string {
+	ms := make(map[string]string, len(msp))
+	for k, sp := range msp {
+		if sp != nil {
+			ms[k] = *sp
+		} else {
+			ms[k] = ""
+		}
+	}
+	return ms
+}
+
+// Bool returns a bool value for the passed bool pointer. It returns false if the pointer is nil.
+func Bool(b *bool) bool {
+	if b != nil {
+		return *b
+	}
+	return false
+}
+
+// Int returns an int value for the passed int pointer. It returns 0 if the pointer is nil.
+func Int(i *int) int {
+	if i != nil {
+		return *i
+	}
+	return 0
+}
+
+// Int32 returns an int value for the passed int pointer. It returns 0 if the pointer is nil.
+func Int32(i *int32) int32 {
+	if i != nil {
+		return *i
+	}
+	return 0
+}
+
+// Int64 returns an int value for the passed int pointer. It returns 0 if the pointer is nil.
+func Int64(i *int64) int64 {
+	if i != nil {
+		return *i
+	}
+	return 0
+}
+
+// Float32 returns an int value for the passed int pointer. It returns 0.0 if the pointer is nil.
+func Float32(i *float32) float32 {
+	if i != nil {
+		return *i
+	}
+	return 0.0
+}
+
+// Float64 returns an int value for the passed int pointer. It returns 0.0 if the pointer is nil.
+func Float64(i *float64) float64 {
+	if i != nil {
+		return *i
+	}
+	return 0.0
+}

--- a/pkg/to/value_test.go
+++ b/pkg/to/value_test.go
@@ -13,23 +13,23 @@ import (
 
 func TestString(t *testing.T) {
 	v := ""
-	require.Equal(t, v, String(&v))
-	require.Equal(t, "", String(nil))
-	require.Equal(t, v, *Ptr(v))
+	require.Exactly(t, v, String(&v))
+	require.Exactly(t, "", String(nil))
+	require.Exactly(t, v, *Ptr(v))
 }
 
 func TestStringSlice(t *testing.T) {
 	v := []string{}
-	require.Equal(t, StringSlice(&v), v)
+	require.Exactly(t, v, StringSlice(&v))
 	require.Nil(t, StringSlice(nil))
 	w := []string{"a", "b"}
-	require.Equal(t, Ptr(w), w)
+	require.Exactly(t, w, Ptr(w))
 }
 
 func TestStringMap(t *testing.T) {
 	msp := map[string]*string{"foo": Ptr("foo"), "bar": Ptr("bar"), "baz": Ptr("baz")}
 	for k, v := range StringMap(msp) {
-		require.Equal(t, *msp[k], v)
+		require.Exactly(t, *msp[k], v)
 	}
 }
 
@@ -37,7 +37,7 @@ func TestStringMapHandlesNil(t *testing.T) {
 	msp := map[string]*string{"foo": Ptr("foo"), "bar": nil, "baz": Ptr("baz")}
 	for k, v := range StringMap(msp) {
 		if msp[k] != nil {
-			require.Equal(t, *msp[k], v)
+			require.Exactly(t, *msp[k], v)
 		}
 	}
 }
@@ -45,56 +45,50 @@ func TestStringMapHandlesNil(t *testing.T) {
 func TestStringMapPtr(t *testing.T) {
 	ms := map[string]string{"foo": "foo", "bar": "bar", "baz": "baz"}
 	for k, msp := range *StringMapPtr(ms) {
-		require.Equal(t, ms[k], *msp)
+		require.Exactly(t, ms[k], *msp)
 	}
 }
 
 func TestBool(t *testing.T) {
 	v := false
-	require.Equal(t, v, Bool(&v))
-	require.Equal(t, false, Bool(nil))
-	w := false
-	require.Equal(t, w, *Ptr(w))
+	require.Exactly(t, v, Bool(&v))
+	require.Exactly(t, false, Bool(nil))
+	require.Exactly(t, v, *Ptr(v))
 }
 
 func TestInt(t *testing.T) {
 	v := 0
 	require.Equal(t, v, Int(&v))
 	require.Equal(t, 0, Int(nil))
-	w := 0
-	require.Equal(t, w, *Ptr(w))
+	require.Equal(t, v, *Ptr(v))
 }
 
 func TestInt32(t *testing.T) {
 	v := int32(0)
-	require.Equal(t, v, Int32(&v))
-	require.Equal(t, 0, Int32(nil))
-	w := 0
-	require.Equal(t, w, *Ptr(w))
+	require.Exactly(t, v, Int32(&v))
+	require.Exactly(t, int32(0), Int32(nil))
+	require.Exactly(t, v, *Ptr(v))
 }
 
 func TestInt64(t *testing.T) {
 	v := int64(0)
-	require.Equal(t, v, Int64(&v))
-	require.Equal(t, 0, Int64(nil))
-	w := 0
-	require.Equal(t, w, *Ptr(w))
+	require.Exactly(t, v, Int64(&v))
+	require.Exactly(t, int64(0), Int64(nil))
+	require.Exactly(t, v, *Ptr(v))
 }
 
 func TestFloat32(t *testing.T) {
 	v := float32(0)
 	require.Equal(t, v, Float32(&v))
-	require.Equal(t, 0, Float32(nil))
-	w := 0
-	require.Equal(t, w, *Ptr(w))
+	require.Exactly(t, float32(0), Float32(nil))
+	require.Equal(t, v, *Ptr(v))
 }
 
 func TestFloat64(t *testing.T) {
 	v := float64(0)
 	require.Equal(t, v, Float64(&v))
-	require.Equal(t, 0, Float64(nil))
-	w := 0
-	require.Equal(t, w, *Ptr(w))
+	require.Exactly(t, float64(0), Float64(nil))
+	require.Equal(t, v, *Ptr(v))
 }
 
 func TestByteSlicePtr(t *testing.T) {

--- a/pkg/to/value_test.go
+++ b/pkg/to/value_test.go
@@ -23,7 +23,7 @@ func TestStringSlice(t *testing.T) {
 	require.Exactly(t, v, StringSlice(&v))
 	require.Nil(t, StringSlice(nil))
 	w := []string{"a", "b"}
-	require.Exactly(t, w, Ptr(w))
+	require.Exactly(t, w, *Ptr(w))
 }
 
 func TestStringMap(t *testing.T) {

--- a/pkg/to/value_test.go
+++ b/pkg/to/value_test.go
@@ -1,0 +1,103 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package to
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestString(t *testing.T) {
+	v := ""
+	require.Equal(t, v, String(&v))
+	require.Equal(t, "", String(nil))
+	require.Equal(t, v, *Ptr(v))
+}
+
+func TestStringSlice(t *testing.T) {
+	v := []string{}
+	require.Equal(t, StringSlice(&v), v)
+	require.Nil(t, StringSlice(nil))
+	w := []string{"a", "b"}
+	require.Equal(t, Ptr(w), w)
+}
+
+func TestStringMap(t *testing.T) {
+	msp := map[string]*string{"foo": Ptr("foo"), "bar": Ptr("bar"), "baz": Ptr("baz")}
+	for k, v := range StringMap(msp) {
+		require.Equal(t, *msp[k], v)
+	}
+}
+
+func TestStringMapHandlesNil(t *testing.T) {
+	msp := map[string]*string{"foo": Ptr("foo"), "bar": nil, "baz": Ptr("baz")}
+	for k, v := range StringMap(msp) {
+		if msp[k] != nil {
+			require.Equal(t, *msp[k], v)
+		}
+	}
+}
+
+func TestStringMapPtr(t *testing.T) {
+	ms := map[string]string{"foo": "foo", "bar": "bar", "baz": "baz"}
+	for k, msp := range *StringMapPtr(ms) {
+		require.Equal(t, ms[k], *msp)
+	}
+}
+
+func TestBool(t *testing.T) {
+	v := false
+	require.Equal(t, v, Bool(&v))
+	require.Equal(t, false, Bool(nil))
+	w := false
+	require.Equal(t, w, *Ptr(w))
+}
+
+func TestInt(t *testing.T) {
+	v := 0
+	require.Equal(t, v, Int(&v))
+	require.Equal(t, 0, Int(nil))
+	w := 0
+	require.Equal(t, w, *Ptr(w))
+}
+
+func TestInt32(t *testing.T) {
+	v := int32(0)
+	require.Equal(t, v, Int32(&v))
+	require.Equal(t, 0, Int32(nil))
+	w := 0
+	require.Equal(t, w, *Ptr(w))
+}
+
+func TestInt64(t *testing.T) {
+	v := int64(0)
+	require.Equal(t, v, Int64(&v))
+	require.Equal(t, 0, Int64(nil))
+	w := 0
+	require.Equal(t, w, *Ptr(w))
+}
+
+func TestFloat32(t *testing.T) {
+	v := float32(0)
+	require.Equal(t, v, Float32(&v))
+	require.Equal(t, 0, Float32(nil))
+	w := 0
+	require.Equal(t, w, *Ptr(w))
+}
+
+func TestFloat64(t *testing.T) {
+	v := float64(0)
+	require.Equal(t, v, Float64(&v))
+	require.Equal(t, 0, Float64(nil))
+	w := 0
+	require.Equal(t, w, *Ptr(w))
+}
+
+func TestByteSlicePtr(t *testing.T) {
+	v := []byte("bytes")
+	require.Equal(t, v, *Ptr(v))
+}


### PR DESCRIPTION
# Description

We have used [autorest/to](https://github.com/Azure/go-autorest/tree/main/autorest/to) and [azcore/to](https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/azcore/to) in many places. autorest is being deprecated and we need our own to helpers. This PR is the initial commit of `to` helper package by leveraging autorest and azcore implementations.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: radius-project/core-team#1106 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
