### PR TITLE
Update redis schema check

### DIFF
--- a/pkg/linkrp/api/v20220315privatepreview/rediscache_conversion_test.go
+++ b/pkg/linkrp/api/v20220315privatepreview/rediscache_conversion_test.go
@@ -323,7 +323,7 @@ func TestRedisCache_ConvertVersionedToDataModel_InvalidRequest(t *testing.T) {
 			require.Equal(t, &expectedErr, err)
 		}
 		if payload == "rediscacheresource-invalid2.json" {
-			expectedErr := v1.ErrClientRP{Code: "BadRequest", Message: "multiple errors were found:\n\thost must be specified when resourceProvisioning is set to manual\n\tport must be specified when resourceProvisioning is set to manual\n\tusername must be provided with password"}
+			expectedErr := v1.ErrClientRP{Code: "BadRequest", Message: "multiple errors were found:\n\thost must be specified when resourceProvisioning is set to manual\n\tport must be specified when resourceProvisioning is set to manual"}
 			_, err = versionedResource.ConvertTo()
 			require.Equal(t, &expectedErr, err)
 		}

--- a/pkg/linkrp/datamodel/rediscache.go
+++ b/pkg/linkrp/datamodel/rediscache.go
@@ -107,9 +107,6 @@ func (redisCache *RedisCache) VerifyInputs() error {
 		if redisCache.Properties.Port == 0 {
 			msgs = append(msgs, "port must be specified when resourceProvisioning is set to manual")
 		}
-		if redisCache.Properties.Username == "" && redisCache.Properties.Secrets.Password != "" {
-			msgs = append(msgs, "username must be provided with password")
-		}
 	}
 
 	if len(msgs) == 1 {

--- a/pkg/linkrp/processors/rediscaches/processor.go
+++ b/pkg/linkrp/processors/rediscaches/processor.go
@@ -92,10 +92,10 @@ func (p *Processor) computeConnectionURI(resource *datamodel.RedisCache) string 
 	}
 
 	if resource.Properties.Username != "" {
-		connectionURI += resource.Properties.Username + ":"
+		connectionURI += resource.Properties.Username
 	}
 	if resource.Properties.Secrets.Password != "" {
-		connectionURI += resource.Properties.Secrets.Password + "@"
+		connectionURI += ":" + resource.Properties.Secrets.Password + "@"
 	}
 
 	connectionURI = fmt.Sprintf("%s%s:%v/0?", connectionURI, resource.Properties.Host, resource.Properties.Port)


### PR DESCRIPTION
# Description

Usernames can be blank with Redis. Updating to remove a check for blank usernames

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: radius-project/core-team#1066

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a22401a</samp>

### Summary
🔥🔑🐛

<!--
1.  🔥 This emoji can represent the removal of code or features, such as the check for the username field and the validation logic for the username field.
2.  🔑 This emoji can represent the password field or the authentication feature, which is the main focus of the changes.
3.  🐛 This emoji can represent the fix of a bug or an error, such as the incorrect format of the connection URI.
-->
This pull request removes the username requirement for Redis cache connections and fixes the connection URI format. It updates the data model, the processor, and the test cases in `pkg/linkrp` accordingly.

> _No username needed_
> _`password` is enough now_
> _Autumn of old code_

### Walkthrough
* Remove username validation and error check for RedisCache data model and API ([link](https://github.com/project-radius/radius/pull/5818/files?diff=unified&w=0#diff-ffc1018142b8536a6e45788602e9ca2cefe9838c42a2ddf79d18fbd73faeba88L326-R326), [link](https://github.com/project-radius/radius/pull/5818/files?diff=unified&w=0#diff-0156924178afa2f7880b2d55f674aa04cba43286bc4dcdc994e5b14c85366ca9L110-L112))
* Fix connection URI format to include colon between username and password in `processor.go` ([link](https://github.com/project-radius/radius/pull/5818/files?diff=unified&w=0#diff-75049449416e41b8a60c705ab6307182133254aa7d58eafcbf1f2456f5019288L95-R98))


