### PR TITLE
Clean up resource groups created 6+ hours before

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -435,8 +435,9 @@ jobs:
       - name: Delete azure resource group - ${{ env.AZURE_TEST_RESOURCE_GROUP }}
         if: always()
         run: |
+          # if deletion fails, purge workflow will purge the resource group and its resources later.
           az group delete \
             --subscription ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }} \
             --name ${{ env.AZURE_TEST_RESOURCE_GROUP }} \
             --yes \
-            --verbose
+            --no-wait

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -252,10 +252,12 @@ jobs:
             :white_check_mark: Starting ${{ matrix.name }} functional tests...
       - name: Create azure resource group - ${{ env.AZURE_TEST_RESOURCE_GROUP }}
         run: |
+          current_time=$(date +%s)
           az group create \
             --location ${{ env.AZURE_LOCATION }} \
             --name $RESOURCE_GROUP \
-            --subscription ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+            --subscription ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }} \
+            --tags creationTime=$current_time
           while [ $(az group exists --name $RESOURCE_GROUP) = false ]; do sleep 2; done
         env:
           RESOURCE_GROUP: ${{ env.AZURE_TEST_RESOURCE_GROUP }}

--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -41,7 +41,7 @@ jobs:
             fi
 
             if [ "$creation_time" = "None" ]; then
-              echo " * :wastebasket: $name - old resource"  >> $GITHUB_STEP_SUMMARY
+              echo " * $name - creationTime: None - skipping"  >> $GITHUB_STEP_SUMMARY
               continue
             fi
 

--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -11,8 +11,8 @@ on:
       - features/*
       - release/*
   schedule:
-    # Run at 23:05 on Sunday.
-    - cron: "5 23 * * 0"
+    # Run every 30 minutes
+    - cron: "30 * * * *"
 env:
   # The test subscription id for testing.
   AZURE_SUBSCRIPTION_ID: '85716382-7362-45c3-ae03-2126e459a123'
@@ -28,8 +28,10 @@ jobs:
         uses: azure/login@v1
         with:
           creds: '{"clientId":"${{ secrets.AZURE_SP_TESTS_APPID }}","clientSecret":"${{ secrets.AZURE_SP_TESTS_PASSWORD }}","subscriptionId":"${{ env.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_SP_TESTS_TENANTID }}"}'
-      - name: Find 6 hours+ old test resource groups
+      - name: Find old test resource groups
         run: |
+          echo "## Test resource group list" >> $GITHUB_STEP_SUMMARY
+
           az account set -s ${{ env.AZURE_SUBSCRIPTION_ID }}
 
           current_time=$(date +%s)
@@ -37,31 +39,33 @@ jobs:
           hours_ago=$((current_time - 6*60*60))
 
           resource_groups=$(az group list --query "[].{Name:name, creationTime:tags.creationTime}" -o tsv)
-
+          
           while IFS=$'\t' read -r name creation_time; do
             if [[ ! "$name" =~ ^"radius-" ]] && [[ ! "$name" =~ ^"radtest-" ]]; then
               continue
             fi
 
             if [ "$creation_time" = "None" ]; then
-              echo $name, old resources
+              echo " * :wastebasket: $name - old resource"  >> $GITHUB_STEP_SUMMARY
+              echo $name >> ${{ env.AZURE_RG_DELETE_LIST_FILE}}
               continue
             fi
 
             # Check if the resource group was created more than 6 hours ago
             if [ "$creation_time" -lt "$hours_ago" ]; then
-              echo $name, $creation_time
+              echo " * :wastebasket: $name - creationTime: $creation_time"  >> $GITHUB_STEP_SUMMARY
               echo $name >> ${{ env.AZURE_RG_DELETE_LIST_FILE}}
+            else
+              echo " * :white_check_mark: $name - creationTime: $creation_time - skipping"  >> $GITHUB_STEP_SUMMARY
             fi
           done <<< "$resource_groups"
 
           cat ${{ env.AZURE_RG_DELETE_LIST_FILE}}
-
-          echo "## Azure resource groups:" >> $GITHUB_STEP_SUMMARY
       - name: Delete Azure resource groups
         run: |
+          echo "## Deleting resource group list" >> $GITHUB_STEP_SUMMARY
           cat ${{ env.AZURE_RG_DELETE_LIST_FILE}} | while read line
           do
               echo " * $line" >> $GITHUB_STEP_SUMMARY
-              # az group delete --resource-group $line --yes
+              az group delete --resource-group $line --yes --verbose
           done

--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -44,6 +44,7 @@ jobs:
             fi
 
             if [ "$creation_time" = "None" ]; then
+              echo $name, old resources
               continue
             fi
 

--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -5,6 +5,11 @@
 
 name: Purge test resources
 on:
+  pull_request:
+    branches:
+      - main
+      - features/*
+      - release/*
   schedule:
     # Run at 23:05 on Sunday.
     - cron: "5 23 * * 0"
@@ -23,19 +28,39 @@ jobs:
         uses: azure/login@v1
         with:
           creds: '{"clientId":"${{ secrets.AZURE_SP_TESTS_APPID }}","clientSecret":"${{ secrets.AZURE_SP_TESTS_PASSWORD }}","subscriptionId":"${{ env.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_SP_TESTS_TENANTID }}"}'
-      - name: Find all deleting resource groups
+      - name: Find 6 hours+ old test resource groups
         run: |
           az account set -s ${{ env.AZURE_SUBSCRIPTION_ID }}
-          # Delete test resource groups created by ADO pipeline
-          az group list --query "[?starts_with(name, 'radius-1')].{name:name}" --output table|grep radius- > ${{ env.AZURE_RG_DELETE_LIST_FILE}}
-          # Delete test resource groups created by functional-test.yaml
-          az group list --query "[?starts_with(name, 'radtest-')].{name:name}" --output table|grep radtest- >> ${{ env.AZURE_RG_DELETE_LIST_FILE}}
+
+          current_time=$(date +%s)
+          # 6 hours ago
+          hours_ago=$((current_time - 6*60*60))
+
+          resource_groups=$(az group list --query "[].{Name:name, creationTime:tags.creationTime}" -o tsv)
+
+          while IFS=$'\t' read -r name creation_time; do
+            if [[ ! "$name" =~ ^"radius-" ]] && [[ ! "$name" =~ ^"radtest-" ]]; then
+              continue
+            fi
+
+            if [ "$creation_time" = "None" ]; then
+              continue
+            fi
+
+            # Check if the resource group was created more than 6 hours ago
+            if [ "$creation_time" -lt "$hours_ago" ]; then
+              echo $name, $creation_time
+              echo $name >> ${{ env.AZURE_RG_DELETE_LIST_FILE}}
+            fi
+          done <<< "$resource_groups"
+
           cat ${{ env.AZURE_RG_DELETE_LIST_FILE}}
+
           echo "## Azure resource groups:" >> $GITHUB_STEP_SUMMARY
       - name: Delete Azure resource groups
         run: |
           cat ${{ env.AZURE_RG_DELETE_LIST_FILE}} | while read line
           do
               echo " * $line" >> $GITHUB_STEP_SUMMARY
-              az group delete --resource-group $line --yes
+              # az group delete --resource-group $line --yes
           done

--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -5,13 +5,8 @@
 
 name: Purge test resources
 on:
-  pull_request:
-    branches:
-      - main
-      - features/*
-      - release/*
   schedule:
-    # Run every 30 minutes
+    # Run every hour in 6 hours window
     - cron: "30 * * * *"
 env:
   # The test subscription id for testing.
@@ -47,7 +42,6 @@ jobs:
 
             if [ "$creation_time" = "None" ]; then
               echo " * :wastebasket: $name - old resource"  >> $GITHUB_STEP_SUMMARY
-              echo $name >> ${{ env.AZURE_RG_DELETE_LIST_FILE}}
               continue
             fi
 

--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -41,7 +41,8 @@ jobs:
             fi
 
             if [ "$creation_time" = "None" ]; then
-              echo " * $name - creationTime: None - skipping"  >> $GITHUB_STEP_SUMMARY
+              echo " * :wastebasket: $name - old resource"  >> $GITHUB_STEP_SUMMARY
+              echo $name >> ${{ env.AZURE_RG_DELETE_LIST_FILE}}
               continue
             fi
 
@@ -50,7 +51,7 @@ jobs:
               echo " * :wastebasket: $name - creationTime: $creation_time"  >> $GITHUB_STEP_SUMMARY
               echo $name >> ${{ env.AZURE_RG_DELETE_LIST_FILE}}
             else
-              echo " * :white_check_mark: $name - creationTime: $creation_time - skipping"  >> $GITHUB_STEP_SUMMARY
+              echo " * :white_check_mark: $name - creationTime: $creation_time"  >> $GITHUB_STEP_SUMMARY
             fi
           done <<< "$resource_groups"
 


### PR DESCRIPTION
# Description

Run every hour to clean up but delete only 6+ hours old resource group

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
