### PR TITLE
Reduce deployment resync duration and fix invalid context usage

### DIFF
--- a/pkg/corerp/config/timeout.go
+++ b/pkg/corerp/config/timeout.go
@@ -22,5 +22,5 @@ import (
 
 var (
 	// AsyncCreateOrUpdateContainerTimeout is the timeout for async create or update container.
-	AsyncCreateOrUpdateContainerTimeout = time.Duration(160) * time.Second
+	AsyncCreateOrUpdateContainerTimeout = time.Duration(120) * time.Second
 )

--- a/pkg/corerp/config/timeout.go
+++ b/pkg/corerp/config/timeout.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1
+package config
 
 import (
 	"time"

--- a/pkg/corerp/frontend/handler/routes.go
+++ b/pkg/corerp/frontend/handler/routes.go
@@ -26,12 +26,13 @@ import (
 	"github.com/project-radius/radius/pkg/armrpc/frontend/defaultoperation"
 	"github.com/project-radius/radius/pkg/armrpc/frontend/server"
 	rp_frontend "github.com/project-radius/radius/pkg/rp/frontend"
-	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 	"github.com/project-radius/radius/pkg/validator"
 	"github.com/project-radius/radius/swagger"
 
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
 	converter "github.com/project-radius/radius/pkg/corerp/datamodel/converter"
+
+	corerp_config "github.com/project-radius/radius/pkg/corerp/config"
 
 	app_ctrl "github.com/project-radius/radius/pkg/corerp/frontend/controller/applications"
 	ctr_ctrl "github.com/project-radius/radius/pkg/corerp/frontend/controller/containers"
@@ -311,7 +312,7 @@ func AddRoutes(ctx context.Context, router *mux.Router, pathBase string, isARM b
 							rp_frontend.PrepareRadiusResource[*datamodel.ContainerResource],
 							ctr_ctrl.ValidateAndMutateRequest,
 						},
-						AsyncOperationTimeout: rpv1.AsyncCreateOrUpdateContainerTimeout,
+						AsyncOperationTimeout: corerp_config.AsyncCreateOrUpdateContainerTimeout,
 					},
 				)
 			},
@@ -329,7 +330,7 @@ func AddRoutes(ctx context.Context, router *mux.Router, pathBase string, isARM b
 							rp_frontend.PrepareRadiusResource[*datamodel.ContainerResource],
 							ctr_ctrl.ValidateAndMutateRequest,
 						},
-						AsyncOperationTimeout: rpv1.AsyncCreateOrUpdateContainerTimeout,
+						AsyncOperationTimeout: corerp_config.AsyncCreateOrUpdateContainerTimeout,
 					},
 				)
 			},

--- a/pkg/corerp/frontend/handler/routes.go
+++ b/pkg/corerp/frontend/handler/routes.go
@@ -26,6 +26,7 @@ import (
 	"github.com/project-radius/radius/pkg/armrpc/frontend/defaultoperation"
 	"github.com/project-radius/radius/pkg/armrpc/frontend/server"
 	rp_frontend "github.com/project-radius/radius/pkg/rp/frontend"
+	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 	"github.com/project-radius/radius/pkg/validator"
 	"github.com/project-radius/radius/swagger"
 
@@ -310,6 +311,7 @@ func AddRoutes(ctx context.Context, router *mux.Router, pathBase string, isARM b
 							rp_frontend.PrepareRadiusResource[*datamodel.ContainerResource],
 							ctr_ctrl.ValidateAndMutateRequest,
 						},
+						AsyncOperationTimeout: rpv1.AsyncCreateOrUpdateContainerTimeout,
 					},
 				)
 			},
@@ -327,6 +329,7 @@ func AddRoutes(ctx context.Context, router *mux.Router, pathBase string, isARM b
 							rp_frontend.PrepareRadiusResource[*datamodel.ContainerResource],
 							ctr_ctrl.ValidateAndMutateRequest,
 						},
+						AsyncOperationTimeout: rpv1.AsyncCreateOrUpdateContainerTimeout,
 					},
 				)
 			},

--- a/pkg/corerp/handlers/kubernetes.go
+++ b/pkg/corerp/handlers/kubernetes.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	corerp_config "github.com/project-radius/radius/pkg/corerp/config"
 	"github.com/project-radius/radius/pkg/kubernetes"
 	"github.com/project-radius/radius/pkg/kubeutil"
 	"github.com/project-radius/radius/pkg/resourcemodel"
@@ -51,7 +52,7 @@ func NewKubernetesHandler(client client.Client, clientSet k8s.Interface) Resourc
 		client:    client,
 		clientSet: clientSet,
 
-		deploymentTimeOut:   rpv1.AsyncCreateOrUpdateContainerTimeout,
+		deploymentTimeOut:   corerp_config.AsyncCreateOrUpdateContainerTimeout,
 		cacheResyncInterval: DefaultCacheResyncInterval,
 	}
 }

--- a/pkg/corerp/handlers/kubernetes.go
+++ b/pkg/corerp/handlers/kubernetes.go
@@ -125,7 +125,7 @@ func (handler *kubernetesHandler) waitUntilDeploymentIsReady(ctx context.Context
 	logger := ucplog.FromContextOrDiscard(ctx)
 
 	doneCh := make(chan bool, 1)
-	statusCh := make(chan string, 5)
+	statusCh := make(chan string, 1)
 
 	ctx, cancel := context.WithTimeout(ctx, handler.deploymentTimeOut)
 	// This ensures that the informer is stopped when this function is returned.
@@ -144,7 +144,7 @@ func (handler *kubernetesHandler) waitUntilDeploymentIsReady(ctx context.Context
 		select {
 		case <-ctx.Done():
 			// TODO: Deployment doesn't describe the detail of POD failures, so we should get the errors from POD - https://github.com/project-radius/radius/issues/5686
-			err := fmt.Errorf("deployment is timed out with the status: %s", lastStatus)
+			err := fmt.Errorf("deployment has timed out with the status: %s", lastStatus)
 			logger.Error(err, "Kubernetes handler failed")
 			return err
 

--- a/pkg/corerp/handlers/kubernetes_test.go
+++ b/pkg/corerp/handlers/kubernetes_test.go
@@ -316,13 +316,13 @@ func TestWaitUntilDeploymentIsReady_Timeout(t *testing.T) {
 			name:              "context timeout",
 			contextTimeout:    time.Duration(1) * time.Second,
 			deploymentTimeout: time.Duration(5) * time.Minute,
-			expectedError:     "job context timed out, name: test-deployment, namespace test-namespace",
+			expectedError:     "deployment is timed out with the status: Deadline is exceeded (ProgressDeadlineExceeded), name: test-deployment, namespace: test-namespace",
 		},
 		{
 			name:              "deployment timeout",
 			contextTimeout:    time.Duration(5) * time.Minute,
 			deploymentTimeout: time.Duration(1) * time.Second,
-			expectedError:     "kubernetes deployment timed out, name: test-deployment, namespace test-namespace, status: Deployment has minimum availability, reason: NewReplicaSetAvailable",
+			expectedError:     "deployment is timed out with the status: Deadline is exceeded (ProgressDeadlineExceeded), name: test-deployment, namespace: test-namespace",
 		},
 	}
 
@@ -339,6 +339,12 @@ func TestWaitUntilDeploymentIsReady_Timeout(t *testing.T) {
 					Status:  corev1.ConditionFalse,
 					Reason:  "NewReplicaSetAvailable",
 					Message: "Deployment has minimum availability",
+				},
+				{
+					Type:    v1.DeploymentProgressing,
+					Status:  corev1.ConditionFalse,
+					Reason:  "ProgressDeadlineExceeded",
+					Message: "Deadline is exceeded",
 				},
 			},
 		},
@@ -397,5 +403,5 @@ func TestWaitUntilDeploymentIsReady_DifferentResourceName(t *testing.T) {
 
 	// It must be timed out because the name of the deployment does not match.
 	require.Error(t, err)
-	require.Equal(t, "kubernetes deployment timed out, name: not-matched-deployment, namespace test-namespace, error occured while fetching latest status: deployments.apps \"not-matched-deployment\" not found", err.Error())
+	require.Equal(t, "deployment is timed out with the status: unknown status, name: not-matched-deployment, namespace test-namespace", err.Error())
 }

--- a/pkg/corerp/handlers/kubernetes_test.go
+++ b/pkg/corerp/handlers/kubernetes_test.go
@@ -337,12 +337,6 @@ func TestWaitUntilDeploymentIsReady_Timeout(t *testing.T) {
 				{
 					Type:    v1.DeploymentProgressing,
 					Status:  corev1.ConditionFalse,
-					Reason:  "NewReplicaSetAvailable",
-					Message: "Deployment has minimum availability",
-				},
-				{
-					Type:    v1.DeploymentProgressing,
-					Status:  corev1.ConditionFalse,
 					Reason:  "ProgressDeadlineExceeded",
 					Message: "Deadline is exceeded",
 				},

--- a/pkg/corerp/handlers/kubernetes_test.go
+++ b/pkg/corerp/handlers/kubernetes_test.go
@@ -316,13 +316,13 @@ func TestWaitUntilDeploymentIsReady_Timeout(t *testing.T) {
 			name:              "context timeout",
 			contextTimeout:    time.Duration(1) * time.Second,
 			deploymentTimeout: time.Duration(5) * time.Minute,
-			expectedError:     "deployment is timed out with the status: Deadline is exceeded (ProgressDeadlineExceeded), name: test-deployment, namespace: test-namespace",
+			expectedError:     "deployment has timed out with the status: Deadline is exceeded (ProgressDeadlineExceeded), name: test-deployment, namespace: test-namespace",
 		},
 		{
 			name:              "deployment timeout",
 			contextTimeout:    time.Duration(5) * time.Minute,
 			deploymentTimeout: time.Duration(1) * time.Second,
-			expectedError:     "deployment is timed out with the status: Deadline is exceeded (ProgressDeadlineExceeded), name: test-deployment, namespace: test-namespace",
+			expectedError:     "deployment has timed out with the status: Deadline is exceeded (ProgressDeadlineExceeded), name: test-deployment, namespace: test-namespace",
 		},
 	}
 
@@ -403,5 +403,5 @@ func TestWaitUntilDeploymentIsReady_DifferentResourceName(t *testing.T) {
 
 	// It must be timed out because the name of the deployment does not match.
 	require.Error(t, err)
-	require.Equal(t, "deployment is timed out with the status: unknown status, name: not-matched-deployment, namespace test-namespace", err.Error())
+	require.Equal(t, "deployment has timed out with the status: unknown status, name: not-matched-deployment, namespace test-namespace", err.Error())
 }

--- a/pkg/rp/v1/timeout.go
+++ b/pkg/rp/v1/timeout.go
@@ -22,5 +22,5 @@ import (
 
 var (
 	// AsyncCreateOrUpdateContainerTimeout is the timeout for async create or update container.
-	AsyncCreateOrUpdateContainerTimeout = time.Duration(2) * time.Minute
+	AsyncCreateOrUpdateContainerTimeout = time.Duration(125) * time.Second
 )

--- a/pkg/rp/v1/timeout.go
+++ b/pkg/rp/v1/timeout.go
@@ -22,5 +22,5 @@ import (
 
 var (
 	// AsyncCreateOrUpdateContainerTimeout is the timeout for async create or update container.
-	AsyncCreateOrUpdateContainerTimeout = time.Duration(125) * time.Second
+	AsyncCreateOrUpdateContainerTimeout = time.Duration(160) * time.Second
 )

--- a/pkg/rp/v1/timeout.go
+++ b/pkg/rp/v1/timeout.go
@@ -22,5 +22,5 @@ import (
 
 var (
 	// AsyncCreateOrUpdateContainerTimeout is the timeout for async create or update container.
-	AsyncCreateOrUpdateContainerTimeout = time.Duration(5) * time.Minute
+	AsyncCreateOrUpdateContainerTimeout = time.Duration(2) * time.Minute
 )

--- a/pkg/rp/v1/timeout.go
+++ b/pkg/rp/v1/timeout.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"time"
+)
+
+var (
+	// AsyncCreateOrUpdateContainerTimeout is the timeout for async create or update container.
+	AsyncCreateOrUpdateContainerTimeout = time.Duration(5) * time.Minute
+)


### PR DESCRIPTION
# Description

* Reduce the deployment resync duration. Now informer will check the deployment every 10 seconds, which means user will get faster response. 
* Fix cancelled context after deployment timed out.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9f6d166</samp>

### Summary
🚀🛠️🧠

<!--
1.  🚀 - This emoji can be used to represent the improved performance of the handler logic, as it suggests speed and efficiency.
2.  🛠️ - This emoji can be used to represent the fixed issues with the context and the deployment status, as it suggests repairing or fixing something that was broken or faulty.
3.  🧠 - This emoji can be used to represent the improved reliability of the handler logic, as it suggests intelligence and logic. Alternatively, one could use 🙌 to suggest confidence and trust.
-->
Improved the Kubernetes handler in `pkg/corerp/handlers/kubernetes.go` by adjusting the cache resync interval and fixing context and deployment status issues.

> _Oh we are the Kubernetes crew, we handle pods and services too_
> _We sync the cache and fix the context, to make our logic run correct_
> _Heave away, haul away, on the count of three_
> _We'll improve the performance and reliability_

### Walkthrough
* Reduce the cache resync interval for the informer that watches Kubernetes resources to improve responsiveness ([link](https://github.com/project-radius/radius/pull/5728/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L49-R49))
  - Use `context.Background()` instead of a cancelled context when calling the API to get a deployment in `waitUntilDeploymentIsReady` ([link](https://github.com/project-radius/radius/pull/5728/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L145-R147))
  - Add a TODO comment to note the need for fetching pod errors in `waitUntilDeploymentIsReady` ([link](https://github.com/project-radius/radius/pull/5728/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L145-R147))
  - Move the `status` variable declaration inside the if block and handle the case of empty conditions slice in `waitUntilDeploymentIsReady` ([link](https://github.com/project-radius/radius/pull/5728/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L153-R160))


