### PR TITLE
Move LinkRP output resource deletion logic to Bicep/Terraform drivers

### DIFF
--- a/pkg/linkrp/backend/controller/createorupdateresource_test.go
+++ b/pkg/linkrp/backend/controller/createorupdateresource_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/require"
 
@@ -297,13 +296,13 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			msc, eng, client, cfg := setupTest(t)
 
-			req := &ctrl.Request{
-				OperationID:      uuid.New(),
-				OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT", // Operation does not affect the behavior of the controller.
-				ResourceID:       TestResourceID,
-				CorrelationID:    uuid.NewString(),
-				OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
-			}
+			// req := &ctrl.Request{
+			// 	OperationID:      uuid.New(),
+			// 	OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT", // Operation does not affect the behavior of the controller.
+			// 	ResourceID:       TestResourceID,
+			// 	CorrelationID:    uuid.NewString(),
+			// 	OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
+			// }
 
 			// Set up an output resource so we can cover resource deletion.
 			status := rpv1.ResourceStatus{
@@ -446,23 +445,23 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 					Times(1)
 			}
 
-			opts := ctrl.Options{
-				StorageClient: msc,
-			}
+			// opts := ctrl.Options{
+			// 	StorageClient: msc,
+			// }
 
-			genCtrl, err := tt.factory(eng, client, cfg, opts)
-			require.NoError(t, err)
+			// genCtrl, err := tt.factory(eng, client, cfg, opts)
+			// require.NoError(t, err)
 
-			res, err := genCtrl.Run(context.Background(), req)
-			if tt.expectedErr != nil {
-				require.False(t, stillPassing)
-				require.Error(t, err)
-				require.Equal(t, tt.expectedErr, err)
-			} else {
-				require.True(t, stillPassing)
-				require.NoError(t, err)
-				require.Equal(t, ctrl.Result{}, res)
-			}
+			// res, err := genCtrl.Run(context.Background(), req)
+			// if tt.expectedErr != nil {
+			// 	require.False(t, stillPassing)
+			// 	require.Error(t, err)
+			// 	require.Equal(t, tt.expectedErr, err)
+			// } else {
+			// 	require.True(t, stillPassing)
+			// 	require.NoError(t, err)
+			// 	require.Equal(t, ctrl.Result{}, res)
+			// }
 		})
 	}
 }

--- a/pkg/linkrp/backend/controller/createorupdateresource_test.go
+++ b/pkg/linkrp/backend/controller/createorupdateresource_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/require"
 
@@ -296,13 +297,13 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 		t.Run(tt.description, func(t *testing.T) {
 			msc, eng, client, cfg := setupTest(t)
 
-			// req := &ctrl.Request{
-			// 	OperationID:      uuid.New(),
-			// 	OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT", // Operation does not affect the behavior of the controller.
-			// 	ResourceID:       TestResourceID,
-			// 	CorrelationID:    uuid.NewString(),
-			// 	OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
-			// }
+			req := &ctrl.Request{
+				OperationID:      uuid.New(),
+				OperationType:    "APPLICATIONS.TEST/TESTRESOURCES|PUT", // Operation does not affect the behavior of the controller.
+				ResourceID:       TestResourceID,
+				CorrelationID:    uuid.NewString(),
+				OperationTimeout: &ctrl.DefaultAsyncOperationTimeout,
+			}
 
 			// Set up an output resource so we can cover resource deletion.
 			status := rpv1.ResourceStatus{
@@ -445,23 +446,23 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 					Times(1)
 			}
 
-			// opts := ctrl.Options{
-			// 	StorageClient: msc,
-			// }
+			opts := ctrl.Options{
+				StorageClient: msc,
+			}
 
-			// genCtrl, err := tt.factory(eng, client, cfg, opts)
-			// require.NoError(t, err)
+			genCtrl, err := tt.factory(eng, client, cfg, opts)
+			require.NoError(t, err)
 
-			// res, err := genCtrl.Run(context.Background(), req)
-			// if tt.expectedErr != nil {
-			// 	require.False(t, stillPassing)
-			// 	require.Error(t, err)
-			// 	require.Equal(t, tt.expectedErr, err)
-			// } else {
-			// 	require.True(t, stillPassing)
-			// 	require.NoError(t, err)
-			// 	require.Equal(t, ctrl.Result{}, res)
-			// }
+			res, err := genCtrl.Run(context.Background(), req)
+			if tt.expectedErr != nil {
+				require.False(t, stillPassing)
+				require.Error(t, err)
+				require.Equal(t, tt.expectedErr, err)
+			} else {
+				require.True(t, stillPassing)
+				require.NoError(t, err)
+				require.Equal(t, ctrl.Result{}, res)
+			}
 		})
 	}
 }

--- a/pkg/linkrp/backend/controller/deleteresource.go
+++ b/pkg/linkrp/backend/controller/deleteresource.go
@@ -27,7 +27,6 @@ import (
 	ds_dm "github.com/project-radius/radius/pkg/datastoresrp/datamodel"
 	"github.com/project-radius/radius/pkg/linkrp"
 	"github.com/project-radius/radius/pkg/linkrp/datamodel"
-	"github.com/project-radius/radius/pkg/linkrp/processors"
 	msg_dm "github.com/project-radius/radius/pkg/messagingrp/datamodel"
 	"github.com/project-radius/radius/pkg/recipes"
 	"github.com/project-radius/radius/pkg/recipes/engine"
@@ -40,15 +39,14 @@ var _ ctrl.Controller = (*DeleteResource)(nil)
 // DeleteResource is the async operation controller to delete Applications.Link resource.
 type DeleteResource struct {
 	ctrl.BaseController
-	client processors.ResourceClient
 	engine engine.Engine
 }
 
 // # Function Explanation
 //
 // NewDeleteResource creates a new DeleteResource controller which is used to delete resources asynchronously.
-func NewDeleteResource(opts ctrl.Options, client processors.ResourceClient, engine engine.Engine) (ctrl.Controller, error) {
-	return &DeleteResource{ctrl.NewBaseAsyncController(opts), client, engine}, nil
+func NewDeleteResource(opts ctrl.Options, engine engine.Engine) (ctrl.Controller, error) {
+	return &DeleteResource{ctrl.NewBaseAsyncController(opts), engine}, nil
 }
 
 // # Function Explanation
@@ -91,7 +89,7 @@ func (c *DeleteResource) Run(ctx context.Context, request *ctrl.Request) (ctrl.R
 			ResourceID:    id.String(),
 		}
 
-		err = c.engine.Delete(ctx, deploymentDataModel.OutputResources(), c.client, recipeData)
+		err = c.engine.Delete(ctx, recipeData, deploymentDataModel.OutputResources())
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/pkg/linkrp/backend/controller/deleteresource.go
+++ b/pkg/linkrp/backend/controller/deleteresource.go
@@ -74,7 +74,7 @@ func (c *DeleteResource) Run(ctx context.Context, request *ctrl.Request) (ctrl.R
 		return ctrl.Result{}, err
 	}
 
-	deploymentDataModel, ok := dataModel.(rpv1.RadiusResourceModel)
+	resourceDataModel, ok := dataModel.(rpv1.RadiusResourceModel)
 	if !ok {
 		return ctrl.NewFailedResult(v1.ErrorDetails{Message: "deployment data model conversion error"}), nil
 	}
@@ -83,13 +83,13 @@ func (c *DeleteResource) Run(ctx context.Context, request *ctrl.Request) (ctrl.R
 	if supportsRecipes && recipeDataModel.Recipe() != nil {
 		recipeData := recipes.ResourceMetadata{
 			Name:          recipeDataModel.Recipe().Name,
-			EnvironmentID: deploymentDataModel.ResourceMetadata().Environment,
-			ApplicationID: deploymentDataModel.ResourceMetadata().Application,
+			EnvironmentID: resourceDataModel.ResourceMetadata().Environment,
+			ApplicationID: resourceDataModel.ResourceMetadata().Application,
 			Parameters:    recipeDataModel.Recipe().Parameters,
 			ResourceID:    id.String(),
 		}
 
-		err = c.engine.Delete(ctx, recipeData, deploymentDataModel.OutputResources())
+		err = c.engine.Delete(ctx, recipeData, resourceDataModel.OutputResources())
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/pkg/linkrp/backend/service.go
+++ b/pkg/linkrp/backend/service.go
@@ -195,7 +195,7 @@ func (s *Service) Run(ctx context.Context) error {
 	for _, rt := range resourceTypes {
 		// Register controllers
 		err = s.Controllers.Register(ctx, rt.TypeName, v1.OperationDelete, func(options ctrl.Options) (ctrl.Controller, error) {
-			return backend_ctrl.NewDeleteResource(options, client)
+			return backend_ctrl.NewDeleteResource(options, client, engine)
 		}, opts)
 		if err != nil {
 			return err

--- a/pkg/linkrp/backend/service.go
+++ b/pkg/linkrp/backend/service.go
@@ -109,7 +109,7 @@ func (s *Service) Run(ctx context.Context) error {
 	engine := engine.NewEngine(engine.Options{
 		ConfigurationLoader: configLoader,
 		Drivers: map[string]driver.Driver{
-			recipes.TemplateKindBicep: driver.NewBicepDriver(clientOptions, deploymentEngineClient),
+			recipes.TemplateKindBicep: driver.NewBicepDriver(clientOptions, deploymentEngineClient, client),
 			recipes.TemplateKindTerraform: driver.NewTerraformDriver(s.Options.UCPConnection, driver.TerraformOptions{
 				Path: s.Options.Config.Terraform.Path,
 			}),
@@ -195,7 +195,7 @@ func (s *Service) Run(ctx context.Context) error {
 	for _, rt := range resourceTypes {
 		// Register controllers
 		err = s.Controllers.Register(ctx, rt.TypeName, v1.OperationDelete, func(options ctrl.Options) (ctrl.Controller, error) {
-			return backend_ctrl.NewDeleteResource(options, client, engine)
+			return backend_ctrl.NewDeleteResource(options, engine)
 		}, opts)
 		if err != nil {
 			return err

--- a/pkg/recipes/driver/bicep.go
+++ b/pkg/recipes/driver/bicep.go
@@ -130,10 +130,10 @@ func (d *bicepDriver) Execute(ctx context.Context, configuration recipes.Configu
 }
 
 // Delete handles output resource deletion and returns an error on failure to delete.
-func (d *bicepDriver) Delete(ctx context.Context, deploymentDataModel rpv1.DeploymentDataModel, client processors.ResourceClient) error {
+func (d *bicepDriver) Delete(ctx context.Context, outputResources []rpv1.OutputResource, client processors.ResourceClient) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
-	orderedOutputResources, err := rpv1.OrderOutputResources(deploymentDataModel.OutputResources())
+	orderedOutputResources, err := rpv1.OrderOutputResources(outputResources)
 	if err != nil {
 		return err
 	}

--- a/pkg/recipes/driver/bicep_test.go
+++ b/pkg/recipes/driver/bicep_test.go
@@ -17,14 +17,20 @@ limitations under the License.
 package driver
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	gomock "github.com/golang/mock/gomock"
 	corerp_datamodel "github.com/project-radius/radius/pkg/corerp/datamodel"
+	"github.com/project-radius/radius/pkg/linkrp/processors"
 	"github.com/project-radius/radius/pkg/recipes"
+	"github.com/project-radius/radius/pkg/resourcemodel"
+	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 	clients "github.com/project-radius/radius/pkg/sdk/clients"
 	"github.com/project-radius/radius/pkg/to"
 	"github.com/project-radius/radius/pkg/ucp/resources"
+	"github.com/project-radius/radius/test/testcontext"
 	"github.com/stretchr/testify/require"
 )
 
@@ -365,4 +371,86 @@ func Test_RecipeResponseWithoutResult(t *testing.T) {
 	actualResponse, err := prepareRecipeResponse(response, resources)
 	require.NoError(t, err)
 	require.Equal(t, expectedResponse, actualResponse)
+}
+
+func setupDeleteInputs(t *testing.T) (bicepDriver, *processors.MockResourceClient) {
+	ctrl := gomock.NewController(t)
+	client := processors.NewMockResourceClient(ctrl)
+
+	driver := bicepDriver{
+		ResourceClient: client,
+	}
+
+	return driver, client
+}
+
+func Test_Driver_Delete_Success(t *testing.T) {
+	ctx := testcontext.New(t)
+	driver, client := setupDeleteInputs(t)
+	outputResources := []rpv1.OutputResource{
+		{
+			LocalID: "RecipeResource0",
+			Identity: resourcemodel.ResourceIdentity{
+				ResourceType: &resourcemodel.ResourceType{
+					Type:     "Service",
+					Provider: "kubernetes",
+				},
+				Data: map[string]any{
+					"apiVersion": "apps/unknown",
+					"kind":       "Deployment",
+					"name":       "redis",
+					"namespace":  "recipe-app",
+				},
+			},
+			RadiusManaged: to.Ptr(true),
+		},
+		{
+			LocalID: "RecipeResource1",
+			Identity: resourcemodel.ResourceIdentity{
+				ResourceType: &resourcemodel.ResourceType{
+					Type:     "Service",
+					Provider: "kubernetes",
+				},
+				Data: map[string]any{
+					"apiVersion": "apps/unknown",
+					"kind":       "Deployment",
+					"name":       "redis",
+					"namespace":  "recipe-app",
+				},
+			},
+			// We don't expect a call to delete to be made when RadiusManaged is false.
+			RadiusManaged: to.Ptr(false),
+		},
+	}
+	client.EXPECT().Delete(ctx, "/planes/kubernetes/local/namespaces/recipe-app/providers/apps/Deployment/redis", resourcemodel.APIVersionUnknown).Times(1).Return(nil)
+
+	err := driver.Delete(ctx, outputResources)
+	require.NoError(t, err)
+}
+
+func Test_Driver_Delete_Error(t *testing.T) {
+	ctx := testcontext.New(t)
+	driver, client := setupDeleteInputs(t)
+	outputResources := []rpv1.OutputResource{
+		{
+			LocalID: "RecipeResource0",
+			Identity: resourcemodel.ResourceIdentity{
+				ResourceType: &resourcemodel.ResourceType{
+					Type:     "KubernetesService",
+					Provider: "kubernetes",
+				},
+				Data: map[string]any{
+					"apiVersion": "invalid api versionn",
+					"kind":       "Deployment",
+					"name":       "redis",
+					"namespace":  "recipe-app",
+				},
+			},
+			RadiusManaged: to.Ptr(true),
+		},
+	}
+	client.EXPECT().Delete(ctx, "/planes/kubernetes/local/namespaces/recipe-app/providers/core/Deployment/redis", resourcemodel.APIVersionUnknown).Times(1).Return(fmt.Errorf("could not find API version for type %q, no supported API versions", outputResources[0].Identity.ResourceType.Type))
+
+	err := driver.Delete(ctx, outputResources)
+	require.Error(t, err)
 }

--- a/pkg/recipes/driver/mock_driver.go
+++ b/pkg/recipes/driver/mock_driver.go
@@ -9,7 +9,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	processors "github.com/project-radius/radius/pkg/linkrp/processors"
 	recipes "github.com/project-radius/radius/pkg/recipes"
 	v1 "github.com/project-radius/radius/pkg/rp/v1"
 )
@@ -38,17 +37,17 @@ func (m *MockDriver) EXPECT() *MockDriverMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockDriver) Delete(arg0 context.Context, arg1 []v1.OutputResource, arg2 processors.ResourceClient) error {
+func (m *MockDriver) Delete(arg0 context.Context, arg1 []v1.OutputResource) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockDriverMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockDriverMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockDriver)(nil).Delete), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockDriver)(nil).Delete), arg0, arg1)
 }
 
 // Execute mocks base method.

--- a/pkg/recipes/driver/mock_driver.go
+++ b/pkg/recipes/driver/mock_driver.go
@@ -9,7 +9,9 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	processors "github.com/project-radius/radius/pkg/linkrp/processors"
 	recipes "github.com/project-radius/radius/pkg/recipes"
+	v1 "github.com/project-radius/radius/pkg/rp/v1"
 )
 
 // MockDriver is a mock of Driver interface.
@@ -33,6 +35,20 @@ func NewMockDriver(ctrl *gomock.Controller) *MockDriver {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDriver) EXPECT() *MockDriverMockRecorder {
 	return m.recorder
+}
+
+// Delete mocks base method.
+func (m *MockDriver) Delete(arg0 context.Context, arg1 v1.DeploymentDataModel, arg2 processors.ResourceClient) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockDriverMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockDriver)(nil).Delete), arg0, arg1, arg2)
 }
 
 // Execute mocks base method.

--- a/pkg/recipes/driver/mock_driver.go
+++ b/pkg/recipes/driver/mock_driver.go
@@ -38,7 +38,7 @@ func (m *MockDriver) EXPECT() *MockDriverMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockDriver) Delete(arg0 context.Context, arg1 v1.DeploymentDataModel, arg2 processors.ResourceClient) error {
+func (m *MockDriver) Delete(arg0 context.Context, arg1 []v1.OutputResource, arg2 processors.ResourceClient) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/pkg/recipes/driver/terraform.go
+++ b/pkg/recipes/driver/terraform.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/google/uuid"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
-	"github.com/project-radius/radius/pkg/linkrp/processors"
 	"github.com/project-radius/radius/pkg/recipes"
 	"github.com/project-radius/radius/pkg/recipes/terraform"
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
@@ -101,7 +100,7 @@ func (d *terraformDriver) Execute(ctx context.Context, configuration recipes.Con
 	return recipeOutputs, errors.New("terraform support is not implemented yet")
 }
 
-func (d *terraformDriver) Delete(ctx context.Context, outputResources []rpv1.OutputResource, client processors.ResourceClient) error {
+func (d *terraformDriver) Delete(ctx context.Context, outputResources []rpv1.OutputResource) error {
 	// TODO: to be implemented in follow up PR
 	return errors.New("terraform delete support is not implemented yet")
 }

--- a/pkg/recipes/driver/terraform.go
+++ b/pkg/recipes/driver/terraform.go
@@ -25,8 +25,10 @@ import (
 
 	"github.com/google/uuid"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	"github.com/project-radius/radius/pkg/linkrp/processors"
 	"github.com/project-radius/radius/pkg/recipes"
 	"github.com/project-radius/radius/pkg/recipes/terraform"
+	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 	"github.com/project-radius/radius/pkg/sdk"
 	"github.com/project-radius/radius/pkg/ucp/ucplog"
 	"github.com/project-radius/radius/pkg/ucp/util"
@@ -97,4 +99,9 @@ func (d *terraformDriver) Execute(ctx context.Context, configuration recipes.Con
 	}
 
 	return recipeOutputs, errors.New("terraform support is not implemented yet")
+}
+
+func (d *terraformDriver) Delete(ctx context.Context, outputResources []rpv1.OutputResource, client processors.ResourceClient) error {
+	// TODO: to be implemented in follow up PR
+	return errors.New("terraform delete support is not implemented yet")
 }

--- a/pkg/recipes/driver/terraform_test.go
+++ b/pkg/recipes/driver/terraform_test.go
@@ -181,4 +181,5 @@ func TestTerraformDriver_Delete_Success(t *testing.T) {
 
 	err := driver.Delete(ctx, []rpv1.OutputResource{})
 	require.Error(t, err)
+	require.Equal(t, "terraform delete support is not implemented yet", err.Error())
 }

--- a/pkg/recipes/driver/terraform_test.go
+++ b/pkg/recipes/driver/terraform_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
 	"github.com/project-radius/radius/pkg/recipes"
 	"github.com/project-radius/radius/pkg/recipes/terraform"
+	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 	"github.com/project-radius/radius/test/testcontext"
 	"github.com/stretchr/testify/require"
 )
@@ -171,4 +172,13 @@ func TestTerraformDriver_Execute_InvalidContextPanics(t *testing.T) {
 	require.Panics(t, func() {
 		_, _ = driver.Execute(ctx, envConfig, recipeMetadata, envRecipe)
 	})
+}
+
+func TestTerraformDriver_Delete_Success(t *testing.T) {
+	ctx := testcontext.New(t)
+
+	_, driver := setup(t)
+
+	err := driver.Delete(ctx, []rpv1.OutputResource{})
+	require.Error(t, err)
 }

--- a/pkg/recipes/driver/types.go
+++ b/pkg/recipes/driver/types.go
@@ -29,7 +29,7 @@ type Driver interface {
 	// Execute fetches the recipe contents and deploys the recipe and returns deployed resources, secrets and values.
 	Execute(ctx context.Context, configuration recipes.Configuration, recipe recipes.ResourceMetadata, definition recipes.EnvironmentDefinition) (*recipes.RecipeOutput, error)
 	// Delete handles deletion of output resources for the recipe deployment.
-	Delete(ctx context.Context, deploymentDataModel rpv1.DeploymentDataModel, client processors.ResourceClient) error
+	Delete(ctx context.Context, outputResources []rpv1.OutputResource, client processors.ResourceClient) error
 }
 
 // RecipeContext Recipe template authors can leverage the RecipeContext parameter to access Link properties to

--- a/pkg/recipes/driver/types.go
+++ b/pkg/recipes/driver/types.go
@@ -19,13 +19,17 @@ package driver
 import (
 	"context"
 
+	"github.com/project-radius/radius/pkg/linkrp/processors"
 	"github.com/project-radius/radius/pkg/recipes"
+	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 )
 
 // Driver is an interface to implement recipe deployment.
 type Driver interface {
 	// Execute fetches the recipe contents and deploys the recipe and returns deployed resources, secrets and values.
 	Execute(ctx context.Context, configuration recipes.Configuration, recipe recipes.ResourceMetadata, definition recipes.EnvironmentDefinition) (*recipes.RecipeOutput, error)
+	// Delete handles deletion of output resources for the recipe deployment.
+	Delete(ctx context.Context, deploymentDataModel rpv1.DeploymentDataModel, client processors.ResourceClient) error
 }
 
 // RecipeContext Recipe template authors can leverage the RecipeContext parameter to access Link properties to

--- a/pkg/recipes/driver/types.go
+++ b/pkg/recipes/driver/types.go
@@ -19,7 +19,6 @@ package driver
 import (
 	"context"
 
-	"github.com/project-radius/radius/pkg/linkrp/processors"
 	"github.com/project-radius/radius/pkg/recipes"
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 )
@@ -29,7 +28,7 @@ type Driver interface {
 	// Execute fetches the recipe contents and deploys the recipe and returns deployed resources, secrets and values.
 	Execute(ctx context.Context, configuration recipes.Configuration, recipe recipes.ResourceMetadata, definition recipes.EnvironmentDefinition) (*recipes.RecipeOutput, error)
 	// Delete handles deletion of output resources for the recipe deployment.
-	Delete(ctx context.Context, outputResources []rpv1.OutputResource, client processors.ResourceClient) error
+	Delete(ctx context.Context, outputResources []rpv1.OutputResource) error
 }
 
 // RecipeContext Recipe template authors can leverage the RecipeContext parameter to access Link properties to

--- a/pkg/recipes/engine/engine.go
+++ b/pkg/recipes/engine/engine.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/project-radius/radius/pkg/linkrp/processors"
 	"github.com/project-radius/radius/pkg/recipes"
 	"github.com/project-radius/radius/pkg/recipes/configloader"
 	"github.com/project-radius/radius/pkg/recipes/driver"
@@ -65,16 +64,19 @@ func (e *engine) Execute(ctx context.Context, recipe recipes.ResourceMetadata) (
 	return driver.Execute(ctx, *configuration, recipe, *definition)
 }
 
-func (e *engine) Delete(ctx context.Context, outputResources []rpv1.OutputResource, client processors.ResourceClient, recipe recipes.ResourceMetadata) error {
+// Delete handles deletion of output resources for the recipe deployment.
+func (e *engine) Delete(ctx context.Context, recipe recipes.ResourceMetadata, outputResources []rpv1.OutputResource) error {
+	// Load Recipe Definition from the environment.
 	definition, err := e.options.ConfigurationLoader.LoadRecipe(ctx, &recipe)
 	if err != nil {
 		return err
 	}
 
+	// Determine Recipe driver type
 	driver, ok := e.options.Drivers[definition.Driver]
 	if !ok {
 		return fmt.Errorf("could not find driver %s", definition.Driver)
 	}
 
-	return driver.Delete(ctx, outputResources, client)
+	return driver.Delete(ctx, outputResources)
 }

--- a/pkg/recipes/engine/engine.go
+++ b/pkg/recipes/engine/engine.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/project-radius/radius/pkg/linkrp/processors"
 	"github.com/project-radius/radius/pkg/recipes"
 	"github.com/project-radius/radius/pkg/recipes/configloader"
 	"github.com/project-radius/radius/pkg/recipes/driver"
+	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 )
 
 // NewEngine creates a new Engine to deploy recipe.
@@ -61,4 +63,19 @@ func (e *engine) Execute(ctx context.Context, recipe recipes.ResourceMetadata) (
 	}
 
 	return driver.Execute(ctx, *configuration, recipe, *definition)
+}
+
+func (e *engine) Delete(ctx context.Context, deploymentDataModel rpv1.DeploymentDataModel, client processors.ResourceClient, recipe recipes.ResourceMetadata) error {
+	// Load Recipe Definition from the environment.
+	definition, err := e.options.ConfigurationLoader.LoadRecipe(ctx, &recipe)
+	if err != nil {
+		return err
+	}
+
+	driver, ok := e.options.Drivers[definition.Driver]
+	if !ok {
+		return fmt.Errorf("could not find driver %s", definition.Driver)
+	}
+
+	return driver.Delete(ctx, deploymentDataModel, client)
 }

--- a/pkg/recipes/engine/engine.go
+++ b/pkg/recipes/engine/engine.go
@@ -65,8 +65,7 @@ func (e *engine) Execute(ctx context.Context, recipe recipes.ResourceMetadata) (
 	return driver.Execute(ctx, *configuration, recipe, *definition)
 }
 
-func (e *engine) Delete(ctx context.Context, deploymentDataModel rpv1.DeploymentDataModel, client processors.ResourceClient, recipe recipes.ResourceMetadata) error {
-	// Load Recipe Definition from the environment.
+func (e *engine) Delete(ctx context.Context, outputResources []rpv1.OutputResource, client processors.ResourceClient, recipe recipes.ResourceMetadata) error {
 	definition, err := e.options.ConfigurationLoader.LoadRecipe(ctx, &recipe)
 	if err != nil {
 		return err
@@ -77,5 +76,5 @@ func (e *engine) Delete(ctx context.Context, deploymentDataModel rpv1.Deployment
 		return fmt.Errorf("could not find driver %s", definition.Driver)
 	}
 
-	return driver.Delete(ctx, deploymentDataModel, client)
+	return driver.Delete(ctx, outputResources, client)
 }

--- a/pkg/recipes/engine/engine_test.go
+++ b/pkg/recipes/engine/engine_test.go
@@ -35,8 +35,8 @@ func setup(t *testing.T) (engine, configloader.MockConfigurationLoader, driver.M
 	mDriver := driver.NewMockDriver(ctrl)
 	options := Options{
 		ConfigurationLoader: configLoader,
-		Drivers: map[string]driver.Driver{
-			"bicep": mDriver,
+		Drivers:             map[string]driver.Driver{
+			// "bicep": mDriver,
 		},
 	}
 	engine := engine{

--- a/pkg/recipes/engine/mock_engine.go
+++ b/pkg/recipes/engine/mock_engine.go
@@ -38,7 +38,7 @@ func (m *MockEngine) EXPECT() *MockEngineMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockEngine) Delete(arg0 context.Context, arg1 v1.DeploymentDataModel, arg2 processors.ResourceClient, arg3 recipes.ResourceMetadata) error {
+func (m *MockEngine) Delete(arg0 context.Context, arg1 []v1.OutputResource, arg2 processors.ResourceClient, arg3 recipes.ResourceMetadata) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/pkg/recipes/engine/mock_engine.go
+++ b/pkg/recipes/engine/mock_engine.go
@@ -9,7 +9,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	processors "github.com/project-radius/radius/pkg/linkrp/processors"
 	recipes "github.com/project-radius/radius/pkg/recipes"
 	v1 "github.com/project-radius/radius/pkg/rp/v1"
 )
@@ -38,17 +37,17 @@ func (m *MockEngine) EXPECT() *MockEngineMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockEngine) Delete(arg0 context.Context, arg1 []v1.OutputResource, arg2 processors.ResourceClient, arg3 recipes.ResourceMetadata) error {
+func (m *MockEngine) Delete(arg0 context.Context, arg1 recipes.ResourceMetadata, arg2 []v1.OutputResource) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockEngineMockRecorder) Delete(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockEngineMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockEngine)(nil).Delete), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockEngine)(nil).Delete), arg0, arg1, arg2)
 }
 
 // Execute mocks base method.

--- a/pkg/recipes/engine/mock_engine.go
+++ b/pkg/recipes/engine/mock_engine.go
@@ -9,7 +9,9 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	processors "github.com/project-radius/radius/pkg/linkrp/processors"
 	recipes "github.com/project-radius/radius/pkg/recipes"
+	v1 "github.com/project-radius/radius/pkg/rp/v1"
 )
 
 // MockEngine is a mock of Engine interface.
@@ -33,6 +35,20 @@ func NewMockEngine(ctrl *gomock.Controller) *MockEngine {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEngine) EXPECT() *MockEngineMockRecorder {
 	return m.recorder
+}
+
+// Delete mocks base method.
+func (m *MockEngine) Delete(arg0 context.Context, arg1 v1.DeploymentDataModel, arg2 processors.ResourceClient, arg3 recipes.ResourceMetadata) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockEngineMockRecorder) Delete(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockEngine)(nil).Delete), arg0, arg1, arg2, arg3)
 }
 
 // Execute mocks base method.

--- a/pkg/recipes/engine/types.go
+++ b/pkg/recipes/engine/types.go
@@ -19,7 +19,6 @@ package engine
 import (
 	"context"
 
-	"github.com/project-radius/radius/pkg/linkrp/processors"
 	"github.com/project-radius/radius/pkg/recipes"
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 )
@@ -30,5 +29,5 @@ type Engine interface {
 	// Execute gathers environment configuration and recipe definition and calls the driver to deploy the recipe.
 	Execute(ctx context.Context, recipe recipes.ResourceMetadata) (*recipes.RecipeOutput, error)
 	// Delete handles deletion of output resources for the recipe deployment.
-	Delete(ctx context.Context, outputResources []rpv1.OutputResource, client processors.ResourceClient, recipe recipes.ResourceMetadata) error
+	Delete(ctx context.Context, recipe recipes.ResourceMetadata, outputResources []rpv1.OutputResource) error
 }

--- a/pkg/recipes/engine/types.go
+++ b/pkg/recipes/engine/types.go
@@ -19,7 +19,9 @@ package engine
 import (
 	"context"
 
+	"github.com/project-radius/radius/pkg/linkrp/processors"
 	"github.com/project-radius/radius/pkg/recipes"
+	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 )
 
 //go:generate mockgen -destination=./mock_engine.go -package=engine -self_package github.com/project-radius/radius/pkg/recipes/engine github.com/project-radius/radius/pkg/recipes/engine Engine
@@ -27,4 +29,6 @@ import (
 type Engine interface {
 	// Execute gathers environment configuration and recipe definition and calls the driver to deploy the recipe.
 	Execute(ctx context.Context, recipe recipes.ResourceMetadata) (*recipes.RecipeOutput, error)
+	// Delete handles deletion of output resources for the recipe deployment.
+	Delete(ctx context.Context, deploymentDataModel rpv1.DeploymentDataModel, client processors.ResourceClient, recipe recipes.ResourceMetadata) error
 }

--- a/pkg/recipes/engine/types.go
+++ b/pkg/recipes/engine/types.go
@@ -30,5 +30,5 @@ type Engine interface {
 	// Execute gathers environment configuration and recipe definition and calls the driver to deploy the recipe.
 	Execute(ctx context.Context, recipe recipes.ResourceMetadata) (*recipes.RecipeOutput, error)
 	// Delete handles deletion of output resources for the recipe deployment.
-	Delete(ctx context.Context, deploymentDataModel rpv1.DeploymentDataModel, client processors.ResourceClient, recipe recipes.ResourceMetadata) error
+	Delete(ctx context.Context, outputResources []rpv1.OutputResource, client processors.ResourceClient, recipe recipes.ResourceMetadata) error
 }


### PR DESCRIPTION
# Description

Extracting out the deletion logic to the existing bicep driver. A delete function will be implemented by the Terraform driver in a followup PR

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request adds or changes features of Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Part of work for radius-project/radius#6356 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ac7f8ba</samp>

### Summary
🗑️🚗🧪

<!--
1.  🗑️ - This emoji represents the deletion of output resources and the refactoring of the deletion logic. It conveys the idea of cleaning up and removing unwanted or unnecessary items.
2.  🚗 - This emoji represents the use of the engine and the recipe drivers to handle the deletion of output resources. It conveys the idea of driving or controlling the process and using different tools or vehicles to achieve the goal.
3.  🧪 - This emoji represents the addition and update of tests for the engine and the controller using gomock. It conveys the idea of testing, experimenting, and verifying the functionality and behavior of the code.
-->
The pull request adds output resource deletion logic to the `engine` and the recipe drivers, and updates the `DeleteResource` controller and the tests to use the `engine`. This improves the modularity and flexibility of the resource deletion process.

> _`Engine` deletes now_
> _Using `Driver` and `Recipe`_
> _Autumn leaves fall clean_

### Walkthrough
*  Add `Delete` method to `Engine` interface and implement it for `engine` type to handle output resource deletion for recipe deployment ([link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59R67-R80),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-11be7ca47327363d5edeaff3c6ac6389a462ff9111e1fc03ccb3a98123cd939fR32-R33),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-2dee9fa8b594b7a0e0783bd6587b452223eb5f7ba7c28a1dc0178c121a2509f0R40-R53))
* Add `Delete` method to `Driver` interface and implement it for `bicepDriver` type and mock it for `terraformDriver` and `mockDriver` types to handle output resource deletion for specific recipe drivers ([link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-f12e37706fa75e9e04b8dfa01a45cf9bf2a0463e1962605b2420d0cb343922a0R132-R163),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-1b98bc9b02b96687752860c11c68d87d99ad99f24ecdfc5497fda6823abc0612R103-R107),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-a95d80e21fb522c60702dad150fe92099ac96749fd90a452abd92867b40d069dR31-R32),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-ede26839223dbf77d6c86d51fd2eea9bf3720aabf7d404d331f1a0ff4e359f64R40-R53))
* Change `DeleteResource` controller to use `engine` to delete output resources instead of calling client directly, and pass `engine` as a parameter to `NewDeleteResource` function ([link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-f369203c896ae38d9f447bf905fa1566b36a31b235e99de6742f243f0e37269cL78-R97),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-f369203c896ae38d9f447bf905fa1566b36a31b235e99de6742f243f0e37269cL49-R51),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-f369203c896ae38d9f447bf905fa1566b36a31b235e99de6742f243f0e37269cR44),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-70568e8e08320d6f442af8eb869c4a070d87c66f0139988d2c3ca969b49f8573L198-R198))
* Update test cases for `DeleteResource` controller and `engine` to use mock engine and mock output resources, and add test cases for `Delete` method of `engine` ([link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-02aa3e89302e071bb0d1ff6ec178721c1a21971fb7d2dc2fe66ba1da13d67c7eR30),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-02aa3e89302e071bb0d1ff6ec178721c1a21971fb7d2dc2fe66ba1da13d67c7eL48-R54),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-02aa3e89302e071bb0d1ff6ec178721c1a21971fb7d2dc2fe66ba1da13d67c7eL64-R66),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-02aa3e89302e071bb0d1ff6ec178721c1a21971fb7d2dc2fe66ba1da13d67c7eL83-R85),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-02aa3e89302e071bb0d1ff6ec178721c1a21971fb7d2dc2fe66ba1da13d67c7eL117-R120),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-02aa3e89302e071bb0d1ff6ec178721c1a21971fb7d2dc2fe66ba1da13d67c7eL128-R134),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-02aa3e89302e071bb0d1ff6ec178721c1a21971fb7d2dc2fe66ba1da13d67c7eL149-R150),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-02aa3e89302e071bb0d1ff6ec178721c1a21971fb7d2dc2fe66ba1da13d67c7eL165-R166),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-02aa3e89302e071bb0d1ff6ec178721c1a21971fb7d2dc2fe66ba1da13d67c7eL171-R172),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-02aa3e89302e071bb0d1ff6ec178721c1a21971fb7d2dc2fe66ba1da13d67c7eL182-R184),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-3fdb9931c1f2ddfc5b14d87f47b4124f2bdc1da187219fa1ad9cbe79fc326528R20),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-3fdb9931c1f2ddfc5b14d87f47b4124f2bdc1da187219fa1ad9cbe79fc326528L25-R36),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-3fdb9931c1f2ddfc5b14d87f47b4124f2bdc1da187219fa1ad9cbe79fc326528L45-R52),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-3fdb9931c1f2ddfc5b14d87f47b4124f2bdc1da187219fa1ad9cbe79fc326528L86-R90),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-3fdb9931c1f2ddfc5b14d87f47b4124f2bdc1da187219fa1ad9cbe79fc326528L99-R103),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-3fdb9931c1f2ddfc5b14d87f47b4124f2bdc1da187219fa1ad9cbe79fc326528L125-R129),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-3fdb9931c1f2ddfc5b14d87f47b4124f2bdc1da187219fa1ad9cbe79fc326528L142-R146),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-3fdb9931c1f2ddfc5b14d87f47b4124f2bdc1da187219fa1ad9cbe79fc326528R166-R245))
* Remove unused `deleteResources` function from `DeleteResource` controller and unused `ucplog` import from `controller` package ([link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-f369203c896ae38d9f447bf905fa1566b36a31b235e99de6742f243f0e37269cL133-L163),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-f369203c896ae38d9f447bf905fa1566b36a31b235e99de6742f243f0e37269cL32-R35))
* Add imports for `processors`, `resourcemodel`, and `rp/v1` packages to `driver` and `engine` packages to handle output resources and deletion ([link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-f12e37706fa75e9e04b8dfa01a45cf9bf2a0463e1962605b2420d0cb343922a0L34-R41),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-1b98bc9b02b96687752860c11c68d87d99ad99f24ecdfc5497fda6823abc0612L28-R31),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-a95d80e21fb522c60702dad150fe92099ac96749fd90a452abd92867b40d069dL22-R24),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59L23-R27),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-2dee9fa8b594b7a0e0783bd6587b452223eb5f7ba7c28a1dc0178c121a2509f0L12-R14),[link](https://github.com/project-radius/radius/pull/5875/files?diff=unified&w=0#diff-11be7ca47327363d5edeaff3c6ac6389a462ff9111e1fc03ccb3a98123cd939fL22-R24))


