### PR TITLE
Enable repository_dispatcher trigger in functional test"

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -26,6 +26,10 @@ on:
       - main
       - features/*
       - release/*
+  # Dispatch on external events
+  repository_dispatch:
+    types: [e2e-test]
+
 env:
   # Go version
   GOVER: '^1.20'
@@ -79,6 +83,22 @@ jobs:
             echo "CHECKOUT_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
             echo "CHECKOUT_REF=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
             echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+      - name: Set up checkout target (repository_dispatch)
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/github-script@v6.2.0
+        with:
+          github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          script: |
+            const testPayload = context.payload.client_payload;
+            if (testPayload && testPayload.command == "ok-to-test") {
+              var fs = require('fs');
+              // Set environment variables
+              fs.appendFileSync(process.env.GITHUB_ENV,
+                `CHECKOUT_REPO=${testPayload.pull_head_repo}\n`+
+                `CHECKOUT_REF=${testPayload.pull_head_ref}\n`+
+                `PR_NUMBER=${testPayload.issue.number}`
+              );
+            }
       - name: Check out code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -90,14 +90,10 @@ jobs:
           github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
           script: |
             const testPayload = context.payload.client_payload;
-            if (testPayload && testPayload.command == "ok-to-test") {
-              var fs = require('fs');
-              // Set environment variables
-              fs.appendFileSync(process.env.GITHUB_ENV,
-                `CHECKOUT_REPO=${testPayload.pull_head_repo}\n`+
-                `CHECKOUT_REF=${testPayload.pull_head_ref}\n`+
-                `PR_NUMBER=${testPayload.issue.number}`
-              );
+            if (testPayload && testPayload.command === `ok-to-test`) {
+              echo "CHECKOUT_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
+              echo "CHECKOUT_REF=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+              echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
             }
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
Trigger e2e tests on repository_dispatch event

# Description

Trigger e2e tests on repository_dispatch event. The remaining changes to create the repository_dispatch event will be made in a separate PR for testing purpose

#5618

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9485678</samp>

### Summary
🧪🍴📥

<!--
1.  🧪 This emoji represents testing, experimentation, or science, and can be used to indicate the functional-test workflow or the e2e-test event type.
2.  🍴 This emoji represents a fork, or a divergence of paths, and can be used to indicate the pull requests from forks or the environment variables for the fork branch and issue number.
3.  📥 This emoji represents an inbox, or a receptacle for incoming messages, and can be used to indicate the external triggering of the workflow or the reading of the event payload.
-->
Enable functional-test workflow to run on external pull requests from forks. Add step to read `e2e-test` event payload and set fork branch and issue number variables.

> _`e2e-test` triggers the doom_
> _From the forks of hell they come_
> _Reading the payload of the beast_
> _Setting the variables for the feast_

### Walkthrough
*  Add a new trigger for the functional-test workflow to run end-to-end tests on pull requests from forks ([link](https://github.com/project-radius/radius/pull/5640/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcR29-R32))
*  Add a new step to the functional-test workflow to read the custom payload of the `repository_dispatch` event and set environment variables for the forked pull request ([link](https://github.com/project-radius/radius/pull/5640/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcR86-R101))


