### PR TITLE
Fix formatting of how-to

### DIFF
--- a/docs/contributing/how-to.md
+++ b/docs/contributing/how-to.md
@@ -2,20 +2,20 @@
 
 We welcome and encourage users to contribute to the Radius open-source project in various ways. By joining our community, you can make a meaningful impact and help shape the future of this project. Here are some ways you can get involved:
 
-    Learn how: Browse our guides for how to [install repository prerequisites](./contributing-code/contributing-code-prerequisites/), [build the code](./contributing-code/contributing-code-building/), [understand the code](./contributing-code/contributing-code-organization/), [write code for the project](./contributing-code/contributing-code-writing/), and [run tests](./contributing-code/contributing-code-tests/). This is essential knowledge for working with the repository.
+* Learn how: Browse our guides for how to [install repository prerequisites](./contributing-code/contributing-code-prerequisites/), [build the code](./contributing-code/contributing-code-building/), [understand the code](./contributing-code/contributing-code-organization/), [write code for the project](./contributing-code/contributing-code-writing/), and [run tests](./contributing-code/contributing-code-tests/). This is essential knowledge for working with the repository.
 
-    Tackle small tasks: Start by addressing small issues or tasks labeled as ["good first issues"](https://github.com/project-radius/radius/issues?q=is:issue+is:open+label:%22good+first+issue%22) This allows you to familiarize yourself with the project and make valuable contributions without a steep learning curve.
+* Tackle small tasks: Start by addressing small issues or tasks labeled as ["good first issues"](https://github.com/project-radius/radius/issues?q=is:issue+is:open+label:%22good+first+issue%22) This allows you to familiarize yourself with the project and make valuable contributions without a steep learning curve.
 
-    Fork the project: Create a personal copy (fork) of the Radius repository on GitHub. This enables you to make changes and experiment as well as submit pull requests.
+* Fork the project: Create a personal copy (fork) of the Radius repository on GitHub. This enables you to make changes and experiment as well as submit pull requests.
 
-    Submit pull requests: Once you've made changes or improvements to your forked repository, [submit a pull request](./contributing-pull-requests/) to the main project. Provide clear descriptions of the purpose and benefits of your changes.
+* Submit pull requests: Once you've made changes or improvements to your forked repository, [submit a pull request](./contributing-pull-requests/) to the main project. Provide clear descriptions of the purpose and benefits of your changes.
 
-    Engage with the community: Participate in discussions, forums, and chat channels related to Radius. Seek guidance, offer help to others, and build connections within the community.
+* Engage with the community: Participate in discussions, forums, and chat channels related to Radius. Seek guidance, offer help to others, and build connections within the community.
 
-    Test and report bugs: Assist in testing Radius by [identifying and reporting bugs](./contributing-issues/). Detailed bug reports help us address issues promptly and enhance the software's quality.
+* Test and report bugs: Assist in testing Radius by [identifying and reporting bugs](./contributing-issues/). Detailed bug reports help us address issues promptly and enhance the software's quality.
 
-    Improve documentation: Enhance the project's [documentation](https://github.com/project-radius/docs) by updating existing content, adding guides, or adding examples. Well-documented projects are easier to use and attract more users.
+* Improve documentation: Enhance the project's [documentation](https://github.com/project-radius/docs) by updating existing content, adding guides, or adding examples. Well-documented projects are easier to use and attract more users.
 
-    Spread the word: Share your positive experiences with Radius through blog posts, talks, or social media. Promote the project to attract more users and contributors. Star the project on GitHub!
+* Spread the word: Share your positive experiences with Radius through blog posts, talks, or social media. Promote the project to attract more users and contributors. Star the project on GitHub!
 
 Join us in shaping the future of Radius. Together, we can build a robust and innovative open-source project. Happy contributing!


### PR DESCRIPTION
Because of the indentation this section is being displayed a code block instead of a list. Adding decorators (`*`) turns it into a list.
