### PR TITLE
Download the correct architecture of bicep compiler

### DIFF
--- a/pkg/cli/tools/binary_tools_test.go
+++ b/pkg/cli/tools/binary_tools_test.go
@@ -6,6 +6,7 @@
 package tools
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"testing"
@@ -34,4 +35,62 @@ func TestGetDownloadURI(t *testing.T) {
 		require.ErrorIs(t, wantErr, gotErr, "GetDownloadURI() error = %v, wantErr %v", gotErr, wantErr)
 	}
 	require.Equal(t, want, got, "GetDownloadURI() got = %v, wantErr %v", got, want)
+}
+
+func TestGetValidPlatform(t *testing.T) {
+	osArchTests := []struct {
+		currentOS   string
+		currentArch string
+		out         string
+		err         error
+	}{
+		{
+			currentOS:   "darwin",
+			currentArch: "amd64",
+			out:         "macos-x64",
+		},
+		{
+			currentOS:   "darwin",
+			currentArch: "arm64",
+			out:         "macos-arm64",
+		},
+		{
+			currentOS:   "windows",
+			currentArch: "amd64",
+			out:         "windows-x64",
+		},
+		{
+			currentOS:   "windows",
+			currentArch: "arm64",
+			out:         "",
+			err:         errors.New("unsupported platform windows/arm64"),
+		},
+		{
+			currentOS:   "linux",
+			currentArch: "amd64",
+			out:         "linux-x64",
+		},
+		{
+			currentOS:   "linux",
+			currentArch: "arm",
+			out:         "linux-arm",
+		},
+		{
+			currentOS:   "linux",
+			currentArch: "arm64",
+			out:         "linux-arm64",
+		},
+	}
+
+	for _, tc := range osArchTests {
+		t.Run(tc.currentOS+"-"+tc.currentArch, func(t *testing.T) {
+			platform, err := GetValidPlatform(tc.currentOS, tc.currentArch)
+			if tc.err != nil {
+				require.ErrorContains(t, err, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.out, platform, "GetValidPlatform() got = %v, want %v", platform, tc.out)
+		})
+	}
 }


### PR DESCRIPTION
# Description

Previously, wei hard-coded the x64 architecture so rad cli always downloaded x64 binary regardless of the current environment where user runs cli. This PR is to download the right architecture binary.

This PR should follow PR https://github.com/project-radius/bicep/pull/589

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: radius-project/core-team#1174

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
