### PR TITLE
Fix rad debug-logs

### DIFF
--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -35,7 +35,10 @@ const (
 	LabelManagedByRadiusRP = "radius-rp"
 
 	FieldManager = "radius-rp"
-	ControlPlane = "radius-control-plane"
+
+	// ControlPlanePartOfLabelValue is the value we use for 'app.kubernetes.io/part-of' in Radius's control-plane components.
+	// This value can be used to query all of the pods that make up the control plane (for example).
+	ControlPlanePartOfLabelValue = "radius"
 
 	AnnotationSecretHash = "radius.dev/secret-hash"
 	RadiusDevPrefix      = "radius.dev/"


### PR DESCRIPTION
# Description



This change fixes a regression in `rad debug-logs`. We changed the labels used in our helm chart and forgot to update the CLI code that queries those labels.

I've also added some more diagnostic information for the case where `rad debug-logs` fails in the future. If we hit another case where no pods are found, it will output some suggested next steps for the user. This is just a safeguard in case we have another regression.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #5987

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a0480f8</samp>

### Summary
🚚🐛✨

<!--
1.  🚚 for the removal of the `ControlPlane` constant and the addition of the `ControlPlanePartOfLabelValue` constant. This emoji conveys the idea of moving or renaming something.
2. 🐛 for the bug fix with the temporary directory deletion. This emoji is commonly used to indicate a bug fix or a patch.
3. ✨ for the update and improvement of the `debugLogs` command. This emoji suggests a new feature or enhancement.
-->
Improved the `debugLogs` command and updated the label convention for the Radius control plane. The `debugLogs` command now handles different scenarios more robustly and uses the `app.kubernetes.io/part-of` label to identify control plane pods. The `kubernetes` package no longer defines a `ControlPlane` constant, and uses `ControlPlanePartOfLabelValue` instead.

> _Sing, O Muse, of the valiant deeds of the Radius engineers_
> _Who changed the names of their control plane parts with skill and care_
> _To match the wise convention of the kubernetes `app` label_
> _And shun the old confusion that the `ControlPlane` constant made_

### Walkthrough
*  Update label selector for Radius control plane pods to use `app.kubernetes.io/part-of` label with value `radius` ([link](https://github.com/project-radius/radius/pull/5989/files?diff=unified&w=0#diff-3abc8210264132b6c7c39842e1f0e9cfc67d8bcffc0dc82370261d4a83005a71L77-R77), [link](https://github.com/project-radius/radius/pull/5989/files?diff=unified&w=0#diff-047ae86eebcf4fe6b0552e33dfae04d8e3aed6ab8051060dbc3fe8dcd01c2fbdL38-R42))
*  Add warning message and suggestions if no pods are found with the label selector in `debugLogs` function ([link](https://github.com/project-radius/radius/pull/5989/files?diff=unified&w=0#diff-3abc8210264132b6c7c39842e1f0e9cfc67d8bcffc0dc82370261d4a83005a71L84-R99))
*  Fix bug that deleted temporary directory with debug logs before user could download it by removing `defer os.RemoveAll(tmpdir)` statement from `debugLogs` function ([link](https://github.com/project-radius/radius/pull/5989/files?diff=unified&w=0#diff-3abc8210264132b6c7c39842e1f0e9cfc67d8bcffc0dc82370261d4a83005a71L104-L105))


