### PR TITLE
Updating Recipe command descriptions

### DIFF
--- a/pkg/cli/cmd/recipe/list/list.go
+++ b/pkg/cli/cmd/recipe/list/list.go
@@ -24,8 +24,8 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 
 	cmd := &cobra.Command{
 		Use:     "list",
-		Short:   "List link recipes",
-		Long:    "List link recipes within an environment",
+		Short:   "List recipes",
+		Long:    "List recipes within an environment",
 		Example: `rad recipe list`,
 		RunE:    framework.RunCommand(runner),
 		Args:    cobra.ExactArgs(0),

--- a/pkg/cli/cmd/recipe/register/register.go
+++ b/pkg/cli/cmd/recipe/register/register.go
@@ -29,22 +29,22 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 
 	cmd := &cobra.Command{
 		Use:   "register",
-		Short: "Add a link recipe to an environment.",
-		Long: `Add a link recipe to an environment.
-		You can specify parameters using the '--parameter' flag ('-p' for short). Parameters can be passed as:
+		Short: "Add a recipe to an environment.",
+		Long: `Add a recipe to an environment.
+You can specify parameters using the '--parameter' flag ('-p' for short). Parameters can be passed as:
 		
-		- A file containing a single value in JSON format
-		- A key-value-pair passed in the command line
+- A file containing a single value in JSON format
+- A key-value-pair passed in the command line
 		`,
 		Example: `
-		# Add a link recipe to an environment
-		rad recipe register --name cosmosdb -e env_name -w workspace --template-path template_path --link-type Applications.Link/mongoDatabases
+# Add a link recipe to an environment
+rad recipe register --name cosmosdb -e env_name -w workspace --template-path template_path --link-type Applications.Link/mongoDatabases
 		
-		# Specify a parameter
-		rad recipe register --name cosmosdb -e env_name -w workspace --template-path template_path --link-type Applications.Link/mongoDatabases --parameters throughput=400
+# Specify a parameter
+rad recipe register --name cosmosdb -e env_name -w workspace --template-path template_path --link-type Applications.Link/mongoDatabases --parameters throughput=400
 		
-		# specify many parameters using a JSON parameter file
-		rad recipe register --name cosmosdb -e env_name -w workspace --template-path template_path --link-type Applications.Link/mongoDatabases --parameters @myfile.json
+# specify many parameters using a JSON parameter file
+rad recipe register --name cosmosdb -e env_name -w workspace --template-path template_path --link-type Applications.Link/mongoDatabases --parameters @myfile.json
 		`,
 		Args: cobra.ExactArgs(0),
 		RunE: framework.RunCommand(runner),

--- a/pkg/cli/cmd/recipe/register/register.go
+++ b/pkg/cli/cmd/recipe/register/register.go
@@ -37,13 +37,13 @@ You can specify parameters using the '--parameter' flag ('-p' for short). Parame
 - A key-value-pair passed in the command line
 		`,
 		Example: `
-# Add a link recipe to an environment
+# Add a recipe to an environment
 rad recipe register --name cosmosdb -e env_name -w workspace --template-path template_path --link-type Applications.Link/mongoDatabases
 		
 # Specify a parameter
 rad recipe register --name cosmosdb -e env_name -w workspace --template-path template_path --link-type Applications.Link/mongoDatabases --parameters throughput=400
 		
-# specify many parameters using a JSON parameter file
+# specify multiple parameters using a JSON parameter file
 rad recipe register --name cosmosdb -e env_name -w workspace --template-path template_path --link-type Applications.Link/mongoDatabases --parameters @myfile.json
 		`,
 		Args: cobra.ExactArgs(0),

--- a/pkg/cli/cmd/recipe/unregister/unregister.go
+++ b/pkg/cli/cmd/recipe/unregister/unregister.go
@@ -26,8 +26,8 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 
 	cmd := &cobra.Command{
 		Use:     "unregister",
-		Short:   "Unregister a link recipe from an environment",
-		Long:    `Unregister a link recipe from an environment`,
+		Short:   "Unregister a recipe from an environment",
+		Long:    `Unregister a recipe from an environment`,
 		Example: `rad recipe unregister --name cosmosdb`,
 		Args:    cobra.ExactArgs(0),
 		RunE:    framework.RunCommand(runner),


### PR DESCRIPTION
## Description
Reformatted the description of `list`, `register` and `unregister` to remove unnecessary tab characters and `link` references.