### PR TITLE
Fix functional test when latest tag doesn't exist

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,15 +69,15 @@ stages:
       inputs:
         command: login
         containerRegistry: radiusdev-acr  # Service connection of radiusdev ACR: https://dev.azure.com/azure-octo/Incubations/_settings/adminservices?resourceId=09d4666f-2486-4dbf-a599-f95622e1ad29
-    - displayName: publish container - $(REL_VERSION)
-      script: |
+    - script: |
         export DOCKER_TAG_VERSION=$REL_VERSION
         make docker-build && make docker-push
-    - displayName: publish test container images - latest
-      continueOnError: 'true' # ignore error if the image is being written.
-      script: |
+      displayName: publish container - $(REL_VERSION)
+    - script: |
         export DOCKER_TAG_VERSION=latest
         make docker-test-image-build && make docker-test-image-push
+      continueOnError: 'true' # ignore error if the image is being written.
+      displayName: publish test container images - latest
 - stage: FunctionalTests
   dependsOn: ImageBuild
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,11 @@ stages:
     - script: |
         export DOCKER_TAG_VERSION=$REL_VERSION
         make docker-build && make docker-push
-      displayName: publish container
+      displayName: publish container - $(REL_VERSION)
+    - script: |
+        export DOCKER_TAG_VERSION=latest
+        make docker-build && make docker-push
+      displayName: publish container - latest
 
 - stage: FunctionalTests
   dependsOn: ImageBuild

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,15 +69,15 @@ stages:
       inputs:
         command: login
         containerRegistry: radiusdev-acr  # Service connection of radiusdev ACR: https://dev.azure.com/azure-octo/Incubations/_settings/adminservices?resourceId=09d4666f-2486-4dbf-a599-f95622e1ad29
-    - script: |
+    - displayName: publish container - $(REL_VERSION)
+      script: |
         export DOCKER_TAG_VERSION=$REL_VERSION
         make docker-build && make docker-push
-      displayName: publish container - $(REL_VERSION)
-    - script: |
+    - displayName: publish container - latest
+      continueOnError: 'true' # ignore error if the image is being written.
+      script: |
         export DOCKER_TAG_VERSION=latest
         make docker-build && make docker-push
-      displayName: publish container - latest
-
 - stage: FunctionalTests
   dependsOn: ImageBuild
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,11 +73,11 @@ stages:
       script: |
         export DOCKER_TAG_VERSION=$REL_VERSION
         make docker-build && make docker-push
-    - displayName: publish container - latest
+    - displayName: publish test container images - latest
       continueOnError: 'true' # ignore error if the image is being written.
       script: |
         export DOCKER_TAG_VERSION=latest
-        make docker-build && make docker-push
+        make docker-test-image-build && make docker-test-image-push
 - stage: FunctionalTests
   dependsOn: ImageBuild
   jobs:

--- a/test/functional/corerp/cli/cli_test.go
+++ b/test/functional/corerp/cli/cli_test.go
@@ -543,7 +543,8 @@ func Test_CLI_DeploymentParameters(t *testing.T) {
 	parameterFilePath := filepath.Join(cwd, parameterFile)
 
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
-		{Executor: step.NewDeployExecutor(template, "@"+parameterFilePath),
+		{
+			Executor: step.NewDeployExecutor(template, "@"+parameterFilePath, functional.GetMagpieTag()),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{

--- a/test/functional/corerp/cli/cli_test.go
+++ b/test/functional/corerp/cli/cli_test.go
@@ -544,7 +544,7 @@ func Test_CLI_DeploymentParameters(t *testing.T) {
 
 	// corerp-kubernetes-cli-parameters.parameters.json uses radiusdev.azurecr.io as a registry parameter.
 	// Use the specified tag only if the test uses radiusdev.azurecr.io registry. Otherwise, use latest tag.
-	magpieTag := "latest"
+	magpieTag := "magpietag=latest"
 	image := functional.GetMagpieImage()
 	if !strings.HasPrefix(image, "magpieimage=radiusdev.azurecr.io") {
 		magpieTag = functional.GetMagpieTag()

--- a/test/functional/corerp/cli/cli_test.go
+++ b/test/functional/corerp/cli/cli_test.go
@@ -542,9 +542,17 @@ func Test_CLI_DeploymentParameters(t *testing.T) {
 	name := "kubernetes-cli-params"
 	parameterFilePath := filepath.Join(cwd, parameterFile)
 
+	// corerp-kubernetes-cli-parameters.parameters.json uses radiusdev.azurecr.io as a registry parameter.
+	// Use the specified tag only if the test uses radiusdev.azurecr.io registry. Otherwise, use latest tag.
+	magpieTag := "latest"
+	image := functional.GetMagpieImage()
+	if !strings.HasPrefix(image, "magpieimage=radiusdev.azurecr.io") {
+		magpieTag = functional.GetMagpieTag()
+	}
+
 	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, "@"+parameterFilePath, functional.GetMagpieTag()),
+			Executor: step.NewDeployExecutor(template, "@"+parameterFilePath, magpieTag),
 			CoreRPResources: &validation.CoreRPResourceSet{
 				Resources: []validation.CoreRPResource{
 					{


### PR DESCRIPTION
# Description

We added clean-up task for radiusdev acr to clean up images regularly. It could delete `latest` tag. One functional test always uses `latest` tag resulting in test failure.  This fix is to:
1. Use the current selected tag instead of using latest
2. Ensure we push `latest` tag for the latest magpie test image when developer runs tests with `latest` tag.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
