### PR TITLE
Add publishing of recipes for pull requests

### DIFF
--- a/.github/scripts/publish-recipes.sh
+++ b/.github/scripts/publish-recipes.sh
@@ -1,0 +1,57 @@
+#! /bin/bash
+
+# Fail immedietly if any command fails
+set -e
+
+# Get command line arguments
+BICEP_PATH=$1
+DIRECTORY=$2
+REGISTRY_PATH=$3
+RECIPE_VERSION=$4
+
+BICEP_EXECUTABLE="$BICEP_PATH/rad-bicep"
+
+# Print usage information
+function print_usage() {
+    echo "Usage: $0 <BICEP_PATH> <DIRECTORY> <REGISTRY_PATH> <RECIPE_VERSION>"
+    echo ""
+    echo "  Publishes all recipes in the repository to the Azure Container Registry. Requires you to be logged into Azure via az login."
+    echo ""
+    echo "  BICEP_PATH: Path to directory containing the bicep executable. For example, ~/.rad/bin"
+    echo "  DIRECTORY: Directory containing the recipes to publish. For example, ./test/functional/testdata/recipes"
+    echo "  REGISTRY_PATH: Registry hostname and path prefix. For example, myregistry.azurecr.io/tests/recipes."
+    echo "  RECIPE_VERSION: Version of the recipe to publish. For example, pr-19293"
+    echo ""
+}
+
+# Verify that the required arguments are present
+if [[ $# -ne 4 ]]; then
+    echo "Error: Missing required arguments"
+    echo ""
+    print_usage
+    exit 1
+fi
+
+# We create output that's intended to be consumed by the GitHub Action summary. If we're
+# not running in a GitHub Action, we'll just silence the output.
+if [[ -z "$GITHUB_STEP_SUMMARY" ]]; then
+    GITHUB_STEP_SUMMARY=/dev/null
+fi
+
+echo "## Recipes published to $REGISTRY_PATH" >> $GITHUB_STEP_SUMMARY
+for RECIPE in $(find "$DIRECTORY" -type f -name "*.bicep")
+do
+    FILENAME=$(basename $RECIPE)
+    PUBLISH_REF="$REGISTRY_PATH/${FILENAME%.*}:$RECIPE_VERSION"
+    
+    # Skip files that start with _. These are not recipes, they are modules that are
+    # used by the recipes.
+    if [[ $RECIPE = _* ]]; then
+        echo "Skipping $RECIPE"
+        continue
+    fi
+
+    echo "Publishing $RECIPE to $PUBLISH_REF"
+    echo "- $PUBLISH_REF" >> $GITHUB_STEP_SUMMARY
+    $BICEP_EXECUTABLE publish $RECIPE --target "br:$PUBLISH_REF"
+done

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -132,6 +132,7 @@ jobs:
             * Dapr: ${{ env.DAPR_VER }}
             * Azure KeyVault CSI driver: ${{ env.AZURE_KEYVAULT_CSI_DRIVER_VER }}
             * Azure Workload identity webhook: ${{ env.AZURE_WORKLOAD_IDENTITY_WEBHOOK_VER }}
+            * recipe location `${{ env.CACHE_REGISTRY}}/test/functional/corerp/recipes/<name>:${{ env.REL_VERSION }}`
             * appcore-rp test image location: `${{ env.CACHE_REGISTRY }}/appcore-rp:${{ env.REL_VERSION }}`
             * ucp test image location: `${{ env.CACHE_REGISTRY }}/ucpd:${{ env.REL_VERSION }}`
 
@@ -186,6 +187,36 @@ jobs:
           append: true
           message: |
             :x: Test image build failed
+      - name: Download rad-bicep
+        run: |
+          mkdir -p dist
+          ./.github/scripts/curl-with-retries.sh https://get.radapp.dev/tools/bicep-extensibility/edge/linux-x64/rad-bicep --output dist/rad-bicep
+          chmod +x dist/rad-bicep
+      - name: Publish Bicep Test Recipes
+        run: |
+          make publish-test-recipes
+        env:
+          RECIPE_REGISTRY: ${{ env.CACHE_REGISTRY }}
+          RECIPE_TAG_VERSION: ${{ env.REL_VERSION }}
+          RAD_BICEP_PATH: dist
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: success() && env.PR_NUMBER != ''
+        continue-on-error: true
+        with:
+          header: teststatus-${{ github.run_id }}
+          number: ${{ env.PR_NUMBER }}
+          append: true
+          message: |
+            :white_check_mark: Test recipe publishing succeeded
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: failure() && env.PR_NUMBER != ''
+        continue-on-error: true
+        with:
+          header: teststatus-${{ github.run_id }}
+          number: ${{ env.PR_NUMBER }}
+          append: true
+          message: |
+            :x: Test recipe publishing failed
   tests:
     name: Run ${{ matrix.name }} functional tests
     needs: build

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@
 ARROW := \033[34;1m=>\033[0m
 
 # order matters for these
-include build/help.mk build/version.mk build/build.mk build/util.mk build/generate.mk build/test.mk build/controller.mk build/docker.mk build/install.mk build/debug.mk
+include build/help.mk build/version.mk build/build.mk build/util.mk build/generate.mk build/test.mk build/controller.mk build/docker.mk build/recipes.mk build/install.mk build/debug.mk

--- a/build/recipes.mk
+++ b/build/recipes.mk
@@ -1,0 +1,20 @@
+# ------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# ------------------------------------------------------------
+
+RECIPE_TAG_VERSION?=latest
+RAD_BICEP_PATH?=$${HOME}/.rad/bin
+
+##@ Recipes
+
+.PHONY: publish-test-recipes
+publish-test-recipes: ## Publishes test recipes to <RECIPE_REGISTRY> with version <RECIPE_TAG_VERSION>
+	@if [ -z "$(RECIPE_REGISTRY)" ]; then echo "Error: RECIPE_REGISTRY must be set to a valid OCI registry"; exit 1; fi
+	
+	@echo "$(ARROW) Publishing recipes from ./test/functional/corerp/resources/testdata/recipes/test-recipes..."
+	./.github/scripts/publish-recipes.sh \
+		${RAD_BICEP_PATH} \
+		./test/functional/corerp/resources/testdata/recipes/test-recipes \
+		${RECIPE_REGISTRY}/test/functional/corerp/recipes \
+		${RECIPE_TAG_VERSION}

--- a/test/functional/corerp/resources/testdata/recipes/test-recipes/README.md
+++ b/test/functional/corerp/resources/testdata/recipes/test-recipes/README.md
@@ -1,0 +1,11 @@
+# Test Recipes
+
+The recipes in this folder are published as part of the PR process to:
+
+> `radiusdev.azurecr.io/test/functional/corerp/<filename>:pr-<pr-number>`
+
+This is important because it allows us to make changes to the recipes, and test them in the same PR that contains the change.
+
+## Non-recipes bicep files
+
+Any Bicep file starting with `_` will be skipped during publishing. Use this as a convention to create shared modules that are not published as recipes. For example `_redis_kubernetes.bicep` would not be published.


### PR DESCRIPTION
# Description

This change adds a publish step to our builds that will upload the recipes we use in tests. Right now these recipes are published manually, and so changes we make to recipes cannot be tested in PRs.

This step adds publishing of recipes to our existing `radiusdev` ACR. The next change will start to consume these recipes from their new paths in our functional tests.
