### PR TITLE
Use UUID validator for tenant id

### DIFF
--- a/pkg/cli/cmd/radinit/azure.go
+++ b/pkg/cli/cmd/radinit/azure.go
@@ -82,7 +82,7 @@ func (r *Runner) enterAzureCloudProvider(ctx context.Context, options *initOptio
 
 	tenantID, err := r.Prompter.GetTextInput(enterAzureServicePrincipalTenantIDPrompt, prompt.TextInputOptions{
 		Placeholder: enterAzureServicePrincipalTenantIDPlaceholder,
-		Validate:    prompt.ValidateResourceName,
+		Validate:    prompt.ValidateUUIDv4,
 	})
 	if errors.Is(err, &prompt.ErrExitConsole{}) {
 		return nil, &cli.FriendlyError{Message: err.Error()}


### PR DESCRIPTION
# Description

This change fixes a bug in the validation for Azure Service Principal tenant ids. We applied the wrong validator here, and are treating it like a resource name, when it is a guid/uuid.

## Issue reference

Fixes: radius-project/core-team#1198

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it

## Auto-generated summary


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a15b3a7</samp>

### Summary
🐛🔧🎨

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change. It conveys that the change resolves an issue that was affecting users and improves the functionality of the code.
2.  🔧 - This emoji represents a tool or configuration change, which is a secondary aspect of the change. It conveys that the change affects how the code interacts with an external service or system, in this case Azure, and modifies the validation logic for a configuration parameter.
3.  🎨 - This emoji represents an improvement or update to the code style or format, which is a tertiary aspect of the change. It conveys that the change makes the code more consistent and readable, by using a more appropriate validation function for the data type.
-->
Fix validation bug for Azure tenant ID in `radinit` command. Use `prompt.ValidateUUIDv4` instead of `prompt.ValidateResourceName` in `pkg/cli/cmd/radinit/azure.go`.

> _`ValidateUUIDv4`_
> _Fixes tenant ID bug now_
> _Autumn of errors_

### Walkthrough
* Fix validation of Azure tenant ID ([link](https://github.com/project-radius/radius/pull/5613/files?diff=unified&w=0#diff-2097082f10a8b2539e709aba19b5ac53a8beca4942e09d78f1c8456997719111L85-R85))


