### PR TITLE
Remove cloud provider double prompts

### DIFF
--- a/pkg/cli/setup/aws.go
+++ b/pkg/cli/setup/aws.go
@@ -65,14 +65,6 @@ func ParseAWSProviderArgs(cmd *cobra.Command, interactive bool, prompter prompt.
 func parseAWSProviderInteractive(cmd *cobra.Command, prompter prompt.Interface) (*radAWS.Provider, error) {
 	ctx := cmd.Context()
 
-	addAWSCred, err := prompt.YesOrNoPrompt("Add AWS provider for cloud resources?", "no", prompter)
-	if err != nil {
-		return nil, err
-	}
-	if !addAWSCred {
-		return nil, nil
-	}
-
 	region, err := prompter.GetTextInput("Enter the region you would like to use to deploy AWS resources:", "Enter a region...")
 	if err != nil {
 		return nil, err

--- a/pkg/cli/setup/azure.go
+++ b/pkg/cli/setup/azure.go
@@ -47,13 +47,6 @@ func ParseAzureProviderArgs(cmd *cobra.Command, interactive bool, prompter promp
 }
 
 func parseAzureProviderInteractive(cmd *cobra.Command, prompter prompt.Interface) (*azure.Provider, error) {
-	addAzureSPN, err := prompt.YesOrNoPrompt("Add Azure provider for cloud resources?", "no", prompter)
-	if err != nil {
-		return nil, err
-	}
-	if !addAzureSPN {
-		return nil, nil
-	}
 	armConfig, err := armauth.NewArmConfig(nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

This PR removes the duplicate prompts for cloud providers. Now that `rad env init -i` has been removed, these prompts can safely be removed.

## Issue reference

Fixes: radius-project/core-team#1073

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
