### PR TITLE
Fail deployments based on pod status

### DIFF
--- a/deploy/Chart/templates/rp/rbac.yaml
+++ b/deploy/Chart/templates/rp/rbac.yaml
@@ -14,6 +14,7 @@ rules:
   - services
   - namespaces
   - serviceaccounts
+  - pods
   verbs:
   - create
   - delete
@@ -51,6 +52,7 @@ rules:
   resources:
   - deployments
   - statefulsets
+  - replicasets
   verbs:
   - create
   - delete

--- a/pkg/corerp/handlers/kubernetes.go
+++ b/pkg/corerp/handlers/kubernetes.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	k8s "k8s.io/client-go/kubernetes"
@@ -69,6 +71,7 @@ type kubernetesHandler struct {
 
 // Put creates or updates a Kubernetes resource described in PutOptions.
 func (handler *kubernetesHandler) Put(ctx context.Context, options *PutOptions) (map[string]string, error) {
+	logger := ucplog.FromContextOrDiscard(ctx)
 	item, err := convertToUnstructured(*options.Resource)
 	if err != nil {
 		return nil, err
@@ -117,6 +120,7 @@ func (handler *kubernetesHandler) Put(ctx context.Context, options *PutOptions) 
 		if err != nil {
 			return nil, err
 		}
+		logger.Info(fmt.Sprintf("Deployment %s in namespace %s is ready", item.GetName(), item.GetNamespace()))
 		return properties, nil
 	default:
 		// We do not monitor the other resource types.
@@ -127,14 +131,15 @@ func (handler *kubernetesHandler) Put(ctx context.Context, options *PutOptions) 
 func (handler *kubernetesHandler) waitUntilDeploymentIsReady(ctx context.Context, item client.Object) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
-	doneCh := make(chan bool, 1)
-	errCh := make(chan error, 1)
+	// When the deployment is done, an error nil will be sent
+	// In case of an error, the error will be sent
+	doneCh := make(chan error, 1)
 
 	ctx, cancel := context.WithTimeout(ctx, handler.deploymentTimeOut)
 	// This ensures that the informer is stopped when this function is returned.
 	defer cancel()
 
-	err := handler.startDeploymentInformer(ctx, item, doneCh, errCh)
+	err := handler.startInformers(ctx, item, doneCh)
 	if err != nil {
 		logger.Error(err, "failed to start deployment informer")
 		return err
@@ -156,70 +161,306 @@ func (handler *kubernetesHandler) waitUntilDeploymentIsReady(ctx context.Context
 		}
 		return fmt.Errorf("deployment timed out, name: %s, namespace %s, status: %s, reason: %s", item.GetName(), item.GetNamespace(), status.Message, status.Reason)
 
-	case <-doneCh:
-		logger.Info(fmt.Sprintf("Marking deployment %s in namespace %s as complete", item.GetName(), item.GetNamespace()))
-		return nil
-
-	case err := <-errCh:
+	case err := <-doneCh:
+		if err == nil {
+			logger.Info(fmt.Sprintf("Marking deployment %s in namespace %s as complete", item.GetName(), item.GetNamespace()))
+		}
 		return err
 	}
 }
 
-func (handler *kubernetesHandler) startDeploymentInformer(ctx context.Context, item client.Object, doneCh chan<- bool, errCh chan<- error) error {
-	informers := informers.NewSharedInformerFactoryWithOptions(handler.clientSet, handler.cacheResyncInterval, informers.WithNamespace(item.GetNamespace()))
+func (handler *kubernetesHandler) addPodInformer(ctx context.Context, informers informers.SharedInformerFactory, item client.Object, doneCh chan<- error) cache.SharedIndexInformer {
+	// Retrieve the pod informer from the factory
+	podInformer := informers.Core().V1().Pods().Informer()
+
+	// Add event handlers to the pod informer
+	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			handler.checkDeploymentStatus(ctx, informers, item, obj, doneCh)
+		},
+		UpdateFunc: func(_, newObj any) {
+			handler.checkDeploymentStatus(ctx, informers, item, newObj, doneCh)
+		},
+	})
+
+	return podInformer
+}
+
+func (handler *kubernetesHandler) addDeploymentInformer(ctx context.Context, informers informers.SharedInformerFactory, item client.Object, doneCh chan<- error) cache.SharedIndexInformer {
 	deploymentInformer := informers.Apps().V1().Deployments().Informer()
 	handlers := cache.ResourceEventHandlerFuncs{
-		AddFunc: func(new_obj any) {
-			obj := new_obj.(*v1.Deployment)
-			// There might be parallel deployments in progress, we need to make sure we are watching the right one
-			if obj.Name != item.GetName() {
-				return
-			}
-			handler.checkDeploymentStatus(ctx, obj, doneCh)
+		AddFunc: func(obj any) {
+			handler.checkDeploymentStatus(ctx, informers, item, obj, doneCh)
 		},
-		UpdateFunc: func(old_obj, new_obj any) {
-			old := old_obj.(*v1.Deployment)
-			new := new_obj.(*v1.Deployment)
-
-			// There might be parallel deployments in progress, we need to make sure we are watching the right one
-			if new.Name != item.GetName() {
-				return
-			}
-
-			if old.ResourceVersion != new.ResourceVersion {
-				handler.checkDeploymentStatus(ctx, new, doneCh)
-			}
+		UpdateFunc: func(_, obj any) {
+			handler.checkDeploymentStatus(ctx, informers, item, obj, doneCh)
 		},
 	}
 
 	deploymentInformer.AddEventHandler(handlers)
-	informers.Start(ctx.Done())
-
-	// Wait for the deployment informer's cache to be synced.
-	if !cache.WaitForCacheSync(ctx.Done(), deploymentInformer.HasSynced) {
-		err := fmt.Errorf("cache sync is failed for deployment informer: name: %s, namespace %s", item.GetName(), item.GetNamespace())
-		return err
-	}
-
-	return nil
+	return deploymentInformer
 }
 
-func (handler *kubernetesHandler) checkDeploymentStatus(ctx context.Context, obj *v1.Deployment, doneCh chan<- bool) {
+func (handler *kubernetesHandler) addReplicaSetInformer(ctx context.Context, informers informers.SharedInformerFactory, item client.Object, doneCh chan<- error) cache.SharedIndexInformer {
+	replicaSetInformer := informers.Apps().V1().ReplicaSets().Informer()
+	handlers := cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			handler.checkDeploymentStatus(ctx, informers, item, obj, doneCh)
+		},
+		UpdateFunc: func(_, obj any) {
+			handler.checkDeploymentStatus(ctx, informers, item, obj, doneCh)
+		},
+	}
+
+	replicaSetInformer.AddEventHandler(handlers)
+	return replicaSetInformer
+}
+
+func (handler *kubernetesHandler) checkDeploymentStatus(ctx context.Context, informerFactory informers.SharedInformerFactory, item client.Object, obj any, doneCh chan<- error) {
 	logger := ucplog.FromContextOrDiscard(ctx)
-	for _, c := range obj.Status.Conditions {
+
+	// Get the deployment
+	deployment, err := informerFactory.Apps().V1().Deployments().Lister().Deployments(item.GetNamespace()).Get(item.GetName())
+	if err != nil {
+		logger.Info(fmt.Sprintf("Unable to find deployment %s in namespace %s", item.GetName(), item.GetNamespace()))
+		return
+	}
+
+	deploymentReplicaSet := handler.getCurrentReplicaSetForDeployment(ctx, informerFactory, deployment)
+	if deploymentReplicaSet == "" {
+		logger.Info(fmt.Sprintf("Unable to find replica set for deployment %s in namespace %s", item.GetName(), item.GetNamespace()))
+		return
+	}
+
+	allReady := handler.checkAllPodsReady(ctx, informerFactory, deployment, deploymentReplicaSet, doneCh)
+	if !allReady {
+		logger.Info("All pods are not ready yet for deployment %s in namespace %s", item.GetName(), item.GetNamespace())
+		return
+	}
+
+	// Check if the deployment is ready
+	for _, c := range deployment.Status.Conditions {
 		// check for complete deployment condition
 		// Reference https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#complete-deployment
 		if c.Type == v1.DeploymentProgressing && c.Status == corev1.ConditionTrue && strings.EqualFold(c.Reason, "NewReplicaSetAvailable") {
-			logger.Info(fmt.Sprintf("Deployment status for deployment: %s in namespace: %s is: %s - %s, Reason: %s", obj.Name, obj.Namespace, c.Type, c.Status, c.Reason))
+			logger.Info(fmt.Sprintf("Deployment status for deployment: %s in namespace: %s is: %s - %s, Reason: %s, Deployment replicaset: %s", deployment.GetName(), deployment.GetNamespace(), c.Type, c.Status, c.Reason, deploymentReplicaSet))
 
 			// ObservedGeneration should be updated to latest generation to avoid stale replicas
-			if obj.Status.ObservedGeneration >= obj.Generation {
-				logger.Info(fmt.Sprintf("Deployment %s in namespace %s is ready. Observed generation: %d, Generation: %d", obj.Name, obj.Namespace, obj.Status.ObservedGeneration, obj.Generation))
-				doneCh <- true
+			if deployment.Status.ObservedGeneration >= deployment.Generation {
+				logger.Info(fmt.Sprintf("Deployment %s in namespace %s is ready. Observed generation: %d, Generation: %d", deployment.Name, deployment.GetNamespace(), deployment.Status.ObservedGeneration, deployment.Generation))
+				doneCh <- nil
 				return
 			}
 		}
 	}
+}
+
+func (handler *kubernetesHandler) getReplicaSetName(pod *corev1.Pod) string {
+	for _, owner := range pod.ObjectMeta.OwnerReferences {
+		if owner.Kind == "ReplicaSet" {
+			return owner.Name
+		}
+	}
+	return ""
+}
+
+func (handler *kubernetesHandler) getCurrentReplicaSetForDeployment(ctx context.Context, informerFactory informers.SharedInformerFactory, item client.Object) string {
+	logger := ucplog.FromContextOrDiscard(ctx)
+
+	// List all replicasets for this deployment
+	rl, err := informerFactory.Apps().V1().ReplicaSets().Lister().ReplicaSets(item.GetNamespace()).List(labels.Everything())
+	if err != nil {
+		// This is a valid state which will eventually be resolved. Therefore, only log the error here.
+		logger.Info(fmt.Sprintf("Unable to find replicasets for deployment %s in namespace %s", item.GetName(), item.GetNamespace()))
+		return ""
+	}
+
+	replicaSets := &v1.ReplicaSetList{}
+	for _, rs := range rl {
+		replicaSets.Items = append(replicaSets.Items, *rs)
+	}
+
+	if replicaSets == nil || len(replicaSets.Items) == 0 {
+		// This is a valid state which will eventually be resolved. Therefore, only log the error here.
+		logger.Info(fmt.Sprintf("Unable to get replicasets in namespace %s", item.GetNamespace()))
+		return ""
+	}
+
+	deployment, err := handler.clientSet.AppsV1().Deployments(item.GetNamespace()).Get(ctx, item.GetName(), metav1.GetOptions{})
+	if err != nil {
+		// This is a valid state which will eventually be resolved. Therefore, only log the error here.
+		logger.Info(fmt.Sprintf("Unable to get deployment %s in namespace %s: %s", item.GetName(), item.GetNamespace(), err.Error()))
+		return ""
+	}
+
+	if deployment == nil {
+		// This is a valid state which will eventually be resolved. Therefore, only log the error here.
+		logger.Info(fmt.Sprintf("Unable to get deployment %s in namespace %s: %s", item.GetName(), item.GetNamespace(), err.Error()))
+		return ""
+	}
+
+	// Find the latest ReplicaSet associated with the deployment
+	var latestRS *v1.ReplicaSet
+	var latestRevision int64 = -1
+	for i, rs := range replicaSets.Items {
+		if !metav1.IsControlledBy(&rs, deployment) {
+			continue
+		}
+		if rs.Annotations == nil {
+			continue
+		}
+		revisionStr, ok := rs.Annotations["deployment.kubernetes.io/revision"]
+		if !ok {
+			continue
+		}
+
+		revision, err := strconv.ParseInt(revisionStr, 10, 64)
+		if err != nil {
+			continue
+		}
+
+		if latestRS == nil || revision > latestRevision {
+			latestRS = &replicaSets.Items[i]
+			latestRevision = revision
+		}
+	}
+
+	if latestRS == nil {
+		logger.Info(fmt.Sprintf("Unable to find any replicasets for deployment %s in namespace %s", item.GetName(), item.GetNamespace()))
+		return ""
+	}
+
+	return latestRS.Name
+}
+
+func (handler *kubernetesHandler) checkPodStatus(ctx context.Context, pod *corev1.Pod) (bool, error) {
+	logger := ucplog.FromContextOrDiscard(ctx)
+
+	conditionPodReady := true
+	for _, cc := range pod.Status.Conditions {
+		// If the resource limits for the container cannot be satisfied, the pod will not be scheduled
+		if cc.Type == corev1.PodScheduled && cc.Status == corev1.ConditionFalse {
+			logger.Info(fmt.Sprintf("Pod %s in namespace %s is not scheduled. Reason: %s, Message: %s", pod.Name, pod.Namespace, cc.Reason, cc.Message))
+			return false, fmt.Errorf("Pod %s in namespace %s is not scheduled. Reason: %s, Message: %s", pod.Name, pod.Namespace, cc.Reason, cc.Message)
+		}
+
+		if cc.Type == corev1.PodReady && cc.Status != corev1.ConditionTrue {
+			// Do not return false here else if the pod transitions to a crash loop backoff state,
+			// we won't be able to detect that condition.
+			conditionPodReady = false
+		}
+
+		if cc.Type == corev1.ContainersReady && cc.Status != corev1.ConditionTrue {
+			// Do not return false here else if the pod transitions to a crash loop backoff state,
+			// we won't be able to detect that condition.
+			conditionPodReady = false
+		}
+	}
+
+	if len(pod.Status.ContainerStatuses) <= 0 {
+		return false, nil
+	}
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		// Check if the container state is terminated or unable to start due to crash loop, image pull back off or error
+		// Note that sometimes a pod can go into running state but can crash later and can go undetected by this condition
+		// We will rely on the user defining a readiness probe to ensure that the pod is ready to serve traffic for those cases
+		if cs.State.Terminated != nil {
+			logger.Info(fmt.Sprintf("Container state is terminated Reason: %s, Message: %s", cs.State.Terminated.Reason, cs.State.Terminated.Message))
+			return false, fmt.Errorf("Container state is 'Terminated' Reason: %s, Message: %s", cs.State.Terminated.Reason, cs.State.Terminated.Message)
+		} else if cs.State.Waiting != nil {
+			if cs.State.Waiting.Reason == "ErrImagePull" || cs.State.Waiting.Reason == "CrashLoopBackOff" || cs.State.Waiting.Reason == "ImagePullBackOff" {
+				message := cs.State.Waiting.Message
+				if cs.LastTerminationState.Terminated != nil {
+					message += " LastTerminationState: " + cs.LastTerminationState.Terminated.Message
+				}
+				return false, fmt.Errorf("Container state is 'Waiting' Reason: %s, Message: %s", cs.State.Waiting.Reason, message)
+			}
+		} else if cs.State.Running == nil {
+			// The container is not yet running
+			return false, nil
+		} else if !cs.Ready {
+			// The container is running but has not passed its readiness probe yet
+			return false, nil
+		}
+	}
+
+	if !conditionPodReady {
+		return false, nil
+	}
+	logger.Info(fmt.Sprintf("All containers for pod %s in namespace: %s are ready", pod.Name, pod.Namespace))
+	return true, nil
+}
+
+func (handler *kubernetesHandler) startInformers(ctx context.Context, item client.Object, doneCh chan<- error) error {
+	logger := ucplog.FromContextOrDiscard(ctx)
+	informers := informers.NewSharedInformerFactoryWithOptions(handler.clientSet, handler.cacheResyncInterval, informers.WithNamespace(item.GetNamespace()))
+
+	handler.addPodInformer(ctx, informers, item, doneCh)
+	handler.addDeploymentInformer(ctx, informers, item, doneCh)
+	handler.addReplicaSetInformer(ctx, informers, item, doneCh)
+
+	// Start the informers
+	informers.Start(ctx.Done())
+
+	// Wait for the deployment and pod informer's cache to be synced.
+	informers.WaitForCacheSync(ctx.Done())
+
+	logger.Info(fmt.Sprintf("Informers started and caches synced for deployment: %s in namespace: %s", item.GetName(), item.GetNamespace()))
+	return nil
+}
+
+func (handler *kubernetesHandler) getPodsInDeployment(ctx context.Context, informerFactory informers.SharedInformerFactory, deployment *v1.Deployment, deploymentReplicaSet string) ([]corev1.Pod, error) {
+	logger := ucplog.FromContextOrDiscard(ctx)
+
+	pods := []corev1.Pod{}
+
+	// List all pods that match the current replica set
+	pl, err := informerFactory.Core().V1().Pods().Lister().Pods(deployment.GetNamespace()).List(labels.Set(deployment.Spec.Selector.MatchLabels).AsSelector())
+	if err != nil {
+		logger.Info(fmt.Sprintf("Unable to find pods for deployment %s in namespace %s", deployment.GetName(), deployment.GetNamespace()))
+		return []corev1.Pod{}, nil
+	}
+
+	podList := &corev1.PodList{}
+	for _, p := range pl {
+		podList.Items = append(podList.Items, *p)
+	}
+
+	// Filter out the pods that are not in the Deployment's current ReplicaSet
+	for _, p := range podList.Items {
+		if handler.getReplicaSetName(&p) == deploymentReplicaSet {
+			pods = append(pods, p)
+		}
+	}
+
+	return pods, nil
+}
+
+func (handler *kubernetesHandler) checkAllPodsReady(ctx context.Context, informerFactory informers.SharedInformerFactory, obj *v1.Deployment, deploymentReplicaSet string, doneCh chan<- error) bool {
+	logger := ucplog.FromContextOrDiscard(ctx)
+	logger.Info(fmt.Sprintf("Checking if all pods in the deployment %s in namespace %s are ready", obj.Name, obj.Namespace))
+
+	podsInDeployment, err := handler.getPodsInDeployment(ctx, informerFactory, obj, deploymentReplicaSet)
+	if err != nil {
+		logger.Info(fmt.Sprintf("Error getting pods for deployment %s in namespace %s: %s", obj.GetName(), obj.GetNamespace(), err))
+		return false
+	}
+
+	allReady := true
+	for _, pod := range podsInDeployment {
+		status, err := handler.checkPodStatus(ctx, &pod)
+		if err != nil {
+			// Terminate the deployment and return the error encountered
+			doneCh <- err
+		}
+		if !status {
+			allReady = false
+		}
+	}
+
+	logger.Info(fmt.Sprintf("All %d pods in the deployment are ready", len(podsInDeployment)))
+	return allReady
 }
 
 // Delete deletes a Kubernetes resource.

--- a/pkg/corerp/handlers/kubernetes_test.go
+++ b/pkg/corerp/handlers/kubernetes_test.go
@@ -560,24 +560,6 @@ func TestGetPodsInDeployment(t *testing.T) {
 	require.Equal(t, pod1.Name, pods[0].Name)
 }
 
-func TestGetReplicaSetName(t *testing.T) {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					Kind: "ReplicaSet",
-					Name: "my-replicaset",
-				},
-			},
-		},
-	}
-
-	handler := &kubernetesHandler{}
-	replicaSetName := handler.getReplicaSetName(pod)
-
-	require.Equal(t, "my-replicaset", replicaSetName)
-}
-
 func TestGetCurrentReplicaSetForDeployment(t *testing.T) {
 	// Create a fake Kubernetes clientset
 	fakeClient := fake.NewSimpleClientset()

--- a/pkg/corerp/handlers/kubernetes_test.go
+++ b/pkg/corerp/handlers/kubernetes_test.go
@@ -937,14 +937,6 @@ func TestCheckDeploymentStatus_AllReady(t *testing.T) {
 			},
 		},
 	}
-	obj := &workqueueItem{
-		key: item.GetName(),
-		obj: testDeployment,
-		meta: &metav1.ObjectMeta{
-			Name:      item.GetName(),
-			Namespace: item.GetNamespace(),
-		},
-	}
 
 	// Create a done channel
 	doneCh := make(chan error, 1)
@@ -954,7 +946,7 @@ func TestCheckDeploymentStatus_AllReady(t *testing.T) {
 		clientSet: fakeClient,
 	}
 
-	go handler.checkDeploymentStatus(ctx, informerFactory, item, obj, doneCh)
+	go handler.checkDeploymentStatus(ctx, informerFactory, item, doneCh)
 
 	err = <-doneCh
 
@@ -1026,14 +1018,6 @@ func TestCheckDeploymentStatus_PodsNotReady(t *testing.T) {
 			},
 		},
 	}
-	obj := &workqueueItem{
-		key: item.GetName(),
-		obj: testDeployment,
-		meta: &metav1.ObjectMeta{
-			Name:      item.GetName(),
-			Namespace: item.GetNamespace(),
-		},
-	}
 
 	// Create a done channel
 	doneCh := make(chan error, 1)
@@ -1043,7 +1027,7 @@ func TestCheckDeploymentStatus_PodsNotReady(t *testing.T) {
 		clientSet: fakeClient,
 	}
 
-	go handler.checkDeploymentStatus(ctx, informerFactory, item, obj, doneCh)
+	go handler.checkDeploymentStatus(ctx, informerFactory, item, doneCh)
 	err = <-doneCh
 
 	// Check that the deployment readiness was checked
@@ -1115,14 +1099,6 @@ func TestCheckDeploymentStatus_ObserverGenerationMismatch(t *testing.T) {
 			},
 		},
 	}
-	obj := &workqueueItem{
-		key: item.GetName(),
-		obj: testDeployment,
-		meta: &metav1.ObjectMeta{
-			Name:      item.GetName(),
-			Namespace: item.GetNamespace(),
-		},
-	}
 
 	// Create a done channel
 	doneCh := make(chan error, 1)
@@ -1132,7 +1108,7 @@ func TestCheckDeploymentStatus_ObserverGenerationMismatch(t *testing.T) {
 		clientSet: fakeClient,
 	}
 
-	handler.checkDeploymentStatus(ctx, informerFactory, item, obj, doneCh)
+	handler.checkDeploymentStatus(ctx, informerFactory, item, doneCh)
 
 	// Check that the deployment readiness was checked
 	require.Zero(t, len(doneCh))

--- a/pkg/corerp/handlers/kubernetes_test.go
+++ b/pkg/corerp/handlers/kubernetes_test.go
@@ -22,17 +22,102 @@ import (
 	"testing"
 	"time"
 
+	"github.com/project-radius/radius/pkg/kubernetes"
 	"github.com/project-radius/radius/pkg/resourcemodel"
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
+	"github.com/project-radius/radius/pkg/to"
 	"github.com/project-radius/radius/test/k8sutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+func int32Ptr(i int32) *int32 { return &i }
+
+type workqueueItem struct {
+	key  string
+	obj  interface{}
+	meta *metav1.ObjectMeta
+}
+
+var testDeployment = &v1.Deployment{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "Deployment",
+		APIVersion: "apps/v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-deployment",
+		Namespace: "test-namespace",
+		Labels: map[string]string{
+			kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
+		},
+	},
+	Spec: v1.DeploymentSpec{
+		Replicas: int32Ptr(1),
+		Selector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app": "test",
+			},
+		},
+	},
+	Status: v1.DeploymentStatus{
+		Conditions: []v1.DeploymentCondition{
+			{
+				Type:    v1.DeploymentProgressing,
+				Status:  corev1.ConditionTrue,
+				Reason:  "NewReplicaSetAvailable",
+				Message: "Deployment has minimum availability",
+			},
+		},
+	},
+}
+
+func addReplicaSetToDeployment(t *testing.T, ctx context.Context, clientset *fake.Clientset, deployment *v1.Deployment) *v1.ReplicaSet {
+	replicaSet := &v1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-replicaset-1",
+			Namespace:   deployment.Namespace,
+			Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(deployment, schema.GroupVersionKind{
+					Group:   v1.SchemeGroupVersion.Group,
+					Version: v1.SchemeGroupVersion.Version,
+					Kind:    "Deployment",
+				}),
+			},
+		},
+	}
+
+	// Add the ReplicaSet objects to the fake Kubernetes clientset
+	_, err := clientset.AppsV1().ReplicaSets(replicaSet.Namespace).Create(ctx, replicaSet, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = clientset.AppsV1().Deployments(deployment.Namespace).Update(ctx, deployment, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	return replicaSet
+}
+
+func startInformers(ctx context.Context, clientSet *fake.Clientset, handler *kubernetesHandler) informers.SharedInformerFactory {
+	// Create a fake replicaset informer and start
+	informerFactory := informers.NewSharedInformerFactory(clientSet, 0)
+
+	// Add informers
+	informerFactory.Apps().V1().Deployments().Informer()
+	informerFactory.Apps().V1().ReplicaSets().Informer()
+	informerFactory.Core().V1().Pods().Informer()
+
+	informerFactory.Start(context.Background().Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
+	return informerFactory
+}
 
 func TestPut(t *testing.T) {
 	putTests := []struct {
@@ -73,26 +158,7 @@ func TestPut(t *testing.T) {
 					ResourceType: resourcemodel.ResourceType{
 						Provider: resourcemodel.ProviderKubernetes,
 					},
-					Resource: &v1.Deployment{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "Deployment",
-							APIVersion: "apps/v1",
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-deployment",
-							Namespace: "test-namespace",
-						},
-						Status: v1.DeploymentStatus{
-							Conditions: []v1.DeploymentCondition{
-								{
-									Type:    v1.DeploymentProgressing,
-									Status:  corev1.ConditionTrue,
-									Reason:  "NewReplicaSetAvailable",
-									Message: "Deployment has minimum availability",
-								},
-							},
-						},
-					},
+					Resource: testDeployment,
 				},
 			},
 			out: map[string]string{
@@ -111,13 +177,17 @@ func TestPut(t *testing.T) {
 			handler := kubernetesHandler{
 				client:              k8sutil.NewFakeKubeClient(nil),
 				clientSet:           nil,
-				deploymentTimeOut:   time.Duration(5) * time.Second,
-				cacheResyncInterval: time.Duration(10) * time.Second,
+				deploymentTimeOut:   time.Duration(50) * time.Second,
+				cacheResyncInterval: time.Duration(1) * time.Second,
 			}
 
-			// only deployment resources need to be watched.
-			if _, ok := tc.in.Resource.Resource.(*v1.Deployment); ok {
-				handler.clientSet = fake.NewSimpleClientset(tc.in.Resource.Resource.(runtime.Object))
+			clientSet := fake.NewSimpleClientset(tc.in.Resource.Resource.(runtime.Object))
+			handler.clientSet = clientSet
+
+			// If the resource is a deployment, we need to add a replica set to it
+			if tc.in.Resource.Resource.(runtime.Object).GetObjectKind().GroupVersionKind().Kind == "Deployment" {
+				// The deployment is not marked as ready till we find a replica set. Therefore, we need to create one.
+				addReplicaSetToDeployment(t, ctx, clientSet, testDeployment)
 			}
 
 			props, err := handler.Put(ctx, tc.in)
@@ -275,11 +345,23 @@ func TestConvertToUnstructured(t *testing.T) {
 
 func TestWaitUntilDeploymentIsReady_NewResource(t *testing.T) {
 	ctx := context.TODO()
+
 	// Create first deployment that will be watched
 	deployment := &v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-deployment",
 			Namespace: "test-namespace",
+			Labels: map[string]string{
+				kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
+			},
+		},
+		Spec: v1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "test",
+				},
+			},
 		},
 		Status: v1.DeploymentStatus{
 			Conditions: []v1.DeploymentCondition{
@@ -293,11 +375,14 @@ func TestWaitUntilDeploymentIsReady_NewResource(t *testing.T) {
 		},
 	}
 
-	deploymentClient := fake.NewSimpleClientset(deployment)
+	clientset := fake.NewSimpleClientset(deployment)
+
+	// The deployment is not marked as ready till we find a replica set. Therefore, we need to create one.
+	addReplicaSetToDeployment(t, ctx, clientset, deployment)
 
 	handler := kubernetesHandler{
-		clientSet:           deploymentClient,
-		deploymentTimeOut:   time.Duration(5) * time.Second,
+		clientSet:           clientset,
+		deploymentTimeOut:   time.Duration(50) * time.Second,
 		cacheResyncInterval: time.Duration(10) * time.Second,
 	}
 
@@ -358,10 +443,10 @@ func TestWaitUntilDeploymentIsReady_DifferentResourceName(t *testing.T) {
 		},
 	}
 
-	deploymentClient := fake.NewSimpleClientset(deployment)
+	clientset := fake.NewSimpleClientset(deployment)
 
 	handler := kubernetesHandler{
-		clientSet:           deploymentClient,
+		clientSet:           clientset,
 		deploymentTimeOut:   time.Duration(1) * time.Second,
 		cacheResyncInterval: time.Duration(10) * time.Second,
 	}
@@ -376,4 +461,679 @@ func TestWaitUntilDeploymentIsReady_DifferentResourceName(t *testing.T) {
 	// It must be timed out because the name of the deployment does not match.
 	require.Error(t, err)
 	require.Equal(t, "deployment timed out, name: not-matched-deployment, namespace test-namespace, error occured while fetching latest status: deployments.apps \"not-matched-deployment\" not found", err.Error())
+}
+
+func TestGetPodsInDeployment(t *testing.T) {
+	// Create a fake Kubernetes clientset
+	fakeClient := fake.NewSimpleClientset()
+
+	// Create a Deployment object
+	deployment := &v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "test-namespace",
+		},
+		Spec: v1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "test-app",
+				},
+			},
+		},
+	}
+
+	// Create a ReplicaSet object
+	replicaset := &v1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-replicaset",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "test-app",
+			},
+		},
+	}
+
+	// Create a Pod object
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod1",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "test-app",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "ReplicaSet",
+					Name:       replicaset.Name,
+					Controller: to.Ptr(true),
+				},
+			},
+		},
+	}
+
+	// Create a Pod object
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod2",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "doesnotmatch",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "ReplicaSet",
+					Name:       "xyz",
+					Controller: to.Ptr(true),
+				},
+			},
+		},
+	}
+
+	// Add the Pod object to the fake Kubernetes clientset
+	_, err := fakeClient.CoreV1().Pods(pod1.Namespace).Create(context.Background(), pod1, metav1.CreateOptions{})
+	require.NoError(t, err, "Failed to create Pod: %v", err)
+
+	_, err = fakeClient.CoreV1().Pods(pod2.Namespace).Create(context.Background(), pod2, metav1.CreateOptions{})
+	require.NoError(t, err, "Failed to create Pod: %v", err)
+
+	// Create a KubernetesHandler object with the fake clientset
+	handler := &kubernetesHandler{
+		clientSet: fakeClient,
+	}
+
+	ctx := context.Background()
+	informerFactory := startInformers(ctx, fakeClient, handler)
+
+	// Call the getPodsInDeployment function
+	pods, err := handler.getPodsInDeployment(ctx, informerFactory, deployment, replicaset.Name)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(pods))
+	require.Equal(t, pod1.Name, pods[0].Name)
+}
+
+func TestGetReplicaSetName(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind: "ReplicaSet",
+					Name: "my-replicaset",
+				},
+			},
+		},
+	}
+
+	handler := &kubernetesHandler{}
+	replicaSetName := handler.getReplicaSetName(pod)
+
+	require.Equal(t, "my-replicaset", replicaSetName)
+}
+
+func TestGetCurrentReplicaSetForDeployment(t *testing.T) {
+	// Create a fake Kubernetes clientset
+	fakeClient := fake.NewSimpleClientset()
+
+	// Create a Deployment object
+	deployment := &v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "test-namespace",
+		},
+	}
+
+	// Create a ReplicaSet object with a higher revision than the other ReplicaSet
+	replicaSet1 := &v1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-replicaset-1",
+			Namespace:   "test-namespace",
+			Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(deployment, schema.GroupVersionKind{
+					Group:   v1.SchemeGroupVersion.Group,
+					Version: v1.SchemeGroupVersion.Version,
+					Kind:    "Deployment",
+				}),
+			},
+		},
+	}
+	// Create another ReplicaSet object with a lower revision than the other ReplicaSet
+	replicaSet2 := &v1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-replicaset-2",
+			Namespace:   "test-namespace",
+			Annotations: map[string]string{"deployment.kubernetes.io/revision": "0"},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(deployment, schema.GroupVersionKind{
+					Group:   v1.SchemeGroupVersion.Group,
+					Version: v1.SchemeGroupVersion.Version,
+					Kind:    "Deployment",
+				}),
+			},
+		},
+	}
+
+	// Add the ReplicaSet objects to the fake Kubernetes clientset
+	_, err := fakeClient.AppsV1().ReplicaSets(replicaSet1.Namespace).Create(context.Background(), replicaSet1, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = fakeClient.AppsV1().ReplicaSets(replicaSet2.Namespace).Create(context.Background(), replicaSet2, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Add the Deployment object to the fake Kubernetes clientset
+	_, err = fakeClient.AppsV1().Deployments(deployment.Namespace).Create(context.Background(), deployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Create a KubernetesHandler object with the fake clientset
+	handler := &kubernetesHandler{
+		clientSet: fakeClient,
+	}
+
+	ctx := context.Background()
+	informerFactory := startInformers(ctx, fakeClient, handler)
+
+	// Call the getNewestReplicaSetForDeployment function
+	replicaSetName := handler.getCurrentReplicaSetForDeployment(ctx, informerFactory, deployment)
+	require.Equal(t, replicaSet1.Name, replicaSetName)
+}
+
+func TestCheckPodStatus(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:    corev1.PodScheduled,
+					Status:  corev1.ConditionFalse,
+					Reason:  "Unschedulable",
+					Message: "0/1 nodes are available: 1 Insufficient cpu.",
+				},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "test-container",
+					Ready: true,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				},
+			},
+		},
+	}
+	podTests := []struct {
+		podCondition    corev1.PodCondition
+		containerStatus corev1.ContainerStatus
+		isReady         bool
+		expectedError   string
+	}{
+		{
+			podCondition: corev1.PodCondition{
+				Type:    corev1.PodScheduled,
+				Status:  corev1.ConditionFalse,
+				Reason:  "Unschedulable",
+				Message: "0/1 nodes are available: 1 Insufficient cpu.",
+			},
+			isReady:       false,
+			expectedError: "Pod test-pod in namespace test-namespace is not scheduled. Reason: Unschedulable, Message: 0/1 nodes are available: 1 Insufficient cpu.",
+		},
+		{
+			containerStatus: corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Reason:  "Error",
+						Message: "Container terminated due to an error",
+					},
+				},
+			},
+			isReady:       false,
+			expectedError: "Container state is 'Terminated' Reason: Error, Message: Container terminated due to an error",
+		},
+		{
+			containerStatus: corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "CrashLoopBackOff",
+						Message: "Back-off 5m0s restarting failed container=test-container pod=test-pod",
+					},
+				},
+			},
+			isReady:       false,
+			expectedError: "Container state is 'Waiting' Reason: CrashLoopBackOff, Message: Back-off 5m0s restarting failed container=test-container pod=test-pod",
+		},
+		{
+			containerStatus: corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{},
+				},
+				Ready: false,
+			},
+			isReady:       false,
+			expectedError: "",
+		},
+		{
+			containerStatus: corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{},
+				},
+				Ready: true,
+			},
+			isReady:       true,
+			expectedError: "",
+		},
+	}
+
+	ctx := context.Background()
+	handler := &kubernetesHandler{}
+	for _, tc := range podTests {
+		pod.Status.Conditions[0] = tc.podCondition
+		pod.Status.ContainerStatuses[0] = tc.containerStatus
+		isReady, err := handler.checkPodStatus(ctx, pod)
+		if tc.expectedError != "" {
+			require.Error(t, err)
+			require.Equal(t, tc.expectedError, err.Error())
+		} else {
+			require.NoError(t, err)
+		}
+		require.Equal(t, tc.isReady, isReady)
+	}
+}
+
+func TestCheckAllPodsReady_Success(t *testing.T) {
+	// Create a fake Kubernetes clientset
+	clientset := fake.NewSimpleClientset()
+
+	ctx := context.Background()
+
+	_, err := clientset.AppsV1().Deployments("test-namespace").Create(ctx, testDeployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	replicaSet := addReplicaSetToDeployment(t, ctx, clientset, testDeployment)
+
+	// Create a pod
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "test",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "test-container",
+					Image: "test-image",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "test-container",
+					Ready: true,
+				},
+			},
+		},
+	}
+	_, err = clientset.CoreV1().Pods("test-namespace").Create(context.Background(), pod, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Create an informer factory and add the deployment and replica set to the cache
+	informerFactory := informers.NewSharedInformerFactory(clientset, 0)
+	informerFactory.Apps().V1().Deployments().Informer().GetIndexer().Add(testDeployment)
+	informerFactory.Apps().V1().ReplicaSets().Informer().GetIndexer().Add(replicaSet)
+	informerFactory.Core().V1().Pods().Informer().GetIndexer().Add(pod)
+
+	// Create a done channel
+	doneCh := make(chan error)
+
+	// Create a handler with the fake clientset
+	handler := &kubernetesHandler{
+		clientSet: clientset,
+	}
+
+	// Call the checkAllPodsReady function
+	allReady := handler.checkAllPodsReady(ctx, informerFactory, testDeployment, replicaSet.GetName(), doneCh)
+
+	// Check that all pods are ready
+	require.True(t, allReady)
+}
+
+func TestCheckAllPodsReady_Fail(t *testing.T) {
+	// Create a fake Kubernetes clientset
+	clientset := fake.NewSimpleClientset()
+
+	ctx := context.Background()
+
+	_, err := clientset.AppsV1().Deployments("test-namespace").Create(ctx, testDeployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	replicaSet := addReplicaSetToDeployment(t, ctx, clientset, testDeployment)
+
+	// Create a pod
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod1",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "test",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "ReplicaSet",
+					Name:       replicaSet.Name,
+					Controller: to.Ptr(true),
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "test-container",
+					Image: "test-image",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "test-container",
+					Ready: false,
+				},
+			},
+		},
+	}
+	_, err = clientset.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Create an informer factory and add the deployment and replica set to the cache
+	informerFactory := informers.NewSharedInformerFactory(clientset, 0)
+	informerFactory.Apps().V1().Deployments().Informer().GetIndexer().Add(testDeployment)
+	informerFactory.Apps().V1().ReplicaSets().Informer().GetIndexer().Add(replicaSet)
+	informerFactory.Core().V1().Pods().Informer().GetIndexer().Add(pod)
+
+	// Create a done channel
+	doneCh := make(chan error)
+
+	// Create a handler with the fake clientset
+	handler := &kubernetesHandler{
+		clientSet: clientset,
+	}
+
+	// Call the checkAllPodsReady function
+	allReady := handler.checkAllPodsReady(ctx, informerFactory, testDeployment, replicaSet.GetName(), doneCh)
+
+	// Check that all pods are ready
+	require.False(t, allReady)
+}
+
+func TestCheckDeploymentStatus_AllReady(t *testing.T) {
+	// Create a fake Kubernetes fakeClient
+	fakeClient := fake.NewSimpleClientset()
+
+	ctx := context.Background()
+	_, err := fakeClient.AppsV1().Deployments("test-namespace").Create(ctx, testDeployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+	replicaSet := addReplicaSetToDeployment(t, ctx, fakeClient, testDeployment)
+
+	// Create a Pod object
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod1",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "test",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "ReplicaSet",
+					Name:       replicaSet.Name,
+					Controller: to.Ptr(true),
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodScheduled,
+					Status: corev1.ConditionTrue,
+				},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "test-container",
+					Ready: true,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				},
+			},
+		},
+	}
+
+	// Add the Pod object to the fake Kubernetes clientset
+	_, err = fakeClient.CoreV1().Pods(pod1.Namespace).Create(ctx, pod1, metav1.CreateOptions{})
+	require.NoError(t, err, "Failed to create Pod: %v", err)
+
+	// Create an informer factory and add the deployment to the cache
+	informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
+	informerFactory.Apps().V1().Deployments().Informer().GetIndexer().Add(testDeployment)
+	informerFactory.Apps().V1().ReplicaSets().Informer().GetIndexer().Add(replicaSet)
+	informerFactory.Core().V1().Pods().Informer().GetIndexer().Add(pod1)
+
+	// Create a fake item and object
+	item := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "test-deployment",
+				"namespace": "test-namespace",
+			},
+		},
+	}
+	obj := &workqueueItem{
+		key: item.GetName(),
+		obj: testDeployment,
+		meta: &metav1.ObjectMeta{
+			Name:      item.GetName(),
+			Namespace: item.GetNamespace(),
+		},
+	}
+
+	// Create a done channel
+	doneCh := make(chan error, 1)
+
+	// Call the checkDeploymentStatus function
+	handler := &kubernetesHandler{
+		clientSet: fakeClient,
+	}
+
+	go handler.checkDeploymentStatus(ctx, informerFactory, item, obj, doneCh)
+
+	err = <-doneCh
+
+	// Check that the deployment readiness was checked
+	require.NoError(t, err)
+}
+
+func TestCheckDeploymentStatus_PodsNotReady(t *testing.T) {
+	// Create a fake Kubernetes fakeClient
+	fakeClient := fake.NewSimpleClientset()
+
+	ctx := context.Background()
+	_, err := fakeClient.AppsV1().Deployments("test-namespace").Create(ctx, testDeployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+	replicaSet := addReplicaSetToDeployment(t, ctx, fakeClient, testDeployment)
+
+	// Create a Pod object
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod1",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "test",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "ReplicaSet",
+					Name:       replicaSet.Name,
+					Controller: to.Ptr(true),
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodScheduled,
+					Status: corev1.ConditionTrue,
+				},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "test-container",
+					Ready: true,
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:  "Error",
+							Message: "Container terminated due to an error",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Add the Pod object to the fake Kubernetes clientset
+	_, err = fakeClient.CoreV1().Pods(pod1.Namespace).Create(ctx, pod1, metav1.CreateOptions{})
+	require.NoError(t, err, "Failed to create Pod: %v", err)
+
+	// Create an informer factory and add the deployment to the cache
+	informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
+	informerFactory.Apps().V1().Deployments().Informer().GetIndexer().Add(testDeployment)
+	informerFactory.Apps().V1().ReplicaSets().Informer().GetIndexer().Add(replicaSet)
+	informerFactory.Core().V1().Pods().Informer().GetIndexer().Add(pod1)
+
+	// Create a fake item and object
+	item := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "test-deployment",
+				"namespace": "test-namespace",
+			},
+		},
+	}
+	obj := &workqueueItem{
+		key: item.GetName(),
+		obj: testDeployment,
+		meta: &metav1.ObjectMeta{
+			Name:      item.GetName(),
+			Namespace: item.GetNamespace(),
+		},
+	}
+
+	// Create a done channel
+	doneCh := make(chan error, 1)
+
+	// Call the checkDeploymentStatus function
+	handler := &kubernetesHandler{
+		clientSet: fakeClient,
+	}
+
+	go handler.checkDeploymentStatus(ctx, informerFactory, item, obj, doneCh)
+	err = <-doneCh
+
+	// Check that the deployment readiness was checked
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "Container state is 'Terminated' Reason: Error, Message: Container terminated due to an error")
+}
+
+func TestCheckDeploymentStatus_ObserverGenerationMismatch(t *testing.T) {
+	// Modify testDeployment to have a different generation than the observed generation
+	testDeployment.Generation = 2
+
+	// Create a fake Kubernetes fakeClient
+	fakeClient := fake.NewSimpleClientset()
+
+	ctx := context.Background()
+	_, err := fakeClient.AppsV1().Deployments("test-namespace").Create(ctx, testDeployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+	replicaSet := addReplicaSetToDeployment(t, ctx, fakeClient, testDeployment)
+
+	// Create a Pod object
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod1",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "test",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "ReplicaSet",
+					Name:       replicaSet.Name,
+					Controller: to.Ptr(true),
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodScheduled,
+					Status: corev1.ConditionTrue,
+				},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "test-container",
+					Ready: true,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				},
+			},
+		},
+	}
+
+	// Add the Pod object to the fake Kubernetes clientset
+	_, err = fakeClient.CoreV1().Pods(pod1.Namespace).Create(ctx, pod1, metav1.CreateOptions{})
+	require.NoError(t, err, "Failed to create Pod: %v", err)
+
+	// Create an informer factory and add the deployment to the cache
+	informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
+	informerFactory.Apps().V1().Deployments().Informer().GetIndexer().Add(testDeployment)
+	informerFactory.Apps().V1().ReplicaSets().Informer().GetIndexer().Add(replicaSet)
+	informerFactory.Core().V1().Pods().Informer().GetIndexer().Add(pod1)
+
+	// Create a fake item and object
+	item := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "test-deployment",
+				"namespace": "test-namespace",
+			},
+		},
+	}
+	obj := &workqueueItem{
+		key: item.GetName(),
+		obj: testDeployment,
+		meta: &metav1.ObjectMeta{
+			Name:      item.GetName(),
+			Namespace: item.GetNamespace(),
+		},
+	}
+
+	// Create a done channel
+	doneCh := make(chan error, 1)
+
+	// Call the checkDeploymentStatus function
+	handler := &kubernetesHandler{
+		clientSet: fakeClient,
+	}
+
+	handler.checkDeploymentStatus(ctx, informerFactory, item, obj, doneCh)
+
+	// Check that the deployment readiness was checked
+	require.Zero(t, len(doneCh))
 }

--- a/test/functional/shared/mechanics/mechanics_test.go
+++ b/test/functional/shared/mechanics/mechanics_test.go
@@ -311,7 +311,7 @@ func Test_InvalidResourceIDs(t *testing.T) {
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployErrorExecutor(template, v1.CodeInvalid, functional.GetMagpieImage()),
+			Executor: step.NewDeployErrorExecutor(template, v1.CodeInvalid, nil, functional.GetMagpieImage()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{

--- a/test/functional/shared/resources/container_test.go
+++ b/test/functional/shared/resources/container_test.go
@@ -221,3 +221,59 @@ func Test_ContainerWithCommandAndArgs(t *testing.T) {
 
 	test.Test(t)
 }
+
+func Test_Container_FailDueToNonExistentImage(t *testing.T) {
+	template := "testdata/corerp-resources-container-nonexistent-container-image.bicep"
+	name := "corerp-resources-container-badimage"
+	appNamespace := "corerp-resources-container-badimage-app"
+	cliError := "Internal"
+	innerError := []string{"ErrImagePull", "ImagePullBackOff"}
+
+	test := shared.NewRPTest(t, name, []shared.TestStep{
+		{
+			Executor:                               step.NewDeployErrorExecutor(template, cliError, innerError, "magpieimage=non-existent-image"),
+			SkipKubernetesOutputResourceValidation: true,
+			SkipObjectValidation:                   true,
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{},
+			},
+			K8sObjects: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					appNamespace: {
+						validation.NewK8sPodForResource(name, "ctnr-cntr-badimage"),
+					},
+				},
+			},
+		},
+	})
+
+	test.Test(t)
+}
+
+func Test_Container_FailDueToBadHealthProbe(t *testing.T) {
+	template := "testdata/corerp-resources-container-bad-healthprobe.bicep"
+	name := "corerp-resources-container-bad-healthprobe"
+	appNamespace := "corerp-resources-container-bad-healthprobe-app"
+	cliError := "Internal"
+	innerError := []string{"CrashLoopBackOff"}
+
+	test := shared.NewRPTest(t, name, []shared.TestStep{
+		{
+			Executor:                               step.NewDeployErrorExecutor(template, cliError, innerError, functional.GetMagpieImage()),
+			SkipKubernetesOutputResourceValidation: true,
+			SkipObjectValidation:                   true,
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{},
+			},
+			K8sObjects: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					appNamespace: {
+						validation.NewK8sPodForResource(name, "ctnr-cntr-bad-healthprobe"),
+					},
+				},
+			},
+		},
+	})
+
+	test.Test(t)
+}

--- a/test/functional/shared/resources/dapr_component_name_conflict_test.go
+++ b/test/functional/shared/resources/dapr_component_name_conflict_test.go
@@ -31,7 +31,7 @@ func Test_DaprComponentNameConflict(t *testing.T) {
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployErrorExecutor(template, v1.CodeInternal),
+			Executor: step.NewDeployErrorExecutor(template, v1.CodeInternal, nil),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{

--- a/test/functional/shared/resources/testdata/corerp-resources-container-bad-healthprobe.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-container-bad-healthprobe.bicep
@@ -1,0 +1,60 @@
+
+import radius as radius
+
+@description('Specifies the location for resources.')
+param location string = 'global'
+
+@description('Specifies the image of the container resource.')
+param magpieimage string
+
+@description('Specifies the port of the container resource.')
+param port int = 5000
+
+@description('Specifies the environment for resources.')
+param environment string
+
+resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
+  name: 'corerp-resources-container-bad-healthprobe'
+  location: location
+  properties: {
+    environment: environment
+    extensions: [
+      {
+          kind: 'kubernetesNamespace'
+          namespace: 'corerp-resources-container-bad-healthprobe-app'
+      }
+    ]
+  }
+}
+
+resource container 'Applications.Core/containers@2022-03-15-privatepreview' = {
+  name: 'ctnr-bad-healthprobe'
+  location: location
+  properties: {
+      application: app.id
+      container: {
+        image: magpieimage
+        readinessProbe:{
+          kind: 'httpGet'
+          containerPort: 5000
+          path: '/bad'
+          failureThreshold:1
+          periodSeconds:1
+        }
+        livenessProbe:{
+          kind: 'httpGet'
+          containerPort: 5000
+          path: '/bad'
+          failureThreshold:1
+          periodSeconds:1
+        }
+        
+        ports: {
+          web: {
+            containerPort: port
+          }
+        }
+      }
+      connections: {}
+    }
+  }

--- a/test/functional/shared/resources/testdata/corerp-resources-container-nonexistent-container-image.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-container-nonexistent-container-image.bicep
@@ -1,0 +1,45 @@
+import radius as radius
+
+@description('Specifies the location for resources.')
+param location string = 'global'
+
+@description('Specifies the image of the container resource.')
+param magpieimage string
+
+@description('Specifies the port of the container resource.')
+param port int = 3000
+
+@description('Specifies the environment for resources.')
+param environment string
+
+resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
+  name: 'corerp-resources-container-badimage'
+  location: location
+  properties: {
+    environment: environment
+    extensions: [
+      {
+          kind: 'kubernetesNamespace'
+          namespace: 'corerp-resources-container-badimage-app'
+      }
+    ]
+  }
+}
+
+resource container 'Applications.Core/containers@2022-03-15-privatepreview' = {
+  name: 'ctnr-ctnr-badimage'
+  location: location
+  properties: {
+    application: app.id
+    container: {
+      image: magpieimage
+      ports: {
+        web: {
+          containerPort: port
+        }
+      }
+    }
+    connections: {}
+  }
+}
+

--- a/test/step/deployerrorexecutor.go
+++ b/test/step/deployerrorexecutor.go
@@ -33,22 +33,24 @@ import (
 var _ Executor = (*DeployErrorExecutor)(nil)
 
 type DeployErrorExecutor struct {
-	Description       string
-	Template          string
-	Parameters        []string
-	ExpectedErrorCode string
+	Description        string
+	Template           string
+	Parameters         []string
+	ExpectedErrorCode  string
+	ExpectedInnerError []string
 
 	// Application sets the `--application` command-line parameter. This is needed in cases where
 	// the application is not defined in bicep.
 	Application string
 }
 
-func NewDeployErrorExecutor(template string, errCode string, parameters ...string) *DeployErrorExecutor {
+func NewDeployErrorExecutor(template string, errCode string, innerError []string, parameters ...string) *DeployErrorExecutor {
 	return &DeployErrorExecutor{
-		Description:       fmt.Sprintf("deploy %s", template),
-		Template:          template,
-		Parameters:        parameters,
-		ExpectedErrorCode: errCode,
+		Description:        fmt.Sprintf("deploy %s", template),
+		Template:           template,
+		Parameters:         parameters,
+		ExpectedErrorCode:  errCode,
+		ExpectedInnerError: innerError,
 	}
 }
 
@@ -75,6 +77,10 @@ func (d *DeployErrorExecutor) Execute(ctx context.Context, t *testing.T, options
 	ok := errors.As(err, &cliErr)
 	require.True(t, ok)
 	require.Equal(t, d.ExpectedErrorCode, cliErr.GetFirstErrorCode())
+
+	if len(d.ExpectedInnerError) > 0 {
+		unpackErrorAndMatch(err, d.ExpectedInnerError)
+	}
 
 	t.Logf("finished deploying %s from file %s", d.Description, d.Template)
 }

--- a/test/step/deployexecutor.go
+++ b/test/step/deployexecutor.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -56,6 +57,22 @@ func (d *DeployExecutor) WithApplication(application string) *DeployExecutor {
 
 func (d *DeployExecutor) GetDescription() string {
 	return d.Description
+}
+
+func unpackErrorAndMatch(err error, failWithAny []string) bool {
+	for _, errString := range failWithAny {
+		cliErr := err.(*radcli.CLIError)
+		for _, detail := range cliErr.ErrorResponse.Error.Details {
+			if detail.Code != "OK" {
+				for _, innerDetail := range detail.Details {
+					if strings.Contains(innerDetail.Message, errString) {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
 }
 
 func (d *DeployExecutor) Execute(ctx context.Context, t *testing.T, options test.TestOptions) {


### PR DESCRIPTION
# Description

Currently even if the pods fail to start, the deployment continues and eventually times out. The only error the user sees is that the deployment timed out. This is an attempt at failing the deployment early and improve the error returned to the user. 

Some of the reasons that a pod can fail are:-

- [ ] Crashing docker image
- [x] Non-existent docker image
- [ ] Health check fails
- [x] Container requesting too many resources
- [x] Image uses python but python not installed
- [x] failed service dependencies
- [ ] Bad volume mount
- [ ] Network issues
- [ ] Non-existent secret

This PR will try to address these failure cases.

radius-project/radius#5686 

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: radius-project/radius#5686 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Adds necessary unit tests for change
* [ ] Adds necessary E2E tests for change
* [ ] Unit tests passing
* [ ] Extended the documentation / Created issue for it

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4f99b10</samp>

### Summary
🚀📝🐛

<!--
1.  🚀 for improving the performance and responsiveness of the async operation.
2.  📝 for adding logging messages and refactoring the code to improve readability.
3.  🐛 for adding a pod informer and error reporting to fix potential bugs and handle errors.
-->
This pull request enhances the async operation functionality in the `armrpc` and `corerp` packages. It improves the cancellation and timeout logic in `worker.go`, and adds logging, refactoring, and pod monitoring in `kubernetes.go`. These changes aim to increase the reliability, performance, and debuggability of the async operation feature.

> _`worker` waits for chan_
> _`kubernetesHandler` tweaks_
> _autumn of refactor_

### Walkthrough
*  Add a channel to signal when the async operation is done or canceled, and modify the error handling and worker logic accordingly ([link](https://github.com/project-radius/radius/pull/5823/files?diff=unified&w=0#diff-5d9b9964242d77606f4868e3fe049978ea1c3f1903afcfeb60c76e19d9785fc5R233), [link](https://github.com/project-radius/radius/pull/5823/files?diff=unified&w=0#diff-5d9b9964242d77606f4868e3fe049978ea1c3f1903afcfeb60c76e19d9785fc5L255-R268), [link](https://github.com/project-radius/radius/pull/5823/files?diff=unified&w=0#diff-5d9b9964242d77606f4868e3fe049978ea1c3f1903afcfeb60c76e19d9785fc5R292-R293)) in `worker.go`


