### PR TITLE
Update the release-process doc for creating patch release

### DIFF
--- a/docs/contributing/contributing-code/release-process.md
+++ b/docs/contributing/contributing-code/release-process.md
@@ -240,6 +240,7 @@ Let's say we have a bug in a release which needs to be patched for an already cr
    ```bash
    git cherry-pick -x <COMMIT HASH>
    ```
+5. Update the file radius/.github/workflows/validate-bicep.yaml to use the release version (eg. v0.17) instead of edge for validating the biceps in the docs and samples repositories. Also modify the version from `env.REL_CHANNEL` to <major>.<minor> (eg. 0.17) for downloading the `rad-bicep-corerp`.
 4. Push the commit to the remote and create a pull request targeting the release branch.
    ```bash
    git push origin <USERNAME>/<BRANCHNAME>


### PR DESCRIPTION
# Description

While creating the patch release, the bicep validation for samples and docs repositories are pointing to the edge branch 
and the since we are cherry-picking the commits some of these validations are failing. Updating the doc to add the step to update the file while creating the branch for the patch release.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
