### PR TITLE
Add address and pathbase properties to controller options

### DIFF
--- a/pkg/armrpc/frontend/controller/controller.go
+++ b/pkg/armrpc/frontend/controller/controller.go
@@ -33,6 +33,25 @@ import (
 
 // Options represents controller options.
 type Options struct {
+	// Address is the listening address where the controller is running, including the hostname and port.
+	//
+	// For example: "localhost:8080".
+	//
+	// The listening address is provided so that it can be used when constructing URLs.
+	Address string
+
+	// PathBase is a URL path prefix that is applied to all requests and should not be considered part of request path
+	// for determining routing or parsing of IDs. It must start with a slash or be empty.
+	//
+	// For example consider the following examples that match the resource ID "/planes/radius/local":
+	//
+	// - base path: "/apis/api.ucp.dev/v1alpha3" and URL path: "/apis/api.ucp.dev/planes/radius/local".
+	// - base path: "" (empty) and request path: "/planes/radius/local".
+	//
+	// Code that needs to process the URL path should ignore the base path prefix when parsing the URL path.
+	// Code that needs to construct a URL path should use the base path prefix when constructing the URL path.
+	PathBase string
+
 	// StorageClient is the data storage client.
 	StorageClient store.StorageClient
 
@@ -42,10 +61,11 @@ type Options struct {
 	// KubeClient is the Kubernetes controller runtime client.
 	KubeClient runtimeclient.Client
 
-	// ResourceType is the string that represents the resource type.
+	// ResourceType is the string that represents the resource type. May be empty of the controller
+	// does not represent a single type of resource.
 	ResourceType string
 
-	// StatusManager
+	// StatusManager is the async operation status manager.
 	StatusManager sm.StatusManager
 }
 

--- a/pkg/armrpc/frontend/server/handler.go
+++ b/pkg/armrpc/frontend/server/handler.go
@@ -98,7 +98,7 @@ func addRequestAttributes(ctx context.Context, req *http.Request) {
 func ConfigureDefaultHandlers(
 	ctx context.Context,
 	rootRouter *mux.Router,
-	pathBase string,
+	rootScopePath string,
 	isAzureProvider bool,
 	providerNamespace string,
 	operationCtrlFactory ControllerFunc,
@@ -119,7 +119,7 @@ func ConfigureDefaultHandlers(
 		}
 		// https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/subscription-lifecycle-api-reference.md#creating-or-updating-a-subscription
 		err = RegisterHandler(ctx, HandlerOptions{
-			ParentRouter:   rootRouter.Path(pathBase).Queries(APIVersionParam, "{"+APIVersionParam+"}").Subrouter(),
+			ParentRouter:   rootRouter.Path(rootScopePath).Queries(APIVersionParam, "{"+APIVersionParam+"}").Subrouter(),
 			ResourceType:   rt,
 			Method:         v1.OperationPut,
 			HandlerFactory: defaultoperation.NewCreateOrUpdateSubscription,
@@ -130,7 +130,7 @@ func ConfigureDefaultHandlers(
 	}
 
 	statusRT := providerNamespace + "/operationstatuses"
-	opStatus := fmt.Sprintf("%s/providers/%s/locations/{location}/operationstatuses/{operationId}", pathBase, providerNamespace)
+	opStatus := fmt.Sprintf("%s/providers/%s/locations/{location}/operationstatuses/{operationId}", rootScopePath, providerNamespace)
 	err := RegisterHandler(ctx, HandlerOptions{
 		ParentRouter:   rootRouter.Path(opStatus).Queries(APIVersionParam, "{"+APIVersionParam+"}").Subrouter(),
 		ResourceType:   statusRT,
@@ -141,7 +141,7 @@ func ConfigureDefaultHandlers(
 		return err
 	}
 
-	opResult := fmt.Sprintf("%s/providers/%s/locations/{location}/operationresults/{operationId}", pathBase, providerNamespace)
+	opResult := fmt.Sprintf("%s/providers/%s/locations/{location}/operationresults/{operationId}", rootScopePath, providerNamespace)
 	err = RegisterHandler(ctx, HandlerOptions{
 		ParentRouter:   rootRouter.Path(opResult).Queries(APIVersionParam, "{"+APIVersionParam+"}").Subrouter(),
 		ResourceType:   statusRT,

--- a/pkg/corerp/frontend/handler/routes.go
+++ b/pkg/corerp/frontend/handler/routes.go
@@ -45,17 +45,18 @@ const (
 	ProviderNamespaceName = "Applications.Core"
 )
 
-func AddRoutes(ctx context.Context, router *mux.Router, pathBase string, isARM bool, ctrlOpts frontend_ctrl.Options) error {
+func AddRoutes(ctx context.Context, router *mux.Router, isARM bool, ctrlOpts frontend_ctrl.Options) error {
+	rootScopePath := ctrlOpts.PathBase
 	if isARM {
-		pathBase += "/subscriptions/{subscriptionID}"
+		rootScopePath += "/subscriptions/{subscriptionID}"
 	} else {
-		pathBase += "/planes/radius/{planeName}"
+		rootScopePath += "/planes/radius/{planeName}"
 	}
 
 	resourceGroupPath := "/resourcegroups/{resourceGroupName}"
 
 	// Configure the default ARM handlers.
-	err := server.ConfigureDefaultHandlers(ctx, router, pathBase, isARM, ProviderNamespaceName, NewGetOperations, ctrlOpts)
+	err := server.ConfigureDefaultHandlers(ctx, router, rootScopePath, isARM, ProviderNamespaceName, NewGetOperations, ctrlOpts)
 	if err != nil {
 		return err
 	}
@@ -64,8 +65,8 @@ func AddRoutes(ctx context.Context, router *mux.Router, pathBase string, isARM b
 	//
 	// These paths are order sensitive and the longer path MUST be registered first.
 	prefixes := []string{
-		pathBase + resourceGroupPath,
-		pathBase,
+		rootScopePath + resourceGroupPath,
+		rootScopePath,
 	}
 
 	specLoader, err := validator.LoadSpec(ctx, ProviderNamespaceName, swagger.SpecFiles, prefixes, "rootScope")
@@ -76,13 +77,13 @@ func AddRoutes(ctx context.Context, router *mux.Router, pathBase string, isARM b
 	// Used to register routes like:
 	//
 	// /planes/radius/{planeName}/providers/applications.core/environments
-	planeScopeRouter := router.PathPrefix(pathBase).Subrouter()
+	planeScopeRouter := router.PathPrefix(rootScopePath).Subrouter()
 	planeScopeRouter.Use(validator.APIValidator(specLoader))
 
 	// Used to register routes like:
 	//
 	// /planes/radius/{planeName}/resourcegroups/{resourceGroupName}/providers/applications.core/environments
-	resourceGroupScopeRouter := router.PathPrefix(pathBase + resourceGroupPath).Subrouter()
+	resourceGroupScopeRouter := router.PathPrefix(rootScopePath + resourceGroupPath).Subrouter()
 	resourceGroupScopeRouter.Use(validator.APIValidator(specLoader))
 
 	// Adds environment resource type routes

--- a/pkg/corerp/frontend/handler/routes_test.go
+++ b/pkg/corerp/frontend/handler/routes_test.go
@@ -186,7 +186,7 @@ func TestHandlers(t *testing.T) {
 
 func assertRouters(t *testing.T, pathBase string, isARM bool, mockSP *dataprovider.MockDataStorageProvider) {
 	r := mux.NewRouter()
-	err := AddRoutes(context.Background(), r, pathBase, isARM, ctrl.Options{DataProvider: mockSP})
+	err := AddRoutes(context.Background(), r, isARM, ctrl.Options{PathBase: pathBase, DataProvider: mockSP})
 	require.NoError(t, err)
 
 	for _, tt := range handlerTests {

--- a/pkg/corerp/frontend/service.go
+++ b/pkg/corerp/frontend/service.go
@@ -50,22 +50,23 @@ func (s *Service) Run(ctx context.Context) error {
 	}
 
 	opts := ctrl.Options{
+		Address:       fmt.Sprintf("%s:%d", s.Options.Config.Server.Host, s.Options.Config.Server.Port),
+		PathBase:      s.Options.Config.Server.PathBase,
 		DataProvider:  s.StorageProvider,
 		KubeClient:    s.KubeClient,
 		StatusManager: s.OperationStatusManager,
 	}
 
-	address := fmt.Sprintf("%s:%d", s.Options.Config.Server.Host, s.Options.Config.Server.Port)
 	err := s.Start(ctx, server.Options{
+		Address:           opts.Address,
 		ProviderNamespace: s.ProviderName,
 		Location:          s.Options.Config.Env.RoleLocation,
-		Address:           address,
 		PathBase:          s.Options.Config.Server.PathBase,
 		// set the arm cert manager for managing client certificate
 		ArmCertMgr:    s.ARMCertManager,
 		EnableArmAuth: s.Options.Config.Server.EnableArmAuth, // when enabled the client cert validation will be done
 		Configure: func(router *mux.Router) error {
-			err := handler.AddRoutes(ctx, router, s.Options.Config.Server.PathBase, !hostoptions.IsSelfHosted(), opts)
+			err := handler.AddRoutes(ctx, router, !hostoptions.IsSelfHosted(), opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/linkrp/frontend/handler/routes.go
+++ b/pkg/linkrp/frontend/handler/routes.go
@@ -43,16 +43,17 @@ const (
 	ProviderNamespaceName = "Applications.Link"
 )
 
-func AddRoutes(ctx context.Context, router *mux.Router, pathBase string, isARM bool, ctrlOpts frontend_ctrl.Options) error {
+func AddRoutes(ctx context.Context, router *mux.Router, isARM bool, ctrlOpts frontend_ctrl.Options) error {
+	rootScopePath := ctrlOpts.PathBase
 	if isARM {
-		pathBase += "/subscriptions/{subscriptionID}"
+		rootScopePath += "/subscriptions/{subscriptionID}"
 	} else {
-		pathBase += "/planes/radius/{planeName}"
+		rootScopePath += "/planes/radius/{planeName}"
 	}
 	resourceGroupPath := "/resourcegroups/{resourceGroupName}"
 
 	// Configure the default ARM handlers.
-	err := server.ConfigureDefaultHandlers(ctx, router, pathBase, isARM, ProviderNamespaceName, NewGetOperations, ctrlOpts)
+	err := server.ConfigureDefaultHandlers(ctx, router, rootScopePath, isARM, ProviderNamespaceName, NewGetOperations, ctrlOpts)
 	if err != nil {
 		return err
 	}
@@ -61,8 +62,8 @@ func AddRoutes(ctx context.Context, router *mux.Router, pathBase string, isARM b
 	//
 	// These paths are order sensitive and the longer path MUST be registered first.
 	prefixes := []string{
-		pathBase + resourceGroupPath,
-		pathBase,
+		rootScopePath + resourceGroupPath,
+		rootScopePath,
 	}
 
 	specLoader, err := validator.LoadSpec(ctx, ProviderNamespaceName, swagger.SpecFiles, prefixes, "rootScope")
@@ -73,13 +74,13 @@ func AddRoutes(ctx context.Context, router *mux.Router, pathBase string, isARM b
 	// Used to register routes like:
 	//
 	// /planes/radius/{planeName}/providers/applications.link/mongodatabases
-	planeScopeRouter := router.PathPrefix(pathBase).Subrouter()
+	planeScopeRouter := router.PathPrefix(rootScopePath).Subrouter()
 	planeScopeRouter.Use(validator.APIValidator(specLoader))
 
 	// Used to register routes like:
 	//
 	// /planes/radius/{planeName}/resourcegroups/{resourceGroupName}/providers/applications.link/mongodatabases
-	resourceGroupScopeRouter := router.PathPrefix(pathBase + resourceGroupPath).Subrouter()
+	resourceGroupScopeRouter := router.PathPrefix(rootScopePath + resourceGroupPath).Subrouter()
 	resourceGroupScopeRouter.Use(validator.APIValidator(specLoader))
 
 	mongoDatabasePlaneRouter := planeScopeRouter.PathPrefix("/providers/applications.link/mongodatabases").Subrouter()

--- a/pkg/linkrp/frontend/handler/routes_test.go
+++ b/pkg/linkrp/frontend/handler/routes_test.go
@@ -270,7 +270,7 @@ func TestHandlers(t *testing.T) {
 
 func assertRouters(t *testing.T, pathBase string, isARM bool, mockSP *dataprovider.MockDataStorageProvider) {
 	r := mux.NewRouter()
-	err := AddRoutes(context.Background(), r, pathBase, isARM, ctrl.Options{DataProvider: mockSP})
+	err := AddRoutes(context.Background(), r, isARM, ctrl.Options{PathBase: pathBase, DataProvider: mockSP})
 	require.NoError(t, err)
 
 	for _, tt := range handlerTests {

--- a/pkg/linkrp/frontend/service.go
+++ b/pkg/linkrp/frontend/service.go
@@ -51,22 +51,23 @@ func (s *Service) Run(ctx context.Context) error {
 	}
 
 	opts := ctrl.Options{
+		Address:       fmt.Sprintf("%s:%d", s.Options.Config.Server.Host, s.Options.Config.Server.Port),
+		PathBase:      s.Options.Config.Server.PathBase,
 		DataProvider:  s.StorageProvider,
 		KubeClient:    s.KubeClient,
 		StatusManager: s.OperationStatusManager,
 	}
 
-	address := fmt.Sprintf("%s:%d", s.Options.Config.Server.Host, s.Options.Config.Server.Port)
 	err := s.Start(ctx, server.Options{
+		Address:           opts.Address,
 		ProviderNamespace: s.ProviderName,
-		Address:           address,
 		Location:          s.Options.Config.Env.RoleLocation,
 		PathBase:          s.Options.Config.Server.PathBase,
 		// set the arm cert manager for managing client certificate
 		ArmCertMgr:    s.ARMCertManager,
 		EnableArmAuth: s.Options.Config.Server.EnableArmAuth, // when enabled the client cert validation will be done
 		Configure: func(router *mux.Router) error {
-			err := handler.AddRoutes(ctx, router, s.Options.Config.Server.PathBase, !hostoptions.IsSelfHosted(), opts)
+			err := handler.AddRoutes(ctx, router, !hostoptions.IsSelfHosted(), opts)
 			if err != nil {
 				return err
 			}

--- a/pkg/middleware/util.go
+++ b/pkg/middleware/util.go
@@ -19,7 +19,7 @@ package middleware
 import "strings"
 
 // GetRelativePath trims the prefix basePath from path
-func GetRelativePath(basePath string, path string) string {
-	trimmedPath := strings.TrimPrefix(path, basePath)
+func GetRelativePath(pathBase string, path string) string {
+	trimmedPath := strings.TrimPrefix(path, pathBase)
 	return trimmedPath
 }

--- a/pkg/ucp/frontend/api/routes.go
+++ b/pkg/ucp/frontend/api/routes.go
@@ -60,12 +60,10 @@ const (
 
 // Register registers the routes for UCP
 func Register(ctx context.Context, router *mux.Router, ctrlOpts ctrl.Options) error {
-	baseURL := ctrlOpts.BasePath
-
 	handlerOptions := []ctrl.HandlerOptions{}
 
 	// If we're in Kubernetes we have some required routes to implement.
-	if baseURL != "" {
+	if ctrlOpts.PathBase != "" {
 		// NOTE: the Kubernetes API Server does not include the gvr (base path) in
 		// the URL for swagger routes.
 		handlerOptions = append(handlerOptions, []ctrl.HandlerOptions{
@@ -75,7 +73,7 @@ func Register(ctx context.Context, router *mux.Router, ctrlOpts ctrl.Options) er
 				HandlerFactory: kubernetes_ctrl.NewOpenAPIv2Doc,
 			},
 			{
-				ParentRouter:   router.Path(baseURL).Subrouter(),
+				ParentRouter:   router.Path(ctrlOpts.PathBase).Subrouter(),
 				Method:         v1.OperationGet,
 				HandlerFactory: kubernetes_ctrl.NewDiscoveryDoc,
 			},
@@ -85,14 +83,14 @@ func Register(ctx context.Context, router *mux.Router, ctrlOpts ctrl.Options) er
 	ctrl.ConfigureDefaultHandlers(router, ctrlOpts.Options)
 
 	logger := ucplog.FromContextOrDiscard(ctx)
-	logger.Info(fmt.Sprintf("Registering routes with base path: %s", baseURL))
+	logger.Info(fmt.Sprintf("Registering routes with path base: %s", ctrlOpts.PathBase))
 
-	specLoader, err := validator.LoadSpec(ctx, "ucp", swagger.SpecFilesUCP, []string{baseURL}, "")
+	specLoader, err := validator.LoadSpec(ctx, "ucp", swagger.SpecFilesUCP, []string{ctrlOpts.PathBase}, "")
 	if err != nil {
 		return err
 	}
 
-	rootScopeRouter := router.PathPrefix(baseURL).Subrouter()
+	rootScopeRouter := router.PathPrefix(ctrlOpts.PathBase).Subrouter()
 	rootScopeRouter.Use(validator.APIValidatorUCP(specLoader))
 
 	planeCollectionSubRouter := rootScopeRouter.Path(planeCollectionPath).Subrouter()
@@ -104,7 +102,7 @@ func Register(ctx context.Context, router *mux.Router, ctrlOpts ctrl.Options) er
 	resourceGroupCollectionSubRouter := rootScopeRouter.Path(resourceGroupCollectionPath).Subrouter()
 	resourceGroupSubRouter := rootScopeRouter.Path(resourceGroupItemPath).Subrouter()
 
-	awsResourcesSubRouter := router.PathPrefix(fmt.Sprintf("%s%s", baseURL, awsPlaneType)).Subrouter()
+	awsResourcesSubRouter := router.PathPrefix(fmt.Sprintf("%s%s", ctrlOpts.PathBase, awsPlaneType)).Subrouter()
 	awsResourceCollectionSubRouter := awsResourcesSubRouter.Path(awsResourceCollectionPath).Subrouter()
 	awsSingleResourceSubRouter := awsResourcesSubRouter.Path(awsResourcePath).Subrouter()
 	awsOperationStatusesSubRouter := awsResourcesSubRouter.PathPrefix(awsOperationStatusesPath).Subrouter()
@@ -113,10 +111,10 @@ func Register(ctx context.Context, router *mux.Router, ctrlOpts ctrl.Options) er
 	awsGetResourceSubRouter := awsResourcesSubRouter.Path(fmt.Sprintf("%s/:%s", awsResourceCollectionPath, getPath)).Subrouter()
 	awsDeleteResourceSubRouter := awsResourcesSubRouter.Path(fmt.Sprintf("%s/:%s", awsResourceCollectionPath, deletePath)).Subrouter()
 
-	azureCredentialCollectionSubRouter := router.Path(fmt.Sprintf("%s%s", baseURL, azureCredentialCollectionPath)).Subrouter()
-	azureCredentialResourceSubRouter := router.Path(fmt.Sprintf("%s%s", baseURL, azureCredentialResourcePath)).Subrouter()
-	awsCredentialCollectionSubRouter := router.Path(fmt.Sprintf("%s%s", baseURL, awsCredentialCollectionPath)).Subrouter()
-	awsCredentialResourceSubRouter := router.Path(fmt.Sprintf("%s%s", baseURL, awsCredentialResourcePath)).Subrouter()
+	azureCredentialCollectionSubRouter := router.Path(fmt.Sprintf("%s%s", ctrlOpts.PathBase, azureCredentialCollectionPath)).Subrouter()
+	azureCredentialResourceSubRouter := router.Path(fmt.Sprintf("%s%s", ctrlOpts.PathBase, azureCredentialResourcePath)).Subrouter()
+	awsCredentialCollectionSubRouter := router.Path(fmt.Sprintf("%s%s", ctrlOpts.PathBase, awsCredentialCollectionPath)).Subrouter()
+	awsCredentialResourceSubRouter := router.Path(fmt.Sprintf("%s%s", ctrlOpts.PathBase, awsCredentialResourcePath)).Subrouter()
 
 	handlerOptions = append(handlerOptions, []ctrl.HandlerOptions{
 		// Planes resource handler registration.
@@ -338,7 +336,7 @@ func Register(ctx context.Context, router *mux.Router, ctrlOpts ctrl.Options) er
 		{
 			// Note that the API validation is not applied to the router used for proxying
 			ParentRouter:   router,
-			Path:           fmt.Sprintf("%s%s", baseURL, planeItemPath),
+			Path:           fmt.Sprintf("%s%s", ctrlOpts.PathBase, planeItemPath),
 			HandlerFactory: planes_ctrl.NewProxyPlane,
 		},
 	}...)

--- a/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
+++ b/pkg/ucp/frontend/controller/awsproxy/awsparsing.go
@@ -114,8 +114,8 @@ func computeResourceID(id resources.ID, resourceID string) string {
 }
 
 // Extract Region from  a URI like /apis/api.ucp.dev/v1alpha3/planes/aws/aws/accounts/817312594854/regions/us-west-2/providers/...
-func readRegionFromRequest(path string, basePath string) (string, armrpc_rest.Response) {
-	path = strings.TrimPrefix(path, basePath)
+func readRegionFromRequest(path string, pathBase string) (string, armrpc_rest.Response) {
+	path = strings.TrimPrefix(path, pathBase)
 	resourceID, err := resources.Parse(path)
 	if err != nil {
 		errResponse := v1.ErrorResponse{

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresource.go
@@ -42,7 +42,6 @@ var _ armrpc_controller.Controller = (*CreateOrUpdateAWSResource)(nil)
 type CreateOrUpdateAWSResource struct {
 	armrpc_controller.Operation[*datamodel.AWSResource, datamodel.AWSResource]
 	awsOptions ctrl.AWSOptions
-	basePath   string
 }
 
 // NewCreateOrUpdateAWSResource creates a new CreateOrUpdateAWSResource.
@@ -52,7 +51,6 @@ func NewCreateOrUpdateAWSResource(opts ctrl.Options) (armrpc_controller.Controll
 			armrpc_controller.ResourceOptions[datamodel.AWSResource]{},
 		),
 		awsOptions: opts.AWSOptions,
-		basePath:   opts.BasePath,
 	}, nil
 }
 
@@ -61,7 +59,7 @@ func (p *CreateOrUpdateAWSResource) Run(ctx context.Context, w http.ResponseWrit
 
 	decoder := json.NewDecoder(req.Body)
 	defer req.Body.Close()
-	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
+	region, errResponse := readRegionFromRequest(req.URL.Path, p.Options().PathBase)
 	if errResponse != nil {
 		return errResponse, nil
 	}
@@ -203,6 +201,6 @@ func (p *CreateOrUpdateAWSResource) Run(ctx context.Context, w http.ResponseWrit
 		"properties": responseProperties,
 	}
 
-	resp := armrpc_rest.NewAsyncOperationResponse(responseBody, v1.LocationGlobal, 201, serviceCtx.ResourceID, operation, "", serviceCtx.ResourceID.RootScope(), p.basePath)
+	resp := armrpc_rest.NewAsyncOperationResponse(responseBody, v1.LocationGlobal, 201, serviceCtx.ResourceID, operation, "", serviceCtx.ResourceID.RootScope(), p.Options().PathBase)
 	return resp, nil
 }

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
@@ -45,7 +45,6 @@ var _ armrpc_controller.Controller = (*CreateOrUpdateAWSResourceWithPost)(nil)
 type CreateOrUpdateAWSResourceWithPost struct {
 	armrpc_controller.Operation[*datamodel.AWSResource, datamodel.AWSResource]
 	awsOptions ctrl.AWSOptions
-	basePath   string
 }
 
 // NewCreateOrUpdateAWSResourceWithPost creates a new CreateOrUpdateAWSResourceWithPost.
@@ -56,14 +55,13 @@ func NewCreateOrUpdateAWSResourceWithPost(opts ctrl.Options) (armrpc_controller.
 			armrpc_controller.ResourceOptions[datamodel.AWSResource]{},
 		),
 		awsOptions: opts.AWSOptions,
-		basePath:   opts.BasePath,
 	}, nil
 }
 
 func (p *CreateOrUpdateAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
 	logger := ucplog.FromContextOrDiscard(ctx)
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
-	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
+	region, errResponse := readRegionFromRequest(req.URL.Path, p.Options().PathBase)
 	if errResponse != nil {
 		return errResponse, nil
 	}
@@ -211,6 +209,6 @@ func (p *CreateOrUpdateAWSResourceWithPost) Run(ctx context.Context, w http.Resp
 		responseBody["name"] = awsResourceIdentifier
 	}
 
-	resp := armrpc_rest.NewAsyncOperationResponse(responseBody, v1.LocationGlobal, 201, serviceCtx.ResourceID, operation, "", serviceCtx.ResourceID.RootScope(), p.basePath)
+	resp := armrpc_rest.NewAsyncOperationResponse(responseBody, v1.LocationGlobal, 201, serviceCtx.ResourceID, operation, "", serviceCtx.ResourceID.RootScope(), p.Options().PathBase)
 	return resp, nil
 }

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresource.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresource.go
@@ -38,7 +38,6 @@ var _ armrpc_controller.Controller = (*DeleteAWSResource)(nil)
 type DeleteAWSResource struct {
 	armrpc_controller.Operation[*datamodel.AWSResource, datamodel.AWSResource]
 	awsOptions ctrl.AWSOptions
-	basePath   string
 }
 
 // NewDeleteAWSResource creates a new DeleteAWSResource.
@@ -48,13 +47,12 @@ func NewDeleteAWSResource(opts ctrl.Options) (armrpc_controller.Controller, erro
 			armrpc_controller.ResourceOptions[datamodel.AWSResource]{},
 		),
 		awsOptions: opts.AWSOptions,
-		basePath:   opts.BasePath,
 	}, nil
 }
 
 func (p *DeleteAWSResource) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
-	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
+	region, errResponse := readRegionFromRequest(req.URL.Path, p.Options().PathBase)
 	if errResponse != nil {
 		return errResponse, nil
 	}
@@ -76,6 +74,6 @@ func (p *DeleteAWSResource) Run(ctx context.Context, w http.ResponseWriter, req 
 		return nil, err
 	}
 
-	resp := armrpc_rest.NewAsyncOperationResponse(map[string]any{}, v1.LocationGlobal, 202, serviceCtx.ResourceID, operation, "", serviceCtx.ResourceID.RootScope(), p.basePath)
+	resp := armrpc_rest.NewAsyncOperationResponse(map[string]any{}, v1.LocationGlobal, 202, serviceCtx.ResourceID, operation, "", serviceCtx.ResourceID.RootScope(), p.Options().PathBase)
 	return resp, nil
 }

--- a/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/deleteawsresourcewithpost.go
@@ -42,7 +42,6 @@ var _ armrpc_controller.Controller = (*DeleteAWSResourceWithPost)(nil)
 type DeleteAWSResourceWithPost struct {
 	armrpc_controller.Operation[*datamodel.AWSResource, datamodel.AWSResource]
 	awsOptions ctrl.AWSOptions
-	basePath   string
 }
 
 // NewDeleteAWSResourceWithPost creates a new DeleteAWSResourceWithPost.
@@ -52,14 +51,13 @@ func NewDeleteAWSResourceWithPost(opts ctrl.Options) (armrpc_controller.Controll
 			armrpc_controller.ResourceOptions[datamodel.AWSResource]{},
 		),
 		awsOptions: opts.AWSOptions,
-		basePath:   opts.BasePath,
 	}, nil
 }
 
 func (p *DeleteAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
 	logger := ucplog.FromContextOrDiscard(ctx)
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
-	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
+	region, errResponse := readRegionFromRequest(req.URL.Path, p.Options().PathBase)
 	if errResponse != nil {
 		return errResponse, nil
 	}
@@ -113,6 +111,6 @@ func (p *DeleteAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWrit
 		return nil, err
 	}
 
-	resp := armrpc_rest.NewAsyncOperationResponse(map[string]any{}, v1.LocationGlobal, 202, serviceCtx.ResourceID, operation, "", serviceCtx.ResourceID.RootScope(), p.basePath)
+	resp := armrpc_rest.NewAsyncOperationResponse(map[string]any{}, v1.LocationGlobal, 202, serviceCtx.ResourceID, operation, "", serviceCtx.ResourceID.RootScope(), p.Options().PathBase)
 	return resp, nil
 }

--- a/pkg/ucp/frontend/controller/awsproxy/getawsoperationresults.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsoperationresults.go
@@ -37,7 +37,6 @@ var _ armrpc_controller.Controller = (*GetAWSOperationResults)(nil)
 type GetAWSOperationResults struct {
 	armrpc_controller.Operation[*datamodel.AWSResource, datamodel.AWSResource]
 	awsOptions ctrl.AWSOptions
-	basePath   string
 }
 
 // NewGetAWSOperationResults creates a new GetAWSOperationResults.
@@ -47,13 +46,12 @@ func NewGetAWSOperationResults(opts ctrl.Options) (armrpc_controller.Controller,
 			armrpc_controller.ResourceOptions[datamodel.AWSResource]{},
 		),
 		awsOptions: opts.AWSOptions,
-		basePath:   opts.BasePath,
 	}, nil
 }
 
 func (p *GetAWSOperationResults) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
-	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
+	region, errResponse := readRegionFromRequest(req.URL.Path, p.Options().PathBase)
 	if errResponse != nil {
 		return errResponse, nil
 	}

--- a/pkg/ucp/frontend/controller/awsproxy/getawsoperationstatuses.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsoperationstatuses.go
@@ -38,7 +38,6 @@ var _ armrpc_controller.Controller = (*GetAWSOperationStatuses)(nil)
 type GetAWSOperationStatuses struct {
 	armrpc_controller.Operation[*datamodel.AWSResource, datamodel.AWSResource]
 	awsOptions ctrl.AWSOptions
-	basePath   string
 }
 
 // NewGetAWSOperationStatuses creates a new GetAWSOperationStatuses.
@@ -48,13 +47,12 @@ func NewGetAWSOperationStatuses(opts ctrl.Options) (armrpc_controller.Controller
 			armrpc_controller.ResourceOptions[datamodel.AWSResource]{},
 		),
 		awsOptions: opts.AWSOptions,
-		basePath:   opts.BasePath,
 	}, nil
 }
 
 func (p *GetAWSOperationStatuses) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
-	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
+	region, errResponse := readRegionFromRequest(req.URL.Path, p.Options().PathBase)
 	if errResponse != nil {
 		return errResponse, nil
 	}

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresource.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresource.go
@@ -37,7 +37,6 @@ var _ armrpc_controller.Controller = (*GetAWSResource)(nil)
 type GetAWSResource struct {
 	armrpc_controller.Operation[*datamodel.AWSResource, datamodel.AWSResource]
 	awsOptions ctrl.AWSOptions
-	basePath   string
 }
 
 // NewGetAWSResource creates a new GetAWSResource.
@@ -47,13 +46,12 @@ func NewGetAWSResource(opts ctrl.Options) (armrpc_controller.Controller, error) 
 			armrpc_controller.ResourceOptions[datamodel.AWSResource]{},
 		),
 		awsOptions: opts.AWSOptions,
-		basePath:   opts.BasePath,
 	}, nil
 }
 
 func (p *GetAWSResource) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
-	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
+	region, errResponse := readRegionFromRequest(req.URL.Path, p.Options().PathBase)
 	if errResponse != nil {
 		return errResponse, nil
 	}

--- a/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/getawsresourcewithpost.go
@@ -45,7 +45,6 @@ var _ armrpc_controller.Controller = (*GetAWSResourceWithPost)(nil)
 type GetAWSResourceWithPost struct {
 	armrpc_controller.Operation[*datamodel.AWSResource, datamodel.AWSResource]
 	awsOptions ctrl.AWSOptions
-	basePath   string
 }
 
 // NewGetAWSResourceWithPost creates a new GetAWSResourceWithPost.
@@ -55,14 +54,13 @@ func NewGetAWSResourceWithPost(opts ctrl.Options) (armrpc_controller.Controller,
 			armrpc_controller.ResourceOptions[datamodel.AWSResource]{},
 		),
 		awsOptions: opts.AWSOptions,
-		basePath:   opts.BasePath,
 	}, nil
 }
 
 func (p *GetAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
 	logger := ucplog.FromContextOrDiscard(ctx)
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
-	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
+	region, errResponse := readRegionFromRequest(req.URL.Path, p.Options().PathBase)
 	if errResponse != nil {
 		return errResponse, nil
 	}
@@ -108,7 +106,7 @@ func (p *GetAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWriter,
 	}, cloudcontrolOpts...)
 
 	if awsclient.IsAWSResourceNotFoundError(err) {
-		return armrpc_rest.NewNotFoundMessageResponse(constructNotFoundResponseMessage(middleware.GetRelativePath(p.basePath, req.URL.Path), awsResourceIdentifier)), nil
+		return armrpc_rest.NewNotFoundMessageResponse(constructNotFoundResponseMessage(middleware.GetRelativePath(p.Options().PathBase, req.URL.Path), awsResourceIdentifier)), nil
 	} else if err != nil {
 		return awsclient.HandleAWSError(err)
 	}

--- a/pkg/ucp/frontend/controller/awsproxy/listawsresources.go
+++ b/pkg/ucp/frontend/controller/awsproxy/listawsresources.go
@@ -37,7 +37,6 @@ var _ armrpc_controller.Controller = (*ListAWSResources)(nil)
 type ListAWSResources struct {
 	armrpc_controller.Operation[*datamodel.AWSResource, datamodel.AWSResource]
 	awsOptions ctrl.AWSOptions
-	basePath   string
 }
 
 // NewListAWSResources creates a new ListAWSResources.
@@ -47,13 +46,12 @@ func NewListAWSResources(opts ctrl.Options) (armrpc_controller.Controller, error
 			armrpc_controller.ResourceOptions[datamodel.AWSResource]{},
 		),
 		awsOptions: opts.AWSOptions,
-		basePath:   opts.BasePath,
 	}, nil
 }
 
 func (p *ListAWSResources) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
-	region, errResponse := readRegionFromRequest(req.URL.Path, p.basePath)
+	region, errResponse := readRegionFromRequest(req.URL.Path, p.Options().PathBase)
 	if errResponse != nil {
 		return errResponse, nil
 	}

--- a/pkg/ucp/frontend/controller/controller.go
+++ b/pkg/ucp/frontend/controller/controller.go
@@ -31,12 +31,6 @@ import (
 
 // Options represents controller options.
 type Options struct {
-	// BasePath is the base path of the controller such as /apis/api.ucp.dev/v1alpha3.
-	BasePath string
-
-	// Address is the address where the controller is running.
-	Address string
-
 	// SecretClient is the client to fetch secrets.
 	SecretClient secret.Client
 

--- a/pkg/ucp/frontend/controller/planes/listplanesbytype.go
+++ b/pkg/ucp/frontend/controller/planes/listplanesbytype.go
@@ -39,7 +39,6 @@ var _ armrpc_controller.Controller = (*ListPlanesByType)(nil)
 // ListPlanesByType is the controller implementation to get the list of UCP planes.
 type ListPlanesByType struct {
 	armrpc_controller.Operation[*datamodel.Plane, datamodel.Plane]
-	basePath string
 }
 
 // NewListPlanesByType creates a new ListPlanesByType.
@@ -51,12 +50,11 @@ func NewListPlanesByType(opts ctrl.Options) (armrpc_controller.Controller, error
 				ResponseConverter: converter.PlaneDataModelToVersioned,
 			},
 		),
-		basePath: opts.BasePath,
 	}, nil
 }
 
 func (e *ListPlanesByType) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
-	path := middleware.GetRelativePath(e.basePath, req.URL.Path)
+	path := middleware.GetRelativePath(e.Options().PathBase, req.URL.Path)
 	// The path is /planes/{planeType}
 	planeType := strings.Split(path, resources.SegmentSeparator)[2]
 	query := store.Query{

--- a/pkg/ucp/frontend/controller/planes/proxyplane.go
+++ b/pkg/ucp/frontend/controller/planes/proxyplane.go
@@ -43,18 +43,12 @@ var _ armrpc_controller.Controller = (*ProxyPlane)(nil)
 // ProxyPlane is the controller implementation to proxy requests to appropriate RP or URL.
 type ProxyPlane struct {
 	armrpc_controller.Operation[*datamodel.Plane, datamodel.Plane]
-	basePath string
-	address  string
 }
 
 // NewProxyPlane creates a new ProxyPlane.
 func NewProxyPlane(opts ctrl.Options) (armrpc_controller.Controller, error) {
 	return &ProxyPlane{
-		Operation: armrpc_controller.NewOperation(opts.Options,
-			armrpc_controller.ResourceOptions[datamodel.Plane]{},
-		),
-		basePath: opts.BasePath,
-		address:  opts.Address,
+		Operation: armrpc_controller.NewOperation(opts.Options, armrpc_controller.ResourceOptions[datamodel.Plane]{}),
 	}, nil
 }
 
@@ -74,7 +68,7 @@ func (p *ProxyPlane) Run(ctx context.Context, w http.ResponseWriter, req *http.R
 
 	// Make a copy of the incoming URL and trim the base path
 	newURL := *req.URL
-	newURL.Path = middleware.GetRelativePath(p.basePath, req.URL.Path)
+	newURL.Path = middleware.GetRelativePath(p.Options().PathBase, req.URL.Path)
 	planeType, name, _, err := resources.ExtractPlanesPrefixFromURLPath(newURL.Path)
 	if err != nil {
 		return nil, err
@@ -158,7 +152,7 @@ func (p *ProxyPlane) Run(ctx context.Context, w http.ResponseWriter, req *http.R
 
 	options := proxy.ReverseProxyOptions{
 		RoundTripper:     otelhttp.NewTransport(http.DefaultTransport),
-		ProxyAddress:     p.address,
+		ProxyAddress:     p.Options().Address,
 		TrimPlanesPrefix: (plane.Properties.Kind != rest.PlaneKindUCPNative),
 	}
 
@@ -177,7 +171,7 @@ func (p *ProxyPlane) Run(ctx context.Context, w http.ResponseWriter, req *http.R
 		HTTPScheme: httpScheme,
 		// The Host field in the request that the client makes to UCP contains the UCP Host address
 		// That address will be used to construct the URL for reverse proxying
-		UCPHost: req.Host + p.basePath,
+		UCPHost: req.Host + p.Options().PathBase,
 	}
 
 	uri, err := url.Parse(newURL.Path)

--- a/pkg/ucp/integrationtests/aws/awstest.go
+++ b/pkg/ucp/integrationtests/aws/awstest.go
@@ -53,7 +53,7 @@ const (
 	testAWSResourceName               = "stream-1"
 	testProxyRequestAWSAsyncPath      = "/planes/aws/aws/accounts/1234567/regions/us-east-1/providers/AWS.Kinesis/locations/global"
 	testAWSRequestToken               = "79B9F0DA-4882-4DC8-A367-6FD3BC122DED" // Random UUID
-	basePath                          = "/apis/api.ucp.dev/v1alpha3"
+	pathBase                          = "/apis/api.ucp.dev/v1alpha3"
 )
 
 func initializeTest(t *testing.T) (*httptest.Server, Client, *aws.MockAWSCloudControlClient, *aws.MockAWSCloudFormationClient) {
@@ -68,22 +68,22 @@ func initializeTest(t *testing.T) (*httptest.Server, Client, *aws.MockAWSCloudCo
 		AnyTimes()
 
 	router := mux.NewRouter()
-	router.Use(servicecontext.ARMRequestCtx(basePath, "global"))
+	router.Use(servicecontext.ARMRequestCtx(pathBase, "global"))
 	ucp := httptest.NewServer(router)
 	ctx := context.Background()
 	err := api.Register(ctx, router, controller.Options{
-		BasePath: basePath,
 		AWSOptions: controller.AWSOptions{
 			AWSCloudControlClient:   cloudControlClient,
 			AWSCloudFormationClient: cloudFormationClient,
 		},
 		Options: armrpc_controller.Options{
+			PathBase:     pathBase,
 			DataProvider: provider,
 		},
 	})
 	require.NoError(t, err)
 
-	ucpClient := NewClient(http.DefaultClient, ucp.URL+basePath)
+	ucpClient := NewClient(http.DefaultClient, ucp.URL+pathBase)
 
 	return ucp, ucpClient, cloudControlClient, cloudFormationClient
 }

--- a/pkg/ucp/integrationtests/aws/createresource_test.go
+++ b/pkg/ucp/integrationtests/aws/createresource_test.go
@@ -63,7 +63,7 @@ func Test_CreateAWSResource(t *testing.T) {
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	createRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPut, ucp.URL+basePath+testProxyRequestAWSPath, body)
+	createRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPut, ucp.URL+pathBase+testProxyRequestAWSPath, body)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := testutil.ARMTestContextFromRequest(createRequest)

--- a/pkg/ucp/integrationtests/aws/createresourcewithpost_test.go
+++ b/pkg/ucp/integrationtests/aws/createresourcewithpost_test.go
@@ -81,7 +81,7 @@ func Test_CreateAWSResourceWithPost(t *testing.T) {
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	createRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPost, ucp.URL+basePath+testProxyRequestAWSCollectionPath+"/:put", body)
+	createRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPost, ucp.URL+pathBase+testProxyRequestAWSCollectionPath+"/:put", body)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := testutil.ARMTestContextFromRequest(createRequest)

--- a/pkg/ucp/integrationtests/aws/deleteresource_test.go
+++ b/pkg/ucp/integrationtests/aws/deleteresource_test.go
@@ -46,7 +46,7 @@ func Test_DeleteAWSResource(t *testing.T) {
 		return &output, nil
 	})
 
-	deleteRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodDelete, ucp.URL+basePath+testProxyRequestAWSPath, nil)
+	deleteRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodDelete, ucp.URL+pathBase+testProxyRequestAWSPath, nil)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := testutil.ARMTestContextFromRequest(deleteRequest)

--- a/pkg/ucp/integrationtests/aws/deleteresourcewithpost_test.go
+++ b/pkg/ucp/integrationtests/aws/deleteresourcewithpost_test.go
@@ -73,7 +73,7 @@ func Test_DeleteAWSResourceWithPost(t *testing.T) {
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	deleteRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPost, ucp.URL+basePath+testProxyRequestAWSCollectionPath+"/:delete", body)
+	deleteRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPost, ucp.URL+pathBase+testProxyRequestAWSCollectionPath+"/:delete", body)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := testutil.ARMTestContextFromRequest(deleteRequest)

--- a/pkg/ucp/integrationtests/aws/getresource_test.go
+++ b/pkg/ucp/integrationtests/aws/getresource_test.go
@@ -54,7 +54,7 @@ func Test_GetAWSResource(t *testing.T) {
 		return &output, nil
 	})
 
-	getRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodGet, ucp.URL+basePath+testProxyRequestAWSPath, nil)
+	getRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodGet, ucp.URL+pathBase+testProxyRequestAWSPath, nil)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := testutil.ARMTestContextFromRequest(getRequest)

--- a/pkg/ucp/integrationtests/aws/getresourcewithpost_test.go
+++ b/pkg/ucp/integrationtests/aws/getresourcewithpost_test.go
@@ -80,7 +80,7 @@ func Test_GetAWSResourceWithPost(t *testing.T) {
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	getRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPost, ucp.URL+basePath+testProxyRequestAWSCollectionPath+"/:get", body)
+	getRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPost, ucp.URL+pathBase+testProxyRequestAWSCollectionPath+"/:get", body)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := testutil.ARMTestContextFromRequest(getRequest)

--- a/pkg/ucp/integrationtests/aws/listresources_test.go
+++ b/pkg/ucp/integrationtests/aws/listresources_test.go
@@ -58,7 +58,7 @@ func Test_ListAWSResources(t *testing.T) {
 		return &output, nil
 	})
 
-	listRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodGet, ucp.URL+basePath+testProxyRequestAWSListPath, nil)
+	listRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodGet, ucp.URL+pathBase+testProxyRequestAWSListPath, nil)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := testutil.ARMTestContextFromRequest(listRequest)

--- a/pkg/ucp/integrationtests/aws/operationresults_test.go
+++ b/pkg/ucp/integrationtests/aws/operationresults_test.go
@@ -46,7 +46,7 @@ func Test_GetOperationResults(t *testing.T) {
 		return &output, nil
 	})
 
-	operationResultsRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodGet, ucp.URL+basePath+testProxyRequestAWSAsyncPath+"/operationResults/"+strings.ToLower(testAWSRequestToken), nil)
+	operationResultsRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodGet, ucp.URL+pathBase+testProxyRequestAWSAsyncPath+"/operationResults/"+strings.ToLower(testAWSRequestToken), nil)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := testutil.ARMTestContextFromRequest(operationResultsRequest)

--- a/pkg/ucp/integrationtests/aws/operationstatuses_test.go
+++ b/pkg/ucp/integrationtests/aws/operationstatuses_test.go
@@ -48,7 +48,7 @@ func Test_GetOperationStatuses(t *testing.T) {
 		return &output, nil
 	})
 
-	operationResultsRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodGet, ucp.URL+basePath+testProxyRequestAWSAsyncPath+"/operationStatuses/"+strings.ToLower(testAWSRequestToken), nil)
+	operationResultsRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodGet, ucp.URL+pathBase+testProxyRequestAWSAsyncPath+"/operationStatuses/"+strings.ToLower(testAWSRequestToken), nil)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := testutil.ARMTestContextFromRequest(operationResultsRequest)

--- a/pkg/ucp/integrationtests/aws/updateresource_test.go
+++ b/pkg/ucp/integrationtests/aws/updateresource_test.go
@@ -94,7 +94,7 @@ func Test_UpdateAWSResource(t *testing.T) {
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	updateRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPut, ucp.URL+basePath+testProxyRequestAWSPath, body)
+	updateRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPut, ucp.URL+pathBase+testProxyRequestAWSPath, body)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := testutil.ARMTestContextFromRequest(updateRequest)

--- a/pkg/ucp/integrationtests/aws/updateresourcewithpost_test.go
+++ b/pkg/ucp/integrationtests/aws/updateresourcewithpost_test.go
@@ -90,7 +90,7 @@ func Test_UpdateAWSResourceWithPost(t *testing.T) {
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	updateRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPost, ucp.URL+basePath+testProxyRequestAWSCollectionPath+"/:put", body)
+	updateRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPost, ucp.URL+pathBase+testProxyRequestAWSCollectionPath+"/:put", body)
 	require.NoError(t, err, "creating request failed")
 
 	ctx := testutil.ARMTestContextFromRequest(updateRequest)

--- a/pkg/ucp/integrationtests/integration_test.go
+++ b/pkg/ucp/integrationtests/integration_test.go
@@ -69,7 +69,7 @@ const (
 	apiVersionQueyParam       = "api-version=2022-09-01-privatepreview"
 	testUCPNativePlaneID      = "/planes/radius/local"
 	testAzurePlaneID          = "/planes/azure/azurecloud"
-	basePath                  = "/apis/api.ucp.dev/v1alpha3"
+	pathBase                  = "/apis/api.ucp.dev/v1alpha3"
 )
 
 var planeKindAzure v20220901privatepreview.PlaneKind = v20220901privatepreview.PlaneKindAzure
@@ -131,7 +131,7 @@ var testResourceGroup = v20220901privatepreview.ResourceGroupResource{
 func Test_ProxyToRP(t *testing.T) {
 	router := mux.NewRouter()
 	ucp := httptest.NewServer(router)
-	router.Use(servicecontext.ARMRequestCtx(basePath, "global"))
+	router.Use(servicecontext.ARMRequestCtx(pathBase, "global"))
 
 	body, err := json.Marshal(applicationList)
 	require.NoError(t, err)
@@ -139,7 +139,7 @@ func Test_ProxyToRP(t *testing.T) {
 	rp := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, testProxyRequestPath, r.URL.Path)
 		w.Header().Add("Content-Type", "application/json")
-		w.Header().Add("Location", ucp.URL+basePath+testProxyRequestPath)
+		w.Header().Add("Location", ucp.URL+pathBase+testProxyRequestPath)
 		w.WriteHeader(http.StatusOK)
 		_, err = w.Write(body)
 	}))
@@ -161,15 +161,15 @@ func Test_ProxyToRP(t *testing.T) {
 
 	ctx := context.Background()
 	err = api.Register(ctx, router, controller.Options{
-		BasePath: basePath,
 		Options: armrpc_controller.Options{
 			DataProvider:  provider,
 			StorageClient: db,
+			PathBase:      pathBase,
 		},
 	})
 	require.NoError(t, err)
 
-	ucpClient := NewClient(http.DefaultClient, ucp.URL+basePath)
+	ucpClient := NewClient(http.DefaultClient, ucp.URL+pathBase)
 
 	// Register RP with UCP
 	registerRP(t, ucp, ucpClient, db, true)
@@ -208,19 +208,19 @@ func Test_ProxyToRP_NonNativePlane(t *testing.T) {
 		AnyTimes()
 
 	router := mux.NewRouter()
-	router.Use(servicecontext.ARMRequestCtx(basePath, "global"))
+	router.Use(servicecontext.ARMRequestCtx(pathBase, "global"))
 	ucp := httptest.NewServer(router)
 	ctx := context.Background()
 	err = api.Register(ctx, router, controller.Options{
-		BasePath: basePath,
 		Options: armrpc_controller.Options{
+			PathBase:      pathBase,
 			DataProvider:  provider,
 			StorageClient: db,
 		},
 	})
 	require.NoError(t, err)
 
-	ucpClient := NewClient(http.DefaultClient, ucp.URL+basePath)
+	ucpClient := NewClient(http.DefaultClient, ucp.URL+pathBase)
 
 	// Register RP with UCP
 	registerRP(t, ucp, ucpClient, db, false)
@@ -241,7 +241,7 @@ func Test_ProxyToRP_ResourceGroupDoesNotExist(t *testing.T) {
 func Test_MethodNotAllowed(t *testing.T) {
 	ucp, ucpClient, _ := initialize(t)
 	// Send a request that will be proxied to the RP
-	request, err := http.NewRequest("DELETE", ucp.URL+basePath+"/planes", nil)
+	request, err := http.NewRequest("DELETE", ucp.URL+pathBase+"/planes", nil)
 	require.NoError(t, err)
 	response, err := ucpClient.httpClient.Do(request)
 	require.NoError(t, err)
@@ -251,7 +251,7 @@ func Test_MethodNotAllowed(t *testing.T) {
 func Test_NotFound(t *testing.T) {
 	ucp, ucpClient, _ := initialize(t)
 	// Send a request that will be proxied to the RP
-	request, err := http.NewRequest("GET", ucp.URL+basePath+"/abc", nil)
+	request, err := http.NewRequest("GET", ucp.URL+pathBase+"/abc", nil)
 	require.NoError(t, err)
 	response, err := ucpClient.httpClient.Do(request)
 	require.NoError(t, err)
@@ -268,7 +268,7 @@ func Test_APIValidationIsApplied(t *testing.T) {
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 
-	createResourceGroupRequest, err := http.NewRequest("PUT", ucp.URL+basePath+"/planes/radius/local/resourcegroups/rg1?api-version=2022-09-01-privatepreview", bytes.NewBuffer(body))
+	createResourceGroupRequest, err := http.NewRequest("PUT", ucp.URL+pathBase+"/planes/radius/local/resourcegroups/rg1?api-version=2022-09-01-privatepreview", bytes.NewBuffer(body))
 	require.NoError(t, err)
 	response, err := ucpClient.httpClient.Do(createResourceGroupRequest)
 	require.NoError(t, err)
@@ -302,19 +302,19 @@ func initialize(t *testing.T) (*httptest.Server, Client, *store.MockStorageClien
 		AnyTimes()
 
 	router := mux.NewRouter()
-	router.Use(servicecontext.ARMRequestCtx(basePath, "global"))
+	router.Use(servicecontext.ARMRequestCtx(pathBase, "global"))
 	ucp := httptest.NewServer(router)
 	ctx := context.Background()
 	err = api.Register(ctx, router, controller.Options{
 		Options: armrpc_controller.Options{
+			PathBase:      pathBase,
 			DataProvider:  provider,
 			StorageClient: db,
 		},
-		BasePath: basePath,
 	})
 	require.NoError(t, err)
 
-	ucpClient := NewClient(http.DefaultClient, ucp.URL+basePath)
+	ucpClient := NewClient(http.DefaultClient, ucp.URL+pathBase)
 
 	// Register RP with UCP
 	registerRP(t, ucp, ucpClient, db, true)
@@ -347,9 +347,9 @@ func registerRP(t *testing.T, ucp *httptest.Server, ucpClient Client, db *store.
 	require.NoError(t, err)
 	var createPlaneRequest *http.Request
 	if ucpNative {
-		createPlaneRequest, err = testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPut, ucp.URL+basePath+"/planes/radius/local?api-version=2022-09-01-privatepreview", body)
+		createPlaneRequest, err = testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPut, ucp.URL+pathBase+"/planes/radius/local?api-version=2022-09-01-privatepreview", body)
 	} else {
-		createPlaneRequest, err = testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPut, ucp.URL+basePath+"/planes/azure/azurecloud?api-version=2022-09-01-privatepreview", body)
+		createPlaneRequest, err = testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPut, ucp.URL+pathBase+"/planes/azure/azurecloud?api-version=2022-09-01-privatepreview", body)
 	}
 	require.NoError(t, err)
 
@@ -389,7 +389,7 @@ func createResourceGroup(t *testing.T, ucp *httptest.Server, ucpClient Client, d
 		return nil, &store.ErrNotFound{}
 	})
 	db.EXPECT().Save(gomock.Any(), gomock.Any(), gomock.Any())
-	createResourceGroupRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPut, ucp.URL+basePath+"/planes/radius/local/resourcegroups/rg1?api-version=2022-09-01-privatepreview", body)
+	createResourceGroupRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPut, ucp.URL+pathBase+"/planes/radius/local/resourcegroups/rg1?api-version=2022-09-01-privatepreview", body)
 	require.NoError(t, err)
 	createResourceGroupResponse, err := ucpClient.httpClient.Do(createResourceGroupRequest)
 	require.NoError(t, err)
@@ -422,13 +422,13 @@ func sendProxyRequest(t *testing.T, ucp *httptest.Server, ucpClient Client, db *
 		}, nil
 	})
 
-	proxyRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPut, ucp.URL+basePath+testProxyRequestPath+"?"+apiVersionQueyParam, nil)
+	proxyRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodPut, ucp.URL+pathBase+testProxyRequestPath+"?"+apiVersionQueyParam, nil)
 	require.NoError(t, err)
 	proxyRequestResponse, err := ucpClient.httpClient.Do(proxyRequest)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, proxyRequestResponse.StatusCode)
 	require.Equal(t, apiVersionQueyParam, proxyRequestResponse.Request.URL.RawQuery)
-	require.Equal(t, "http://"+proxyRequest.Host+basePath+testProxyRequestPath, proxyRequestResponse.Header["Location"][0])
+	require.Equal(t, "http://"+proxyRequest.Host+pathBase+testProxyRequestPath, proxyRequestResponse.Header["Location"][0])
 
 	defer proxyRequestResponse.Body.Close()
 	proxyRequestResponseBody, err := io.ReadAll(proxyRequestResponse.Body)
@@ -448,7 +448,7 @@ func sendProxyRequest_AzurePlane(t *testing.T, ucp *httptest.Server, ucpClient C
 		return &data, nil
 	})
 
-	proxyRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodGet, ucp.URL+basePath+"/planes/azure/azurecloud"+testProxyRequestAzurePath+"?"+apiVersionQueyParam, nil)
+	proxyRequest, err := testutil.GetARMTestHTTPRequestFromURL(context.Background(), http.MethodGet, ucp.URL+pathBase+"/planes/azure/azurecloud"+testProxyRequestAzurePath+"?"+apiVersionQueyParam, nil)
 	require.NoError(t, err)
 	proxyRequestResponse, err := ucpClient.httpClient.Do(proxyRequest)
 	require.NoError(t, err)
@@ -479,7 +479,7 @@ func sendProxyRequest_ResourceGroupDoesNotExist(t *testing.T, ucp *httptest.Serv
 	db.EXPECT().Get(gomock.Any(), rgID.String()).DoAndReturn(func(ctx context.Context, id string, options ...store.GetOptions) (*store.Object, error) {
 		return nil, &store.ErrNotFound{}
 	})
-	proxyRequest, err := http.NewRequest("GET", ucp.URL+basePath+testProxyRequestPath+"?"+apiVersionQueyParam, nil)
+	proxyRequest, err := http.NewRequest("GET", ucp.URL+pathBase+testProxyRequestPath+"?"+apiVersionQueyParam, nil)
 	require.NoError(t, err)
 	proxyRequestResponse, err := ucpClient.httpClient.Do(proxyRequest)
 	require.NoError(t, err)
@@ -499,10 +499,10 @@ func Test_RequestWithBadAPIVersion(t *testing.T) {
 	ctx := context.Background()
 	err := api.Register(ctx, router, controller.Options{
 		Options: armrpc_controller.Options{
+			PathBase:      pathBase,
 			DataProvider:  provider,
 			StorageClient: db,
 		},
-		BasePath: basePath,
 	})
 	require.NoError(t, err)
 
@@ -522,10 +522,10 @@ func Test_RequestWithBadAPIVersion(t *testing.T) {
 	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 	ucp := httptest.NewServer(router)
-	request, err := http.NewRequest(http.MethodGet, ucp.URL+basePath+"/planes/radius/local?api-version=unsupported-version", bytes.NewBuffer(body))
+	request, err := http.NewRequest(http.MethodGet, ucp.URL+pathBase+"/planes/radius/local?api-version=unsupported-version", bytes.NewBuffer(body))
 	require.NoError(t, err)
 
-	ucpClient := NewClient(http.DefaultClient, ucp.URL+basePath)
+	ucpClient := NewClient(http.DefaultClient, ucp.URL+pathBase)
 	response, err := ucpClient.httpClient.Do(request)
 	require.NoError(t, err)
 

--- a/pkg/ucp/server/server.go
+++ b/pkg/ucp/server/server.go
@@ -62,7 +62,7 @@ type Options struct {
 	ProfilerProviderOptions profilerprovider.ProfilerProviderOptions
 	TracerProviderOptions   trace.Options
 	TLSCertDir              string
-	BasePath                string
+	PathBase                string
 	InitialPlanes           []rest.Plane
 	Identity                hostoptions.Identity
 	UCPConnection           sdk.Connection
@@ -130,7 +130,7 @@ func NewServerOptionsFromEnvironment() (Options, error) {
 	return Options{
 		Port:                    port,
 		TLSCertDir:              tlsCertDir,
-		BasePath:                basePath,
+		PathBase:                basePath,
 		StorageProviderOptions:  storeOpts,
 		SecretProviderOptions:   secretOpts,
 		QueueProviderOptions:    qproviderOpts,
@@ -154,7 +154,7 @@ func NewServer(options *Options) (*hosting.Host, error) {
 			ProviderName:           UCPProviderName,
 			Address:                ":" + options.Port,
 			TLSCertDir:             options.TLSCertDir,
-			BasePath:               options.BasePath,
+			PathBase:               options.PathBase,
 			StorageProviderOptions: options.StorageProviderOptions,
 			SecretProviderOptions:  options.SecretProviderOptions,
 			QueueProviderOptions:   options.QueueProviderOptions,


### PR DESCRIPTION
# Description

This change takes a step towards consolidating the functionality for controllers in the Radius Repo. Previously we had three different types for controllers and three different options types. So far we we've consolidated down to a single controller interface and two options types.

This change adds the following properties to the armrpc controller options type:

- Address
- PathBase

These properties are heavily used in UCP but not frequently used in the CoreRP or LinkRP controllers.

Additionally, I make renames to be consistent in using `pathBase` over `basePath`.

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1efa215</samp>

### Summary
🚚🛠️🔗

<!--
1.  🚚 This emoji represents the removal or renaming of variables and parameters related to the URL path prefix, which simplifies the code and avoids redundancy and inconsistency.
2.  🛠️ This emoji represents the addition or modification of features or functions related to the controller's address and URL path prefix, which improves the flexibility and clarity of the code.
3.  🔗 This emoji represents the use of the `PathBase` field from the `ctrl.Options` struct to construct or trim the URL paths for the controller routes, which ensures consistency and correctness of the code.
-->
This pull request refactors the code related to the URL path prefix and the listening address for the controller in various packages. It eliminates redundant and inconsistent fields and parameters, and uses the `ctrl.Options` struct to pass the configuration options consistently. It also adds support for multiple resource types in the `armrpc` package and clarifies the role of the status manager. It updates the tests and the utility functions accordingly.

> _Oh, we're the crew of the `ctrl` ship, and we sail the code sea_
> _We've got to fix the `pathBase`, and make it consistent, you see_
> _So heave away, me hearties, heave away with me_
> _We'll use the `Options` struct, and set the `PathBase` field free_

### Walkthrough
*  Add `Address` and `PathBase` fields to the `controller` package to store the listening address and the URL path prefix for the controller ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-02f644f0b91f28040a46a2b213fca0f77f300773b24c244317b09caa4d94a54fR36-R54))
*  Pass `Address` and `PathBase` fields to the `server` package as part of the `Options` struct ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-02f644f0b91f28040a46a2b213fca0f77f300773b24c244317b09caa4d94a54fR36-R54), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-7ea25eedbaa97be92839b34529ce6c828e50f74b8845eaefc02832c23cd6d833R53-R54), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-88ccdb30c30e2dcde3aa40031dca1aae8d9ca2db02bca474e110a6a1b3cbf46aR54-R55), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-0a6525922e20605ab1c49572f263820eabd7acab2b7b582e5edb36736da6ba51R163-R164))
*  Remove `Address` and `PathBase` fields from the `Options` struct passed to the `Start` function of the `server` package, as they are redundant and could cause inconsistency ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-7ea25eedbaa97be92839b34529ce6c828e50f74b8845eaefc02832c23cd6d833L58-R63), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-88ccdb30c30e2dcde3aa40031dca1aae8d9ca2db02bca474e110a6a1b3cbf46aL59-R63), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-0a6525922e20605ab1c49572f263820eabd7acab2b7b582e5edb36736da6ba51L157-L158))
*  Allow `ResourceType` field in the `Options` struct to be empty if the controller does not represent a single type of resource ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-02f644f0b91f28040a46a2b213fca0f77f300773b24c244317b09caa4d94a54fL45-R68))
*  Rename `pathBase` parameter in the `ConfigureDefaultHandlers` function to `rootScopePath` to avoid confusion with the `PathBase` field in the `Options` struct ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-396513193f1b5b9c9b3a0095d03ef768cf67732757091f664bf7142812b10d75L101-R101))
*  Replace `pathBase` variable with `rootScopePath` variable in the `RegisterHandler` calls for the subscription lifecycle, operation statuses, and operation results APIs ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-396513193f1b5b9c9b3a0095d03ef768cf67732757091f664bf7142812b10d75L122-R122), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-396513193f1b5b9c9b3a0095d03ef768cf67732757091f664bf7142812b10d75L133-R133), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-396513193f1b5b9c9b3a0095d03ef768cf67732757091f664bf7142812b10d75L144-R144))
*  Remove `pathBase` parameter from the `AddRoutes` functions in the `handler` packages, as it is no longer needed ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L48-R53), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL46-R56))
*  Replace `pathBase` variable with `rootScopePath` variable in the `ConfigureDefaultHandlers` calls and the `prefixes` slices in the `AddRoutes` functions ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L58-R59), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L67-R69), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL64-R66))
*  Replace `pathBase` variable with `rootScopePath` variable in the `PathPrefix` calls for the `planeScopeRouter` and the `resourceGroupScopeRouter` in the `AddRoutes` functions ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L79-R80), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L85-R86), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL76-R77), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL82-R83))
*  Replace `pathBase` variable with `PathBase` field from the `ctrl.Options` struct in the `assertRouters` functions in the `routes_test.go` files ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-0710457d98e776f97314721f5e8bfba29a045f6181aa8e48214744abe0bf7ed7L189-R189), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-0b907f728ed11ad6f1305d729cbdd4d587ec377b36e60dd280bd182eb5c7be2fL273-R273))
*  Remove `baseURL` variable from the `Register` function in the `api` package, as it is no longer needed ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-dfb7e47b7c3b87c21cf5cf682dec097126f3276a8019a440cc0bd74855a074e7L63-R66))
*  Replace `baseURL` variable with `ctrlOpts.PathBase` variable in the `ParentRouter` field of the `HandlerOptions` struct, the `LoadSpec` call, the `PathPrefix` call, the `Path` calls for the AWS resources, Azure and AWS credential, and proxy plane subrouters, and the `Register` function in the `api` package ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-dfb7e47b7c3b87c21cf5cf682dec097126f3276a8019a440cc0bd74855a074e7L78-R76), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-dfb7e47b7c3b87c21cf5cf682dec097126f3276a8019a440cc0bd74855a074e7L88-R93), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-dfb7e47b7c3b87c21cf5cf682dec097126f3276a8019a440cc0bd74855a074e7L107-R105), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-dfb7e47b7c3b87c21cf5cf682dec097126f3276a8019a440cc0bd74855a074e7L116-R117), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-dfb7e47b7c3b87c21cf5cf682dec097126f3276a8019a440cc0bd74855a074e7L341-R339))
*  Rename `BasePath` field in the `ServiceOptions` struct to `PathBase` to match the naming convention used in the rest of the code ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-0a6525922e20605ab1c49572f263820eabd7acab2b7b582e5edb36736da6ba51L73-R73))
*  Replace `options.BasePath` variable with `options.PathBase` variable in the `ARMRequestCtx` call and the `FromARMRequest` call in the `server.go` file ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-0a6525922e20605ab1c49572f263820eabd7acab2b7b582e5edb36736da6ba51L190-R190), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-0a6525922e20605ab1c49572f263820eabd7acab2b7b582e5edb36736da6ba51L262-R262))
*  Rename `basePath` parameter in the `GetRelativePath` function to `pathBase` to match the naming convention used in the rest of the code ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-9daa957c1937229d415832e582b933385cf04806ed3815a47464e86084425f5dL22-R23))
*  Rename `basePath` parameter in the `readRegionFromRequest` function to `pathBase` to match the naming convention used in the rest of the code ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-ed6d189120ab5108395d1dffe2a7f5409df69acbd36c759eff9c30be5216e854L117-R118))
*  Remove `basePath` field from the `CreateOrUpdateAWSResource`, `CreateOrUpdateAWSResourceWithPost`, `DeleteAWSResource`, `DeleteAWSResourceWithPost`, `GetAWSOperationResults`, `GetAWSOperationStatuses`, `GetAWSResource`, and `GetAWSResourceWithPost` structs, as it is no longer needed ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-47b17a722d0816817e56719e35e13e61a5d81e9ba6c1cbce2ba594b39777fff6L45), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-1b4711e5a98c1e69e2b191e732147631a391a65773bd38b473431c707eaf50cbL48), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-225a87c32ae8b8596beea950b68da1c0a63ea912b3c82a0befc23146cb003200L41), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-7bcc26d3254b3ea519947c2e61b570e0b4671ed64f1def015322b19ad87b732dL45), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-d327e9801eb9dda963c4a4cb9503ba1467762b7b9777a5aa5393e6bed935f248L40), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-c5c14584d8368ee3a045ba27263aeee82f902c79337219cfbf18ea0e3cd60487L41), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-2cb3d65c7d3aadbcd9813f340895acc09f6e540d24d95e7fcbde676bd0f148b9L40), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-5664daccf0ace2636d59ad24a12e1f1c243fd443af39528e34e70adc2d71cc3cL48))
*  Remove `basePath` field from the `opts` variable in the `NewCreateOrUpdateAWSResource`, `NewCreateOrUpdateAWSResourceWithPost`, `NewDeleteAWSResource`, `NewDeleteAWSResourceWithPost`, `NewGetAWSOperationResults`, `NewGetAWSOperationStatuses`, `NewGetAWSResource`, and `NewGetAWSResourceWithPost` functions, as it is no longer needed ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-47b17a722d0816817e56719e35e13e61a5d81e9ba6c1cbce2ba594b39777fff6L55), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-1b4711e5a98c1e69e2b191e732147631a391a65773bd38b473431c707eaf50cbL59), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-225a87c32ae8b8596beea950b68da1c0a63ea912b3c82a0befc23146cb003200L51), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-7bcc26d3254b3ea519947c2e61b570e0b4671ed64f1def015322b19ad87b732dL55), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-d327e9801eb9dda963c4a4cb9503ba1467762b7b9777a5aa5393e6bed935f248L50), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-c5c14584d8368ee3a045ba27263aeee82f902c79337219cfbf18ea0e3cd60487L51), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-2cb3d65c7d3aadbcd9813f340895acc09f6e540d24d95e7fcbde676bd0f148b9L50), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-5664daccf0ace2636d59ad24a12e1f1c243fd443af39528e34e70adc2d71cc3cL58))
*  Replace `basePath` variable with `Options().PathBase` variable in the `readRegionFromRequest` calls, the `NewAsyncOperationResponse` calls, and the `NewNotFoundMessageResponse` call in the `awsproxy` package ([link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-47b17a722d0816817e56719e35e13e61a5d81e9ba6c1cbce2ba594b39777fff6L64-R62), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-47b17a722d0816817e56719e35e13e61a5d81e9ba6c1cbce2ba594b39777fff6L206-R204), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-1b4711e5a98c1e69e2b191e732147631a391a65773bd38b473431c707eaf50cbL66-R64), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-1b4711e5a98c1e69e2b191e732147631a391a65773bd38b473431c707eaf50cbL214-R212), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-225a87c32ae8b8596beea950b68da1c0a63ea912b3c82a0befc23146cb003200L57-R55), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-225a87c32ae8b8596beea950b68da1c0a63ea912b3c82a0befc23146cb003200L79-R77), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-7bcc26d3254b3ea519947c2e61b570e0b4671ed64f1def015322b19ad87b732dL62-R60), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-7bcc26d3254b3ea519947c2e61b570e0b4671ed64f1def015322b19ad87b732dL116-R114), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-d327e9801eb9dda963c4a4cb9503ba1467762b7b9777a5aa5393e6bed935f248L56-R54), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-c5c14584d8368ee3a045ba27263aeee82f902c79337219cfbf18ea0e3cd60487L57-R55), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-2cb3d65c7d3aadbcd9813f340895acc09f6e540d24d95e7fcbde676bd0f148b9L56-R54), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-5664daccf0ace2636d59ad24a12e1f1c243fd443af39528e34e70adc2d71cc3cL65-R63), [link](https://github.com/project-radius/radius/pull/5756/files?diff=unified&w=0#diff-5664daccf0ace2636d59ad24a12e1f1c243fd443af39528e34e70adc2d71cc3cL111-R109))


