### PR TITLE
Suppress etcd logs in integration test

### DIFF
--- a/pkg/ucp/integrationtests/testserver/testserver.go
+++ b/pkg/ucp/integrationtests/testserver/testserver.go
@@ -100,7 +100,7 @@ func Start(t *testing.T) *TestServer {
 		// and you'll be able to see the spam from etcd.
 		//
 		// This is caught by the race checker and will fail your pr if you do it.
-		//ctx := context.Background()
+		ctx := context.Background()
 		err := etcd.Run(ctx)
 		if err != nil {
 			t.Logf("error from etcd: %v", err)


### PR DESCRIPTION
# Description

These logs can cause a conflict with the test framework by writing to the log stream after the test is complete. This can cause the test to fail and it's somewhat nondetermininistic.

Failing test run: https://github.com/project-radius/radius/actions/runs/5059560812/jobs/9081272674

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it
