### PR TITLE
Fix macOS + ARM build break

### DIFF
--- a/pkg/cli/tools/binary_tools_test.go
+++ b/pkg/cli/tools/binary_tools_test.go
@@ -23,9 +23,9 @@ func TestGetDownloadURI(t *testing.T) {
 
 	switch runtime.GOOS {
 	case "darwin":
-		want = fmt.Sprint(version.Channel(), "/macos-x64/test-bin")
+		want = fmt.Sprintf("%s/%s-%s/test-bin", version.Channel(), "macos", runtime.GOARCH)
 	case "linux", "windows":
-		want = fmt.Sprintf("%s/%s-x64/test-bin", version.Channel(), runtime.GOOS)
+		want = fmt.Sprintf("%s/%s-%s/test-bin", version.Channel(), runtime.GOOS, runtime.GOARCH)
 	default:
 		wantErr = true
 	}


### PR DESCRIPTION
We don't run the tests on Mac in the CI, and this failure would only occur on Apple Silicon.