### PR TITLE
Make Retry-After header configurable

### DIFF
--- a/pkg/armrpc/api/v1/types.go
+++ b/pkg/armrpc/api/v1/types.go
@@ -8,11 +8,19 @@ package v1
 import (
 	"net/http"
 	"strings"
+	"time"
 )
 
 const (
-	// DefaultRetryAfter is the default value in seconds for the Retry-After header.
+	// DefaultRetryAfter is the default value in seconds for the Retry-After header. This value is used
+	// to determine the polling frequency of the client for long-running operations. Consider setting
+	// a smaller value like 5 seconds if your operations are expected to be fast.
 	DefaultRetryAfter = "60"
+
+	// DefaultRetryAfterDuration is the default value in time.Duration for the Retry-After header. This value is used
+	// to determine the polling frequency of the client for long-running operations. Consider setting
+	// a smaller value like 5 seconds if your operations are expected to be fast.
+	DefaultRetryAfterDuration = 60 * time.Second
 )
 
 // OperationMethod is the ARM operation of resource.

--- a/pkg/armrpc/asyncoperation/statusmanager/mock_statusmanager.go
+++ b/pkg/armrpc/asyncoperation/statusmanager/mock_statusmanager.go
@@ -68,7 +68,7 @@ func (mr *MockStatusManagerMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomo
 }
 
 // QueueAsyncOperation mocks base method.
-func (m *MockStatusManager) QueueAsyncOperation(arg0 context.Context, arg1 *v1.ARMRequestContext, arg2 time.Duration) error {
+func (m *MockStatusManager) QueueAsyncOperation(arg0 context.Context, arg1 *v1.ARMRequestContext, arg2 QueueOperationOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "QueueAsyncOperation", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/pkg/armrpc/asyncoperation/statusmanager/status.go
+++ b/pkg/armrpc/asyncoperation/statusmanager/status.go
@@ -21,6 +21,9 @@ type Status struct {
 	// Location represents the location of operationstatus.
 	Location string `json:"location"`
 
+	// RetryAfter is the value of the Retry-After header that will be used for async operations.
+	RetryAfter time.Duration `json:"retryAfter"`
+
 	// HomeTenantID is async operation caller's tenant id such as the value from x-ms-home-tenant-id header.
 	HomeTenantID string `json:"clientTenantID,omitempty"`
 

--- a/pkg/armrpc/frontend/controller/controller.go
+++ b/pkg/armrpc/frontend/controller/controller.go
@@ -58,6 +58,11 @@ type ResourceOptions[T any] struct {
 
 	// AsyncOperationTimeout is the default timeout duration of async put operation.
 	AsyncOperationTimeout time.Duration
+
+	// AsyncOperationRetryAfter is the value of the Retry-After header that will be used for async operations.
+	// If this is 0 then the default value of v1.DefaultRetryAfter will be used. Consider setting this to a smaller
+	// value like 5 seconds if your operations will complete quickly.
+	AsyncOperationRetryAfter time.Duration
 }
 
 // TODO: Remove Controller when all controller uses Operation

--- a/pkg/armrpc/frontend/defaultoperation/getoperationresult.go
+++ b/pkg/armrpc/frontend/defaultoperation/getoperationresult.go
@@ -8,7 +8,9 @@ package defaultoperation
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"time"
 
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	manager "github.com/project-radius/radius/pkg/armrpc/asyncoperation/statusmanager"
@@ -49,7 +51,7 @@ func (e *GetOperationResult) Run(ctx context.Context, w http.ResponseWriter, req
 	if !os.Status.IsTerminal() {
 		headers := map[string]string{
 			"Location":    req.URL.String(),
-			"Retry-After": v1.DefaultRetryAfter,
+			"Retry-After": fmt.Sprintf("%v", os.RetryAfter.Truncate(time.Second).Seconds()),
 		}
 		return rest.NewAsyncOperationResultResponse(headers), nil
 	}

--- a/pkg/armrpc/frontend/defaultoperation/getoperationresult_test.go
+++ b/pkg/armrpc/frontend/defaultoperation/getoperationresult_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	manager "github.com/project-radius/radius/pkg/armrpc/asyncoperation/statusmanager"
@@ -105,6 +106,7 @@ func TestGetOperationResultRun(t *testing.T) {
 			ctx := testutil.ARMTestContextFromRequest(req)
 
 			osDataModel.Status = tt.provisioningState
+			osDataModel.RetryAfter = time.Second * 5
 
 			mStorageClient.
 				EXPECT().
@@ -131,7 +133,7 @@ func TestGetOperationResultRun(t *testing.T) {
 				require.Equal(t, req.URL.String(), w.Header().Get("Location"))
 
 				require.NotNil(t, w.Header().Get("Retry-After"))
-				require.Equal(t, v1.DefaultRetryAfter, w.Header().Get("Retry-After"))
+				require.Equal(t, "5", w.Header().Get("Retry-After"))
 			}
 		})
 	}


### PR DESCRIPTION
# Description

This change makes the value of the Retry-After header configurable for async operations. The Retry-After header is used by clients (including rad CLI) to determine the polling frequency of a long-running operation.

The goal of making this configurable to make some of our CLI operations feel more responsive as part of #5164. Right now deleting an application takes approximately a minute which is in line with the default Retry-After value of 60 seconds.

This PR only does the plumbing of making the value configuable. The next PR will actually adjust the numbers.



## Issue reference

Part of: #5164

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
