### PR TITLE
Disable flaky tests

### DIFF
--- a/pkg/cli/cmd/radinit/display_test.go
+++ b/pkg/cli/cmd/radinit/display_test.go
@@ -40,6 +40,7 @@ var (
 // We can try again when the test framework is more mature.
 
 func Test_summaryModel(t *testing.T) {
+	t.Skip("these tests are failing sporadically. tracked by #5762")
 	waitForRender := func(t *testing.T, reader io.Reader) string {
 		normalized := ""
 		teatest.WaitFor(t, reader, func(bts []byte) bool {

--- a/pkg/cli/prompt/text/text_test.go
+++ b/pkg/cli/prompt/text/text_test.go
@@ -72,6 +72,8 @@ func Test_NewTextModel_UpdateEchoMode(t *testing.T) {
 }
 
 func Test_E2E(t *testing.T) {
+	t.Skip("these tests are failing sporadically. tracked by #5762")
+
 	// Note: unfortunately I ran into bugs with the testing framework while trying to test more advance
 	// scenarios like validation. The output coming from the framework was truncated, so I just couldn't do it :(.
 	//


### PR DESCRIPTION
# Description

These tests have been failing sporadically even with an extended timeout. The test framework provided by bubbletea is new and relatively unproven. Disabling these while we follow up with the maintainers.

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 33aebbc</samp>

### Summary
:warning::bug::test_tube:

<!--
1.  :warning: - This emoji conveys that the changes are not ideal and are only meant to be temporary. It also warns the reviewers and other developers that the tests are being skipped and that there is an underlying issue that needs to be addressed.
2.  :bug: - This emoji indicates that the changes are related to a bug or an issue that is affecting the functionality or quality of the code. It also signals that the issue is tracked and has a reference number that can be used to find more information or follow the progress of the fix.
3.  :test_tube: - This emoji represents that the changes are related to testing or test cases. It also implies that the changes are not affecting the main logic or features of the code, but only the way they are verified or validated.
-->
Skip some failing tests in the `radinit` and `text` packages due to issue #5762. This is a temporary workaround to unblock the pull request until the issue is fixed.

> _`radinit` tests skipped_
> _Issue #5762 lingers_
> _Winter of our code_

### Walkthrough
* Skip tests in `radinit` package due to intermittent failures (#5762) ([link](https://github.com/project-radius/radius/pull/5763/files?diff=unified&w=0#diff-652ce55ed8af3f822e7c546447ced1d2daf2e8d2c586f783cdac0ec3f9bd8513R43))
* Skip tests in `Test_NewTextModel_UpdateEchoMode` function for the same reason (#5762) ([link](https://github.com/project-radius/radius/pull/5763/files?diff=unified&w=0#diff-a95b3c117c873821d9473cd582ee12f2ffccb36c71d5fd41b1a3897f0268d957R75-R76))


