### PR TITLE
Skipping failing AWS tests

### DIFF
--- a/test/functional/ucp/aws_test.go
+++ b/test/functional/ucp/aws_test.go
@@ -44,6 +44,7 @@ var (
 )
 
 func Test_AWS_DeleteResource(t *testing.T) {
+	t.Skip("https://github.com/project-radius/radius/issues/5967")
 	ctx := context.Background()
 
 	bucketName := generateS3BucketName()
@@ -105,6 +106,7 @@ func Test_AWS_DeleteResource(t *testing.T) {
 }
 
 func Test_AWS_ListResources(t *testing.T) {
+	t.Skip("https://github.com/project-radius/radius/issues/5967")
 	ctx := context.Background()
 
 	var bucketName = generateS3BucketName()


### PR DESCRIPTION
# Description

* Temporarily skipping failing AWS tests

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6c5b545</samp>

### Summary
🚧🐛🛠️

<!--
1.  🚧 - This emoji conveys the idea of a temporary workaround or something that is under construction, which fits the situation of skipping the tests until the issue is resolved.
2.  🐛 - This emoji represents a bug or an issue, which is the cause of the need to skip the tests in the first place.
3.  🛠️ - This emoji signifies a tool or a fix, which is what the AWS integration issue needs and what the skipped tests are waiting for.
-->
Skip some functional tests for `ucp` package that depend on AWS integration. This is to avoid test failures caused by an external issue.

> _`ucp` tests skipped_
> _AWS issue blocks deletion_
> _Autumn of frustration_

### Walkthrough
*  Skip the entire `ucp` package from running the functional tests due to a known issue with the AWS integration ([link](https://github.com/project-radius/radius/pull/5986/files?diff=unified&w=0#diff-2d5a34a49e4e626af7e0e23138264625b74141c8f254810a163540809b93415eR47))
*  Skip the `Test_AWS_DeleteResource` function from running the functional test for the same reason ([link](https://github.com/project-radius/radius/pull/5986/files?diff=unified&w=0#diff-2d5a34a49e4e626af7e0e23138264625b74141c8f254810a163540809b93415eR109))


