### PR TITLE
Look at pod events to determine failing readiness probe [do not review]

### DIFF
--- a/deploy/Chart/templates/rp/rbac.yaml
+++ b/deploy/Chart/templates/rp/rbac.yaml
@@ -15,6 +15,7 @@ rules:
   - namespaces
   - serviceaccounts
   - pods
+  - events
   verbs:
   - create
   - delete

--- a/pkg/armrpc/asyncoperation/controller/request.go
+++ b/pkg/armrpc/asyncoperation/controller/request.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	// DefaultAsyncOperationTimeout is the default timeout duration of async operation.
-	DefaultAsyncOperationTimeout = time.Duration(120) * time.Second
+	DefaultAsyncOperationTimeout = time.Duration(30) * time.Second
 )
 
 // Request is a message used for async request queue message broker.

--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -285,6 +285,7 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 			logger.Info("Cancelling async operation.")
 
 			opCancel()
+			fmt.Println("@@@@@ Done invoking cancel function")
 			errMessage := fmt.Sprintf("Operation (%s) has timed out because it was processing longer than %d s.", asyncReq.OperationType, int(asyncReq.Timeout().Seconds()))
 			result := ctrl.NewCanceledResult(errMessage)
 			result.Error.Target = asyncReq.ResourceID

--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -285,6 +285,7 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 			logger.Info("Cancelling async operation.")
 
 			opCancel()
+			time.Sleep(10 * time.Second)
 			fmt.Println("@@@@@ Done invoking cancel function")
 			errMessage := fmt.Sprintf("Operation (%s) has timed out because it was processing longer than %d s.", asyncReq.OperationType, int(asyncReq.Timeout().Seconds()))
 			result := ctrl.NewCanceledResult(errMessage)

--- a/pkg/corerp/handlers/kubernetes.go
+++ b/pkg/corerp/handlers/kubernetes.go
@@ -52,7 +52,7 @@ const (
 // Create an interface for deployment waiter and http proxy waiter
 type ResourceWaiter interface {
 	addDynamicEventHandler(ctx context.Context, informerFactory dynamicinformer.DynamicSharedInformerFactory, informer cache.SharedIndexInformer, item client.Object, doneCh chan<- error)
-	addEventHandler(ctx context.Context, informerFactory informers.SharedInformerFactory, informer cache.SharedIndexInformer, item client.Object, doneCh chan<- error)
+	addEventHandler(ctx context.Context, informerFactory informers.SharedInformerFactory, informer cache.SharedIndexInformer, item client.Object, doneCh chan<- deploymentStatus)
 	waitUntilReady(ctx context.Context, item client.Object) error
 }
 

--- a/pkg/corerp/handlers/kubernetes_deployment_waiter.go
+++ b/pkg/corerp/handlers/kubernetes_deployment_waiter.go
@@ -85,18 +85,17 @@ func (handler *deploymentWaiter) waitUntilReady(ctx context.Context, item client
 
 	var possibleFailureCauses []string
 
+	dep, err := handler.clientSet.AppsV1().Deployments(item.GetNamespace()).Get(ctx, item.GetName(), metav1.GetOptions{})
+	if err != nil {
+		fmt.Println("@@@@ error getting deployment", err.Error())
+		return fmt.Errorf("deployment cannot be fetched, name: %s, namespace %s, error: %w", item.GetName(), item.GetNamespace(), err)
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			fmt.Println("@@@@@ Inside ctx.Done()")
 			// Get the final deployment status
-			dep, err := handler.clientSet.AppsV1().Deployments(item.GetNamespace()).Get(ctx, item.GetName(), metav1.GetOptions{})
-			if err != nil {
-				return fmt.Errorf("deployment timed out, name: %s, namespace %s, error occured while fetching latest status: %w", item.GetName(), item.GetNamespace(), err)
-			}
-
-			fmt.Println("@@@@@ Now get the latest available observation of deployment current state")
-
 			// Now get the latest available observation of deployment current state
 			// note that there can be a race condition here, by the time it fetches the latest status, deployment might be succeeded
 			status := v1.DeploymentCondition{}
@@ -108,6 +107,7 @@ func (handler *deploymentWaiter) waitUntilReady(ctx context.Context, item client
 			fmt.Println("@@@@@ Marking deployment as timed out")
 			// Return the error with the possible failure causes
 			errString := fmt.Sprintf("deployment timed out, name: %s, namespace %s, status: %s, reason: %s", item.GetName(), item.GetNamespace(), status.Message, status.Reason)
+
 			if len(possibleFailureCauses) > 0 {
 				errString += fmt.Sprintf(", possible failure causes: %s", strings.Join(possibleFailureCauses, ", "))
 			}
@@ -118,8 +118,14 @@ func (handler *deploymentWaiter) waitUntilReady(ctx context.Context, item client
 				logger.Info(fmt.Sprintf("Marking deployment %s in namespace %s as complete", item.GetName(), item.GetNamespace()))
 				return status.err
 			} else if status.possibleFailureCause != "" {
-				possibleFailureCauses = append(possibleFailureCauses, status.possibleFailureCause)
-				fmt.Println("@@@@@ possibleFailureCauses", status.possibleFailureCause)
+				for _, cause := range possibleFailureCauses {
+					if strings.Contains(cause, status.possibleFailureCause) {
+						// Already added this possible failure cause. Do not add again
+						break
+					}
+					possibleFailureCauses = append(possibleFailureCauses, status.possibleFailureCause)
+					fmt.Println("@@@@@ possibleFailureCauses", status.possibleFailureCause)
+				}
 				continue
 			} else {
 				// Deployment is ready
@@ -188,6 +194,9 @@ func (handler *deploymentWaiter) startInformers(ctx context.Context, item client
 
 	// Add event handlers to the replicaset informer
 	handler.addEventHandler(ctx, informerFactory, informerFactory.Apps().V1().ReplicaSets().Informer(), item, doneCh)
+
+	// Add event handlers to the events informer
+	handler.addEventHandler(ctx, informerFactory, informerFactory.Core().V1().Events().Informer(), item, doneCh)
 
 	// Start the informers
 	informerFactory.Start(ctx.Done())
@@ -344,12 +353,14 @@ func (handler *deploymentWaiter) checkPodStatus(ctx context.Context, informerFac
 		} else if !cs.Ready {
 			// The container is running but has not passed its readiness probe yet
 			// Check the pod events to see if the pod failed readiness probe
-			fmt.Println("@@@@@ cs.Ready false. Checking pod events")
+			fmt.Println("@@@@@ cs.Ready false. Checking pod events in namespace: ", pod.Namespace)
 			events, err := informerFactory.Core().V1().Events().Lister().Events(pod.Namespace).List(labels.Everything())
 			if err != nil {
+				fmt.Println("@@@@ Unable to get events for pod")
 				logger.Info("Unable to get events for pod")
 				return false, deploymentStatus{}
 			}
+			fmt.Println("@@@@@ len(events)", len(events))
 
 			// Sort events by creation timestamp in descending order
 			sort.Slice(events, func(i, j int) bool {
@@ -368,11 +379,14 @@ func (handler *deploymentWaiter) checkPodStatus(ctx context.Context, informerFac
 		}
 	}
 
+	fmt.Println("@@@@@ Outside of container status. Checking pod events in namespace: ", pod.Namespace)
 	events, err := informerFactory.Core().V1().Events().Lister().Events(pod.Namespace).List(labels.Everything())
 	if err != nil {
+		fmt.Println("@@@@ Unable to get events for pod")
 		logger.Info("Unable to get events for pod")
 		return false, deploymentStatus{}
 	}
+	fmt.Println("@@@@@ len(events)", len(events))
 
 	// Sort events by creation timestamp in descending order
 	sort.Slice(events, func(i, j int) bool {

--- a/pkg/corerp/handlers/kubernetes_deployment_waiter_test.go
+++ b/pkg/corerp/handlers/kubernetes_deployment_waiter_test.go
@@ -99,6 +99,7 @@ func startInformers(ctx context.Context, clientSet *fake.Clientset, handler *kub
 	informerFactory.Apps().V1().Deployments().Informer()
 	informerFactory.Apps().V1().ReplicaSets().Informer()
 	informerFactory.Core().V1().Pods().Informer()
+	informerFactory.Core().V1().Events().Informer()
 
 	informerFactory.Start(context.Background().Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
@@ -435,106 +436,106 @@ func TestCheckPodStatus(t *testing.T) {
 		isReady         bool
 		expectedError   string
 	}{
-		{
-			// Container is in Terminated state
-			podCondition: nil,
-			containerStatus: []corev1.ContainerStatus{
-				{
-					State: corev1.ContainerState{
-						Terminated: &corev1.ContainerStateTerminated{
-							Reason:  "Error",
-							Message: "Container terminated due to an error",
-						},
-					},
-				},
-			},
-			isReady:       false,
-			expectedError: "Container state is 'Terminated' Reason: Error, Message: Container terminated due to an error",
-		},
-		{
-			// Container is in CrashLoopBackOff state
-			podCondition: nil,
-			containerStatus: []corev1.ContainerStatus{
-				{
-					State: corev1.ContainerState{
-						Waiting: &corev1.ContainerStateWaiting{
-							Reason:  "CrashLoopBackOff",
-							Message: "Back-off 5m0s restarting failed container=test-container pod=test-pod",
-						},
-					},
-				},
-			},
-			isReady:       false,
-			expectedError: "Container state is 'Waiting' Reason: CrashLoopBackOff, Message: Back-off 5m0s restarting failed container=test-container pod=test-pod",
-		},
-		{
-			// Container is in ErrImagePull state
-			podCondition: nil,
-			containerStatus: []corev1.ContainerStatus{
-				{
-					State: corev1.ContainerState{
-						Waiting: &corev1.ContainerStateWaiting{
-							Reason:  "ErrImagePull",
-							Message: "Cannot pull image",
-						},
-					},
-				},
-			},
-			isReady:       false,
-			expectedError: "Container state is 'Waiting' Reason: ErrImagePull, Message: Cannot pull image",
-		},
-		{
-			// Container is in ImagePullBackOff state
-			podCondition: nil,
-			containerStatus: []corev1.ContainerStatus{
-				{
-					State: corev1.ContainerState{
-						Waiting: &corev1.ContainerStateWaiting{
-							Reason:  "ImagePullBackOff",
-							Message: "ImagePullBackOff",
-						},
-					},
-				},
-			},
-			isReady:       false,
-			expectedError: "Container state is 'Waiting' Reason: ImagePullBackOff, Message: ImagePullBackOff",
-		},
-		{
-			// No container statuses available
-			isReady:       false,
-			expectedError: "",
-		},
-		{
-			// Container is in Waiting state but not a terminally failed state
-			podCondition: nil,
-			containerStatus: []corev1.ContainerStatus{
-				{
-					State: corev1.ContainerState{
-						Waiting: &corev1.ContainerStateWaiting{
-							Reason:  "ContainerCreating",
-							Message: "Container is being created",
-						},
-					},
-					Ready: false,
-				},
-			},
-			isReady:       false,
-			expectedError: "",
-		},
-		{
-			// Container's Running state is nil
-			podCondition: nil,
-			containerStatus: []corev1.ContainerStatus{
-				{
-					State: corev1.ContainerState{
-						Running: nil,
-					},
-					Ready: false,
-				},
-			},
-			isReady:       false,
-			expectedError: "",
-		},
+		// {
+		// 	// Container is in Terminated state
+		// 	podCondition: nil,
+		// 	containerStatus: []corev1.ContainerStatus{
+		// 		{
+		// 			State: corev1.ContainerState{
+		// 				Terminated: &corev1.ContainerStateTerminated{
+		// 					Reason:  "Error",
+		// 					Message: "Container terminated due to an error",
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	isReady:       false,
+		// 	expectedError: "Container state is 'Terminated' Reason: Error, Message: Container terminated due to an error",
+		// },
+		// {
+		// 	// Container is in CrashLoopBackOff state
+		// 	podCondition: nil,
+		// 	containerStatus: []corev1.ContainerStatus{
+		// 		{
+		// 			State: corev1.ContainerState{
+		// 				Waiting: &corev1.ContainerStateWaiting{
+		// 					Reason:  "CrashLoopBackOff",
+		// 					Message: "Back-off 5m0s restarting failed container=test-container pod=test-pod",
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	isReady:       false,
+		// 	expectedError: "Container state is 'Waiting' Reason: CrashLoopBackOff, Message: Back-off 5m0s restarting failed container=test-container pod=test-pod",
+		// },
+		// {
+		// 	// Container is in ErrImagePull state
+		// 	podCondition: nil,
+		// 	containerStatus: []corev1.ContainerStatus{
+		// 		{
+		// 			State: corev1.ContainerState{
+		// 				Waiting: &corev1.ContainerStateWaiting{
+		// 					Reason:  "ErrImagePull",
+		// 					Message: "Cannot pull image",
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	isReady:       false,
+		// 	expectedError: "Container state is 'Waiting' Reason: ErrImagePull, Message: Cannot pull image",
+		// },
+		// {
+		// 	// Container is in ImagePullBackOff state
+		// 	podCondition: nil,
+		// 	containerStatus: []corev1.ContainerStatus{
+		// 		{
+		// 			State: corev1.ContainerState{
+		// 				Waiting: &corev1.ContainerStateWaiting{
+		// 					Reason:  "ImagePullBackOff",
+		// 					Message: "ImagePullBackOff",
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	isReady:       false,
+		// 	expectedError: "Container state is 'Waiting' Reason: ImagePullBackOff, Message: ImagePullBackOff",
+		// },
+		// {
+		// 	// No container statuses available
+		// 	isReady:       false,
+		// 	expectedError: "",
+		// },
+		// {
+		// 	// Container is in Waiting state but not a terminally failed state
+		// 	podCondition: nil,
+		// 	containerStatus: []corev1.ContainerStatus{
+		// 		{
+		// 			State: corev1.ContainerState{
+		// 				Waiting: &corev1.ContainerStateWaiting{
+		// 					Reason:  "ContainerCreating",
+		// 					Message: "Container is being created",
+		// 				},
+		// 			},
+		// 			Ready: false,
+		// 		},
+		// 	},
+		// 	isReady:       false,
+		// 	expectedError: "",
+		// },
+		// {
+		// 	// Container's Running state is nil
+		// 	podCondition: nil,
+		// 	containerStatus: []corev1.ContainerStatus{
+		// 		{
+		// 			State: corev1.ContainerState{
+		// 				Running: nil,
+		// 			},
+		// 			Ready: false,
+		// 		},
+		// 	},
+		// 	isReady:       false,
+		// 	expectedError: "",
+		// },
 		{
 			// Readiness check is not yet passed
 			podCondition: nil,
@@ -549,33 +550,35 @@ func TestCheckPodStatus(t *testing.T) {
 			isReady:       false,
 			expectedError: "",
 		},
-		{
-			// Container is in Ready state
-			podCondition: nil,
-			containerStatus: []corev1.ContainerStatus{
-				{
-					State: corev1.ContainerState{
-						Running: &corev1.ContainerStateRunning{},
-					},
-					Ready: true,
-				},
-			},
-			isReady:       true,
-			expectedError: "",
-		},
+		// {
+		// 	// Container is in Ready state
+		// 	podCondition: nil,
+		// 	containerStatus: []corev1.ContainerStatus{
+		// 		{
+		// 			State: corev1.ContainerState{
+		// 				Running: &corev1.ContainerStateRunning{},
+		// 			},
+		// 			Ready: true,
+		// 		},
+		// 	},
+		// 	isReady:       true,
+		// 	expectedError: "",
+		// },
 	}
 
 	ctx := context.Background()
 	deploymentWaiter := NewDeploymentWaiter(fake.NewSimpleClientset())
+	clientset := fake.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(clientset, 0)
 	for _, tc := range podTests {
 		pod.Status.Conditions = tc.podCondition
 		pod.Status.ContainerStatuses = tc.containerStatus
-		isReady, err := deploymentWaiter.checkPodStatus(ctx, pod)
+		isReady, status := deploymentWaiter.checkPodStatus(ctx, informerFactory, pod)
 		if tc.expectedError != "" {
-			require.Error(t, err)
-			require.Equal(t, tc.expectedError, err.Error())
+			require.Error(t, status.err)
+			require.Equal(t, tc.expectedError, status.err.Error())
 		} else {
-			require.NoError(t, err)
+			require.NoError(t, status.err)
 		}
 		require.Equal(t, tc.isReady, isReady)
 	}
@@ -627,7 +630,7 @@ func TestCheckAllPodsReady_Success(t *testing.T) {
 	addTestObjects(t, clientset, informerFactory, testDeployment, replicaSet, pod)
 
 	// Create a done channel
-	doneCh := make(chan error)
+	doneCh := make(chan deploymentStatus)
 
 	// Create a handler with the fake clientset
 	deploymentWaiter := &deploymentWaiter{
@@ -694,7 +697,7 @@ func TestCheckAllPodsReady_Fail(t *testing.T) {
 	addTestObjects(t, clientset, informerFactory, testDeployment, replicaSet, pod)
 
 	// Create a done channel
-	doneCh := make(chan error)
+	doneCh := make(chan deploymentStatus)
 
 	// Create a handler with the fake clientset
 	deploymentWaiter := &deploymentWaiter{
@@ -771,7 +774,7 @@ func TestCheckDeploymentStatus_AllReady(t *testing.T) {
 	}
 
 	// Create a done channel
-	doneCh := make(chan error, 1)
+	doneCh := make(chan deploymentStatus, 1)
 
 	// Call the checkDeploymentStatus function
 	deploymentWaiter := &deploymentWaiter{
@@ -780,10 +783,10 @@ func TestCheckDeploymentStatus_AllReady(t *testing.T) {
 
 	deploymentWaiter.checkDeploymentStatus(ctx, informerFactory, item, doneCh)
 
-	err = <-doneCh
+	status := <-doneCh
 
 	// Check that the deployment readiness was checked
-	require.Nil(t, err)
+	require.Nil(t, status.err)
 }
 
 func TestCheckDeploymentStatus_NoReplicaSetsFound(t *testing.T) {
@@ -845,7 +848,7 @@ func TestCheckDeploymentStatus_NoReplicaSetsFound(t *testing.T) {
 	}
 
 	// Create a done channel
-	doneCh := make(chan error, 1)
+	doneCh := make(chan deploymentStatus, 1)
 
 	// Call the checkDeploymentStatus function
 	deploymentWaiter := &deploymentWaiter{
@@ -924,19 +927,19 @@ func TestCheckDeploymentStatus_PodsNotReady(t *testing.T) {
 	}
 
 	// Create a done channel
-	doneCh := make(chan error, 1)
+	doneCh := make(chan deploymentStatus, 1)
 
 	// Call the checkDeploymentStatus function
 	deploymentWaiter := &deploymentWaiter{
 		clientSet: fakeClient,
 	}
 
-	go deploymentWaiter.checkDeploymentStatus(ctx, informerFactory, item, doneCh)
-	err = <-doneCh
+	require.False(t, deploymentWaiter.checkDeploymentStatus(ctx, informerFactory, item, doneCh))
+	status := <-doneCh
 
 	// Check that the deployment readiness was checked
-	require.Error(t, err)
-	require.Equal(t, err.Error(), "Container state is 'Terminated' Reason: Error, Message: Container terminated due to an error")
+	require.Error(t, status.err)
+	require.Equal(t, status.err.Error(), "Container state is 'Terminated' Reason: Error, Message: Container terminated due to an error")
 }
 
 func TestCheckDeploymentStatus_ObservedGenerationMismatch(t *testing.T) {
@@ -1006,7 +1009,7 @@ func TestCheckDeploymentStatus_ObservedGenerationMismatch(t *testing.T) {
 	}
 
 	// Create a done channel
-	doneCh := make(chan error, 1)
+	doneCh := make(chan deploymentStatus, 1)
 
 	// Call the checkDeploymentStatus function
 	deploymentWaiter := &deploymentWaiter{
@@ -1095,7 +1098,7 @@ func TestCheckDeploymentStatus_DeploymentNotProgressing(t *testing.T) {
 	}
 
 	// Create a done channel
-	doneCh := make(chan error, 1)
+	doneCh := make(chan deploymentStatus, 1)
 
 	// Call the checkDeploymentStatus function
 	deploymentWaiter := &deploymentWaiter{
@@ -1113,4 +1116,20 @@ func addTestObjects(t *testing.T, fakeClient *fake.Clientset, informerFactory in
 	require.NoError(t, err, "Failed to add replica set to informer cache")
 	err = informerFactory.Core().V1().Pods().Informer().GetIndexer().Add(pod)
 	require.NoError(t, err, "Failed to add pod to informer cache")
+	// event := &corev1.Event{
+	// 	ObjectMeta: metav1.ObjectMeta{
+	// 		Name:      "test-event",
+	// 		Namespace: "test-namespace",
+	// 	},
+	// 	InvolvedObject: corev1.ObjectReference{
+	// 		Kind:       "Deployment",
+	// 		Name:       deployment.Name,
+	// 		UID:        deployment.UID,
+	// 		APIVersion: "apps/v1",
+	// 	},
+	// 	Reason: "None",
+	// 	Type:   "Warning",
+	// }
+	// err = informerFactory.Core().V1().Events().Informer().GetIndexer().Add(event)
+	// require.NoError(t, err, "Failed to add event to informer cache")
 }

--- a/pkg/corerp/handlers/kubernetes_http_proxy_waiter.go
+++ b/pkg/corerp/handlers/kubernetes_http_proxy_waiter.go
@@ -61,7 +61,7 @@ func (handler *httpProxyWaiter) addDynamicEventHandler(ctx context.Context, info
 }
 
 // addEventHandler is not implemented for HTTPProxyWaiter
-func (handler *httpProxyWaiter) addEventHandler(ctx context.Context, informerFactory informers.SharedInformerFactory, informer cache.SharedIndexInformer, item client.Object, doneCh chan<- error) {
+func (handler *httpProxyWaiter) addEventHandler(ctx context.Context, informerFactory informers.SharedInformerFactory, informer cache.SharedIndexInformer, item client.Object, doneCh chan<- deploymentStatus) {
 }
 
 func (handler *httpProxyWaiter) waitUntilReady(ctx context.Context, obj client.Object) error {

--- a/pkg/validator/loader_test.go
+++ b/pkg/validator/loader_test.go
@@ -56,12 +56,12 @@ func Test_ParseSpecFilePath(t *testing.T) {
 			},
 		},
 		{
-			path: "specification/applications/resource-manager/Applications.Core/stable/2022-03-15/gateways.json",
+			path: "specification/applications/resource-manager/Applications.Core/stable/2023-10-01/gateways.json",
 			parsed: map[string]string{
 				"productname":  "applications",
 				"provider":     "applications.core",
 				"state":        "stable",
-				"version":      "2022-03-15",
+				"version":      "2023-10-01",
 				"resourcetype": "gateways",
 			},
 		},

--- a/test/functional/shared/resources/testdata/corerp-resources-container-bad-readinessprobe.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-container-bad-readinessprobe.bicep
@@ -1,0 +1,53 @@
+import radius as radius
+
+@description('Specifies the location for resources.')
+param location string = 'global'
+
+@description('Specifies the image of the container resource.')
+param magpieimage string
+
+@description('Specifies the port of the container resource.')
+param port int = 5000
+
+@description('Specifies the environment for resources.')
+param environment string
+
+resource app 'Applications.Core/applications@2023-10-01-preview' = {
+  name: 'corerp-resources-container-bad-readiness'
+  location: location
+  properties: {
+    environment: environment
+    extensions: [
+      {
+          kind: 'kubernetesNamespace'
+          namespace: 'corerp-resources-container-bad-readiness-app'
+      }
+    ]
+  }
+}
+
+resource container 'Applications.Core/containers@2023-10-01-preview' = {
+  name: 'ctnr-bad-readiness'
+  location: location
+  properties: {
+      application: app.id
+      container: {
+        image: magpieimage
+        readinessProbe:{
+          kind: 'httpGet'
+          containerPort: 5000
+          path: '/bad'
+          failureThreshold:1
+          periodSeconds:1
+          initialDelaySeconds:0
+        }
+
+        ports: {
+          web: {
+            containerPort: port
+          }
+        }
+      }
+      connections: {}
+    }
+  }


### PR DESCRIPTION
# Description

_Please explain the changes you've made._

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c0e3f78</samp>

### Summary
🐛🧪🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is the case for the first and third changes, which modify the existing test functions to adapt to the new signature of the NewDeployErrorExecutor function, which is a bug fix for the DeployErrorExecutor type.
2.  🧪 - This emoji represents a test, which is the case for the second change, which adds three new test functions to the container_test.go file, which test different failure scenarios for the container resource.
3.  🚀 - This emoji represents a feature, which is the case for the fourth, fifth, and sixth changes, which add new bicep template files to define the container resource with different properties and failure scenarios, which are used by the new test functions.
-->
This pull request enhances the deployment status checking logic and the error validation and testing logic for the radius project. It updates the `rbac.yaml` file to grant more permissions to the radius service account, and improves the Kubernetes handler code in `kubernetes.go`. It also adds a new parameter and function to the DeployErrorExecutor type and function in `deployerrorexecutor.go` and `deployexecutor.go`, and modifies the test functions and bicep templates in `mechanics_test.go`, `container_test.go`, and `dapr_component_name_conflict_test.go` to use the new parameter and function. The pull request adds new test functions and bicep templates to test different failure scenarios for the container resource.

> _This pull request has many changes_
> _To test and deploy resources in stages_
> _It uses `DeployErrorExecutor`_
> _And `unpackErrorAndMatch` for better_
> _Validation of error messages_

### Walkthrough
*  Add pods, events, and replicasets resources to the rbac.yaml file to allow the radius service account to list and watch them for the new deployment status checking logic ([link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-13e38bac99402c4ae82609aaba31139f5f9f7c229d1bd955032255cb18f356c6R17-R18), [link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-13e38bac99402c4ae82609aaba31139f5f9f7c229d1bd955032255cb18f356c6R56))
*  Add sort, strconv, and labels packages to the kubernetes.go file to sort events by timestamp, parse deployment and replicaset revisions, and create label selectors for Kubernetes objects, respectively, for the new deployment status checking logic ([link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7R23-R24), [link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7R39))
*  Add a logger variable to the kubernetesHandler type to log messages and errors throughout the handler methods, especially in the new deployment status checking logic ([link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7R75))
*  Add a log message to the Put method of the kubernetesHandler type when the deployment is ready, including the deployment name and namespace ([link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7R124))
*  Modify the waitUntilDeploymentIsReady method of the kubernetesHandler type to use a single doneCh channel that sends an error value instead of separate doneCh and errCh channels, to simplify the channel handling logic and avoid potential deadlock issues ([link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L130-R137), [link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L137-R143), [link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L159-R451))
*  Rename the startDeploymentInformer method to startInformers, which reflects the fact that the method now starts multiple informers for different Kubernetes resources, such as pods, events, deployments, and replicasets, which are used in the new deployment status checking logic ([link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L130-R137), [link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L137-R143))
*  Modify the DeployErrorExecutor type to add a new field named ExpectedInnerError, which is a slice of strings that represents the expected inner error messages or reasons that should be present in the error response from the radius CLI, and use it to check the inner details of the error response and match them with the expected values ([link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-080ae4c3111a76dd50048a311bc3c6ec238797dc4e599b9d6f06146fe1f0774aL36-R40), [link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-080ae4c3111a76dd50048a311bc3c6ec238797dc4e599b9d6f06146fe1f0774aR81-R84))
*  Modify the NewDeployErrorExecutor function to add a new parameter named innerError, which is a slice of strings that represents the expected inner error messages or reasons that should be present in the error response from the radius CLI, and pass it to the ExpectedInnerError field of the DeployErrorExecutor instance ([link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-080ae4c3111a76dd50048a311bc3c6ec238797dc4e599b9d6f06146fe1f0774aL46-R53))
*  Add the strings package to the deployexecutor.go file to use the strings.Contains function, which is used in the unpackErrorAndMatch function, which is defined in the same file ([link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-0de37fc45fbf7b80897ad9629baddd6f12cfa407da847316e6296771a6b0d6e4R24))
*  Add a new function named unpackErrorAndMatch to the deployexecutor.go file, which takes an error and a slice of strings as arguments, and iterates over the slice and the error response details, and returns true if any of the expected inner error messages or reasons are found in the error response, or false otherwise ([link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-0de37fc45fbf7b80897ad9629baddd6f12cfa407da847316e6296771a6b0d6e4R62-R77))
*  Modify the Test_InvalidResourceIDs and Test_DaprComponentNameConflict functions in the mechanics_test.go and dapr_component_name_conflict_test.go files, respectively, to add a nil parameter to the NewDeployErrorExecutor function, to adapt to the new signature of the function, which now accepts an expected inner error parameter ([link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-d38a59fddb3034eb8c0448c1fed4cabfdfc8f134dfb427656ad969ea6f647f9cL314-R314), [link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-c4523dc3ad460dc3baaaa98429900f8e43efdb6fce8ab40e8f368d82b79db387L34-R34))
*  Add three new test functions to the container_test.go file, which test different failure scenarios for the container resource, such as using a non-existent image, using a bad readiness or liveness probe, or failing the readiness probe, and use the NewDeployErrorExecutor function with different parameters to test the error responses ([link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-9442e1a784d8aba972917e5cfd69a85102d0b1393b88dc2be87e84a47c794970R224-R308))
*  Add three new bicep template files to the testdata folder, which define the container resource with different properties and failure scenarios, such as using a non-existent image, using a bad readiness or liveness probe, or failing the readiness probe, and use them in the new test functions in the container_test.go file ([link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-ef6234c9645603241e8c7805e06b2d4d605bac228a0d462547291a4eba674f98R1-R60), [link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-b83bafa4c758544b24fcb352566ef8d8a8d613024e465ea6b454dcead31e006dR1-R52), [link](https://github.com/project-radius/radius/pull/5941/files?diff=unified&w=0#diff-b3aeaac1a944b3d686d26ed0f0bb108b0766fed4a650c2b554d6e153c6c78863R1-R45))


