### PR TITLE
Add Comments: Part 8 (pkg/azure)

### DIFF
--- a/pkg/azure/armauth/auth.go
+++ b/pkg/azure/armauth/auth.go
@@ -46,7 +46,10 @@ type Options struct {
 	CredentialProvider sdk_cred.CredentialProvider[sdk_cred.AzureCredential]
 }
 
-// NewArmConfig gets the configuration we use for managing ARM resources
+// # Function Explanation
+//
+// NewArmConfig creates a new ArmConfig instance with the given options, or default options if none are provided, and
+// returns it or an error if one occurs.
 func NewArmConfig(opt *Options) (*ArmConfig, error) {
 	if opt == nil {
 		opt = &Options{}
@@ -62,7 +65,9 @@ func NewArmConfig(opt *Options) (*ArmConfig, error) {
 	}, nil
 }
 
-// NewARMCredential returns new azure client credential
+// # Function Explanation
+//
+// NewARMCredential evaluates the authentication method and returns the appropriate credential.
 func NewARMCredential(opt *Options) (azcore.TokenCredential, error) {
 	authMethod := GetAuthMethod()
 
@@ -80,7 +85,9 @@ func NewARMCredential(opt *Options) (azcore.TokenCredential, error) {
 	}
 }
 
-// GetAuthMethod returns the authentication method used by the RP
+// # Function Explanation
+//
+// GetAuthMethod returns the authentication method to use based on environment variables.
 func GetAuthMethod() string {
 	// Allow explicit configuration of the auth method, and fall back
 	// to auto-detection if unspecified
@@ -101,7 +108,9 @@ func GetAuthMethod() string {
 	}
 }
 
-// IsServicePrincipalConfigured determines whether a service principal is specifed
+// # Function Explanation
+//
+// IsServicePrincipalConfigured checks if ServicePrincipalAuth is the authentication method configured.
 func IsServicePrincipalConfigured() (bool, error) {
 	return GetAuthMethod() == ServicePrincipalAuth, nil
 }

--- a/pkg/azure/azcli/azcli.go
+++ b/pkg/azure/azcli/azcli.go
@@ -23,7 +23,10 @@ import (
 	"runtime"
 )
 
-// RunCLICommand runs an az CLI command with stdout and stderr forwarded to this process's output.
+// # Function Explanation
+//
+// RunCLICommand runs the Azure CLI command based on the OS type and returns an error if the command fails.
+// It forwards the stdout and stderr to this process's output.
 func RunCLICommand(args ...string) error {
 	var executableName string
 	var executableArgs []string

--- a/pkg/azure/clientv2/clients.go
+++ b/pkg/azure/clientv2/clients.go
@@ -47,19 +47,27 @@ type Options struct {
 	BaseURI string
 }
 
-// NewFederatedIdentityClient creates new federated identity client.
+// # Function Explanation
+//
+// NewFederatedIdentityClient creates a new FederatedIdentityCredentialsClient and returns it along with any error.
 func NewFederatedIdentityClient(subscriptionID string, options *Options) (*armmsi.FederatedIdentityCredentialsClient, error) {
 	// TODO: Add LRU cache to maintain the clients.
 	return armmsi.NewFederatedIdentityCredentialsClient(subscriptionID, options.Cred, defaultClientOptions)
 }
 
-// NewUserAssignedIdentityClient creates new user assigned managed identity client.
+// # Function Explanation
+//
+// NewUserAssignedIdentityClient creates a new UserAssignedIdentitiesClient with the given subscriptionID and Options and
+// returns it, or an error if one occurs.
 func NewUserAssignedIdentityClient(subscriptionID string, options *Options) (*armmsi.UserAssignedIdentitiesClient, error) {
 	// TODO: Add LRU cache to maintain the clients.
 	return armmsi.NewUserAssignedIdentitiesClient(subscriptionID, options.Cred, defaultClientOptions)
 }
 
-// NewCustomActionClient creates an instance of the CustomActionClient.
+// # Function Explanation
+//
+// NewCustomActionClient creates a new CustomActionClient with the provided subscriptionID and Options, and returns an
+// error if one occurs.
 func NewCustomActionClient(subscriptionID string, options *Options) (*CustomActionClient, error) {
 	baseURI := DefaultBaseURI
 	if options.BaseURI != "" {
@@ -83,12 +91,16 @@ func NewCustomActionClient(subscriptionID string, options *Options) (*CustomActi
 	}, nil
 }
 
-// NewSubscriptionsClient creates a new generic client to handle subscriptions.
+// # Function Explanation
+//
+// NewSubscriptionsClient creates a new ARM Subscriptions Client using the provided options and returns it, or an error if one occurs.
 func NewSubscriptionsClient(options *Options) (*armsubscriptions.Client, error) {
 	return armsubscriptions.NewClient(options.Cred, defaultClientOptions)
 }
 
-// NewGenericResourceClient creates a new generic client to handle resources.
+// # Function Explanation
+//
+// NewGenericResourceClient creates a new ARM resources client with the given subscription ID, options and client options.
 func NewGenericResourceClient(subscriptionID string, options *Options, clientOptions *arm.ClientOptions) (*armresources.Client, error) {
 	// Allow setting client options for testing.
 	if clientOptions == nil {
@@ -97,7 +109,10 @@ func NewGenericResourceClient(subscriptionID string, options *Options, clientOpt
 	return armresources.NewClient(subscriptionID, options.Cred, clientOptions)
 }
 
-// NewProvidersClient creates a new client that can be used to look up resource providers and API versions.
+// # Function Explanation
+//
+// NewProvidersClient creates a new ARM ProvidersClient with the given subscription ID and ARM ClientOptions,
+// that can be used to look up resource providers and API versions.
 func NewProvidersClient(subcriptionID string, options *Options, clientOptions *arm.ClientOptions) (*armresources.ProvidersClient, error) {
 	// Allow setting client options for testing.
 	if clientOptions == nil {
@@ -106,37 +121,53 @@ func NewProvidersClient(subcriptionID string, options *Options, clientOptions *a
 	return armresources.NewProvidersClient(subcriptionID, options.Cred, clientOptions)
 }
 
-// NewAccountsClient creates a new accounts client to handle storage accounts.
+// # Function Explanation
+//
+// NewAccountsClient creates a new ARM Storage Accounts Client with the given subscription ID and options.
 func NewAccountsClient(subscriptionID string, options *Options) (*armstorage.AccountsClient, error) {
 	return armstorage.NewAccountsClient(subscriptionID, options.Cred, defaultClientOptions)
 }
 
-// NewRoleDefinitionsClient creates a new role definitions client to handle role definitions.
+// # Function Explanation
+//
+// NewRoleDefinitionsClient creates a new RoleDefinitionsClient from the given Options and returns it, or an error if one occurs.
 func NewRoleDefinitionsClient(options *Options) (*armauthorization.RoleDefinitionsClient, error) {
 	return armauthorization.NewRoleDefinitionsClient(options.Cred, defaultClientOptions)
 }
 
-// NewRoleAssignmentsClient creates a new role assignments client to handle role assignments.
+// # Function Explanation
+//
+// NewRoleAssignmentsClient creates a new RoleAssignmentsClient with the given subscriptionID and Options, and returns an
+// error if one occurs.
 func NewRoleAssignmentsClient(subscriptionID string, options *Options) (*armauthorization.RoleAssignmentsClient, error) {
 	return armauthorization.NewRoleAssignmentsClient(subscriptionID, options.Cred, defaultClientOptions)
 }
 
-// NewServiceBusNamespacesClient creates a new service bus namespaces client to handle service bus namespaces.
+// # Function Explanation
+//
+// NewServiceBusNamespacesClient creates a new ARM Service Bus Namespaces Client with the given subscription ID and
+// options.
 func NewServiceBusNamespacesClient(subscriptionID string, options *Options) (*armservicebus.NamespacesClient, error) {
 	return armservicebus.NewNamespacesClient(subscriptionID, options.Cred, defaultClientOptions)
 }
 
-// NewDeploymentsClient creates a new deployments client to handle deployments.
+// # Function Explanation
+//
+// // NewDeploymentsClient creates a new DeploymentsClient which can be used to manage Azure deployments.
 func NewDeploymentsClient(subscriptionID string, options *Options) (*armresources.DeploymentsClient, error) {
 	return armresources.NewDeploymentsClient(subscriptionID, options.Cred, defaultClientOptions)
 }
 
-// NewDeploymentOperationsClient creates a new deployment operations client to handle deployment related operations.
+// # Function Explanation
+//
+// NewDeploymentOperationsClient creates a new ARM deployment operations client for managing deployment operations.
 func NewDeploymentOperationsClient(subscriptionID string, options *Options) (*armresources.DeploymentOperationsClient, error) {
 	return armresources.NewDeploymentOperationsClient(subscriptionID, options.Cred, defaultClientOptions)
 }
 
-// NewResourceGroupsClient creates a new resource groups client to handle resource groups.
+// # Function Explanation
+//
+// NewResourceGroupsClient creates a new ARM Resource Groups Client with the given subscription ID and options.
 func NewResourceGroupsClient(subscriptionID string, options *Options) (*armresources.ResourceGroupsClient, error) {
 	return armresources.NewResourceGroupsClient(subscriptionID, options.Cred, defaultClientOptions)
 }

--- a/pkg/azure/clientv2/common.go
+++ b/pkg/azure/clientv2/common.go
@@ -21,7 +21,10 @@ import (
 	"fmt"
 )
 
-// GetResourceGroupLocation returns the location of the resource group.
+// # Function Explanation
+//
+// GetResourceGroupLocation retrieves the location of a given resource group from an Azure subscription. It returns an
+// error if the resource group or the subscription cannot be found.
 func GetResourceGroupLocation(ctx context.Context, subscriptionID string, resourceGroupName string, options *Options) (*string, error) {
 	client, err := NewResourceGroupsClient(subscriptionID, options)
 	if err != nil {

--- a/pkg/azure/clientv2/customaction.go
+++ b/pkg/azure/clientv2/customaction.go
@@ -43,7 +43,10 @@ type CustomActionClient struct {
 	baseURI  string
 }
 
-// InvokeCustomAction invokes a custom action on the given resource.
+// # Function Explanation
+//
+// InvokeCustomAction sends a request to the server to invoke a custom action on the given resource
+// and returns the response body and an error if one occurs.
 func (client *CustomActionClient) InvokeCustomAction(ctx context.Context, resourceID, apiVersion, action string) (*ClientCustomActionResponse, error) {
 	req, err := client.customActionCreateRequest(ctx, resourceID, apiVersion, action)
 	if err != nil {

--- a/pkg/azure/clientv2/errors.go
+++ b/pkg/azure/clientv2/errors.go
@@ -23,6 +23,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
+// # Function Explanation
+//
 // Is404Error returns true if the error is a 404 payload from an autorest operation.
 func Is404Error(err error) bool {
 	respErr, ok := ExtractResponseError(err)
@@ -37,6 +39,8 @@ func Is404Error(err error) bool {
 	return false
 }
 
+// # Function Explanation
+//
 // ExtractResponseError extracts the ResponseError from the error.
 // Returns true if the error is a ResponseError.
 func ExtractResponseError(err error) (*azcore.ResponseError, bool) {

--- a/pkg/azure/clientv2/unfold.go
+++ b/pkg/azure/clientv2/unfold.go
@@ -46,6 +46,8 @@ type ServiceError struct {
 	AdditionalInfo []map[string]any         `json:"additionalInfo,omitempty" yaml:"additionalInfo,omitempty"`
 }
 
+// # Function Explanation
+//
 // UnfoldServiceError unfolds the Details field in the given azure.ServiceError,
 // and convert messages which are raw JSON of an radclient.ErrorResponse into
 // structured radclient.ErrorDetails fields.
@@ -88,6 +90,8 @@ func UnfoldServiceError(in *generated.ErrorDetail) *ServiceError {
 	return out
 }
 
+// # Function Explanation
+//
 // UnfoldErrorDetails extract the Message field of a given *radclient.ErrorDetail
 // into its correspoding Details field, which is structured.
 func UnfoldErrorDetails(d *generated.ErrorDetail) generated.ErrorDetail {
@@ -127,10 +131,15 @@ type WrappedErrorResponse struct {
 	ErrorResponse generated.ErrorResponse
 }
 
+// # Function Explanation
+//
+// Error returns the error message from the ErrorResponse struct.
 func (w WrappedErrorResponse) Error() string {
 	return *w.ErrorResponse.Error.Message
 }
 
+// # Function Explanation
+//
 // TryUnfoldErrorResponse takes an error that wrapped a radclient.ErrorResponse
 // and unfold nested JSON messages into structured radclient.ErrorDetail field.
 //
@@ -166,7 +175,9 @@ func extractString(o any) *string {
 	return to.Ptr(fmt.Sprintf("%v", o))
 }
 
-// TryUnfoldResponseError unfolds an azcore.ResponseError.
+// # Function Explanation
+//
+// TryUnfoldResponseError attempts to convert a ResponseError into an ErrorDetails object.
 func TryUnfoldResponseError(err error) *v1.ErrorDetails {
 	respErr, ok := err.(*azcore.ResponseError)
 	if !ok {

--- a/pkg/azure/credential/ucpcredentials.go
+++ b/pkg/azure/credential/ucpcredentials.go
@@ -66,7 +66,7 @@ type UCPCredential struct {
 // # Function Explanation
 //
 // NewUCPCredential creates a new UCPCredential with the given options and returns it, or returns an error if the
-// provider is not defined or the duration is 0. Pass nil to accept default options.
+// provider is not defined. If Duration is 0, it is set to DefaultDuration. Pass nil to accept default options.
 func NewUCPCredential(options UCPCredentialOptions) (*UCPCredential, error) {
 	if options.Provider == nil {
 		return nil, errors.New("undefined provider")

--- a/pkg/azure/credential/ucpcredentials.go
+++ b/pkg/azure/credential/ucpcredentials.go
@@ -63,7 +63,10 @@ type UCPCredential struct {
 	nextExpiry atomic.Int64
 }
 
-// NewUCPCredential creates a UCPCredential. Pass nil to accept default options.
+// # Function Explanation
+//
+// NewUCPCredential creates a new UCPCredential with the given options and returns it, or returns an error if the
+// provider is not defined or the duration is 0. Pass nil to accept default options.
 func NewUCPCredential(options UCPCredentialOptions) (*UCPCredential, error) {
 	if options.Provider == nil {
 		return nil, errors.New("undefined provider")
@@ -134,7 +137,10 @@ func (c *UCPCredential) refreshCredentials(ctx context.Context) error {
 	return nil
 }
 
-// GetToken requests an access token from the hosting environment. This method is called automatically by Azure SDK clients.
+// # Function Explanation
+//
+// GetToken attempts to refresh the Azure service principal credential if it is expired and then returns an
+// access token if the credential is ready. This method is called automatically by Azure SDK clients.
 func (c *UCPCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
 	logger := ucplog.FromContextOrDiscard(ctx)
 

--- a/pkg/azure/roleassignment/roleassignment.go
+++ b/pkg/azure/roleassignment/roleassignment.go
@@ -34,7 +34,10 @@ import (
 	"github.com/project-radius/radius/pkg/ucp/ucplog"
 )
 
-// Create assigns the specified role name to the Identity over the specified scope
+// # Function Explanation
+//
+// Create checks if a role assignment already exists for a given managed identity, and if not, creates a new role
+// assignment. If an error is encountered, it is retried up to 100 times.
 // principalID - The principal ID assigned to the role. This maps to the ID inside the Active Directory. It can point to a user, service principal, or security group.
 // scope - fully qualified identifier of the scope of the role assignment to create. Example: '/subscriptions/{subscription-id}/',
 // '/subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/providers/{resource-provider}/{resource-type}/{resource-name}'
@@ -118,7 +121,10 @@ func Create(ctx context.Context, armConfig *armauth.ArmConfig, subscriptionID, p
 	return nil, fmt.Errorf("failed to create role assignment for role '%s': %w", roleNameOrID, err)
 }
 
-// Delete deletes the specified role name over the specified scope.
+// # Function Explanation
+//
+// Delete parses the roleID, creates a role assignments client, and deletes the role assignment with the given roleID,
+// returning an error if one occurs.
 func Delete(ctx context.Context, armConfig *armauth.ArmConfig, roleID string) error {
 	rID, err := resources.Parse(roleID)
 	if err != nil {
@@ -144,7 +150,11 @@ func Delete(ctx context.Context, armConfig *armauth.ArmConfig, roleID string) er
 	return nil
 }
 
-// Returns roleDefinitionID: fully qualified identifier of role definition, example: "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+// # Function Explanation
+//
+// GetRoleDefinitionID checks if the provided roleNameOrID is a role definition ID or a role name, and returns the
+// corresponding role definition ID.
+// roleDefinitionID: fully qualified identifier of role definition, example: "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
 func GetRoleDefinitionID(ctx context.Context, armConfig *armauth.ArmConfig, subscriptionID, scope, roleNameOrID string) (roleDefinitionID string, err error) {
 	if strings.HasPrefix(roleNameOrID, "/subscriptions/") {
 		roleDefinitionID = roleNameOrID

--- a/pkg/azure/tokencredentials/anonymous.go
+++ b/pkg/azure/tokencredentials/anonymous.go
@@ -33,17 +33,25 @@ type AnonymousCredential struct {
 // Use this type when implementing a stateless policy as a first-class function.
 type PolicyFunc func(*policy.Request) (*http.Response, error)
 
+// # Function Explanation
+//
 // Do implements the Policy interface on PolicyFunc.
 func (pf PolicyFunc) Do(req *policy.Request) (*http.Response, error) {
 	return pf(req)
 }
 
+// # Function Explanation
+//
+// NewAuthenticationPolicy creates a new authentication policy based on the given options.
 func (*AnonymousCredential) NewAuthenticationPolicy(options policy.BearerTokenOptions) policy.Policy {
 	return PolicyFunc(func(req *policy.Request) (*http.Response, error) {
 		return req.Next()
 	})
 }
 
+// # Function Explanation
+//
+// GetToken returns an AccessToken and an error if the request fails.
 func (a *AnonymousCredential) GetToken(ctx context.Context, options policy.TokenRequestOptions) (azcore.AccessToken, error) {
 	return azcore.AccessToken{}, nil
 }


### PR DESCRIPTION
# Description

This is another PR for adding comments to functions in Radius. In this PR, I've added comments for the pkg/azure folder.

References:
- Design doc - https://microsoft.sharepoint.com/teams/radiuscoreteam/Shared%20Documents/General/Design%20Docs/2023-04%20auto-generate-comments.docx?web=1

Other PRs in this series:
- https://github.com/project-radius/radius/pull/5531
- https://github.com/project-radius/radius/pull/5627
- https://github.com/project-radius/radius/pull/5643
- https://github.com/project-radius/radius/pull/5834
- https://github.com/project-radius/radius/pull/5835
- https://github.com/project-radius/radius/pull/5845
- https://github.com/project-radius/radius/pull/5850


## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #5423 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 70eba18</samp>

### Summary
📝🔒🐛

<!--
1.  📝 - This emoji represents writing, documentation, or comments, and can be used for any change that adds or improves code comments or documentation.
2.  🔒 - This emoji represents security, authentication, or authorization, and can be used for any change that involves Azure credentials, tokens, role assignments, or permissions.
3.  🐛 - This emoji represents a bug, error, or issue, and can be used for any change that fixes, handles, or prevents errors or bugs in the code.
-->
This pull request adds documentation comments to various functions and structs in the `radius` project, mainly in the `pkg/azure` directory. The comments improve the readability and maintainability of the code, and explain the functionality and parameters of the functions and structs. The pull request also adds some comment placeholders to some error functions that need documentation.

> _Some functions in radius lacked docs_
> _So the author added some blocks_
> _With comments galore_
> _They explained the core_
> _Of `clientv2` and `roleassignment` mocks_

### Walkthrough
*  Add comments to various functions in the `armauth`, `azcli`, `clientv2`, `credential`, `roleassignment`, and `tokencredentials` packages to explain their purposes, parameters, and return values ([link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-69af8f69ba9f1800c73cb28457e35cbd482130f826a69bc1b4593ea733a0471cL49-R52), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-69af8f69ba9f1800c73cb28457e35cbd482130f826a69bc1b4593ea733a0471cL65-R70), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-69af8f69ba9f1800c73cb28457e35cbd482130f826a69bc1b4593ea733a0471cL83-R90), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-69af8f69ba9f1800c73cb28457e35cbd482130f826a69bc1b4593ea733a0471cL104-R113), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-81a0e709efaf0290ca00b2493c70a6ca1908b1d65b93dc79d3423c2a81b283adL26-R29), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-30b3c068407e2879a004117b19f540d5ab6e4a28daa61365a315cb6d5f5c7ca2L50-R52), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-30b3c068407e2879a004117b19f540d5ab6e4a28daa61365a315cb6d5f5c7ca2L56-R61), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-30b3c068407e2879a004117b19f540d5ab6e4a28daa61365a315cb6d5f5c7ca2L62-R70), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-30b3c068407e2879a004117b19f540d5ab6e4a28daa61365a315cb6d5f5c7ca2L86-R103), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-30b3c068407e2879a004117b19f540d5ab6e4a28daa61365a315cb6d5f5c7ca2L100-R115), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-30b3c068407e2879a004117b19f540d5ab6e4a28daa61365a315cb6d5f5c7ca2L109-R170), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-17d59b7b5b1a92feb25b92bfd786aad03e23406340c49e81b1e21ffacf00ffdbL24-R27), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-28d9c33a9ea4c136250fa8e8690c381d78cff8fd4b75414fde25996d03fe2ca2L46-R49), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-e5163edb48b8540151507039fc5f53647a9f5370b14329bb8d63ed9a80d85ecdL130-R142), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-e5163edb48b8540151507039fc5f53647a9f5370b14329bb8d63ed9a80d85ecdL169-R180), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-b35a87eca0927679a65091343d0c7ca182d7d9c0b6b7c52d796d68ff7600b765L66-R69), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-b35a87eca0927679a65091343d0c7ca182d7d9c0b6b7c52d796d68ff7600b765L137-R143), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-3a2a6eae0073a6144a423e6756d52eacdd25246738580cede836d0a8fc60fc88L37-R40), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-3a2a6eae0073a6144a423e6756d52eacdd25246738580cede836d0a8fc60fc88L121-R127), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-3a2a6eae0073a6144a423e6756d52eacdd25246738580cede836d0a8fc60fc88L147-R157), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-8b892e158ecbc4b797190af31cc1a272b90b4534df86a1328e2425e19e139006R43-R45), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-8b892e158ecbc4b797190af31cc1a272b90b4534df86a1328e2425e19e139006R52-R54))
* Add comment placeholders to some functions in the `clientv2` and `tokencredentials` packages to indicate that they need further explanation ([link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-20b0c2fdb6583ff53fb3e04635b282e83da96caab78a259a27553a36170570deR26-R27), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-20b0c2fdb6583ff53fb3e04635b282e83da96caab78a259a27553a36170570deR42-R43), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-e5163edb48b8540151507039fc5f53647a9f5370b14329bb8d63ed9a80d85ecdR49-R50), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-e5163edb48b8540151507039fc5f53647a9f5370b14329bb8d63ed9a80d85ecdR93-R94), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-8b892e158ecbc4b797190af31cc1a272b90b4534df86a1328e2425e19e139006R36-R37))
* Add a comment to the `Error` function in the `clientv2` package to explain its return value ([link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-e5163edb48b8540151507039fc5f53647a9f5370b14329bb8d63ed9a80d85ecdL130-R142))
* Add comments to the `UnmarshalJSON` functions in the `clientv2` package to explain their logic and parameters ([link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-e5163edb48b8540151507039fc5f53647a9f5370b14329bb8d63ed9a80d85ecdR49-R50), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-e5163edb48b8540151507039fc5f53647a9f5370b14329bb8d63ed9a80d85ecdR93-R94))
* Add comments to the `TryUnfoldErrorResponse` and `TryUnfoldResponseError` functions in the `clientv2` package to explain their purposes and parameters ([link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-e5163edb48b8540151507039fc5f53647a9f5370b14329bb8d63ed9a80d85ecdL130-R142), [link](https://github.com/project-radius/radius/pull/5856/files?diff=unified&w=0#diff-e5163edb48b8540151507039fc5f53647a9f5370b14329bb8d63ed9a80d85ecdL169-R180))


