### PR TITLE
Add resource client for links/recipes

### DIFF
--- a/pkg/azure/clientv2/clients.go
+++ b/pkg/azure/clientv2/clients.go
@@ -78,8 +78,21 @@ func NewSubscriptionsClient(options *Options) (*armsubscriptions.Client, error) 
 }
 
 // NewGenericResourceClient creates a new generic client to handle resources.
-func NewGenericResourceClient(subscriptionID string, options *Options) (*armresources.Client, error) {
-	return armresources.NewClient(subscriptionID, options.Cred, defaultClientOptions)
+func NewGenericResourceClient(subscriptionID string, options *Options, clientOptions *arm.ClientOptions) (*armresources.Client, error) {
+	// Allow setting client options for testing.
+	if clientOptions == nil {
+		clientOptions = defaultClientOptions
+	}
+	return armresources.NewClient(subscriptionID, options.Cred, clientOptions)
+}
+
+// NewProvidersClient creates a new client that can be used to look up resource providers and API versions.
+func NewProvidersClient(subcriptionID string, options *Options, clientOptions *arm.ClientOptions) (*armresources.ProvidersClient, error) {
+	// Allow setting client options for testing.
+	if clientOptions == nil {
+		clientOptions = defaultClientOptions
+	}
+	return armresources.NewProvidersClient(subcriptionID, options.Cred, clientOptions)
 }
 
 // NewAccountsClient creates a new accounts client to handle storage accounts.

--- a/pkg/corerp/handlers/arm_handler.go
+++ b/pkg/corerp/handlers/arm_handler.go
@@ -76,7 +76,7 @@ func getByID(ctx context.Context, options *clientv2.Options, identity resourcemo
 		return nil, err
 	}
 
-	client, err := clientv2.NewGenericResourceClient(parsed.FindScope(ucpresources.SubscriptionsSegment), options)
+	client, err := clientv2.NewGenericResourceClient(parsed.FindScope(ucpresources.SubscriptionsSegment), options, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/linkrp/backend/controller/createorupdateresource.go
+++ b/pkg/linkrp/backend/controller/createorupdateresource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/project-radius/radius/pkg/linkrp/processors"
 	"github.com/project-radius/radius/pkg/recipes"
 	"github.com/project-radius/radius/pkg/recipes/engine"
+	"github.com/project-radius/radius/pkg/resourcemodel"
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 	"github.com/project-radius/radius/pkg/ucp/store"
 	"github.com/project-radius/radius/pkg/ucp/ucplog"
@@ -27,7 +28,7 @@ type CreateOrUpdateResource[P interface {
 }, T any] struct {
 	ctrl.BaseController
 	processor processors.ResourceProcessor[P, T]
-	engine       engine.Engine
+	engine    engine.Engine
 	client    processors.ResourceClient
 }
 
@@ -120,7 +121,7 @@ func (c *CreateOrUpdateResource[P, T]) garbageCollectResources(ctx context.Conte
 	for _, resource := range diff {
 		id := resource.Identity.GetID()
 		logger.Info(fmt.Sprintf("Deleting output resource: %q", id), ucplog.LogFieldTargetResourceID, id)
-		err := c.client.Delete(ctx, id)
+		err := c.client.Delete(ctx, id, resourcemodel.APIVersionUnknown)
 		if err != nil {
 			return err
 		}

--- a/pkg/linkrp/backend/controller/createorupdateresource_test.go
+++ b/pkg/linkrp/backend/controller/createorupdateresource_test.go
@@ -321,12 +321,12 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 
 			if tt.getErr == nil && !tt.conversionFailure && tt.recipeErr == nil && tt.processorErr == nil && tt.resourceClientErr != nil {
 				client.EXPECT().
-					Delete(gomock.Any(), oldOutputResourceResourceID).
+					Delete(gomock.Any(), oldOutputResourceResourceID, resourcemodel.APIVersionUnknown).
 					Return(tt.resourceClientErr).
 					Times(1)
 			} else if tt.getErr == nil && !tt.conversionFailure && tt.recipeErr == nil && tt.processorErr == nil {
 				client.EXPECT().
-					Delete(gomock.Any(), oldOutputResourceResourceID).
+					Delete(gomock.Any(), oldOutputResourceResourceID, resourcemodel.APIVersionUnknown).
 					Return(nil).
 					Times(1)
 			}

--- a/pkg/linkrp/handlers/arm_handler.go
+++ b/pkg/linkrp/handlers/arm_handler.go
@@ -68,7 +68,7 @@ func (handler *armHandler) Delete(ctx context.Context, resource *rpv1.OutputReso
 		return err
 	}
 
-	client, err := clientv2.NewGenericResourceClient(parsed.FindScope(ucpresources.SubscriptionsSegment), &handler.arm.ClientOptions)
+	client, err := clientv2.NewGenericResourceClient(parsed.FindScope(ucpresources.SubscriptionsSegment), &handler.arm.ClientOptions, nil)
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func getByID(ctx context.Context, options *clientv2.Options, id, apiVersion stri
 	logger := ucplog.FromContextOrDiscard(ctx)
 	logger.Info("Fetching arm resource by id")
 
-	client, err := clientv2.NewGenericResourceClient(parsed.FindScope(ucpresources.SubscriptionsSegment), options)
+	client, err := clientv2.NewGenericResourceClient(parsed.FindScope(ucpresources.SubscriptionsSegment), options, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/linkrp/processors/mock_resourceclient.go
+++ b/pkg/linkrp/processors/mock_resourceclient.go
@@ -35,29 +35,15 @@ func (m *MockResourceClient) EXPECT() *MockResourceClientMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockResourceClient) Delete(arg0 context.Context, arg1 string) error {
+func (m *MockResourceClient) Delete(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockResourceClientMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockResourceClientMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockResourceClient)(nil).Delete), arg0, arg1)
-}
-
-// Get mocks base method.
-func (m *MockResourceClient) Get(arg0 context.Context, arg1 string, arg2 interface{}) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Get indicates an expected call of Get.
-func (mr *MockResourceClientMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockResourceClient)(nil).Get), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockResourceClient)(nil).Delete), arg0, arg1, arg2)
 }

--- a/pkg/linkrp/processors/resourceclient.go
+++ b/pkg/linkrp/processors/resourceclient.go
@@ -1,0 +1,248 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package processors
+
+import (
+	context "context"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/project-radius/radius/pkg/azure/armauth"
+	"github.com/project-radius/radius/pkg/azure/clientv2"
+	aztoken "github.com/project-radius/radius/pkg/azure/tokencredentials"
+	"github.com/project-radius/radius/pkg/cli/clients_new/generated"
+	"github.com/project-radius/radius/pkg/resourcemodel"
+	"github.com/project-radius/radius/pkg/sdk"
+	"github.com/project-radius/radius/pkg/trace"
+	"github.com/project-radius/radius/pkg/ucp/resources"
+	"github.com/project-radius/radius/pkg/ucp/ucplog"
+	"go.opentelemetry.io/otel/attribute"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/discovery"
+	runtime_client "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type resourceClient struct {
+	arm *armauth.ArmConfig
+
+	// armClientOptions is used to create ARM clients. Provide a Transport to override for testing.
+	armClientOptions *arm.ClientOptions
+
+	// connection is the connection to use for UCP resources. Override this for testing.
+	connection sdk.Connection
+
+	// k8sClient is the Kubernetes client used to delete Kubernetes resources. Override this for testing.
+	k8sClient runtime_client.Client
+
+	// k8sDiscoveryClient is the Kubernetes client to used for API version lookups on Kubernetes resources. Override this for testing.
+	k8sDiscoveryClient discovery.ServerGroupsInterface
+}
+
+// NewResourceClient creates a new resource client.
+func NewResourceClient(arm *armauth.ArmConfig, connection sdk.Connection, k8sClient runtime_client.Client, k8sDiscoveryClient discovery.ServerGroupsInterface) *resourceClient {
+	return &resourceClient{arm: arm, connection: connection, k8sClient: k8sClient, k8sDiscoveryClient: k8sDiscoveryClient}
+}
+
+// Delete deletes a resource by id.
+func (c *resourceClient) Delete(ctx context.Context, id string, apiVersion string) error {
+	parsed, err := resources.ParseResource(id)
+	if err != nil {
+		return err
+	}
+
+	// Performing deletion is going to fire of potentially many requests due to discovery and polling. Creating
+	// a span will help categorize the requests in traces.
+	attributes := []attribute.KeyValue{{Key: attribute.Key(ucplog.LogFieldTargetResourceID), Value: attribute.StringValue(id)}}
+	ctx, span := trace.StartCustomSpan(ctx, "resourceclient.Delete", trace.BackendTracerName, attributes)
+	defer span.End()
+
+	// Ideally we'd do all of our resource deletion through UCP. Unfortunately we have not yet integrated
+	// Azure and Kubernetes resources yet, so those are handled as special cases here.
+	ns := strings.ToLower(parsed.PlaneNamespace())
+
+	if !parsed.IsUCPQualfied() || strings.HasPrefix(ns, "azure/") {
+		return c.wrapError(parsed, c.deleteAzureResource(ctx, parsed, apiVersion))
+	} else if strings.HasPrefix(ns, "kubernetes/") {
+		return c.wrapError(parsed, c.deleteKubernetesResource(ctx, parsed, apiVersion))
+	} else {
+		return c.wrapError(parsed, c.deleteUCPResource(ctx, parsed, apiVersion))
+	}
+}
+
+func (c *resourceClient) wrapError(id resources.ID, err error) error {
+	if err != nil {
+		return &ResourceError{Inner: err, ID: id.String()}
+	}
+
+	return nil
+}
+
+func (c *resourceClient) deleteAzureResource(ctx context.Context, id resources.ID, apiVersion string) error {
+	var err error
+	if id.IsUCPQualfied() {
+		id, err = resources.ParseResource(resources.MakeRelativeID(id.ScopeSegments()[1:], id.TypeSegments()...))
+		if err != nil {
+			return err
+		}
+	}
+
+	if apiVersion == "" || apiVersion == resourcemodel.APIVersionUnknown {
+
+		apiVersion, err = c.lookupARMAPIVersion(ctx, id)
+		if err != nil {
+			return err
+		}
+	}
+
+	client, err := clientv2.NewGenericResourceClient(id.FindScope(resources.SubscriptionsSegment), &c.arm.ClientOptions, c.armClientOptions)
+	if err != nil {
+		return err
+	}
+
+	poller, err := client.BeginDeleteByID(ctx, id.String(), apiVersion, &armresources.ClientBeginDeleteByIDOptions{})
+	if err != nil {
+		return err
+	}
+
+	_, err = poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *resourceClient) lookupARMAPIVersion(ctx context.Context, id resources.ID) (string, error) {
+	client, err := clientv2.NewProvidersClient(id.FindScope(resources.SubscriptionsSegment), &c.arm.ClientOptions, c.armClientOptions)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Get(ctx, id.ProviderNamespace(), nil)
+	if err != nil {
+		return "", err
+	}
+
+	// We need to match on the resource type name without the provider namespace.
+	shortType := strings.TrimPrefix(id.Type(), id.ProviderNamespace()+"/")
+	for _, rt := range resp.ResourceTypes {
+		if !strings.EqualFold(shortType, *rt.ResourceType) {
+			continue
+		}
+		if rt.DefaultAPIVersion != nil {
+			return *rt.DefaultAPIVersion, nil
+		}
+
+		if len(rt.APIVersions) > 0 {
+			return *rt.APIVersions[0], nil
+		}
+
+		return "", fmt.Errorf("could not find API version for type %q, no supported API versions", id.Type())
+
+	}
+
+	return "", fmt.Errorf("could not find API version for type %q, type was not found", id.Type())
+}
+
+func (c *resourceClient) deleteUCPResource(ctx context.Context, id resources.ID, apiVersion string) error {
+	// NOTE: the API version passed in here is ignored.
+	//
+	// We're using a generated client that understands Radius' currently supported API version.
+	//
+	// For AWS resources, the server does not yet validate the API version.
+	//
+	// In the future we should change this to look up API versions dynamically like we do for ARM.
+	client, err := generated.NewGenericResourcesClient(id.RootScope(), id.Type(), &aztoken.AnonymousCredential{}, sdk.NewClientOptions(c.connection))
+	if err != nil {
+		return err
+	}
+
+	poller, err := client.BeginDelete(ctx, id.Name(), nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *resourceClient) deleteKubernetesResource(ctx context.Context, id resources.ID, apiVersion string) error {
+	if apiVersion == "" || apiVersion == resourcemodel.APIVersionUnknown {
+		var err error
+		apiVersion, err = c.lookupKubernetesAPIVersion(ctx, id)
+		if err != nil {
+			return err
+		}
+	}
+
+	identity := resourcemodel.FromUCPID(id, apiVersion)
+	gvk, ns, name, err := identity.RequireKubernetes()
+	if err != nil {
+		// We don't expect this to fail, but just in case....
+		return fmt.Errorf("could not understand kubernetes resource id %q: %w", id.String(), err)
+	}
+
+	metadata := map[string]any{
+		name: name,
+	}
+	if ns != "" {
+		metadata["namespace"] = ns
+	}
+
+	obj := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": gvk.GroupVersion().String(),
+			"kind":       gvk.Kind,
+			"metadata":   metadata,
+		},
+	}
+
+	err = runtime_client.IgnoreNotFound(c.k8sClient.Delete(ctx, &obj))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *resourceClient) lookupKubernetesAPIVersion(ctx context.Context, id resources.ID) (string, error) {
+	identity := resourcemodel.FromUCPID(id, resourcemodel.APIVersionUnknown)
+	gvk, _, _, err := identity.RequireKubernetes()
+	if err != nil {
+		// We don't expect this to fail, but just in case....
+		return "", fmt.Errorf("could not find API version for type %q: %w", id.Type(), err)
+	}
+
+	list, err := c.k8sDiscoveryClient.ServerGroups()
+	if err != nil {
+		return "", fmt.Errorf("could not find API version for type %q: %w", id.Type(), err)
+	}
+
+	for _, group := range list.Groups {
+		if gvk.Group != group.Name {
+			continue
+		}
+
+		if group.PreferredVersion.Version != "" {
+			return group.PreferredVersion.Version, nil
+		}
+
+		if len(group.Versions) > 0 {
+			return group.Versions[0].Version, nil
+		}
+
+		return "", fmt.Errorf("could not find API version for type %q, no supported API versions", id.Type())
+
+	}
+
+	return "", fmt.Errorf("could not find API version for type %q, type was not found", id.Type())
+}

--- a/pkg/linkrp/processors/resourceclient_test.go
+++ b/pkg/linkrp/processors/resourceclient_test.go
@@ -1,0 +1,454 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package processors
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	"github.com/project-radius/radius/pkg/azure/armauth"
+	"github.com/project-radius/radius/pkg/azure/clientv2"
+	aztoken "github.com/project-radius/radius/pkg/azure/tokencredentials"
+	"github.com/project-radius/radius/pkg/sdk"
+	"github.com/project-radius/radius/pkg/to"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	ARMResourceID                    = "/subscriptions/0000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm"
+	ARMProviderPath                  = "/subscriptions/0000/providers/Microsoft.Compute"
+	AzureUCPResourceID               = "/planes/azure/azurecloud/subscriptions/0000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm"
+	ARMAPIVersion                    = "2020-01-01"
+	AWSResourceID                    = "/planes/aws/aws/accounts/0000/regions/us-east-1/providers/AWS.Kinesis/Streams/test-stream"
+	KubernetesCoreGroupResourceID    = "/planes/kubernetes/local/namespaces/test-namespace/providers/core/Secret/test-name"
+	KubernetesNonCoreGroupResourceID = "/planes/kubernetes/local/namespaces/test-namespace/providers/apps/Deployment/test-name"
+)
+
+func Test_Delete_InvalidResourceID(t *testing.T) {
+	c := NewResourceClient(nil, nil, nil, nil)
+	err := c.Delete(context.Background(), "invalid", "")
+	require.Error(t, err)
+}
+
+func Test_Delete_ARM(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc(ARMResourceID, handleDeleteSuccess(t))
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		c := NewResourceClient(newArmOptions(server.URL), nil, nil, nil)
+		c.armClientOptions = newClientOptions(server.Client(), server.URL)
+
+		err := c.Delete(context.Background(), ARMResourceID, ARMAPIVersion)
+		require.NoError(t, err)
+	})
+
+	t.Run("success (ucp absolute ID)", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc(ARMResourceID, handleDeleteSuccess(t)) // Note, the /planes... prefix is not part of the request.
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		c := NewResourceClient(newArmOptions(server.URL), nil, nil, nil)
+		c.armClientOptions = newClientOptions(server.Client(), server.URL)
+
+		err := c.Delete(context.Background(), AzureUCPResourceID, ARMAPIVersion)
+		require.NoError(t, err)
+	})
+
+	t.Run("failure - delete fails", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc(ARMResourceID, handleJSONResponse(t, v1.ErrorResponse{
+			Error: v1.ErrorDetails{
+				Code: v1.CodeConflict,
+			},
+		}, 409))
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		c := NewResourceClient(newArmOptions(server.URL), nil, nil, nil)
+		c.armClientOptions = newClientOptions(server.Client(), server.URL)
+
+		err := c.Delete(context.Background(), ARMResourceID, ARMAPIVersion)
+		require.Error(t, err)
+		require.IsType(t, &ResourceError{}, err)
+	})
+
+	t.Run("success - lookup API Version (default)", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc(ARMResourceID, handleDeleteSuccess(t))
+		mux.HandleFunc(ARMProviderPath, handleJSONResponse(t, armresources.Provider{
+			Namespace: to.Ptr("Microsoft.Compute"),
+			ResourceTypes: []*armresources.ProviderResourceType{
+				{
+					ResourceType: to.Ptr("anotherType"),
+					APIVersions:  []*string{},
+				},
+				{
+					ResourceType:      to.Ptr("virtualMachines"),
+					DefaultAPIVersion: to.Ptr(ARMAPIVersion),
+				},
+			},
+		}, 200))
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		c := NewResourceClient(newArmOptions(server.URL), nil, nil, nil)
+		c.armClientOptions = newClientOptions(server.Client(), server.URL)
+
+		err := c.Delete(context.Background(), ARMResourceID, "")
+		require.NoError(t, err)
+	})
+
+	t.Run("success - lookup API Version (first available)", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc(ARMResourceID, handleDeleteSuccess(t))
+		mux.HandleFunc(ARMProviderPath, handleJSONResponse(t, armresources.Provider{
+			Namespace: to.Ptr("Microsoft.Compute"),
+			ResourceTypes: []*armresources.ProviderResourceType{
+				{
+					ResourceType: to.Ptr("virtualMachines"),
+					APIVersions:  []*string{to.Ptr("2020-01-01"), to.Ptr("2020-01-02")},
+				},
+			},
+		}, 200))
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		c := NewResourceClient(newArmOptions(server.URL), nil, nil, nil)
+		c.armClientOptions = newClientOptions(server.Client(), server.URL)
+
+		err := c.Delete(context.Background(), ARMResourceID, "")
+		require.NoError(t, err)
+	})
+
+	t.Run("failure - lookup API Version - provider not found", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc(ARMProviderPath, handleNotFound(t))
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		c := NewResourceClient(newArmOptions(server.URL), nil, nil, nil)
+		c.armClientOptions = newClientOptions(server.Client(), server.URL)
+
+		err := c.Delete(context.Background(), ARMResourceID, "")
+		require.Error(t, err)
+		require.IsType(t, &ResourceError{}, err)
+	})
+
+	t.Run("failure - lookup API Version - resource type not found", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc(ARMProviderPath, handleJSONResponse(t, armresources.Provider{
+			Namespace:     to.Ptr("Microsoft.Compute"),
+			ResourceTypes: []*armresources.ProviderResourceType{},
+		}, 200))
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		c := NewResourceClient(newArmOptions(server.URL), nil, nil, nil)
+		c.armClientOptions = newClientOptions(server.Client(), server.URL)
+
+		err := c.Delete(context.Background(), ARMResourceID, "")
+		require.Error(t, err)
+		require.IsType(t, &ResourceError{}, err)
+		require.Contains(t, err.Error(), "could not find API version for type \"Microsoft.Compute/virtualMachines\", type was not found")
+	})
+
+	t.Run("failure - lookup API Version - no api versions", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc(ARMProviderPath, handleJSONResponse(t, armresources.Provider{
+			Namespace: to.Ptr("Microsoft.Compute"),
+			ResourceTypes: []*armresources.ProviderResourceType{
+				{
+					ResourceType: to.Ptr("virtualMachines"),
+					APIVersions:  []*string{},
+				},
+			},
+		}, 200))
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		c := NewResourceClient(newArmOptions(server.URL), nil, nil, nil)
+		c.armClientOptions = newClientOptions(server.Client(), server.URL)
+
+		err := c.Delete(context.Background(), ARMResourceID, "")
+		require.Error(t, err)
+		require.IsType(t, &ResourceError{}, err)
+		require.Contains(t, err.Error(), "could not find API version for type \"Microsoft.Compute/virtualMachines\", no supported API versions")
+	})
+}
+
+func Test_Delete_Kubernetes(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		client := fake.NewClientBuilder().WithObjects(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-name",
+				Namespace: "test-namespace",
+			},
+		}).Build()
+
+		c := NewResourceClient(nil, nil, client, nil)
+
+		err := c.Delete(context.Background(), KubernetesCoreGroupResourceID, "v1")
+		require.NoError(t, err)
+	})
+
+	t.Run("success (non-core)", func(t *testing.T) {
+		client := fake.NewClientBuilder().WithObjects(&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-name",
+				Namespace: "test-namespace",
+			},
+		}).Build()
+
+		c := NewResourceClient(nil, nil, client, nil)
+
+		err := c.Delete(context.Background(), KubernetesNonCoreGroupResourceID, "v1")
+		require.NoError(t, err)
+	})
+
+	// Note: unfortunately there isn't a great way to test a deletion failure with the runtime client.
+
+	t.Run("success - lookup API Version (preferred)", func(t *testing.T) {
+		client := fake.NewClientBuilder().WithObjects(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-name",
+				Namespace: "test-namespace",
+			},
+		}).Build()
+
+		dc := &discoveryClient{
+			Groups: &metav1.APIGroupList{
+				Groups: []metav1.APIGroup{
+					{
+						Name:             "apps",
+						PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: "apps/v1", Version: "v1"},
+					},
+					{
+						Name:             "",
+						PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: "v1", Version: "v1"},
+					},
+				},
+			},
+		}
+
+		c := NewResourceClient(nil, nil, client, dc)
+
+		err := c.Delete(context.Background(), KubernetesCoreGroupResourceID, "")
+		require.NoError(t, err)
+	})
+
+	t.Run("success - lookup API Version (first available)", func(t *testing.T) {
+		client := fake.NewClientBuilder().WithObjects(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-name",
+				Namespace: "test-namespace",
+			},
+		}).Build()
+
+		dc := &discoveryClient{
+			Groups: &metav1.APIGroupList{
+				Groups: []metav1.APIGroup{
+					{
+						Name:             "apps",
+						PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: "apps/v1", Version: ""},
+					},
+					{
+						Name:             "",
+						PreferredVersion: metav1.GroupVersionForDiscovery{},
+						Versions: []metav1.GroupVersionForDiscovery{
+							{GroupVersion: "v1", Version: "v1"},
+							{GroupVersion: "v1beta1", Version: "v1beta1"},
+						},
+					},
+				},
+			},
+		}
+
+		c := NewResourceClient(nil, nil, client, dc)
+
+		err := c.Delete(context.Background(), KubernetesCoreGroupResourceID, "")
+		require.NoError(t, err)
+	})
+
+	t.Run("failure - lookup API Version - group not found", func(t *testing.T) {
+		client := fake.NewClientBuilder().WithObjects(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-name",
+				Namespace: "test-namespace",
+			},
+		}).Build()
+
+		dc := &discoveryClient{
+			Groups: &metav1.APIGroupList{
+				Groups: []metav1.APIGroup{},
+			},
+		}
+
+		c := NewResourceClient(nil, nil, client, dc)
+
+		err := c.Delete(context.Background(), KubernetesCoreGroupResourceID, "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "could not find API version for type \"core/Secret\", type was not found")
+	})
+
+	t.Run("failure - lookup API Version - no api versions", func(t *testing.T) {
+		client := fake.NewClientBuilder().WithObjects(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-name",
+				Namespace: "test-namespace",
+			},
+		}).Build()
+
+		dc := &discoveryClient{
+			Groups: &metav1.APIGroupList{
+				Groups: []metav1.APIGroup{
+					{
+						Name:             "",
+						PreferredVersion: metav1.GroupVersionForDiscovery{},
+						Versions:         []metav1.GroupVersionForDiscovery{},
+					},
+				},
+			},
+		}
+
+		c := NewResourceClient(nil, nil, client, dc)
+
+		err := c.Delete(context.Background(), KubernetesCoreGroupResourceID, "")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "could not find API version for type \"core/Secret\", no supported API versions")
+	})
+}
+
+func Test_Delete_UCP(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc(AWSResourceID, handleDeleteSuccess(t))
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		connection, err := sdk.NewDirectConnection(server.URL)
+		require.NoError(t, err)
+
+		c := NewResourceClient(nil, connection, nil, nil)
+
+		err = c.Delete(context.Background(), AWSResourceID, "")
+		require.NoError(t, err)
+	})
+
+	t.Run("failure - delete fails", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc(AWSResourceID, handleJSONResponse(t, v1.ErrorResponse{
+			Error: v1.ErrorDetails{
+				Code: v1.CodeConflict,
+			},
+		}, 409))
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		connection, err := sdk.NewDirectConnection(server.URL)
+		require.NoError(t, err)
+
+		c := NewResourceClient(nil, connection, nil, nil)
+
+		err = c.Delete(context.Background(), AWSResourceID, "")
+		require.Error(t, err)
+		require.IsType(t, &ResourceError{}, err)
+	})
+}
+
+func newArmOptions(url string) *armauth.ArmConfig {
+	return &armauth.ArmConfig{
+		ClientOptions: clientv2.Options{
+			Cred:    &aztoken.AnonymousCredential{},
+			BaseURI: url,
+		},
+	}
+}
+
+func newClientOptions(c *http.Client, url string) *arm.ClientOptions {
+	return &arm.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Transport: &wrapper{Client: c},
+			Cloud: cloud.Configuration{
+				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+					cloud.ResourceManager: {
+						Endpoint: url,
+						Audience: "https://management.core.windows.net",
+					},
+				},
+			},
+		},
+	}
+}
+
+func handleDeleteSuccess(t *testing.T) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		w.WriteHeader(204)
+	}
+}
+
+func handleJSONResponse(t *testing.T, response any, statusCode int) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		b, err := json.Marshal(&response)
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, err = w.Write(b)
+		require.NoError(t, err)
+	}
+}
+
+func handleNotFound(t *testing.T) func(w http.ResponseWriter, r *http.Request) {
+	return handleJSONResponse(t, v1.ErrorResponse{
+		Error: v1.ErrorDetails{
+			Code: v1.CodeNotFound,
+		},
+	}, 404)
+}
+
+// wrapper implements the INTERNAL interface that autorest uses for transport :(.
+type wrapper struct {
+	Client *http.Client
+}
+
+func (w *wrapper) Do(req *http.Request) (*http.Response, error) {
+	return w.Client.Do(req)
+}
+
+type discoveryClient struct {
+	Groups *metav1.APIGroupList
+}
+
+func (d *discoveryClient) ServerGroups() (*metav1.APIGroupList, error) {
+	return d.Groups, nil
+}

--- a/pkg/linkrp/processors/types.go
+++ b/pkg/linkrp/processors/types.go
@@ -7,6 +7,7 @@ package processors
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/project-radius/radius/pkg/recipes"
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
@@ -28,9 +29,34 @@ type ResourceProcessor[P interface {
 
 // ResourceClient is a client used by resource processors for interacting with UCP resources.
 type ResourceClient interface {
-	// Get retrieves a resource by id. Populate the 'obj' parameter with a reference to the desired type.
-	Get(ctx context.Context, id string, obj any) error
-
 	// Delete deletes a resource by id.
-	Delete(ctx context.Context, id string) error
+	//
+	// If the API version is omitted, then an attempt will be made to look up the API version.
+	Delete(ctx context.Context, id string, apiVersion string) error
+}
+
+// ResourceError represents an error that occured while processing a resource.
+type ResourceError struct {
+	ID    string
+	Inner error
+}
+
+// Error formats the error as a string.
+func (e *ResourceError) Error() string {
+	return fmt.Sprintf("failed to delete resource %q: %v", e.ID, e.Inner)
+}
+
+// Unwrap gets the wrapper error of this ResourceDeletionErr.
+func (e *ResourceError) Unwrap() error {
+	return e.Inner
+}
+
+// ValidationError represents a user-facing validation message reported by the processor.
+type ValidationError struct {
+	Message string
+}
+
+// Error gets the string representation of the error.
+func (e *ValidationError) Error() string {
+	return e.Message
 }

--- a/pkg/linkrp/processors/validator.go
+++ b/pkg/linkrp/processors/validator.go
@@ -62,16 +62,6 @@ func NewValidator(connectionValues *map[string]any, connectionSecrets *map[strin
 	}
 }
 
-// ValidationError represents a user-facing validation message.
-type ValidationError struct {
-	Message string
-}
-
-// Error gets the string representation of the error.
-func (e *ValidationError) Error() string {
-	return e.Message
-}
-
 // AddResourceField registers a field containing a resource ID with the validator.
 func (v *Validator) AddResourceField(ref *string) {
 	v.resourceField = ref


### PR DESCRIPTION
# Description

This change adds a new resource client type for use in our links/recipes. The new client only supports deletion, and supports Azure, AWS, and Kubernetes resources.

Additionally the client can infer the API version to use. This is important for recipes, because we handle a lot of different resource types there and want to avoid hardcoded knowledge. Since this is just being used for deletion, we really don't care about the API version used, we just want to pick one.

This client also works with the limitations that we have today in UCP:

- Azure resources go directly to ARM without proxying.
- Kubernetes resources go directly to Kubernetes without proxying.
- We have a hardcoded API version for Radius.

This limitations are OK for now because the code won't change when we improve the client.

This is not hooked up to anything yet, breaking up a larger changeset into smaller, more reviewable chunks. 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
