### PR TITLE
Update rad init prompt for AWS provider

### DIFF
--- a/pkg/cli/cmd/radinit/aws.go
+++ b/pkg/cli/cmd/radinit/aws.go
@@ -31,7 +31,7 @@ const (
 	enterAWSIAMAcessKeyIDPrompt           = "Enter the IAM access key id:"
 	enterAWSIAMAcessKeyIDPlaceholder      = "Enter IAM access key id..."
 	enterAWSIAMSecretAccessKeyPrompt      = "Enter your IAM Secret Access Keys:"
-	enterAWSIAMSecretAccessKeyPlaceholder = "Enter IAM access key..."
+	enterAWSIAMSecretAccessKeyPlaceholder = "Enter IAM secret access key..."
 	errNotEmptyTemplate                   = "%s cannot be empty"
 
 	awsAccessKeysCreateInstructionFmt = "\nAWS IAM Access keys (Access key ID and Secret access key) are required to access and create AWS resources.\n\nFor example, you can create one using the following command:\n\033[36maws iam create-access-key\033[0m\n\nFor more information refer to https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html.\n\n"

--- a/pkg/cli/cmd/radinit/aws.go
+++ b/pkg/cli/cmd/radinit/aws.go
@@ -30,7 +30,7 @@ const (
 	enterAWSRegionPlaceholder             = "Enter a region..."
 	enterAWSIAMAcessKeyIDPrompt           = "Enter the IAM access key id:"
 	enterAWSIAMAcessKeyIDPlaceholder      = "Enter IAM access key id..."
-	enterAWSIAMSecretAccessKeyPrompt      = "Enter your IAM Secret Access Keys:"
+	enterAWSIAMSecretAccessKeyPrompt      = "Enter your IAM Secret Access Key:"
 	enterAWSIAMSecretAccessKeyPlaceholder = "Enter IAM secret access key..."
 	errNotEmptyTemplate                   = "%s cannot be empty"
 


### PR DESCRIPTION
# Description

Minor update to make the prompt for AWS secret key explicit. Right now it prompts `Enter IAM access key id...` followed with `Enter IAM access key...` making it hard to realize that the latter prompt is for secret key.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6d5bb96</samp>

### Summary
📝🛠️🌐

<!--
1.  📝 This emoji can be used to indicate that a text or wording change was made, such as editing a placeholder or a prompt message.
2.  🛠️ This emoji can be used to indicate that a fix or improvement was made, such as correcting a typo or enhancing the user experience.
3.  🌐 This emoji can be used to indicate that a change was related to a web or internet service, such as AWS or another cloud provider.
-->
Fixed a typo in the `enterAWSIAMSecretAccessKeyPlaceholder` variable and aligned it with the AWS terminology. This affects the `radinit` command in the `pkg/cli/cmd/radinit/aws.go` file.

> _`secret` in lowercase_
> _matches AWS and prompt text_
> _a clear autumn sky_

### Walkthrough
* Lowercased the word "secret" in the AWS IAM secret access key placeholder to match AWS terminology and prompt message ([link](https://github.com/project-radius/radius/pull/5771/files?diff=unified&w=0#diff-d6b087c827d9069ad74b4cb04ab94eafb6e3b2759ddfd2e8ffa9a8557bf7cf74L34-R34))


