### PR TITLE
Fix undefined repo name in functional test run

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -67,6 +67,8 @@ env:
   AWS_ACCOUNT_ID: '${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}'
   # The current GitHub action link
   ACTION_LINK: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+  # The repository name
+  REPO_NAME: '${{ github.repository }}'
   # The Deployment Engine image
   DE_IMAGE: 'radius.azurecr.io/deployment-engine'
   # The Deployment Engine tag
@@ -129,7 +131,7 @@ jobs:
               fs.appendFileSync(process.env.GITHUB_ENV,
                 `DE_IMAGE=${clientPayload.de_image}\n`+
                 `DE_TAG=${clientPayload.de_tag}\n`+
-                `CHECKOUT_REPO=${github.repository}\n`+
+                `CHECKOUT_REPO=${process.env.REPO_NAME}\n`+
                 `CHECKOUT_REF=refs/heads/main`
               );
             }

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -67,8 +67,6 @@ env:
   AWS_ACCOUNT_ID: '${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}'
   # The current GitHub action link
   ACTION_LINK: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-  # The repository name
-  REPO_NAME: '${{ github.repository }}'
   # The Deployment Engine image
   DE_IMAGE: 'radius.azurecr.io/deployment-engine'
   # The Deployment Engine tag
@@ -131,7 +129,7 @@ jobs:
               fs.appendFileSync(process.env.GITHUB_ENV,
                 `DE_IMAGE=${clientPayload.de_image}\n`+
                 `DE_TAG=${clientPayload.de_tag}\n`+
-                `CHECKOUT_REPO=${process.env.REPO_NAME}\n`+
+                `CHECKOUT_REPO=${{ github.repository }}\n`+
                 `CHECKOUT_REF=refs/heads/main`
               );
             }


### PR DESCRIPTION
# Description

* Fix undefined repo name in functional test run

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4d88ac1</samp>

### Summary
:recycle::sparkles::wrench:

<!--
1.  :recycle: - This emoji represents the improvement in reusability and maintainability of the workflow file by introducing a new environment variable.
2.  :sparkles: - This emoji represents the new feature of using the repository name in the functional-test workflow.
3.  :wrench: - This emoji represents the configuration change of adding a new environment variable to the workflow file.
-->
Add `REPO_NAME` environment variable to functional-test workflow. This simplifies the workflow file and makes it easier to adapt to different repositories.

> _`REPO_NAME` is the key to our destiny_
> _We unleash the power of the workflow_
> _No more hardcoding, no more dependency_
> _We rise above the chaos and the sorrow_

### Walkthrough
*  Define `REPO_NAME` environment variable to store repository name ([link](https://github.com/project-radius/radius/pull/5951/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcR70-R71))
*  Use `REPO_NAME` instead of hard-coded `github.repository` in `CHECKOUT_REPO` parameter ([link](https://github.com/project-radius/radius/pull/5951/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL132-R134))


