### PR TITLE
Adding a test client to remove the dep to autorest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.2.0
-	github.com/Azure/go-autorest/autorest v0.11.28
 	github.com/Azure/secrets-store-csi-driver-provider-azure v1.3.0
 	github.com/aws/aws-sdk-go-v2 v1.17.0
 	github.com/aws/aws-sdk-go-v2/config v1.15.15
@@ -89,6 +88,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest v0.11.28 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.21 // indirect
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect

--- a/test/functional/corerp/resources/gateway_test.go
+++ b/test/functional/corerp/resources/gateway_test.go
@@ -225,7 +225,7 @@ func Test_HTTPSGateway(t *testing.T) {
 }
 
 func testGatewayAvailability(t *testing.T, hostname, baseURL, path string, expectedStatusCode int, isHttps bool) error {
-	urlPath := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), strings.TrimPrefix(path, "/"))
+	urlPath := strings.TrimSuffix(baseURL, "/") + "/" + strings.TrimPrefix(path, "/")
 	req, err := http.NewRequest(http.MethodGet, urlPath, nil)
 	if err != nil {
 		return err

--- a/test/functional/corerp/resources/gateway_test.go
+++ b/test/functional/corerp/resources/gateway_test.go
@@ -11,10 +11,10 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/Azure/go-autorest/autorest"
 	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/corerp"
 	"github.com/project-radius/radius/test/step"
@@ -225,9 +225,8 @@ func Test_HTTPSGateway(t *testing.T) {
 }
 
 func testGatewayAvailability(t *testing.T, hostname, baseURL, path string, expectedStatusCode int, isHttps bool) error {
-	req, err := autorest.Prepare(&http.Request{},
-		autorest.WithBaseURL(baseURL),
-		autorest.WithPath(path))
+	urlPath := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), strings.TrimPrefix(path, "/"))
+	req, err := http.NewRequest(http.MethodGet, urlPath, nil)
 	if err != nil {
 		return err
 	}
@@ -236,27 +235,21 @@ func testGatewayAvailability(t *testing.T, hostname, baseURL, path string, expec
 		req.Host = hostname
 	}
 
-	// Send requests to backing container via port-forward
-	response, err := autorest.SendWithSender(
-		newTestHTTPClient(isHttps, hostname),
-		req,
-		autorest.WithLogging(functional.NewTestLogger(t)),
-		autorest.DoErrorUnlessStatusCode(expectedStatusCode),
-		autorest.DoRetryForDuration(retryTimeout, retryBackoff))
-
-	if response.Body != nil {
-		defer response.Body.Close()
-	}
-
+	client := newTestHTTPClient(isHttps, hostname)
+	res, err := client.Do(req)
 	if err != nil {
 		return err
+	}
+
+	if res.StatusCode != expectedStatusCode {
+		return fmt.Errorf("expected status code %d, got %d", expectedStatusCode, res.StatusCode)
 	}
 
 	// Encountered the correct status code
 	return nil
 }
 
-func newTestHTTPClient(isHttps bool, hostname string) autorest.Sender {
+func newTestHTTPClient(isHttps bool, hostname string) *http.Client {
 	transport := &http.Transport{
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
@@ -276,5 +269,8 @@ func newTestHTTPClient(isHttps bool, hostname string) autorest.Sender {
 			ServerName:         hostname,
 		}
 	}
-	return &http.Client{Transport: transport}
+
+	return &http.Client{
+		Transport: transport,
+	}
 }

--- a/test/functional/samples/tutorial_test.go
+++ b/test/functional/samples/tutorial_test.go
@@ -308,8 +308,7 @@ func sendRequest(t *testing.T, req *http.Request, expectedStatusCode int) (*http
 }
 
 func sendGetRequest(t *testing.T, hostname, baseURL, path string, expectedStatusCode int) (*http.Response, error) {
-	urlPath := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), strings.TrimPrefix(path, "/"))
-	req, err := http.NewRequest(http.MethodGet, urlPath, nil)
+	req, err := http.NewRequest(http.MethodGet, getURLPath(baseURL, path), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -324,9 +323,7 @@ func sendPostRequest(t *testing.T, hostname, baseURL, path string, body *[]byte,
 	}
 
 	bodyReader := bytes.NewReader(*body)
-
-	urlPath := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), strings.TrimPrefix(path, "/"))
-	req, err := http.NewRequest(http.MethodPost, urlPath, bodyReader)
+	req, err := http.NewRequest(http.MethodPost, getURLPath(baseURL, path), bodyReader)
 	if err != nil {
 		return nil, err
 	}
@@ -342,9 +339,7 @@ func sendPutRequest(t *testing.T, hostname, baseURL, path string, body *[]byte, 
 	}
 
 	bodyReader := bytes.NewReader(*body)
-
-	urlPath := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), strings.TrimPrefix(path, "/"))
-	req, err := http.NewRequest(http.MethodPut, urlPath, bodyReader)
+	req, err := http.NewRequest(http.MethodPut, getURLPath(baseURL, path), bodyReader)
 	if err != nil {
 		return nil, err
 	}
@@ -355,12 +350,15 @@ func sendPutRequest(t *testing.T, hostname, baseURL, path string, body *[]byte, 
 }
 
 func sendDeleteRequest(t *testing.T, hostname, baseURL, path string, expectedStatusCode int) (*http.Response, error) {
-	urlPath := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), strings.TrimPrefix(path, "/"))
-	req, err := http.NewRequest(http.MethodDelete, urlPath, nil)
+	req, err := http.NewRequest(http.MethodDelete, getURLPath(baseURL, path), nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Host = hostname
 
 	return sendRequest(t, req, expectedStatusCode)
+}
+
+func getURLPath(baseURL, path string) string {
+	return strings.TrimSuffix(baseURL, "/") + "/" + strings.TrimPrefix(path, "/")
 }

--- a/test/functional/samples/tutorial_test.go
+++ b/test/functional/samples/tutorial_test.go
@@ -6,6 +6,7 @@
 package samples
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -13,14 +14,15 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/Azure/go-autorest/autorest"
 	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/corerp"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
+
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -293,65 +295,72 @@ func testGatewayWithPortForward(t *testing.T, ctx context.Context, at corerp.Cor
 }
 
 func sendRequest(t *testing.T, req *http.Request, expectedStatusCode int) (*http.Response, error) {
-	// Using autorest as an http client library because of its retry capabilities
-	return autorest.Send(req,
-		autorest.WithLogging(functional.NewTestLogger(t)),
-		autorest.DoErrorUnlessStatusCode(expectedStatusCode),
-		autorest.DoRetryForDuration(retryTimeout, retryBackoff))
-}
-
-func sendGetRequest(t *testing.T, hostname, baseURL, path string, expectedStatusCode int) (*http.Response, error) {
-	req, err := autorest.Prepare(&http.Request{},
-		autorest.AsGet(),
-		autorest.WithBaseURL(baseURL),
-		autorest.WithPath(path))
+	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 
+	if res.StatusCode != expectedStatusCode {
+		return nil, fmt.Errorf("expected status code %d, got %d", expectedStatusCode, res.StatusCode)
+	}
+
+	return res, nil
+}
+
+func sendGetRequest(t *testing.T, hostname, baseURL, path string, expectedStatusCode int) (*http.Response, error) {
+	urlPath := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), strings.TrimPrefix(path, "/"))
+	req, err := http.NewRequest(http.MethodGet, urlPath, nil)
+	if err != nil {
+		return nil, err
+	}
 	req.Host = hostname
+
 	return sendRequest(t, req, expectedStatusCode)
 }
 
 func sendPostRequest(t *testing.T, hostname, baseURL, path string, body *[]byte, expectedStatusCode int) (*http.Response, error) {
-	req, err := autorest.Prepare(&http.Request{},
-		autorest.AsPost(),
-		autorest.AsJSON(),
-		autorest.WithBytes(body),
-		autorest.WithBaseURL(baseURL),
-		autorest.WithPath(path))
+	if body == nil {
+		return nil, fmt.Errorf("body cannot be nil")
+	}
+
+	bodyReader := bytes.NewReader(*body)
+
+	urlPath := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), strings.TrimPrefix(path, "/"))
+	req, err := http.NewRequest(http.MethodPost, urlPath, bodyReader)
 	if err != nil {
 		return nil, err
 	}
-
+	req.Header.Set("Content-Type", "application/json")
 	req.Host = hostname
+
 	return sendRequest(t, req, expectedStatusCode)
 }
 
 func sendPutRequest(t *testing.T, hostname, baseURL, path string, body *[]byte, expectedStatusCode int) (*http.Response, error) {
-	req, err := autorest.Prepare(&http.Request{},
-		autorest.AsPut(),
-		autorest.AsJSON(),
-		autorest.WithBytes(body),
-		autorest.WithBaseURL(baseURL),
-		autorest.WithPath(path))
+	if body == nil {
+		return nil, fmt.Errorf("body cannot be nil")
+	}
+
+	bodyReader := bytes.NewReader(*body)
+
+	urlPath := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), strings.TrimPrefix(path, "/"))
+	req, err := http.NewRequest(http.MethodPut, urlPath, bodyReader)
 	if err != nil {
 		return nil, err
 	}
-
+	req.Header.Set("Content-Type", "application/json")
 	req.Host = hostname
+
 	return sendRequest(t, req, expectedStatusCode)
 }
 
 func sendDeleteRequest(t *testing.T, hostname, baseURL, path string, expectedStatusCode int) (*http.Response, error) {
-	req, err := autorest.Prepare(&http.Request{},
-		autorest.AsDelete(),
-		autorest.WithBaseURL(baseURL),
-		autorest.WithPath(path))
+	urlPath := fmt.Sprintf("%s/%s", strings.TrimSuffix(baseURL, "/"), strings.TrimPrefix(path, "/"))
+	req, err := http.NewRequest(http.MethodDelete, urlPath, nil)
 	if err != nil {
 		return nil, err
 	}
-
 	req.Host = hostname
+
 	return sendRequest(t, req, expectedStatusCode)
 }


### PR DESCRIPTION
# Description
Adding a test client from the new SDK to remove the dep to `autorest` package.

This branch will be rebased with the main after [this PR](https://github.com/project-radius/radius/pull/5088) is merged.

## Issue reference
Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
