### PR TITLE
Add validation helper for resource processors

### DIFF
--- a/pkg/linkrp/processors/util.go
+++ b/pkg/linkrp/processors/util.go
@@ -1,0 +1,58 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package processors
+
+import (
+	"fmt"
+
+	"github.com/project-radius/radius/pkg/recipes"
+	"github.com/project-radius/radius/pkg/resourcemodel"
+	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
+	"github.com/project-radius/radius/pkg/to"
+	"github.com/project-radius/radius/pkg/ucp/resources"
+)
+
+// GetOutputResourcesFromRecipe is a utility function that converts a resource ID provided by a user into an
+// OutputResource. This should be used for processing mode == 'resource'.
+func GetOutputResourceFromResourceID(resourceID string) (rpv1.OutputResource, error) {
+	id, err := resources.ParseResource(resourceID)
+	if err != nil {
+		return rpv1.OutputResource{}, &ValidationError{Message: fmt.Sprintf("resource id %q is invalid", resourceID)}
+	}
+
+	identity := resourcemodel.FromUCPID(id, "")
+	result := rpv1.OutputResource{
+		LocalID:       fmt.Sprintf("Resource%d", 0), // The dependency sorting code requires unique LocalIDs
+		Identity:      identity,
+		ResourceType:  *identity.ResourceType,
+		RadiusManaged: to.Ptr(false), // Generally when we parse a resource ID from a resource field, it's externally managed.
+	}
+
+	return result, nil
+}
+
+// GetOutputResourcesFromRecipe is a utility function that converts the resources in the recipe output into a list of OutputResources.
+func GetOutputResourcesFromRecipe(output *recipes.RecipeOutput) ([]rpv1.OutputResource, error) {
+	results := []rpv1.OutputResource{}
+	for i, resource := range output.Resources {
+		id, err := resources.ParseResource(resource)
+		if err != nil {
+			return nil, &ValidationError{Message: fmt.Sprintf("resource id %q returned by recipe is invalid", resource)}
+		}
+
+		identity := resourcemodel.FromUCPID(id, "")
+		result := rpv1.OutputResource{
+			LocalID:       fmt.Sprintf("RecipeResource%d", i), // The dependency sorting code requires unique LocalIDs
+			Identity:      identity,
+			ResourceType:  *identity.ResourceType,
+			RadiusManaged: to.Ptr(true),
+		}
+
+		results = append(results, result)
+	}
+
+	return results, nil
+}

--- a/pkg/linkrp/processors/util_test.go
+++ b/pkg/linkrp/processors/util_test.go
@@ -1,0 +1,93 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package processors
+
+import (
+	"testing"
+
+	"github.com/project-radius/radius/pkg/recipes"
+	"github.com/project-radius/radius/pkg/resourcemodel"
+	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
+	"github.com/project-radius/radius/pkg/to"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GetOutputResourceFromResourceID(t *testing.T) {
+	id := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Cache/redis/test-resource1"
+
+	redisType := resourcemodel.ResourceType{
+		Type:     "Microsoft.Cache/redis",
+		Provider: resourcemodel.ProviderAzure,
+	}
+
+	expected := rpv1.OutputResource{
+		LocalID:       "Resource0",
+		ResourceType:  redisType,
+		Identity:      resourcemodel.NewARMIdentity(&redisType, id, "unknown"),
+		RadiusManaged: to.Ptr(false),
+	}
+
+	actual, err := GetOutputResourceFromResourceID(id)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func Test_GetOutputResourceFromResourceID_Invalid(t *testing.T) {
+	id := "/////asdf////"
+
+	actual, err := GetOutputResourceFromResourceID(id)
+	require.Error(t, err)
+	require.Empty(t, actual)
+	require.IsType(t, &ValidationError{}, err)
+	require.Equal(t, "resource id \"/////asdf////\" is invalid", err.Error())
+}
+
+func Test_GetOutputResourcesFromRecipe(t *testing.T) {
+	output := recipes.RecipeOutput{
+		Resources: []string{
+			"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Cache/redis/test-resource1",
+			"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Cache/redis/test-resource2",
+		},
+	}
+
+	redisType := resourcemodel.ResourceType{
+		Type:     "Microsoft.Cache/redis",
+		Provider: resourcemodel.ProviderAzure,
+	}
+
+	expected := []rpv1.OutputResource{
+		{
+			LocalID:       "RecipeResource0",
+			ResourceType:  redisType,
+			Identity:      resourcemodel.NewARMIdentity(&redisType, output.Resources[0], "unknown"),
+			RadiusManaged: to.Ptr(true),
+		},
+		{
+			LocalID:       "RecipeResource1",
+			ResourceType:  redisType,
+			Identity:      resourcemodel.NewARMIdentity(&redisType, output.Resources[1], "unknown"),
+			RadiusManaged: to.Ptr(true),
+		},
+	}
+
+	actual, err := GetOutputResourcesFromRecipe(&output)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+func Test_GetOutputResourcesFromRecipe_Invalid(t *testing.T) {
+	output := recipes.RecipeOutput{
+		Resources: []string{
+			"/////asdf////",
+		},
+	}
+
+	actual, err := GetOutputResourcesFromRecipe(&output)
+	require.Error(t, err)
+	require.Empty(t, actual)
+	require.IsType(t, &ValidationError{}, err)
+	require.Equal(t, "resource id \"/////asdf////\" returned by recipe is invalid", err.Error())
+}

--- a/pkg/linkrp/processors/validator.go
+++ b/pkg/linkrp/processors/validator.go
@@ -1,0 +1,287 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package processors
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/project-radius/radius/pkg/recipes"
+	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
+)
+
+const (
+	kindConnectionValue  = "connection value"
+	kindConnectionSecret = "connection secret"
+)
+
+// Validator provides validation support to be used with the data model of a resource type that supports recipes.
+//
+// The Validator can be used to:
+//
+// - Extract output resources from a `resource` field
+// - Extract output resources from the recipe out
+// - Extract connection values and connection secrets from the recipe output
+// - Apply values and secrets from the recipe output to the resource data model.
+type Validator struct {
+	resourceField  *string
+	fields         []func(output *recipes.RecipeOutput) string
+	computedFields []func(output *recipes.RecipeOutput) string
+
+	// ConnectionValues stores the connection values extracted from the data model and recipe output.
+	ConnectionValues map[string]any
+
+	// ConnectionSecrets stores the connection secrets extracted from the data model and recipe output.
+	ConnectionSecrets map[string]rpv1.SecretValueReference
+
+	// OutputResources stores the output resources extracted from the data model and recipe output.
+	OutputResources *[]rpv1.OutputResource
+}
+
+// NewValidator creates a new Validator. Use the parameters to pass in pointers to the corresponding fields on the resource
+// data model.
+func NewValidator(connectionValues *map[string]any, connectionSecrets *map[string]rpv1.SecretValueReference, outputResources *[]rpv1.OutputResource) *Validator {
+	if *connectionValues == nil {
+		*connectionValues = map[string]any{}
+	}
+	if *connectionSecrets == nil {
+		*connectionSecrets = map[string]rpv1.SecretValueReference{}
+	}
+	if *outputResources == nil {
+		*outputResources = []rpv1.OutputResource{}
+	}
+
+	return &Validator{
+		ConnectionValues:  *connectionValues,
+		ConnectionSecrets: *connectionSecrets,
+		OutputResources:   outputResources,
+	}
+}
+
+// ValidationError represents a user-facing validation message.
+type ValidationError struct {
+	Message string
+}
+
+// Error gets the string representation of the error.
+func (e *ValidationError) Error() string {
+	return e.Message
+}
+
+// AddResourceField registers a field containing a resource ID with the validator.
+func (v *Validator) AddResourceField(ref *string) {
+	v.resourceField = ref
+}
+
+// AddRequiredInt32Field registers a field containing a required int32 connection value. The zero value will be treated as an "unset" value.
+func (v *Validator) AddRequiredInt32Field(name string, ref *int32) {
+	v.fields = append(v.fields, bind(v, name, ref, true, false, "int32", convertToInt32, nil))
+}
+
+// AddOptionalInt32Field registers a field containing an optional int32 connection value. The zero value will be treated as an "unset" value.
+func (v *Validator) AddOptionalInt32Field(name string, ref *int32) {
+	v.fields = append(v.fields, bind(v, name, ref, false, false, "int32", convertToInt32, nil))
+}
+
+// AddRequiredStringField registers a field containing a required string connection value. The empty string will be treated as an "unset" value.
+func (v *Validator) AddRequiredStringField(name string, ref *string) {
+	v.fields = append(v.fields, bind(v, name, ref, true, false, "string", convertToString, nil))
+}
+
+// AddOptionalStringField registers a field containing an optional string connection value. The empty string will be treated as an "unset" value.
+func (v *Validator) AddOptionalStringField(name string, ref *string) {
+	v.fields = append(v.fields, bind(v, name, ref, false, false, "string", convertToString, nil))
+}
+
+// AddRequiredSecretField registers a field containing a required string connection secret. The empty string will be treated as an "unset" value.
+func (v *Validator) AddRequiredSecretField(name string, ref *string) {
+	// Note: secrets are always strings
+	v.fields = append(v.fields, bind(v, name, ref, true, true, "string", convertToString, nil))
+}
+
+// AddRequiredSecretField registers a field containing an optional string connection secret. The empty string will be treated as an "unset" value.
+func (v *Validator) AddOptionalSecretField(name string, ref *string) {
+	// Note: secrets are always strings
+	v.fields = append(v.fields, bind(v, name, ref, false, true, "string", convertToString, nil))
+}
+
+// AddComputedSecretField registers a field containing a computed string connection secret. The empty string will be treated as an "unset" value.
+//
+// The compute function will be called if the secret is not already set or provided by the recipe. Inside the compute function
+// it is safe to assume that other non-computed fields have been populated already.
+//
+// The compute function will not be called if a validation error has previously occurred.
+func (v *Validator) AddComputedSecretField(name string, ref *string, compute func() (string, *ValidationError)) {
+	// Note: secrets are always strings
+	v.computedFields = append(v.computedFields, bind(v, name, ref, false, true, "string", convertToString, compute))
+}
+
+// SetAndValidate will bind fields from the recipe output, populate output resources, and populate connection values/secrets.
+//
+// This function returns *ValidationError for validation failures.
+//
+// After calling SetAndValidate, the connection values/secrets and output resources will be populated.
+func (v *Validator) SetAndValidate(output *recipes.RecipeOutput) error {
+	msgs := []string{}
+
+	if output != nil {
+		recipeResources, err := GetOutputResourcesFromRecipe(output)
+		if err != nil {
+			return err
+		}
+
+		*v.OutputResources = append(*v.OutputResources, recipeResources...)
+	}
+
+	if v.resourceField != nil {
+		outputResource, err := GetOutputResourceFromResourceID(*v.resourceField)
+		if err != nil {
+			return err
+		}
+
+		*v.OutputResources = append(*v.OutputResources, outputResource)
+	}
+
+	for _, field := range v.fields {
+		msg := field(output)
+		if msg != "" {
+			msgs = append(msgs, msg)
+		}
+	}
+
+	// Run computed fields iff there are no errors so far. Computed fields
+	// get to read the state of all non-computed fields.
+	if len(msgs) == 0 {
+		for _, field := range v.computedFields {
+			msg := field(output)
+			if msg != "" {
+				msgs = append(msgs, msg)
+			}
+		}
+	}
+
+	if len(msgs) == 1 {
+		return &ValidationError{Message: msgs[0]}
+	}
+
+	if len(msgs) > 0 {
+		msg := fmt.Sprintf("validation returned multiple errors:\n\n%v", strings.Join(msgs, "\n"))
+		return &ValidationError{Message: msg}
+	}
+
+	return nil
+}
+
+func bind[T any](v *Validator, name string, ref *T, required bool, secret bool, typeName string, convert func(value any) (T, bool), compute func() (T, *ValidationError)) func(output *recipes.RecipeOutput) string {
+	return func(output *recipes.RecipeOutput) string {
+		valueKind := kindConnectionValue
+		propertyPath := fmt.Sprintf(".properties.%v", name)
+		if secret {
+			valueKind = kindConnectionSecret
+			propertyPath = fmt.Sprintf(".properties.secrets.%v", name)
+		}
+
+		existing := *ref
+		if !reflect.ValueOf(existing).IsZero() {
+			// Field is already set
+			v.recordValue(name, *ref, secret)
+			return ""
+		}
+
+		if output == nil {
+			// Note: required and computed are mutually exclusive
+			if required {
+				return v.buildRequiredValueError(name, false, valueKind, propertyPath)
+			}
+
+			if compute != nil {
+				return computeValue(v, name, ref, secret, compute)
+			}
+
+			return ""
+		}
+
+		// OK we have a recipe
+		var value any
+		var ok bool
+		if secret {
+			value, ok = output.Secrets[name]
+		} else {
+			value, ok = output.Values[name]
+		}
+		if !ok {
+			// Note: required and computed are mutually exclusive
+			if required {
+				return v.buildRequiredValueError(name, true, valueKind, propertyPath)
+			}
+
+			if compute == nil {
+				return "" // Optional
+			}
+
+			return computeValue(v, name, ref, secret, compute)
+		}
+
+		converted, ok := convert(value)
+		if !ok {
+			return v.buildTypeMismatchError(name, typeName, valueKind, value)
+		}
+
+		*ref = converted
+		v.recordValue(name, converted, secret)
+		return ""
+	}
+}
+
+func computeValue[T any](v *Validator, name string, ref *T, secret bool, compute func() (T, *ValidationError)) string {
+	value, err := compute()
+	if err != nil {
+		return err.Error()
+	}
+
+	*ref = value
+	v.recordValue(name, value, secret)
+	return ""
+}
+
+func convertToString(value any) (string, bool) {
+	converted, ok := value.(string)
+	return converted, ok
+}
+
+func convertToInt32(value any) (int32, bool) {
+	switch v := value.(type) {
+	case int32:
+		return v, true
+	case int:
+		return int32(v), true
+	case float64:
+		return int32(v), true
+	default:
+		return int32(0), false
+	}
+}
+
+func (v *Validator) recordValue(name string, value any, secret bool) {
+	if secret {
+		v.ConnectionSecrets[name] = rpv1.SecretValueReference{Value: value.(string)}
+	} else {
+		v.ConnectionValues[name] = value
+	}
+}
+
+func (v *Validator) buildTypeMismatchError(name string, typeName string, valueKind string, value any) string {
+	return fmt.Sprintf("the %v %q provided by the recipe is expected to be a %s, got %T", valueKind, name, typeName, value)
+}
+
+func (v *Validator) buildRequiredValueError(name string, recipe bool, valueKind string, propertyPath string) string {
+	if recipe {
+		return fmt.Sprintf("the %v %q should be provided by the recipe, set '%v' to provide a value manually", valueKind, name, propertyPath)
+	}
+
+	return fmt.Sprintf("the %v %q must be provided when not using a recipe. Set '%v' to provide a value manually", valueKind, name, propertyPath)
+}

--- a/pkg/linkrp/processors/validator_test.go
+++ b/pkg/linkrp/processors/validator_test.go
@@ -1,0 +1,702 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package processors
+
+import (
+	"testing"
+
+	"github.com/project-radius/radius/pkg/recipes"
+	"github.com/project-radius/radius/pkg/resourcemodel"
+	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
+	"github.com/project-radius/radius/pkg/to"
+	"github.com/project-radius/radius/pkg/ucp/resources"
+	"github.com/stretchr/testify/require"
+)
+
+type testDatamodel struct {
+	StringField            string
+	AnotherCoolStringField string
+	Int32Field             int32
+}
+
+func Test_NewValidator(t *testing.T) {
+	t.Run("empty datastores", func(t *testing.T) {
+		var outputResources []rpv1.OutputResource
+		var values map[string]any
+		var secrets map[string]rpv1.SecretValueReference
+
+		v := NewValidator(&values, &secrets, &outputResources)
+		require.NotNil(t, v)
+		require.NotNil(t, outputResources)
+		require.NotNil(t, values)
+		require.NotNil(t, secrets)
+
+		require.Same(t, &outputResources, v.OutputResources)
+		require.Equal(t, values, v.ConnectionValues)
+		require.Equal(t, secrets, v.ConnectionSecrets)
+	})
+
+	t.Run("provided datastores", func(t *testing.T) {
+		outputResources := []rpv1.OutputResource{}
+		values := map[string]any{}
+		secrets := map[string]rpv1.SecretValueReference{}
+
+		v := NewValidator(&values, &secrets, &outputResources)
+		require.NotNil(t, v)
+		require.NotNil(t, outputResources)
+		require.NotNil(t, values)
+		require.NotNil(t, secrets)
+
+		require.Same(t, &outputResources, v.OutputResources)
+		require.Equal(t, values, v.ConnectionValues)
+		require.Equal(t, secrets, v.ConnectionSecrets)
+	})
+}
+
+func Test_Validator_SetAndValidate_OutputResources(t *testing.T) {
+	t.Run("no resource field and no recipe", func(t *testing.T) {
+		outputResources := []rpv1.OutputResource{}
+		values := map[string]any{}
+		secrets := map[string]rpv1.SecretValueReference{}
+
+		v := NewValidator(&values, &secrets, &outputResources)
+		err := v.SetAndValidate(nil)
+		require.NoError(t, err)
+
+		require.Empty(t, outputResources)
+	})
+	t.Run("resource field is empty", func(t *testing.T) {
+		outputResources := []rpv1.OutputResource{}
+		values := map[string]any{}
+		secrets := map[string]rpv1.SecretValueReference{}
+
+		var resource *string
+
+		v := NewValidator(&values, &secrets, &outputResources)
+		v.AddResourceField(resource)
+
+		err := v.SetAndValidate(nil)
+		require.NoError(t, err)
+
+		require.Empty(t, outputResources)
+	})
+	t.Run("recipe has no resources", func(t *testing.T) {
+		outputResources := []rpv1.OutputResource{}
+		values := map[string]any{}
+		secrets := map[string]rpv1.SecretValueReference{}
+
+		v := NewValidator(&values, &secrets, &outputResources)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{})
+		require.NoError(t, err)
+
+		require.Empty(t, outputResources)
+	})
+	t.Run("resource field invalid id", func(t *testing.T) {
+		outputResources := []rpv1.OutputResource{}
+		values := map[string]any{}
+		secrets := map[string]rpv1.SecretValueReference{}
+
+		resource := "////invalid//////"
+
+		v := NewValidator(&values, &secrets, &outputResources)
+		v.AddResourceField(&resource)
+
+		err := v.SetAndValidate(nil)
+		require.Error(t, err)
+		require.IsType(t, &ValidationError{}, err)
+		require.Equal(t, "resource id \"////invalid//////\" is invalid", err.Error())
+
+	})
+
+	t.Run("recipe invalid id", func(t *testing.T) {
+		outputResources := []rpv1.OutputResource{}
+		values := map[string]any{}
+		secrets := map[string]rpv1.SecretValueReference{}
+
+		output := recipes.RecipeOutput{
+			Resources: []string{"////invalid//////"},
+		}
+
+		v := NewValidator(&values, &secrets, &outputResources)
+
+		err := v.SetAndValidate(&output)
+		require.Error(t, err)
+		require.IsType(t, &ValidationError{}, err)
+		require.Equal(t, "resource id \"////invalid//////\" returned by recipe is invalid", err.Error())
+	})
+
+	t.Run("resources success", func(t *testing.T) {
+		outputResources := []rpv1.OutputResource{}
+		values := map[string]any{}
+		secrets := map[string]rpv1.SecretValueReference{}
+
+		resource := "/planes/aws/aws/accounts/1234/regions/us-west-1/providers/AWS.Kinesis/Stream/my-stream1"
+
+		output := recipes.RecipeOutput{
+			Resources: []string{"/planes/aws/aws/accounts/1234/regions/us-west-1/providers/AWS.Kinesis/Stream/my-stream2"},
+		}
+
+		mustparse := func(id string) resources.ID {
+			parsed, err := resources.ParseResource(id)
+			require.NoError(t, err)
+			return parsed
+		}
+
+		v := NewValidator(&values, &secrets, &outputResources)
+		v.AddResourceField(&resource)
+
+		err := v.SetAndValidate(&output)
+		require.NoError(t, err)
+
+		expected := []rpv1.OutputResource{
+			{
+				LocalID:       "RecipeResource0",
+				Identity:      resourcemodel.FromUCPID(mustparse(output.Resources[0]), ""),
+				ResourceType:  *resourcemodel.FromUCPID(mustparse(output.Resources[0]), "").ResourceType,
+				RadiusManaged: to.Ptr(true),
+			},
+			{
+				LocalID:       "Resource0",
+				Identity:      resourcemodel.FromUCPID(mustparse(resource), ""),
+				ResourceType:  *resourcemodel.FromUCPID(mustparse(resource), "").ResourceType,
+				RadiusManaged: to.Ptr(false),
+			},
+		}
+
+		require.Equal(t, expected, outputResources)
+	})
+}
+
+func Test_Validator_SetAndValidate_Required_Strings(t *testing.T) {
+	t.Run("existing required value preserved", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField: "existing",
+		}
+
+		v.AddRequiredStringField("test", &model.StringField)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": "ignored"}})
+		require.NoError(t, err)
+		require.Equal(t, "existing", model.StringField)
+		require.Equal(t, "existing", v.ConnectionValues["test"])
+		require.Empty(t, v.ConnectionSecrets)
+	})
+
+	t.Run("existing required secret preserved", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField: "existing",
+		}
+
+		v.AddRequiredSecretField("test", &model.StringField)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Secrets: map[string]any{"test": "ignored"}})
+		require.NoError(t, err)
+		require.Equal(t, "existing", model.StringField)
+		require.Equal(t, rpv1.SecretValueReference{Value: "existing"}, v.ConnectionSecrets["test"])
+		require.Empty(t, v.ConnectionValues)
+	})
+
+	t.Run("required recipe value set", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField: "",
+		}
+		v.AddRequiredStringField("test", &model.StringField)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": "new"}})
+		require.NoError(t, err)
+		require.Equal(t, "new", model.StringField)
+		require.Equal(t, "new", v.ConnectionValues["test"])
+		require.Empty(t, v.ConnectionSecrets)
+	})
+
+	t.Run("required recipe secret set", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField: "",
+		}
+		v.AddRequiredSecretField("test", &model.StringField)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Secrets: map[string]any{"test": "new"}})
+		require.NoError(t, err)
+		require.Equal(t, "new", model.StringField)
+		require.Equal(t, rpv1.SecretValueReference{Value: "new"}, v.ConnectionSecrets["test"])
+		require.Empty(t, v.ConnectionValues)
+	})
+
+	t.Run("required value missing with recipe", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField: "",
+		}
+		v.AddRequiredStringField("test", &model.StringField)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{})
+		require.Error(t, err)
+		require.IsType(t, &ValidationError{}, err)
+		require.Equal(t, "the connection value \"test\" should be provided by the recipe, set '.properties.test' to provide a value manually", err.Error())
+	})
+
+	t.Run("required value missing without recipe", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField: "",
+		}
+		v.AddRequiredStringField("test", &model.StringField)
+
+		err := v.SetAndValidate(nil)
+		require.Error(t, err)
+		require.IsType(t, &ValidationError{}, err)
+		require.Equal(t, "the connection value \"test\" must be provided when not using a recipe. Set '.properties.test' to provide a value manually", err.Error())
+	})
+
+	t.Run("required secret missing with recipe", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField: "",
+		}
+		v.AddRequiredSecretField("test", &model.StringField)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{})
+		require.Error(t, err)
+		require.IsType(t, &ValidationError{}, err)
+		require.Equal(t, "the connection secret \"test\" should be provided by the recipe, set '.properties.secrets.test' to provide a value manually", err.Error())
+	})
+
+	t.Run("required secret missing without recipe", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField: "",
+		}
+		v.AddRequiredSecretField("test", &model.StringField)
+
+		err := v.SetAndValidate(nil)
+		require.Error(t, err)
+		require.IsType(t, &ValidationError{}, err)
+		require.Equal(t, "the connection secret \"test\" must be provided when not using a recipe. Set '.properties.secrets.test' to provide a value manually", err.Error())
+	})
+}
+
+func Test_Validator_SetAndValidate_Optional_Strings(t *testing.T) {
+	t.Run("existing optional value preserved", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField: "existing",
+		}
+
+		v.AddOptionalStringField("test", &model.StringField)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": "ignored"}})
+		require.NoError(t, err)
+		require.Equal(t, "existing", model.StringField)
+		require.Equal(t, "existing", v.ConnectionValues["test"])
+		require.Empty(t, v.ConnectionSecrets)
+	})
+
+	t.Run("existing optional secret preserved", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField: "existing",
+		}
+
+		v.AddOptionalSecretField("test", &model.StringField)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Secrets: map[string]any{"test": "ignored"}})
+		require.NoError(t, err)
+		require.Equal(t, "existing", model.StringField)
+		require.Equal(t, rpv1.SecretValueReference{Value: "existing"}, v.ConnectionSecrets["test"])
+		require.Empty(t, v.ConnectionValues)
+	})
+
+	t.Run("optional recipe value set", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField: "",
+		}
+		v.AddOptionalStringField("test", &model.StringField)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": "new"}})
+		require.NoError(t, err)
+		require.Equal(t, "new", model.StringField)
+		require.Equal(t, "new", v.ConnectionValues["test"])
+		require.Empty(t, v.ConnectionSecrets)
+	})
+
+	t.Run("Optional recipe secret set", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField: "",
+		}
+		v.AddOptionalSecretField("test", &model.StringField)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Secrets: map[string]any{"test": "new"}})
+		require.NoError(t, err)
+		require.Equal(t, "new", model.StringField)
+		require.Equal(t, rpv1.SecretValueReference{Value: "new"}, v.ConnectionSecrets["test"])
+		require.Empty(t, v.ConnectionValues)
+	})
+
+	t.Run("optional value missing with recipe", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField: "",
+		}
+		v.AddOptionalStringField("test", &model.StringField)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{})
+		require.NoError(t, err)
+		require.Equal(t, "", model.StringField)
+		require.Empty(t, v.ConnectionValues)
+		require.Empty(t, v.ConnectionSecrets)
+	})
+
+	t.Run("optional value missing without recipe", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField: "",
+		}
+		v.AddOptionalStringField("test", &model.StringField)
+
+		err := v.SetAndValidate(nil)
+		require.NoError(t, err)
+		require.Equal(t, "", model.StringField)
+		require.Empty(t, v.ConnectionValues)
+		require.Empty(t, v.ConnectionSecrets)
+	})
+
+	t.Run("optional secret missing with recipe", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField: "",
+		}
+		v.AddOptionalSecretField("test", &model.StringField)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{})
+		require.NoError(t, err)
+		require.Equal(t, "", model.StringField)
+		require.Empty(t, v.ConnectionValues)
+		require.Empty(t, v.ConnectionSecrets)
+	})
+
+	t.Run("optional secret missing without recipe", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField: "",
+		}
+		v.AddOptionalSecretField("test", &model.StringField)
+
+		err := v.SetAndValidate(nil)
+		require.NoError(t, err)
+		require.Equal(t, "", model.StringField)
+		require.Empty(t, v.ConnectionValues)
+		require.Empty(t, v.ConnectionSecrets)
+	})
+}
+
+func Test_Validator_SetAndValidate_Computed_Strings(t *testing.T) {
+	// Code path for computed strings is the same as optional, except when the value is missing.\
+	t.Run("computed secret is computed with recipe", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField:            "",
+			AnotherCoolStringField: "",
+		}
+		v.AddComputedSecretField("computed", &model.AnotherCoolStringField, func() (string, *ValidationError) {
+			// Computed values have access to non-computed values
+			return model.StringField + "-computed", nil
+		})
+		v.AddOptionalStringField("regular", &model.StringField)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"regular": "YO"}})
+		require.NoError(t, err)
+		require.Equal(t, "YO", model.StringField)
+		require.Equal(t, "YO-computed", model.AnotherCoolStringField)
+		require.Equal(t, map[string]any{"regular": "YO"}, v.ConnectionValues)
+		require.Equal(t, map[string]rpv1.SecretValueReference{"computed": {Value: "YO-computed"}}, v.ConnectionSecrets)
+	})
+
+	t.Run("computed secret is computed without recipe", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField:            "YO",
+			AnotherCoolStringField: "",
+		}
+		v.AddComputedSecretField("computed", &model.AnotherCoolStringField, func() (string, *ValidationError) {
+			// Computed values have access to non-computed values
+			return model.StringField + "-computed", nil
+		})
+		v.AddOptionalStringField("regular", &model.StringField)
+
+		err := v.SetAndValidate(nil)
+		require.NoError(t, err)
+		require.Equal(t, "YO", model.StringField)
+		require.Equal(t, "YO-computed", model.AnotherCoolStringField)
+		require.Equal(t, map[string]any{"regular": "YO"}, v.ConnectionValues)
+		require.Equal(t, map[string]rpv1.SecretValueReference{"computed": {Value: "YO-computed"}}, v.ConnectionSecrets)
+	})
+
+	t.Run("computed secret error", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField:            "",
+			AnotherCoolStringField: "",
+		}
+		v.AddComputedSecretField("computed", &model.AnotherCoolStringField, func() (string, *ValidationError) {
+			return "", &ValidationError{Message: "OH NO!"}
+		})
+		v.AddOptionalStringField("regular", &model.StringField)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"regular": "YO"}})
+		require.Error(t, err)
+		require.IsType(t, &ValidationError{}, err)
+		require.Equal(t, "OH NO!", err.Error())
+	})
+
+	t.Run("computed secret not run if regular fields error", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField:            "",
+			AnotherCoolStringField: "",
+		}
+		v.AddComputedSecretField("computed", &model.AnotherCoolStringField, func() (string, *ValidationError) {
+			t.FailNow() // Should not be called
+			return "", &ValidationError{Message: "OH NO!"}
+		})
+		v.AddRequiredStringField("regular", &model.StringField)
+
+		err := v.SetAndValidate(nil)
+		require.Error(t, err)
+		require.IsType(t, &ValidationError{}, err)
+		require.Equal(t, "the connection value \"regular\" must be provided when not using a recipe. Set '.properties.regular' to provide a value manually", err.Error())
+	})
+}
+
+func Test_Validator_SetAndValidate_TypeMismatch_Strings(t *testing.T) {
+	// Type mismatches are only possible with recipes
+	t.Run("type mismatch with recipe", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			StringField: "",
+		}
+
+		v.AddRequiredStringField("test", &model.StringField)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": 3}})
+		require.Error(t, err)
+		require.IsType(t, &ValidationError{}, err)
+		require.Equal(t, "the connection value \"test\" provided by the recipe is expected to be a string, got int", err.Error())
+	})
+}
+
+func Test_Validator_SetAndValidate_Required_Int32(t *testing.T) {
+	t.Run("existing required value preserved", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			Int32Field: 47,
+		}
+
+		v.AddRequiredInt32Field("test", &model.Int32Field)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": int32(43)}})
+		require.NoError(t, err)
+		require.Equal(t, int32(47), model.Int32Field)
+		require.Equal(t, int32(47), v.ConnectionValues["test"])
+		require.Empty(t, v.ConnectionSecrets)
+	})
+
+	t.Run("required recipe value set", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			Int32Field: 0,
+		}
+		v.AddRequiredInt32Field("test", &model.Int32Field)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": int32(43)}})
+		require.NoError(t, err)
+		require.Equal(t, int32(43), model.Int32Field)
+		require.Equal(t, int32(43), v.ConnectionValues["test"])
+		require.Empty(t, v.ConnectionSecrets)
+	})
+
+	t.Run("required value missing with recipe", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			Int32Field: 0,
+		}
+		v.AddRequiredInt32Field("test", &model.Int32Field)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{})
+		require.Error(t, err)
+		require.IsType(t, &ValidationError{}, err)
+		require.Equal(t, "the connection value \"test\" should be provided by the recipe, set '.properties.test' to provide a value manually", err.Error())
+	})
+
+	t.Run("required value missing without recipe", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			Int32Field: 0,
+		}
+		v.AddRequiredInt32Field("test", &model.Int32Field)
+
+		err := v.SetAndValidate(nil)
+		require.Error(t, err)
+		require.IsType(t, &ValidationError{}, err)
+		require.Equal(t, "the connection value \"test\" must be provided when not using a recipe. Set '.properties.test' to provide a value manually", err.Error())
+	})
+}
+
+func Test_Validator_SetAndValidate_Optional_Int32(t *testing.T) {
+	t.Run("existing optional value preserved", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			Int32Field: 47,
+		}
+
+		v.AddOptionalInt32Field("test", &model.Int32Field)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": int32(43)}})
+		require.NoError(t, err)
+		require.Equal(t, int32(47), model.Int32Field)
+		require.Equal(t, int32(47), v.ConnectionValues["test"])
+		require.Empty(t, v.ConnectionSecrets)
+	})
+
+	t.Run("optional recipe value set", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			Int32Field: 0,
+		}
+		v.AddOptionalInt32Field("test", &model.Int32Field)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": int32(43)}})
+		require.NoError(t, err)
+		require.Equal(t, int32(43), model.Int32Field)
+		require.Equal(t, int32(43), v.ConnectionValues["test"])
+		require.Empty(t, v.ConnectionSecrets)
+	})
+
+	t.Run("optional value missing with recipe", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			Int32Field: 0,
+		}
+		v.AddOptionalInt32Field("test", &model.Int32Field)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{})
+		require.NoError(t, err)
+		require.Equal(t, int32(0), model.Int32Field)
+		require.Empty(t, v.ConnectionValues)
+		require.Empty(t, v.ConnectionSecrets)
+	})
+
+	t.Run("optional value missing without recipe", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			Int32Field: 0,
+		}
+		v.AddOptionalInt32Field("test", &model.Int32Field)
+
+		err := v.SetAndValidate(nil)
+		require.NoError(t, err)
+		require.Equal(t, int32(0), model.Int32Field)
+		require.Empty(t, v.ConnectionValues)
+		require.Empty(t, v.ConnectionSecrets)
+	})
+}
+
+func Test_Validator_TypeConversions_Int32(t *testing.T) {
+	t.Run("conversion from int", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			Int32Field: 0,
+		}
+		v.AddOptionalInt32Field("test", &model.Int32Field)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": int(43)}})
+		require.NoError(t, err)
+		require.Equal(t, int32(43), model.Int32Field)
+		require.Equal(t, int32(43), v.ConnectionValues["test"])
+		require.Empty(t, v.ConnectionSecrets)
+	})
+
+	t.Run("conversion from float64", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			Int32Field: 0,
+		}
+		v.AddOptionalInt32Field("test", &model.Int32Field)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": float64(43.1)}})
+		require.NoError(t, err)
+		require.Equal(t, int32(43), model.Int32Field)
+		require.Equal(t, int32(43), v.ConnectionValues["test"])
+		require.Empty(t, v.ConnectionSecrets)
+	})
+
+	t.Run("failed conversion", func(t *testing.T) {
+		v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+		model := testDatamodel{
+			Int32Field: 0,
+		}
+		v.AddOptionalInt32Field("test", &model.Int32Field)
+
+		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": "heyyyyy"}})
+		require.Error(t, err)
+		require.IsType(t, &ValidationError{}, err)
+		require.Equal(t, "the connection value \"test\" provided by the recipe is expected to be a int32, got string", err.Error())
+	})
+}
+
+func Test_Validator_SetAndValidate_MultipleErrors(t *testing.T) {
+	v := NewValidator(&map[string]any{}, &map[string]rpv1.SecretValueReference{}, &[]rpv1.OutputResource{})
+
+	model := testDatamodel{
+		StringField:            "",
+		AnotherCoolStringField: "",
+	}
+	v.AddRequiredStringField("one", &model.StringField)
+	v.AddRequiredStringField("two", &model.AnotherCoolStringField)
+
+	err := v.SetAndValidate(nil)
+	require.Error(t, err)
+	require.IsType(t, &ValidationError{}, err)
+	require.Equal(t, "validation returned multiple errors:\n\nthe connection value \"one\" must be provided when not using a recipe. Set '.properties.one' to provide a value manually\nthe connection value \"two\" must be provided when not using a recipe. Set '.properties.two' to provide a value manually", err.Error())
+}


### PR DESCRIPTION
# Description

This change introduces some validation utilities that we will use while authoring resource processors.

The goal of the validator is to turn our processors into declarative-ish code. It implements all of the semantics we want for processing the results of executing a recipe. See commends on the Validator type for details.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Example

It's a little hard to understand the purpose of this code without an example. For your viewing pleasure here's the implementation of the processor for Redis.

Compare this with: https://github.com/project-radius/radius/blob/main/pkg/linkrp/renderers/rediscaches/renderer.go

```go
type Processor struct {
	Client processors.ResourceClient
}

func (p *Processor) Process(ctx context.Context, resource *datamodel.RedisCache, output *recipes.RecipeOutput) error {
	validator := processors.NewValidator(&resource.ComputedValues, &resource.SecretValues, &resource.Properties.BasicResourceProperties.Status.OutputResources)
	validator.AddResourceField(&resource.Properties.Resource)
	validator.AddRequiredStringField(renderers.Host, &resource.Properties.Host)
	validator.AddRequiredInt32Field(renderers.Port, &resource.Properties.Port)
	validator.AddOptionalStringField(renderers.UsernameStringValue, &resource.Properties.Username)
	validator.AddOptionalSecretField(renderers.PasswordStringHolder, &resource.Properties.Secrets.Password)
	validator.AddComputedSecretField(renderers.ConnectionStringValue, &resource.Properties.Secrets.ConnectionString, func() (string, *processors.ValidationError) {
		return p.computeConnectionString(resource), nil
	})

	err := validator.SetAndValidate(output)
	if err != nil {
		return v1.NewClientErrInvalidRequest(err.Error())
	}

	return nil
}

func (p *Processor) computeConnectionString(resource *datamodel.RedisCache) string {
	ssl := resource.Properties.Port == 6380
	connectionString := fmt.Sprintf("%s:%v,abortConnect=False", resource.Properties.Host, resource.Properties.Port)
	if ssl {
		connectionString = connectionString + ",ssl=True"
	}

	if resource.Properties.Username != "" && resource.Properties.Secrets.Password != "" {
		connectionString = connectionString + ",user=" + resource.Properties.Username + ",password=" + resource.Properties.Secrets.Password
	}

	return connectionString
}
```