### PR TITLE
HTTPRoute: Extend KME functionality for cascaded Labels/Annotations from env, app

### DIFF
--- a/pkg/corerp/renderers/httproute/render.go
+++ b/pkg/corerp/renderers/httproute/render.go
@@ -87,7 +87,7 @@ func (r *Renderer) makeService(ctx context.Context, route *datamodel.HTTPRoute, 
 			Name:        kubernetes.NormalizeResourceName(route.Name),
 			Namespace:   options.Environment.Namespace,
 			Labels:      getLabels(ctx, options, appId.Name(), route),
-			Annotations: getAnnotations(ctx, options, appId.Name(), route),
+			Annotations: getAnnotations(ctx, options),
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: kubernetes.MakeRouteSelectorLabels(appId.Name(), resourceTypeSuffix, route.Name),
@@ -133,7 +133,7 @@ func getLabels(ctx context.Context, options renderers.RenderOptions, appIdName s
 	return nil
 }
 
-func getAnnotations(ctx context.Context, options renderers.RenderOptions, appIdName string, route *datamodel.HTTPRoute) map[string]string {
+func getAnnotations(ctx context.Context, options renderers.RenderOptions) map[string]string {
 	//Create KubernetesMetadata structs to merge annotations
 	annMap := &kube.Metadata{}
 	envOpts := &options.Environment

--- a/pkg/corerp/renderers/httproute/render.go
+++ b/pkg/corerp/renderers/httproute/render.go
@@ -109,7 +109,7 @@ func (r *Renderer) makeService(ctx context.Context, route *datamodel.HTTPRoute, 
 func getLabels(ctx context.Context, options renderers.RenderOptions, appIdName string, route *datamodel.HTTPRoute) map[string]string {
 	//Create KubernetesMetadata structs to merge labels
 	lblMap := &kube.Metadata{
-		CurrObjectMeta: kubernetes.MakeDescriptiveLabels(appIdName, route.Name, route.ResourceTypeName()),
+		ObjectMetadata: kubernetes.MakeDescriptiveLabels(appIdName, route.Name, route.ResourceTypeName()),
 	}
 
 	envOpts := &options.Environment
@@ -126,8 +126,8 @@ func getLabels(ctx context.Context, options renderers.RenderOptions, appIdName s
 
 	// Merge cumulative label values from Env->App->Container->InputExt kubernetes metadata. In case of collisions, Env->App->Container->InputExt
 	// values are merged in that order. Spec labels are not updated.
-	if updObjectMetaLabels, _ := lblMap.Merge(ctx); updObjectMetaLabels != nil && len(updObjectMetaLabels) > 0 {
-		return updObjectMetaLabels
+	if metaLabels, _ := lblMap.Merge(ctx); len(metaLabels) > 0 {
+		return metaLabels
 	}
 
 	return nil
@@ -150,8 +150,8 @@ func getAnnotations(ctx context.Context, options renderers.RenderOptions, appIdN
 
 	// Merge cumulative annotations values from Env->App->Container->InputExt kubernetes metadata. In case of collisions, rightmost entity wins
 	// Spec annotations are not updated.
-	if updObjectMetaAnnotations, _ := annMap.Merge(ctx); updObjectMetaAnnotations != nil && len(updObjectMetaAnnotations) > 0 {
-		return updObjectMetaAnnotations
+	if metaAnnotations, _ := annMap.Merge(ctx); len(metaAnnotations) > 0 {
+		return metaAnnotations
 	}
 
 	return nil

--- a/pkg/corerp/renderers/httproute/render.go
+++ b/pkg/corerp/renderers/httproute/render.go
@@ -87,7 +87,7 @@ func (r *Renderer) makeService(ctx context.Context, route *datamodel.HTTPRoute, 
 			Name:        kubernetes.NormalizeResourceName(route.Name),
 			Namespace:   options.Environment.Namespace,
 			Labels:      getLabels(ctx, options, appId.Name(), route),
-			Annotations: getAnnotations(ctx, options),
+			Annotations: getAnnotations(ctx, options, appId.Name(), route),
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: kubernetes.MakeRouteSelectorLabels(appId.Name(), resourceTypeSuffix, route.Name),
@@ -133,7 +133,7 @@ func getLabels(ctx context.Context, options renderers.RenderOptions, appIdName s
 	return nil
 }
 
-func getAnnotations(ctx context.Context, options renderers.RenderOptions) map[string]string {
+func getAnnotations(ctx context.Context, options renderers.RenderOptions, appIdName string, route *datamodel.HTTPRoute) map[string]string {
 	//Create KubernetesMetadata structs to merge annotations
 	annMap := &kube.Metadata{}
 	envOpts := &options.Environment

--- a/pkg/corerp/renderers/httproute/render.go
+++ b/pkg/corerp/renderers/httproute/render.go
@@ -107,7 +107,7 @@ func (r *Renderer) makeService(ctx context.Context, route *datamodel.HTTPRoute, 
 }
 
 func getLabels(ctx context.Context, options renderers.RenderOptions, appIdName string, route *datamodel.HTTPRoute) map[string]string {
-	//Create KubernetesMetadata structs to merge labels
+	// Create KubernetesMetadata struct to merge labels
 	lblMap := &kube.Metadata{
 		ObjectMetadata: kubernetes.MakeDescriptiveLabels(appIdName, route.Name, route.ResourceTypeName()),
 	}
@@ -134,7 +134,7 @@ func getLabels(ctx context.Context, options renderers.RenderOptions, appIdName s
 }
 
 func getAnnotations(ctx context.Context, options renderers.RenderOptions) map[string]string {
-	//Create KubernetesMetadata structs to merge annotations
+	// Create KubernetesMetadata struct to merge annotations
 	annMap := &kube.Metadata{}
 	envOpts := &options.Environment
 	appOpts := &options.Application

--- a/pkg/corerp/renderers/httproute/render.go
+++ b/pkg/corerp/renderers/httproute/render.go
@@ -111,9 +111,9 @@ func getLabels(ctx context.Context, options renderers.RenderOptions, appIdName s
 	lblMap := &kube.Metadata{
 		CurrObjectMeta: kubernetes.MakeDescriptiveLabels(appIdName, route.Name, route.ResourceTypeName()),
 	}
+
 	envOpts := &options.Environment
 	appOpts := &options.Application
-
 	envKmeExists := envOpts != nil && envOpts.KubernetesMetadata != nil
 	appKmeExists := appOpts != nil && appOpts.KubernetesMetadata != nil
 
@@ -138,7 +138,6 @@ func getAnnotations(ctx context.Context, options renderers.RenderOptions, appIdN
 	annMap := &kube.Metadata{}
 	envOpts := &options.Environment
 	appOpts := &options.Application
-
 	envKmeExists := envOpts != nil && envOpts.KubernetesMetadata != nil
 	appKmeExists := appOpts != nil && appOpts.KubernetesMetadata != nil
 

--- a/pkg/corerp/renderers/httproute/render.go
+++ b/pkg/corerp/renderers/httproute/render.go
@@ -19,6 +19,7 @@ import (
 	"github.com/project-radius/radius/pkg/corerp/renderers"
 	"github.com/project-radius/radius/pkg/kubernetes"
 	"github.com/project-radius/radius/pkg/resourcekinds"
+	"github.com/project-radius/radius/pkg/rp/kube"
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 	"github.com/project-radius/radius/pkg/ucp/resources"
 )
@@ -56,7 +57,7 @@ func (r Renderer) Render(ctx context.Context, dm v1.DataModelInterface, options 
 		},
 	}
 
-	service, err := r.makeService(route, options)
+	service, err := r.makeService(ctx, route, options)
 	if err != nil {
 		return renderers.RendererOutput{}, err
 	}
@@ -68,7 +69,7 @@ func (r Renderer) Render(ctx context.Context, dm v1.DataModelInterface, options 
 	}, nil
 }
 
-func (r *Renderer) makeService(route *datamodel.HTTPRoute, options renderers.RenderOptions) (rpv1.OutputResource, error) {
+func (r *Renderer) makeService(ctx context.Context, route *datamodel.HTTPRoute, options renderers.RenderOptions) (rpv1.OutputResource, error) {
 	appId, err := resources.ParseResource(route.Properties.Application)
 	if err != nil {
 		return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("invalid application id: %s. id: %s", err.Error(), route.Properties.Application))
@@ -76,6 +77,7 @@ func (r *Renderer) makeService(route *datamodel.HTTPRoute, options renderers.Ren
 
 	typeParts := strings.Split(ResourceType, "/")
 	resourceTypeSuffix := typeParts[len(typeParts)-1]
+	lbl, ann := getLabelsAnnotations(ctx, options, appId.Name(), route)
 
 	service := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -83,9 +85,10 @@ func (r *Renderer) makeService(route *datamodel.HTTPRoute, options renderers.Ren
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      kubernetes.NormalizeResourceName(route.Name),
-			Namespace: options.Environment.Namespace,
-			Labels:    kubernetes.MakeDescriptiveLabels(appId.Name(), route.Name, route.ResourceTypeName()),
+			Name:        kubernetes.NormalizeResourceName(route.Name),
+			Namespace:   options.Environment.Namespace,
+			Labels:      lbl,
+			Annotations: ann,
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: kubernetes.MakeRouteSelectorLabels(appId.Name(), resourceTypeSuffix, route.Name),
@@ -102,4 +105,38 @@ func (r *Renderer) makeService(route *datamodel.HTTPRoute, options renderers.Ren
 	}
 
 	return rpv1.NewKubernetesOutputResource(resourcekinds.Service, rpv1.LocalIDService, service, service.ObjectMeta), nil
+}
+
+func getLabelsAnnotations(ctx context.Context, options renderers.RenderOptions, appIdName string, route *datamodel.HTTPRoute) (map[string]string, map[string]string) {
+	//Create KubernetesMetadata structs to merge labels and annotations
+	annMap := &kube.Metadata{}
+	lblMap := &kube.Metadata{
+		CurrObjectMeta: kubernetes.MakeDescriptiveLabels(appIdName, route.Name, route.ResourceTypeName()),
+	}
+
+	envOpts := &options.Environment
+	appOpts := &options.Application
+
+	envKmeExists := envOpts != nil && envOpts.KubernetesMetadata != nil
+	appKmeExists := appOpts != nil && appOpts.KubernetesMetadata != nil
+
+	if envKmeExists && envOpts.KubernetesMetadata.Labels != nil {
+		lblMap.EnvData = envOpts.KubernetesMetadata.Labels
+	}
+	if appKmeExists && appOpts.KubernetesMetadata.Labels != nil {
+		lblMap.AppData = appOpts.KubernetesMetadata.Labels
+	}
+	if envKmeExists && envOpts.KubernetesMetadata.Annotations != nil {
+		annMap.EnvData = envOpts.KubernetesMetadata.Annotations
+	}
+	if appKmeExists && appOpts.KubernetesMetadata.Annotations != nil {
+		annMap.AppData = appOpts.KubernetesMetadata.Annotations
+	}
+
+	// Merge cumulative label, annotations values from Env->App->Container->InputExt kubernetes metadata. In case of collisions, rightmost entity wins
+	// Spec labels and annotations are not updated.
+	updObjectMetaLabels, _ := lblMap.Merge(ctx)
+	updObjectMetaAnnotations, _ := annMap.Merge(ctx)
+
+	return updObjectMetaLabels, updObjectMetaAnnotations
 }

--- a/pkg/corerp/renderers/httproute/render_test.go
+++ b/pkg/corerp/renderers/httproute/render_test.go
@@ -134,6 +134,7 @@ func TestHTTPRouteRenderer(t *testing.T) {
 				require.Equal(t, tt.expectedMaps.metaLbl, service.Labels)
 			} else {
 				require.Equal(t, kubernetes.MakeDescriptiveLabels(applicationName, resourceName, resource.ResourceTypeName()), service.Labels)
+				require.Nil(t, service.Annotations)
 			}
 		})
 	}
@@ -166,14 +167,13 @@ func makeResource(t *testing.T, properties *datamodel.HTTPRouteProperties) *data
 
 func getRenderOptions(opt int) renderers.RenderOptions {
 	/*
-		opt: 0 - no KubeMetadata
-		opt: 1 - env KubeMetadata
-		opt: 2 - env and app KubeMetadata
+		opt: 1 - Env KubeMetadata
+		opt: 2 - Env and App KubeMetadata
 	*/
 
 	dependencies := map[string]renderers.RendererDependency{}
 	option := renderers.RenderOptions{Dependencies: dependencies}
-	if opt == 0 {
+	if !(opt == 1 || opt == 2) {
 		return option
 	}
 
@@ -257,7 +257,6 @@ func getExpectedMaps(envOnly bool) *expectedMaps {
 		metaLbl["app.lbl1"] = "app.lblval1"
 		metaLbl["app.lbl2"] = "app.lblval2"
 		metaLbl["test.lbl1"] = "override.app.lblval1"
-
 	}
 
 	return &expectedMaps{

--- a/pkg/corerp/renderers/httproute/render_test.go
+++ b/pkg/corerp/renderers/httproute/render_test.go
@@ -1,8 +1,3 @@
-// ------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
-
 package httproute
 
 import (
@@ -30,157 +25,120 @@ const (
 	applicationPath = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/"
 )
 
+type setupMaps struct {
+	envKubeMetadataExt *datamodel.KubeMetadataExtension
+	appKubeMetadataExt *datamodel.KubeMetadataExtension
+}
+
+type expectedMaps struct {
+	metaAnn map[string]string
+	metaLbl map[string]string
+}
+
 func createContext(t *testing.T) context.Context {
 	logger, err := ucplog.NewTestLogger(t)
 	if err != nil {
 		t.Log("Unable to initialize logger")
 		return context.Background()
 	}
+
 	return logr.NewContext(context.Background(), logger)
+}
+
+func TestHTTPRouteRenderer(t *testing.T) {
+	tests := []struct {
+		name         string
+		port         int32
+		options      renderers.RenderOptions
+		setupMaps    *setupMaps
+		expectedMaps *expectedMaps
+	}{
+		{
+			name:         "WithPort",
+			port:         6379,
+			options:      getRenderOptions(0),
+			setupMaps:    nil,
+			expectedMaps: nil,
+		},
+		{
+			name:         "WithDefaultPort",
+			port:         renderers.DefaultPort,
+			options:      getRenderOptions(0),
+			setupMaps:    nil,
+			expectedMaps: nil,
+		},
+		{
+			name:         "WithEnvKME",
+			port:         renderers.DefaultPort,
+			options:      getRenderOptions(1),
+			setupMaps:    getSetUpMaps(true),
+			expectedMaps: getExpectedMaps(true),
+		},
+		{
+			name:         "WithEnvAppKME",
+			port:         renderers.DefaultPort,
+			options:      getRenderOptions(2),
+			setupMaps:    getSetUpMaps(false),
+			expectedMaps: getExpectedMaps(false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Renderer{}
+
+			properties := makeHTTPRouteProperties(tt.port)
+			resource := makeResource(t, &properties)
+
+			output, err := r.Render(context.Background(), resource, tt.options)
+			require.NoError(t, err)
+			require.Len(t, output.Resources, 1)
+			require.Empty(t, output.SecretValues)
+
+			expectedServicePort := corev1.ServicePort{
+				Name:       resourceName,
+				Port:       tt.port,
+				TargetPort: intstr.FromString(kubernetes.GetShortenedTargetPortName(ResourceTypeSuffix + resource.Name)),
+				Protocol:   "TCP",
+			}
+			expectedValues := map[string]rpv1.ComputedValueReference{
+				"hostname": {Value: kubernetes.NormalizeResourceName(resourceName)},
+				"port":     {Value: tt.port},
+				"scheme":   {Value: "http"},
+				"url":      {Value: fmt.Sprintf("http://%s:%d", kubernetes.NormalizeResourceName(resourceName), tt.port)},
+			}
+
+			require.Equal(t, expectedValues, output.ComputedValues)
+
+			service, outputResource := kubernetes.FindService(output.Resources)
+			expectedOutputResource := rpv1.NewKubernetesOutputResource(resourcekinds.Service, rpv1.LocalIDService, service, service.ObjectMeta)
+
+			require.Equal(t, expectedOutputResource, outputResource)
+			require.Equal(t, kubernetes.NormalizeResourceName(resource.Name), service.Name)
+			require.Equal(t, "", service.Namespace)
+			require.Equal(t, kubernetes.MakeRouteSelectorLabels(applicationName, ResourceTypeSuffix, resourceName), service.Spec.Selector)
+			require.Equal(t, corev1.ServiceTypeClusterIP, service.Spec.Type)
+			require.Len(t, service.Spec.Ports, 1)
+
+			servicePort := service.Spec.Ports[0]
+			require.Equal(t, expectedServicePort, servicePort)
+
+			// Check values of labels and annotations
+			if tt.expectedMaps != nil {
+				require.Equal(t, tt.expectedMaps.metaAnn, service.Annotations)
+				require.Equal(t, tt.expectedMaps.metaLbl, service.Labels)
+			} else {
+				require.Equal(t, kubernetes.MakeDescriptiveLabels(applicationName, resourceName, resource.ResourceTypeName()), service.Labels)
+			}
+		})
+	}
 }
 
 func Test_GetDependencyIDs_Empty(t *testing.T) {
 	r := &Renderer{}
-
 	dependencies, _, err := r.GetDependencyIDs(createContext(t), &datamodel.HTTPRoute{})
 	require.NoError(t, err)
 	require.Empty(t, dependencies)
-}
-
-func Test_Render_WithPort(t *testing.T) {
-	r := &Renderer{}
-	var port int32 = 6379
-
-	dependencies := map[string]renderers.RendererDependency{}
-	properties := makeHTTPRouteProperties(port)
-	resource := makeResource(t, &properties)
-
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: renderers.EnvironmentOptions{}})
-	require.NoError(t, err)
-	require.Len(t, output.Resources, 1)
-	require.Empty(t, output.SecretValues)
-
-	expectedValues := map[string]rpv1.ComputedValueReference{
-		"hostname": {Value: kubernetes.NormalizeResourceName(resourceName)},
-		"port":     {Value: port},
-		"scheme":   {Value: "http"},
-		"url":      {Value: fmt.Sprintf("http://%s:%d", kubernetes.NormalizeResourceName(resourceName), port)},
-	}
-	require.Equal(t, expectedValues, output.ComputedValues)
-
-	service, outputResource := kubernetes.FindService(output.Resources)
-
-	expectedOutputResource := rpv1.NewKubernetesOutputResource(resourcekinds.Service, rpv1.LocalIDService, service, service.ObjectMeta)
-	require.Equal(t, expectedOutputResource, outputResource)
-
-	require.Equal(t, kubernetes.NormalizeResourceName(resource.Name), service.Name)
-	require.Equal(t, "", service.Namespace)
-	require.Equal(t, kubernetes.MakeDescriptiveLabels(applicationName, resourceName, resource.ResourceTypeName()), service.Labels)
-
-	require.Equal(t, kubernetes.MakeRouteSelectorLabels(applicationName, ResourceTypeSuffix, resourceName), service.Spec.Selector)
-	require.Equal(t, corev1.ServiceTypeClusterIP, service.Spec.Type)
-
-	require.Len(t, service.Spec.Ports, 1)
-	servicePort := service.Spec.Ports[0]
-
-	expectedServicePort := corev1.ServicePort{
-		Name:       resourceName,
-		Port:       port,
-		TargetPort: intstr.FromString(kubernetes.GetShortenedTargetPortName(ResourceTypeSuffix + resource.Name)),
-		Protocol:   "TCP",
-	}
-	require.Equal(t, expectedServicePort, servicePort)
-}
-
-func Test_Render_WithDefaultPort(t *testing.T) {
-	r := &Renderer{}
-
-	defaultPort := renderers.DefaultPort
-	dependencies := map[string]renderers.RendererDependency{}
-	properties := makeHTTPRouteProperties(defaultPort)
-	resource := makeResource(t, &properties)
-
-	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: renderers.EnvironmentOptions{}})
-	require.NoError(t, err)
-	require.Len(t, output.Resources, 1)
-	require.Empty(t, output.SecretValues)
-
-	expectedValues := map[string]rpv1.ComputedValueReference{
-		"hostname": {Value: kubernetes.NormalizeResourceName(resourceName)},
-		"port":     {Value: defaultPort},
-		"scheme":   {Value: "http"},
-		"url":      {Value: fmt.Sprintf("http://%s:%d", kubernetes.NormalizeResourceName(resourceName), defaultPort)},
-	}
-	require.Equal(t, expectedValues, output.ComputedValues)
-
-	service, outputResource := kubernetes.FindService(output.Resources)
-
-	expectedOutputResource := rpv1.NewKubernetesOutputResource(resourcekinds.Service, rpv1.LocalIDService, service, service.ObjectMeta)
-	require.Equal(t, expectedOutputResource, outputResource)
-
-	require.Equal(t, kubernetes.NormalizeResourceName(resource.Name), service.Name)
-	require.Equal(t, "", service.Namespace)
-	require.Equal(t, kubernetes.MakeDescriptiveLabels(applicationName, resourceName, resource.ResourceTypeName()), service.Labels)
-
-	require.Equal(t, kubernetes.MakeRouteSelectorLabels(applicationName, ResourceTypeSuffix, resourceName), service.Spec.Selector)
-	require.Equal(t, corev1.ServiceTypeClusterIP, service.Spec.Type)
-
-	require.Len(t, service.Spec.Ports, 1)
-	port := service.Spec.Ports[0]
-
-	expectedPort := corev1.ServicePort{
-		Name:       resourceName,
-		Port:       defaultPort,
-		TargetPort: intstr.FromString(kubernetes.GetShortenedTargetPortName(ResourceTypeSuffix + resource.Name)),
-		Protocol:   "TCP",
-	}
-	require.Equal(t, expectedPort, port)
-}
-
-func Test_Render_WithNameSpace(t *testing.T) {
-	r := &Renderer{}
-
-	defaultPort := renderers.DefaultPort
-	dependencies := map[string]renderers.RendererDependency{}
-	properties := makeHTTPRouteProperties(defaultPort)
-	resource := makeResource(t, &properties)
-	options := renderers.RenderOptions{Dependencies: dependencies, Environment: renderers.EnvironmentOptions{Namespace: "testNamespace"}}
-
-	output, err := r.Render(context.Background(), resource, options)
-	require.NoError(t, err)
-	require.Len(t, output.Resources, 1)
-	require.Empty(t, output.SecretValues)
-
-	expectedValues := map[string]rpv1.ComputedValueReference{
-		"hostname": {Value: kubernetes.NormalizeResourceName(resourceName)},
-		"port":     {Value: defaultPort},
-		"scheme":   {Value: "http"},
-		"url":      {Value: fmt.Sprintf("http://%s:%d", kubernetes.NormalizeResourceName(resourceName), defaultPort)},
-	}
-	require.Equal(t, expectedValues, output.ComputedValues)
-
-	service, outputResource := kubernetes.FindService(output.Resources)
-
-	expectedOutputResource := rpv1.NewKubernetesOutputResource(resourcekinds.Service, rpv1.LocalIDService, service, service.ObjectMeta)
-	require.Equal(t, expectedOutputResource, outputResource)
-
-	require.Equal(t, kubernetes.NormalizeResourceName(resource.Name), service.Name)
-	require.Equal(t, options.Environment.Namespace, service.Namespace)
-	require.Equal(t, kubernetes.MakeDescriptiveLabels(applicationName, resourceName, resource.ResourceTypeName()), service.Labels)
-
-	require.Equal(t, kubernetes.MakeRouteSelectorLabels(applicationName, ResourceTypeSuffix, resourceName), service.Spec.Selector)
-	require.Equal(t, corev1.ServiceTypeClusterIP, service.Spec.Type)
-
-	require.Len(t, service.Spec.Ports, 1)
-	port := service.Spec.Ports[0]
-
-	expectedPort := corev1.ServicePort{
-		Name:       resourceName,
-		Port:       defaultPort,
-		TargetPort: intstr.FromString(kubernetes.GetShortenedTargetPortName(ResourceTypeSuffix + resource.Name)),
-		Protocol:   "TCP",
-	}
-	require.Equal(t, expectedPort, port)
 }
 
 func makeHTTPRouteProperties(port int32) datamodel.HTTPRouteProperties {
@@ -197,5 +155,108 @@ func makeHTTPRouteProperties(port int32) datamodel.HTTPRouteProperties {
 func makeResource(t *testing.T, properties *datamodel.HTTPRouteProperties) *datamodel.HTTPRoute {
 	dm := datamodel.HTTPRoute{Properties: properties}
 	dm.Name = resourceName
+
 	return &dm
+}
+
+func getRenderOptions(opt int) renderers.RenderOptions {
+	/*
+		opt: 0 - no KubeMetadata
+		opt: 1 - env KubeMetadata
+		opt: 2 - env and app KubeMetadata
+	*/
+
+	dependencies := map[string]renderers.RendererDependency{}
+	option := renderers.RenderOptions{Dependencies: dependencies}
+	if opt == 0 {
+		return option
+	}
+
+	option.Environment = renderers.EnvironmentOptions{
+		KubernetesMetadata: &datamodel.KubeMetadataExtension{
+			Annotations: getSetUpMaps(true).envKubeMetadataExt.Annotations,
+			Labels:      getSetUpMaps(true).envKubeMetadataExt.Labels,
+		}}
+
+	if opt == 2 {
+		option.Application = renderers.ApplicationOptions{
+			KubernetesMetadata: &datamodel.KubeMetadataExtension{
+				Annotations: getSetUpMaps(false).appKubeMetadataExt.Annotations,
+				Labels:      getSetUpMaps(false).appKubeMetadataExt.Labels,
+			}}
+	}
+
+	return option
+}
+
+func getSetUpMaps(envOnly bool) *setupMaps {
+	setupMap := setupMaps{}
+
+	envKubeMetadataExt := &datamodel.KubeMetadataExtension{
+		Annotations: map[string]string{
+			"env.ann1":  "env.annval1",
+			"env.ann2":  "env.annval2",
+			"test.ann1": "env.annval1",
+		},
+		Labels: map[string]string{
+			"env.lbl1":  "env.lblval1",
+			"env.lbl2":  "env.lblval2",
+			"test.lbl1": "env.lblval1",
+		},
+	}
+	appKubeMetadataExt := &datamodel.KubeMetadataExtension{
+		Annotations: map[string]string{
+			"app.ann1":  "app.annval1",
+			"app.ann2":  "app.annval2",
+			"test.ann1": "override.app.annval1",
+		},
+		Labels: map[string]string{
+			"app.lbl1":  "app.lblval1",
+			"app.lbl2":  "app.lblval2",
+			"test.lbl1": "override.app.lblval1",
+		},
+	}
+
+	setupMap.envKubeMetadataExt = envKubeMetadataExt
+
+	if !envOnly {
+		setupMap.appKubeMetadataExt = appKubeMetadataExt
+	}
+
+	return &setupMap
+}
+
+func getExpectedMaps(envOnly bool) *expectedMaps {
+	metaAnn := map[string]string{
+		"env.ann1":  "env.annval1",
+		"env.ann2":  "env.annval2",
+		"test.ann1": "env.annval1",
+	}
+	metaLbl := map[string]string{
+		"env.lbl1":                     "env.lblval1",
+		"env.lbl2":                     "env.lblval2",
+		"test.lbl1":                    "env.lblval1",
+		"app.kubernetes.io/managed-by": "radius-rp",
+		"app.kubernetes.io/name":       "test-route",
+		"app.kubernetes.io/part-of":    "test-application",
+		"radius.dev/application":       "test-application",
+		"radius.dev/resource":          "test-route",
+		"radius.dev/resource-type":     "applications.core-httproutes",
+	}
+
+	if !envOnly {
+		metaAnn["app.ann1"] = "app.annval1"
+		metaAnn["app.ann2"] = "app.annval2"
+		metaAnn["test.ann1"] = "override.app.annval1"
+
+		metaLbl["app.lbl1"] = "app.lblval1"
+		metaLbl["app.lbl2"] = "app.lblval2"
+		metaLbl["test.lbl1"] = "override.app.lblval1"
+
+	}
+
+	return &expectedMaps{
+		metaAnn: metaAnn,
+		metaLbl: metaLbl,
+	}
 }

--- a/pkg/corerp/renderers/httproute/render_test.go
+++ b/pkg/corerp/renderers/httproute/render_test.go
@@ -1,3 +1,8 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
 package httproute
 
 import (

--- a/pkg/corerp/renderers/httproute/render_test.go
+++ b/pkg/corerp/renderers/httproute/render_test.go
@@ -98,28 +98,28 @@ func TestHTTPRouteRenderer(t *testing.T) {
 		expectedMaps *expectedMaps
 	}{
 		{
-			name:         "WithPort",
+			name:         "Test_Port",
 			port:         6379,
 			options:      getRenderOptions(0),
 			setupMaps:    nil,
 			expectedMaps: nil,
 		},
 		{
-			name:         "WithDefaultPort",
+			name:         "Test_DefaultPort",
 			port:         renderers.DefaultPort,
 			options:      getRenderOptions(0),
 			setupMaps:    nil,
 			expectedMaps: nil,
 		},
 		{
-			name:         "WithEnvKME",
+			name:         "Test_With_Environment_Kubernetes_Metadata",
 			port:         renderers.DefaultPort,
 			options:      getRenderOptions(1),
 			setupMaps:    getSetUpMaps(true),
 			expectedMaps: getExpectedMaps(true),
 		},
 		{
-			name:         "WithEnvAppKME",
+			name:         "Test_With_Environment_Application_Kubernetes_Metadata",
 			port:         renderers.DefaultPort,
 			options:      getRenderOptions(2),
 			setupMaps:    getSetUpMaps(false),

--- a/pkg/corerp/renderers/httproute/render_test.go
+++ b/pkg/corerp/renderers/httproute/render_test.go
@@ -28,6 +28,45 @@ const (
 	applicationName = "test-application"
 	resourceName    = "test-route"
 	applicationPath = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/"
+
+	// User Inputs for testing
+	envAnnotationKey1 = "env.ann1"
+	envAnnotationKey2 = "env.ann2"
+	envAnnotationVal1 = "env.annval1"
+	envAnnotationVal2 = "env.annval2"
+
+	envLabelKey1 = "env.lbl1"
+	envLabelKey2 = "env.lbl2"
+	envLabelVal1 = "env.lblval1"
+	envLabelVal2 = "env.lblval2"
+
+	appAnnotationKey1 = "app.ann1"
+	appAnnotationKey2 = "app.ann2"
+	appAnnotationVal1 = "app.annval1"
+	appAnnotationVal2 = "app.annval2"
+
+	appLabelKey1 = "app.lbl1"
+	appLabelKey2 = "app.lbl2"
+	appLabelVal1 = "env.lblval1"
+	appLabelVal2 = "env.lblval2"
+
+	overrideKey1 = "test.ann1"
+	overrideKey2 = "test.lbl1"
+	overrideVal1 = "override.app.annval1"
+	overrideVal2 = "override.app.lblval1"
+
+	managedbyKey    = "app.kubernetes.io/managed-by"
+	managedbyVal    = "radius-rp"
+	nameKey         = "app.kubernetes.io/name"
+	nameVal         = "test-route"
+	partofKey       = "app.kubernetes.io/part-of"
+	partofVal       = "test-application"
+	appKey          = "radius.dev/application"
+	appVal          = "test-application"
+	resourceKey     = "radius.dev/resource"
+	resourceVal     = "test-route"
+	resourcetypeKey = "radius.dev/resource-type"
+	resourcetypeVal = "applications.core-httproutes"
 )
 
 type setupMaps struct {
@@ -199,26 +238,26 @@ func getSetUpMaps(envOnly bool) *setupMaps {
 
 	envKubeMetadataExt := &datamodel.KubeMetadataExtension{
 		Annotations: map[string]string{
-			"env.ann1":  "env.annval1",
-			"env.ann2":  "env.annval2",
-			"test.ann1": "env.annval1",
+			envAnnotationKey1: envAnnotationVal1,
+			envAnnotationKey2: envAnnotationVal2,
+			overrideKey1:      envAnnotationVal1,
 		},
 		Labels: map[string]string{
-			"env.lbl1":  "env.lblval1",
-			"env.lbl2":  "env.lblval2",
-			"test.lbl1": "env.lblval1",
+			envLabelKey1: envLabelVal1,
+			envLabelKey2: envLabelVal2,
+			overrideKey2: envLabelVal1,
 		},
 	}
 	appKubeMetadataExt := &datamodel.KubeMetadataExtension{
 		Annotations: map[string]string{
-			"app.ann1":  "app.annval1",
-			"app.ann2":  "app.annval2",
-			"test.ann1": "override.app.annval1",
+			appAnnotationKey1: appAnnotationVal1,
+			appAnnotationKey2: appAnnotationVal2,
+			overrideKey1:      overrideVal1,
 		},
 		Labels: map[string]string{
-			"app.lbl1":  "app.lblval1",
-			"app.lbl2":  "app.lblval2",
-			"test.lbl1": "override.app.lblval1",
+			appLabelKey1: appLabelVal1,
+			appLabelKey2: appLabelVal2,
+			overrideKey2: overrideVal2,
 		},
 	}
 
@@ -233,30 +272,30 @@ func getSetUpMaps(envOnly bool) *setupMaps {
 
 func getExpectedMaps(envOnly bool) *expectedMaps {
 	metaAnn := map[string]string{
-		"env.ann1":  "env.annval1",
-		"env.ann2":  "env.annval2",
-		"test.ann1": "env.annval1",
+		envAnnotationKey1: envAnnotationVal1,
+		envAnnotationKey2: envAnnotationVal2,
+		overrideKey1:      envAnnotationVal1,
 	}
 	metaLbl := map[string]string{
-		"env.lbl1":                     "env.lblval1",
-		"env.lbl2":                     "env.lblval2",
-		"test.lbl1":                    "env.lblval1",
-		"app.kubernetes.io/managed-by": "radius-rp",
-		"app.kubernetes.io/name":       "test-route",
-		"app.kubernetes.io/part-of":    "test-application",
-		"radius.dev/application":       "test-application",
-		"radius.dev/resource":          "test-route",
-		"radius.dev/resource-type":     "applications.core-httproutes",
+		envLabelKey1:    envLabelVal1,
+		envLabelKey2:    envLabelVal2,
+		overrideKey2:    envLabelVal1,
+		managedbyKey:    managedbyVal,
+		nameKey:         nameVal,
+		partofKey:       partofVal,
+		appKey:          appVal,
+		resourceKey:     resourceVal,
+		resourcetypeKey: resourcetypeVal,
 	}
 
 	if !envOnly {
-		metaAnn["app.ann1"] = "app.annval1"
-		metaAnn["app.ann2"] = "app.annval2"
-		metaAnn["test.ann1"] = "override.app.annval1"
+		metaAnn[appAnnotationKey1] = appAnnotationVal1
+		metaAnn[appAnnotationKey2] = appAnnotationVal2
+		metaAnn[overrideKey1] = overrideVal1
 
-		metaLbl["app.lbl1"] = "app.lblval1"
-		metaLbl["app.lbl2"] = "app.lblval2"
-		metaLbl["test.lbl1"] = "override.app.lblval1"
+		metaLbl[appLabelKey1] = appLabelVal1
+		metaLbl[appLabelKey2] = appLabelVal2
+		metaLbl[overrideKey2] = overrideVal2
 	}
 
 	return &expectedMaps{

--- a/pkg/corerp/renderers/httproute/render_test.go
+++ b/pkg/corerp/renderers/httproute/render_test.go
@@ -29,7 +29,7 @@ const (
 	resourceName    = "test-route"
 	applicationPath = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/"
 
-	// User Inputs for testing
+	// User Inputs for testing labels and annotations
 	envAnnotationKey1 = "env.ann1"
 	envAnnotationKey2 = "env.ann2"
 	envAnnotationVal1 = "env.annval1"

--- a/pkg/corerp/renderers/kubernetesmetadata/render.go
+++ b/pkg/corerp/renderers/kubernetesmetadata/render.go
@@ -89,7 +89,7 @@ func (r *Renderer) Render(ctx context.Context, dm v1.DataModelInterface, options
 			annMap.EnvMap = envOpts.KubernetesMetadata.Annotations
 		}
 		if appKmeExists && appOpts.KubernetesMetadata.Annotations != nil {
-			annMap.AppMap = envOpts.KubernetesMetadata.Annotations
+			annMap.AppMap = appOpts.KubernetesMetadata.Annotations
 		}
 
 		// Merge cumulative annotation values from Env->App->Container->InputExt kubernetes metadata. In case of collisions, rightmost entity wins
@@ -110,10 +110,10 @@ func (r *Renderer) Render(ctx context.Context, dm v1.DataModelInterface, options
 		}
 
 		if envKmeExists && envOpts.KubernetesMetadata.Labels != nil {
-			annMap.EnvMap = envOpts.KubernetesMetadata.Labels
+			lblMap.EnvMap = envOpts.KubernetesMetadata.Labels
 		}
 		if appKmeExists && appOpts.KubernetesMetadata.Labels != nil {
-			annMap.AppMap = envOpts.KubernetesMetadata.Labels
+			lblMap.AppMap = appOpts.KubernetesMetadata.Labels
 		}
 
 		// Merge cumulative label values from Env->App->Container->InputExt kubernetes metadata. In case of collisions, rightmost entity wins

--- a/pkg/corerp/renderers/kubernetesmetadata/render.go
+++ b/pkg/corerp/renderers/kubernetesmetadata/render.go
@@ -76,8 +76,8 @@ func processAnnotations(ctx context.Context, options renderers.RenderOptions, de
 
 	//Create KubernetesMetadata struct to merge annotations
 	ann := &kube.Metadata{
-		CurrObjectMeta: existingMetaAnnotations,
-		CurrSpec:       existingSpecAnnotations,
+		ObjectMetadata: existingMetaAnnotations,
+		SpecData:       existingSpecAnnotations,
 	}
 
 	if kubeMetadataExt != nil && kubeMetadataExt.Annotations != nil {
@@ -94,8 +94,8 @@ func processAnnotations(ctx context.Context, options renderers.RenderOptions, de
 	}
 
 	// Merge cumulative annotation values from Env->App->Container->InputExt kubernetes metadata. In case of collisions, rightmost entity wins
-	updMetaAnnotations, updSpecAnnotations := ann.Merge(ctx)
-	setAnnotations(dep, updMetaAnnotations, updSpecAnnotations)
+	metaAnnotations, specAnnotations := ann.Merge(ctx)
+	setAnnotations(dep, metaAnnotations, specAnnotations)
 }
 
 func processLabels(ctx context.Context, options renderers.RenderOptions, dep *appsv1.Deployment, kubeMetadataExt *datamodel.KubeMetadataExtension) {
@@ -103,8 +103,8 @@ func processLabels(ctx context.Context, options renderers.RenderOptions, dep *ap
 
 	//Create KubernetesMetadata struct to merge labels
 	lbl := &kube.Metadata{
-		CurrObjectMeta: existingMetaLabels,
-		CurrSpec:       existingSpecLabels,
+		ObjectMetadata: existingMetaLabels,
+		SpecData:       existingSpecLabels,
 	}
 
 	if kubeMetadataExt != nil && kubeMetadataExt.Labels != nil {
@@ -121,8 +121,8 @@ func processLabels(ctx context.Context, options renderers.RenderOptions, dep *ap
 	}
 
 	// Merge cumulative label values from Env->App->Container->InputExt kubernetes metadata. In case of collisions, rightmost entity wins
-	updObjectMetaLabels, updSpecLabels := lbl.Merge(ctx)
-	setLabels(dep, updObjectMetaLabels, updSpecLabels)
+	metaLabels, specLabels := lbl.Merge(ctx)
+	setLabels(dep, metaLabels, specLabels)
 }
 
 func getAnnotations(dep *appsv1.Deployment) (map[string]string, map[string]string) {

--- a/pkg/corerp/renderers/kubernetesmetadata/render.go
+++ b/pkg/corerp/renderers/kubernetesmetadata/render.go
@@ -101,7 +101,7 @@ func processAnnotations(ctx context.Context, options renderers.RenderOptions, de
 func processLabels(ctx context.Context, options renderers.RenderOptions, dep *appsv1.Deployment, kubeMetadataExt *datamodel.KubeMetadataExtension) {
 	existingMetaLabels, existingSpecLabels := getLabels(dep)
 
-	//Create KubernetesMetadata struct to merge labels
+	// Create KubernetesMetadata struct to merge labels
 	lbl := &kube.Metadata{
 		ObjectMetadata: existingMetaLabels,
 		SpecData:       existingSpecLabels,

--- a/pkg/rp/kube/kubernetesmetadata.go
+++ b/pkg/rp/kube/kubernetesmetadata.go
@@ -17,11 +17,11 @@ import (
 // Metadata represents KubernetesMetadata data. It includes labels/annotations defined as KubernetesMetadataExtension at the
 // Environment/Application/Current Resource(Container eg.) level and pre-existing labels/annotations that may be present in the outputresource.
 type Metadata struct {
-	EnvData        map[string]string // Contains labels/annotations defined as a KubernetesMetadataExtension at the Environment level.
-	AppData        map[string]string // Contains labels/annotations defined as a KubernetesMetadataExtension at the Application level.
-	Input          map[string]string // Contains labels/annotations defined as a KubernetesMetadataExtension at the Current Resource level.
-	ObjectMetadata map[string]string // Contains labels/annotations that are in the outputresource at the ObjectMeta level.
-	SpecData       map[string]string // Contains labels/annotations that are in the outputresource at the Spec level.
+	EnvData        map[string]string // EnvData contains labels/annotations defined as a KubernetesMetadataExtension at the Environment level.
+	AppData        map[string]string // AppData contains labels/annotations defined as a KubernetesMetadataExtension at the Application level.
+	Input          map[string]string // Input contains labels/annotations defined as a KubernetesMetadataExtension at the Current Resource level.
+	ObjectMetadata map[string]string // ObjectMetadata contains labels/annotations that are in the outputresource at the ObjectMeta level.
+	SpecData       map[string]string // SpecData contains labels/annotations that are in the outputresource at the Spec level.
 }
 
 // Merge merges environment, application maps with current values and returns updated metaMap and specMap

--- a/pkg/rp/kube/kubernetesmetadata.go
+++ b/pkg/rp/kube/kubernetesmetadata.go
@@ -14,14 +14,19 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-// Metadata represents KubernetesMetadata data.
+// Metadata represents KubernetesMetadata data. It includes labels/annotations defined as KubernetesMetadataExtension at the
+// Environment/Application/Current Resource(Container eg.) level and pre-existing labels/annotations that may be present in the outputresource.
 type Metadata struct {
-	EnvData        map[string]string
-	AppData        map[string]string
-	Input          map[string]string
-	CurrObjectMeta map[string]string
-	CurrSpec       map[string]string
+	EnvData        map[string]string // Contains labels/annotations defined as a KubernetesMetadataExtension at the Environment level.
+	AppData        map[string]string // Contains labels/annotations defined as a KubernetesMetadataExtension at the Application level.
+	Input          map[string]string // Contains labels/annotations defined as a KubernetesMetadataExtension at the Current Resource level.
+	ObjectMetadata map[string]string // Contains labels/annotations that are in the outputresource at the ObjectMeta level.
+	SpecData       map[string]string // Contains labels/annotations that are in the outputresource at the Spec level.
 }
+
+// More info:
+// ObjectMeta: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+// Spec: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 
 // Merge merges environment, application maps with current values and returns updated metaMap and specMap
 func (km *Metadata) Merge(ctx context.Context) (map[string]string, map[string]string) {
@@ -40,11 +45,12 @@ func (km *Metadata) Merge(ctx context.Context) (map[string]string, map[string]st
 	km.Input = rejectReservedEntries(ctx, km.Input)
 
 	// Cumulative Env+App Labels (mergeMap) is now merged with new input map. Existing metaLabels and specLabels are subsequently merged with the result map.
+	// In case of collisions, rightmost entity wins
 	mergeMap = labels.Merge(mergeMap, km.Input)
-	updMetaMap := labels.Merge(km.CurrObjectMeta, mergeMap)
-	updSpecMap := labels.Merge(km.CurrSpec, mergeMap)
+	metaMap := labels.Merge(km.ObjectMetadata, mergeMap)
+	specMap := labels.Merge(km.SpecData, mergeMap)
 
-	return updMetaMap, updSpecMap
+	return metaMap, specMap
 }
 
 // rejectReservedEntries rejects custom user entries that would affect Radius reserved keys

--- a/pkg/rp/kube/kubernetesmetadata.go
+++ b/pkg/rp/kube/kubernetesmetadata.go
@@ -14,51 +14,50 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-// KubernetesMetadata represents KubernetesMetadata data which will be subsequently cascaded to the current resource.
-// Note: We have RenderOptions both in CoreRp and LinkRp. If/When we would want to consolidate them, we can then update this struct to use RenderOptions instead of env and app specific data.
-type KubernetesMetadataMap struct {
-	EnvMap      map[string]string
-	AppMap      map[string]string
-	InputMap    map[string]string
-	CurrMetaMap map[string]string
-	CurrSpecMap map[string]string
+// Metadata represents KubernetesMetadata data.
+type Metadata struct {
+	EnvData        map[string]string
+	AppData        map[string]string
+	Input          map[string]string
+	CurrObjectMeta map[string]string
+	CurrSpec       map[string]string
 }
 
 // MergeMaps merges environment, application maps with current values and returns updated metaMap and specMap
-func (km *KubernetesMetadataMap) Merge(ctx context.Context) (map[string]string, map[string]string) {
+func (km *Metadata) Merge(ctx context.Context) (map[string]string, map[string]string) {
 	mergeMap := map[string]string{}
 
-	if km.EnvMap != nil {
-		mergeMap = km.EnvMap
+	if km.EnvData != nil {
+		mergeMap = km.EnvData
 	}
-	if km.AppMap != nil {
+	if km.AppData != nil {
 		// mergeMap is now updated with merged map of env+app data.
-		mergeMap = labels.Merge(mergeMap, km.AppMap)
+		mergeMap = labels.Merge(mergeMap, km.AppData)
 	}
 
 	// Reject custom user entries that may affect Radius reserved keys.
 	mergeMap = rejectReservedEntries(ctx, mergeMap)
-	km.InputMap = rejectReservedEntries(ctx, km.InputMap)
+	km.Input = rejectReservedEntries(ctx, km.Input)
 
 	// Cumulative Env+App Labels (mergeMap) is now merged with new input map. Existing metaLabels and specLabels are subsequently merged with the result map.
-	mergeMap = labels.Merge(mergeMap, km.InputMap)
+	mergeMap = labels.Merge(mergeMap, km.Input)
 
-	updMetaMap := labels.Merge(km.CurrMetaMap, mergeMap)
-	updSpecMap := labels.Merge(km.CurrSpecMap, mergeMap)
+	updMetaMap := labels.Merge(km.CurrObjectMeta, mergeMap)
+	updSpecMap := labels.Merge(km.CurrSpec, mergeMap)
 
 	return updMetaMap, updSpecMap
 }
 
 // Reject custom user entries that would affect Radius reserved keys
-func rejectReservedEntries(ctx context.Context, InputMap map[string]string) map[string]string {
+func rejectReservedEntries(ctx context.Context, inputMap map[string]string) map[string]string {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
-	for k := range InputMap {
+	for k := range inputMap {
 		if strings.HasPrefix(k, kubernetes.RadiusDevPrefix) {
 			logger.Info("User provided label/annotation key starts with 'radius.dev/' and is not being applied", "key", k)
-			delete(InputMap, k)
+			delete(inputMap, k)
 		}
 	}
 
-	return InputMap
+	return inputMap
 }

--- a/pkg/rp/kube/kubernetesmetadata.go
+++ b/pkg/rp/kube/kubernetesmetadata.go
@@ -41,7 +41,6 @@ func (km *Metadata) Merge(ctx context.Context) (map[string]string, map[string]st
 
 	// Cumulative Env+App Labels (mergeMap) is now merged with new input map. Existing metaLabels and specLabels are subsequently merged with the result map.
 	mergeMap = labels.Merge(mergeMap, km.Input)
-
 	updMetaMap := labels.Merge(km.CurrObjectMeta, mergeMap)
 	updSpecMap := labels.Merge(km.CurrSpec, mergeMap)
 

--- a/pkg/rp/kube/kubernetesmetadata.go
+++ b/pkg/rp/kube/kubernetesmetadata.go
@@ -1,0 +1,64 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package kube
+
+import (
+	"context"
+	"strings"
+
+	"github.com/project-radius/radius/pkg/kubernetes"
+	"github.com/project-radius/radius/pkg/ucp/ucplog"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// KubernetesMetadata represents KubernetesMetadata data which will be subsequently cascaded to the current resource.
+// Note: We have RenderOptions both in CoreRp and LinkRp. If/When we would want to consolidate them, we can then update this struct to use RenderOptions instead of env and app specific data.
+type KubernetesMetadataMap struct {
+	EnvMap      map[string]string
+	AppMap      map[string]string
+	InputMap    map[string]string
+	CurrMetaMap map[string]string
+	CurrSpecMap map[string]string
+}
+
+// MergeMaps merges environment, application maps with current values and returns updated metaMap and specMap
+func (km *KubernetesMetadataMap) Merge(ctx context.Context) (map[string]string, map[string]string) {
+	mergeMap := map[string]string{}
+
+	if km.EnvMap != nil {
+		mergeMap = km.EnvMap
+	}
+	if km.AppMap != nil {
+		// mergeMap is now updated with merged map of env+app data.
+		mergeMap = labels.Merge(mergeMap, km.AppMap)
+	}
+
+	// Reject custom user entries that may affect Radius reserved keys.
+	mergeMap = rejectReservedEntries(ctx, mergeMap)
+	km.InputMap = rejectReservedEntries(ctx, km.InputMap)
+
+	// Cumulative Env+App Labels (mergeMap) is now merged with new input map. Existing metaLabels and specLabels are subsequently merged with the result map.
+	mergeMap = labels.Merge(mergeMap, km.InputMap)
+
+	updMetaMap := labels.Merge(km.CurrMetaMap, mergeMap)
+	updSpecMap := labels.Merge(km.CurrSpecMap, mergeMap)
+
+	return updMetaMap, updSpecMap
+}
+
+// Reject custom user entries that would affect Radius reserved keys
+func rejectReservedEntries(ctx context.Context, InputMap map[string]string) map[string]string {
+	logger := ucplog.FromContextOrDiscard(ctx)
+
+	for k := range InputMap {
+		if strings.HasPrefix(k, kubernetes.RadiusDevPrefix) {
+			logger.Info("User provided label/annotation key starts with 'radius.dev/' and is not being applied", "key", k)
+			delete(InputMap, k)
+		}
+	}
+
+	return InputMap
+}

--- a/pkg/rp/kube/kubernetesmetadata.go
+++ b/pkg/rp/kube/kubernetesmetadata.go
@@ -23,7 +23,7 @@ type Metadata struct {
 	CurrSpec       map[string]string
 }
 
-// MergeMaps merges environment, application maps with current values and returns updated metaMap and specMap
+// Merge merges environment, application maps with current values and returns updated metaMap and specMap
 func (km *Metadata) Merge(ctx context.Context) (map[string]string, map[string]string) {
 	mergeMap := map[string]string{}
 
@@ -48,7 +48,7 @@ func (km *Metadata) Merge(ctx context.Context) (map[string]string, map[string]st
 	return updMetaMap, updSpecMap
 }
 
-// Reject custom user entries that would affect Radius reserved keys
+// rejectReservedEntries rejects custom user entries that would affect Radius reserved keys
 func rejectReservedEntries(ctx context.Context, inputMap map[string]string) map[string]string {
 	logger := ucplog.FromContextOrDiscard(ctx)
 

--- a/test/functional/corerp/resources/kubemetadata_httproute_test.go
+++ b/test/functional/corerp/resources/kubemetadata_httproute_test.go
@@ -1,0 +1,85 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package resource_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/project-radius/radius/test/functional"
+	"github.com/project-radius/radius/test/functional/corerp"
+	"github.com/project-radius/radius/test/step"
+	"github.com/project-radius/radius/test/validation"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_KubeMetadataHTTPRoute(t *testing.T) {
+	template := "testdata/corerp-resources-httproute-kubernetesmetadata.bicep"
+	name := "corerp-app-rte-kme"
+	appNamespace := "corerp-ns-rte-kme-app"
+
+	expectedAnnotations := map[string]string{
+		"user.ann.1": "user.ann.val.1",
+		"user.ann.2": "user.ann.val.2",
+	}
+
+	expectedLabels := map[string]string{
+		"app.kubernetes.io/managed-by": "radius-rp",
+		"app.kubernetes.io/name":       "ctnr-rte-kme",
+		"app.kubernetes.io/part-of":    "corerp-app-rte-kme",
+		"radius.dev/application":       "corerp-app-rte-kme",
+		"radius.dev/resource":          "ctnr-rte-kme",
+		"radius.dev/resource-type":     "applications.core-httproutes",
+		"user.lbl.1":                   "user.lbl.val.1",
+		"user.lbl.2":                   "user.lbl.val.2",
+	}
+
+	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
+		{
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
+			CoreRPResources: &validation.CoreRPResourceSet{
+				Resources: []validation.CoreRPResource{
+					{
+						Name: name,
+						Type: validation.ApplicationsResource,
+					},
+					{
+						Name: "ctnr-rte-kme-ctnr",
+						Type: validation.ContainersResource,
+						App:  name,
+					},
+					{
+						Name: "ctnr-rte-kme",
+						Type: validation.HttpRoutesResource,
+						App:  name,
+					},
+				},
+			},
+			K8sObjects: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					appNamespace: {
+						validation.NewK8sPodForResource(name, "ctnr-rte-kme-ctnr"),
+						validation.NewK8sServiceForResource(name, "ctnr-rte-kme"),
+					},
+				},
+			},
+			PostStepVerify: func(ctx context.Context, t *testing.T, test corerp.CoreRPTest) {
+
+				// Verify service labels and annotations
+				service, err := test.Options.K8sClient.CoreV1().Services(appNamespace).Get(ctx, "ctnr-rte-kme", metav1.GetOptions{})
+				require.NoError(t, err)
+				require.NotNil(t, service)
+
+				require.True(t, isMapSubSet(expectedAnnotations, service.Annotations))
+				require.True(t, isMapSubSet(expectedLabels, service.Labels))
+
+			},
+		},
+	})
+
+	test.Test(t)
+}

--- a/test/functional/corerp/resources/kubemetadata_httproute_test.go
+++ b/test/functional/corerp/resources/kubemetadata_httproute_test.go
@@ -74,9 +74,8 @@ func Test_KubeMetadataHTTPRoute(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, service)
 
-				require.True(t, isMapSubSet(expectedAnnotations, service.Annotations))
-				require.True(t, isMapSubSet(expectedLabels, service.Labels))
-
+				require.Truef(t, isMapSubSet(expectedAnnotations, service.Annotations), "Annotations do not match. expected: %v, actual: %v", expectedAnnotations, service.Annotations)
+				require.Truef(t, isMapSubSet(expectedLabels, service.Labels), "Labels do not match. expected: %v, actual: %v", expectedLabels, service.Labels)
 			},
 		},
 	})

--- a/test/functional/corerp/resources/testdata/corerp-resources-httproute-kubernetesmetadata.bicep
+++ b/test/functional/corerp/resources/testdata/corerp-resources-httproute-kubernetesmetadata.bicep
@@ -1,0 +1,68 @@
+import radius as radius
+
+@description('Specifies the location for resources.')
+param location string = 'global'
+
+@description('Specifies the image of the container resource.')
+param magpieimage string
+
+@description('Specifies the port of the container resource.')
+param port int = 3000
+
+@description('Specifies the environment for resources.')
+param environment string
+
+resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
+  name: 'corerp-app-rte-kme'
+  location: location
+  properties: {
+    environment: environment
+    extensions: [
+      {
+          kind: 'kubernetesNamespace'
+          namespace: 'corerp-ns-rte-kme-app'
+      }
+      {
+        kind: 'kubernetesMetadata'
+        annotations: {
+          'user.ann.1': 'user.ann.val.1'
+          'user.ann.2': 'user.ann.val.2'
+        }
+        labels: {
+          'user.lbl.1': 'user.lbl.val.1'
+          'user.lbl.2': 'user.lbl.val.2'
+        }
+      }
+    ]
+  }
+}
+
+resource container 'Applications.Core/containers@2022-03-15-privatepreview' = {
+  name: 'ctnr-rte-kme-ctnr'
+  location: location
+  properties: {
+    application: app.id
+    container: {
+      image: magpieimage
+      env: {
+        rteUrl: httproute.properties.url
+      }
+      ports: {
+        web: {
+          containerPort: port
+          provides: httproute.id
+        }
+      }
+    }
+    connections: {}
+  }
+}
+
+resource httproute 'Applications.Core/httpRoutes@2022-03-15-privatepreview' = {
+  name: 'ctnr-rte-kme'
+  location: location
+  properties: {
+    application: app.id
+    port: port
+  }
+}


### PR DESCRIPTION
# Description
Implementation of extending KME functionality to HTTPRoute. Labels/Annotations set on Environment and/or Application are cascaded to HTTPRoute resources.

(Also refactored existing unit tests for HTTPRoute to tbl driven tests)

[ADO Link](https://dev.azure.com/azure-octo/Incubations/_sprints/taskboard/Team%20Beaker/Incubations/Radius/Sprint%2012?workitem=6383)
Issue Reference radius-project/core-team#1082

Fixes: radius-project/core-team#1082 (HTTPRoute. Separate PR for Gateway)

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
