### PR TITLE
Add terraform recipes test infra

### DIFF
--- a/.github/scripts/cleanup-cluster.sh
+++ b/.github/scripts/cleanup-cluster.sh
@@ -29,7 +29,7 @@ do
         echo "skip deletion: $r"
     else
         echo "delete resource: $r"
-        kubectl delete resources.ucp.dev $r -n radius-system
+        kubectl delete resources.ucp.dev $r -n radius-system --ignore-not-found=true
     fi
 done
 

--- a/.github/workflows/e2e-test-azure.yaml
+++ b/.github/workflows/e2e-test-azure.yaml
@@ -55,8 +55,9 @@ env:
   # gotestsum version - see: https://github.com/gotestyourself/gotestsum
   GOTESTSUM_VER: 1.10.0
 
-  # ACR for storing test images
+  # ACR for storing test images and recipes
   CACHE_REGISTRY: radiusdev.azurecr.io
+  BICEP_RECIPE_REGISTRY: radiusdev.azurecr.io
   # The radius functional test timeout
   FUNCTIONALTEST_TIMEOUT: 60m
   # The Azure Location to store test resources
@@ -77,6 +78,9 @@ env:
   AKS_CLUSTER_NAME: 'radiuse2e00-aks'
   # The resource group for AKS_CLUSTER_NAME resource.
   AKS_RESOURCE_GROUP: 'radiuse2e00'
+
+    # Server where terraform test modules are deployed
+  TF_RECIPE_MODULE_SERVER_URL: "http://tf-module-server.radius-test-tf-module-server.svc.cluster.local"
 
 jobs:
   build:
@@ -188,8 +192,8 @@ jobs:
           <summary> Click here to see the list of tools in the current test run</summary>
 
           * gotestsum ${{ env.GOTESTSUM_VER }}
-          * Bicep recipe location `${{ env.CACHE_REGISTRY}}/test/functional/shared/recipes/<name>:${{ steps.gen-id.outputs.REL_VERSION }}`
-          * Terraform recipe location `http://tf-module-server.radius-test-tf-module-server.svc.cluster.local/<name>.zip` (in cluster)
+          * Bicep recipe location `${{ env.BICEP_RECIPE_REGISTRY}}/test/functional/shared/recipes/<name>:${{ steps.gen-id.outputs.REL_VERSION }}`
+          * Terraform recipe location `${{ env.TF_RECIPE_MODULE_SERVER_URL }}/<name>.zip` (in cluster)
           * applications-rp test image location: `${{ env.CACHE_REGISTRY }}/applications-rp:${{ steps.gen-id.outputs.REL_VERSION }}`
           * ucp test image location: `${{ env.CACHE_REGISTRY }}/ucpd:${{ steps.gen-id.outputs.REL_VERSION }}`
 
@@ -256,7 +260,7 @@ jobs:
           echo "CHECKOUT_REPO=${{ steps.gen-id.outputs.CHECKOUT_REPO }}" >> ./dist/cache/.buildenv
           echo "CHECKOUT_REF=$(git rev-parse HEAD)" >> ./dist/cache/.buildenv
           echo "PR_NUMBER=${{ steps.gen-id.outputs.PR_NUMBER }}" >> ./dist/cache/.buildenv
-          echo "RECIPE_TAG_VERSION=${{ steps.gen-id.outputs.REL_VERSION }}" >> ./dist/cache/.buildenv
+          echo "BICEP_RECIPE_TAG_VERSION=${{ steps.gen-id.outputs.REL_VERSION }}" >> ./dist/cache/.buildenv
       - name: Store the latest binaries into cache
         uses: actions/cache/save@v3
         if: steps.skip-build.outputs.SKIP_BUILD != 'true' && success()
@@ -268,8 +272,7 @@ jobs:
         run: |
           make publish-test-bicep-recipes
         env:
-          RECIPE_REGISTRY: ${{ env.CACHE_REGISTRY }}
-          RECIPE_TAG_VERSION: ${{ env.REL_VERSION }}
+          BICEP_RECIPE_TAG_VERSION: ${{ env.REL_VERSION }}
           RAD_BICEP_PATH: dist
       - name: Log Bicep recipe publish status (success)
         if: steps.skip-build.outputs.SKIP_BUILD != 'true' && success()
@@ -292,7 +295,7 @@ jobs:
       PR_NUMBER: ${{ needs.build.outputs.PR_NUMBER }}
       AZURE_TEST_RESOURCE_GROUP: radtest-${{ needs.build.outputs.UNIQUE_ID }}-e2e-all
       RAD_CLI_ARTIFACT_NAME: ${{ needs.build.outputs.RAD_CLI_ARTIFACT_NAME }}
-      RECIPE_TAG_VERSION: ${{ needs.build.outputs.REL_VERSION }}
+      BICEP_RECIPE_TAG_VERSION: ${{ needs.build.outputs.REL_VERSION }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -450,8 +453,6 @@ jobs:
           RADIUS_SAMPLES_REPO_ROOT: ${{ github.workspace }}/samples
           # Test_MongoDB_Recipe_Parameters is using the following environment variable.
           INTEGRATION_TEST_RESOURCE_GROUP_NAME: ${{ env.AZURE_TEST_RESOURCE_GROUP }}
-          RECIPE_REGISTRY: ${{ env.CACHE_REGISTRY }}
-          RECIPE_TAG_VERSION: ${{ env.RECIPE_TAG_VERSION }}
           FUNC_TEST_OIDC_ISSUER: ${{ env.FUNCTEST_OIDC_ISSUER }}
       - name: Log radius e2e test status (success)
         if: success()

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -48,8 +48,9 @@ env:
   AZURE_KEYVAULT_CSI_DRIVER_VER: '1.4.2'
   # Azure workload identity webhook chart version
   AZURE_WORKLOAD_IDENTITY_WEBHOOK_VER: '1.0.0'
-  # ACR for storing test images
+  # ACR for storing test images and recipes
   CACHE_REGISTRY: radiusdev.azurecr.io
+  BICEP_RECIPE_REGISTRY: radiusdev.azurecr.io
   # The radius functional test timeout
   FUNCTIONALTEST_TIMEOUT: 60m
   # The Azure Location to store test resources
@@ -64,6 +65,8 @@ env:
   AWS_ACCOUNT_ID: '${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}'
   # The current GitHub action link
   ACTION_LINK: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+  # Server where terraform test modules are deployed
+  TF_RECIPE_MODULE_SERVER_URL: "http://tf-module-server.radius-test-tf-module-server.svc.cluster.local"
 
 jobs:
   build:
@@ -169,8 +172,8 @@ jobs:
             * Dapr: ${{ env.DAPR_VER }}
             * Azure KeyVault CSI driver: ${{ env.AZURE_KEYVAULT_CSI_DRIVER_VER }}
             * Azure Workload identity webhook: ${{ env.AZURE_WORKLOAD_IDENTITY_WEBHOOK_VER }}
-            * Bicep recipe location `${{ env.CACHE_REGISTRY}}/test/functional/shared/recipes/<name>:${{ env.REL_VERSION }}`
-            * Terraform recipe location `http://tf-module-server.radius-test-tf-module-server.svc.cluster.local/<name>.zip` (in cluster)
+            * Bicep recipe location `${{ env.BICEP_RECIPE_REGISTRY}}/test/functional/shared/recipes/<name>:${{ env.REL_VERSION }}`
+            * Terraform recipe location `${{ env.TF_RECIPE_MODULE_SERVER_URL }}/<name>.zip` (in cluster)
             * applications-rp test image location: `${{ env.CACHE_REGISTRY }}/applications-rp:${{ env.REL_VERSION }}`
             * ucp test image location: `${{ env.CACHE_REGISTRY }}/ucpd:${{ env.REL_VERSION }}`
 
@@ -243,8 +246,7 @@ jobs:
         run: |
           make publish-test-bicep-recipes
         env:
-          RECIPE_REGISTRY: ${{ env.CACHE_REGISTRY }}
-          RECIPE_TAG_VERSION: ${{ env.REL_VERSION }}
+          BICEP_RECIPE_TAG_VERSION: ${{ env.REL_VERSION }}
           RAD_BICEP_PATH: dist
       - uses: marocchino/sticky-pull-request-comment@v2
         if: success() && env.PR_NUMBER != ''
@@ -280,7 +282,7 @@ jobs:
       PR_NUMBER: ${{ needs.build.outputs.PR_NUMBER }}
       AZURE_TEST_RESOURCE_GROUP: radtest-${{ needs.build.outputs.UNIQUE_ID }}-${{ matrix.name }}
       RAD_CLI_ARTIFACT_NAME: ${{ needs.build.outputs.RAD_CLI_ARTIFACT_NAME }}
-      RECIPE_TAG_VERSION: ${{ needs.build.outputs.REL_VERSION }}
+      BICEP_RECIPE_TAG_VERSION: ${{ needs.build.outputs.REL_VERSION }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -483,8 +485,6 @@ jobs:
           RADIUS_SAMPLES_REPO_ROOT: ${{ github.workspace }}/samples
           # Test_MongoDB_Recipe_Parameters is using the following environment variable.
           INTEGRATION_TEST_RESOURCE_GROUP_NAME: ${{ env.AZURE_TEST_RESOURCE_GROUP }}
-          RECIPE_REGISTRY: ${{ env.CACHE_REGISTRY }}
-          RECIPE_TAG_VERSION: ${{ env.RECIPE_TAG_VERSION }}
       - name: Upload container logs
         if: always()
         uses: actions/upload-artifact@v3

--- a/build/recipes.mk
+++ b/build/recipes.mk
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ------------------------------------------------------------
 
-RECIPE_TAG_VERSION?=latest
+BICEP_RECIPE_TAG_VERSION?=latest
 RAD_BICEP_PATH?=$${HOME}/.rad/bin
 
 TERRAFORM_MODULE_SERVER_NAMESPACE=radius-test-tf-module-server
@@ -24,15 +24,15 @@ TERRAFORM_MODULE_CONFIGMAP_NAME=tf-module-server-content
 ##@ Recipes
 
 .PHONY: publish-test-bicep-recipes
-publish-test-bicep-recipes: ## Publishes test recipes to <RECIPE_REGISTRY> with version <RECIPE_TAG_VERSION>
-	@if [ -z "$(RECIPE_REGISTRY)" ]; then echo "Error: RECIPE_REGISTRY must be set to a valid OCI registry"; exit 1; fi
+publish-test-bicep-recipes: ## Publishes test recipes to <BICEP_RECIPE_REGISTRY> with version <BICEP_RECIPE_TAG_VERSION>
+	@if [ -z "$(BICEP_RECIPE_REGISTRY)" ]; then echo "Error: BICEP_RECIPE_REGISTRY must be set to a valid OCI registry"; exit 1; fi
 	
 	@echo "$(ARROW) Publishing Bicep test recipes from ./test/functional/shared/resources/testdata/recipes/test-bicep-recipes..."
 	./.github/scripts/publish-recipes.sh \
 		${RAD_BICEP_PATH} \
 		./test/functional/shared/resources/testdata/recipes/test-bicep-recipes \
-		${RECIPE_REGISTRY}/test/functional/shared/recipes \
-		${RECIPE_TAG_VERSION}
+		${BICEP_RECIPE_REGISTRY}/test/functional/shared/recipes \
+		${BICEP_RECIPE_TAG_VERSION}
 
 .PHONY: publish-test-terraform-recipes
 publish-test-terraform-recipes: ## Publishes test terraform recipes to the current Kubernetes cluster
@@ -53,5 +53,5 @@ publish-test-terraform-recipes: ## Publishes test terraform recipes to the curre
 
 	@echo "$(ARROW) Web server ready. Recipes published to http://$(TERRAFORM_MODULE_SERVER_DEPLOYMENT_NAME).$(TERRAFORM_MODULE_SERVER_NAMESPACE).svc.cluster.local/<recipe_name>.zip"
 	@echo "$(ARROW) To test use:"
-	@echo "$(ARROW)     kubectl port-forward svc/$(TERRAFORM_MODULE_SERVER_DEPLOYMENT_NAME) 8080:80 -n $(TERRAFORM_MODULE_SERVER_NAMESPACE)"
-	@echo "$(ARROW)     curl http://localhost:8080/<recipe-name>.zip --output <recipe-name>.zip"
+	@echo "$(ARROW)     kubectl port-forward svc/$(TERRAFORM_MODULE_SERVER_DEPLOYMENT_NAME) 8999:80 -n $(TERRAFORM_MODULE_SERVER_NAMESPACE)"
+	@echo "$(ARROW)     curl http://localhost:8999/<recipe-name>.zip --output <recipe-name>.zip"

--- a/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
+++ b/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
@@ -40,7 +40,7 @@ As much as possible, the tests use product functionality such as the Radius CLI 
 2. Make sure `rad-bicep` is downloaded (`rad bicep download`)
 3. Create a container registry (must be Azure Container Registry for now)
 4. Log-in to the container registry `az acr login -n <registry-name>`
-5. Publish Bicep test recipes by running `RECIPE_REGISTRY=<registry-name>.azurecr.io make publish-test-bicep-recipes`
+5. Publish Bicep test recipes by running `BICEP_RECIPE_REGISTRY=<registry-name>.azurecr.io make publish-test-bicep-recipes`
 6. Publish Terraform test recipes by running `make publish-test-terraform-recipes`
 7. Create a Radius environment with `rad init` and specify the default namespace
 

--- a/test/functional/messagingrp/resources/rabbitmq_test.go
+++ b/test/functional/messagingrp/resources/rabbitmq_test.go
@@ -83,7 +83,7 @@ func Test_RabbitMQ_Recipe(t *testing.T) {
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), "password=guest", functional.GetRecipeRegistry(), functional.GetRecipeVersion()),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), "password=guest", functional.GetBicepRecipeRegistry(), functional.GetBicepRecipeVersion()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{

--- a/test/functional/shared/resources/dapr_pubsub_test.go
+++ b/test/functional/shared/resources/dapr_pubsub_test.go
@@ -75,7 +75,7 @@ func Test_DaprPubSubBroker_Recipe(t *testing.T) {
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), functional.GetRecipeRegistry(), functional.GetRecipeVersion()),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), functional.GetBicepRecipeRegistry(), functional.GetBicepRecipeVersion()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{

--- a/test/functional/shared/resources/dapr_secretstore_test.go
+++ b/test/functional/shared/resources/dapr_secretstore_test.go
@@ -72,7 +72,7 @@ func Test_DaprSecretStore_Recipe(t *testing.T) {
 
 	test := shared.NewRPTest(t, appNamespace, []shared.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), functional.GetRecipeRegistry(), functional.GetRecipeVersion()),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), functional.GetBicepRecipeRegistry(), functional.GetBicepRecipeVersion()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{

--- a/test/functional/shared/resources/dapr_statestore_test.go
+++ b/test/functional/shared/resources/dapr_statestore_test.go
@@ -77,7 +77,7 @@ func Test_DaprStateStore_Recipe(t *testing.T) {
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), functional.GetRecipeRegistry(), functional.GetRecipeVersion()),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), functional.GetBicepRecipeRegistry(), functional.GetBicepRecipeVersion()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{

--- a/test/functional/shared/resources/extender_test.go
+++ b/test/functional/shared/resources/extender_test.go
@@ -73,7 +73,7 @@ func Test_Extender_Recipe(t *testing.T) {
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, functional.GetRecipeRegistry(), functional.GetRecipeVersion()),
+			Executor: step.NewDeployExecutor(template, functional.GetBicepRecipeRegistry(), functional.GetBicepRecipeVersion()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
@@ -119,8 +119,8 @@ func Test_Extender_RecipeAWS(t *testing.T) {
 				fmt.Sprintf("bucketName=%s", bucketName),
 				functional.GetAWSAccountId(),
 				functional.GetAWSRegion(),
-				functional.GetRecipeRegistry(),
-				functional.GetRecipeVersion(),
+				functional.GetBicepRecipeRegistry(),
+				functional.GetBicepRecipeVersion(),
 			),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{

--- a/test/functional/shared/resources/microsoftsql_test.go
+++ b/test/functional/shared/resources/microsoftsql_test.go
@@ -87,7 +87,7 @@ func Test_SQLDatabase_Recipe(t *testing.T) {
 	appNamespace := "corerp-resources-sqldb-recipe-app"
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), functional.GetRecipeRegistry(), functional.GetRecipeVersion()),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), functional.GetBicepRecipeRegistry(), functional.GetBicepRecipeVersion()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{

--- a/test/functional/shared/resources/mongodb_test.go
+++ b/test/functional/shared/resources/mongodb_test.go
@@ -88,7 +88,7 @@ func Test_MongoDB_Recipe(t *testing.T) {
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), functional.GetRecipeRegistry(), functional.GetRecipeVersion()),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), functional.GetBicepRecipeRegistry(), functional.GetBicepRecipeVersion()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
@@ -144,7 +144,7 @@ func Test_MongoDB_RecipeParameters(t *testing.T) {
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), functional.GetRecipeRegistry(), functional.GetRecipeVersion()),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), functional.GetBicepRecipeRegistry(), functional.GetBicepRecipeVersion()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
@@ -209,7 +209,7 @@ func Test_MongoDB_Recipe_ContextParameter(t *testing.T) {
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), functional.GetRecipeRegistry(), functional.GetRecipeVersion()),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), functional.GetBicepRecipeRegistry(), functional.GetBicepRecipeVersion()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{

--- a/test/functional/shared/resources/rabbitmq_test.go
+++ b/test/functional/shared/resources/rabbitmq_test.go
@@ -83,7 +83,7 @@ func Test_RabbitMQ_Recipe(t *testing.T) {
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), "password=guest", functional.GetRecipeRegistry(), functional.GetRecipeVersion()),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), "password=guest", functional.GetBicepRecipeRegistry(), functional.GetBicepRecipeVersion()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{

--- a/test/functional/shared/resources/redis_test.go
+++ b/test/functional/shared/resources/redis_test.go
@@ -82,7 +82,7 @@ func Test_RedisRecipe(t *testing.T) {
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, functional.GetRecipeRegistry(), functional.GetRecipeVersion()),
+			Executor: step.NewDeployExecutor(template, functional.GetBicepRecipeRegistry(), functional.GetBicepRecipeVersion()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
@@ -113,7 +113,7 @@ func Test_RedisDefaultRecipe(t *testing.T) {
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, functional.GetRecipeRegistry(), functional.GetRecipeVersion()),
+			Executor: step.NewDeployExecutor(template, functional.GetBicepRecipeRegistry(), functional.GetBicepRecipeVersion()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{

--- a/test/functional/shared/resources/testdata/recipes/test-terraform-recipes/README.md
+++ b/test/functional/shared/resources/testdata/recipes/test-terraform-recipes/README.md
@@ -21,13 +21,13 @@ This URL is only accessible inside the cluster.
 If you need to verify the content, use:
 
 ```txt
-kubectl port-forward svc/tf-module-server 8080:80 -n radius-test-tf-module-server 
+kubectl port-forward svc/tf-module-server 8999:80 -n radius-test-tf-module-server 
 ```
 
 Then you can access the recipe download at:
 
 ```txt
-http://localhost:8080/<recipe_name>.zip
+http://localhost:8999/<recipe_name>.zip
 ```
 
 ---- 
@@ -36,6 +36,6 @@ Or reference a module from Terraform:
 
 ```hcl
 module "testing" {
-  source = "http://localhost:8080/<recipe_name>.zip"
+  source = "http://localhost:8999/<recipe_name>.zip"
 }
 ```

--- a/test/functional/shared/test.go
+++ b/test/functional/shared/test.go
@@ -39,10 +39,13 @@ func NewRPTestOptions(t *testing.T) RPTestOptions {
 	t.Logf("Using container tag: %s - set REL_VERSION to override", tag)
 	t.Logf("Using magpie image: %s/magpiego:%s", registry, tag)
 
-	_, recipeRegistry, _ := strings.Cut(functional.GetRecipeRegistry(), "=")
-	_, recipeTag, _ := strings.Cut(functional.GetRecipeVersion(), "=")
-	t.Logf("Using recipe registry: %s - set RECIPE_REGISTRY to override", recipeRegistry)
-	t.Logf("Using recipe tag: %s - set RECIPE_TAG_VERSION to override", recipeTag)
+	_, bicepRecipeRegistry, _ := strings.Cut(functional.GetBicepRecipeRegistry(), "=")
+	_, bicepRecipeTag, _ := strings.Cut(functional.GetBicepRecipeVersion(), "=")
+	t.Logf("Using recipe registry: %s - set BICEP_RECIPE_REGISTRY to override", bicepRecipeRegistry)
+	t.Logf("Using recipe tag: %s - set BICEP_RECIPE_TAG_VERSION to override", bicepRecipeTag)
+
+	_, terraformRecipeModuleServerURL, _ := strings.Cut(functional.GetTerraformRecipeModuleServerURL(), "=")
+	t.Logf("Using terraform recipe module server URL: %s - set TF_RECIPE_MODULE_SERVER_URL to override", terraformRecipeModuleServerURL)
 
 	ctx := testcontext.New(t)
 

--- a/test/functional/testUtil.go
+++ b/test/functional/testUtil.go
@@ -78,20 +78,38 @@ type ProxyMetadata struct {
 	Status   string
 }
 
-func GetRecipeRegistry() string {
-	defaultRecipeRegistry := os.Getenv("RECIPE_REGISTRY")
+func GetBicepRecipeRegistry() string {
+	defaultRecipeRegistry := os.Getenv("BICEP_RECIPE_REGISTRY")
 	if defaultRecipeRegistry == "" {
 		defaultRecipeRegistry = "radiusdev.azurecr.io"
 	}
 	return "registry=" + defaultRecipeRegistry
 }
 
-func GetRecipeVersion() string {
-	defaultVersion := os.Getenv("RECIPE_TAG_VERSION")
+func GetBicepRecipeVersion() string {
+	defaultVersion := os.Getenv("BICEP_RECIPE_TAG_VERSION")
 	if defaultVersion == "" {
 		defaultVersion = "latest"
 	}
 	return "version=" + defaultVersion
+}
+
+// GetTerraformRecipeModuleServerURL gets the terraform module server to use in tests from the environment variable
+// TF_RECIPE_MODULE_SERVER_URL. If the environment variable is not set, it uses the default value
+// for local testing (http://localhost:8999).
+//
+// The data is returned in bicep parameter format using the parameter name 'moduleServer'. The return value of this
+// function can be used as a parameter to 'rad deploy'.
+//
+// Example:
+//
+//	moduleServer=http://localhost:8999.
+func GetTerraformRecipeModuleServerURL() string {
+	u := os.Getenv("TF_RECIPE_MODULE_SERVER_URL")
+	if u == "" {
+		return "moduleServer=http://localhost:8999"
+	}
+	return "moduleServer=" + u
 }
 
 func GetAWSAccountId() string {


### PR DESCRIPTION
# Description

This change adds the remaining plumbing to consume our test terraform recipes from a functional test. I have already written a functional test that uses this new functionality but we need to make some additional product code changes to enable it, so I'm not including it in this PR.

The main change in this PR is renaming terminology where appropriate. Many places where we refer to recipes in test infra (env-vars, log statements, etc) don't clarify whether they are for Bicep or Terraform, which will cause confusion. So the main change here is actually renaming for clarity.

The other change I'm making is in the recommended port for the TF module server for local testing. 8080 is used by one of our RPs, so it's not a good choice. It doesn't really matter which port we choose, but we want to make sure it doesn't cause conflicts.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).


## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c41ad4d</samp>

### Summary
🚀🔄🐛

<!--
1.  🚀 - This emoji represents the enhancement of the functional tests to support both Bicep and Terraform test recipes, as well as the improved clarity and consistency of the code and configuration.
2.  🔄 - This emoji represents the renaming of the environment variables, functions, and variables related to the Bicep recipe registry and tag, to avoid confusion with the Terraform recipe version and module server URL.
3.  🐛 - This emoji represents the fixing of the port conflict issue in the `test-terraform-recipes` folder, which could cause errors when testing the Terraform test recipes.
-->
Renamed and added environment variables and functions related to Bicep and Terraform recipe registry, tag, and module server URL. This improves the clarity, consistency, and flexibility of the workflow, build, and test configurations and code for the Bicep and Terraform recipes. Updated the documentation and references accordingly.

> _`BICEP_RECIPE` now_
> _clarifies the test recipes_
> _`Terraform` joins in_

### Walkthrough
*  Rename environment variables and functions related to Bicep recipe registry and tag to avoid confusion with Terraform recipe version ([link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-4f62b287c879d688a637961bed711c48e0809bd32559ec524e5d7aa911cc0bd1L259-R259),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-4f62b287c879d688a637961bed711c48e0809bd32559ec524e5d7aa911cc0bd1L271-R272),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-4f62b287c879d688a637961bed711c48e0809bd32559ec524e5d7aa911cc0bd1L295-R295),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-4f62b287c879d688a637961bed711c48e0809bd32559ec524e5d7aa911cc0bd1L453-R454),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL246-R247),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL486-R487),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-d2dfe02e16036198b889fbfbe653f36f04311c2dea672498040231bfcba93d4fL17-R17),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-d2dfe02e16036198b889fbfbe653f36f04311c2dea672498040231bfcba93d4fL27-R28),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-d2dfe02e16036198b889fbfbe653f36f04311c2dea672498040231bfcba93d4fL34-R35),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-e286d51f1368685af6439c0bd568dc2cbee5c7c3806112b211a8844754c0b1c6L43-R43),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-e16f5cab974f71f4df44663630ca48bc4230cf6d4ecccef1e4f494322a63677bL86-R86),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-ce9f04c345fae8a925e32970581daaad2cfe0e3ba987695a0f459298c177cde1L78-R78),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-a1aba07e5042704f25fb56dafacabee8e5799becca2a7af03dfbe4e91fdca5b7L75-R75),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-06271efadd0dd9a8c856888c0fba48cb91fb8b7ad46c27537798e31af014c8bcL80-R80),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-ea6b32716a499d0deffb7fc13fe99ab1fb5b4fa7f67576e4b89757e76d813b5bL76-R76),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-ea6b32716a499d0deffb7fc13fe99ab1fb5b4fa7f67576e4b89757e76d813b5bL122-R123),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-2eb4b67b97eba2554fe54033a042ef2a2ddc88b52efe07174cfa6638ef56caf4L90-R90),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-2685ba23686c6f342fa9a52d067ed3531ea852aff4223d4903b51e16265e8768L91-R91),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-2685ba23686c6f342fa9a52d067ed3531ea852aff4223d4903b51e16265e8768L145-R145),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-2685ba23686c6f342fa9a52d067ed3531ea852aff4223d4903b51e16265e8768L208-R208),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-13b9148639b27cae4eef241c4356ec6dcf0a626e19f466a4b40773c2f15ea06fL86-R86),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-1d3c41f66f63475492f8471c7c8032101a9b3e8f932602d7f7f965b76df79291L85-R85),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-1d3c41f66f63475492f8471c7c8032101a9b3e8f932602d7f7f965b76df79291L116-R116),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-ca65669bbb1ffbb902e1e73c239e499e677a3efd9ab7e9f63ff826d14e604057L42-R49),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-d7fffa085c17b99a173ae530015cc075c39419e8ff504aea56ef80eb527b3c18L81-R82),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-d7fffa085c17b99a173ae530015cc075c39419e8ff504aea56ef80eb527b3c18L89-R90))
* Add environment variable and function for Terraform recipe module server URL to support Terraform test recipes ([link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-d2dfe02e16036198b889fbfbe653f36f04311c2dea672498040231bfcba93d4fL56-R56),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-b019bdd7fbb0066cd0206d7dd2e6341d1469d3c2d6d800350bdc022a138e2827L24-R24),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-b019bdd7fbb0066cd0206d7dd2e6341d1469d3c2d6d800350bdc022a138e2827L30-R30),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-b019bdd7fbb0066cd0206d7dd2e6341d1469d3c2d6d800350bdc022a138e2827L39-L38),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-ca65669bbb1ffbb902e1e73c239e499e677a3efd9ab7e9f63ff826d14e604057L42-R49),[link](https://github.com/project-radius/radius/pull/5931/files?diff=unified&w=0#diff-d7fffa085c17b99a173ae530015cc075c39419e8ff504aea56ef80eb527b3c18R97-R114))


