### PR TITLE
Clean up sample resource groups and container images in 3 days

### DIFF
--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: snok/container-retention-policy@v2
         with:
           image-names: dev/*
-          cut-off: A week ago UTC
+          cut-off: 2 days ago UTC
           account-type: org
           org-name: project-radius
           token: ${{ secrets.GH_RAD_CI_BOT_PAT }}

--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: snok/container-retention-policy@v2
         with:
           image-names: dev/*
-          cut-off: 2 days ago UTC
+          cut-off: 3 days ago UTC
           account-type: org
           org-name: project-radius
           token: ${{ secrets.GH_RAD_CI_BOT_PAT }}

--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -60,7 +60,7 @@ jobs:
           current_time=$(date +%s)
           hours_ago=$((current_time - ${{ env.VALID_RESOURCE_WINDOW }}))
           while IFS=$'\t' read -r name creation_time; do
-            if [[ ! "$name" =~ ^"radius-" ]] && [[ ! "$name" =~ ^"radtest-" ]]; then
+            if [[ ! "$name" =~ ^"samplestest-" ]] && [[ ! "$name" =~ ^"radtest-" ]]; then
               continue
             fi
 


### PR DESCRIPTION
# Description

* Delete dev container images in 2 days (org: 1 week)
* I found the sample repo has the workflow to purge the resource groups. I think it is eaiser to maintain the single workflow to clean up resources in the single place. 

https://github.com/project-radius/samples/blob/v0.23/.github/workflows/purge-test-resources.yaml

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).


## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a4a3b21</samp>

### Summary
:recycle::wrench::test_tube:

<!--
1.  :recycle: - This emoji can be used to indicate that the changes are related to cleanup, recycling, or optimization of resources or code.
2.  :wrench: - This emoji can be used to indicate that the changes are related to fixing, adjusting, or improving something, such as a bug, a configuration, or a feature.
3.  :test_tube: - This emoji can be used to indicate that the changes are related to testing, experimentation, or verification of something, such as a functionality, a scenario, or a hypothesis.
-->
Updated the purge-test-resources workflow to use the new naming convention for samplestest resource groups. This helps to avoid deleting unintended resources in Azure.

> _`samplestest` names_
> _filter out old resources_
> _autumn cleanup time_

### Walkthrough
*  Update the condition for filtering out resource groups that should not be deleted in the workflow for purging test resources ([link](https://github.com/project-radius/radius/pull/5957/files?diff=unified&w=0#diff-9270fafc31ef4b50d35d1295e9f99f96013853c295c29c92c387492f62cd570dL63-R63))


