### PR TITLE
Provide RuntimeConfiguration to processor

### DIFF
--- a/pkg/linkrp/processors/rediscaches/processor.go
+++ b/pkg/linkrp/processors/rediscaches/processor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/project-radius/radius/pkg/linkrp/datamodel"
 	"github.com/project-radius/radius/pkg/linkrp/processors"
 	"github.com/project-radius/radius/pkg/linkrp/renderers"
-	"github.com/project-radius/radius/pkg/recipes"
 )
 
 const (
@@ -23,10 +22,12 @@ const (
 	RedisSSLPort = 6380
 )
 
+// Processor is a processor for RedisCache resources.
 type Processor struct {
 }
 
-func (p *Processor) Process(ctx context.Context, resource *datamodel.RedisCache, output *recipes.RecipeOutput) error {
+// Process implements the processors.Processor interface for RedisCache resources.
+func (p *Processor) Process(ctx context.Context, resource *datamodel.RedisCache, options processors.Options) error {
 	validator := processors.NewValidator(&resource.ComputedValues, &resource.SecretValues, &resource.Properties.Status.OutputResources)
 	validator.AddResourceField(&resource.Properties.Resource)
 	validator.AddRequiredStringField(renderers.Host, &resource.Properties.Host)
@@ -37,7 +38,7 @@ func (p *Processor) Process(ctx context.Context, resource *datamodel.RedisCache,
 		return p.computeConnectionString(resource), nil
 	})
 
-	err := validator.SetAndValidate(output)
+	err := validator.SetAndValidate(options.RecipeOutput)
 	if err != nil {
 		return err
 	}

--- a/pkg/linkrp/processors/types.go
+++ b/pkg/linkrp/processors/types.go
@@ -22,7 +22,16 @@ type ResourceProcessor[P interface {
 }, T any] interface {
 	// Process is called to process the results of recipe execution or any other changes to the resource
 	// data model. Process should modify the datamodel in place to perform updates.
-	Process(ctx context.Context, resource P, output *recipes.RecipeOutput) error
+	Process(ctx context.Context, resource P, options Options) error
+}
+
+// Options defines the options passed to the resource processor.
+type Options struct {
+	// RuntimeConfiguration represents the configuration of the target runtime.
+	RuntimeConfiguration recipes.RuntimeConfiguration
+
+	// RecipeOutput represents the output of executing a recipe (may be nil).
+	RecipeOutput *recipes.RecipeOutput
 }
 
 // ValidationError represents a user-facing validation message reported by the processor.


### PR DESCRIPTION
# Description

This change adds the RuntimeConfiguration to the set of data provided to a processor. This was a gap we identified while working on Dapr state store support. Since the Dapr state store processor needs to create Kubernetes resources, it needs to know the runtime configuration to get the correct namespace.

This change adds the infrastructure needed to get this data, and updates the unit tests of the controller + existing redis processor. The Dapr state store processor will land in a follow up PR, as several changes need to go in first.
