### PR TITLE
Add commands for setting provider scope on env resource

### DIFF
--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	env_list "github.com/project-radius/radius/pkg/cli/cmd/env/list"
 	"github.com/project-radius/radius/pkg/cli/cmd/env/namespace"
 	env_show "github.com/project-radius/radius/pkg/cli/cmd/env/show"
+	env_update "github.com/project-radius/radius/pkg/cli/cmd/env/update"
 	group "github.com/project-radius/radius/pkg/cli/cmd/group"
 	"github.com/project-radius/radius/pkg/cli/cmd/radInit"
 	recipe_list "github.com/project-radius/radius/pkg/cli/cmd/recipe/list"
@@ -198,6 +199,9 @@ func initSubCommands() {
 
 	envShowCmd, _ := env_show.NewCommand(framework)
 	envCmd.AddCommand(envShowCmd)
+
+	envUpdateCmd, _ := env_update.NewCommand(framework)
+	envCmd.AddCommand(envUpdateCmd)
 
 	workspaceCreateCmd, _ := workspace_create.NewCommand(framework)
 	workspaceCmd.AddCommand(workspaceCreateCmd)

--- a/pkg/cli/clients/clients.go
+++ b/pkg/cli/clients/clients.go
@@ -138,7 +138,7 @@ type ApplicationsManagementClient interface {
 	CreateApplicationIfNotFound(ctx context.Context, applicationName string, resource corerp.ApplicationResource) error
 
 	DeleteApplication(ctx context.Context, applicationName string) (bool, error)
-	CreateEnvironment(ctx context.Context, envName, location, namespace, envKind, resourceId string, recipeProperties map[string]*corerp.EnvironmentRecipeProperties, providers *corerp.Providers, useDevRecipes bool) (bool, error)
+	CreateEnvironment(ctx context.Context, envName string, location string, envProperties *corerp.EnvironmentProperties) (bool, error)
 
 	// ListEnvironmentsInResourceGroup lists all environments in the configured scope (assumes configured scope is a resource group)
 	ListEnvironmentsInResourceGroup(ctx context.Context) ([]corerp.EnvironmentResource, error)

--- a/pkg/cli/clients/mock_applicationsclient.go
+++ b/pkg/cli/clients/mock_applicationsclient.go
@@ -52,18 +52,18 @@ func (mr *MockApplicationsManagementClientMockRecorder) CreateApplicationIfNotFo
 }
 
 // CreateEnvironment mocks base method.
-func (m *MockApplicationsManagementClient) CreateEnvironment(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string, arg6 map[string]*v20220315privatepreview.EnvironmentRecipeProperties, arg7 *v20220315privatepreview.Providers, arg8 bool) (bool, error) {
+func (m *MockApplicationsManagementClient) CreateEnvironment(arg0 context.Context, arg1, arg2 string, arg3 *v20220315privatepreview.EnvironmentProperties) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateEnvironment", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	ret := m.ctrl.Call(m, "CreateEnvironment", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateEnvironment indicates an expected call of CreateEnvironment.
-func (mr *MockApplicationsManagementClientMockRecorder) CreateEnvironment(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
+func (mr *MockApplicationsManagementClientMockRecorder) CreateEnvironment(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEnvironment", reflect.TypeOf((*MockApplicationsManagementClient)(nil).CreateEnvironment), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEnvironment", reflect.TypeOf((*MockApplicationsManagementClient)(nil).CreateEnvironment), arg0, arg1, arg2, arg3)
 }
 
 // CreateOrUpdateApplication mocks base method.

--- a/pkg/cli/cmd/commonflags/flags.go
+++ b/pkg/cli/cmd/commonflags/flags.go
@@ -14,14 +14,18 @@ import (
 )
 
 const (
-	SetEnvAzureFlag         = "set-azure"
-	AzureSubscriptionIdFlag = "azure-subscriptionid"
-	AzureResourceGroupFlag  = "azure-resourcegroup"
-	SetEnvAWSFlag           = "set-aws"
-	AWSRegionFlag           = "aws-region"
-	AWSAccountIdFlag        = "aws-account"
-	ClearEnvAzureFlag       = "clear-azure"
-	ClearEnvAWSFlag         = "clear-aws"
+	// AzureSubscriptionIdFlag provides azure subscription Id.
+	AzureSubscriptionIdFlag = "azure-subscription-id"
+	// AzureResourceGroupFlag provides azure resource group.
+	AzureResourceGroupFlag = "azure-resource-group"
+	// AWSRegionFlag provides aws region.
+	AWSRegionFlag = "aws-region"
+	// AWSAccountIdFlag provides aws accound id.
+	AWSAccountIdFlag = "aws-account-id"
+	// ClearEnvAzureFlag tells the command to clear azure scope on the environment it is configured.
+	ClearEnvAzureFlag = "clear-azure"
+	// ClearEnvAWSFlag tells the command to clear aws scope on the environment it is configured.
+	ClearEnvAWSFlag = "clear-aws"
 )
 
 func AddOutputFlag(cmd *cobra.Command) {
@@ -62,31 +66,33 @@ func AddRecipeFlag(cmd *cobra.Command) {
 }
 
 func AddAzureScopeFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool(SetEnvAzureFlag, false, "Specify if azure provider needs to be set on env")
 	AddAzureSubscriptionFlag(cmd)
 	AddAzureResourceGroupFlag(cmd)
-	cmd.MarkFlagsRequiredTogether(SetEnvAzureFlag, AzureSubscriptionIdFlag, AzureResourceGroupFlag)
+	cmd.MarkFlagsRequiredTogether(AzureSubscriptionIdFlag, AzureResourceGroupFlag)
+	cmd.MarkFlagsMutuallyExclusive(AzureSubscriptionIdFlag, ClearEnvAzureFlag)
+	cmd.MarkFlagsMutuallyExclusive(AzureResourceGroupFlag, ClearEnvAzureFlag)
 }
 
 func AddAzureSubscriptionFlag(cmd *cobra.Command) {
-	cmd.Flags().String(AzureSubscriptionIdFlag, "", "Subscription id of the azure app on env")
+	cmd.Flags().String(AzureSubscriptionIdFlag, "", "The subscription ID where Azure resources will be deployed")
 }
 
 func AddAzureResourceGroupFlag(cmd *cobra.Command) {
-	cmd.Flags().String(AzureResourceGroupFlag, "", "Resource group of the azure app")
+	cmd.Flags().String(AzureResourceGroupFlag, "", "The resource group where Azure resources will be deployed")
 }
 
 func AddAWSScopeFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool(SetEnvAWSFlag, false, "Specify if aws provider needs to be set on env")
 	AddAWSRegionFlag(cmd)
 	AddAWSAccountFlag(cmd)
-	cmd.MarkFlagsRequiredTogether(SetEnvAWSFlag, AWSRegionFlag, AWSAccountIdFlag)
+	cmd.MarkFlagsRequiredTogether(AWSRegionFlag, AWSAccountIdFlag)
+	cmd.MarkFlagsMutuallyExclusive(AWSRegionFlag, ClearEnvAWSFlag)
+	cmd.MarkFlagsMutuallyExclusive(AWSAccountIdFlag, ClearEnvAWSFlag)
 }
 
 func AddAWSRegionFlag(cmd *cobra.Command) {
-	cmd.Flags().String(AWSRegionFlag, "", "Region of the aws app")
+	cmd.Flags().String(AWSRegionFlag, "", "The region where AWS resources will be deployed")
 }
 
 func AddAWSAccountFlag(cmd *cobra.Command) {
-	cmd.Flags().String(AWSAccountIdFlag, "", "Account Id of the aws app")
+	cmd.Flags().String(AWSAccountIdFlag, "", "The account ID where AWS resources will be deployed")
 }

--- a/pkg/cli/cmd/commonflags/flags.go
+++ b/pkg/cli/cmd/commonflags/flags.go
@@ -13,6 +13,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	SetEnvAzureFlag         = "set-azure"
+	AzureSubscriptionIdFlag = "azure-subscriptionid"
+	AzureResourceGroupFlag  = "azure-resourcegroup"
+	SetEnvAWSFlag           = "set-aws"
+	AWSRegionFlag           = "aws-region"
+	AWSAccountIdFlag        = "aws-account"
+	ClearEnvAzureFlag       = "clear-azure"
+	ClearEnvAWSFlag         = "clear-aws"
+)
+
 func AddOutputFlag(cmd *cobra.Command) {
 	description := fmt.Sprintf("output format (supported formats are %s)", strings.Join(output.SupportedFormats(), ", "))
 	cmd.Flags().StringP("output", "o", output.DefaultFormat, description)
@@ -48,4 +59,34 @@ func AddParameterFlag(cmd *cobra.Command) {
 
 func AddRecipeFlag(cmd *cobra.Command) {
 	cmd.Flags().String("name", "", "The recipe name")
+}
+
+func AddAzureScopeFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool(SetEnvAzureFlag, false, "Specify if azure provider needs to be set on env")
+	AddAzureSubscriptionFlag(cmd)
+	AddAzureResourceGroupFlag(cmd)
+	cmd.MarkFlagsRequiredTogether(SetEnvAzureFlag, AzureSubscriptionIdFlag, AzureResourceGroupFlag)
+}
+
+func AddAzureSubscriptionFlag(cmd *cobra.Command) {
+	cmd.Flags().String(AzureSubscriptionIdFlag, "", "Subscription id of the azure app on env")
+}
+
+func AddAzureResourceGroupFlag(cmd *cobra.Command) {
+	cmd.Flags().String(AzureResourceGroupFlag, "", "Resource group of the azure app")
+}
+
+func AddAWSScopeFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool(SetEnvAWSFlag, false, "Specify if aws provider needs to be set on env")
+	AddAWSRegionFlag(cmd)
+	AddAWSAccountFlag(cmd)
+	cmd.MarkFlagsRequiredTogether(SetEnvAWSFlag, AWSRegionFlag, AWSAccountIdFlag)
+}
+
+func AddAWSRegionFlag(cmd *cobra.Command) {
+	cmd.Flags().String(AWSRegionFlag, "", "Region of the aws app")
+}
+
+func AddAWSAccountFlag(cmd *cobra.Command) {
+	cmd.Flags().String(AWSAccountIdFlag, "", "Account Id of the aws app")
 }

--- a/pkg/cli/cmd/env/create/create.go
+++ b/pkg/cli/cmd/env/create/create.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	corerp "github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
+	"github.com/project-radius/radius/pkg/to"
 	"github.com/spf13/cobra"
 
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
@@ -158,7 +159,14 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	isEnvCreated, err := client.CreateEnvironment(ctx, r.EnvironmentName, v1.LocationGlobal, r.Namespace, "Kubernetes", "", map[string]*corerp.EnvironmentRecipeProperties{}, &corerp.Providers{}, !r.SkipDevRecipes)
+	envProperties := &corerp.EnvironmentProperties{
+		UseDevRecipes: to.Ptr(!r.SkipDevRecipes),
+		Compute: &corerp.KubernetesCompute{
+			Namespace: to.Ptr(r.Namespace),
+		},
+	}
+
+	isEnvCreated, err := client.CreateEnvironment(ctx, r.EnvironmentName, v1.LocationGlobal, envProperties)
 	if err != nil || !isEnvCreated {
 		return err
 	}

--- a/pkg/cli/cmd/env/create/create_test.go
+++ b/pkg/cli/cmd/env/create/create_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
 	corerp "github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
+	"github.com/project-radius/radius/pkg/to"
 	"github.com/project-radius/radius/pkg/ucp/api/v20220901privatepreview"
 	"github.com/project-radius/radius/test/radcli"
 	"github.com/stretchr/testify/require"
@@ -110,8 +111,14 @@ func Test_Run_Success(t *testing.T) {
 		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
 
 		namespaceClient := namespace.NewMockInterface(ctrl)
+		testEnvProperties := &corerp.EnvironmentProperties{
+			UseDevRecipes: to.Ptr(true),
+			Compute: &corerp.KubernetesCompute{
+				Namespace: to.Ptr("default"),
+			},
+		}
 		appManagementClient.EXPECT().
-			CreateEnvironment(context.Background(), "default", v1.LocationGlobal, "default", "Kubernetes", gomock.Any(), gomock.Any(), &corerp.Providers{}, gomock.Any()).
+			CreateEnvironment(context.Background(), "default", v1.LocationGlobal, testEnvProperties).
 			Return(true, nil).Times(1)
 
 		configFileInterface := framework.NewMockConfigFileInterface(ctrl)
@@ -148,8 +155,14 @@ func Test_Run_SkipDevRecipes(t *testing.T) {
 			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
 
 			namespaceClient := namespace.NewMockInterface(ctrl)
+			testEnvProperties := &corerp.EnvironmentProperties{
+				UseDevRecipes: to.Ptr(false),
+				Compute: &corerp.KubernetesCompute{
+					Namespace: to.Ptr("default"),
+				},
+			}
 			appManagementClient.EXPECT().
-				CreateEnvironment(context.Background(), "default", v1.LocationGlobal, "default", "Kubernetes", gomock.Any(), gomock.Any(), gomock.Any(), false).
+				CreateEnvironment(context.Background(), "default", v1.LocationGlobal, testEnvProperties).
 				Return(true, nil).Times(1)
 
 			configFileInterface := framework.NewMockConfigFileInterface(ctrl)
@@ -184,8 +197,14 @@ func Test_Run_SkipDevRecipes(t *testing.T) {
 			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
 
 			namespaceClient := namespace.NewMockInterface(ctrl)
+			testEnvProperties := &corerp.EnvironmentProperties{
+				UseDevRecipes: to.Ptr(true),
+				Compute: &corerp.KubernetesCompute{
+					Namespace: to.Ptr("default"),
+				},
+			}
 			appManagementClient.EXPECT().
-				CreateEnvironment(context.Background(), "default", v1.LocationGlobal, "default", "Kubernetes", gomock.Any(), gomock.Any(), gomock.Any(), true).
+				CreateEnvironment(context.Background(), "default", v1.LocationGlobal, testEnvProperties).
 				Return(true, nil).Times(1)
 
 			configFileInterface := framework.NewMockConfigFileInterface(ctrl)

--- a/pkg/cli/cmd/env/update/update.go
+++ b/pkg/cli/cmd/env/update/update.go
@@ -177,16 +177,16 @@ func (r *Runner) Run(ctx context.Context) error {
 		env.Properties.Providers = &corerp.Providers{}
 	}
 	// only update azure provider info if user requires it.
-	if r.providers.Azure != nil && r.providers.Azure.Scope != nil {
-		env.Properties.Providers.Azure = r.providers.Azure
-	} else if r.clearEnvAzure {
+	if r.clearEnvAzure {
 		env.Properties.Providers.Azure = nil
+	} else if r.providers.Azure != nil && r.providers.Azure.Scope != nil {
+		env.Properties.Providers.Azure = r.providers.Azure
 	}
 	// only update aws provider info if user requires it.
-	if r.providers.Aws != nil && r.providers.Aws.Scope != nil {
-		env.Properties.Providers.Aws = r.providers.Aws
-	} else if r.clearEnvAws {
+	if r.clearEnvAws {
 		env.Properties.Providers.Aws = nil
+	} else if r.providers.Aws != nil && r.providers.Aws.Scope != nil {
+		env.Properties.Providers.Aws = r.providers.Aws
 	}
 
 	isEnvUpdated, err := client.CreateEnvironment(ctx, r.EnvName, v1.LocationGlobal, env.Properties)

--- a/pkg/cli/cmd/env/update/update.go
+++ b/pkg/cli/cmd/env/update/update.go
@@ -1,0 +1,229 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package update
+
+import (
+	"context"
+	"fmt"
+
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	"github.com/project-radius/radius/pkg/cli"
+	"github.com/project-radius/radius/pkg/cli/clients"
+	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
+	"github.com/project-radius/radius/pkg/cli/connections"
+	"github.com/project-radius/radius/pkg/cli/framework"
+	"github.com/project-radius/radius/pkg/cli/objectformats"
+	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/project-radius/radius/pkg/cli/workspaces"
+	corerp "github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
+	"github.com/project-radius/radius/pkg/to"
+	"github.com/spf13/cobra"
+)
+
+const (
+	setAndClearErrMessage = "Cannot set and clear env provider"
+	envNotFoundErrMessage = "Env Creation required before udpation"
+	azureScopeTemplate    = "/subscriptions/%s/resourceGroups/%s"
+	awsScopeTemplate      = "/planes/aws/aws/accounts/%s/regions/%s"
+)
+
+// NewCommand creates an instance of the command and runner for the `rad env update` command.
+func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
+	runner := NewRunner(factory)
+	runner.providers = &corerp.Providers{
+		Azure: &corerp.ProvidersAzure{},
+		Aws:   &corerp.ProvidersAws{},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "update [envName]",
+		Short: "Updates configurable environment details.",
+		Long:  `Updates configurable environment details. provider on env is one example`,
+		Args:  cobra.MinimumNArgs(1),
+		Example: `
+# Update azure provider on enviroment
+# When setting azure provider, subscriptionId and resourcegroup flags are required
+rad env update my-env --set-azure-provider --subscription-id='subId' --resourcegroup='rgId'
+
+# Update aws provider on environment
+# When setting aws provider, region and accountId flags are required
+rad env update my-env --set-aws-provider --region='us-west-2' --accountId='aId'
+`,
+		RunE: framework.RunCommand(runner),
+	}
+
+	commonflags.AddWorkspaceFlag(cmd)
+	commonflags.AddResourceGroupFlag(cmd)
+	commonflags.AddAzureScopeFlags(cmd)
+	commonflags.AddAWSScopeFlags(cmd)
+	commonflags.AddOutputFlag(cmd)
+
+	cmd.Flags().Bool(commonflags.ClearEnvAzureFlag, false, "Specify if azure provider needs to be cleared on env")
+	cmd.Flags().Bool(commonflags.ClearEnvAWSFlag, false, "Specify if aws provider needs to be cleared on env")
+
+	return cmd, runner
+}
+
+// Runner is the runner implementation for the `rad env update` command.
+type Runner struct {
+	ConfigHolder      *framework.ConfigHolder
+	ConnectionFactory connections.Factory
+	Workspace         *workspaces.Workspace
+	Output            output.Interface
+
+	envName       string
+	setEnvAzure   bool
+	setEnvAws     bool
+	clearEnvAzure bool
+	clearEnvAws   bool
+	providers     *corerp.Providers
+}
+
+// NewRunner creates a new instance of the `rad env update` runner.
+func NewRunner(factory framework.Factory) *Runner {
+	return &Runner{
+		ConnectionFactory: factory.GetConnectionFactory(),
+		ConfigHolder:      factory.GetConfigHolder(),
+		Output:            factory.GetOutput(),
+	}
+}
+
+// Validate runs validation for the `rad env update` command.
+func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
+	workspace, err := cli.RequireWorkspace(cmd, r.ConfigHolder.Config, r.ConfigHolder.DirectoryConfig)
+	if err != nil {
+		return err
+	}
+	r.Workspace = workspace
+
+	scope, err := cli.RequireScope(cmd, *r.Workspace)
+	if err != nil {
+		return err
+	}
+	r.Workspace.Scope = scope
+
+	r.envName = args[0]
+
+	r.setEnvAzure, err = cmd.Flags().GetBool(commonflags.SetEnvAzureFlag)
+	if err != nil {
+		return err
+	}
+
+	r.clearEnvAzure, err = cmd.Flags().GetBool(commonflags.ClearEnvAzureFlag)
+	if err != nil {
+		return err
+	}
+
+	if r.setEnvAzure && r.clearEnvAzure {
+		return &cli.FriendlyError{Message: setAndClearErrMessage}
+	}
+
+	if r.setEnvAzure {
+		// TODO: Validate Azure scope components (https://github.com/project-radius/radius/issues/5155)
+		azureSubId, err := cmd.Flags().GetString(commonflags.AzureSubscriptionIdFlag)
+		if err != nil {
+			return err
+		}
+
+		azureResourceGroup, err := cmd.Flags().GetString(commonflags.AzureResourceGroupFlag)
+		if err != nil {
+			return err
+		}
+		r.providers.Azure.Scope = to.Ptr(fmt.Sprintf(azureScopeTemplate, azureSubId, azureResourceGroup))
+	}
+
+	if r.clearEnvAws {
+		r.providers.Aws = nil
+	}
+
+	r.setEnvAws, err = cmd.Flags().GetBool(commonflags.SetEnvAWSFlag)
+	if err != nil {
+		return err
+	}
+
+	r.clearEnvAws, err = cmd.Flags().GetBool(commonflags.ClearEnvAWSFlag)
+	if err != nil {
+		return err
+	}
+
+	if r.setEnvAws && r.clearEnvAws {
+		return &cli.FriendlyError{Message: setAndClearErrMessage}
+	}
+
+	if r.setEnvAws {
+		// TODO: Validate AWS scope components (https://github.com/project-radius/radius/issues/5155)
+		// stsclient can be used to validate
+		awsRegion, err := cmd.Flags().GetString(commonflags.AWSRegionFlag)
+		if err != nil {
+			return err
+		}
+
+		awsAccount, err := cmd.Flags().GetString(commonflags.AWSAccountIdFlag)
+		if err != nil {
+			return err
+		}
+		r.providers.Aws.Scope = to.Ptr(fmt.Sprintf(awsScopeTemplate, awsAccount, awsRegion))
+
+	}
+
+	return nil
+}
+
+// Run runs the `rad env update` command.
+func (r *Runner) Run(ctx context.Context) error {
+	r.Output.LogInfo("Updating Environment...")
+
+	client, err := r.ConnectionFactory.CreateApplicationsManagementClient(ctx, *r.Workspace)
+	if err != nil {
+		return err
+	}
+
+	env, err := client.GetEnvDetails(ctx, r.envName)
+	if err != nil {
+		if clients.Is404Error(err) {
+			return &cli.FriendlyError{Message: envNotFoundErrMessage}
+		}
+		return err
+	}
+	providers := &corerp.Providers{}
+	//in case provider already exists, fetch it on local.
+	if env.Properties.Providers != nil {
+		providers = env.Properties.Providers
+	}
+	// only update azure provider info if user requires it.
+	if r.setEnvAzure || r.clearEnvAzure {
+		providers.Azure = r.providers.Azure
+	}
+	// only update aws provider info if user requires it.
+	if r.setEnvAws || r.clearEnvAws {
+		providers.Aws = r.providers.Aws
+	}
+
+	var namespace string
+	compute, ok := env.Properties.Compute.(*corerp.KubernetesCompute)
+	if ok {
+		namespace = *compute.Namespace
+	} else {
+		namespace = r.envName
+
+	}
+
+	isEnvUpdated, err := client.CreateEnvironment(ctx, r.envName, v1.LocationGlobal, namespace, "Kubernetes", "", map[string]*corerp.EnvironmentRecipeProperties{}, providers, *env.Properties.UseDevRecipes)
+	// In case of 304 (env not updated but no error), return nil
+	if err != nil || !isEnvUpdated {
+		return err
+	}
+
+	env.Properties.Providers = providers
+	err = r.Output.WriteFormatted("table", env, objectformats.GetEnvironmentTableFormat())
+	if err != nil {
+		return err
+	}
+
+	r.Output.LogInfo("Successfully updated environment %q.", r.envName)
+
+	return nil
+}

--- a/pkg/cli/cmd/env/update/update_test.go
+++ b/pkg/cli/cmd/env/update/update_test.go
@@ -32,7 +32,7 @@ func Test_Validate(t *testing.T) {
 
 	testcases := []radcli.ValidateInput{
 		{
-			Name:          "Update Env Command without pro",
+			Name:          "Update Env Command without any flags",
 			Input:         []string{"default"},
 			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{

--- a/pkg/cli/cmd/env/update/update_test.go
+++ b/pkg/cli/cmd/env/update/update_test.go
@@ -59,15 +59,6 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "Update Env Command with invalid flag groups",
-			Input:         []string{"default", "--azure-subscription-id", "testSubId"},
-			ExpectedValid: false,
-			ConfigHolder: framework.ConfigHolder{
-				ConfigFilePath: "",
-				Config:         configWithWorkspace,
-			},
-		},
-		{
 			Name: "Update Env Command with both providers set",
 			Input: []string{"default", "--azure-subscription-id", "testSubId", "--azure-resource-group", "testResourceGroup",
 				"--aws-region", "us-west-2", "--aws-account-id", "testAWSAccount",
@@ -139,6 +130,11 @@ func Test_Update(t *testing.T) {
 		require.NoError(t, err)
 
 		environment.Properties.Providers = testProviders
+		obj := objectformats.OutputEnvObject{
+			EnvName:   "test-env",
+			Recipes:   0,
+			Providers: 2,
+		}
 
 		expected := []any{
 			output.LogOutput{
@@ -146,7 +142,7 @@ func Test_Update(t *testing.T) {
 			},
 			output.FormattedOutput{
 				Format:  "table",
-				Obj:     environment,
+				Obj:     obj,
 				Options: objectformats.GetUpdateEnvironmentTableFormat(),
 			},
 			output.LogOutput{
@@ -218,6 +214,11 @@ func Test_Update(t *testing.T) {
 		require.NoError(t, err)
 
 		environment.Properties.Providers = testProviders
+		obj := objectformats.OutputEnvObject{
+			EnvName:   "test-env",
+			Recipes:   0,
+			Providers: 2,
+		}
 
 		expected := []any{
 			output.LogOutput{
@@ -225,7 +226,7 @@ func Test_Update(t *testing.T) {
 			},
 			output.FormattedOutput{
 				Format:  "table",
-				Obj:     environment,
+				Obj:     obj,
 				Options: objectformats.GetUpdateEnvironmentTableFormat(),
 			},
 			output.LogOutput{

--- a/pkg/cli/cmd/env/update/update_test.go
+++ b/pkg/cli/cmd/env/update/update_test.go
@@ -1,0 +1,237 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package update
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	"github.com/project-radius/radius/pkg/cli/clients"
+	"github.com/project-radius/radius/pkg/cli/connections"
+	"github.com/project-radius/radius/pkg/cli/framework"
+	"github.com/project-radius/radius/pkg/cli/objectformats"
+	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/project-radius/radius/pkg/cli/workspaces"
+	corerp "github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
+	"github.com/project-radius/radius/pkg/to"
+	"github.com/project-radius/radius/test/radcli"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CommandValidation(t *testing.T) {
+	radcli.SharedCommandValidation(t, NewCommand)
+}
+
+func Test_Validate(t *testing.T) {
+	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
+
+	testcases := []radcli.ValidateInput{
+		{
+			Name:          "Update Env Command with",
+			Input:         []string{"default"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+		},
+		{
+			Name:          "Update Env Command without env arg",
+			Input:         []string{},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+		},
+		{
+			Name:          "Update Env Command with single provider set",
+			Input:         []string{"default", "--set-azure", "--azure-subscriptionid", "testSubId", "--azure-resourcegroup", "testResourceGroup"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+		},
+		{
+			Name:          "Update Env Command with set and clear for same provider",
+			Input:         []string{"default", "--set-azure", "--azure-subscriptionid", "testSubId", "--azure-resourcegroup", "testResourceGroup", "--clear-azure"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+		},
+		{
+			Name: "Update Env Command with both providers set",
+			Input: []string{"default", "--set-azure", "--azure-subscriptionid", "testSubId", "--azure-resourcegroup", "testResourceGroup",
+				"--set-aws", "--aws-region", "us-west-2", "--aws-account", "testAWSAccount",
+			},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+		},
+	}
+	radcli.SharedValidateValidation(t, NewCommand, testcases)
+}
+
+func Test_Update(t *testing.T) {
+	t.Run("Success: Update Environment With Providers", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		environment := corerp.EnvironmentResource{
+			Name: to.Ptr("test-env"),
+			Properties: &corerp.EnvironmentProperties{
+				UseDevRecipes: to.Ptr(false),
+			},
+		}
+
+		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
+		appManagementClient.EXPECT().
+			GetEnvDetails(gomock.Any(), "test-env").
+			Return(environment, nil).
+			Times(1)
+
+		testProviders := &corerp.Providers{
+			Azure: &corerp.ProvidersAzure{
+				Scope: to.Ptr("/subscriptions/testSubId/resourceGroups/test-group"),
+			},
+			Aws: &corerp.ProvidersAws{
+				Scope: to.Ptr("/planes/aws/aws/accounts/testAwsAccount/regions/us-west-2"),
+			},
+		}
+
+		appManagementClient.EXPECT().
+			CreateEnvironment(gomock.Any(), "test-env", v1.LocationGlobal, "test-env",
+				"Kubernetes", "", gomock.Any(),
+				gomock.Any(), false).
+			Return(true, nil).
+			Times(1)
+
+		workspace := &workspaces.Workspace{
+			Connection: map[string]any{
+				"kind":    "kubernetes",
+				"context": "kind-kind",
+			},
+			Name:  "kind-kind",
+			Scope: "/planes/radius/local/resourceGroups/test-group",
+		}
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+			Workspace:         workspace,
+			Output:            outputSink,
+			envName:           "test-env",
+			setEnvAzure:       true,
+			providers:         testProviders,
+		}
+
+		err := runner.Run(context.Background())
+		require.NoError(t, err)
+
+		environment.Properties.Providers = testProviders
+
+		expected := []any{
+			output.LogOutput{
+				Format:  "Updating Environment...",
+			},
+			output.FormattedOutput{
+				Format:  "table",
+				Obj:     environment,
+				Options: objectformats.GetEnvironmentTableFormat(),
+			},
+			output.LogOutput{
+				Format:  "Successfully updated environment %q.",
+				Params: []any{"test-env"},
+			},
+		}
+
+		require.Equal(t, expected, outputSink.Writes)
+	})
+	t.Run("Success: Update Environment With Existing Providers", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		environment := corerp.EnvironmentResource{
+			Name: to.Ptr("test-env"),
+			Properties: &corerp.EnvironmentProperties{
+				Providers: &corerp.Providers{
+					Azure: &corerp.ProvidersAzure{
+						Scope: to.Ptr("/subscriptions/testSubId-1/resourceGroups/test-group-1"),
+					},
+				},
+				UseDevRecipes: to.Ptr(false),
+			},
+		}
+
+		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
+		appManagementClient.EXPECT().
+			GetEnvDetails(gomock.Any(), "test-env").
+			Return(environment, nil).
+			Times(1)
+
+		testProviders := &corerp.Providers{
+			Azure: &corerp.ProvidersAzure{
+				Scope: to.Ptr("/subscriptions/testSubId/resourceGroups/test-group"),
+			},
+			Aws: &corerp.ProvidersAws{
+				Scope: to.Ptr("/planes/aws/aws/accounts/testAwsAccount/regions/us-west-2"),
+			},
+		}
+
+		appManagementClient.EXPECT().
+			CreateEnvironment(gomock.Any(), "test-env", v1.LocationGlobal, "test-env",
+				"Kubernetes", "", gomock.Any(),
+				gomock.Any(), false).
+			Return(true, nil).
+			Times(1)
+
+		workspace := &workspaces.Workspace{
+			Connection: map[string]any{
+				"kind":    "kubernetes",
+				"context": "kind-kind",
+			},
+			Name:  "kind-kind",
+			Scope: "/planes/radius/local/resourceGroups/test-group",
+		}
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+			Workspace:         workspace,
+			Output:            outputSink,
+			envName:           "test-env",
+			setEnvAzure:       true,
+			providers:         testProviders,
+		}
+
+		err := runner.Run(context.Background())
+		require.NoError(t, err)
+
+		environment.Properties.Providers = testProviders
+
+		expected := []any{
+			output.LogOutput{
+				Format:  "Updating Environment...",
+			},
+			output.FormattedOutput{
+				Format:  "table",
+				Obj:     environment,
+				Options: objectformats.GetEnvironmentTableFormat(),
+			},
+			output.LogOutput{
+				Format:  "Successfully updated environment %q.",
+				Params: []any{"test-env"},
+			},
+		}
+
+		require.Equal(t, expected, outputSink.Writes)
+	})
+}

--- a/pkg/cli/cmd/env/update/update_test.go
+++ b/pkg/cli/cmd/env/update/update_test.go
@@ -32,7 +32,7 @@ func Test_Validate(t *testing.T) {
 
 	testcases := []radcli.ValidateInput{
 		{
-			Name:          "Update Env Command with",
+			Name:          "Update Env Command without pro",
 			Input:         []string{"default"},
 			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
@@ -51,7 +51,7 @@ func Test_Validate(t *testing.T) {
 		},
 		{
 			Name:          "Update Env Command with single provider set",
-			Input:         []string{"default", "--set-azure", "--azure-subscriptionid", "testSubId", "--azure-resourcegroup", "testResourceGroup"},
+			Input:         []string{"default", "--azure-subscription-id", "testSubId", "--azure-resource-group", "testResourceGroup"},
 			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
@@ -59,8 +59,8 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "Update Env Command with set and clear for same provider",
-			Input:         []string{"default", "--set-azure", "--azure-subscriptionid", "testSubId", "--azure-resourcegroup", "testResourceGroup", "--clear-azure"},
+			Name:          "Update Env Command with invalid flag groups",
+			Input:         []string{"default", "--azure-subscription-id", "testSubId"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
@@ -69,8 +69,8 @@ func Test_Validate(t *testing.T) {
 		},
 		{
 			Name: "Update Env Command with both providers set",
-			Input: []string{"default", "--set-azure", "--azure-subscriptionid", "testSubId", "--azure-resourcegroup", "testResourceGroup",
-				"--set-aws", "--aws-region", "us-west-2", "--aws-account", "testAWSAccount",
+			Input: []string{"default", "--azure-subscription-id", "testSubId", "--azure-resource-group", "testResourceGroup",
+				"--aws-region", "us-west-2", "--aws-account-id", "testAWSAccount",
 			},
 			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
@@ -109,10 +109,12 @@ func Test_Update(t *testing.T) {
 			},
 		}
 
+		testEnvProperties := &corerp.EnvironmentProperties{
+			UseDevRecipes: to.Ptr(false),
+			Providers:     testProviders,
+		}
 		appManagementClient.EXPECT().
-			CreateEnvironment(gomock.Any(), "test-env", v1.LocationGlobal, "test-env",
-				"Kubernetes", "", gomock.Any(),
-				gomock.Any(), false).
+			CreateEnvironment(gomock.Any(), "test-env", v1.LocationGlobal, testEnvProperties).
 			Return(true, nil).
 			Times(1)
 
@@ -129,8 +131,7 @@ func Test_Update(t *testing.T) {
 			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
 			Workspace:         workspace,
 			Output:            outputSink,
-			envName:           "test-env",
-			setEnvAzure:       true,
+			EnvName:           "test-env",
 			providers:         testProviders,
 		}
 
@@ -141,15 +142,15 @@ func Test_Update(t *testing.T) {
 
 		expected := []any{
 			output.LogOutput{
-				Format:  "Updating Environment...",
+				Format: "Updating Environment...",
 			},
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     environment,
-				Options: objectformats.GetEnvironmentTableFormat(),
+				Options: objectformats.GetUpdateEnvironmentTableFormat(),
 			},
 			output.LogOutput{
-				Format:  "Successfully updated environment %q.",
+				Format: "Successfully updated environment %q.",
 				Params: []any{"test-env"},
 			},
 		}
@@ -187,10 +188,12 @@ func Test_Update(t *testing.T) {
 			},
 		}
 
+		testEnvProperties := &corerp.EnvironmentProperties{
+			UseDevRecipes: to.Ptr(false),
+			Providers:     testProviders,
+		}
 		appManagementClient.EXPECT().
-			CreateEnvironment(gomock.Any(), "test-env", v1.LocationGlobal, "test-env",
-				"Kubernetes", "", gomock.Any(),
-				gomock.Any(), false).
+			CreateEnvironment(gomock.Any(), "test-env", v1.LocationGlobal, testEnvProperties).
 			Return(true, nil).
 			Times(1)
 
@@ -207,8 +210,7 @@ func Test_Update(t *testing.T) {
 			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
 			Workspace:         workspace,
 			Output:            outputSink,
-			envName:           "test-env",
-			setEnvAzure:       true,
+			EnvName:           "test-env",
 			providers:         testProviders,
 		}
 
@@ -219,15 +221,15 @@ func Test_Update(t *testing.T) {
 
 		expected := []any{
 			output.LogOutput{
-				Format:  "Updating Environment...",
+				Format: "Updating Environment...",
 			},
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     environment,
-				Options: objectformats.GetEnvironmentTableFormat(),
+				Options: objectformats.GetUpdateEnvironmentTableFormat(),
 			},
 			output.LogOutput{
-				Format:  "Successfully updated environment %q.",
+				Format: "Successfully updated environment %q.",
 				Params: []any{"test-env"},
 			},
 		}

--- a/pkg/cli/cmd/radInit/init.go
+++ b/pkg/cli/cmd/radInit/init.go
@@ -415,8 +415,16 @@ func (r *Runner) Run(ctx context.Context) error {
 			return err
 		}
 
+		envProperties := corerp.EnvironmentProperties{
+			Compute: &corerp.KubernetesCompute{
+				Namespace: to.Ptr(r.Namespace),
+			},
+			Providers: &providers,
+			UseDevRecipes: to.Ptr(!r.SkipDevRecipes),
+		}
+
 		r.Output.LogInfo("Configuring Cloud providers")
-		isEnvCreated, err := client.CreateEnvironment(ctx, r.EnvName, v1.LocationGlobal, r.Namespace, "kubernetes", "", map[string]*corerp.EnvironmentRecipeProperties{}, &providers, !r.SkipDevRecipes)
+		isEnvCreated, err := client.CreateEnvironment(ctx, r.EnvName, v1.LocationGlobal, &envProperties)
 		if err != nil || !isEnvCreated {
 			return &cli.FriendlyError{Message: "Failed to create radius environment"}
 		}

--- a/pkg/cli/cmd/radInit/init_test.go
+++ b/pkg/cli/cmd/radInit/init_test.go
@@ -457,8 +457,19 @@ func Test_Run_InstallAndCreateEnvironment_WithAzureProvider_WithRecipes(t *testi
 		CreateUCPGroup(context.Background(), "deployments", "local", "default", gomock.Any()).
 		Return(true, nil).Times(1)
 	skipRecipes := false
+	testEnvProperties := &corerp.EnvironmentProperties{
+		Compute: &corerp.KubernetesCompute{
+			Namespace: to.Ptr("defaultNamespace"),
+		},
+		UseDevRecipes: to.Ptr(!skipRecipes),
+		Providers: &corerp.Providers{
+			Azure: &corerp.ProvidersAzure{
+				Scope: to.Ptr("/subscriptions/test-subscription/resourceGroups/test-rg"),
+			},
+		},
+	}
 	appManagementClient.EXPECT().
-		CreateEnvironment(context.Background(), "default", v1.LocationGlobal, "defaultNamespace", "kubernetes", gomock.Any(), gomock.Any(), gomock.Any(), !skipRecipes).
+		CreateEnvironment(context.Background(), "default", v1.LocationGlobal, testEnvProperties).
 		Return(true, nil).Times(1)
 
 	credentialManagementClient := cli_credential.NewMockCredentialManagementClient(ctrl)
@@ -522,8 +533,19 @@ func Test_Run_InstallAndCreateEnvironment_WithAWSProvider(t *testing.T) {
 	appManagementClient.EXPECT().
 		CreateUCPGroup(context.Background(), "deployments", "local", "default", gomock.Any()).
 		Return(true, nil).Times(1)
+	testEnvProperties := &corerp.EnvironmentProperties{
+		Compute: &corerp.KubernetesCompute{
+			Namespace: to.Ptr("defaultNamespace"),
+		},
+		UseDevRecipes: to.Ptr(true),
+		Providers: &corerp.Providers{
+			Aws: &corerp.ProvidersAws{
+				Scope: to.Ptr("/planes/aws/aws/accounts/test-account-id/regions/us-west-2"),
+			},
+		},
+	}
 	appManagementClient.EXPECT().
-		CreateEnvironment(context.Background(), "default", v1.LocationGlobal, "defaultNamespace", "kubernetes", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		CreateEnvironment(context.Background(), "default", v1.LocationGlobal, testEnvProperties).
 		Return(true, nil).Times(1)
 
 	credentialManagementClient := cli_credential.NewMockCredentialManagementClient(ctrl)
@@ -584,8 +606,15 @@ func Test_Run_InstallAndCreateEnvironment_WithoutAzureProvider_WithSkipRecipes(t
 		CreateUCPGroup(context.Background(), "deployments", "local", "default", gomock.Any()).
 		Return(true, nil).Times(1)
 	skipRecipes := true
+	testEnvProperties := &corerp.EnvironmentProperties{
+		Compute: &corerp.KubernetesCompute{
+			Namespace: to.Ptr("defaultNamespace"),
+		},
+		UseDevRecipes: to.Ptr(!skipRecipes),
+		Providers:     &corerp.Providers{},
+	}
 	appManagementClient.EXPECT().
-		CreateEnvironment(context.Background(), "default", v1.LocationGlobal, "defaultNamespace", "kubernetes", gomock.Any(), gomock.Any(), gomock.Any(), !skipRecipes).
+		CreateEnvironment(context.Background(), "default", v1.LocationGlobal, testEnvProperties).
 		Return(true, nil).Times(1)
 
 	configFileInterface.EXPECT().

--- a/pkg/cli/cmd/recipe/register/register.go
+++ b/pkg/cli/cmd/recipe/register/register.go
@@ -13,7 +13,6 @@ import (
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/bicep"
-	"github.com/project-radius/radius/pkg/cli/cmd"
 	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/framework"
@@ -149,12 +148,12 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	recipeProperties := envResource.Properties.Recipes
-	if recipeProperties[r.RecipeName] != nil {
-		return &cli.FriendlyError{Message: fmt.Sprintf("recipe with name %q already exists in the environment %q", r.RecipeName, r.Workspace.Environment)}
-	}
-
 	if recipeProperties == nil {
 		recipeProperties = map[string]*corerpapps.EnvironmentRecipeProperties{}
+	}
+
+	if recipeProperties[r.RecipeName] != nil {
+		return &cli.FriendlyError{Message: fmt.Sprintf("recipe with name %q already exists in the environment %q", r.RecipeName, r.Workspace.Environment)}
 	}
 
 	recipeProperties[r.RecipeName] = &corerpapps.EnvironmentRecipeProperties{
@@ -163,9 +162,9 @@ func (r *Runner) Run(ctx context.Context) error {
 		Parameters:   bicep.ConvertToMapStringInterface(r.Parameters),
 	}
 
-	namespace := cmd.GetNamespace(envResource)
+	envResource.Properties.Recipes = recipeProperties
 
-	isEnvCreated, err := client.CreateEnvironment(ctx, r.Workspace.Environment, v1.LocationGlobal, namespace, "Kubernetes", *envResource.ID, recipeProperties, envResource.Properties.Providers, *envResource.Properties.UseDevRecipes)
+	isEnvCreated, err := client.CreateEnvironment(ctx, r.Workspace.Environment, v1.LocationGlobal, envResource.Properties)
 	if err != nil || !isEnvCreated {
 		return &cli.FriendlyError{Message: fmt.Sprintf("failed to register the recipe %s to the environment %s: %s", r.RecipeName, *envResource.ID, err.Error())}
 	}

--- a/pkg/cli/cmd/recipe/register/register_test.go
+++ b/pkg/cli/cmd/recipe/register/register_test.go
@@ -102,23 +102,27 @@ func Test_Run(t *testing.T) {
 	t.Run("Register recipe Success", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 
-		envResource := v20220315privatepreview.EnvironmentResource{
-			ID:       to.Ptr("/planes/radius/local/resourcegroups/kind-kind/providers/applications.core/environments/kind-kind"),
-			Name:     to.Ptr("kind-kind"),
-			Type:     to.Ptr("applications.core/environments"),
-			Location: to.Ptr(v1.LocationGlobal),
-			Properties: &v20220315privatepreview.EnvironmentProperties{
-				UseDevRecipes: to.Ptr(true),
-				Recipes: map[string]*v20220315privatepreview.EnvironmentRecipeProperties{
-					"cosmosDB": {
-						LinkType:     to.Ptr(linkrp.MongoDatabasesResourceType),
-						TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
-					},
-				},
-				Compute: &v20220315privatepreview.KubernetesCompute{
-					Namespace: to.Ptr("default"),
-				},
+		testRecipes := map[string]*v20220315privatepreview.EnvironmentRecipeProperties{
+			"cosmosDB": {
+				LinkType:     to.Ptr(linkrp.MongoDatabasesResourceType),
+				TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
 			},
+		}
+
+		testEnvProperties := &v20220315privatepreview.EnvironmentProperties{
+			UseDevRecipes: to.Ptr(true),
+			Recipes:       testRecipes,
+			Compute: &v20220315privatepreview.KubernetesCompute{
+				Namespace: to.Ptr("default"),
+			},
+		}
+
+		envResource := v20220315privatepreview.EnvironmentResource{
+			ID:         to.Ptr("/planes/radius/local/resourcegroups/kind-kind/providers/applications.core/environments/kind-kind"),
+			Name:       to.Ptr("kind-kind"),
+			Type:       to.Ptr("applications.core/environments"),
+			Location:   to.Ptr(v1.LocationGlobal),
+			Properties: testEnvProperties,
 		}
 
 		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
@@ -126,7 +130,7 @@ func Test_Run(t *testing.T) {
 			GetEnvDetails(gomock.Any(), gomock.Any()).
 			Return(envResource, nil).Times(1)
 		appManagementClient.EXPECT().
-			CreateEnvironment(context.Background(), "kind-kind", v1.LocationGlobal, "default", "Kubernetes", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			CreateEnvironment(context.Background(), "kind-kind", v1.LocationGlobal, testEnvProperties).
 			Return(true, nil).Times(1)
 
 		outputSink := &output.MockOutput{}
@@ -147,24 +151,26 @@ func Test_Run(t *testing.T) {
 	t.Run("Register recipe with parameters", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 
-		envResource := v20220315privatepreview.EnvironmentResource{
-			ID:       to.Ptr("/planes/radius/local/resourcegroups/kind-kind/providers/applications.core/environments/kind-kind"),
-			Name:     to.Ptr("kind-kind"),
-			Type:     to.Ptr("applications.core/environments"),
-			Location: to.Ptr(v1.LocationGlobal),
-			Properties: &v20220315privatepreview.EnvironmentProperties{
-				UseDevRecipes: to.Ptr(true),
-				Recipes: map[string]*v20220315privatepreview.EnvironmentRecipeProperties{
-					"cosmosDB": {
-						LinkType:     to.Ptr(linkrp.MongoDatabasesResourceType),
-						TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
-						Parameters:   map[string]any{"throughput": 400},
-					},
-				},
-				Compute: &v20220315privatepreview.KubernetesCompute{
-					Namespace: to.Ptr("default"),
+		testEnvProperties := &v20220315privatepreview.EnvironmentProperties{
+			UseDevRecipes: to.Ptr(true),
+			Recipes: map[string]*v20220315privatepreview.EnvironmentRecipeProperties{
+				"cosmosDB": {
+					LinkType:     to.Ptr(linkrp.MongoDatabasesResourceType),
+					TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+					Parameters:   map[string]any{"throughput": 400},
 				},
 			},
+			Compute: &v20220315privatepreview.KubernetesCompute{
+				Namespace: to.Ptr("default"),
+			},
+		}
+
+		envResource := v20220315privatepreview.EnvironmentResource{
+			ID:         to.Ptr("/planes/radius/local/resourcegroups/kind-kind/providers/applications.core/environments/kind-kind"),
+			Name:       to.Ptr("kind-kind"),
+			Type:       to.Ptr("applications.core/environments"),
+			Location:   to.Ptr(v1.LocationGlobal),
+			Properties: testEnvProperties,
 		}
 
 		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
@@ -172,7 +178,7 @@ func Test_Run(t *testing.T) {
 			GetEnvDetails(gomock.Any(), gomock.Any()).
 			Return(envResource, nil).Times(1)
 		appManagementClient.EXPECT().
-			CreateEnvironment(context.Background(), "kind-kind", v1.LocationGlobal, "default", "Kubernetes", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			CreateEnvironment(context.Background(), "kind-kind", v1.LocationGlobal, testEnvProperties).
 			Return(true, nil).Times(1)
 
 		outputSink := &output.MockOutput{}
@@ -193,28 +199,29 @@ func Test_Run(t *testing.T) {
 
 	t.Run("Register recipe with no namespace", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-
-		envResource := v20220315privatepreview.EnvironmentResource{
-			ID:       to.Ptr("/planes/radius/local/resourcegroups/kind-kind/providers/applications.core/environments/kind-kind"),
-			Name:     to.Ptr("kind-kind"),
-			Type:     to.Ptr("applications.core/environments"),
-			Location: to.Ptr(v1.LocationGlobal),
-			Properties: &v20220315privatepreview.EnvironmentProperties{
-				UseDevRecipes: to.Ptr(true),
-				Recipes: map[string]*v20220315privatepreview.EnvironmentRecipeProperties{
-					"cosmosDB": {
-						LinkType:     to.Ptr(linkrp.MongoDatabasesResourceType),
-						TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
-					},
+		testEnvProperties := &v20220315privatepreview.EnvironmentProperties{
+			UseDevRecipes: to.Ptr(true),
+			Recipes: map[string]*v20220315privatepreview.EnvironmentRecipeProperties{
+				"cosmosDB": {
+					LinkType:     to.Ptr(linkrp.MongoDatabasesResourceType),
+					TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
 				},
 			},
+		}
+
+		envResource := v20220315privatepreview.EnvironmentResource{
+			ID:         to.Ptr("/planes/radius/local/resourcegroups/kind-kind/providers/applications.core/environments/kind-kind"),
+			Name:       to.Ptr("kind-kind"),
+			Type:       to.Ptr("applications.core/environments"),
+			Location:   to.Ptr(v1.LocationGlobal),
+			Properties: testEnvProperties,
 		}
 		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
 		appManagementClient.EXPECT().
 			GetEnvDetails(gomock.Any(), gomock.Any()).
 			Return(envResource, nil).Times(1)
 		appManagementClient.EXPECT().
-			CreateEnvironment(context.Background(), "kind-kind", v1.LocationGlobal, "", "Kubernetes", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			CreateEnvironment(context.Background(), "kind-kind", v1.LocationGlobal, testEnvProperties).
 			Return(true, nil).Times(1)
 
 		outputSink := &output.MockOutput{}

--- a/pkg/cli/cmd/recipe/unregister/unregister.go
+++ b/pkg/cli/cmd/recipe/unregister/unregister.go
@@ -101,9 +101,9 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	namespace := cmd.GetNamespace(envResource)
 	delete(recipeProperties, r.RecipeName)
-	isEnvCreated, err := client.CreateEnvironment(ctx, r.Workspace.Environment, v1.LocationGlobal, namespace, "Kubernetes", *envResource.ID, recipeProperties, envResource.Properties.Providers, *envResource.Properties.UseDevRecipes)
+	envResource.Properties.Recipes = recipeProperties
+	isEnvCreated, err := client.CreateEnvironment(ctx, r.Workspace.Environment, v1.LocationGlobal, envResource.Properties)
 	if err != nil || !isEnvCreated {
 		return &cli.FriendlyError{Message: fmt.Sprintf("failed to unregister the recipe %s from the environment %s: %s", r.RecipeName, *envResource.ID, err.Error())}
 	}

--- a/pkg/cli/cmd/recipe/unregister/unregister_test.go
+++ b/pkg/cli/cmd/recipe/unregister/unregister_test.go
@@ -76,23 +76,25 @@ func Test_Run(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
-			envResource := v20220315privatepreview.EnvironmentResource{
-				ID:       to.Ptr("/planes/radius/local/resourcegroups/kind-kind/providers/applications.core/environments/kind-kind"),
-				Name:     to.Ptr("kind-kind"),
-				Type:     to.Ptr("applications.core/environments"),
-				Location: to.Ptr(v1.LocationGlobal),
-				Properties: &v20220315privatepreview.EnvironmentProperties{
-					UseDevRecipes: to.Ptr(true),
-					Recipes: map[string]*v20220315privatepreview.EnvironmentRecipeProperties{
-						"cosmosDB": {
-							LinkType:     to.Ptr(linkrp.MongoDatabasesResourceType),
-							TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
-						},
-					},
-					Compute: &v20220315privatepreview.KubernetesCompute{
-						Namespace: to.Ptr("default"),
+			testEnvProperties := &v20220315privatepreview.EnvironmentProperties{
+				UseDevRecipes: to.Ptr(true),
+				Recipes: map[string]*v20220315privatepreview.EnvironmentRecipeProperties{
+					"cosmosDB": {
+						LinkType:     to.Ptr(linkrp.MongoDatabasesResourceType),
+						TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
 					},
 				},
+				Compute: &v20220315privatepreview.KubernetesCompute{
+					Namespace: to.Ptr("default"),
+				},
+			}
+
+			envResource := v20220315privatepreview.EnvironmentResource{
+				ID:         to.Ptr("/planes/radius/local/resourcegroups/kind-kind/providers/applications.core/environments/kind-kind"),
+				Name:       to.Ptr("kind-kind"),
+				Type:       to.Ptr("applications.core/environments"),
+				Location:   to.Ptr(v1.LocationGlobal),
+				Properties: testEnvProperties,
 			}
 
 			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
@@ -100,7 +102,7 @@ func Test_Run(t *testing.T) {
 				GetEnvDetails(gomock.Any(), gomock.Any()).
 				Return(envResource, nil).Times(1)
 			appManagementClient.EXPECT().
-				CreateEnvironment(context.Background(), "kind-kind", v1.LocationGlobal, "default", "Kubernetes", gomock.Any(), map[string]*v20220315privatepreview.EnvironmentRecipeProperties{}, gomock.Any(), gomock.Any()).
+				CreateEnvironment(context.Background(), "kind-kind", v1.LocationGlobal, testEnvProperties).
 				Return(true, nil).Times(1)
 
 			outputSink := &output.MockOutput{}
@@ -118,20 +120,22 @@ func Test_Run(t *testing.T) {
 		t.Run("No Namespace", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
-			envResource := v20220315privatepreview.EnvironmentResource{
-				ID:       to.Ptr("/planes/radius/local/resourcegroups/kind-kind/providers/applications.core/environments/kind-kind"),
-				Name:     to.Ptr("kind-kind"),
-				Type:     to.Ptr("applications.core/environments"),
-				Location: to.Ptr(v1.LocationGlobal),
-				Properties: &v20220315privatepreview.EnvironmentProperties{
-					UseDevRecipes: to.Ptr(true),
-					Recipes: map[string]*v20220315privatepreview.EnvironmentRecipeProperties{
-						"cosmosDB": {
-							LinkType:     to.Ptr(linkrp.MongoDatabasesResourceType),
-							TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
-						},
+			testEnvProperties := &v20220315privatepreview.EnvironmentProperties{
+				UseDevRecipes: to.Ptr(true),
+				Recipes: map[string]*v20220315privatepreview.EnvironmentRecipeProperties{
+					"cosmosDB": {
+						LinkType:     to.Ptr(linkrp.MongoDatabasesResourceType),
+						TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
 					},
 				},
+			}
+
+			envResource := v20220315privatepreview.EnvironmentResource{
+				ID:         to.Ptr("/planes/radius/local/resourcegroups/kind-kind/providers/applications.core/environments/kind-kind"),
+				Name:       to.Ptr("kind-kind"),
+				Type:       to.Ptr("applications.core/environments"),
+				Location:   to.Ptr(v1.LocationGlobal),
+				Properties: testEnvProperties,
 			}
 
 			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
@@ -139,7 +143,7 @@ func Test_Run(t *testing.T) {
 				GetEnvDetails(gomock.Any(), gomock.Any()).
 				Return(envResource, nil).Times(1)
 			appManagementClient.EXPECT().
-				CreateEnvironment(context.Background(), "kind-kind", v1.LocationGlobal, "", "Kubernetes", gomock.Any(), map[string]*v20220315privatepreview.EnvironmentRecipeProperties{}, gomock.Any(), gomock.Any()).
+				CreateEnvironment(context.Background(), "kind-kind", v1.LocationGlobal, testEnvProperties).
 				Return(true, nil).Times(1)
 
 			outputSink := &output.MockOutput{}

--- a/pkg/cli/objectformats/objectformats.go
+++ b/pkg/cli/objectformats/objectformats.go
@@ -193,6 +193,29 @@ func GetEnvironmentRecipesTableFormat() output.FormatterOptions {
 	}
 }
 
+func GetEnvironmentTableFormat() output.FormatterOptions {
+	return output.FormatterOptions{
+		Columns: []output.Column{
+			{
+				Heading:  "ENV_NAME",
+				JSONPath: "{ .Name }",
+			},
+			{
+				Heading:  "AZURE",
+				JSONPath: "{ .Properties.Providers.Azure.Scope }",
+			},
+			{
+				Heading:  "AWS",
+				JSONPath: "{ .Properties.Providers.Aws.Scope }",
+			},
+			{
+				Heading:  "DEV_RECIPES",
+				JSONPath: "{ .Properties.UseDevRecipes }",
+			},
+		},
+	}
+}
+
 func GetRecipeParamsTableFormat() output.FormatterOptions {
 	return output.FormatterOptions{
 		Columns: []output.Column{

--- a/pkg/cli/objectformats/objectformats.go
+++ b/pkg/cli/objectformats/objectformats.go
@@ -200,6 +200,7 @@ type OutputEnvObject struct {
 	Providers   int
 }
 
+// GetUpdateEnvironmentTableFormat returns the fields to output from env object after upation.
 func GetUpdateEnvironmentTableFormat() output.FormatterOptions {
 	return output.FormatterOptions{
 		Columns: []output.Column{
@@ -208,7 +209,7 @@ func GetUpdateEnvironmentTableFormat() output.FormatterOptions {
 				JSONPath: "{ .EnvName }",
 			},
 			{
-				Heading:  "COMPUTE_KIND",
+				Heading:  "COMPUTE",
 				JSONPath: "{ .ComputeKind }",
 			},
 			{

--- a/pkg/cli/objectformats/objectformats.go
+++ b/pkg/cli/objectformats/objectformats.go
@@ -193,24 +193,32 @@ func GetEnvironmentRecipesTableFormat() output.FormatterOptions {
 	}
 }
 
-func GetEnvironmentTableFormat() output.FormatterOptions {
+func GetUpdateEnvironmentTableFormat() output.FormatterOptions {
 	return output.FormatterOptions{
 		Columns: []output.Column{
 			{
-				Heading:  "ENV_NAME",
-				JSONPath: "{ .Name }",
+				Heading:  "NAME",
+				JSONPath: "{ .EnvName }",
 			},
 			{
-				Heading:  "AZURE",
-				JSONPath: "{ .Properties.Providers.Azure.Scope }",
+				Heading:  "AZURE_SUBSCRIPTION",
+				JSONPath: "{ .AzureSubId }",
 			},
 			{
-				Heading:  "AWS",
-				JSONPath: "{ .Properties.Providers.Aws.Scope }",
+				Heading:  "AZURE_RESOURCE_GROUP",
+				JSONPath: "{ .AzureRgId }",
+			},
+			{
+				Heading:  "AWS_ACCOUNT",
+				JSONPath: "{ .AWSAccountId }",
+			},
+			{
+				Heading:  "AWS_REGION",
+				JSONPath: "{ .AWSRegion }",
 			},
 			{
 				Heading:  "DEV_RECIPES",
-				JSONPath: "{ .Properties.UseDevRecipes }",
+				JSONPath: "{ .UseDevRecipes }",
 			},
 		},
 	}

--- a/pkg/cli/objectformats/objectformats.go
+++ b/pkg/cli/objectformats/objectformats.go
@@ -193,6 +193,13 @@ func GetEnvironmentRecipesTableFormat() output.FormatterOptions {
 	}
 }
 
+type OutputEnvObject struct {
+	EnvName     string
+	ComputeKind string
+	Recipes     int
+	Providers   int
+}
+
 func GetUpdateEnvironmentTableFormat() output.FormatterOptions {
 	return output.FormatterOptions{
 		Columns: []output.Column{
@@ -201,24 +208,16 @@ func GetUpdateEnvironmentTableFormat() output.FormatterOptions {
 				JSONPath: "{ .EnvName }",
 			},
 			{
-				Heading:  "AZURE_SUBSCRIPTION",
-				JSONPath: "{ .AzureSubId }",
+				Heading:  "COMPUTE_KIND",
+				JSONPath: "{ .ComputeKind }",
 			},
 			{
-				Heading:  "AZURE_RESOURCE_GROUP",
-				JSONPath: "{ .AzureRgId }",
+				Heading:  "RECIPES",
+				JSONPath: "{ .Recipes }",
 			},
 			{
-				Heading:  "AWS_ACCOUNT",
-				JSONPath: "{ .AWSAccountId }",
-			},
-			{
-				Heading:  "AWS_REGION",
-				JSONPath: "{ .AWSRegion }",
-			},
-			{
-				Heading:  "DEV_RECIPES",
-				JSONPath: "{ .UseDevRecipes }",
+				Heading:  "PROVIDERS",
+				JSONPath: "{ .Providers }",
 			},
 		},
 	}

--- a/pkg/cli/objectformats/objectformats_test.go
+++ b/pkg/cli/objectformats/objectformats_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_EnvTableFormat(t *testing.T) {
+func Test_GenericEnvTableFormat(t *testing.T) {
 	obj := v20220315privatepreview.EnvironmentResource{
 		Name: to.Ptr("test_env_resource"),
 	}
@@ -25,5 +25,29 @@ func Test_EnvTableFormat(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := "NAME\ntest_env_resource\n"
+	require.Equal(t, expected, buffer.String())
+}
+
+func Test_EnvTableFormat(t *testing.T) {
+	obj := v20220315privatepreview.EnvironmentResource{
+		Name: to.Ptr("test_env_resource"),
+		Properties: &v20220315privatepreview.EnvironmentProperties{
+			Providers: &v20220315privatepreview.Providers{
+				Azure: &v20220315privatepreview.ProvidersAzure{
+					Scope: to.Ptr("/subscriptions/testSubId/resourceGroups/testResourceGroup"),
+				},
+				Aws: &v20220315privatepreview.ProvidersAws{
+					Scope: to.Ptr("/planes/aws/aws/accounts/testAccountId/regions/us-west-2"),
+				},
+			},
+			UseDevRecipes: to.Ptr(false),
+		},
+	}
+
+	buffer := &bytes.Buffer{}
+	err := output.Write(output.FormatTable, obj, buffer, GetEnvironmentTableFormat())
+	require.NoError(t, err)
+
+	expected := "ENV_NAME           AZURE                                                      AWS                                                       DEV_RECIPES\ntest_env_resource  /subscriptions/testSubId/resourceGroups/testResourceGroup  /planes/aws/aws/accounts/testAccountId/regions/us-west-2  false\n"
 	require.Equal(t, expected, buffer.String())
 }

--- a/pkg/cli/objectformats/objectformats_test.go
+++ b/pkg/cli/objectformats/objectformats_test.go
@@ -15,6 +15,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type updateEnvObject struct {
+	EnvName       string
+	AzureSubId    string
+	AzureRgId     string
+	AWSAccountId  string
+	AWSRegion     string
+	UseDevRecipes bool
+}
+
 func Test_GenericEnvTableFormat(t *testing.T) {
 	obj := v20220315privatepreview.EnvironmentResource{
 		Name: to.Ptr("test_env_resource"),
@@ -29,25 +38,19 @@ func Test_GenericEnvTableFormat(t *testing.T) {
 }
 
 func Test_EnvTableFormat(t *testing.T) {
-	obj := v20220315privatepreview.EnvironmentResource{
-		Name: to.Ptr("test_env_resource"),
-		Properties: &v20220315privatepreview.EnvironmentProperties{
-			Providers: &v20220315privatepreview.Providers{
-				Azure: &v20220315privatepreview.ProvidersAzure{
-					Scope: to.Ptr("/subscriptions/testSubId/resourceGroups/testResourceGroup"),
-				},
-				Aws: &v20220315privatepreview.ProvidersAws{
-					Scope: to.Ptr("/planes/aws/aws/accounts/testAccountId/regions/us-west-2"),
-				},
-			},
-			UseDevRecipes: to.Ptr(false),
-		},
+	obj := updateEnvObject{
+		EnvName:       "test_env_resource",
+		AzureSubId:    "testSubId",
+		AzureRgId:     "testResourceGroup",
+		AWSAccountId:  "testAccountId",
+		AWSRegion:     "us-west-2",
+		UseDevRecipes: true,
 	}
 
 	buffer := &bytes.Buffer{}
-	err := output.Write(output.FormatTable, obj, buffer, GetEnvironmentTableFormat())
+	err := output.Write(output.FormatTable, obj, buffer, GetUpdateEnvironmentTableFormat())
 	require.NoError(t, err)
 
-	expected := "ENV_NAME           AZURE                                                      AWS                                                       DEV_RECIPES\ntest_env_resource  /subscriptions/testSubId/resourceGroups/testResourceGroup  /planes/aws/aws/accounts/testAccountId/regions/us-west-2  false\n"
+	expected := "NAME               AZURE_SUBSCRIPTION  AZURE_RESOURCE_GROUP  AWS_ACCOUNT    AWS_REGION  DEV_RECIPES\ntest_env_resource  testSubId           testResourceGroup     testAccountId  us-west-2   true\n"
 	require.Equal(t, expected, buffer.String())
 }

--- a/pkg/cli/objectformats/objectformats_test.go
+++ b/pkg/cli/objectformats/objectformats_test.go
@@ -15,15 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type updateEnvObject struct {
-	EnvName       string
-	AzureSubId    string
-	AzureRgId     string
-	AWSAccountId  string
-	AWSRegion     string
-	UseDevRecipes bool
-}
-
 func Test_GenericEnvTableFormat(t *testing.T) {
 	obj := v20220315privatepreview.EnvironmentResource{
 		Name: to.Ptr("test_env_resource"),
@@ -38,19 +29,17 @@ func Test_GenericEnvTableFormat(t *testing.T) {
 }
 
 func Test_EnvTableFormat(t *testing.T) {
-	obj := updateEnvObject{
-		EnvName:       "test_env_resource",
-		AzureSubId:    "testSubId",
-		AzureRgId:     "testResourceGroup",
-		AWSAccountId:  "testAccountId",
-		AWSRegion:     "us-west-2",
-		UseDevRecipes: true,
+	obj := OutputEnvObject{
+		EnvName:     "test_env_resource",
+		ComputeKind: "kubernetes",
+		Recipes:     3,
+		Providers:   2,
 	}
 
 	buffer := &bytes.Buffer{}
 	err := output.Write(output.FormatTable, obj, buffer, GetUpdateEnvironmentTableFormat())
 	require.NoError(t, err)
 
-	expected := "NAME               AZURE_SUBSCRIPTION  AZURE_RESOURCE_GROUP  AWS_ACCOUNT    AWS_REGION  DEV_RECIPES\ntest_env_resource  testSubId           testResourceGroup     testAccountId  us-west-2   true\n"
+	expected := "NAME               COMPUTE_KIND  RECIPES   PROVIDERS\ntest_env_resource  kubernetes    3         2\n"
 	require.Equal(t, expected, buffer.String())
 }

--- a/pkg/cli/objectformats/objectformats_test.go
+++ b/pkg/cli/objectformats/objectformats_test.go
@@ -40,6 +40,6 @@ func Test_EnvTableFormat(t *testing.T) {
 	err := output.Write(output.FormatTable, obj, buffer, GetUpdateEnvironmentTableFormat())
 	require.NoError(t, err)
 
-	expected := "NAME               COMPUTE_KIND  RECIPES   PROVIDERS\ntest_env_resource  kubernetes    3         2\n"
+	expected := "NAME               COMPUTE     RECIPES   PROVIDERS\ntest_env_resource  kubernetes  3         2\n"
 	require.Equal(t, expected, buffer.String())
 }

--- a/pkg/cli/ucp/ucp_management.go
+++ b/pkg/cli/ucp/ucp_management.go
@@ -302,15 +302,13 @@ func (amc *ARMApplicationsManagementClient) CreateApplicationIfNotFound(ctx cont
 }
 
 // Creates a radius environment resource
-func (amc *ARMApplicationsManagementClient) CreateEnvironment(ctx context.Context, envName string, location string, namespace string, envKind string, resourceId string, recipeProperties map[string]*corerpv20220315.EnvironmentRecipeProperties, providers *corerpv20220315.Providers, useDevRecipes bool) (bool, error) {
+func (amc *ARMApplicationsManagementClient) CreateEnvironment(ctx context.Context, envName string, location string, envProperties *corerpv20220315.EnvironmentProperties) (bool, error) {
 	client, err := corerpv20220315.NewEnvironmentsClient(amc.RootScope, &aztoken.AnonymousCredential{}, amc.ClientOptions)
 	if err != nil {
 		return false, err
 	}
 
-	envCompute := corerpv20220315.KubernetesCompute{Kind: &envKind, Namespace: &namespace, ResourceID: &resourceId}
-	properties := corerpv20220315.EnvironmentProperties{Compute: &envCompute, Recipes: recipeProperties, Providers: providers, UseDevRecipes: &useDevRecipes}
-	_, err = client.CreateOrUpdate(ctx, envName, corerpv20220315.EnvironmentResource{Location: &location, Properties: &properties}, &corerpv20220315.EnvironmentsClientCreateOrUpdateOptions{})
+	_, err = client.CreateOrUpdate(ctx, envName, corerpv20220315.EnvironmentResource{Location: &location, Properties: envProperties}, &corerpv20220315.EnvironmentsClientCreateOrUpdateOptions{})
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
 Description
- Add rad env update command to populate provider scope on env resource
- Add flag to clear provider scope in the same command
issue: https://github.com/project-radius/radius/issues/5089

rad env update default --azure-subscription-id testSubId --azure-resource-group testResourceGroup
<img width="590" alt="Screenshot 2023-03-09 at 2 16 55 AM" src="https://user-images.githubusercontent.com/99223262/223849275-2f84b12a-2470-4cab-a02e-85f4aa8a5eea.png">

rad env update default --azure-subscription-id testSubId
<img width="1255" alt="Screenshot 2023-03-09 at 2 35 17 AM" src="https://user-images.githubusercontent.com/99223262/223849777-4bdd5f7a-d4cd-478f-9ee9-3392736d8d37.png">

rad env update default --azure-subscription-id testSubId --azure-resource-group testResourceGroup --clear-azure
<img width="1257" alt="Screenshot 2023-03-09 at 2 46 21 AM" src="https://user-images.githubusercontent.com/99223262/223852118-4a328c6e-32dc-4419-9a01-c6003ac928eb.png">



rad env update default --clear-azure --clear-aws
<img width="516" alt="Screenshot 2023-03-09 at 2 42 32 AM" src="https://user-images.githubusercontent.com/99223262/223851279-7db3628f-d3dd-4e28-91d7-08a82df4c7c5.png">






## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: radius-project/core-team#1100 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
