### PR TITLE
HOTFIX - unpopulated providers in environment resource

### DIFF
--- a/pkg/cli/cmd/env/create/create.go
+++ b/pkg/cli/cmd/env/create/create.go
@@ -157,7 +157,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	var err error
 	if r.Workspace.ProviderConfig != (workspaces.ProviderConfig{}) && r.Workspace.ProviderConfig.Azure != nil &&
 		(r.Workspace.ProviderConfig.Azure.SubscriptionID != "" && r.Workspace.ProviderConfig.Azure.ResourceGroup != "") {
-		providers, err = cmd.CreateEnvProviders([]interface{}{r.Workspace.ProviderConfig.Azure, nil})
+		providers, err = cmd.CreateEnvProviders([]any{r.Workspace.ProviderConfig.Azure, nil})
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/cmd/env/create/create.go
+++ b/pkg/cli/cmd/env/create/create.go
@@ -14,10 +14,7 @@ import (
 
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/cli"
-	"github.com/project-radius/radius/pkg/cli/aws"
-	"github.com/project-radius/radius/pkg/cli/azure"
 	"github.com/project-radius/radius/pkg/cli/clients"
-	"github.com/project-radius/radius/pkg/cli/cmd"
 	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
 	"github.com/project-radius/radius/pkg/cli/cmd/env/namespace"
 	"github.com/project-radius/radius/pkg/cli/connections"
@@ -152,41 +149,16 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func providersFromWorkspace(ws *workspaces.Workspace) []any {
-	providerList := []any{}
-	wsAzure := ws.ProviderConfig.Azure
-	if wsAzure != nil && wsAzure.SubscriptionID != "" && wsAzure.ResourceGroup != "" {
-		providerList = append(providerList, &azure.Provider{
-			SubscriptionID: wsAzure.SubscriptionID,
-			ResourceGroup:  wsAzure.ResourceGroup,
-		})
-	}
-
-	wsAWS := ws.ProviderConfig.AWS
-	if wsAWS != nil && wsAWS.AccountId != "" && wsAWS.Region != "" {
-		providerList = append(providerList, &aws.Provider{
-			AccountId:    wsAWS.AccountId,
-			TargetRegion: wsAWS.Region,
-		})
-	}
-	return providerList
-}
-
 // Run runs the `rad env create` command.
 func (r *Runner) Run(ctx context.Context) error {
 	r.Output.LogInfo("Creating Environment...")
-
-	providers, err := cmd.CreateEnvProviders(providersFromWorkspace(r.Workspace))
-	if err != nil {
-		return err
-	}
 
 	client, err := r.ConnectionFactory.CreateApplicationsManagementClient(ctx, *r.Workspace)
 	if err != nil {
 		return err
 	}
 
-	isEnvCreated, err := client.CreateEnvironment(ctx, r.EnvironmentName, v1.LocationGlobal, r.Namespace, "Kubernetes", "", map[string]*corerp.EnvironmentRecipeProperties{}, &providers, !r.SkipDevRecipes)
+	isEnvCreated, err := client.CreateEnvironment(ctx, r.EnvironmentName, v1.LocationGlobal, r.Namespace, "Kubernetes", "", map[string]*corerp.EnvironmentRecipeProperties{}, &corerp.Providers{}, !r.SkipDevRecipes)
 	if err != nil || !isEnvCreated {
 		return err
 	}

--- a/pkg/cli/cmd/env/create/create_test.go
+++ b/pkg/cli/cmd/env/create/create_test.go
@@ -13,7 +13,10 @@ import (
 	"github.com/golang/mock/gomock"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/cli"
+	"github.com/project-radius/radius/pkg/cli/aws"
+	"github.com/project-radius/radius/pkg/cli/azure"
 	"github.com/project-radius/radius/pkg/cli/clients"
+	"github.com/project-radius/radius/pkg/cli/cmd"
 	"github.com/project-radius/radius/pkg/cli/cmd/env/namespace"
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/framework"
@@ -103,31 +106,107 @@ func Test_Validate(t *testing.T) {
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
 }
 
-func Test_Run(t *testing.T) {
-	t.Run("Run env create tests", func(t *testing.T) {
-		t.Run("Success", func(t *testing.T) {
+func Test_Run_Success(t *testing.T) {
+	runCreateTests := []struct {
+		name             string
+		providerConfig   workspaces.ProviderConfig
+		expectedProvider []any
+	}{
+		{
+			name: "Run env create with only Azure",
+			providerConfig: workspaces.ProviderConfig{
+				Azure: &workspaces.AzureProvider{
+					SubscriptionID: "test-subscription",
+					ResourceGroup:  "test-rg",
+				},
+			},
+			expectedProvider: []any{
+				&azure.Provider{
+					SubscriptionID: "test-subscription",
+					ResourceGroup:  "test-rg",
+				},
+			},
+		},
+		{
+			name: "Run env create with only AWS",
+			providerConfig: workspaces.ProviderConfig{
+				AWS: &workspaces.AWSProvider{
+					AccountId: "0",
+					Region:    "westus",
+				},
+			},
+			expectedProvider: []any{
+				&aws.Provider{
+					AccountId:    "0",
+					TargetRegion: "westus",
+				},
+			},
+		},
+		{
+			name: "Run env create with Azure and AWS",
+			providerConfig: workspaces.ProviderConfig{
+				Azure: &workspaces.AzureProvider{
+					SubscriptionID: "test-subscription",
+					ResourceGroup:  "test-rg",
+				},
+				AWS: &workspaces.AWSProvider{
+					AccountId: "0",
+					Region:    "westus",
+				},
+			},
+			expectedProvider: []any{
+				&azure.Provider{
+					SubscriptionID: "test-subscription",
+					ResourceGroup:  "test-rg",
+				},
+				&aws.Provider{
+					AccountId:    "0",
+					TargetRegion: "westus",
+				},
+			},
+		},
+		{
+			name:             "Run env create without providers",
+			expectedProvider: []any{},
+		},
+		{
+			name: "Run env create without incomplete providers",
+			providerConfig: workspaces.ProviderConfig{
+				Azure: &workspaces.AzureProvider{
+					SubscriptionID: "test-subscription",
+					ResourceGroup:  "",
+				},
+				AWS: &workspaces.AWSProvider{
+					AccountId: "0",
+					Region:    "",
+				},
+			},
+			expectedProvider: []any{},
+		},
+	}
+
+	for _, tc := range runCreateTests {
+		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
 
+			p, err := cmd.CreateEnvProviders(tc.expectedProvider)
+			require.NoError(t, err)
+
 			namespaceClient := namespace.NewMockInterface(ctrl)
 			appManagementClient.EXPECT().
-				CreateEnvironment(context.Background(), "default", v1.LocationGlobal, "default", "Kubernetes", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				CreateEnvironment(context.Background(), "default", v1.LocationGlobal, "default", "Kubernetes", gomock.Any(), gomock.Any(), &p, gomock.Any()).
 				Return(true, nil).Times(1)
 
 			configFileInterface := framework.NewMockConfigFileInterface(ctrl)
 			outputSink := &output.MockOutput{}
-			azureProvider := &workspaces.AzureProvider{
-				SubscriptionID: "test-subscription",
-				ResourceGroup:  "test-rg"}
-			awsProvider := &workspaces.AWSProvider{}
-			providerConfig := workspaces.ProviderConfig{Azure: azureProvider, AWS: awsProvider}
 			workspace := &workspaces.Workspace{
 				Connection: map[string]any{
 					"kind":    "kubernetes",
 					"context": "kind-kind",
 				},
 				Name:           "defaultWorkspace",
-				ProviderConfig: providerConfig,
+				ProviderConfig: tc.providerConfig,
 			}
 
 			runner := &Runner{
@@ -143,92 +222,10 @@ func Test_Run(t *testing.T) {
 				SkipDevRecipes:      true,
 			}
 
-			err := runner.Run(context.Background())
+			err = runner.Run(context.Background())
 			require.NoError(t, err)
 		})
-	})
-}
-
-func Test_RunWithoutAzureProvider(t *testing.T) {
-	t.Run("Run env create tests", func(t *testing.T) {
-		t.Run("Success", func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
-
-			namespaceClient := namespace.NewMockInterface(ctrl)
-			appManagementClient.EXPECT().
-				CreateEnvironment(context.Background(), "default", v1.LocationGlobal, "default", "Kubernetes", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-				Return(true, nil).Times(1)
-
-			configFileInterface := framework.NewMockConfigFileInterface(ctrl)
-			outputSink := &output.MockOutput{}
-
-			awsProvider := &workspaces.AWSProvider{}
-			providerConfig := workspaces.ProviderConfig{AWS: awsProvider}
-			workspace := &workspaces.Workspace{
-				Connection: map[string]any{
-					"kind":    "kubernetes",
-					"context": "kind-kind",
-				},
-				Name:           "defaultWorkspace",
-				ProviderConfig: providerConfig,
-			}
-
-			runner := &Runner{
-				ConnectionFactory:   &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
-				ConfigHolder:        &framework.ConfigHolder{ConfigFilePath: "filePath"},
-				Output:              outputSink,
-				Workspace:           workspace,
-				EnvironmentName:     "default",
-				UCPResourceGroup:    "default",
-				Namespace:           "default",
-				NamespaceInterface:  namespaceClient,
-				ConfigFileInterface: configFileInterface,
-			}
-
-			err := runner.Run(context.Background())
-			require.NoError(t, err)
-		})
-	})
-}
-
-func Test_Run_WithoutProvider(t *testing.T) {
-	t.Run("Run env create tests", func(t *testing.T) {
-		t.Run("Success", func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
-
-			namespaceClient := namespace.NewMockInterface(ctrl)
-			appManagementClient.EXPECT().
-				CreateEnvironment(context.Background(), "default", v1.LocationGlobal, "default", "Kubernetes", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-				Return(true, nil).Times(1)
-
-			configFileInterface := framework.NewMockConfigFileInterface(ctrl)
-			outputSink := &output.MockOutput{}
-			workspace := &workspaces.Workspace{
-				Connection: map[string]any{
-					"kind":    "kubernetes",
-					"context": "kind-kind",
-				},
-				Name: "defaultWorkspace",
-			}
-
-			runner := &Runner{
-				ConnectionFactory:   &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
-				ConfigHolder:        &framework.ConfigHolder{ConfigFilePath: "filePath"},
-				Output:              outputSink,
-				Workspace:           workspace,
-				EnvironmentName:     "default",
-				UCPResourceGroup:    "default",
-				Namespace:           "default",
-				NamespaceInterface:  namespaceClient,
-				ConfigFileInterface: configFileInterface,
-			}
-
-			err := runner.Run(context.Background())
-			require.NoError(t, err)
-		})
-	})
+	}
 }
 
 func Test_Run_SkipDevRecipes(t *testing.T) {

--- a/pkg/cli/cmd/env/show/show_test.go
+++ b/pkg/cli/cmd/env/show/show_test.go
@@ -156,7 +156,7 @@ func Test_Show(t *testing.T) {
 
 		err := runner.Run(context.Background())
 		require.Error(t, err)
-		require.ErrorIs(t, err, &cli.FriendlyError{})
+		require.ErrorIs(t, err, &cli.FriendlyError{Message: "The environment \"test-env\" was not found or has been deleted."})
 
 		require.Empty(t, outputSink.Writes)
 	})

--- a/pkg/cli/cmd/radInit/init.go
+++ b/pkg/cli/cmd/radInit/init.go
@@ -401,8 +401,16 @@ func (r *Runner) Run(ctx context.Context) error {
 			return err
 		}
 
+		providerList := []any{}
+		if r.AzureCloudProvider != nil {
+			providerList = append(providerList, r.AzureCloudProvider)
+		}
+		if r.AwsCloudProvider != nil {
+			providerList = append(providerList, r.AwsCloudProvider)
+		}
+
 		// create the providers scope to the environment and register credentials at provider plane
-		providers, err := cmd.CreateEnvProviders([]any{r.AzureCloudProvider, r.AwsCloudProvider})
+		providers, err := cmd.CreateEnvProviders(providerList)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/cmd/radInit/init.go
+++ b/pkg/cli/cmd/radInit/init.go
@@ -402,7 +402,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 
 		// create the providers scope to the environment and register credentials at provider plane
-		providers, err := cmd.CreateEnvProviders([]interface{}{r.AzureCloudProvider, r.AwsCloudProvider})
+		providers, err := cmd.CreateEnvProviders([]any{r.AzureCloudProvider, r.AwsCloudProvider})
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/cmd/utils.go
+++ b/pkg/cli/cmd/utils.go
@@ -23,20 +23,22 @@ func CreateEnvProviders(providersList []any) (corerp.Providers, error) {
 	for _, provider := range providersList {
 		if provider != nil {
 			switch p := provider.(type) {
-			case azure.Provider:
+			case *azure.Provider:
 				if res.Azure != nil {
 					return res, &cli.FriendlyError{Message: "Only one azure provider can be configured to a scope"}
 				}
 				res.Azure = &corerp.ProvidersAzure{
 					Scope: to.Ptr("/subscriptions/" + p.SubscriptionID + "/resourceGroups/" + p.ResourceGroup),
 				}
-			case aws.Provider:
+			case *aws.Provider:
 				if res.Aws != nil {
 					return res, &cli.FriendlyError{Message: "Only one aws provider can be configured to a scope"}
 				}
 				res.Aws = &corerp.ProvidersAws{
-					Scope: to.Ptr("planes/aws/aws/accounts/" + p.AccountId + "/regions/" + p.TargetRegion),
+					Scope: to.Ptr("/planes/aws/aws/accounts/" + p.AccountId + "/regions/" + p.TargetRegion),
 				}
+			default:
+				return res, &cli.FriendlyError{Message: "Internal error: cannot create environement with the invalid provider type"}
 			}
 		}
 	}

--- a/pkg/cli/cmd/utils.go
+++ b/pkg/cli/cmd/utils.go
@@ -21,6 +21,10 @@ import (
 func CreateEnvProviders(providersList []any) (corerp.Providers, error) {
 	var res corerp.Providers
 	for _, provider := range providersList {
+		if provider == nil {
+			continue
+		}
+
 		switch p := provider.(type) {
 		case *azure.Provider:
 			if res.Azure != nil {
@@ -36,8 +40,6 @@ func CreateEnvProviders(providersList []any) (corerp.Providers, error) {
 			res.Aws = &corerp.ProvidersAws{
 				Scope: to.Ptr("/planes/aws/aws/accounts/" + p.AccountId + "/regions/" + p.TargetRegion),
 			}
-		case nil:
-			// skip the provider
 		default:
 			return res, &cli.FriendlyError{Message: fmt.Sprintf("Internal error: cannot create environment with '%T' type", provider)}
 		}

--- a/pkg/cli/cmd/utils.go
+++ b/pkg/cli/cmd/utils.go
@@ -39,7 +39,7 @@ func CreateEnvProviders(providersList []any) (corerp.Providers, error) {
 		case nil:
 			// skip the provider
 		default:
-			return res, &cli.FriendlyError{Message: "Internal error: cannot create environement with the invalid provider type"}
+			return res, &cli.FriendlyError{Message: fmt.Sprintf("Internal error: cannot create environment with '%T' type", provider)}
 		}
 	}
 	return res, nil

--- a/pkg/cli/cmd/utils.go
+++ b/pkg/cli/cmd/utils.go
@@ -41,7 +41,7 @@ func CreateEnvProviders(providersList []any) (corerp.Providers, error) {
 				Scope: to.Ptr("/planes/aws/aws/accounts/" + p.AccountId + "/regions/" + p.TargetRegion),
 			}
 		default:
-			return res, &cli.FriendlyError{Message: fmt.Sprintf("Internal error: cannot create environment with '%T' type", provider)}
+			return res, &cli.FriendlyError{Message: fmt.Sprintf("Internal error: cannot create environment with invalid type '%T'", provider)}
 		}
 	}
 	return res, nil

--- a/pkg/cli/cmd/utils.go
+++ b/pkg/cli/cmd/utils.go
@@ -21,25 +21,23 @@ import (
 func CreateEnvProviders(providersList []any) (corerp.Providers, error) {
 	var res corerp.Providers
 	for _, provider := range providersList {
-		if provider != nil {
-			switch p := provider.(type) {
-			case *azure.Provider:
-				if res.Azure != nil {
-					return res, &cli.FriendlyError{Message: "Only one azure provider can be configured to a scope"}
-				}
-				res.Azure = &corerp.ProvidersAzure{
-					Scope: to.Ptr("/subscriptions/" + p.SubscriptionID + "/resourceGroups/" + p.ResourceGroup),
-				}
-			case *aws.Provider:
-				if res.Aws != nil {
-					return res, &cli.FriendlyError{Message: "Only one aws provider can be configured to a scope"}
-				}
-				res.Aws = &corerp.ProvidersAws{
-					Scope: to.Ptr("/planes/aws/aws/accounts/" + p.AccountId + "/regions/" + p.TargetRegion),
-				}
-			default:
-				return res, &cli.FriendlyError{Message: "Internal error: cannot create environement with the invalid provider type"}
+		switch p := provider.(type) {
+		case *azure.Provider:
+			if res.Azure != nil {
+				return res, &cli.FriendlyError{Message: "Only one azure provider can be configured to a scope"}
 			}
+			res.Azure = &corerp.ProvidersAzure{
+				Scope: to.Ptr("/subscriptions/" + p.SubscriptionID + "/resourceGroups/" + p.ResourceGroup),
+			}
+		case *aws.Provider:
+			if res.Aws != nil {
+				return res, &cli.FriendlyError{Message: "Only one aws provider can be configured to a scope"}
+			}
+			res.Aws = &corerp.ProvidersAws{
+				Scope: to.Ptr("/planes/aws/aws/accounts/" + p.AccountId + "/regions/" + p.TargetRegion),
+			}
+		default:
+			return res, &cli.FriendlyError{Message: "Internal error: cannot create environement with the invalid provider type"}
 		}
 	}
 	return res, nil

--- a/pkg/cli/cmd/utils.go
+++ b/pkg/cli/cmd/utils.go
@@ -21,14 +21,13 @@ import (
 func CreateEnvProviders(providersList []any) (corerp.Providers, error) {
 	var res corerp.Providers
 	for _, provider := range providersList {
-		if provider == nil {
-			continue
-		}
-
 		switch p := provider.(type) {
 		case *azure.Provider:
 			if res.Azure != nil {
 				return res, &cli.FriendlyError{Message: "Only one azure provider can be configured to a scope"}
+			}
+			if p == nil {
+				break
 			}
 			res.Azure = &corerp.ProvidersAzure{
 				Scope: to.Ptr("/subscriptions/" + p.SubscriptionID + "/resourceGroups/" + p.ResourceGroup),
@@ -37,9 +36,14 @@ func CreateEnvProviders(providersList []any) (corerp.Providers, error) {
 			if res.Aws != nil {
 				return res, &cli.FriendlyError{Message: "Only one aws provider can be configured to a scope"}
 			}
+			if p == nil {
+				break
+			}
 			res.Aws = &corerp.ProvidersAws{
 				Scope: to.Ptr("/planes/aws/aws/accounts/" + p.AccountId + "/regions/" + p.TargetRegion),
 			}
+		case nil:
+			// skip nil provider
 		default:
 			return res, &cli.FriendlyError{Message: fmt.Sprintf("Internal error: cannot create environment with invalid type '%T'", provider)}
 		}

--- a/pkg/cli/cmd/utils.go
+++ b/pkg/cli/cmd/utils.go
@@ -36,6 +36,8 @@ func CreateEnvProviders(providersList []any) (corerp.Providers, error) {
 			res.Aws = &corerp.ProvidersAws{
 				Scope: to.Ptr("/planes/aws/aws/accounts/" + p.AccountId + "/regions/" + p.TargetRegion),
 			}
+		case nil:
+			// skip the provider
 		default:
 			return res, &cli.FriendlyError{Message: "Internal error: cannot create environement with the invalid provider type"}
 		}

--- a/pkg/cli/cmd/utils_test.go
+++ b/pkg/cli/cmd/utils_test.go
@@ -36,6 +36,15 @@ func TestCreateEnvProviders(t *testing.T) {
 			err:       &cli.FriendlyError{Message: "Internal error: cannot create environement with the invalid provider type"},
 		},
 		{
+			name: "nil provider",
+			providers: []any{
+				nil,
+				&azure.Provider{SubscriptionID: "testSubs", ResourceGroup: "testRG"},
+			},
+			out: corerp.Providers{},
+			err: &cli.FriendlyError{Message: "Internal error: cannot create environement with the invalid provider type"},
+		},
+		{
 			name: "only azure provider",
 			providers: []any{
 				&azure.Provider{SubscriptionID: "testSubs", ResourceGroup: "testRG"},

--- a/pkg/cli/cmd/utils_test.go
+++ b/pkg/cli/cmd/utils_test.go
@@ -36,13 +36,17 @@ func TestCreateEnvProviders(t *testing.T) {
 			err:       &cli.FriendlyError{Message: "Internal error: cannot create environement with the invalid provider type"},
 		},
 		{
-			name: "nil provider",
+			name: "skip nil provider",
 			providers: []any{
 				nil,
 				&azure.Provider{SubscriptionID: "testSubs", ResourceGroup: "testRG"},
 			},
-			out: corerp.Providers{},
-			err: &cli.FriendlyError{Message: "Internal error: cannot create environement with the invalid provider type"},
+			out: corerp.Providers{
+				Azure: &corerp.ProvidersAzure{
+					Scope: to.Ptr("/subscriptions/testSubs/resourceGroups/testRG"),
+				},
+			},
+			err: nil,
 		},
 		{
 			name: "only azure provider",

--- a/pkg/cli/cmd/utils_test.go
+++ b/pkg/cli/cmd/utils_test.go
@@ -33,7 +33,7 @@ func TestCreateEnvProviders(t *testing.T) {
 			name:      "invalid provider types",
 			providers: []any{azure.Provider{}},
 			out:       corerp.Providers{},
-			err:       &cli.FriendlyError{Message: "Internal error: cannot create environment with 'azure.Provider' type"},
+			err:       &cli.FriendlyError{Message: "Internal error: cannot create environment with invalid type 'azure.Provider'"},
 		},
 		{
 			name: "skip nil provider",

--- a/pkg/cli/cmd/utils_test.go
+++ b/pkg/cli/cmd/utils_test.go
@@ -33,7 +33,7 @@ func TestCreateEnvProviders(t *testing.T) {
 			name:      "invalid provider types",
 			providers: []any{azure.Provider{}},
 			out:       corerp.Providers{},
-			err:       &cli.FriendlyError{Message: "Internal error: cannot create environement with the invalid provider type"},
+			err:       &cli.FriendlyError{Message: "Internal error: cannot create environment with 'azure.Provider' type"},
 		},
 		{
 			name: "skip nil provider",

--- a/pkg/cli/cmd/utils_test.go
+++ b/pkg/cli/cmd/utils_test.go
@@ -17,6 +17,9 @@ import (
 )
 
 func TestCreateEnvProviders(t *testing.T) {
+	var nilAzureProvider *azure.Provider = nil
+	var nilAWSProvider *aws.Provider = nil
+
 	providersTests := []struct {
 		name      string
 		providers []any
@@ -97,6 +100,31 @@ func TestCreateEnvProviders(t *testing.T) {
 				},
 			},
 			err: &cli.FriendlyError{Message: "Only one aws provider can be configured to a scope"},
+		},
+		{
+			name: "azure and aws providers",
+			providers: []any{
+				&azure.Provider{SubscriptionID: "testSubs", ResourceGroup: "testRG"},
+				&aws.Provider{AccountId: "0", TargetRegion: "westus"},
+			},
+			out: corerp.Providers{
+				Azure: &corerp.ProvidersAzure{
+					Scope: to.Ptr("/subscriptions/testSubs/resourceGroups/testRG"),
+				},
+				Aws: &corerp.ProvidersAws{
+					Scope: to.Ptr("/planes/aws/aws/accounts/0/regions/westus"),
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "skip typed nil value",
+			providers: []any{
+				nilAzureProvider,
+				nilAWSProvider,
+			},
+			out: corerp.Providers{},
+			err: nil,
 		},
 	}
 

--- a/pkg/cli/cmd/utils_test.go
+++ b/pkg/cli/cmd/utils_test.go
@@ -1,0 +1,97 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/project-radius/radius/pkg/cli"
+	"github.com/project-radius/radius/pkg/cli/aws"
+	"github.com/project-radius/radius/pkg/cli/azure"
+	corerp "github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
+	"github.com/project-radius/radius/pkg/to"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateEnvProviders(t *testing.T) {
+	providersTests := []struct {
+		name      string
+		providers []any
+		out       corerp.Providers
+		err       error
+	}{
+		{
+			name:      "empty providers",
+			providers: []any{},
+			out:       corerp.Providers{},
+			err:       nil,
+		},
+		{
+			name:      "invalid provider types",
+			providers: []any{azure.Provider{}},
+			out:       corerp.Providers{},
+			err:       &cli.FriendlyError{Message: "Internal error: cannot create environement with the invalid provider type"},
+		},
+		{
+			name: "only azure provider",
+			providers: []any{
+				&azure.Provider{SubscriptionID: "testSubs", ResourceGroup: "testRG"},
+			},
+			out: corerp.Providers{
+				Azure: &corerp.ProvidersAzure{
+					Scope: to.Ptr("/subscriptions/testSubs/resourceGroups/testRG"),
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "multiple azure providers",
+			providers: []any{
+				&azure.Provider{SubscriptionID: "testSubs", ResourceGroup: "testRG"},
+				&azure.Provider{SubscriptionID: "testSub2", ResourceGroup: "testRG2"},
+			},
+			out: corerp.Providers{
+				Azure: &corerp.ProvidersAzure{
+					Scope: to.Ptr("/subscriptions/testSubs/resourceGroups/testRG"),
+				},
+			},
+			err: &cli.FriendlyError{Message: "Only one azure provider can be configured to a scope"},
+		},
+		{
+			name: "only aws provider",
+			providers: []any{
+				&aws.Provider{AccountId: "0", TargetRegion: "westus"},
+			},
+			out: corerp.Providers{
+				Aws: &corerp.ProvidersAws{
+					Scope: to.Ptr("/planes/aws/aws/accounts/0/regions/westus"),
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "multiple aws providers",
+			providers: []any{
+				&aws.Provider{AccountId: "0", TargetRegion: "westus"},
+				&aws.Provider{AccountId: "1", TargetRegion: "eastus"},
+			},
+			out: corerp.Providers{
+				Aws: &corerp.ProvidersAws{
+					Scope: to.Ptr("/planes/aws/aws/accounts/0/regions/westus"),
+				},
+			},
+			err: &cli.FriendlyError{Message: "Only one aws provider can be configured to a scope"},
+		},
+	}
+
+	for _, tc := range providersTests {
+		t.Run(tc.name, func(t *testing.T) {
+			provider, err := CreateEnvProviders(tc.providers)
+			require.Equal(t, tc.out, provider)
+			require.ErrorIs(t, err, tc.err)
+		})
+	}
+}

--- a/pkg/cli/errors.go
+++ b/pkg/cli/errors.go
@@ -21,8 +21,8 @@ func (fe *FriendlyError) Error() string {
 }
 
 func (fe *FriendlyError) Is(target error) bool {
-	_, ok := target.(*FriendlyError)
-	return ok
+	e, ok := target.(*FriendlyError)
+	return ok && fe.Message == e.Message
 }
 
 // ClusterUnreachableError is an error type to be thrown when the kubernetes cluster


### PR DESCRIPTION
# Description

This PR fixes two bugs:

1. The bug neither handles provider pointer types correctly nor treats invalid provider type as an error. This PR fixes `CreateEnvProviders` to handle provider pointer types correctly and returns the error if it is invalid type. This PR includes the missing unit-tests.

2. `rad env create` doesn't handle aws workspace correctly and unit-test is incorrect. This is unexpected behavior and codes.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: radius-project/core-team#1121

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
