### PR TITLE
Mask credentials in `rad init` interactive mode

### DIFF
--- a/pkg/cli/cmd/radinit/aws.go
+++ b/pkg/cli/cmd/radinit/aws.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/aws"
 	"github.com/project-radius/radius/pkg/cli/prompt"
@@ -51,7 +52,7 @@ func (r *Runner) enterAWSCloudProvider(ctx context.Context, options *initOptions
 		return nil, err
 	}
 
-	secretAccessKey, err := r.Prompter.GetTextInput(enterAWSIAMSecretAccessKeyPrompt, prompt.TextInputOptions{Placeholder: enterAWSIAMSecretAccessKeyPlaceholder})
+	secretAccessKey, err := r.Prompter.GetTextInput(enterAWSIAMSecretAccessKeyPrompt, prompt.TextInputOptions{Placeholder: enterAWSIAMSecretAccessKeyPlaceholder, EchoMode: textinput.EchoPassword})
 	if errors.Is(err, &prompt.ErrExitConsole{}) {
 		return nil, &cli.FriendlyError{Message: err.Error()}
 	} else if err != nil {

--- a/pkg/cli/cmd/radinit/azure.go
+++ b/pkg/cli/cmd/radinit/azure.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/azure"
 	"github.com/project-radius/radius/pkg/cli/prompt"
@@ -73,7 +74,7 @@ func (r *Runner) enterAzureCloudProvider(ctx context.Context, options *initOptio
 		return nil, err
 	}
 
-	clientSecret, err := r.Prompter.GetTextInput(enterAzureServicePrincipalPasswordPrompt, prompt.TextInputOptions{Placeholder: enterAzureServicePrincipalPasswordPlaceholder})
+	clientSecret, err := r.Prompter.GetTextInput(enterAzureServicePrincipalPasswordPrompt, prompt.TextInputOptions{Placeholder: enterAzureServicePrincipalPasswordPlaceholder, EchoMode: textinput.EchoPassword})
 	if errors.Is(err, &prompt.ErrExitConsole{}) {
 		return nil, &cli.FriendlyError{Message: err.Error()}
 	} else if err != nil {

--- a/pkg/cli/prompt/text/text.go
+++ b/pkg/cli/prompt/text/text.go
@@ -38,6 +38,9 @@ type TextModelOptions struct {
 
 	// Validate defines a validator for the user input.
 	Validate func(string) error
+
+	// EchoMode indicates the input behavior of the text input field (e.g. password).
+	EchoMode textinput.EchoMode
 }
 
 // Model is text model for bubble tea.
@@ -69,6 +72,7 @@ func NewTextModel(prompt string, options TextModelOptions) Model {
 	ti.Focus()
 	ti.Width = 40
 	ti.Placeholder = options.Placeholder
+	ti.EchoMode = options.EchoMode
 
 	return Model{
 		Style:     lipgloss.NewStyle(), // No border or padding by default

--- a/pkg/cli/prompt/text/text_test.go
+++ b/pkg/cli/prompt/text/text_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/acarl005/stripansi"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/exp/teatest"
 	"github.com/stretchr/testify/require"
@@ -47,6 +48,26 @@ func Test_NewTextModel(t *testing.T) {
 
 	require.Equal(t, "test prompt", model.prompt)
 	require.Equal(t, options.Placeholder, model.textInput.Placeholder)
+	require.Equal(t, textinput.EchoNormal, model.textInput.EchoMode)
+	require.Nil(t, model.textInput.Validate) // See comments in NewTextModel.
+}
+
+func Test_NewTextModel_UpdateEchoMode(t *testing.T) {
+	options := TextModelOptions{
+		Default:     "test default",
+		Placeholder: "test placeholder",
+		Validate: func(input string) error {
+			return nil
+		},
+		EchoMode: textinput.EchoPassword,
+	}
+	model := NewTextModel("test prompt", options)
+	require.NotNil(t, model)
+	require.NotNil(t, model.textInput)
+
+	require.Equal(t, "test prompt", model.prompt)
+	require.Equal(t, options.Placeholder, model.textInput.Placeholder)
+	require.Equal(t, textinput.EchoPassword, model.textInput.EchoMode)
 	require.Nil(t, model.textInput.Validate) // See comments in NewTextModel.
 }
 


### PR DESCRIPTION
# Description

* Mask AWS secret access key in `rad init`
* Mask Azure SP password in `rad init`

## Issue reference
![Pasted image 20230605183430](https://github.com/project-radius/radius/assets/32342549/3d3f461e-f30b-4162-baf8-f77c93005046)
![Pasted image 20230605190824](https://github.com/project-radius/radius/assets/32342549/ef526ceb-4607-4985-9f75-3109aa526853)

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #3953

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 41db3b1</samp>

### Summary
🔒🙈🎛️

<!--
1.  🔒 - This emoji represents the security aspect of masking sensitive input, such as secret keys or passwords.
2.  🙈 - This emoji represents the hiding or obscuring of the input characters, which makes them invisible or unreadable to the user and others.
3.  🎛️ - This emoji represents the new option or configuration that the user can set for the text input component, such as the echo mode.
-->
This pull request enhances the `radius` CLI by adding a new option to control the input behavior of text input components, such as masking sensitive information. It uses the `textinput` package from the `bubbles` library and applies it to the `radinit` command for the AWS and Azure cloud providers. It also adds a unit test for the text input component.

> _`TextInput` is the key to the cloud_
> _But secrets must be hidden from the crowd_
> _We mask the input with `EchoMode`_
> _And test the prompt with `textinput.Model`_

### Walkthrough
*  Add `EchoMode` field to `TextInputOptions` struct to configure input behavior of text input component ([link](https://github.com/project-radius/radius/pull/5644/files?diff=unified&w=0#diff-9cc29225e4b4a9ce3eacd8d8c7f982efdf28c1a78fdb6c5f8fc84348adc82136R41-R43))
*  Assign `EchoMode` field of `TextInputOptions` to `EchoMode` field of `textinput.Model` to pass option from caller to component ([link](https://github.com/project-radius/radius/pull/5644/files?diff=unified&w=0#diff-9cc29225e4b4a9ce3eacd8d8c7f982efdf28c1a78fdb6c5f8fc84348adc82136R75))
*  Import `textinput` package from `bubbles` library to access text input component and echo mode constants in `aws.go`, `azure.go`, and `text_test.go` ([link](https://github.com/project-radius/radius/pull/5644/files?diff=unified&w=0#diff-d6b087c827d9069ad74b4cb04ab94eafb6e3b2759ddfd2e8ffa9a8557bf7cf74R24), [link](https://github.com/project-radius/radius/pull/5644/files?diff=unified&w=0#diff-2097082f10a8b2539e709aba19b5ac53a8beca4942e09d78f1c8456997719111R27), [link](https://github.com/project-radius/radius/pull/5644/files?diff=unified&w=0#diff-a95b3c117c873821d9473cd582ee12f2ffccb36c71d5fd41b1a3897f0268d957R26))
*  Set echo mode of secret access key text input field to `textinput.EchoPassword` in `aws.go` to mask input with asterisks ([link](https://github.com/project-radius/radius/pull/5644/files?diff=unified&w=0#diff-d6b087c827d9069ad74b4cb04ab94eafb6e3b2759ddfd2e8ffa9a8557bf7cf74L54-R55))
*  Set echo mode of client secret text input field to `textinput.EchoPassword` in `azure.go` to mask input with asterisks ([link](https://github.com/project-radius/radius/pull/5644/files?diff=unified&w=0#diff-2097082f10a8b2539e709aba19b5ac53a8beca4942e09d78f1c8456997719111L76-R77))
*  Add unit test function `Test_NewTextModel_UpdateEchoMode` in `text_test.go` to test creation of text model with custom echo mode option ([link](https://github.com/project-radius/radius/pull/5644/files?diff=unified&w=0#diff-a95b3c117c873821d9473cd582ee12f2ffccb36c71d5fd41b1a3897f0268d957L50-R73))


