### PR TITLE
Update prompt width to 40 characters

### DIFF
--- a/pkg/cli/prompt/text/text.go
+++ b/pkg/cli/prompt/text/text.go
@@ -35,7 +35,7 @@ func NewTextModel(promptMsg string, placeHolder string) Model {
 	ti := textinput.New()
 	ti.Placeholder = placeHolder
 	ti.Focus()
-	ti.Width = 20
+	ti.Width = 40
 
 	return Model{
 		textInput:    ti,


### PR DESCRIPTION
# Description

The prompt width is currently hard-coded to 20

This PR updates it to 40 so we can display GUIDS without clipping

Long term we may want more customization here, but dropping in a strategic fix to get us unblocked on cloud provider experiences

## Issue reference

Fixes: radius-project/core-team#1126

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
