### PR TITLE
Update to pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,23 +2,27 @@
 
 _Please explain the changes you've made._
 
-## Issue reference
+## Type of change
 
 <!--
-We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
+
+Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.
+
+If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 
+
+-->
+
+- This pull request fixes a bug in Radius and has an approved issue (issue link required).
+- This pull request adds or changes features of Radius and has an approved issue (issue link required).
+- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
+
+<!--
+
+Please update the following to link the associated issue. This is required for some kinds of changes (see above).
+
 -->
 
 Fixes: #issue_number
-
-## Checklist
-
-Please make sure you've  completed the relevant tasks for this PR, out of the following list:
-
-* [ ] Code compiles correctly
-* [ ] Adds necessary unit tests for change
-* [ ] Adds necessary E2E tests for change
-* [ ] Unit tests passing
-* [ ] Extended the documentation / Created issue for it
 
 ## Auto-generated summary
 

--- a/docs/contributing/contributing-pull-requests/README.md
+++ b/docs/contributing/contributing-pull-requests/README.md
@@ -35,7 +35,7 @@ The following tips should help you decide which option to choose:
 
 - Does this change fix a bug in Radius? We define a bug as a case where Radius does not as advertised, or where a crash or some other kind of internal failure occurs. If you said Yes, then choose the first option (Bugfix).
 - Does this change introduce new features or behaviors? Does this change modify an existing feature of Radius in a way that's visible to users? If you said Yes, choose the second option (Feature).
-- If neither of the two previous options sound right, and there's no user-visible change in your pull request then choose the third option (Task).
+- If neither of the two previous options sounds right, and there's no user-visible change in your pull request then choose the third option (Task).
 
 We use Task as a catch-all for changes that have no direct user-visible impact. In practice many changes are Tasks, and we don't include them in the release notes. This includes minor refactors, code/style cleanup, test improvements, correcting misspellings in comments, changes to build processes, etc.
 

--- a/docs/contributing/contributing-pull-requests/README.md
+++ b/docs/contributing/contributing-pull-requests/README.md
@@ -25,7 +25,28 @@ A pull request will need to pass the following checkpoints to be accepted:
 - Testing: automated tests will run against your changes
 - Code review: you will get feedback from a maintainer or other contributors in the form of comments
 
-We expect that contributors have run basic validations (`make build test lint`) before sending a pull request. See [building the repo](../contributing-code/contributing-code-building/) for more information. If you get stuck during this step feel free to open the pull request anyway and ask for help.
+We expect that contributors have run basic validations (`make build test lint`) before sending a pull request. See [building the repo](../contributing-code/contributing-code-building/) for more information. If you get stuck during this step feel free to open the pull request anyway and ask for help in our [forum](https://discordapp.com/channels/1113519723347456110/1115302284356767814).
+
+## Filling out the pull request template
+
+Our pull request template will ask you two choose one of three options from a list when submitting the pull request. Telling us what type of change the pull request contains will help us author the release notes and informs reviewers about what to look for in your pull request.
+
+The following tips should help you decide which option to choose:
+
+- Does this change fix a bug in Radius? We define a bug as a case where Radius does not as advertised, or where a crash or some other kind of internal failure occurs. If you said Yes, then choose the first option (Bugfix).
+- Does this change introduce new features or behaviors? Does this change modify an existing feature of Radius in a way that's visible to users? If you said Yes, choose the second option (Feature).
+- If neither of the two previous options sound right, and there's no user-visible change in your pull request then choose the third option (Task).
+
+We use Task as a catch-all for changes that have no direct user-visible impact. In practice many changes are Tasks, and we don't include them in the release notes. This includes minor refactors, code/style cleanup, test improvements, correcting misspellings in comments, changes to build processes, etc.
+
+
+### Copilot summary
+
+Our pull-request template includes a summary from Github Copilot. This will generate a description of your changes as well as links to the most relevant files. 
+
+You can find an example [here](https://github.com/project-radius/radius/pull/5614).
+
+## Tips
 
 Keep reading for some tips about how to get your pull requests accepted!
 
@@ -62,11 +83,6 @@ We run [CodeQL](https://codeql.github.com/) as part of the pull-request process 
 
 If CodeQL fails due to your changes, please work with the maintainers to resolve the issue.
 
-## Copilot Summary
-
-Our pull-request template includes a summary from Github Copilot. This will generate a description of your changes as well as links to the most relevant files. 
-
-You can find an example [here](https://github.com/project-radius/radius/pull/5614).
 
 ## Code review
 

--- a/docs/contributing/contributing-pull-requests/README.md
+++ b/docs/contributing/contributing-pull-requests/README.md
@@ -33,7 +33,7 @@ Our pull request template will ask you to choose one of three options from a lis
 
 The following tips should help you decide which option to choose:
 
-- Does this change fix a bug in Radius? We define a bug as a case where Radius does not as advertised, or where a crash or some other kind of internal failure occurs. If you said Yes, then choose the first option (Bugfix).
+- Does this change fix a bug in Radius? We define a bug as a case where Radius does not work as advertised, or where a crash or some other kind of internal failure occurs. If you said Yes, then choose the first option (Bugfix).
 - Does this change introduce new features or behaviors? Does this change modify an existing feature of Radius in a way that's visible to users? If you said Yes, choose the second option (Feature).
 - If neither of the two previous options sounds right, and there's no user-visible change in your pull request then choose the third option (Task).
 

--- a/docs/contributing/contributing-pull-requests/README.md
+++ b/docs/contributing/contributing-pull-requests/README.md
@@ -29,7 +29,7 @@ We expect that contributors have run basic validations (`make build test lint`) 
 
 ## Filling out the pull request template
 
-Our pull request template will ask you two choose one of three options from a list when submitting the pull request. Telling us what type of change the pull request contains will help us author the release notes and informs reviewers about what to look for in your pull request.
+Our pull request template will ask you to choose one of three options from a list when submitting the pull request. Telling us what type of change the pull request contains will help us author the release notes and informs reviewers about what to look for in your pull request.
 
 The following tips should help you decide which option to choose:
 


### PR DESCRIPTION
# Description

This change streamlines our pull request template with an eye towards simplifying our release notes process in the future.

There are two big changes compared to today:

- Getting rid of the checklist
- Adding a 'tell us what type of change this is' selector

We're getting rid of the checklist because as reviewers it does not tell us anything. Many of us do not fill it out (myself included) which is a good sign that it's not helpful and adds extra process overhead without a benefit.

The thing replacing is to intended to:

- Clearly document what kind of change is being made and the expectations.
- Add enforcement for linking issues via a bot (will be done next).
- Aid in the generation of release notes via automation (will be done in the future).

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0600859</samp>

### Summary
📝🚀🛠️

<!--
1.  📝 - This emoji can be used to represent a change that involves updating or adding documentation, such as the pull request template or the contributing guide.
2.  🚀 - This emoji can be used to represent a change that introduces a new feature or enhances an existing one, such as the new `Type of change` section that helps contributors and maintainers classify the pull requests.
3.  🛠️ - This emoji can be used to represent a change that fixes a bug or improves the functionality of the code, such as the validation process that ensures the quality and consistency of the pull requests.
-->
Updated the contributing guide and the pull request template to improve the validation process and the categorization of changes. Added a `Type of change` section to the template and removed the `Copilot Summary` section from the guide.

> _`Pull requests` of doom, choose your type of change_
> _Bug fix, feature, or task, link the issue or face the rage_
> _Follow the `contributing guide`, or the validation will fail_
> _No more `Copilot Summary`, we don't need your AI tale_

### Walkthrough
*  Add a new `Type of change` section to the pull request template, asking contributors to select one of three options: bug fix, feature, or task ([link](https://github.com/project-radius/radius/pull/5822/files?diff=unified&w=0#diff-b2496e80299b8c3150b1944450bd81c622e04e13d15c411d291db0927d75fd6bL5-R26))
*  Update the contributing guide to explain the `Type of change` section and provide tips on how to choose the right option ([link](https://github.com/project-radius/radius/pull/5822/files?diff=unified&w=0#diff-fb0f7798935160052ab4612b954c50fb8f31d3825cce346f5feb693c418f2abaL28-R50))
*  Remove the `Copilot Summary` section from the contributing guide, as it is now part of the pull request template ([link](https://github.com/project-radius/radius/pull/5822/files?diff=unified&w=0#diff-fb0f7798935160052ab4612b954c50fb8f31d3825cce346f5feb693c418f2abaL65-R86))


