### PR TITLE
Add Comments: Part 13 (pkg/kube*)

### DIFF
--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -173,15 +173,17 @@ func NormalizeDaprResourceName(name string) string {
 
 // # Function Explanation
 //
-// ConvertResourceTypeToLabelValue replaces the first occurrence of "/" with "-" in the given string and returns the
-// modified string. Example: Applications.Core/containers becomes Applications.Core-Containers
+// ConvertResourceTypeToLabelValue converts the given string to a value that Kubernetes allows i.e.
+// it replaces the first occurrence of "/" with "-" and returns the modified string.
+// Example: Applications.Core/containers becomes Applications.Core-Containers
 func ConvertResourceTypeToLabelValue(resourceType string) string {
 	return strings.Replace(resourceType, "/", "-", 1)
 }
 
 // # Function Explanation
 //
-// ConvertLabelToResourceType replaces the first occurrence of "-" with "/" in the given string and returns the result.
+// ConvertLabelToResourceType converts from kubernetes label value to Radius resource type i.e.
+// it replaces the first occurrence of "-" with "/" in the given string and returns the result.
 // Example: Applications.Core-containers becomes Applications.Core/Containers
 func ConvertLabelToResourceType(labelValue string) string {
 	return strings.Replace(labelValue, "-", "/", 1)

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -62,6 +62,8 @@ const (
 // In general, descriptive labels should be applied all to Kubernetes objects, and selector labels should be used
 // when programmatically querying those objects.
 
+// # Function Explanation
+//
 // MakeDescriptiveLabels returns a map of the descriptive labels for a Kubernetes resource associated with a Radius resource.
 // The descriptive labels are a superset of the selector labels.
 func MakeDescriptiveLabels(application string, resource string, resourceType string) map[string]string {
@@ -75,6 +77,8 @@ func MakeDescriptiveLabels(application string, resource string, resourceType str
 	}
 }
 
+// # Function Explanation
+//
 // MakeDescriptiveLabels returns a map of the descriptive labels for a Kubernetes Dapr resource associated with a Radius resource.
 // The descriptive labels are a superset of the selector labels.
 func MakeDescriptiveDaprLabels(application string, resource string, resourceType string) map[string]any {
@@ -92,6 +96,8 @@ func MakeDescriptiveDaprLabels(application string, resource string, resourceType
 	}
 }
 
+// # Function Explanation
+//
 // MakeSelectorLabels returns a map of labels suitable for a Kubernetes selector to identify a labeled Radius-managed
 // Kubernetes object.
 //
@@ -109,6 +115,8 @@ func MakeSelectorLabels(application string, resource string) map[string]string {
 	}
 }
 
+// # Function Explanation
+//
 // MakeRouteSelectorLabels returns a map of labels suitable for a Kubernetes selector to identify a labeled Radius-managed
 // Kubernetes object.
 //
@@ -124,6 +132,8 @@ func MakeRouteSelectorLabels(application string, resourceType string, route stri
 	}
 }
 
+// # Function Explanation
+//
 // NormalizeResourceName normalizes resource name used for kubernetes resource name scoped in namespace.
 // All name will be validated by swagger validation so that it does not get non-RFC1035 compliant characters.
 // Therefore, this function will lowercase the name without allowed character validation.
@@ -141,9 +151,12 @@ func NormalizeResourceName(name string) string {
 	return normalized
 }
 
+// # Function Explanation
+//
 // NormalizeDaprResourceName normalizes resource name used for kubernetes Dapr resource name scoped in namespace.
 // All name will be validated by swagger validation so that it does not get non-RFC1035 compliant characters.
-// Therefore, this function will lowercase the name without allowed character validation.
+// Therefore, this function will lowercase the name without allowed character validation. This function panics
+// if the name is invalid.
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names
 func NormalizeDaprResourceName(name string) string {
 	normalized := strings.ToLower(name)
@@ -158,15 +171,17 @@ func NormalizeDaprResourceName(name string) string {
 	return normalized
 }
 
-// ConvertResourceTypeToLabelValue function gets a Radius Resource type and converts it
-// to a value that Kubernetes allows.
-// Example: Applications.Core/containers becomes Applications.Core.Containers
+// # Function Explanation
+//
+// ConvertResourceTypeToLabelValue replaces the first occurrence of "/" with "-" in the given string and returns the
+// modified string. Example: Applications.Core/containers becomes Applications.Core-Containers
 func ConvertResourceTypeToLabelValue(resourceType string) string {
 	return strings.Replace(resourceType, "/", "-", 1)
 }
 
-// ConvertLabelToResourceType function gets a label and converts it
-// to a Radius Resource type.
+// # Function Explanation
+//
+// ConvertLabelToResourceType replaces the first occurrence of "-" with "/" in the given string and returns the result.
 // Example: Applications.Core-containers becomes Applications.Core/Containers
 func ConvertLabelToResourceType(labelValue string) string {
 	return strings.Replace(labelValue, "-", "/", 1)

--- a/pkg/kubernetes/object.go
+++ b/pkg/kubernetes/object.go
@@ -30,7 +30,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
-// FindDeployment finds deployment in a list of output resources
+// # Function Explanation
+//
+// FindDeployment searches through a slice of OutputResource objects and returns the first Deployment object and its
+// associated OutputResource object.
 func FindDeployment(resources []rpv1.OutputResource) (*appsv1.Deployment, rpv1.OutputResource) {
 	for _, r := range resources {
 		if r.ResourceType.Type != resourcekinds.Deployment {
@@ -48,7 +51,10 @@ func FindDeployment(resources []rpv1.OutputResource) (*appsv1.Deployment, rpv1.O
 	return nil, rpv1.OutputResource{}
 }
 
-// FindService finds service in a list of output resources
+// # Function Explanation
+//
+// FindService searches through a slice of OutputResource objects and returns the first Service object found and the
+// OutputResource object it was found in.
 func FindService(resources []rpv1.OutputResource) (*corev1.Service, rpv1.OutputResource) {
 	for _, r := range resources {
 		if r.ResourceType.Type != resourcekinds.Service {
@@ -66,7 +72,10 @@ func FindService(resources []rpv1.OutputResource) (*corev1.Service, rpv1.OutputR
 	return nil, rpv1.OutputResource{}
 }
 
-// FindSecret finds secret in a list of output resources
+// # Function Explanation
+//
+// FindSecret iterates through a slice of OutputResource objects and returns the first Secret object found and its
+// corresponding OutputResource object.
 func FindSecret(resources []rpv1.OutputResource) (*corev1.Secret, rpv1.OutputResource) {
 	for _, r := range resources {
 		if r.ResourceType.Type != resourcekinds.Secret {
@@ -84,7 +93,10 @@ func FindSecret(resources []rpv1.OutputResource) (*corev1.Secret, rpv1.OutputRes
 	return nil, rpv1.OutputResource{}
 }
 
-// FindHttpRouteByLocalID finds a (non-root) HTTPProxy in a list of output resources, keyed by its localID
+// # Function Explanation
+//
+// FindHttpRouteByLocalID searches through a slice of OutputResources to find a HTTPProxy resource
+// with the given localID.
 func FindHttpRouteByLocalID(resources []rpv1.OutputResource, localID string) (*contourv1.HTTPProxy, rpv1.OutputResource) {
 	for _, r := range resources {
 		if r.ResourceType.Type != resourcekinds.KubernetesHTTPRoute || r.LocalID != localID {
@@ -107,7 +119,10 @@ func FindHttpRouteByLocalID(resources []rpv1.OutputResource, localID string) (*c
 	return nil, rpv1.OutputResource{}
 }
 
-// FindGateway finds a root HTTPProxy in a list of output resources
+// # Function Explanation
+//
+// FindGateway iterates through a slice of OutputResources and returns the first HTTPProxy resource found with a
+// VirtualHost set.
 func FindGateway(resources []rpv1.OutputResource) (*contourv1.HTTPProxy, rpv1.OutputResource) {
 	for _, r := range resources {
 		if r.ResourceType.Type != resourcekinds.Gateway {
@@ -130,8 +145,10 @@ func FindGateway(resources []rpv1.OutputResource) (*contourv1.HTTPProxy, rpv1.Ou
 	return nil, rpv1.OutputResource{}
 }
 
-// GetShortenedTargetPortName is used to generate a unique port name based on a resource id.
-// This is used to link up the a Service and Deployment.
+// # Function Explanation
+//
+// GetShortenedTargetPortName takes in a string and returns a shortened version of it by using a hashing algorithm.
+// This generates a unique port name based on a resource id and can be used to link up a Service and Deployment.
 func GetShortenedTargetPortName(name string) string {
 	// targetPort can only be a maximum of 15 characters long.
 	// 32 bit number should always be less than that.
@@ -140,11 +157,16 @@ func GetShortenedTargetPortName(name string) string {
 	return "a" + fmt.Sprint(h.Sum32())
 }
 
-// IsValidObjectName returns true if name is valid Kubernetes object name
+// # Function Explanation
+//
+// IsValidObjectName checks if the given string is a valid DNS1123 label.
 func IsValidObjectName(name string) bool {
 	return len(validation.IsDNS1123Label(name)) == 0
 }
 
+// # Function Explanation
+//
+// IsValidDaprObjectName checks if the given string is a valid Dapr object name and returns a boolean value.
 func IsValidDaprObjectName(name string) bool {
 	return len(validation.IsDNS1123Subdomain(name)) == 0
 }

--- a/pkg/kubernetes/object.go
+++ b/pkg/kubernetes/object.go
@@ -159,7 +159,7 @@ func GetShortenedTargetPortName(name string) string {
 
 // # Function Explanation
 //
-// IsValidObjectName checks if the given string is a valid DNS1123 label.
+// IsValidObjectName checks if the given string is a valid Kubernetes object name.
 func IsValidObjectName(name string) bool {
 	return len(validation.IsDNS1123Label(name)) == 0
 }

--- a/pkg/kubeutil/client.go
+++ b/pkg/kubeutil/client.go
@@ -27,7 +27,10 @@ import (
 	csidriver "sigs.k8s.io/secrets-store-csi-driver/apis/v1alpha1"
 )
 
-// NewRuntimeClient creates new kubernetes clients.
+// # Function Explanation
+//
+// NewRuntimeClient creates a new runtime client using the given config and adds the
+// required resource schemes to the client.
 func NewRuntimeClient(config *rest.Config) (runtimeclient.Client, error) {
 	scheme := runtime.NewScheme()
 

--- a/pkg/kubeutil/config.go
+++ b/pkg/kubeutil/config.go
@@ -57,8 +57,10 @@ func buildConfigOptions(options *ConfigOptions) *ConfigOptions {
 	return options
 }
 
-// LoadConfigFile loads kubernetes config from specified config file.
-// If configFilePath is empty, it will use the default config from home directory.
+// # Function Explanation
+//
+// LoadConfigFile loads the Kubernetes config file from the given path, or will load the default
+// config from the home directory if no path is provided.
 func LoadConfigFile(configFilePath string) (*api.Config, error) {
 	if configFilePath == "" {
 		configFilePath = clientcmd.RecommendedHomeFile
@@ -67,7 +69,10 @@ func LoadConfigFile(configFilePath string) (*api.Config, error) {
 	return clientcmd.LoadFromFile(configFilePath)
 }
 
-// NewClientConfig loads kubeconfig in cluster or from the file.
+// # Function Explanation
+//
+// NewClientConfig builds a Kubernetes client config from either in-cluster or local configuration, and sets the QPS and
+// Burst values if provided. It returns an error if the config cannot be built.
 func NewClientConfig(options *ConfigOptions) (*rest.Config, error) {
 	options = buildConfigOptions(options)
 
@@ -95,7 +100,11 @@ func NewClientConfig(options *ConfigOptions) (*rest.Config, error) {
 	return config, nil
 }
 
-// NewClientConfigFromLocal loads config from local home directory.
+// # Function Explanation
+//
+// NewClientConfigFromLocal builds a Kubernetes client config from a ConfigOptions instance, loading the config file from the
+// ConfigFilePath and setting the QPS and Burst values if specified. It returns an error if the config file cannot be loaded
+// or the client config cannot be initialized.
 func NewClientConfigFromLocal(options *ConfigOptions) (*rest.Config, error) {
 	options = buildConfigOptions(options)
 

--- a/pkg/kubeutil/namespace.go
+++ b/pkg/kubeutil/namespace.go
@@ -25,7 +25,10 @@ import (
 	runtime_client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// PatchNamespace creates a namespace if it does not exist.
+// # Function Explanation
+//
+// PatchNamespace creates a new namespace with the given name and labels it with the given label, then applies it to the
+// cluster. It returns an error if the patch operation fails.
 func PatchNamespace(ctx context.Context, client runtime_client.Client, namespace string) error {
 	ns := &unstructured.Unstructured{
 		Object: map[string]any{


### PR DESCRIPTION
# Description

This is another PR adding comments to functions in Radius. In this PR, I address folders pkg/kubernetes and pkg/kubeutil.

Refs:
- Design doc - https://microsoft.sharepoint.com/teams/radiuscoreteam/Shared%20Documents/General/Design%20Docs/2023-04%20auto-generate-comments.docx?web=1

Other PRs in this series:
- https://github.com/project-radius/radius/pull/5531
- https://github.com/project-radius/radius/pull/5627
- https://github.com/project-radius/radius/pull/5643
- https://github.com/project-radius/radius/pull/5834
- https://github.com/project-radius/radius/pull/5835
- https://github.com/project-radius/radius/pull/5845
- https://github.com/project-radius/radius/pull/5850
- https://github.com/project-radius/radius/pull/5856
- https://github.com/project-radius/radius/pull/5859
- https://github.com/project-radius/radius/pull/5865
- https://github.com/project-radius/radius/pull/5868
- https://github.com/project-radius/radius/pull/5922


## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #5423 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3025c2f</samp>

### Summary
📝🛠️🌐

<!--
1.  📝 - This emoji means "memo" or "document" and can be used to represent changes that add or improve comments or documentation for code.
2.  🛠️ - This emoji means "hammer and wrench" or "tool" and can be used to represent changes that modify or fix the logic or functionality of code.
3.  🌐 - This emoji means "globe with meridians" or "worldwide" and can be used to represent changes that affect the interaction or compatibility of code with external systems or platforms, such as Kubernetes.
-->
This pull request improves the documentation and readability of the `kubernetes` and `kubeutil` packages, which handle Kubernetes resources and labels for the project-radius application. It adds and modifies comments for various functions and files, and adjusts some logic to handle Dapr resource names.

> _`kubernetes` code_
> _comments explain and enhance_
> _autumn leaves of logic_

### Walkthrough
*  Add and modify comments to explain the functions and types in the `pkg/kubernetes` package ([link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-047ae86eebcf4fe6b0552e33dfae04d8e3aed6ab8051060dbc3fe8dcd01c2fbdR65-R66), [link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-047ae86eebcf4fe6b0552e33dfae04d8e3aed6ab8051060dbc3fe8dcd01c2fbdR80-R81), [link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-047ae86eebcf4fe6b0552e33dfae04d8e3aed6ab8051060dbc3fe8dcd01c2fbdR99-R100), [link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-047ae86eebcf4fe6b0552e33dfae04d8e3aed6ab8051060dbc3fe8dcd01c2fbdR118-R119), [link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-047ae86eebcf4fe6b0552e33dfae04d8e3aed6ab8051060dbc3fe8dcd01c2fbdR135-R136), [link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-047ae86eebcf4fe6b0552e33dfae04d8e3aed6ab8051060dbc3fe8dcd01c2fbdL144-R159), [link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-047ae86eebcf4fe6b0552e33dfae04d8e3aed6ab8051060dbc3fe8dcd01c2fbdL161-R184), [link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-0cc21bb313b8e37f2ed17c65b98c5007620c4591766454972fbcfccacb2769b0L33-R36), [link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-0cc21bb313b8e37f2ed17c65b98c5007620c4591766454972fbcfccacb2769b0L51-R57), [link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-0cc21bb313b8e37f2ed17c65b98c5007620c4591766454972fbcfccacb2769b0L69-R78), [link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-0cc21bb313b8e37f2ed17c65b98c5007620c4591766454972fbcfccacb2769b0L87-R99), [link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-0cc21bb313b8e37f2ed17c65b98c5007620c4591766454972fbcfccacb2769b0L110-R125), [link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-0cc21bb313b8e37f2ed17c65b98c5007620c4591766454972fbcfccacb2769b0L133-R151), [link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-0cc21bb313b8e37f2ed17c65b98c5007620c4591766454972fbcfccacb2769b0L143-R169))
*  Add and modify comments to explain the functions in the `pkg/kubeutil` package that create and load Kubernetes client configs ([link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-b3324b732dceb7f64aaed7f68a8480160843308905abb13c850bb4c8f34f36bcL60-R63), [link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-b3324b732dceb7f64aaed7f68a8480160843308905abb13c850bb4c8f34f36bcL70-R75), [link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-b3324b732dceb7f64aaed7f68a8480160843308905abb13c850bb4c8f34f36bcL98-R107))
*  Add a comment to explain the function in the `pkg/kubeutil` package that patches a namespace with a label ([link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-27b5780feaeb27a263d78f09ef495cfc8d01d355cdca0dd6d295b586bd01d3d3L28-R31))
*  Add a comment to explain the function in the `pkg/kubeutil` package that creates a new runtime client with the required resource schemes ([link](https://github.com/project-radius/radius/pull/5923/files?diff=unified&w=0#diff-155e49c593063a1659469e14fe3d16d6880a5fb03b8705344b07d7793d80de2bL30-R33))


