### PR TITLE
Correction in docs URL

### DIFF
--- a/docs/contributing/contributing-releases/README.md
+++ b/docs/contributing/contributing-releases/README.md
@@ -142,7 +142,7 @@ If sample validation passes, we can start the process of creating the final rele
    
    1. Create a new branch named `v0.21` from `edge`, substituting the new version number
    1. Within `docs/config.toml`:
-      - Change `baseURL` to `https://radapp.dev/` instead of `https://edge.radapp.dev/`
+      - Change `baseURL` to `https://docs.radapp.dev/` instead of `https://edge.radapp.dev/`
       - Change `version` to `v0.21` instead of `edge`, substituting the new version number
       - Change `chart_version` (Helm chart) to `0.21.0`, substituting the new version number
    1. Within `docs/layouts/partials/hooks/body-end.html`:


### PR DESCRIPTION

# Description

Correction in url update for docs repo found during release v0.23

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a10a128</samp>

### Summary
📝🌐🐛

<!--
1.  📝 - This emoji represents documentation or writing, and can be used for any changes that update or improve the documentation site or the guides.
2.  🌐 - This emoji represents the web or the internet, and can be used for any changes that affect the website or its configuration, such as changing the domain name or adding new features.
3.  🐛 - This emoji represents a bug or a fix, and can be used for any changes that correct a mistake or resolve an issue, such as fixing a typo or a broken link.
-->
This pull request improves the documentation site for project-radius by adjusting the `baseURL` and fixing a typo in the `contributing-releases/README.md` guide.

> _We are the ones who document the code_
> _We fix the typos and the `baseURL` mode_
> _We guide the contributors to release their work_
> _We write the `README.md` with a metal smirk_

### Walkthrough
* Updated the documentation site's domain name to `docs.radapp.dev` in the `baseURL` setting of `docs/config.toml` ([link](https://github.com/project-radius/radius/pull/5905/files?diff=unified&w=0#diff-4b032acb8e706dca3cf78512aadf53ee8b05354e51cd46023ed550c0625b33fbL145-R145))
* Fixed a typo in `docs/contributing/contributing-releases/README.md`, changing "through" to "thorough" ([link](https://github.com/project-radius/radius/pull/5905/files?diff=unified&w=0#diff-4b032acb8e706dca3cf78512aadf53ee8b05354e51cd46023ed550c0625b33fbL263-R263))


