### PR TITLE
Cleaning up `release.yaml`

### DIFF
--- a/.github/scripts/release-create-repo-tag.sh
+++ b/.github/scripts/release-create-repo-tag.sh
@@ -17,17 +17,11 @@
 set -xe
 
 REPOSITORY=$1
-MAIN_BRANCH=$2
-VERSION=$3
-FINAL_RELEASE=$4
+VERSION=$2
+FINAL_RELEASE=$3
 
 if [[ -z "$REPOSITORY" ]]; then
   echo "Error: REPOSITORY is not set."
-  exit 1
-fi
-
-if [[ -z "$MAIN_BRANCH" ]]; then
-  echo "Error: MAIN_BRANCH is not set."
   exit 1
 fi
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,17 +82,17 @@ jobs:
           echo "* Release date: $(date)" >> $GITHUB_STEP_SUMMARY
       - name: Release project-radius/radius version ${{ env.RELEASE_VERSION }}
         run: |
-          ./radius-pr/.github/scripts/release-create-repo-tag.sh radius main ${{ env.RELEASE_VERSION }} ${{ env.FINAL_RELEASE }}
+          ./radius-pr/.github/scripts/release-create-repo-tag.sh radius ${{ env.RELEASE_VERSION }} ${{ env.FINAL_RELEASE }}
         if: success()
       - name: Release project-radius/bicep version ${{ env.RELEASE_VERSION }}
         run: |
-          ./radius-pr/.github/scripts/release-create-repo-tag.sh bicep bicep-extensibility ${{ env.RELEASE_VERSION }} ${{ env.FINAL_RELEASE }}
+          ./radius-pr/.github/scripts/release-create-repo-tag.sh bicep ${{ env.RELEASE_VERSION }} ${{ env.FINAL_RELEASE }}
         if: success()
       - name: Release project-radius/deployment-engine version ${{ env.RELEASE_VERSION }}
         run: |
-          ./radius-pr/.github/scripts/release-create-repo-tag.sh deployment-engine main ${{ env.RELEASE_VERSION }} ${{ env.FINAL_RELEASE }}
+          ./radius-pr/.github/scripts/release-create-repo-tag.sh deployment-engine ${{ env.RELEASE_VERSION }} ${{ env.FINAL_RELEASE }}
         if: success()
       - name: Release project-radius/recipes version ${{ env.RELEASE_VERSION }}
         run: |
-          ./radius-pr/.github/scripts/release-create-repo-tag.sh recipes main ${{ env.RELEASE_VERSION }} ${{ env.FINAL_RELEASE }}
+          ./radius-pr/.github/scripts/release-create-repo-tag.sh recipes ${{ env.RELEASE_VERSION }} ${{ env.FINAL_RELEASE }}
         if: success()


### PR DESCRIPTION
# Description

* MAIN_BRANCH is not required anymore. I removed it.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a44236d</samp>

### Summary
🚚🧹📝

<!--
1.  🚚 - This emoji represents the removal of the `MAIN_BRANCH` argument from the workflow and the script, as it implies something being taken away or moved.
2.  🧹 - This emoji represents the simplification and cleanup of the script by removing unused code and checks, as it implies tidying up or sweeping away clutter.
3.  📝 - This emoji represents the documentation update that explains the new usage of the script and the workflow, as it implies writing or editing text.
-->
Removed the `MAIN_BRANCH` argument from the `release-create-repo-tag.sh` script and its callers. This simplifies the script and the `release.yaml` workflow that creates tags for sub-repositories.

> _Sing, O Muse, of the agile heroes who craft the code_
> _That powers the web and delights the users with its mode._
> _They strive to simplify their workflows and remove excess_
> _Like the `MAIN_BRANCH` argument, a needless source of stress._

### Walkthrough
*  Remove unused `MAIN_BRANCH` parameter from `release-create-repo-tag.sh` script and its calls ([link](https://github.com/project-radius/radius/pull/5814/files?diff=unified&w=0#diff-b905e2cb1c300436cb9b302750ef3ec4b6215c01eafc006ce0d7bc39354e2a36L20-R21), [link](https://github.com/project-radius/radius/pull/5814/files?diff=unified&w=0#diff-b905e2cb1c300436cb9b302750ef3ec4b6215c01eafc006ce0d7bc39354e2a36L29-L33), [link](https://github.com/project-radius/radius/pull/5814/files?diff=unified&w=0#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL85-R97))


