### PR TITLE
Add helm linter to workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -263,6 +263,7 @@ jobs:
     env:
       ARTIFACT_DIR: ./dist/Charts
       HELM_PACKAGE_DIR: helm
+      HELM_CHARTS_DIR: deploy/Chart
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -274,9 +275,10 @@ jobs:
         run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
       - name: Parse release version and set environment variables
         run: python ./.github/scripts/get_release_version.py
+      - name: Run Helm linter
+        run: |
+          helm lint ${{ env.HELM_CHARTS_DIR }}
       - name: Package Helm chart
-        env:
-          HELM_CHARTS_DIR: deploy/Chart
         run: |
           mkdir -p ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
           helm package ${{ env.HELM_CHARTS_DIR }} --version ${{ env.CHART_VERSION }} --app-version ${{ env.REL_VERSION }} --destination ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}


### PR DESCRIPTION
# Description

Helm has linter itself. This is to run linter before publishing helm chart.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: #issue_number

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0e0691c</samp>

### Summary
🚀🌐🧹

<!--
1.  🚀 - This emoji represents the improvement of the Helm chart workflow, which can be seen as a launch or boost of the project's quality and efficiency.
2.  🌐 - This emoji represents the environment variable for the chart directory, which can be seen as a way of defining the global or universal scope of the chart within the workflow.
3.  🧹 - This emoji represents the Helm linter step, which can be seen as a way of cleaning or tidying up the chart code and ensuring it follows the best practices and standards.
-->
Improve Helm chart workflow and linting in `.github/workflows/build.yaml`

> _To improve the Helm chart workflow_
> _We set an env var for `chartDir`_
> _And added a step_
> _To lint with some pep_
> _And catch any errors that occur_

### Walkthrough
* Set `HELM_CHARTS_DIR` environment variable to Helm chart directory path ([link](https://github.com/project-radius/radius/pull/5817/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R266))
* Add step to run Helm linter on Helm chart directory before packaging it ([link](https://github.com/project-radius/radius/pull/5817/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L277-R281))


