### PR TITLE
Update release-process.md to include codespaces changes

### DIFF
--- a/docs/contributing/contributing-code/release-process.md
+++ b/docs/contributing/contributing-code/release-process.md
@@ -150,13 +150,19 @@ If sample validation passes, we can start the process of creating the final rele
 
 1. Update the project-radius/samples repository to point to latest release
 
-   ```
-   git checkout edge
-   git pull origin edge
-   git checkout -b v0.16
-   git pull origin v0.16
-   git push origin v0.16
-   ```
+  1. Create 0.16 and point to the latest  
+      ```
+      git checkout edge
+      git pull origin edge
+      git checkout -b v0.16
+      git pull origin v0.16
+      git push origin v0.16
+      ```
+  1. Within .devcontainer/devcontainer.json
+      - Change the 'RADIUS_VERSION' to 'edge'
+
+  1. Within .devcontainer/Dockerfile
+      - Change the Bicep extension url to 'https://radiuspublic.blob.core.windows.net/tools/vscode-extensibility/stable/rad-vscode-bicep.vsix'
 
 ### Post release sanity check
 


### PR DESCRIPTION
# Description
Adding a release step for codespaces dev containers to build from the latest release 
https://github.com/project-radius/samples/pull/210

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ffcb452</samp>

### Summary
📝🔄🚀

<!--
1.  📝 - This emoji represents documentation or writing, and can be used to indicate that the steps to update the samples repository have been modified or updated.
2.  🔄 - This emoji represents syncing or updating, and can be used to indicate that the samples repository needs to be synced or updated to point to the latest release of the radius CLI and the Bicep extension.
3.  🚀 - This emoji represents launching or releasing, and can be used to indicate that the changes are related to the release process of the radius CLI and the Bicep extension.
-->
Updated the release process documentation to reflect the latest dependencies of the project-radius/samples repository. Added substeps to ensure the samples use the correct versions of the `radius` CLI and the `Bicep` extension.

> _Samples need update_
> _`radius` and `bicep` versions_
> _Cut by release process_

### Walkthrough
* Modify the steps to update the samples repository to use the latest release ([link](https://github.com/project-radius/radius/pull/5602/files?diff=unified&w=0#diff-d974e6253969aa44966420774b8720ffd19e4a57727d6e82a845944248589a41L153-R166))


