### PR TITLE
Make display order of recipe parameters deterministic

### DIFF
--- a/pkg/cli/cmd/recipe/show/show.go
+++ b/pkg/cli/cmd/recipe/show/show.go
@@ -8,6 +8,7 @@ package show
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
@@ -161,6 +162,11 @@ func (r *Runner) Run(ctx context.Context) error {
 
 		recipeParams = append(recipeParams, paramItem)
 	}
+
+	// Sort parameters so that results are deterministic.
+	sort.Slice(recipeParams, func(i, j int) bool {
+		return recipeParams[i].Name > recipeParams[j].Name
+	})
 
 	err = r.Output.WriteFormatted(r.Format, recipeParams, objectformats.GetRecipeParamsTableFormat())
 	if err != nil {


### PR DESCRIPTION
# Description

This change sorts the parameters displayed by `rad recipe show` so that the order will be deterministic. This fixes a flaky test.
