### PR TITLE
Remove add to project job

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -33,13 +33,3 @@ jobs:
               fi
             fi
           done
-    
-  project:
-    name: Add Issue to Core Team project
-    runs-on: [self-hosted,1ES.Pool=1ES-Radius ]
-    steps:
-      - name: Add Issue to Core Team project
-        uses: actions/add-to-project@v0.3.0
-        with:
-          project-url: https://github.com/orgs/project-radius/projects/1
-          github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}


### PR DESCRIPTION
# Description

GitHub Issues now automatically adds Issues to projects so our custom job isn't needed anymore

See https://github.blog/changelog/2023-01-19-github-issues-january-19th-update/#%F0%9F%A4%96-automatically-add-project-items-enterprise-accounts-only for more information
