### PR TITLE
Enable fallback workspace for some easy commands

### DIFF
--- a/pkg/cli/cmd/credential/credential.go
+++ b/pkg/cli/cmd/credential/credential.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCommand creates an instance of the command for the `rad provider` command.
+// NewCommand creates an instance of the command for the `rad credential` command.
 func NewCommand(factory framework.Factory) *cobra.Command {
 	// This command is not runnable, and thus has no runner.
 	cmd := &cobra.Command{

--- a/pkg/cli/cmd/credential/list/list.go
+++ b/pkg/cli/cmd/credential/list/list.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCommand creates an instance of the command and runner for the `rad provider list` command.
+// NewCommand creates an instance of the command and runner for the `rad credential list` command.
 func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	runner := NewRunner(factory)
 
@@ -41,7 +41,7 @@ rad credential list
 	return cmd, runner
 }
 
-// Runner is the runner implementation for the `rad provider list` command.
+// Runner is the runner implementation for the `rad credential list` command.
 type Runner struct {
 	ConfigHolder      *framework.ConfigHolder
 	ConnectionFactory connections.Factory
@@ -50,7 +50,7 @@ type Runner struct {
 	Workspace         *workspaces.Workspace
 }
 
-// NewRunner creates a new instance of the `rad provider list` runner.
+// NewRunner creates a new instance of the `rad credential list` runner.
 func NewRunner(factory framework.Factory) *Runner {
 	return &Runner{
 		ConfigHolder:      factory.GetConfigHolder(),
@@ -59,18 +59,13 @@ func NewRunner(factory framework.Factory) *Runner {
 	}
 }
 
-// Validate runs validation for the `rad provider list` command.
+// Validate runs validation for the `rad credential list` command.
 func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	workspace, err := cli.RequireWorkspace(cmd, r.ConfigHolder.Config, r.ConfigHolder.DirectoryConfig)
 	if err != nil {
 		return err
 	}
 	r.Workspace = workspace
-
-	// TODO: support fallback workspace
-	if !r.Workspace.IsNamedWorkspace() {
-		return workspaces.ErrNamedWorkspaceRequired
-	}
 
 	format, err := cli.RequireOutput(cmd)
 	if err != nil {
@@ -81,7 +76,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// Run runs the `rad provider list` command.
+// Run runs the `rad credential list` command.
 func (r *Runner) Run(ctx context.Context) error {
 	r.Output.LogInfo("Listing credentials for all cloud providers for Radius installation %q...", r.Workspace.FmtConnection())
 	client, err := r.ConnectionFactory.CreateCredentialManagementClient(ctx, *r.Workspace)

--- a/pkg/cli/cmd/credential/register/aws/aws.go
+++ b/pkg/cli/cmd/credential/register/aws/aws.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCommand creates an instance of the command and runner for the `rad provider create azure` command.
+// NewCommand creates an instance of the command and runner for the `rad credential register aws` command.
 func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	runner := NewRunner(factory)
 
@@ -57,7 +57,7 @@ rad credential register aws --access-key-id <access-key-id> --secret-access-key 
 	return cmd, runner
 }
 
-// Runner is the runner implementation for the `rad provider register aws` command.
+// Runner is the runner implementation for the `rad credential register aws` command.
 type Runner struct {
 	ConfigHolder      *framework.ConfigHolder
 	ConnectionFactory connections.Factory
@@ -70,7 +70,7 @@ type Runner struct {
 	KubeContext     string
 }
 
-// NewRunner creates a new instance of the `rad provider register aws` runner.
+// NewRunner creates a new instance of the `rad credential register aws` runner.
 func NewRunner(factory framework.Factory) *Runner {
 	return &Runner{
 		ConfigHolder:      factory.GetConfigHolder(),

--- a/pkg/cli/cmd/credential/register/azure/azure.go
+++ b/pkg/cli/cmd/credential/register/azure/azure.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"fmt"
 
-
-	"github.com/project-radius/radius/pkg/to"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
@@ -20,12 +18,13 @@ import (
 	"github.com/project-radius/radius/pkg/cli/framework"
 	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
+	"github.com/project-radius/radius/pkg/to"
 	ucp "github.com/project-radius/radius/pkg/ucp/api/v20220901privatepreview"
-	
+
 	"github.com/spf13/cobra"
 )
 
-// NewCommand creates an instance of the command and runner for the `rad provider create azure` command.
+// NewCommand creates an instance of the command and runner for the `rad credential create azure` command.
 func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	runner := NewRunner(factory)
 
@@ -43,7 +42,7 @@ Radius environments, and Radius links.
 Radius will use the provided subscription and resource group as the default target scope for Bicep deployment.
 The provided service principal must have the Contributor or Owner role assigned for the provided resource group
 in order to create or manage resources contained in the group. The resource group should be created before
-calling 'rad provider create azure'.
+calling 'rad credential register azure'.
 ` + common.LongDescriptionBlurb,
 		Example: `
 # Register (Add or update) cloud provider credential for Azure with service principal authentication
@@ -68,7 +67,7 @@ rad credential register azure --client-id <client id/app id> --client-secret <cl
 	return cmd, runner
 }
 
-// Runner is the runner implementation for the `rad provider create azure` command.
+// Runner is the runner implementation for the `rad credential register azure` command.
 type Runner struct {
 	ConfigHolder      *framework.ConfigHolder
 	ConnectionFactory connections.Factory
@@ -98,11 +97,6 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	r.Workspace = workspace
-
-	// TODO: support fallback workspace
-	if !r.Workspace.IsNamedWorkspace() {
-		return workspaces.ErrNamedWorkspaceRequired
-	}
 
 	format, err := cli.RequireOutput(cmd)
 	if err != nil {

--- a/pkg/cli/cmd/credential/register/register.go
+++ b/pkg/cli/cmd/credential/register/register.go
@@ -7,13 +7,13 @@ package register
 
 import (
 	"github.com/project-radius/radius/pkg/cli/cmd/credential/common"
-	credential_register_azure "github.com/project-radius/radius/pkg/cli/cmd/credential/register/azure"
 	credential_register_aws "github.com/project-radius/radius/pkg/cli/cmd/credential/register/aws"
+	credential_register_azure "github.com/project-radius/radius/pkg/cli/cmd/credential/register/azure"
 	"github.com/project-radius/radius/pkg/cli/framework"
 	"github.com/spf13/cobra"
 )
 
-// NewCommand creates an instance of the command for the `rad provider create` command.
+// NewCommand creates an instance of the command for the `rad credential create` command.
 func NewCommand(factory framework.Factory) *cobra.Command {
 	// This command is not runnable, and thus has no runner.
 	cmd := &cobra.Command{

--- a/pkg/cli/cmd/credential/show/show.go
+++ b/pkg/cli/cmd/credential/show/show.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCommand creates an instance of the command and runner for the `rad provider show` command.
+// NewCommand creates an instance of the command and runner for the `rad credential show` command.
 func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	runner := NewRunner(factory)
 
@@ -46,7 +46,7 @@ rad credential show aws
 	return cmd, runner
 }
 
-// Runner is the runner implementation for the `rad provider show` command.
+// Runner is the runner implementation for the `rad credential show` command.
 type Runner struct {
 	ConfigHolder      *framework.ConfigHolder
 	ConnectionFactory connections.Factory
@@ -56,7 +56,7 @@ type Runner struct {
 	Kind              string
 }
 
-// NewRunner creates a new instance of the `rad provider show` runner.
+// NewRunner creates a new instance of the `rad credential show` runner.
 func NewRunner(factory framework.Factory) *Runner {
 	return &Runner{
 		ConfigHolder:      factory.GetConfigHolder(),
@@ -65,18 +65,13 @@ func NewRunner(factory framework.Factory) *Runner {
 	}
 }
 
-// Validate runs validation for the `rad provider show` command.
+// Validate runs validation for the `rad credential show` command.
 func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	workspace, err := cli.RequireWorkspace(cmd, r.ConfigHolder.Config, r.ConfigHolder.DirectoryConfig)
 	if err != nil {
 		return err
 	}
 	r.Workspace = workspace
-
-	// TODO: support fallback workspace
-	if !r.Workspace.IsNamedWorkspace() {
-		return workspaces.ErrNamedWorkspaceRequired
-	}
 
 	format, err := cli.RequireOutput(cmd)
 	if err != nil {
@@ -93,7 +88,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// Run runs the `rad provider show` command.
+// Run runs the `rad credential show` command.
 func (r *Runner) Run(ctx context.Context) error {
 	r.Output.LogInfo("Showing credential for cloud provider %q for Radius installation %q...", r.Kind, r.Workspace.FmtConnection())
 	client, err := r.ConnectionFactory.CreateCredentialManagementClient(ctx, *r.Workspace)

--- a/pkg/cli/cmd/credential/unregister/unregister.go
+++ b/pkg/cli/cmd/credential/unregister/unregister.go
@@ -18,7 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCommand creates an instance of the command and runner for the `rad provider delete` command.
+// NewCommand creates an instance of the command and runner for the `rad credential unregister` command.
 func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	runner := NewRunner(factory)
 
@@ -43,7 +43,7 @@ rad credential unregister aws
 	return cmd, runner
 }
 
-// Runner is the runner implementation for the `rad provider delete` command.
+// Runner is the runner implementation for the `rad credential unregister` command.
 type Runner struct {
 	ConfigHolder      *framework.ConfigHolder
 	ConnectionFactory connections.Factory
@@ -53,7 +53,7 @@ type Runner struct {
 	Kind              string
 }
 
-// NewRunner creates a new instance of the `rad provider delete` runner.
+// NewRunner creates a new instance of the `rad credential unregister` runner.
 func NewRunner(factory framework.Factory) *Runner {
 	return &Runner{
 		ConfigHolder:      factory.GetConfigHolder(),
@@ -62,7 +62,7 @@ func NewRunner(factory framework.Factory) *Runner {
 	}
 }
 
-// Validate runs validation for the `rad provider delete` command.
+// Validate runs validation for the `rad credential unregister` command.
 func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	// Validate command line args and
 	workspace, err := cli.RequireWorkspace(cmd, r.ConfigHolder.Config, r.ConfigHolder.DirectoryConfig)
@@ -70,11 +70,6 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	r.Workspace = workspace
-
-	// TODO: support fallback workspace
-	if !r.Workspace.IsNamedWorkspace() {
-		return workspaces.ErrNamedWorkspaceRequired
-	}
 
 	format, err := cli.RequireOutput(cmd)
 	if err != nil {
@@ -91,7 +86,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// Run runs the `rad provider delete` command.
+// Run runs the `rad credential unregister` command.
 func (r *Runner) Run(ctx context.Context) error {
 	r.Output.LogInfo("Unregistering %q cloud provider credential for Radius installation %q...", r.Kind, r.Workspace.FmtConnection())
 	client, err := r.ConnectionFactory.CreateCredentialManagementClient(ctx, *r.Workspace)

--- a/pkg/cli/cmd/recipe/list/list.go
+++ b/pkg/cli/cmd/recipe/list/list.go
@@ -66,11 +66,6 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
-	// TODO: support fallback workspace
-	if !r.Workspace.IsNamedWorkspace() {
-		return workspaces.ErrNamedWorkspaceRequired
-	}
-
 	environment, err := cli.RequireEnvironmentName(cmd, args, *workspace)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/recipe/register/register.go
+++ b/pkg/cli/cmd/recipe/register/register.go
@@ -94,11 +94,6 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
-	// TODO: support fallback workspace
-	if !r.Workspace.IsNamedWorkspace() {
-		return workspaces.ErrNamedWorkspaceRequired
-	}
-
 	environment, err := cli.RequireEnvironmentName(cmd, args, *workspace)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/recipe/unregister/unregister.go
+++ b/pkg/cli/cmd/recipe/unregister/unregister.go
@@ -70,11 +70,6 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
-	// TODO: support fallback workspace
-	if !r.Workspace.IsNamedWorkspace() {
-		return workspaces.ErrNamedWorkspaceRequired
-	}
-
 	environment, err := cli.RequireEnvironmentName(cmd, args, *workspace)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/workspace/show/show.go
+++ b/pkg/cli/cmd/workspace/show/show.go
@@ -63,11 +63,6 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// TODO: support fallback workspace
-	if !workspace.IsNamedWorkspace() {
-		return workspaces.ErrNamedWorkspaceRequired
-	}
-
 	format, err := cli.RequireOutput(cmd)
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description

These commands actually already support the fallback workspace and have test coverage for it. I think folks just copy-pasted the guard and the associated TODO. I verified that they all have existing tests.

I also found some places where comments were wrong about the naming of commands, did a searche and fixed everything I could find.

## Issue reference

Part of: #4401

