### PR TITLE
Fix RC release version tag in chart

### DIFF
--- a/deploy/Chart/Chart.yaml
+++ b/deploy/Chart/Chart.yaml
@@ -4,7 +4,7 @@ name: radius
 # version is the chart version, which will be replaced when this chart is packaged.
 version: '0.42.42-dev'
 # appVersion is the version of Radius, which will be replaced when this chart is packaged.
-appVersion: 'latest'
+appVersion: 'edge'
 home: https://radapp.dev
 sources:
   - https://github.com/project-radius/radius/tree/main/deploy/Chart

--- a/deploy/Chart/templates/_helpers.tpl
+++ b/deploy/Chart/templates/_helpers.tpl
@@ -1,10 +1,12 @@
 {{/* Parse version and extract major and manor version from Appversion for image tag. */}}
 {{- define "radius.versiontag" }}
 {{- $version := .Chart.AppVersion }}
+{{- /* Set latest if version is edge */}}
 {{- if eq $version "edge" }}
   {{- $version = "latest" }}
 {{- end -}}
-{{- if ne $version "latest" }}
+{{- /* Tag version will be 'major.minor' unless version is latest or rc release */}}
+{{- if and (ne $version "latest") (not (contains "rc" $version)) }}
   {{- $ver := split "." $version }}
   {{- $version = printf "%s.%s" $ver._0 $ver._1 }}
 {{- end -}}


### PR DESCRIPTION
# Description

I forgot the fact that we used the full version for rc image tag in the previous refactoring. This is the fix to use the correct tag for RC release. I validated it by creating manifest yaml.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bc1797e</samp>

### Summary
🏷️🧪📝

<!--
1.  🏷️ - This emoji represents the change of the image tag from `latest` to `edge` and the modification of the `radius.versiontag` function to handle release candidate versions. The emoji is commonly used to denote labels, tags, or categories.
2. 🧪 - This emoji represents the use of the `edge` tag for the development branch of the Radius repository, which implies that the application is undergoing testing and experimentation. The emoji is commonly used to denote testing, science, or experiments.
3. 📝 - This emoji represents the addition of comments to the `radius.versiontag` function to clarify the logic and the purpose of the function. The emoji is commonly used to denote writing, documentation, or notes.
-->
Updated the Helm chart files for the Radius application to use the `edge` tag for the development branch and to handle release candidate versions in the label format.

> _`appVersion` changed_
> _`radius.versiontag` too_
> _Helm chart adapts - spring_

### Walkthrough
*  Update the image tag of the Radius application to `edge` for the development branch ([link](https://github.com/project-radius/radius/pull/5727/files?diff=unified&w=0#diff-f284fdc3b5faa17316f1b96af55e098431733d6fce3b615d201317539cfaf2d3L7-R7))
*  Improve the `radius.versiontag` template function to handle release candidate versions and add comments ([link](https://github.com/project-radius/radius/pull/5727/files?diff=unified&w=0#diff-0ba89421395856d6246fed28806565a0d3475d08fdd81093c97091a888ef6529L4-R9))


