### PR TITLE
Fix publicEndpointOverride reference (cherry-picked)

### DIFF
--- a/deploy/Chart/templates/rp/deployment.yaml
+++ b/deploy/Chart/templates/rp/deployment.yaml
@@ -43,9 +43,9 @@ spec:
           value: 'self-hosted'
         - name: K8S_CLUSTER
           value: 'true'
-        {{- if .Values.publicEndpointOverride}}
+        {{- if .Values.rp.publicEndpointOverride}}
         - name: RADIUS_PUBLIC_ENDPOINT_OVERRIDE
-          value: {{ .Values.publicEndpointOverride }}
+          value: {{ .Values.rp.publicEndpointOverride }}
         {{- end }}
         ports:
         - containerPort: 5443


### PR DESCRIPTION
# Description

This is the chery picked commit

This is to fix incorrect publicEndpointOverride reference. I confirmed that `helm manifest . --set rp.publicEndpointOverride=localhost:8081` generates the write template.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation. -->

Fixes: #5776

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f853bd1</samp>

### Summary
🚚🛠️🧪

<!--
1. 🚚 This emoji can be used to indicate that something was moved or relocated, such as the `publicEndpointOverride` value in the `values.yaml` file.
2. 🛠️ This emoji can be used to indicate that something was fixed or improved, such as the template that now reflects the correct path to the `publicEndpointOverride` value.
3. 🧪 This emoji can be used to indicate that something was related to testing or experimentation, such as the use case for overriding the public endpoint of the radius service.
-->
Update template to use new location of `publicEndpointOverride` value. This improves the configuration of the radius service deployment.

> _`publicEndpointOverride`_
> _Moved under `rp` field_
> _A winter testing_

### Walkthrough
* Move `publicEndpointOverride` value to a nested field under `rp` in `values.yaml` and update template accordingly
([link](https://github.com/project-radius/radius/pull/5777/files?diff=unified&w=0#diff-92bd08c7c2302e12d2ceb2f7bf0a5bdd0016bb8e2eb2639588e994366e9ee841L46-R48))

(cherry picked from commit c2ca7bc856dd12ad00a29535ec4a9353331e3936)

# Description

_Please explain the changes you've made._

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0f6f065</samp>

### Summary
🚚🛠️🌐

<!--
1.  🚚 - This emoji can be used to indicate that something was moved or relocated, such as the `publicEndpointOverride` value.
2.  🛠️ - This emoji can be used to indicate that something was fixed or improved, such as avoiding conflicts with other subcharts that may use the same value.
3.  🌐 - This emoji can be used to indicate that something relates to the web or networking, such as the public endpoint for the radius service.
-->
Moved `publicEndpointOverride` value to `rp` subchart and used it as an environment variable for the radius pod. This avoids conflicts and allows customizing the public endpoint for the radius service.

> _`publicEndpointOverride`_
> _Moved to `rp` subchart_
> _Avoids conflicts_

### Walkthrough
* Move `publicEndpointOverride` value to `rp` subchart to avoid conflicts ([link](https://github.com/project-radius/radius/pull/5780/files?diff=unified&w=0#diff-92bd08c7c2302e12d2ceb2f7bf0a5bdd0016bb8e2eb2639588e994366e9ee841L46-R48))
* Set `RADIUS_PUBLIC_ENDPOINT_OVERRIDE` environment variable in radius pod using `publicEndpointOverride` value ([link](https://github.com/project-radius/radius/pull/5780/files?diff=unified&w=0#diff-92bd08c7c2302e12d2ceb2f7bf0a5bdd0016bb8e2eb2639588e994366e9ee841L46-R48))


