### PR TITLE
Add remaining types to dev recipes processing

### DIFF
--- a/pkg/cli/cmd/radinit/recipe.go
+++ b/pkg/cli/cmd/radinit/recipe.go
@@ -152,10 +152,20 @@ func getResourceTypeFromPath(repo string) (resourceType string) {
 // getLinkType returns the link type for the given resource type.
 func getLinkType(resourceType string) string {
 	switch resourceType {
+	case "daprpubsubbrokers":
+		return linkrp.DaprPubSubBrokersResourceType
+	case "daprsecretstores":
+		return linkrp.DaprSecretStoresResourceType
+	case "daprstatestores":
+		return linkrp.DaprStateStoresResourceType
 	case "mongodatabases":
 		return linkrp.MongoDatabasesResourceType
+	case "rabbitmqmessagequeues":
+		return linkrp.RabbitMQMessageQueuesResourceType
 	case "rediscaches":
 		return linkrp.RedisCachesResourceType
+	case "sqldatabases":
+		return linkrp.SqlDatabasesResourceType
 	default:
 		return ""
 	}

--- a/pkg/cli/cmd/radinit/recipe_test.go
+++ b/pkg/cli/cmd/radinit/recipe_test.go
@@ -80,6 +80,26 @@ func Test_getLinkType(t *testing.T) {
 		want         string
 	}{
 		{
+			"Dapr PubSub Link Type",
+			"daprpubsubbrokers",
+			"Applications.Link/daprPubSubBrokers",
+		},
+		{
+			"Dapr Secret Store Link Type",
+			"daprsecretstores",
+			"Applications.Link/daprSecretStores",
+		},
+		{
+			"Dapr State Store Link Type",
+			"daprstatestores",
+			"Applications.Link/daprStateStores",
+		},
+		{
+			"Rabbit MQ Link Type",
+			"rabbitmqmessagequeues",
+			"Applications.Link/rabbitMQMessageQueues",
+		},
+		{
 			"Redis Cache Link Type",
 			"rediscaches",
 			"Applications.Link/redisCaches",
@@ -90,8 +110,13 @@ func Test_getLinkType(t *testing.T) {
 			"Applications.Link/mongoDatabases",
 		},
 		{
+			"SQL Database Link Type",
+			"sqldatabases",
+			"Applications.Link/sqlDatabases",
+		},
+		{
 			"Invalid Link Type",
-			"daprstatestores",
+			"unsupported",
 			"",
 		},
 	}


### PR DESCRIPTION
# Description

Today we have hard-coded support for redis and mongo types for dev recipes.

This PR adds the remaining types now that they have Recipes support.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Partially addresses #5775 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Adds necessary unit tests for change
* [x] Adds necessary E2E tests for change
* [x] Unit tests passing
* [x] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5af7734</samp>

### Summary
🚀🧪🔗

<!--
1.  🚀 - This emoji represents the addition of new features or enhancements to the existing functionality of the CLI. The new resource types for linking applications to external services are examples of new features that enable users to leverage more dapr capabilities from the CLI.
2.  🧪 - This emoji represents the addition and modification of test cases for the `getLinkType` function. The test cases ensure that the function behaves as expected for different resource types and scenarios. The emoji also conveys the idea of experimentation and validation of the code changes.
3.  🔗 - This emoji represents the concept of linking or connecting applications to external services. The emoji is relevant to the main purpose of the `getLinkType` function and the linkrp constants. The emoji also suggests the idea of integration and interoperability between different systems.
-->
Updated `getLinkType` function and tests to support more resource types for linking applications. The function now handles dapr, rabbit mq, and sql resources based on the linkrp constants.

> _To link apps to services with ease_
> _We updated the `getLinkType` function, please_
> _It supports more resource types_
> _Like dapr and rabbit mq bites_
> _And sql databases that store keys_

### Walkthrough
*  Add support for more resource types in `getLinkType` function ([link](https://github.com/project-radius/radius/pull/5778/files?diff=unified&w=0#diff-8d95f3c1fe28429c99ace05511baa39ad8209147381755da6007c8781ed17be2L155-R168))
*  Update `Test_getLinkType` function to include test cases for new resource types and modify invalid case ([link](https://github.com/project-radius/radius/pull/5778/files?diff=unified&w=0#diff-c87f030551272551caefea8389b7c31b6159f47554e26f88ca38453234bd92a1R83-R102), [link](https://github.com/project-radius/radius/pull/5778/files?diff=unified&w=0#diff-c87f030551272551caefea8389b7c31b6159f47554e26f88ca38453234bd92a1L93-R119))


