### PR TITLE
Fix for list recipes flakey unit test

### DIFF
--- a/pkg/cli/cmd/recipe/list/list.go
+++ b/pkg/cli/cmd/recipe/list/list.go
@@ -18,6 +18,7 @@ package list
 
 import (
 	"context"
+	"sort"
 
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
@@ -119,6 +120,9 @@ func (r *Runner) Run(ctx context.Context) error {
 			envRecipes = append(envRecipes, recipe)
 		}
 	}
+	sort.Slice(envRecipes, func(i, j int) bool {
+		return envRecipes[i].Name < envRecipes[j].Name
+	})
 	err = r.Output.WriteFormatted(r.Format, envRecipes, objectformats.GetEnvironmentRecipesTableFormat())
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/recipe/list/list_test.go
+++ b/pkg/cli/cmd/recipe/list/list_test.go
@@ -18,7 +18,6 @@ package list
 
 import (
 	"context"
-	"sort"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -141,15 +140,6 @@ func Test_Run(t *testing.T) {
 				Options: objectformats.GetEnvironmentRecipesTableFormat(),
 			},
 		}
-		exp := expected[0].(output.FormattedOutput).Obj.([]types.EnvironmentRecipe)
-		act := outputSink.Writes[0].(output.FormattedOutput).Obj.([]types.EnvironmentRecipe)
-
-		sort.Slice(exp, func(i, j int) bool {
-			return exp[i].Name < exp[j].Name
-		})
-		sort.Slice(act, func(i, j int) bool {
-			return act[i].Name < act[j].Name
-		})
-		require.Equal(t, exp, act)
+		require.Equal(t, expected, outputSink.Writes)
 	})
 }

--- a/pkg/cli/cmd/recipe/list/list_test.go
+++ b/pkg/cli/cmd/recipe/list/list_test.go
@@ -97,16 +97,6 @@ func Test_Run(t *testing.T) {
 							TemplatePath:    to.Ptr("Azure/cosmosdb/azurerm"),
 							TemplateVersion: to.Ptr("1.1.0"),
 						},
-						"cosmosDB-terraform1": {
-							TemplateKind:    to.Ptr(recipes.TemplateKindTerraform),
-							TemplatePath:    to.Ptr("Azure/cosmosdb/azurerm"),
-							TemplateVersion: to.Ptr("1.1.0"),
-						},
-						"cosmosDB-terraform2": {
-							TemplateKind:    to.Ptr(recipes.TemplateKindTerraform),
-							TemplatePath:    to.Ptr("Azure/cosmosdb/azurerm"),
-							TemplateVersion: to.Ptr("1.1.0"),
-						},
 					},
 				},
 			},
@@ -120,20 +110,6 @@ func Test_Run(t *testing.T) {
 			},
 			{
 				Name:            "cosmosDB-terraform",
-				LinkType:        linkrp.MongoDatabasesResourceType,
-				TemplateKind:    recipes.TemplateKindTerraform,
-				TemplatePath:    "Azure/cosmosdb/azurerm",
-				TemplateVersion: "1.1.0",
-			},
-			{
-				Name:            "cosmosDB-terraform1",
-				LinkType:        linkrp.MongoDatabasesResourceType,
-				TemplateKind:    recipes.TemplateKindTerraform,
-				TemplatePath:    "Azure/cosmosdb/azurerm",
-				TemplateVersion: "1.1.0",
-			},
-			{
-				Name:            "cosmosDB-terraform2",
 				LinkType:        linkrp.MongoDatabasesResourceType,
 				TemplateKind:    recipes.TemplateKindTerraform,
 				TemplatePath:    "Azure/cosmosdb/azurerm",

--- a/pkg/cli/cmd/recipe/list/list_test.go
+++ b/pkg/cli/cmd/recipe/list/list_test.go
@@ -18,6 +18,7 @@ package list
 
 import (
 	"context"
+	"sort"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -96,6 +97,16 @@ func Test_Run(t *testing.T) {
 							TemplatePath:    to.Ptr("Azure/cosmosdb/azurerm"),
 							TemplateVersion: to.Ptr("1.1.0"),
 						},
+						"cosmosDB-terraform1": {
+							TemplateKind:    to.Ptr(recipes.TemplateKindTerraform),
+							TemplatePath:    to.Ptr("Azure/cosmosdb/azurerm"),
+							TemplateVersion: to.Ptr("1.1.0"),
+						},
+						"cosmosDB-terraform2": {
+							TemplateKind:    to.Ptr(recipes.TemplateKindTerraform),
+							TemplatePath:    to.Ptr("Azure/cosmosdb/azurerm"),
+							TemplateVersion: to.Ptr("1.1.0"),
+						},
 					},
 				},
 			},
@@ -109,6 +120,20 @@ func Test_Run(t *testing.T) {
 			},
 			{
 				Name:            "cosmosDB-terraform",
+				LinkType:        linkrp.MongoDatabasesResourceType,
+				TemplateKind:    recipes.TemplateKindTerraform,
+				TemplatePath:    "Azure/cosmosdb/azurerm",
+				TemplateVersion: "1.1.0",
+			},
+			{
+				Name:            "cosmosDB-terraform1",
+				LinkType:        linkrp.MongoDatabasesResourceType,
+				TemplateKind:    recipes.TemplateKindTerraform,
+				TemplatePath:    "Azure/cosmosdb/azurerm",
+				TemplateVersion: "1.1.0",
+			},
+			{
+				Name:            "cosmosDB-terraform2",
 				LinkType:        linkrp.MongoDatabasesResourceType,
 				TemplateKind:    recipes.TemplateKindTerraform,
 				TemplatePath:    "Azure/cosmosdb/azurerm",
@@ -140,6 +165,15 @@ func Test_Run(t *testing.T) {
 				Options: objectformats.GetEnvironmentRecipesTableFormat(),
 			},
 		}
-		require.Equal(t, expected, outputSink.Writes)
+		exp := expected[0].(output.FormattedOutput).Obj.([]types.EnvironmentRecipe)
+		act := outputSink.Writes[0].(output.FormattedOutput).Obj.([]types.EnvironmentRecipe)
+
+		sort.Slice(exp, func(i, j int) bool {
+			return exp[i].Name < exp[j].Name
+		})
+		sort.Slice(act, func(i, j int) bool {
+			return act[i].Name < act[j].Name
+		})
+		require.Equal(t, exp, act)
 	})
 }


### PR DESCRIPTION
# Description

List recipes unit test is failing intermittently as the output list of recipes in expected is not in the same order as the list of recipes in actual object. Added changes to sort both the array before compare the objects/

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ca33c69</samp>

### Summary
🧪📝🔀

<!--
1.  🧪 - This emoji represents testing, which is the main focus of the changes. It can be used to indicate that new test cases or logic were added or modified to improve the quality and coverage of the code.
2.  📝 - This emoji represents documentation, which is another aspect of the changes. It can be used to indicate that comments or other forms of documentation were added or updated to explain the code or the test cases.
3.  🔀 - This emoji represents sorting, which is a specific functionality that was imported and used in the changes. It can be used to indicate that the order or arrangement of data or elements was manipulated or affected by the code.
-->
Improved test coverage and robustness of `list` command for recipes with duplicate template paths and versions. Added `sort` package to `list_test.go`.

> _To test recipes with the same path_
> _We need some new logic and math_
> _We import `sort` to compare_
> _The slices that we prepare_
> _And check if they match what we hath_

### Walkthrough
* Import `sort` package to enable sorting of slices in test assertions ([link](https://github.com/project-radius/radius/pull/5894/files?diff=unified&w=0#diff-455cce87d0a66ee8bd33b2e8549200653478b7e582745b3976b77200d45aed91R21))
* Add two mock recipes with the same template path and version to simulate multiple recipes scenario ([link](https://github.com/project-radius/radius/pull/5894/files?diff=unified&w=0#diff-455cce87d0a66ee8bd33b2e8549200653478b7e582745b3976b77200d45aed91R100-R109))
* Add two expected output objects to match the mock recipes in the test case ([link](https://github.com/project-radius/radius/pull/5894/files?diff=unified&w=0#diff-455cce87d0a66ee8bd33b2e8549200653478b7e582745b3976b77200d45aed91R128-R141))
* Modify test assertion to sort expected and actual output slices by name before comparing them ([link](https://github.com/project-radius/radius/pull/5894/files?diff=unified&w=0#diff-455cce87d0a66ee8bd33b2e8549200653478b7e582745b3976b77200d45aed91L143-R177))


