### PR TITLE
Link to contributing.md in the repo from readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Every month we host a community call to showcase new features, review upcoming m
 
 ## Contributing to Radius
 
-Visit [Contributing](https://docs.radapp.dev/contributing/) for more information on how to contribute to Radius.
+Visit [Contributing](./CONTRIBUTING.md) for more information on how to contribute to Radius.
 To author Radius Recipes visit [Author Custom Radius Recipes](https://docs.radapp.dev/operations/custom-recipes/).
 To contribute to Radius documentation visit [Radius documentation](https://docs.radapp.dev/contributing/docs/)
 


### PR DESCRIPTION
# Description

We want to send readers to the contributing docs in the repo rather than to the docs website. The repo is where all of the contributing guides live.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).


## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9c20e44</samp>

### Summary
📝🛠️🙌

<!--
1.  📝 - This emoji can be used to indicate that the changes involve documentation or writing, such as updating the `README.md` file.
2.  🛠️ - This emoji can be used to indicate that the changes involve fixing or improving something, such as broken links or outdated information.
3.  🙌 - This emoji can be used to indicate that the changes involve collaboration or community, such as referencing the contributing guide and code of conduct.
-->
Improved documentation for contributors by updating and fixing links in `README.md`.

> _The README file had some broken links_
> _That needed some fixes and tweaks_
> _So they updated the guide_
> _And the code of conduct side_
> _To welcome more contributors who seek_

### Walkthrough
* Update the links to the contributing guide and the code of conduct in `README.md` ([link](https://github.com/project-radius/radius/pull/5870/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R54), [link](https://github.com/project-radius/radius/pull/5870/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L79-R79))


