### PR TITLE
Make validation tolerant of intermediate states

### DIFF
--- a/pkg/cli/prompt/text/text_test.go
+++ b/pkg/cli/prompt/text/text_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package text
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/acarl005/stripansi"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	// Set this to a big value when debugging.
+	waitTimeout = 1 * time.Second
+)
+
+func Test_NewTextModel(t *testing.T) {
+	options := TextModelOptions{
+		Default:     "test default",
+		Placeholder: "test placeholder",
+		Validate: func(input string) error {
+			return nil
+		},
+	}
+	model := NewTextModel("test prompt", options)
+	require.NotNil(t, model)
+	require.NotNil(t, model.textInput)
+
+	require.Equal(t, "test prompt", model.prompt)
+	require.Equal(t, options.Placeholder, model.textInput.Placeholder)
+	require.Nil(t, model.textInput.Validate) // See comments in NewTextModel.
+}
+
+func Test_E2E(t *testing.T) {
+	// Note: unfortunately I ran into bugs with the testing framework while trying to test more advance
+	// scenarios like validation. The output coming from the framework was truncated, so I just couldn't do it :(.
+	//
+	// At the time of writing the test framework is new and unsupported. We should try again when its more mature.
+
+	setup := func(t *testing.T) *teatest.TestModel {
+		options := TextModelOptions{
+			Default:     "test default",
+			Placeholder: "test placeholder",
+		}
+		model := NewTextModel("test prompt", options)
+		return teatest.NewTestModel(t, model, teatest.WithInitialTermSize(80, 50))
+	}
+
+	normalizeOutput := func(bts []byte) string {
+		return stripansi.Strip(strings.ReplaceAll(string(bts), "\r\n", "\n"))
+	}
+	waitForContains := func(t *testing.T, reader io.Reader, target string) string {
+		normalized := ""
+		teatest.WaitFor(t, reader, func(bts []byte) bool {
+			normalized = normalizeOutput(bts)
+			t.Logf("Testing output:\n\n%s", normalized)
+			return strings.Contains(normalized, target)
+		}, teatest.WithDuration(waitTimeout))
+
+		return normalized
+	}
+	waitForInitialRender := func(t *testing.T, reader io.Reader) string {
+		return waitForContains(t, reader, ">")
+	}
+
+	t.Run("confirm default", func(t *testing.T) {
+		tm := setup(t)
+		output := waitForInitialRender(t, tm.Output())
+
+		expected := "test prompt\n" +
+			"\n" +
+			"> test placeholder\n" +
+			"\n" +
+			"(ctrl+c to quit)"
+		require.Equal(t, expected, output)
+
+		tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
+		tm.WaitFinished(t, teatest.WithFinalTimeout(waitTimeout))
+		bts, err := io.ReadAll(tm.FinalOutput(t))
+		require.NoError(t, err)
+
+		output = normalizeOutput(bts)
+		require.Empty(t, strings.TrimSpace(output)) // Output sometimes contains a single space.
+		require.True(t, tm.FinalModel(t).(Model).valueEntered)
+		require.False(t, tm.FinalModel(t).(Model).Quitting)
+		require.Equal(t, "test default", tm.FinalModel(t).(Model).GetValue())
+	})
+
+	t.Run("confirm value", func(t *testing.T) {
+		tm := setup(t)
+		output := waitForInitialRender(t, tm.Output())
+
+		expected := "test prompt\n" +
+			"\n" +
+			"> test placeholder\n" +
+			"\n" +
+			"(ctrl+c to quit)"
+		require.Equal(t, expected, output)
+
+		tm.Type("abcd")
+		tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
+		tm.WaitFinished(t, teatest.WithFinalTimeout(waitTimeout))
+		bts, err := io.ReadAll(tm.FinalOutput(t))
+		require.NoError(t, err)
+
+		output = normalizeOutput(bts)
+		require.Empty(t, strings.TrimSpace(output)) // Output sometimes contains a single space.
+		require.True(t, tm.FinalModel(t).(Model).valueEntered)
+		require.False(t, tm.FinalModel(t).(Model).Quitting)
+		require.Equal(t, "abcd", tm.FinalModel(t).(Model).GetValue())
+	})
+
+	t.Run("cancel", func(t *testing.T) {
+		tm := setup(t)
+		output := waitForInitialRender(t, tm.Output())
+
+		expected := "test prompt\n" +
+			"\n" +
+			"> test placeholder\n" +
+			"\n" +
+			"(ctrl+c to quit)"
+		require.Equal(t, expected, output)
+
+		tm.Send(tea.KeyMsg{Type: tea.KeyCtrlC})
+		tm.WaitFinished(t, teatest.WithFinalTimeout(waitTimeout))
+		bts, err := io.ReadAll(tm.FinalOutput(t))
+		require.NoError(t, err)
+
+		output = normalizeOutput(bts)
+		require.Empty(t, strings.TrimSpace(output)) // Output sometimes contains a single space.
+		require.False(t, tm.FinalModel(t).(Model).valueEntered)
+		require.True(t, tm.FinalModel(t).(Model).Quitting)
+		require.Equal(t, "test default", tm.FinalModel(t).(Model).GetValue())
+	})
+}


### PR DESCRIPTION
# Description

This change works around a bug in bubbletea's text component to give us the correct validation behavior we need. Unfortunately the text component's validation support does not allow intermediate states to be input.

For example if you're trying to input `prod-aws`, but `prod-` is invalid, then you'll just be stuck.

The fix for this is to handle validation ourselves at a higher level. This allows the text field to contain invalid values, but prevents them from being submitted.

I added some tests for the text component since we had none. Unfortunately I ran into the same bug as before with the teatest framework (truncated output). I was able to add basic test cases but blocked from doing anything advanced.

## Issue reference

Fixes: #5611

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a221099</samp>

### Summary
🧪🐛🛠️

<!--
1.  🧪 - This emoji represents testing, experimentation, or science. It can be used to indicate that the change adds new tests or improves the test coverage of the codebase.
2.  🐛 - This emoji represents a bug, an error, or a flaw. It can be used to indicate that the change fixes a bug or resolves an issue in the codebase.
3.  🛠️ - This emoji represents a tool, a repair, or a construction. It can be used to indicate that the change modifies or improves the functionality or performance of the codebase.
-->
This pull request fixes a bug and adds tests for the `text` package in the CLI prompt module. It replaces the `textinput` library validation with a custom one and adds a new test file `text_test.go` with unit and end-to-end tests. The tests use the `teatest` framework and cover some common input scenarios.

> _Sing, O Muse, of the cunning code review_
> _That fixed the text input for the prompt,_
> _And added tests to check the model true_
> _With teatest framework and helpers prompt._

### Walkthrough
*  Remove unused `errMsg` type from `text` package ([link](https://github.com/project-radius/radius/pull/5614/files?diff=unified&w=0#diff-9cc29225e4b4a9ce3eacd8d8c7f982efdf28c1a78fdb6c5f8fc84348adc82136L27-L30))
*  Fix text input validation bug by bypassing library support and implementing custom logic in `NewTextModel` and `Update` functions ([link](https://github.com/project-radius/radius/pull/5614/files?diff=unified&w=0#diff-9cc29225e4b4a9ce3eacd8d8c7f982efdf28c1a78fdb6c5f8fc84348adc82136L62-R71), [link](https://github.com/project-radius/radius/pull/5614/files?diff=unified&w=0#diff-9cc29225e4b4a9ce3eacd8d8c7f982efdf28c1a78fdb6c5f8fc84348adc82136R95-R99), [link](https://github.com/project-radius/radius/pull/5614/files?diff=unified&w=0#diff-9cc29225e4b4a9ce3eacd8d8c7f982efdf28c1a78fdb6c5f8fc84348adc82136L102-R117))
*  Add unit and end-to-end tests for text input prompt in `text_test.go` file, using `teatest` framework and helper functions ([link](https://github.com/project-radius/radius/pull/5614/files?diff=unified&w=0#diff-a95b3c117c873821d9473cd582ee12f2ffccb36c71d5fd41b1a3897f0268d957R1-R160))


