### PR TITLE
Handling dev recipes conflict with user defined recipes

### DIFF
--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
@@ -79,12 +79,7 @@ func (e *CreateOrUpdateEnvironment) Run(ctx context.Context, w http.ResponseWrit
 				if devRecipes[resourceType] != nil {
 					for recipeName, recipeDetails := range recipes {
 						if newResourceRecipes[resourceType] != nil {
-							if val, ok := newResourceRecipes[resourceType][recipeName]; ok && val.TemplatePath != recipeDetails.TemplatePath {
-								if errorRecipes != "" {
-									errorRecipes += ", "
-								}
-								errorRecipes += fmt.Sprintf("recipe with name %s (linkType %s and templatePath %s)", recipeName, resourceType, val.TemplatePath)
-							} else {
+							if _, ok := newResourceRecipes[resourceType][recipeName]; !ok {
 								newResourceRecipes[resourceType][recipeName] = recipeDetails
 							}
 						} else {

--- a/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/createorupdateenvironment.go
@@ -71,10 +71,7 @@ func (e *CreateOrUpdateEnvironment) Run(ctx context.Context, w http.ResponseWrit
 		}
 		newResourceRecipes := newResource.Properties.Recipes
 		if newResourceRecipes != nil {
-			errorPrefix := "recipe name(s) reserved for devRecipes for: "
-			var errorRecipes string
-			// validate that if the input recipe is updating an existing dev recipe with a different templatepath
-			// if the input recipe has the same name as that of the dev recipe but different templatepath return an error
+			// validate that if the input recipe name is present in dev recipes and overwrite it with the new recipe details if present else add it to the recipe list.
 			for resourceType, recipes := range devRecipes {
 				if devRecipes[resourceType] != nil {
 					for recipeName, recipeDetails := range recipes {
@@ -87,9 +84,6 @@ func (e *CreateOrUpdateEnvironment) Run(ctx context.Context, w http.ResponseWrit
 						}
 					}
 				}
-			}
-			if errorRecipes != "" {
-				return nil, fmt.Errorf(errorPrefix + errorRecipes)
 			}
 		} else {
 			newResource.Properties.Recipes = devRecipes

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentuserrecipesconflictwithdevrecipes20220315privatepreview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentuserrecipesconflictwithdevrecipes20220315privatepreview_datamodel.json
@@ -23,7 +23,7 @@
         "recipes": {
             "Applications.Link/mongoDatabases":{
                 "mongo-azure": {
-                    "templatePath": "radiusdev.azurecr.io/mongo:1.0"
+                    "templatePath": "radiusdev.azurecr.io/test/mongo:1.0"
                 }
             },
             "Applications.Link/redisCaches":{
@@ -32,7 +32,7 @@
                 }
             }
         },
-        "useDevRecipes": false,
+        "useDevRecipes": true,
         "providers": {
             "azure": {
                 "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentuserrecipesconflictwithdevrecipes20220315privatepreview_input.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentuserrecipesconflictwithdevrecipes20220315privatepreview_input.json
@@ -9,7 +9,7 @@
         "recipes": {
             "Applications.Link/mongoDatabases":{
                 "mongo-azure": {
-                    "templatePath": "radiusdev.azurecr.io/mongo:1.0"
+                    "templatePath": "radiusdev.azurecr.io/test/mongo:1.0"
                 }
             }
         },

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentuserrecipesconflictwithdevrecipes20220315privatepreview_output.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentuserrecipesconflictwithdevrecipes20220315privatepreview_output.json
@@ -1,0 +1,41 @@
+{
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/applications.core/environments/env0",
+    "location": "West US",
+    "name": "env0",
+    "properties": {
+      "compute": {
+        "kind": "kubernetes",
+        "resourceId": "fakeid",
+        "namespace": "default"
+      },
+      "providers": {
+        "azure": {
+          "scope": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg"
+        }
+      },
+      "recipes": {
+        "Applications.Link/mongoDatabases":{
+            "mongo-azure": {
+                "templatePath": "radiusdev.azurecr.io/test/mongo:1.0"
+            }
+        },
+        "Applications.Link/redisCaches":{
+            "redis-kubernetes": {                 
+                "templatePath": "radius.azurecr.io/recipes/rediscaches/kubernetes:1.0"
+            }
+        }
+    },
+      "useDevRecipes": true,
+      "provisioningState": "Succeeded"
+    },
+    "systemData": {
+      "createdAt": "2022-03-22T18:54:52.6857175Z",
+      "createdBy": "fake@hotmail.com",
+      "createdByType": "User",
+      "lastModifiedAt": "2022-03-22T18:57:52.6857175Z",
+      "lastModifiedBy": "fake@hotmail.com",
+      "lastModifiedByType": "User"
+    },
+    "tags": {},
+    "type": "applications.core/environments"
+  }

--- a/pkg/corerp/frontend/controller/environments/v20220315privatepreview_test.go
+++ b/pkg/corerp/frontend/controller/environments/v20220315privatepreview_test.go
@@ -86,12 +86,19 @@ func getTestModelsAppendDevRecipesToExisting20220315privatepreview() (*datamodel
 	return envExistingDataModel, envInput, envDataModel, expectedOutput
 }
 
-func getTestModelsUserRecipesConflictWithReservedNames20220315privatepreview() *v20220315privatepreview.EnvironmentResource {
-	rawInput := testutil.ReadFixture("environmentuserrecipesconflictwithreservednames20220315privatepreview_input.json")
+func getTestModelsUserRecipesConflictWithDevRecipes20220315privatepreview() (*v20220315privatepreview.EnvironmentResource, *datamodel.Environment, *v20220315privatepreview.EnvironmentResource) {
+	rawInput := testutil.ReadFixture("environmentuserrecipesconflictwithdevrecipes20220315privatepreview_input.json")
 	envInput := &v20220315privatepreview.EnvironmentResource{}
 	_ = json.Unmarshal(rawInput, envInput)
 
-	return envInput
+	rawDataModel := testutil.ReadFixture("environmentuserrecipesconflictwithdevrecipes20220315privatepreview_datamodel.json")
+	envDataModel := &datamodel.Environment{}
+	_ = json.Unmarshal(rawDataModel, envDataModel)
+
+	rawExpectedOutput := testutil.ReadFixture("environmentuserrecipesconflictwithdevrecipes20220315privatepreview_output.json")
+	expectedOutput := &v20220315privatepreview.EnvironmentResource{}
+	_ = json.Unmarshal(rawExpectedOutput, expectedOutput)
+	return envInput, envDataModel, expectedOutput
 }
 
 func getTestModelsExistingUserRecipesConflictWithReservedNames20220315privatepreview() (*datamodel.Environment, *v20220315privatepreview.EnvironmentResource) {

--- a/pkg/corerp/frontend/controller/environments/v20220315privatepreview_test.go
+++ b/pkg/corerp/frontend/controller/environments/v20220315privatepreview_test.go
@@ -101,19 +101,6 @@ func getTestModelsUserRecipesConflictWithDevRecipes20220315privatepreview() (*v2
 	return envInput, envDataModel, expectedOutput
 }
 
-func getTestModelsExistingUserRecipesConflictWithReservedNames20220315privatepreview() (*datamodel.Environment, *v20220315privatepreview.EnvironmentResource) {
-
-	rawExistingDataModel := testutil.ReadFixture("environmentuserrecipesconflictwithreservednamesoriginal20220315privatepreview_datamodel.json")
-	envExistingDataModel := &datamodel.Environment{}
-	_ = json.Unmarshal(rawExistingDataModel, envExistingDataModel)
-
-	rawInput := testutil.ReadFixture("environmentuserrecipesconflictwithreservednames20220315privatepreview_input.json")
-	envInput := &v20220315privatepreview.EnvironmentResource{}
-	_ = json.Unmarshal(rawInput, envInput)
-
-	return envExistingDataModel, envInput
-}
-
 func getTestModelsGetRecipeMetadata20220315privatepreview() (*v20220315privatepreview.Recipe, *datamodel.Environment, *v20220315privatepreview.EnvironmentRecipeProperties) {
 	rawInput := testutil.ReadFixture("environmentgetrecipemetadata20220315privatepreview_input.json")
 	envInput := &v20220315privatepreview.Recipe{}

--- a/test/functional/corerp/cli/cli_test.go
+++ b/test/functional/corerp/cli/cli_test.go
@@ -86,8 +86,12 @@ func verifyRecipeCLI(ctx context.Context, t *testing.T, test corerp.CoreRPTest) 
 	})
 
 	t.Run("Validate rad recipe register with recipe name conflicting with dev recipe", func(t *testing.T) {
-		_, err := cli.RecipeRegister(ctx, envName, "mongo-azure", recipeTemplate, linkType)
-		require.Error(t, err)
+		output, err := cli.RecipeRegister(ctx, envName, "mongo-azure", recipeTemplate, linkType)
+		require.Contains(t, output, "Successfully linked recipe")
+		require.NoError(t, err)
+		output, err = cli.Recipelist(ctx, envName)
+		require.NoError(t, err)
+		require.Regexp(t, recipeTemplate, output)
 	})
 }
 


### PR DESCRIPTION
# Description

Changing the behavior of recipe registration when use provides the recipe name that is same as the one defined in dev recipe for the given resource type.

Instead of throwing an error (what we do today), ex:
"recipe name(s) reserved for devRecipes for: recipe with name mongo-azure (linkType Applications.Link/mongoDatabases and templatePath radiusdev.azurecr.io/mongo:1.0)"

we overwrite the recipe with user provided recipe information.

FYI: this behavior would change with the introduction of recipe packs, where dev recipe packs and user defined packs can have recipe with same name for the same type.


## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [ ] Extended the documentation / Created issue for it
