### PR TITLE
Automate Publish recipes to ACR for functional tests

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -13,6 +13,7 @@ DOCKER_REGISTRY ?=radiusdev.azurecr.io
 ENVTEST_ASSETS_DIR=$(shell pwd)/bin
 K8S_VERSION=1.23.*
 ENV_SETUP=$(GOBIN)/setup-envtest$(BINARY_EXT)
+TEST_RECIPES_PATH=test/functional/corerp/resources/testdata/recipes/test-recipes/
 
 # Use gotestsum if available, otherwise use go test. We want to enable testing with just 'make test'
 # without external dependencies, but want to use gotestsum in our CI pipelines for the improved
@@ -46,9 +47,9 @@ test-validate-cli: ## Run cli integration tests
 test-functional-kubernetes: ## Runs Kubernetes functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
 
-publish-recipes:
-	@for file in $(shell ls $(MYDIR)); do \
-		$(HOME)/.rad/bin/rad-bicep publish $(MYDIR)$${file} --target br:radiusdev.azurecr.io/recipes/functionaltest/`basename -s .bicep $${file}`:1.0; \
+publish-recipes-to-acr:
+	@for file in $(shell ls $(TEST_RECIPES_PATH)); do \
+		$(HOME)/.rad/bin/rad-bicep publish $(TEST_RECIPES_PATH)$${file} --target br:radiusdev.azurecr.io/recipes/functionaltest/`basename -s .bicep $${file}`:1.0; \
 	done
 test-functional-corerp: ## Runs Applications.Core functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/corerp/... -timeout ${TEST_TIMEOUT} -v -parallel 10 $(GOTEST_OPTS)

--- a/build/test.mk
+++ b/build/test.mk
@@ -46,6 +46,10 @@ test-validate-cli: ## Run cli integration tests
 test-functional-kubernetes: ## Runs Kubernetes functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
 
+publish-recipes:
+	@for file in $(shell ls $(MYDIR)); do \
+		$(HOME)/.rad/bin/rad-bicep publish $(MYDIR)$${file} --target br:radiusdev.azurecr.io/recipes/functionaltest/`basename -s .bicep $${file}`:1.0; \
+	done
 test-functional-corerp: ## Runs Applications.Core functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/corerp/... -timeout ${TEST_TIMEOUT} -v -parallel 10 $(GOTEST_OPTS)
 

--- a/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
+++ b/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
@@ -45,6 +45,7 @@ The tests use our product functionality (the Radius config file) to configure th
 
 When you're running locally with this configuration, the tests will use your locally selected Radius environment and your local copy of `rad`. The executeCoreRPFunctionalTest.sh scripts creates the azure resources and exports the values to be used in the functional test and runs:
  ```sh
+    make publish-recipes-to-acr
     make test-functional-corerp
  ```
 

--- a/test/executeCoreRPFunctionalTest.sh
+++ b/test/executeCoreRPFunctionalTest.sh
@@ -28,4 +28,5 @@ export AZURE_MONGODB_RESOURCE_ID=$( jq -r '.properties.outputs.mongoDatabaseId.v
 export AZURE_REDIS_RESOURCE_ID=$( jq -r '.properties.outputs.redisCacheId.value' <<< "${resp}" )
 export AZURE_TABLESTORAGE_RESOURCE_ID=$( jq -r '.properties.outputs.tableStorageAccId.value' <<< "${resp}" )
 export AZURE_COSMOS_MONGODB_ACCOUNT_ID=$( jq -r '.properties.outputs.cosmosMongoAccountID.value' <<< "${resp}" )
+make publish-recipes-to-acr
 make test-functional-corerp


### PR DESCRIPTION
# Description

To test a recipe in functional tests today, we need to first manually publish the recipe to an ACR and update it every time a change is made. This pr addresses automating the process of publishing the test recipes to ACR. 
All recipe files added under  test/functional/corerp/resources/testdata/recipes/test-recipes will be publish to ACR.
ex: `dapr_state_store_recipe.bicep` will be published to ACR with template path `radiusdev.azurecr.io/recipes/functionaltest/dapr_state_store_recipe:1.0
`
## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it
