### PR TITLE
Deployment fail error combinelogic [do not review]

### DIFF
--- a/deploy/Chart/templates/rp/rbac.yaml
+++ b/deploy/Chart/templates/rp/rbac.yaml
@@ -14,6 +14,7 @@ rules:
   - services
   - namespaces
   - serviceaccounts
+  - pods
   verbs:
   - create
   - delete
@@ -51,6 +52,7 @@ rules:
   resources:
   - deployments
   - statefulsets
+  - replicasets
   verbs:
   - create
   - delete

--- a/pkg/corerp/handlers/kubernetes.go
+++ b/pkg/corerp/handlers/kubernetes.go
@@ -226,7 +226,7 @@ func (handler *kubernetesHandler) checkDeploymentStatus(ctx context.Context, inf
 		return
 	}
 
-	deploymentReplicaSet := handler.getNewestReplicaSetForDeployment(ctx, informerFactory, deployment)
+	deploymentReplicaSet := handler.getCurrentReplicaSetForDeployment(ctx, informerFactory, deployment)
 	if deploymentReplicaSet == "" {
 		logger.Info(fmt.Sprintf("Unable to find replica set for deployment %s in namespace %s", item.GetName(), item.GetNamespace()))
 		return
@@ -264,7 +264,7 @@ func (handler *kubernetesHandler) getReplicaSetName(pod *corev1.Pod) string {
 	return ""
 }
 
-func (handler *kubernetesHandler) getNewestReplicaSetForDeployment(ctx context.Context, informerFactory informers.SharedInformerFactory, item client.Object) string {
+func (handler *kubernetesHandler) getCurrentReplicaSetForDeployment(ctx context.Context, informerFactory informers.SharedInformerFactory, item client.Object) string {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
 	// List all replicasets for this deployment
@@ -451,6 +451,7 @@ func (handler *kubernetesHandler) checkAllPodsReady(ctx context.Context, informe
 	for _, pod := range podsInDeployment {
 		status, err := handler.checkPodStatus(ctx, &pod)
 		if err != nil {
+			// Terminate the deployment and return the error encountered
 			doneCh <- err
 		}
 		if !status {

--- a/pkg/corerp/handlers/kubernetes_test.go
+++ b/pkg/corerp/handlers/kubernetes_test.go
@@ -630,7 +630,7 @@ func TestGetNewestReplicaSetForDeployment(t *testing.T) {
 	informerFactory := startInformers(ctx, fakeClient, handler)
 
 	// Call the getNewestReplicaSetForDeployment function
-	replicaSetName := handler.getNewestReplicaSetForDeployment(ctx, informerFactory, deployment)
+	replicaSetName := handler.getCurrentReplicaSetForDeployment(ctx, informerFactory, deployment)
 	require.Equal(t, replicaSet1.Name, replicaSetName)
 }
 
@@ -817,7 +817,6 @@ func TestCheckDeploymentStatus_AllReady(t *testing.T) {
 	handler := &kubernetesHandler{
 		clientSet: fakeClient,
 	}
-	startInformers(ctx, fakeClient, handler)
 
 	go handler.checkDeploymentStatus(ctx, informerFactory, item, obj, doneCh)
 
@@ -909,7 +908,6 @@ func TestCheckDeploymentStatus_PodsNotReady(t *testing.T) {
 	handler := &kubernetesHandler{
 		clientSet: fakeClient,
 	}
-	startInformers(ctx, fakeClient, handler)
 
 	go handler.checkDeploymentStatus(ctx, informerFactory, item, obj, doneCh)
 	err = <-doneCh
@@ -1001,7 +999,6 @@ func TestCheckDeploymentStatus_ObserverGenerationMismatch(t *testing.T) {
 	handler := &kubernetesHandler{
 		clientSet: fakeClient,
 	}
-	startInformers(ctx, fakeClient, handler)
 
 	handler.checkDeploymentStatus(ctx, informerFactory, item, obj, doneCh)
 

--- a/pkg/corerp/handlers/kubernetes_test.go
+++ b/pkg/corerp/handlers/kubernetes_test.go
@@ -901,7 +901,7 @@ func TestDeploymentEventHandler(t *testing.T) {
 
 	// Call the deployment event handler with the mock objects
 	doneCh := make(chan error)
-	go handler.deploymentEventHandler(ctx, deployment, deployment, doneCh)
+	go handler.checkDeploymentStatus(ctx, deployment, deployment, doneCh)
 
 	// Wait for the handler to finish
 	err = <-doneCh

--- a/pkg/corerp/handlers/kubernetes_test.go
+++ b/pkg/corerp/handlers/kubernetes_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/project-radius/radius/pkg/kubernetes"
 	"github.com/project-radius/radius/pkg/resourcemodel"
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 	"github.com/project-radius/radius/pkg/to"
@@ -71,6 +72,9 @@ func TestPut(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-deployment",
 			Namespace: "test-namespace",
+			Labels: map[string]string{
+				kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
+			},
 		},
 		Spec: v1.DeploymentSpec{
 			Replicas: int32Ptr(1),
@@ -323,6 +327,9 @@ func TestWaitUntilDeploymentIsReady_NewResource(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-deployment",
 			Namespace: "test-namespace",
+			Labels: map[string]string{
+				kubernetes.LabelManagedBy: kubernetes.LabelManagedByRadiusRP,
+			},
 		},
 		Spec: v1.DeploymentSpec{
 			Replicas: int32Ptr(1),

--- a/pkg/corerp/handlers/kubernetes_test.go
+++ b/pkg/corerp/handlers/kubernetes_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/project-radius/radius/pkg/resourcemodel"
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
+	"github.com/project-radius/radius/pkg/to"
 	"github.com/project-radius/radius/test/k8sutil"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/apps/v1"
@@ -31,10 +32,66 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+func int32Ptr(i int32) *int32 { return &i }
+
+func addReplicaSetToDeployment(t *testing.T, ctx context.Context, clientset *fake.Clientset, deployment *v1.Deployment) {
+	replicaSet := &v1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-replicaset-1",
+			Namespace:   deployment.Namespace,
+			Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(deployment, schema.GroupVersionKind{
+					Group:   v1.SchemeGroupVersion.Group,
+					Version: v1.SchemeGroupVersion.Version,
+					Kind:    "Deployment",
+				}),
+			},
+		},
+	}
+
+	// Add the ReplicaSet objects to the fake Kubernetes clientset
+	_, err := clientset.AppsV1().ReplicaSets(replicaSet.Namespace).Create(ctx, replicaSet, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = clientset.AppsV1().Deployments(deployment.Namespace).Update(ctx, deployment, metav1.UpdateOptions{})
+	require.NoError(t, err)
+}
+
 func TestPut(t *testing.T) {
+	deployment := &v1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "test-namespace",
+		},
+		Spec: v1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "test",
+				},
+			},
+		},
+		Status: v1.DeploymentStatus{
+			Conditions: []v1.DeploymentCondition{
+				{
+					Type:    v1.DeploymentProgressing,
+					Status:  corev1.ConditionTrue,
+					Reason:  "NewReplicaSetAvailable",
+					Message: "Deployment has minimum availability",
+				},
+			},
+		},
+	}
+
 	putTests := []struct {
 		name string
 		in   *PutOptions
@@ -73,26 +130,7 @@ func TestPut(t *testing.T) {
 					ResourceType: resourcemodel.ResourceType{
 						Provider: resourcemodel.ProviderKubernetes,
 					},
-					Resource: &v1.Deployment{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "Deployment",
-							APIVersion: "apps/v1",
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "test-deployment",
-							Namespace: "test-namespace",
-						},
-						Status: v1.DeploymentStatus{
-							Conditions: []v1.DeploymentCondition{
-								{
-									Type:    v1.DeploymentProgressing,
-									Status:  corev1.ConditionTrue,
-									Reason:  "NewReplicaSetAvailable",
-									Message: "Deployment has minimum availability",
-								},
-							},
-						},
-					},
+					Resource: deployment,
 				},
 			},
 			out: map[string]string{
@@ -115,9 +153,13 @@ func TestPut(t *testing.T) {
 				cacheResyncInterval: time.Duration(10) * time.Second,
 			}
 
-			// only deployment resources need to be watched.
-			if _, ok := tc.in.Resource.Resource.(*v1.Deployment); ok {
-				handler.clientSet = fake.NewSimpleClientset(tc.in.Resource.Resource.(runtime.Object))
+			clientSet := fake.NewSimpleClientset(tc.in.Resource.Resource.(runtime.Object))
+			handler.clientSet = clientSet
+
+			// If the resource is a deployment, we need to add a replica set to it
+			if tc.in.Resource.Resource.(runtime.Object).GetObjectKind().GroupVersionKind().Kind == "Deployment" {
+				// The deployment is not marked as ready till we find a replica set. Therefore, we need to create one.
+				addReplicaSetToDeployment(t, ctx, clientSet, deployment)
 			}
 
 			props, err := handler.Put(ctx, tc.in)
@@ -145,7 +187,7 @@ func TestDelete(t *testing.T) {
 	handler := kubernetesHandler{
 		client:              k8sutil.NewFakeKubeClient(nil),
 		deploymentTimeOut:   time.Duration(1) * time.Second,
-		cacheResyncInterval: time.Duration(10) * time.Second,
+		cacheResyncInterval: time.Duration(30) * time.Second,
 	}
 
 	err := handler.client.Create(ctx, deployment)
@@ -275,11 +317,20 @@ func TestConvertToUnstructured(t *testing.T) {
 
 func TestWaitUntilDeploymentIsReady_NewResource(t *testing.T) {
 	ctx := context.TODO()
+
 	// Create first deployment that will be watched
 	deployment := &v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-deployment",
 			Namespace: "test-namespace",
+		},
+		Spec: v1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "test",
+				},
+			},
 		},
 		Status: v1.DeploymentStatus{
 			Conditions: []v1.DeploymentCondition{
@@ -293,11 +344,14 @@ func TestWaitUntilDeploymentIsReady_NewResource(t *testing.T) {
 		},
 	}
 
-	deploymentClient := fake.NewSimpleClientset(deployment)
+	clientset := fake.NewSimpleClientset(deployment)
+
+	// The deployment is not marked as ready till we find a replica set. Therefore, we need to create one.
+	addReplicaSetToDeployment(t, ctx, clientset, deployment)
 
 	handler := kubernetesHandler{
-		clientSet:           deploymentClient,
-		deploymentTimeOut:   time.Duration(5) * time.Second,
+		clientSet:           clientset,
+		deploymentTimeOut:   time.Duration(50) * time.Second,
 		cacheResyncInterval: time.Duration(10) * time.Second,
 	}
 
@@ -358,10 +412,10 @@ func TestWaitUntilDeploymentIsReady_DifferentResourceName(t *testing.T) {
 		},
 	}
 
-	deploymentClient := fake.NewSimpleClientset(deployment)
+	clientset := fake.NewSimpleClientset(deployment)
 
 	handler := kubernetesHandler{
-		clientSet:           deploymentClient,
+		clientSet:           clientset,
 		deploymentTimeOut:   time.Duration(1) * time.Second,
 		cacheResyncInterval: time.Duration(10) * time.Second,
 	}
@@ -376,4 +430,425 @@ func TestWaitUntilDeploymentIsReady_DifferentResourceName(t *testing.T) {
 	// It must be timed out because the name of the deployment does not match.
 	require.Error(t, err)
 	require.Equal(t, "deployment timed out, name: not-matched-deployment, namespace test-namespace, error occured while fetching latest status: deployments.apps \"not-matched-deployment\" not found", err.Error())
+}
+
+func TestGetPodsInDeployment(t *testing.T) {
+	// Create a fake Kubernetes clientset
+	fakeClient := fake.NewSimpleClientset()
+
+	// Create a Deployment object
+	deployment := &v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "test-namespace",
+		},
+		Spec: v1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "test-app",
+				},
+			},
+		},
+	}
+
+	// Create a ReplicaSet object
+	replicaset := &v1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-replicaset",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "test-app",
+			},
+		},
+	}
+
+	// Create a Pod object
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"app": "test-app",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "ReplicaSet",
+					Name:       replicaset.Name,
+					Controller: to.Ptr(true),
+				},
+			},
+		},
+	}
+
+	// Add the Pod object to the fake Kubernetes clientset
+	_, err := fakeClient.CoreV1().Pods(pod.Namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create Pod: %v", err)
+	}
+
+	// Create a KubernetesHandler object with the fake clientset
+	handler := &kubernetesHandler{
+		clientSet: fakeClient,
+	}
+
+	// Call the getPodsInDeployment function
+	pods, err := handler.getPodsInDeployment(context.Background(), deployment, replicaset.Name)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(pods))
+	require.Equal(t, pod.Name, pods[0].Name)
+}
+
+func TestGetReplicaSetName(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind: "ReplicaSet",
+					Name: "my-replicaset",
+				},
+			},
+		},
+	}
+
+	handler := &kubernetesHandler{}
+	replicaSetName := handler.getReplicaSetName(pod)
+
+	require.Equal(t, "my-replicaset", replicaSetName)
+}
+
+func TestGetNewestReplicaSetForDeployment(t *testing.T) {
+	// Create a fake Kubernetes clientset
+	fakeClient := fake.NewSimpleClientset()
+
+	// Create a Deployment object
+	deployment := &v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "test-namespace",
+		},
+	}
+
+	// Create a ReplicaSet object with a higher revision than the other ReplicaSet
+	replicaSet1 := &v1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-replicaset-1",
+			Namespace:   "test-namespace",
+			Annotations: map[string]string{"deployment.kubernetes.io/revision": "1"},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(deployment, schema.GroupVersionKind{
+					Group:   v1.SchemeGroupVersion.Group,
+					Version: v1.SchemeGroupVersion.Version,
+					Kind:    "Deployment",
+				}),
+			},
+		},
+	}
+	// Create another ReplicaSet object with a lower revision than the other ReplicaSet
+	replicaSet2 := &v1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-replicaset-2",
+			Namespace:   "test-namespace",
+			Annotations: map[string]string{"deployment.kubernetes.io/revision": "0"},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(deployment, schema.GroupVersionKind{
+					Group:   v1.SchemeGroupVersion.Group,
+					Version: v1.SchemeGroupVersion.Version,
+					Kind:    "Deployment",
+				}),
+			},
+		},
+	}
+
+	// Add the ReplicaSet objects to the fake Kubernetes clientset
+	_, err := fakeClient.AppsV1().ReplicaSets(replicaSet1.Namespace).Create(context.Background(), replicaSet1, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = fakeClient.AppsV1().ReplicaSets(replicaSet2.Namespace).Create(context.Background(), replicaSet2, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Add the Deployment object to the fake Kubernetes clientset
+	_, err = fakeClient.AppsV1().Deployments(deployment.Namespace).Create(context.Background(), deployment, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Create a KubernetesHandler object with the fake clientset
+	handler := &kubernetesHandler{
+		clientSet: fakeClient,
+	}
+
+	// Call the getNewestReplicaSetForDeployment function
+	replicaSetName, err := handler.getNewestReplicaSetForDeployment(context.Background(), deployment)
+	require.NoError(t, err)
+	require.Equal(t, replicaSet1.Name, replicaSetName)
+}
+
+func TestCheckPodStatus(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:    corev1.PodScheduled,
+					Status:  corev1.ConditionFalse,
+					Reason:  "Unschedulable",
+					Message: "0/1 nodes are available: 1 Insufficient cpu.",
+				},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "test-container",
+					Ready: true,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				},
+			},
+		},
+	}
+	podTests := []struct {
+		podCondition    corev1.PodCondition
+		containerStatus corev1.ContainerStatus
+		isReady         bool
+		expectedError   string
+	}{
+		{
+			podCondition: corev1.PodCondition{
+				Type:    corev1.PodScheduled,
+				Status:  corev1.ConditionFalse,
+				Reason:  "Unschedulable",
+				Message: "0/1 nodes are available: 1 Insufficient cpu.",
+			},
+			isReady:       false,
+			expectedError: "Pod test-pod in namespace test-namespace is not scheduled. Reason: Unschedulable, Message: 0/1 nodes are available: 1 Insufficient cpu.",
+		},
+		{
+			containerStatus: corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Reason:  "Error",
+						Message: "Container terminated due to an error",
+					},
+				},
+			},
+			isReady:       false,
+			expectedError: "Container state is 'Terminated' Reason: Error, Message: Container terminated due to an error",
+		},
+		{
+			containerStatus: corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "CrashLoopBackOff",
+						Message: "Back-off 5m0s restarting failed container=test-container pod=test-pod",
+					},
+				},
+			},
+			isReady:       false,
+			expectedError: "Container state is 'Waiting' Reason: CrashLoopBackOff, Message: Back-off 5m0s restarting failed container=test-container pod=test-pod",
+		},
+		{
+			containerStatus: corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{},
+				},
+				Ready: false,
+			},
+			isReady:       false,
+			expectedError: "",
+		},
+		{
+			containerStatus: corev1.ContainerStatus{
+				State: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{},
+				},
+				Ready: true,
+			},
+			isReady:       true,
+			expectedError: "",
+		},
+	}
+
+	ctx := context.Background()
+	handler := &kubernetesHandler{}
+	for _, tc := range podTests {
+		pod.Status.Conditions[0] = tc.podCondition
+		pod.Status.ContainerStatuses[0] = tc.containerStatus
+		isReady, err := handler.checkPodStatus(ctx, pod)
+		if tc.expectedError != "" {
+			require.Error(t, err)
+			require.Equal(t, tc.expectedError, err.Error())
+		} else {
+			require.NoError(t, err)
+		}
+		require.Equal(t, tc.isReady, isReady)
+	}
+}
+
+func TestPodEventHandler(t *testing.T) {
+	// Create a new mock client
+	fakeClient := fake.NewSimpleClientset()
+
+	// Create a new deployment with a replica set
+	deployment := &v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "default",
+		},
+		Spec: v1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "test",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test-container",
+							Image: "nginx",
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err := fakeClient.AppsV1().Deployments("default").Create(context.Background(), deployment, metav1.CreateOptions{})
+	require.NoError(t, err, "Failed to create deployment")
+
+	// Create a new replica set for the deployment
+	replicaSet := &v1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-replicaset",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app": "test",
+			},
+		},
+		Spec: v1.ReplicaSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "test",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test-container",
+							Image: "nginx",
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err = fakeClient.AppsV1().ReplicaSets("default").Create(context.Background(), replicaSet, metav1.CreateOptions{})
+	require.NoError(t, err, "Failed to create replica set")
+
+	// Create a new pod for the deployment
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app": "test",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "test-container",
+					Image: "nginx",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:    corev1.PodScheduled,
+					Status:  corev1.ConditionFalse,
+					Reason:  "Unschedulable",
+					Message: "0/1 nodes are available: 1 Insufficient cpu.",
+				},
+			},
+		},
+	}
+	_, err = fakeClient.CoreV1().Pods("default").Create(context.Background(), pod, metav1.CreateOptions{})
+	require.NoError(t, err, "Failed to create pod")
+
+	// Create a new handler with the mock client
+	handler := &kubernetesHandler{
+		clientSet: fakeClient,
+	}
+
+	// Call the pod event handler with the mock objects
+	doneCh := make(chan error)
+	go handler.podEventHandler(context.Background(), deployment, pod, doneCh)
+
+	// Wait for the handler to finish
+	err = <-doneCh
+	require.Error(t, err, "Pod event handler should have returned an error")
+}
+
+func TestDeploymentEventHandler(t *testing.T) {
+	// Create a new mock fakeClient
+	fakeClient := fake.NewSimpleClientset()
+
+	// Create a new deployment
+	deployment := &v1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deployment",
+			Namespace: "test-namespace",
+		},
+		Spec: v1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "test",
+				},
+			},
+		},
+		Status: v1.DeploymentStatus{
+			Conditions: []v1.DeploymentCondition{
+				{
+					Type:    v1.DeploymentProgressing,
+					Status:  corev1.ConditionTrue,
+					Reason:  "NewReplicaSetAvailable",
+					Message: "Deployment has minimum availability",
+				},
+			},
+		},
+	}
+
+	_, err := fakeClient.AppsV1().Deployments("test-namespace").Create(context.Background(), deployment, metav1.CreateOptions{})
+	require.NoError(t, err, "Error creating deployment")
+
+	addReplicaSetToDeployment(t, context.Background(), fakeClient, deployment)
+
+	// Create a new handler with the mock client
+	handler := &kubernetesHandler{
+		clientSet: fakeClient,
+	}
+
+	// Call the deployment event handler with the mock objects
+	doneCh := make(chan error)
+	go handler.deploymentEventHandler(context.Background(), deployment, deployment, doneCh)
+
+	// Wait for the handler to finish
+	err = <-doneCh
+	require.NoError(t, err, "Error handling deployment event")
 }

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
@@ -61,7 +61,6 @@ func NewCreateOrUpdateAWSResourceWithPost(opts armrpc_controller.Options, awsCli
 func (p *CreateOrUpdateAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
 	logger := ucplog.FromContextOrDiscard(ctx)
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
-	logger.Info("Trying to create or update resource", "resourceType", serviceCtx.ResourceTypeInAWSFormat(), "resourceID", serviceCtx.ResourceID)
 	region, errResponse := readRegionFromRequest(req.URL.Path, p.Options().PathBase)
 	if errResponse != nil {
 		return errResponse, nil

--- a/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
+++ b/pkg/ucp/frontend/controller/awsproxy/createorupdateawsresourcewithpost.go
@@ -61,6 +61,7 @@ func NewCreateOrUpdateAWSResourceWithPost(opts armrpc_controller.Options, awsCli
 func (p *CreateOrUpdateAWSResourceWithPost) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (armrpc_rest.Response, error) {
 	logger := ucplog.FromContextOrDiscard(ctx)
 	serviceCtx := servicecontext.AWSRequestContextFromContext(ctx)
+	logger.Info("Trying to create or update resource", "resourceType", serviceCtx.ResourceTypeInAWSFormat(), "resourceID", serviceCtx.ResourceID)
 	region, errResponse := readRegionFromRequest(req.URL.Path, p.Options().PathBase)
 	if errResponse != nil {
 		return errResponse, nil

--- a/test/functional/shared/mechanics/mechanics_test.go
+++ b/test/functional/shared/mechanics/mechanics_test.go
@@ -312,8 +312,8 @@ func Test_InvalidResourceIDs(t *testing.T) {
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
 			Executor: step.NewDeployErrorExecutor(template, v1.CodeInvalid, nil, functional.GetMagpieImage()),
-			CoreRPResources: &validation.CoreRPResourceSet{
-				Resources: []validation.CoreRPResource{
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{
 					{
 						Name: name,
 						Type: validation.ApplicationsResource,

--- a/test/functional/shared/mechanics/mechanics_test.go
+++ b/test/functional/shared/mechanics/mechanics_test.go
@@ -311,9 +311,9 @@ func Test_InvalidResourceIDs(t *testing.T) {
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployErrorExecutor(template, v1.CodeInvalid, functional.GetMagpieImage()),
-			RPResources: &validation.RPResourceSet{
-				Resources: []validation.RPResource{
+			Executor: step.NewDeployErrorExecutor(template, v1.CodeInvalid, nil, functional.GetMagpieImage()),
+			CoreRPResources: &validation.CoreRPResourceSet{
+				Resources: []validation.CoreRPResource{
 					{
 						Name: name,
 						Type: validation.ApplicationsResource,

--- a/test/functional/shared/resources/container_test.go
+++ b/test/functional/shared/resources/container_test.go
@@ -221,3 +221,59 @@ func Test_ContainerWithCommandAndArgs(t *testing.T) {
 
 	test.Test(t)
 }
+
+func Test_Container_FailDueToNonExistentImage(t *testing.T) {
+	template := "testdata/corerp-resources-container-nonexistent-container-image.bicep"
+	name := "corerp-resources-container-badimage"
+	appNamespace := "corerp-resources-container-badimage-app"
+	cliError := "Internal"
+	innerError := []string{"ErrImagePull", "ImagePullBackOff"}
+
+	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
+		{
+			Executor:                               step.NewDeployErrorExecutor(template, cliError, innerError, "magpieimage=non-existent-image"),
+			SkipKubernetesOutputResourceValidation: true,
+			SkipObjectValidation:                   true,
+			CoreRPResources: &validation.CoreRPResourceSet{
+				Resources: []validation.CoreRPResource{},
+			},
+			K8sObjects: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					appNamespace: {
+						validation.NewK8sPodForResource(name, "ctnr-cntr-badimage"),
+					},
+				},
+			},
+		},
+	})
+
+	test.Test(t)
+}
+
+func Test_Container_FailDueToBadHealthProbe(t *testing.T) {
+	template := "testdata/corerp-resources-container-bad-healthprobe.bicep"
+	name := "corerp-resources-container-bad-healthprobe"
+	appNamespace := "corerp-resources-container-bad-healthprobe-app"
+	cliError := "Internal"
+	innerError := []string{"CrashLoopBackOff"}
+
+	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
+		{
+			Executor:                               step.NewDeployErrorExecutor(template, cliError, innerError, functional.GetMagpieImage()),
+			SkipKubernetesOutputResourceValidation: true,
+			SkipObjectValidation:                   true,
+			CoreRPResources: &validation.CoreRPResourceSet{
+				Resources: []validation.CoreRPResource{},
+			},
+			K8sObjects: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					appNamespace: {
+						validation.NewK8sPodForResource(name, "ctnr-cntr-bad-healthprobe"),
+					},
+				},
+			},
+		},
+	})
+
+	test.Test(t)
+}

--- a/test/functional/shared/resources/container_test.go
+++ b/test/functional/shared/resources/container_test.go
@@ -229,13 +229,13 @@ func Test_Container_FailDueToNonExistentImage(t *testing.T) {
 	cliError := "Internal"
 	innerError := []string{"ErrImagePull", "ImagePullBackOff"}
 
-	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
+	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
 			Executor:                               step.NewDeployErrorExecutor(template, cliError, innerError, "magpieimage=non-existent-image"),
 			SkipKubernetesOutputResourceValidation: true,
 			SkipObjectValidation:                   true,
-			CoreRPResources: &validation.CoreRPResourceSet{
-				Resources: []validation.CoreRPResource{},
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{},
 			},
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
@@ -257,13 +257,13 @@ func Test_Container_FailDueToBadHealthProbe(t *testing.T) {
 	cliError := "Internal"
 	innerError := []string{"CrashLoopBackOff"}
 
-	test := corerp.NewCoreRPTest(t, name, []corerp.TestStep{
+	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
 			Executor:                               step.NewDeployErrorExecutor(template, cliError, innerError, functional.GetMagpieImage()),
 			SkipKubernetesOutputResourceValidation: true,
 			SkipObjectValidation:                   true,
-			CoreRPResources: &validation.CoreRPResourceSet{
-				Resources: []validation.CoreRPResource{},
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{},
 			},
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{

--- a/test/functional/shared/resources/dapr_component_name_conflict_test.go
+++ b/test/functional/shared/resources/dapr_component_name_conflict_test.go
@@ -31,9 +31,9 @@ func Test_DaprComponentNameConflict(t *testing.T) {
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployErrorExecutor(template, v1.CodeInternal),
-			RPResources: &validation.RPResourceSet{
-				Resources: []validation.RPResource{
+			Executor: step.NewDeployErrorExecutor(template, v1.CodeInternal, nil),
+			CoreRPResources: &validation.CoreRPResourceSet{
+				Resources: []validation.CoreRPResource{
 					{
 						Name: "corerp-resources-dapr-component-name-conflict",
 						Type: validation.ApplicationsResource,

--- a/test/functional/shared/resources/dapr_component_name_conflict_test.go
+++ b/test/functional/shared/resources/dapr_component_name_conflict_test.go
@@ -32,8 +32,8 @@ func Test_DaprComponentNameConflict(t *testing.T) {
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
 			Executor: step.NewDeployErrorExecutor(template, v1.CodeInternal, nil),
-			CoreRPResources: &validation.CoreRPResourceSet{
-				Resources: []validation.CoreRPResource{
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{
 					{
 						Name: "corerp-resources-dapr-component-name-conflict",
 						Type: validation.ApplicationsResource,

--- a/test/functional/shared/resources/testdata/corerp-resources-container-bad-healthprobe.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-container-bad-healthprobe.bicep
@@ -1,0 +1,60 @@
+
+import radius as radius
+
+@description('Specifies the location for resources.')
+param location string = 'global'
+
+@description('Specifies the image of the container resource.')
+param magpieimage string
+
+@description('Specifies the port of the container resource.')
+param port int = 5000
+
+@description('Specifies the environment for resources.')
+param environment string
+
+resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
+  name: 'corerp-resources-container-bad-healthprobe'
+  location: location
+  properties: {
+    environment: environment
+    extensions: [
+      {
+          kind: 'kubernetesNamespace'
+          namespace: 'corerp-resources-container-bad-healthprobe-app'
+      }
+    ]
+  }
+}
+
+resource container 'Applications.Core/containers@2022-03-15-privatepreview' = {
+  name: 'ctnr-bad-healthprobe'
+  location: location
+  properties: {
+      application: app.id
+      container: {
+        image: magpieimage
+        readinessProbe:{
+          kind: 'httpGet'
+          containerPort: 5000
+          path: '/bad'
+          failureThreshold:1
+          periodSeconds:1
+        }
+        livenessProbe:{
+          kind: 'httpGet'
+          containerPort: 5000
+          path: '/bad'
+          failureThreshold:1
+          periodSeconds:1
+        }
+        
+        ports: {
+          web: {
+            containerPort: port
+          }
+        }
+      }
+      connections: {}
+    }
+  }

--- a/test/functional/shared/resources/testdata/corerp-resources-container-nonexistent-container-image.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-container-nonexistent-container-image.bicep
@@ -1,0 +1,45 @@
+import radius as radius
+
+@description('Specifies the location for resources.')
+param location string = 'global'
+
+@description('Specifies the image of the container resource.')
+param magpieimage string
+
+@description('Specifies the port of the container resource.')
+param port int = 3000
+
+@description('Specifies the environment for resources.')
+param environment string
+
+resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
+  name: 'corerp-resources-container-badimage'
+  location: location
+  properties: {
+    environment: environment
+    extensions: [
+      {
+          kind: 'kubernetesNamespace'
+          namespace: 'corerp-resources-container-badimage-app'
+      }
+    ]
+  }
+}
+
+resource container 'Applications.Core/containers@2022-03-15-privatepreview' = {
+  name: 'ctnr-ctnr-badimage'
+  location: location
+  properties: {
+    application: app.id
+    container: {
+      image: magpieimage
+      ports: {
+        web: {
+          containerPort: port
+        }
+      }
+    }
+    connections: {}
+  }
+}
+

--- a/test/step/deployerrorexecutor.go
+++ b/test/step/deployerrorexecutor.go
@@ -33,22 +33,24 @@ import (
 var _ Executor = (*DeployErrorExecutor)(nil)
 
 type DeployErrorExecutor struct {
-	Description       string
-	Template          string
-	Parameters        []string
-	ExpectedErrorCode string
+	Description        string
+	Template           string
+	Parameters         []string
+	ExpectedErrorCode  string
+	ExpectedInnerError []string
 
 	// Application sets the `--application` command-line parameter. This is needed in cases where
 	// the application is not defined in bicep.
 	Application string
 }
 
-func NewDeployErrorExecutor(template string, errCode string, parameters ...string) *DeployErrorExecutor {
+func NewDeployErrorExecutor(template string, errCode string, innerError []string, parameters ...string) *DeployErrorExecutor {
 	return &DeployErrorExecutor{
-		Description:       fmt.Sprintf("deploy %s", template),
-		Template:          template,
-		Parameters:        parameters,
-		ExpectedErrorCode: errCode,
+		Description:        fmt.Sprintf("deploy %s", template),
+		Template:           template,
+		Parameters:         parameters,
+		ExpectedErrorCode:  errCode,
+		ExpectedInnerError: innerError,
 	}
 }
 
@@ -75,6 +77,10 @@ func (d *DeployErrorExecutor) Execute(ctx context.Context, t *testing.T, options
 	ok := errors.As(err, &cliErr)
 	require.True(t, ok)
 	require.Equal(t, d.ExpectedErrorCode, cliErr.GetFirstErrorCode())
+
+	if len(d.ExpectedInnerError) > 0 {
+		unpackErrorAndMatch(err, d.ExpectedInnerError)
+	}
 
 	t.Logf("finished deploying %s from file %s", d.Description, d.Template)
 }

--- a/test/step/deployexecutor.go
+++ b/test/step/deployexecutor.go
@@ -83,6 +83,6 @@ func (d *DeployExecutor) Execute(ctx context.Context, t *testing.T, options test
 	t.Logf("deploying %s from file %s", d.Description, d.Template)
 	cli := radcli.NewCLI(t, options.ConfigFilePath)
 	err = cli.Deploy(ctx, templateFilePath, d.Application, d.Parameters...)
-	require.NoError(t, err)
+	require.NoErrorf(t, err, "failed to deploy %s", d.Description)
 	t.Logf("finished deploying %s from file %s", d.Description, d.Template)
 }


### PR DESCRIPTION
# Description

_Please explain the changes you've made._

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5199aec</samp>

### Summary
🐳🚨🛠️

<!--
1.  🐳 - This emoji represents the container resource and the tests related to it. It also conveys the idea of deploying applications using containers.
2.  🚨 - This emoji represents the deployment errors and the feature to test the inner error details. It also conveys the idea of alerting the user about the deployment failures and the reasons behind them.
3.  🛠️ - This emoji represents the enhancements to the kubernetes handler and the rbac permissions. It also conveys the idea of fixing and improving the functionality and performance of the handler.
-->
This pull request improves the rp service account permissions, the kubernetes handler logic, and the deployment error testing in the radius project. It updates the `rbac.yaml` file, the `kubernetes.go` file, and the `deployerrorexecutor.go` and `deployexecutor.go` files. It also adds new test functions and bicep templates to verify the deployment error scenarios for container resources.

> _Some changes were made to the code_
> _To test how the container mode_
> _Would handle bad cases_
> _With `DeployErrorExecutor` traces_
> _And kubernetes handler reload_

### Walkthrough
*  Add and modify informers for deployment, pod and replicaset resources to check the status of container resources ([link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7R23), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7R63-R68), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L68-R80), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7R129), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L130-R142), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L137-R148), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L159-R505), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-13e38bac99402c4ae82609aaba31139f5f9f7c229d1bd955032255cb18f356c6R17), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-13e38bac99402c4ae82609aaba31139f5f9f7c229d1bd955032255cb18f356c6R55))
*  Add and modify tests for container resources that fail to deploy due to non-existent image or bad health probe ([link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-9442e1a784d8aba972917e5cfd69a85102d0b1393b88dc2be87e84a47c794970R224-R279), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-ef6234c9645603241e8c7805e06b2d4d605bac228a0d462547291a4eba674f98R1-R60), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-b3aeaac1a944b3d686d26ed0f0bb108b0766fed4a650c2b554d6e153c6c78863R1-R45), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-080ae4c3111a76dd50048a311bc3c6ec238797dc4e599b9d6f06146fe1f0774aL36-R40), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-080ae4c3111a76dd50048a311bc3c6ec238797dc4e599b9d6f06146fe1f0774aL46-R53), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-080ae4c3111a76dd50048a311bc3c6ec238797dc4e599b9d6f06146fe1f0774aR81-R84), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-0de37fc45fbf7b80897ad9629baddd6f12cfa407da847316e6296771a6b0d6e4R24), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-0de37fc45fbf7b80897ad9629baddd6f12cfa407da847316e6296771a6b0d6e4R62-R77))
*  Modify the DeployErrorExecutor type and function to accept and check the expected inner error of the deployment error ([link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-080ae4c3111a76dd50048a311bc3c6ec238797dc4e599b9d6f06146fe1f0774aL36-R40), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-080ae4c3111a76dd50048a311bc3c6ec238797dc4e599b9d6f06146fe1f0774aL46-R53), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-080ae4c3111a76dd50048a311bc3c6ec238797dc4e599b9d6f06146fe1f0774aR81-R84), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-0de37fc45fbf7b80897ad9629baddd6f12cfa407da847316e6296771a6b0d6e4R24), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-0de37fc45fbf7b80897ad9629baddd6f12cfa407da847316e6296771a6b0d6e4R62-R77))
*  Modify the existing tests that use the DeployErrorExecutor function to pass a nil parameter for the expected inner error ([link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-d38a59fddb3034eb8c0448c1fed4cabfdfc8f134dfb427656ad969ea6f647f9cL314-R314), [link](https://github.com/project-radius/radius/pull/5893/files?diff=unified&w=0#diff-c4523dc3ad460dc3baaaa98429900f8e43efdb6fce8ab40e8f368d82b79db387L34-R34))


