### PR TITLE
Improve failure reporting in CLI

### DIFF
--- a/pkg/sdk/health.go
+++ b/pkg/sdk/health.go
@@ -18,8 +18,12 @@ package sdk
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"sort"
+	"strings"
 )
 
 // ErrRadiusNotInstalled is the error reported when Radius is not installed for a connection.
@@ -61,7 +65,7 @@ func TestConnection(ctx context.Context, connection Connection) error {
 	if resp.StatusCode == http.StatusNotFound {
 		return &ErrRadiusNotInstalled{}
 	} else if resp.StatusCode >= 400 {
-		return fmt.Errorf("an unknown error occurred, status code was %d", resp.StatusCode)
+		return reportErrorFromResponse(resp)
 	}
 
 	return nil
@@ -75,4 +79,41 @@ func createHealthCheckRequest(ctx context.Context, url string) (*http.Request, e
 
 	req.Header.Set("Accept", "application/json")
 	return req, nil
+}
+
+func reportErrorFromResponse(resp *http.Response) error {
+	message := &strings.Builder{}
+	_, _ = message.WriteString("An unknown error was returned while testing Radius API status:\n")
+	_, _ = message.WriteString(fmt.Sprintf("Status Code: %d\n", resp.StatusCode))
+
+	_, _ = message.WriteString("Response Headers:\n")
+	keys := []string{}
+	for key := range resp.Header {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+	for _, key := range keys {
+		for _, value := range resp.Header[key] {
+			_, _ = message.WriteString(fmt.Sprintf("  %s: %s\n", key, value))
+		}
+	}
+
+	if resp.Body == nil {
+		_, _ = message.WriteString("Response Body: (empty)\n")
+	} else if resp.Header.Get("Content-Type") == "application/json" {
+		defer resp.Body.Close()
+
+		_, _ = message.WriteString("Response Body:\n")
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			_, _ = message.WriteString(fmt.Sprintf("  Error reading response body: %s\n", err))
+			return errors.New(message.String())
+		}
+
+		_, _ = message.Write(b)
+		_, _ = message.WriteString("\n")
+	}
+
+	return errors.New(message.String())
 }

--- a/pkg/sdk/health_test.go
+++ b/pkg/sdk/health_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sdk
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_reportErrorFromResponse(t *testing.T) {
+	t.Run("empty body", func(t *testing.T) {
+		response := &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Header: http.Header{
+				"Content-Type":   []string{"application/json"},
+				"Another-Header": []string{"some", "value"},
+			},
+			Body: nil,
+		}
+
+		expected := errors.New(`An unknown error was returned while testing Radius API status:
+Status Code: 502
+Response Headers:
+  Another-Header: some
+  Another-Header: value
+  Content-Type: application/json
+Response Body: (empty)
+`)
+		actual := reportErrorFromResponse(response)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("with body", func(t *testing.T) {
+		response := &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Header: http.Header{
+				"Content-Type":   []string{"application/json"},
+				"Another-Header": []string{"some", "value"},
+			},
+			Body: io.NopCloser(bytes.NewBufferString(`{"message": "some error"}`)),
+		}
+
+		expected := errors.New(`An unknown error was returned while testing Radius API status:
+Status Code: 502
+Response Headers:
+  Another-Header: some
+  Another-Header: value
+  Content-Type: application/json
+Response Body:
+{"message": "some error"}
+`)
+		actual := reportErrorFromResponse(response)
+		require.Equal(t, expected, actual)
+	})
+}


### PR DESCRIPTION
# Description

We have logic in the CLI to detect the Radius install and ping it for overall health before beginning other operations. This is helpful because we can report failures gracefully if the endpoint is down or not installed, before moving on to the actual business logic of whatever the CLI is trying to do.

We have a user report of intermittent failures of this check, likely outside of Radius. More information is needed to debug these failures, and so this PR logs significantly more information for troubleshooting. This is our first time seeing this particular failure mode, and so more insight is needed to find the root cause.


## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #5988

Output looks like: 

```txt
Error: An unknown error was returned while testing Radius API status:
Status Code: 400
Response Headers:
  Audit-Id: 5a063496-a5c2-4322-8b65-70f88016bb69
  Cache-Control: no-cache, private
  Content-Length: 195
  Content-Type: application/json
  Date: Tue, 01 Aug 2023 21:58:58 GMT
  X-Kubernetes-Pf-Flowschema-Uid: f3e86811-db45-4667-912d-a361295a2360
  X-Kubernetes-Pf-Prioritylevel-Uid: e6c55688-8c1d-4ced-8dbb-552016e7ac1c
Response Body:
{
  "error": {
    "code": "InvalidApiVersionParameter",
    "message": "API version '' for type 'ucp/openapi' is not supported. The supported api-versions are '2022-09-01-privatepreview'."
  }
}


TraceId:  ecff790a726c4455ca46db91d8c53de4
```

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fcad394</samp>

### Summary
:heavy_plus_sign::wrench::white_check_mark:

<!--
1.  :heavy_plus_sign: This emoji indicates that a new file or feature was added to the project. In this case, the `health_test.go` file is a new addition that provides unit tests for the `reportErrorFromResponse` function.
2.  :wrench: This emoji indicates that a bug was fixed or an improvement was made to the existing code. In this case, the `TestConnection` function was improved by using the `reportErrorFromResponse` function to provide better error messages.
3.  :white_check_mark: This emoji indicates that a test was added or passed. In this case, the `health_test.go` file contains tests that verify the behavior of the `reportErrorFromResponse` function.
-->
The `sdk` package adds a function `reportErrorFromResponse` to improve error handling of the `TestConnection` function. The function extracts more information from the Radius API response. The package also adds unit tests for the new function in `pkg/sdk/health_test.go`.

> _Oh we are the coders of the `sdk` package_
> _We test our connections with the Radius API_
> _We heave and we ho and we `reportErrorFromResponse`_
> _We make our code better with every pull request_

### Walkthrough
*  Add unit tests for `reportErrorFromResponse` function in `pkg/sdk/health_test.go` ([link](https://github.com/project-radius/radius/pull/5990/files?diff=unified&w=0#diff-9e33bed466fff65b47b845df6f308235a215257300ec9c7b424fe5c4e344a953R1-R74))
*  Use `reportErrorFromResponse` function to provide detailed error messages in `TestConnection` function in `pkg/sdk/health.go` ([link](https://github.com/project-radius/radius/pull/5990/files?diff=unified&w=0#diff-286bfd2cd8d008b26e9a187ac18b7b5946b4c6119330a9ddc02a8c6a20dba4d1L64-R68))
*  Import additional packages for `reportErrorFromResponse` function in `pkg/sdk/health.go` ([link](https://github.com/project-radius/radius/pull/5990/files?diff=unified&w=0#diff-286bfd2cd8d008b26e9a187ac18b7b5946b4c6119330a9ddc02a8c6a20dba4d1L21-R26))
*  Define `reportErrorFromResponse` function to construct error messages from response objects in `pkg/sdk/health.go` ([link](https://github.com/project-radius/radius/pull/5990/files?diff=unified&w=0#diff-286bfd2cd8d008b26e9a187ac18b7b5946b4c6119330a9ddc02a8c6a20dba4d1R83-R119))


