### PR TITLE
Add BaseResource for UCP plane and resourcegroup

### DIFF
--- a/pkg/armrpc/frontend/server/handler.go
+++ b/pkg/armrpc/frontend/server/handler.go
@@ -145,7 +145,7 @@ func ConfigureDefaultHandlers(
 	return nil
 }
 
-// Responds with an HTTP 500
+// HandleError creates the internal error respones with 500 code.
 func HandleError(ctx context.Context, w http.ResponseWriter, req *http.Request, err error) {
 	logger := ucplog.FromContextOrDiscard(ctx)
 	logger.Error(err, "unhandled error")

--- a/pkg/armrpc/frontend/server/handler.go
+++ b/pkg/armrpc/frontend/server/handler.go
@@ -54,13 +54,13 @@ func RegisterHandler(ctx context.Context, opts HandlerOptions, ctrlOpts ctrl.Opt
 
 		response, err := ctrl.Run(hctx, w, req)
 		if err != nil {
-			handleError(hctx, w, req, err)
+			HandleError(hctx, w, req, err)
 			return
 		}
 
 		err = response.Apply(hctx, w, req)
 		if err != nil {
-			handleError(hctx, w, req, err)
+			HandleError(hctx, w, req, err)
 			return
 		}
 	}
@@ -146,7 +146,7 @@ func ConfigureDefaultHandlers(
 }
 
 // Responds with an HTTP 500
-func handleError(ctx context.Context, w http.ResponseWriter, req *http.Request, err error) {
+func HandleError(ctx context.Context, w http.ResponseWriter, req *http.Request, err error) {
 	logger := ucplog.FromContextOrDiscard(ctx)
 	logger.Error(err, "unhandled error")
 

--- a/pkg/armrpc/frontend/server/handler_test.go
+++ b/pkg/armrpc/frontend/server/handler_test.go
@@ -30,7 +30,7 @@ func Test_HandlerErrModelConversion(t *testing.T) {
 	req := httptest.NewRequest(handlerTest.method, handlerTest.url, nil)
 	responseWriter := httptest.NewRecorder()
 	err := &v1.ErrModelConversion{PropertyName: "namespace", ValidValue: "63 characters or less"}
-	handleError(context.Background(), responseWriter, req, err)
+	HandleError(context.Background(), responseWriter, req, err)
 
 	bodyBytes, e := io.ReadAll(responseWriter.Body)
 	require.NoError(t, e)
@@ -52,7 +52,7 @@ func Test_HandlerErrInvalidModelConversion(t *testing.T) {
 
 	req := httptest.NewRequest(handlerTest.method, handlerTest.url, nil)
 	responseWriter := httptest.NewRecorder()
-	handleError(context.Background(), responseWriter, req, v1.ErrInvalidModelConversion)
+	HandleError(context.Background(), responseWriter, req, v1.ErrInvalidModelConversion)
 
 	bodyBytes, e := io.ReadAll(responseWriter.Body)
 	require.NoError(t, e)
@@ -75,7 +75,7 @@ func Test_HandlerErrInternal(t *testing.T) {
 	req := httptest.NewRequest(handlerTest.method, handlerTest.url, nil)
 	responseWriter := httptest.NewRecorder()
 	err := errors.New("Internal error")
-	handleError(context.Background(), responseWriter, req, err)
+	HandleError(context.Background(), responseWriter, req, err)
 
 	bodyBytes, e := io.ReadAll(responseWriter.Body)
 	require.NoError(t, e)

--- a/pkg/cli/cmd/group/create/create.go
+++ b/pkg/cli/cmd/group/create/create.go
@@ -19,7 +19,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/project-radius/radius/pkg/to"
-	v20220315privatepreview "github.com/project-radius/radius/pkg/ucp/api/v20220901privatepreview"
+	"github.com/project-radius/radius/pkg/ucp/api/v20220901privatepreview"
 )
 
 // NewCommand creates an instance of the command and runner for the `rad group create` command.
@@ -99,7 +99,7 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	r.Output.LogInfo("creating resource group %q in workspace %q...\n", r.UCPResourceGroupName, r.Workspace.Name)
 
-	_, err = client.CreateUCPGroup(ctx, "radius", "local", r.UCPResourceGroupName, v20220315privatepreview.ResourceGroupResource{
+	_, err = client.CreateUCPGroup(ctx, "radius", "local", r.UCPResourceGroupName, v20220901privatepreview.ResourceGroupResource{
 		Location: to.Ptr(v1.LocationGlobal),
 	})
 	if err != nil {
@@ -108,7 +108,7 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	// TODO: we TEMPORARILY create a resource group in the deployments plane because the deployments RP requires it.
 	// We'll remove this in the future.
-	_, err = client.CreateUCPGroup(ctx, "deployments", "local", r.UCPResourceGroupName, v20220315privatepreview.ResourceGroupResource{
+	_, err = client.CreateUCPGroup(ctx, "deployments", "local", r.UCPResourceGroupName, v20220901privatepreview.ResourceGroupResource{
 		Location: to.Ptr(v1.LocationGlobal),
 	})
 	if err != nil {

--- a/pkg/ucp/api/v20220901privatepreview/plane_conversion.go
+++ b/pkg/ucp/api/v20220901privatepreview/plane_conversion.go
@@ -41,10 +41,12 @@ func (src *PlaneResource) ConvertTo() (v1.DataModelInterface, error) {
 	// No validation for AWS plane.
 
 	converted := &datamodel.Plane{
-		TrackedResource: v1.TrackedResource{
-			ID:   to.String(src.ID),
-			Name: to.String(src.Name),
-			Type: to.String(src.Type),
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:   to.String(src.ID),
+				Name: to.String(src.Name),
+				Type: to.String(src.Type),
+			},
 		},
 		Properties: datamodel.PlaneProperties{
 			Kind:              datamodel.PlaneKind(*src.Properties.Kind),

--- a/pkg/ucp/api/v20220901privatepreview/plane_conversion_test.go
+++ b/pkg/ucp/api/v20220901privatepreview/plane_conversion_test.go
@@ -27,10 +27,12 @@ func TestPlaneConvertVersionedToDataModel(t *testing.T) {
 		{
 			filename: "planeresource.json",
 			expected: &datamodel.Plane{
-				TrackedResource: v1.TrackedResource{
-					ID:   "/planes/radius/local",
-					Name: "local",
-					Type: "System.Planes/radius",
+				BaseResource: v1.BaseResource{
+					TrackedResource: v1.TrackedResource{
+						ID:   "/planes/radius/local",
+						Name: "local",
+						Type: "System.Planes/radius",
+					},
 				},
 				Properties: datamodel.PlaneProperties{
 					Kind: datamodel.PlaneKind(PlaneKindUCPNative),

--- a/pkg/ucp/api/v20220901privatepreview/resourcegroup_conversion.go
+++ b/pkg/ucp/api/v20220901privatepreview/resourcegroup_conversion.go
@@ -16,12 +16,14 @@ func (src *ResourceGroupResource) ConvertTo() (v1.DataModelInterface, error) {
 	// Note: SystemData conversion isn't required since this property comes ARM and datastore.
 
 	converted := &datamodel.ResourceGroup{
-		TrackedResource: v1.TrackedResource{
-			ID:       to.String(src.ID),
-			Name:     to.String(src.Name),
-			Type:     to.String(src.Type),
-			Location: to.String(src.Location),
-			Tags:     to.StringMap(src.Tags),
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:       to.String(src.ID),
+				Name:     to.String(src.Name),
+				Type:     to.String(src.Type),
+				Location: to.String(src.Location),
+				Tags:     to.StringMap(src.Tags),
+			},
 		},
 	}
 

--- a/pkg/ucp/api/v20220901privatepreview/resourcegroup_conversion_test.go
+++ b/pkg/ucp/api/v20220901privatepreview/resourcegroup_conversion_test.go
@@ -25,13 +25,15 @@ func TestResourceGroupConvertVersionedToDataModel(t *testing.T) {
 		{
 			filename: "resourcegroup.json",
 			expected: &datamodel.ResourceGroup{
-				TrackedResource: v1.TrackedResource{
-					ID:       "/planes/radius/local/resourceGroups/test-rg",
-					Name:     "test-rg",
-					Type:     "System.Resources/resourceGroups",
-					Location: v1.LocationGlobal,
-					Tags: map[string]string{
-						"env": "dev",
+				BaseResource: v1.BaseResource{
+					TrackedResource: v1.TrackedResource{
+						ID:       "/planes/radius/local/resourceGroups/test-rg",
+						Name:     "test-rg",
+						Type:     "System.Resources/resourceGroups",
+						Location: v1.LocationGlobal,
+						Tags: map[string]string{
+							"env": "dev",
+						},
 					},
 				},
 			},

--- a/pkg/ucp/datamodel/awsresource.go
+++ b/pkg/ucp/datamodel/awsresource.go
@@ -1,0 +1,45 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package datamodel
+
+import v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+
+// AWSResource represents any AWS Resource.
+type AWSResource struct {
+}
+
+// AWSResource is not a tracked resource, so it does not implement ResourceDataModel.
+// However need to implement the methods to satisfy the interface.
+
+// Dummy interface implementation of GetSystemData to ensure that AWSResource implements ResourceDataModel.
+func (a *AWSResource) GetSystemData() *v1.SystemData {
+	return nil
+}
+
+// Dummy interface implementation of GetBaseResource to ensure that AWSResource implements ResourceDataModel.
+func (a *AWSResource) GetBaseResource() *v1.BaseResource {
+	return nil
+}
+
+// Dummy interface implementation of ProvisioningState to ensure that AWSResource implements ResourceDataModel.
+func (a *AWSResource) ProvisioningState() v1.ProvisioningState {
+	return v1.ProvisioningState("")
+}
+
+// Dummy interface implementation of SetProvisioningState to ensure that AWSResource implements ResourceDataModel.
+func (a *AWSResource) SetProvisioningState(state v1.ProvisioningState) {
+
+}
+
+// Dummy interface implementation of UpdateMetadata to ensure that AWSResource implements ResourceDataModel.
+func (a *AWSResource) UpdateMetadata(ctx *v1.ARMRequestContext, oldResource *v1.BaseResource) {
+
+}
+
+// Dummy interface implementation of ResourceTypeName to ensure that AWSResource implements ResourceDataModel.
+func (a *AWSResource) ResourceTypeName() string {
+	return "UCP/AWSResource"
+}

--- a/pkg/ucp/datamodel/awsresource.go
+++ b/pkg/ucp/datamodel/awsresource.go
@@ -8,38 +8,37 @@ package datamodel
 import v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 
 // AWSResource represents any AWS Resource.
+// AWSResource is not a tracked resource, so it does not implement ResourceDataModel.
+// However need to implement the methods to satisfy the interface.
 type AWSResource struct {
 }
 
-// AWSResource is not a tracked resource, so it does not implement ResourceDataModel.
-// However need to implement the methods to satisfy the interface.
-
-// Dummy interface implementation of GetSystemData to ensure that AWSResource implements ResourceDataModel.
+// GetSystemData is not implemented for AWS proxy resource.
 func (a *AWSResource) GetSystemData() *v1.SystemData {
 	return nil
 }
 
-// Dummy interface implementation of GetBaseResource to ensure that AWSResource implements ResourceDataModel.
+// GetBaseResource is not implemented for AWS proxy resource.
 func (a *AWSResource) GetBaseResource() *v1.BaseResource {
 	return nil
 }
 
-// Dummy interface implementation of ProvisioningState to ensure that AWSResource implements ResourceDataModel.
+// ProvisioningState is not implemented for AWS proxy resource.
 func (a *AWSResource) ProvisioningState() v1.ProvisioningState {
 	return v1.ProvisioningState("")
 }
 
-// Dummy interface implementation of SetProvisioningState to ensure that AWSResource implements ResourceDataModel.
+// SetProvisioningState is not implemented for AWS proxy resource.
 func (a *AWSResource) SetProvisioningState(state v1.ProvisioningState) {
 
 }
 
-// Dummy interface implementation of UpdateMetadata to ensure that AWSResource implements ResourceDataModel.
+// UpdateMetadata is not implemented for AWS proxy resource.
 func (a *AWSResource) UpdateMetadata(ctx *v1.ARMRequestContext, oldResource *v1.BaseResource) {
 
 }
 
-// Dummy interface implementation of ResourceTypeName to ensure that AWSResource implements ResourceDataModel.
+// ResourceTypeName returns the resource type name.
 func (a *AWSResource) ResourceTypeName() string {
 	return "UCP/AWSResource"
 }

--- a/pkg/ucp/datamodel/plane.go
+++ b/pkg/ucp/datamodel/plane.go
@@ -21,7 +21,7 @@ type PlaneProperties struct {
 
 // Plane represents UCP Plane.
 type Plane struct {
-	v1.TrackedResource
+	v1.BaseResource
 
 	// Properties is the properties of the resource.
 	Properties PlaneProperties `json:"properties"`

--- a/pkg/ucp/datamodel/resourcegroup.go
+++ b/pkg/ucp/datamodel/resourcegroup.go
@@ -9,7 +9,7 @@ import v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 
 // ResourceGroup represents UCP ResourceGroup.
 type ResourceGroup struct {
-	v1.TrackedResource
+	v1.BaseResource
 }
 
 func (p ResourceGroup) ResourceTypeName() string {

--- a/pkg/ucp/frontend/controller/planes/createorupdateplane_test.go
+++ b/pkg/ucp/frontend/controller/planes/createorupdateplane_test.go
@@ -50,10 +50,12 @@ func Test_CreateUCPNativePlane(t *testing.T) {
 	url := "/planes/radius/local?api-version=2022-09-01-privatepreview"
 
 	dataModelPlane := datamodel.Plane{
-		TrackedResource: v1.TrackedResource{
-			ID:   "/planes/radius/local",
-			Type: "System.Planes/radius",
-			Name: "local",
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:   "/planes/radius/local",
+				Type: "System.Planes/radius",
+				Name: "local",
+			},
 		},
 		Properties: datamodel.PlaneProperties{
 			ResourceProviders: map[string]*string{

--- a/pkg/ucp/frontend/controller/planes/getplane_test.go
+++ b/pkg/ucp/frontend/controller/planes/getplane_test.go
@@ -41,10 +41,12 @@ func Test_GetPlaneByID(t *testing.T) {
 	url := "/planes/radius/local?api-version=2022-09-01-privatepreview"
 
 	dbPlane := datamodel.Plane{
-		TrackedResource: v1.TrackedResource{
-			ID:   "/planes/radius/local",
-			Type: "radius",
-			Name: "local",
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:   "/planes/radius/local",
+				Type: "radius",
+				Name: "local",
+			},
 		},
 		Properties: datamodel.PlaneProperties{
 			Kind: rest.PlaneKindUCPNative,

--- a/pkg/ucp/frontend/controller/resourcegroups/createorupdateresourcegroup_test.go
+++ b/pkg/ucp/frontend/controller/resourcegroups/createorupdateresourcegroup_test.go
@@ -52,12 +52,14 @@ func Test_CreateResourceGroup(t *testing.T) {
 	testResourceGroupName := "test-rg"
 
 	resourceGroup := datamodel.ResourceGroup{
-		TrackedResource: v1.TrackedResource{
-			ID:       testResourceGroupID,
-			Name:     testResourceGroupName,
-			Type:     ResourceGroupType,
-			Location: v1.LocationGlobal,
-			Tags:     map[string]string{},
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:       testResourceGroupID,
+				Name:     testResourceGroupName,
+				Type:     ResourceGroupType,
+				Location: v1.LocationGlobal,
+				Tags:     map[string]string{},
+			},
 		},
 	}
 

--- a/pkg/ucp/frontend/controller/resourcegroups/deleteresourcegroup_test.go
+++ b/pkg/ucp/frontend/controller/resourcegroups/deleteresourcegroup_test.go
@@ -36,10 +36,12 @@ func Test_DeleteResourceGroupByID(t *testing.T) {
 	require.NoError(t, err)
 
 	rg := datamodel.ResourceGroup{
-		TrackedResource: v1.TrackedResource{
-			ID:   "/planes/radius/local/resourceGroups/default",
-			Name: "default",
-			Type: ResourceGroupType,
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:   "/planes/radius/local/resourceGroups/default",
+				Name: "default",
+				Type: ResourceGroupType,
+			},
 		},
 	}
 
@@ -79,10 +81,12 @@ func Test_NonEmptyResourceGroup_CannotBeDeleted(t *testing.T) {
 	require.NoError(t, err)
 
 	rg := datamodel.ResourceGroup{
-		TrackedResource: v1.TrackedResource{
-			ID:   "/planes/radius/local/resourceGroups/default",
-			Name: "default",
-			Type: ResourceGroupType,
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:   "/planes/radius/local/resourceGroups/default",
+				Name: "default",
+				Type: ResourceGroupType,
+			},
 		},
 	}
 

--- a/pkg/ucp/frontend/controller/resourcegroups/getresourcegroup_test.go
+++ b/pkg/ucp/frontend/controller/resourcegroups/getresourcegroup_test.go
@@ -40,12 +40,14 @@ func Test_GetResourceGroupByID(t *testing.T) {
 	testResourceGroupName := "test-rg"
 	path := testResourceGroupID + "?api-version=2022-09-01-privatepreview"
 	rg := datamodel.ResourceGroup{
-		TrackedResource: v1.TrackedResource{
-			ID:       testResourceGroupID,
-			Name:     testResourceGroupName,
-			Type:     ResourceGroupType,
-			Location: v1.LocationGlobal,
-			Tags:     map[string]string{},
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:       testResourceGroupID,
+				Name:     testResourceGroupName,
+				Type:     ResourceGroupType,
+				Location: v1.LocationGlobal,
+				Tags:     map[string]string{},
+			},
 		},
 	}
 

--- a/pkg/ucp/frontend/controller/resourcegroups/listresourcegroups_test.go
+++ b/pkg/ucp/frontend/controller/resourcegroups/listresourcegroups_test.go
@@ -48,11 +48,13 @@ func Test_ListResourceGroups(t *testing.T) {
 	testResourceGroupName := "test-rg"
 
 	rg := datamodel.ResourceGroup{
-		TrackedResource: v1.TrackedResource{
-			ID:       testResourceGroupID,
-			Name:     testResourceGroupName,
-			Type:     ResourceGroupType,
-			Location: v1.LocationGlobal,
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:       testResourceGroupID,
+				Name:     testResourceGroupName,
+				Type:     ResourceGroupType,
+				Location: v1.LocationGlobal,
+			},
 		},
 	}
 

--- a/pkg/ucp/integrationtests/integration_test.go
+++ b/pkg/ucp/integrationtests/integration_test.go
@@ -71,10 +71,12 @@ var applicationList = []map[string]any{
 }
 
 var testUCPNativePlane = datamodel.Plane{
-	TrackedResource: armrpc_v1.TrackedResource{
-		ID:   "/planes/radius/local",
-		Type: "radius",
-		Name: "local",
+	BaseResource: v1.BaseResource{
+		TrackedResource: armrpc_v1.TrackedResource{
+			ID:   "/planes/radius/local",
+			Type: "radius",
+			Name: "local",
+		},
 	},
 	Properties: datamodel.PlaneProperties{
 		Kind: rest.PlaneKindUCPNative,


### PR DESCRIPTION
# Description

Splitting PR #5142 into parts. This part adds:-
- BaseResource for UCP plane and resourcegroup 
- Introduces AWS Resource with a dummy ResourceDataModel implementation

#5175 

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
