### PR TITLE
Set polling frequency for deletion to 5 sec

### DIFF
--- a/pkg/cli/ucp/ucp_management.go
+++ b/pkg/cli/ucp/ucp_management.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -22,6 +23,15 @@ import (
 	"github.com/project-radius/radius/pkg/linkrp"
 	ucpv20220901 "github.com/project-radius/radius/pkg/ucp/api/v20220901privatepreview"
 	"github.com/project-radius/radius/pkg/ucp/resources"
+)
+
+const (
+	// pollFrequency is the polling frequency used for put/delete operations.
+	//
+	// This is set to a relatively low number because we're inside the cluster. This is a good
+	// balance to feel responsible for quick operations without generating a wasteful amount of traffic.
+	// The default would be 30 seconds.
+	pollFrequency = time.Second * 5
 )
 
 type ARMApplicationsManagementClient struct {
@@ -160,7 +170,7 @@ func (amc *ARMApplicationsManagementClient) DeleteResource(ctx context.Context, 
 		return false, err
 	}
 
-	_, err = poller.PollUntilDone(ctx, nil)
+	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: pollFrequency})
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Fixes: #5164

This change sets the polling frequency of asynchronous delete operations to 5 seconds for UCP/Radius resources. Currently we can take a very long time to delete things due to the default polling interval of 30 seconds. Since this traffic is just to the user's Radius install we're not concerned about overwhelming the server with a 5 second interval.

I reviewed all of the other places in code where we use async operations as a client. The AWS and Azure resource code paths still use the 30 second interval. I didn't see a good reason to change this right now. Everywhere else in code we already use a 5 second interval (recipes) with the same justification.
