### PR TITLE
Implement redis processor

### DIFF
--- a/pkg/linkrp/processors/rediscaches/doc.go
+++ b/pkg/linkrp/processors/rediscaches/doc.go
@@ -1,0 +1,7 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+// rediscaches contains the resource processor for redis caches. See the processors package for more information.
+package rediscaches

--- a/pkg/linkrp/processors/rediscaches/processor.go
+++ b/pkg/linkrp/processors/rediscaches/processor.go
@@ -1,0 +1,63 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package rediscaches
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/project-radius/radius/pkg/linkrp/datamodel"
+	"github.com/project-radius/radius/pkg/linkrp/processors"
+	"github.com/project-radius/radius/pkg/linkrp/renderers"
+	"github.com/project-radius/radius/pkg/recipes"
+)
+
+const (
+	// RedisNonSSLPort is the default port for Redis non-SSL connections.
+	RedisNonSSLPort = 6379
+
+	// RedisSSLPort is the default port for Redis SSL connections.
+	RedisSSLPort = 6380
+)
+
+type Processor struct {
+}
+
+func (p *Processor) Process(ctx context.Context, resource *datamodel.RedisCache, output *recipes.RecipeOutput) error {
+	validator := processors.NewValidator(&resource.ComputedValues, &resource.SecretValues, &resource.Properties.Status.OutputResources)
+	validator.AddResourceField(&resource.Properties.Resource)
+	validator.AddRequiredStringField(renderers.Host, &resource.Properties.Host)
+	validator.AddRequiredInt32Field(renderers.Port, &resource.Properties.Port)
+	validator.AddOptionalStringField(renderers.UsernameStringValue, &resource.Properties.Username)
+	validator.AddOptionalSecretField(renderers.PasswordStringHolder, &resource.Properties.Secrets.Password)
+	validator.AddComputedSecretField(renderers.ConnectionStringValue, &resource.Properties.Secrets.ConnectionString, func() (string, *processors.ValidationError) {
+		return p.computeConnectionString(resource), nil
+	})
+
+	err := validator.SetAndValidate(output)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Processor) computeConnectionString(resource *datamodel.RedisCache) string {
+	ssl := resource.Properties.Port == RedisSSLPort
+	connectionString := fmt.Sprintf("%s:%v,abortConnect=False", resource.Properties.Host, resource.Properties.Port)
+	if ssl {
+		connectionString = connectionString + ",ssl=True"
+	}
+
+	if resource.Properties.Username != "" {
+		connectionString = connectionString + ",user=" + resource.Properties.Username
+	}
+	if resource.Properties.Secrets.Password != "" {
+		connectionString = connectionString + ",password=" + resource.Properties.Secrets.Password
+	}
+
+	return connectionString
+}

--- a/pkg/linkrp/processors/rediscaches/processor_test.go
+++ b/pkg/linkrp/processors/rediscaches/processor_test.go
@@ -1,0 +1,211 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package rediscaches
+
+import (
+	"context"
+	"testing"
+
+	"github.com/project-radius/radius/pkg/linkrp/datamodel"
+	"github.com/project-radius/radius/pkg/linkrp/processors"
+	"github.com/project-radius/radius/pkg/recipes"
+	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Process(t *testing.T) {
+	processor := Processor{}
+
+	const azureRedisResourceID1 = "/subscriptions/0000/resourceGroups/test-group/providers/Microsoft.Cache/redis/myredis1"
+	const azureRedisResourceID2 = "/subscriptions/0000/resourceGroups/test-group/providers/Microsoft.Cache/redis/myredis2"
+	const host = "myredis.redis.cache.windows.net"
+	const connectionString = "myredis.redis.cache.windows.net:6380,abortConnect=False,ssl=True,user=testuser,password=testpassword"
+	const username = "testuser"
+	const password = "testpassword"
+
+	t.Run("success - recipe", func(t *testing.T) {
+		resource := &datamodel.RedisCache{}
+		output := &recipes.RecipeOutput{
+			Resources: []string{
+				azureRedisResourceID1,
+			},
+			Values: map[string]any{
+				"host":     host,
+				"port":     RedisSSLPort,
+				"username": username,
+			},
+			Secrets: map[string]any{
+				"password": password,
+
+				// Let the connection string be computed, it will result in the same value
+				// as the variable 'connectionString'
+			},
+		}
+
+		err := processor.Process(context.Background(), resource, output)
+		require.NoError(t, err)
+
+		require.Equal(t, host, resource.Properties.Host)
+		require.Equal(t, int32(RedisSSLPort), resource.Properties.Port)
+		require.Equal(t, username, resource.Properties.Username)
+		require.Equal(t, password, resource.Properties.Secrets.Password)
+		require.Equal(t, connectionString, resource.Properties.Secrets.ConnectionString)
+
+		expectedValues := map[string]any{
+			"host":     host,
+			"port":     int32(RedisSSLPort),
+			"username": username,
+		}
+		expectedSecrets := map[string]rpv1.SecretValueReference{
+			"connectionString": {
+				Value: connectionString,
+			},
+			"password": {
+				Value: password,
+			},
+		}
+
+		expectedOutputResources, err := processors.GetOutputResourcesFromRecipe(output)
+		require.NoError(t, err)
+
+		require.Equal(t, expectedValues, resource.ComputedValues)
+		require.Equal(t, expectedSecrets, resource.SecretValues)
+		require.Equal(t, expectedOutputResources, resource.Properties.Status.OutputResources)
+	})
+
+	t.Run("success - values", func(t *testing.T) {
+		resource := &datamodel.RedisCache{
+			Properties: datamodel.RedisCacheProperties{
+				RedisResourceProperties: datamodel.RedisResourceProperties{
+					Resource: azureRedisResourceID1,
+				},
+				RedisValuesProperties: datamodel.RedisValuesProperties{
+					Host:     host,
+					Port:     RedisSSLPort,
+					Username: username,
+				},
+				Secrets: datamodel.RedisCacheSecrets{
+					Password:         password,
+					ConnectionString: connectionString,
+				},
+			},
+		}
+		err := processor.Process(context.Background(), resource, nil)
+		require.NoError(t, err)
+
+		require.Equal(t, host, resource.Properties.Host)
+		require.Equal(t, int32(RedisSSLPort), resource.Properties.Port)
+		require.Equal(t, username, resource.Properties.Username)
+		require.Equal(t, password, resource.Properties.Secrets.Password)
+		require.Equal(t, connectionString, resource.Properties.Secrets.ConnectionString)
+
+		expectedValues := map[string]any{
+			"host":     host,
+			"port":     int32(RedisSSLPort),
+			"username": username,
+		}
+		expectedSecrets := map[string]rpv1.SecretValueReference{
+			"password": {
+				Value: password,
+			},
+			"connectionString": {
+				Value: connectionString,
+			},
+		}
+
+		expectedOutputResource, err := processors.GetOutputResourceFromResourceID(azureRedisResourceID1)
+		require.NoError(t, err)
+
+		require.Equal(t, expectedValues, resource.ComputedValues)
+		require.Equal(t, expectedSecrets, resource.SecretValues)
+		require.Equal(t, []rpv1.OutputResource{expectedOutputResource}, resource.Properties.Status.OutputResources)
+	})
+
+	t.Run("success - recipe with value overrides", func(t *testing.T) {
+		resource := &datamodel.RedisCache{
+			Properties: datamodel.RedisCacheProperties{
+				RedisResourceProperties: datamodel.RedisResourceProperties{
+					Resource: azureRedisResourceID1,
+				},
+				RedisValuesProperties: datamodel.RedisValuesProperties{
+					Host:     host,
+					Port:     RedisSSLPort,
+					Username: username,
+				},
+				Secrets: datamodel.RedisCacheSecrets{
+					Password:         password,
+					ConnectionString: connectionString,
+				},
+			},
+		}
+		output := &recipes.RecipeOutput{
+			Resources: []string{
+				azureRedisResourceID2,
+			},
+
+			// Values and secrets will be overridden by the resource.
+			Values: map[string]any{
+				"host":     "asdf",
+				"port":     3333,
+				"username": "asdf",
+			},
+			Secrets: map[string]any{
+				"password":         "asdf",
+				"connectionString": "asdf",
+			},
+		}
+
+		err := processor.Process(context.Background(), resource, output)
+		require.NoError(t, err)
+
+		require.Equal(t, host, resource.Properties.Host)
+		require.Equal(t, int32(RedisSSLPort), resource.Properties.Port)
+		require.Equal(t, username, resource.Properties.Username)
+		require.Equal(t, password, resource.Properties.Secrets.Password)
+		require.Equal(t, connectionString, resource.Properties.Secrets.ConnectionString)
+
+		expectedValues := map[string]any{
+			"host":     host,
+			"port":     int32(RedisSSLPort),
+			"username": username,
+		}
+		expectedSecrets := map[string]rpv1.SecretValueReference{
+			"password": {
+				Value: password,
+			},
+			"connectionString": {
+				Value: connectionString,
+			},
+		}
+
+		expectedOutputResources := []rpv1.OutputResource{}
+
+		recipeOutputResources, err := processors.GetOutputResourcesFromRecipe(output)
+		require.NoError(t, err)
+		expectedOutputResources = append(expectedOutputResources, recipeOutputResources...)
+
+		resourceFieldOutputResource, err := processors.GetOutputResourceFromResourceID(azureRedisResourceID1)
+		require.NoError(t, err)
+		expectedOutputResources = append(expectedOutputResources, resourceFieldOutputResource)
+
+		require.Equal(t, expectedValues, resource.ComputedValues)
+		require.Equal(t, expectedSecrets, resource.SecretValues)
+		require.Equal(t, expectedOutputResources, resource.Properties.Status.OutputResources)
+	})
+
+	t.Run("failure - missing required values", func(t *testing.T) {
+		resource := &datamodel.RedisCache{}
+		output := &recipes.RecipeOutput{}
+
+		err := processor.Process(context.Background(), resource, output)
+		require.Error(t, err)
+		require.IsType(t, &processors.ValidationError{}, err)
+		require.Equal(t, `validation returned multiple errors:
+
+the connection value "host" should be provided by the recipe, set '.properties.host' to provide a value manually
+the connection value "port" should be provided by the recipe, set '.properties.port' to provide a value manually`, err.Error())
+	})
+}

--- a/pkg/linkrp/processors/types.go
+++ b/pkg/linkrp/processors/types.go
@@ -25,6 +25,16 @@ type ResourceProcessor[P interface {
 	Process(ctx context.Context, resource P, output *recipes.RecipeOutput) error
 }
 
+// ValidationError represents a user-facing validation message reported by the processor.
+type ValidationError struct {
+	Message string
+}
+
+// Error gets the string representation of the error.
+func (e *ValidationError) Error() string {
+	return e.Message
+}
+
 //go:generate mockgen -destination=./mock_resourceclient.go -package=processors -self_package github.com/project-radius/radius/pkg/linkrp/processors github.com/project-radius/radius/pkg/linkrp/processors ResourceClient
 
 // ResourceClient is a client used by resource processors for interacting with UCP resources.
@@ -49,14 +59,4 @@ func (e *ResourceError) Error() string {
 // Unwrap gets the wrapper error of this ResourceDeletionErr.
 func (e *ResourceError) Unwrap() error {
 	return e.Inner
-}
-
-// ValidationError represents a user-facing validation message reported by the processor.
-type ValidationError struct {
-	Message string
-}
-
-// Error gets the string representation of the error.
-func (e *ValidationError) Error() string {
-	return e.Message
 }

--- a/pkg/linkrp/processors/validator.go
+++ b/pkg/linkrp/processors/validator.go
@@ -127,7 +127,7 @@ func (v *Validator) SetAndValidate(output *recipes.RecipeOutput) error {
 		*v.OutputResources = append(*v.OutputResources, recipeResources...)
 	}
 
-	if v.resourceField != nil {
+	if v.resourceField != nil && *v.resourceField != "" {
 		outputResource, err := GetOutputResourceFromResourceID(*v.resourceField)
 		if err != nil {
 			return err

--- a/pkg/linkrp/processors/validator_test.go
+++ b/pkg/linkrp/processors/validator_test.go
@@ -68,7 +68,7 @@ func Test_Validator_SetAndValidate_OutputResources(t *testing.T) {
 
 		require.Empty(t, outputResources)
 	})
-	t.Run("resource field is empty", func(t *testing.T) {
+	t.Run("resource field is nil", func(t *testing.T) {
 		outputResources := []rpv1.OutputResource{}
 		values := map[string]any{}
 		secrets := map[string]rpv1.SecretValueReference{}
@@ -77,6 +77,21 @@ func Test_Validator_SetAndValidate_OutputResources(t *testing.T) {
 
 		v := NewValidator(&values, &secrets, &outputResources)
 		v.AddResourceField(resource)
+
+		err := v.SetAndValidate(nil)
+		require.NoError(t, err)
+
+		require.Empty(t, outputResources)
+	})
+	t.Run("resource field is empty", func(t *testing.T) {
+		outputResources := []rpv1.OutputResource{}
+		values := map[string]any{}
+		secrets := map[string]rpv1.SecretValueReference{}
+
+		resource := ""
+
+		v := NewValidator(&values, &secrets, &outputResources)
+		v.AddResourceField(&resource)
 
 		err := v.SetAndValidate(nil)
 		require.NoError(t, err)


### PR DESCRIPTION
# Description

This change implements the first 'processor' for one of our links using the new infrastructure.

This redis implementation implements the new semantics that we agreed to recently:

- Recipes are the default
- Resource binding is removed
- Values set on the resource can override values provided by a recipe

This is not hooked up to anything yet. That will be done next. 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [X] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [X] Unit tests passing
* [ ] Extended the documentation / Created issue for it
