### PR TITLE
Add Comments: Part 11 (pkg/datastorerp)

### DIFF
--- a/pkg/datastoresrp/api/v20220315privatepreview/mongodatabase_conversion.go
+++ b/pkg/datastoresrp/api/v20220315privatepreview/mongodatabase_conversion.go
@@ -26,7 +26,10 @@ import (
 	"github.com/project-radius/radius/pkg/to"
 )
 
-// ConvertTo converts from the versioned MongoDatabase resource to version-agnostic datamodel.
+// # Function Explanation
+//
+// ConvertTo converts from the versioned MongoDatabase resource to version-agnostic datamodel
+// and returns an error if the mode is unsupported.
 func (src *MongoDatabaseResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.MongoDatabase{
 		BaseResource: v1.BaseResource{
@@ -105,7 +108,10 @@ func (src *MongoDatabaseResource) ConvertTo() (v1.DataModelInterface, error) {
 	return converted, nil
 }
 
+// # Function Explanation
+//
 // ConvertFrom converts from version-agnostic datamodel to the versioned MongoDatabase resource.
+// It returns an error if an unsupported mode is encountered.
 func (dst *MongoDatabaseResource) ConvertFrom(src v1.DataModelInterface) error {
 	mongo, ok := src.(*datamodel.MongoDatabase)
 	if !ok {
@@ -171,7 +177,10 @@ func (dst *MongoDatabaseResource) ConvertFrom(src v1.DataModelInterface) error {
 	return nil
 }
 
-// ConvertFrom converts from version-agnostic datamodel to the versioned MongoDatabaseSecrets instance.
+// # Function Explanation
+//
+// ConvertFrom converts from version-agnostic datamodel to the versioned MongoDatabaseSecrets instance and returns an error if
+// the conversion fails.
 func (dst *MongoDatabaseSecrets) ConvertFrom(src v1.DataModelInterface) error {
 	mongoSecrets, ok := src.(*datamodel.MongoDatabaseSecrets)
 	if !ok {
@@ -185,6 +194,8 @@ func (dst *MongoDatabaseSecrets) ConvertFrom(src v1.DataModelInterface) error {
 	return nil
 }
 
+// # Function Explanation
+//
 // ConvertTo converts from the versioned MongoDatabaseSecrets instance to version-agnostic datamodel.
 func (src *MongoDatabaseSecrets) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.MongoDatabaseSecrets{

--- a/pkg/datastoresrp/api/v20220315privatepreview/mongodatabase_conversion_test.go
+++ b/pkg/datastoresrp/api/v20220315privatepreview/mongodatabase_conversion_test.go
@@ -29,6 +29,9 @@ import (
 
 type fakeResource struct{}
 
+// # Function Explanation
+//
+// ResourceTypeName returns the string "FakeResource" as the resource type.
 func (f *fakeResource) ResourceTypeName() string {
 	return "FakeResource"
 }

--- a/pkg/datastoresrp/api/v20220315privatepreview/rediscache_conversion.go
+++ b/pkg/datastoresrp/api/v20220315privatepreview/rediscache_conversion.go
@@ -26,7 +26,9 @@ import (
 	"github.com/project-radius/radius/pkg/to"
 )
 
-// ConvertTo converts from the versioned RedisCache resource to version-agnostic datamodel.
+// # Function Explanation
+//
+// ConvertTo converts from the versioned RedisCache resource to version-agnostic datamodel and returns an error if the mode is unsupported.
 func (src *RedisCacheResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.RedisCache{
 		BaseResource: v1.BaseResource{
@@ -102,7 +104,10 @@ func (src *RedisCacheResource) ConvertTo() (v1.DataModelInterface, error) {
 	return converted, nil
 }
 
-// ConvertFrom converts from version-agnostic datamodel to the versioned RedisCache resource.
+// # Function Explanation
+//
+// ConvertFrom converts from version-agnostic datamodel to the versioned RedisCache resource and returns error
+// if the conversion fails.
 func (dst *RedisCacheResource) ConvertFrom(src v1.DataModelInterface) error {
 	redis, ok := src.(*datamodel.RedisCache)
 	if !ok {
@@ -166,7 +171,10 @@ func (dst *RedisCacheResource) ConvertFrom(src v1.DataModelInterface) error {
 	return nil
 }
 
-// ConvertFrom converts from version-agnostic datamodel to the versioned RedisCacheSecrets instance.
+// # Function Explanation
+//
+// ConvertFrom converts from version-agnostic datamodel to the versioned RedisCacheSecrets instance and
+// returns an error if the conversion fails.
 func (dst *RedisCacheSecrets) ConvertFrom(src v1.DataModelInterface) error {
 	redisSecrets, ok := src.(*datamodel.RedisCacheSecrets)
 	if !ok {
@@ -179,6 +187,8 @@ func (dst *RedisCacheSecrets) ConvertFrom(src v1.DataModelInterface) error {
 	return nil
 }
 
+// # Function Explanation
+//
 // ConvertTo converts from the versioned RedisCacheSecrets instance to version-agnostic datamodel.
 func (src *RedisCacheSecrets) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.RedisCacheSecrets{

--- a/pkg/datastoresrp/api/v20220315privatepreview/sqldatabase_conversion.go
+++ b/pkg/datastoresrp/api/v20220315privatepreview/sqldatabase_conversion.go
@@ -26,7 +26,10 @@ import (
 	"github.com/project-radius/radius/pkg/to"
 )
 
-// ConvertTo converts from the versioned SqlDatabase resource to version-agnostic datamodel.
+// # Function Explanation
+//
+// ConvertTo converts from the versioned SqlDatabase resource to version-agnostic datamodel,
+// returning an error if the mode is unsupported or required properties are missing.
 func (src *SQLDatabaseResource) ConvertTo() (v1.DataModelInterface, error) {
 	converted := &datamodel.SqlDatabase{
 		BaseResource: v1.BaseResource{
@@ -80,6 +83,8 @@ func (src *SQLDatabaseResource) ConvertTo() (v1.DataModelInterface, error) {
 	return converted, nil
 }
 
+// # Function Explanation
+//
 // ConvertFrom converts from version-agnostic datamodel to the versioned SqlDatabase resource.
 func (dst *SQLDatabaseResource) ConvertFrom(src v1.DataModelInterface) error {
 	sql, ok := src.(*datamodel.SqlDatabase)

--- a/pkg/datastoresrp/datamodel/converter/mongodatabase_converter.go
+++ b/pkg/datastoresrp/datamodel/converter/mongodatabase_converter.go
@@ -24,7 +24,10 @@ import (
 	"github.com/project-radius/radius/pkg/datastoresrp/datamodel"
 )
 
-// MongoDatabaseDataModelFromVersioned converts version agnostic MongoDatabase datamodel to versioned model.
+// # Function Explanation
+//
+// MongoDatabaseDataModelFromVersioned converts version agnostic MongoDatabase datamodel to versioned model based on the
+// specified version, and returns an error if the version is not supported.
 func MongoDatabaseDataModelToVersioned(model *datamodel.MongoDatabase, version string) (v1.VersionedModelInterface, error) {
 	switch version {
 	case v20220315privatepreview.Version:
@@ -36,7 +39,10 @@ func MongoDatabaseDataModelToVersioned(model *datamodel.MongoDatabase, version s
 	}
 }
 
-// MongoDatabaseDataModelToVersioned converts versioned MongoDatabase model to datamodel.
+// # Function Explanation
+//
+// MongoDatabaseDataModelFromVersioned converts versioned MongoDatabase model to datamodel based on the specified version
+// and returns an error if the version is not supported.
 func MongoDatabaseDataModelFromVersioned(content []byte, version string) (*datamodel.MongoDatabase, error) {
 	switch version {
 	case v20220315privatepreview.Version:
@@ -52,7 +58,10 @@ func MongoDatabaseDataModelFromVersioned(content []byte, version string) (*datam
 	}
 }
 
-// MongoDatabaseSecretsDataModelFromVersioned converts version agnostic MongoDatabaseSecrets datamodel to versioned model.
+// # Function Explanation
+//
+// MongoDatabaseSecretsDataModelToVersioned converts version agnostic MongoDatabaseSecrets datamodel to versioned model and returns a
+// an error if the version is not supported.
 func MongoDatabaseSecretsDataModelToVersioned(model *datamodel.MongoDatabaseSecrets, version string) (v1.VersionedModelInterface, error) {
 	switch version {
 	case v20220315privatepreview.Version:

--- a/pkg/datastoresrp/datamodel/converter/rediscache_converter.go
+++ b/pkg/datastoresrp/datamodel/converter/rediscache_converter.go
@@ -24,7 +24,10 @@ import (
 	"github.com/project-radius/radius/pkg/datastoresrp/datamodel"
 )
 
-// RedisCacheDataModelFromVersioned converts version agnostic RedisCache datamodel to versioned model.
+// # Function Explanation
+//
+// RedisCacheDataModelToVersioned converts version agnostic RedisCache datamodel to versioned model,
+// returning an error if the conversion fails.
 func RedisCacheDataModelToVersioned(model *datamodel.RedisCache, version string) (v1.VersionedModelInterface, error) {
 	switch version {
 	case v20220315privatepreview.Version:
@@ -41,7 +44,10 @@ func RedisCacheDataModelToVersioned(model *datamodel.RedisCache, version string)
 	}
 }
 
-// RedisCacheDataModelToVersioned converts versioned RedisCache model to datamodel.
+// # Function Explanation
+//
+// RedisCacheDataModelFromVersioned converts versioned RedisCache model to datamodel and returns an error
+// if the conversion fails.
 func RedisCacheDataModelFromVersioned(content []byte, version string) (*datamodel.RedisCache, error) {
 	switch version {
 	case v20220315privatepreview.Version:
@@ -57,6 +63,10 @@ func RedisCacheDataModelFromVersioned(content []byte, version string) (*datamode
 	}
 }
 
+// # Function Explanation
+//
+// RedisCacheSecretsDataModelToVersioned converts a RedisCacheSecrets data model to a versioned model interface based on
+// the given version, returning an error if the version is not supported.
 func RedisCacheSecretsDataModelToVersioned(model *datamodel.RedisCacheSecrets, version string) (v1.VersionedModelInterface, error) {
 	switch version {
 	case v20220315privatepreview.Version:

--- a/pkg/datastoresrp/datamodel/converter/sqldatabase_converter.go
+++ b/pkg/datastoresrp/datamodel/converter/sqldatabase_converter.go
@@ -24,7 +24,10 @@ import (
 	"github.com/project-radius/radius/pkg/datastoresrp/datamodel"
 )
 
-// SqlDatabaseDataModelFromVersioned converts version agnostic SqlDatabase datamodel to versioned model.
+// # Function Explanation
+//
+// SqlDatabaseDataModelToVersioned converts version agnostic SqlDatabase datamodel to versioned model
+// and returns an error if the version is not supported.
 func SqlDatabaseDataModelToVersioned(model *datamodel.SqlDatabase, version string) (v1.VersionedModelInterface, error) {
 	switch version {
 	case v20220315privatepreview.Version:
@@ -37,7 +40,10 @@ func SqlDatabaseDataModelToVersioned(model *datamodel.SqlDatabase, version strin
 	}
 }
 
-// SqlDatabaseDataModelToVersioned converts versioned SqlDatabase model to datamodel.
+// # Function Explanation
+//
+// SqlDatabaseDataModelFromVersioned converts versioned SqlDatabase model to datamodel
+// or returns an error if the JSON unmarshalling or conversion fails.
 func SqlDatabaseDataModelFromVersioned(content []byte, version string) (*datamodel.SqlDatabase, error) {
 	switch version {
 	case v20220315privatepreview.Version:

--- a/pkg/datastoresrp/datamodel/mongodatabase.go
+++ b/pkg/datastoresrp/datamodel/mongodatabase.go
@@ -52,11 +52,17 @@ type MongoDatabaseSecrets struct {
 	ConnectionString string `json:"connectionString"`
 }
 
+// # Function Explanation
+//
+// IsEmpty checks if the MongoDatabaseSecrets instance is empty.
 func (mongoSecrets MongoDatabaseSecrets) IsEmpty() bool {
 	return mongoSecrets == MongoDatabaseSecrets{}
 }
 
-// ApplyDeploymentOutput applies the properties changes based on the deployment output.
+// # Function Explanation
+//
+// ApplyDeploymentOutput updates the MongoDatabase instance's properties, computed values and secret values
+// with the given DeploymentOutput.
 func (r *MongoDatabase) ApplyDeploymentOutput(do rpv1.DeploymentOutput) error {
 	r.Properties.Status.OutputResources = do.DeployedOutputResources
 	r.ComputedValues = do.ComputedValues
@@ -68,20 +74,30 @@ func (r *MongoDatabase) ApplyDeploymentOutput(do rpv1.DeploymentOutput) error {
 	return nil
 }
 
-// OutputResources returns the output resources array.
+// # Function Explanation
+//
+// OutputResources returns the OutputResources from the Status of the MongoDatabase instance.
 func (r *MongoDatabase) OutputResources() []rpv1.OutputResource {
 	return r.Properties.Status.OutputResources
 }
 
+// # Function Explanation
+//
 // ResourceMetadata returns the application resource metadata.
 func (r *MongoDatabase) ResourceMetadata() *rpv1.BasicResourceProperties {
 	return &r.Properties.BasicResourceProperties
 }
 
+// # Function Explanation
+//
+// ResourceTypeName returns the resource type for MongoDatabase.
 func (mongoSecrets *MongoDatabaseSecrets) ResourceTypeName() string {
 	return linkrp.N_MongoDatabasesResourceType
 }
 
+// # Function Explanation
+//
+// ResourceTypeName returns the resource type for MongoDatabase.
 func (mongo *MongoDatabase) ResourceTypeName() string {
 	return linkrp.N_MongoDatabasesResourceType
 }

--- a/pkg/datastoresrp/datamodel/rediscache.go
+++ b/pkg/datastoresrp/datamodel/rediscache.go
@@ -38,7 +38,10 @@ type RedisCache struct {
 	linkrpdm.LinkMetadata
 }
 
-// ApplyDeploymentOutput applies the properties changes based on the deployment output.
+// # Function Explanation
+//
+// ApplyDeploymentOutput sets the Status, ComputedValues, SecretValues, Host, Port and Username properties of the
+// RedisCache instance based on the DeploymentOutput object.
 func (r *RedisCache) ApplyDeploymentOutput(do rpv1.DeploymentOutput) error {
 	r.Properties.Status.OutputResources = do.DeployedOutputResources
 	r.ComputedValues = do.ComputedValues
@@ -70,20 +73,30 @@ func (r *RedisCache) ApplyDeploymentOutput(do rpv1.DeploymentOutput) error {
 	return nil
 }
 
+// # Function Explanation
+//
 // OutputResources returns the output resources array.
 func (r *RedisCache) OutputResources() []rpv1.OutputResource {
 	return r.Properties.Status.OutputResources
 }
 
+// # Function Explanation
+//
 // ResourceMetadata returns the application resource metadata.
 func (r *RedisCache) ResourceMetadata() *rpv1.BasicResourceProperties {
 	return &r.Properties.BasicResourceProperties
 }
 
+// # Function Explanation
+//
+// ResourceTypeName returns the resource type for RedisCache.
 func (redis *RedisCache) ResourceTypeName() string {
 	return linkrp.N_RedisCachesResourceType
 }
 
+// # Function Explanation
+//
+// Method IsEmpty checks if the RedisCacheSecrets instance is nil or empty.
 func (redisSecrets *RedisCacheSecrets) IsEmpty() bool {
 	return redisSecrets == nil || *redisSecrets == RedisCacheSecrets{}
 }
@@ -116,6 +129,9 @@ type RedisCacheSecrets struct {
 	Password         string `json:"password"`
 }
 
+// # Function Explanation
+//
+// ResourceTypeName returns the resource type for RedisCache.
 func (redis RedisCacheSecrets) ResourceTypeName() string {
 	return linkrp.N_RedisCachesResourceType
 }

--- a/pkg/datastoresrp/datamodel/sqldatabase.go
+++ b/pkg/datastoresrp/datamodel/sqldatabase.go
@@ -34,22 +34,31 @@ type SqlDatabase struct {
 	linkrpdm.LinkMetadata
 }
 
-// ApplyDeploymentOutput applies the properties changes based on the deployment output.
+// # Function Explanation
+//
+// ApplyDeploymentOutput applies the properties changes based on the deployment output and returns no error.
 func (r *SqlDatabase) ApplyDeploymentOutput(do rpv1.DeploymentOutput) error {
 	r.Properties.Status.OutputResources = do.DeployedOutputResources
 	return nil
 }
 
+// # Function Explanation
+//
 // OutputResources returns the output resources array.
 func (r *SqlDatabase) OutputResources() []rpv1.OutputResource {
 	return r.Properties.Status.OutputResources
 }
 
+// # Function Explanation
+//
 // ResourceMetadata returns the application resource metadata.
 func (r *SqlDatabase) ResourceMetadata() *rpv1.BasicResourceProperties {
 	return &r.Properties.BasicResourceProperties
 }
 
+// # Function Explanation
+//
+// ResourceTypeName returns the resource type for SqlDatabase.
 func (sql *SqlDatabase) ResourceTypeName() string {
 	return linkrp.N_SqlDatabasesResourceType
 }

--- a/pkg/datastoresrp/frontend/controller/mongodatabases/listsecretsmongodatabase.go
+++ b/pkg/datastoresrp/frontend/controller/mongodatabases/listsecretsmongodatabase.go
@@ -35,7 +35,9 @@ type ListSecretsMongoDatabase struct {
 	ctrl.Operation[*datamodel.MongoDatabase, datamodel.MongoDatabase]
 }
 
-// NewListSecretsMongoDatabase creates a new instance of ListSecretsMongoDatabase.
+// # Function Explanation
+//
+// // NewListSecretsMongoDatabase creates a new instance of ListSecretsMongoDatabase.
 func NewListSecretsMongoDatabase(opts ctrl.Options) (ctrl.Controller, error) {
 	return &ListSecretsMongoDatabase{
 		Operation: ctrl.NewOperation(opts,
@@ -46,7 +48,9 @@ func NewListSecretsMongoDatabase(opts ctrl.Options) (ctrl.Controller, error) {
 	}, nil
 }
 
-// Run returns secrets values for the specified MongoDatabase resource
+// # Function Explanation
+//
+// Run returns secrets values for the specified MongoDatabase resource.
 func (ctrl *ListSecretsMongoDatabase) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (rest.Response, error) {
 	sCtx := v1.ARMRequestContextFromContext(ctx)
 

--- a/pkg/datastoresrp/frontend/controller/rediscaches/listsecretsrediscache.go
+++ b/pkg/datastoresrp/frontend/controller/rediscaches/listsecretsrediscache.go
@@ -37,7 +37,9 @@ type ListSecretsRedisCache struct {
 	ctrl.Operation[*datamodel.RedisCache, datamodel.RedisCache]
 }
 
-// NewListSecretsRedisCache creates a new instance of ListSecretsRedisCache.
+// # Function Explanation
+//
+// NewListSecretsRedisCache creates a new instance of ListSecretsRedisCache and returns it without an  error.
 func NewListSecretsRedisCache(opts ctrl.Options) (ctrl.Controller, error) {
 	return &ListSecretsRedisCache{
 		Operation: ctrl.NewOperation(opts,
@@ -48,7 +50,9 @@ func NewListSecretsRedisCache(opts ctrl.Options) (ctrl.Controller, error) {
 	}, nil
 }
 
-// Run returns secrets values for the specified RedisCache resource
+// # Function Explanation
+//
+// Run retrieves the secrets associated with a RedisCache resource and returns them in the requested API version.
 func (ctrl *ListSecretsRedisCache) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (rest.Response, error) {
 	sCtx := v1.ARMRequestContextFromContext(ctx)
 


### PR DESCRIPTION
# Description

This is another PR adding comments to functions in Radius. In this PR, I've added comments for functions in the pkg/datastorerp folder.

Refs:
- Design doc - https://microsoft.sharepoint.com/teams/radiuscoreteam/Shared%20Documents/General/Design%20Docs/2023-04%20auto-generate-comments.docx?web=1

Other PRs in this series:
- https://github.com/project-radius/radius/pull/5531
- https://github.com/project-radius/radius/pull/5627
- https://github.com/project-radius/radius/pull/5643
- https://github.com/project-radius/radius/pull/5834
- https://github.com/project-radius/radius/pull/5835
- https://github.com/project-radius/radius/pull/5845
- https://github.com/project-radius/radius/pull/5850
- https://github.com/project-radius/radius/pull/5856
- https://github.com/project-radius/radius/pull/5859
- https://github.com/project-radius/radius/pull/5865
- https://github.com/project-radius/radius/pull/5868

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).


Fixes: #5423 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 44bb994</samp>

### Summary
📝🔀🔐

<!--
1.  📝 - This emoji represents adding comments or documentation to the code, which is the main purpose of most of these changes.
2.  🔀 - This emoji represents converting or transforming data between different formats or models, which is a common functionality of many of these changes.
3.  🔐 - This emoji represents dealing with secrets or sensitive data, which is a relevant aspect of some of these changes.
-->
This pull request adds comments and documentation to various files related to MongoDB, Redis, and SQL database resources in the `pkg/datastoresrp` package. It improves the readability, clarity, and maintainability of the code and the API conversion and data model conversion logic. It also identifies some areas that need further documentation or improvement.

> _This pull request adds some comments_
> _To structs and methods of contents_
> _That convert and list_
> _Mongo, Redis, and SQL with_
> _Some logic and error preventments_

### Walkthrough
*  Add comments to explain the purpose, logic, error handling and return value of various methods and functions related to the data model, API and controller of MongoDB, RedisCache and SQLDatabase resources ([link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-8ec39d09595474b8e8f3011847bbf8d28be10d8d597f69e126304c06a6e67856R32-R34), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-e6b3567b3b3507e8f44d589a9ad3a01cab23b81ae33da641b574ca234626c851L29-R32), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-e6b3567b3b3507e8f44d589a9ad3a01cab23b81ae33da641b574ca234626c851L108-R114), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-e6b3567b3b3507e8f44d589a9ad3a01cab23b81ae33da641b574ca234626c851L174-R183), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-fd655b396fa3db1ad70e59a769157bc202698d5caa51a746bcb42d6bd3474be9L27-R30), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-fd655b396fa3db1ad70e59a769157bc202698d5caa51a746bcb42d6bd3474be9L39-R45), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-fd655b396fa3db1ad70e59a769157bc202698d5caa51a746bcb42d6bd3474be9L55-R64), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-b463cddd0e8f4aa4356725d5f2eb81f215216544149ac54b74a0a910868665a1L55-R65), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-b463cddd0e8f4aa4356725d5f2eb81f215216544149ac54b74a0a910868665a1L71-R85), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-b463cddd0e8f4aa4356725d5f2eb81f215216544149ac54b74a0a910868665a1L81-R100),  [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-165fcf628028b767e7e91984f499a511f6b822dacb02728a4a6e186d737f446eL38-R40), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-165fcf628028b767e7e91984f499a511f6b822dacb02728a4a6e186d737f446eL49-R53))
* Add comments to explain the purpose, logic, error handling and return value of various methods and functions related to the data model, API and controller of RedisCache resources ([link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-a223280ec64b549ba2bb2d8f210a4d58c422c8454632afbfac914b1aace08bc0L29-R31), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-a223280ec64b549ba2bb2d8f210a4d58c422c8454632afbfac914b1aace08bc0L105-R110), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-a223280ec64b549ba2bb2d8f210a4d58c422c8454632afbfac914b1aace08bc0L169-R177), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-61cba2ebf105f84e9747c6f06c17ce7abb977605ed5a525219f0d61f994cda3eL27-R30), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-61cba2ebf105f84e9747c6f06c17ce7abb977605ed5a525219f0d61f994cda3eL44-R50), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-61cba2ebf105f84e9747c6f06c17ce7abb977605ed5a525219f0d61f994cda3eR66-R69), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-0edf5ad38ca1c7194bb66f75828b10cd79c512f9fdabea5eb00db52e016a8f39L41-R44), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-0edf5ad38ca1c7194bb66f75828b10cd79c512f9fdabea5eb00db52e016a8f39L83-R99), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-1ffdf29bf29ee9a158926c166f6439e6c5346c8e0be056916dc8e272139b859cL40-R42), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-1ffdf29bf29ee9a158926c166f6439e6c5346c8e0be056916dc8e272139b859cL51-R55))
* Add comments to explain the purpose, logic, error handling and return value of various methods and functions related to the data model, API and controller of SQLDatabase resources ([link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-3fe00a764d1ddf3cfc90d7d5bf571cb6a44358d20a328938c255b59dd61565a1L29-R32), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-f4dae2749b4f41d7a4b3a90c7fe52e2f8bfbc6d244ba0cfc410864ed0ff66e22L27-R30), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-f4dae2749b4f41d7a4b3a90c7fe52e2f8bfbc6d244ba0cfc410864ed0ff66e22L40-R46), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-79d6e8286f9b10662ae6ec8e91f5c32a7d53fcc762f922c4452130b1fe0005dbL37-R39), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-79d6e8286f9b10662ae6ec8e91f5c32a7d53fcc762f922c4452130b1fe0005dbR59-R61))
* Add comment placeholders for methods that need further explanation, such as `ConvertTo` and `ConvertFrom` methods of the `MongoDatabaseSecrets` and `RedisCacheSecrets` structs, and `OutputResources` and `ResourceMetadata` methods of the `RedisCache` and `SqlDatabase` structs ([link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-e6b3567b3b3507e8f44d589a9ad3a01cab23b81ae33da641b574ca234626c851R197-R198), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-a223280ec64b549ba2bb2d8f210a4d58c422c8454632afbfac914b1aace08bc0R190-R191), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-3fe00a764d1ddf3cfc90d7d5bf571cb6a44358d20a328938c255b59dd61565a1R86-R87), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-0edf5ad38ca1c7194bb66f75828b10cd79c512f9fdabea5eb00db52e016a8f39R76-R77), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-0edf5ad38ca1c7194bb66f75828b10cd79c512f9fdabea5eb00db52e016a8f39R83-R84), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-79d6e8286f9b10662ae6ec8e91f5c32a7d53fcc762f922c4452130b1fe0005dbR45-R46), [link](https://github.com/project-radius/radius/pull/5868/files?diff=unified&w=0#diff-79d6e8286f9b10662ae6ec8e91f5c32a7d53fcc762f922c4452130b1fe0005dbR52-R53))


