### PR TITLE
Enable fallback workspace for last commands

### DIFF
--- a/pkg/cli/cmd/deploy/deploy_test.go
+++ b/pkg/cli/cmd/deploy/deploy_test.go
@@ -130,8 +130,23 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "rad deploy - fallback workspace invalid",
-			Input:         []string{"app.bicep"},
+			Name:          "rad deploy - fallback workspace",
+			Input:         []string{"app.bicep", "--group", "my-group", "--environment", "prod"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         radcli.LoadEmptyConfig(t),
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				mocks.ApplicationManagementClient.EXPECT().
+					GetEnvDetails(gomock.Any(), "prod").
+					Return(v20220315privatepreview.EnvironmentResource{}, nil).
+					Times(1)
+			},
+		},
+		{
+			Name:          "rad deploy - fallback workspace requires resource group",
+			Input:         []string{"app.bicep", "--environment", "prod"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",

--- a/pkg/cli/cmd/env/create/create.go
+++ b/pkg/cli/cmd/env/create/create.go
@@ -85,11 +85,6 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	r.Workspace = workspace
 
-	// TODO: support fallback workspace
-	if !r.Workspace.IsNamedWorkspace() {
-		return workspaces.ErrNamedWorkspaceRequired
-	}
-
 	r.EnvironmentName, err = cli.RequireEnvironmentNameArgs(cmd, args, *workspace)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/env/create/create_test.go
+++ b/pkg/cli/cmd/env/create/create_test.go
@@ -32,7 +32,9 @@ func Test_CommandValidation(t *testing.T) {
 
 func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
-	testResourceGroup := v20220901privatepreview.ResourceGroupResource{}
+	testResourceGroup := v20220901privatepreview.ResourceGroupResource{
+		Name: to.Ptr("test-resource-group"),
+	}
 
 	testcases := []radcli.ValidateInput{
 		{
@@ -76,6 +78,19 @@ func Test_Validate(t *testing.T) {
 		},
 		{
 			Name:          "Create command with fallback workspace",
+			Input:         []string{"testingenv", "--group", *testResourceGroup.Name},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         radcli.LoadEmptyConfig(t),
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				// Valid create command
+				createMocksWithValidCommand(mocks.Namespace, mocks.ApplicationManagementClient, testResourceGroup)
+			},
+		},
+		{
+			Name:          "Create command with fallback workspace - requires resource group",
 			Input:         []string{"testingenv"},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{

--- a/pkg/cli/cmd/run/run.go
+++ b/pkg/cli/cmd/run/run.go
@@ -55,6 +55,7 @@ rad run app.bicep --parameters @myfile.json --parameters version=latest
 	}
 
 	commonflags.AddWorkspaceFlag(cmd)
+	commonflags.AddResourceGroupFlag(cmd)
 	commonflags.AddEnvironmentNameFlag(cmd)
 	commonflags.AddApplicationNameFlag(cmd)
 	cmd.Flags().StringArrayP("parameters", "p", []string{}, "Specify parameters for the deployment")

--- a/test/radcli/shared.go
+++ b/test/radcli/shared.go
@@ -68,6 +68,7 @@ func SharedCommandValidation(t *testing.T, factory func(framework framework.Fact
 }
 
 func SharedValidateValidation(t *testing.T, factory func(framework framework.Factory) (*cobra.Command, framework.Runner), testcases []ValidateInput) {
+	t.Helper()
 	for _, testcase := range testcases {
 		t.Run(testcase.Name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)


### PR DESCRIPTION
# Description

This change enables the fallback workspace for the last two commands (env create, and deploy/run). For env create, we actally already had the right behavior. For deploy, we needed to add support for the resource group as a CLI arg.

## Issue reference
Part of #4401

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

*[x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
