### PR TITLE
Add Grafana JSON upload step

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -37,6 +37,14 @@ jobs:
           connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
           overwrite: 'true'
           extra_args: '--destination-path rad --pattern install.ps1'
+      - name: Upload Grafana dashboard
+        uses: bacongobbler/azure-blob-storage-upload@v3.0.0
+        with:
+          source_dir: 'grafana'
+          container_name: 'tools'
+          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
+          overwrite: 'true'
+          extra_args: '--destination-path grafana --pattern *.json --timeout 300'
       
       # Logic: If this is a real release (tagged, non-rc) then compare to our existing full
       # release and see if it's newer. This prevents a patch release of an older vintage from overwriting

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -321,7 +321,7 @@ jobs:
         ./.github/scripts/namespace-is-empty.sh
 
   publish:
-    name: Publish rad CLI binaries and Grafana dashboard
+    name: Publish rad CLI binaries
     needs: [ 'build' ]
     runs-on: [self-hosted,1ES.Pool=1ES-Radius ]
     if: (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') # upload on push to main or tag
@@ -402,14 +402,6 @@ jobs:
           connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
           overwrite: 'true'
           extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/windows-x64/ --pattern rad.exe --timeout 300'
-      - name: Upload Grafana dashboard
-        uses: bacongobbler/azure-blob-storage-upload@v3
-        with:
-          source_dir: grafana
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path grafana/ --pattern *.json --timeout 300'
 
   delete_artifacts:
     name: Delete artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -321,7 +321,7 @@ jobs:
         ./.github/scripts/namespace-is-empty.sh
 
   publish:
-    name: Publish rad CLI binaries
+    name: Publish rad CLI binaries and Grafana dashboard
     needs: [ 'build' ]
     runs-on: [self-hosted,1ES.Pool=1ES-Radius ]
     if: (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') # upload on push to main or tag
@@ -402,6 +402,14 @@ jobs:
           connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
           overwrite: 'true'
           extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/windows-x64/ --pattern rad.exe --timeout 300'
+      - name: Upload Grafana dashboard
+        uses: bacongobbler/azure-blob-storage-upload@v3
+        with:
+          source_dir: grafana
+          container_name: 'tools'
+          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
+          overwrite: 'true'
+          extra_args: '--destination-path grafana/ --pattern *.json --timeout 300'
 
   delete_artifacts:
     name: Delete artifacts

--- a/docs/contributing/contributing-code/release-process.md
+++ b/docs/contributing/contributing-code/release-process.md
@@ -125,7 +125,6 @@ If sample validation passes, we can start the process of creating the final rele
 1. Go through steps 1-3 of "Creating an RC release" above, substituting the final release version instead of the RC version.
 
    For example, if the RC version is `v0.17.0-rc1`, the final release version would be `v0.17.0`.
-1. Manually upload [Grafana dashboard json](https://github.com/project-radius/radius/tree/main/grafana) to radiuspublic storage account under `tools/grafana`.
 1. Purge the [CDN cache](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourcegroups/assets/providers/Microsoft.Cdn/profiles/Radius/endpoints/radius/overview)
 1. Manually download the VS Code extension from the latest version (`tools/vscode-extensibility/0.17/`) and upload to `tools/vscode-extensibility/stable/` in the [storage account](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourceGroups/assets/providers/Microsoft.Storage/storageAccounts/radiuspublic/storagebrowser). See https://github.com/project-radius/radius/issues/4101 for more details on the bug.
 1. Check the stable version marker


### PR DESCRIPTION
# Description

Adds a step to upload the Grafana JSON to the tools directory.

Doesn't use a versioned directory because we don't version the grafana dashboards currently, and the docs link doesn't use a versioned URL.
