### PR TITLE
Skip MongoDB recipe test

### DIFF
--- a/test/functional/shared/resources/mongodb_test.go
+++ b/test/functional/shared/resources/mongodb_test.go
@@ -130,6 +130,8 @@ func Test_MongoDB_Recipe(t *testing.T) {
 // If the same parameters are set by the developer and the operator then the developer parameters are applied in to resolve conflicts.
 // Container uses the mongoDB link to connect to the mongoDB resource
 func Test_MongoDB_RecipeParameters(t *testing.T) {
+	t.Skip("Skipping test as creating/deleting cosmosdb resource is unreliable - https://github.com/project-radius/radius/issues/5929")
+
 	template := "testdata/corerp-resources-mongodb-recipe-parameters.bicep"
 	name := "corerp-resources-mongodb-recipe-parameters"
 	appNamespace := "corerp-resources-mongodb-recipe-param-app"

--- a/test/functional/shared/resources/mongodb_test.go
+++ b/test/functional/shared/resources/mongodb_test.go
@@ -194,6 +194,7 @@ func Test_MongoDB_RecipeParameters(t *testing.T) {
 // and container using the mongoDB link to connect to the underlying mongoDB resource.
 func Test_MongoDB_Recipe_ContextParameter(t *testing.T) {
 	t.Skip("Skipping test as creating/deleting cosmosdb resource is unreliable - https://github.com/project-radius/radius/issues/5929")
+
 	template := "testdata/corerp-resources-mongodb-recipe-context.bicep"
 	name := "corerp-resources-mongodb-recipe-context"
 	appNamespace := "corerp-resources-mongodb-recipe-context-app"

--- a/test/functional/shared/resources/mongodb_test.go
+++ b/test/functional/shared/resources/mongodb_test.go
@@ -193,6 +193,7 @@ func Test_MongoDB_RecipeParameters(t *testing.T) {
 // a default recipe using the context parameter generated and set by linkRP,
 // and container using the mongoDB link to connect to the underlying mongoDB resource.
 func Test_MongoDB_Recipe_ContextParameter(t *testing.T) {
+	t.Skip("Skipping test as creating/deleting cosmosdb resource is unreliable - https://github.com/project-radius/radius/issues/5929")
 	template := "testdata/corerp-resources-mongodb-recipe-context.bicep"
 	name := "corerp-resources-mongodb-recipe-context"
 	appNamespace := "corerp-resources-mongodb-recipe-context-app"


### PR DESCRIPTION
# Description

Skip MongoDB recipe test due to the deleting failures of cosmos DB.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: radius-project/core-team#1243

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e830ce0</samp>

### Summary
🐛🚧🚫

<!--
1.  🐛 - This emoji represents a bug fix, which was the main goal of the pull request.
2.  🚧 - This emoji represents work in progress, which indicates that the test function was skipped temporarily and not permanently removed.
3.  🚫 - This emoji represents a test being skipped or disabled, which is the direct effect of the change.
-->
Skipped a flaky functional test for mongodb recipe parameters in `test/functional/shared/resources/mongodb_test.go`. This was done to avoid intermittent failures while fixing a bug related to mongodb resource creation.

> _`Test_MongoDB_RecipeParameters`_
> _Skipped to avoid flaky tests_
> _Cosmosdb troubles - kireji_

### Walkthrough
* Skip the test function `Test_MongoDB_RecipeParameters` to avoid flaky failures due to cosmosdb resource issues ([link](https://github.com/project-radius/radius/pull/5930/files?diff=unified&w=0#diff-2685ba23686c6f342fa9a52d067ed3531ea852aff4223d4903b51e16265e8768R196))


