### PR TITLE
small improvements in aws deletion test code

### DIFF
--- a/test/functional/shared/rptest.go
+++ b/test/functional/shared/rptest.go
@@ -329,9 +329,12 @@ func (ct RPTest) Test(t *testing.T) {
 
 						// Use AWS CloudControl.Get method to validate that the resource is deleted
 						notFound, err = validation.IsAWSResourceNotFound(ctx, &resource, ct.Options.AWSClient)
-						t.Logf("checking existence of resource %s failed with err: %s", resource.Name, err)
 
 						if notFound {
+							t.Logf("AWS resource %s to be deleted was not found", resource.Identifier)
+							break
+						} else if err != nil {
+							t.Logf("checking existence of resource %s failed with err: %s", resource.Name, err)
 							break
 						} else {
 							// Wait for 10 seconds


### PR DESCRIPTION
# Description

Attempt to improve https://github.com/project-radius/radius/issues/5636

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #5636 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 183c8d7</samp>

### Summary
:loudspeaker::loop::white_check_mark:

<!--
1.  :loudspeaker: This emoji can be used to indicate that the change adds a log message, which can help with debugging and troubleshooting the test case.
2.  :loop: This emoji can be used to indicate that the change breaks the loop when there is an error, which can prevent unnecessary iterations and potential infinite loops.
3.  :white_check_mark: This emoji can be used to indicate that the change improves the reliability of the test case, which can increase the confidence and quality of the code.
-->
Improve test case for deleting AWS resources with CloudControl API. Add log message and error handling in `test/functional/shared/rptest.go`.

> _`CloudControl` test_
> _log and break on error_
> _autumn leaves falling_

### Walkthrough
*  Add a log message and break the loop when deleting AWS resources fails or is not found ([link](https://github.com/project-radius/radius/pull/5885/files?diff=unified&w=0#diff-f9ca7b9a91d5b71a3d9cbd29a179a8253f51f2755b89cceef405b46ecd03999bL332-R338))


