### PR TITLE
Remove step on manual VSCode upload

### DIFF
--- a/docs/contributing/contributing-code/release-process.md
+++ b/docs/contributing/contributing-code/release-process.md
@@ -127,7 +127,6 @@ If sample validation passes, we can start the process of creating the final rele
    For example, if the RC version is `v0.17.0-rc1`, the final release version would be `v0.17.0`.
 1. Manually upload [Grafana dashboard json](https://github.com/project-radius/radius/tree/main/grafana) to radiuspublic storage account under `tools/grafana`.
 1. Purge the [CDN cache](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourcegroups/assets/providers/Microsoft.Cdn/profiles/Radius/endpoints/radius/overview)
-1. Manually download the VS Code extension from the latest version (`tools/vscode-extensibility/0.17/`) and upload to `tools/vscode-extensibility/stable/` in the [storage account](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourceGroups/assets/providers/Microsoft.Storage/storageAccounts/radiuspublic/storagebrowser). See https://github.com/project-radius/radius/issues/4101 for more details on the bug.
 1. Check the stable version marker
 
    The file https://get.radapp.dev/version/stable.txt should contain (in plain text) the channel you just created.


### PR DESCRIPTION
# Description

Once https://github.com/project-radius/bicep/pull/582 is merged we can remove the manual step from the release process.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes https://github.com/project-radius/radius/issues/1877

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [x] Extended the documentation / Created issue for it
