### PR TITLE
fix rad recipe register

### DIFF
--- a/pkg/cli/cmd/recipe/register/register.go
+++ b/pkg/cli/cmd/recipe/register/register.go
@@ -77,15 +77,6 @@ type Runner struct {
 	Parameters        map[string]map[string]any
 }
 
-// TODO: This is a temporary fix in the CLI to unblock users, and should be removed after long term fix is implemented on the server side as a part of https://github.com/project-radius/radius/issues/5179.
-// Currently only 4 dev recipes are supported: https://github.com/project-radius/radius/blob/main/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go#L134. This list should be updated if support for more recipes is added on the server.
-var reservedDevRecipesName = map[string]bool{
-	"mongo-azure":      true,
-	"mongo-kubernetes": true,
-	"redis-kubernetes": true,
-	"redis-azure":      true,
-}
-
 // NewRunner creates a new instance of the `rad recipe register` runner.
 func NewRunner(factory framework.Factory) *Runner {
 	return &Runner{
@@ -160,11 +151,8 @@ func (r *Runner) Run(ctx context.Context) error {
 	recipeProperties := envResource.Properties.Recipes
 	if recipeProperties[r.RecipeName] != nil {
 		return &cli.FriendlyError{Message: fmt.Sprintf("recipe with name %q already exists in the environment %q", r.RecipeName, r.Workspace.Environment)}
-	} else if ok := reservedDevRecipesName[r.RecipeName]; ok {
-		// TODO: This is a temporary fix in the CLI to unblock users, and should be removed
-		// after long term fix is implemented on the server side as a part of https://github.com/project-radius/radius/issues/5179.
-		return &cli.FriendlyError{Message: fmt.Sprintf("recipe with name %q is reserved for dev recipes", r.RecipeName)}
 	}
+
 	if recipeProperties == nil {
 		recipeProperties = map[string]*corerpapps.EnvironmentRecipeProperties{}
 	}

--- a/pkg/cli/cmd/recipe/register/register_test.go
+++ b/pkg/cli/cmd/recipe/register/register_test.go
@@ -7,7 +7,6 @@ package register
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -271,50 +270,4 @@ func Test_Run(t *testing.T) {
 		err := runner.Run(context.Background())
 		require.Error(t, err)
 	})
-
-	t.Run("Register recipe with name matching the dev recipes", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		envResource := v20220315privatepreview.EnvironmentResource{
-			ID:       to.Ptr("/planes/radius/local/resourcegroups/kind-kind/providers/applications.core/environments/kind-kind"),
-			Name:     to.Ptr("kind-kind"),
-			Type:     to.Ptr("applications.core/environments"),
-			Location: to.Ptr(v1.LocationGlobal),
-			Properties: &v20220315privatepreview.EnvironmentProperties{
-				Recipes: map[string]*v20220315privatepreview.EnvironmentRecipeProperties{
-					"cosmosDB": {
-						LinkType:     to.Ptr(linkrp.MongoDatabasesResourceType),
-						TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
-					},
-					"mongo-azure": {
-						LinkType:     to.Ptr(linkrp.MongoDatabasesResourceType),
-						TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
-					},
-					"redis-kubernetes": {
-						LinkType:     to.Ptr("Applications.Link/redisCaches"),
-						TemplatePath: to.Ptr("radius.azurecr.io/recipes/rediscaches/kubernetes:1.0"),
-					},
-				},
-			},
-		}
-
-		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
-		appManagementClient.EXPECT().
-			GetEnvDetails(gomock.Any(), gomock.Any()).
-			Return(envResource, nil).Times(1)
-
-		outputSink := &output.MockOutput{}
-
-		runner := &Runner{
-			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
-			Output:            outputSink,
-			Workspace:         &workspaces.Workspace{Environment: "kind-kind"},
-			TemplatePath:      "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
-			LinkType:          linkrp.MongoDatabasesResourceType,
-			RecipeName:        "mongo-azure",
-		}
-
-		err := runner.Run(context.Background())
-		require.ErrorContains(t, err, fmt.Sprintf("recipe with name %q already exists in the environment", runner.RecipeName))
-	})
-
 }

--- a/pkg/cli/cmd/recipe/register/register_test.go
+++ b/pkg/cli/cmd/recipe/register/register_test.go
@@ -285,6 +285,14 @@ func Test_Run(t *testing.T) {
 						LinkType:     to.Ptr(linkrp.MongoDatabasesResourceType),
 						TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
 					},
+					"mongo-azure": {
+						LinkType:     to.Ptr(linkrp.MongoDatabasesResourceType),
+						TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+					},
+					"redis-kubernetes": {
+						LinkType:     to.Ptr("Applications.Link/redisCaches"),
+						TemplatePath: to.Ptr("radius.azurecr.io/recipes/rediscaches/kubernetes:1.0"),
+					},
 				},
 			},
 		}
@@ -306,7 +314,7 @@ func Test_Run(t *testing.T) {
 		}
 
 		err := runner.Run(context.Background())
-		require.ErrorContains(t, err, fmt.Sprintf("recipe with name %q is reserved for dev recipes", runner.RecipeName))
+		require.ErrorContains(t, err, fmt.Sprintf("recipe with name %q already exists in the environment", runner.RecipeName))
 	})
 
 }

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
@@ -75,9 +75,7 @@ func (e *CreateOrUpdateEnvironment) Run(ctx context.Context, w http.ResponseWrit
 		// after long term fix is implemented as part of https://github.com/project-radius/radius/issues/5179.
 		if newResource.Properties.Recipes != nil {
 			for k, v := range newResource.Properties.Recipes {
-				if val, ok := devRecipes[k]; !ok {
-					customRecipes[k] = v
-				} else if val.TemplatePath != v.TemplatePath {
+				if val, ok := devRecipes[k]; !ok || val.TemplatePath != v.TemplatePath {
 					customRecipes[k] = v
 				}
 			}

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
@@ -65,7 +65,6 @@ func (e *CreateOrUpdateEnvironment) Run(ctx context.Context, w http.ResponseWrit
 	}
 
 	// Update Recipes mapping with dev recipes.
-	customRecipes := map[string]datamodel.EnvironmentRecipeProperties{}
 	if newResource.Properties.UseDevRecipes {
 		devRecipes, err := getDevRecipes(ctx)
 		if err != nil {
@@ -74,15 +73,10 @@ func (e *CreateOrUpdateEnvironment) Run(ctx context.Context, w http.ResponseWrit
 		// TODO: This is a temporary fix to unblock users to register recipes using bicep, and should be removed
 		// after long term fix is implemented as part of https://github.com/project-radius/radius/issues/5179.
 		if newResource.Properties.Recipes != nil {
-			for k, v := range newResource.Properties.Recipes {
-				if val, ok := devRecipes[k]; !ok || val.TemplatePath != v.TemplatePath {
-					customRecipes[k] = v
-				}
-			}
 			errorPrefix := "recipe name(s) reserved for devRecipes for: "
 			var errorRecipes string
-			for k, v := range customRecipes {
-				if _, ok := devRecipes[k]; ok {
+			for k, v := range newResource.Properties.Recipes {
+				if val, ok := devRecipes[k]; ok && val.TemplatePath != v.TemplatePath {
 					if errorRecipes != "" {
 						errorRecipes += ", "
 					}

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
@@ -70,11 +70,11 @@ func (e *CreateOrUpdateEnvironment) Run(ctx context.Context, w http.ResponseWrit
 		if err != nil {
 			return nil, err
 		}
-		// TODO: This is a temporary fix to unblock users to register recipes using bicep, and should be removed
-		// after long term fix is implemented as part of https://github.com/project-radius/radius/issues/5179.
 		if newResource.Properties.Recipes != nil {
 			errorPrefix := "recipe name(s) reserved for devRecipes for: "
 			var errorRecipes string
+			// validate that if the input recipe is updating an existing dev recipe with a different templatepath
+			// if the input recipe has the same name as that of the dev recipe but different templatepath return an error
 			for k, v := range newResource.Properties.Recipes {
 				if val, ok := devRecipes[k]; ok && val.TemplatePath != v.TemplatePath {
 					if errorRecipes != "" {

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
@@ -32,15 +32,6 @@ type CreateOrUpdateEnvironment struct {
 	ctrl.Operation[*datamodel.Environment, datamodel.Environment]
 }
 
-// TODO: This is a temporary fix to unblock users to register recipes using bicep, and should be removed after long term fix is implemented as part of https://github.com/project-radius/radius/issues/5179.
-// Currently only 4 dev recipes are supported: https://github.com/project-radius/radius/blob/main/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go#L134. This list should be updated if support for more recipes is added.
-var reservedDevRecipesName = map[string]bool{
-	"mongo-azure":      true,
-	"mongo-kubernetes": true,
-	"redis-kubernetes": true,
-	"redis-azure":      true,
-}
-
 // NewCreateOrUpdateEnvironment creates a new CreateOrUpdateEnvironment.
 func NewCreateOrUpdateEnvironment(opts ctrl.Options) (ctrl.Controller, error) {
 	return &CreateOrUpdateEnvironment{
@@ -74,18 +65,26 @@ func (e *CreateOrUpdateEnvironment) Run(ctx context.Context, w http.ResponseWrit
 	}
 
 	// Update Recipes mapping with dev recipes.
+	customRecipes := map[string]datamodel.EnvironmentRecipeProperties{}
 	if newResource.Properties.UseDevRecipes {
 		devRecipes, err := getDevRecipes(ctx)
 		if err != nil {
 			return nil, err
 		}
+		// TODO: This is a temporary fix to unblock users to register recipes using bicep, and should be removed
+		// after long term fix is implemented as part of https://github.com/project-radius/radius/issues/5179.
 		if newResource.Properties.Recipes != nil {
-			// TODO: This is a temporary fix to unblock users to register recipes using bicep, and should be removed
-			// after long term fix is implemented as part of https://github.com/project-radius/radius/issues/5179.
+			for k, v := range newResource.Properties.Recipes {
+				if val, ok := devRecipes[k]; !ok {
+					customRecipes[k] = v
+				} else if val.TemplatePath != v.TemplatePath {
+					customRecipes[k] = v
+				}
+			}
 			errorPrefix := "recipe name(s) reserved for devRecipes for: "
 			var errorRecipes string
-			for k, v := range newResource.Properties.Recipes {
-				if ok := reservedDevRecipesName[k]; ok {
+			for k, v := range customRecipes {
+				if _, ok := devRecipes[k]; ok {
 					if errorRecipes != "" {
 						errorRecipes += ", "
 					}

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
 	"github.com/project-radius/radius/pkg/linkrp"
+	"github.com/project-radius/radius/pkg/to"
 	"github.com/project-radius/radius/pkg/ucp/store"
 	"github.com/project-radius/radius/test/testutil"
 
@@ -570,6 +571,89 @@ func TestCreateOrUpdateRunDevRecipes(t *testing.T) {
 			t,
 			err,
 			"recipe name(s) reserved for devRecipes for: recipe with name mongo-azure (linkType Applications.Link/mongoDatabases and templatePath radiusdev.azurecr.io/mongo:1.0)")
+	})
+	t.Run("test input recipes that has dev recipes", func(t *testing.T) {
+		envInput := &v20220315privatepreview.EnvironmentResource{
+			Location: to.Ptr("West US"),
+			Properties: &v20220315privatepreview.EnvironmentProperties{
+				Compute: &v20220315privatepreview.KubernetesCompute{
+					Kind:       to.Ptr("kubernetes"),
+					ResourceID: to.Ptr("fakeid"),
+					Namespace:  to.Ptr("default"),
+				},
+				UseDevRecipes: to.Ptr(true),
+				Providers: &v20220315privatepreview.Providers{
+					Azure: &v20220315privatepreview.ProvidersAzure{
+						Scope: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"),
+					},
+				},
+				Recipes: map[string]*v20220315privatepreview.EnvironmentRecipeProperties{
+					"redis": {
+						LinkType:     to.Ptr("Applications.Link/redisCache"),
+						TemplatePath: to.Ptr("radiusdev.azurecr.io/redis:1.0"),
+					},
+					"mongo-azure": {
+						LinkType:     to.Ptr("Applications.Link/mongoDatabases"),
+						TemplatePath: to.Ptr("radius.azurecr.io/recipes/mongodatabases/azure:1.0"),
+					},
+					"redis-kubernetes": {
+						LinkType:     to.Ptr("Applications.Link/redisCaches"),
+						TemplatePath: to.Ptr("radius.azurecr.io/recipes/rediscaches/kubernetes:1.0"),
+					},
+				},
+			},
+		}
+		rawExpectedOutput := testutil.ReadFixture("environmentappenddevrecipes20220315privatepreview_output.json")
+		expectedOutput := &v20220315privatepreview.EnvironmentResource{}
+		_ = json.Unmarshal(rawExpectedOutput, expectedOutput)
+
+		rawDataModel := testutil.ReadFixture("environmentappenddevrecipes20220315privatepreview_datamodel.json")
+		envDataModel := &datamodel.Environment{}
+		_ = json.Unmarshal(rawDataModel, envDataModel)
+
+		w := httptest.NewRecorder()
+		req, _ := testutil.GetARMTestHTTPRequest(ctx, http.MethodGet, testHeaderfile, envInput)
+		ctx := testutil.ARMTestContextFromRequest(req)
+
+		expectedOutput.SystemData.CreatedAt = expectedOutput.SystemData.LastModifiedAt
+		expectedOutput.SystemData.CreatedBy = expectedOutput.SystemData.LastModifiedBy
+		expectedOutput.SystemData.CreatedByType = expectedOutput.SystemData.LastModifiedByType
+
+		mStorageClient.
+			EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, id string, _ ...store.GetOptions) (*store.Object, error) {
+				return nil, &store.ErrNotFound{}
+			})
+		mStorageClient.
+			EXPECT().
+			Query(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, query store.Query, options ...store.QueryOptions) (*store.ObjectQueryResult, error) {
+				return &store.ObjectQueryResult{
+					Items: []store.Object{},
+				}, nil
+			})
+		mStorageClient.
+			EXPECT().
+			Save(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, obj *store.Object, opts ...store.SaveOptions) error {
+				obj.ETag = "new-resource-etag"
+				obj.Data = envDataModel
+				return nil
+			})
+
+		opts := ctrl.Options{
+			StorageClient: mStorageClient,
+		}
+
+		ctl, err := NewCreateOrUpdateEnvironment(opts)
+		require.NoError(t, err)
+		resp, err := ctl.Run(ctx, w, req)
+		require.NoError(t, err)
+		_ = resp.Apply(ctx, w, req)
+		actualOutput := &v20220315privatepreview.EnvironmentResource{}
+		_ = json.Unmarshal(w.Body.Bytes(), actualOutput)
+		require.Equal(t, expectedOutput, actualOutput)
 	})
 
 	t.Run("Existing user recipe conflicts with dev recipe names ", func(t *testing.T) {

--- a/test/functional/corerp/cli/cli_test.go
+++ b/test/functional/corerp/cli/cli_test.go
@@ -43,10 +43,11 @@ const (
 func verifyRecipeCLI(ctx context.Context, t *testing.T, test corerp.CoreRPTest) {
 	options := corerp.NewCoreRPTestOptions(t)
 	cli := radcli.NewCLI(t, options.ConfigFilePath)
-	// get the current environment to switch back to after the test
+	// get the current environment to switch back to after the test since the environment is used
+	// for AWS test and has the AWS scope which the environment created in this does not.
 	output, err := cli.EnvShow(ctx)
 	require.NoError(t, err)
-	// switch to the environment used in the test template
+	// switch to the environment used in the test template since it has dev recipes enabled.
 	_, err = cli.EnvSwitch(ctx, test.Steps[0].CoreRPResources.Resources[0].Name)
 	prevEnv := strings.Trim(strings.Split(output, "\n")[1], " ")
 	require.NoError(t, err)
@@ -94,9 +95,10 @@ func verifyRecipeCLI(ctx context.Context, t *testing.T, test corerp.CoreRPTest) 
 	t.Run("Validate rad recipe register with recipe name conflicting with dev recipe", func(t *testing.T) {
 		output, err := cli.RecipeRegister(ctx, "mongo-azure", recipeTemplate, linkType)
 		require.Error(t, err)
-		require.Contains(t, output, fmt.Sprintf("recipe with name %q already exists in the environment", "mongo-azure"))
+		require.Contains(t, output, "recipe with name \"mongo-azure\" already exists in the environment")
 	})
-	// switch the environment back
+	// switch the environment back since the environment created by this test does not have the
+	// aws provider scope and gets deleted after the test runs
 	_, err = cli.EnvSwitch(ctx, prevEnv)
 	require.NoError(t, err)
 }

--- a/test/functional/corerp/cli/cli_test.go
+++ b/test/functional/corerp/cli/cli_test.go
@@ -43,6 +43,7 @@ const (
 func verifyRecipeCLI(ctx context.Context, t *testing.T, test corerp.CoreRPTest) {
 	options := corerp.NewCoreRPTestOptions(t)
 	cli := radcli.NewCLI(t, options.ConfigFilePath)
+	cli.EnvSwitch(ctx, test.Steps[0].CoreRPResources.Resources[0].Name)
 	recipeName := "recipeName"
 	recipeTemplate := "testpublicrecipe.azurecr.io/bicep/modules/testTemplate:v1"
 	linkType := "Applications.Link/linkType"
@@ -87,7 +88,7 @@ func verifyRecipeCLI(ctx context.Context, t *testing.T, test corerp.CoreRPTest) 
 	t.Run("Validate rad recipe register with recipe name conflicting with dev recipe", func(t *testing.T) {
 		output, err := cli.RecipeRegister(ctx, "mongo-azure", recipeTemplate, linkType)
 		require.Error(t, err)
-		require.Contains(t, output, fmt.Sprintf("recipe with name %q is reserved for dev recipes", "mongo-azure"))
+		require.Contains(t, output, fmt.Sprintf("recipe with name %q already exists in the environment", "mongo-azure"))
 	})
 }
 

--- a/test/radcli/cli.go
+++ b/test/radcli/cli.go
@@ -181,6 +181,15 @@ func (cli *CLI) EnvStatus(ctx context.Context) (string, error) {
 	return cli.RunCommand(ctx, args)
 }
 
+func (cli *CLI) EnvSwitch(ctx context.Context, environmentName string) (string, error) {
+	args := []string{
+		"env",
+		"switch",
+		environmentName,
+	}
+	return cli.RunCommand(ctx, args)
+}
+
 func (cli *CLI) EnvList(ctx context.Context) (string, error) {
 	args := []string{
 		"env",

--- a/test/radcli/cli.go
+++ b/test/radcli/cli.go
@@ -181,6 +181,14 @@ func (cli *CLI) EnvStatus(ctx context.Context) (string, error) {
 	return cli.RunCommand(ctx, args)
 }
 
+func (cli *CLI) EnvShow(ctx context.Context) (string, error) {
+	args := []string{
+		"env",
+		"show",
+	}
+	return cli.RunCommand(ctx, args)
+}
+
 func (cli *CLI) EnvSwitch(ctx context.Context, environmentName string) (string, error) {
 	args := []string{
 		"env",


### PR DESCRIPTION
# Description

The PR is a a temporary fix for registering command on the server side using bicep that has the same name as that of devrecipe

#### CLI Test Result:
```
pratiksm@Pratikshyas-MacBook-Pro radius % rad recipe list
NAME              TYPE                              TEMPLATE
mongo-azure       Applications.Link/mongoDatabases  radius.azurecr.io/recipes/mongodatabases/azure:1.0
redis-kubernetes  Applications.Link/redisCaches     radius.azurecr.io/recipes/rediscaches/kubernetes:1.0
pratiksm@Pratikshyas-MacBook-Pro radius % rad recipe register --name mongo-azure -e myenv -w kind-kind  --template-path radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0 --link-type Applications.Link/mongoDatabases
Error: recipe with name "mongo-azure" already exists in the environment "myenv"
pratiksm@Pratikshyas-MacBook-Pro radius % rad recipe register --name mongo -e myenv -w kind-kind  --template-path radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0 --link-type Applications.Link/mongoDatabases 
Successfully linked recipe "mongo" to environment "myenv" 
pratiksm@Pratikshyas-MacBook-Pro radius % rad recipe list
NAME              TYPE                              TEMPLATE
mongo             Applications.Link/mongoDatabases  radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0
mongo-azure       Applications.Link/mongoDatabases  radius.azurecr.io/recipes/mongodatabases/azure:1.0
redis-kubernetes  Applications.Link/redisCaches     radius.azurecr.io/recipes/rediscaches/kubernetes:1.0
```
#### Bicep test result
Bicep Content
```
resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
  name: 'corerp-resources-environment-env'
  location: location
  properties: {
    compute: {
      kind: 'kubernetes'
      resourceId: 'self'
      namespace: 'corerp-resources-environment-env'
    }
    recipes: {
      recipe1: {
          linkType: 'Applications.Link/mongoDatabases' 
          templatePath: 'testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1' 
      }
    }
    useDevRecipes: true
  }
}
```

```
pratiksm@Pratikshyas-MacBook-Pro radius % rad deploy /Users/pratiksm/Documents/MyGoWorkSpace/src/project-radius/radius/test/functional/corerp/resources/testdata/corerp-resources-environment.bicep
Building /Users/pratiksm/Documents/MyGoWorkSpace/src/project-radius/radius/test/functional/corerp/resources/testdata/corerp-resources-environment.bicep...
Deploying template '/Users/pratiksm/Documents/MyGoWorkSpace/src/project-radius/radius/test/functional/corerp/resources/testdata/corerp-resources-environment.bicep' for application 'radius' and environment 'myenv' from workspace 'kind-kind'...

Deployment In Progress...

Completed            corerp-resources-environment-env Applications.Core/environments

Deployment Complete

Resources:
    corerp-resources-environment-env Applications.Core/environments
pratiksm@Pratikshyas-MacBook-Pro radius % rad env switch corerp-resources-environment-env
Switching default environment from myenv to corerp-resources-environment-env
Successfully wrote configuration to /Users/pratiksm/.rad/config.yaml
pratiksm@Pratikshyas-MacBook-Pro radius % rad recipe list                                
NAME              TYPE                              TEMPLATE
recipe1           Applications.Link/mongoDatabases  testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1
redis-kubernetes  Applications.Link/redisCaches     radius.azurecr.io/recipes/rediscaches/kubernetes:1.0
mongo-azure       Applications.Link/mongoDatabases  radius.azurecr.io/recipes/mongodatabases/azure:1.0

```
## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
