### PR TITLE
Restore service principal creation message

### DIFF
--- a/pkg/cli/setup/azure.go
+++ b/pkg/cli/setup/azure.go
@@ -69,7 +69,7 @@ func parseAzureProviderInteractive(cmd *cobra.Command, prompter prompt.Interface
 	}
 
 	fmt.Printf(
-		"\nA Service Principal Name (SPN) with a corresponding role assignment and scope for your resource group is required to create Azure resources.\n\nFor example, you can create one using the following command:\n\033[36maz ad sp create-for-rbac --role Owner --scope /subscriptions/%s/resourceGroups/%s\033[0m\n\nFor more information, see: https://docs.microsoft.com/cli/azure/ad/sp?view=azure-cli-latest#az-ad-sp-create-for-rbac and https://aka.ms/azadsp-more\n\n",
+		"\nAn Azure service principal with a corresponding role assignment on your resource group is required to create Azure resources.\n\nFor example, you can create one using the following command:\n\033[36maz ad sp create-for-rbac --role Owner --scope /subscriptions/%s/resourceGroups/%s\033[0m\n\nFor more information refer to https://docs.microsoft.com/cli/azure/ad/sp?view=azure-cli-latest#az-ad-sp-create-for-rbac and https://aka.ms/azadsp-more\n\n",
 		subscription.ID,
 		resourceGroup,
 	)

--- a/pkg/cli/setup/azure.go
+++ b/pkg/cli/setup/azure.go
@@ -68,6 +68,12 @@ func parseAzureProviderInteractive(cmd *cobra.Command, prompter prompt.Interface
 		return nil, err
 	}
 
+	fmt.Printf(
+		"\nA Service Principal Name (SPN) with a corresponding role assignment and scope for your resource group is required to create Azure resources.\n\nFor example, you can create one using the following command:\n\033[36maz ad sp create-for-rbac --role Owner --scope /subscriptions/%s/resourceGroups/%s\033[0m\n\nFor more information, see: https://docs.microsoft.com/cli/azure/ad/sp?view=azure-cli-latest#az-ad-sp-create-for-rbac and https://aka.ms/azadsp-more\n\n",
+		subscription.ID,
+		resourceGroup,
+	)
+
 	clientID, err := prompter.GetTextInput(
 		"Enter the `appId` of the service principal used to create Azure resources",
 		"Enter AppId...",


### PR DESCRIPTION
# Description

Restores the message to create a service principal that was removed in https://github.com/project-radius/radius/pull/3704

## Issue reference

Fixes: radius-project/core-team#1124

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
