### PR TITLE
Use provider scope from environment resource while rad deploy

### DIFF
--- a/pkg/cli/clients/clients.go
+++ b/pkg/cli/clients/clients.go
@@ -11,6 +11,7 @@ import (
 	"os"
 
 	"github.com/project-radius/radius/pkg/cli/clients_new/generated"
+	"github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
 	corerp "github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
 	ucp_v20220901privatepreview "github.com/project-radius/radius/pkg/ucp/api/v20220901privatepreview"
 	ucpresources "github.com/project-radius/radius/pkg/ucp/resources"
@@ -40,6 +41,9 @@ type DeploymentOptions struct {
 
 	// Parameters is the set of parameters passed to the deployment.
 	Parameters DeploymentParameters
+
+	// Proivders are the cloud providers configured on the environment for deployment.
+	Providers *v20220315privatepreview.Providers
 
 	// ProgressChan is a channel used to signal progress of the deployment operation.
 	// The deployment client MUST close the channel if it was provided.

--- a/pkg/cli/cmd/deploy/deploy_test.go
+++ b/pkg/cli/cmd/deploy/deploy_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
+	"github.com/project-radius/radius/pkg/to"
 	"github.com/project-radius/radius/test/radcli"
 	"github.com/stretchr/testify/require"
 )
@@ -73,7 +74,15 @@ func Test_Validate(t *testing.T) {
 			ConfigureMocks: func(mocks radcli.ValidateMocks) {
 				mocks.ApplicationManagementClient.EXPECT().
 					GetEnvDetails(gomock.Any(), "prod").
-					Return(v20220315privatepreview.EnvironmentResource{}, nil).
+					Return(v20220315privatepreview.EnvironmentResource{
+						Properties: &v20220315privatepreview.EnvironmentProperties{
+							Providers: &v20220315privatepreview.Providers{
+								Azure: &v20220315privatepreview.ProvidersAzure{
+									Scope: to.Ptr("/subscriptions/test-subId/resourceGroups/test-rg"),
+								},
+							},
+						},
+					}, nil).
 					Times(1)
 
 			},
@@ -163,18 +172,6 @@ func Test_Run(t *testing.T) {
 			Return(map[string]any{}, nil).
 			Times(1)
 
-		options := deploy.Options{}
-
-		deployMock := deploy.NewMockInterface(ctrl)
-		deployMock.EXPECT().
-			DeployWithProgress(gomock.Any(), gomock.Any()).
-			DoAndReturn(func(ctx context.Context, o deploy.Options) (clients.DeploymentResult, error) {
-				// Capture options for verification
-				options = o
-				return clients.DeploymentResult{}, nil
-			}).
-			Times(1)
-
 		workspace := &workspaces.Workspace{
 			Connection: map[string]any{
 				"kind":    "kubernetes",
@@ -182,17 +179,50 @@ func Test_Run(t *testing.T) {
 			},
 			Name: "kind-kind",
 		}
+
+		providers := &v20220315privatepreview.Providers{
+			Azure: &v20220315privatepreview.ProvidersAzure{
+				Scope: to.Ptr("/subscriptions/test-subId/resourceGroups/test-rg"),
+			},
+		}
+
+		filePath := "app.bicep"
+		progressText := fmt.Sprintf(
+			"Deploying template '%v' into environment '%v' from workspace '%v'...\n\n"+
+				"Deployment In Progress...", filePath, radcli.TestEnvironmentName, workspace.Name)
+
+		options := deploy.Options{
+			Providers:      providers,
+			EnvironmentID:  fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/applications.core/environments/%s", radcli.TestEnvironmentName, radcli.TestEnvironmentName),
+			Workspace:      *workspace,
+			Parameters:     map[string]map[string]any{},
+			CompletionText: "Deployment Complete",
+			ProgressText:   progressText,
+			Template:       map[string]any{},
+		}
+
+		deployMock := deploy.NewMockInterface(ctrl)
+		deployMock.EXPECT().
+			DeployWithProgress(gomock.Any(), options).
+			DoAndReturn(func(ctx context.Context, o deploy.Options) (clients.DeploymentResult, error) {
+				// Capture options for verification
+				options = o
+				return clients.DeploymentResult{}, nil
+			}).
+			Times(1)
+
 		outputSink := &output.MockOutput{}
 		runner := &Runner{
 			Bicep:  bicep,
 			Deploy: deployMock,
 			Output: outputSink,
 
-			FilePath:        "app.bicep",
+			FilePath:        filePath,
 			EnvironmentID:   fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/applications.core/environments/%s", radcli.TestEnvironmentName, radcli.TestEnvironmentName),
 			EnvironmentName: radcli.TestEnvironmentName,
 			Parameters:      map[string]map[string]any{},
 			Workspace:       workspace,
+			Providers:       providers,
 		}
 
 		err := runner.Run(context.Background())

--- a/pkg/cli/connections/factory.go
+++ b/pkg/cli/connections/factory.go
@@ -84,8 +84,6 @@ func (i *impl) CreateDeploymentClient(ctx context.Context, workspace workspaces.
 		Client:              dc,
 		OperationsClient:    doc,
 		RadiusResourceGroup: id.FindScope(resources.ResourceGroupsSegment),
-		AzProvider:          workspace.ProviderConfig.Azure,
-		AWSProvider:         workspace.ProviderConfig.AWS,
 	}, nil
 }
 

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -53,6 +53,7 @@ func DeployWithProgress(ctx context.Context, options Options) (clients.Deploymen
 	result, err := deploymentClient.Deploy(ctx, clients.DeploymentOptions{
 		Template:     options.Template,
 		Parameters:   options.Parameters,
+		Providers:    options.Providers,
 		ProgressChan: progressChan,
 	})
 

--- a/pkg/cli/deploy/types.go
+++ b/pkg/cli/deploy/types.go
@@ -11,6 +11,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
+	"github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
 )
 
 // Interface is the interface for executing Bicep deployments in the CLI.
@@ -39,6 +40,9 @@ type Options struct {
 
 	// Workspace is the workspace to use for deployment.
 	Workspace workspaces.Workspace
+
+	// Providers are the cloud providers configured on the env for deployment
+	Providers *v20220315privatepreview.Providers
 
 	// ProgressText is a message displayed on the console when deployment begins.
 	ProgressText string

--- a/pkg/cli/deployment/deploy_test.go
+++ b/pkg/cli/deployment/deploy_test.go
@@ -8,17 +8,19 @@ package deployment
 import (
 	"testing"
 
-	"github.com/project-radius/radius/pkg/cli/workspaces"
+	"github.com/project-radius/radius/pkg/cli/clients"
+	"github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
 	sdkclients "github.com/project-radius/radius/pkg/sdk/clients"
+	"github.com/project-radius/radius/pkg/to"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_GetProviderConfigs(t *testing.T) {
 	resourceDeploymentClient := ResourceDeploymentClient{
 		RadiusResourceGroup: "testrg",
-		Client:              &sdkclients.ResourceDeploymentsClient{},
-		OperationsClient:    &sdkclients.ResourceDeploymentOperationsClient{},
-		AzProvider:          &workspaces.AzureProvider{},
+	}
+	options := clients.DeploymentOptions{
+		Providers: &v20220315privatepreview.Providers{},
 	}
 
 	var expectedConfig sdkclients.ProviderConfig
@@ -36,7 +38,7 @@ func Test_GetProviderConfigs(t *testing.T) {
 		},
 	}
 
-	providerConfig := resourceDeploymentClient.GetProviderConfigs()
+	providerConfig := resourceDeploymentClient.GetProviderConfigs(options)
 	require.Equal(t, providerConfig, expectedConfig)
 }
 
@@ -45,9 +47,13 @@ func Test_GetProviderConfigsWithAzProvider(t *testing.T) {
 		RadiusResourceGroup: "testrg",
 		Client:              &sdkclients.ResourceDeploymentsClient{},
 		OperationsClient:    &sdkclients.ResourceDeploymentOperationsClient{},
-		AzProvider: &workspaces.AzureProvider{
-			SubscriptionID: "dummy",
-			ResourceGroup:  "azrg",
+	}
+
+	options := clients.DeploymentOptions{
+		Providers: &v20220315privatepreview.Providers{
+			Azure: &v20220315privatepreview.ProvidersAzure{
+				Scope: to.Ptr("/subscriptions/dummy/resourceGroups/azrg"),
+			},
 		},
 	}
 
@@ -73,6 +79,6 @@ func Test_GetProviderConfigsWithAzProvider(t *testing.T) {
 		},
 	}
 
-	providerConfig := resourceDeploymentClient.GetProviderConfigs()
+	providerConfig := resourceDeploymentClient.GetProviderConfigs(options)
 	require.Equal(t, providerConfig, expectedConfig)
 }


### PR DESCRIPTION
# Description
- Use provider scope from environment created for deployment instead of the provider scope from workspace config
issue: https://github.com/project-radius/radius/issues/4983

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: radius-project/core-team#1081 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
