### PR TITLE
Add docs on CodeQL

### DIFF
--- a/docs/contributing/contributing-code/contributing-code-writing/README.md
+++ b/docs/contributing/contributing-code/contributing-code-writing/README.md
@@ -53,6 +53,10 @@ Right now we don't have automated enforcement of this rule, so expect it to come
 
 We run [golint-ci](https://github.com/golangci/golangci-lint) as part of the pull-request process for static analysis. We don't have many customizations and mostly rely on the defaults.
 
+### CodeQL security analysis
+
+We run [CodeQL](https://codeql.github.com/) as part of the pull-request process for security analysis. If the CodeQL analysis finds a security issue it will be reported as part of the PR checks. CodeQL is not currently required to pass for a PR to be merged, as it may be triggered by other alerts within the repo.
+
 ## Appendix: style guidance we don't follow
 
 We mostly ignore the Google style guide's [guidance for testing](https://google.github.io/styleguide/go/decisions#assertion-libraries). In particular, we really like [assertion libraries](https://github.com/stretchr/testify) and use them in our tests.

--- a/docs/contributing/contributing-code/contributing-code-writing/README.md
+++ b/docs/contributing/contributing-code/contributing-code-writing/README.md
@@ -57,6 +57,8 @@ We run [golint-ci](https://github.com/golangci/golangci-lint) as part of the pul
 
 We run [CodeQL](https://codeql.github.com/) as part of the pull-request process for security analysis. If the CodeQL analysis finds a security issue it will be reported as part of the PR checks. CodeQL is not currently required to pass for a PR to be merged, as it may be triggered by other alerts within the repo.
 
+If CodeQL fails due to your changes, please work with the maintainers to resolve the issue.
+
 ## Appendix: style guidance we don't follow
 
 We mostly ignore the Google style guide's [guidance for testing](https://google.github.io/styleguide/go/decisions#assertion-libraries). In particular, we really like [assertion libraries](https://github.com/stretchr/testify) and use them in our tests.

--- a/docs/contributing/contributing-pull-requests/README.md
+++ b/docs/contributing/contributing-pull-requests/README.md
@@ -56,6 +56,10 @@ Ideally everything works the first time, but you may not be so lucky! Our automa
 
 If you get stuck with a failure you can't understand, feel free to ask the maintainers for help.
 
+### CodeQL security analysis
+
+We run [CodeQL](https://codeql.github.com/) as part of the pull-request process for security analysis. If the CodeQL analysis finds a security issue it will be reported as part of the PR checks. CodeQL is not currently required to pass for a PR to be merged, as it may be triggered by other alerts within the repo.
+
 ## Copilot Summary
 
 Our pull-request template includes a summary from Github Copilot. This will generate a description of your changes as well as links to the most relevant files. 

--- a/docs/contributing/contributing-pull-requests/README.md
+++ b/docs/contributing/contributing-pull-requests/README.md
@@ -60,6 +60,8 @@ If you get stuck with a failure you can't understand, feel free to ask the maint
 
 We run [CodeQL](https://codeql.github.com/) as part of the pull-request process for security analysis. If the CodeQL analysis finds a security issue it will be reported as part of the PR checks. CodeQL is not currently required to pass for a PR to be merged, as it may be triggered by other alerts within the repo.
 
+If CodeQL fails due to your changes, please work with the maintainers to resolve the issue.
+
 ## Copilot Summary
 
 Our pull-request template includes a summary from Github Copilot. This will generate a description of your changes as well as links to the most relevant files. 


### PR DESCRIPTION
# Description

Now that CodeQL has been enabled on the repo this PR adds documentation to the writing and PR contributing docs on what CodeQL is and how to work with it

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 44ce8f2</samp>

### Summary
:mag::shield::robot:

<!--
1.  :mag: This emoji represents the idea of linting or scanning code for issues, which is what CodeQL does. It also suggests a sense of curiosity or investigation, which is relevant for security analysis.
2.  :shield: This emoji represents the idea of security or protection, which is the main goal of CodeQL. It also suggests a sense of confidence or trust, which is important for contributors and users of the project.
3.  :robot: This emoji represents the idea of automation or integration, which is how CodeQL works as a GitHub action. It also suggests a sense of efficiency or innovation, which is desirable for the project.
-->
This pull request updates the documentation for contributors to include information about CodeQL, a security analysis tool that runs as a GitHub action on the project. The change affects the `Linting` and `Automated tests` sections of the `docs/contributing/contributing-code-writing/README.md` and `docs/contributing/contributing-pull-requests/README.md` files.

> _`CodeQL` checks code_
> _Security analysis_
> _Autumn leaves fall fast_

### Walkthrough
*  Add a subsection about CodeQL security analysis to the documentation ([link](https://github.com/project-radius/radius/pull/5662/files?diff=unified&w=0#diff-19c6617fdff9355dc160bf265e7efdc44ac178e0a5257bd6bd96a22dd56f1883R56-R59), [link](https://github.com/project-radius/radius/pull/5662/files?diff=unified&w=0#diff-fb0f7798935160052ab4612b954c50fb8f31d3825cce346f5feb693c418f2abaR59-R62))


