### PR TITLE
Bump AsyncDeleteMongoDatabaseTimeout to 20mins

### DIFF
--- a/pkg/linkrp/frontend/controller/types.go
+++ b/pkg/linkrp/frontend/controller/types.go
@@ -24,7 +24,7 @@ var (
 	// AsyncCreateOrUpdateMongoDatabaseTimeout is the timeout for async create or update mongo database
 	AsyncCreateOrUpdateMongoDatabaseTimeout = time.Duration(10) * time.Minute
 	// AsyncDeleteMongoDatabaseTimeout is the timeout for async delete mongo database
-	AsyncDeleteMongoDatabaseTimeout = time.Duration(15) * time.Minute
+	AsyncDeleteMongoDatabaseTimeout = time.Duration(20) * time.Minute
 
 	// AsyncCreateOrUpdateSqlTimeout is the timeout for async create or update sql database
 	AsyncCreateOrUpdateSqlDatabaseTimeout = time.Duration(10) * time.Minute


### PR DESCRIPTION
# Description

Deleting Mongo DB takes 15+mins. We're trying to bump the timeout to 20 mins for the mitigation.

![image](https://github.com/project-radius/radius/assets/11863108/fee759e6-5bec-4c05-9156-60a495d1381f)

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: radius-project/core-team#1243

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8bc088e</samp>

### Summary
🕑🗑️🚀

<!--
1.  🕑 - This emoji represents the increase in the timeout duration, as it shows a clock face with two o'clock, indicating a longer time span.
2.  🗑️ - This emoji represents the deletion of the mongo database, as it shows a wastebasket, indicating something being discarded or removed.
3.  🚀 - This emoji represents the improvement in the reliability and performance of the linkrp frontend controller, as it shows a rocket, indicating something being fast, efficient, or advanced.
-->
Increased the timeout for async deletion of mongo databases in `linkrp` frontend controller. This improves the reliability and performance of the controller when handling large databases.

> _`AsyncDelete` waits_
> _Large mongo databases slow_
> _Winter patience grows_

### Walkthrough
* Increase the timeout for deleting mongo databases from 15 to 20 minutes (`[link](https://github.com/project-radius/radius/pull/5926/files?diff=unified&w=0#diff-f2917d2c692a615ad7bd04dc17bc79dc9081a4b72f5d9a82f676c16b1684f531L27-R27)`). This improves the reliability and performance of the linkrp frontend controller when handling large databases.


