### PR TITLE
Reduce GC count in appcoreRP upon start up

### DIFF
--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -56,6 +56,9 @@ const (
 
 	// deduplicationDuration is the default duration for the deduplication detection.
 	defaultDeduplicationDuration = time.Duration(30) * time.Second
+
+	// defaultDequeueInterval is the default duration for the dequeue interval.
+	defaultDequeueInterval = time.Duration(200) * time.Millisecond
 )
 
 // Options configures AsyncRequestProcessorWorker
@@ -74,6 +77,9 @@ type Options struct {
 
 	// DeduplicationDuration is the duration for the deduplication detection.
 	DeduplicationDuration time.Duration
+
+	// DequeueIntervalDuration is the duration for the dequeue interval.
+	DequeueIntervalDuration time.Duration
 }
 
 // AsyncRequestProcessWorker is the worker to process async requests.
@@ -107,6 +113,9 @@ func New(
 	if options.DeduplicationDuration == time.Duration(0) {
 		options.DeduplicationDuration = defaultDeduplicationDuration
 	}
+	if options.DequeueIntervalDuration == time.Duration(0) {
+		options.DequeueIntervalDuration = defaultDequeueInterval
+	}
 
 	return &AsyncRequestProcessWorker{
 		options:      options,
@@ -123,8 +132,7 @@ func New(
 // resource and operation status, and running the operation. It returns an error if it fails to start the dequeuer.
 func (w *AsyncRequestProcessWorker) Start(ctx context.Context) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
-
-	msgCh, err := queue.StartDequeuer(ctx, w.requestQueue)
+	msgCh, err := queue.StartDequeuer(ctx, w.requestQueue, queue.WithDequeueInterval(w.options.DequeueIntervalDuration))
 	if err != nil {
 		return err
 	}

--- a/pkg/ucp/queue/apiserver/client.go
+++ b/pkg/ucp/queue/apiserver/client.go
@@ -284,7 +284,7 @@ func (c *Client) extendItem(ctx context.Context, id string, expectedDequeueCount
 	return result, nil
 }
 
-func (c *Client) Dequeue(ctx context.Context, opts ...client.DequeueOptions) (*client.Message, error) {
+func (c *Client) Dequeue(ctx context.Context, opts client.QueueClientConfig) (*client.Message, error) {
 	var result *v1alpha1.QueueMessage
 
 	DequeuedMessageError := func(err error) bool {

--- a/pkg/ucp/queue/apiserver/client_test.go
+++ b/pkg/ucp/queue/apiserver/client_test.go
@@ -133,7 +133,7 @@ func TestClient(t *testing.T) {
 
 		err = client1.Enqueue(ctx, client.NewMessage("{}"))
 		require.NoError(t, err)
-		msg, err := client2.Dequeue(ctx)
+		msg, err := client2.Dequeue(ctx, client.QueueClientConfig{})
 		require.NoError(t, err)
 
 		// Increase DequeueCount to mimic the situation when client1 updates message by the clock skew.

--- a/pkg/ucp/queue/client/client.go
+++ b/pkg/ucp/queue/client/client.go
@@ -39,8 +39,6 @@ var (
 
 	// ErrEmptyMessage represents nil or empty Message.
 	ErrEmptyMessage = errors.New("message must not be nil or message is empty")
-
-	defaultDequeueInterval = time.Duration(200) * time.Millisecond
 )
 
 //go:generate mockgen -destination=./mock_client.go -package=client -self_package github.com/project-radius/radius/pkg/ucp/queue/client github.com/project-radius/radius/pkg/ucp/queue/client Client

--- a/pkg/ucp/queue/client/client.go
+++ b/pkg/ucp/queue/client/client.go
@@ -40,7 +40,7 @@ var (
 	// ErrEmptyMessage represents nil or empty Message.
 	ErrEmptyMessage = errors.New("message must not be nil or message is empty")
 
-	dequeueInterval = time.Duration(5) * time.Millisecond
+	defaultDequeueInterval = time.Duration(200) * time.Millisecond
 )
 
 //go:generate mockgen -destination=./mock_client.go -package=client -self_package github.com/project-radius/radius/pkg/ucp/queue/client github.com/project-radius/radius/pkg/ucp/queue/client Client
@@ -51,7 +51,7 @@ type Client interface {
 	Enqueue(ctx context.Context, msg *Message, opts ...EnqueueOptions) error
 
 	// Dequeue dequeues message from queue.
-	Dequeue(ctx context.Context, opts ...DequeueOptions) (*Message, error)
+	Dequeue(ctx context.Context, cfg QueueClientConfig) (*Message, error)
 
 	// FinishMessage finishes or deletes the message in the queue.
 	FinishMessage(ctx context.Context, msg *Message) error
@@ -67,7 +67,11 @@ func StartDequeuer(ctx context.Context, cli Client, opts ...DequeueOptions) (<-c
 
 	go func() {
 		for {
-			msg, err := cli.Dequeue(ctx, opts...)
+			var queueconfig QueueClientConfig
+			if opts != nil {
+				queueconfig = NewDequeueConfig(opts...)
+			}
+			msg, err := cli.Dequeue(ctx, queueconfig)
 			if err == nil {
 				out <- msg
 			} else if !errors.Is(err, ErrMessageNotFound) {
@@ -78,8 +82,9 @@ func StartDequeuer(ctx context.Context, cli Client, opts ...DequeueOptions) (<-c
 			case <-ctx.Done():
 				close(out)
 				return
-			case <-time.After(dequeueInterval):
+			case <-time.After(queueconfig.DequeueIntervalDuration):
 			}
+
 		}
 	}()
 

--- a/pkg/ucp/queue/client/mock_client.go
+++ b/pkg/ucp/queue/client/mock_client.go
@@ -35,23 +35,18 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Dequeue mocks base method.
-func (m *MockClient) Dequeue(arg0 context.Context, arg1 ...DequeueOptions) (*Message, error) {
+func (m *MockClient) Dequeue(arg0 context.Context, arg1 QueueClientConfig) (*Message, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0}
-	for _, a := range arg1 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "Dequeue", varargs...)
+	ret := m.ctrl.Call(m, "Dequeue", arg0, arg1)
 	ret0, _ := ret[0].(*Message)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Dequeue indicates an expected call of Dequeue.
-func (mr *MockClientMockRecorder) Dequeue(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Dequeue(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0}, arg1...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dequeue", reflect.TypeOf((*MockClient)(nil).Dequeue), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dequeue", reflect.TypeOf((*MockClient)(nil).Dequeue), arg0, arg1)
 }
 
 // Enqueue mocks base method.

--- a/pkg/ucp/queue/client/options.go
+++ b/pkg/ucp/queue/client/options.go
@@ -26,8 +26,9 @@ type (
 		// violate compatibility.
 		private()
 	}
-	// DequeueOptions applies an option to Dequeue().
+
 	DequeueOptions interface {
+		// ApplyDequeueOption applies DequeueOptions to QueueClientConfig.
 		ApplyDequeueOption(QueueClientConfig) QueueClientConfig
 		// A private method to prevent users implementing the
 		// interface and so future additions to it will not

--- a/pkg/ucp/queue/client/options.go
+++ b/pkg/ucp/queue/client/options.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package client
 
+import "time"
+
 type (
 	// EnqueueOptions applies an option to Enqueue().
 	EnqueueOptions interface {
@@ -24,12 +26,48 @@ type (
 		// violate compatibility.
 		private()
 	}
-
 	// DequeueOptions applies an option to Dequeue().
 	DequeueOptions interface {
+		ApplyDequeueOption(QueueClientConfig) QueueClientConfig
 		// A private method to prevent users implementing the
 		// interface and so future additions to it will not
 		// violate compatibility.
 		private()
 	}
 )
+
+// QueueClientConfig is a configuration for queue client APIs.
+type QueueClientConfig struct {
+	// DequeueIntervalDuration is the time duration between 2 successive dequeue attempts on the queue
+	DequeueIntervalDuration time.Duration
+}
+
+type dequeueOptions struct {
+	fn func(QueueClientConfig) QueueClientConfig
+}
+
+// ApplyDequeueOption applies the configuration to the queue client.
+func (q *dequeueOptions) ApplyDequeueOption(cfg QueueClientConfig) QueueClientConfig {
+	return q.fn(cfg)
+}
+
+// WithDequeueInterval sets dequeueing interval.
+func WithDequeueInterval(t time.Duration) DequeueOptions {
+	return &dequeueOptions{
+		fn: func(cfg QueueClientConfig) QueueClientConfig {
+			cfg.DequeueIntervalDuration = t
+			return cfg
+		},
+	}
+}
+
+func (q dequeueOptions) private() {}
+
+// NewDequeueConfig returns new queue config for StartDequeuer().
+func NewDequeueConfig(opts ...DequeueOptions) QueueClientConfig {
+	cfg := QueueClientConfig{}
+	for _, opt := range opts {
+		cfg = opt.ApplyDequeueOption(cfg)
+	}
+	return cfg
+}

--- a/pkg/ucp/queue/inmemory/client.go
+++ b/pkg/ucp/queue/inmemory/client.go
@@ -60,7 +60,7 @@ func (c *Client) Enqueue(ctx context.Context, msg *client.Message, options ...cl
 }
 
 // Dequeue dequeues message from the in-memory queue.
-func (c *Client) Dequeue(ctx context.Context, opts ...client.DequeueOptions) (*client.Message, error) {
+func (c *Client) Dequeue(ctx context.Context, opts client.QueueClientConfig) (*client.Message, error) {
 	msg := c.queue.Dequeue()
 	if msg == nil {
 		return nil, client.ErrMessageNotFound

--- a/test/ucp/queuetest/shared.go
+++ b/test/ucp/queuetest/shared.go
@@ -81,7 +81,7 @@ func RunTest(t *testing.T, cli client.Client, clear func(t *testing.T)) {
 
 		checked := map[string]*client.Message{}
 		for i := 0; i < num; i++ {
-			msg, err := cli.Dequeue(ctx)
+			msg, err := cli.Dequeue(ctx, client.QueueClientConfig{})
 			require.NoError(t, err)
 			result := &testQueueMessage{}
 			err = json.Unmarshal(msg.Data, result)
@@ -104,24 +104,24 @@ func RunTest(t *testing.T, cli client.Client, clear func(t *testing.T)) {
 		err := queueTestMessage(cli, 2)
 		require.NoError(t, err)
 
-		msg1, err := cli.Dequeue(ctx)
+		msg1, err := cli.Dequeue(ctx, client.QueueClientConfig{})
 		require.NoError(t, err)
 		require.NotNil(t, msg1)
 
 		time.Sleep(10 * time.Millisecond)
 
-		msg2, err := cli.Dequeue(ctx)
+		msg2, err := cli.Dequeue(ctx, client.QueueClientConfig{})
 		require.NoError(t, err)
 		require.NotNil(t, msg2)
 
 		// Ensure that queue doesn't have any valid messages
-		_, err = cli.Dequeue(ctx)
+		_, err = cli.Dequeue(ctx, client.QueueClientConfig{})
 		require.ErrorIs(t, err, client.ErrMessageNotFound)
 
 		// Dequeue until message is requeued.
 		var msg3 *client.Message
 		for {
-			msg3, err = cli.Dequeue(ctx)
+			msg3, err = cli.Dequeue(ctx, client.QueueClientConfig{})
 			if err == nil {
 				break
 			}
@@ -137,16 +137,16 @@ func RunTest(t *testing.T, cli client.Client, clear func(t *testing.T)) {
 		err := queueTestMessage(cli, 2)
 		require.NoError(t, err)
 
-		msg1, err := cli.Dequeue(ctx)
+		msg1, err := cli.Dequeue(ctx, client.QueueClientConfig{})
 		require.NoError(t, err)
 		t.Logf("%s %v", msg1.ID, msg1.NextVisibleAt)
 
-		msg2, err := cli.Dequeue(ctx)
+		msg2, err := cli.Dequeue(ctx, client.QueueClientConfig{})
 		require.NoError(t, err)
 		t.Logf("%s %v", msg2.ID, msg2.NextVisibleAt)
 
 		// Ensure that queue doesn't have any valid messages
-		_, err = cli.Dequeue(ctx)
+		_, err = cli.Dequeue(ctx, client.QueueClientConfig{})
 		require.ErrorIs(t, err, client.ErrMessageNotFound)
 		// Extend msg1 after sometime
 		time.Sleep(TestMessageLockTime / 2)
@@ -157,7 +157,7 @@ func RunTest(t *testing.T, cli client.Client, clear func(t *testing.T)) {
 
 		for {
 			// msg2 is requeued. msg3 must be msg2
-			msg3, err := cli.Dequeue(ctx)
+			msg3, err := cli.Dequeue(ctx, client.QueueClientConfig{})
 			if err == nil {
 				t.Logf("%s %v", msg3.ID, msg3.NextVisibleAt)
 				require.Equal(t, msg2.ID, msg3.ID)
@@ -173,18 +173,18 @@ func RunTest(t *testing.T, cli client.Client, clear func(t *testing.T)) {
 		err := queueTestMessage(cli, 2)
 		require.NoError(t, err)
 
-		msg1, err := cli.Dequeue(ctx)
+		msg1, err := cli.Dequeue(ctx, client.QueueClientConfig{})
 		require.NoError(t, err)
 		t.Logf("%s %v", msg1.ID, msg1.NextVisibleAt)
 
 		time.Sleep(TestMessageLockTime / 2)
 
-		msg2, err := cli.Dequeue(ctx)
+		msg2, err := cli.Dequeue(ctx, client.QueueClientConfig{})
 		require.NoError(t, err)
 		t.Logf("%s %v", msg2.ID, msg2.NextVisibleAt)
 
 		for {
-			msg3, err := cli.Dequeue(ctx)
+			msg3, err := cli.Dequeue(ctx, client.QueueClientConfig{})
 			if err == nil {
 				t.Logf("%s %v", msg3.ID, msg3.NextVisibleAt)
 				break
@@ -200,7 +200,7 @@ func RunTest(t *testing.T, cli client.Client, clear func(t *testing.T)) {
 
 	t.Run("StartDequeuer dequeues message via channel", func(t *testing.T) {
 		clear(t)
-		msgCh, err := client.StartDequeuer(ctx, cli)
+		msgCh, err := client.StartDequeuer(ctx, cli, client.WithDequeueInterval(5))
 		require.NoError(t, err)
 
 		recvCnt := 0

--- a/test/ucp/queuetest/shared.go
+++ b/test/ucp/queuetest/shared.go
@@ -33,6 +33,8 @@ const (
 	TestMessageLockTime = time.Duration(1) * time.Second
 
 	pollingInterval = time.Duration(100) * time.Millisecond
+
+	defaultTestDequeueInterval = time.Duration(5) * time.Millisecond
 )
 
 type testQueueMessage struct {
@@ -200,7 +202,7 @@ func RunTest(t *testing.T, cli client.Client, clear func(t *testing.T)) {
 
 	t.Run("StartDequeuer dequeues message via channel", func(t *testing.T) {
 		clear(t)
-		msgCh, err := client.StartDequeuer(ctx, cli, client.WithDequeueInterval(5))
+		msgCh, err := client.StartDequeuer(ctx, cli, client.WithDequeueInterval(defaultTestDequeueInterval))
 		require.NoError(t, err)
 
 		recvCnt := 0


### PR DESCRIPTION
# Description

Currently just upon starting up, the GC count in AppCore RP is somehwat High and continues to grow very quickly. 

With self-hosted yamls ( using apiserver as queue provider) - 
```
12:09 PM# NumGC = 33
12:15 PM # NumGC = 60
```
This is tracing back to below function call, as seen while debugging with pprof:
```
(pprof) top 6 -cum  
Showing nodes accounting for 0.03GB, 0.43% of 6.78GB total
Dropped 429 nodes (cum <= 0.03GB)
Showing top 6 nodes out of 188
      flat  flat%   sum%        cum   cum%
         0     0%     0%     5.43GB 80.09%  github.com/project-radius/radius/pkg/ucp/queue/client.StartDequeuer.func1
    0.01GB  0.19%  0.19%     5.37GB 79.22%  github.com/project-radius/radius/pkg/ucp/queue/apiserver.(*Client).Dequeue
    0.02GB  0.24%  0.43%     5.36GB 79.03%  k8s.io/client-go/util/retry.OnError
         0     0%  0.43%     5.34GB 78.79%  k8s.io/apimachinery/pkg/util/wait.ExponentialBackoff
         0     0%  0.43%     5.34GB 78.79%  k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection
  ```
Which can be made better by increasing the dequeueInterval which currently has been set to aa very low value of 5 ms.

Increasing this to 200 ms. 


## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
https://dev.azure.com/azure-octo/Incubations/_workitems/edit/8277

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #5713



## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9b06bbd</samp>

### Summary
🚀🌐🔋

<!--
1.  🚀 - This emoji can be used to indicate that the change was part of a performance improvement or optimization, as it suggests speed and efficiency.
2.  🌐 - This emoji can be used to indicate that the change affects the network traffic or communication between the queue client and server, as it suggests the internet or web.
3.  🔋 - This emoji can be used to indicate that the change reduces the CPU usage or power consumption of the queue client, as it suggests a battery or energy saving.
-->
Increased the polling interval of the queue client in `pkg/ucp/queue/client/client.go` to improve performance.

> _`dequeueInterval`_
> _Longer now, for less resource_
> _Winter of the queue_

### Walkthrough
* Increase the polling interval of the queue client to reduce CPU and network usage ([link](https://github.com/project-radius/radius/pull/5855/files?diff=unified&w=0#diff-cbac5049d30d4aa9882949ddccb8e4993918e3243fff7c9922128e87d0444809L43-R43))


