### PR TITLE
Update `rad run` docs to describe logs and port-forward

### DIFF
--- a/pkg/cli/cmd/run/run.go
+++ b/pkg/cli/cmd/run/run.go
@@ -33,9 +33,9 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 		Short: "Run an application",
 		Long: `Run an application specified by a Bicep or ARM template
 	
-	The run command compiles a Bicep or ARM template and runs it in your default environment (unless otherwise specified).
+The run command compiles a Bicep or ARM template and runs it in your default environment (unless otherwise specified). It also automatically port-forwards container ports and streams container logs to a user's terminal.
 		
-	The run command accepts the same parameters as the 'rad deploy' command. See the 'rad deploy' help for more information.
+The run command accepts the same parameters as the 'rad deploy' command. See the 'rad deploy' help for more information.
 	`,
 		Example: `
 # Run app.bicep


### PR DESCRIPTION
# Description

Today we're missing information about port-forwarding and log streaming in the `rad run` documentation

This updates the cobra strings. Also note that the indentation is fixed as well