### PR TITLE
re-enable dapr tests

### DIFF
--- a/pkg/linkrp/frontend/controller/daprstatestores/deletedaprstatestore.go
+++ b/pkg/linkrp/frontend/controller/daprstatestores/deletedaprstatestore.go
@@ -21,9 +21,8 @@ import (
 var _ ctrl.Controller = (*DeleteDaprStateStore)(nil)
 
 const (
-	// AsyncDeleteDeleteDaprStateStoreOperationTimeout is the default timeout duration of async delete dapr state store operation.
-	// DaprStateStore takes 1-2 mins to delete.
-	AsyncDeleteDeleteDaprStateStoreOperationTimeout = time.Duration(300) * time.Second
+	// AsyncDeleteDaprStateStoreOperationTimeout is the default timeout duration of async delete dapr state store operation.
+	AsyncDeleteDaprStateStoreOperationTimeout = time.Duration(1200) * time.Second
 )
 
 // DeleteDaprStateStore is the controller implementation to delete daprStateStore link resource.
@@ -61,7 +60,7 @@ func (daprStateStore *DeleteDaprStateStore) Run(ctx context.Context, w http.Resp
 		return r, err
 	}
 
-	if r, err := daprStateStore.PrepareAsyncOperation(ctx, old, v1.ProvisioningStateAccepted, AsyncDeleteDeleteDaprStateStoreOperationTimeout, &etag); r != nil || err != nil {
+	if r, err := daprStateStore.PrepareAsyncOperation(ctx, old, v1.ProvisioningStateAccepted, AsyncDeleteDaprStateStoreOperationTimeout, &etag); r != nil || err != nil {
 		return r, err
 	}
 

--- a/test/functional/corerp/resources/dapr_statestore_test.go
+++ b/test/functional/corerp/resources/dapr_statestore_test.go
@@ -57,7 +57,6 @@ func Test_DaprStateStoreGeneric(t *testing.T) {
 }
 
 func Test_DaprStateStoreTableStorage(t *testing.T) {
-	t.Skipf("Enable this test once test flakiness is fixed. - https://github.com/project-radius/radius/issues/5053")
 
 	template := "testdata/corerp-resources-dapr-statestore-tablestorage.bicep"
 	name := "corerp-resources-dapr-statestore-tablestorage"
@@ -99,8 +98,6 @@ func Test_DaprStateStoreTableStorage(t *testing.T) {
 }
 
 func Test_DaprStateStore_Recipe(t *testing.T) {
-	t.Skip("This is flaky. Tracked by: https://github.com/project-radius/radius/issues/5047")
-
 	template := "testdata/corerp-resources-dapr-statestore-recipe.bicep"
 	name := "corerp-resources-dss-recipe"
 	appNamespace := "corerp-resources-dss-recipe-app"


### PR DESCRIPTION
# Description

This PR re-enables the dapr tests.
The deletion of azure tablestorage sometime takes more than 5 mins. Hence the tests were failing. 
Increased the timeout.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: [AB#6109](https://dev.azure.com/azure-octo/Incubations/_sprints/taskboard/Project%20Radius%20Team%20C/Incubations/Radius/Sprint%2010?workitem=6109)



## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
