### PR TITLE
remove AWS region from helm chart

### DIFF
--- a/cmd/ucpd/ucp-self-hosted-dev.yaml
+++ b/cmd/ucpd/ucp-self-hosted-dev.yaml
@@ -28,7 +28,7 @@ queueProvider:
 
 profilerProvider:
   enabled: true
-  port: 6060
+  port: 6061
 
 #Default planes configuration with which ucp starts
 # TODO: Remove azure and aws planes once rad provider commands are supported

--- a/deploy/Chart/charts/ucp/templates/ucp.yaml
+++ b/deploy/Chart/charts/ucp/templates/ucp.yaml
@@ -35,10 +35,6 @@ spec:
           value: '/var/tls/cert'
         - name: PORT
           value: '9443'
-{{ if and .Values.provider .Values.provider.aws }}
-        - name: AWS_REGION
-          value: {{ .Values.provider.aws.region }}
-{{ end }}
         name: ucp
         ports:
         - containerPort: 9443

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -4,10 +4,6 @@ de:
 ucp:
   image: radius.azurecr.io/ucpd
   tag: latest 
-  # provider can be also set using rad env init --provider-aws 
-  # provider:
-  #   aws: 
-  #     region:"us-east"
 rp:
   image: radius.azurecr.io/appcore-rp
   tag: latest

--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
@@ -103,7 +103,7 @@ func computeResourceID(id resources.ID, resourceID string) string {
 }
 
 // Extract Region from  a URI like /apis/api.ucp.dev/v1alpha3/planes/aws/aws/accounts/817312594854/regions/us-west-2/providers/...
-func readRegionFromRequest(path string, basePath string) (string, *armrpc_rest.Response) {
+func readRegionFromRequest(path string, basePath string) (string, armrpc_rest.Response) {
 	path = strings.TrimPrefix(path, basePath)
 	resourceID, err := resources.Parse(path)
 	if err != nil {
@@ -115,7 +115,7 @@ func readRegionFromRequest(path string, basePath string) (string, *armrpc_rest.R
 		}
 
 		response := armrpc_rest.NewBadRequestARMResponse(errResponse)
-		return "", &response
+		return "", response
 	}
 	region := resourceID.FindScope("Regions")
 	if region == "" {
@@ -126,7 +126,7 @@ func readRegionFromRequest(path string, basePath string) (string, *armrpc_rest.R
 			},
 		}
 		response := armrpc_rest.NewBadRequestARMResponse(errResponse)
-		return "", &response
+		return "", response
 
 	}
 	return region, nil

--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
@@ -117,7 +117,7 @@ func readRegionFromRequest(path string, basePath string) (string, armrpc_rest.Re
 		response := armrpc_rest.NewBadRequestARMResponse(errResponse)
 		return "", response
 	}
-	region := resourceID.FindScope("Regions")
+	region := resourceID.FindScope(resources.RegionsSegment)
 	if region == "" {
 		errResponse := v1.ErrorResponse{
 			Error: v1.ErrorDetails{

--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
@@ -99,3 +99,17 @@ func computeResourceID(id resources.ID, resourceID string) string {
 	computedID := strings.Split(id.String(), "/:")[0] + resources.SegmentSeparator + resourceID
 	return computedID
 }
+
+// Extract Region from  a URI like /apis/api.ucp.dev/v1alpha3/planes/aws/aws/accounts/817312594854/regions/us-west-2/providers/...
+func readRegionFromRequest(path string, basePath string) (string, error) {
+	path = strings.TrimPrefix(path, basePath)
+	resourceID, err := resources.Parse(path)
+	if err != nil {
+		return "", err
+	}
+	region := resourceID.FindScope("Regions")
+	if region == "" {
+		return "", fmt.Errorf("region not found in AWS request")
+	}
+	return region, nil
+}

--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing_test.go
@@ -124,3 +124,18 @@ func TestGetPrimaryIdentifiersFromSchema_PrimaryIdentifierWrongDataType(t *testi
 	require.Nil(t, primaryIdentifiers)
 	require.EqualError(t, err, "primaryIdentifier is not an array")
 }
+
+func Test_ExtractRegionFromURLPath_Invalid(t *testing.T) {
+	URLPath := "/planes/deployments/local/resourcegroups/localrp/providers/Microsoft.Resources/deployments/rad-deploy-06221c5e-104d-4472-bb74-876b441c7663"
+	region, err := readRegionFromRequest(URLPath, "/apis/api.ucp.dev/v1alpha3")
+	require.Error(t, err, "%q should have failed", URLPath)
+	require.Empty(t, region)
+
+}
+
+func Test_ExtractRegionFromURLPath_Valid(t *testing.T) {
+	URLPath := "/apis/api.ucp.dev/v1alpha3/planes/aws/aws/accounts/817312594854/regions/us-west-2/providers/AWS.S3/Bucket/:put?api-version=default"
+	region, err := readRegionFromRequest(URLPath, "/apis/api.ucp.dev/v1alpha3")
+	require.NoError(t, err, "%q should have not have failed", URLPath)
+	require.Equal(t, "us-west-2", region)
+}

--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing_test.go
@@ -127,15 +127,15 @@ func TestGetPrimaryIdentifiersFromSchema_PrimaryIdentifierWrongDataType(t *testi
 
 func Test_ExtractRegionFromURLPath_Invalid(t *testing.T) {
 	URLPath := "/planes/deployments/local/resourcegroups/localrp/providers/Microsoft.Resources/deployments/rad-deploy-06221c5e-104d-4472-bb74-876b441c7663"
-	region, err := readRegionFromRequest(URLPath, "/apis/api.ucp.dev/v1alpha3")
-	require.Error(t, err, "%q should have failed", URLPath)
+	region, errResponse := readRegionFromRequest(URLPath, "/apis/api.ucp.dev/v1alpha3")
+	require.NotNil(t, errResponse)
 	require.Empty(t, region)
 
 }
 
 func Test_ExtractRegionFromURLPath_Valid(t *testing.T) {
 	URLPath := "/apis/api.ucp.dev/v1alpha3/planes/aws/aws/accounts/817312594854/regions/us-west-2/providers/AWS.S3/Bucket/:put?api-version=default"
-	region, err := readRegionFromRequest(URLPath, "/apis/api.ucp.dev/v1alpha3")
-	require.NoError(t, err, "%q should have not have failed", URLPath)
+	region, errResponse := readRegionFromRequest(URLPath, "/apis/api.ucp.dev/v1alpha3")
+	require.Nil(t, errResponse)
 	require.Equal(t, "us-west-2", region)
 }

--- a/pkg/ucp/frontend/controller/awsproxy/awsproxytest.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsproxytest.go
@@ -72,6 +72,16 @@ func CreateKinesisStreamTestResource(resourceName string) *AWSTestResource {
 	return CreateAWSTestResource(resourceType, awsResourceType, resourceName, provider, arn, typeSchema)
 }
 
+func CreateKinesisStreamTestResourceWithInvalidRegion(resourceName string) *AWSTestResource {
+	resourceType := AWSKinesisStreamResourceType
+	awsResourceType := AWSKinesisStreamAWSResourceType
+	provider := "AWS.Kinesis"
+	arn := fmt.Sprintf("arn:aws:kinesis:us-west-2:123456789012:stream:%s", resourceName)
+	typeSchema := getMockKinesisStreamResourceTypeSchema()
+
+	return CreateAWSTestResourceWithInvalidRegion(resourceType, awsResourceType, resourceName, provider, arn, typeSchema)
+}
+
 func CreateMemoryDBClusterTestResource(resourceName string) *AWSTestResource {
 	resourceType := AWSMemoryDBClusterResourceType
 	awsResourceType := AWSMemoryDBClusterAWSResourceType
@@ -110,6 +120,28 @@ func CreateAWSTestResource(resourceType, awsResourceType, resourceName, provider
 		OperationStatusesPath: fmt.Sprintf("/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/%s/locations/us-west-2/operationStatuses/2345678", resourceType),
 		LocationHeader:        fmt.Sprintf("http://localhost:5000/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/%s/locations/global/operationResults/79b9f0da-4882-4dc8-a367-6fd3bc122ded", provider),
 		AzureAsyncOpHeader:    fmt.Sprintf("http://localhost:5000/planes/aws/aws/accounts/1234567/regions/us-west-2/providers/%s/locations/global/operationStatuses/79b9f0da-4882-4dc8-a367-6fd3bc122ded", provider),
+		Schema:                schema,
+	}
+}
+
+func CreateAWSTestResourceWithInvalidRegion(resourceType, awsResourceType, resourceName, provider, arn string, typeSchema map[string]any) *AWSTestResource {
+	serialized, err := json.Marshal(typeSchema)
+	if err != nil {
+		return nil
+	}
+	schema := string(serialized)
+
+	return &AWSTestResource{
+		ResourceType:          resourceType,
+		AWSResourceType:       awsResourceType,
+		ResourceName:          resourceName,
+		ARN:                   arn,
+		CollectionPath:        fmt.Sprintf("/planes/aws/aws/accounts/1234567/providers/%s", resourceType),
+		SingleResourcePath:    fmt.Sprintf("/planes/aws/aws/accounts/1234567/providers/%s/%s", resourceType, resourceName),
+		OperationResultsPath:  fmt.Sprintf("/planes/aws/aws/accounts/1234567/providers/%s/locations/us-west-2/operationResults/1234567", resourceType),
+		OperationStatusesPath: fmt.Sprintf("/planes/aws/aws/accounts/1234567/providers/%s/locations/us-west-2/operationStatuses/2345678", resourceType),
+		LocationHeader:        fmt.Sprintf("http://localhost:5000/planes/aws/aws/accounts/1234567/providers/%s/locations/global/operationResults/79b9f0da-4882-4dc8-a367-6fd3bc122ded", provider),
+		AzureAsyncOpHeader:    fmt.Sprintf("http://localhost:5000/planes/aws/aws/accounts/1234567/providers/%s/locations/global/operationStatuses/79b9f0da-4882-4dc8-a367-6fd3bc122ded", provider),
 		Schema:                schema,
 	}
 }

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource.go
@@ -52,7 +52,7 @@ func (p *CreateOrUpdateAWSResource) Run(ctx context.Context, w http.ResponseWrit
 	defer req.Body.Close()
 	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
 	if errResponse != nil {
-		return *errResponse, nil
+		return errResponse, nil
 	}
 
 	body := map[string]any{}

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource_test.go
@@ -108,6 +108,66 @@ func Test_CreateAWSResource(t *testing.T) {
 	require.Equal(t, expectedResponseObject, actualResponseObject)
 }
 
+func Test_CreateAWSResourceInvalidRegion(t *testing.T) {
+	testResource := CreateKinesisStreamTestResourceWithInvalidRegion(uuid.NewString())
+	testOptions := setupTest(t)
+
+	requestBody := map[string]any{
+		"properties": map[string]any{
+			"RetentionPeriodHours": 178,
+			"ShardCount":           3,
+		},
+	}
+	requestBodyBytes, err := json.Marshal(requestBody)
+	require.NoError(t, err)
+
+	awsController, err := NewCreateOrUpdateAWSResource(ctrl.Options{
+		AWSOptions: ctrl.AWSOptions{
+			AWSCloudControlClient:   testOptions.AWSCloudControlClient,
+			AWSCloudFormationClient: testOptions.AWSCloudFormationClient,
+		},
+		Options: armrpc_controller.Options{
+			StorageClient: testOptions.StorageClient,
+		},
+	})
+	require.NoError(t, err)
+
+	request, err := http.NewRequest(http.MethodPut, testResource.SingleResourcePath, bytes.NewBuffer(requestBodyBytes))
+	request.Host = testHost
+	request.URL.Host = testHost
+	request.URL.Scheme = testScheme
+
+	require.NoError(t, err)
+
+	ctx := testutil.ARMTestContextFromRequest(request)
+	actualResponse, err := awsController.Run(ctx, nil, request)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	err = actualResponse.Apply(ctx, w, request)
+	require.NoError(t, err)
+
+	res := w.Result()
+	require.Equal(t, http.StatusBadRequest, res.StatusCode)
+
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	expectedResponseObject := map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    "BadRequest",
+			"message": "failed to read region from request path: 'regions' not found",
+		},
+	}
+
+	actualResponseObject := map[string]any{}
+	err = json.Unmarshal(body, &actualResponseObject)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedResponseObject, actualResponseObject)
+}
+
 func Test_UpdateAWSResource(t *testing.T) {
 	testResource := CreateMemoryDBClusterTestResource(uuid.NewString())
 

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource_test.go
@@ -130,7 +130,7 @@ func Test_UpdateAWSResource(t *testing.T) {
 
 	testOptions := setupTest(t)
 
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&cloudcontrol.GetResourceOutput{
@@ -224,7 +224,7 @@ func Test_UpdateNoChangesDoesNotCallUpdate(t *testing.T) {
 
 	testOptions := setupTest(t)
 
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&cloudcontrol.GetResourceOutput{

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
@@ -54,7 +54,7 @@ func (p *CreateOrUpdateAWSResourceWithPost) Run(ctx context.Context, w http.Resp
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
 	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
 	if errResponse != nil {
-		return *errResponse, nil
+		return errResponse, nil
 	}
 
 	properties, err := readPropertiesFromBody(req)

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
@@ -203,15 +203,3 @@ func (p *CreateOrUpdateAWSResourceWithPost) Run(ctx context.Context, w http.Resp
 	resp := armrpc_rest.NewAsyncOperationResponse(responseBody, v1.LocationGlobal, 201, serviceCtx.ResourceID, operation, "", serviceCtx.ResourceID.RootScope(), p.basePath)
 	return resp, nil
 }
-
-func CloudControlRegionOption(region string) func(*cloudcontrol.Options) {
-	return func(o *cloudcontrol.Options) {
-		o.Region = region
-	}
-}
-
-func CloudFormationWithRegionOption(region string) func(*cloudformation.Options) {
-	return func(o *cloudformation.Options) {
-		o.Region = region
-	}
-}

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost_test.go
@@ -29,7 +29,7 @@ func Test_CreateAWSResourceWithPost(t *testing.T) {
 	testOptions := setupTest(t)
 	testResource := CreateMemoryDBClusterTestResource(uuid.NewString())
 
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&cloudformation.DescribeTypeOutput{
 			TypeName: aws.String(testResource.AWSResourceType),
 			Schema:   aws.String(testResource.Schema),
@@ -107,6 +107,7 @@ func Test_CreateAWSResourceWithPost(t *testing.T) {
 }
 
 func Test_UpdateAWSResourceWithPost(t *testing.T) {
+	t.Skip()
 	testResource := CreateMemoryDBClusterTestResource(uuid.NewString())
 
 	output := cloudformation.DescribeTypeOutput{
@@ -115,7 +116,7 @@ func Test_UpdateAWSResourceWithPost(t *testing.T) {
 	}
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	getResponseBody := map[string]any{
 		"ClusterName": testResource.ResourceName,
@@ -217,7 +218,7 @@ func Test_UpdateAWSResourceWithPost_NoChangesNoops(t *testing.T) {
 	}
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	getResponseBody := map[string]any{
 		"ClusterName": testResource.ResourceName,
@@ -313,7 +314,7 @@ func Test_CreateAWSResourceWithPost_NoPrimaryIdentifierAvailable(t *testing.T) {
 	}
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	testOptions.AWSCloudControlClient.EXPECT().CreateResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&cloudcontrol.CreateResourceOutput{
@@ -392,7 +393,7 @@ func Test_CreateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	}
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		nil, &types.ResourceNotFoundException{
@@ -478,7 +479,7 @@ func Test_UpdateAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	}
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	getResponseBody := map[string]any{
 		"ClusterIdentifier": clusterIdentifierValue,

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost_test.go
@@ -107,7 +107,6 @@ func Test_CreateAWSResourceWithPost(t *testing.T) {
 }
 
 func Test_UpdateAWSResourceWithPost(t *testing.T) {
-	t.Skip()
 	testResource := CreateMemoryDBClusterTestResource(uuid.NewString())
 
 	output := cloudformation.DescribeTypeOutput{

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresource.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresource.go
@@ -45,7 +45,7 @@ func (p *DeleteAWSResource) Run(ctx context.Context, w http.ResponseWriter, req 
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
 	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
 	if errResponse != nil {
-		return *errResponse, nil
+		return errResponse, nil
 	}
 
 	cloudControlOpts := []func(*cloudcontrol.Options){CloudControlRegionOption(region)}

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresource.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresource.go
@@ -43,23 +43,12 @@ func NewDeleteAWSResource(opts ctrl.Options) (armrpc_controller.Controller, erro
 
 func (p *DeleteAWSResource) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
-	region, err := readRegionFromRequest(req.URL.Path, p.basePath)
-	if err != nil {
-		e := v1.ErrorResponse{
-			Error: v1.ErrorDetails{
-				Code:    v1.CodeInvalid,
-				Message: "failed to read region from request path",
-			},
-		}
-
-		response := armrpc_rest.NewBadRequestARMResponse(e)
-		err = response.Apply(ctx, w, req)
-		if err != nil {
-			return nil, err
-		}
+	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
+	if errResponse != nil {
+		return *errResponse, nil
 	}
 
-	cloudControlOpts := []func(*cloudcontrol.Options){CCWithRegion(region)}
+	cloudControlOpts := []func(*cloudcontrol.Options){CloudControlRegionOption(region)}
 	response, err := p.awsOptions.AWSCloudControlClient.DeleteResource(ctx, &cloudcontrol.DeleteResourceInput{
 		TypeName:   to.Ptr(serviceCtx.ResourceTypeInAWSFormat()),
 		Identifier: aws.String(serviceCtx.ResourceID.Name()),

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost.go
@@ -50,7 +50,7 @@ func (p *DeleteAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWrit
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
 	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
 	if errResponse != nil {
-		return *errResponse, nil
+		return errResponse, nil
 	}
 
 	cloudControlOpts := []func(*cloudcontrol.Options){CloudControlRegionOption(region)}

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost_test.go
@@ -34,7 +34,7 @@ func Test_DeleteAWSResourceWithPost(t *testing.T) {
 	}
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	testOptions.AWSCloudControlClient.EXPECT().DeleteResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		&cloudcontrol.DeleteResourceOutput{
@@ -92,7 +92,7 @@ func Test_DeleteAWSResourceWithPost_ResourceDoesNotExist(t *testing.T) {
 	}
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	testOptions.AWSCloudControlClient.EXPECT().DeleteResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		nil, &types.ResourceNotFoundException{
@@ -163,12 +163,12 @@ func Test_DeleteAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	}
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	testOptions.AWSCloudControlClient.EXPECT().DeleteResource(ctx, &cloudcontrol.DeleteResourceInput{
 		TypeName:   aws.String(testResource.AWSResourceType),
 		Identifier: aws.String("abc|xyz"),
-	}).Return(
+	}, gomock.Any()).Return(
 		&cloudcontrol.DeleteResourceOutput{
 			ProgressEvent: &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,

--- a/pkg/ucp/frontend/controller/awsproxy/getawsoperationresults.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsoperationresults.go
@@ -44,7 +44,7 @@ func (p *GetAWSOperationResults) Run(ctx context.Context, w http.ResponseWriter,
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
 	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
 	if errResponse != nil {
-		return *errResponse, nil
+		return errResponse, nil
 	}
 	cloudControlOpts := []func(*cloudcontrol.Options){CloudControlRegionOption(region)}
 	response, err := p.awsOptions.AWSCloudControlClient.GetResourceRequestStatus(ctx, &cloudcontrol.GetResourceRequestStatusInput{

--- a/pkg/ucp/frontend/controller/awsproxy/getawsoperationresults.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsoperationresults.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	armrpcv1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	armrpc_controller "github.com/project-radius/radius/pkg/armrpc/frontend/controller"
 	armrpc_rest "github.com/project-radius/radius/pkg/armrpc/rest"
 	awsclient "github.com/project-radius/radius/pkg/ucp/aws"
@@ -26,6 +27,7 @@ var _ armrpc_controller.Controller = (*GetAWSOperationResults)(nil)
 type GetAWSOperationResults struct {
 	armrpc_controller.Operation[*datamodel.AWSResource, datamodel.AWSResource]
 	awsOptions ctrl.AWSOptions
+	basePath   string
 }
 
 // NewGetAWSOperationResults creates a new GetAWSOperationResults.
@@ -35,15 +37,33 @@ func NewGetAWSOperationResults(opts ctrl.Options) (armrpc_controller.Controller,
 			armrpc_controller.ResourceOptions[datamodel.AWSResource]{},
 		),
 		awsOptions: opts.AWSOptions,
+		basePath:   opts.BasePath,
 	}, nil
 }
 
 func (p *GetAWSOperationResults) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
+	region, err := readRegionFromRequest(req.URL.Path, p.basePath)
+	if err != nil {
+		e := v1.ErrorResponse{
+			Error: v1.ErrorDetails{
+				Code:    v1.CodeInvalid,
+				Message: "failed to read region from request path",
+			},
+		}
 
+		response := armrpc_rest.NewBadRequestARMResponse(e)
+		err = response.Apply(ctx, w, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	cloudControlOpts := []func(*cloudcontrol.Options){CCWithRegion(region)}
 	response, err := p.awsOptions.AWSCloudControlClient.GetResourceRequestStatus(ctx, &cloudcontrol.GetResourceRequestStatusInput{
 		RequestToken: aws.String(serviceCtx.ResourceID.Name()),
-	})
+	}, cloudControlOpts...)
+
 	if awsclient.IsAWSResourceNotFoundError(err) {
 		return armrpc_rest.NewNotFoundResponse(serviceCtx.ResourceID), nil
 	} else if err != nil {

--- a/pkg/ucp/frontend/controller/awsproxy/getawsoperationresults.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsoperationresults.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	armrpcv1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
-	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	armrpc_controller "github.com/project-radius/radius/pkg/armrpc/frontend/controller"
 	armrpc_rest "github.com/project-radius/radius/pkg/armrpc/rest"
 	awsclient "github.com/project-radius/radius/pkg/ucp/aws"
@@ -43,23 +42,11 @@ func NewGetAWSOperationResults(opts ctrl.Options) (armrpc_controller.Controller,
 
 func (p *GetAWSOperationResults) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
-	region, err := readRegionFromRequest(req.URL.Path, p.basePath)
-	if err != nil {
-		e := v1.ErrorResponse{
-			Error: v1.ErrorDetails{
-				Code:    v1.CodeInvalid,
-				Message: "failed to read region from request path",
-			},
-		}
-
-		response := armrpc_rest.NewBadRequestARMResponse(e)
-		err = response.Apply(ctx, w, req)
-		if err != nil {
-			return nil, err
-		}
+	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
+	if errResponse != nil {
+		return *errResponse, nil
 	}
-
-	cloudControlOpts := []func(*cloudcontrol.Options){CCWithRegion(region)}
+	cloudControlOpts := []func(*cloudcontrol.Options){CloudControlRegionOption(region)}
 	response, err := p.awsOptions.AWSCloudControlClient.GetResourceRequestStatus(ctx, &cloudcontrol.GetResourceRequestStatusInput{
 		RequestToken: aws.String(serviceCtx.ResourceID.Name()),
 	}, cloudControlOpts...)

--- a/pkg/ucp/frontend/controller/awsproxy/getawsoperationstatuses.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsoperationstatuses.go
@@ -45,7 +45,7 @@ func (p *GetAWSOperationStatuses) Run(ctx context.Context, w http.ResponseWriter
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
 	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
 	if errResponse != nil {
-		return *errResponse, nil
+		return errResponse, nil
 	}
 
 	cloudControlOpts := []func(*cloudcontrol.Options){CloudControlRegionOption(region)}

--- a/pkg/ucp/frontend/controller/awsproxy/getawsoperationstatuses.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsoperationstatuses.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
 	armrpcv1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	manager "github.com/project-radius/radius/pkg/armrpc/asyncoperation/statusmanager"
 	armrpc_controller "github.com/project-radius/radius/pkg/armrpc/frontend/controller"
 	armrpc_rest "github.com/project-radius/radius/pkg/armrpc/rest"
@@ -27,6 +28,7 @@ var _ armrpc_controller.Controller = (*GetAWSOperationStatuses)(nil)
 type GetAWSOperationStatuses struct {
 	armrpc_controller.Operation[*datamodel.AWSResource, datamodel.AWSResource]
 	awsOptions ctrl.AWSOptions
+	basePath   string
 }
 
 // NewGetAWSOperationStatuses creates a new GetAWSOperationStatuses.
@@ -36,15 +38,32 @@ func NewGetAWSOperationStatuses(opts ctrl.Options) (armrpc_controller.Controller
 			armrpc_controller.ResourceOptions[datamodel.AWSResource]{},
 		),
 		awsOptions: opts.AWSOptions,
+		basePath:   opts.BasePath,
 	}, nil
 }
 
 func (p *GetAWSOperationStatuses) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
+	region, err := readRegionFromRequest(req.URL.Path, p.basePath)
+	if err != nil {
+		e := v1.ErrorResponse{
+			Error: v1.ErrorDetails{
+				Code:    v1.CodeInvalid,
+				Message: "failed to read region from request path",
+			},
+		}
 
+		response := armrpc_rest.NewBadRequestARMResponse(e)
+		err = response.Apply(ctx, w, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	cloudControlOpts := []func(*cloudcontrol.Options){CCWithRegion(region)}
 	response, err := p.awsOptions.AWSCloudControlClient.GetResourceRequestStatus(ctx, &cloudcontrol.GetResourceRequestStatusInput{
 		RequestToken: aws.String(serviceCtx.ResourceID.Name()),
-	})
+	}, cloudControlOpts...)
 	if awsclient.IsAWSResourceNotFoundError(err) {
 		return armrpc_rest.NewNotFoundResponse(serviceCtx.ResourceID), nil
 	} else if err != nil {

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresource.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresource.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
-	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	armrpc_controller "github.com/project-radius/radius/pkg/armrpc/frontend/controller"
 	armrpc_rest "github.com/project-radius/radius/pkg/armrpc/rest"
 	"github.com/project-radius/radius/pkg/to"
@@ -43,23 +42,12 @@ func NewGetAWSResource(opts ctrl.Options) (armrpc_controller.Controller, error) 
 
 func (p *GetAWSResource) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
-	region, err := readRegionFromRequest(req.URL.Path, p.basePath)
-	if err != nil {
-		e := v1.ErrorResponse{
-			Error: v1.ErrorDetails{
-				Code:    v1.CodeInvalid,
-				Message: "failed to read region from request path",
-			},
-		}
-
-		response := armrpc_rest.NewBadRequestARMResponse(e)
-		err = response.Apply(ctx, w, req)
-		if err != nil {
-			return nil, err
-		}
+	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
+	if errResponse != nil {
+		return *errResponse, nil
 	}
 
-	cloudControlOpts := []func(*cloudcontrol.Options){CCWithRegion(region)}
+	cloudControlOpts := []func(*cloudcontrol.Options){CloudControlRegionOption(region)}
 	response, err := p.awsOptions.AWSCloudControlClient.GetResource(ctx, &cloudcontrol.GetResourceInput{
 		TypeName:   to.Ptr(serviceCtx.ResourceTypeInAWSFormat()),
 		Identifier: aws.String(serviceCtx.ResourceID.Name()),

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresource.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresource.go
@@ -44,7 +44,7 @@ func (p *GetAWSResource) Run(ctx context.Context, w http.ResponseWriter, req *ht
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
 	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
 	if errResponse != nil {
-		return *errResponse, nil
+		return errResponse, nil
 	}
 
 	cloudControlOpts := []func(*cloudcontrol.Options){CloudControlRegionOption(region)}

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresource_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresource_test.go
@@ -115,7 +115,7 @@ func Test_GetAWSResource_UnknownError(t *testing.T) {
 	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any()).Return(nil, errors.New("something bad happened"))
+	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("something bad happened"))
 
 	awsController, err := NewGetAWSResource(ctrl.Options{
 		AWSOptions: ctrl.AWSOptions{
@@ -143,7 +143,7 @@ func Test_GetAWSResource_SmithyError(t *testing.T) {
 	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any()).Return(nil, &smithy.OperationError{
+	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, &smithy.OperationError{
 		Err: &smithyhttp.ResponseError{
 			Err: &smithy.GenericAPIError{
 				Code:    "NotFound",

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost.go
@@ -53,7 +53,7 @@ func (p *GetAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWriter,
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
 	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
 	if errResponse != nil {
-		return *errResponse, nil
+		return errResponse, nil
 	}
 
 	properties, err := readPropertiesFromBody(req)

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost_test.go
@@ -41,7 +41,7 @@ func Test_GetAWSResourceWithPost(t *testing.T) {
 	}
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	getResponseBody := map[string]any{
 		"Name":                 testResource.ResourceName,
@@ -108,7 +108,7 @@ func Test_GetAWSResourceWithPost_NotFound(t *testing.T) {
 	}
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 		nil, &types.ResourceNotFoundException{
@@ -154,9 +154,9 @@ func Test_GetAWSResourceWithPost_UnknownError(t *testing.T) {
 	}
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any()).Return(nil, errors.New("something bad happened"))
+	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("something bad happened"))
 
 	awsController, err := NewGetAWSResourceWithPost(ctrl.Options{
 		AWSOptions: ctrl.AWSOptions{
@@ -197,9 +197,9 @@ func Test_GetAWSResourceWithPost_SmithyError(t *testing.T) {
 	}
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
-	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any()).Return(nil, &smithy.OperationError{
+	testOptions.AWSCloudControlClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, &smithy.OperationError{
 		Err: &smithyhttp.ResponseError{
 			Err: &smithy.GenericAPIError{
 				Code:    "NotFound",
@@ -267,7 +267,7 @@ func Test_GetAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	}
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	testOptions.AWSCloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	getResponseBody := map[string]any{
 		"ClusterIdentifier": clusterIdentifierValue,
@@ -279,7 +279,7 @@ func Test_GetAWSResourceWithPost_MultiIdentifier(t *testing.T) {
 	testOptions.AWSCloudControlClient.EXPECT().GetResource(ctx, &cloudcontrol.GetResourceInput{
 		TypeName:   aws.String(testResource.AWSResourceType),
 		Identifier: aws.String("abc|xyz"),
-	}).Return(
+	}, gomock.Any()).Return(
 		&cloudcontrol.GetResourceOutput{
 			ResourceDescription: &types.ResourceDescription{
 				Identifier: aws.String(testResource.ResourceName),

--- a/pkg/ucp/frontend/controller/awsproxy/listawsresources.go
+++ b/pkg/ucp/frontend/controller/awsproxy/listawsresources.go
@@ -11,6 +11,7 @@ import (
 	"path"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	armrpc_controller "github.com/project-radius/radius/pkg/armrpc/frontend/controller"
 	armrpc_rest "github.com/project-radius/radius/pkg/armrpc/rest"
 	"github.com/project-radius/radius/pkg/to"
@@ -26,6 +27,7 @@ var _ armrpc_controller.Controller = (*ListAWSResources)(nil)
 type ListAWSResources struct {
 	armrpc_controller.Operation[*datamodel.AWSResource, datamodel.AWSResource]
 	awsOptions ctrl.AWSOptions
+	basePath   string
 }
 
 // NewListAWSResources creates a new ListAWSResources.
@@ -35,16 +37,33 @@ func NewListAWSResources(opts ctrl.Options) (armrpc_controller.Controller, error
 			armrpc_controller.ResourceOptions[datamodel.AWSResource]{},
 		),
 		awsOptions: opts.AWSOptions,
+		basePath:   opts.BasePath,
 	}, nil
 }
 
 func (p *ListAWSResources) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
+	region, err := readRegionFromRequest(req.URL.Path, p.basePath)
+	if err != nil {
+		e := v1.ErrorResponse{
+			Error: v1.ErrorDetails{
+				Code:    v1.CodeInvalid,
+				Message: "failed to read region from request path",
+			},
+		}
 
+		response := armrpc_rest.NewBadRequestARMResponse(e)
+		err = response.Apply(ctx, w, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	cloudControlOpts := []func(*cloudcontrol.Options){CCWithRegion(region)}
 	// TODO pagination
 	response, err := p.awsOptions.AWSCloudControlClient.ListResources(ctx, &cloudcontrol.ListResourcesInput{
 		TypeName: to.Ptr(serviceCtx.ResourceTypeInAWSFormat()),
-	})
+	}, cloudControlOpts...)
 	if err != nil {
 		return awsclient.HandleAWSError(err)
 	}

--- a/pkg/ucp/frontend/controller/awsproxy/listawsresources.go
+++ b/pkg/ucp/frontend/controller/awsproxy/listawsresources.go
@@ -11,7 +11,6 @@ import (
 	"path"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
-	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	armrpc_controller "github.com/project-radius/radius/pkg/armrpc/frontend/controller"
 	armrpc_rest "github.com/project-radius/radius/pkg/armrpc/rest"
 	"github.com/project-radius/radius/pkg/to"
@@ -43,23 +42,12 @@ func NewListAWSResources(opts ctrl.Options) (armrpc_controller.Controller, error
 
 func (p *ListAWSResources) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
-	region, err := readRegionFromRequest(req.URL.Path, p.basePath)
-	if err != nil {
-		e := v1.ErrorResponse{
-			Error: v1.ErrorDetails{
-				Code:    v1.CodeInvalid,
-				Message: "failed to read region from request path",
-			},
-		}
-
-		response := armrpc_rest.NewBadRequestARMResponse(e)
-		err = response.Apply(ctx, w, req)
-		if err != nil {
-			return nil, err
-		}
+	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
+	if errResponse != nil {
+		return *errResponse, nil
 	}
 
-	cloudControlOpts := []func(*cloudcontrol.Options){CCWithRegion(region)}
+	cloudControlOpts := []func(*cloudcontrol.Options){CloudControlRegionOption(region)}
 	// TODO pagination
 	response, err := p.awsOptions.AWSCloudControlClient.ListResources(ctx, &cloudcontrol.ListResourcesInput{
 		TypeName: to.Ptr(serviceCtx.ResourceTypeInAWSFormat()),

--- a/pkg/ucp/frontend/controller/awsproxy/listawsresources.go
+++ b/pkg/ucp/frontend/controller/awsproxy/listawsresources.go
@@ -44,7 +44,7 @@ func (p *ListAWSResources) Run(ctx context.Context, w http.ResponseWriter, req *
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
 	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
 	if errResponse != nil {
-		return *errResponse, nil
+		return errResponse, nil
 	}
 
 	cloudControlOpts := []func(*cloudcontrol.Options){CloudControlRegionOption(region)}

--- a/pkg/ucp/frontend/controller/awsproxy/listawsresources_test.go
+++ b/pkg/ucp/frontend/controller/awsproxy/listawsresources_test.go
@@ -108,7 +108,7 @@ func Test_ListAWSResourcesEmpty(t *testing.T) {
 	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudControlClient.EXPECT().ListResources(gomock.Any(), gomock.Any()).Return(&cloudcontrol.ListResourcesOutput{}, nil)
+	testOptions.AWSCloudControlClient.EXPECT().ListResources(gomock.Any(), gomock.Any(), gomock.Any()).Return(&cloudcontrol.ListResourcesOutput{}, nil)
 
 	awsController, err := NewListAWSResources(ctrl.Options{
 		AWSOptions: ctrl.AWSOptions{
@@ -139,7 +139,7 @@ func Test_ListAWSResource_UnknownError(t *testing.T) {
 	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudControlClient.EXPECT().ListResources(gomock.Any(), gomock.Any()).Return(nil, errors.New("something bad happened"))
+	testOptions.AWSCloudControlClient.EXPECT().ListResources(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("something bad happened"))
 
 	awsController, err := NewListAWSResources(ctrl.Options{
 		AWSOptions: ctrl.AWSOptions{
@@ -167,7 +167,7 @@ func Test_ListAWSResource_SmithyError(t *testing.T) {
 	testResource := CreateKinesisStreamTestResource(uuid.NewString())
 
 	testOptions := setupTest(t)
-	testOptions.AWSCloudControlClient.EXPECT().ListResources(gomock.Any(), gomock.Any()).Return(nil, &smithy.OperationError{
+	testOptions.AWSCloudControlClient.EXPECT().ListResources(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, &smithy.OperationError{
 		Err: &smithyhttp.ResponseError{
 			Err: &smithy.GenericAPIError{
 				Code:    "NotFound",

--- a/pkg/ucp/frontend/controller/awsproxy/options.go
+++ b/pkg/ucp/frontend/controller/awsproxy/options.go
@@ -1,0 +1,24 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+package awsproxy
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+)
+
+// CloudControlRegionOption sets the region for the CloudControl client.
+func CloudControlRegionOption(region string) func(*cloudcontrol.Options) {
+	return func(o *cloudcontrol.Options) {
+		o.Region = region
+	}
+}
+
+// CloudFormationRegionOption sets the region for the CloudFormation client.
+func CloudFormationWithRegionOption(region string) func(*cloudformation.Options) {
+	return func(o *cloudformation.Options) {
+		o.Region = region
+	}
+}

--- a/pkg/ucp/integrationtests/aws/createresourcewithpost_test.go
+++ b/pkg/ucp/integrationtests/aws/createresourcewithpost_test.go
@@ -40,7 +40,7 @@ func Test_CreateAWSResourceWithPost(t *testing.T) {
 		Schema:   to.Ptr(string(serialized)),
 	}
 
-	cloudformationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	cloudformationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	cloudcontrolClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, params *cloudcontrol.GetResourceInput, optFns ...func(*cloudcontrol.Options)) (*cloudcontrol.GetResourceOutput, error) {
 		notfound := types.ResourceNotFoundException{

--- a/pkg/ucp/integrationtests/aws/deleteresourcewithpost_test.go
+++ b/pkg/ucp/integrationtests/aws/deleteresourcewithpost_test.go
@@ -40,7 +40,7 @@ func Test_DeleteAWSResourceWithPost(t *testing.T) {
 		Schema:   to.Ptr(string(serialized)),
 	}
 
-	cloudformationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	cloudformationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	cloudcontrolClient.EXPECT().DeleteResource(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, params *cloudcontrol.DeleteResourceInput, optFns ...func(*cloudcontrol.Options)) (*cloudcontrol.DeleteResourceOutput, error) {
 		output := cloudcontrol.DeleteResourceOutput{

--- a/pkg/ucp/integrationtests/aws/getresourcewithpost_test.go
+++ b/pkg/ucp/integrationtests/aws/getresourcewithpost_test.go
@@ -40,7 +40,7 @@ func Test_GetAWSResourceWithPost(t *testing.T) {
 		Schema:   to.Ptr(string(serialized)),
 	}
 
-	cloudformationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	cloudformationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	getResponseBody := map[string]any{
 		"RetentionPeriodHours": 178,

--- a/pkg/ucp/integrationtests/aws/updateresource_test.go
+++ b/pkg/ucp/integrationtests/aws/updateresource_test.go
@@ -53,7 +53,7 @@ func Test_UpdateAWSResource(t *testing.T) {
 		Schema:   aws.String(string(serialized)),
 	}
 
-	cloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	cloudFormationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	cloudcontrolClient.EXPECT().GetResource(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, params *cloudcontrol.GetResourceInput, optFns ...func(*cloudcontrol.Options)) (*cloudcontrol.GetResourceOutput, error) {
 		output := cloudcontrol.GetResourceOutput{

--- a/pkg/ucp/integrationtests/aws/updateresourcewithpost_test.go
+++ b/pkg/ucp/integrationtests/aws/updateresourcewithpost_test.go
@@ -40,7 +40,7 @@ func Test_UpdateAWSResourceWithPost(t *testing.T) {
 		Schema:   to.Ptr(string(serialized)),
 	}
 
-	cloudformationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any()).Return(&output, nil)
+	cloudformationClient.EXPECT().DescribeType(gomock.Any(), gomock.Any(), gomock.Any()).Return(&output, nil)
 
 	getResponseBody := map[string]any{
 		"Name":                 "testStream",

--- a/test/functional/ucp/aws_test.go
+++ b/test/functional/ucp/aws_test.go
@@ -144,8 +144,7 @@ func setupTestAWSResource(t *testing.T, ctx context.Context, resourceName string
 	desiredStateBytes, err := json.Marshal(desiredState)
 	require.NoError(t, err)
 
-	cloudControlOpts := []func(*cloudcontrol.Options){}
-	cloudControlOpts = append(cloudControlOpts, awsproxy.CCWithRegion("us-west-2"))
+	cloudControlOpts := []func(*cloudcontrol.Options){awsproxy.CloudControlRegionOption("us-west-2")}
 
 	response, err := awsClient.CreateResource(ctx, &cloudcontrol.CreateResourceInput{
 		TypeName:     &awsS3BucketResourceType,


### PR DESCRIPTION
# Description
This PR removes AWS region from helm charts and sets the right region for AWS requests made by cloudcontrol and cloud formation clients based on the region indicated by the request URL.

## Issue reference
Fixes: #5493

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ X] Code compiles correctly
* [ X] Adds necessary unit tests for change
* [ X] Adds necessary E2E tests for change
* [ X] Unit tests passing
* [ NA] Extended the documentation / Created issue for it
