### PR TITLE
Use GHCR for container images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,6 +42,7 @@ env:
   GOTESTSUMVERSION: 1.10.0
 
   # Use radiusdev.azurecr.io for PR build. Otherwise, use radius.azurecr.io.
+  # TODO_LAUNCH: Remove this variable when we opensource the repo - https://github.com/project-radius/radius/issues/5892
   DOCKER_REGISTRY: ${{ github.event_name == 'pull_request' && 'radiusdev.azurecr.io' || 'radius.azurecr.io' }}
 
   # GitHub Actor for pushing images to GHCR

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,8 +44,8 @@ env:
   # Use radiusdev.azurecr.io for PR build. Otherwise, use radius.azurecr.io.
   DOCKER_REGISTRY: ${{ github.event.pull_request.number && 'radiusdev.azurecr.io' || 'radius.azurecr.io' }}
 
-  # radius bot GitHub Account name
-  RAD_BOT_ACTOR: rad-ci-bot
+  # GitHub Actor for pushing images to GHCR
+  GHCR_ACTOR: rad-ci-bot
 
   # Container registry url for GitHub container registry.
   CONTAINER_REGISTRY: ${{ github.event.pull_request.number && 'ghcr.io/project-radius/dev' || 'ghcr.io/project-radius/radius' }}
@@ -203,7 +203,7 @@ jobs:
   # - tag the image with the PR version if the trigger was a PR
   # - push the image for pushes to master, or to a tag
 
-  # TODO: Remove 'image' job when we opensource the repo - https://github.com/project-radius/radius/issues/5892
+  # TODO_LAUNCH: Remove 'image' job when we opensource the repo - https://github.com/project-radius/radius/issues/5892
   images:
     name: Container image build
     runs-on: [self-hosted,1ES.Pool=1ES-Radius ]
@@ -295,7 +295,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ env.RAD_BOT_ACTOR }}
+          username: ${{ env.GHCR_ACTOR }}
           password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -269,7 +269,6 @@ jobs:
   # publish_image is building and publishing images to GHCR.
   publish_images:
     name: Build and publish container images
-    if: github.event_name != 'pull_request'
     runs-on: [self-hosted,1ES.Pool=1ES-Radius ]
     steps:
       - name: Check out code

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ env:
   RAD_BOT_ACTOR: rad-ci-bot
 
   # Container registry url for GitHub container registry.
-  CONTAINER_REGISTRY: ${{ github.event.pull_request.number && 'ghcr.io/project-radius/radius-dev' || 'ghcr.io/project-radius/radius' }}
+  CONTAINER_REGISTRY: ${{ github.event.pull_request.number && 'ghcr.io/project-radius/dev' || 'ghcr.io/project-radius/radius' }}
 
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,13 +42,13 @@ env:
   GOTESTSUMVERSION: 1.10.0
 
   # Use radiusdev.azurecr.io for PR build. Otherwise, use radius.azurecr.io.
-  DOCKER_REGISTRY: ${{ github.event.pull_request.number && 'radiusdev.azurecr.io' || 'radius.azurecr.io' }}
+  DOCKER_REGISTRY: ${{ github.event_name == 'pull_request' && 'radiusdev.azurecr.io' || 'radius.azurecr.io' }}
 
   # GitHub Actor for pushing images to GHCR
   GHCR_ACTOR: rad-ci-bot
 
   # Container registry url for GitHub container registry.
-  CONTAINER_REGISTRY: ${{ github.event.pull_request.number && 'ghcr.io/project-radius/dev' || 'ghcr.io/project-radius/radius' }}
+  CONTAINER_REGISTRY: ${{ github.event_name == 'pull_request' && 'ghcr.io/project-radius/dev' || 'ghcr.io/project-radius/radius' }}
 
 jobs:
   build:
@@ -252,7 +252,7 @@ jobs:
         run: |
           make docker-test-image-build && make docker-test-image-push
           make docker-multi-arch-push
-        if: startsWith(github.ref, 'refs/pull/') # push image on pr
+        if: github.event_name == 'pull_request'
         env:
           DOCKER_REGISTRY: ${{ env.DOCKER_REGISTRY }}
           DOCKER_TAG_VERSION: ${{ env.REL_VERSION }} # includes PR number
@@ -268,6 +268,7 @@ jobs:
   # publish_image is building and publishing images to GHCR.
   publish_images:
     name: Build and publish container images
+    if: github.event_name != 'pull_request'
     runs-on: [self-hosted,1ES.Pool=1ES-Radius ]
     steps:
       - name: Check out code
@@ -315,7 +316,7 @@ jobs:
         run: |
           make docker-test-image-build && make docker-test-image-push
           make docker-multi-arch-push
-        if: startsWith(github.ref, 'refs/pull/') # push image on pr
+        if: github.event_name == 'pull_request'
         env:
           DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
           DOCKER_TAG_VERSION: ${{ env.REL_VERSION }} # includes PR number

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ env:
   RAD_BOT_ACTOR: rad-ci-bot
 
   # Container registry url for GitHub container registry.
-  CONTAINER_REGISTRY: ${{ github.event.pull_request.number && 'ghcr.io/project-radius/test' || 'ghcr.io/project-radius/radius' }}
+  CONTAINER_REGISTRY: ${{ github.event.pull_request.number && 'ghcr.io/project-radius/radius-dev' || 'ghcr.io/project-radius/radius' }}
 
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,12 @@ env:
   # Use radiusdev.azurecr.io for PR build. Otherwise, use radius.azurecr.io.
   DOCKER_REGISTRY: ${{ github.event.pull_request.number && 'radiusdev.azurecr.io' || 'radius.azurecr.io' }}
 
+  # radius bot GitHub Account name
+  RAD_BOT_ACTOR: rad-ci-bot
+
+  # Container registry url for GitHub container registry.
+  CONTAINER_REGISTRY: ${{ github.event.pull_request.number && 'ghcr.io/project-radius/test' || 'ghcr.io/project-radius/radius' }}
+
 jobs:
   build:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
@@ -196,6 +202,8 @@ jobs:
   # - tag the image as latest and with a version if the trigger was a tag
   # - tag the image with the PR version if the trigger was a PR
   # - push the image for pushes to master, or to a tag
+
+  # TODO: Remove 'image' job when we opensource the repo - https://github.com/project-radius/radius/issues/5892
   images:
     name: Container image build
     runs-on: [self-hosted,1ES.Pool=1ES-Radius ]
@@ -256,9 +264,72 @@ jobs:
         env:
           DOCKER_REGISTRY: ${{ env.DOCKER_REGISTRY }}
           DOCKER_TAG_VERSION: ${{ env.REL_CHANNEL }}
+
+  # publish_image is building and publishing images to GHCR.
+  publish_images:
+    name: Build and publish container images
+    runs-on: [self-hosted,1ES.Pool=1ES-Radius ]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Parse release version and set environment variables
+        run: python ./.github/scripts/get_release_version.py
+      - name: Set up Go ${{ env.GOVER }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GOVER }}
+      - name: Get Go Cache path
+        id: go-cache-paths
+        run: |
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ${{ steps.go-cache-paths.outputs.go-build }}
+            ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ env.RAD_BOT_ACTOR }}
+          password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+      - name: Push container images (latest)
+        run: |
+          make docker-test-image-build && make docker-test-image-push
+          make docker-multi-arch-push
+        if: (github.ref == 'refs/heads/main') # push image to latest on merge to main
+        env:
+          DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
+          DOCKER_TAG_VERSION: latest
+      - name: Push container images (PR)
+        run: |
+          make docker-test-image-build && make docker-test-image-push
+          make docker-multi-arch-push
+        if: startsWith(github.ref, 'refs/pull/') # push image on pr
+        env:
+          DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
+          DOCKER_TAG_VERSION: ${{ env.REL_VERSION }} # includes PR number
+      - name: Push container images (release)
+        run: |
+          make docker-test-image-build && make docker-test-image-push
+          make docker-multi-arch-push
+        if: startsWith(github.ref, 'refs/tags/v') # push image on tag
+        env:
+          DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
+          DOCKER_TAG_VERSION: ${{ env.REL_CHANNEL }}
   helm:
     name: Helm chart build
-    needs: ['images']
+    needs: ['images', 'publish_images']
     runs-on: [self-hosted,1ES.Pool=1ES-Radius ]
     env:
       ARTIFACT_DIR: ./dist/Charts

--- a/.github/workflows/e2e-test-azure.yaml
+++ b/.github/workflows/e2e-test-azure.yaml
@@ -57,6 +57,9 @@ env:
 
   # ACR for storing test images
   CACHE_REGISTRY: radiusdev.azurecr.io
+
+  RECIPE_REGISTRY: radiusdev.azurecr.io
+
   # The radius functional test timeout
   FUNCTIONALTEST_TIMEOUT: 60m
   # The Azure Location to store test resources
@@ -188,7 +191,7 @@ jobs:
           <summary> Click here to see the list of tools in the current test run</summary>
 
           * gotestsum ${{ env.GOTESTSUM_VER }}
-          * Bicep recipe location `${{ env.CACHE_REGISTRY}}/test/functional/shared/recipes/<name>:${{ steps.gen-id.outputs.REL_VERSION }}`
+          * Bicep recipe location `${{ env.RECIPE_REGISTRY}}/test/functional/shared/recipes/<name>:${{ steps.gen-id.outputs.REL_VERSION }}`
           * Terraform recipe location `http://tf-module-server.radius-test-tf-module-server.svc.cluster.local/<name>.zip` (in cluster)
           * applications-rp test image location: `${{ env.CACHE_REGISTRY }}/applications-rp:${{ steps.gen-id.outputs.REL_VERSION }}`
           * ucp test image location: `${{ env.CACHE_REGISTRY }}/ucpd:${{ steps.gen-id.outputs.REL_VERSION }}`
@@ -268,7 +271,7 @@ jobs:
         run: |
           make publish-test-bicep-recipes
         env:
-          RECIPE_REGISTRY: ${{ env.CACHE_REGISTRY }}
+          RECIPE_REGISTRY: ${{ env.RECIPE_REGISTRY }}
           RECIPE_TAG_VERSION: ${{ env.REL_VERSION }}
           RAD_BICEP_PATH: dist
       - name: Log Bicep recipe publish status (success)
@@ -450,7 +453,7 @@ jobs:
           RADIUS_SAMPLES_REPO_ROOT: ${{ github.workspace }}/samples
           # Test_MongoDB_Recipe_Parameters is using the following environment variable.
           INTEGRATION_TEST_RESOURCE_GROUP_NAME: ${{ env.AZURE_TEST_RESOURCE_GROUP }}
-          RECIPE_REGISTRY: ${{ env.CACHE_REGISTRY }}
+          RECIPE_REGISTRY: ${{ env.RECIPE_REGISTRY }}
           RECIPE_TAG_VERSION: ${{ env.RECIPE_TAG_VERSION }}
           FUNC_TEST_OIDC_ISSUER: ${{ env.FUNCTEST_OIDC_ISSUER }}
       - name: Log radius e2e test status (success)

--- a/.github/workflows/e2e-test-azure.yaml
+++ b/.github/workflows/e2e-test-azure.yaml
@@ -40,7 +40,7 @@ name: E2E test on Azure
 on:
   schedule:
     # Run every 1 hours
-    - cron: "0 0/1 * * *"
+    - cron: "0 * * * *"
   pull_request:
     branches:
       - main

--- a/.github/workflows/e2e-test-azure.yaml
+++ b/.github/workflows/e2e-test-azure.yaml
@@ -58,8 +58,6 @@ env:
   # ACR for storing test images
   CACHE_REGISTRY: radiusdev.azurecr.io
 
-  RECIPE_REGISTRY: radiusdev.azurecr.io
-
   # The radius functional test timeout
   FUNCTIONALTEST_TIMEOUT: 60m
   # The Azure Location to store test resources
@@ -191,7 +189,7 @@ jobs:
           <summary> Click here to see the list of tools in the current test run</summary>
 
           * gotestsum ${{ env.GOTESTSUM_VER }}
-          * Bicep recipe location `${{ env.RECIPE_REGISTRY}}/test/functional/shared/recipes/<name>:${{ steps.gen-id.outputs.REL_VERSION }}`
+          * Bicep recipe location `${{ env.CACHE_REGISTRY}}/test/functional/shared/recipes/<name>:${{ steps.gen-id.outputs.REL_VERSION }}`
           * Terraform recipe location `http://tf-module-server.radius-test-tf-module-server.svc.cluster.local/<name>.zip` (in cluster)
           * applications-rp test image location: `${{ env.CACHE_REGISTRY }}/applications-rp:${{ steps.gen-id.outputs.REL_VERSION }}`
           * ucp test image location: `${{ env.CACHE_REGISTRY }}/ucpd:${{ steps.gen-id.outputs.REL_VERSION }}`
@@ -271,7 +269,7 @@ jobs:
         run: |
           make publish-test-bicep-recipes
         env:
-          RECIPE_REGISTRY: ${{ env.RECIPE_REGISTRY }}
+          RECIPE_REGISTRY: ${{ env.CACHE_REGISTRY }}
           RECIPE_TAG_VERSION: ${{ env.REL_VERSION }}
           RAD_BICEP_PATH: dist
       - name: Log Bicep recipe publish status (success)
@@ -453,7 +451,7 @@ jobs:
           RADIUS_SAMPLES_REPO_ROOT: ${{ github.workspace }}/samples
           # Test_MongoDB_Recipe_Parameters is using the following environment variable.
           INTEGRATION_TEST_RESOURCE_GROUP_NAME: ${{ env.AZURE_TEST_RESOURCE_GROUP }}
-          RECIPE_REGISTRY: ${{ env.RECIPE_REGISTRY }}
+          RECIPE_REGISTRY: ${{ env.CACHE_REGISTRY }}
           RECIPE_TAG_VERSION: ${{ env.RECIPE_TAG_VERSION }}
           FUNC_TEST_OIDC_ISSUER: ${{ env.FUNCTEST_OIDC_ISSUER }}
       - name: Log radius e2e test status (success)

--- a/.github/workflows/e2e-test-azure.yaml
+++ b/.github/workflows/e2e-test-azure.yaml
@@ -57,6 +57,7 @@ env:
 
   # ACR for storing test images and recipes
   CACHE_REGISTRY: radiusdev.azurecr.io
+  # Container registry for storing recipe artifacts
   BICEP_RECIPE_REGISTRY: radiusdev.azurecr.io
   # The radius functional test timeout
   FUNCTIONALTEST_TIMEOUT: 60m
@@ -71,8 +72,8 @@ env:
   # The AWS account ID
   AWS_ACCOUNT_ID: '${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}'
 
-  # The valid radius build time window in seconds to rebuild radius. 12 hours = 12 * 60 * 60 = 43200
-  VALID_RADIUS_BUILD_WINDOW: 43200
+  # The valid radius build time window in seconds to rebuild radius. 24 hours = 24 * 60 * 60 = 86400
+  VALID_RADIUS_BUILD_WINDOW: 86400
 
   # The AKS cluster name
   AKS_CLUSTER_NAME: 'radiuse2e00-aks'
@@ -272,6 +273,7 @@ jobs:
         run: |
           make publish-test-bicep-recipes
         env:
+          BICEP_RECIPE_REGISTRY: ${{ env.BICEP_RECIPE_REGISTRY }}
           BICEP_RECIPE_TAG_VERSION: ${{ env.REL_VERSION }}
           RAD_BICEP_PATH: dist
       - name: Log Bicep recipe publish status (success)

--- a/.github/workflows/e2e-test-azure.yaml
+++ b/.github/workflows/e2e-test-azure.yaml
@@ -57,7 +57,6 @@ env:
 
   # ACR for storing test images
   CACHE_REGISTRY: radiusdev.azurecr.io
-
   # The radius functional test timeout
   FUNCTIONALTEST_TIMEOUT: 60m
   # The Azure Location to store test resources

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -457,6 +457,7 @@ jobs:
           rad credential register aws \
             --access-key-id ${{ secrets.FUNCTEST_AWS_ACCESS_KEY_ID }} --secret-access-key ${{ secrets.FUNCTEST_AWS_SECRET_ACCESS_KEY }}
           
+          # TODO_LAUNCH: Remove this login once we move recipe to GHCR - https://github.com/project-radius/radius/issues/5892
           az acr login -n ${{ env.BICEP_RECIPE_REGISTRY }}
       - uses: marocchino/sticky-pull-request-comment@v2
         if: failure() && env.PR_NUMBER != ''

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -49,7 +49,7 @@ env:
   # Azure workload identity webhook chart version
   AZURE_WORKLOAD_IDENTITY_WEBHOOK_VER: '1.0.0'
   # ACR for storing test images
-  CACHE_REGISTRY: radiusdev.azurecr.io
+  CACHE_REGISTRY: ghcr.io/project-radius/test
   # The radius functional test timeout
   FUNCTIONALTEST_TIMEOUT: 60m
   # The Azure Location to store test resources
@@ -354,6 +354,16 @@ jobs:
           # AZURE_OIDC_ISSUER
           eval "export $(echo "${{ secrets.FUNCTEST_AZURE_OIDC_JSON }}" | jq -r 'to_entries | map("\(.key)=\(.value)") | @sh')"
 
+          cat <<EOF > "./ghcr_secret.json"
+          {
+            "auths": {
+              "ghcr.io/project-radius": {
+                "auth": "${{ secrets.GITHUB_TOKEN }}"
+              }
+            }
+          }
+          EOF
+
           # Create KinD cluster with OIDC Issuer keys
           echo $AZURE_OIDC_ISSUER_PUBLIC_KEY | base64 -d > sa.pub
           echo $AZURE_OIDC_ISSUER_PRIVATE_KEY | base64 -d > sa.key
@@ -367,6 +377,8 @@ jobs:
                 containerPath: /etc/kubernetes/pki/sa.pub
               - hostPath: ./sa.key
                 containerPath: /etc/kubernetes/pki/sa.key
+              - hostPath: ./ghcr_secret.json
+                containerPath: /var/lib/kubelet/config.json
             kubeadmConfigPatches:
             - |
               kind: ClusterConfiguration

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -361,16 +361,8 @@ jobs:
           # AZURE_OIDC_ISSUER
           eval "export $(echo "${{ secrets.FUNCTEST_AZURE_OIDC_JSON }}" | jq -r 'to_entries | map("\(.key)=\(.value)") | @sh')"
 
-          AUTHKEY=$(echo -n ${{ env.RAD_BOT_ACTOR }}:${{ secrets.GH_RAD_CI_BOT_PAT }}|base64)
-          cat <<EOF > "./ghcr_secret.json"
-          {
-            "auths": {
-              "ghcr.io/project-radius": {
-                "auth": "$AUTHKEY"
-              }
-            }
-          }
-          EOF
+          AUTHKEY=$(echo -n "${{ env.RAD_BOT_ACTOR }}:${{ secrets.GH_RAD_CI_BOT_PAT }}" | base64)
+          echo "{\"auths\":{\"ghcr.io\":{\"auth\":\"${AUTHKEY}\"}}}" > "./ghcr_secret.json"
 
           # Create KinD cluster with OIDC Issuer keys
           echo $AZURE_OIDC_ISSUER_PUBLIC_KEY | base64 -d > sa.pub

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -253,7 +253,6 @@ jobs:
           make publish-test-bicep-recipes
         env:
           BICEP_RECIPE_REGISTRY: ${{ env.BICEP_RECIPE_REGISTRY }}
-          BICEP_RECIPE_TAG_VERSION: ${{ env.BICEP_RECIPE_TAG_VERSION }}
           RAD_BICEP_PATH: dist
       - uses: marocchino/sticky-pull-request-comment@v2
         if: success() && env.PR_NUMBER != ''

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -49,7 +49,7 @@ env:
   # Azure workload identity webhook chart version
   AZURE_WORKLOAD_IDENTITY_WEBHOOK_VER: '1.0.0'
   # ACR for storing test images
-  CACHE_REGISTRY: ghcr.io/project-radius/radius-dev
+  CACHE_REGISTRY: ghcr.io/project-radius/dev
   # The radius functional test timeout
   FUNCTIONALTEST_TIMEOUT: 60m
   # The Azure Location to store test resources
@@ -66,6 +66,8 @@ env:
   ACTION_LINK: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
 
   RAD_BOT_ACTOR: rad-ci-bot
+
+  RECIPE_REGISTRY: radiusdev.azurecr.io
 
 jobs:
   build:
@@ -171,7 +173,7 @@ jobs:
             * Dapr: ${{ env.DAPR_VER }}
             * Azure KeyVault CSI driver: ${{ env.AZURE_KEYVAULT_CSI_DRIVER_VER }}
             * Azure Workload identity webhook: ${{ env.AZURE_WORKLOAD_IDENTITY_WEBHOOK_VER }}
-            * Bicep recipe location `${{ env.CACHE_REGISTRY}}/test/functional/shared/recipes/<name>:${{ env.REL_VERSION }}`
+            * Bicep recipe location `${{ env.RECIPE_REGISTRY}}/test/functional/shared/recipes/<name>:${{ env.REL_VERSION }}`
             * Terraform recipe location `http://tf-module-server.radius-test-tf-module-server.svc.cluster.local/<name>.zip` (in cluster)
             * applications-rp test image location: `${{ env.CACHE_REGISTRY }}/applications-rp:${{ env.REL_VERSION }}`
             * ucp test image location: `${{ env.CACHE_REGISTRY }}/ucpd:${{ env.REL_VERSION }}`
@@ -248,7 +250,7 @@ jobs:
         run: |
           make publish-test-bicep-recipes
         env:
-          RECIPE_REGISTRY: ${{ env.CACHE_REGISTRY }}
+          RECIPE_REGISTRY: ${{ env.RECIPE_REGISTRY }}
           RECIPE_TAG_VERSION: ${{ env.REL_VERSION }}
           RAD_BICEP_PATH: dist
       - uses: marocchino/sticky-pull-request-comment@v2
@@ -459,7 +461,7 @@ jobs:
           rad credential register aws \
             --access-key-id ${{ secrets.FUNCTEST_AWS_ACCESS_KEY_ID }} --secret-access-key ${{ secrets.FUNCTEST_AWS_SECRET_ACCESS_KEY }}
           
-          az acr login -n ${{ env.CACHE_REGISTRY }}
+          az acr login -n ${{ env.RECIPE_REGISTRY }}
       - uses: marocchino/sticky-pull-request-comment@v2
         if: failure() && env.PR_NUMBER != ''
         continue-on-error: true
@@ -501,7 +503,7 @@ jobs:
           RADIUS_SAMPLES_REPO_ROOT: ${{ github.workspace }}/samples
           # Test_MongoDB_Recipe_Parameters is using the following environment variable.
           INTEGRATION_TEST_RESOURCE_GROUP_NAME: ${{ env.AZURE_TEST_RESOURCE_GROUP }}
-          RECIPE_REGISTRY: ${{ env.CACHE_REGISTRY }}
+          RECIPE_REGISTRY: ${{ env.RECIPE_REGISTRY }}
           RECIPE_TAG_VERSION: ${{ env.RECIPE_TAG_VERSION }}
       - name: Upload container logs
         if: always()

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -51,6 +51,7 @@ env:
   # Container registry for storing test images and recipes
   CACHE_REGISTRY: ghcr.io/project-radius/dev
   # Container registry for storing recipe artifacts
+  # TODO_LAUNCH: Change it to ghcr.io/project-radius/dev - https://github.com/project-radius/radius/issues/5892
   BICEP_RECIPE_REGISTRY: radiusdev.azurecr.io
   # The radius functional test timeout
   FUNCTIONALTEST_TIMEOUT: 60m
@@ -69,7 +70,8 @@ env:
   # Server where terraform test modules are deployed
   TF_RECIPE_MODULE_SERVER_URL: "http://tf-module-server.radius-test-tf-module-server.svc.cluster.local"
 
-  RAD_BOT_ACTOR: rad-ci-bot
+  # GitHub Actor for pushing images to GHCR
+  GHCR_ACTOR: rad-ci-bot
 
 jobs:
   build:
@@ -193,7 +195,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ env.RAD_BOT_ACTOR }}
+          username: ${{ env.GHCR_ACTOR }}
           password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
       - uses: marocchino/sticky-pull-request-comment@v2
         if: env.PR_NUMBER != ''
@@ -363,7 +365,7 @@ jobs:
           # AZURE_OIDC_ISSUER
           eval "export $(echo "${{ secrets.FUNCTEST_AZURE_OIDC_JSON }}" | jq -r 'to_entries | map("\(.key)=\(.value)") | @sh')"
 
-          AUTHKEY=$(echo -n "${{ env.RAD_BOT_ACTOR }}:${{ secrets.GH_RAD_CI_BOT_PAT }}" | base64)
+          AUTHKEY=$(echo -n "${{ env.GHCR_ACTOR }}:${{ secrets.GH_RAD_CI_BOT_PAT }}" | base64)
           echo "{\"auths\":{\"ghcr.io\":{\"auth\":\"${AUTHKEY}\"}}}" > "./ghcr_secret.json"
 
           # Create KinD cluster with OIDC Issuer keys

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -455,7 +455,7 @@ jobs:
           rad credential register aws \
             --access-key-id ${{ secrets.FUNCTEST_AWS_ACCESS_KEY_ID }} --secret-access-key ${{ secrets.FUNCTEST_AWS_SECRET_ACCESS_KEY }}
           
-          az acr login -n ${{ env.RECIPE_REGISTRY }}
+          az acr login -n ${{ env.BICEP_RECIPE_REGISTRY }}
       - uses: marocchino/sticky-pull-request-comment@v2
         if: failure() && env.PR_NUMBER != ''
         continue-on-error: true

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -64,6 +64,8 @@ env:
   AWS_ACCOUNT_ID: '${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}'
   # The current GitHub action link
   ACTION_LINK: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+  
+  RAD_BOT_ACTOR: rad-ci-bot
 
 jobs:
   build:
@@ -183,9 +185,12 @@ jobs:
         uses: azure/login@v1
         with:
           creds: '{"clientId":"${{ secrets.INTEGRATION_TEST_SP_APP_ID }}","clientSecret":"${{ secrets.INTEGRATION_TEST_SP_PASSWORD }}","subscriptionId":"${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.INTEGRATION_TEST_TENANT_ID }}"}'
-      - name: Login ACR - ${{ env.CACHE_REGISTRY }}
-        run: |
-          az acr login -n ${{ env.CACHE_REGISTRY }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ env.RAD_BOT_ACTOR }}
+          password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
       - uses: marocchino/sticky-pull-request-comment@v2
         if: env.PR_NUMBER != ''
         continue-on-error: true

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -49,7 +49,7 @@ env:
   # Azure workload identity webhook chart version
   AZURE_WORKLOAD_IDENTITY_WEBHOOK_VER: '1.0.0'
   # ACR for storing test images
-  CACHE_REGISTRY: ghcr.io/project-radius/test
+  CACHE_REGISTRY: ghcr.io/project-radius/radius-dev
   # The radius functional test timeout
   FUNCTIONALTEST_TIMEOUT: 60m
   # The Azure Location to store test resources

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -487,6 +487,7 @@ jobs:
 
           make test-functional-${{ matrix.name }}
         env:
+          DOCKER_REGISTRY: ${{ env.CACHE_REGISTRY }}
           TEST_TIMEOUT: ${{ env.FUNCTIONALTEST_TIMEOUT }}
           RADIUS_CONTAINER_LOG_PATH: ${{ github.workspace }}/${{ env.RADIUS_CONTAINER_LOG_BASE }}
           AWS_ACCESS_KEY_ID: ${{ secrets.FUNCTEST_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -64,7 +64,7 @@ env:
   AWS_ACCOUNT_ID: '${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}'
   # The current GitHub action link
   ACTION_LINK: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-  
+
   RAD_BOT_ACTOR: rad-ci-bot
 
 jobs:
@@ -359,11 +359,12 @@ jobs:
           # AZURE_OIDC_ISSUER
           eval "export $(echo "${{ secrets.FUNCTEST_AZURE_OIDC_JSON }}" | jq -r 'to_entries | map("\(.key)=\(.value)") | @sh')"
 
+          AUTHKEY=$(echo -n ${{ env.RAD_BOT_ACTOR }}:${{ secrets.GH_RAD_CI_BOT_PAT }}|base64)
           cat <<EOF > "./ghcr_secret.json"
           {
             "auths": {
               "ghcr.io/project-radius": {
-                "auth": "${{ secrets.GITHUB_TOKEN }}"
+                "auth": "$AUTHKEY"
               }
             }
           }

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -253,6 +253,7 @@ jobs:
           make publish-test-bicep-recipes
         env:
           BICEP_RECIPE_REGISTRY: ${{ env.BICEP_RECIPE_REGISTRY }}
+          BICEP_RECIPE_TAG_VERSION: ${{ env.REL_VERSION }}
           RAD_BICEP_PATH: dist
       - uses: marocchino/sticky-pull-request-comment@v2
         if: success() && env.PR_NUMBER != ''

--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: snok/container-retention-policy@v2
         with:
           image-names: dev/*, radius-test/*, test/*
-          cut-off: A hour ago UTC
+          cut-off: 1 hour ago UTC
           account-type: org
           org-name: project-radius
           token: ${{ secrets.GH_RAD_CI_BOT_PAT }}

--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -19,11 +19,27 @@ on:
   schedule:
     # Run twice a day
     - cron: "30 0,12 * * *"
+  pull_request:
+    branches:
+      - main
+
 env:
   AZURE_RG_DELETE_LIST_FILE: 'az_rg_list.txt'
   # The valid resource time window in seconds to delete the test resources. 6 hours
   VALID_RESOURCE_WINDOW: 6*60*60
 jobs:
+  purge_gchr_dev:
+    name: Delete old unused container images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete 'dev' containers older than a week
+        uses: snok/container-retention-policy@v2
+        with:
+          image-names: dev/*, radius-test/*, test/*
+          cut-off: A hour ago UTC
+          account-type: org
+          org-name: project-radius
+          token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
   purge_azure_resources:
     name: Azure resources clean-ups
     runs-on: [self-hosted,1ES.Pool=1ES-Radius ]

--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -19,9 +19,6 @@ on:
   schedule:
     # Run twice a day
     - cron: "30 0,12 * * *"
-  pull_request:
-    branches:
-      - main
 
 env:
   AZURE_RG_DELETE_LIST_FILE: 'az_rg_list.txt'
@@ -35,8 +32,8 @@ jobs:
       - name: Delete 'dev' containers older than a week
         uses: snok/container-retention-policy@v2
         with:
-          image-names: dev/*, radius-test/*, test/*
-          cut-off: 1 hour ago UTC
+          image-names: dev/*
+          cut-off: A week ago UTC
           account-type: org
           org-name: project-radius
           token: ${{ secrets.GH_RAD_CI_BOT_PAT }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ kcp.exe
 docs/.hugo_build.lock
 main
 
+test/functional/shared/cli/testdata/tmp-*
+
 .vscode/
 .DS_Store
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ cadl/node_modules
 
 # terraform state
 .terraform/
+
+# temporary test files starting with tmp-
+tmp-*

--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,6 @@ kcp.exe
 docs/.hugo_build.lock
 main
 
-test/functional/shared/cli/testdata/tmp-*
-
 .vscode/
 .DS_Store
 .idea/

--- a/build/docker.mk
+++ b/build/docker.mk
@@ -35,6 +35,7 @@ docker-build-$(1): build-$(1)-linux-amd64
 		--platform linux/amd64 \
 		-t $(DOCKER_REGISTRY)/$(1):$(DOCKER_TAG_VERSION) \
 		--label org.opencontainers.image.source="$(IMAGE_SRC)" \
+		--label org.opencontainers.image.description="$(1)" \
 		--label org.opencontainers.image.version="$(REL_VERSION)" \
 		--label org.opencontainers.image.revision="$(GIT_COMMIT)"
 else
@@ -43,6 +44,7 @@ docker-build-$(1):
 	docker build $(2) -f $(3) \
 		-t $(DOCKER_REGISTRY)/$(1)\:$(DOCKER_TAG_VERSION) \
 		--label org.opencontainers.image.source="$(IMAGE_SRC)" \
+		--label org.opencontainers.image.description="$(1)" \
 		--label org.opencontainers.image.version="$(REL_VERSION)" \
 		--label org.opencontainers.image.revision="$(GIT_COMMIT)"
 endif
@@ -62,6 +64,7 @@ docker-multi-arch-push-$(1): build-$(1)-linux-arm64 build-$(1)-linux-amd64 build
 		--platform linux/amd64,linux/arm64,linux/arm \
 		-t $(DOCKER_REGISTRY)/$(1):$(DOCKER_TAG_VERSION) \
 		--label org.opencontainers.image.source="$(IMAGE_SRC)" \
+		--label org.opencontainers.image.description="$(1)" \
 		--label org.opencontainers.image.version="$(REL_VERSION)" \
 		--label org.opencontainers.image.revision="$(GIT_COMMIT)" \
 		--push $(2)

--- a/build/docker.mk
+++ b/build/docker.mk
@@ -16,6 +16,7 @@
 
 DOCKER_REGISTRY?=$(shell whoami)
 DOCKER_TAG_VERSION?=latest
+IMAGE_SRC?=https://github.com/project-radius/radius
 
 ##@ Docker Images
 
@@ -33,6 +34,7 @@ docker-build-$(1): build-$(1)-linux-amd64
 	cd $(OUT_DIR) && docker build $(2) -f ./Dockerfile-$(1) \
 		--platform linux/amd64 \
 		-t $(DOCKER_REGISTRY)/$(1):$(DOCKER_TAG_VERSION) \
+		--label org.opencontainers.image.source="$(IMAGE_SRC)" \
 		--label org.opencontainers.image.version="$(REL_VERSION)" \
 		--label org.opencontainers.image.revision="$(GIT_COMMIT)"
 else
@@ -40,6 +42,7 @@ docker-build-$(1):
 	@echo "$(ARROW) Building image $(DOCKER_REGISTRY)/$(1)\:$(DOCKER_TAG_VERSION)"
 	docker build $(2) -f $(3) \
 		-t $(DOCKER_REGISTRY)/$(1)\:$(DOCKER_TAG_VERSION) \
+		--label org.opencontainers.image.source="$(IMAGE_SRC)" \
 		--label org.opencontainers.image.version="$(REL_VERSION)" \
 		--label org.opencontainers.image.revision="$(GIT_COMMIT)"
 endif
@@ -58,6 +61,7 @@ docker-multi-arch-push-$(1): build-$(1)-linux-arm64 build-$(1)-linux-amd64 build
 	cd $(OUT_DIR) && docker buildx build -f ./Dockerfile-$(1) \
 		--platform linux/amd64,linux/arm64,linux/arm \
 		-t $(DOCKER_REGISTRY)/$(1):$(DOCKER_TAG_VERSION) \
+		--label org.opencontainers.image.source="$(IMAGE_SRC)" \
 		--label org.opencontainers.image.version="$(REL_VERSION)" \
 		--label org.opencontainers.image.revision="$(GIT_COMMIT)" \
 		--push $(2)

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -582,7 +582,9 @@ func createParametersFile(t *testing.T) (string, func()) {
 	err = os.WriteFile(paramFile.Name(), []byte(paramJSONBody), os.FileMode(0755))
 	require.NoError(t, err)
 
-	return paramFile.Name(), func() {}
+	return paramFile.Name(), func() {
+		os.Remove(paramFile.Name())
+	}
 }
 
 func Test_CLI_DeploymentParameters(t *testing.T) {

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -580,9 +580,7 @@ func createParametersFile(t *testing.T) (string, func()) {
 	err = os.WriteFile(paramFile.Name(), []byte(fmt.Sprintf(paramFileBody, registryVal)), os.FileMode(0755))
 	require.NoError(t, err)
 
-	return paramFile.Name(), func() {
-		os.Remove(paramFile.Name())
-	}
+	return paramFile.Name(), func() {}
 }
 
 func Test_CLI_DeploymentParameters(t *testing.T) {

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -562,7 +562,7 @@ func Test_CLI_Delete(t *testing.T) {
 }
 
 func createParametersFile(t *testing.T) (string, func()) {
-	paramFile, err := os.CreateTemp("", "")
+	paramFile, err := os.CreateTemp("./testdata", "tmp-*-parameters.json")
 	require.NoError(t, err)
 
 	registryVal, _ := functional.SetDefault()

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -561,26 +561,47 @@ func Test_CLI_Delete(t *testing.T) {
 	})
 }
 
+func createParametersFile(t *testing.T) (string, func()) {
+	paramFile, err := os.CreateTemp("", "")
+	require.NoError(t, err)
+
+	registryVal, _ := functional.SetDefault()
+	paramFileBody := `
+{
+	"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+	"contentVersion": "1.0.0.0",
+	"parameters": {
+		"registry": {
+			"value": "%s"
+		}
+	}
+}`
+
+	err = os.WriteFile(paramFile.Name(), []byte(fmt.Sprintf(paramFileBody, registryVal)), os.FileMode(0755))
+	require.NoError(t, err)
+
+	return paramFile.Name(), func() {
+		os.Remove(paramFile.Name())
+	}
+}
+
 func Test_CLI_DeploymentParameters(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 
 	template := "testdata/corerp-kubernetes-cli-parameters.bicep"
-	parameterFile := "testdata/corerp-kubernetes-cli-parameters.parameters.json"
 	name := "kubernetes-cli-params"
+
+	parameterFile, cleanup := createParametersFile(t)
+	defer cleanup()
 	parameterFilePath := filepath.Join(cwd, parameterFile)
 
 	// corerp-kubernetes-cli-parameters.parameters.json uses radiusdev.azurecr.io as a registry parameter.
 	// Use the specified tag only if the test uses radiusdev.azurecr.io registry. Otherwise, use latest tag.
-	magpieTag := "magpietag=latest"
-	image := functional.GetMagpieImage()
-	if !strings.HasPrefix(image, "magpieimage=radiusdev.azurecr.io") {
-		magpieTag = functional.GetMagpieTag()
-	}
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, "@"+parameterFilePath, magpieTag),
+			Executor: step.NewDeployExecutor(template, "@"+parameterFilePath, functional.GetMagpieTag()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -576,8 +576,10 @@ func createParametersFile(t *testing.T) (string, func()) {
 		}
 	}
 }`
+	paramJSONBody := fmt.Sprintf(paramFileBody, registryVal)
+	t.Log(paramJSONBody)
 
-	err = os.WriteFile(paramFile.Name(), []byte(fmt.Sprintf(paramFileBody, registryVal)), os.FileMode(0755))
+	err = os.WriteFile(paramFile.Name(), []byte(paramJSONBody), os.FileMode(0755))
 	require.NoError(t, err)
 
 	return paramFile.Name(), func() {}

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -561,8 +561,8 @@ func Test_CLI_Delete(t *testing.T) {
 	})
 }
 
-func createParametersFile(t *testing.T) (string, func()) {
-	paramFile, err := os.CreateTemp("./testdata", "tmp-*-parameters.json")
+func createParametersFile(t *testing.T) string {
+	paramFile, err := os.CreateTemp(t.TempDir(), "tmp-*-parameters.json")
 	require.NoError(t, err)
 
 	registryVal, _ := functional.SetDefault()
@@ -582,9 +582,7 @@ func createParametersFile(t *testing.T) (string, func()) {
 	err = os.WriteFile(paramFile.Name(), []byte(paramJSONBody), os.FileMode(0755))
 	require.NoError(t, err)
 
-	return paramFile.Name(), func() {
-		os.Remove(paramFile.Name())
-	}
+	return paramFile.Name()
 }
 
 func Test_CLI_DeploymentParameters(t *testing.T) {
@@ -594,9 +592,7 @@ func Test_CLI_DeploymentParameters(t *testing.T) {
 	template := "testdata/corerp-kubernetes-cli-parameters.bicep"
 	name := "kubernetes-cli-params"
 
-	parameterFile, cleanup := createParametersFile(t)
-	defer cleanup()
-	parameterFilePath := filepath.Join(cwd, parameterFile)
+	parameterFilePath := filepath.Join(cwd, createParametersFile(t))
 
 	// corerp-kubernetes-cli-parameters.parameters.json uses radiusdev.azurecr.io as a registry parameter.
 	// Use the specified tag only if the test uses radiusdev.azurecr.io registry. Otherwise, use latest tag.

--- a/test/functional/shared/cli/testdata/corerp-kubernetes-cli-parameters.parameters.json
+++ b/test/functional/shared/cli/testdata/corerp-kubernetes-cli-parameters.parameters.json
@@ -1,9 +1,0 @@
-{
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "registry": {
-            "value": "radiusdev.azurecr.io"
-        }
-    }
-}


### PR DESCRIPTION
# Description

This is to publish the images to GHCR and ACR side by side and purge 7+ days old `dev/*` images regularly.

## Type of change

- This pull request adds or changes features of Radius and has an approved issue (issue link required).

Fixes: radius-project/radius#6362 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f9d075e</samp>

### Summary
🐳🔄🌐

<!--
1.  🐳 - This emoji represents Docker, the container technology that is used to build and run the images.
2.  🔄 - This emoji represents migration, as the images are moved from one registry to another.
3.  🌐 - This emoji represents multi-architecture support, as the images can now run on different platforms and architectures.
-->
This pull request improves the container image building and publishing workflow for the project. It switches the registry to `GHCR`, enables cross-platform compatibility with `Docker Buildx`, and documents the open-sourcing steps in `.github/workflows/build.yaml`.

> _To improve our container image flow_
> _We switched from Docker Hub to GHCR, yo_
> _With Docker Buildx_
> _We support multi-arch_
> _And added some comments for open-source, though_

### Walkthrough
*  Migrate from Docker Hub to GHCR for storing the container images ([link](https://github.com/project-radius/radius/pull/5915/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R47-R52), [link](https://github.com/project-radius/radius/pull/5915/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L259-R332))
  - Add environment variables `RAD_BOT_ACTOR` and `CONTAINER_REGISTRY` to the workflow in `.github/workflows/build.yaml` ([link](https://github.com/project-radius/radius/pull/5915/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R47-R52))
  - Add a new job `publish_images` to build and push images to GHCR using Docker Buildx and different tag schemes ([link](https://github.com/project-radius/radius/pull/5915/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L259-R332))
  - Modify the `helm` job to depend on the `publish_images` job and use the `CONTAINER_REGISTRY` variable ([link](https://github.com/project-radius/radius/pull/5915/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L259-R332))
* Prepare for open-sourcing the repository and switching to GHCR as the default registry ([link](https://github.com/project-radius/radius/pull/5915/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R205-R206))
  - Add a comment to mark the `image` job as a temporary workaround until the repository is open-sourced in `.github/workflows/build.yaml` ([link](https://github.com/project-radius/radius/pull/5915/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R205-R206))
  - Link to an issue that tracks the progress of the open-sourcing process in the comment ([link](https://github.com/project-radius/radius/pull/5915/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R205-R206))


