### PR TITLE
Revert "Revert "Ban functions that exit the process (#5359)" (#5365)"

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+# see https://golangci-lint.run/usage/configuration/ for documentation
+linters:
+  enable:
+  - forbidigo
+linters-settings:
+  forbidigo:
+    # Forbid the following identifiers (list of regexp)
+    #
+    # Add a comment to the offending line with '//nolint:forbidigo' to suppress the rule if
+    # you're working inside the main() function.
+    forbid:
+      # These APIs exit the process. These are OK to use in the main() function,
+      # and not ANYWHERE else.
+      - 'os\.Exit(# Do not use except for inside main(). Suppress this message with //nolint:forbidigo at the end of the line if it is correct.)?'
+      - 'log\.Fatal(f|ln)?(# Do not use except for inside main(). Suppress this message with //nolint:forbidigo at the end of the line if it is correct.)?'

--- a/cmd/appcore-async/main.go
+++ b/cmd/appcore-async/main.go
@@ -32,19 +32,19 @@ func main() {
 	defaultConfig := fmt.Sprintf("radius-%s.yaml", hostoptions.Environment())
 	flag.StringVar(&configFile, "config-file", defaultConfig, "The service configuration file.")
 	if configFile == "" {
-		log.Fatal("config-file is empty.")
+		log.Fatal("config-file is empty.") //nolint:forbidigo // this is OK inside the main function.
 	}
 
 	flag.Parse()
 
 	options, err := hostoptions.NewHostOptionsFromEnvironment(configFile)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 	}
 
 	logger, flush, err := ucplog.NewLogger(logging.AppCoreLoggerName, &options.Config.Logging)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 	}
 	defer flush()
 
@@ -95,7 +95,7 @@ func main() {
 	// gracefully, so just crash if that happens.
 	err = <-stopped
 	if err == nil {
-		os.Exit(0)
+		os.Exit(0) //nolint:forbidigo // this is OK inside the main function.
 	} else {
 		panic(err)
 	}

--- a/cmd/appcore-rp/main.go
+++ b/cmd/appcore-rp/main.go
@@ -34,18 +34,18 @@ import (
 
 const serviceName = "applications.core"
 
-func newLinkHosts(configFile string, enableAsyncWorker bool) ([]hosting.Service, *hostoptions.HostOptions) {
+func newLinkHosts(configFile string, enableAsyncWorker bool) ([]hosting.Service, *hostoptions.HostOptions, error) {
 	hostings := []hosting.Service{}
 	options, err := hostoptions.NewHostOptionsFromEnvironment(configFile)
 	if err != nil {
-		log.Fatal(err)
+		return nil, nil, err
 	}
 	hostings = append(hostings, link_frontend.NewService(options))
 	if enableAsyncWorker {
 		hostings = append(hostings, link_backend.NewService(options))
 	}
 
-	return hostings, &options
+	return hostings, &options, nil
 }
 
 func main() {
@@ -64,14 +64,14 @@ func main() {
 	flag.StringVar(&linkConfigFile, "link-config", defaultLinkConfig, "The service configuration file for Applications.Link.")
 
 	if configFile == "" {
-		log.Fatal("config-file is empty.")
+		log.Fatal("config-file is empty.") //nolint:forbidigo // this is OK inside the main function.
 	}
 
 	flag.Parse()
 
 	options, err := hostoptions.NewHostOptionsFromEnvironment(configFile)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 	}
 	hostingSvc := []hosting.Service{frontend.NewService(options)}
 
@@ -88,7 +88,7 @@ func main() {
 
 	logger, flush, err := ucplog.NewLogger(logging.AppCoreLoggerName, &options.Config.Logging)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 	}
 	defer flush()
 
@@ -102,7 +102,11 @@ func main() {
 	if runLink && linkConfigFile != "" {
 		logger.Info("Run Applications.Link.")
 		var linkSvcs []hosting.Service
-		linkSvcs, linkOpts = newLinkHosts(linkConfigFile, enableAsyncWorker)
+		var err error
+		linkSvcs, linkOpts, err = newLinkHosts(linkConfigFile, enableAsyncWorker)
+		if err != nil {
+			log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
+		}
 		hostingSvc = append(hostingSvc, linkSvcs...)
 	}
 
@@ -136,11 +140,11 @@ func main() {
 	tracerOpts.ServiceName = serviceName
 	shutdown, err := trace.InitTracer(tracerOpts)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 	}
 	defer func() {
 		if err := shutdown(ctx); err != nil {
-			log.Fatal("failed to shutdown TracerProvider: %w", err)
+			log.Printf("failed to shutdown TracerProvider: %v\n", err)
 		}
 
 	}()
@@ -165,7 +169,7 @@ func main() {
 	// gracefully, so just crash if that happens.
 	err = <-stopped
 	if err == nil {
-		os.Exit(0)
+		os.Exit(0) //nolint:forbidigo // this is OK inside the main function.
 	} else {
 		panic(err)
 	}

--- a/cmd/applink-rp/main.go
+++ b/cmd/applink-rp/main.go
@@ -40,14 +40,14 @@ func main() {
 	flag.BoolVar(&enableAsyncWorker, "enable-asyncworker", true, "Flag to run async request process worker (for private preview and dev/test purpose).")
 
 	if configFile == "" {
-		log.Fatal("config-file is empty.")
+		log.Fatal("config-file is empty.") //nolint:forbidigo // this is OK inside the main function.
 	}
 
 	flag.Parse()
 
 	options, err := hostoptions.NewHostOptionsFromEnvironment(configFile)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 	}
 	hostingSvc := []hosting.Service{frontend.NewService(options)}
 
@@ -64,7 +64,7 @@ func main() {
 
 	logger, flush, err := ucplog.NewLogger(logging.AppLinkLoggerName, &options.Config.Logging)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 	}
 	defer flush()
 
@@ -98,11 +98,11 @@ func main() {
 	tracerOpts.ServiceName = serviceName
 	shutdown, err := trace.InitTracer(tracerOpts)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 	}
 	defer func() {
 		if err := shutdown(ctx); err != nil {
-			log.Fatal("failed to shutdown TracerProvider: %w", err)
+			log.Printf("failed to shutdown TracerProvider: %v\n", err)
 		}
 
 	}()
@@ -127,7 +127,7 @@ func main() {
 	// gracefully, so just crash if that happens.
 	err = <-stopped
 	if err == nil {
-		os.Exit(0)
+		os.Exit(0) //nolint:forbidigo // this is OK inside the main function.
 	} else {
 		panic(err)
 	}

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -20,7 +20,7 @@ import (
 
 func main() {
 	if len(os.Args) != 2 {
-		log.Fatal("usage: go run cmd/docgen/main.go <output directory>")
+		log.Fatal("usage: go run cmd/docgen/main.go <output directory>") //nolint:forbidigo // this is OK inside the main function.
 	}
 
 	output := os.Args[1]
@@ -28,15 +28,15 @@ func main() {
 	if os.IsNotExist(err) {
 		err = os.Mkdir(output, 0755)
 		if err != nil {
-			log.Fatal(err)
+			log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 		}
 	} else if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 	}
 
 	err = doc.GenMarkdownTreeCustom(cmd.RootCmd, output, frontmatter, link)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 	}
 }
 

--- a/cmd/rad/main.go
+++ b/cmd/rad/main.go
@@ -6,9 +6,14 @@
 package main
 
 import (
+	"os"
+
 	"github.com/project-radius/radius/cmd/rad/cmd"
 )
 
 func main() {
-	cmd.Execute()
+	err := cmd.Execute()
+	if err != nil {
+		os.Exit(1) //nolint:forbidigo // this is OK inside the main function.
+	}
 }

--- a/cmd/ucpd/cmd/root.go
+++ b/cmd/ucpd/cmd/root.go
@@ -34,7 +34,7 @@ var rootCmd = &cobra.Command{
 
 		logger, flush, err := ucplog.NewLogger(ucplog.LoggerName, &options.LoggingOptions)
 		if err != nil {
-			log.Fatal(err)
+			log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 		}
 		defer flush()
 
@@ -58,11 +58,11 @@ var rootCmd = &cobra.Command{
 		options.TracerProviderOptions.ServiceName = server.ServiceName
 		shutdown, err := trace.InitTracer(options.TracerProviderOptions)
 		if err != nil {
-			log.Fatal(err)
+			log.Fatal(err) //nolint:forbidigo // this is OK inside the main function.
 		}
 		defer func() {
 			if err := shutdown(ctx); err != nil {
-				log.Fatal("failed to shutdown TracerProvider: %w", err)
+				log.Printf("failed to shutdown TracerProvider: %v\n", err)
 			}
 		}()
 
@@ -87,7 +87,7 @@ var rootCmd = &cobra.Command{
 		// gracefully, so just crash if that happens.
 		err = <-stopped
 		if err == nil {
-			os.Exit(0)
+			os.Exit(0) //nolint:forbidigo // this is OK inside the main function.
 		} else {
 			panic(err)
 		}

--- a/test/magpiego/bindings/keyvault.go
+++ b/test/magpiego/bindings/keyvault.go
@@ -40,7 +40,7 @@ func KeyVaultBinding(envParams map[string]string) BindingStatus {
 	// Get the secret
 	_, err = client.GetSecret(context.TODO(), "TestSecret", resp.ID.Version(), nil)
 	if err != nil {
-		log.Fatalf("failed to get the secret: %v", err)
+		log.Printf("failed to get the secret: %v\n", err)
 		return BindingStatus{false, "failed to get the secret"}
 	}
 

--- a/test/magpiego/main.go
+++ b/test/magpiego/main.go
@@ -23,6 +23,6 @@ func main() {
 	}
 	if err != nil {
 		log.Println("Terminating Magpie. Encountered error - ", err.Error())
-		os.Exit(1)
+		os.Exit(1) //nolint:forbidigo // this is OK inside the main function.
 	}
 }


### PR DESCRIPTION
This reverts commit 05f8c802c1790dabf7a6e65279da52a92a396f9d.

# Description

This change reverts the revert of previous PR https://github.com/project-radius/radius/pull/5359. The previous iteration broke the build and was reverted.

## Issue reference

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
