### PR TITLE
Ban functions that exit the process

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+# see https://golangci-lint.run/usage/configuration/ for documentation
+linters:
+  enable:
+  - forbidigo
+linters-settings:
+  forbidigo:
+    # Forbid the following identifiers (list of regexp)
+    #
+    # Add a comment to the offending line with '//nolint:forbidigo' to suppress the rule if
+    # you're working inside the main() function.
+    forbid:
+      # These APIs exit the process. These are OK to use in the main() function,
+      # and not ANYWHERE else.
+      - 'os\.Exit(# Do not use except for inside main(). Suppress this message with //nolint:forbidigo at the end of the line if it is correct.)?'
+      - 'log\.Fatal(f|ln)?(# Do not use except for inside main(). Suppress this message with //nolint:forbidigo at the end of the line if it is correct.)?'

--- a/cmd/appcore-async/main.go
+++ b/cmd/appcore-async/main.go
@@ -32,19 +32,19 @@ func main() {
 	defaultConfig := fmt.Sprintf("radius-%s.yaml", hostoptions.Environment())
 	flag.StringVar(&configFile, "config-file", defaultConfig, "The service configuration file.")
 	if configFile == "" {
-		log.Fatal("config-file is empty.")
+		log.Fatal("config-file is empty.") //nolint:forbidigo // this is OK inside the main function.
 	}
 
 	flag.Parse()
 
 	options, err := hostoptions.NewHostOptionsFromEnvironment(configFile)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 	}
 
 	logger, flush, err := ucplog.NewLogger(logging.AppCoreLoggerName, &options.Config.Logging)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 	}
 	defer flush()
 
@@ -95,7 +95,7 @@ func main() {
 	// gracefully, so just crash if that happens.
 	err = <-stopped
 	if err == nil {
-		os.Exit(0)
+		os.Exit(0) //nolint:forbidigo // this is OK inside the main function.
 	} else {
 		panic(err)
 	}

--- a/cmd/applink-rp/main.go
+++ b/cmd/applink-rp/main.go
@@ -39,14 +39,14 @@ func main() {
 	flag.BoolVar(&enableAsyncWorker, "enable-asyncworker", true, "Flag to run async request process worker (for private preview and dev/test purpose).")
 
 	if configFile == "" {
-		log.Fatal("config-file is empty.")
+		log.Fatal("config-file is empty.") //nolint:forbidigo // this is OK inside the main function.
 	}
 
 	flag.Parse()
 
 	options, err := hostoptions.NewHostOptionsFromEnvironment(configFile)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 	}
 	hostingSvc := []hosting.Service{frontend.NewService(options)}
 
@@ -58,7 +58,7 @@ func main() {
 
 	logger, flush, err := ucplog.NewLogger(logging.AppLinkLoggerName, &options.Config.Logging)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 	}
 	defer flush()
 
@@ -92,11 +92,11 @@ func main() {
 	tracerOpts.ServiceName = serviceName
 	shutdown, err := trace.InitTracer(tracerOpts)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 	}
 	defer func() {
 		if err := shutdown(ctx); err != nil {
-			log.Fatal("failed to shutdown TracerProvider: %w", err)
+			log.Printf("failed to shutdown TracerProvider: %v\n", err)
 		}
 
 	}()
@@ -121,7 +121,7 @@ func main() {
 	// gracefully, so just crash if that happens.
 	err = <-stopped
 	if err == nil {
-		os.Exit(0)
+		os.Exit(0) //nolint:forbidigo // this is OK inside the main function.
 	} else {
 		panic(err)
 	}

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -20,7 +20,7 @@ import (
 
 func main() {
 	if len(os.Args) != 2 {
-		log.Fatal("usage: go run cmd/docgen/main.go <output directory>")
+		log.Fatal("usage: go run cmd/docgen/main.go <output directory>") //nolint:forbidigo // this is OK inside the main function.
 	}
 
 	output := os.Args[1]
@@ -28,15 +28,15 @@ func main() {
 	if os.IsNotExist(err) {
 		err = os.Mkdir(output, 0755)
 		if err != nil {
-			log.Fatal(err)
+			log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 		}
 	} else if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 	}
 
 	err = doc.GenMarkdownTreeCustom(cmd.RootCmd, output, frontmatter, link)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 	}
 }
 

--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
@@ -105,15 +104,19 @@ func prettyPrintJSON(o any) (string, error) {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 // It also initializes the tracerprovider for cli.
-func Execute() {
+//
+// Execute returns true
+func Execute() error {
 	ctx := context.WithValue(context.Background(), ConfigHolderKey, ConfigHolder)
 
 	shutdown, err := trace.InitTracer(trace.Options{
 		ServiceName: serviceName,
 	})
 	if err != nil {
-		log.Fatal(err)
+		fmt.Println("Error:", err)
+		return err
 	}
+
 	defer func() {
 		_ = shutdown(ctx)
 	}()
@@ -126,12 +129,14 @@ func Execute() {
 	if errors.Is(&cli.FriendlyError{}, err) {
 		fmt.Println(err.Error())
 		fmt.Println("\nTraceId: ", span.SpanContext().TraceID().String())
-		os.Exit(1)
+		return err
 	} else if err != nil {
 		fmt.Println("Error:", prettyPrintRPError(err))
 		fmt.Println("\nTraceId: ", span.SpanContext().TraceID().String())
-		os.Exit(1)
+		return err
 	}
+
+	return nil
 }
 
 func init() {
@@ -246,7 +251,7 @@ func initConfig() {
 	v, err := cli.LoadConfig(ConfigHolder.ConfigFilePath)
 	if err != nil {
 		fmt.Printf("Error: failed to load config: %v\n", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // this is OK inside the CLI startup.
 	}
 
 	ConfigHolder.Config = v
@@ -254,13 +259,13 @@ func initConfig() {
 	wd, err := os.Getwd()
 	if err != nil {
 		fmt.Printf("Error: failed to find current working directory: %v\n", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // this is OK inside the CLI startup.
 	}
 
 	dc, err := config.LoadDirectoryConfig(wd)
 	if err != nil {
 		fmt.Printf("Error: failed to load config: %v\n", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // this is OK inside the CLI startup.
 	}
 
 	ConfigHolder.DirectoryConfig = dc

--- a/cmd/rad/main.go
+++ b/cmd/rad/main.go
@@ -6,9 +6,14 @@
 package main
 
 import (
+	"os"
+
 	"github.com/project-radius/radius/cmd/rad/cmd"
 )
 
 func main() {
-	cmd.Execute()
+	err := cmd.Execute()
+	if err == nil {
+		os.Exit(1) //nolint:forbidigo // this is OK inside the main function.
+	}
 }

--- a/cmd/ucpd/cmd/root.go
+++ b/cmd/ucpd/cmd/root.go
@@ -14,11 +14,11 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/project-radius/radius/pkg/trace"
+	"github.com/project-radius/radius/pkg/ucp/dataprovider"
+	"github.com/project-radius/radius/pkg/ucp/hosting"
 	"github.com/project-radius/radius/pkg/ucp/server"
 	"github.com/project-radius/radius/pkg/ucp/ucplog"
 	"github.com/spf13/cobra"
-	"github.com/project-radius/radius/pkg/ucp/dataprovider"
-	"github.com/project-radius/radius/pkg/ucp/hosting"
 	etcdclient "go.etcd.io/etcd/client/v3"
 )
 
@@ -34,7 +34,7 @@ var rootCmd = &cobra.Command{
 
 		logger, flush, err := ucplog.NewLogger(ucplog.LoggerName, &options.LoggingOptions)
 		if err != nil {
-			log.Fatal(err)
+			log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 		}
 		defer flush()
 
@@ -58,11 +58,11 @@ var rootCmd = &cobra.Command{
 		options.TracerProviderOptions.ServiceName = server.ServiceName
 		shutdown, err := trace.InitTracer(options.TracerProviderOptions)
 		if err != nil {
-			log.Fatal(err)
+			log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 		}
 		defer func() {
 			if err := shutdown(ctx); err != nil {
-				log.Fatal("failed to shutdown TracerProvider: %w", err)
+				log.Printf("failed to shutdown TracerProvider: %v\n", err)
 			}
 		}()
 
@@ -87,7 +87,7 @@ var rootCmd = &cobra.Command{
 		// gracefully, so just crash if that happens.
 		err = <-stopped
 		if err == nil {
-			os.Exit(0)
+			os.Exit(0) //nolint:forbidigo // this is OK inside the main function.
 		} else {
 			panic(err)
 		}

--- a/test/magpiego/bindings/keyvault.go
+++ b/test/magpiego/bindings/keyvault.go
@@ -40,7 +40,7 @@ func KeyVaultBinding(envParams map[string]string) BindingStatus {
 	// Get the secret
 	_, err = client.GetSecret(context.TODO(), "TestSecret", resp.ID.Version(), nil)
 	if err != nil {
-		log.Fatalf("failed to get the secret: %v", err)
+		log.Printf("failed to get the secret: %v\n", err)
 		return BindingStatus{false, "failed to get the secret"}
 	}
 

--- a/test/magpiego/main.go
+++ b/test/magpiego/main.go
@@ -23,6 +23,6 @@ func main() {
 	}
 	if err != nil {
 		log.Println("Terminating Magpie. Encountered error - ", err.Error())
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // this is OK inside the main function.
 	}
 }


### PR DESCRIPTION
This change uses golang-ci to ban usage of functions that exit the process. Namely `os.Exit` and `log.Fatal` (and similar). We've had problems where usage of these functions creeps into our reusable code causes bugs by skipping cleanup (`defer`) when an error condition is triggered.

The linter will flag ALL usages, so the right thing to do is add a supression on any correct usages (eg: in `main()`).

For all existing usages of these functions I did minor changes where possible to avoid them. When exiting the process is the correct thing to do, I added suppressions.

# Description

_Please explain the changes you've made._

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
