### PR TITLE
Add nightly test for CLI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
         run:
           echo "RAD_VERSION=$(curl https://get.radapp.dev/version/stable.txt)" >> $GITHUB_ENV
       - name: Download file
-        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/${{ matrix.os }}-${{ matrix.arch }}/{{ matrix.file }} --fail-with-body -o ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.file }}
+        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/${{ matrix.os }}-${{ matrix.arch }}/${{ matrix.file }} --fail-with-body -o ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.file }}
       - name: Test Linux x64
         if: ${{ matrix.os == 'linux' && matrix.arch == 'x64' }}
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,8 +16,9 @@ jobs:
     steps:
       - name: Download and parse latest version
         run:
-          export RAD_VERSION=$(curl https://get.radapp.dev/version/stable.txt)
-          echo "RAD_VERSION=$RAD_VERSION" >> $GITHUB_ENV
+          echo "RAD_VERSION=$(curl https://get.radapp.dev/version/stable.txt)" >> $GITHUB_ENV
+      - name: Print version
+        run: echo ${{ env.RAD_VERSION }}
       - name: Download macOS x64
         run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/macos-x64/rad  --fail-with-body -o rad-macos-x64
       - name: Download macOS arm64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download and parse latest version
-        run: export RAD_VERSION=$(curl https://get.radapp.dev/version/stable.txt)
+        run:
+          export RAD_VERSION=$(curl https://get.radapp.dev/version/stable.txt)
+          echo "RAD_VERSION=$RAD_VERSION" >> $GITHUB_ENV
       - name: Download macOS x64
         run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/macos-x64/rad -o rad-macos-x64
       - name: Download macOS arm64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,30 +13,40 @@ on:
 jobs:
   download:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: linux
+            arch: x64
+            file: rad
+          - os: linux
+            arch: arm64
+            file: rad
+          - os: linux
+            arch: arm
+            file: rad
+          - os: macos
+            arch: x64
+            file: rad
+          - os: macos
+            arch: arm64
+            file: rad
+          - os: windows
+            arch: x64
+            file: rad.exe
     steps:
       - name: Download and parse latest version
         run:
           echo "RAD_VERSION=$(curl https://get.radapp.dev/version/stable.txt)" >> $GITHUB_ENV
-      - name: Print version
-        run: echo ${{ env.RAD_VERSION }}
-      - name: Download macOS x64
-        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/macos-x64/rad  --fail-with-body -o rad-macos-x64
-      - name: Download macOS arm64
-        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/macos-arm64/rad  --fail-with-body -o rad-macos-arm64
-      - name: Download Linux arm64
-        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/linux-arm64/rad  --fail-with-body -o rad-linux-arm64
-      - name: Download Linux arm
-        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/linux-arm/rad  --fail-with-body -o rad-linux-arm
-      - name: Download Linux x64
-        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/linux-x64/rad  --fail-with-body -o rad-linux-x64
-      - name: Download Windows x64
-        run: curl -O https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/windows-x64/rad.exe --fail-with-body -o rad-windows-x64.exe
+      - name: Download file
+        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/{{ matrix.os }}-${{ matrix.arch }}/{{ matrix.file }} --fail-with-body -o {{ matrix.os }}-${{ matrix.arch }}-{{ matrix.file }}
       - name: Test Linux x64
+        if: ${{ matrix.os == 'linux' && matrix.arch == 'x64' }}
         run: |
-          chmod +x ./rad-linux-x64
-          ./rad-linux-x64 version
-      #- name: Create GitHub issue on failure
-        #if: ${{ failure() }}
-        #env:
-        #  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        #run: gh issue create --title "CLI nightly test failed" --body "Test failed on ${{ github.repository }}. See [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details." --repo ${{ github.repository }}
+          chmod +x ./{{ matrix.os }}-${{ matrix.arch }}-{{ matrix.file }}
+          ./{{ matrix.os }}-${{ matrix.arch }}-{{ matrix.file }} version
+      - name: Create GitHub issue on failure
+        if: ${{ failure() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh issue create --title "CLI nightly test failed" --body "Test failed on ${{ github.repository }}. See [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details." --repo ${{ github.repository }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,22 +15,21 @@ jobs:
           curl https://get.radapp.dev/version/stable.txt
           echo "RAD_VERSION=$(cat stable.txt)" >> $GITHUB_ENV
       - name: Download macOS x64
-        run: |
-          curl https://get.radapp.dev/tools/rad/$RAD_VERSION/macos-x64/rad -o rad-macos-x64
+        run: curl https://get.radapp.dev/tools/rad/$RAD_VERSION/macos-x64/rad -o rad-macos-x64
       - name: Download macOS arm64
-        run: |
-          curl https://get.radapp.dev/tools/rad/$RAD_VERSION/macos-arm64/rad -o rad-macos-arm64
+        run: curl https://get.radapp.dev/tools/rad/$RAD_VERSION/macos-arm64/rad -o rad-macos-arm64
       - name: Download Linux arm64
-        run: |
-          curl https://get.radapp.dev/tools/rad/$RAD_VERSION/linux-arm64/rad -o rad-linux-arm64
+        run: curl https://get.radapp.dev/tools/rad/$RAD_VERSION/linux-arm64/rad -o rad-linux-arm64
       - name: Download Linux arm
-        run: |
-          curl https://get.radapp.dev/tools/rad/$RAD_VERSION/linux-arm/rad -o rad-linux-arm
+        run: curl https://get.radapp.dev/tools/rad/$RAD_VERSION/linux-arm/rad -o rad-linux-arm
       - name: Download Linux x64
-        run: |
-          curl https://get.radapp.dev/tools/rad/$RAD_VERSION/linux-x64/rad -o rad-linux-x64
+        run: curl https://get.radapp.dev/tools/rad/$RAD_VERSION/linux-x64/rad -o rad-linux-x64
       - name: Download Windows x64
-        run: |
-          curl -O https://get.radapp.dev/tools/rad/$RAD_VERSION/windows-x64/rad.exe -o rad-windows-x64.exe
+        run: curl -O https://get.radapp.dev/tools/rad/$RAD_VERSION/windows-x64/rad.exe -o rad-windows-x64.exe
       - name: Test Linux x64
         run: ./rad-linux-x64 version
+      - name: Create GitHub issue on failure
+        if: ${{ failure() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh issue create --title "CLI nightly test failed" --body "Test failed on ${{ github.repository }}. See [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details." --repo ${{ github.repository }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,36 @@
+name: Nightly rad CLI tests
+
+on:
+  schedule:
+    # Run every day at 11:47 PM UTC
+    - cron: '47 23 * * *'
+  workflow_dispatch:
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download and parse latest version
+        run: |
+          curl https://get.radapp.dev/version/stable.txt
+          echo "RAD_VERSION=$(cat stable.txt)" >> $GITHUB_ENV
+      - name: Download macOS x64
+        run: |
+          curl https://get.radapp.dev/tools/rad/$RAD_VERSION/macos-x64/rad -o rad-macos-x64
+      - name: Download macOS arm64
+        run: |
+          curl https://get.radapp.dev/tools/rad/$RAD_VERSION/macos-arm64/rad -o rad-macos-arm64
+      - name: Download Linux arm64
+        run: |
+          curl https://get.radapp.dev/tools/rad/$RAD_VERSION/linux-arm64/rad -o rad-linux-arm64
+      - name: Download Linux arm
+        run: |
+          curl https://get.radapp.dev/tools/rad/$RAD_VERSION/linux-arm/rad -o rad-linux-arm
+      - name: Download Linux x64
+        run: |
+          curl https://get.radapp.dev/tools/rad/$RAD_VERSION/linux-x64/rad -o rad-linux-x64
+      - name: Download Windows x64
+        run: |
+          curl -O https://get.radapp.dev/tools/rad/$RAD_VERSION/windows-x64/rad.exe -o rad-windows-x64.exe
+      - name: Test Linux x64
+        run: ./rad-linux-x64 version

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,12 +39,12 @@ jobs:
         run:
           echo "RAD_VERSION=$(curl https://get.radapp.dev/version/stable.txt)" >> $GITHUB_ENV
       - name: Download file
-        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/{{ matrix.os }}-${{ matrix.arch }}/{{ matrix.file }} --fail-with-body -o {{ matrix.os }}-${{ matrix.arch }}-{{ matrix.file }}
+        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/${{ matrix.os }}-${{ matrix.arch }}/{{ matrix.file }} --fail-with-body -o ${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.file }}
       - name: Test Linux x64
         if: ${{ matrix.os == 'linux' && matrix.arch == 'x64' }}
         run: |
-          chmod +x ./{{ matrix.os }}-${{ matrix.arch }}-{{ matrix.file }}
-          ./{{ matrix.os }}-${{ matrix.arch }}-{{ matrix.file }} version
+          chmod +x ./${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.file }}
+          ./${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.file }} version
       - name: Create GitHub issue on failure
         if: ${{ failure() }}
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,4 +49,4 @@ jobs:
         if: ${{ failure() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh issue create --title "CLI nightly test failed" --body "Test failed on ${{ github.repository }}. See [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details." --repo ${{ github.repository }}
+        run: gh issue create --title "CLI nightly test failed - ${{ matrix.os }}-${{ matrix.arch }}" --body "Test failed on ${{ github.repository }} for ${{ matrix.os }}-${{ matrix.arch }}. See [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details." --repo ${{ github.repository }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,10 @@ on:
     # Run every day at 11:47 PM UTC
     - cron: '47 23 * * *'
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - .github/workflows/test.yaml
 
 jobs:
   download:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,17 +19,17 @@ jobs:
           curl https://get.radapp.dev/version/stable.txt
           echo "RAD_VERSION=$(cat stable.txt)" >> $GITHUB_ENV
       - name: Download macOS x64
-        run: curl https://get.radapp.dev/tools/rad/$RAD_VERSION/macos-x64/rad -o rad-macos-x64
+        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/macos-x64/rad -o rad-macos-x64
       - name: Download macOS arm64
-        run: curl https://get.radapp.dev/tools/rad/$RAD_VERSION/macos-arm64/rad -o rad-macos-arm64
+        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/macos-arm64/rad -o rad-macos-arm64
       - name: Download Linux arm64
-        run: curl https://get.radapp.dev/tools/rad/$RAD_VERSION/linux-arm64/rad -o rad-linux-arm64
+        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/linux-arm64/rad -o rad-linux-arm64
       - name: Download Linux arm
-        run: curl https://get.radapp.dev/tools/rad/$RAD_VERSION/linux-arm/rad -o rad-linux-arm
+        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/linux-arm/rad -o rad-linux-arm
       - name: Download Linux x64
-        run: curl https://get.radapp.dev/tools/rad/$RAD_VERSION/linux-x64/rad -o rad-linux-x64
+        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/linux-x64/rad -o rad-linux-x64
       - name: Download Windows x64
-        run: curl -O https://get.radapp.dev/tools/rad/$RAD_VERSION/windows-x64/rad.exe -o rad-windows-x64.exe
+        run: curl -O https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/windows-x64/rad.exe -o rad-windows-x64.exe
       - name: Test Linux x64
         run: |
           chmod +x ./rad-linux-x64
@@ -39,3 +39,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh issue create --title "CLI nightly test failed" --body "Test failed on ${{ github.repository }}. See [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details." --repo ${{ github.repository }}
+        

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,9 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download and parse latest version
-        run: |
-          curl https://get.radapp.dev/version/stable.txt
-          echo "RAD_VERSION=$(cat stable.txt)" >> $GITHUB_ENV
+        run: export RAD_VERSION=$(curl https://get.radapp.dev/version/stable.txt)
       - name: Download macOS x64
         run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/macos-x64/rad -o rad-macos-x64
       - name: Download macOS arm64
@@ -39,4 +37,3 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh issue create --title "CLI nightly test failed" --body "Test failed on ${{ github.repository }}. See [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details." --repo ${{ github.repository }}
-        

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,23 +19,23 @@ jobs:
           export RAD_VERSION=$(curl https://get.radapp.dev/version/stable.txt)
           echo "RAD_VERSION=$RAD_VERSION" >> $GITHUB_ENV
       - name: Download macOS x64
-        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/macos-x64/rad -o rad-macos-x64
+        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/macos-x64/rad  --fail-with-body -o rad-macos-x64
       - name: Download macOS arm64
-        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/macos-arm64/rad -o rad-macos-arm64
+        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/macos-arm64/rad  --fail-with-body -o rad-macos-arm64
       - name: Download Linux arm64
-        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/linux-arm64/rad -o rad-linux-arm64
+        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/linux-arm64/rad  --fail-with-body -o rad-linux-arm64
       - name: Download Linux arm
-        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/linux-arm/rad -o rad-linux-arm
+        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/linux-arm/rad  --fail-with-body -o rad-linux-arm
       - name: Download Linux x64
-        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/linux-x64/rad -o rad-linux-x64
+        run: curl https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/linux-x64/rad  --fail-with-body -o rad-linux-x64
       - name: Download Windows x64
-        run: curl -O https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/windows-x64/rad.exe -o rad-windows-x64.exe
+        run: curl -O https://get.radapp.dev/tools/rad/${{ env.RAD_VERSION }}/windows-x64/rad.exe --fail-with-body -o rad-windows-x64.exe
       - name: Test Linux x64
         run: |
           chmod +x ./rad-linux-x64
           ./rad-linux-x64 version
-      - name: Create GitHub issue on failure
-        if: ${{ failure() }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh issue create --title "CLI nightly test failed" --body "Test failed on ${{ github.repository }}. See [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details." --repo ${{ github.repository }}
+      #- name: Create GitHub issue on failure
+        #if: ${{ failure() }}
+        #env:
+        #  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        #run: gh issue create --title "CLI nightly test failed" --body "Test failed on ${{ github.repository }}. See [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details." --repo ${{ github.repository }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,9 @@ jobs:
       - name: Download Windows x64
         run: curl -O https://get.radapp.dev/tools/rad/$RAD_VERSION/windows-x64/rad.exe -o rad-windows-x64.exe
       - name: Test Linux x64
-        run: ./rad-linux-x64 version
+        run: |
+          chmod +x ./rad-linux-x64
+          ./rad-linux-x64 version
       - name: Create GitHub issue on failure
         if: ${{ failure() }}
         env:


### PR DESCRIPTION
# Description

Adds a new nightly test for CLI.

Downloads the CLI from the CDN and runs `rad version`.

