### PR TITLE
Revert "Stop build if coverage is lower than main"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -112,6 +112,9 @@ jobs:
           else
             COLOR=green
           fi
+          
+          DIFF_RATE=$(echo "$UT_COVERAGE-$MAIN_COVERAGE" | bc -l)
+          echo "diff_coverage=$DIFF_RATE" >> $GITHUB_ENV
 
           echo "coverage_img=https://img.shields.io/badge/coverage-$UT_COVERAGE%25-$COLOR" >> $GITHUB_ENV
           # copy coverage to cache

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -113,9 +113,6 @@ jobs:
             COLOR=green
           fi
 
-          DIFF_RATE=$(echo "$UT_COVERAGE-$MAIN_COVERAGE" | bc -l)
-          echo "diff_coverage=$DIFF_RATE" >> $GITHUB_ENV
-
           echo "coverage_img=https://img.shields.io/badge/coverage-$UT_COVERAGE%25-$COLOR" >> $GITHUB_ENV
           # copy coverage to cache
           cp ./dist/ut_coverage.txt ./dist/cache/
@@ -151,14 +148,8 @@ jobs:
 
             * Your PR branch coverage: ${{ env.ut_coverage }} %
             * main branch coverage: ${{ env.main_coverage }} %
-            * diff coverage: ${{ env.diff_coverage }} %
 
             > The coverage result does not include the functional test coverage. 
-      - name: Stop build if PR branch coverage is lower than main branch.
-        if: (env.main_coverage > env.ut_coverage) &&  matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && github.event.pull_request
-        run: |
-          echo "stop build to prevent from merging PR because coverage is down from ${{ env.main_coverage }} % to ${{ env.ut_coverage }} %."
-          exit 1
       - name: Save coverage (only main push)
         uses: actions/cache/save@v3
         if: matrix.target_arch == 'amd64' && matrix.target_os == 'linux' && github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -148,6 +148,7 @@ jobs:
 
             * Your PR branch coverage: ${{ env.ut_coverage }} %
             * main branch coverage: ${{ env.main_coverage }} %
+            * diff coverage: ${{ env.diff_coverage }} %
 
             > The coverage result does not include the functional test coverage. 
       - name: Save coverage (only main push)


### PR DESCRIPTION
Reverts enforcement of coverage blocker on builds per discussion with @nicolejms 