### PR TITLE
Skip comment for the forked branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -136,7 +136,7 @@ jobs:
             ./dist/ut_coverage.txt
             ./dist/ut_coverage.html
       - name: Add coverage result comment
-        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && github.event.pull_request
+        if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository
         uses: peter-evans/create-or-update-comment@v2.1.1
         with:
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
# Description

In private repo, GITHUB_SECRET is not populated if the PR repo is a forked. This change is to skip comment step.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
