### PR TITLE
Fix test failure issue creation

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -522,6 +522,5 @@ jobs:
               ...context.repo,
               title: `Scheduled functional test failed - Run ID: ${context.runId}`,
               labels: ['bug'],
-              assignees: ['Radius-Eng'],
               body: `## Bug information \n\nThis bug is generated automatically if the scheduled functional test fails. The Radius functional test operates on a schedule of every 4 hours during weekdays and every 12 hours over the weekend. It's important to understand that the test may fail due to workflow infrastructure issues, like network problems, rather than the flakiness of the test itself. For the further investigation, please visit [here](${process.env.ACTION_LINK}).`
             })


### PR DESCRIPTION
# Description

GitHub Team cannot be `assignees`. So issue creation is failing now.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1f35b10</samp>

### Summary
🚫🧹🤷

<!--
1.  🚫 - This emoji conveys the idea of removing or deleting something, which is what happened to the `assignees` field. It can also imply a negative or unwanted outcome, which might be the case if the issue is not assigned to anyone who can fix it.
2.  🧹 - This emoji suggests the idea of cleaning or simplifying something, which is the intention behind omitting the `assignees` field. It can also imply a positive or desirable outcome, which might be the case if the workflow configuration is easier to read and maintain.
3.  🤷 - This emoji expresses the idea of uncertainty or indifference, which might be the attitude of the workflow creator or the issue creator towards the `assignees` field. It can also imply a lack of responsibility or accountability, which might be the case if the issue is not assigned to anyone who can fix it.
-->
Removed `assignees` field from `create-issue` step in `.github/workflows/functional-test.yaml`. This simplifies the workflow and avoids assigning issues to a specific team.

> _`assignees` gone_
> _workflow config simplified_
> _autumn leaves fall fast_

### Walkthrough
* Remove `assignees` field from `create-issue` step in `functional-test` workflow ([link](https://github.com/project-radius/radius/pull/5710/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL525)). This simplifies the workflow configuration and avoids assigning issues to a specific team. The workflow runs functional tests on every pull request to the `main` branch of the `.github/workflows/functional-test.yaml` file and creates an issue if any test fails.


