### PR TITLE
User Confirmation Prompt Before rad resource delete

### DIFF
--- a/pkg/cli/cmd/resource/delete/delete.go
+++ b/pkg/cli/cmd/resource/delete/delete.go
@@ -18,7 +18,9 @@ package delete
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/project-radius/radius/pkg/cli"
@@ -26,8 +28,13 @@ import (
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/framework"
 	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/project-radius/radius/pkg/cli/prompt"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/spf13/cobra"
+)
+
+const (
+	deleteConfirmation = "Are you sure you want to delete environment '%v'?"
 )
 
 // NewCommand creates an instance of the command and runner for the `rad resource delete` command.
@@ -63,6 +70,10 @@ type Runner struct {
 	ResourceType      string
 	ResourceName      string
 	Format            string
+
+	InputPrompter     prompt.Interface
+	EnvironmentName string
+	Confirm         bool
 }
 
 // NewRunner creates a new instance of the `rad resource delete` runner.
@@ -106,6 +117,20 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 
 // Run runs the `rad resource delete` command.
 func (r *Runner) Run(ctx context.Context) error {
+	// Prompt user to confirm deletion
+	if !r.Confirm {
+		confirmed, err := prompt.YesOrNoPrompt(fmt.Sprintf(deleteConfirmation, r.EnvironmentName), prompt.ConfirmNo, r.InputPrompter)
+		if err != nil {
+			if errors.Is(err, &prompt.ErrExitConsole{}) {
+				return &cli.FriendlyError{Message: err.Error()}
+			}
+			return err
+		}
+		if !confirmed {
+			return nil
+		}
+	}
+
 	client, err := r.ConnectionFactory.CreateApplicationsManagementClient(ctx, *r.Workspace)
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/resource/delete/delete.go
+++ b/pkg/cli/cmd/resource/delete/delete.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	deleteConfirmation = "Are you sure you want to delete resource '%v'?"
+	deleteConfirmation = "Are you sure you want to delete resource %v of type %v?"
 )
 
 // NewCommand creates an instance of the command and runner for the `rad resource delete` command.

--- a/pkg/cli/cmd/resource/delete/delete.go
+++ b/pkg/cli/cmd/resource/delete/delete.go
@@ -126,7 +126,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 func (r *Runner) Run(ctx context.Context) error {
 	// Prompt user to confirm deletion
 	if !r.Confirm {
-		confirmed, err := prompt.YesOrNoPrompt(fmt.Sprintf(deleteConfirmation, r.ResourceName), prompt.ConfirmNo, r.InputPrompter)
+		confirmed, err := prompt.YesOrNoPrompt(fmt.Sprintf(deleteConfirmation, r.ResourceName, r.ResourceType), prompt.ConfirmNo, r.InputPrompter)
 		if err != nil {
 			if errors.Is(err, &prompt.ErrExitConsole{}) {
 				return &cli.FriendlyError{Message: err.Error()}

--- a/pkg/cli/cmd/resource/delete/delete.go
+++ b/pkg/cli/cmd/resource/delete/delete.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	deleteConfirmation = "Are you sure you want to delete environment '%v'?"
+	deleteConfirmation = "Are you sure you want to delete resource '%v'?"
 )
 
 // NewCommand creates an instance of the command and runner for the `rad resource delete` command.
@@ -72,7 +72,6 @@ type Runner struct {
 	Format            string
 
 	InputPrompter     prompt.Interface
-	EnvironmentName string
 	Confirm         bool
 }
 
@@ -82,6 +81,7 @@ func NewRunner(factory framework.Factory) *Runner {
 		ConfigHolder:      factory.GetConfigHolder(),
 		ConnectionFactory: factory.GetConnectionFactory(),
 		Output:            factory.GetOutput(),
+		InputPrompter:     factory.GetPrompter(),
 	}
 }
 
@@ -119,7 +119,8 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 func (r *Runner) Run(ctx context.Context) error {
 	// Prompt user to confirm deletion
 	if !r.Confirm {
-		confirmed, err := prompt.YesOrNoPrompt(fmt.Sprintf(deleteConfirmation, r.EnvironmentName), prompt.ConfirmNo, r.InputPrompter)
+		// ISSUE: r.InputPrompter is nil when it shouldn't be. This is causing segfault
+		confirmed, err := prompt.YesOrNoPrompt(fmt.Sprintf(deleteConfirmation, r.ResourceName), prompt.ConfirmNo, r.InputPrompter)
 		if err != nil {
 			if errors.Is(err, &prompt.ErrExitConsole{}) {
 				return &cli.FriendlyError{Message: err.Error()}

--- a/pkg/cli/cmd/resource/delete/delete.go
+++ b/pkg/cli/cmd/resource/delete/delete.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	deleteConfirmation = "Are you sure you want to delete resource %v of type %v?"
+	deleteConfirmation = "Are you sure you want to delete resource '%v'?"
 )
 
 // NewCommand creates an instance of the command and runner for the `rad resource delete` command.

--- a/pkg/cli/cmd/resource/delete/delete_test.go
+++ b/pkg/cli/cmd/resource/delete/delete_test.go
@@ -18,8 +18,8 @@ package delete
 
 import (
 	"context"
-	"testing"
 	"fmt"
+	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/project-radius/radius/pkg/cli/clients"
@@ -232,7 +232,14 @@ func Test_Run(t *testing.T) {
 	
 			err := runner.Run(context.Background())
 			require.NoError(t, err)
-			require.Empty(t, outputSink.Writes)
+
+			expected := []any{
+				output.LogOutput{
+					Format: "resource %q of type %q NOT deleted",
+					Params: []any{"test-container", "containers"},
+				},
+			}
+			require.Equal(t, expected, outputSink.Writes)
 		})
 	})
 }

--- a/pkg/cli/cmd/resource/delete/delete_test.go
+++ b/pkg/cli/cmd/resource/delete/delete_test.go
@@ -19,12 +19,14 @@ package delete
 import (
 	"context"
 	"testing"
+	"fmt"
 
 	"github.com/golang/mock/gomock"
 	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/connections"
 	"github.com/project-radius/radius/pkg/cli/framework"
 	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/project-radius/radius/pkg/cli/prompt"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/project-radius/radius/test/radcli"
 	"github.com/stretchr/testify/require"
@@ -106,6 +108,7 @@ func Test_Run(t *testing.T) {
 				ResourceType:      "containers",
 				ResourceName:      "test-container",
 				Format:            "table",
+				Confirm:           true,
 			}
 
 			err := runner.Run(context.Background())
@@ -138,6 +141,7 @@ func Test_Run(t *testing.T) {
 				ResourceType:      "containers",
 				ResourceName:      "test-container",
 				Format:            "table",
+				Confirm:           true,
 			}
 
 			err := runner.Run(context.Background())
@@ -149,6 +153,86 @@ func Test_Run(t *testing.T) {
 				},
 			}
 			require.Equal(t, expected, outputSink.Writes)
+		})
+
+		t.Run("Success: Prompt Confirmed", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+	
+			promptMock := prompt.NewMockInterface(ctrl)
+			promptMock.EXPECT().
+				GetListInput([]string{prompt.ConfirmNo, prompt.ConfirmYes}, fmt.Sprintf(deleteConfirmation, "test-container")).
+				Return(prompt.ConfirmYes, nil).
+				Times(1)
+	
+			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
+			appManagementClient.EXPECT().
+				DeleteResource(gomock.Any(), "containers", "test-container").
+				Return(true, nil).
+				Times(1)
+	
+			workspace := &workspaces.Workspace{
+				Connection: map[string]any{
+					"kind":    "kubernetes",
+					"context": "kind-kind",
+				},
+				Name:  "kind-kind",
+				Scope: "/planes/radius/local/resourceGroups/test-group",
+			}
+			outputSink := &output.MockOutput{}
+			runner := &Runner{
+				ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+				Output:            outputSink,
+				Workspace:         workspace,
+				ResourceType:      "containers",
+				ResourceName:      "test-container",
+				Format:            "table",
+				InputPrompter:     promptMock,
+			}
+	
+			err := runner.Run(context.Background())
+			require.NoError(t, err)
+	
+			expected := []any{
+				output.LogOutput{
+					Format: "Resource deleted",
+				},
+			}
+	
+			require.Equal(t, expected, outputSink.Writes)
+		})
+	
+		t.Run("Success: Prompt Cancelled", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+	
+			promptMock := prompt.NewMockInterface(ctrl)
+			promptMock.EXPECT().
+				GetListInput([]string{prompt.ConfirmNo, prompt.ConfirmYes}, fmt.Sprintf(deleteConfirmation, "test-container")).
+				Return(prompt.ConfirmNo, nil).
+				Times(1)
+	
+			workspace := &workspaces.Workspace{
+				Connection: map[string]any{
+					"kind":    "kubernetes",
+					"context": "kind-kind",
+				},
+				Name:  "kind-kind",
+				Scope: "/planes/radius/local/resourceGroups/test-group",
+			}
+			outputSink := &output.MockOutput{}
+			runner := &Runner{
+				InputPrompter:   promptMock,
+				Workspace:       workspace,
+				Format:          "table",
+				Output:          outputSink,
+				ResourceType:      "containers",
+				ResourceName:      "test-container",
+			}
+	
+			err := runner.Run(context.Background())
+			require.NoError(t, err)
+			require.Empty(t, outputSink.Writes)
 		})
 	})
 }

--- a/pkg/cli/cmd/resource/delete/delete_test.go
+++ b/pkg/cli/cmd/resource/delete/delete_test.go
@@ -161,7 +161,7 @@ func Test_Run(t *testing.T) {
 	
 			promptMock := prompt.NewMockInterface(ctrl)
 			promptMock.EXPECT().
-				GetListInput([]string{prompt.ConfirmNo, prompt.ConfirmYes}, fmt.Sprintf(deleteConfirmation, "test-container")).
+				GetListInput([]string{prompt.ConfirmNo, prompt.ConfirmYes}, fmt.Sprintf(deleteConfirmation, "test-container", "containers")).
 				Return(prompt.ConfirmYes, nil).
 				Times(1)
 	
@@ -208,7 +208,7 @@ func Test_Run(t *testing.T) {
 	
 			promptMock := prompt.NewMockInterface(ctrl)
 			promptMock.EXPECT().
-				GetListInput([]string{prompt.ConfirmNo, prompt.ConfirmYes}, fmt.Sprintf(deleteConfirmation, "test-container")).
+				GetListInput([]string{prompt.ConfirmNo, prompt.ConfirmYes}, fmt.Sprintf(deleteConfirmation, "test-container", "containers")).
 				Return(prompt.ConfirmNo, nil).
 				Times(1)
 	


### PR DESCRIPTION
# Description

Added a CLI prompt that asks confirms user's intent before deleting a resource. This prompt appears when the user calls ```rad resource delete <resource_type> <resource_name>```. Functionality is very similar to the CLI prompt for ```rad env delete```.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #3500 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change _(not needed)_
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it _(auto-generated)_

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ed1f17b</samp>

### Summary
🗑️🧪🎁

<!--
1.  🗑️ - This emoji represents the delete command and the confirmation prompt for deleting resources.
2.  🧪 - This emoji represents the tests that were added for the prompt functionality and the delete command.
3.  🎁 - This emoji represents the new feature of prompt functionality that was added to the delete command.
-->
Added a confirmation prompt for the `delete` command in the `radius` CLI. This allows users to confirm or cancel the deletion of resources using the `prompt` package and a `Confirm` flag. Modified the `delete.go` and `delete_test.go` files in the `pkg/cli/cmd/resource/delete` directory to implement and test this feature.

> _`Delete` the resources, face the doom_
> _Confirm your choice, or seal your tomb_
> _`Validate` the errors, and the input_
> _`Prompt` the user, don't let them quit_

### Walkthrough
*  Add prompt functionality to the delete command ([link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-3f4a366bd6e44a81411d950e97c32a90c1c46a9b4c3e2e26bcd6b122d6f07649L21-R23), [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-3f4a366bd6e44a81411d950e97c32a90c1c46a9b4c3e2e26bcd6b122d6f07649L29-R39), [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-3f4a366bd6e44a81411d950e97c32a90c1c46a9b4c3e2e26bcd6b122d6f07649R73-R75), [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-3f4a366bd6e44a81411d950e97c32a90c1c46a9b4c3e2e26bcd6b122d6f07649R84), [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-3f4a366bd6e44a81411d950e97c32a90c1c46a9b4c3e2e26bcd6b122d6f07649R120-R134), [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-464b7b5996cfe8627dbb1e38698744cd559d2b41a4b308f74730cce2605923b3R22), [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-464b7b5996cfe8627dbb1e38698744cd559d2b41a4b308f74730cce2605923b3R29), [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-464b7b5996cfe8627dbb1e38698744cd559d2b41a4b308f74730cce2605923b3R111), [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-464b7b5996cfe8627dbb1e38698744cd559d2b41a4b308f74730cce2605923b3R144), [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-464b7b5996cfe8627dbb1e38698744cd559d2b41a4b308f74730cce2605923b3R157-R236))
  - Import `prompt`, `errors`, and `fmt` packages to use prompt interface and handle errors and strings (`delete.go`: [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-3f4a366bd6e44a81411d950e97c32a90c1c46a9b4c3e2e26bcd6b122d6f07649L21-R23), [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-3f4a366bd6e44a81411d950e97c32a90c1c46a9b4c3e2e26bcd6b122d6f07649L29-R39), `delete_test.go`: [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-464b7b5996cfe8627dbb1e38698744cd559d2b41a4b308f74730cce2605923b3R22), [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-464b7b5996cfe8627dbb1e38698744cd559d2b41a4b308f74730cce2605923b3R29))
  - Add `InputPrompter` and `Confirm` fields to the `Runner` struct to store the prompt interface and the flag for skipping the confirmation prompt (`delete.go`: [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-3f4a366bd6e44a81411d950e97c32a90c1c46a9b4c3e2e26bcd6b122d6f07649R73-R75))
  - Initialize the `InputPrompter` field with the `factory.GetPrompter()` method in the `NewRunner` function (`delete.go`: [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-3f4a366bd6e44a81411d950e97c32a90c1c46a9b4c3e2e26bcd6b122d6f07649R84))
  - Modify the `Validate` function to check if the `Confirm` flag was set to false, and if so, to prompt the user to confirm the deletion using the `prompt.YesOrNoPrompt` function (`delete.go`: [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-3f4a366bd6e44a81411d950e97c32a90c1c46a9b4c3e2e26bcd6b122d6f07649R120-R134))
  - Set the `Confirm` field to true for the test cases that simulate the flag being passed to the command (`delete_test.go`: [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-464b7b5996cfe8627dbb1e38698744cd559d2b41a4b308f74730cce2605923b3R111), [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-464b7b5996cfe8627dbb1e38698744cd559d2b41a4b308f74730cce2605923b3R144))
  - Add two new test cases to test the prompt functionality, using a mock prompt interface to control the input and output (`delete_test.go`: [link](https://github.com/project-radius/radius/pull/5647/files?diff=unified&w=0#diff-464b7b5996cfe8627dbb1e38698744cd559d2b41a4b308f74730cce2605923b3R157-R236))


