### PR TITLE
Release v0.23.0-rc1

### DIFF
--- a/pkg/cli/cmd/recipe/list/list.go
+++ b/pkg/cli/cmd/recipe/list/list.go
@@ -18,6 +18,7 @@ package list
 
 import (
 	"context"
+	"sort"
 
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
@@ -119,6 +120,9 @@ func (r *Runner) Run(ctx context.Context) error {
 			envRecipes = append(envRecipes, recipe)
 		}
 	}
+	sort.Slice(envRecipes, func(i, j int) bool {
+		return envRecipes[i].Name < envRecipes[j].Name
+	})
 	err = r.Output.WriteFormatted(r.Format, envRecipes, objectformats.GetEnvironmentRecipesTableFormat())
 	if err != nil {
 		return err

--- a/versions.json
+++ b/versions.json
@@ -4,7 +4,7 @@
     "description": "stable is the release that we want to be the default version for users"
   },
   "latest": {
-    "version": "v0.22.0-rc2",
+    "version": "v0.23.0-rc1",
     "description": "latest is the most recent release, which may be a pre-release"
   }
 }


### PR DESCRIPTION
# Description

version change to trigger v0.23.0-rc1 release candidate

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cd9afe0</samp>

### Summary
🚀📝🔖

<!--
1.  🚀 - This emoji conveys the idea of launching a new release candidate version, which is a significant milestone for the project and its users. It also implies excitement and anticipation for the upcoming features and improvements that the release candidate offers.
2.  📝 - This emoji indicates that the change involved updating a document or a configuration file, which is a common and important task for maintaining the project. It also suggests clarity and precision, as the `latest` key needs to match the exact version number of the release candidate.
3.  🔖 - This emoji represents a tag or a label, which is a way of marking a specific point in the project's history or codebase. It also implies organization and categorization, as the release candidate version follows a naming convention that distinguishes it from other versions.
-->
Updated the `latest` version of radius to `v0.23.0-rc1` in the `versions.json` file. This prepares the project for testing and releasing the new candidate version.

> _`latest` key changed_
> _`v0.23.0-rc1` is ready_
> _autumn of testing_

### Walkthrough
* Update the latest version to `v0.23.0-rc1` in `versions.json` ([link](https://github.com/project-radius/radius/pull/5891/files?diff=unified&w=0#diff-2b39d33506bc7a34cef4b9ebf4cf8b1e3a5532f2131ceb37011b94261cec5f8cL7-R7))


