### PR TITLE
Add `test-failure` label

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -527,6 +527,6 @@ jobs:
             github.rest.issues.create({
               ...context.repo,
               title: `Scheduled functional test failed - Run ID: ${context.runId}`,
-              labels: ['bug'],
+              labels: ['bug', 'test-failure'],
               body: `## Bug information \n\nThis bug is generated automatically if the scheduled functional test fails. The Radius functional test operates on a schedule of every 4 hours during weekdays and every 12 hours over the weekend. It's important to understand that the test may fail due to workflow infrastructure issues, like network problems, rather than the flakiness of the test itself. For the further investigation, please visit [here](${process.env.ACTION_LINK}).`
             })


### PR DESCRIPTION
# Description

This is to add `test-failure` label to the test failure report issue.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).


## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ade19b3</samp>

### Summary
🏷️🚨🕒

<!--
1.  🏷️ - This emoji represents the labels field and the addition of a new label to the issue creation request. It conveys the idea of categorization and organization of the issues.
2.  🚨 - This emoji represents the test-failure label and the urgency of the issue that is created by the functional test workflow. It conveys the idea of alerting and notifying the project-radius/radius team about the test failure and the need for investigation and resolution.
3.  🕒 - This emoji represents the cron schedule and the periodicity of the functional test workflow. It conveys the idea of time and frequency of the test execution and the issue creation.
-->
Updated the functional test workflow to add the `test-failure` label to the issues it creates. This change helps to identify and prioritize the issues related to the test failures.

> _`test-failure` label_
> _categorizes the issues_
> _autumn of the code_

### Walkthrough
* Add `test-failure` label to issue creation request for functional test failures ([link](https://github.com/project-radius/radius/pull/5871/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL530-R530)). This helps to categorize and filter the issues in the `.github/workflows/functional-test.yaml` file, which runs the functional test workflow on a cron schedule and creates an issue if the test fails.


