### PR TITLE
Adding retries to bicep download

### DIFF
--- a/.github/scripts/curl-with-retries.sh
+++ b/.github/scripts/curl-with-retries.sh
@@ -1,4 +1,37 @@
 # See https://everything.curl.dev/usingcurl/downloads/retry
 #
 # Unfortunately we can't use --retry-all-errors as the agent does not support it.
-curl $@ --retry 5
+
+# Number of retries
+MAX_RETRIES=5
+
+# Retry delay in seconds
+RETRY_DELAY=5
+
+# Retry loop
+RETRY_COUNT=0
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+    # Download the file with retries and resume capability
+    curl --retry $MAX_RETRIES --retry-delay $RETRY_DELAY --continue-at - $@
+
+    # Check if the download was successful
+    if [ $? -eq 0 ]; then
+        echo "File downloaded successfully"
+        break
+    fi
+
+    # Download failed, increase the retry count
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+
+    # Check if there are more retries left
+    if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+        # Retry after delay
+        echo "Retrying in $RETRY_DELAY seconds..."
+        sleep $RETRY_DELAY
+    fi
+done
+
+# Check if the maximum number of retries exceeded
+if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+    echo "Maximum number of retries exceeded"
+fi

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -56,7 +56,7 @@ env:
 jobs:
   build:
     name: Build Radius for test
-    runs-on: [self-hosted,1ES.Pool=1ES-Radius ]
+    runs-on: [ self-hosted, 1ES.Pool=1ES-Radius ]
     outputs:
       REL_VERSION: ${{ steps.gen-id.outputs.REL_VERSION }}
       UNIQUE_ID: ${{ steps.gen-id.outputs.UNIQUE_ID }}
@@ -237,7 +237,7 @@ jobs:
   tests:
     name: Run ${{ matrix.name }} functional tests
     needs: build
-    runs-on: [self-hosted,1ES.Pool=1ES-Radius ]
+    runs-on: [ self-hosted, 1ES.Pool=1ES-Radius ]
     strategy:
       fail-fast: true
       matrix:
@@ -361,7 +361,7 @@ jobs:
         run: |
           helm repo add azure-workload-identity https://azure.github.io/azure-workload-identity/charts
           helm install workload-identity-webhook azure-workload-identity/workload-identity-webhook --namespace radius-default --create-namespace --version ${{ env.AZURE_WORKLOAD_IDENTITY_WEBHOOK_VER }} --set azureTenantID=${{ secrets.INTEGRATION_TEST_TENANT_ID }}
-      - name: Download Bicep.
+      - name: Download Bicep
         run: |
           chmod +x ./bin/rad
           export PATH=$GITHUB_WORKSPACE/bin:$PATH

--- a/pkg/cli/bicep/bicep.go
+++ b/pkg/cli/bicep/bicep.go
@@ -17,12 +17,18 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/project-radius/radius/pkg/cli/tools"
 )
 
-const radBicepEnvVar = "RAD_BICEP"
-const binaryName = "rad-bicep"
+const (
+	radBicepEnvVar = "RAD_BICEP"
+	binaryName     = "rad-bicep"
+	dirPrefix      = "bicep-extensibility"
+	retryAttempts  = 10
+	retryDelaySecs = 5
+)
 
 // IsBicepInstalled returns true if our local copy of bicep is installed
 func IsBicepInstalled() (bool, error) {
@@ -67,20 +73,55 @@ func DownloadBicep() error {
 		return err
 	}
 
-	resp, err := http.Get(uri)
-	if err != nil {
-		return fmt.Errorf("failed to download bicep: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("failed to download bicep from '%s'with status code: %d", uri, resp.StatusCode)
-	}
-
 	filepath, err := tools.GetLocalFilepath(radBicepEnvVar, binaryName)
 	if err != nil {
 		return err
 	}
 
-	return tools.DownloadToFolder(filepath, resp)
+	retryAttempts := 10
+	for attempt := 1; attempt <= retryAttempts; attempt++ {
+		success, err := retry(uri, filepath, attempt, retryAttempts)
+		if err != nil {
+			return err
+		}
+		if success {
+			break
+		}
+	}
+
+	return nil
+}
+
+func retry(uri, filepath string, attempt, retryAttempts int) (bool, error) {
+	resp, err := http.Get(uri)
+	if err != nil {
+		if attempt == retryAttempts {
+			return false, fmt.Errorf("failed to download bicep: %v", err)
+		}
+		fmt.Printf("Attempt %d failed to download bicep: %v\nRetrying...", attempt, err)
+		time.Sleep(retryDelaySecs * time.Second)
+		return false, nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if attempt == retryAttempts {
+			return false, fmt.Errorf("failed to download bicep from '%s' with status code: %d", uri, resp.StatusCode)
+		}
+		fmt.Printf("Attempt %d failed to download bicep from '%s' with status code: %d\nRetrying...", attempt, uri, resp.StatusCode)
+		time.Sleep(retryDelaySecs * time.Second)
+		return false, nil
+	}
+
+	err = tools.DownloadToFolder(filepath, resp)
+	if err != nil {
+		if attempt == retryAttempts {
+			return false, fmt.Errorf("failed to download bicep: %v", err)
+		}
+		fmt.Printf("Attempt %d failed to download bicep: %v\nRetrying...", attempt, err)
+		time.Sleep(retryDelaySecs * time.Second)
+		return false, nil
+	}
+
+	return true, nil
 }


### PR DESCRIPTION
# Description

There seems to be some kind of flakiness around the Download Bicep steps of our CI/CD pipeline. Updating the two places that initiate the Download Bicep step with a new retry logic.

## Issue reference
Fixes: radius-project/core-team#1190 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
