### PR TITLE
Fixing UCP functional test failure: "waiter state transitioned to Failure"

### DIFF
--- a/test/functional/ucp/aws_test.go
+++ b/test/functional/ucp/aws_test.go
@@ -138,7 +138,7 @@ func setupTestAWSResource(t *testing.T, ctx context.Context, resourceName string
 	var awsClient aws.AWSCloudControlClient = cloudcontrol.NewFromConfig(cfg)
 	desiredState := map[string]any{
 		"BucketName":    resourceName,
-		"AccessControl": "PublicRead",
+		"AccessControl": "Private",
 	}
 	desiredStateBytes, err := json.Marshal(desiredState)
 	require.NoError(t, err)


### PR DESCRIPTION
# Description

* Fixing UCP functional test failures by changing the deployed S3 bucket to be Private

Not sure why this was causing issues. It seems like changing this to Private helped though.

```
❯ aws cloudcontrol get-resource-request-status --request-token 2f9de39e-1748-40bc-a34b-67c2304fe022
{
    "ProgressEvent": {
        "TypeName": "AWS::S3::Bucket",
        "Identifier": "wsucpfunctionaltestbucket-2c7f8e56-ac04-4a68-98e8-33dae571f3eb",
        "RequestToken": "2f9de39e-1748-40bc-a34b-67c2304fe022",
        "Operation": "CREATE",
        "OperationStatus": "FAILED",
        "EventTime": "2023-04-18T15:50:28.826000-07:00",
        "StatusMessage": "Bucket cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced setting (Service: S3, Status Code: 400, Request ID: S4GEXAFGECJ0AQ36, Extended Request ID: 5kXkF7tM/QfKFAw8Hlj2Y3AUecuGpEyVKtnXOR1ZnolFovCfps+A2IcN5TD7zE3WnWkxSj23jxI=)",
        "ErrorCode": "InvalidRequest"
    }
}
```

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
