### PR TITLE
Fixing AWS connection URL to use Recipe output

### DIFF
--- a/pkg/linkrp/processors/rediscaches/processor.go
+++ b/pkg/linkrp/processors/rediscaches/processor.go
@@ -45,7 +45,7 @@ func (p *Processor) Process(ctx context.Context, resource *datamodel.RedisCache,
 	validator.AddRequiredStringField(renderers.Host, &resource.Properties.Host)
 	validator.AddRequiredInt32Field(renderers.Port, &resource.Properties.Port)
 	validator.AddOptionalStringField(renderers.UsernameStringValue, &resource.Properties.Username)
-	validator.AddComputedBoolField(renderers.SSL, &resource.Properties.TLS, func() (bool, *processors.ValidationError) {
+	validator.AddComputedBoolField(renderers.TLS, &resource.Properties.TLS, func() (bool, *processors.ValidationError) {
 		return p.computeSSL(resource), nil
 	})
 	validator.AddOptionalSecretField(renderers.PasswordStringHolder, &resource.Properties.Secrets.Password)

--- a/pkg/linkrp/processors/rediscaches/processor_test.go
+++ b/pkg/linkrp/processors/rediscaches/processor_test.go
@@ -76,7 +76,7 @@ func Test_Process(t *testing.T) {
 			"host":     host,
 			"port":     int32(RedisNonSSLPort),
 			"username": username,
-			"ssl":      false,
+			"tls":      false,
 		}
 		expectedSecrets := map[string]rpv1.SecretValueReference{
 			"connectionString": {
@@ -85,7 +85,7 @@ func Test_Process(t *testing.T) {
 			"password": {
 				Value: password,
 			},
-			"connectionURI": {
+			"url": {
 				Value: connectionURI_NonSSL,
 			},
 		}
@@ -127,7 +127,7 @@ func Test_Process(t *testing.T) {
 			"host":     host,
 			"port":     int32(RedisSSLPort),
 			"username": username,
-			"ssl":      true,
+			"tls":      true,
 		}
 		expectedSecrets := map[string]rpv1.SecretValueReference{
 			"password": {
@@ -136,7 +136,7 @@ func Test_Process(t *testing.T) {
 			"connectionString": {
 				Value: connectionString,
 			},
-			"connectionURI": {
+			"url": {
 				Value: connectionURI,
 			},
 		}
@@ -158,13 +158,13 @@ func Test_Process(t *testing.T) {
 			Properties: datamodel.RedisCacheProperties{
 				Resources: []*linkrp.ResourceReference{{ID: azureRedisResourceID1}},
 				Host:      host,
-				Port:      RedisSSLPort,
+				Port:      RedisNonSSLPort,
 				Username:  username,
+				TLS:       true,
 
 				Secrets: datamodel.RedisCacheSecrets{
 					Password:         password,
 					ConnectionString: connectionString,
-					URL:              connectionURI,
 				},
 			},
 		}
@@ -178,12 +178,11 @@ func Test_Process(t *testing.T) {
 					"host":     "asdf",
 					"port":     3333,
 					"username": "asdf",
-					"ssl":      true,
 				},
 				Secrets: map[string]any{
 					"password":         "asdf",
 					"connectionString": "asdf",
-					"connectionURI":    "asdf",
+					"url":              "asdf",
 				},
 			},
 		}
@@ -192,17 +191,17 @@ func Test_Process(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, host, resource.Properties.Host)
-		require.Equal(t, int32(RedisSSLPort), resource.Properties.Port)
+		require.Equal(t, int32(RedisNonSSLPort), resource.Properties.Port)
 		require.Equal(t, username, resource.Properties.Username)
 		require.Equal(t, password, resource.Properties.Secrets.Password)
 		require.Equal(t, connectionString, resource.Properties.Secrets.ConnectionString)
-		require.Equal(t, connectionURI, resource.Properties.Secrets.URL)
+		require.Equal(t, "asdf", resource.Properties.Secrets.URL)
 
 		expectedValues := map[string]any{
 			"host":     host,
-			"port":     int32(RedisSSLPort),
+			"port":     int32(RedisNonSSLPort),
 			"username": username,
-			"ssl":      true,
+			"tls":      true,
 		}
 		expectedSecrets := map[string]rpv1.SecretValueReference{
 			"password": {
@@ -211,8 +210,8 @@ func Test_Process(t *testing.T) {
 			"connectionString": {
 				Value: connectionString,
 			},
-			"connectionURI": {
-				Value: connectionURI,
+			"url": {
+				Value: "asdf",
 			},
 		}
 

--- a/pkg/linkrp/renderers/types.go
+++ b/pkg/linkrp/renderers/types.go
@@ -18,7 +18,7 @@ package renderers
 
 const (
 	ConnectionStringValue = "connectionString"
-	ConnectionURIValue    = "connectionURI"
+	ConnectionURIValue    = "url"
 	DatabaseNameValue     = "database"
 	ServerNameValue       = "server"
 	UsernameStringValue   = "username"
@@ -26,5 +26,5 @@ const (
 	Host                  = "host"
 	Port                  = "port"
 	ComponentNameKey      = "componentName"
-	SSL                   = "ssl"
+	TLS                   = "tls"
 )


### PR DESCRIPTION
# Description

Fixing bug with AWS connection URL

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue #5861.
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #5861 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9f2ed1f</samp>

### Summary
🔒🔄🧹

<!--
1.  🔒 - This emoji represents the change from SSL to TLS, which is a more secure and modern protocol for encryption and authentication. It also conveys the idea of protecting the data and connection from unauthorized access.
2.  🔄 - This emoji represents the change from connectionURI to url, which is a more standard and concise way of specifying the Redis server address and parameters. It also conveys the idea of transforming or converting the input data into a different format or representation.
3.  🧹 - This emoji represents the change from using different field names in the renderers package and the Redis client library, to using the same field names for consistency and clarity. It also conveys the idea of cleaning up or simplifying the code and avoiding confusion.
-->
Updated the `linkrp` package to use consistent field names and logic for Redis connection URI and TLS. This involved changing the `Process` and `renderers` functions in the `RedisCacheProcessor` struct and their corresponding test file.

> _We're working on the `RedisCacheProcessor`_
> _We're making it more secure and proper_
> _We're changing `SSL` to `TLS`_
> _And we're heaving on the count of three_

### Walkthrough
*  Renamed the `SSL` field to `TLS` in the `Process` function of the `RedisCacheProcessor` struct and the corresponding tests to match the Redis client library convention ([link](https://github.com/project-radius/radius/pull/5862/files?diff=unified&w=0#diff-75049449416e41b8a60c705ab6307182133254aa7d58eafcbf1f2456f5019288L48-R48), [link](https://github.com/project-radius/radius/pull/5862/files?diff=unified&w=0#diff-d12d43e5445048117c2bfc5eaf8fe583f458e99c24e3cb4705cd8fd4cec1083bL79-R79), [link](https://github.com/project-radius/radius/pull/5862/files?diff=unified&w=0#diff-d12d43e5445048117c2bfc5eaf8fe583f458e99c24e3cb4705cd8fd4cec1083bL130-R130), [link](https://github.com/project-radius/radius/pull/5862/files?diff=unified&w=0#diff-d12d43e5445048117c2bfc5eaf8fe583f458e99c24e3cb4705cd8fd4cec1083bL161-R167), [link](https://github.com/project-radius/radius/pull/5862/files?diff=unified&w=0#diff-d12d43e5445048117c2bfc5eaf8fe583f458e99c24e3cb4705cd8fd4cec1083bL195-R204))
*  Renamed the `connectionURI` field to `url` in the `renderers` package constants and the corresponding tests to match the Redis client library convention ([link](https://github.com/project-radius/radius/pull/5862/files?diff=unified&w=0#diff-e1ed4d071002e1cb7af88405b722fe9a5bdc2291307fc5962e034aca4dfd4705L21-R21), [link](https://github.com/project-radius/radius/pull/5862/files?diff=unified&w=0#diff-d12d43e5445048117c2bfc5eaf8fe583f458e99c24e3cb4705cd8fd4cec1083bL88-R88), [link](https://github.com/project-radius/radius/pull/5862/files?diff=unified&w=0#diff-d12d43e5445048117c2bfc5eaf8fe583f458e99c24e3cb4705cd8fd4cec1083bL139-R139), [link](https://github.com/project-radius/radius/pull/5862/files?diff=unified&w=0#diff-d12d43e5445048117c2bfc5eaf8fe583f458e99c24e3cb4705cd8fd4cec1083bL181-R185), [link](https://github.com/project-radius/radius/pull/5862/files?diff=unified&w=0#diff-d12d43e5445048117c2bfc5eaf8fe583f458e99c24e3cb4705cd8fd4cec1083bL214-R214))
*  Adjusted the `Port` and `URL` fields in the expected resource properties and secrets in the `Test_Process` function of the `RedisCacheProcessor` test file to reflect the logic of the `computeSSL` function, which checks the port number to determine the TLS value ([link](https://github.com/project-radius/radius/pull/5862/files?diff=unified&w=0#diff-d12d43e5445048117c2bfc5eaf8fe583f458e99c24e3cb4705cd8fd4cec1083bL161-R167), [link](https://github.com/project-radius/radius/pull/5862/files?diff=unified&w=0#diff-d12d43e5445048117c2bfc5eaf8fe583f458e99c24e3cb4705cd8fd4cec1083bL195-R204))


