### PR TITLE
Fix to show the configured credentials

### DIFF
--- a/pkg/cli/credential/azure_credential_management.go
+++ b/pkg/cli/credential/azure_credential_management.go
@@ -119,7 +119,7 @@ func (cpm *AzureCredentialManagementClient) Get(ctx context.Context, credentialN
 		return ProviderCredentialConfiguration{}, err
 	}
 
-	azureServicePrincipal, ok := resp.AzureCredentialResource.Properties.(*ucp.AzureCredentialProperties)
+	azureServicePrincipal, ok := resp.AzureCredentialResource.Properties.(*ucp.AzureServicePrincipalProperties)
 	if !ok {
 		return ProviderCredentialConfiguration{}, clierrors.Message("Unable to find credentials for cloud provider %s.", credentialName)
 	}
@@ -129,7 +129,10 @@ func (cpm *AzureCredentialManagementClient) Get(ctx context.Context, credentialN
 			Name:    AzureCredential,
 			Enabled: true,
 		},
-		AzureCredentials: azureServicePrincipal,
+		AzureCredentials: &ucp.AzureCredentialProperties{
+			Kind:              azureServicePrincipal.Kind,
+			ProvisioningState: azureServicePrincipal.ProvisioningState,
+		},
 	}
 
 	return providerCredentialConfiguration, nil


### PR DESCRIPTION
# Description

rad show credentials <cloudprovider> is supposed to show the configured credentials. However, due to a bug, this returns not found. This PR fixes the bug.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).


<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: radius-project/core-team#1213 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 09ea4f8</samp>

### Summary
🔧🧪🌐

<!--
1.  🔧 - This emoji represents a wrench or a tool, which can be used to indicate a refactoring or improvement of existing code.
2.  🧪 - This emoji represents a test tube or an experiment, which can be used to indicate a testing or verification of code functionality or quality.
3.  🌐 - This emoji represents a globe or a network, which can be used to indicate a cloud or web-related feature or change.
-->
Refactor the credential management logic for AWS and Azure to support multiple credential types and return consistent structs. Simplify the AWS `Get` function and fix the plane name and properties type. Add a new test function to verify the `Get` function for both cloud providers.

> _Oh we're the coders of the cloud, we make the credentials proud_
> _We refactor and we test, we always do our best_
> _We pull and push and merge, we make the logic converge_
> _Heave away, me hearties, heave away on `Get`_

### Walkthrough
*  Simplify and unify the credential management logic for AWS and Azure by assuming a single credential name and returning a consistent credential configuration struct ([link](https://github.com/project-radius/radius/pull/5924/files?diff=unified&w=0#diff-3413ca05710f169ca29edc2f09b44945561cb4854cc0514ea3106645af5b08c7L77-R97), [link](https://github.com/project-radius/radius/pull/5924/files?diff=unified&w=0#diff-98f38c5950bbd370f9042abd2175d5dfa2cdf1ac0decd50bc396b05fe3af80d4L122-R122), [link](https://github.com/project-radius/radius/pull/5924/files?diff=unified&w=0#diff-98f38c5950bbd370f9042abd2175d5dfa2cdf1ac0decd50bc396b05fe3af80d4L132-R135))
*  Add a test function to verify the expected output of the `Get` function for both cloud providers using mock clients ([link](https://github.com/project-radius/radius/pull/5924/files?diff=unified&w=0#diff-74d325685b64ca9087ae783938d84a43c046451df26c1bc598b61b7cf2a3ad36R397-R446))


