### PR TITLE
Add JobAttempt to Artifact Name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -250,7 +250,7 @@ stages:
         PROJECT_RADIUS_SAMPLES_REPO_ABS_PATH: $(Build.SourcesDirectory)/samples
     - publish: $(Build.SourcesDirectory)/dist/container_logs
       displayName: Publish container logs
-      artifact: $(targetName)FunctionalTest.$(Build.BuildNumber)
+      artifact: $(targetName)FunctionalTest.$(Build.BuildNumber).$(System.JobAttempt)
       condition: always()
     - script: |
         az group delete \


### PR DESCRIPTION
# Description

Today, we name our artifact name for container logs `$(targetName)FunctionalTest.$(Build.BuildNumber)`.

This leads to a name like: `corerpFunctionalTest.20230405.4`, which successfully runs on the first try.

However, when you rerun the job more than once in the same day it produces the same name. See [this run](https://dev.azure.com/azure-octo/Incubations/_build/results?buildId=38342&view=logs&j=f85304aa-7666-5b5d-a62b-ba21cf5e74fe&t=7d211f47-c54d-58cf-2094-e9a779cec6de&s=2a2931e6-50e7-587b-ef9c-54e447fcd102) for an example where run 1 and run 2 have the same name.

**Run 1**
<img width="354" alt="image" src="https://user-images.githubusercontent.com/54363786/230457572-25098496-f794-4604-9f87-a4c661e8e8a1.png">

**Run 2**
<img width="378" alt="image" src="https://user-images.githubusercontent.com/54363786/230457628-c363973b-fc1f-4611-898f-cb92d818708b.png">

## Root cause

By default, [Build.BuildNumber](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services) returns [`$(Date:yyyyMMdd).$(Rev:r)`](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number?view=azure-devops&tabs=yaml), where `Rev:r` is the revision of the build. It does not increment on retries of a job.

## Fixing this

To make sure artifacts produce unique names on each job run, we can use [System.JobAttempt](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#system-variables-devops-services) to name the artifact with the attempt number.

## Issue reference

Fixes: #5411 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [x] Extended the documentation / Created issue for it
