### PR TITLE
Assign Radius-Eng team to the functional test failure bug

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -515,5 +515,6 @@ jobs:
               ...context.repo,
               title: `Scheduled functional test failed - Run ID: ${context.runId}`,
               labels: ['bug'],
+              assignees: ['Radius-Eng'],
               body: `## Bug information \n\nThis bug is generated automatically if the scheduled functional test fails. The Radius functional test operates on a schedule of every 4 hours during weekdays and every 12 hours over the weekend. It's important to understand that the test may fail due to workflow infrastructure issues, like network problems, rather than the flakiness of the test itself. For the further investigation, please visit [here](${process.env.ACTION_LINK}).`
             })


### PR DESCRIPTION
# Description

This is to enable email notification when issue is created. 

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9802ede</samp>

### Summary
:white_check_mark::eyes::wrench:

<!--
1.  :white_check_mark: This emoji represents the passing of the functional tests and the creation of the pull request. It conveys a sense of success, completion, and validation.
2.  :eyes: This emoji represents the request for review from the Radius-Eng team. It conveys a sense of attention, curiosity, and feedback.
3.  :wrench: This emoji represents the maintenance and improvement of the radius project. It conveys a sense of work, tool, and skill.
-->
Assign Radius-Eng team as reviewers of functional-test pull requests. This ensures that the team is aware of and can review the code changes that pass the functional tests.

> _`Radius-Eng` team_
> _reviews pull requests from tests_
> _autumn leaves falling_

### Walkthrough
* Assign Radius-Eng team as reviewers of pull request ([link](https://github.com/project-radius/radius/pull/5676/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcR518))


