### PR TITLE
Errata in Dapr utility functions

### DIFF
--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -66,8 +66,12 @@ func MakeDescriptiveLabels(application string, resource string, resourceType str
 
 // MakeDescriptiveLabels returns a map of the descriptive labels for a Kubernetes Dapr resource associated with a Radius resource.
 // The descriptive labels are a superset of the selector labels.
-func MakeDescriptiveDaprLabels(application string, resource string, resourceType string) map[string]string {
-	return map[string]string{
+func MakeDescriptiveDaprLabels(application string, resource string, resourceType string) map[string]any {
+	// K8s fake client requires this to be map[string]any :(
+	//
+	// Please don't try to change this to map[string]string as it is going to cause some tests to panic
+	// with an error deep inside Kubernetes code.
+	return map[string]any{
 		LabelRadiusApplication:  NormalizeResourceName(application),
 		LabelRadiusResource:     NormalizeDaprResourceName(resource),
 		LabelRadiusResourceType: strings.ToLower(ConvertResourceTypeToLabelValue(resourceType)),

--- a/pkg/linkrp/handlers/dapr_component.go
+++ b/pkg/linkrp/handlers/dapr_component.go
@@ -51,7 +51,7 @@ func (handler *daprComponentHandler) Put(ctx context.Context, resource *rpv1.Out
 		return resourcemodel.ResourceIdentity{}, properties, nil
 	}
 
-	err = checkResourceNameUniqueness(ctx, handler.k8s, properties[ResourceName], properties[KubernetesNamespaceKey], serviceCtx.ResourceID.Type())
+	err = CheckDaprResourceNameUniqueness(ctx, handler.k8s, kubernetes.NormalizeDaprResourceName(properties[ResourceName]), properties[KubernetesNamespaceKey], properties[ResourceName], serviceCtx.ResourceID.Type())
 	if err != nil {
 		return resourcemodel.ResourceIdentity{}, nil, err
 	}

--- a/pkg/linkrp/handlers/dapr_pubsub_servicebus.go
+++ b/pkg/linkrp/handlers/dapr_pubsub_servicebus.go
@@ -79,7 +79,7 @@ func (handler *daprPubSubServiceBusHandler) Put(ctx context.Context, resource *r
 		return resourcemodel.ResourceIdentity{}, nil, err
 	}
 
-	err = checkResourceNameUniqueness(ctx, handler.k8s, kubernetes.NormalizeDaprResourceName(properties[ResourceName]), properties[KubernetesNamespaceKey], linkrp.DaprPubSubBrokersResourceType)
+	err = CheckDaprResourceNameUniqueness(ctx, handler.k8s, kubernetes.NormalizeDaprResourceName(properties[ResourceName]), properties[KubernetesNamespaceKey], properties[ResourceName], linkrp.DaprPubSubBrokersResourceType)
 	if err != nil {
 		return resourcemodel.ResourceIdentity{}, nil, err
 	}

--- a/pkg/linkrp/handlers/dapr_statestore_storage.go
+++ b/pkg/linkrp/handlers/dapr_statestore_storage.go
@@ -79,7 +79,7 @@ func (handler *daprStateStoreAzureStorageHandler) Put(ctx context.Context, resou
 		return resourcemodel.ResourceIdentity{}, nil, err
 	}
 
-	err = checkResourceNameUniqueness(ctx, handler.k8s, kubernetes.NormalizeDaprResourceName(properties[ResourceName]), properties[KubernetesNamespaceKey], linkrp.DaprStateStoresResourceType)
+	err = CheckDaprResourceNameUniqueness(ctx, handler.k8s, kubernetes.NormalizeDaprResourceName(properties[ResourceName]), properties[KubernetesNamespaceKey], properties[ResourceName], linkrp.DaprStateStoresResourceType)
 	if err != nil {
 		return resourcemodel.ResourceIdentity{}, nil, err
 	}

--- a/pkg/linkrp/handlers/util.go
+++ b/pkg/linkrp/handlers/util.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const daprConflictFmt = "the Dapr component name '%q' is already in use by another resource. Dapr component and resource names must be unique across all Dapr types (eg: StateStores, PubSubBrokers, SecretStores, etc.). Please select a new name and try again"
+
 func convertToUnstructured(resource rpv1.OutputResource) (unstructured.Unstructured, error) {
 	if resource.ResourceType.Provider != resourcemodel.ProviderKubernetes {
 		return unstructured.Unstructured{}, errors.New("wrong resource type")
@@ -40,7 +42,15 @@ func convertToUnstructured(resource rpv1.OutputResource) (unstructured.Unstructu
 	return unstructured.Unstructured{Object: c}, nil
 }
 
-func checkResourceNameUniqueness(ctx context.Context, k8s client.Client, resourceName string, namespace string, resourceType string) error {
+// CheckDaprResourceNameUniqueness checks if the resource name is unique in the namespace. If the resource name is not unique, it returns an error.
+//
+// This protects against some of the following scenarios:
+//
+// - Two Dapr resources with the same component name but different types.
+// - Two Dapr resources with different UCP resource names, but the same Dapr component name.
+//
+// Note: the Dapr component name and UCP resource name are NOT the same thing. Users can override the Dapr component name.
+func CheckDaprResourceNameUniqueness(ctx context.Context, k8s client.Client, componentName string, namespace string, resourceName string, resourceType string) error {
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(schema.GroupVersionKind{
 		Kind:    "Component",
@@ -48,20 +58,25 @@ func checkResourceNameUniqueness(ctx context.Context, k8s client.Client, resourc
 	})
 	err := k8s.Get(ctx, client.ObjectKey{
 		Namespace: namespace,
-		Name:      resourceName,
+		Name:      componentName,
 	}, u)
-	// Object with the same name doesn't exist.
 	if k8serrors.IsNotFound(err) {
+		// Object with the same name doesn't exist.
 		return nil
-	}
-	if err != nil {
+	} else if err != nil {
 		return err
 	}
 
-	// Object with the same name exists, checking the labels to see if they are the same objects.
-	if label, ok := u.GetLabels()[kubernetes.LabelRadiusResourceType]; ok && kubernetes.ConvertLabelToResourceType(label) != strings.ToLower(resourceType) {
-		return fmt.Errorf("the Dapr component name '%q' is already in use by another resource. Dapr component and resource names must be unique across all Dapr types (eg: StateStores, PubSubBrokers, SecretStores, etc.). Please select a new name and try again", resourceName)
+	// Object with the same name exists, checking the labels to see if they are 'owned' by the same Radius
+	// resource.
+	//
+	// We also need to handle the case where the component has no Radius labels.
+	resourceTypeLabel := u.GetLabels()[kubernetes.LabelRadiusResourceType]
+	resourceNameLabel := u.GetLabels()[kubernetes.LabelRadiusResource]
+	if strings.EqualFold(resourceNameLabel, resourceName) &&
+		strings.EqualFold(kubernetes.ConvertLabelToResourceType(resourceTypeLabel), resourceType) {
+		return nil
 	}
 
-	return nil
+	return fmt.Errorf(daprConflictFmt, componentName)
 }

--- a/pkg/linkrp/handlers/util_test.go
+++ b/pkg/linkrp/handlers/util_test.go
@@ -1,0 +1,89 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/project-radius/radius/pkg/kubernetes"
+	"github.com/project-radius/radius/pkg/linkrp"
+	"github.com/project-radius/radius/test/k8sutil"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func Test_CheckDaprResourceNameUniqueness_NotFound(t *testing.T) {
+	client := k8sutil.NewFakeKubeClient(nil)
+
+	err := CheckDaprResourceNameUniqueness(context.Background(), client, "test-component", "default", "test-resource", linkrp.DaprStateStoresResourceType)
+	require.NoError(t, err)
+}
+
+func Test_CheckDaprResourceNameUniqueness_SameRadiusResource(t *testing.T) {
+	labels := kubernetes.MakeDescriptiveDaprLabels("test-app", "test-resource", linkrp.DaprStateStoresResourceType)
+	existing := createUnstructuredComponent("test-component", "default", labels)
+	client := k8sutil.NewFakeKubeClient(nil, existing)
+
+	err := CheckDaprResourceNameUniqueness(context.Background(), client, "test-component", "default", "test-resource", linkrp.DaprStateStoresResourceType)
+	require.NoError(t, err)
+}
+
+func Test_CheckDaprResourceNameUniqueness_NoLabels(t *testing.T) {
+	existing := createUnstructuredComponent("test-component", "default", nil)
+	client := k8sutil.NewFakeKubeClient(nil, existing)
+
+	err := CheckDaprResourceNameUniqueness(context.Background(), client, "test-component", "default", "test-resource", linkrp.DaprStateStoresResourceType)
+	require.Error(t, err)
+	require.Equal(t, fmt.Sprintf(daprConflictFmt, "test-component"), err.Error())
+}
+
+func Test_CheckDaprResourceNameUniqueness_DifferentResourceNames(t *testing.T) {
+	labels := kubernetes.MakeDescriptiveDaprLabels("test-app", "different-resource", linkrp.DaprStateStoresResourceType)
+	existing := createUnstructuredComponent("test-component", "default", labels)
+	client := k8sutil.NewFakeKubeClient(nil, existing)
+
+	err := CheckDaprResourceNameUniqueness(context.Background(), client, "test-component", "default", "test-resource", linkrp.DaprStateStoresResourceType)
+	require.Error(t, err)
+	require.Equal(t, fmt.Sprintf(daprConflictFmt, "test-component"), err.Error())
+}
+
+func Test_CheckDaprResourceNameUniqueness_DifferentResourceTypes(t *testing.T) {
+	labels := kubernetes.MakeDescriptiveDaprLabels("test-app", "test-resource", linkrp.DaprPubSubBrokersResourceType)
+	existing := createUnstructuredComponent("test-component", "default", labels)
+	client := k8sutil.NewFakeKubeClient(nil, existing)
+
+	err := CheckDaprResourceNameUniqueness(context.Background(), client, "test-component", "default", "test-resource", linkrp.DaprStateStoresResourceType)
+	require.Error(t, err)
+	require.Equal(t, fmt.Sprintf(daprConflictFmt, "test-component"), err.Error())
+}
+
+func createUnstructuredComponent(name string, namespace string, labels map[string]any) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Kind:    "Component",
+		Version: "dapr.io/v1alpha1",
+	})
+	u.SetNamespace(namespace)
+	u.SetName(name)
+
+	if labels == nil {
+		return u
+	}
+
+	// This is (unfortunately) needed, because unstructured wants a map[string]string for labels. However
+	// some of the fake clients want a map[string]any and WILL NOT work with map[string]string. So our API
+	// returns map[string]any.
+	copy := map[string]string{}
+	for k, v := range labels {
+		copy[k] = v.(string)
+	}
+
+	u.SetLabels(copy)
+	return u
+}

--- a/pkg/linkrp/processors/util.go
+++ b/pkg/linkrp/processors/util.go
@@ -16,7 +16,7 @@ import (
 	"github.com/project-radius/radius/pkg/ucp/resources"
 )
 
-// GetOutputResourcesFromResourcesField is a utility function that converts a resource ID sprovided by a user into an
+// GetOutputResourcesFromResourcesField is a utility function that converts a resource ID provided by a user into an
 // OutputResource. This should be used for processing the '.properties.resources' field of a resource.
 func GetOutputResourcesFromResourcesField(field []*linkrp.ResourceReference) ([]rpv1.OutputResource, error) {
 	results := []rpv1.OutputResource{}

--- a/pkg/linkrp/renderers/dapr/generic.go
+++ b/pkg/linkrp/renderers/dapr/generic.go
@@ -35,10 +35,14 @@ func (daprGeneric DaprGeneric) Validate() error {
 	return nil
 }
 
-func ConstructDaprGeneric(daprGeneric DaprGeneric, appName string, resourceName string, namespace string, resourceType string) (unstructured.Unstructured, error) {
+// ConstructDaprGeneric constructs a Dapr component.
+//
+// The component name and resource name may be different. The component name is the name of the Dapr
+// Kubernetes Component object to be created. Resource name is the name of the Radius resource.
+func ConstructDaprGeneric(daprGeneric DaprGeneric, namespace string, componentName string, applicationName string, resourceName string, resourceType string) (unstructured.Unstructured, error) {
 	// Convert the metadata map to a yaml list with keys name and value as per
 	// Dapr specs: https://docs.dapr.io/reference/components-reference/
-	yamlListItems := []map[string]any{}
+	yamlListItems := []any{} // K8s fake client requires this ..... :(
 	for k, v := range daprGeneric.Metadata {
 		yamlItem := map[string]any{
 			"name":  k,
@@ -54,8 +58,8 @@ func ConstructDaprGeneric(daprGeneric DaprGeneric, appName string, resourceName 
 			"kind":       "Component",
 			"metadata": map[string]any{
 				"namespace": namespace,
-				"name":      kubernetes.NormalizeDaprResourceName(resourceName),
-				"labels":    kubernetes.MakeDescriptiveDaprLabels(appName, resourceName, resourceType),
+				"name":      kubernetes.NormalizeDaprResourceName(componentName),
+				"labels":    kubernetes.MakeDescriptiveDaprLabels(applicationName, resourceName, resourceType),
 			},
 			"spec": map[string]any{
 				"type":     *daprGeneric.Type,

--- a/pkg/linkrp/renderers/daprpubsubbrokers/generic.go
+++ b/pkg/linkrp/renderers/daprpubsubbrokers/generic.go
@@ -68,7 +68,7 @@ func getDaprGeneric(daprGeneric dapr.DaprGeneric, resource datamodel.DaprPubSubB
 		return nil, err
 	}
 
-	daprGenericResource, err := dapr.ConstructDaprGeneric(daprGeneric, applicationName, resource.Name, namespace, resource.ResourceTypeName())
+	daprGenericResource, err := dapr.ConstructDaprGeneric(daprGeneric, namespace, resource.Name, applicationName, resource.Name, resource.ResourceTypeName())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/linkrp/renderers/daprpubsubbrokers/renderer_test.go
+++ b/pkg/linkrp/renderers/daprpubsubbrokers/renderer_test.go
@@ -82,8 +82,8 @@ func Test_Render_Generic_Success(t *testing.T) {
 			"spec": map[string]any{
 				"type":    pubsubType,
 				"version": daprPubSubVersion,
-				"metadata": []map[string]any{
-					{
+				"metadata": []any{
+					map[string]any{
 						"name":  "foo",
 						"value": "bar",
 					},
@@ -192,7 +192,7 @@ func Test_ConstructDaprPubSubGeneric(t *testing.T) {
 		Version:  &properties.Version,
 		Metadata: properties.Metadata,
 	}
-	item, err := dapr.ConstructDaprGeneric(daprGeneric, applicationName, resourceName, "radius-test", linkrp.DaprPubSubBrokersResourceType)
+	item, err := dapr.ConstructDaprGeneric(daprGeneric, "radius-test", resourceName, applicationName, resourceName, linkrp.DaprPubSubBrokersResourceType)
 	require.NoError(t, err, "Unable to construct Pub/Sub resource spec")
 
 	expected := unstructured.Unstructured{

--- a/pkg/linkrp/renderers/daprsecretstores/renderer.go
+++ b/pkg/linkrp/renderers/daprsecretstores/renderer.go
@@ -98,7 +98,7 @@ func GetDaprGeneric(daprGeneric dapr.DaprGeneric, resource datamodel.DaprSecretS
 		return nil, err
 	}
 
-	daprGenericResource, err := dapr.ConstructDaprGeneric(daprGeneric, applicationName, resource.Name, namespace, resource.ResourceTypeName())
+	daprGenericResource, err := dapr.ConstructDaprGeneric(daprGeneric, namespace, resource.Name, applicationName, resource.Name, resource.ResourceTypeName())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/linkrp/renderers/daprsecretstores/renderer_test.go
+++ b/pkg/linkrp/renderers/daprsecretstores/renderer_test.go
@@ -122,8 +122,8 @@ func Test_Render_Generic_Success(t *testing.T) {
 			"spec": map[string]any{
 				"type":    linkrp.DaprSecretStoresResourceType,
 				"version": "v1",
-				"metadata": []map[string]any{
-					{
+				"metadata": []any{
+					map[string]any{
 						"name":  "foo",
 						"value": "bar",
 					},

--- a/pkg/linkrp/renderers/daprstatestores/generic.go
+++ b/pkg/linkrp/renderers/daprstatestores/generic.go
@@ -43,7 +43,7 @@ func getDaprGeneric(daprGeneric dapr.DaprGeneric, dm v1.ResourceDataModel, appli
 	if !ok {
 		return nil, v1.ErrInvalidModelConversion
 	}
-	daprGenericResource, err := dapr.ConstructDaprGeneric(daprGeneric, applicationName, resource.Name, namespace, linkrp.DaprStateStoresResourceType)
+	daprGenericResource, err := dapr.ConstructDaprGeneric(daprGeneric, namespace, resource.Name, applicationName, resource.Name, linkrp.DaprStateStoresResourceType)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/linkrp/renderers/daprstatestores/renderer_test.go
+++ b/pkg/linkrp/renderers/daprstatestores/renderer_test.go
@@ -199,8 +199,8 @@ func Test_Render_Generic_Success(t *testing.T) {
 			"spec": map[string]any{
 				"type":    stateStoreType,
 				"version": daprStateStoreVersion,
-				"metadata": []map[string]any{
-					{
+				"metadata": []any{
+					map[string]any{
 						"name":  "foo",
 						"value": "bar",
 					},


### PR DESCRIPTION
# Description

While updating the Dapr state store resource behaviors, I had a chance to look at this functionality with fresh eyes. There were some gaps here. We recently make the Dapr component name configurable (separate from the resource name). A lot of existing code overloads these two concepts (resource name == name of a Radius resource, component name == name of a Kubernetes resource).

I added parameters to these functions where appropriate. New code should set them to the appropriate values. Old code should keep its existing behavior (as it will soon be removed).

I also added some tests and handling for cases that were missing in the conflict detection logic

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
