### PR TITLE
Update recipe metadata name for default recipe

### DIFF
--- a/pkg/recipes/configloader/environment.go
+++ b/pkg/recipes/configloader/environment.go
@@ -110,19 +110,24 @@ func getRecipeDefinition(environment *v20220315privatepreview.EnvironmentResourc
 	if environment.Properties.Recipes == nil {
 		return nil, &recipes.ErrRecipeNotFound{Name: recipe.Name, Environment: recipe.EnvironmentID}
 	}
+
 	resource, err := resources.ParseResource(recipe.ResourceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse resourceID: %q %w", recipe.ResourceID, err)
 	}
-	if recipe.Name == "" {
-		recipe.Name = defaultRecipeName
+
+	// TODO Remove this logic to populate recipe name, after https://github.com/project-radius/radius/issues/5649 is implemented
+	recipeName := recipe.Name
+	if recipeName == "" {
+		recipeName = defaultRecipeName
 	}
-	found, ok := environment.Properties.Recipes[resource.Type()][recipe.Name]
+	found, ok := environment.Properties.Recipes[resource.Type()][recipeName]
 	if !ok {
 		return nil, &recipes.ErrRecipeNotFound{Name: recipe.Name, Environment: recipe.EnvironmentID}
 	}
 
 	return &recipes.Definition{
+		Name:         recipeName,
 		Driver:       *found.TemplateKind,
 		ResourceType: resource.Type(),
 		Parameters:   found.Parameters,

--- a/pkg/recipes/configloader/environment.go
+++ b/pkg/recipes/configloader/environment.go
@@ -98,7 +98,7 @@ func getConfiguration(environment *v20220315privatepreview.EnvironmentResource, 
 }
 
 // LoadRecipe fetches the recipe information from the environment.
-func (e *environmentLoader) LoadRecipe(ctx context.Context, recipe recipes.Metadata) (*recipes.Definition, error) {
+func (e *environmentLoader) LoadRecipe(ctx context.Context, recipe *recipes.Metadata) (*recipes.Definition, error) {
 	environment, err := util.FetchEnvironment(ctx, recipe.EnvironmentID, e.ArmClientOptions)
 	if err != nil {
 		return nil, err
@@ -106,7 +106,7 @@ func (e *environmentLoader) LoadRecipe(ctx context.Context, recipe recipes.Metad
 	return getRecipeDefinition(environment, recipe)
 }
 
-func getRecipeDefinition(environment *v20220315privatepreview.EnvironmentResource, recipe recipes.Metadata) (*recipes.Definition, error) {
+func getRecipeDefinition(environment *v20220315privatepreview.EnvironmentResource, recipe *recipes.Metadata) (*recipes.Definition, error) {
 	if environment.Properties.Recipes == nil {
 		return nil, &recipes.ErrRecipeNotFound{Name: recipe.Name, Environment: recipe.EnvironmentID}
 	}

--- a/pkg/recipes/configloader/environment_test.go
+++ b/pkg/recipes/configloader/environment_test.go
@@ -212,20 +212,21 @@ func TestGetRecipeDefinition(t *testing.T) {
 	t.Run("invalid resource id", func(t *testing.T) {
 		metadata := recipeMetadata
 		metadata.ResourceID = "invalid-id"
-		_, err := getRecipeDefinition(&envResource, metadata)
+		_, err := getRecipeDefinition(&envResource, &metadata)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to parse resourceID")
 	})
-	t.Run("empty recipe name", func(t *testing.T) {
+	t.Run("empty recipe name loads default recipe", func(t *testing.T) {
 		metadata := recipeMetadata
 		metadata.Name = ""
-		_, err := getRecipeDefinition(&envResource, metadata)
+		_, err := getRecipeDefinition(&envResource, &metadata)
 		require.NoError(t, err)
+		require.Equal(t, "default", metadata.Name)
 	})
-	t.Run("recipe not found", func(t *testing.T) {
+	t.Run("recipe not found for the resource type", func(t *testing.T) {
 		metadata := recipeMetadata
 		metadata.ResourceID = redisID
-		_, err := getRecipeDefinition(&envResource, metadata)
+		_, err := getRecipeDefinition(&envResource, &metadata)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "could not find recipe")
 	})
@@ -238,14 +239,14 @@ func TestGetRecipeDefinition(t *testing.T) {
 				"foo": "bar",
 			},
 		}
-		recipeDef, err := getRecipeDefinition(&envResource, recipeMetadata)
+		recipeDef, err := getRecipeDefinition(&envResource, &recipeMetadata)
 		require.NoError(t, err)
 		require.Equal(t, recipeDef, &expected)
 	})
-	t.Run("", func(t *testing.T) {
+	t.Run("no recipes registered to the environment", func(t *testing.T) {
 		envResourceNilRecipe := envResource
 		envResourceNilRecipe.Properties.Recipes = nil
-		_, err := getRecipeDefinition(&envResourceNilRecipe, recipeMetadata)
+		_, err := getRecipeDefinition(&envResourceNilRecipe, &recipeMetadata)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "could not find recipe")
 	})

--- a/pkg/recipes/configloader/environment_test.go
+++ b/pkg/recipes/configloader/environment_test.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	kind            = "kubernetes"
-	namespace       = "default"
+	envNamespace    = "default"
 	appNamespace    = "app-default"
 	envResourceId   = "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/env0"
 	appResourceId   = "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/applications/app0"
@@ -36,13 +36,15 @@ const (
 	awsScope        = "/planes/aws/aws/accounts/000/regions/cool-region"
 	mongoResourceID = "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Link/mongoDatabases/mongo-database-0"
 	redisID         = "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Link/redisCaches/redis-0"
+
+	recipeName = "cosmosDB"
 )
 
 func Test_GetConfigurationAzure(t *testing.T) {
 	envConfig := &recipes.Configuration{
 		Runtime: recipes.RuntimeConfiguration{
 			Kubernetes: &recipes.KubernetesRuntime{
-				EnvironmentNamespace: "default",
+				EnvironmentNamespace: envNamespace,
 			},
 		},
 		Providers: createAzureProvider(),
@@ -51,7 +53,7 @@ func Test_GetConfigurationAzure(t *testing.T) {
 		Properties: &model.EnvironmentProperties{
 			Compute: &model.KubernetesCompute{
 				Kind:       to.Ptr(kind),
-				Namespace:  to.Ptr(namespace),
+				Namespace:  to.Ptr(envNamespace),
 				ResourceID: to.Ptr(envResourceId),
 			},
 			Providers: &model.Providers{
@@ -70,7 +72,7 @@ func Test_GetConfigurationAWS(t *testing.T) {
 	envConfig := &recipes.Configuration{
 		Runtime: recipes.RuntimeConfiguration{
 			Kubernetes: &recipes.KubernetesRuntime{
-				EnvironmentNamespace: "default",
+				EnvironmentNamespace: envNamespace,
 			},
 		},
 		Providers: createAWSProvider(),
@@ -79,7 +81,7 @@ func Test_GetConfigurationAWS(t *testing.T) {
 		Properties: &model.EnvironmentProperties{
 			Compute: &model.KubernetesCompute{
 				Kind:       to.Ptr(kind),
-				Namespace:  to.Ptr(namespace),
+				Namespace:  to.Ptr(envNamespace),
 				ResourceID: to.Ptr(envResourceId),
 			},
 			Providers: &model.Providers{
@@ -122,7 +124,7 @@ func Test_InvalidApplicationError(t *testing.T) {
 		Properties: &model.EnvironmentProperties{
 			Compute: &model.KubernetesCompute{
 				Kind:       to.Ptr(kind),
-				Namespace:  to.Ptr(namespace),
+				Namespace:  to.Ptr(envNamespace),
 				ResourceID: to.Ptr(envResourceId),
 			},
 		},
@@ -179,7 +181,7 @@ func TestGetRecipeDefinition(t *testing.T) {
 		Properties: &model.EnvironmentProperties{
 			Compute: &model.KubernetesCompute{
 				Kind:       to.Ptr(kind),
-				Namespace:  to.Ptr(namespace),
+				Namespace:  to.Ptr(envNamespace),
 				ResourceID: to.Ptr(envResourceId),
 			},
 			Providers: &model.Providers{
@@ -189,14 +191,14 @@ func TestGetRecipeDefinition(t *testing.T) {
 			},
 			Recipes: map[string]map[string]*model.EnvironmentRecipeProperties{
 				"Applications.Link/mongoDatabases": {
-					"cosmosDB": {
+					recipeName: {
 						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
 						TemplatePath: to.Ptr("radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"),
 						Parameters: map[string]any{
 							"foo": "bar",
 						},
 					},
-					"default": {
+					defaultRecipeName: {
 						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
 						TemplatePath: to.Ptr("radiusdev.azurecr.io/recipes/mongoDefault/azure:1.0"),
 					},
@@ -205,7 +207,7 @@ func TestGetRecipeDefinition(t *testing.T) {
 		},
 	}
 	recipeMetadata := recipes.Metadata{
-		Name:          "cosmosDB",
+		Name:          recipeName,
 		EnvironmentID: envResourceId,
 		ResourceID:    mongoResourceID,
 	}
@@ -219,9 +221,10 @@ func TestGetRecipeDefinition(t *testing.T) {
 	t.Run("empty recipe name loads default recipe", func(t *testing.T) {
 		metadata := recipeMetadata
 		metadata.Name = ""
-		_, err := getRecipeDefinition(&envResource, &metadata)
+		definition, err := getRecipeDefinition(&envResource, &metadata)
 		require.NoError(t, err)
-		require.Equal(t, "default", metadata.Name)
+		require.Equal(t, defaultRecipeName, definition.Name)
+		require.Equal(t, "", metadata.Name)
 	})
 	t.Run("recipe not found for the resource type", func(t *testing.T) {
 		metadata := recipeMetadata
@@ -232,6 +235,7 @@ func TestGetRecipeDefinition(t *testing.T) {
 	})
 	t.Run("success", func(t *testing.T) {
 		expected := recipes.Definition{
+			Name:         recipeName,
 			Driver:       recipes.TemplateKindBicep,
 			ResourceType: "Applications.Link/mongoDatabases",
 			TemplatePath: "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0",

--- a/pkg/recipes/configloader/mock_config_loader.go
+++ b/pkg/recipes/configloader/mock_config_loader.go
@@ -51,7 +51,7 @@ func (mr *MockConfigurationLoaderMockRecorder) LoadConfiguration(arg0, arg1 inte
 }
 
 // LoadRecipe mocks base method.
-func (m *MockConfigurationLoader) LoadRecipe(arg0 context.Context, arg1 recipes.Metadata) (*recipes.Definition, error) {
+func (m *MockConfigurationLoader) LoadRecipe(arg0 context.Context, arg1 *recipes.Metadata) (*recipes.Definition, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadRecipe", arg0, arg1)
 	ret0, _ := ret[0].(*recipes.Definition)

--- a/pkg/recipes/configloader/types.go
+++ b/pkg/recipes/configloader/types.go
@@ -26,5 +26,5 @@ type ConfigurationLoader interface {
 	// LoadConfiguration fetches environment/application information and return runtime and provider configuration.
 	LoadConfiguration(ctx context.Context, recipe recipes.Metadata) (*recipes.Configuration, error)
 	// LoadRecipe fetches the recipe information from the environment.
-	LoadRecipe(ctx context.Context, recipe recipes.Metadata) (*recipes.Definition, error)
+	LoadRecipe(ctx context.Context, recipe *recipes.Metadata) (*recipes.Definition, error)
 }

--- a/pkg/recipes/driver/bicep.go
+++ b/pkg/recipes/driver/bicep.go
@@ -60,7 +60,7 @@ type bicepDriver struct {
 // Execute fetches the recipe contents from acr and deploys the recipe by making a call to ucp and returns the recipe result.
 func (d *bicepDriver) Execute(ctx context.Context, configuration recipes.Configuration, recipe recipes.Metadata, definition recipes.Definition) (*recipes.RecipeOutput, error) {
 	logger := logr.FromContextOrDiscard(ctx)
-	logger.Info(fmt.Sprintf("Deploying recipe: %q, template: %q", recipe.Name, definition.TemplatePath))
+	logger.Info(fmt.Sprintf("Deploying recipe: %q, template: %q", definition.Name, definition.TemplatePath))
 
 	recipeData := make(map[string]any)
 	err := util.ReadFromRegistry(ctx, definition.TemplatePath, &recipeData)

--- a/pkg/recipes/engine/engine.go
+++ b/pkg/recipes/engine/engine.go
@@ -45,7 +45,7 @@ type engine struct {
 // Execute gathers environment configuration and recipe definition and calls the driver to deploy the recipe.
 func (e *engine) Execute(ctx context.Context, recipe recipes.Metadata) (*recipes.RecipeOutput, error) {
 	// Load Recipe Definition from the environment.
-	definition, err := e.options.ConfigurationLoader.LoadRecipe(ctx, recipe)
+	definition, err := e.options.ConfigurationLoader.LoadRecipe(ctx, &recipe)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/recipes/types.go
+++ b/pkg/recipes/types.go
@@ -45,6 +45,8 @@ type KubernetesRuntime struct {
 
 // Definition represents the recipe configuration details.
 type Definition struct {
+	// Name represents the name of the recipe within the environment
+	Name string
 	// Driver represents the kind of infrastructure language used to define recipe.
 	Driver string
 	// ResourceType represents the type of the link this recipe can be consumed by.


### PR DESCRIPTION
# Description

Fix config loader loadRecipeDefinition to populate recipe name when default recipe is used. Since the metadata object was being passed by value, the name was being updated only within the scope of the function, resulting into empty recipe name being transmitted to the driver. This went unnoticed since recipe name is only used in a log statement for bicep, I caught it while implementing Terraform driver.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: https://dev.azure.com/azure-octo/Incubations/_workitems/edit/8092

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change  -- tested end to end locally for Terraform
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it -- not applicable

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 251469f</samp>

### Summary
🛠️🧪♻️

<!--
1.  🛠️ - This emoji represents the modification of the `LoadRecipe` method signatures and the `Execute` method to use pointers instead of values. It conveys the idea of fixing or improving something.
2.  🧪 - This emoji represents the updated and added tests for the `getRecipeDefinition` function. It conveys the idea of testing or experimenting with something.
3.  ♻️ - This emoji represents the refactoring of the `LoadRecipe` and `getRecipeDefinition` functions to use pointers for efficiency and consistency. It conveys the idea of recycling or reusing something.
-->
Refactored the `LoadRecipe` method and related functions to use pointers to `recipes.Metadata` structs instead of values for efficiency and consistency. Updated and added tests for the `getRecipeDefinition` function in `pkg/recipes/configloader/environment_test.go`.

> _Sing, O Muse, of the valiant code review_
> _That changed the way the recipes were loaded_
> _By passing pointers to the metadata_
> _And not the values, as before they did._

### Walkthrough
*  Modify `LoadRecipe` method signature to take pointer to `recipes.Metadata` struct in `ConfigurationLoader` interface and its implementations (`environmentLoader` and `MockConfigurationLoader`) ([link](https://github.com/project-radius/radius/pull/5635/files?diff=unified&w=0#diff-0b45f6a08490c2a47c6ead052f97e5b5be965617c8ab927d9b0a297088a92a6eL101-R101), [link](https://github.com/project-radius/radius/pull/5635/files?diff=unified&w=0#diff-0b45f6a08490c2a47c6ead052f97e5b5be965617c8ab927d9b0a297088a92a6eL109-R109), [link](https://github.com/project-radius/radius/pull/5635/files?diff=unified&w=0#diff-6b98331b028bed068e0b2b15cb479a69956e0c3c644e3543d5fb5bd2498f598bL54-R54), [link](https://github.com/project-radius/radius/pull/5635/files?diff=unified&w=0#diff-4d83472b7398a045c3d976446454b511aadc5cf3c032cad81c0aaa40386ccf0aL29-R29), [link](https://github.com/project-radius/radius/pull/5635/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59L48-R48))
* Update `TestGetRecipeDefinition` function to pass pointers to `recipes.Metadata` structs and add new test case for empty recipe name ([link](https://github.com/project-radius/radius/pull/5635/files?diff=unified&w=0#diff-65acf2bf2022da8569dcb67552c9315b5391f0e45ec60913e55787517b1311dfL215-R229), [link](https://github.com/project-radius/radius/pull/5635/files?diff=unified&w=0#diff-65acf2bf2022da8569dcb67552c9315b5391f0e45ec60913e55787517b1311dfL241-R249))


