### PR TITLE
Make curl-with-retries do retries

### DIFF
--- a/.github/scripts/curl-with-retries.sh
+++ b/.github/scripts/curl-with-retries.sh
@@ -1,9 +1,4 @@
-for i in {1..5}
-do
-    curl $@
-    echo "$?"
-    if [[ "$?" -eq 0 ]]
-    then
-    break
-    fi
-done
+# See https://everything.curl.dev/usingcurl/downloads/retry
+#
+# Unfortunately we can't use --retry-all-errors as the agent does not support it.
+curl $@ --retry 5


### PR DESCRIPTION
# Description

There's a bug in this script that prevents it from actually retrying. Running `echo` resets the built-in variable `$?`. Oops.
