### PR TITLE
Ensure cache is synced before processing

### DIFF
--- a/pkg/corerp/handlers/kubernetes.go
+++ b/pkg/corerp/handlers/kubernetes.go
@@ -42,9 +42,9 @@ import (
 )
 
 const (
-	// DefaultDeploymentTimeout is the timeout for waiting for a deployment to be ready.
-	// Deployment duration should not reach to this timeout since async operation worker will time out context before this time.
-	DefaultDeploymentTimeout = time.Minute * time.Duration(10)
+	// MaxDeploymentTimeout is the max timeout for waiting for a deployment to be ready.
+	// Deployment duration should not reach to this timeout since async operation worker will time out context before MaxDeploymentTimeout.
+	MaxDeploymentTimeout = time.Minute * time.Duration(10)
 	// DefaultCacheResyncInterval is the interval for resyncing informer.
 	DefaultCacheResyncInterval = time.Second * time.Duration(30)
 )
@@ -54,7 +54,7 @@ func NewKubernetesHandler(client client.Client, clientSet k8s.Interface) Resourc
 	return &kubernetesHandler{
 		client:              client,
 		clientSet:           clientSet,
-		deploymentTimeOut:   DefaultDeploymentTimeout,
+		deploymentTimeOut:   MaxDeploymentTimeout,
 		cacheResyncInterval: DefaultCacheResyncInterval,
 	}
 }

--- a/pkg/corerp/handlers/kubernetes.go
+++ b/pkg/corerp/handlers/kubernetes.go
@@ -43,9 +43,10 @@ import (
 
 const (
 	// DefaultDeploymentTimeout is the timeout for waiting for a deployment to be ready.
-	DefaultDeploymentTimeout = time.Minute * time.Duration(5)
+	// Deployment duration should not reach to this timeout since async operation worker will time out context before this time.
+	DefaultDeploymentTimeout = time.Minute * time.Duration(10)
 	// DefaultCacheResyncInterval is the interval for resyncing informer.
-	DefaultCacheResyncInterval = time.Minute * time.Duration(2)
+	DefaultCacheResyncInterval = time.Second * time.Duration(30)
 )
 
 // NewKubernetesHandler creates Kubernetes Resource handler instance.

--- a/pkg/corerp/handlers/kubernetes.go
+++ b/pkg/corerp/handlers/kubernetes.go
@@ -165,7 +165,6 @@ func (handler *kubernetesHandler) waitUntilDeploymentIsReady(ctx context.Context
 }
 
 func (handler *kubernetesHandler) startDeploymentInformer(ctx context.Context, item client.Object, doneCh chan<- bool, errCh chan<- error) error {
-	logger := ucplog.FromContextOrDiscard(ctx)
 	informers := informers.NewSharedInformerFactoryWithOptions(handler.clientSet, handler.cacheResyncInterval, informers.WithNamespace(item.GetNamespace()))
 	deploymentInformer := informers.Apps().V1().Deployments().Informer()
 	handlers := cache.ResourceEventHandlerFuncs{


### PR DESCRIPTION
# Description

I can see multiple functional test failures by container deployment timeouts after removing waitforsync call. Using WaitForCacheSync is the best practice to ensure queue is synced. I reverted it back.

* Ensure cache is synced before processing.
* Adjust Informer Cache Resync to be shorter.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: https://github.com/project-radius/radius/issues/5722

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d37e2b2</samp>

### Summary
🚀🛠️📈

<!--
1.  🚀 - This emoji represents the performance improvement aspect of the changes, as it conveys the idea of speed and efficiency.
2.  🛠️ - This emoji represents the error handling and cache sync logic improvement aspect of the changes, as it conveys the idea of fixing and repairing issues.
3.  📈 - This emoji represents the reliability enhancement aspect of the changes, as it conveys the idea of growth and progress.
-->
Improved the Kubernetes handler for Radius agent deployment by optimizing the cache sync and error handling logic in `startDeploymentInformer`. Reduced the cache resync interval in `pkg/corerp/handlers/kubernetes.go` to enhance performance.

> _Oh we are the brave Kubernetes handlers_
> _We sync the cache and deploy the agents_
> _We shorten the resync and handle errors_
> _We heave away and haul on the count of three_

### Walkthrough
* Reduce the cache resync interval for the Kubernetes handler to improve responsiveness ([link](https://github.com/project-radius/radius/pull/5724/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L48-R48))
* Simplify the error handling and avoid leaking informers by returning an error instead of a function from `startDeploymentInformer` ([link](https://github.com/project-radius/radius/pull/5724/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L133-R141), [link](https://github.com/project-radius/radius/pull/5724/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L163-R167))
* Ensure the latest state of the deployment by waiting for the cache sync before returning from `startDeploymentInformer` ([link](https://github.com/project-radius/radius/pull/5724/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L193-R203))


