### PR TITLE
Update contibuting docs for app model changes

### DIFF
--- a/docs/contributing/contributing-code/contributing-code-schema-changes/README.md
+++ b/docs/contributing/contributing-code/contributing-code-schema-changes/README.md
@@ -11,7 +11,7 @@ In order to update or create a new schema follow these steps:
     make generate
     ```
     This will generate the OpenAPI spec and API client for all namespaces and run mockgen to generate mocks.
-        <details>
+    <details>
     <summary>Alternately, if you would like to manually generate the OpenAPI spec and API client, follow these steps:</summary>
 
     1. Run the following command to generate the OpenAPI spec with the newly added changes

--- a/docs/contributing/contributing-code/contributing-code-schema-changes/README.md
+++ b/docs/contributing/contributing-code/contributing-code-schema-changes/README.md
@@ -6,23 +6,30 @@ This page will explain the process to make a change to Radius' REST API (eg: add
 
 In order to update or create a new schema follow these steps:
 1. Create or update the applicable CADL files (named after resource type) within the `cadl` directory in the root of the radius repo
-2. Run the following command to generate the OpenAPI spec with the newly added changes:
-    ```bash  
-    npx cadl compile .
-    ```
-3. Generate the client code by running autorest. For example, to generate the LinkRP resources run:
-    ```bash 
-    autorest pkg/linkrp/api/README.md --tag=link-2022-03-15-privatepreview
-    ```    
-    autotrest cnfiguration file i.e README.md is generally found in pkg/\<namespace\>/api/ directory, and it file has the details on the what tag-link to be used.
-4. You can alternatively run the below command instead of steps 2 and 3 to generate OpenAPI spec and the API client.
-    ```bash  
+2. Run `make generate` to generate the OpenAPI spec and API clients:
+    ```bash
     make generate
     ```
-    which is used to generate OpenAPi Specs and API client for all namespace and runs mockgen to generate mocks.
-5. Add any necessary changes to the Radius resource provider to support the newly added types
-6. Add any necessary tests, as needed
-7. Open a pull request in the radius repo
+    This will generate the OpenAPI spec and API client for all namespaces and run mockgen to generate mocks.
+        <details>
+    <summary>Alternately, if you would like to manually generate the OpenAPI spec and API client, follow these steps:</summary>
+
+    1. Run the following command to generate the OpenAPI spec with the newly added changes
+
+        ```bash
+        npx cadl compile .
+        ```
+    2. Generate the client code by running autorest
+
+        For example, to generate the LinkRP resources run:
+        ```bash
+        autorest pkg/linkrp/api/README.md --tag=link-2022-03-15-privatepreview
+        ```
+        The autotrest configuration file (_i.e README.md_) is generally found in `pkg/<NAMESPACE>/api/` directory and has details on which tag to use.
+    </details>
+3. Add any necessary changes to the Radius resource provider to support the newly added types
+4. Add any necessary tests, as needed
+5. Open a pull request in the radius repo
 
 Creating a pull request in the radius repo that contains application model changes triggers an automated pull request in bicep repo with the bicep type changes. You will merge this in step 3.
 


### PR DESCRIPTION
# Description

Follow up pr to address https://github.com/project-radius/radius/pull/5773#discussion_r1240488277
## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: https://github.com/project-radius/radius/issues/5661

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e835f93</samp>

### Summary
📝🧹🚀

<!--
1.  📝 - This emoji represents the act of writing or editing documentation, which is the main purpose of this change.
2.  🧹 - This emoji represents the act of cleaning or simplifying something, which is what the change does by removing unnecessary steps and details from the main section.
3.  🚀 - This emoji represents the act of improving or speeding up something, which is what the change does by making the generation process easier and faster for the users.
-->
Simplified the documentation on generating the OpenAPI spec and API client in `docs/contributing/contributing-code/contributing-code-schema-changes/README.md` by using `make generate` as the default option.

> _`make generate` now_
> _simplifies the docs for users_
> _manual steps hidden_

### Walkthrough
*  Simplify the instructions for generating the OpenAPI spec and API client by recommending `make generate` and moving the manual steps to a collapsible details section ([link](https://github.com/project-radius/radius/pull/5852/files?diff=unified&w=0#diff-75c80cc14be37fb7c211406cad8842938ecf06f13f8e96cce2ffc1fd0773a4abL9-R33))


