### PR TITLE
Add 'rad app connections' command

### DIFF
--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -30,6 +30,7 @@ import (
 	"github.com/project-radius/radius/pkg/cli/bicep"
 	"github.com/project-radius/radius/pkg/cli/clierrors"
 	app_switch "github.com/project-radius/radius/pkg/cli/cmd/app/appswitch"
+	app_connections "github.com/project-radius/radius/pkg/cli/cmd/app/connections"
 	app_delete "github.com/project-radius/radius/pkg/cli/cmd/app/delete"
 	app_list "github.com/project-radius/radius/pkg/cli/cmd/app/list"
 	app_show "github.com/project-radius/radius/pkg/cli/cmd/app/show"
@@ -271,6 +272,9 @@ func initSubCommands() {
 
 	appSwitchCmd, _ := app_switch.NewCommand(framework)
 	applicationCmd.AddCommand(appSwitchCmd)
+
+	appConnectionsCmd, _ := app_connections.NewCommand(framework)
+	applicationCmd.AddCommand(appConnectionsCmd)
 
 	envSwitchCmd, _ := env_switch.NewCommand(framework)
 	envCmd.AddCommand(envSwitchCmd)

--- a/pkg/cli/cmd/app/connections/compute.go
+++ b/pkg/cli/cmd/app/connections/compute.go
@@ -1,0 +1,380 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connections
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/go-openapi/jsonpointer"
+	"github.com/project-radius/radius/pkg/cli/clients_new/generated"
+	"github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
+	"github.com/project-radius/radius/pkg/resourcemodel"
+	"github.com/project-radius/radius/pkg/ucp/resources"
+)
+
+// compute constructs an application graph from the given application and environment resources.
+//
+// This function does not return errors and will ignore missing or corrupted data. It is expected that the caller
+// will display the results to a human user, so rather than failing to compute the graph, we will return partial
+// results with annotations for errors.
+//
+// NOTE: this code DOES NOT yet process connections involving HTTP routes.
+func compute(applicationName string, applicationResources []generated.GenericResource, environmentResources []generated.GenericResource) *applicationGraph {
+	// The first step is to figure out what resources are part of the application.
+	//
+	// Since Radius has both application-scoped and environment-scoped resources we need to merge the two lists
+	// and take care to annotate each resource with whether it's part of the application or not. Any application-scoped
+	// resource will be part of the application, so we also filter duplicates.
+	//
+	// We produce two data-structures:
+	// - resources (all "known" resources) using the API wire format
+	// - resourcesByIDInApplication (a map of resource ID to whether the resource is part of the application).
+	//
+	// This allows us to reason about three sets of resources:
+	// - Resources that belong to the application: resourcesByIDInApplication[id] == true
+	// - Resources that are "known" but don't belong to the application: resourcesByIDInApplication[id] == false
+	// - Resources that "external":  ok, _ := resourcesByIDInApplication[id]; !ok (not in the map)
+	resources := []generated.GenericResource{}
+	resourcesByIDInApplication := map[string]bool{}
+
+	for _, resource := range applicationResources {
+		resources = append(resources, resource)
+
+		// Application-scoped resources are by definition "in" the application
+		resourcesByIDInApplication[*resource.ID] = true
+	}
+
+	for _, resource := range environmentResources {
+		_, found := resourcesByIDInApplication[*resource.ID]
+		if found {
+			// Appears in both application and environment lists, avoid duplicates.
+			continue
+		}
+
+		// This is an environment-scoped resource. We need to process the connections
+		// to determine if it's part of the application.
+		resources = append(resources, resource)
+		resourcesByIDInApplication[*resource.ID] = false
+	}
+
+	// Next we need to process each entry in the resources list and build up the application graph.
+	resourceEntriesByID := map[string]resourceEntry{}
+	for _, resource := range resources {
+		entry := resourceEntryFromID(*resource.ID)
+		entry.Connections = connectionsFromAPIData(resource)
+		entry.Resources = outputResourcesFromAPIData(resource)
+
+		resourceEntriesByID[*resource.ID] = entry
+	}
+
+	// Now we've massaged the data into a format we like, but we still don't have a comprehensive list
+	// of everything in the application. There are two categories we need to address:
+	//
+	// - Cloud resources that are referenced by an application-scoped resource (recursively).
+	// - Environment-scoped resources referenced by an application-scoped resource (recursively).
+	//
+	// To do this we'll do a breadth first search of the graph starting with the application-scoped resources. We can
+	// use `resourcesByIDInApplication` to track the nodes we have already visited and prevent duplicates. It's important
+	// to note that a resource never transitions from being "in" the application to being "out", so we only need to visit
+	// each node once.
+	//
+	// Since we're exploring a graph, we're using a "queue" to process resources in a breadth-first manner.
+	queue := []string{}
+
+	// While we do this we'll also build up a bi-directional adjency map of connections so we can resolve in-bound
+	// connections.
+	connectionsBySource := map[string][]connectionEntry{}
+	connectionsByDestination := map[string][]connectionEntry{}
+
+	// First process add resources we *know* are in the application to the queue. As we explore the graph we'll
+	// visit resources outside the application if necessary.
+	for _, entry := range resourceEntriesByID {
+		if resourcesByIDInApplication[entry.ID] {
+			queue = append(queue, entry.ID)
+		}
+	}
+
+	for len(queue) > 0 {
+		// Pop!
+		id := queue[0]
+		queue = queue[1:]
+		entry := resourceEntriesByID[id]
+
+		for _, connection := range entry.Connections {
+			destination := connection.To
+
+			// If the connection has an error, we don't need to process it further.
+			if destination.Error != "" {
+				continue
+			}
+
+			// For each connection let's make sure the destination is also part of the application graph. This handles
+			// The two cases mentioned above.
+			inApplication, found := resourcesByIDInApplication[destination.ID]
+			if !found {
+				// Case 1) This is a cloud resource that is referenced by an application-scoped resource.
+				//
+				// Add it to the queue for processing, and include it in the application.
+				//
+				// Since this is a cloud resource we need to create a new entry in 'resourceEntriesByID'.
+				queue = append(queue, destination.ID)
+				resourceEntriesByID[destination.ID] = resourceEntryFromID(destination.ID)
+				resourcesByIDInApplication[destination.ID] = true
+
+			}
+			if !inApplication {
+				// Case 2) This is an environment-scoped resource that is referenced by an application-scoped resource.
+				//
+				// Add it to the queue for processing, and include it in the application.
+				//
+				// This resource may have connections to other resources, since we are adding it to the queue, that guarantees
+				// it will also have its connections processed.
+				//
+				// Since this is an environment-scoped resource it should already have an entry in 'resourceEntriesByID'.
+				queue = append(queue, destination.ID)
+				resourcesByIDInApplication[destination.ID] = true
+			}
+
+			// Note the connection in both directions.
+			connectionsBySource[connection.From.ID] = append(connectionsBySource[connection.From.ID], connection)
+			connectionsByDestination[connection.To.ID] = append(connectionsByDestination[connection.To.ID], connection)
+		}
+	}
+
+	// Now we know *fully* the set of resources in the application. We can build the final graph.
+	graph := applicationGraph{ApplicationName: applicationName, Resources: map[string]resourceEntry{}}
+	for id, inApplication := range resourcesByIDInApplication {
+		if !inApplication {
+			continue // Not in application, skip
+		}
+
+		// We have one job left to do, which is to update the inbound connections. The outbound connections
+		// were already done.
+		entry := resourceEntriesByID[id]
+		connectionsIn := connectionsByDestination[id]
+		entry.Connections = append(entry.Connections, connectionsIn...)
+
+		// Print connections in stable order.
+		sort.Slice(entry.Connections, func(i, j int) bool {
+			// Connections are guaranteed to have a name.
+			return entry.Connections[i].Name < entry.Connections[j].Name
+		})
+
+		graph.Resources[id] = entry
+	}
+
+	return &graph
+}
+
+// nodeFromID creates a node from a resource ID.
+func nodeFromID(id string) node {
+	parsed, err := resources.ParseResource(id)
+	if err != nil {
+		return node{Error: err.Error()}
+	}
+
+	return node{
+		ID:   id,
+		Name: parsed.Name(),
+		Type: parsed.Type(),
+	}
+}
+
+// resourceEntryFromID creates a resourceEntry from a resource ID.
+func resourceEntryFromID(id string) resourceEntry {
+	return resourceEntry{node: nodeFromID(id)}
+}
+
+// outputResourceEntryFromID creates a outputResourceEntry from a resource ID.
+func outputResourceEntryFromID(id string) outputResourceEntry {
+	return outputResourceEntry{node: nodeFromID(id)}
+}
+
+// outputResourcesFromAPIData processes the generic resource representation returned by the Radius API
+// and produces a list of output resources.
+func outputResourcesFromAPIData(resource generated.GenericResource) []outputResourceEntry {
+	// We need to access the output resources in a weakly-typed way since the data type we're
+	// working with is a property bag.
+	//
+	// Any Radius resource type that supports output resources uses the following property path to return them.
+	p, err := jsonpointer.New("/properties/status/outputResources")
+	if err != nil {
+		// This should never fail since we're hard-coding the path.
+		panic("parsing JSON pointer should not fail: " + err.Error())
+	}
+
+	raw, _, err := p.Get(&resource)
+	if err != nil {
+		// Not found, this is fine.
+		return []outputResourceEntry{}
+	}
+
+	ors, ok := raw.([]any)
+	if !ok {
+		// Not an array, this is fine.
+		return []outputResourceEntry{}
+	}
+
+	// The data is returned as an array of JSON objects. We need to convert each object from a map[string]any
+	// to the strongly-typed format we understand.
+	//
+	// If we enounter an error processing this data, just and an "invalid" output resource entry.
+	entries := []outputResourceEntry{}
+	for _, or := range ors {
+		// This is the wire format returned by the API for an output resource.
+		type outputResourceWireFormat struct {
+			Identity map[string]string `json:"Identity"`
+			LocalID  string            `json:"LocalID"`
+			Provider string            `json:"Provider"`
+		}
+
+		data := outputResourceWireFormat{}
+		err = toStronglyTypedData(or, &data)
+		if err != nil {
+			entries = append(entries, outputResourceEntry{node: node{Error: err.Error()}})
+			continue
+		}
+
+		// Now build the entry from the API data
+		entry := outputResourceEntry{}
+		switch data.Provider {
+		case resourcemodel.ProviderAzure:
+			fallthrough
+		case resourcemodel.ProviderAWS:
+			entry = outputResourceEntryFromID(data.Identity["id"])
+			entry.Provider = data.Provider
+
+		case resourcemodel.ProviderKubernetes:
+			resourceType := data.Identity["kind"]
+			group, _, found := strings.Cut(data.Identity["apiVersion"], "/")
+			if found && group != "" {
+				resourceType = fmt.Sprintf("%s/%s", group, data.Identity["kind"])
+			}
+
+			// NOTE: we don't have a resource ID for a Kubernetes resource (yet).
+			entry.ID = ""
+			entry.Name = data.Identity["name"]
+			entry.Type = resourceType
+			entry.Provider = data.Provider
+
+		default:
+			entry = outputResourceEntry{node: node{Error: fmt.Sprintf("unknown provider '%s'", data.Provider)}}
+		}
+
+		entries = append(entries, entry)
+	}
+
+	// Produce a stable output
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Provider != entries[j].Provider {
+			return entries[i].Provider < entries[j].Provider
+		}
+		if entries[i].Type != entries[j].Type {
+			return entries[i].Type < entries[j].Type
+		}
+		if entries[i].Name != entries[j].Name {
+			return entries[i].Name < entries[j].Name
+		}
+		if entries[i].ID != entries[j].ID {
+			return entries[i].ID < entries[j].ID
+		}
+
+		return entries[i].Error < entries[j].Error
+	})
+
+	return entries
+}
+
+// connectionsFromAPIData resolves the outbound connections for a resource from the generic resource representation.
+// For example if the resource is an 'Applications.Core/container' then this function can find it's connections
+// to other resources like databases. Conversely if the resource is a database then this function
+// will not find any connections (because they are inbound). Inbound connections are processed later.
+func connectionsFromAPIData(resource generated.GenericResource) []connectionEntry {
+	// We need to access the connections in a weakly-typed way since the data type we're
+	// working with is a property bag.
+	//
+	// Any Radius resource type that supports connections uses the following property path to return them.
+	p, err := jsonpointer.New("/properties/connections")
+	if err != nil {
+		// This should never fail since we're hard-coding the path.
+		panic("parsing JSON pointer should not fail: " + err.Error())
+	}
+
+	raw, _, err := p.Get(&resource)
+	if err != nil {
+		// Not found, this is fine.
+		return []connectionEntry{}
+	}
+
+	connections, ok := raw.(map[string]any)
+	if !ok {
+		// Not a map of objects, this is fine.
+		return []connectionEntry{}
+	}
+
+	// The data is returned as a map of JSON objects. We need to convert each object from a map[string]any
+	// to the strongly-typed format we understand.
+	//
+	// If we encounter an error processing this data, just and an "invalid" connection entry.
+	entries := []connectionEntry{}
+	for name, connection := range connections {
+
+		data := v20220315privatepreview.ConnectionProperties{}
+		err := toStronglyTypedData(connection, &data)
+		if err != nil {
+			entries = append(entries, connectionEntry{
+				Name: name,
+				From: nodeFromID(*resource.ID),
+				To:   node{Error: err.Error()},
+			})
+			continue
+		}
+
+		entries = append(entries, connectionEntry{
+			Name: name,
+			From: nodeFromID(*resource.ID),
+			To:   nodeFromID(*data.Source),
+		})
+	}
+
+	// Produce a stable output
+	sort.Slice(entries, func(i, j int) bool {
+		// Connections are guaranteed to have a name.
+		return entries[i].Name < entries[j].Name
+	})
+
+	return entries
+}
+
+// toStronglyTypedData uses JSON marshalling and unmarshalling to convert a weakly-typed
+// representation to a strongly-typed one.
+func toStronglyTypedData(data any, result any) error {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(b, result)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cli/cmd/app/connections/compute_test.go
+++ b/pkg/cli/cmd/app/connections/compute_test.go
@@ -1,0 +1,459 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connections
+
+import (
+	"testing"
+
+	"github.com/project-radius/radius/pkg/cli/clients_new/generated"
+	"github.com/project-radius/radius/pkg/to"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_compute(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		applicationResources := []generated.GenericResource{}
+		environmentResources := []generated.GenericResource{}
+
+		actual := compute("test-app", applicationResources, environmentResources)
+
+		expected := &applicationGraph{"test-app", map[string]resourceEntry{}}
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("no application resources", func(t *testing.T) {
+		applicationResources := []generated.GenericResource{}
+		environmentResources := []generated.GenericResource{
+			{
+				ID:         to.Ptr(redisResourceID),
+				Properties: makeResourceProperties(nil, []any{redisAWSOutputResource}),
+			},
+		}
+
+		actual := compute("test-app", applicationResources, environmentResources)
+
+		expected := &applicationGraph{"test-app", map[string]resourceEntry{}}
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("no connections", func(t *testing.T) {
+		applicationResources := []generated.GenericResource{
+			{
+				ID:         to.Ptr(containerResourceID),
+				Properties: makeResourceProperties(nil, []any{containerDeploymentOutputResource}),
+			},
+		}
+		environmentResources := []generated.GenericResource{
+			{
+				ID:         to.Ptr(redisResourceID),
+				Properties: makeResourceProperties(nil, []any{redisAWSOutputResource}),
+			},
+		}
+		// Application resources are also part of the environment.
+		environmentResources = append(environmentResources, applicationResources...)
+
+		actual := compute("test-app", applicationResources, environmentResources)
+
+		expected := &applicationGraph{"test-app", map[string]resourceEntry{
+			containerResourceID: {
+				node:        nodeFromID(containerResourceID),
+				Connections: []connectionEntry{},
+				Resources: []outputResourceEntry{
+					{
+						node: node{
+							Name: "demo",
+							Type: "apps/Deployment",
+						},
+						Provider: "kubernetes",
+					},
+				},
+			},
+		}}
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("connections to multiple", func(t *testing.T) {
+		applicationResources := []generated.GenericResource{
+			{
+				ID: to.Ptr(containerResourceID),
+				Properties: makeResourceProperties(
+					map[string]string{
+						"A": makeRedisResourceID("a"),
+						"B": makeRedisResourceID("b"),
+						"C": azureRedisCacheResourceID, // Direct connection to cloud resource
+						"D": "asdf-invalid-YO",         // Invalid connection
+					},
+					[]any{containerDeploymentOutputResource}),
+			},
+			{
+				ID:         to.Ptr(makeRedisResourceID("a")),
+				Properties: makeResourceProperties(nil, []any{redisAzureOutputResource}),
+			},
+		}
+		environmentResources := []generated.GenericResource{
+			{
+				ID:         to.Ptr(makeRedisResourceID("b")),
+				Properties: makeResourceProperties(nil, []any{redisAWSOutputResource}),
+			},
+		}
+		// Application resources are also part of the environment.
+		environmentResources = append(environmentResources, applicationResources...)
+
+		actual := compute("test-app", applicationResources, environmentResources)
+
+		expected := &applicationGraph{
+			ApplicationName: "test-app",
+			Resources: map[string]resourceEntry{
+				containerResourceID: {
+					node: nodeFromID(containerResourceID),
+					Connections: []connectionEntry{
+						{
+							Name: "A",
+							From: nodeFromID(containerResourceID),
+							To:   nodeFromID(makeRedisResourceID("a")),
+						},
+						{
+							Name: "B",
+							From: nodeFromID(containerResourceID),
+							To:   nodeFromID(makeRedisResourceID("b")),
+						},
+						{
+							Name: "C",
+							From: nodeFromID(containerResourceID),
+							To:   nodeFromID(azureRedisCacheResourceID),
+						},
+						{
+							Name: "D",
+							From: nodeFromID(containerResourceID),
+							To:   nodeFromID("asdf-invalid-YO"),
+						},
+					},
+					Resources: []outputResourceEntry{
+						{
+							node: node{
+								Name: "demo",
+								Type: "apps/Deployment",
+							},
+							Provider: "kubernetes",
+						},
+					},
+				},
+				makeRedisResourceID("a"): {
+					node: nodeFromID(makeRedisResourceID("a")),
+					Connections: []connectionEntry{
+						{
+							Name: "A",
+							From: nodeFromID(containerResourceID),
+							To:   nodeFromID(makeRedisResourceID("a")),
+						},
+					},
+					Resources: []outputResourceEntry{
+						{
+							node:     nodeFromID(azureRedisCacheResourceID),
+							Provider: "azure",
+						},
+					},
+				},
+				makeRedisResourceID("b"): {
+					node: nodeFromID(makeRedisResourceID("b")),
+					Connections: []connectionEntry{
+						{
+							Name: "B",
+							From: nodeFromID(containerResourceID),
+							To:   nodeFromID(makeRedisResourceID("b")),
+						},
+					},
+					Resources: []outputResourceEntry{
+						{
+							node:     nodeFromID(awsMemoryDBResourceID),
+							Provider: "aws",
+						},
+					},
+				},
+				azureRedisCacheResourceID: {
+					node: nodeFromID(azureRedisCacheResourceID),
+					Connections: []connectionEntry{
+						{
+							Name: "C",
+							From: nodeFromID(containerResourceID),
+							To:   nodeFromID(azureRedisCacheResourceID),
+						},
+					},
+				},
+			},
+		}
+		require.Equal(t, expected, actual)
+	})
+}
+
+func Test_nodeFromID(t *testing.T) {
+	t.Run("parse valid resource ID", func(t *testing.T) {
+		node := nodeFromID(applicationResourceID)
+		require.Equal(t, applicationResourceID, node.ID)
+		require.Equal(t, "test-app", node.Name)
+		require.Equal(t, "Applications.Core/applications", node.Type)
+		require.Equal(t, "", node.Error)
+	})
+
+	t.Run("parse invalid resource ID", func(t *testing.T) {
+		node := nodeFromID("\ndkdkfkdfs\t")
+		require.Equal(t, "", node.ID)
+		require.Equal(t, "", node.Name)
+		require.Equal(t, "", node.Type)
+		require.Equal(t, "'\ndkdkfkdfs\t' is not a valid resource id", node.Error)
+	})
+}
+
+func Test_outputResourcesFromAPIData(t *testing.T) {
+	t.Run("parse valid output resources", func(t *testing.T) {
+		outputResources := []any{
+			redisAWSOutputResource,
+			redisAzureOutputResource,
+			containerDeploymentOutputResource,
+		}
+		resource := generated.GenericResource{
+			ID:         to.Ptr(containerResourceID),
+			Properties: makeResourceProperties(nil, outputResources),
+		}
+
+		// Output is always sorted.
+		expected := []outputResourceEntry{
+			{
+				node:     nodeFromID(awsMemoryDBResourceID),
+				Provider: "aws",
+			},
+			{
+				node:     nodeFromID(azureRedisCacheResourceID),
+				Provider: "azure",
+			},
+			// Kubernetes resources don't currently a resource ID.
+			{
+				node: node{
+					Name: "demo",
+					Type: "apps/Deployment",
+				},
+				Provider: "kubernetes",
+			},
+		}
+
+		actual := outputResourcesFromAPIData(resource)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("parse invalid output resources", func(t *testing.T) {
+		// An invalid output resource doesn't prevent other output resources from being parsed.
+		outputResources := []any{
+			redisAWSOutputResource,
+			makeAzureOutputResource("asdf-invalid-YO"),
+			containerDeploymentOutputResource,
+		}
+		resource := generated.GenericResource{
+			ID:         to.Ptr(containerResourceID),
+			Properties: makeResourceProperties(nil, outputResources),
+		}
+
+		// Output is always sorted.
+		expected := []outputResourceEntry{
+			{
+				node:     nodeFromID(awsMemoryDBResourceID),
+				Provider: "aws",
+			},
+			{
+				node:     nodeFromID("asdf-invalid-YO"),
+				Provider: "azure",
+			},
+			// Kubernetes resources don't currently a resource ID.
+			{
+				node: node{
+					Name: "demo",
+					Type: "apps/Deployment",
+				},
+				Provider: "kubernetes",
+			},
+		}
+
+		actual := outputResourcesFromAPIData(resource)
+		require.Equal(t, expected, actual)
+		require.Equal(t, "'asdf-invalid-YO' is not a valid resource id", actual[1].Error)
+	})
+
+	t.Run("parse invalid output resource provider", func(t *testing.T) {
+		outputResources := []any{
+			map[string]any{
+				"provider": "no idea",
+			},
+		}
+		resource := generated.GenericResource{
+			ID:         to.Ptr(containerResourceID),
+			Properties: makeResourceProperties(nil, outputResources),
+		}
+
+		// Output is always sorted.
+		expected := []outputResourceEntry{
+			{
+				node: node{
+					Error: "unknown provider 'no idea'",
+				},
+			},
+		}
+
+		actual := outputResourcesFromAPIData(resource)
+		require.Equal(t, expected, actual)
+		require.Equal(t, "unknown provider 'no idea'", actual[0].Error)
+	})
+
+	t.Run("no status", func(t *testing.T) {
+		resource := generated.GenericResource{
+			ID:         to.Ptr(containerResourceID),
+			Properties: map[string]any{},
+		}
+
+		expected := []outputResourceEntry{}
+
+		actual := outputResourcesFromAPIData(resource)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("no output resources", func(t *testing.T) {
+		outputResources := []any{}
+		resource := generated.GenericResource{
+			ID: to.Ptr(containerResourceID),
+			Properties: map[string]any{
+				"status": map[string]any{
+					"outputResources": outputResources,
+				},
+			},
+		}
+
+		expected := []outputResourceEntry{}
+
+		actual := outputResourcesFromAPIData(resource)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("non-array output resources", func(t *testing.T) {
+		resource := generated.GenericResource{
+			ID: to.Ptr(containerResourceID),
+			Properties: map[string]any{
+				"status": map[string]any{
+					"outputResources": "hey there, this is not an array",
+				},
+			},
+		}
+
+		expected := []outputResourceEntry{}
+
+		actual := outputResourcesFromAPIData(resource)
+		require.Equal(t, expected, actual)
+	})
+}
+
+func Test_connectionsFromAPIData(t *testing.T) {
+	t.Run("parse valid connections", func(t *testing.T) {
+		connections := map[string]string{
+			"A": makeRedisResourceID("a"),
+			"B": makeRedisResourceID("b"),
+			"C": makeRedisResourceID("c"),
+		}
+		resource := generated.GenericResource{
+			ID:         to.Ptr(containerResourceID),
+			Properties: makeResourceProperties(connections, nil),
+		}
+
+		// Output is always sorted.
+		expected := []connectionEntry{
+			{
+				Name: "A",
+				From: nodeFromID(containerResourceID),
+				To:   nodeFromID(makeRedisResourceID("a")),
+			},
+			{
+				Name: "B",
+				From: nodeFromID(containerResourceID),
+				To:   nodeFromID(makeRedisResourceID("b")),
+			},
+			{
+				Name: "C",
+				From: nodeFromID(containerResourceID),
+				To:   nodeFromID(makeRedisResourceID("c")),
+			},
+		}
+
+		actual := connectionsFromAPIData(resource)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("parse invalid connections", func(t *testing.T) {
+		connections := map[string]string{
+			"A": makeRedisResourceID("a"),
+			"B": "asdf-invalid-YO",
+			"C": makeRedisResourceID("c"),
+		}
+		resource := generated.GenericResource{
+			ID:         to.Ptr(containerResourceID),
+			Properties: makeResourceProperties(connections, nil),
+		}
+
+		expected := []connectionEntry{
+			{
+				Name: "A",
+				From: nodeFromID(containerResourceID),
+				To:   nodeFromID(makeRedisResourceID("a")),
+			},
+			{
+				Name: "B",
+				From: nodeFromID(containerResourceID),
+				To:   nodeFromID("asdf-invalid-YO"),
+			},
+			{
+				Name: "C",
+				From: nodeFromID(containerResourceID),
+				To:   nodeFromID(makeRedisResourceID("c")),
+			},
+		}
+
+		actual := connectionsFromAPIData(resource)
+		require.Equal(t, expected, actual)
+
+		// A single failure does not stop connections from being found.
+		require.Equal(t, "'asdf-invalid-YO' is not a valid resource id", actual[1].To.Error)
+	})
+
+	t.Run("no connections", func(t *testing.T) {
+		resource := generated.GenericResource{
+			ID:         to.Ptr(containerResourceID),
+			Properties: map[string]any{},
+		}
+
+		actual := connectionsFromAPIData(resource)
+		require.Equal(t, []connectionEntry{}, actual)
+	})
+
+	t.Run("non-map connections", func(t *testing.T) {
+		t.Run("no connections", func(t *testing.T) {
+			resource := generated.GenericResource{
+				ID: to.Ptr(containerResourceID),
+				Properties: map[string]any{
+					"connections": "hey there, this is not a map!",
+				},
+			}
+
+			actual := connectionsFromAPIData(resource)
+			require.Equal(t, []connectionEntry{}, actual)
+		})
+	})
+}

--- a/pkg/cli/cmd/app/connections/connections.go
+++ b/pkg/cli/cmd/app/connections/connections.go
@@ -1,0 +1,131 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package connections
+
+import (
+	"context"
+
+	"github.com/project-radius/radius/pkg/cli"
+	"github.com/project-radius/radius/pkg/cli/clients"
+	"github.com/project-radius/radius/pkg/cli/clierrors"
+	"github.com/project-radius/radius/pkg/cli/cmd/commonflags"
+	"github.com/project-radius/radius/pkg/cli/connections"
+	"github.com/project-radius/radius/pkg/cli/framework"
+	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/project-radius/radius/pkg/cli/workspaces"
+	"github.com/project-radius/radius/pkg/ucp/resources"
+	"github.com/spf13/cobra"
+)
+
+// NewCommand creates an instance of the command and runner for the `rad app connections` command.
+func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
+	runner := NewRunner(factory)
+	cmd := &cobra.Command{
+		Use:   "connections",
+		Short: "Shows the connections for an application.",
+		Long:  `Shows the connections for an application`,
+		Args:  cobra.MaximumNArgs(1),
+		Example: `
+# Show connections for current application
+rad app connections
+
+# Show connections for specified application
+rad app connections my-application`,
+		RunE: framework.RunCommand(runner),
+	}
+
+	commonflags.AddWorkspaceFlag(cmd)
+	commonflags.AddResourceGroupFlag(cmd)
+	commonflags.AddEnvironmentNameFlag(cmd)
+	commonflags.AddApplicationNameFlag(cmd)
+
+	return cmd, runner
+}
+
+// Runner is the runner implementation for the `rad app connections` command.
+type Runner struct {
+	ConfigHolder      *framework.ConfigHolder
+	ConnectionFactory connections.Factory
+	Output            output.Interface
+
+	ApplicationName string
+	EnvironmentName string
+	Workspace       *workspaces.Workspace
+}
+
+// NewRunner creates a new instance of the `rad app connections` runner.
+func NewRunner(factory framework.Factory) *Runner {
+	return &Runner{
+		ConfigHolder:      factory.GetConfigHolder(),
+		Output:            factory.GetOutput(),
+		ConnectionFactory: factory.GetConnectionFactory(),
+	}
+}
+
+// Validate runs validation for the `rad app connections` command.
+func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
+	workspace, err := cli.RequireWorkspace(cmd, r.ConfigHolder.Config, r.ConfigHolder.DirectoryConfig)
+	if err != nil {
+		return err
+	}
+	r.Workspace = workspace
+
+	r.Workspace.Scope, err = cli.RequireScope(cmd, *r.Workspace)
+	if err != nil {
+		return err
+	}
+
+	r.ApplicationName, err = cli.RequireApplicationArgs(cmd, args, *r.Workspace)
+	if err != nil {
+		return err
+	}
+
+	client, err := r.ConnectionFactory.CreateApplicationsManagementClient(cmd.Context(), *r.Workspace)
+	if err != nil {
+		return err
+	}
+
+	// Validate that the application exists
+	app, err := client.ShowApplication(cmd.Context(), r.ApplicationName)
+	if clients.Is404Error(err) {
+		return clierrors.Message("Application %q does not exist or has been deleted.", r.ApplicationName)
+	} else if err != nil {
+		return err
+	}
+
+	parsed, err := resources.ParseResource(*app.Properties.Environment)
+	if err != nil {
+		return err
+	}
+
+	r.EnvironmentName = parsed.Name()
+
+	return nil
+}
+
+// Run runs the `rad app connections` command.
+func (r *Runner) Run(ctx context.Context) error {
+	client, err := r.ConnectionFactory.CreateApplicationsManagementClient(ctx, *r.Workspace)
+	if err != nil {
+		return err
+	}
+
+	applicationResources, err := client.ListAllResourcesByApplication(ctx, r.ApplicationName)
+	if err != nil {
+		return err
+	}
+
+	environmentResources, err := client.ListAllResourcesByEnvironment(ctx, r.EnvironmentName)
+	if err != nil {
+		return err
+	}
+
+	graph := compute(r.ApplicationName, applicationResources, environmentResources)
+	display := display(graph)
+	r.Output.LogInfo(display)
+
+	return nil
+}

--- a/pkg/cli/cmd/app/connections/connections_test.go
+++ b/pkg/cli/cmd/app/connections/connections_test.go
@@ -1,0 +1,187 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// ------------------------------------------------------------
+
+package connections
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/golang/mock/gomock"
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	"github.com/project-radius/radius/pkg/cli/clients"
+	"github.com/project-radius/radius/pkg/cli/clients_new/generated"
+	"github.com/project-radius/radius/pkg/cli/connections"
+	"github.com/project-radius/radius/pkg/cli/framework"
+	"github.com/project-radius/radius/pkg/cli/output"
+	"github.com/project-radius/radius/pkg/cli/workspaces"
+	"github.com/project-radius/radius/pkg/corerp/api/v20220315privatepreview"
+	"github.com/project-radius/radius/pkg/to"
+	"github.com/project-radius/radius/test/radcli"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CommandValidation(t *testing.T) {
+	radcli.SharedCommandValidation(t, NewCommand)
+}
+
+func Test_Validate(t *testing.T) {
+	application := v20220315privatepreview.ApplicationResource{
+		Name: to.Ptr("test-app"),
+		ID:   to.Ptr(applicationResourceID),
+		Type: to.Ptr("Applications.Core/applications"),
+		Properties: &v20220315privatepreview.ApplicationProperties{
+			Environment: to.Ptr(environmentResourceID),
+		},
+	}
+
+	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
+	testcases := []radcli.ValidateInput{
+		{
+			Name:          "Connections command application (positional)",
+			Input:         []string{"test-app"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				mocks.ApplicationManagementClient.EXPECT().
+					ShowApplication(gomock.Any(), "test-app").
+					Return(application, nil).
+					Times(1)
+			},
+			ValidateCallback: func(t *testing.T, r framework.Runner) {
+				runner := r.(*Runner)
+				// These values are used by Run()
+				require.Equal(t, "test-app", runner.ApplicationName)
+				require.Equal(t, "test-env", runner.EnvironmentName)
+			},
+		},
+		{
+			Name:          "Connections command application (flag)",
+			Input:         []string{"-a", "test-app"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				mocks.ApplicationManagementClient.EXPECT().
+					ShowApplication(gomock.Any(), "test-app").
+					Return(application, nil).
+					Times(1)
+			},
+			ValidateCallback: func(t *testing.T, r framework.Runner) {
+				runner := r.(*Runner)
+				// These values are used by Run()
+				require.Equal(t, "test-app", runner.ApplicationName)
+				require.Equal(t, "test-env", runner.EnvironmentName)
+			},
+		},
+		{
+			Name:          "Connections command missing application",
+			Input:         []string{"-a", "test-app"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				mocks.ApplicationManagementClient.EXPECT().
+					ShowApplication(gomock.Any(), "test-app").
+					Return(v20220315privatepreview.ApplicationResource{}, &azcore.ResponseError{ErrorCode: v1.CodeNotFound}).
+					Times(1)
+			},
+		},
+		{
+			Name:          "Connections command with incorrect args",
+			Input:         []string{"foo", "bar"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+		},
+	}
+	radcli.SharedValidateValidation(t, NewCommand, testcases)
+}
+
+func Test_Run(t *testing.T) {
+	// This example is a very simple example of the application graph as an integration test.
+	// The unit tests for this package cover the more complex cases.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	applicationResources := []generated.GenericResource{
+		{
+			ID:         to.Ptr(containerResourceID),
+			Properties: makeResourceProperties(map[string]string{"db": redisResourceID}, []any{containerDeploymentOutputResource}),
+		},
+	}
+	environmentResources := []generated.GenericResource{
+		{
+			ID:         to.Ptr(redisResourceID),
+			Properties: makeResourceProperties(nil, []any{redisAWSOutputResource}),
+		},
+	}
+
+	appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
+	appManagementClient.EXPECT().
+		ListAllResourcesByApplication(gomock.Any(), "test-app").
+		Return(applicationResources, nil).
+		Times(1)
+	appManagementClient.EXPECT().
+		ListAllResourcesByEnvironment(gomock.Any(), "test-env").
+		Return(environmentResources, nil).
+		Times(1)
+
+	workspace := &workspaces.Workspace{
+		Connection: map[string]any{
+			"kind":    "kubernetes",
+			"context": "kind-kind",
+		},
+		Name:  "kind-kind",
+		Scope: "/planes/radius/local/resourceGroups/test-group",
+	}
+	outputSink := &output.MockOutput{}
+	runner := &Runner{
+		ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+		Workspace:         workspace,
+		Output:            outputSink,
+
+		// Populated by Validate()
+		ApplicationName: "test-app",
+		EnvironmentName: "test-env",
+	}
+
+	err := runner.Run(context.Background())
+	require.NoError(t, err)
+
+	expectedOutput := `Displaying application: test-app
+
+Name: webapp (Applications.Core/containers)
+Connections:
+  webapp -> redis (Applications.Datastores/redisCaches)
+Resources:
+  demo (kubernetes: apps/Deployment)
+
+Name: redis (Applications.Datastores/redisCaches)
+Connections:
+  webapp (Applications.Core/containers) -> redis
+Resources:
+  redis-aqbjixghynqgg (aws: AWS.MemoryDB/Cluster)
+
+`
+
+	expected := []any{
+		output.LogOutput{
+			Format: expectedOutput,
+		},
+	}
+
+	require.Equal(t, expected, outputSink.Writes)
+}

--- a/pkg/cli/cmd/app/connections/display.go
+++ b/pkg/cli/cmd/app/connections/display.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connections
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// display builds the formatted output for the application graph as text.
+func display(graph *applicationGraph) string {
+	applicationResources := []resourceEntry{}
+	for _, resource := range graph.Resources {
+		applicationResources = append(applicationResources, resource)
+	}
+
+	// Sort by type (containers first), and then by name, then by id.
+	containerType := "Applications.Core/containers"
+	sort.Slice(applicationResources, func(i, j int) bool {
+		if strings.EqualFold(applicationResources[i].Type, containerType) !=
+			strings.EqualFold(applicationResources[j].Type, containerType) {
+
+			return strings.EqualFold(applicationResources[i].Type, containerType)
+		}
+
+		if applicationResources[i].Type != applicationResources[j].Type {
+			return applicationResources[i].Type < applicationResources[j].Type
+		}
+
+		if applicationResources[i].Name != applicationResources[j].Name {
+			return applicationResources[i].Name < applicationResources[j].Name
+		}
+
+		if applicationResources[i].ID != applicationResources[j].ID {
+			return applicationResources[i].ID < applicationResources[j].ID
+		}
+
+		return applicationResources[i].Error < applicationResources[j].Error
+	})
+
+	output := &strings.Builder{}
+
+	output.WriteString(fmt.Sprintf("Displaying application: %s\n\n", graph.ApplicationName))
+
+	if len(applicationResources) == 0 {
+		output.WriteString("(empty)")
+		output.WriteString("\n\n")
+		return output.String()
+	}
+
+	for _, resource := range applicationResources {
+		if resource.Error != "" {
+			output.WriteString(fmt.Sprintf("Error: %s\n", resource.Error))
+			continue
+		}
+
+		output.WriteString(fmt.Sprintf("Name: %s (%s)\n", resource.Name, resource.Type))
+
+		if len(resource.Connections) == 0 {
+			output.WriteString("Connections: (none)\n")
+		} else {
+			output.WriteString("Connections:\n")
+			for _, connection := range resource.Connections {
+				if connection.To.Error != "" {
+					output.WriteString(fmt.Sprintf("  %s -> %s (%s)\n", connection.From.Name, "error", connection.To.Error))
+					continue
+				}
+
+				// We format the connection differently depending on whether it's inbound or outbound.
+				if connection.From.ID == resource.ID {
+					// Outbound
+					output.WriteString(fmt.Sprintf("  %s -> %s (%s)\n", connection.From.Name, connection.To.Name, connection.To.Type))
+				} else {
+					// Inbound
+					output.WriteString(fmt.Sprintf("  %s (%s) -> %s\n", connection.From.Name, connection.From.Type, connection.To.Name))
+				}
+			}
+		}
+
+		if len(resource.Resources) == 0 {
+			output.WriteString("Resources: (none)\n")
+		} else {
+			output.WriteString("Resources:\n")
+			for _, resource := range resource.Resources {
+				if resource.Error != "" {
+					output.WriteString(fmt.Sprintf("Error: %s\n", resource.Error))
+					continue
+				}
+
+				link := makeHyperlink(resource)
+				if link == "" {
+					output.WriteString(fmt.Sprintf("  %s (%s: %s)\n", resource.Name, resource.Provider, resource.Type))
+				} else {
+					output.WriteString(fmt.Sprintf("  %s (%s: %s) %s\n", resource.Name, resource.Provider, resource.Type, link))
+				}
+			}
+		}
+
+		output.WriteString("\n")
+	}
+
+	return output.String()
+}
+
+func makeHyperlink(resource outputResourceEntry) string {
+	// Just azure for now.
+	if resource.Provider != "azure" {
+		return ""
+	}
+
+	// format of an Azure portal URL:
+	//
+	// https://portal.azure.com/#@{tenantId}/resource{resourceId}
+	url := fmt.Sprintf("https://portal.azure.com/#@%s/resource%s", "72f988bf-86f1-41af-91ab-2d7cd011db47", resource.ID)
+
+	// This is the magic incantation for a console hyperlink.
+	// \x1b]8;;h { URL } \x07 { link text } \x1b]8;;\x07
+	return fmt.Sprintf("\x1b]8;;%s\x07%s\x1b]8;;\x07\n", url, "open portal")
+}

--- a/pkg/cli/cmd/app/connections/display_test.go
+++ b/pkg/cli/cmd/app/connections/display_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_display(t *testing.T) {
+	t.Run("empty graph", func(t *testing.T) {
+		graph := &applicationGraph{
+			ApplicationName: "test-app",
+			Resources:       map[string]resourceEntry{},
+		}
+
+		expected := `Displaying application: test-app
+
+(empty)
+
+`
+		actual := display(graph)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("complex application", func(t *testing.T) {
+		graph := &applicationGraph{
+			ApplicationName: "test-app",
+			Resources: map[string]resourceEntry{
+				containerResourceID: {
+					node: nodeFromID(containerResourceID),
+					Connections: []connectionEntry{
+						{
+							Name: "A",
+							From: nodeFromID(containerResourceID),
+							To:   nodeFromID(makeRedisResourceID("a")),
+						},
+						{
+							Name: "B",
+							From: nodeFromID(containerResourceID),
+							To:   nodeFromID(makeRedisResourceID("b")),
+						},
+						{
+							Name: "C",
+							From: nodeFromID(containerResourceID),
+							To:   nodeFromID(azureRedisCacheResourceID),
+						},
+						{
+							Name: "D",
+							From: nodeFromID(containerResourceID),
+							To:   nodeFromID("asdf-invalid-YO"),
+						},
+					},
+					Resources: []outputResourceEntry{
+						{
+							node: node{
+								Name: "demo",
+								Type: "apps/Deployment",
+							},
+							Provider: "kubernetes",
+						},
+					},
+				},
+				makeRedisResourceID("a"): {
+					node: nodeFromID(makeRedisResourceID("a")),
+					Connections: []connectionEntry{
+						{
+							Name: "A",
+							From: nodeFromID(containerResourceID),
+							To:   nodeFromID(makeRedisResourceID("a")),
+						},
+					},
+					Resources: []outputResourceEntry{
+						{
+							node:     nodeFromID(azureRedisCacheResourceID),
+							Provider: "azure",
+						},
+					},
+				},
+				makeRedisResourceID("b"): {
+					node: nodeFromID(makeRedisResourceID("b")),
+					Connections: []connectionEntry{
+						{
+							Name: "B",
+							From: nodeFromID(containerResourceID),
+							To:   nodeFromID(makeRedisResourceID("b")),
+						},
+					},
+					Resources: []outputResourceEntry{
+						{
+							node:     nodeFromID(awsMemoryDBResourceID),
+							Provider: "aws",
+						},
+					},
+				},
+				azureRedisCacheResourceID: {
+					node: nodeFromID(azureRedisCacheResourceID),
+					Connections: []connectionEntry{
+						{
+							Name: "C",
+							From: nodeFromID(containerResourceID),
+							To:   nodeFromID(azureRedisCacheResourceID),
+						},
+					},
+				},
+			},
+		}
+
+		expected := `Displaying application: test-app
+
+Name: webapp (Applications.Core/containers)
+Connections:
+  webapp -> a (Applications.Datastores/redisCaches)
+  webapp -> b (Applications.Datastores/redisCaches)
+  webapp -> redis (Microsoft.Cache/Redis)
+  webapp -> error ('asdf-invalid-YO' is not a valid resource id)
+Resources:
+  demo (kubernetes: apps/Deployment)
+
+Name: a (Applications.Datastores/redisCaches)
+Connections:
+  webapp (Applications.Core/containers) -> a
+Resources:
+  redis (azure: Microsoft.Cache/Redis) %s
+
+Name: b (Applications.Datastores/redisCaches)
+Connections:
+  webapp (Applications.Core/containers) -> b
+Resources:
+  redis-aqbjixghynqgg (aws: AWS.MemoryDB/Cluster)
+
+Name: redis (Microsoft.Cache/Redis)
+Connections:
+  webapp (Applications.Core/containers) -> redis
+Resources: (none)
+
+`
+
+		// The link contains escape sequences that we can't write in an `` string.
+		link := makeHyperlink(graph.Resources[makeRedisResourceID("a")].Resources[0])
+		expected = fmt.Sprintf(expected, link)
+
+		actual := display(graph)
+		require.Equal(t, expected, actual)
+	})
+}

--- a/pkg/cli/cmd/app/connections/shareddata_test.go
+++ b/pkg/cli/cmd/app/connections/shareddata_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connections
+
+// This file contains shared variables and functions used in tests.
+
+var environmentResourceID = "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/environments/test-env"
+var applicationResourceID = "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/applications/test-app"
+var containerResourceID = "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/containers/webapp"
+var redisResourceID = "/planes/radius/local/resourceGroups/test-group/providers/Applications.Datastores/redisCaches/redis"
+
+var awsMemoryDBResourceID = "/planes/aws/aws/accounts/00000000/regions/us-west-2/providers/AWS.MemoryDB/Cluster/redis-aqbjixghynqgg"
+var azureRedisCacheResourceID = "/planes/azure/azure/subscriptions/00000000/resourceGroups/azure-group/providers/Microsoft.Cache/Redis/redis"
+
+func makeRedisResourceID(name string) string {
+	return "/planes/radius/local/resourceGroups/test-group/providers/Applications.Datastores/redisCaches/" + name
+}
+
+var containerDeploymentOutputResource any = makeKubernetesOutputResource("apps/v1", "Deployment", "default-demo", "demo")
+var redisAWSOutputResource any = makeAWSOutputResource(awsMemoryDBResourceID)
+var redisAzureOutputResource any = makeAzureOutputResource(azureRedisCacheResourceID)
+
+// makeKubernetesOutputResource creates a Kubernetes output resource.
+func makeKubernetesOutputResource(apiVersion string, kind string, namespace string, name string) map[string]any {
+	return map[string]any{
+		"Identity": map[string]any{
+			"apiVersion": apiVersion,
+			"kind":       kind,
+			"name":       name,
+			"namespace":  namespace,
+		},
+		"LocalID":  "Ignored",
+		"Provider": "kubernetes",
+	}
+}
+
+// makeAWSOutputResource creates an AWS output resource.
+func makeAWSOutputResource(id string) map[string]any {
+	return map[string]any{
+		"Identity": map[string]any{
+			"id": id,
+		},
+		"LocalID":  "Ignored",
+		"Provider": "aws",
+	}
+}
+
+// makeAzureOutputResource creates an Azure output resource.
+func makeAzureOutputResource(id string) map[string]any {
+	return map[string]any{
+		"Identity": map[string]any{
+			"id": id,
+		},
+		"LocalID":  "Ignored",
+		"Provider": "azure",
+	}
+}
+
+// makeResourceProperties creates a map of resource properties for a resource.
+//
+// connections should contain a map of name -> resource ID.
+// outputResources should contain the list of output resources.
+func makeResourceProperties(connections map[string]string, outputResources []any) map[string]any {
+	properties := map[string]any{}
+
+	if connections != nil {
+		c := map[string]any{}
+		for name, id := range connections {
+			c[name] = map[string]any{
+				"source": id,
+			}
+		}
+		properties["connections"] = c
+	}
+
+	if len(outputResources) > 0 {
+		status := map[string]any{
+			"outputResources": outputResources,
+		}
+		properties["status"] = status
+	}
+
+	return properties
+}

--- a/pkg/cli/cmd/app/connections/types.go
+++ b/pkg/cli/cmd/app/connections/types.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connections
+
+// applicationGraph represnts the Radius application graph, a directed graph of interconnected
+// resources that describe the application architecture and patterns of communication.
+//
+// The application graph supports serialization from and to JSON.
+type applicationGraph struct {
+	// ApplicationName is the name of the application.
+	ApplicationName string `json:"applicationName"`
+
+	// Resources is the set of resources that are part of the application. Includes environment-scoped
+	// resources and cloud (non-Radius) resources that are referenced by an application-scoped
+	// resource via 'connections'.
+	//
+	// Resources is indexed by resource ID.
+	Resources map[string]resourceEntry `json:"resources"`
+}
+
+// resourceEntry represents a resource in the application graph. This could be a Radius resource like
+// 'Applications.Core/containers' or a cloud resource like 'Microsoft.Storage/storageAccounts'.
+type resourceEntry struct {
+	node
+
+	// Connections is the set of connections involving this resource (both in-bound and out-bound).
+	Connections []connectionEntry `json:"connections"`
+
+	// Resources is the set of output resources owned by this resource. For example an 'Applications.Core/containers'
+	// running on Kubernetes may own a Kubernetes Deployment, Secret, Service, etc.
+	Resources []outputResourceEntry `json:"resources"`
+}
+
+// node defines a set of shared fields for resources and output resources.
+type node struct {
+	// Name is the name of the resource.
+	Name string `json:"name"`
+
+	// Type is the resource type.
+	Type string `json:"type"`
+
+	// ID is the resource id.
+	ID string `json:"id"`
+
+	// Error represents a node with invalid data.
+	Error string `json:"error,omitempty"`
+}
+
+// connectionEntry represents a connection between two resources in the application graph.
+type connectionEntry struct {
+	// Name is the name of the connection.
+	Name string `json:"name"`
+
+	// From is the source of the connection (eg: an 'Applications.Core/containers').
+	From node `json:"from"`
+
+	// To is the destination of the connection (eg: a 'Microsoft.Storage/storageAccounts').
+	To node `json:"to"`
+}
+
+// outputResourceEntry represents an output resource owned by a resource in the application graph.
+type outputResourceEntry struct {
+	node
+
+	// Provider is the cloud provider for the output resource. (eg: Azure)
+	Provider string `json:"provider"`
+}


### PR DESCRIPTION
# Description

This change adds the 'rad app connections' command that I have been using in external demos for some time. This displays a text-mode version of the application graph including output resources.

We plan to move this functionality to the server when possible. Right now the CLI can query all of the resources and build the graph itself.

## Type of change

- This pull request adds or changes features of Radius and has an approved issue (issue link required).


Fixes: #5168

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4e0e1a3</samp>

### Summary
🌐🚀🔗

<!--
1.  🌐 - This emoji represents the concept of connections or networks, which is relevant to the app connections feature. It also suggests the idea of a graph or web of resources, which is how the app connections command displays the output.
2.  🚀 - This emoji represents the idea of launching or deploying applications, which is one of the main use cases for the app connections command. It also suggests speed and efficiency, which are desirable qualities for a command line tool.
3.  🔗 - This emoji represents the idea of links or relationships, which is another way of describing the app connections feature. It also suggests the ability to create or explore connections between different resources, which is what the app connections command enables.
-->
This pull request adds a new `app connections` subcommand to the `rad` CLI, which allows users to view and manage the connections between their applications and other resources in their Radius workspace. The pull request adds a new `app_connections` package in the `pkg/cli/cmd/app` directory, which contains the code for computing, displaying, and testing the application graph. The pull request also imports and uses some existing packages for common flags, test utilities, and hyperlinks.

> _If you want to see how apps connect_
> _You can use the `app connections` sect_
> _It computes and displays_
> _The graph in some ways_
> _And links to the portal for inspect_

### Walkthrough
*  Import app_connections package and add app connections subcommand to app command ([link](https://github.com/project-radius/radius/pull/5907/files?diff=unified&w=0#diff-d36b7b4d04f01a6cf60c50dd9c01da8fb8c190231ea4c59cbbfbe070178b510bR33), [link](https://github.com/project-radius/radius/pull/5907/files?diff=unified&w=0#diff-d36b7b4d04f01a6cf60c50dd9c01da8fb8c190231ea4c59cbbfbe070178b510bR276-R278))
* Create and run app connections command with common flags for workspace, resource group, environment name, and application name ([link](https://github.com/project-radius/radius/pull/5907/files?diff=unified&w=0#diff-eb0083d8df9479acb2d5b36bf150aa410e371a26a01619d09c933a73994aa563R1-R131))
* Compute application graph from application and environment resources returned by Radius API ([link](https://github.com/project-radius/radius/pull/5907/files?diff=unified&w=0#diff-ef65dc502b1e82b84929bb88995888d432dfcd5b22bae9617db4cc9e62c3ea75R1-R380))
* Format output of app connections command as text with hyperlinks to Azure portal for Azure resources ([link](https://github.com/project-radius/radius/pull/5907/files?diff=unified&w=0#diff-4f7eb1b87450e514060b9a723481a450367aa8213bf5b4bdf88b28eb0cb29156R1-R134))
* Define types for application graph, resources, connections, and output resources with JSON tags ([link](https://github.com/project-radius/radius/pull/5907/files?diff=unified&w=0#diff-f74fa4f0d9d88c29c096531a1ce72f87f64216ce569095b107bd781118069161R1-R81))
* Test app connections command logic with gomock and testify packages and radcli package for shared test utilities (`connections_test.go`, [link](https://github.com/project-radius/radius/pull/5907/files?diff=unified&w=0#diff-d96d9836e87411749e15c7f8ffe2e8a965b05ba5e2f2bffd7e345ee9c14cdf82R1-R187))
* Test display function with testify package (`display_test.go`, [link](https://github.com/project-radius/radius/pull/5907/files?diff=unified&w=0#diff-2ea0f5d8c1601d4f81ccb46307c5924313b42f62338bd02d75d3612710474155R1-R162))
* Share variables and functions for testing (`shareddata_test.go`, [link](https://github.com/project-radius/radius/pull/5907/files?diff=unified&w=0#diff-93eebb9e1838349eb065d882299ce573fa15aecbc82ac3b1bead75639f4d1482R1-R98))


