### PR TITLE
Revert /lgtm command

### DIFF
--- a/.github/scripts/radius-bot.js
+++ b/.github/scripts/radius-bot.js
@@ -16,7 +16,11 @@ limitations under the License.
 
 module.exports = async ({ github, context }) => {
     if (context.eventName === 'issue_comment' && context.payload.action === 'created') {
-        await handleIssueCommentCreate({ github, context });
+        try {
+            await handleIssueCommentCreate({ github, context });
+        } catch (error) {
+            console.log(`[handleIssueCommentCreate] unexpected error: ${error}`);
+        }
     }
 }
 
@@ -40,54 +44,9 @@ async function handleIssueCommentCreate({ github, context }) {
         case '/ok-to-test':
             await cmdOkToTest(github, issue, isFromPulls, username);
             break;
-        case '/lgtm':
-            await cmdApprovePR(github, issue, isFromPulls, username);
-            break;
         default:
             console.log(`[handleIssueCommentCreate] command ${command} not found, exiting.`);
             break;
-    }
-}
-
-
-/**
- * Approve the pull request.
- * @param {*} github GitHub object reference
- * @param {*} issue GitHub issue object
- * @param {boolean} isFromPulls is the workflow triggered by a pull request?
- * @param {string} userName is the user who trigger the command
- */
-async function cmdApprovePR(github, issue, isFromPulls, userName) {
-    if (!isFromPulls) {
-        console.log('[cmdOkToTest] only pull requests supported, skipping command execution.');
-        return;
-    }
-
-    // Check if the user has permission to trigger e2e test with an issue comment
-    const org = 'project-radius';
-    console.log(`Checking team membership for: ${userName}`);
-    const isMember = await checkTeamMembership(github, org, process.env.TEAM_SLUG, userName);
-    if (!isMember) {
-        console.log(`${userName} is not a member of the ${teamSlug} team.`);
-        return;
-    }
-
-    // Get pull request
-    const pull = await github.rest.pulls.get({
-        owner: issue.owner,
-        repo: issue.repo,
-        pull_number: issue.number,
-    });
-
-    if (pull && pull.data) {
-        await github.rest.pulls.createReview({
-            owner: issue.owner,
-            repo: issue.repo,
-            pull_number: issue.number,
-            event: 'APPROVE',
-        })
-
-        console.log('Approve PR');
     }
 }
 

--- a/.github/scripts/radius-bot.js
+++ b/.github/scripts/radius-bot.js
@@ -30,7 +30,7 @@ async function handleIssueCommentCreate({ github, context }) {
     const issue = context.issue;
     const isFromPulls = !!payload.issue.pull_request;
     const commentBody = payload.comment.body;
-    const username = context.actor.toLowerCase();
+    const username = context.actor;
 
     if (!commentBody) {
         console.log('[handleIssueCommentCreate] comment body not found, exiting.');
@@ -55,9 +55,9 @@ async function handleIssueCommentCreate({ github, context }) {
  * @param {*} github GitHub object reference
  * @param {*} issue GitHub issue object
  * @param {boolean} isFromPulls is the workflow triggered by a pull request?
- * @param {string} userName is the user who trigger the command
+ * @param {string} username is the user who trigger the command
  */
-async function cmdOkToTest(github, issue, isFromPulls, userName) {
+async function cmdOkToTest(github, issue, isFromPulls, username) {
     if (!isFromPulls) {
         console.log('[cmdOkToTest] only pull requests supported, skipping command execution.');
         return;
@@ -65,10 +65,10 @@ async function cmdOkToTest(github, issue, isFromPulls, userName) {
 
     // Check if the user has permission to trigger e2e test with an issue comment
     const org = 'project-radius';
-    console.log(`Checking team membership for: ${userName}`);
-    const isMember = await checkTeamMembership(github, org, process.env.TEAM_SLUG, userName);
+    console.log(`Checking team membership for: ${username}`);
+    const isMember = await checkTeamMembership(github, org, process.env.TEAM_SLUG, username);
     if (!isMember) {
-        console.log(`${userName} is not a member of the ${teamSlug} team.`);
+        console.log(`${username} is not a member of the ${teamSlug} team.`);
         return;
     }
 
@@ -102,12 +102,12 @@ async function cmdOkToTest(github, issue, isFromPulls, userName) {
     }
 }
 
-async function checkTeamMembership(github, org, teamSlug, userName) {
+async function checkTeamMembership(github, org, teamSlug, username) {
     try {
         const response = await github.rest.teams.getMembershipForUserInOrg({
             org: org,
             team_slug: teamSlug,
-            username: userName,
+            username: username,
         });
         return response.data.state === 'active';
     } catch (error) {


### PR DESCRIPTION
# Description

/lgtm will not work since it always uses bot username as a approval.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9abec5f</samp>

### Summary
🗑️🛠️🚫

<!--
1.  🗑️ - This emoji represents the removal or deletion of something, which in this case is the `/lgtm` command and function. It conveys the idea of simplifying or cleaning up the script by getting rid of unused or unnecessary code.
2.  🛠️ - This emoji represents the fixing or improvement of something, which in this case is the error handling for the issue comment handler. It conveys the idea of enhancing the robustness or reliability of the script by handling possible errors or exceptions that might occur when processing comments.
3.  🚫 - This emoji represents the prohibition or prevention of something, which in this case is the conflict with the GitHub code review feature. It conveys the idea of avoiding or resolving a potential problem or issue that might arise from having two different ways of approving pull requests (the `/lgtm` command and the GitHub code review feature).
-->
This pull request simplifies the `radius-bot.js` script by removing the `/lgtm` command and adding error handling. This avoids conflicts with the GitHub code review feature and makes the script more robust.

> _Sing, O Muse, of the valiant coder who dared_
> _To alter the script of the radiant radius-bot,_
> _Removing the `/lgtm` command, which once declared_
> _The approval of changes with a swift and simple dot._

### Walkthrough
*  Catch and log errors in issue comment handling (`[link](https://github.com/project-radius/radius/pull/5718/files?diff=unified&w=0#diff-b94c0e124b5b65fb6fa8785928c5331547c124a96ecc225f93df9445a29a5109L19-R23)`)


