### PR TITLE
Structure of Terraform Observability

### DIFF
--- a/pkg/metrics/asyncoperationmetrics.go
+++ b/pkg/metrics/asyncoperationmetrics.go
@@ -44,17 +44,6 @@ const (
 	AsnycOperationDuration = "asyncoperation.duration"
 )
 
-const (
-	// ResourceTypeAttrKey is the attribute name for resource type.
-	ResourceTypeAttrKey = "resource_type"
-
-	// OperationTypeAttrKey is the attribute name for operation type.
-	OperationTypeAttrKey = "operation_type"
-
-	// OperationStateAttrKey is the attribute name for operation state.
-	OperationStateAttrKey = "operation_state"
-)
-
 type asyncOperationMetrics struct {
 	counters       map[string]metric.Int64Counter
 	valueRecorders map[string]metric.Float64Histogram

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -19,6 +19,12 @@ package metrics
 var (
 	// DefaultAsyncOperationMetrics holds async operation metrics definitions.
 	DefaultAsyncOperationMetrics = newAsyncOperationMetrics()
+
+	// DefaultRecipeEngineMetrics holds recipe engine metrics definitions.
+	DefaultRecipeEngineMetrics = newRecipeEngineMetrics()
+
+	// DefaultTerraformDriverMetrics holds Terraform driver metrics definitions.
+	DefaultTerraformDriverMetrics = newTerraformDriverMetrics()
 )
 
 // # Function Explanation
@@ -26,6 +32,14 @@ var (
 // InitMetrics initializes metrics for Radius.
 func InitMetrics() error {
 	if err := DefaultAsyncOperationMetrics.Init(); err != nil {
+		return err
+	}
+
+	if err := DefaultRecipeEngineMetrics.Init(); err != nil {
+		return err
+	}
+
+	if err := DefaultTerraformDriverMetrics.Init(); err != nil {
 		return err
 	}
 

--- a/pkg/metrics/recipeenginemetrics.go
+++ b/pkg/metrics/recipeenginemetrics.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	// RecipeExecutionCount is the metric name for the recipe execution count.
+	RecipeExecutionCount = "recipe.execution"
+
+	// RecipeExecutionDuration is the metric name for the recipe execution duration.
+	RecipeExecutionDuration = "recipe.execution.duration"
+
+	// RecipeDeletionCount is the metric name for the recipe deletion count.
+	RecipeDeletionCount = "recipe.deletion"
+
+	// RecipeDeletionDuration is the metric name for the recipe deletion duration.
+	RecipeDeletionDuration = "recipe.deletion.duration"
+
+	// RecipeDownloadCount is the metric name for the recipe download count.
+	RecipeDownloadCount = "recipe.download"
+
+	// RecipeDownloadDuration is the metric name for the recipe download duration.
+	RecipeDownloadDuration = "recipe.download.duration"
+)
+
+type recipeEngineMetrics struct {
+	counters       map[string]metric.Int64Counter
+	valueRecorders map[string]metric.Float64Histogram
+}
+
+func newRecipeEngineMetrics() *recipeEngineMetrics {
+	return &recipeEngineMetrics{
+		counters:       make(map[string]metric.Int64Counter),
+		valueRecorders: make(map[string]metric.Float64Histogram),
+	}
+}
+
+func (m *recipeEngineMetrics) Init() error {
+	meter := otel.GetMeterProvider().Meter("recipe-engine-metrics")
+
+	var err error
+	m.counters[RecipeExecutionCount], err = meter.Int64Counter(RecipeExecutionCount)
+	if err != nil {
+		return err
+	}
+
+	m.valueRecorders[RecipeExecutionDuration], err = meter.Float64Histogram(RecipeExecutionDuration)
+	if err != nil {
+		return err
+	}
+
+	m.counters[RecipeDeletionCount], err = meter.Int64Counter(RecipeDeletionCount)
+	if err != nil {
+		return err
+	}
+
+	m.valueRecorders[RecipeDeletionDuration], err = meter.Float64Histogram(RecipeDeletionDuration)
+	if err != nil {
+		return err
+	}
+
+	m.counters[RecipeDownloadCount], err = meter.Int64Counter(RecipeDownloadCount)
+	if err != nil {
+		return err
+	}
+
+	m.valueRecorders[RecipeDownloadDuration], err = meter.Float64Histogram(RecipeDownloadDuration)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *recipeEngineMetrics) RecordRecipeExecution(ctx context.Context, attrs ...attribute.KeyValue) {
+	if m.counters[RecipeExecutionCount] != nil {
+		m.counters[RecipeExecutionCount].Add(ctx, 1, metric.WithAttributes(attrs...))
+	}
+}
+
+func (m *recipeEngineMetrics) RecordRecipeExecutionDuration(ctx context.Context, startTime time.Time, attrs ...attribute.KeyValue) {
+	if m.valueRecorders[RecipeExecutionDuration] != nil {
+		elapsedTime := float64(time.Since(startTime)) / float64(time.Millisecond)
+		m.valueRecorders[AsnycOperationDuration].Record(ctx, elapsedTime, metric.WithAttributes(attrs...))
+	}
+}
+
+func (m *recipeEngineMetrics) RecordRecipeDeletion(ctx context.Context, attrs ...attribute.KeyValue) {
+	if m.counters[RecipeDeletionCount] != nil {
+		m.counters[RecipeDeletionCount].Add(ctx, 1, metric.WithAttributes(attrs...))
+	}
+}
+
+func (m *recipeEngineMetrics) RecordRecipeDeletionDuration(ctx context.Context, startTime time.Time, attrs ...attribute.KeyValue) {
+	if m.valueRecorders[RecipeDeletionDuration] != nil {
+		elapsedTime := float64(time.Since(startTime)) / float64(time.Millisecond)
+		m.valueRecorders[RecipeDeletionDuration].Record(ctx, elapsedTime, metric.WithAttributes(attrs...))
+	}
+}
+
+func (m *recipeEngineMetrics) RecordRecipeDownload(ctx context.Context, attrs ...attribute.KeyValue) {
+	if m.counters[RecipeDownloadCount] != nil {
+		m.counters[RecipeDownloadCount].Add(ctx, 1, metric.WithAttributes(attrs...))
+	}
+}
+
+func (m *recipeEngineMetrics) RecordRecipeDownloadDuration(ctx context.Context, startTime time.Time, attrs ...attribute.KeyValue) {
+	if m.valueRecorders[RecipeDownloadDuration] != nil {
+		elapsedTime := float64(time.Since(startTime)) / float64(time.Millisecond)
+		m.valueRecorders[RecipeDownloadDuration].Record(ctx, elapsedTime, metric.WithAttributes(attrs...))
+	}
+}

--- a/pkg/metrics/terraformdrivermetrics.go
+++ b/pkg/metrics/terraformdrivermetrics.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	// TerraformInstallationDuration is the metric name for the Terraform installation duration.
+	TerraformInstallationDuration = "terraform.installation.duration"
+
+	// TerraformBinaryDownloadDuration is the metric name for the Terraform binary download duration.
+	TerraformBinaryDownloadDuration = "terraform.binary.download.duration"
+
+	// TerraformInitializationDuration is the metric name for the Terraform initialization duration.
+	TerraformInitializationDuration = "terraform.initialization.duration"
+)
+
+type terraformDriverMetrics struct {
+	counters       map[string]metric.Int64Counter
+	valueRecorders map[string]metric.Float64Histogram
+}
+
+func newTerraformDriverMetrics() *terraformDriverMetrics {
+	return &terraformDriverMetrics{
+		counters:       make(map[string]metric.Int64Counter),
+		valueRecorders: make(map[string]metric.Float64Histogram),
+	}
+}
+
+func (m *terraformDriverMetrics) Init() error {
+	meter := otel.GetMeterProvider().Meter("terraform-driver-metrics")
+
+	var err error
+
+	m.valueRecorders[TerraformInstallationDuration], err = meter.Float64Histogram(TerraformInstallationDuration)
+	if err != nil {
+		return err
+	}
+
+	m.valueRecorders[TerraformBinaryDownloadDuration], err = meter.Float64Histogram(TerraformBinaryDownloadDuration)
+	if err != nil {
+		return err
+	}
+
+	m.valueRecorders[TerraformInitializationDuration], err = meter.Float64Histogram(TerraformInitializationDuration)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *terraformDriverMetrics) RecordTerraformInstallationDuration(ctx context.Context, startTime time.Time, attrs []attribute.KeyValue) {
+	if m.valueRecorders[TerraformInstallationDuration] != nil {
+		elapsedTime := float64(time.Since(startTime)) / float64(time.Millisecond)
+		m.valueRecorders[TerraformInstallationDuration].Record(ctx, elapsedTime, metric.WithAttributes(attrs...))
+	}
+}
+
+func (m *terraformDriverMetrics) RecordTerraformBinaryDownloadDuration(ctx context.Context, startTime time.Time, attrs []attribute.KeyValue) {
+	if m.valueRecorders[TerraformBinaryDownloadDuration] != nil {
+		elapsedTime := float64(time.Since(startTime)) / float64(time.Millisecond)
+		m.valueRecorders[TerraformBinaryDownloadDuration].Record(ctx, elapsedTime, metric.WithAttributes(attrs...))
+	}
+}
+
+func (m *terraformDriverMetrics) RecordTerraformInitializationDuration(ctx context.Context, startTime time.Time, attrs []attribute.KeyValue) {
+	if m.valueRecorders[TerraformInitializationDuration] != nil {
+		elapsedTime := float64(time.Since(startTime)) / float64(time.Millisecond)
+		m.valueRecorders[TerraformInitializationDuration].Record(ctx, elapsedTime, metric.WithAttributes(attrs...))
+	}
+}

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const (
+	// ResourceTypeAttrKey is the attribute name for the resource type.
+	ResourceTypeAttrKey = "resource_type"
+
+	// OperationTypeAttrKey is the attribute name for the operation type.
+	OperationTypeAttrKey = "operation_type"
+
+	// OperationStateAttrKey is the attribute name for the operation state.
+	OperationStateAttrKey = "operation_state"
+
+	// DriverAttrKey is the attribute name for the recipe driver.
+	DriverAttrKey = "driver"
+
+	// TemplatePathAttrKey is the attribute name for the template path.
+	TemplatePathAttrKey = "template_path"
+
+	// RecipeExecutionResultAttrKey is the attribute name for the recipe execution result.
+	RecipeExecutionResultAttrKey = "recipe_execution_result"
+
+	// RecipeDownloadResultAttrKey is the attribute name for the recipe download result.
+	RecipeDownloadResultAttrKey = "recipe_download_result"
+)
+
+// GenerateDriverAttribute generates a driver attribute to be used in a metric.
+func GenerateDriverAttribute(driver string) attribute.KeyValue {
+	return attribute.String(DriverAttrKey, strings.ToLower(driver))
+}
+
+// GenerateResourceTypeAttribute generates a resource type attribute to be used in a metric.
+func GenerateResourceTypeAttribute(resourceType string) attribute.KeyValue {
+	return attribute.String(ResourceTypeAttrKey, strings.ToLower(resourceType))
+}
+
+// GenerateTemplatePathAttribute generates a template path attribute to be used in a metric.
+func GenerateTemplatePathAttribute(templatePath string) attribute.KeyValue {
+	return attribute.String(TemplatePathAttrKey, strings.ToLower(templatePath))
+}
+
+// GenerateRecipeExecutionResultAttribute generates a recipe execution result attribute to be used in a metric.
+func GenerateRecipeExecutionResultAttribute(result string) attribute.KeyValue {
+	return attribute.String(RecipeExecutionResultAttrKey, strings.ToLower(result))
+}
+
+// GenerateRecipeDownloadResultAttribute generates a recipe download result attribute to be used in a metric.
+func GenerateRecipeDownloadResultAttribute(result string) attribute.KeyValue {
+	return attribute.String(RecipeDownloadResultAttrKey, strings.ToLower(result))
+}


### PR DESCRIPTION
# Description
1. Adding Default Recipe Metrics to be used by the Recipe Engine.
2. Adding Log Level and Stdout/Stderr for TF Libraries used.

![image](https://github.com/project-radius/radius/assets/5220939/a4fc4504-3be3-4f71-be6f-ab72010fe4f9)

## Type of change
- This pull request adds or changes features of Radius and has an approved issue (issue link required).

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8c55f19</samp>

### Summary
📊📝📄

<!--
1.  📊 This emoji represents the addition of metrics and tracing capabilities to the recipe engine, which can help monitor and analyze the performance and outcomes of the recipes.
2.  📝 This emoji represents the addition of logging functionality to the terraform package, which can help debug and troubleshoot the installer and terraform processes.
3.  📄 This emoji represents the addition of a new file `recipemetrics.go` to the metrics package, which defines the recipe metrics types and functions.
-->
This pull request adds metrics and logging features to the recipe engine and the terraform package of the project. It defines and initializes recipe metrics in the `metrics` package, and records them in the `engine` package. It also adds logging functionality to the `terraform` package, and comments the plans for logging configuration and output handling. The changes affect the files `pkg/metrics/metrics.go`, `pkg/recipes/engine/engine.go`, `pkg/recipes/terraform/execute.go`, `pkg/metrics/recipemetrics.go`, and `pkg/recipes/terraform/module.go`.

> _We're the crew of the recipe engine, we measure and record_
> _We use `metrics` and `tracing` to keep our code aboard_
> _We heave and ho on the count of three, we log with `terraform`_
> _We're the crew of the recipe engine, we make our project perform_

### Walkthrough
*  Add recipe metrics types and functions to `metrics` package ([link](https://github.com/project-radius/radius/pull/5981/files?diff=unified&w=0#diff-961794da2b6100bac726f4bba7963ab2aae9966b6596113dcd4385bc2f32a714R1-R89))
*  Initialize and record recipe metrics in `engine` and `metrics` packages ([link](https://github.com/project-radius/radius/pull/5981/files?diff=unified&w=0#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23R22-R24), [link](https://github.com/project-radius/radius/pull/5981/files?diff=unified&w=0#diff-4bc91a74bc47b8467cdcd25a7e3fe1651dbe44907f478377eca31b982f444f23R35-R38), [link](https://github.com/project-radius/radius/pull/5981/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59L22-R24), [link](https://github.com/project-radius/radius/pull/5981/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59L64-R93))
*  Set loggers for installer and terraform in `terraform` package ([link](https://github.com/project-radius/radius/pull/5981/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482R22), [link](https://github.com/project-radius/radius/pull/5981/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482R56-R60), [link](https://github.com/project-radius/radius/pull/5981/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482R148-R154), [link](https://github.com/project-radius/radius/pull/5981/files?diff=unified&w=0#diff-4f4cb2009f77e8f5e252eee95f3ed880148fc285798ef4b7bbeb970525ad7b5aR62-R68))
*  Add comment to `engine` type about span and metrics plan ([link](https://github.com/project-radius/radius/pull/5981/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59R50-R59))
*  Remove empty line in `terraform` package ([link](https://github.com/project-radius/radius/pull/5981/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482R125))


