### PR TITLE
Increaing the redis resource creation timeout to 60mins

### DIFF
--- a/pkg/linkrp/frontend/handler/routes.go
+++ b/pkg/linkrp/frontend/handler/routes.go
@@ -394,7 +394,7 @@ func AddRoutes(ctx context.Context, router *mux.Router, pathBase string, isARM b
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.RedisCache]{
 							rp_frontend.PrepareRadiusResource[*datamodel.RedisCache],
 						},
-						AsyncOperationTimeout: time.Duration(10) * time.Minute,
+						AsyncOperationTimeout: time.Duration(60) * time.Minute, // azure/aws redis resource creation is takes between 20-50 mins.
 					},
 				)
 			},
@@ -411,7 +411,7 @@ func AddRoutes(ctx context.Context, router *mux.Router, pathBase string, isARM b
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.RedisCache]{
 							rp_frontend.PrepareRadiusResource[*datamodel.RedisCache],
 						},
-						AsyncOperationTimeout: time.Duration(10) * time.Minute,
+						AsyncOperationTimeout: time.Duration(60) * time.Minute, // azure/aws redis resource creation is takes between 20-50 mins.
 					},
 				)
 			},
@@ -425,7 +425,7 @@ func AddRoutes(ctx context.Context, router *mux.Router, pathBase string, isARM b
 					frontend_ctrl.ResourceOptions[datamodel.RedisCache]{
 						RequestConverter:      converter.RedisCacheDataModelFromVersioned,
 						ResponseConverter:     converter.RedisCacheDataModelToVersioned,
-						AsyncOperationTimeout: time.Duration(10) * time.Minute,
+						AsyncOperationTimeout: time.Duration(30) * time.Minute,
 					},
 				)
 			},


### PR DESCRIPTION
# Description

Azure/Aws redis resource creation takes 20-50mins, so setting the timeout to 60mins and deletion timeout to 30mins. 

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: https://github.com/project-radius/radius/issues/5187
## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
