### PR TITLE
BugFix: Using a recipe with environment parameters and no developer-parameters crashes

### DIFF
--- a/pkg/linkrp/handlers/recipe_handler_test.go
+++ b/pkg/linkrp/handlers/recipe_handler_test.go
@@ -127,6 +127,40 @@ func Test_DevParameterWithContextParameter(t *testing.T) {
 	require.Equal(t, expectedParams, actualParams)
 }
 
+func Test_EmptyDevParameterWithContextParameter(t *testing.T) {
+	recipeContext := linkrp.RecipeContext{
+		Resource: linkrp.Resource{
+			ResourceInfo: linkrp.ResourceInfo{
+				ID:   "/subscriptions/testSub/resourceGroups/testGroup/providers/applications.link/mongodatabases/mongo0",
+				Name: "mongo0",
+			},
+			Type: "Applications.Link/mongoDatabases",
+		},
+		Application: linkrp.ResourceInfo{
+			ID:   "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+			Name: "testApplication",
+		},
+		Environment: linkrp.ResourceInfo{
+			ID:   "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+			Name: "env0",
+		},
+		Runtime: linkrp.Runtime{
+			Kubernetes: linkrp.Kubernetes{
+				EnvironmentNamespace: "radius-test-env",
+				Namespace:            "radius-test-app",
+			},
+		},
+	}
+
+	expectedParams := map[string]any{
+		"context": map[string]any{
+			"value": recipeContext,
+		},
+	}
+	actualParams := createRecipeParameters(nil, nil, true, &recipeContext)
+	require.Equal(t, expectedParams, actualParams)
+}
+
 func Test_ContextParameterError(t *testing.T) {
 	envID := "error-env"
 	linkContext, err := CreateRecipeContextParameter("/subscriptions/testSub/resourceGroups/testGroup/providers/applications.link/mongodatabases/mongo0", envID, "radius-test-env", "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/testApplication", "radius-test-app")

--- a/pkg/linkrp/handlers/recipe_helper.go
+++ b/pkg/linkrp/handlers/recipe_helper.go
@@ -69,6 +69,9 @@ func CreateRecipeContextParameter(resourceID, environmentID, environmentNamespac
 // In case of conflict the developer parameter takes precedence. If recipe has context parameter defined adds the context information to the parameters list
 func createRecipeParameters(devParams, operatorParams map[string]any, isCxtSet bool, recipeContext *linkrp.RecipeContext) map[string]any {
 	parameters := map[string]any{}
+	if devParams == nil {
+		devParams = map[string]any{}
+	}
 	for k, v := range operatorParams {
 		if _, ok := devParams[k]; !ok {
 			devParams[k] = v


### PR DESCRIPTION
# Description
Bug fix for issue: Using a recipe with environment parameters and no developer-parameters crashes

Fixes: #5198 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
