### PR TITLE
DaprRP Functional Tests

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -307,7 +307,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        name: [ucp,shared,msgrp,daprrp,samples]
+        name: [ucp,shared,msgrp,samples]
     env:
       UNIQUE_ID: ${{ needs.build.outputs.UNIQUE_ID }}
       REL_VERSION: ${{ needs.build.outputs.REL_VERSION }}

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -307,7 +307,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        name: [ucp,shared,msgrp,samples]
+        name: [ucp,shared,msgrp,daprrp,samples]
     env:
       UNIQUE_ID: ${{ needs.build.outputs.UNIQUE_ID }}
       REL_VERSION: ${{ needs.build.outputs.REL_VERSION }}

--- a/build/test.mk
+++ b/build/test.mk
@@ -54,7 +54,7 @@ test-get-envtools:
 test-validate-cli: ## Run cli integration tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) -coverpkg= ./pkg/cli/cmd/... ./cmd/rad/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
 
-test-functional-all: test-functional-ucp test-functional-shared test-functional-msgrp test-functional-daprrp ## Runs all functional tests
+test-functional-all: test-functional-ucp test-functional-shared test-functional-msgrp ## Runs all functional tests
 
 test-functional-kubernetes: ## Runs Kubernetes functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
@@ -64,9 +64,6 @@ test-functional-shared: ## Runs shared functional tests
 
 test-functional-msgrp: ## Runs Messaging RP functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/messagingrp/... -timeout ${TEST_TIMEOUT} -v -parallel 2 $(GOTEST_OPTS)
-
-test-functional-daprrp: ## Runs Dapr RP functional tests
-	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/daprrp/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
 
 test-functional-samples: ## Runs Samples functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/samples/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)

--- a/build/test.mk
+++ b/build/test.mk
@@ -54,7 +54,7 @@ test-get-envtools:
 test-validate-cli: ## Run cli integration tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) -coverpkg= ./pkg/cli/cmd/... ./cmd/rad/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
 
-test-functional-all: test-functional-ucp test-functional-shared test-functional-msgrp ## Runs all functional tests
+test-functional-all: test-functional-ucp test-functional-shared test-functional-msgrp test-functional-daprrp ## Runs all functional tests
 
 test-functional-kubernetes: ## Runs Kubernetes functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
@@ -64,6 +64,9 @@ test-functional-shared: ## Runs shared functional tests
 
 test-functional-msgrp: ## Runs Messaging RP functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/messagingrp/... -timeout ${TEST_TIMEOUT} -v -parallel 2 $(GOTEST_OPTS)
+
+test-functional-daprrp: ## Runs Dapr RP functional tests
+	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/daprrp/... -timeout ${TEST_TIMEOUT} -v -parallel 3 $(GOTEST_OPTS)
 
 test-functional-samples: ## Runs Samples functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/samples/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)

--- a/build/test.mk
+++ b/build/test.mk
@@ -54,7 +54,7 @@ test-get-envtools:
 test-validate-cli: ## Run cli integration tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) -coverpkg= ./pkg/cli/cmd/... ./cmd/rad/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
 
-test-functional-all: test-functional-ucp test-functional-shared test-functional-msgrp  ## Runs all functional tests
+test-functional-all: test-functional-ucp test-functional-shared test-functional-msgrp test-functional-daprrp ## Runs all functional tests
 
 test-functional-kubernetes: ## Runs Kubernetes functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
@@ -64,6 +64,9 @@ test-functional-shared: ## Runs shared functional tests
 
 test-functional-msgrp: ## Runs Messaging RP functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/messagingrp/... -timeout ${TEST_TIMEOUT} -v -parallel 2 $(GOTEST_OPTS)
+
+test-functional-daprrp: ## Runs Dapr RP functional tests
+	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/daprrp/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
 
 test-functional-samples: ## Runs Samples functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/samples/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)

--- a/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
+++ b/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
@@ -61,6 +61,7 @@ When you're running locally with this configuration, the tests will use your loc
  ```sh
     make test-functional-shared
     make test-functional-msgrp
+    make test-functional-daprrp
  ```
 
 You can also run/debug individual tests from VSCode.

--- a/pkg/armrpc/asyncoperation/statusmanager/statusmanager.go
+++ b/pkg/armrpc/asyncoperation/statusmanager/statusmanager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
@@ -75,7 +76,7 @@ func New(storeClient store.StorageClient, q queue.Client, providerName, location
 
 // operationStatusResourceID function is to build the operationStatus resourceID.
 func (aom *statusManager) operationStatusResourceID(id resources.ID, operationID uuid.UUID) string {
-	return fmt.Sprintf("%s/providers/%s/locations/%s/operationstatuses/%s", id.PlaneScope(), id.ProviderNamespace(), aom.location, operationID)
+	return fmt.Sprintf("%s/providers/%s/locations/%s/operationstatuses/%s", id.PlaneScope(), strings.ToLower(id.ProviderNamespace()), aom.location, operationID)
 }
 
 // # Function Explanation

--- a/pkg/armrpc/asyncoperation/statusmanager/statusmanager_test.go
+++ b/pkg/armrpc/asyncoperation/statusmanager/statusmanager_test.go
@@ -19,7 +19,6 @@ package statusmanager
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -107,7 +106,7 @@ func TestOperationStatusResourceID(t *testing.T) {
 			rid, err := resources.ParseResource(tc.resourceID)
 			require.NoError(t, err)
 			url := sm.operationStatusResourceID(rid, tc.operationID)
-			require.Equal(t, strings.ToLower(tc.operationResourceID), strings.ToLower(url))
+			require.Equal(t, tc.operationResourceID, url)
 		})
 	}
 }

--- a/pkg/cli/cmd/radinit/recipe.go
+++ b/pkg/cli/cmd/radinit/recipe.go
@@ -175,6 +175,12 @@ func getLinkType(resourceType string) string {
 		return linkrp.SqlDatabasesResourceType
 	case "rabbitmqqueues":
 		return linkrp.N_RabbitMQQueuesResourceType
+	case "pubsubbrokers":
+		return linkrp.N_DaprPubSubBrokersResourceType
+	case "secretstores":
+		return linkrp.N_DaprSecretStoresResourceType
+	case "statestores":
+		return linkrp.N_DaprStateStoresResourceType
 	default:
 		return ""
 	}

--- a/pkg/corerp/api/v20220315privatepreview/util.go
+++ b/pkg/corerp/api/v20220315privatepreview/util.go
@@ -134,6 +134,9 @@ func isValidLinkType(link string) bool {
 		linkrp.SqlDatabasesResourceType,
 		// Resources After Split of LinkRP Namespace
 		linkrp.N_RabbitMQQueuesResourceType,
+		linkrp.N_DaprPubSubBrokersResourceType,
+		linkrp.N_DaprSecretStoresResourceType,
+		linkrp.N_DaprStateStoresResourceType,
 	}
 	return slices.Contains(linkTypes, link)
 }

--- a/test/executeFunctionalTest.sh
+++ b/test/executeFunctionalTest.sh
@@ -41,3 +41,4 @@ export AZURE_TABLESTORAGE_RESOURCE_ID=$( jq -r '.properties.outputs.tableStorage
 export AZURE_COSMOS_MONGODB_ACCOUNT_ID=$( jq -r '.properties.outputs.cosmosMongoAccountID.value' <<< "${resp}" )
 make test-functional-shared
 make test-functional-msgrp
+make test-functional-daprrp

--- a/test/functional/daprrp/dapr_component_name_conflict_test.go
+++ b/test/functional/daprrp/dapr_component_name_conflict_test.go
@@ -27,7 +27,7 @@ import (
 
 func Test_DaprComponentNameConflict(t *testing.T) {
 	template := "resources/testdata/daprrp-resources-component-name-conflict.bicep"
-	name := "daprrp-resources-component-name-conflict"
+	name := "daprrp-rs-component-name-conflict"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -35,7 +35,7 @@ func Test_DaprComponentNameConflict(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "daprrp-resources-component-name-conflict",
+						Name: "daprrp-rs-component-name-conflict",
 						Type: validation.ApplicationsResource,
 					},
 				},

--- a/test/functional/daprrp/dapr_component_name_conflict_test.go
+++ b/test/functional/daprrp/dapr_component_name_conflict_test.go
@@ -19,46 +19,28 @@ package resource_test
 import (
 	"testing"
 
-	"github.com/project-radius/radius/test/functional"
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/test/functional/shared"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
 )
 
-func Test_DaprServiceInvocation(t *testing.T) {
-	template := "testdata/corerp-resources-dapr-serviceinvocation.bicep"
-	name := "dapr-serviceinvocation"
-	appNamespace := "default-dapr-serviceinvocation"
+func Test_DaprComponentNameConflict(t *testing.T) {
+	template := "resources/testdata/daprrp-resources-component-name-conflict.bicep"
+	name := "daprrp-resources-component-name-conflict"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
+			Executor: step.NewDeployErrorExecutor(template, v1.CodeInternal),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: name,
+						Name: "daprrp-resources-component-name-conflict",
 						Type: validation.ApplicationsResource,
 					},
-					{
-						Name: "dapr-frontend-old",
-						Type: validation.ContainersResource,
-						App:  name,
-					},
-					{
-						Name: "dapr-backend-old",
-						Type: validation.ContainersResource,
-						App:  name,
-					},
 				},
 			},
-			K8sObjects: &validation.K8sObjectSet{
-				Namespaces: map[string][]validation.K8sObject{
-					appNamespace: {
-						validation.NewK8sPodForResource(name, "dapr-frontend-old"),
-						validation.NewK8sPodForResource(name, "dapr-backend-old"),
-					},
-				},
-			},
+			K8sObjects: &validation.K8sObjectSet{},
 		},
 	})
 	test.RequiredFeatures = []shared.RequiredFeature{shared.FeatureDapr}

--- a/test/functional/daprrp/dapr_component_name_conflict_test.go
+++ b/test/functional/daprrp/dapr_component_name_conflict_test.go
@@ -31,7 +31,7 @@ func Test_DaprComponentNameConflict(t *testing.T) {
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployErrorExecutor(template, v1.CodeInternal),
+			Executor: step.NewDeployErrorExecutor(template, v1.CodeInternal, nil),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{

--- a/test/functional/daprrp/dapr_pubsub_test.go
+++ b/test/functional/daprrp/dapr_pubsub_test.go
@@ -27,10 +27,10 @@ import (
 	"github.com/project-radius/radius/test/validation"
 )
 
-func Test_DaprStateStore_Manual(t *testing.T) {
-	template := "testdata/corerp-resources-dapr-statestore-manual.bicep"
-	name := "corerp-resources-dapr-statestore-manual"
-	appNamespace := "default-corerp-resources-dapr-statestore-manual"
+func Test_DaprPubSubBroker_Manual(t *testing.T) {
+	template := "resources/testdata/daprrp-resources-pubsub-broker-manual.bicep"
+	name := "dpsb-manual-app"
+	appNamespace := "default-dpsb-manual-app"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -38,17 +38,17 @@ func Test_DaprStateStore_Manual(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "corerp-resources-dapr-statestore-manual",
+						Name: "dpsb-manual-app",
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "dapr-sts-manual-ctnr-old",
+						Name: "dpsb-manual-app-ctnr",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dapr-sts-manual-old",
-						Type: validation.O_DaprStateStoresResource,
+						Name: "dpsb-manual",
+						Type: validation.DaprPubSubBrokersResource,
 						App:  name,
 					},
 				},
@@ -56,11 +56,9 @@ func Test_DaprStateStore_Manual(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dapr-sts-manual-ctnr-old"),
-
-						// Deployed as supporting resources using Kubernetes Bicep extensibility.
-						validation.NewK8sPodForResource(name, "dapr-sts-manual-redis-old").ValidateLabels(false),
-						validation.NewK8sServiceForResource(name, "dapr-sts-manual-redis-old").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "dpsb-manual-app-ctnr"),
+						validation.NewK8sPodForResource(name, "dpsb-manual-redis").ValidateLabels(false),
+						validation.NewK8sServiceForResource(name, "dpsb-manual-redis").ValidateLabels(false),
 					},
 				},
 			},
@@ -70,10 +68,10 @@ func Test_DaprStateStore_Manual(t *testing.T) {
 	test.Test(t)
 }
 
-func Test_DaprStateStore_Recipe(t *testing.T) {
-	template := "testdata/corerp-resources-dapr-statestore-recipe.bicep"
-	name := "corerp-resources-dapr-sts-recipe"
-	appNamespace := "corerp-environment-recipes-env"
+func Test_DaprPubSubBroker_Recipe(t *testing.T) {
+	template := "resources/testdata/daprrp-resources-pubsub-broker-recipe.bicep"
+	name := "dpsb-recipe-app"
+	appNamespace := "dpsb-recipe-env"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -81,22 +79,22 @@ func Test_DaprStateStore_Recipe(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "corerp-environment-recipes-env",
+						Name: "dpsb-recipe-env",
 						Type: validation.EnvironmentsResource,
 					},
 					{
-						Name: "corerp-resources-dapr-sts-recipe",
+						Name: "dpsb-recipe-app",
 						Type: validation.ApplicationsResource,
 						App:  name,
 					},
 					{
-						Name: "dapr-sts-recipe-ctnr-old",
+						Name: "dpsb-recipe-app-ctnr",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dapr-sts-recipe-old",
-						Type: validation.O_DaprStateStoresResource,
+						Name: "dpsb-recipe",
+						Type: validation.DaprPubSubBrokersResource,
 						App:  name,
 						OutputResources: []validation.OutputResourceResponse{
 							{
@@ -114,7 +112,7 @@ func Test_DaprStateStore_Recipe(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dapr-sts-recipe-ctnr-old").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "dpsb-recipe-ctnr").ValidateLabels(false),
 					},
 				},
 			},

--- a/test/functional/daprrp/dapr_secretstore_test.go
+++ b/test/functional/daprrp/dapr_secretstore_test.go
@@ -17,38 +17,36 @@ limitations under the License.
 package resource_test
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/project-radius/radius/pkg/resourcemodel"
 	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/shared"
 	"github.com/project-radius/radius/test/step"
 	"github.com/project-radius/radius/test/validation"
 )
 
-func Test_DaprStateStore_Manual(t *testing.T) {
-	template := "testdata/corerp-resources-dapr-statestore-manual.bicep"
-	name := "corerp-resources-dapr-statestore-manual"
-	appNamespace := "default-corerp-resources-dapr-statestore-manual"
+func Test_DaprSecretStore_Manual(t *testing.T) {
+	template := "resources/testdata/daprrp-resources-secretstore-manual.bicep"
+	name := "daprrp-resources-secretstore-manual"
+	appNamespace := "default-daprrp-resources-secretstore-manual"
 
-	test := shared.NewRPTest(t, name, []shared.TestStep{
+	test := shared.NewRPTest(t, appNamespace, []shared.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), fmt.Sprintf("namespace=%s", appNamespace)),
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "corerp-resources-dapr-statestore-manual",
+						Name: name,
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "dapr-sts-manual-ctnr-old",
+						Name: "gnrc-scs-ctnr",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dapr-sts-manual-old",
-						Type: validation.O_DaprStateStoresResource,
+						Name: "gnrc-scs-manual",
+						Type: validation.DaprSecretStoresResource,
 						App:  name,
 					},
 				},
@@ -56,70 +54,53 @@ func Test_DaprStateStore_Manual(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dapr-sts-manual-ctnr-old"),
-
-						// Deployed as supporting resources using Kubernetes Bicep extensibility.
-						validation.NewK8sPodForResource(name, "dapr-sts-manual-redis-old").ValidateLabels(false),
-						validation.NewK8sServiceForResource(name, "dapr-sts-manual-redis-old").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "gnrc-scs-ctnr"),
 					},
 				},
 			},
 		},
-	})
+	}, shared.K8sSecretResource(appNamespace, "mysecret", "", "fakekey", []byte("fakevalue")))
 	test.RequiredFeatures = []shared.RequiredFeature{shared.FeatureDapr}
+
 	test.Test(t)
 }
 
-func Test_DaprStateStore_Recipe(t *testing.T) {
-	template := "testdata/corerp-resources-dapr-statestore-recipe.bicep"
-	name := "corerp-resources-dapr-sts-recipe"
-	appNamespace := "corerp-environment-recipes-env"
+func Test_DaprSecretStore_Recipe(t *testing.T) {
+	template := "resources/testdata/daprrp-resources-secretstore-recipe.bicep"
+	name := "daprrp-resources-secretstore-recipe"
+	appNamespace := "daprrp-resources-secretstore-recipe"
 
-	test := shared.NewRPTest(t, name, []shared.TestStep{
+	test := shared.NewRPTest(t, appNamespace, []shared.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), functional.GetBicepRecipeRegistry(), functional.GetBicepRecipeVersion()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "corerp-environment-recipes-env",
-						Type: validation.EnvironmentsResource,
-					},
-					{
-						Name: "corerp-resources-dapr-sts-recipe",
+						Name: name,
 						Type: validation.ApplicationsResource,
-						App:  name,
 					},
 					{
-						Name: "dapr-sts-recipe-ctnr-old",
+						Name: "gnrc-scs-ctnr-recipe",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dapr-sts-recipe-old",
-						Type: validation.O_DaprStateStoresResource,
+						Name: "gnrc-scs-recipe",
+						Type: validation.DaprSecretStoresResource,
 						App:  name,
-						OutputResources: []validation.OutputResourceResponse{
-							{
-								Provider: resourcemodel.ProviderKubernetes,
-								LocalID:  "RecipeResource0",
-							},
-							{
-								Provider: resourcemodel.ProviderKubernetes,
-								LocalID:  "RecipeResource1",
-							},
-						},
 					},
 				},
 			},
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dapr-sts-recipe-ctnr-old").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "gnrc-scs-ctnr-recipe").ValidateLabels(false),
 					},
 				},
 			},
 		},
-	})
+	}, shared.K8sSecretResource(appNamespace, "mysecret", "", "fakekey", []byte("fakevalue")))
 	test.RequiredFeatures = []shared.RequiredFeature{shared.FeatureDapr}
+
 	test.Test(t)
 }

--- a/test/functional/daprrp/dapr_secretstore_test.go
+++ b/test/functional/daprrp/dapr_secretstore_test.go
@@ -27,8 +27,8 @@ import (
 
 func Test_DaprSecretStore_Manual(t *testing.T) {
 	template := "resources/testdata/daprrp-resources-secretstore-manual.bicep"
-	name := "daprrp-resources-secretstore-manual"
-	appNamespace := "default-daprrp-resources-secretstore-manual"
+	name := "daprrp-rs-secretstore-manual"
+	appNamespace := "default-daprrp-rs-secretstore-manual"
 
 	test := shared.NewRPTest(t, appNamespace, []shared.TestStep{
 		{
@@ -67,8 +67,8 @@ func Test_DaprSecretStore_Manual(t *testing.T) {
 
 func Test_DaprSecretStore_Recipe(t *testing.T) {
 	template := "resources/testdata/daprrp-resources-secretstore-recipe.bicep"
-	name := "daprrp-resources-secretstore-recipe"
-	appNamespace := "daprrp-resources-secretstore-recipe"
+	name := "daprrp-rs-secretstore-recipe"
+	appNamespace := "daprrp-rs-secretstore-recipe"
 
 	test := shared.NewRPTest(t, appNamespace, []shared.TestStep{
 		{

--- a/test/functional/daprrp/dapr_serviceinvocation_test.go
+++ b/test/functional/daprrp/dapr_serviceinvocation_test.go
@@ -26,9 +26,9 @@ import (
 )
 
 func Test_DaprServiceInvocation(t *testing.T) {
-	template := "testdata/corerp-resources-dapr-serviceinvocation.bicep"
+	template := "resources/testdata/daprrp-resources-serviceinvocation.bicep"
 	name := "dapr-serviceinvocation"
-	appNamespace := "default-dapr-serviceinvocation"
+	appNamespace := "default-serviceinvocation"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -40,12 +40,12 @@ func Test_DaprServiceInvocation(t *testing.T) {
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "dapr-frontend-old",
+						Name: "dapr-frontend",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dapr-backend-old",
+						Name: "dapr-backend",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
@@ -54,8 +54,8 @@ func Test_DaprServiceInvocation(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dapr-frontend-old"),
-						validation.NewK8sPodForResource(name, "dapr-backend-old"),
+						validation.NewK8sPodForResource(name, "dapr-frontend"),
+						validation.NewK8sPodForResource(name, "dapr-backend"),
 					},
 				},
 			},

--- a/test/functional/daprrp/dapr_serviceinvocation_test.go
+++ b/test/functional/daprrp/dapr_serviceinvocation_test.go
@@ -28,7 +28,7 @@ import (
 func Test_DaprServiceInvocation(t *testing.T) {
 	template := "resources/testdata/daprrp-resources-serviceinvocation.bicep"
 	name := "dapr-serviceinvocation"
-	appNamespace := "default-serviceinvocation"
+	appNamespace := "default-dapr-serviceinvocation"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{

--- a/test/functional/daprrp/dapr_statestore_test.go
+++ b/test/functional/daprrp/dapr_statestore_test.go
@@ -29,8 +29,8 @@ import (
 
 func Test_DaprStateStore_Manual(t *testing.T) {
 	template := "resources/testdata/daprrp-resources-statestore-manual.bicep"
-	name := "daprrp-resources-statestore-manual"
-	appNamespace := "default-daprrp-resources-statestore-manual"
+	name := "daprrp-rs-statestore-manual"
+	appNamespace := "default-daprrp-rs-statestore-manual"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -38,7 +38,7 @@ func Test_DaprStateStore_Manual(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "daprrp-resources-statestore-manual",
+						Name: "daprrp-rs-statestore-manual",
 						Type: validation.ApplicationsResource,
 					},
 					{
@@ -72,8 +72,8 @@ func Test_DaprStateStore_Manual(t *testing.T) {
 
 func Test_DaprStateStore_Recipe(t *testing.T) {
 	template := "resources/testdata/daprrp-resources-statestore-recipe.bicep"
-	name := "daprrp-resources-sts-recipe"
-	appNamespace := "daprrp-environment-recipes-env"
+	name := "daprrp-rs-sts-recipe"
+	appNamespace := "daprrp-env-recipes-env"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -81,11 +81,11 @@ func Test_DaprStateStore_Recipe(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "daprrp-environment-recipes-env",
+						Name: "daprrp-env-recipes-env",
 						Type: validation.EnvironmentsResource,
 					},
 					{
-						Name: "daprrp-resources-sts-recipe",
+						Name: "daprrp-rs-sts-recipe",
 						Type: validation.ApplicationsResource,
 						App:  name,
 					},

--- a/test/functional/daprrp/dapr_statestore_test.go
+++ b/test/functional/daprrp/dapr_statestore_test.go
@@ -28,9 +28,9 @@ import (
 )
 
 func Test_DaprStateStore_Manual(t *testing.T) {
-	template := "testdata/corerp-resources-dapr-statestore-manual.bicep"
-	name := "corerp-resources-dapr-statestore-manual"
-	appNamespace := "default-corerp-resources-dapr-statestore-manual"
+	template := "resources/testdata/daprrp-resources-statestore-manual.bicep"
+	name := "daprrp-resources-statestore-manual"
+	appNamespace := "default-daprrp-resources-statestore-manual"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -38,17 +38,17 @@ func Test_DaprStateStore_Manual(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "corerp-resources-dapr-statestore-manual",
+						Name: "daprrp-resources-statestore-manual",
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "dapr-sts-manual-ctnr-old",
+						Name: "dapr-sts-manual-ctnr",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dapr-sts-manual-old",
-						Type: validation.O_DaprStateStoresResource,
+						Name: "dapr-sts-manual",
+						Type: validation.DaprStateStoresResource,
 						App:  name,
 					},
 				},
@@ -56,11 +56,11 @@ func Test_DaprStateStore_Manual(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dapr-sts-manual-ctnr-old"),
+						validation.NewK8sPodForResource(name, "dapr-sts-manual-ctnr"),
 
 						// Deployed as supporting resources using Kubernetes Bicep extensibility.
-						validation.NewK8sPodForResource(name, "dapr-sts-manual-redis-old").ValidateLabels(false),
-						validation.NewK8sServiceForResource(name, "dapr-sts-manual-redis-old").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "dapr-sts-manual-redis").ValidateLabels(false),
+						validation.NewK8sServiceForResource(name, "dapr-sts-manual-redis").ValidateLabels(false),
 					},
 				},
 			},
@@ -71,9 +71,9 @@ func Test_DaprStateStore_Manual(t *testing.T) {
 }
 
 func Test_DaprStateStore_Recipe(t *testing.T) {
-	template := "testdata/corerp-resources-dapr-statestore-recipe.bicep"
-	name := "corerp-resources-dapr-sts-recipe"
-	appNamespace := "corerp-environment-recipes-env"
+	template := "resources/testdata/daprrp-resources-statestore-recipe.bicep"
+	name := "daprrp-resources-sts-recipe"
+	appNamespace := "daprrp-environment-recipes-env"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -81,22 +81,22 @@ func Test_DaprStateStore_Recipe(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "corerp-environment-recipes-env",
+						Name: "daprrp-environment-recipes-env",
 						Type: validation.EnvironmentsResource,
 					},
 					{
-						Name: "corerp-resources-dapr-sts-recipe",
+						Name: "daprrp-resources-sts-recipe",
 						Type: validation.ApplicationsResource,
 						App:  name,
 					},
 					{
-						Name: "dapr-sts-recipe-ctnr-old",
+						Name: "dapr-sts-recipe-ctnr",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dapr-sts-recipe-old",
-						Type: validation.O_DaprStateStoresResource,
+						Name: "dapr-sts-recipe",
+						Type: validation.DaprStateStoresResource,
 						App:  name,
 						OutputResources: []validation.OutputResourceResponse{
 							{
@@ -114,7 +114,7 @@ func Test_DaprStateStore_Recipe(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dapr-sts-recipe-ctnr-old").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "dapr-sts-recipe-ctnr").ValidateLabels(false),
 					},
 				},
 			},

--- a/test/functional/daprrp/resources/testdata/daprrp-resources-component-name-conflict.bicep
+++ b/test/functional/daprrp/resources/testdata/daprrp-resources-component-name-conflict.bicep
@@ -5,7 +5,7 @@ param environment string
 param location string = resourceGroup().location
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'corerp-resources-dapr-component-name-conflict'
+  name: 'daprrp-resources-component-name-conflict'
   location: 'global'
   properties: {
     environment: environment
@@ -13,8 +13,8 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 }
 
 // Dapr Component #1
-resource pubsub 'Applications.Link/daprPubSubBrokers@2022-03-15-privatepreview' = {
-  name: 'dapr-component-old'
+resource pubsub 'Applications.Dapr/pubSubBrokers@2022-03-15-privatepreview' = {
+  name: 'dapr-component'
   location: 'global'
   properties: {
     environment: environment
@@ -37,13 +37,13 @@ resource namespace 'Microsoft.ServiceBus/namespaces@2017-04-01' = {
   name: 'dapr-ns-${guid(resourceGroup().name)}'
   location: location
   tags: {
-    radiustest: 'corerp-resources-dapr-pubsub-servicebus'
+    radiustest: 'daprrp-resources-pubsub-servicebus'
   }
 }
 
 // Dapr Component #2
-resource secretstore 'Applications.Link/daprSecretStores@2022-03-15-privatepreview' = {
-  name: 'dapr-component-old'
+resource secretstore 'Applications.Dapr/secretStores@2022-03-15-privatepreview' = {
+  name: 'dapr-component'
   location: 'global'
   properties: {
     environment: environment

--- a/test/functional/daprrp/resources/testdata/daprrp-resources-component-name-conflict.bicep
+++ b/test/functional/daprrp/resources/testdata/daprrp-resources-component-name-conflict.bicep
@@ -5,7 +5,7 @@ param environment string
 param location string = resourceGroup().location
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'daprrp-resources-component-name-conflict'
+  name: 'daprrp-rs-component-name-conflict'
   location: 'global'
   properties: {
     environment: environment

--- a/test/functional/daprrp/resources/testdata/daprrp-resources-pubsub-broker-manual.bicep
+++ b/test/functional/daprrp/resources/testdata/daprrp-resources-pubsub-broker-manual.bicep
@@ -5,19 +5,19 @@ param environment string
 param namespace string = 'default'
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'corerp-resources-dapr-statestore-manual'
+  name: 'dpsb-manual-app'
   properties: {
     environment: environment
   }
 }
 
 resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-manual-ctnr-old'
+  name: 'dpsb-manual-app-ctnr'
   properties: {
     application: app.id
     connections: {
-      daprstatestore: {
-        source: statestore.id
+      daprpubsub: {
+        source: pubsubBroker.id
       }
     }
     container: {
@@ -31,7 +31,7 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
     extensions: [
       {
         kind: 'daprSidecar'
-        appId: 'gnrc-sts-ctnr'
+        appId: 'dpsb-manual-app-ctnr'
         appPort: 3000
       }
     ]
@@ -39,23 +39,23 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
 }
 
 
-module redis 'modules/redis-selfhost.bicep' = {
-  name: 'dapr-sts-manual-redis-deployment-old'
+module redis '../../../shared/resources/testdata/modules/redis-selfhost.bicep' = {
+  name: 'dpsb-manual-redis-deployment'
   params: {
-    name: 'dapr-sts-manual-redis'
+    name: 'dpsb-manual-redis'
     namespace: namespace
     application: app.name
   }
 }
 
 
-resource statestore 'Applications.Link/daprStateStores@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-manual-old'
+resource pubsubBroker 'Applications.Dapr/pubSubBrokers@2022-03-15-privatepreview' = {
+  name: 'dpsb-manual'
   properties: {
     application: app.id
     environment: environment
     resourceProvisioning: 'manual'
-    type: 'state.redis'
+    type: 'pubsub.redis'
     metadata: {
       redisHost: '${redis.outputs.host}:${redis.outputs.port}'
       redisPassword: ''

--- a/test/functional/daprrp/resources/testdata/daprrp-resources-pubsub-broker-recipe.bicep
+++ b/test/functional/daprrp/resources/testdata/daprrp-resources-pubsub-broker-recipe.bicep
@@ -5,18 +5,18 @@ param registry string
 param version string
 
 resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
-  name: 'corerp-environment-recipes-env'
+  name: 'dpsb-recipe-env'
   properties: {
     compute: {
       kind: 'kubernetes'
       resourceId: 'self'
-      namespace: 'corerp-environment-recipes-env'
+      namespace: 'dpsb-recipe-env'
     }
     recipes: {
-      'Applications.Link/daprStateStores': {
+      'Applications.Dapr/pubSubBrokers': {
         default: {
           templateKind: 'bicep'
-          templatePath: '${registry}/test/functional/shared/recipes/dapr-state-store:${version}'
+          templatePath: '${registry}/test/functional/shared/recipes/dapr-pubsub-broker:${version}'
         }
       }
     }
@@ -24,25 +24,25 @@ resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
 }
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'corerp-resources-dapr-sts-recipe'
+  name: 'dpsb-recipe-app'
   properties: {
     environment: env.id
     extensions: [
       {
         kind: 'kubernetesNamespace'
-        namespace: 'corerp-resources-dapr-sts-recipe'
+        namespace: 'dpsb-recipe-app'
       }
     ]
   }
 }
 
-resource webapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-recipe-ctnr-old'
+resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
+  name: 'dpsb-recipe-app-ctnr'
   properties: {
     application: app.id
     connections: {
-      daprstatestore: {
-        source: statestore.id
+      daprpubsub: {
+        source: pubsubBroker.id
       }
     }
     container: {
@@ -56,15 +56,15 @@ resource webapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
     extensions: [
       {
         kind: 'daprSidecar'
-        appId: 'dapr-sts-recipe-ctnr'
+        appId: 'dpsb-recipe-app-ctnr'
         appPort: 3000
       }
     ]
   }
 }
 
-resource statestore 'Applications.Link/daprStateStores@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-recipe-old'
+resource pubsubBroker 'Applications.Dapr/pubSubBrokers@2022-03-15-privatepreview' = {
+  name: 'dpsb-recipe'
   properties: {
     application: app.id
     environment: env.id

--- a/test/functional/daprrp/resources/testdata/daprrp-resources-secretstore-manual.bicep
+++ b/test/functional/daprrp/resources/testdata/daprrp-resources-secretstore-manual.bicep
@@ -7,7 +7,7 @@ param environment string
 param location string = resourceGroup().location
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'corerp-resources-dapr-secretstore-manual'
+  name: 'daprrp-resources-secretstore-manual'
   location: location
   properties: {
     environment: environment
@@ -15,7 +15,7 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 }
 
 resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'gnrc-scs-ctnr-old'
+  name: 'gnrc-scs-ctnr'
   properties: {
     application: app.id
     connections: {
@@ -41,8 +41,8 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
   }
 }
 
-resource secretstore 'Applications.Link/daprSecretStores@2022-03-15-privatepreview' = {
-  name: 'gnrc-scs-manual-old'
+resource secretstore 'Applications.Dapr/secretStores@2022-03-15-privatepreview' = {
+  name: 'gnrc-scs-manual'
   location: location
   properties: {
     environment: environment

--- a/test/functional/daprrp/resources/testdata/daprrp-resources-secretstore-manual.bicep
+++ b/test/functional/daprrp/resources/testdata/daprrp-resources-secretstore-manual.bicep
@@ -7,7 +7,7 @@ param environment string
 param location string = resourceGroup().location
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'daprrp-resources-secretstore-manual'
+  name: 'daprrp-rs-secretstore-manual'
   location: location
   properties: {
     environment: environment

--- a/test/functional/daprrp/resources/testdata/daprrp-resources-secretstore-recipe.bicep
+++ b/test/functional/daprrp/resources/testdata/daprrp-resources-secretstore-recipe.bicep
@@ -1,22 +1,24 @@
 import radius as radius
 
 param magpieimage string
+
+param location string = resourceGroup().location
 param registry string
 param version string
 
 resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
-  name: 'corerp-environment-recipes-env'
+  name: 'daprrp-environment-secretstore-recipes-env'
   properties: {
     compute: {
       kind: 'kubernetes'
       resourceId: 'self'
-      namespace: 'corerp-environment-recipes-env'
+      namespace: 'daprrp-environment-secretstore-recipes-env'
     }
     recipes: {
-      'Applications.Link/daprStateStores': {
+      'Applications.Dapr/secretStores': {
         default: {
           templateKind: 'bicep'
-          templatePath: '${registry}/test/functional/shared/recipes/dapr-state-store:${version}'
+          templatePath: '${registry}/test/functional/shared/recipes/dapr-secret-store:${version}'
         }
       }
     }
@@ -24,25 +26,26 @@ resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
 }
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'corerp-resources-dapr-sts-recipe'
+  name: 'daprrp-resources-secretstore-recipe'
   properties: {
     environment: env.id
     extensions: [
       {
         kind: 'kubernetesNamespace'
-        namespace: 'corerp-resources-dapr-sts-recipe'
+        namespace: 'daprrp-resources-secretstore-recipe'
       }
     ]
   }
 }
 
-resource webapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-recipe-ctnr-old'
+resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
+  name: 'gnrc-scs-ctnr-recipe'
+  location: location
   properties: {
     application: app.id
     connections: {
-      daprstatestore: {
-        source: statestore.id
+      daprsecretstore: {
+        source: secretstore.id
       }
     }
     container: {
@@ -56,17 +59,18 @@ resource webapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
     extensions: [
       {
         kind: 'daprSidecar'
-        appId: 'dapr-sts-recipe-ctnr'
+        appId: 'gnrc-ss-ctnr-recipe'
         appPort: 3000
       }
     ]
   }
 }
 
-resource statestore 'Applications.Link/daprStateStores@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-recipe-old'
+resource secretstore 'Applications.Dapr/secretStores@2022-03-15-privatepreview' = {
+  name: 'gnrc-scs-recipe'
+  location: location
   properties: {
-    application: app.id
     environment: env.id
+    application: app.id
   }
 }

--- a/test/functional/daprrp/resources/testdata/daprrp-resources-secretstore-recipe.bicep
+++ b/test/functional/daprrp/resources/testdata/daprrp-resources-secretstore-recipe.bicep
@@ -7,12 +7,12 @@ param registry string
 param version string
 
 resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
-  name: 'daprrp-environment-secretstore-recipes-env'
+  name: 'daprrp-env-secretstore-recipes-env'
   properties: {
     compute: {
       kind: 'kubernetes'
       resourceId: 'self'
-      namespace: 'daprrp-environment-secretstore-recipes-env'
+      namespace: 'daprrp-env-secretstore-recipes-env'
     }
     recipes: {
       'Applications.Dapr/secretStores': {
@@ -26,13 +26,13 @@ resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
 }
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'daprrp-resources-secretstore-recipe'
+  name: 'daprrp-rs-secretstore-recipe'
   properties: {
     environment: env.id
     extensions: [
       {
         kind: 'kubernetesNamespace'
-        namespace: 'daprrp-resources-secretstore-recipe'
+        namespace: 'daprrp-rs-secretstore-recipe'
       }
     ]
   }

--- a/test/functional/daprrp/resources/testdata/daprrp-resources-serviceinvocation.bicep
+++ b/test/functional/daprrp/resources/testdata/daprrp-resources-serviceinvocation.bicep
@@ -5,7 +5,7 @@ param environment string
 param magpieimage string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'dapr-serviceinvocation-old'
+  name: 'dapr-serviceinvocation'
   location: location
   properties: {
     environment: environment
@@ -13,7 +13,7 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 }
 
 resource frontend 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dapr-frontend-old'
+  name: 'dapr-frontend'
   location: location
   properties: {
     application: app.id
@@ -39,7 +39,7 @@ resource frontend 'Applications.Core/containers@2022-03-15-privatepreview' = {
 }
 
 resource backend 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dapr-backend-old'
+  name: 'dapr-backend'
   location: location
   properties: {
     application: app.id

--- a/test/functional/daprrp/resources/testdata/daprrp-resources-statestore-manual.bicep
+++ b/test/functional/daprrp/resources/testdata/daprrp-resources-statestore-manual.bicep
@@ -5,14 +5,14 @@ param environment string
 param namespace string = 'default'
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'corerp-resources-dapr-statestore-manual'
+  name: 'daprrp-resources-statestore-manual'
   properties: {
     environment: environment
   }
 }
 
 resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-manual-ctnr-old'
+  name: 'dapr-sts-manual-ctnr'
   properties: {
     application: app.id
     connections: {
@@ -39,8 +39,8 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
 }
 
 
-module redis 'modules/redis-selfhost.bicep' = {
-  name: 'dapr-sts-manual-redis-deployment-old'
+module redis '../../../shared/resources/testdata/modules/redis-selfhost.bicep' = {
+  name: 'dapr-sts-manual-redis-deployment'
   params: {
     name: 'dapr-sts-manual-redis'
     namespace: namespace
@@ -49,8 +49,8 @@ module redis 'modules/redis-selfhost.bicep' = {
 }
 
 
-resource statestore 'Applications.Link/daprStateStores@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-manual-old'
+resource statestore 'Applications.Dapr/stateStores@2022-03-15-privatepreview' = {
+  name: 'dapr-sts-manual'
   properties: {
     application: app.id
     environment: environment

--- a/test/functional/daprrp/resources/testdata/daprrp-resources-statestore-manual.bicep
+++ b/test/functional/daprrp/resources/testdata/daprrp-resources-statestore-manual.bicep
@@ -5,7 +5,7 @@ param environment string
 param namespace string = 'default'
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'daprrp-resources-statestore-manual'
+  name: 'daprrp-rs-statestore-manual'
   properties: {
     environment: environment
   }

--- a/test/functional/daprrp/resources/testdata/daprrp-resources-statestore-recipe.bicep
+++ b/test/functional/daprrp/resources/testdata/daprrp-resources-statestore-recipe.bicep
@@ -5,12 +5,12 @@ param registry string
 param version string
 
 resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
-  name: 'daprrp-environment-recipes-env'
+  name: 'daprrp-env-recipes-env'
   properties: {
     compute: {
       kind: 'kubernetes'
       resourceId: 'self'
-      namespace: 'daprrp-environment-recipes-env'
+      namespace: 'daprrp-env-recipes-env'
     }
     recipes: {
       'Applications.Dapr/stateStores': {
@@ -24,13 +24,13 @@ resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
 }
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'daprrp-resources-sts-recipe'
+  name: 'daprrp-rs-sts-recipe'
   properties: {
     environment: env.id
     extensions: [
       {
         kind: 'kubernetesNamespace'
-        namespace: 'daprrp-resources-sts-recipe'
+        namespace: 'daprrp-rs-sts-recipe'
       }
     ]
   }

--- a/test/functional/daprrp/resources/testdata/daprrp-resources-statestore-recipe.bicep
+++ b/test/functional/daprrp/resources/testdata/daprrp-resources-statestore-recipe.bicep
@@ -5,15 +5,15 @@ param registry string
 param version string
 
 resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
-  name: 'corerp-environment-recipes-env'
+  name: 'daprrp-environment-recipes-env'
   properties: {
     compute: {
       kind: 'kubernetes'
       resourceId: 'self'
-      namespace: 'corerp-environment-recipes-env'
+      namespace: 'daprrp-environment-recipes-env'
     }
     recipes: {
-      'Applications.Link/daprStateStores': {
+      'Applications.Dapr/stateStores': {
         default: {
           templateKind: 'bicep'
           templatePath: '${registry}/test/functional/shared/recipes/dapr-state-store:${version}'
@@ -24,20 +24,20 @@ resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
 }
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'corerp-resources-dapr-sts-recipe'
+  name: 'daprrp-resources-sts-recipe'
   properties: {
     environment: env.id
     extensions: [
       {
         kind: 'kubernetesNamespace'
-        namespace: 'corerp-resources-dapr-sts-recipe'
+        namespace: 'daprrp-resources-sts-recipe'
       }
     ]
   }
 }
 
 resource webapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-recipe-ctnr-old'
+  name: 'dapr-sts-recipe-ctnr'
   properties: {
     application: app.id
     connections: {
@@ -63,8 +63,8 @@ resource webapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
   }
 }
 
-resource statestore 'Applications.Link/daprStateStores@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-recipe-old'
+resource statestore 'Applications.Dapr/stateStores@2022-03-15-privatepreview' = {
+  name: 'dapr-sts-recipe'
   properties: {
     application: app.id
     environment: env.id

--- a/test/functional/shared/resources/dapr_component_name_conflict_test.go
+++ b/test/functional/shared/resources/dapr_component_name_conflict_test.go
@@ -27,7 +27,7 @@ import (
 
 func Test_DaprComponentNameConflict(t *testing.T) {
 	template := "testdata/corerp-resources-dapr-component-name-conflict.bicep"
-	name := "corerp-resources-dapr-component-name-conflict"
+	name := "corerp-resources-dcnc-old"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -35,7 +35,7 @@ func Test_DaprComponentNameConflict(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "corerp-resources-dapr-component-name-conflict",
+						Name: "corerp-resources-dcnc-old",
 						Type: validation.ApplicationsResource,
 					},
 				},

--- a/test/functional/shared/resources/dapr_pubsub_test.go
+++ b/test/functional/shared/resources/dapr_pubsub_test.go
@@ -29,8 +29,8 @@ import (
 
 func Test_DaprPubSubBroker_Manual(t *testing.T) {
 	template := "testdata/corerp-resources-dapr-pubsub-broker-manual.bicep"
-	name := "dpsb-manual-app-old"
-	appNamespace := "default-dpsb-manual-app-old"
+	name := "dpsb-manual-app"
+	appNamespace := "default-dpsb-manual-app"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -38,16 +38,16 @@ func Test_DaprPubSubBroker_Manual(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "dpsb-manual-app-old",
+						Name: "dpsb-manual-app",
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "dpsb-manual-app-ctnr-old",
+						Name: "dpsb-manual-app-ctnr",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dpsb-manual-old",
+						Name: "dpsb-manual",
 						Type: validation.O_DaprPubSubBrokersResource,
 						App:  name,
 					},
@@ -56,9 +56,9 @@ func Test_DaprPubSubBroker_Manual(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dpsb-manual-app-ctnr-old"),
-						validation.NewK8sPodForResource(name, "dpsb-manual-redis-old").ValidateLabels(false),
-						validation.NewK8sServiceForResource(name, "dpsb-manual-redis-old").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "dpsb-manual-app-ctnr"),
+						validation.NewK8sPodForResource(name, "dpsb-manual-redis").ValidateLabels(false),
+						validation.NewK8sServiceForResource(name, "dpsb-manual-redis").ValidateLabels(false),
 					},
 				},
 			},
@@ -70,8 +70,8 @@ func Test_DaprPubSubBroker_Manual(t *testing.T) {
 
 func Test_DaprPubSubBroker_Recipe(t *testing.T) {
 	template := "testdata/corerp-resources-dapr-pubsub-broker-recipe.bicep"
-	name := "dpsb-recipe-app-old"
-	appNamespace := "dpsb-recipe-env-old"
+	name := "dpsb-recipe-app"
+	appNamespace := "dpsb-recipe-env"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -79,21 +79,21 @@ func Test_DaprPubSubBroker_Recipe(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "dpsb-recipe-env-old",
+						Name: "dpsb-recipe-env",
 						Type: validation.EnvironmentsResource,
 					},
 					{
-						Name: "dpsb-recipe-app-old",
+						Name: "dpsb-recipe-app",
 						Type: validation.ApplicationsResource,
 						App:  name,
 					},
 					{
-						Name: "dpsb-recipe-app-ctnr-old",
+						Name: "dpsb-recipe-app-ctnr",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dpsb-recipe-old",
+						Name: "dpsb-recipe",
 						Type: validation.O_DaprPubSubBrokersResource,
 						App:  name,
 						OutputResources: []validation.OutputResourceResponse{
@@ -112,7 +112,7 @@ func Test_DaprPubSubBroker_Recipe(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dpsb-recipe-ctnr-old").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "dpsb-recipe-ctnr").ValidateLabels(false),
 					},
 				},
 			},

--- a/test/functional/shared/resources/dapr_pubsub_test.go
+++ b/test/functional/shared/resources/dapr_pubsub_test.go
@@ -29,8 +29,8 @@ import (
 
 func Test_DaprPubSubBroker_Manual(t *testing.T) {
 	template := "testdata/corerp-resources-dapr-pubsub-broker-manual.bicep"
-	name := "dpsb-manual-app"
-	appNamespace := "default-dpsb-manual-app"
+	name := "dpsb-mnl-app-old"
+	appNamespace := "default-dpsb-mnl-app-old"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -38,16 +38,16 @@ func Test_DaprPubSubBroker_Manual(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "dpsb-manual-app",
+						Name: "dpsb-mnl-app-old",
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "dpsb-manual-app-ctnr",
+						Name: "dpsb-mnl-app-ctnr-old",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dpsb-manual",
+						Name: "dpsb-mnl-old",
 						Type: validation.O_DaprPubSubBrokersResource,
 						App:  name,
 					},
@@ -56,9 +56,9 @@ func Test_DaprPubSubBroker_Manual(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dpsb-manual-app-ctnr"),
-						validation.NewK8sPodForResource(name, "dpsb-manual-redis").ValidateLabels(false),
-						validation.NewK8sServiceForResource(name, "dpsb-manual-redis").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "dpsb-mnl-app-ctnr-old"),
+						validation.NewK8sPodForResource(name, "dpsb-mnl-redis-old").ValidateLabels(false),
+						validation.NewK8sServiceForResource(name, "dpsb-mnl-redis-old").ValidateLabels(false),
 					},
 				},
 			},
@@ -70,8 +70,8 @@ func Test_DaprPubSubBroker_Manual(t *testing.T) {
 
 func Test_DaprPubSubBroker_Recipe(t *testing.T) {
 	template := "testdata/corerp-resources-dapr-pubsub-broker-recipe.bicep"
-	name := "dpsb-recipe-app"
-	appNamespace := "dpsb-recipe-env"
+	name := "dpsb-recipe-app-old"
+	appNamespace := "dpsb-recipe-env-old"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -79,21 +79,21 @@ func Test_DaprPubSubBroker_Recipe(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "dpsb-recipe-env",
+						Name: "dpsb-recipe-env-old",
 						Type: validation.EnvironmentsResource,
 					},
 					{
-						Name: "dpsb-recipe-app",
+						Name: "dpsb-recipe-app-old",
 						Type: validation.ApplicationsResource,
 						App:  name,
 					},
 					{
-						Name: "dpsb-recipe-app-ctnr",
+						Name: "dpsb-recipe-app-ctnr-old",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dpsb-recipe",
+						Name: "dpsb-recipe-old",
 						Type: validation.O_DaprPubSubBrokersResource,
 						App:  name,
 						OutputResources: []validation.OutputResourceResponse{
@@ -112,7 +112,7 @@ func Test_DaprPubSubBroker_Recipe(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dpsb-recipe-ctnr").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "dpsb-recipe-app-ctnr-old").ValidateLabels(false),
 					},
 				},
 			},

--- a/test/functional/shared/resources/dapr_pubsub_test.go
+++ b/test/functional/shared/resources/dapr_pubsub_test.go
@@ -29,8 +29,8 @@ import (
 
 func Test_DaprPubSubBroker_Manual(t *testing.T) {
 	template := "testdata/corerp-resources-dapr-pubsub-broker-manual.bicep"
-	name := "dpsb-manual-app"
-	appNamespace := "default-dpsb-manual-app"
+	name := "dpsb-manual-app-old"
+	appNamespace := "default-dpsb-manual-app-old"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -38,17 +38,17 @@ func Test_DaprPubSubBroker_Manual(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "dpsb-manual-app",
+						Name: "dpsb-manual-app-old",
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "dpsb-manual-app-ctnr",
+						Name: "dpsb-manual-app-ctnr-old",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dpsb-manual",
-						Type: validation.DaprPubSubBrokersResource,
+						Name: "dpsb-manual-old",
+						Type: validation.O_DaprPubSubBrokersResource,
 						App:  name,
 					},
 				},
@@ -56,9 +56,9 @@ func Test_DaprPubSubBroker_Manual(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dpsb-manual-app-ctnr"),
-						validation.NewK8sPodForResource(name, "dpsb-manual-redis").ValidateLabels(false),
-						validation.NewK8sServiceForResource(name, "dpsb-manual-redis").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "dpsb-manual-app-ctnr-old"),
+						validation.NewK8sPodForResource(name, "dpsb-manual-redis-old").ValidateLabels(false),
+						validation.NewK8sServiceForResource(name, "dpsb-manual-redis-old").ValidateLabels(false),
 					},
 				},
 			},
@@ -70,8 +70,8 @@ func Test_DaprPubSubBroker_Manual(t *testing.T) {
 
 func Test_DaprPubSubBroker_Recipe(t *testing.T) {
 	template := "testdata/corerp-resources-dapr-pubsub-broker-recipe.bicep"
-	name := "dpsb-recipe-app"
-	appNamespace := "dpsb-recipe-env"
+	name := "dpsb-recipe-app-old"
+	appNamespace := "dpsb-recipe-env-old"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -79,22 +79,22 @@ func Test_DaprPubSubBroker_Recipe(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "dpsb-recipe-env",
+						Name: "dpsb-recipe-env-old",
 						Type: validation.EnvironmentsResource,
 					},
 					{
-						Name: "dpsb-recipe-app",
+						Name: "dpsb-recipe-app-old",
 						Type: validation.ApplicationsResource,
 						App:  name,
 					},
 					{
-						Name: "dpsb-recipe-app-ctnr",
+						Name: "dpsb-recipe-app-ctnr-old",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dpsb-recipe",
-						Type: validation.DaprPubSubBrokersResource,
+						Name: "dpsb-recipe-old",
+						Type: validation.O_DaprPubSubBrokersResource,
 						App:  name,
 						OutputResources: []validation.OutputResourceResponse{
 							{
@@ -112,7 +112,7 @@ func Test_DaprPubSubBroker_Recipe(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dpsb-recipe-ctnr").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "dpsb-recipe-ctnr-old").ValidateLabels(false),
 					},
 				},
 			},

--- a/test/functional/shared/resources/dapr_secretstore_test.go
+++ b/test/functional/shared/resources/dapr_secretstore_test.go
@@ -40,13 +40,13 @@ func Test_DaprSecretStore_Manual_Generic(t *testing.T) {
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "gnrc-scs-ctnr",
+						Name: "gnrc-scs-ctnr-old",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "gnrc-scs-manual",
-						Type: validation.DaprSecretStoresResource,
+						Name: "gnrc-scs-manual-old",
+						Type: validation.O_DaprSecretStoresResource,
 						App:  name,
 					},
 				},
@@ -54,7 +54,7 @@ func Test_DaprSecretStore_Manual_Generic(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "gnrc-scs-ctnr"),
+						validation.NewK8sPodForResource(name, "gnrc-scs-ctnr-old"),
 					},
 				},
 			},
@@ -80,13 +80,13 @@ func Test_DaprSecretStore_Recipe(t *testing.T) {
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "gnrc-scs-ctnr-recipe",
+						Name: "gnrc-scs-ctnr-recipe-old",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "gnrc-scs-recipe",
-						Type: validation.DaprSecretStoresResource,
+						Name: "gnrc-scs-recipe-old",
+						Type: validation.O_DaprSecretStoresResource,
 						App:  name,
 					},
 				},
@@ -94,7 +94,7 @@ func Test_DaprSecretStore_Recipe(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "gnrc-scs-ctnr-recipe").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "gnrc-scs-ctnr-recipe-old").ValidateLabels(false),
 					},
 				},
 			},

--- a/test/functional/shared/resources/dapr_secretstore_test.go
+++ b/test/functional/shared/resources/dapr_secretstore_test.go
@@ -40,12 +40,12 @@ func Test_DaprSecretStore_Manual_Generic(t *testing.T) {
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "gnrc-scs-ctnr-old",
+						Name: "gnrc-scs-ctnr",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "gnrc-scs-manual-old",
+						Name: "gnrc-scs-manual",
 						Type: validation.O_DaprSecretStoresResource,
 						App:  name,
 					},
@@ -54,7 +54,7 @@ func Test_DaprSecretStore_Manual_Generic(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "gnrc-scs-ctnr-old"),
+						validation.NewK8sPodForResource(name, "gnrc-scs-ctnr"),
 					},
 				},
 			},
@@ -80,12 +80,12 @@ func Test_DaprSecretStore_Recipe(t *testing.T) {
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "gnrc-scs-ctnr-recipe-old",
+						Name: "gnrc-scs-ctnr-recipe",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "gnrc-scs-recipe-old",
+						Name: "gnrc-scs-recipe",
 						Type: validation.O_DaprSecretStoresResource,
 						App:  name,
 					},
@@ -94,7 +94,7 @@ func Test_DaprSecretStore_Recipe(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "gnrc-scs-ctnr-recipe-old").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "gnrc-scs-ctnr-recipe").ValidateLabels(false),
 					},
 				},
 			},

--- a/test/functional/shared/resources/dapr_secretstore_test.go
+++ b/test/functional/shared/resources/dapr_secretstore_test.go
@@ -27,8 +27,8 @@ import (
 
 func Test_DaprSecretStore_Manual_Generic(t *testing.T) {
 	template := "testdata/corerp-resources-dapr-secretstore-manual.bicep"
-	name := "corerp-resources-dapr-secretstore-manual"
-	appNamespace := "default-corerp-resources-dapr-secretstore-manual"
+	name := "corerp-resources-dssm-old"
+	appNamespace := "default-corerp-resources-dssm-old"
 
 	test := shared.NewRPTest(t, appNamespace, []shared.TestStep{
 		{
@@ -40,12 +40,12 @@ func Test_DaprSecretStore_Manual_Generic(t *testing.T) {
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "gnrc-scs-ctnr",
+						Name: "gnrc-scs-ctnr-old",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "gnrc-scs-manual",
+						Name: "gnrc-scs-manual-old",
 						Type: validation.O_DaprSecretStoresResource,
 						App:  name,
 					},
@@ -54,7 +54,7 @@ func Test_DaprSecretStore_Manual_Generic(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "gnrc-scs-ctnr"),
+						validation.NewK8sPodForResource(name, "gnrc-scs-ctnr-old"),
 					},
 				},
 			},
@@ -67,8 +67,8 @@ func Test_DaprSecretStore_Manual_Generic(t *testing.T) {
 
 func Test_DaprSecretStore_Recipe(t *testing.T) {
 	template := "testdata/corerp-resources-dapr-secretstore-recipe.bicep"
-	name := "corerp-resources-dapr-secretstore-recipe"
-	appNamespace := "corerp-resources-dapr-secretstore-recipe"
+	name := "corerp-resources-dssr-old"
+	appNamespace := "corerp-resources-dssr-old"
 
 	test := shared.NewRPTest(t, appNamespace, []shared.TestStep{
 		{
@@ -80,12 +80,12 @@ func Test_DaprSecretStore_Recipe(t *testing.T) {
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "gnrc-scs-ctnr-recipe",
+						Name: "gnrc-scs-ctnr-recipe-old",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "gnrc-scs-recipe",
+						Name: "gnrc-scs-recipe-old",
 						Type: validation.O_DaprSecretStoresResource,
 						App:  name,
 					},
@@ -94,7 +94,7 @@ func Test_DaprSecretStore_Recipe(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "gnrc-scs-ctnr-recipe").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "gnrc-scs-ctnr-recipe-old").ValidateLabels(false),
 					},
 				},
 			},

--- a/test/functional/shared/resources/dapr_serviceinvocation_test.go
+++ b/test/functional/shared/resources/dapr_serviceinvocation_test.go
@@ -27,8 +27,8 @@ import (
 
 func Test_DaprServiceInvocation(t *testing.T) {
 	template := "testdata/corerp-resources-dapr-serviceinvocation.bicep"
-	name := "dapr-serviceinvocation"
-	appNamespace := "default-dapr-serviceinvocation"
+	name := "dapr-si-old"
+	appNamespace := "default-dapr-si-old"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -40,12 +40,12 @@ func Test_DaprServiceInvocation(t *testing.T) {
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "dapr-frontend",
+						Name: "dapr-frontend-old",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dapr-backend",
+						Name: "dapr-backend-old",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
@@ -54,8 +54,8 @@ func Test_DaprServiceInvocation(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dapr-frontend"),
-						validation.NewK8sPodForResource(name, "dapr-backend"),
+						validation.NewK8sPodForResource(name, "dapr-frontend-old"),
+						validation.NewK8sPodForResource(name, "dapr-backend-old"),
 					},
 				},
 			},

--- a/test/functional/shared/resources/dapr_serviceinvocation_test.go
+++ b/test/functional/shared/resources/dapr_serviceinvocation_test.go
@@ -40,12 +40,12 @@ func Test_DaprServiceInvocation(t *testing.T) {
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "dapr-frontend-old",
+						Name: "dapr-frontend",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dapr-backend-old",
+						Name: "dapr-backend",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
@@ -54,8 +54,8 @@ func Test_DaprServiceInvocation(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dapr-frontend-old"),
-						validation.NewK8sPodForResource(name, "dapr-backend-old"),
+						validation.NewK8sPodForResource(name, "dapr-frontend"),
+						validation.NewK8sPodForResource(name, "dapr-backend"),
 					},
 				},
 			},

--- a/test/functional/shared/resources/dapr_statestore_test.go
+++ b/test/functional/shared/resources/dapr_statestore_test.go
@@ -29,8 +29,8 @@ import (
 
 func Test_DaprStateStore_Manual(t *testing.T) {
 	template := "testdata/corerp-resources-dapr-statestore-manual.bicep"
-	name := "corerp-resources-dapr-statestore-manual"
-	appNamespace := "default-corerp-resources-dapr-statestore-manual"
+	name := "corerp-resources-dsstm-old"
+	appNamespace := "default-corerp-resources-dsstm-old"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -38,16 +38,16 @@ func Test_DaprStateStore_Manual(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "corerp-resources-dapr-statestore-manual",
+						Name: "corerp-resources-dsstm-old",
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "dapr-sts-manual-ctnr",
+						Name: "dapr-sts-manual-ctnr-old",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dapr-sts-manual",
+						Name: "dapr-sts-manual-old",
 						Type: validation.O_DaprStateStoresResource,
 						App:  name,
 					},
@@ -56,11 +56,11 @@ func Test_DaprStateStore_Manual(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dapr-sts-manual-ctnr"),
+						validation.NewK8sPodForResource(name, "dapr-sts-manual-ctnr-old"),
 
 						// Deployed as supporting resources using Kubernetes Bicep extensibility.
-						validation.NewK8sPodForResource(name, "dapr-sts-manual-redis").ValidateLabels(false),
-						validation.NewK8sServiceForResource(name, "dapr-sts-manual-redis").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "dapr-sts-manual-redis-old").ValidateLabels(false),
+						validation.NewK8sServiceForResource(name, "dapr-sts-manual-redis-old").ValidateLabels(false),
 					},
 				},
 			},
@@ -72,8 +72,8 @@ func Test_DaprStateStore_Manual(t *testing.T) {
 
 func Test_DaprStateStore_Recipe(t *testing.T) {
 	template := "testdata/corerp-resources-dapr-statestore-recipe.bicep"
-	name := "corerp-resources-dapr-sts-recipe"
-	appNamespace := "corerp-environment-recipes-env"
+	name := "corerp-rs-dapr-sts-recipe-old"
+	appNamespace := "corerp-env-recipes-env-old"
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -81,21 +81,21 @@ func Test_DaprStateStore_Recipe(t *testing.T) {
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: "corerp-environment-recipes-env",
+						Name: "corerp-env-recipes-env-old",
 						Type: validation.EnvironmentsResource,
 					},
 					{
-						Name: "corerp-resources-dapr-sts-recipe",
+						Name: "corerp-rs-dapr-sts-recipe-old",
 						Type: validation.ApplicationsResource,
 						App:  name,
 					},
 					{
-						Name: "dapr-sts-recipe-ctnr",
+						Name: "dapr-sts-recipe-ctnr-old",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dapr-sts-recipe",
+						Name: "dapr-sts-recipe-old",
 						Type: validation.O_DaprStateStoresResource,
 						App:  name,
 						OutputResources: []validation.OutputResourceResponse{
@@ -114,7 +114,7 @@ func Test_DaprStateStore_Recipe(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dapr-sts-recipe-ctnr").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "dapr-sts-recipe-ctnr-old").ValidateLabels(false),
 					},
 				},
 			},

--- a/test/functional/shared/resources/dapr_statestore_test.go
+++ b/test/functional/shared/resources/dapr_statestore_test.go
@@ -42,12 +42,12 @@ func Test_DaprStateStore_Manual(t *testing.T) {
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "dapr-sts-manual-ctnr-old",
+						Name: "dapr-sts-manual-ctnr",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dapr-sts-manual-old",
+						Name: "dapr-sts-manual",
 						Type: validation.O_DaprStateStoresResource,
 						App:  name,
 					},
@@ -56,11 +56,11 @@ func Test_DaprStateStore_Manual(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dapr-sts-manual-ctnr-old"),
+						validation.NewK8sPodForResource(name, "dapr-sts-manual-ctnr"),
 
 						// Deployed as supporting resources using Kubernetes Bicep extensibility.
-						validation.NewK8sPodForResource(name, "dapr-sts-manual-redis-old").ValidateLabels(false),
-						validation.NewK8sServiceForResource(name, "dapr-sts-manual-redis-old").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "dapr-sts-manual-redis").ValidateLabels(false),
+						validation.NewK8sServiceForResource(name, "dapr-sts-manual-redis").ValidateLabels(false),
 					},
 				},
 			},
@@ -90,12 +90,12 @@ func Test_DaprStateStore_Recipe(t *testing.T) {
 						App:  name,
 					},
 					{
-						Name: "dapr-sts-recipe-ctnr-old",
+						Name: "dapr-sts-recipe-ctnr",
 						Type: validation.ContainersResource,
 						App:  name,
 					},
 					{
-						Name: "dapr-sts-recipe-old",
+						Name: "dapr-sts-recipe",
 						Type: validation.O_DaprStateStoresResource,
 						App:  name,
 						OutputResources: []validation.OutputResourceResponse{
@@ -114,7 +114,7 @@ func Test_DaprStateStore_Recipe(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dapr-sts-recipe-ctnr-old").ValidateLabels(false),
+						validation.NewK8sPodForResource(name, "dapr-sts-recipe-ctnr").ValidateLabels(false),
 					},
 				},
 			},

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-component-name-conflict.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-component-name-conflict.bicep
@@ -5,7 +5,7 @@ param environment string
 param location string = resourceGroup().location
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'corerp-resources-dapr-component-name-conflict'
+  name: 'corerp-resources-dcnc-old'
   location: 'global'
   properties: {
     environment: environment
@@ -14,7 +14,7 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 
 // Dapr Component #1
 resource pubsub 'Applications.Link/daprPubSubBrokers@2022-03-15-privatepreview' = {
-  name: 'dapr-component'
+  name: 'dapr-component-old'
   location: 'global'
   properties: {
     environment: environment
@@ -43,7 +43,7 @@ resource namespace 'Microsoft.ServiceBus/namespaces@2017-04-01' = {
 
 // Dapr Component #2
 resource secretstore 'Applications.Link/daprSecretStores@2022-03-15-privatepreview' = {
-  name: 'dapr-component'
+  name: 'dapr-component-old'
   location: 'global'
   properties: {
     environment: environment

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-component-name-conflict.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-component-name-conflict.bicep
@@ -14,7 +14,7 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 
 // Dapr Component #1
 resource pubsub 'Applications.Link/daprPubSubBrokers@2022-03-15-privatepreview' = {
-  name: 'dapr-component-old'
+  name: 'dapr-component'
   location: 'global'
   properties: {
     environment: environment
@@ -43,7 +43,7 @@ resource namespace 'Microsoft.ServiceBus/namespaces@2017-04-01' = {
 
 // Dapr Component #2
 resource secretstore 'Applications.Link/daprSecretStores@2022-03-15-privatepreview' = {
-  name: 'dapr-component-old'
+  name: 'dapr-component'
   location: 'global'
   properties: {
     environment: environment

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-pubsub-broker-manual.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-pubsub-broker-manual.bicep
@@ -5,14 +5,14 @@ param environment string
 param namespace string = 'default'
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'dpsb-manual-app'
+  name: 'dpsb-mnl-app-old'
   properties: {
     environment: environment
   }
 }
 
 resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dpsb-manual-app-ctnr'
+  name: 'dpsb-mnl-app-ctnr-old'
   properties: {
     application: app.id
     connections: {
@@ -31,18 +31,17 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
     extensions: [
       {
         kind: 'daprSidecar'
-        appId: 'dpsb-manual-app-ctnr'
+        appId: 'dpsb-mnl-app-ctnr-old'
         appPort: 3000
       }
     ]
   }
 }
 
-
 module redis 'modules/redis-selfhost.bicep' = {
-  name: 'dpsb-manual-redis-deployment'
+  name: 'dpsb-mnl-redis-old-deployment'
   params: {
-    name: 'dpsb-manual-redis'
+    name: 'dpsb-mnl-redis-old'
     namespace: namespace
     application: app.name
   }
@@ -50,7 +49,7 @@ module redis 'modules/redis-selfhost.bicep' = {
 
 
 resource pubsubBroker 'Applications.Link/daprPubSubBrokers@2022-03-15-privatepreview' = {
-  name: 'dpsb-manual'
+  name: 'dpsb-mnl-old'
   properties: {
     application: app.id
     environment: environment

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-pubsub-broker-manual.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-pubsub-broker-manual.bicep
@@ -5,14 +5,14 @@ param environment string
 param namespace string = 'default'
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'dpsb-manual-app'
+  name: 'dpsb-manual-app-old'
   properties: {
     environment: environment
   }
 }
 
 resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dpsb-manual-app-ctnr'
+  name: 'dpsb-manual-app-ctnr-old'
   properties: {
     application: app.id
     connections: {
@@ -31,7 +31,7 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
     extensions: [
       {
         kind: 'daprSidecar'
-        appId: 'dpsb-manual-app-ctnr'
+        appId: 'dpsb-manual-app-old'
         appPort: 3000
       }
     ]
@@ -40,9 +40,9 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
 
 
 module redis 'modules/redis-selfhost.bicep' = {
-  name: 'dpsb-manual-redis-deployment'
+  name: 'dpsb-manual-redis-deployment-old'
   params: {
-    name: 'dpsb-manual-redis'
+    name: 'dpsb-manual-redis-old'
     namespace: namespace
     application: app.name
   }
@@ -50,7 +50,7 @@ module redis 'modules/redis-selfhost.bicep' = {
 
 
 resource pubsubBroker 'Applications.Link/daprPubSubBrokers@2022-03-15-privatepreview' = {
-  name: 'dpsb-manual'
+  name: 'dpsb-manual-old'
   properties: {
     application: app.id
     environment: environment

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-pubsub-broker-manual.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-pubsub-broker-manual.bicep
@@ -5,14 +5,14 @@ param environment string
 param namespace string = 'default'
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'dpsb-manual-app-old'
+  name: 'dpsb-manual-app'
   properties: {
     environment: environment
   }
 }
 
 resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dpsb-manual-app-ctnr-old'
+  name: 'dpsb-manual-app-ctnr'
   properties: {
     application: app.id
     connections: {
@@ -31,7 +31,7 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
     extensions: [
       {
         kind: 'daprSidecar'
-        appId: 'dpsb-manual-app-old'
+        appId: 'dpsb-manual-app-ctnr'
         appPort: 3000
       }
     ]
@@ -40,9 +40,9 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
 
 
 module redis 'modules/redis-selfhost.bicep' = {
-  name: 'dpsb-manual-redis-deployment-old'
+  name: 'dpsb-manual-redis-deployment'
   params: {
-    name: 'dpsb-manual-redis-old'
+    name: 'dpsb-manual-redis'
     namespace: namespace
     application: app.name
   }
@@ -50,7 +50,7 @@ module redis 'modules/redis-selfhost.bicep' = {
 
 
 resource pubsubBroker 'Applications.Link/daprPubSubBrokers@2022-03-15-privatepreview' = {
-  name: 'dpsb-manual-old'
+  name: 'dpsb-manual'
   properties: {
     application: app.id
     environment: environment

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-pubsub-broker-recipe.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-pubsub-broker-recipe.bicep
@@ -5,7 +5,7 @@ param registry string
 param version string
 
 resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
-  name: 'dpsb-recipe-env'
+  name: 'dpsb-recipe-env-old'
   properties: {
     compute: {
       kind: 'kubernetes'
@@ -24,7 +24,7 @@ resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
 }
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'dpsb-recipe-app'
+  name: 'dpsb-recipe-app-old'
   properties: {
     environment: env.id
     extensions: [
@@ -37,7 +37,7 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 }
 
 resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dpsb-recipe-app-ctnr'
+  name: 'dpsb-recipe-app-ctnr-old'
   properties: {
     application: app.id
     connections: {
@@ -64,7 +64,7 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
 }
 
 resource pubsubBroker 'Applications.Link/daprPubSubBrokers@2022-03-15-privatepreview' = {
-  name: 'dpsb-recipe'
+  name: 'dpsb-recipe-old'
   properties: {
     application: app.id
     environment: env.id

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-pubsub-broker-recipe.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-pubsub-broker-recipe.bicep
@@ -5,12 +5,12 @@ param registry string
 param version string
 
 resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
-  name: 'dpsb-recipe-env'
+  name: 'dpsb-recipe-env-old'
   properties: {
     compute: {
       kind: 'kubernetes'
       resourceId: 'self'
-      namespace: 'dpsb-recipe-env'
+      namespace: 'dpsb-recipe-env-old'
     }
     recipes: {
       'Applications.Link/daprPubSubBrokers': {
@@ -24,20 +24,20 @@ resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
 }
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'dpsb-recipe-app'
+  name: 'dpsb-recipe-app-old'
   properties: {
     environment: env.id
     extensions: [
       {
         kind: 'kubernetesNamespace'
-        namespace: 'dpsb-recipe-app'
+        namespace: 'dpsb-recipe-app-old'
       }
     ]
   }
 }
 
 resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dpsb-recipe-app-ctnr'
+  name: 'dpsb-recipe-app-ctnr-old'
   properties: {
     application: app.id
     connections: {
@@ -56,7 +56,7 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
     extensions: [
       {
         kind: 'daprSidecar'
-        appId: 'dpsb-recipe-app-ctnr'
+        appId: 'dpsb-recipe-app-ctnr-old'
         appPort: 3000
       }
     ]
@@ -64,7 +64,7 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
 }
 
 resource pubsubBroker 'Applications.Link/daprPubSubBrokers@2022-03-15-privatepreview' = {
-  name: 'dpsb-recipe'
+  name: 'dpsb-recipe-old'
   properties: {
     application: app.id
     environment: env.id

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-pubsub-broker-recipe.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-pubsub-broker-recipe.bicep
@@ -5,7 +5,7 @@ param registry string
 param version string
 
 resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
-  name: 'dpsb-recipe-env-old'
+  name: 'dpsb-recipe-env'
   properties: {
     compute: {
       kind: 'kubernetes'
@@ -24,7 +24,7 @@ resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
 }
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'dpsb-recipe-app-old'
+  name: 'dpsb-recipe-app'
   properties: {
     environment: env.id
     extensions: [
@@ -37,7 +37,7 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 }
 
 resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dpsb-recipe-app-ctnr-old'
+  name: 'dpsb-recipe-app-ctnr'
   properties: {
     application: app.id
     connections: {
@@ -64,7 +64,7 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
 }
 
 resource pubsubBroker 'Applications.Link/daprPubSubBrokers@2022-03-15-privatepreview' = {
-  name: 'dpsb-recipe-old'
+  name: 'dpsb-recipe'
   properties: {
     application: app.id
     environment: env.id

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-secretstore-manual.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-secretstore-manual.bicep
@@ -7,7 +7,7 @@ param environment string
 param location string = resourceGroup().location
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'corerp-resources-dapr-secretstore-manual'
+  name: 'corerp-resources-dssm-old'
   location: location
   properties: {
     environment: environment
@@ -15,7 +15,7 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 }
 
 resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'gnrc-scs-ctnr'
+  name: 'gnrc-scs-ctnr-old'
   properties: {
     application: app.id
     connections: {
@@ -34,7 +34,7 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
     extensions: [
       {
         kind: 'daprSidecar'
-        appId: 'gnrc-ss-ctnr'
+        appId: 'gnrc-ss-ctnr-old'
         appPort: 3000
       }
     ]
@@ -42,7 +42,7 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
 }
 
 resource secretstore 'Applications.Link/daprSecretStores@2022-03-15-privatepreview' = {
-  name: 'gnrc-scs-manual'
+  name: 'gnrc-scs-manual-old'
   location: location
   properties: {
     environment: environment

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-secretstore-manual.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-secretstore-manual.bicep
@@ -15,7 +15,7 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 }
 
 resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'gnrc-scs-ctnr-old'
+  name: 'gnrc-scs-ctnr'
   properties: {
     application: app.id
     connections: {
@@ -42,7 +42,7 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
 }
 
 resource secretstore 'Applications.Link/daprSecretStores@2022-03-15-privatepreview' = {
-  name: 'gnrc-scs-manual-old'
+  name: 'gnrc-scs-manual'
   location: location
   properties: {
     environment: environment

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-secretstore-recipe.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-secretstore-recipe.bicep
@@ -39,7 +39,7 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 }
 
 resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'gnrc-scs-ctnr-recipe-old'
+  name: 'gnrc-scs-ctnr-recipe'
   location: location
   properties: {
     application: app.id
@@ -67,7 +67,7 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
 }
 
 resource secretstore 'Applications.Link/daprSecretStores@2022-03-15-privatepreview' = {
-  name: 'gnrc-scs-recipe-old'
+  name: 'gnrc-scs-recipe'
   location: location
   properties: {
     environment: env.id

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-secretstore-recipe.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-secretstore-recipe.bicep
@@ -7,12 +7,12 @@ param registry string
 param version string
 
 resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
-  name: 'corerp-environment-secretstore-recipes-env'
+  name: 'corerp-resources-dssr-env-old'
   properties: {
     compute: {
       kind: 'kubernetes'
       resourceId: 'self'
-      namespace: 'corerp-environment-secretstore-recipes-env'
+      namespace: 'corerp-resources-dssr-env-old'
     }
     recipes: {
       'Applications.Link/daprSecretStores': {
@@ -26,20 +26,20 @@ resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
 }
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'corerp-resources-dapr-secretstore-recipe'
+  name: 'corerp-resources-dssr-old'
   properties: {
     environment: env.id
     extensions: [
       {
         kind: 'kubernetesNamespace'
-        namespace: 'corerp-resources-dapr-secretstore-recipe'
+        namespace: 'corerp-resources-dssr-old'
       }
     ]
   }
 }
 
 resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'gnrc-scs-ctnr-recipe'
+  name: 'gnrc-scs-ctnr-recipe-old'
   location: location
   properties: {
     application: app.id
@@ -59,7 +59,7 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
     extensions: [
       {
         kind: 'daprSidecar'
-        appId: 'gnrc-ss-ctnr-recipe'
+        appId: 'gnrc-ss-ctnr-recipe-old'
         appPort: 3000
       }
     ]
@@ -67,7 +67,7 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
 }
 
 resource secretstore 'Applications.Link/daprSecretStores@2022-03-15-privatepreview' = {
-  name: 'gnrc-scs-recipe'
+  name: 'gnrc-scs-recipe-old'
   location: location
   properties: {
     environment: env.id

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-secretstore-recipe.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-secretstore-recipe.bicep
@@ -39,7 +39,7 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 }
 
 resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'gnrc-scs-ctnr-recipe'
+  name: 'gnrc-scs-ctnr-recipe-old'
   location: location
   properties: {
     application: app.id
@@ -67,7 +67,7 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
 }
 
 resource secretstore 'Applications.Link/daprSecretStores@2022-03-15-privatepreview' = {
-  name: 'gnrc-scs-recipe'
+  name: 'gnrc-scs-recipe-old'
   location: location
   properties: {
     environment: env.id

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-serviceinvocation.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-serviceinvocation.bicep
@@ -5,7 +5,7 @@ param environment string
 param magpieimage string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'dapr-serviceinvocation-old'
+  name: 'dapr-serviceinvocation'
   location: location
   properties: {
     environment: environment
@@ -13,7 +13,7 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 }
 
 resource frontend 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dapr-frontend-old'
+  name: 'dapr-frontend'
   location: location
   properties: {
     application: app.id
@@ -39,7 +39,7 @@ resource frontend 'Applications.Core/containers@2022-03-15-privatepreview' = {
 }
 
 resource backend 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dapr-backend-old'
+  name: 'dapr-backend'
   location: location
   properties: {
     application: app.id

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-serviceinvocation.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-serviceinvocation.bicep
@@ -5,7 +5,7 @@ param environment string
 param magpieimage string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'dapr-serviceinvocation'
+  name: 'dapr-si-old'
   location: location
   properties: {
     environment: environment
@@ -13,7 +13,7 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 }
 
 resource frontend 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dapr-frontend'
+  name: 'dapr-frontend-old'
   location: location
   properties: {
     application: app.id
@@ -21,7 +21,7 @@ resource frontend 'Applications.Core/containers@2022-03-15-privatepreview' = {
       image: magpieimage
       env: {
         // Used by magpie to communicate with the backend.
-        CONNECTION_DAPRHTTPROUTE_APPID: 'backend'
+        CONNECTION_DAPRHTTPROUTE_APPID: 'backend-old'
       }
       readinessProbe:{
         kind:'httpGet'
@@ -32,14 +32,14 @@ resource frontend 'Applications.Core/containers@2022-03-15-privatepreview' = {
     extensions: [
       {
         kind: 'daprSidecar'
-        appId: 'frontend'
+        appId: 'frontend-old'
       }
     ]
   }
 }
 
 resource backend 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dapr-backend'
+  name: 'dapr-backend-old'
   location: location
   properties: {
     application: app.id
@@ -59,7 +59,7 @@ resource backend 'Applications.Core/containers@2022-03-15-privatepreview' = {
     extensions: [
       {
         kind: 'daprSidecar'
-        appId: 'backend'
+        appId: 'backend-old'
         appPort: 3000
       }
     ]

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-statestore-manual.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-statestore-manual.bicep
@@ -12,7 +12,7 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 }
 
 resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-manual-ctnr-old'
+  name: 'dapr-sts-manual-ctnr'
   properties: {
     application: app.id
     connections: {
@@ -40,7 +40,7 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
 
 
 module redis 'modules/redis-selfhost.bicep' = {
-  name: 'dapr-sts-manual-redis-deployment-old'
+  name: 'dapr-sts-manual-redis-deployment'
   params: {
     name: 'dapr-sts-manual-redis'
     namespace: namespace
@@ -50,7 +50,7 @@ module redis 'modules/redis-selfhost.bicep' = {
 
 
 resource statestore 'Applications.Link/daprStateStores@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-manual-old'
+  name: 'dapr-sts-manual'
   properties: {
     application: app.id
     environment: environment

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-statestore-manual.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-statestore-manual.bicep
@@ -5,14 +5,14 @@ param environment string
 param namespace string = 'default'
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'corerp-resources-dapr-statestore-manual'
+  name: 'corerp-resources-dsstm-old'
   properties: {
     environment: environment
   }
 }
 
 resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-manual-ctnr'
+  name: 'dapr-sts-manual-ctnr-old'
   properties: {
     application: app.id
     connections: {
@@ -31,7 +31,7 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
     extensions: [
       {
         kind: 'daprSidecar'
-        appId: 'gnrc-sts-ctnr'
+        appId: 'gnrc-sts-ctnr-old'
         appPort: 3000
       }
     ]
@@ -40,9 +40,9 @@ resource myapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
 
 
 module redis 'modules/redis-selfhost.bicep' = {
-  name: 'dapr-sts-manual-redis-deployment'
+  name: 'dapr-sts-manual-redis-old-deployment'
   params: {
-    name: 'dapr-sts-manual-redis'
+    name: 'dapr-sts-manual-redis-old'
     namespace: namespace
     application: app.name
   }
@@ -50,7 +50,7 @@ module redis 'modules/redis-selfhost.bicep' = {
 
 
 resource statestore 'Applications.Link/daprStateStores@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-manual'
+  name: 'dapr-sts-manual-old'
   properties: {
     application: app.id
     environment: environment

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-statestore-recipe.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-statestore-recipe.bicep
@@ -37,7 +37,7 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 }
 
 resource webapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-recipe-ctnr-old'
+  name: 'dapr-sts-recipe-ctnr'
   properties: {
     application: app.id
     connections: {
@@ -64,7 +64,7 @@ resource webapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
 }
 
 resource statestore 'Applications.Link/daprStateStores@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-recipe-old'
+  name: 'dapr-sts-recipe'
   properties: {
     application: app.id
     environment: env.id

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-statestore-recipe.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-statestore-recipe.bicep
@@ -5,12 +5,12 @@ param registry string
 param version string
 
 resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
-  name: 'corerp-environment-recipes-env'
+  name: 'corerp-env-recipes-env-old'
   properties: {
     compute: {
       kind: 'kubernetes'
       resourceId: 'self'
-      namespace: 'corerp-environment-recipes-env'
+      namespace: 'corerp-env-recipes-env-old'
     }
     recipes: {
       'Applications.Link/daprStateStores': {
@@ -24,20 +24,20 @@ resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
 }
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'corerp-resources-dapr-sts-recipe'
+  name: 'corerp-rs-dapr-sts-recipe-old'
   properties: {
     environment: env.id
     extensions: [
       {
         kind: 'kubernetesNamespace'
-        namespace: 'corerp-resources-dapr-sts-recipe'
+        namespace: 'corerp-rs-dapr-sts-recipe-old'
       }
     ]
   }
 }
 
 resource webapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-recipe-ctnr'
+  name: 'dapr-sts-recipe-ctnr-old'
   properties: {
     application: app.id
     connections: {
@@ -56,7 +56,7 @@ resource webapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
     extensions: [
       {
         kind: 'daprSidecar'
-        appId: 'dapr-sts-recipe-ctnr'
+        appId: 'dapr-sts-recipe-ctnr-old'
         appPort: 3000
       }
     ]
@@ -64,7 +64,7 @@ resource webapp 'Applications.Core/containers@2022-03-15-privatepreview' = {
 }
 
 resource statestore 'Applications.Link/daprStateStores@2022-03-15-privatepreview' = {
-  name: 'dapr-sts-recipe'
+  name: 'dapr-sts-recipe-old'
   properties: {
     application: app.id
     environment: env.id

--- a/test/validation/shared.go
+++ b/test/validation/shared.go
@@ -46,13 +46,16 @@ const (
 	O_RabbitMQMessageQueuesResource = "applications.link/rabbitMQMessageQueues"
 	RedisCachesResource             = "applications.link/redisCaches"
 	SQLDatabasesResource            = "applications.link/sqlDatabases"
-	DaprPubSubBrokersResource       = "applications.link/daprPubSubBrokers"
-	DaprSecretStoresResource        = "applications.link/daprSecretStores"
-	DaprStateStoresResource         = "applications.link/daprStateStores"
+	O_DaprPubSubBrokersResource     = "applications.link/daprPubSubBrokers"
+	O_DaprSecretStoresResource      = "applications.link/daprSecretStores"
+	O_DaprStateStoresResource       = "applications.link/daprStateStores"
 	ExtendersResource               = "applications.link/extenders"
 
 	// New resources after splitting LinkRP namespace
-	RabbitMQQueuesResource = "applications.messaging/rabbitMQQueues"
+	RabbitMQQueuesResource    = "applications.messaging/rabbitMQQueues"
+	DaprPubSubBrokersResource = "applications.dapr/pubSubBrokers"
+	DaprSecretStoresResource  = "applications.dapr/secretStores"
+	DaprStateStoresResource   = "applications.dapr/stateStores"
 )
 
 type RPResource struct {


### PR DESCRIPTION
# Description

Adding functional tests for new namespace DaprRP
These should run in parallel with 'shared' and other functional tests.
Tests under functional/shared will run as before till Phase 3 when we remove tests for resources under Applications.Link namespace and cut over to new/split namespaces.

## Type of change
- This pull request adds or changes features of Radius and has an approved issue #3499.

Fixes: Part of #3499 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 00fdde6</samp>

### Summary
🧪📦🚀

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate the addition of new test cases, test workflows, or test scripts.
2. 📦 - This emoji represents a package, box, or container, and can be used to indicate the addition of a new package, module, or feature, or the modification of an existing one.
3. 🚀 - This emoji represents a rocket, launch, or speed, and can be used to indicate the addition of a new functionality, enhancement, or performance improvement, or the deployment of a new version.
-->
This pull request adds functional testing for the daprrp package, which is a feature that allows users to create and manage Dapr resources using Bicep templates. It also renames some existing resources and pods in other Dapr test cases to avoid conflicts. It modifies the makefile, the test script, the GitHub workflow, and the documentation to support the new daprrp tests. It adds several Go test files and Bicep template files for different Dapr resource scenarios, such as pubsub, secret store, service invocation, and state store.

> _To test Dapr resources with ease_
> _We added some new Bicep templates_
> _And some Go test files_
> _With various styles_
> _And a `daprrp` make target, please_

### Walkthrough
*  Add a new matrix entry for the functional test workflow to run the tests for the daprrp feature ([link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL307-R307))
*  Add a new make target for running the daprrp functional tests, which invokes the `executeFunctionalTest.sh` script with the daprrp argument ([link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-607e82dd7ce2736355a7703fb1a4a832dddb294c3683c4b51a5118218e379712L57-R57))
*  Define the `test-functional-daprrp` make target, which runs the Go test command for the `daprrp` package under the `test/functional` directory ([link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-607e82dd7ce2736355a7703fb1a4a832dddb294c3683c4b51a5118218e379712R68-R70))
*  Modify the `executeFunctionalTest.sh` script to accept the daprrp argument and run the `test-functional-daprrp` make target accordingly ([link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-252ae72d26e6fe739218ecf55bf7cfb1b90b2c4f1d48f7d863eea59f4152c445L44-L42))
*  Add a new line to the documentation for running functional tests, to show how to use the `test-functional-daprrp` make target ([link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-e286d51f1368685af6439c0bd568dc2cbee5c7c3806112b211a8844754c0b1c6R64))
  *  A test case for validating the error scenario when two Dapr components have the same name in the same application ([link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-1afbf56aa926ed8a7c8f200587712e77b9677b08904b6eacbaee522fff0927f6R1-R49))
  *  Two test cases for validating the Dapr pubsub broker resource, one with manual provisioning and one with recipe provisioning ([link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-9a6c029550d1c5b3bf1ec0c77525e20f26fe1ebb980b54ee20f1aaf253965922R1-R123))
  *  Two test cases for validating the Dapr secret store resource, one with manual provisioning and one with recipe provisioning ([link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-3c241abe05a99967207db1d0d573c292bd35add20b631d86573315e5fb71911fR1-R106))
  *  A test case for validating the Dapr service invocation feature, using two containers with Dapr sidecars ([link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-52c74e64d0e14616b14932549e35323b0f3dc61b4bded88d4d93a5ba25bf6b21R1-R67))
  *  Two test cases for validating the Dapr state store resource, one with manual provisioning and one with recipe provisioning ([link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-175c643bec9a553b195d07b69769dc0b86188779f6ddbafa79f0fd569de1f0b1R1-R125))
*  Add new Bicep template files for the `daprrp` test cases, which define the Dapr resources and the containers that use them, under the `test/functional/daprrp/resources/testdata` directory ([link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-08296b3b1e222a8c6bc6f4efba29c91b818bd4a63aaa530927c53f1814d6ce1cR1-R58), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-643b3bb1349df6bf5e659fd8c0637edda42103a8c931d7de6d35723cf72cbc6eR1-R65), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-d4879a44cdf97275bbb23f60d21e3bde6056259182908671390efeb478bb0af4R1-R72), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-c9a4a1999eed0e459e95647f0a8acbd4f96cb72eed526bf91aad46b458ab5357R1-R57), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-c368089fbea17097e67fa573b5ca510b8d49d112ecb5e119e14448998998dad5R1-R76), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-3b4c8d64a66b90594e45fc987606c419a99a3bb206c2c52e8055714920ba9eceR1-R68), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-38294ac7949adbe0f9315ffc7ee4cd0af50ed1c4d047bb9cbaa3a77d788ece0cR1-R65), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-434f543b461cfe699bb42f9f26aa2ac5d5f910284445f8617461e82ab868b36dR1-R72))
*  Modify the names of the application and container resources for the existing Dapr test cases, to avoid name conflicts with the new `daprrp` test cases ([link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-ce9f04c345fae8a925e32970581daaad2cfe0e3ba987695a0f459298c177cde1L32-R33), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-ce9f04c345fae8a925e32970581daaad2cfe0e3ba987695a0f459298c177cde1L41-R50), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-ce9f04c345fae8a925e32970581daaad2cfe0e3ba987695a0f459298c177cde1L59-R61), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-ce9f04c345fae8a925e32970581daaad2cfe0e3ba987695a0f459298c177cde1L73-R74), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-ce9f04c345fae8a925e32970581daaad2cfe0e3ba987695a0f459298c177cde1L82-R96), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-ce9f04c345fae8a925e32970581daaad2cfe0e3ba987695a0f459298c177cde1L115-R115), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-a1aba07e5042704f25fb56dafacabee8e5799becca2a7af03dfbe4e91fdca5b7L43-R48), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-a1aba07e5042704f25fb56dafacabee8e5799becca2a7af03dfbe4e91fdca5b7L57-R57), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-a1aba07e5042704f25fb56dafacabee8e5799becca2a7af03dfbe4e91fdca5b7L83-R88), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-a1aba07e5042704f25fb56dafacabee8e5799becca2a7af03dfbe4e91fdca5b7L97-R97), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-19b9c4f1b5907875ffc516da7e2c8073164eb31875cf7dc13f0405197ab26f20L43-R48), [link](https://github.com/project-radius/radius/pull/5959/files?diff=unified&w=0#diff-19b9c4f1b5907875ffc516da7e2c8073164eb31875cf7dc13f0405197ab26f20L57-R58))


