### PR TITLE
Fix bubble tea exit handler for ctrl+c, esc (#5145)

### DIFF
--- a/pkg/cli/cmd/env/delete/delete.go
+++ b/pkg/cli/cmd/env/delete/delete.go
@@ -7,6 +7,7 @@ package delete
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/project-radius/radius/pkg/cli"
@@ -121,6 +122,9 @@ func (r *Runner) Run(ctx context.Context) error {
 	if !r.Confirm {
 		confirmed, err := prompt.YesOrNoPrompt(fmt.Sprintf(deleteConfirmation, r.EnvironmentName), "no", r.InputPrompter)
 		if err != nil {
+			if errors.Is(err, &prompt.ErrExitConsole{}) {
+				return &cli.FriendlyError{Message: err.Error()}
+			}
 			return err
 		}
 		if !confirmed {

--- a/pkg/cli/cmd/group/delete/delete.go
+++ b/pkg/cli/cmd/group/delete/delete.go
@@ -7,6 +7,7 @@ package delete
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/project-radius/radius/pkg/cli"
@@ -96,6 +97,9 @@ func (r *Runner) Run(ctx context.Context) error {
 			"no",
 			r.InputPrompter)
 		if err != nil {
+			if errors.Is(err, &prompt.ErrExitConsole{}) {
+				return &cli.FriendlyError{Message: err.Error()}
+			}
 			return err
 		}
 

--- a/pkg/cli/cmd/group/delete/delete_test.go
+++ b/pkg/cli/cmd/group/delete/delete_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/framework"
@@ -158,6 +159,29 @@ func Test_Run(t *testing.T) {
 			require.Equal(t, expected, outputSink.Writes)
 
 		})
+	})
+
+	t.Run("Exit console with interrupt signal", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+
+		outputSink := &output.MockOutput{}
+		prompter := prompt.NewMockInterface(ctrl)
+		prompter.EXPECT().
+			GetListInput([]string{"No", "Yes"}, "Are you sure you want to delete the resource group 'testrg'? A resource group can be deleted only when empty").
+			Return("", &prompt.ErrExitConsole{}).
+			Times(1)
+
+		runner := &Runner{
+			UCPResourceGroupName: "testrg",
+			Confirmation:         false,
+			InputPrompter:        prompter,
+			Output:               outputSink,
+		}
+
+		err := runner.Run(context.Background())
+		require.Equal(t, err, &cli.FriendlyError{Message: prompt.ErrExitConsoleMessage})
+		require.Empty(t, outputSink.Writes)
+
 	})
 
 }

--- a/pkg/cli/cmd/radInit/init.go
+++ b/pkg/cli/cmd/radInit/init.go
@@ -7,6 +7,7 @@ package radInit
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -137,6 +138,9 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	// In dev mode we will just take the default kubecontext
 	r.KubeContext, err = selectKubeContext(kubeContextList.CurrentContext, kubeContextList.Contexts, !r.Dev, r.Prompter)
 	if err != nil {
+		if errors.Is(err, &prompt.ErrExitConsole{}) {
+			return &cli.FriendlyError{Message: err.Error()}
+		}
 		return &cli.FriendlyError{Message: "KubeContext not specified"}
 	}
 
@@ -154,6 +158,9 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		output.LogInfo(fmt.Sprintf("Radius control plane is already installed to context '%s'...", r.KubeContext))
 		y, err := prompt.YesOrNoPrompt(confirmReinstallRadiusPrompt, "no", r.Prompter)
 		if err != nil {
+			if errors.Is(err, &prompt.ErrExitConsole{}) {
+				return &cli.FriendlyError{Message: err.Error()}
+			}
 			return &cli.FriendlyError{Message: "Unable to read reinstall prompt"}
 		}
 		if y {
@@ -202,6 +209,9 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		if r.Dev {
 			r.EnvName, err = common.SelectExistingEnvironment(cmd, "default", false, r.Prompter, environments)
 			if err != nil {
+				if errors.Is(err, &prompt.ErrExitConsole{}) {
+					return &cli.FriendlyError{Message: err.Error()}
+				}
 				return err
 			}
 		}
@@ -209,6 +219,9 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		if r.EnvName == "" {
 			r.EnvName, err = common.SelectExistingEnvironment(cmd, "default", true, r.Prompter, environments)
 			if err != nil {
+				if errors.Is(err, &prompt.ErrExitConsole{}) {
+					return &cli.FriendlyError{Message: err.Error()}
+				}
 				return err
 			}
 		}
@@ -260,6 +273,9 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		} else {
 			r.EnvName, err = common.SelectEnvironmentName(cmd, "default", true, r.Prompter)
 			if err != nil {
+				if errors.Is(err, &prompt.ErrExitConsole{}) {
+					return &cli.FriendlyError{Message: err.Error()}
+				}
 				return &cli.FriendlyError{Message: "Failed to read env name"}
 			}
 		}
@@ -276,22 +292,34 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 			// Configuring Cloud Provider
 			addingCloudProvider, err := prompt.YesOrNoPrompt(confirmCloudProviderPrompt, "no", r.Prompter)
 			if err != nil {
+				if errors.Is(err, &prompt.ErrExitConsole{}) {
+					return &cli.FriendlyError{Message: err.Error()}
+				}
 				return &cli.FriendlyError{Message: "Error reading cloud provider"}
 			}
 			for addingCloudProvider {
 				cloudProvider, err := selectCloudProvider(r.Prompter)
 				if err != nil {
+					if errors.Is(err, &prompt.ErrExitConsole{}) {
+						return &cli.FriendlyError{Message: err.Error()}
+					}
 					return &cli.FriendlyError{Message: "Error reading cloud provider"}
 				}
 				switch cloudProvider {
 				case common.AzureCloudProvider:
 					r.AzureCloudProvider, err = r.SetupInterface.ParseAzureProviderArgs(cmd, true, r.Prompter)
 					if err != nil {
+						if errors.Is(err, &prompt.ErrExitConsole{}) {
+							return &cli.FriendlyError{Message: err.Error()}
+						}
 						return err
 					}
 				case common.AWSCloudProvider:
 					r.AwsCloudProvider, err = r.SetupInterface.ParseAWSProviderArgs(cmd, true, r.Prompter)
 					if err != nil {
+						if errors.Is(err, &prompt.ErrExitConsole{}) {
+							return &cli.FriendlyError{Message: err.Error()}
+						}
 						return err
 					}
 				case backNavigator:
@@ -301,6 +329,9 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 				}
 				addingCloudProvider, err = prompt.YesOrNoPrompt(confirmCloudProviderPrompt, "no", r.Prompter)
 				if err != nil {
+					if errors.Is(err, &prompt.ErrExitConsole{}) {
+						return &cli.FriendlyError{Message: err.Error()}
+					}
 					return &cli.FriendlyError{Message: "Error reading cloud provider"}
 				}
 			}
@@ -314,6 +345,9 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 
 	r.ScaffoldApplication, err = prompt.YesOrNoPrompt(confirmSetupApplicationPrompt, "Yes", r.Prompter)
 	if err != nil {
+		if errors.Is(err, &prompt.ErrExitConsole{}) {
+			return &cli.FriendlyError{Message: err.Error()}
+		}
 		return err
 	}
 
@@ -535,7 +569,7 @@ func chooseApplicationName(prompter prompt.Interface) (string, error) {
 
 	appName, err := prompter.GetTextInput(enterApplicationName, "enter app name...")
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	isValid, errMsg, _ := prompt.ResourceName(appName)
 	if !isValid {

--- a/pkg/cli/cmd/radInit/init_test.go
+++ b/pkg/cli/cmd/radInit/init_test.go
@@ -423,6 +423,20 @@ func Test_Validate(t *testing.T) {
 				setScaffoldApplicationPromptNo(mocks.Prompter)
 			},
 		},
+		{
+			Name:          "Init Command exit console with interrupt signal",
+			Input:         []string{},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         config,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				// Radius is already installed, no reinstall
+				initGetKubeContextSuccess(mocks.Kubernetes)
+				initKubeContextWithInterruptSignal(mocks.Prompter)
+			},
+		},
 	}
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
 }
@@ -729,6 +743,12 @@ func initKubeContextSelectionError(prompter *prompt.MockInterface) {
 	prompter.EXPECT().
 		GetListInput(gomock.Any(), selectKubeContextPrompt).
 		Return("", errors.New("cannot read selection")).Times(1)
+}
+
+func initKubeContextWithInterruptSignal(prompter *prompt.MockInterface) {
+	prompter.EXPECT().
+		GetListInput(gomock.Any(), selectKubeContextPrompt).
+		Return("", &prompt.ErrExitConsole{}).Times(1)
 }
 
 func initRadiusReinstallNo(prompter *prompt.MockInterface) {

--- a/pkg/cli/cmd/workspace/delete/delete.go
+++ b/pkg/cli/cmd/workspace/delete/delete.go
@@ -7,6 +7,7 @@ package delete
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/project-radius/radius/pkg/cli"
@@ -95,6 +96,9 @@ func (r *Runner) Run(ctx context.Context) error {
 		message := fmt.Sprintf(deleteConfirmationFmt, r.Workspace.Name)
 		confirmed, err := prompt.YesOrNoPrompt(message, "no", r.InputPrompter)
 		if err != nil {
+			if errors.Is(err, &prompt.ErrExitConsole{}) {
+				return &cli.FriendlyError{Message: err.Error()}
+			}
 			return err
 		}
 

--- a/pkg/cli/cmd/workspace/delete/delete_test.go
+++ b/pkg/cli/cmd/workspace/delete/delete_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/framework"
 	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/project-radius/radius/pkg/cli/prompt"
@@ -166,6 +167,29 @@ func Test_Run(t *testing.T) {
 		err := runner.Run(context.Background())
 		require.NoError(t, err)
 
+		require.Empty(t, outputSink.Writes)
+	})
+
+	t.Run("Exit Console with interrupt", func(t *testing.T) {
+		outputSink := &output.MockOutput{}
+
+		prompter := prompt.NewMockInterface(ctrl)
+		prompter.EXPECT().
+			GetListInput([]string{"No", "Yes"}, fmt.Sprintf(deleteConfirmationFmt, "test-workspace")).
+			Return("", &prompt.ErrExitConsole{}).
+			Times(1)
+
+		runner := &Runner{
+			ConfigHolder:  &framework.ConfigHolder{},
+			Output:        outputSink,
+			InputPrompter: prompter,
+			Workspace: &workspaces.Workspace{
+				Name: "test-workspace",
+			},
+		}
+
+		err := runner.Run(context.Background())
+		require.Equal(t, err, &cli.FriendlyError{Message: prompt.ErrExitConsoleMessage})
 		require.Empty(t, outputSink.Writes)
 	})
 }

--- a/pkg/cli/prompt/list/list.go
+++ b/pkg/cli/prompt/list/list.go
@@ -8,7 +8,6 @@ package list
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
@@ -103,7 +102,8 @@ func (m ListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch keypress := msg.String(); keypress {
 		case "ctrl+c", "esc", "q":
-			os.Exit(1)
+			m.Quitting = true
+			return m, tea.Quit
 		case "enter":
 			if m.List.FilterState() != list.Filtering {
 				i, ok := m.List.SelectedItem().(item)

--- a/pkg/cli/prompt/prompt.go
+++ b/pkg/cli/prompt/prompt.go
@@ -25,6 +25,7 @@ const (
 	No
 
 	InvalidResourceNameMessage = "name must be made up of alphanumeric characters and hyphens, and must begin with an alphabetic character and end with an alphanumeric character"
+	ErrExitConsoleMessage      = "exiting command"
 )
 
 func MatchAll(validators ...func(string) (bool, string, error)) func(string) (bool, string, error) {
@@ -183,6 +184,9 @@ func (i *Impl) GetTextInput(promptMsg string, defaultPlaceHolder string) (string
 	if !ok {
 		return "", &ErrUnsupportedModel{}
 	}
+	if tm.Quitting {
+		return "", &ErrExitConsole{}
+	}
 
 	return tm.GetValue(), nil
 }
@@ -201,8 +205,28 @@ func (i *Impl) GetListInput(items []string, promptMsg string) (string, error) {
 	if !ok {
 		return "", &ErrUnsupportedModel{}
 	}
+	if lm.Quitting {
+		return "", &ErrExitConsole{}
+	}
 
 	return lm.Choice, nil
+}
+
+var _ error = (*ErrExitConsole)(nil)
+
+// ErrExitConsole represents interrupt commands being entered.
+type ErrExitConsole struct {
+}
+
+// Error returns the error message.
+func (e *ErrExitConsole) Error() string {
+	return ErrExitConsoleMessage
+}
+
+// Is checks for the error type is ErrExitConsole.
+func (e *ErrExitConsole) Is(target error) bool {
+	_, ok := target.(*ErrExitConsole)
+	return ok
 }
 
 // YesOrNoPrompt Creates a Yes or No prompt where user has to select either a Yes or No as input

--- a/pkg/cli/prompt/text/text.go
+++ b/pkg/cli/prompt/text/text.go
@@ -7,7 +7,6 @@ package text
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -27,6 +26,7 @@ type Model struct {
 	textInput    textinput.Model
 	promptMsg    string
 	valueEntered bool
+	Quitting     bool
 	err          error
 }
 
@@ -61,7 +61,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.valueEntered = true
 			return m, tea.Quit
 		case tea.KeyCtrlC, tea.KeyEsc:
-			os.Exit(1)
+			m.Quitting = true
+			return m, tea.Quit
 		}
 
 	// We handle errors just like any other message


### PR DESCRIPTION
# Description

- bubble tea modifies terminal state and sets the state back as part of clean up code after the prompts are done executing
- os.exit() on exit key inputs terminates the clean up code. This corrupts the terminal state and doesn't allow interrupt commands like ctrl+c later on
issue: https://github.com/project-radius/radius/issues/5143

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation. -->

Fixes: radius-project/core-team#1110

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it

---------

Co-authored-by: Bharath Joginapally <bharath@Bharaths-MacBook-Pro.local>
(cherry picked from commit 9054cd1d2966e8335f90dcc98630a59244c4e776)

# Description

_Please explain the changes you've made._

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
