### PR TITLE
Switch DevOps syncing back to ubuntu-latest

### DIFF
--- a/.github/workflows/devops-boards.yaml
+++ b/.github/workflows/devops-boards.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   alert:
-    runs-on: [self-hosted,1ES.Pool=1ES-Radius ]
+    runs-on: ubuntu-latest
     steps:
       - uses: danhellem/github-actions-issue-to-work-item@v2.0
         env:


### PR DESCRIPTION
# Description

Switching ADO sync back to ubuntu-latest as 1ES-Radius takes 1-2 minutes to spin up

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
