### PR TITLE
trigger tests on PR comment [test PR - do not review]

### DIFF
--- a/.github/scripts/test-trigger.js
+++ b/.github/scripts/test-trigger.js
@@ -1,0 +1,84 @@
+
+module.exports = async ({ github, context }) => {
+    if (
+        context.eventName == 'issue_comment' &&
+        context.payload.action == 'created'
+    ) {
+        await handleIssueCommentCreate({ github, context })
+    }
+}
+
+// Handle issue comment create event.
+async function handleIssueCommentCreate({ github, context }) {
+    const payload = context.payload
+    const issue = context.issue
+    const isFromPulls = !!payload.issue.pull_request
+    const commentBody = payload.comment.body
+
+    if (!commentBody) {
+        console.log(
+            '[handleIssueCommentCreate] comment body not found, exiting.'
+        )
+        return
+    }
+    const commandParts = commentBody.split(/\s+/)
+    const command = commandParts.shift()
+
+
+    switch (command) {
+        case '/ok-to-test':
+            await cmdOkToTest(github, issue, isFromPulls)
+            break
+        default:
+            console.log(
+                `[handleIssueCommentCreate] command ${command} not found, exiting.`
+            )
+            break
+    }
+}
+
+/**
+ * Trigger e2e test for the pull request.
+ * @param {*} github GitHub object reference
+ * @param {*} issue GitHub issue object
+ * @param {boolean} isFromPulls is the workflow triggered by a pull request?
+ */
+async function cmdOkToTest(github, issue, isFromPulls) {
+    if (!isFromPulls) {
+        console.log(
+            '[cmdOkToTest] only pull requests supported, skipping command execution.'
+        )
+        return
+    }
+
+    // Get pull request
+    const pull = await github.pulls.get({
+        owner: issue.owner,
+        repo: issue.repo,
+        pull_number: issue.number,
+    })
+
+    if (pull && pull.data) {
+        // Get commit id and repo from pull head
+        const testPayload = {
+            pull_head_ref: pull.data.head.sha,
+            pull_head_repo: pull.data.head.repo.full_name,
+            command: 'ok-to-test',
+            issue: issue,
+        }
+
+        // Fire repository_dispatch event to trigger e2e test
+        await github.repos.createDispatchEvent({
+            owner: issue.owner,
+            repo: issue.repo,
+            event_type: 'e2e-test',
+            client_payload: testPayload,
+        })
+
+        console.log(
+            `[cmdOkToTest] triggered E2E test for ${JSON.stringify(
+                testPayload
+            )}`
+        )
+    }
+}

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -26,6 +26,10 @@ on:
       - main
       - features/*
       - release/*
+  # Dispatch on external events
+  repository_dispatch:
+    types: [e2e-test]
+
 env:
   # Go version
   GOVER: '^1.20'
@@ -501,3 +505,16 @@ jobs:
               labels: ['bug'],
               body: `## Bug information \n\nThis bug is generated automatically if the scheduled functional test fails. The Radius functional test operates on a schedule of every 4 hours during weekdays and every 12 hours over the weekend. It's important to understand that the test may fail due to workflow infrastructure issues, like network problems, rather than the flakiness of the test itself. For the further investigation, please visit [here](${process.env.ACTION_LINK}).`
             })
+  trigger-tests:
+    name: Trigger CI/CD tests
+    runs-on: [ self-hosted, 1ES.Pool=1ES-Radius ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3 # required to make the script available for next step
+      - name: Comment analyzer
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          script: |
+            const script = require('./.github/scripts/test-trigger.js')
+            await script({github, context})

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -1,6 +1,8 @@
 name: Issues Automation
 
 on:
+  issue_comment:
+    types: [created]
   issues:
     types: [opened]
 
@@ -33,3 +35,16 @@ jobs:
               fi
             fi
           done
+  trigger-tests:
+    name: Trigger CI/CD tests
+    runs-on: [ self-hosted, 1ES.Pool=1ES-Radius ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3 # required to make the script available for next step
+      - name: Comment analyzer
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          script: |
+            const script = require('./.github/scripts/test-trigger.js')
+            await script({github, context})


### PR DESCRIPTION
# Description

_Please explain the changes you've made._

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7056f3f</samp>

### Summary
🚀🧪💬

<!--
1.  🚀 for adding a new feature to trigger end-to-end tests on demand.
2.  🧪 for updating the functional-test workflow to enable end-to-end testing.
3.  💬 for enabling the issues workflow to run end-to-end tests based on issue comments.
-->
This pull request adds a new feature to allow end-to-end testing on demand via issue comments. It introduces a new script `test-trigger.js` that handles the test commands and dispatches repository events, and updates the `functional-test.yaml` and `issues.yaml` workflows to use the script.

> _`test-trigger.js`_
> _Checks comments for commands_
> _Autumn of testing_

### Walkthrough
*  Add a new script `test-trigger.js` to handle issue comment events and trigger end-to-end tests if needed ([link](https://github.com/project-radius/radius/pull/5621/files?diff=unified&w=0#diff-ab289f2d60d1055b9ebc794d1cb6010afb8dff4cf839770a5c799b6b83e1417fL1-R83))
*  Enable the `functional-test.yaml` workflow to run on repository dispatch events with the type `e2e-test` ([link](https://github.com/project-radius/radius/pull/5621/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcR29-R32))
*  Add a new job `trigger-tests` to the `functional-test.yaml` workflow that runs the `test-trigger.js` script on a self-hosted runner ([link](https://github.com/project-radius/radius/pull/5621/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcR508-R520))
*  Enable the `issues.yaml` workflow to run on issue comment events with the type `created` ([link](https://github.com/project-radius/radius/pull/5621/files?diff=unified&w=0#diff-fe198ee6d6945e09ccefa6351febac68b4b18f3ebc3503e720a8c7fee65ea5c7R4-R5))
*  Add the same job `trigger-tests` to the `issues.yaml` workflow that runs the `test-trigger.js` script on a self-hosted runner ([link](https://github.com/project-radius/radius/pull/5621/files?diff=unified&w=0#diff-fe198ee6d6945e09ccefa6351febac68b4b18f3ebc3503e720a8c7fee65ea5c7R38-R50))


