### PR TITLE
Update build.yaml concurrency group to include the GitHub ref

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ on:
 
 concurrency:
   # Cancel the previously triggered build for only PR build.
-  group: build-${{ github.event.pull_request.number || github.sha }}
+  group: build-${github.ref}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
# Description

* Updating build.yaml to include the github ref
  - Fixes the issue where pushing the branch cancels the tag workflow run

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #5772

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 120e190</samp>

### Summary
🚀🌲🚫

<!--
1.  🚀 - This emoji represents the improvement in efficiency and speed of the build process, as it can run concurrently for different branches or tags and avoid wasting resources on outdated builds.
2.  🌲 - This emoji represents the inclusion of the branch or tag name in the concurrency group, as it can be seen as a way of grouping or identifying different versions or variants of the code.
3.  🚫 - This emoji represents the cancellation of the previous build for the same branch or tag, as it can be seen as a way of preventing or stopping unnecessary or redundant work.
-->
Modified the concurrency group for the build workflow to run concurrently for different branches or tags. This improves the build efficiency and reliability.

> _`github.ref` cuts_
> _concurrency group for builds_
> _autumn leaves falling_

### Walkthrough
*  Modify the concurrency group for the build workflow to include the branch or tag name ([link](https://github.com/project-radius/radius/pull/5779/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L33-R33))


