### PR TITLE
Fix Windows installation script

### DIFF
--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -95,8 +95,6 @@ if (-Not ($UserPathEnvironmentVar -like '*radius*')) {
 }
 Write-Output "rad CLI has been successfully installed"
 
-Write-Output "rad CLI has been successfully installed"
-
 Write-Output "`r`nInstalling Bicep..."
 $cmd = (Start-Process -NoNewWindow -FilePath $RadiusCliFilePath -ArgumentList "bicep download" -PassThru -Wait)
 if ($cmd.ExitCode -ne 0) {

--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -5,13 +5,13 @@
 
 param (
     [string]$Version,
-    [string]$RadiusRoot = "c:\radius"
+    [string]$RadiusRoot = "$env:LOCALAPPDATA\radius"
 )
 
 Write-Output ""
 $ErrorActionPreference = 'stop'
 
-#Escape space of RadiusRoot path
+# Escape space of RadiusRoot path
 $RadiusRoot = $RadiusRoot -replace ' ', '` '
 
 # Constants
@@ -86,16 +86,11 @@ catch [Net.WebException] {
 Write-Output "rad CLI version: $(Invoke-Expression "$RadiusCliFilePath version -o json | ConvertFrom-JSON | Select-Object -ExpandProperty version")"
 
 # Add RadiusRoot directory to User Path environment variable
-$UserPathEnvironmentVar = (Get-Item -Path HKCU:\Environment).GetValue(
-    'PATH', # the registry-value name
-    $null, # the default value to return if no such value exists.
-    'DoNotExpandEnvironmentNames' # the option that suppresses expansion
-)
+$UserPathEnvironmentVar = [Environment]::GetEnvironmentVariable("PATH", "User")
 
-Write-Output "Adding $RadiusRoot to User Path..."  
 if (-Not ($UserPathEnvironmentVar -like '*radius*')) {
-    # [Environment]::SetEnvironmentVariable sets the value kind as REG_SZ, use the function below to set a value of kind REG_EXPAND_SZ
-    Set-ItemProperty HKCU:\Environment "PATH" "$UserPathEnvironmentVar$RadiusRoot" -Type ExpandString
+    Write-Output "Adding $RadiusRoot to User Path..."
+    [System.Environment]::SetEnvironmentVariable("PATH", $UserPathEnvironmentVar + ";$RadiusRoot", "User")
     # Also add the path to the current session
     $env:PATH += ";$RadiusRoot"
 }

--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -86,6 +86,12 @@ catch [Net.WebException] {
 Write-Output "rad CLI version: $(Invoke-Expression "$RadiusCliFilePath version -o json | ConvertFrom-JSON | Select-Object -ExpandProperty version")"
 
 # Add RadiusRoot directory to User Path environment variable
+$UserPathEnvironmentVar = (Get-Item -Path HKCU:\Environment).GetValue(	
+    'PATH', # the registry-value name	
+    $null, # the default value to return if no such value exists.	
+    'DoNotExpandEnvironmentNames' # the option that suppresses expansion	
+)	
+
 Write-Output "Adding $RadiusRoot to User Path..."  
 if (-Not ($UserPathEnvironmentVar -like '*radius*')) {
     # [Environment]::SetEnvironmentVariable sets the value kind as REG_SZ, use the function below to set a value of kind REG_EXPAND_SZ

--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -86,11 +86,11 @@ catch [Net.WebException] {
 Write-Output "rad CLI version: $(Invoke-Expression "$RadiusCliFilePath version -o json | ConvertFrom-JSON | Select-Object -ExpandProperty version")"
 
 # Add RadiusRoot directory to User Path environment variable
-$UserPathEnvironmentVar = (Get-Item -Path HKCU:\Environment).GetValue(	
-    'PATH', # the registry-value name	
-    $null, # the default value to return if no such value exists.	
-    'DoNotExpandEnvironmentNames' # the option that suppresses expansion	
-)	
+$UserPathEnvironmentVar = (Get-Item -Path HKCU:\Environment).GetValue(
+    'PATH', # the registry-value name
+    $null, # the default value to return if no such value exists.
+    'DoNotExpandEnvironmentNames' # the option that suppresses expansion
+)
 
 Write-Output "Adding $RadiusRoot to User Path..."  
 if (-Not ($UserPathEnvironmentVar -like '*radius*')) {


### PR DESCRIPTION
# Description

This PR does 2 things:

1. Changes default installation path to %LOCALAPPDATA%\radius, instead of C:\radius. This is better because:
   - It does not require admin privileges
   - It installers only for the current user
   - It follows Windows best practices for binary location
2. Fixes an issue where the installation script corrupts the user's environment variables on a fresh install of Windows

## Issue reference

Fixes: #5446 
Fixes #5444 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
