### PR TITLE
Create env in current workspace if one exists

### DIFF
--- a/pkg/cli/cmd/radinit/options.go
+++ b/pkg/cli/cmd/radinit/options.go
@@ -76,7 +76,7 @@ func (r *Runner) enterInitOptions(ctx context.Context) (*initOptions, *workspace
 		return nil, nil, err
 	}
 
-	ws, err := cli.GetCurrentWorkspace(r.ConfigHolder.Config)
+	ws, err := cli.GetWorkspace(r.ConfigHolder.Config, "")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/cli/cmd/radinit/options.go
+++ b/pkg/cli/cmd/radinit/options.go
@@ -118,6 +118,9 @@ func (r *Runner) enterInitOptions(ctx context.Context) (*initOptions, *workspace
 		workspace.Scope = fmt.Sprintf("/planes/radius/local/resourceGroups/%s", options.Environment.Name)
 		return &options, workspace, nil
 	}
+
 	ws.Environment = fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Applications.Core/environments/%s", options.Environment.Name, options.Environment.Name)
+	ws.Scope = fmt.Sprintf("/planes/radius/local/resourceGroups/%s", options.Environment.Name)
+
 	return &options, ws, nil
 }

--- a/pkg/cli/cmd/radinit/options.go
+++ b/pkg/cli/cmd/radinit/options.go
@@ -118,6 +118,6 @@ func (r *Runner) enterInitOptions(ctx context.Context) (*initOptions, *workspace
 		workspace.Scope = fmt.Sprintf("/planes/radius/local/resourceGroups/%s", options.Environment.Name)
 		return &options, workspace, nil
 	}
-
+	ws.Environment = fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Applications.Core/environments/%s", options.Environment.Name, options.Environment.Name)
 	return &options, ws, nil
 }

--- a/pkg/cli/cmd/radinit/options.go
+++ b/pkg/cli/cmd/radinit/options.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/project-radius/radius/pkg/cli"
 	cli_aws "github.com/project-radius/radius/pkg/cli/aws"
 	"github.com/project-radius/radius/pkg/cli/azure"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
@@ -75,8 +76,13 @@ func (r *Runner) enterInitOptions(ctx context.Context) (*initOptions, *workspace
 		return nil, nil, err
 	}
 
+	ws, err := cli.GetCurrentWorkspace(r.ConfigHolder.Config)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	// Set up a connection so we can list environments.
-	workspace := workspaces.Workspace{
+	workspace := &workspaces.Workspace{
 		Connection: map[string]any{
 			"context": options.Cluster.Context,
 			"kind":    workspaces.KindKubernetes,
@@ -88,7 +94,7 @@ func (r *Runner) enterInitOptions(ctx context.Context) (*initOptions, *workspace
 		Scope: "/planes/radius/local",
 	}
 
-	err = r.enterEnvironmentOptions(ctx, &workspace, &options)
+	err = r.enterEnvironmentOptions(ctx, workspace, &options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -105,10 +111,13 @@ func (r *Runner) enterInitOptions(ctx context.Context) (*initOptions, *workspace
 
 	options.Recipes.DevRecipes = r.Dev
 
-	// Update the workspace with the information we captured about the environment.
-	workspace.Name = options.Environment.Name
-	workspace.Environment = fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Applications.Core/environments/%s", options.Environment.Name, options.Environment.Name)
-	workspace.Scope = fmt.Sprintf("/planes/radius/local/resourceGroups/%s", options.Environment.Name)
+	if ws == nil {
+		// Update the workspace with the information we captured about the environment.
+		workspace.Name = options.Environment.Name
+		workspace.Environment = fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Applications.Core/environments/%s", options.Environment.Name, options.Environment.Name)
+		workspace.Scope = fmt.Sprintf("/planes/radius/local/resourceGroups/%s", options.Environment.Name)
+		return &options, workspace, nil
+	}
 
-	return &options, &workspace, nil
+	return &options, ws, nil
 }

--- a/pkg/cli/cmd/radinit/options_test.go
+++ b/pkg/cli/cmd/radinit/options_test.go
@@ -160,8 +160,8 @@ workspaces:
 				"context": "cool-beans",
 				"kind":    workspaces.KindKubernetes,
 			},
-			Environment: "/a/b/c/providers/Applications.Core/environments/ice-cold",
-			Scope:       "/a/b/c",
+			Environment: "/planes/radius/local/resourceGroups/test-env/providers/Applications.Core/environments/test-env",
+			Scope:       "/planes/radius/local/resourceGroups/test-env",
 			Source:      "userconfig",
 		}
 		require.Equal(t, expectedWorkspace, *workspace)

--- a/pkg/cli/cmd/radinit/options_test.go
+++ b/pkg/cli/cmd/radinit/options_test.go
@@ -17,15 +17,18 @@ limitations under the License.
 package radinit
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/project-radius/radius/pkg/cli/framework"
 	"github.com/project-radius/radius/pkg/cli/helm"
 	"github.com/project-radius/radius/pkg/cli/kubernetes"
 	"github.com/project-radius/radius/pkg/cli/prompt"
 	"github.com/project-radius/radius/pkg/cli/workspaces"
 	"github.com/project-radius/radius/pkg/version"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,7 +38,7 @@ func Test_enterInitOptions(t *testing.T) {
 		prompter := prompt.NewMockInterface(ctrl)
 		k8s := kubernetes.NewMockInterface(ctrl)
 		helm := helm.NewMockInterface(ctrl)
-		runner := Runner{Prompter: prompter, KubernetesInterface: k8s, HelmInterface: helm, Dev: true}
+		runner := Runner{Prompter: prompter, KubernetesInterface: k8s, HelmInterface: helm, Dev: true, ConfigHolder: &framework.ConfigHolder{Config: viper.New()}}
 
 		initGetKubeContextSuccess(k8s)
 		initHelmMockRadiusNotInstalled(helm)
@@ -79,7 +82,7 @@ func Test_enterInitOptions(t *testing.T) {
 		prompter := prompt.NewMockInterface(ctrl)
 		k8s := kubernetes.NewMockInterface(ctrl)
 		helm := helm.NewMockInterface(ctrl)
-		runner := Runner{Prompter: prompter, KubernetesInterface: k8s, HelmInterface: helm}
+		runner := Runner{Prompter: prompter, KubernetesInterface: k8s, HelmInterface: helm, ConfigHolder: &framework.ConfigHolder{Config: viper.New()}}
 
 		initGetKubeContextSuccess(k8s)
 		initKubeContextWithKind(prompter)
@@ -118,4 +121,75 @@ func Test_enterInitOptions(t *testing.T) {
 		}
 		require.Equal(t, expectedOptions, *options)
 	})
+
+	t.Run("existing-workspace", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		prompter := prompt.NewMockInterface(ctrl)
+		k8s := kubernetes.NewMockInterface(ctrl)
+		helm := helm.NewMockInterface(ctrl)
+
+		var yaml = `
+workspaces:
+  default: abc
+  items:
+    abc:
+      connection:
+        kind: kubernetes
+        context: cool-beans
+      scope: /a/b/c
+      environment: /a/b/c/providers/Applications.Core/environments/ice-cold
+`
+		v, err := makeConfig(yaml)
+		runner := Runner{Prompter: prompter, KubernetesInterface: k8s, HelmInterface: helm, ConfigHolder: &framework.ConfigHolder{Config: v}}
+
+		require.NoError(t, err)
+		initGetKubeContextSuccess(k8s)
+		initKubeContextWithKind(prompter)
+		initHelmMockRadiusNotInstalled(helm)
+		initEnvNamePrompt(prompter, "test-env")
+		initNamespacePrompt(prompter, "test-namespace")
+		initAddCloudProviderPromptNo(prompter)
+		setScaffoldApplicationPromptNo(prompter)
+
+		options, workspace, err := runner.enterInitOptions(context.Background())
+		require.NoError(t, err)
+
+		expectedWorkspace := workspaces.Workspace{
+			Name: "abc",
+			Connection: map[string]any{
+				"context": "cool-beans",
+				"kind":    workspaces.KindKubernetes,
+			},
+			Environment: "/a/b/c/providers/Applications.Core/environments/ice-cold",
+			Scope:       "/a/b/c",
+			Source:      "userconfig",
+		}
+		require.Equal(t, expectedWorkspace, *workspace)
+
+		expectedOptions := initOptions{
+			Cluster: clusterOptions{
+				Context:   "kind-kind",
+				Install:   true,
+				Namespace: "radius-system",
+				Version:   version.Version(),
+			},
+			Environment: environmentOptions{
+				Create:    true,
+				Name:      "test-env",
+				Namespace: "test-namespace",
+			},
+		}
+		require.Equal(t, expectedOptions, *options)
+	})
+}
+
+func makeConfig(yaml string) (*viper.Viper, error) {
+	v := viper.New()
+	v.SetConfigType("YAML")
+	err := v.ReadConfig(bytes.NewBuffer([]byte(yaml)))
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
 }

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -171,23 +171,6 @@ func GetWorkspace(v *viper.Viper, name string) (*workspaces.Workspace, error) {
 	return section.GetWorkspace(name)
 }
 
-// # Function Explanation
-// GetCurrentWorkspace reads the workspace section of the config and returns the current workspace.
-func GetCurrentWorkspace(v *viper.Viper) (*workspaces.Workspace, error) {
-	section, err := ReadWorkspaceSection(v)
-	if err != nil {
-		return nil, err
-	}
-
-	// Do not specify a name which will return the default workspace
-	ws, err := section.GetWorkspace("")
-	if err != nil {
-		return nil, err
-	}
-
-	return ws, nil
-}
-
 func getConfig(configFilePath string) (*viper.Viper, error) {
 	config := viper.New()
 

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -171,6 +171,23 @@ func GetWorkspace(v *viper.Viper, name string) (*workspaces.Workspace, error) {
 	return section.GetWorkspace(name)
 }
 
+// # Function Explanation
+// GetCurrentWorkspace reads the workspace section of the config and returns the current workspace.
+func GetCurrentWorkspace(v *viper.Viper) (*workspaces.Workspace, error) {
+	section, err := ReadWorkspaceSection(v)
+	if err != nil {
+		return nil, err
+	}
+
+	// Do not specify a name which will return the default workspace
+	ws, err := section.GetWorkspace("")
+	if err != nil {
+		return nil, err
+	}
+
+	return ws, nil
+}
+
 func getConfig(configFilePath string) (*viper.Viper, error) {
 	config := viper.New()
 

--- a/pkg/cli/config_test.go
+++ b/pkg/cli/config_test.go
@@ -175,6 +175,46 @@ workspaces:
 	require.Equal(t, map[string]any{"kind": "kubernetes", "context": "cool-beans"}, ws.Connection)
 }
 
+func Test_GetCurrentWorkspace_NoneExists(t *testing.T) {
+	var yaml = `
+`
+
+	v, err := makeConfig(yaml)
+	require.NoError(t, err)
+
+	ws, err := GetCurrentWorkspace(v)
+	require.NoError(t, err)
+	require.Nil(t, ws)
+}
+
+func Test_GetCurrentWorkspace_ExistingDefault(t *testing.T) {
+	var yaml = `
+workspaces:
+  default: test
+  items:
+    abc:
+      connection:
+        kind: kubernetes
+        context: cool-beans1
+      scope: /a/b/c
+      environment: /a/b/c/providers/Applications.Core/environments/ice-cold
+    test:
+      connection:
+        kind: kubernetes
+        context: cool-beans
+      scope: /a/b/c
+      environment: /a/b/c/providers/Applications.Core/environments/ice-cold
+`
+
+	v, err := makeConfig(yaml)
+	require.NoError(t, err)
+
+	ws, err := GetCurrentWorkspace(v)
+	require.NoError(t, err)
+	require.NotNil(t, ws)
+	require.Equal(t, "test", ws.Name)
+}
+
 func makeConfig(yaml string) (*viper.Viper, error) {
 	v := viper.New()
 	v.SetConfigType("YAML")

--- a/pkg/cli/config_test.go
+++ b/pkg/cli/config_test.go
@@ -175,44 +175,16 @@ workspaces:
 	require.Equal(t, map[string]any{"kind": "kubernetes", "context": "cool-beans"}, ws.Connection)
 }
 
-func Test_GetCurrentWorkspace_NoneExists(t *testing.T) {
+func Test_GetWorkspace_NoneExists(t *testing.T) {
 	var yaml = `
 `
 
 	v, err := makeConfig(yaml)
 	require.NoError(t, err)
 
-	ws, err := GetCurrentWorkspace(v)
+	ws, err := GetWorkspace(v, "")
 	require.NoError(t, err)
 	require.Nil(t, ws)
-}
-
-func Test_GetCurrentWorkspace_ExistingDefault(t *testing.T) {
-	var yaml = `
-workspaces:
-  default: test
-  items:
-    abc:
-      connection:
-        kind: kubernetes
-        context: cool-beans1
-      scope: /a/b/c
-      environment: /a/b/c/providers/Applications.Core/environments/ice-cold
-    test:
-      connection:
-        kind: kubernetes
-        context: cool-beans
-      scope: /a/b/c
-      environment: /a/b/c/providers/Applications.Core/environments/ice-cold
-`
-
-	v, err := makeConfig(yaml)
-	require.NoError(t, err)
-
-	ws, err := GetCurrentWorkspace(v)
-	require.NoError(t, err)
-	require.NotNil(t, ws)
-	require.Equal(t, "test", ws.Name)
 }
 
 func makeConfig(yaml string) (*viper.Viper, error) {


### PR DESCRIPTION
# Description

These changes check if a workspace exists. If yes, it creates the new env in the current workspace. If no workspace exists, a new one is created (as before)

#bug

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #5585 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a0eaf57</samp>

### Summary
🧪📝🛠️

<!--
1.  🧪 This emoji represents testing, and it is suitable for the first change, which adds two new test functions to the `cli` package test file.
2.  📝 This emoji represents writing or editing, and it is suitable for the second change, which adds a new function `GetCurrentWorkspace` to the `cli` package.
3.  🛠️ This emoji represents fixing or improving, and it is suitable for the third and fourth changes, which update the `radinit` package test file and the `radinit` package to use the new function and handle different scenarios.
-->
This pull request adds a new function `GetCurrentWorkspace` to the `cli` package, which returns the current workspace from the config file. It also updates the `radinit` package to use this function and handle both cases of creating a new workspace or using an existing one. It also adds and updates some tests for these changes.

> _Oh we're the radinit crew and we know what to do_
> _We'll get the workspace from the `cli` package too_
> _And if there's none in the config we'll make a new one for you_
> _Heave away, heave away, heave away on the count of three_

### Walkthrough
*  Add `GetCurrentWorkspace` function to `cli` package to read the workspace section of the config and return the current workspace, if any ([link](https://github.com/project-radius/radius/pull/5882/files?diff=unified&w=0#diff-824ea2ad29208ac6074dc67bb9e1c9598e5e3d2c303f19cb881dd250ea63c7a2R174-R190))
*  Modify `enterInitOptions` function in `radinit` package to use `GetCurrentWorkspace` function to get the existing workspace from the config, if any, and store it in a variable `ws` ([link](https://github.com/project-radius/radius/pull/5882/files?diff=unified&w=0#diff-a786a8b7ff8510f7a22696b1be6f2a304c325c404b381caff53b758e8e1ec482L78-R85), [link](https://github.com/project-radius/radius/pull/5882/files?diff=unified&w=0#diff-a786a8b7ff8510f7a22696b1be6f2a304c325c404b381caff53b758e8e1ec482L108-R122))
*  Change `workspace` variable in `enterInitOptions` function to be a pointer to a `workspaces.Workspace` struct instead of a value, to avoid copying the struct unnecessarily ([link](https://github.com/project-radius/radius/pull/5882/files?diff=unified&w=0#diff-a786a8b7ff8510f7a22696b1be6f2a304c325c404b381caff53b758e8e1ec482L78-R85), [link](https://github.com/project-radius/radius/pull/5882/files?diff=unified&w=0#diff-a786a8b7ff8510f7a22696b1be6f2a304c325c404b381caff53b758e8e1ec482L91-R97))
*  Pass `workspace` pointer to `enterEnvironmentOptions` function, instead of passing a value, to avoid copying the struct unnecessarily ([link](https://github.com/project-radius/radius/pull/5882/files?diff=unified&w=0#diff-a786a8b7ff8510f7a22696b1be6f2a304c325c404b381caff53b758e8e1ec482L91-R97))
*  Add test case to `Test_enterInitOptions` function in `radinit` package test file, which tests the scenario where there is an existing workspace in the config and the `enterInitOptions` function should use it instead of creating a new one ([link](https://github.com/project-radius/radius/pull/5882/files?diff=unified&w=0#diff-8ade53961f66c9f7818a671656cdac5de7967ea3c6dcb1d54a6b63b13e27f653L121-R195))
*  Add helper function `makeConfig` to `radinit` package test file, to create a mock config from a YAML string ([link](https://github.com/project-radius/radius/pull/5882/files?diff=unified&w=0#diff-8ade53961f66c9f7818a671656cdac5de7967ea3c6dcb1d54a6b63b13e27f653L121-R195))
*  Add test functions to `cli` package test file, which test the `GetCurrentWorkspace` function with different scenarios: one where there is no workspace in the config, and one where there is an existing default workspace in the config ([link](https://github.com/project-radius/radius/pull/5882/files?diff=unified&w=0#diff-98fe5f978ff5fb39151083ef0e986d1214e7c270953d451e942ec1d464fab608R178-R217))
*  Import `cli` package in `radinit` package, to access the `GetCurrentWorkspace` function ([link](https://github.com/project-radius/radius/pull/5882/files?diff=unified&w=0#diff-a786a8b7ff8510f7a22696b1be6f2a304c325c404b381caff53b758e8e1ec482R22))
*  Import `bytes`, `framework`, and `viper` packages in `radinit` package test file, to create a mock config and access the `ConfigHolder` struct that was added to the `Runner` struct ([link](https://github.com/project-radius/radius/pull/5882/files?diff=unified&w=0#diff-8ade53961f66c9f7818a671656cdac5de7967ea3c6dcb1d54a6b63b13e27f653L20-R25), [link](https://github.com/project-radius/radius/pull/5882/files?diff=unified&w=0#diff-8ade53961f66c9f7818a671656cdac5de7967ea3c6dcb1d54a6b63b13e27f653R31))
*  Initialize a `ConfigHolder` with a mock config and assign it to the `Runner` struct in `Test_enterInitOptions` function in `radinit` package test file, to test the `GetCurrentWorkspace` function ([link](https://github.com/project-radius/radius/pull/5882/files?diff=unified&w=0#diff-8ade53961f66c9f7818a671656cdac5de7967ea3c6dcb1d54a6b63b13e27f653L38-R41), [link](https://github.com/project-radius/radius/pull/5882/files?diff=unified&w=0#diff-8ade53961f66c9f7818a671656cdac5de7967ea3c6dcb1d54a6b63b13e27f653L82-R85))


