### PR TITLE
Populate workload identity label to pod

### DIFF
--- a/pkg/corerp/renderers/container/azure/identity.go
+++ b/pkg/corerp/renderers/container/azure/identity.go
@@ -26,6 +26,10 @@ import (
 const (
 	azureWorkloadIdentityClientID = "azure.workload.identity/client-id"
 	azureWorkloadIdentityTenantID = "azure.workload.identity/tenant-id"
+
+	// AzureWorkloadIdentityUseKey represents the key of azure workload identity to enable in Pod and SA.
+	// https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html?highlight=azure.workload.identity#pod
+	AzureWorkloadIdentityUseKey = "azure.workload.identity/use"
 )
 
 // MakeManagedIdentity builds a user-assigned managed identity output resource.
@@ -158,7 +162,7 @@ func extractIdentityInfo(options *handlers.PutOptions) (clientID string, tenantI
 // MakeFederatedIdentitySA builds service account for the federated identity.
 func MakeFederatedIdentitySA(appName, name, namespace string, resource *datamodel.ContainerResource) *rpv1.OutputResource {
 	labels := kubernetes.MakeDescriptiveLabels(appName, resource.Name, resource.Type)
-	labels["azure.workload.identity/use"] = "true"
+	labels[AzureWorkloadIdentityUseKey] = "true"
 
 	sa := &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -413,6 +413,9 @@ func (r Renderer) makeDeployment(ctx context.Context, applicationName string, op
 		saAccount := azrenderer.MakeFederatedIdentitySA(applicationName, serviceAccountName, options.Environment.Namespace, resource)
 		outputResources = append(outputResources, *saAccount)
 
+		// This is required to enable workload identity.
+		podLabels[azrenderer.AzureWorkloadIdentityUseKey] = "true"
+
 		deps = append(deps, rpv1.Dependency{LocalID: rpv1.LocalIDServiceAccount})
 
 		// 4. Add RBAC resources to the dependencies.

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
 	"github.com/project-radius/radius/pkg/corerp/handlers"
 	"github.com/project-radius/radius/pkg/corerp/renderers"
+	azrenderer "github.com/project-radius/radius/pkg/corerp/renderers/container/azure"
 	azvolrenderer "github.com/project-radius/radius/pkg/corerp/renderers/volume/azure"
 	"github.com/project-radius/radius/pkg/kubernetes"
 	"github.com/project-radius/radius/pkg/resourcekinds"
@@ -1156,6 +1157,10 @@ func Test_Render_PersistentAzureKeyVaultVolumes(t *testing.T) {
 	require.Equal(t, deploymentSpec.Dependencies[3].LocalID, "KubernetesRole")
 	require.Equal(t, deploymentSpec.Dependencies[4].LocalID, "KubernetesRoleBinding")
 	require.Equal(t, deploymentSpec.Dependencies[5].LocalID, "Secret")
+
+	// Verify pod template
+	podTemplate := deploymentSpec.Resource.(*appsv1.Deployment).Spec.Template
+	require.Equal(t, "true", podTemplate.ObjectMeta.Labels[azrenderer.AzureWorkloadIdentityUseKey])
 
 	// Verify volume spec
 	volumes := deploymentSpec.Resource.(*appsv1.Deployment).Spec.Template.Spec.Volumes


### PR DESCRIPTION
# Description

Workload identity webhook controller 1.0.0 is released with the breaking change. The following label should be populated in Pod. 

```
azure.workload.identity/use: "true"
```

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #5348 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
