### PR TITLE
Set Pod resource limit for Radius containers.

### DIFF
--- a/deploy/Chart/charts/de/templates/de.yaml
+++ b/deploy/Chart/charts/de/templates/de.yaml
@@ -25,8 +25,14 @@ spec:
     spec:
       serviceAccountName: de-manager
       containers:
-      - args:
+      - name: de
+        image: {{ .Values.image }}:{{ .Values.tag }}
+        args:
         - --kubernetes=true
+      {{- if .Values.resources }}
+        resources:
+      {{ toYaml .Values.resources | indent 4 }}
+      {{- end }}
         env:
         - name: SKIP_ARM
           value: "false"
@@ -44,8 +50,6 @@ spec:
         - name: ASPNETCORE_Zipkin__Endpoint
           value: {{ .Values.global.zipkin.url }}
         {{ end }}
-        image: {{ .Values.image }}:{{ .Values.tag }}
-        name: de
         ports:
         - containerPort: 6443
           name: bicep-de-api

--- a/deploy/Chart/charts/de/templates/de.yaml
+++ b/deploy/Chart/charts/de/templates/de.yaml
@@ -52,10 +52,9 @@ spec:
           protocol: TCP
         securityContext:
           allowPrivilegeEscalation: false
-{{- if .Values.resources }}
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
-{{- end }}
+        {{- if .Values.resources }}
+        resources:{{ toYaml .Values.resources | nindent 10 }}
+        {{- end }}
       terminationGracePeriodSeconds: 10
 ---
 apiVersion: v1

--- a/deploy/Chart/charts/de/templates/de.yaml
+++ b/deploy/Chart/charts/de/templates/de.yaml
@@ -29,10 +29,6 @@ spec:
         image: {{ .Values.image }}:{{ .Values.tag }}
         args:
         - --kubernetes=true
-      {{- if .Values.resources }}
-        resources:
-      {{ toYaml .Values.resources | indent 4 }}
-      {{- end }}
         env:
         - name: SKIP_ARM
           value: "false"
@@ -56,6 +52,10 @@ spec:
           protocol: TCP
         securityContext:
           allowPrivilegeEscalation: false
+{{- if .Values.resources }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+{{- end }}
       terminationGracePeriodSeconds: 10
 ---
 apiVersion: v1

--- a/deploy/Chart/charts/rp/templates/deployment.yaml
+++ b/deploy/Chart/charts/rp/templates/deployment.yaml
@@ -63,10 +63,9 @@ spec:
           mountPath: /etc/config
         securityContext:
           allowPrivilegeEscalation: false
-{{- if .Values.resources }}
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
-{{- end }}
+        {{- if .Values.resources }}
+        resources:{{ toYaml .Values.resources | nindent 10 }}
+        {{- end }}
       volumes:
         - name: config-volume
           configMap:

--- a/deploy/Chart/charts/rp/templates/deployment.yaml
+++ b/deploy/Chart/charts/rp/templates/deployment.yaml
@@ -25,11 +25,16 @@ spec:
     spec:
       serviceAccountName: appcore-rp
       containers:
-      - args:
+      - name: appcore-rp
+        image: {{ .Values.image }}:{{ .Values.tag }}
+        args:
         - --config-file=/etc/config/radius-self-host.yaml
         - --run-link
         - --link-config=/etc/config/link-self-host.yaml
-        image: {{ .Values.image }}:{{ .Values.tag }}
+      {{- if .Values.resources }}
+        resources:
+      {{ toYaml .Values.resources | indent 4 }}
+      {{- end }}
         env:
         - name: SKIP_ARM
           value: 'false'
@@ -43,7 +48,6 @@ spec:
         - name: RADIUS_PUBLIC_ENDPOINT_OVERRIDE
           value: {{ .Values.publicEndpointOverride }}
         {{ end }}
-        name: appcore-rp
         ports:
         - containerPort: 5443
           name: appcore-rp

--- a/deploy/Chart/charts/rp/templates/deployment.yaml
+++ b/deploy/Chart/charts/rp/templates/deployment.yaml
@@ -31,10 +31,6 @@ spec:
         - --config-file=/etc/config/radius-self-host.yaml
         - --run-link
         - --link-config=/etc/config/link-self-host.yaml
-      {{- if .Values.resources }}
-        resources:
-      {{ toYaml .Values.resources | indent 4 }}
-      {{- end }}
         env:
         - name: SKIP_ARM
           value: 'false'
@@ -67,6 +63,10 @@ spec:
           mountPath: /etc/config
         securityContext:
           allowPrivilegeEscalation: false
+{{- if .Values.resources }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+{{- end }}
       volumes:
         - name: config-volume
           configMap:

--- a/deploy/Chart/charts/ucp/templates/ucp.yaml
+++ b/deploy/Chart/charts/ucp/templates/ucp.yaml
@@ -25,7 +25,8 @@ spec:
     spec:
       serviceAccountName: ucp
       containers:
-      - image: "{{ .Values.image }}:{{ .Values.tag }}"
+      - name: ucp
+        image: "{{ .Values.image }}:{{ .Values.tag }}"
         env:
         - name: UCP_CONFIG
           value: /etc/config/ucp-config.yaml
@@ -35,7 +36,6 @@ spec:
           value: '/var/tls/cert'
         - name: PORT
           value: '9443'
-        name: ucp
         ports:
         - containerPort: 9443
           name: ucp
@@ -45,20 +45,18 @@ spec:
           name: metrics
           protocol: TCP
         {{ end }}
-      {{- if .Values.resources }}
-        resources:
-      {{ toYaml .Values.resources | indent 4 }}
-      {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
+{{- if .Values.resources }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+{{- end }}
         volumeMounts:
         - name: config-volume
           mountPath: /etc/config
         - name: cert
           mountPath: '/var/tls/cert'
           readOnly: true
-        securityContext:
-          allowPrivilegeEscalation: false
       volumes:
         - name: config-volume
           configMap:

--- a/deploy/Chart/charts/ucp/templates/ucp.yaml
+++ b/deploy/Chart/charts/ucp/templates/ucp.yaml
@@ -45,6 +45,10 @@ spec:
           name: metrics
           protocol: TCP
         {{ end }}
+      {{- if .Values.resources }}
+        resources:
+      {{ toYaml .Values.resources | indent 4 }}
+      {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:

--- a/deploy/Chart/charts/ucp/templates/ucp.yaml
+++ b/deploy/Chart/charts/ucp/templates/ucp.yaml
@@ -47,10 +47,9 @@ spec:
         {{ end }}
         securityContext:
           allowPrivilegeEscalation: false
-{{- if .Values.resources }}
-        resources:
-{{ toYaml .Values.resources | indent 10 }}
-{{- end }}
+        {{- if .Values.resources }}
+        resources:{{ toYaml .Values.resources | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: config-volume
           mountPath: /etc/config

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -1,13 +1,29 @@
 de:
   image: radius.azurecr.io/deployment-engine
   tag: latest
+  resources:
+    requests:
+      # request memory is the average memory usage + 10% buffer.
+      memory: "130Mi"
+    limits:
+      memory: "300Mi"
 ucp:
   image: radius.azurecr.io/ucpd
-  tag: latest 
+  tag: latest
+  resources:
+    requests:
+      memory: "60Mi"
+    limits:
+      memory: "300Mi"
 rp:
   image: radius.azurecr.io/appcore-rp
   tag: latest
   publicEndpointOverride: ""
+  resources:
+    requests:
+      memory: "160Mi"
+    limits:
+      memory: "300Mi"
 global:
   prometheus:
     enabled: true

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -1,40 +1,29 @@
 de:
   image: radius.azurecr.io/deployment-engine
   tag: latest
-  resources: {
-    "requests": {
-      # request memory is the average memory usage + 10% margin.
-      "memory": "130Mi"
-    },
-    "limits": {
-      "memory": "300Mi"
-    }
-  }
+  resources:
+    requests:
+      # request memory is the average memory usage + 10% buffer.
+      memory: "130Mi"
+    limits:
+      memory: "300Mi"
 ucp:
   image: radius.azurecr.io/ucpd
   tag: latest
-  resources: {
-    "requests": {
-      # request memory is the average memory usage + 10% margin.
-      "memory": "60Mi"
-    },
-    "limits": {
-      "memory": "300Mi"
-    }
-  }
+  resources:
+    requests:
+      memory: "60Mi"
+    limits:
+      memory: "300Mi"
 rp:
   image: radius.azurecr.io/appcore-rp
   tag: latest
   publicEndpointOverride: ""
-  resources: {
-    "requests": {
-      # request memory is the average memory usage + 10% margin.
-      "memory": "160Mi"
-    },
-    "limits": {
-      "memory": "300Mi"
-    }
-  }
+  resources:
+    requests:
+      memory: "160Mi"
+    limits:
+      memory: "300Mi"
 global:
   prometheus:
     enabled: true

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -1,29 +1,40 @@
 de:
   image: radius.azurecr.io/deployment-engine
   tag: latest
-  resources:
-    requests:
-      # request memory is the average memory usage + 10% buffer.
-      memory: "130Mi"
-    limits:
-      memory: "300Mi"
+  resources: {
+    "requests": {
+      # request memory is the average memory usage + 10% margin.
+      "memory": "130Mi"
+    },
+    "limits": {
+      "memory": "300Mi"
+    }
+  }
 ucp:
   image: radius.azurecr.io/ucpd
   tag: latest
-  resources:
-    requests:
-      memory: "60Mi"
-    limits:
-      memory: "300Mi"
+  resources: {
+    "requests": {
+      # request memory is the average memory usage + 10% margin.
+      "memory": "60Mi"
+    },
+    "limits": {
+      "memory": "300Mi"
+    }
+  }
 rp:
   image: radius.azurecr.io/appcore-rp
   tag: latest
   publicEndpointOverride: ""
-  resources:
-    requests:
-      memory: "160Mi"
-    limits:
-      memory: "300Mi"
+  resources: {
+    "requests": {
+      # request memory is the average memory usage + 10% margin.
+      "memory": "160Mi"
+    },
+    "limits": {
+      "memory": "300Mi"
+    }
+  }
 global:
   prometheus:
     enabled: true


### PR DESCRIPTION
# Description

This is to set the resource limit of each radius container resource.

Set the request memory limit by average memory usage + 10% buffer. 

![image](https://github.com/project-radius/radius/assets/11863108/5d771927-ed5a-413e-80c7-96c2b1fb8088)


## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #3079 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 069b167</samp>

### Summary
🛠️📝🚀

<!--
1.  🛠️ - This emoji represents the addition of conditional blocks and resource configuration fields, which are tools for customizing the container specifications and resource allocation.
2.  📝 - This emoji represents the changes to the values file, which is a document that provides the input for the container configuration and resource allocation.
3.  🚀 - This emoji represents the improvement of the container configuration and customization options, which enable faster and more efficient deployment of the components.
-->
The pull request adds resource configuration options for the deployment engine, appcore-rp, and ucp components in the `deploy/Chart` Helm chart. This allows the user to customize the memory requests and limits for each container in the chart. The changes affect the templates and values files in the chart subdirectories.

> _We are the masters of the helm charts_
> _We set the limits and requests for our parts_
> _We customize our containers with name and image_
> _We deploy our components with power and courage_

### Walkthrough
*  Add `resources` field to values file for each component with default memory requests and limits ([link](https://github.com/project-radius/radius/pull/5663/files?diff=unified&w=0#diff-344923809e38a5b4c75b67a576228cf7573194fac37e773cd54334f2be49d297L4-R26))
*  Use `resources` field from values file to conditionally set resource requests and limits for containers in deployment templates ([link](https://github.com/project-radius/radius/pull/5663/files?diff=unified&w=0#diff-93ad33e9b90c83778035b737609786229239c3dcbd5fe8de395bd6bd182ddfffL28-R35), [link](https://github.com/project-radius/radius/pull/5663/files?diff=unified&w=0#diff-b0478d7037e525dd1dd577a38bd8d316205126b2c77a28f976ea97e0a86be830L28-R37), [link](https://github.com/project-radius/radius/pull/5663/files?diff=unified&w=0#diff-0971975305eb30d15d0f2fa810c7b8483cd28195275b1514294e4b3cd88b2d04R48-R51))
*  Assign names and images to containers in `de` and `appcore-rp` deployment templates ([link](https://github.com/project-radius/radius/pull/5663/files?diff=unified&w=0#diff-93ad33e9b90c83778035b737609786229239c3dcbd5fe8de395bd6bd182ddfffL28-R35), [link](https://github.com/project-radius/radius/pull/5663/files?diff=unified&w=0#diff-b0478d7037e525dd1dd577a38bd8d316205126b2c77a28f976ea97e0a86be830L28-R37))
*  Remove redundant `name` and `image` fields from containers in `de` and `appcore-rp` deployment templates ([link](https://github.com/project-radius/radius/pull/5663/files?diff=unified&w=0#diff-93ad33e9b90c83778035b737609786229239c3dcbd5fe8de395bd6bd182ddfffL47-L48), [link](https://github.com/project-radius/radius/pull/5663/files?diff=unified&w=0#diff-b0478d7037e525dd1dd577a38bd8d316205126b2c77a28f976ea97e0a86be830L46))


