### PR TITLE
corerp structured logging

### DIFF
--- a/cmd/appcore-rp/radius-self-hosted.yaml
+++ b/cmd/appcore-rp/radius-self-hosted.yaml
@@ -30,7 +30,7 @@ ucp:
   kind: kubernetes
 logging:
   level: "info"
-  json: false
+  json: true
 # Tracing configuration
 tracerProvider:
   serviceName: "rp"

--- a/deploy/Chart/charts/de/templates/de.yaml
+++ b/deploy/Chart/charts/de/templates/de.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         control-plane: de
         app.kubernetes.io/part-of: radius-control-plane
+      annotations:
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "6443"
+        prometheus.io/scrape: "true"
     spec:
       serviceAccountName: de-manager
       containers:
@@ -34,7 +38,11 @@ spec:
           value: https://ucp.radius-system:443/apis/api.ucp.dev/v1alpha3
         - name: ASPNETCORE_Logging__LogLevel__Default
           value: "Debug"
-        image: {{ .Values.global.engine.image }}:{{ .Values.global.engine.tag }}
+        - name: ASPNETCORE_Zipkin__Endpoint
+          value: "http://jaeger:9411/api/v2/spans"
+        # image: {{ .Values.global.engine.image }}:{{ .Values.global.engine.tag }}
+        # THIS IS a temporary change for validation.
+        image: radius.azurecr.io/deployment-engine:pr-330
         name: de
         ports:
         - containerPort: 6443

--- a/pkg/logging/logfields.go
+++ b/pkg/logging/logfields.go
@@ -7,6 +7,8 @@ package logging
 const (
 	AppCoreLoggerName string = "applications.core"
 	AppLinkLoggerName string = "applications.link"
+
+	ServiceName string = "rp"
 )
 
 // Field names for structured logging
@@ -21,7 +23,10 @@ const (
 	LogFieldLocalID            = "localID"
 	LogFieldNamespace          = "namespace"
 	LogFieldOperationID        = "operationID"
+	LogFieldOperationType      = "operationType"
+	LogFieldAttributes         = "attributes"
 	LogFieldOperationStatus    = "operationStatus"
+	LogFieldDequeueCount       = "dequeueCount"
 	LogFieldResourceGroup      = "resourceGroup"
 	LogFieldResourceID         = "resourceID"
 	LogFieldResourceName       = "resourceName"
@@ -32,4 +37,5 @@ const (
 	LogFieldSubscriptionID     = "subscriptionID"
 	LogFieldResourceKind       = "resourceKind"
 	LogHTTPStatusCode          = "statusCode"
+	LogFieldRPHostName         = "rpHostName"
 )

--- a/pkg/middleware/appendlogger.go
+++ b/pkg/middleware/appendlogger.go
@@ -6,36 +6,71 @@
 package middleware
 
 import (
+	"fmt"
+	"net"
 	"net/http"
+	"os"
 
+	"github.com/go-logr/logr"
 	"github.com/project-radius/radius/pkg/logging"
 	"github.com/project-radius/radius/pkg/ucp/resources"
 	"github.com/project-radius/radius/pkg/ucp/ucplog"
+	"github.com/project-radius/radius/pkg/version"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Append logger values to the context based on the Resource ID (if present).
 func AppendLogValues(h http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
+		values := []any{}
+
+		attr := map[attribute.Key]string{}
+		attr[semconv.ServiceNameKey] = logging.ServiceName
+		attr[semconv.ServiceVersionKey] = version.Channel()
+		attr[semconv.HTTPMethodKey] = r.Method
+		attr[semconv.HTTPTargetKey] = r.URL.RequestURI()
+		attr[semconv.HTTPRequestContentLengthKey] = fmt.Sprint(r.ContentLength)
+
 		id, err := resources.Parse(r.URL.Path)
-		if err != nil {
+		if err == nil {
+			attr[attribute.Key(ucplog.LogFieldResourceID)] = id.String()
+		} else {
 			// This just means the request is for an ARM resource. Not an error.
 			h.ServeHTTP(w, r)
 			return
 		}
 
-		values := []any{}
-		values = append(values, logging.LogFieldResourceID, id.String())
+		host, _ := os.Hostname()
+		attr = AddAttribute(semconv.HostNameKey, host, attr)
 
-		// TODO: populate correlation id and w3c trace parent id - https://github.com/project-radius/core-team/issues/53
+		clientIP := r.Header.Get(ucplog.HttpXForwardedForHeader)
+		if clientIP == "" {
+			remote := r.RemoteAddr
+			clientIP, _, _ = net.SplitHostPort(remote)
+		}
+		attr = AddAttribute(semconv.HTTPClientIPKey, clientIP, attr)
 
-		// values = append(values, logging.LogFieldSubscriptionID, id.SubscriptionID)
-		// values = append(values, logging.LogFieldResourceGroup, id.ResourceGroup)
-		// values = append(values, logging.LogFieldResourceType, id.Type())
-		// values = append(values, logging.LogFieldResourceName, id.QualifiedName())
+		if len(attr) > 0 {
+			values = append(values,
+				ucplog.LogFieldAttributes, attr,
+			)
+		}
 
-		r = r.WithContext(ucplog.WrapLogContext(r.Context(), values...))
+		sc := trace.SpanFromContext(r.Context())
+		values = append(values,
+			ucplog.LogFieldSpanId, sc.SpanContext().SpanID().String(),
+			ucplog.LogFieldTraceId, sc.SpanContext().TraceID().String(),
+		)
+
+		values = AddLogValue(ucplog.LogFieldCorrelationID, r.Header.Get(ucplog.LogFieldCorrelationID), values)
+
+		logger := logr.FromContextOrDiscard(r.Context()).WithValues(values...)
+		r = r.WithContext(logr.NewContext(r.Context(), logger))
 		h.ServeHTTP(w, r)
 	}
 
 	return http.HandlerFunc(fn)
+
 }

--- a/pkg/middleware/ucp_logging.go
+++ b/pkg/middleware/ucp_logging.go
@@ -6,23 +6,64 @@
 package middleware
 
 import (
+	"fmt"
+	"net"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/project-radius/radius/pkg/ucp/resources"
 	"github.com/project-radius/radius/pkg/ucp/ucplog"
+	"github.com/project-radius/radius/pkg/version"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"go.opentelemetry.io/otel/trace"
 )
 
+const invalidTrace string = "00-00000000000000000000000000000000-0000000000000000-00"
+
 // UseLogValues appends logging values to the context based on the request.
-func UseLogValues(h http.Handler, basePath string) http.Handler {
+func UseLogValues(h http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		values := []any{}
+
+		attr := map[attribute.Key]string{}
+		attr[semconv.ServiceNameKey] = ucplog.UCPServiceName
+		attr[semconv.ServiceVersionKey] = version.Channel()
+		attr[semconv.HTTPMethodKey] = r.Method
+		attr[semconv.HTTPTargetKey] = r.URL.RequestURI()
+		attr[semconv.HTTPRequestContentLengthKey] = fmt.Sprint(r.ContentLength)
+
+		id, err := resources.Parse(r.URL.Path)
+		if err == nil {
+			attr[attribute.Key(ucplog.LogFieldResourceID)] = id.String()
+		}
+
+		host, _ := os.Hostname()
+		attr = AddAttribute(semconv.HostNameKey, host, attr)
+
+		clientIP := r.Header.Get(ucplog.HttpXForwardedForHeader)
+		if clientIP == "" {
+			remote := r.RemoteAddr
+			clientIP, _, _ = net.SplitHostPort(remote)
+		}
+		attr = AddAttribute(semconv.HTTPClientIPKey, clientIP, attr)
+
+		if len(attr) > 0 {
+			values = append(values,
+				ucplog.LogFieldAttributes, attr,
+			)
+		}
+
+		sc := trace.SpanFromContext(r.Context())
 		values = append(values,
-			ucplog.LogFieldHTTPMethod, r.Method,
-			ucplog.LogFieldRequestPath, r.URL,
-			ucplog.LogFieldContentLength, r.ContentLength,
-			ucplog.LogFieldCorrelationID, r.Header.Get(ucplog.LogFieldCorrelationID),
+			ucplog.LogFieldSpanId, sc.SpanContext().SpanID().String(),
+			ucplog.LogFieldTraceId, sc.SpanContext().TraceID().String(),
 		)
+
+		values = AddLogValue(ucplog.LogFieldCorrelationID, r.Header.Get(ucplog.LogFieldCorrelationID), values)
+
 		logger := logr.FromContextOrDiscard(r.Context()).WithValues(values...)
 		r = r.WithContext(logr.NewContext(r.Context(), logger))
 		h.ServeHTTP(w, r)
@@ -34,4 +75,22 @@ func UseLogValues(h http.Handler, basePath string) http.Handler {
 func GetRelativePath(basePath string, path string) string {
 	trimmedPath := strings.TrimPrefix(path, basePath)
 	return trimmedPath
+}
+
+func AddAttribute(attrKey attribute.Key, value string, m map[attribute.Key]string) map[attribute.Key]string {
+	if value != "" {
+		m[attrKey] = value
+	}
+	return m
+}
+
+func AddLogValue(key string, value any, values []any) []any {
+	if key == "" || value == "" {
+		return values
+	}
+	return append(values, key, value)
+}
+
+func IsValidTraceID(w3cTraceID string) bool {
+	return w3cTraceID != "" && w3cTraceID != invalidTrace
 }

--- a/pkg/ucp/frontend/api/server.go
+++ b/pkg/ucp/frontend/api/server.go
@@ -166,7 +166,7 @@ func (s *Service) Initialize(ctx context.Context) (*http.Server, error) {
 	}
 
 	app := http.Handler(r)
-	app = middleware.UseLogValues(app, s.options.BasePath)
+	app = middleware.UseLogValues(app)
 	app = servicecontext.ARMRequestCtx(s.options.BasePath, "global")(app)
 
 	if s.options.EnableMetrics {

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	http "net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -106,7 +107,7 @@ func (p *CreateOrUpdateAWSResourceWithPost) Run(ctx context.Context, w http.Resp
 	}
 
 	if existing {
-		logger.Info("Updating resource", "resourceType", resourceType, "resourceID", awsResourceIdentifier)
+		logger.Info(fmt.Sprintf("Updating resource : resourceType %q resourceID %q", resourceType, awsResourceIdentifier))
 
 		// Generate patch
 		currentState := []byte(*getResponse.ResourceDescription.Properties)
@@ -151,7 +152,7 @@ func (p *CreateOrUpdateAWSResourceWithPost) Run(ctx context.Context, w http.Resp
 			return resp, nil
 		}
 	} else {
-		logger.Info("Creating resource", "resourceType", resourceType, "resourceID", awsResourceIdentifier)
+		logger.Info(fmt.Sprintf("Creating resource : resourceType %q resourceID %q", resourceType, awsResourceIdentifier))
 		response, err := cloudControlClient.CreateResource(ctx, &cloudcontrol.CreateResourceInput{
 			TypeName:     &resourceType,
 			DesiredState: aws.String(string(desiredState)),

--- a/pkg/ucp/frontend/controller/planes/proxyplane.go
+++ b/pkg/ucp/frontend/controller/planes/proxyplane.go
@@ -123,13 +123,10 @@ func (p *ProxyPlane) Run(ctx context.Context, w http.ResponseWriter, req *http.R
 			err = fmt.Errorf("provider %s not configured", resourceID.ProviderNamespace())
 			return nil, err
 		}
-		ctx = ucplog.WrapLogContext(ctx,
-			ucplog.LogFieldPlaneURL, proxyURL)
 	} else {
 		// For a non UCP-native plane, the configuration should have a URL to which
 		// all the requests will be forwarded
 		proxyURL = plane.Properties.URL
-		ctx = ucplog.WrapLogContext(ctx, ucplog.LogFieldPlaneURL, proxyURL)
 	}
 
 	downstream, err := url.Parse(proxyURL)
@@ -149,8 +146,6 @@ func (p *ProxyPlane) Run(ctx context.Context, w http.ResponseWriter, req *http.R
 	if req.TLS != nil {
 		httpScheme = "https"
 	}
-
-	ctx = ucplog.WrapLogContext(ctx, ucplog.LogFieldHTTPScheme, httpScheme)
 
 	requestInfo := proxy.UCPRequestInfo{
 		PlaneURL:   proxyURL,

--- a/pkg/ucp/frontend/controller/resourcegroups/createorupdateresourcegroup.go
+++ b/pkg/ucp/frontend/controller/resourcegroups/createorupdateresourcegroup.go
@@ -19,7 +19,6 @@ import (
 	ctrl "github.com/project-radius/radius/pkg/ucp/frontend/controller"
 	"github.com/project-radius/radius/pkg/ucp/resources"
 	"github.com/project-radius/radius/pkg/ucp/store"
-	"github.com/project-radius/radius/pkg/ucp/ucplog"
 )
 
 var _ armrpc_controller.Controller = (*CreateOrUpdateResourceGroup)(nil)
@@ -59,7 +58,6 @@ func (r *CreateOrUpdateResourceGroup) Run(ctx context.Context, w http.ResponseWr
 	newResource.Name = id.Name()
 	newResource.Type = ResourceGroupType
 
-	ctx = ucplog.WrapLogContext(ctx, ucplog.LogFieldResourceGroup, id)
 	logger := logr.FromContextOrDiscard(ctx)
 
 	existingResource := datamodel.ResourceGroup{}

--- a/pkg/ucp/frontend/controller/resourcegroups/deleteresourcegroup.go
+++ b/pkg/ucp/frontend/controller/resourcegroups/deleteresourcegroup.go
@@ -18,7 +18,6 @@ import (
 	ctrl "github.com/project-radius/radius/pkg/ucp/frontend/controller"
 	"github.com/project-radius/radius/pkg/ucp/resources"
 	"github.com/project-radius/radius/pkg/ucp/store"
-	"github.com/project-radius/radius/pkg/ucp/ucplog"
 )
 
 var _ armrpc_controller.Controller = (*DeleteResourceGroup)(nil)
@@ -77,7 +76,6 @@ func (r *DeleteResourceGroup) Run(ctx context.Context, w http.ResponseWriter, re
 }
 
 func (e *DeleteResourceGroup) listResources(ctx context.Context, db store.StorageClient, path string) (datamodel.ResourceList, error) {
-	ctx = ucplog.WrapLogContext(ctx, ucplog.LogFieldRequestPath, path)
 	var query store.Query
 	query.RootScope = path
 	query.ScopeRecursive = true

--- a/pkg/ucp/proxy/policy.go
+++ b/pkg/ucp/proxy/policy.go
@@ -6,11 +6,11 @@
 package proxy
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/go-logr/logr"
 	"github.com/project-radius/radius/pkg/ucp/resources"
-	"github.com/project-radius/radius/pkg/ucp/ucplog"
 )
 
 func workaround28169(r *http.Request) {
@@ -54,15 +54,13 @@ func logDownstreamRequest(r *http.Request) {
 
 func logDownstreamResponse(r *http.Response) error {
 	logger := logr.FromContextOrDiscard(r.Request.Context())
-	logger.Info("received proxy response from downstream", ucplog.LogHTTPStatusCode, r.StatusCode)
-
+	logger.Info(fmt.Sprintf("received proxy response HTTP status code from downstream %d", r.StatusCode))
 	return nil
 }
 
 func logUpstreamResponse(r *http.Response) error {
 	logger := logr.FromContextOrDiscard(r.Request.Context())
-	logger.Info("sending proxy response to upstream", ucplog.LogHTTPStatusCode, r.StatusCode)
-
+	logger.Info(fmt.Sprintf("sending proxy response %d to upstream ", r.StatusCode))
 	return nil
 }
 

--- a/pkg/ucp/proxy/types.go
+++ b/pkg/ucp/proxy/types.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/project-radius/radius/pkg/ucp/rest"
-	"github.com/project-radius/radius/pkg/ucp/ucplog"
 )
 
 type UCPRequestInfo struct {
@@ -157,10 +156,6 @@ func convertHeaderToUCPIDs(ctx context.Context, headerName string, header []stri
 	if requestInfo.PlaneKind == "" {
 		return fmt.Errorf("Plane Kind unknown. Cannot convert response header")
 	}
-	ctx = ucplog.WrapLogContext(ctx,
-		ucplog.LogFieldUCPHost, requestInfo.UCPHost,
-		ucplog.LogFieldHTTPScheme, requestInfo.HTTPScheme,
-	)
 
 	var planeID string
 	if requestInfo.PlaneKind != rest.PlaneKindUCPNative {

--- a/pkg/ucp/ucplog/log.go
+++ b/pkg/ucp/ucplog/log.go
@@ -25,6 +25,11 @@ const (
 	DefaultLoggerName string = "radius"
 	LogLevel          string = "RADIUS_LOGGING_LEVEL" // Env variable that determines the log level
 	LogProfile        string = "RADIUS_LOGGING_JSON"  // Env variable that determines the logger config presets
+
+	// keys to conform with otel log schema
+	OtelMessageKey string = "message"
+	OtelTimeKey    string = "timestamp"
+	OtelLevelKey   string = "severity"
 )
 
 // Log levels
@@ -102,6 +107,9 @@ func initLoggingConfig(options *LoggingOptions) (*zap.Logger, error) {
 	}
 	cfg.EncoderConfig.CallerKey = zapcore.OmitKey
 	cfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	cfg.EncoderConfig.MessageKey = OtelMessageKey
+	cfg.EncoderConfig.LevelKey = OtelLevelKey
+	cfg.EncoderConfig.TimeKey = OtelTimeKey
 	// Build the logger config based on profile and custom presets
 	logger, err := cfg.Build()
 	if err != nil {
@@ -143,7 +151,6 @@ func NewTestLogger(t *testing.T) (logr.Logger, error) {
 // WrapLogContext modifies the log context in provided context to include the keyValues provided, and returns this modified context
 func WrapLogContext(ctx context.Context, keyValues ...any) context.Context {
 	logger := logr.FromContextOrDiscard(ctx)
-
 	ctx = logr.NewContext(ctx, logger.WithValues(keyValues...))
 	return ctx
 }

--- a/pkg/ucp/ucplog/logfields.go
+++ b/pkg/ucp/ucplog/logfields.go
@@ -6,41 +6,36 @@
 package ucplog
 
 const (
-	UCPLoggerName string = "ucp"
+	UCPLoggerName  string = "ucplogger"
+	UCPServiceName string = "ucp"
 )
 
 // Field names for structured logging
 const (
-	// LogHTTPStatusCode represents the HTTP status code of response from downstream as seen by UCP.
-	LogHTTPStatusCode string = "ResponseStatusCode"
-
-	// LogFieldRequestPath represents the path of the request URL.
-	LogFieldRequestPath string = "RequestPath"
-
-	// LogFieldHTTPScheme represents the scheme of HTTP request.
-	LogFieldHTTPScheme string = "RequestScheme"
-
-	// LogFieldPlaneURL represents the URL to which this request will be proxied to.
-	LogFieldPlaneURL string = "ProxyURL"
-
-	// LogFieldResourceGroup represents the UCP resource group.
-	LogFieldResourceGroup string = "UCPResourceGroup"
-
-	// LogFieldHTTPMethod represents the HTTP request method of request recieved by UCP from client.
-	LogFieldHTTPMethod string = "RequestMethod"
-
-	// LogFieldRequestURL represents the HTTP request URL of request received by UCP from client.
-	LogFieldRequestURL string = "RequestURL"
-
-	// LogFieldContentLength represents the content-length of the HTTP request/ response received by UCP.
-	LogFieldContentLength string = "ContentLength"
-
-	// LogFieldUCPHost represents the UCP server host name.
-	LogFieldUCPHost string = "UCPHost"
-
 	// LogFieldUCPHost represents the Resource ID.
-	LogFieldResourceID string = "ResourceID"
+	LogFieldResourceID string = "resourceId"
 
 	// LogFieldCorrelationID represents the X-Correlation-ID that may be present in the incoming request.
-	LogFieldCorrelationID string = "X-Correlation-ID"
+	LogFieldCorrelationID string = "correlationId"
+
+	// LogFieldServiceID represents the name of the service generating the log entry
+	LogFieldServiceID string = "serviceId"
+
+	// LogFieldAttributes represents the optional attributes associated with a log message
+	LogFieldAttributes string = "attributes"
+
+	// LogFieldTraceId represents the traceId retrieved from traceparent header of the current HTTP request
+	LogFieldTraceId string = "traceId"
+
+	// LogFieldSpanId represents the spanId retrieved from traceparent header of current HTTP request
+	LogFieldSpanId string = "spanId"
+
+	// LogFieldTraceFlags represents the flags retrieved from traceparent header of current HTTP request
+	LogFieldTraceFlags string = "traceFlags"
+
+	// HttpXForwardedForHeader represents the x-forwarded-for HTTP header
+	HttpXForwardedForHeader string = "x-forwarded-for"
+
+	// HttpUserAgent represents the user-agent HTTP header
+	HttpUserAgent string = "user-agent"
 )


### PR DESCRIPTION
# Description

logging to conform with approved design for mandatory fields at 
https://microsoft.sharepoint.com/:w:/r/teams/radiuscoreteam/_layouts/15/Doc.aspx?sourcedoc=%7B328A2A5F-057B-4721-976B-9966D3D1B469%7D&file=2023-01%20Radius%20Logs%20And%20Traces.docx&action=default&mobileredirect=true&DefaultItemOpen=1&share=IQFfKooyewUhR5drmWbT0bRpAS_RilA2dqu24GqSRuM00JE
```
Mandatory Fields  

level: debug, info, warn, error (zap provided) 

timestamp: helps search for log entries across the microservices in a specific issue timeframe, such as deployment taking long or throwing errors from XXX timestamp to YYY timestamp. All services should log in timestamp UTC so that the order of logs generated across services can be correlated easily and can help us determine sequences and lags (if any) (zap provided, but format needs work) 

serviceId: Identifies the service generating this log. Could be one of ucp, core, link, de 

correlationId: nonstandard correlation ID. 

clientIp : IP of client as seen by UCP 

userAgent: User-agent string of client as seen by UCP 

w3cTraceId: traceparent id 

resourceID : radius resourceID 

version: version of the service 

instance: hostname 

message: text describing the event as applicable 
```

**Output With this PR**
ts, msg field names are zap provided. Therefore they dont conform with the spec names "timestamp" and "message".

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
