### PR TITLE
disable pod unschedulable check 

### DIFF
--- a/pkg/corerp/handlers/kubernetes.go
+++ b/pkg/corerp/handlers/kubernetes.go
@@ -355,12 +355,6 @@ func (handler *kubernetesHandler) checkPodStatus(ctx context.Context, pod *corev
 
 	conditionPodReady := true
 	for _, cc := range pod.Status.Conditions {
-		// If the resource limits for the container cannot be satisfied, the pod will not be scheduled
-		if cc.Type == corev1.PodScheduled && cc.Status == corev1.ConditionFalse {
-			logger.Info(fmt.Sprintf("Pod is not scheduled. Reason: %s, Message: %s", cc.Reason, cc.Message))
-			return false, fmt.Errorf("Pod %s in namespace %s is not scheduled. Reason: %s, Message: %s", pod.Name, pod.Namespace, cc.Reason, cc.Message)
-		}
-
 		if cc.Type == corev1.PodReady && cc.Status != corev1.ConditionTrue {
 			// Do not return false here else if the pod transitions to a crash loop backoff state,
 			// we won't be able to detect that condition.

--- a/pkg/corerp/handlers/kubernetes_test.go
+++ b/pkg/corerp/handlers/kubernetes_test.go
@@ -650,19 +650,6 @@ func TestCheckPodStatus(t *testing.T) {
 		expectedError   string
 	}{
 		{
-			// Pod is unschedulable
-			podCondition: []corev1.PodCondition{
-				{
-					Type:    corev1.PodScheduled,
-					Status:  corev1.ConditionFalse,
-					Reason:  "Unschedulable",
-					Message: "0/1 nodes are available: 1 Insufficient cpu.",
-				},
-			},
-			isReady:       false,
-			expectedError: "Pod test-pod in namespace test-namespace is not scheduled. Reason: Unschedulable, Message: 0/1 nodes are available: 1 Insufficient cpu.",
-		},
-		{
 			// Container is in Terminated state
 			podCondition: nil,
 			containerStatus: []corev1.ContainerStatus{


### PR DESCRIPTION
# Description

#5823 made an incorrect assumption that pod unschedulable is a terminally failing state. The cluster autoscaler can trigger and fix those pods. The check introduced by #5823 immediately classifies the deployment as failed if it sees an unschedulable pod without giving it a chance to recover. This PR removes the check for unschedulable pods to classify that as a deployment failure.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #5964 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 89cbf69</samp>

### Summary
🔄🛠️🚀

<!--
1.  🔄 This emoji represents the idea of retrying or rescheduling something that failed or was not possible before. It can also be used to indicate a change or update in the status or condition of something. In this case, it reflects the change that allows the pod to be rescheduled by the Kubernetes scheduler if the resource limits are not met initially.
2.  🛠️ This emoji represents the idea of fixing, repairing, or improving something that is broken or not working well. It can also be used to indicate a tool, a solution, or a skill that is useful or helpful for a task or problem. In this case, it reflects the change that aims to improve the resilience and reliability of the pod deployment process.
3.  🚀 This emoji represents the idea of launching, deploying, or starting something that is new, exciting, or innovative. It can also be used to indicate speed, progress, or success in achieving a goal or completing a project. In this case, it reflects the change that involves the pod deployment process, which is a key step in running an application or service on Kubernetes.
-->
Comment out pod scheduling check in `kubernetes.go` to enable pod rescheduling by Kubernetes. This is part of a pull request to improve pod deployment resilience and reliability.

> _`pod` may fail first_
> _retry with scheduler's help_
> _spring of resilience_

### Walkthrough
*  Remove the error check for pod scheduling status ([link](https://github.com/project-radius/radius/pull/5968/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L359-R362)) in `pkg/corerp/handlers/kubernetes.go` to allow pod rescheduling by Kubernetes if resource limits are not met initially


