### PR TITLE
Increase timeout of bubbletea UI tests

### DIFF
--- a/pkg/cli/cmd/radinit/display_test.go
+++ b/pkg/cli/cmd/radinit/display_test.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	// Set this to a big value when debugging.
-	waitTimeout = 1 * time.Second
+	waitTimeout = 5 * time.Second
 )
 
 // NOTE: I tried my best to write a test for the progress model. It was possible to write a good test, but

--- a/pkg/cli/prompt/text/text_test.go
+++ b/pkg/cli/prompt/text/text_test.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	// Set this to a big value when debugging.
-	waitTimeout = 1 * time.Second
+	waitTimeout = 5 * time.Second
 )
 
 func Test_NewTextModel(t *testing.T) {


### PR DESCRIPTION
# Description

We've seen failures of these (sporadic) with a small timeout. Upping this to something large to see if it improves the reliability. Separately looking into where we can take some other action.

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4b96b99</samp>

### Summary
:clock5::test_tube::computer:

<!--
1.  :clock5: - This emoji represents the increase in the wait timeout from 1 second to 5 seconds. It can be used to indicate that the change affects the timing or duration of something.
2.  :test_tube: - This emoji represents the fact that the change was made for testing purposes and does not affect the functionality of the code. It can be used to indicate that the change is related to testing, debugging, or quality assurance.
3.  :computer: - This emoji represents the fact that the change affects the terminal output and the interaction with the user. It can be used to indicate that the change is related to the user interface, the command-line, or the terminal.
-->
Increased `waitTimeout` variable for terminal testing in `radinit` and `text` packages. This reduces the risk of flaky tests due to output timing.

> _`waitTimeout` grows_
> _flaky tests need more patience_
> _winter is coming_

### Walkthrough
* Increase the `waitTimeout` variable for testing terminal output from 1 second to 5 seconds in the `radinit` and `text` packages ([link](https://github.com/project-radius/radius/pull/5748/files?diff=unified&w=0#diff-652ce55ed8af3f822e7c546447ced1d2daf2e8d2c586f783cdac0ec3f9bd8513L34-R34), [link](https://github.com/project-radius/radius/pull/5748/files?diff=unified&w=0#diff-a95b3c117c873821d9473cd582ee12f2ffccb36c71d5fd41b1a3897f0268d957L34-R34))


