### PR TITLE
enhance logging for delete resources

### DIFF
--- a/pkg/armrpc/frontend/defaultoperation/defaultasyncdelete.go
+++ b/pkg/armrpc/frontend/defaultoperation/defaultasyncdelete.go
@@ -23,6 +23,7 @@ import (
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	ctrl "github.com/project-radius/radius/pkg/armrpc/frontend/controller"
 	"github.com/project-radius/radius/pkg/armrpc/rest"
+	"github.com/project-radius/radius/pkg/ucp/ucplog"
 )
 
 // DefaultAsyncDelete is the controller implementation to delete async resource.
@@ -43,6 +44,7 @@ func NewDefaultAsyncDelete[P interface {
 
 // Run executes DefaultAsyncDelete operation
 func (e *DefaultAsyncDelete[P, T]) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (rest.Response, error) {
+	log := ucplog.FromContextOrDiscard(ctx)
 	serviceCtx := v1.ARMRequestContextFromContext(ctx)
 	old, etag, err := e.GetResource(ctx, serviceCtx.ResourceID)
 	if err != nil {
@@ -50,6 +52,7 @@ func (e *DefaultAsyncDelete[P, T]) Run(ctx context.Context, w http.ResponseWrite
 	}
 
 	if old == nil {
+		log.Info("Resource not found")
 		return rest.NewNoContentResponse(), nil
 	}
 


### PR DESCRIPTION
# Description

Add log message to scenario where we are trying to delete a resource that has already been deleted
Now in rp logs we can see 
```
2023-06-09T14:32:04.375-0700	INFO	applications.core.Applications.Core	defaultoperation/defaultasyncdelete.go:55	Resource not found	{"serviceName": "applications.core", "version": "edge", "hostName": "Nithyas-MacBook-Pro.local", "resourceId": "/planes/radius/local/resourcegroups/localrp/providers/applications.core/containers/foo", "traceId": "c602e98d85c67fa295613dcfc60ae167", "spanId": "90162385ac28dba9"}
```

corresponding to the below message on cli side

```
Resource 'foo' of type 'Applications.Core/containers' does not exist or has already been deleted
```

## Issue reference


Fixes: #5271

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 91593d1</samp>

### Summary
📝🔄🗑️

<!--
1.  📝 - This emoji can be used to represent adding logging or documentation to the code, as it depicts a memo or a note.
2.  🔄 - This emoji can be used to represent retrying or looping logic, as it depicts a circular arrow or a refresh icon.
3.  🗑️ - This emoji can be used to represent deleting or removing something, as it depicts a trash can or a bin.
-->
Added unified logging to defaultoperation package. Used `ucplog` to log messages with context and correlation ID in `defaultasyncdelete.go` and `defaultsyncdelete.go`.

> _Oh we are the coders of the `defaultoperation`_
> _We log our messages with `ucplog` and correlation_
> _We heave and we ho and we delete what we can_
> _And if we can't find it we retry it again_

### Walkthrough
* Import and initialize `ucplog` package for unified logging in `defaultoperation` package ([link](https://github.com/project-radius/radius/pull/5695/files?diff=unified&w=0#diff-178e7c58d9d20488e7dc4ae05181dd096a03bbcec5b853d4d8d50a0454a71d78R26),[link](https://github.com/project-radius/radius/pull/5695/files?diff=unified&w=0#diff-fd40527ca5ce33c461dee5e81ed30eddeca3473aec2866a71ca1986a605d2512R28),[link](https://github.com/project-radius/radius/pull/5695/files?diff=unified&w=0#diff-178e7c58d9d20488e7dc4ae05181dd096a03bbcec5b853d4d8d50a0454a71d78R47),[link](https://github.com/project-radius/radius/pull/5695/files?diff=unified&w=0#diff-fd40527ca5ce33c461dee5e81ed30eddeca3473aec2866a71ca1986a605d2512R49))
* Add `log.Info` statements to `Run` methods of `DefaultAsyncDelete` and `DefaultSyncDelete` structs to log messages when resource to be deleted is not found or not found after retrying in `defaultasyncdelete.go` and `defaultsyncdelete.go` files ([link](https://github.com/project-radius/radius/pull/5695/files?diff=unified&w=0#diff-178e7c58d9d20488e7dc4ae05181dd096a03bbcec5b853d4d8d50a0454a71d78R55),[link](https://github.com/project-radius/radius/pull/5695/files?diff=unified&w=0#diff-fd40527ca5ce33c461dee5e81ed30eddeca3473aec2866a71ca1986a605d2512R58),[link](https://github.com/project-radius/radius/pull/5695/files?diff=unified&w=0#diff-fd40527ca5ce33c461dee5e81ed30eddeca3473aec2866a71ca1986a605d2512R74))


