### PR TITLE
Add patch namespace and split test utils

### DIFF
--- a/pkg/cli/kubernetes/kubernetes_test.go
+++ b/pkg/cli/kubernetes/kubernetes_test.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/project-radius/radius/test/testutil"
+	"github.com/project-radius/radius/test/k8sutil"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,7 +23,7 @@ import (
 func TestEnsureNamespace(t *testing.T) {
 	f := k8sfake.NewSimpleClientset(&v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: "radius-test"}})
 
-	testutil.PrependPatchReactor(f, "namespaces", func(pa clienttesting.PatchAction) runtime.Object {
+	k8sutil.PrependPatchReactor(f, "namespaces", func(pa clienttesting.PatchAction) runtime.Object {
 		return &v1.Namespace{
 			ObjectMeta: meta_v1.ObjectMeta{
 				Name: pa.GetName(),

--- a/pkg/corerp/frontend/controller/applications/createorupdateapplication_test.go
+++ b/pkg/corerp/frontend/controller/applications/createorupdateapplication_test.go
@@ -21,6 +21,7 @@ import (
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 	"github.com/project-radius/radius/pkg/ucp/resources"
 	"github.com/project-radius/radius/pkg/ucp/store"
+	"github.com/project-radius/radius/test/k8sutil"
 	"github.com/project-radius/radius/test/testutil"
 
 	"github.com/golang/mock/gomock"
@@ -96,7 +97,7 @@ func TestCreateOrUpdateApplicationRun_CreateNew_20220315PrivatePreview(t *testin
 			opts := ctrl.Options{
 				StorageClient: tCtx.MockSC,
 				DataProvider:  tCtx.MockSP,
-				KubeClient:    testutil.NewFakeKubeClient(nil),
+				KubeClient:    k8sutil.NewFakeKubeClient(nil),
 			}
 
 			ctl, err := NewCreateOrUpdateApplication(opts)
@@ -182,7 +183,7 @@ func TestCreateOrUpdateApplicationRun_Update_20220315PrivatePreview(t *testing.T
 			opts := ctrl.Options{
 				StorageClient: tCtx.MockSC,
 				DataProvider:  tCtx.MockSP,
-				KubeClient:    testutil.NewFakeKubeClient(nil),
+				KubeClient:    k8sutil.NewFakeKubeClient(nil),
 			}
 
 			ctl, err := NewCreateOrUpdateApplication(opts)
@@ -249,7 +250,7 @@ func TestCreateOrUpdateApplicationRun_PatchNonExisting_20220315PrivatePreview(t 
 			opts := ctrl.Options{
 				StorageClient: tCtx.MockSC,
 				DataProvider:  tCtx.MockSP,
-				KubeClient:    testutil.NewFakeKubeClient(nil),
+				KubeClient:    k8sutil.NewFakeKubeClient(nil),
 			}
 
 			ctl, err := NewCreateOrUpdateApplication(opts)
@@ -322,7 +323,7 @@ func TestCreateOrUpdateApplicationRun_PatchExisting_20220315PrivatePreview(t *te
 			opts := ctrl.Options{
 				StorageClient: tCtx.MockSC,
 				DataProvider:  tCtx.MockSP,
-				KubeClient:    testutil.NewFakeKubeClient(nil),
+				KubeClient:    k8sutil.NewFakeKubeClient(nil),
 			}
 
 			ctl, err := NewCreateOrUpdateApplication(opts)
@@ -426,7 +427,7 @@ func TestCreateOrUpdateApplicationRun_CreateExisting_20220315PrivatePreview(t *t
 			opts := ctrl.Options{
 				StorageClient: tCtx.MockSC,
 				DataProvider:  tCtx.MockSP,
-				KubeClient:    testutil.NewFakeKubeClient(nil),
+				KubeClient:    k8sutil.NewFakeKubeClient(nil),
 			}
 
 			ctl, err := NewCreateOrUpdateApplication(opts)
@@ -446,7 +447,7 @@ func TestPopulateKubernetesNamespace_valid_namespace(t *testing.T) {
 	opts := ctrl.Options{
 		StorageClient: tCtx.MockSC,
 		DataProvider:  tCtx.MockSP,
-		KubeClient:    testutil.NewFakeKubeClient(nil),
+		KubeClient:    k8sutil.NewFakeKubeClient(nil),
 	}
 
 	ctl, err := NewCreateOrUpdateApplication(opts)
@@ -560,7 +561,7 @@ func TestPopulateKubernetesNamespace_invalid_property(t *testing.T) {
 	opts := ctrl.Options{
 		StorageClient: tCtx.MockSC,
 		DataProvider:  tCtx.MockSP,
-		KubeClient:    testutil.NewFakeKubeClient(nil),
+		KubeClient:    k8sutil.NewFakeKubeClient(nil),
 	}
 
 	ctl, err := NewCreateOrUpdateApplication(opts)

--- a/pkg/corerp/frontend/controller/applications/deleteapplication_test.go
+++ b/pkg/corerp/frontend/controller/applications/deleteapplication_test.go
@@ -16,6 +16,7 @@ import (
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	ctrl "github.com/project-radius/radius/pkg/armrpc/frontend/controller"
 	"github.com/project-radius/radius/pkg/ucp/store"
+	"github.com/project-radius/radius/test/k8sutil"
 	"github.com/project-radius/radius/test/testutil"
 
 	"github.com/golang/mock/gomock"
@@ -111,7 +112,7 @@ func TestDeleteApplicationRun_20220315PrivatePreview(t *testing.T) {
 
 			opts := ctrl.Options{
 				StorageClient: tCtx.MockSC,
-				KubeClient:    testutil.NewFakeKubeClient(nil),
+				KubeClient:    k8sutil.NewFakeKubeClient(nil),
 			}
 
 			ctl, err := NewDeleteApplication(opts)

--- a/pkg/corerp/frontend/controller/volumes/validator_test.go
+++ b/pkg/corerp/frontend/controller/volumes/validator_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/project-radius/radius/pkg/armrpc/rest"
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
 	"github.com/project-radius/radius/pkg/ucp/resources"
-	"github.com/project-radius/radius/test/testutil"
+	"github.com/project-radius/radius/test/k8sutil"
 
 	"github.com/stretchr/testify/require"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -44,7 +44,7 @@ func TestValidateRequest(t *testing.T) {
 	err := apiextv1.AddToScheme(crdScheme)
 	require.NoError(t, err)
 
-	crdFakeClient := testutil.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
+	crdFakeClient := k8sutil.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apiextensions.k8s.io/v1",
 			Kind:       "CustomResourceDefinition",
@@ -55,7 +55,7 @@ func TestValidateRequest(t *testing.T) {
 	})
 
 	// Create default Kubernetes fake client.
-	defaultFakeClient := testutil.NewFakeKubeClient(crdScheme)
+	defaultFakeClient := k8sutil.NewFakeKubeClient(crdScheme)
 
 	type args struct {
 		ctx         context.Context

--- a/pkg/kubeutil/namespace.go
+++ b/pkg/kubeutil/namespace.go
@@ -1,0 +1,38 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package kubeutil
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/project-radius/radius/pkg/kubernetes"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	runtime_client "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// PatchNamespace creates a namespace if it does not exist.
+func PatchNamespace(ctx context.Context, client runtime_client.Client, namespace string) error {
+	ns := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata": map[string]any{
+				"name": namespace,
+				"labels": map[string]any{
+					kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
+				},
+			},
+		},
+	}
+
+	err := client.Patch(ctx, ns, runtime_client.Apply, &runtime_client.PatchOptions{FieldManager: kubernetes.FieldManager})
+	if err != nil {
+		return fmt.Errorf("error applying namespace: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/kubeutil/namespace_test.go
+++ b/pkg/kubeutil/namespace_test.go
@@ -1,0 +1,46 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package kubeutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/project-radius/radius/test/k8sutil"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	runtime_client "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func Test_PatchNamespace(t *testing.T) {
+	client := k8sutil.NewFakeKubeClient(scheme.Scheme)
+
+	err := PatchNamespace(context.Background(), client, "test")
+	require.NoError(t, err)
+
+	ns := &unstructured.Unstructured{}
+	ns.SetAPIVersion("v1")
+	ns.SetKind("Namespace")
+
+	err = client.Get(context.Background(), runtime_client.ObjectKey{Name: "test"}, ns)
+	require.NoError(t, err)
+
+	expected := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata": map[string]any{
+				"name":            "test",
+				"resourceVersion": "1",
+				"labels": map[string]any{
+					"app.kubernetes.io/managed-by": "radius-rp",
+				},
+			},
+		},
+	}
+	require.Equal(t, expected, ns)
+}

--- a/pkg/linkrp/frontend/controller/daprinvokehttproutes/createorupdatedaprinvokehttproute_test.go
+++ b/pkg/linkrp/frontend/controller/daprinvokehttproutes/createorupdatedaprinvokehttproute_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/project-radius/radius/pkg/linkrp/renderers"
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 	"github.com/project-radius/radius/pkg/ucp/store"
+	"github.com/project-radius/radius/test/k8sutil"
 	"github.com/project-radius/radius/test/testutil"
 
 	"github.com/golang/mock/gomock"
@@ -108,7 +109,7 @@ func TestCreateOrUpdateDaprInvokeHttpRoute_20220315PrivatePreview(t *testing.T) 
 			err := apiextv1.AddToScheme(crdScheme)
 			require.NoError(t, err)
 
-			kubeClient := testutil.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
+			kubeClient := k8sutil.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "apiextensions.k8s.io/v1",
 					Kind:       "CustomResourceDefinition",
@@ -118,7 +119,7 @@ func TestCreateOrUpdateDaprInvokeHttpRoute_20220315PrivatePreview(t *testing.T) 
 				},
 			})
 			if testcase.daprMissing {
-				kubeClient = testutil.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
+				kubeClient = k8sutil.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
 			}
 
 			opts := frontend_ctrl.Options{
@@ -213,7 +214,7 @@ func TestCreateOrUpdateDaprInvokeHttpRoute_20220315PrivatePreview(t *testing.T) 
 			err := apiextv1.AddToScheme(crdScheme)
 			require.NoError(t, err)
 
-			kubeClient := testutil.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
+			kubeClient := k8sutil.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "apiextensions.k8s.io/v1",
 					Kind:       "CustomResourceDefinition",
@@ -223,7 +224,7 @@ func TestCreateOrUpdateDaprInvokeHttpRoute_20220315PrivatePreview(t *testing.T) 
 				},
 			})
 			if testcase.daprMissing {
-				kubeClient = testutil.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
+				kubeClient = k8sutil.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
 			}
 
 			opts := frontend_ctrl.Options{

--- a/pkg/linkrp/frontend/controller/daprpubsubbrokers/createorupdatedaprpubsubbroker_test.go
+++ b/pkg/linkrp/frontend/controller/daprpubsubbrokers/createorupdatedaprpubsubbroker_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/project-radius/radius/pkg/resourcemodel"
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 	"github.com/project-radius/radius/pkg/ucp/store"
+	"github.com/project-radius/radius/test/k8sutil"
 	"github.com/project-radius/radius/test/testutil"
 
 	"github.com/golang/mock/gomock"
@@ -156,7 +157,7 @@ func TestCreateOrUpdateDaprPubSubBroker_20220315PrivatePreview(t *testing.T) {
 			err := apiextv1.AddToScheme(crdScheme)
 			require.NoError(t, err)
 
-			kubeClient := testutil.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
+			kubeClient := k8sutil.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "apiextensions.k8s.io/v1",
 					Kind:       "CustomResourceDefinition",
@@ -166,7 +167,7 @@ func TestCreateOrUpdateDaprPubSubBroker_20220315PrivatePreview(t *testing.T) {
 				},
 			})
 			if testcase.daprMissing {
-				kubeClient = testutil.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
+				kubeClient = k8sutil.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
 			}
 
 			opts := frontend_ctrl.Options{
@@ -261,7 +262,7 @@ func TestCreateOrUpdateDaprPubSubBroker_20220315PrivatePreview(t *testing.T) {
 			err := apiextv1.AddToScheme(crdScheme)
 			require.NoError(t, err)
 
-			kubeClient := testutil.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
+			kubeClient := k8sutil.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "apiextensions.k8s.io/v1",
 					Kind:       "CustomResourceDefinition",
@@ -271,7 +272,7 @@ func TestCreateOrUpdateDaprPubSubBroker_20220315PrivatePreview(t *testing.T) {
 				},
 			})
 			if testcase.daprMissing {
-				kubeClient = testutil.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
+				kubeClient = k8sutil.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
 			}
 
 			opts := frontend_ctrl.Options{

--- a/pkg/linkrp/frontend/controller/daprsecretstores/createorupdatedaprsecretstore_test.go
+++ b/pkg/linkrp/frontend/controller/daprsecretstores/createorupdatedaprsecretstore_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/project-radius/radius/pkg/resourcemodel"
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 	"github.com/project-radius/radius/pkg/ucp/store"
+	"github.com/project-radius/radius/test/k8sutil"
 	"github.com/project-radius/radius/test/testutil"
 
 	"github.com/golang/mock/gomock"
@@ -132,7 +133,7 @@ func TestCreateOrUpdateDaprSecretStore_20220315PrivatePreview(t *testing.T) {
 			err := apiextv1.AddToScheme(crdScheme)
 			require.NoError(t, err)
 
-			kubeClient := testutil.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
+			kubeClient := k8sutil.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "apiextensions.k8s.io/v1",
 					Kind:       "CustomResourceDefinition",
@@ -142,7 +143,7 @@ func TestCreateOrUpdateDaprSecretStore_20220315PrivatePreview(t *testing.T) {
 				},
 			})
 			if testcase.daprMissing {
-				kubeClient = testutil.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
+				kubeClient = k8sutil.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
 			}
 
 			opts := frontend_ctrl.Options{
@@ -237,7 +238,7 @@ func TestCreateOrUpdateDaprSecretStore_20220315PrivatePreview(t *testing.T) {
 			err := apiextv1.AddToScheme(crdScheme)
 			require.NoError(t, err)
 
-			kubeClient := testutil.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
+			kubeClient := k8sutil.NewFakeKubeClient(crdScheme, &apiextv1.CustomResourceDefinition{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "apiextensions.k8s.io/v1",
 					Kind:       "CustomResourceDefinition",
@@ -247,7 +248,7 @@ func TestCreateOrUpdateDaprSecretStore_20220315PrivatePreview(t *testing.T) {
 				},
 			})
 			if testcase.daprMissing {
-				kubeClient = testutil.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
+				kubeClient = k8sutil.NewFakeKubeClient(crdScheme) // Will return 404 for missing CRD
 			}
 
 			opts := frontend_ctrl.Options{

--- a/pkg/linkrp/handlers/dapr_pubsub_servicebus.go
+++ b/pkg/linkrp/handlers/dapr_pubsub_servicebus.go
@@ -15,6 +15,7 @@ import (
 	"github.com/project-radius/radius/pkg/azure/armauth"
 	"github.com/project-radius/radius/pkg/azure/clientv2"
 	"github.com/project-radius/radius/pkg/kubernetes"
+	"github.com/project-radius/radius/pkg/kubeutil"
 	"github.com/project-radius/radius/pkg/linkrp"
 	"github.com/project-radius/radius/pkg/resourcemodel"
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
@@ -103,7 +104,7 @@ func (handler *daprPubSubServiceBusHandler) Delete(ctx context.Context, resource
 }
 
 func (handler *daprPubSubServiceBusHandler) PatchDaprPubSub(ctx context.Context, properties map[string]string, cs string, resource *rpv1.OutputResource) error {
-	err := handler.PatchNamespace(ctx, properties[KubernetesNamespaceKey])
+	err := kubeutil.PatchNamespace(ctx, handler.k8s, properties[KubernetesNamespaceKey])
 	if err != nil {
 		return err
 	}

--- a/pkg/linkrp/handlers/dapr_statestore_storage.go
+++ b/pkg/linkrp/handlers/dapr_statestore_storage.go
@@ -15,6 +15,7 @@ import (
 	"github.com/project-radius/radius/pkg/azure/armauth"
 	"github.com/project-radius/radius/pkg/azure/clientv2"
 	"github.com/project-radius/radius/pkg/kubernetes"
+	"github.com/project-radius/radius/pkg/kubeutil"
 	"github.com/project-radius/radius/pkg/linkrp"
 	"github.com/project-radius/radius/pkg/resourcemodel"
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
@@ -101,7 +102,7 @@ func (handler *daprStateStoreAzureStorageHandler) Delete(ctx context.Context, re
 }
 
 func (handler *daprStateStoreAzureStorageHandler) createDaprStateStore(ctx context.Context, accountName string, accountKey string, properties map[string]string) error {
-	err := handler.PatchNamespace(ctx, properties[KubernetesNamespaceKey])
+	err := kubeutil.PatchNamespace(ctx, handler.k8s, properties[KubernetesNamespaceKey])
 	if err != nil {
 		return err
 	}

--- a/pkg/ucp/secret/kubernetes/client_test.go
+++ b/pkg/ucp/secret/kubernetes/client_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/project-radius/radius/pkg/ucp/secret"
-	"github.com/project-radius/radius/test/testutil"
+	"github.com/project-radius/radius/test/k8sutil"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/kubectl/pkg/scheme"
@@ -23,7 +23,7 @@ const (
 
 func Test_Save(t *testing.T) {
 	k8sFakeClient := Client{
-		K8sClient: testutil.NewFakeKubeClient(scheme.Scheme),
+		K8sClient: k8sutil.NewFakeKubeClient(scheme.Scheme),
 	}
 	ctx := context.Background()
 	secretValue, err := json.Marshal("test_secret_value")
@@ -69,7 +69,7 @@ func Test_Save(t *testing.T) {
 
 func Test_Get(t *testing.T) {
 	k8sFakeClient := Client{
-		K8sClient: testutil.NewFakeKubeClient(scheme.Scheme),
+		K8sClient: k8sutil.NewFakeKubeClient(scheme.Scheme),
 	}
 	ctx := context.Background()
 	secretValue, err := json.Marshal("test_secret_value")
@@ -108,7 +108,7 @@ func Test_Get(t *testing.T) {
 
 func Test_Delete(t *testing.T) {
 	k8sFakeClient := Client{
-		K8sClient: testutil.NewFakeKubeClient(scheme.Scheme),
+		K8sClient: k8sutil.NewFakeKubeClient(scheme.Scheme),
 	}
 	ctx := context.Background()
 	secretValue, err := json.Marshal("test_secret_value")

--- a/test/k8sutil/doc.go
+++ b/test/k8sutil/doc.go
@@ -1,0 +1,7 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+// k8sutil contains test utilities for kubernetes.
+package k8sutil


### PR DESCRIPTION
## Description

This change adds the server-side "patch namespace" functionality to a shared utility package and adds tests for it.

Adding tests triggered a need to refactor our `testutil` package. The problem is that `testutil` references many different abstractions across Radius (like store and secrets) which causes a package reference cycle. Our shared Kubernetes utilities are used by the store, and secret manager.

The fix is to split the Kubernetes testutils functionality into its own package. 'utils' packages need to be really granular in Go or else you end up with cycles like this frequently.

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
