### PR TITLE
Add az cli command for purging CDN

### DIFF
--- a/docs/contributing/contributing-releases/README.md
+++ b/docs/contributing/contributing-releases/README.md
@@ -127,6 +127,10 @@ If sample validation passes, we can start the process of creating the final rele
    For example, if the RC version is `v0.21.0-rc1`, the final release version would be `v0.21.0`.
 1. Create a new release note document in the [release-notes](../../release-notes/) directory. Follow the directory's README.md for instructions on how to create a new release note document. Include this file in the release version pull request.
 1. Purge the [CDN cache](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/66d1209e-1382-45d3-99bb-650e6bf63fc0/resourcegroups/assets/providers/Microsoft.Cdn/profiles/Radius/endpoints/radius/overview)
+   ```bash
+   $ az login
+   $ az cdn endpoint purge --subscription 66d1209e-1382-45d3-99bb-650e6bf63fc0 --resource-group assets --name radius --profile-name Radius --content-paths "/*"
+   ```
 1. Check the stable version marker
 
    The file https://get.radapp.dev/version/stable.txt should contain (in plain text) the channel you just created.


### PR DESCRIPTION
# Description

Add az cli command for purging CDN.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 21b0ae0</samp>

### Summary
🚀🌐🧹

<!--
1.  🚀 - This emoji can be used to indicate that the change is related to deploying or releasing the project, as it suggests speed and launch. It is also a common emoji for celebrating achievements or milestones.
2.  🌐 - This emoji can be used to indicate that the change is related to the web or the internet, as it depicts a globe or a network. It is also a common emoji for web development or web services.
3.  🧹 - This emoji can be used to indicate that the change is related to cleaning or purging something, as it depicts a broom or a sweep. It is also a common emoji for maintenance or optimization tasks.
-->
This pull request updates the `docs/contributing/contributing-releases/README.md` file to include a step for purging the Azure CDN cache for the Radius assets. This improves the consistency and reliability of the release process.

> _`purge_cdn_cache`_
> _A new command for release_
> _Autumn leaves refresh_

### Walkthrough
* Add command to purge Azure CDN cache for Radius assets after creating final release ([link](https://github.com/project-radius/radius/pull/5955/files?diff=unified&w=0#diff-4b032acb8e706dca3cf78512aadf53ee8b05354e51cd46023ed550c0625b33fbR130-R133))


