### PR TITLE
Add ResourceReference datamodel type and validator

### DIFF
--- a/pkg/linkrp/processors/rediscaches/processor.go
+++ b/pkg/linkrp/processors/rediscaches/processor.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/project-radius/radius/pkg/linkrp"
 	"github.com/project-radius/radius/pkg/linkrp/datamodel"
 	"github.com/project-radius/radius/pkg/linkrp/processors"
 	"github.com/project-radius/radius/pkg/linkrp/renderers"
@@ -29,7 +30,18 @@ type Processor struct {
 // Process implements the processors.Processor interface for RedisCache resources.
 func (p *Processor) Process(ctx context.Context, resource *datamodel.RedisCache, options processors.Options) error {
 	validator := processors.NewValidator(&resource.ComputedValues, &resource.SecretValues, &resource.Properties.Status.OutputResources)
-	validator.AddResourceField(&resource.Properties.Resource)
+
+	// TODO: update data model and remove the workaround
+	// validator.AddResourcesField(&resource.Properties.Resource)
+
+	// Begin workaround
+	resources := []*linkrp.ResourceReference{}
+	if resource.Properties.Resource != "" {
+		resources = append(resources, &linkrp.ResourceReference{ID: resource.Properties.Resource})
+	}
+	validator.AddResourcesField(&resources)
+	// End workaround
+
 	validator.AddRequiredStringField(renderers.Host, &resource.Properties.Host)
 	validator.AddRequiredInt32Field(renderers.Port, &resource.Properties.Port)
 	validator.AddOptionalStringField(renderers.UsernameStringValue, &resource.Properties.Username)

--- a/pkg/linkrp/processors/rediscaches/processor_test.go
+++ b/pkg/linkrp/processors/rediscaches/processor_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/project-radius/radius/pkg/linkrp"
 	"github.com/project-radius/radius/pkg/linkrp/datamodel"
 	"github.com/project-radius/radius/pkg/linkrp/processors"
 	"github.com/project-radius/radius/pkg/recipes"
@@ -118,12 +119,16 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		expectedOutputResource, err := processors.GetOutputResourceFromResourceID(azureRedisResourceID1)
+		expectedOutputResources, err := processors.GetOutputResourcesFromResourcesField([]*linkrp.ResourceReference{
+			{
+				ID: azureRedisResourceID1,
+			},
+		})
 		require.NoError(t, err)
 
 		require.Equal(t, expectedValues, resource.ComputedValues)
 		require.Equal(t, expectedSecrets, resource.SecretValues)
-		require.Equal(t, []rpv1.OutputResource{expectedOutputResource}, resource.Properties.Status.OutputResources)
+		require.Equal(t, expectedOutputResources, resource.Properties.Status.OutputResources)
 	})
 
 	t.Run("success - recipe with value overrides", func(t *testing.T) {
@@ -191,9 +196,13 @@ func Test_Process(t *testing.T) {
 		require.NoError(t, err)
 		expectedOutputResources = append(expectedOutputResources, recipeOutputResources...)
 
-		resourceFieldOutputResource, err := processors.GetOutputResourceFromResourceID(azureRedisResourceID1)
+		resourceFieldOutputResources, err := processors.GetOutputResourcesFromResourcesField([]*linkrp.ResourceReference{
+			{
+				ID: azureRedisResourceID1,
+			},
+		})
 		require.NoError(t, err)
-		expectedOutputResources = append(expectedOutputResources, resourceFieldOutputResource)
+		expectedOutputResources = append(expectedOutputResources, resourceFieldOutputResources...)
 
 		require.Equal(t, expectedValues, resource.ComputedValues)
 		require.Equal(t, expectedSecrets, resource.SecretValues)

--- a/pkg/linkrp/processors/util.go
+++ b/pkg/linkrp/processors/util.go
@@ -8,6 +8,7 @@ package processors
 import (
 	"fmt"
 
+	"github.com/project-radius/radius/pkg/linkrp"
 	"github.com/project-radius/radius/pkg/recipes"
 	"github.com/project-radius/radius/pkg/resourcemodel"
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
@@ -15,23 +16,27 @@ import (
 	"github.com/project-radius/radius/pkg/ucp/resources"
 )
 
-// GetOutputResourcesFromRecipe is a utility function that converts a resource ID provided by a user into an
-// OutputResource. This should be used for processing mode == 'resource'.
-func GetOutputResourceFromResourceID(resourceID string) (rpv1.OutputResource, error) {
-	id, err := resources.ParseResource(resourceID)
-	if err != nil {
-		return rpv1.OutputResource{}, &ValidationError{Message: fmt.Sprintf("resource id %q is invalid", resourceID)}
+// GetOutputResourcesFromResourcesField is a utility function that converts a resource ID sprovided by a user into an
+// OutputResource. This should be used for processing the '.properties.resources' field of a resource.
+func GetOutputResourcesFromResourcesField(field []*linkrp.ResourceReference) ([]rpv1.OutputResource, error) {
+	results := []rpv1.OutputResource{}
+	for i, resource := range field {
+		id, err := resources.ParseResource(resource.ID)
+		if err != nil {
+			return nil, &ValidationError{Message: fmt.Sprintf("resource id %q is invalid", resource.ID)}
+		}
+
+		identity := resourcemodel.FromUCPID(id, "")
+		result := rpv1.OutputResource{
+			LocalID:       fmt.Sprintf("Resource%d", i), // The dependency sorting code requires unique LocalIDs
+			Identity:      identity,
+			ResourceType:  *identity.ResourceType,
+			RadiusManaged: to.Ptr(false), // Generally when we parse a resource ID from a resource field, it's externally managed.
+		}
+		results = append(results, result)
 	}
 
-	identity := resourcemodel.FromUCPID(id, "")
-	result := rpv1.OutputResource{
-		LocalID:       fmt.Sprintf("Resource%d", 0), // The dependency sorting code requires unique LocalIDs
-		Identity:      identity,
-		ResourceType:  *identity.ResourceType,
-		RadiusManaged: to.Ptr(false), // Generally when we parse a resource ID from a resource field, it's externally managed.
-	}
-
-	return result, nil
+	return results, nil
 }
 
 // GetOutputResourcesFromRecipe is a utility function that converts the resources in the recipe output into a list of OutputResources.

--- a/pkg/linkrp/processors/validator_test.go
+++ b/pkg/linkrp/processors/validator_test.go
@@ -8,6 +8,7 @@ package processors
 import (
 	"testing"
 
+	"github.com/project-radius/radius/pkg/linkrp"
 	"github.com/project-radius/radius/pkg/recipes"
 	"github.com/project-radius/radius/pkg/resourcemodel"
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
@@ -40,9 +41,11 @@ func Test_NewValidator(t *testing.T) {
 	})
 
 	t.Run("provided datastores", func(t *testing.T) {
-		outputResources := []rpv1.OutputResource{}
-		values := map[string]any{}
-		secrets := map[string]rpv1.SecretValueReference{}
+		outputResources := []rpv1.OutputResource{
+			{},
+		}
+		values := map[string]any{"test": ""}
+		secrets := map[string]rpv1.SecretValueReference{"test": {}}
 
 		v := NewValidator(&values, &secrets, &outputResources)
 		require.NotNil(t, v)
@@ -53,6 +56,10 @@ func Test_NewValidator(t *testing.T) {
 		require.Same(t, &outputResources, v.OutputResources)
 		require.Equal(t, values, v.ConnectionValues)
 		require.Equal(t, secrets, v.ConnectionSecrets)
+
+		require.Empty(t, outputResources)
+		require.Empty(t, values)
+		require.Empty(t, secrets)
 	})
 }
 
@@ -68,30 +75,30 @@ func Test_Validator_SetAndValidate_OutputResources(t *testing.T) {
 
 		require.Empty(t, outputResources)
 	})
-	t.Run("resource field is nil", func(t *testing.T) {
+	t.Run("resources field is nil", func(t *testing.T) {
 		outputResources := []rpv1.OutputResource{}
 		values := map[string]any{}
 		secrets := map[string]rpv1.SecretValueReference{}
 
-		var resource *string
+		var resources *[]*linkrp.ResourceReference
 
 		v := NewValidator(&values, &secrets, &outputResources)
-		v.AddResourceField(resource)
+		v.AddResourcesField(resources)
 
 		err := v.SetAndValidate(nil)
 		require.NoError(t, err)
 
 		require.Empty(t, outputResources)
 	})
-	t.Run("resource field is empty", func(t *testing.T) {
+	t.Run("resources field is empty", func(t *testing.T) {
 		outputResources := []rpv1.OutputResource{}
 		values := map[string]any{}
 		secrets := map[string]rpv1.SecretValueReference{}
 
-		resource := ""
+		resources := []*linkrp.ResourceReference{}
 
 		v := NewValidator(&values, &secrets, &outputResources)
-		v.AddResourceField(&resource)
+		v.AddResourcesField(&resources)
 
 		err := v.SetAndValidate(nil)
 		require.NoError(t, err)
@@ -110,15 +117,15 @@ func Test_Validator_SetAndValidate_OutputResources(t *testing.T) {
 
 		require.Empty(t, outputResources)
 	})
-	t.Run("resource field invalid id", func(t *testing.T) {
+	t.Run("resources field invalid id", func(t *testing.T) {
 		outputResources := []rpv1.OutputResource{}
 		values := map[string]any{}
 		secrets := map[string]rpv1.SecretValueReference{}
 
-		resource := "////invalid//////"
+		resources := []*linkrp.ResourceReference{{ID: "////invalid//////"}}
 
 		v := NewValidator(&values, &secrets, &outputResources)
-		v.AddResourceField(&resource)
+		v.AddResourcesField(&resources)
 
 		err := v.SetAndValidate(nil)
 		require.Error(t, err)
@@ -149,7 +156,11 @@ func Test_Validator_SetAndValidate_OutputResources(t *testing.T) {
 		values := map[string]any{}
 		secrets := map[string]rpv1.SecretValueReference{}
 
-		resource := "/planes/aws/aws/accounts/1234/regions/us-west-1/providers/AWS.Kinesis/Stream/my-stream1"
+		resourcesField := []*linkrp.ResourceReference{
+			{
+				ID: "/planes/aws/aws/accounts/1234/regions/us-west-1/providers/AWS.Kinesis/Stream/my-stream1",
+			},
+		}
 
 		output := recipes.RecipeOutput{
 			Resources: []string{"/planes/aws/aws/accounts/1234/regions/us-west-1/providers/AWS.Kinesis/Stream/my-stream2"},
@@ -162,7 +173,7 @@ func Test_Validator_SetAndValidate_OutputResources(t *testing.T) {
 		}
 
 		v := NewValidator(&values, &secrets, &outputResources)
-		v.AddResourceField(&resource)
+		v.AddResourcesField(&resourcesField)
 
 		err := v.SetAndValidate(&output)
 		require.NoError(t, err)
@@ -176,8 +187,8 @@ func Test_Validator_SetAndValidate_OutputResources(t *testing.T) {
 			},
 			{
 				LocalID:       "Resource0",
-				Identity:      resourcemodel.FromUCPID(mustparse(resource), ""),
-				ResourceType:  *resourcemodel.FromUCPID(mustparse(resource), "").ResourceType,
+				Identity:      resourcemodel.FromUCPID(mustparse(resourcesField[0].ID), ""),
+				ResourceType:  *resourcemodel.FromUCPID(mustparse(resourcesField[0].ID), "").ResourceType,
 				RadiusManaged: to.Ptr(false),
 			},
 		}

--- a/pkg/linkrp/types.go
+++ b/pkg/linkrp/types.go
@@ -32,6 +32,14 @@ type LinkRecipe struct {
 	Parameters map[string]any `json:"parameters,omitempty"`
 }
 
+// ResourceReference represents a reference to a resource that was deployed by the user
+// and specified as part of a link resource.
+//
+// This type should be used in datamodels for the '.properties.resources' field.
+type ResourceReference struct {
+	ID string `json:"id"`
+}
+
 // RecipeContext Recipe template authors can leverage the RecipeContext parameter to access Link properties to
 // generate name and properties that are unique for the Link calling the recipe.
 type RecipeContext struct {


### PR DESCRIPTION
# Description

This change adds ResourceReference as part of our data model. This is the type that will be used for all of our resources that expose a '.properties.resources' field. This also adds support to the validator to include this pattern.

Since the redis data model was not changed yet, there's a small workaround in place. This will get removed almost immediately, as we're working on the data model changes for redis already.
