### PR TITLE
Fix functional test by dispatch trigger

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -88,15 +88,19 @@ jobs:
             echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
       - name: Set up checkout target (repository_dispatch)
         if: github.event_name == 'repository_dispatch'
-        uses: actions/github-script@v6.2.0
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
           script: |
             const testPayload = context.payload.client_payload;
             if (testPayload && testPayload.command === `ok-to-test`) {
-              echo "CHECKOUT_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
-              echo "CHECKOUT_REF=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
-              echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+              var fs = require('fs');
+              // Set environment variables
+              fs.appendFileSync(process.env.GITHUB_ENV,
+                `CHECKOUT_REPO=${testPayload.pull_head_repo}\n`+
+                `CHECKOUT_REF=${testPayload.pull_head_ref}\n`+
+                `PR_NUMBER=${testPayload.issue.number}`
+              );
             }
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description

We need to use javascript syntax for github-actions, not bash commands.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 254cf6f</samp>

### Summary
🛠️🧪🔄

<!--
1.  🛠️ - This emoji represents fixing or repairing something, which is what the step did by using the latest action and the `fs` module to avoid errors and bugs.
2.  🧪 - This emoji represents testing or experimenting, which is what the functional-test workflow does by running tests on different platforms and browsers.
3.  🔄 - This emoji represents updating or refreshing something, which is what the step did by using the latest version of the action and the `fs` module to ensure compatibility and performance.
-->
Improved the functional-test workflow for pull requests by using a newer action and a built-in module. This change affects the `.github/workflows/functional-test.yaml` file.

> _We are the functional-test warriors_
> _We use the latest `github-script` to fight_
> _We set up the checkout target with `fs`_
> _We test the pull requests in the night_

### Walkthrough
*  Simplify the `uses` field of the `Set up checkout target (repository_dispatch)` step to use the major version tag of the `actions/github-script` action ([link](https://github.com/project-radius/radius/pull/5712/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL91-R91))
*  Fix the environment variable setting for Windows runners by using the `fs` module instead of the `echo` command in the `Set up checkout target (repository_dispatch)` step ([link](https://github.com/project-radius/radius/pull/5712/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL97-R103))
*  Use the `testPayload` object to get the pull request information for the `repository_dispatch` event in the `Set up checkout target (repository_dispatch)` step ([link](https://github.com/project-radius/radius/pull/5712/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL97-R103))


