### PR TITLE
Add Comments: Part 7 (pkg/armrpc - refinements)

### DIFF
--- a/pkg/armrpc/api/v1/armrequestcontext.go
+++ b/pkg/armrpc/api/v1/armrequestcontext.go
@@ -241,11 +241,9 @@ func FromARMRequest(r *http.Request, pathBase, location string) (*ARMRequestCont
 	return rpcCtx, nil
 }
 
-// Summary: SystemData returns unmarshalled RawSystemMetaData.
-//
 // # Function Explanation
 //
-// SystemData parses the RawSystemMetadata field of the ARMRequestContext struct and returns a
+// SystemData returns unmarshalled RawSystemMetaData. It parses the RawSystemMetadata field of the ARMRequestContext struct and returns a
 // SystemData struct, returning an empty SystemData struct if an error occurs during the parsing.
 func (rc ARMRequestContext) SystemData() *SystemData {
 	if rc.RawSystemMetadata == "" {

--- a/pkg/armrpc/api/v1/armrequestcontext.go
+++ b/pkg/armrpc/api/v1/armrequestcontext.go
@@ -241,7 +241,7 @@ func FromARMRequest(r *http.Request, pathBase, location string) (*ARMRequestCont
 	return rpcCtx, nil
 }
 
-// SystemData returns unmarshalled RawSystemMetaData.
+// Summary: SystemData returns unmarshalled RawSystemMetaData.
 //
 // # Function Explanation
 //
@@ -282,8 +282,6 @@ func getQueryItemCount(topQueryParam string) (int, error) {
 	return topParam, err
 }
 
-// ARMRequestContextFromContext extracts ARMRPContext from http context.
-//
 // # Function Explanation
 //
 // ARMRequestContextFromContext retrieves an ARMRequestContext from a given context. Panic if the context does
@@ -292,8 +290,6 @@ func ARMRequestContextFromContext(ctx context.Context) *ARMRequestContext {
 	return ctx.Value(armContextKey).(*ARMRequestContext)
 }
 
-// WithARMRequestContext injects ARMRequestContext into the given http context.
-//
 // # Function Explanation
 //
 // WithARMRequestContext adds the ARMRequestContext to the context and returns the new context.
@@ -301,8 +297,6 @@ func WithARMRequestContext(ctx context.Context, armctx *ARMRequestContext) conte
 	return context.WithValue(ctx, armContextKey, armctx)
 }
 
-// ParsePathBase gets the URL info before the plane types (i.e. host, base path, etc)
-//
 // # Function Explanation
 //
 // ParsePathBase takes in a string and returns a string representing the base path of the string if it contains either

--- a/pkg/armrpc/api/v1/error.go
+++ b/pkg/armrpc/api/v1/error.go
@@ -35,14 +35,14 @@ type ErrModelConversion struct {
 
 // # Function Explanation
 //
-// Error() returns an error string describing the property name and valid value.
+// Error returns an error string describing the property name and valid value.
 func (e *ErrModelConversion) Error() string {
 	return fmt.Sprintf("%s must be %s.", e.PropertyName, e.ValidValue)
 }
 
 // # Function Explanation
 //
-// Is() checks if the target error is of type ErrModelConversion.
+// Is checks if the target error is of type ErrModelConversion.
 func (e *ErrModelConversion) Is(target error) bool {
 	_, ok := target.(*ErrModelConversion)
 	return ok

--- a/pkg/armrpc/api/v1/systemdata.go
+++ b/pkg/armrpc/api/v1/systemdata.go
@@ -33,7 +33,7 @@ type SystemData struct {
 	LastModifiedAt string `json:"lastModifiedAt,omitempty"`
 }
 
-// UpdateSystemData creates or updates new systemdata from old and new resources.
+// Summary: UpdateSystemData creates or updates new systemdata from old and new resources.
 //
 // # Function Explanation
 //

--- a/pkg/armrpc/api/v1/systemdata.go
+++ b/pkg/armrpc/api/v1/systemdata.go
@@ -33,8 +33,6 @@ type SystemData struct {
 	LastModifiedAt string `json:"lastModifiedAt,omitempty"`
 }
 
-// Summary: UpdateSystemData creates or updates new systemdata from old and new resources.
-//
 // # Function Explanation
 //
 // UpdateSystemData updates the existing SystemData object with the new SystemData object, filling in any missing fields

--- a/pkg/armrpc/api/v1/types.go
+++ b/pkg/armrpc/api/v1/types.go
@@ -59,8 +59,6 @@ var operationMethodToHTTPMethod = map[OperationMethod]string{
 	OperationProxy: "",
 }
 
-// HTTPMethod converts OperationMethod to HTTP Method.
-//
 // # Function Explanation
 //
 // HTTPMethod returns HTTP method corresponding to the given OperationMethod, or POST if

--- a/pkg/armrpc/asyncoperation/controller/controller.go
+++ b/pkg/armrpc/asyncoperation/controller/controller.go
@@ -58,8 +58,6 @@ type BaseController struct {
 	options Options
 }
 
-// NewBaseAsyncController creates BaseAsyncController instance.
-//
 // # Function Explanation
 //
 // NewBaseAsyncController creates a new BaseController instance with the given Options for Async Operation.

--- a/pkg/armrpc/asyncoperation/controller/request.go
+++ b/pkg/armrpc/asyncoperation/controller/request.go
@@ -58,8 +58,6 @@ type Request struct {
 	OperationTimeout *time.Duration `json:"asyncOperationTimeout"`
 }
 
-// Timeout gets the async operation timeout duration.
-//
 // # Function Explanation
 //
 // Timeout gets the operation timeout and returns the default timeout unless it specifies.
@@ -70,8 +68,6 @@ func (r *Request) Timeout() time.Duration {
 	return *r.OperationTimeout
 }
 
-// ARMRequestContext creates the ARM request context from async operation request.
-//
 // # Function Explanation
 //
 // ARMRequestContext creates v1.ARMRequestContext object from async operation request. It returns error if the given resource id is invalid.

--- a/pkg/armrpc/asyncoperation/controller/result.go
+++ b/pkg/armrpc/asyncoperation/controller/result.go
@@ -32,8 +32,6 @@ type Result struct {
 	state *v1.ProvisioningState
 }
 
-// NewCanceledResult creates the canceled asynchronous operation result.
-//
 // # Function Explanation
 //
 // NewCanceledResult creates a new Result object with a canceled status and the given message.
@@ -43,8 +41,6 @@ func NewCanceledResult(message string) Result {
 	return r
 }
 
-// NewFailedResult creates the failed asynchronous operation result.
-//
 // # Function Explanation
 //
 // NewFailedResult creates a new Result object with the given error details and sets the failed flag to true.
@@ -67,8 +63,6 @@ func (r *Result) SetFailed(err v1.ErrorDetails, requeue bool) {
 	}
 }
 
-// SetCanceled sets the response status to Canceled.
-//
 // # Function Explanation
 //
 // SetCanceled sets the Result's Requeue field to false, sets the ProvisioningState to Canceled and sets the Error field
@@ -85,8 +79,6 @@ func (r *Result) SetCanceled(message string) {
 	}
 }
 
-// SetProvisioningState sets provisioning state.
-//
 // # Function Explanation
 //
 // SetProvisioningState sets the state of a Result object to the given ProvisioningState.
@@ -94,8 +86,6 @@ func (r *Result) SetProvisioningState(s v1.ProvisioningState) {
 	r.state = &s
 }
 
-// ProvisioningState gets the provisioning state of the result.
-//
 // # Function Explanation
 //
 // ProvisioningState returns the provisioning state of the request object, which is either v1.ProvisioningStateSucceeded

--- a/pkg/armrpc/asyncoperation/worker/service.go
+++ b/pkg/armrpc/asyncoperation/worker/service.go
@@ -51,11 +51,9 @@ type Service struct {
 	KubeClientSet kubernetes.Interface
 }
 
-// Init initializes worker service.
-//
 // # Function Explanation
 //
-// Init initializes the StorageProvider, RequestQueue, OperationStatusManager, Controllers, KubeClient and
+// Init initializes worker service - it initializes the StorageProvider, RequestQueue, OperationStatusManager, Controllers, KubeClient and
 // returns an error if any of these operations fail.
 func (s *Service) Init(ctx context.Context) error {
 	s.StorageProvider = dataprovider.NewStorageProvider(s.Options.Config.StorageProvider)
@@ -85,8 +83,6 @@ func (s *Service) Init(ctx context.Context) error {
 	return nil
 }
 
-// Start starts the worker.
-//
 // # Function Explanation
 //
 // Start creates and starts a worker, and logs any errors that occur while starting the worker.

--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -117,11 +117,9 @@ func New(
 	}
 }
 
-// Start starts worker's message loop.
-//
 // # Function Explanation
 //
-// Start starts a loop to process messages from a queue concurrently, and handles deduplication, updating
+// Start starts worker's message loop - it starts a loop to process messages from a queue concurrently, and handles deduplication, updating
 // resource and operation status, and running the operation. It returns an error if it fails to start the dequeuer.
 func (w *AsyncRequestProcessWorker) Start(ctx context.Context) error {
 	logger := ucplog.FromContextOrDiscard(ctx)

--- a/pkg/armrpc/frontend/controller/controller.go
+++ b/pkg/armrpc/frontend/controller/controller.go
@@ -142,11 +142,9 @@ func (b *BaseController) StatusManager() sm.StatusManager {
 	return b.options.StatusManager
 }
 
-// GetResource is the helper to get the resource via storage client.
-//
 // # Function Explanation
 //
-// GetResource gets a resource from data store for id, set the retrieved resource to out argument and returns 
+// GetResource gets a resource from data store for id, set the retrieved resource to out argument and returns
 // the ETag of the resource and an error if one occurs.
 func (c *BaseController) GetResource(ctx context.Context, id string, out any) (etag string, err error) {
 	etag = ""
@@ -160,8 +158,6 @@ func (c *BaseController) GetResource(ctx context.Context, id string, out any) (e
 	return
 }
 
-// SaveResource is the helper to save the resource via storage client.
-//
 // # Function Explanation
 //
 // SaveResource saves a resource to the data store with an ETag and returns a store object or an error if the save fails.
@@ -179,8 +175,6 @@ func (c *BaseController) SaveResource(ctx context.Context, id string, in any, et
 	return nr, nil
 }
 
-// UpdateSystemData creates or updates new systemdata from old and new resources.
-//
 // # Function Explanation
 //
 // UpdateSystemData updates the system data fields in the old object with the new object's fields, backfilling the created
@@ -210,8 +204,6 @@ func UpdateSystemData(old v1.SystemData, new v1.SystemData) v1.SystemData {
 	return newSystemData
 }
 
-// BuildTrackedResource create TrackedResource instance from request context
-//
 // # Function Explanation
 //
 // BuildTrackedResource takes in a context and returns a v1.TrackedResource object with the ID, Name, Type and Location

--- a/pkg/armrpc/frontend/controller/operation.go
+++ b/pkg/armrpc/frontend/controller/operation.go
@@ -207,12 +207,10 @@ func (c *Operation[P, T]) ConstructSyncResponse(ctx context.Context, method, eta
 	return rest.NewOKResponseWithHeaders(versioned, headers), nil
 }
 
-// ConstructAsyncResponse constructs asynchronous API response.
-//
 // # Function Explanation
 //
-// ConstructAsyncResponse creates an asynchronous response for a given resource, method and etag. It converts the resource 
-// to the appropriate version and sets the response code to either Accepted or Created depending on the method. It also sets 
+// ConstructAsyncResponse creates an asynchronous response for a given resource, method and etag. It converts the resource
+// to the appropriate version and sets the response code to either Accepted or Created depending on the method. It also sets
 // the RetryAfter value if it is specified in the resourceOptions. If an error occurs, it is returned to the caller.
 func (c *Operation[P, T]) ConstructAsyncResponse(ctx context.Context, method, etag string, resource *T) (rest.Response, error) {
 	serviceCtx := v1.ARMRequestContextFromContext(ctx)

--- a/pkg/armrpc/frontend/controller/util.go
+++ b/pkg/armrpc/frontend/controller/util.go
@@ -48,13 +48,11 @@ var (
 	ErrResourceAlreadyExists = errors.New("resource already exists")
 )
 
-// ReadJSONBody extracts the content from request.
-//
 // # Function Explanation
 //
-// ReadJSONBody reads the body of the request if the content type is "application/json".
-// It returns the body as a byte array or an error if the content type is not supported or an error
-// occurs while reading the body.
+// ReadJSONBody extracts the content from request - it reads the body of the request if the content type
+// is "application/json". It returns the body as a byte array or an error if the content type is not supported
+// or an error occurs while reading the body.
 func ReadJSONBody(r *http.Request) ([]byte, error) {
 	defer r.Body.Close()
 
@@ -73,10 +71,8 @@ func ReadJSONBody(r *http.Request) ([]byte, error) {
 	return data, nil
 }
 
-// ValidateETag receives an ARMRequestContect and gathers the values in the If-Match and/or
-// If-None-Match headers and then checks to see if the etag of the resource matches what is requested.
-//
 // # Function Explanation
+//
 // ValidateETag checks the If-Match and If-None-Match headers of the ARMRequestContext against the provided etag,
 // and returns an error if the etag does not match either header.
 func ValidateETag(armRequestContext v1.ARMRequestContext, etag string) error {

--- a/pkg/armrpc/frontend/defaultoperation/defaultasyncdelete.go
+++ b/pkg/armrpc/frontend/defaultoperation/defaultasyncdelete.go
@@ -41,8 +41,6 @@ func NewDefaultAsyncDelete[P interface {
 	return &DefaultAsyncDelete[P, T]{ctrl.NewOperation[P](opts, resourceOpts)}, nil
 }
 
-// Run executes DefaultAsyncDelete operation
-//
 // # Function Explanation
 //
 // Run executes asynchronous delete operation by validating the request, executing custom delete filters, and starting async job, and returns an async response.

--- a/pkg/armrpc/frontend/defaultoperation/defaultasyncput.go
+++ b/pkg/armrpc/frontend/defaultoperation/defaultasyncput.go
@@ -41,11 +41,9 @@ func NewDefaultAsyncPut[P interface {
 	return &DefaultAsyncPut[P, T]{ctrl.NewOperation[P](opts, resourceOpts)}, nil
 }
 
-// Run executes DefaultAsyncPut operation.
-//
 // # Function Explanation
 //
-// Run executes asynchronous create or update operation by validating new resource metadata, ensuring if it is new resource 
+// Run executes asynchronous create or update operation by validating new resource metadata, ensuring if it is new resource
 // or updated resource, running custom update filters, and queuing async operation and returns an async response.
 func (e *DefaultAsyncPut[P, T]) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (rest.Response, error) {
 	serviceCtx := v1.ARMRequestContextFromContext(ctx)

--- a/pkg/armrpc/frontend/defaultoperation/defaultsyncdelete.go
+++ b/pkg/armrpc/frontend/defaultoperation/defaultsyncdelete.go
@@ -43,12 +43,10 @@ func NewDefaultSyncDelete[P interface {
 	return &DefaultSyncDelete[P, T]{ctrl.NewOperation[P](opts, resourceOpts)}, nil
 }
 
-// Run executes DefaultSyncDelete operation
-//
 // # Function Explanation
 //
-// Run executes synchronous deletion operation. It retrieves the resource from the store, runs custom delete filters, 
-// and then deletes the resource from the data store. If the resource is not found, a No Content response is returned. 
+// Run executes synchronous deletion operation. It retrieves the resource from the store, runs custom delete filters,
+// and then deletes the resource from the data store. If the resource is not found, a No Content response is returned.
 // If an error occurs during the delete, an error is returned.
 func (e *DefaultSyncDelete[P, T]) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (rest.Response, error) {
 	serviceCtx := v1.ARMRequestContextFromContext(ctx)

--- a/pkg/armrpc/frontend/defaultoperation/defaultsyncput.go
+++ b/pkg/armrpc/frontend/defaultoperation/defaultsyncput.go
@@ -41,11 +41,9 @@ func NewDefaultSyncPut[P interface {
 	return &DefaultSyncPut[P, T]{ctrl.NewOperation[P](opts, resourceOpts)}, nil
 }
 
-// Run executes DefaultSyncPut operation.
-//
 // # Function Explanation
 //
-// Run executes synchronous create or update operation by validating new resource metadata, ensuring if it is new resource or updated resource, 
+// Run executes synchronous create or update operation by validating new resource metadata, ensuring if it is new resource or updated resource,
 // running custom update filters, and upserting resource metadata and returns an resource as a response.
 func (e *DefaultSyncPut[P, T]) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (rest.Response, error) {
 	serviceCtx := v1.ARMRequestContextFromContext(ctx)

--- a/pkg/armrpc/frontend/defaultoperation/getoperationresult.go
+++ b/pkg/armrpc/frontend/defaultoperation/getoperationresult.go
@@ -43,13 +43,12 @@ func NewGetOperationResult(opts ctrl.Options) (ctrl.Controller, error) {
 	return &GetOperationResult{ctrl.NewBaseController(opts)}, nil
 }
 
-// Run returns the response with necessary headers about the async operation.
-//
 // # Function Explanation
 //
-// Run checks if the operation is in a terminal state, and if not, returns an AsyncOperationResultResponse with the Location
-// and Retry-After headers set. If the operation is in a terminal state, it returns a NoContentResponse. If the operation is
-// not found, it returns a NotFoundResponse. If an error occurs, it returns a BadRequestResponse.
+// Run returns the response with necessary headers about the async operation - it checks if the operation is in a terminal state,
+// and if not, returns an AsyncOperationResultResponse with the Location and Retry-After headers set. If the operation is in a
+// terminal state, it returns a NoContentResponse. If the operation is not found, it returns a NotFoundResponse. If an error occurs,
+// it returns a BadRequestResponse.
 // Spec: https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/async-api-reference.md#azure-asyncoperation-resource-format
 func (e *GetOperationResult) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (rest.Response, error) {
 	serviceCtx := v1.ARMRequestContextFromContext(ctx)

--- a/pkg/armrpc/frontend/server/handler.go
+++ b/pkg/armrpc/frontend/server/handler.go
@@ -75,8 +75,6 @@ type HandlerOptions struct {
 	ControllerFactory ControllerFunc
 }
 
-// HandlerForController returns a http.HandlerFunc that will run the given controller.
-//
 // # Function Explanation
 //
 // HandlerForController creates a http.HandlerFunc function that runs resource provider frontend controller, renders a

--- a/pkg/armrpc/frontend/server/server.go
+++ b/pkg/armrpc/frontend/server/server.go
@@ -51,12 +51,11 @@ type Options struct {
 	ArmCertMgr        *authentication.ArmCertManager
 }
 
-// New creates a frontend server that can listen on the provided address and serve requests.
-//
 // # Function Explanation
 //
-// New creates an HTTP server with a router, configures the router with the given options, adds the default middlewares for logging,
-// authentication, and service context, and returns the server.
+// New creates a frontend server that can listen on the provided address and serve requests - it creates an HTTP server with a router,
+// configures the router with the given options, adds the default middlewares for logging, authentication, and service context, and
+// then returns the server.
 func New(ctx context.Context, options Options) (*http.Server, error) {
 	r := mux.NewRouter()
 	if options.Configure != nil {

--- a/pkg/armrpc/frontend/server/service.go
+++ b/pkg/armrpc/frontend/server/service.go
@@ -47,11 +47,9 @@ type Service struct {
 	KubeClient controller_runtime.Client
 }
 
-// Init initializes web service.
-//
 // # Function Explanation
 //
-// Init initializes the StorageProvider, QueueProvider, OperationStatusManager, KubeClient and ARMCertManager
+// Init initializes web service - it initializes the StorageProvider, QueueProvider, OperationStatusManager, KubeClient and ARMCertManager
 // with the given context and returns an error if any of the initialization fails.
 func (s *Service) Init(ctx context.Context) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
@@ -84,11 +82,9 @@ func (s *Service) Init(ctx context.Context) error {
 	return nil
 }
 
-// Start starts HTTP server.
-//
 // # Function Explanation
 //
-// Start starts listening on a given address and shutdown the server gracefully when context is cancelled.
+// Start starts HTTP server, listening on a given address and shutdown the server gracefully when context is cancelled.
 func (s *Service) Start(ctx context.Context, opt Options) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
 	ctx = hostoptions.WithContext(ctx, s.Options.Config)

--- a/pkg/armrpc/servicecontext/middleware.go
+++ b/pkg/armrpc/servicecontext/middleware.go
@@ -24,8 +24,6 @@ import (
 	"github.com/project-radius/radius/pkg/armrpc/rest"
 )
 
-// ARMRequestCtx is the middleware to inject ARMRequestContext to the http request.
-//
 // # Function Explanation
 //
 // ARMRequestCtx is a middleware handler that adds an ARM request context to an incoming request. It takes in a pathBase


### PR DESCRIPTION
# Description

This PR is a slight departure from the usual PRs I send in this series - this one is specifically about reducing/merging comments in the armrpc folder.
- Design Doc: https://microsoft.sharepoint.com/teams/radiuscoreteam/Shared%20Documents/General/Design%20Docs/2023-04%20auto-generate-comments.docx?web=1
- Original PR for armrpc comments: https://github.com/project-radius/radius/pull/5627

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #5423 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d7f77a5</samp>

### Summary
📝🔀🚚

<!--
1.  📝 for updating documentation
2.  🔀 for moving code between files
3.  🚚 for moving code to a separate file
-->
Refactored and documented some functions related to ARM request context and error handling in `pkg/armrpc/api/v1`. Moved the HTTPMethod function to `armrequestcontext.go` and added summary tags to some exported functions.

> _Oh we're the coders of the sea, and we document what we do_
> _We write our summaries and tags, for every function new_
> _We move our code around the files, to keep them neat and clear_
> _And when we face an error, we make sure it's well-declared_

### Walkthrough
*  Document exported methods and functions with summary tags in Go convention ([link](https://github.com/project-radius/radius/pull/5850/files?diff=unified&w=0#diff-d467735d13613b59d7644368aa68280b91ee003b21872edea14fdce1316ca7c1L244-R244), [link](https://github.com/project-radius/radius/pull/5850/files?diff=unified&w=0#diff-2eceb8165f1fee75332421817aa46bd423ebcf81931a95e84b5e7428a6687458L36-R36))
*  Move HTTPMethod, SystemData, ARMRequestContextFromContext, WithARMRequestContext, and ParsePathBase functions to `armrequestcontext.go` file and document them there ([link](https://github.com/project-radius/radius/pull/5850/files?diff=unified&w=0#diff-d467735d13613b59d7644368aa68280b91ee003b21872edea14fdce1316ca7c1L285-L286), [link](https://github.com/project-radius/radius/pull/5850/files?diff=unified&w=0#diff-d467735d13613b59d7644368aa68280b91ee003b21872edea14fdce1316ca7c1L295-L296), [link](https://github.com/project-radius/radius/pull/5850/files?diff=unified&w=0#diff-d467735d13613b59d7644368aa68280b91ee003b21872edea14fdce1316ca7c1L304-L305), [link](https://github.com/project-radius/radius/pull/5850/files?diff=unified&w=0#diff-66f19d316ddd07d63870a3dc89d97bb120b10b462eaa0c5dd168eb95f3b2aa29L62-L63))
*  Update comments for Error and Is methods of ErrModelConversion type to follow Go convention ([link](https://github.com/project-radius/radius/pull/5850/files?diff=unified&w=0#diff-5e96835f8e5f827a7abe5161017f65d77666e0bf13e86b95db35cbfa9ddec05cL38-R38), [link](https://github.com/project-radius/radius/pull/5850/files?diff=unified&w=0#diff-5e96835f8e5f827a7abe5161017f65d77666e0bf13e86b95db35cbfa9ddec05cL45-R45))


