### PR TITLE
Update cloud-provider credential refresh timeout

### DIFF
--- a/pkg/azure/credential/ucpcredentials.go
+++ b/pkg/azure/credential/ucpcredentials.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// DefaultExpireDuration is the default expiry duration.
-	DefaultExpireDuration = time.Minute * time.Duration(15)
+	DefaultExpireDuration = time.Second * time.Duration(30)
 )
 
 var _ azcore.TokenCredential = (*UCPCredential)(nil)

--- a/pkg/cli/cmd/credential/common/doc.go
+++ b/pkg/cli/cmd/credential/common/doc.go
@@ -9,9 +9,8 @@ package common
 // The newlines are intentional, don't make changes without looking at the formatting.
 const LongDescriptionBlurb = `
 
-Radius cloud provider integrations enable Radius to deploy cloud resources using Bicep, and for Radius
-environments and links to integrate with those cloud resources. Radius also stores credentials for
-use when accessing cloud resources.
+Radius cloud providers enable Radius environments to deploy and integrate with cloud resources (Azure, AWS).
+The Radius control-plane stores credentials for use when accessing cloud resources.
 
 Cloud providers are configured per-Radius-installation. Configuration commands will use the current workspace
 or the workspace specified by '--workspace' to configure Radius. Modifications to cloud provider configuration

--- a/pkg/cli/cmd/credential/register/aws/aws.go
+++ b/pkg/cli/cmd/credential/register/aws/aws.go
@@ -29,13 +29,13 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 
 	cmd := &cobra.Command{
 		Use:   "aws",
-		Short: "Register (add or update) AWS cloud provider credential for a Radius installation.",
-		Long: `Register (add or update) AWS cloud provider credential for a Radius installation.
+		Short: "Register (Add or update) AWS cloud provider credential for a Radius installation.",
+		Long: `Register (Add or update) AWS cloud provider credential for a Radius installation..
 
-Radius will use a provided IAM access key and secret access key for deploying and interacting with AWS resources.
-The provided IAM role must have any applicable resource role(s) in order to create or manage resources.
-		
-Updates to the AWS credential can take up to 30 seconds to fully refresh.
+This command is intended for scripting or advanced use-cases. See 'rad init' for a user-friendly way
+to configure these settings.
+
+Radius will use the provided IAM credential for all interations with AWS. 
 ` + common.LongDescriptionBlurb,
 		Example: `
 # Register (Add or update) cloud provider credential for AWS with IAM authentication
@@ -122,7 +122,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 // Run runs the `rad credential register aws` command.
 func (r *Runner) Run(ctx context.Context) error {
 
-	r.Output.LogInfo("Configuring credential for cloud provider %q for Radius installation %q...", "aws", r.Workspace.FmtConnection())
+	r.Output.LogInfo("Registering credential for %q cloud provider in Radius installation %q...", "aws", r.Workspace.FmtConnection())
 	client, err := r.ConnectionFactory.CreateCredentialManagementClient(ctx, *r.Workspace)
 	if err != nil {
 		return err
@@ -144,7 +144,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	r.Output.LogInfo("Successfully Configured credential for cloud provider %q", "aws")
+	r.Output.LogInfo("Successfully registered credential for %q cloud provider. Tokens may take up to 30 seconds to refresh.", "aws")
 
 	return nil
 }

--- a/pkg/cli/cmd/credential/register/aws/aws.go
+++ b/pkg/cli/cmd/credential/register/aws/aws.go
@@ -29,13 +29,13 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 
 	cmd := &cobra.Command{
 		Use:   "aws",
-		Short: "Register (Add or update) AWS cloud provider credential for a Radius installation.",
-		Long: `Register (Add or update) AWS cloud provider credential for a Radius installation..
+		Short: "Register (add or update) AWS cloud provider credential for a Radius installation.",
+		Long: `Register (add or update) AWS cloud provider credential for a Radius installation.
 
-This command is intended for scripting or advanced use-cases. See 'rad init' for a user-friendly way
-to configure these settings.
-
-Radius will use the provided IAM credential for all interations with AWS. 
+Radius will use a provided IAM access key and secret access key for deploying and interacting with AWS resources.
+The provided IAM role must have any applicable resource role(s) in order to create or manage resources.
+		
+Updates to the AWS credential can take up to 30 seconds to fully refresh.
 ` + common.LongDescriptionBlurb,
 		Example: `
 # Register (Add or update) cloud provider credential for AWS with IAM authentication

--- a/pkg/cli/cmd/credential/register/aws/aws_test.go
+++ b/pkg/cli/cmd/credential/register/aws/aws_test.go
@@ -129,11 +129,11 @@ func Test_Run(t *testing.T) {
 
 			expected := []any{
 				output.LogOutput{
-					Format: "Configuring credential for cloud provider %q for Radius installation %q...",
+					Format: "Registering credential for %q cloud provider in Radius installation %q...",
 					Params: []any{"aws", "Kubernetes (context=my-context)"},
 				},
 				output.LogOutput{
-					Format: "Successfully Configured credential for cloud provider %q",
+					Format: "Successfully registered credential for %q cloud provider. Tokens may take up to 30 seconds to refresh.",
 					Params: []any{"aws"},
 				},
 			}

--- a/pkg/cli/cmd/credential/register/azure/azure.go
+++ b/pkg/cli/cmd/credential/register/azure/azure.go
@@ -30,19 +30,13 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 
 	cmd := &cobra.Command{
 		Use:   "azure",
-		Short: "Register (Add or update) Azure cloud provider credential for a Radius installation.",
-		Long: `Register (Add or update) Azure cloud provider credential for a Radius installation..
+		Short: "Register (add or update) Azure cloud provider credential for a Radius installation.",
+		Long: `Register (add or update) Azure cloud provider credential for a Radius installation.
 
-This command is intended for scripting or advanced use-cases. See 'rad init' for a user-friendly way
-to configure these settings.
+Radius will use a provided Azure Active Directory service principal for deploying and interacting with Azure resources.
+The provided service principal must have the Contributor or Owner role assigned any target scopes (subscription or resource group) in order to create or manage resources.
 
-Radius will use the provided service principal for all interations with Azure, including Bicep deployment, 
-Radius environments, and Radius links. 
-
-Radius will use the provided subscription and resource group as the default target scope for Bicep deployment.
-The provided service principal must have the Contributor or Owner role assigned for the provided resource group
-in order to create or manage resources contained in the group. The resource group should be created before
-calling 'rad credential register azure'.
+Updates to the Azure credential can take up to 30 seconds to fully refresh.
 ` + common.LongDescriptionBlurb,
 		Example: `
 # Register (Add or update) cloud provider credential for Azure with service principal authentication

--- a/pkg/cli/cmd/credential/register/azure/azure.go
+++ b/pkg/cli/cmd/credential/register/azure/azure.go
@@ -30,13 +30,19 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 
 	cmd := &cobra.Command{
 		Use:   "azure",
-		Short: "Register (add or update) Azure cloud provider credential for a Radius installation.",
-		Long: `Register (add or update) Azure cloud provider credential for a Radius installation.
+		Short: "Register (Add or update) Azure cloud provider credential for a Radius installation.",
+		Long: `Register (Add or update) Azure cloud provider credential for a Radius installation..
 
-Radius will use a provided Azure Active Directory service principal for deploying and interacting with Azure resources.
-The provided service principal must have the Contributor or Owner role assigned any target scopes (subscription or resource group) in order to create or manage resources.
+This command is intended for scripting or advanced use-cases. See 'rad init' for a user-friendly way
+to configure these settings.
 
-Updates to the Azure credential can take up to 30 seconds to fully refresh.
+Radius will use the provided service principal for all interations with Azure, including Bicep deployment, 
+Radius environments, and Radius links. 
+
+Radius will use the provided subscription and resource group as the default target scope for Bicep deployment.
+The provided service principal must have the Contributor or Owner role assigned for the provided resource group
+in order to create or manage resources contained in the group. The resource group should be created before
+calling 'rad credential register azure'.
 ` + common.LongDescriptionBlurb,
 		Example: `
 # Register (Add or update) cloud provider credential for Azure with service principal authentication
@@ -130,7 +136,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	// 1) Update server-side to add/change credentials
 	// 2) Update local config (all matching workspaces) to remove the scope
 
-	r.Output.LogInfo("Configuring credential for cloud provider %q for Radius installation %q...", "azure", r.Workspace.FmtConnection())
+	r.Output.LogInfo("Registering credential for %q cloud provider in Radius installation %q...", "azure", r.Workspace.FmtConnection())
 	client, err := r.ConnectionFactory.CreateCredentialManagementClient(ctx, *r.Workspace)
 	if err != nil {
 		return err
@@ -156,5 +162,8 @@ func (r *Runner) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	r.Output.LogInfo("Successfully registered credential for %q cloud provider. Tokens may take up to 30 seconds to refresh.", "azure")
+
 	return nil
 }

--- a/pkg/cli/cmd/credential/register/azure/azure_test.go
+++ b/pkg/cli/cmd/credential/register/azure/azure_test.go
@@ -204,7 +204,7 @@ func Test_Run(t *testing.T) {
 				},
 				output.LogOutput{
 					Format: "Successfully registered credential for %q cloud provider. Tokens may take up to 30 seconds to refresh.",
-					Params: []any{"aws"},
+					Params: []any{"azure"},
 				},
 			}
 			require.Equal(t, expected, outputSink.Writes)

--- a/pkg/cli/cmd/credential/register/azure/azure_test.go
+++ b/pkg/cli/cmd/credential/register/azure/azure_test.go
@@ -199,8 +199,12 @@ func Test_Run(t *testing.T) {
 
 			expected := []any{
 				output.LogOutput{
-					Format: "Configuring credential for cloud provider %q for Radius installation %q...",
+					Format: "Registering credential for %q cloud provider in Radius installation %q...",
 					Params: []any{"azure", "Kubernetes (context=my-context)"},
+				},
+				output.LogOutput{
+					Format: "Successfully registered credential for %q cloud provider. Tokens may take up to 30 seconds to refresh.",
+					Params: []any{"aws"},
 				},
 			}
 			require.Equal(t, expected, outputSink.Writes)


### PR DESCRIPTION
# Description

Today we refresh UCP cloud provider credentials every 15 minutes

This PR updates this to 30 seconds and documents the behavior in the `rad credential register` CLI command

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: radius-project/core-team#1176

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [x] Extended the documentation / Created issue for it
