### PR TITLE
Add AWS access keys create instruction message

### DIFF
--- a/pkg/cli/cmd/radinit/aws.go
+++ b/pkg/cli/cmd/radinit/aws.go
@@ -36,7 +36,7 @@ const (
 	enterAWSIAMSecretAccessKeyPlaceholder = "Enter IAM access key..."
 	errNotEmptyTemplate                   = "%s cannot be empty"
 
-	awsAccessIDAndKeyCreateInstructionFmt = "\nIAM Access keys (an access key ID and a secret access key) are required to access and create AWS resources.\n\nFor example, you can create one using the following command:\n\033[36maws iam create-access-key\033[0m\n\nFor more information refer to https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html.\n\n"
+	awsAccessKeysCreateInstructionFmt = "\nAWS IAM Access keys (Access key ID and Secret access key) are required to access and create AWS resources.\n\nFor example, you can create one using the following command:\n\033[36maws iam create-access-key\033[0m\n\nFor more information refer to https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html.\n\n"
 )
 
 func (r *Runner) enterAWSCloudProvider(ctx context.Context, options *initOptions) (*aws.Provider, error) {
@@ -47,7 +47,7 @@ func (r *Runner) enterAWSCloudProvider(ctx context.Context, options *initOptions
 		return nil, err
 	}
 
-	r.Output.LogInfo(awsAccessIDAndKeyCreateInstructionFmt)
+	r.Output.LogInfo(awsAccessKeysCreateInstructionFmt)
 
 	accessKeyID, err := r.Prompter.GetTextInput(enterAWSIAMAcessKeyIDPrompt, prompt.TextInputOptions{Placeholder: enterAWSIAMAcessKeyIDPlaceholder})
 	if errors.Is(err, &prompt.ErrExitConsole{}) {

--- a/pkg/cli/cmd/radinit/aws.go
+++ b/pkg/cli/cmd/radinit/aws.go
@@ -35,6 +35,8 @@ const (
 	enterAWSIAMSecretAccessKeyPrompt      = "Enter your IAM Secret Access Keys:"
 	enterAWSIAMSecretAccessKeyPlaceholder = "Enter IAM access key..."
 	errNotEmptyTemplate                   = "%s cannot be empty"
+
+	awsAccessIDAndKeyCreateInstructionFmt = "\nIAM Access keys (an access key ID and a secret access key) are required to access and create AWS resources.\n\nFor example, you can create one using the following command:\n\033[36maws iam create-access-key\033[0m\n\nFor more information refer to https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html.\n\n"
 )
 
 func (r *Runner) enterAWSCloudProvider(ctx context.Context, options *initOptions) (*aws.Provider, error) {
@@ -44,6 +46,8 @@ func (r *Runner) enterAWSCloudProvider(ctx context.Context, options *initOptions
 	} else if err != nil {
 		return nil, err
 	}
+
+	r.Output.LogInfo(awsAccessIDAndKeyCreateInstructionFmt)
 
 	accessKeyID, err := r.Prompter.GetTextInput(enterAWSIAMAcessKeyIDPrompt, prompt.TextInputOptions{Placeholder: enterAWSIAMAcessKeyIDPlaceholder})
 	if errors.Is(err, &prompt.ErrExitConsole{}) {

--- a/pkg/cli/cmd/radinit/aws_test.go
+++ b/pkg/cli/cmd/radinit/aws_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/golang/mock/gomock"
 	"github.com/project-radius/radius/pkg/cli/aws"
+	"github.com/project-radius/radius/pkg/cli/output"
 	"github.com/project-radius/radius/pkg/cli/prompt"
 	"github.com/project-radius/radius/pkg/to"
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,8 @@ func Test_enterAWSCloudProvider(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	prompter := prompt.NewMockInterface(ctrl)
 	client := aws.NewMockClient(ctrl)
-	runner := Runner{Prompter: prompter, awsClient: client}
+	outputSink := output.MockOutput{}
+	runner := Runner{Prompter: prompter, awsClient: client, Output: &outputSink}
 
 	setAWSRegionPrompt(prompter, "region")
 	setAWSAccessKeyIDPrompt(prompter, "access-key-id")
@@ -50,4 +52,5 @@ func Test_enterAWSCloudProvider(t *testing.T) {
 		AccountID:       "account-id",
 	}
 	require.Equal(t, expected, provider)
+	require.Equal(t, []any{output.LogOutput{Format: awsAccessKeysCreateInstructionFmt}}, outputSink.Writes)
 }

--- a/pkg/cli/cmd/radinit/cloud_test.go
+++ b/pkg/cli/cmd/radinit/cloud_test.go
@@ -121,7 +121,13 @@ func Test_enterCloudProviderOptions(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, options.CloudProviders.Azure)
 		require.Equal(t, awsProvider, *options.CloudProviders.AWS)
-		require.Empty(t, outputSink.Writes)
+
+		expectedWrites := []any{
+			output.LogOutput{
+				Format: awsAccessKeysCreateInstructionFmt,
+			},
+		}
+		require.Equal(t, expectedWrites, outputSink.Writes)
 	})
 
 	t.Run("azure provider", func(t *testing.T) {
@@ -178,6 +184,9 @@ func Test_enterCloudProviderOptions(t *testing.T) {
 
 		expectedWrites := []any{
 			output.LogOutput{
+				Format: awsAccessKeysCreateInstructionFmt,
+			},
+			output.LogOutput{
 				Format: azureServicePrincipalCreateInstructionsFmt,
 				Params: []any{azureProvider.SubscriptionID, azureProvider.ResourceGroup},
 			},
@@ -212,6 +221,15 @@ func Test_enterCloudProviderOptions(t *testing.T) {
 		require.Nil(t, options.CloudProviders.Azure)
 		require.Equal(t, awsProvider, *options.CloudProviders.AWS)
 		require.Equal(t, "another-region", options.CloudProviders.AWS.Region)
-		require.Empty(t, outputSink.Writes)
+
+		expectedWrites := []any{
+			output.LogOutput{
+				Format: awsAccessKeysCreateInstructionFmt,
+			},
+			output.LogOutput{
+				Format: awsAccessKeysCreateInstructionFmt,
+			},
+		}
+		require.Equal(t, expectedWrites, outputSink.Writes)
 	})
 }


### PR DESCRIPTION
# Description

Add access keys creation instruction message for AWS during rad init.

Screenshot:

<img width="960" alt="image" src="https://github.com/project-radius/radius/assets/11863108/cef5f3c1-9755-4959-8d4d-8e873abcac42">

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: https://github.com/project-radius/radius/issues/5439

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ced35a8</samp>

### Summary
✨📝☁️

<!--
1.  ✨ Sparkles: This emoji is often used to indicate new features or enhancements to existing functionality. In this case, adding instructions for creating AWS access keys is a helpful addition to the `radinit` command that improves the user experience and guides them through the setup process.
2.  📝 Memo: This emoji is commonly used to signify documentation updates or additions. In this case, the instructions for creating AWS access keys are a form of documentation that explains how to use the `radinit` command with AWS as a cloud provider.
3.  ☁️ Cloud: This emoji is sometimes used to represent cloud computing or cloud services. In this case, the instructions for creating AWS access keys are related to AWS, which is a popular cloud provider that the `radinit` command supports.
-->
Improved user experience for `radinit` command by adding AWS access key instructions. Updated `pkg/cli/cmd/radinit/aws.go` file with the new instructions.

> _`radinit` is the key to the cloud_
> _Choose your provider and scream it loud_
> _AWS will ask you for your secrets_
> _Don't let them fall into the wrong hands_

### Walkthrough
*  Add instructions for creating AWS access keys to radinit package ([link](https://github.com/project-radius/radius/pull/5687/files?diff=unified&w=0#diff-d6b087c827d9069ad74b4cb04ab94eafb6e3b2759ddfd2e8ffa9a8557bf7cf74R38-R39))
*  Display instructions before prompting user to enter AWS credentials and region in enterAWSCloudProvider function ([link](https://github.com/project-radius/radius/pull/5687/files?diff=unified&w=0#diff-d6b087c827d9069ad74b4cb04ab94eafb6e3b2759ddfd2e8ffa9a8557bf7cf74R50-R51))
*  Use ANSI escape codes to color example command in cyan for better visibility ([link](https://github.com/project-radius/radius/pull/5687/files?diff=unified&w=0#diff-d6b087c827d9069ad74b4cb04ab94eafb6e3b2759ddfd2e8ffa9a8557bf7cf74R38-R39))


