### PR TITLE
Fix init --dev double prompting bug

### DIFF
--- a/pkg/cli/cmd/radinit/init.go
+++ b/pkg/cli/cmd/radinit/init.go
@@ -194,22 +194,21 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	// If there are any existing environments and we're not reinstalling, ask to use
 	// one of those first.
 	//
-	// "reinstall" repreresents the the user-intent to reconfigure cloud providers,
-	// we also need to force re-creation of the envionment to do that, so we don't want
+	// "reinstall" represents the the user-intent to reconfigure cloud providers,
+	// we also need to force re-creation of the environment to do that, so we don't want
 	// to reuse an existing one.
 	if len(environments) > 0 && !r.Reinstall {
 
 		// In dev mode, we take the default without asking if it's an option.
 		//
-		// The best way to accomplish that is to run SelectedExistingEnvironment in non-interactive mode
-		// first, and then try again interactively if we get no results.
+		// The best way to accomplish that is to check if there's an environment named "default"
+		// If not, we prompt the user for an input of remaining options
 		if r.Dev {
-			r.EnvName, err = SelectExistingEnvironment(cmd, "default", r.Prompter, environments)
-			if err != nil {
-				if errors.Is(err, &prompt.ErrExitConsole{}) {
-					return &cli.FriendlyError{Message: err.Error()}
+			for _, env := range environments {
+				if strings.EqualFold("default", *env.Name) {
+					r.EnvName = "default"
 				}
-				return err
+				break
 			}
 		}
 

--- a/pkg/cli/cmd/radinit/init.go
+++ b/pkg/cli/cmd/radinit/init.go
@@ -207,8 +207,8 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 			for _, env := range environments {
 				if strings.EqualFold("default", *env.Name) {
 					r.EnvName = "default"
+					break
 				}
-				break
 			}
 		}
 

--- a/pkg/cli/cmd/radinit/init_test.go
+++ b/pkg/cli/cmd/radinit/init_test.go
@@ -269,7 +269,31 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name:          "rad init --dev chooses existing environment",
+			Name:          "rad init --dev chooses existing environment without default",
+			Input:         []string{"--dev"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         config,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				// Radius is already installed, no reinstall
+				initGetKubeContextSuccess(mocks.Kubernetes)
+				initHelmMockRadiusInstalled(mocks.Helm)
+
+				// Configure an existing environment - this will be chosen automatically
+				setExistingEnvironments(mocks.ApplicationManagementClient, []corerp.EnvironmentResource{
+					{
+						Name: to.Ptr("myenv"),
+					},
+				})
+				initExistingEnvironmentSelection(mocks.Prompter, "myenv")
+				// No application
+				setScaffoldApplicationPromptNo(mocks.Prompter)
+			},
+		},
+		{
+			Name:          "rad init --dev chooses existing environment with default",
 			Input:         []string{"--dev"},
 			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
@@ -287,7 +311,6 @@ func Test_Validate(t *testing.T) {
 						Name: to.Ptr("default"),
 					},
 				})
-				initExistingEnvironmentSelection(mocks.Prompter, "default")
 				// No application
 				setScaffoldApplicationPromptNo(mocks.Prompter)
 			},


### PR DESCRIPTION
# Description

Today we double prompt a user for an environment name during `rad init --dev`

This was because at one point there was a  noninteractive mode for `SelectExistingEnvironment`, which was removed. That meant we always interactively prompted instead of choosing "default".

This PR updates the --dev logic to choose "default" if available, else prompt the user if there is no default, dev environment.

## Issue reference

Fixes: radius-project/core-team#1181

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [x] Extended the documentation / Created issue for it
