### PR TITLE
Patching Release 0.23 for reported issues

### DIFF
--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -37,7 +37,10 @@ const (
 
 	// TODO: Are we removing this too?
 	FieldManager = "radius-rp"
-	ControlPlane = "radius-control-plane"
+
+	// ControlPlanePartOfLabelValue is the value we use for 'app.kubernetes.io/part-of' in Radius's control-plane components.
+	// This value can be used to query all of the pods that make up the control plane (for example).
+	ControlPlanePartOfLabelValue = "radius"
 
 	AnnotationSecretHash = "radius.dev/secret-hash"
 	RadiusDevPrefix      = "radius.dev/"

--- a/pkg/sdk/health.go
+++ b/pkg/sdk/health.go
@@ -18,8 +18,12 @@ package sdk
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"sort"
+	"strings"
 )
 
 // ErrRadiusNotInstalled is the error reported when Radius is not installed for a connection.
@@ -57,7 +61,7 @@ func TestConnection(ctx context.Context, connection Connection) error {
 	if resp.StatusCode == http.StatusNotFound {
 		return &ErrRadiusNotInstalled{}
 	} else if resp.StatusCode >= 400 {
-		return fmt.Errorf("an unknown error occurred, status code was %d", resp.StatusCode)
+		return reportErrorFromResponse(resp)
 	}
 
 	return nil
@@ -71,4 +75,41 @@ func createHealthCheckRequest(ctx context.Context, url string) (*http.Request, e
 
 	req.Header.Set("Accept", "application/json")
 	return req, nil
+}
+
+func reportErrorFromResponse(resp *http.Response) error {
+	message := &strings.Builder{}
+	_, _ = message.WriteString("An unknown error was returned while testing Radius API status:\n")
+	_, _ = message.WriteString(fmt.Sprintf("Status Code: %d\n", resp.StatusCode))
+
+	_, _ = message.WriteString("Response Headers:\n")
+	keys := []string{}
+	for key := range resp.Header {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+	for _, key := range keys {
+		for _, value := range resp.Header[key] {
+			_, _ = message.WriteString(fmt.Sprintf("  %s: %s\n", key, value))
+		}
+	}
+
+	if resp.Body == nil {
+		_, _ = message.WriteString("Response Body: (empty)\n")
+	} else if resp.Header.Get("Content-Type") == "application/json" {
+		defer resp.Body.Close()
+
+		_, _ = message.WriteString("Response Body:\n")
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			_, _ = message.WriteString(fmt.Sprintf("  Error reading response body: %s\n", err))
+			return errors.New(message.String())
+		}
+
+		_, _ = message.Write(b)
+		_, _ = message.WriteString("\n")
+	}
+
+	return errors.New(message.String())
 }

--- a/pkg/sdk/health_test.go
+++ b/pkg/sdk/health_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sdk
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_reportErrorFromResponse(t *testing.T) {
+	t.Run("empty body", func(t *testing.T) {
+		response := &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Header: http.Header{
+				"Content-Type":   []string{"application/json"},
+				"Another-Header": []string{"some", "value"},
+			},
+			Body: nil,
+		}
+
+		expected := errors.New(`An unknown error was returned while testing Radius API status:
+Status Code: 502
+Response Headers:
+  Another-Header: some
+  Another-Header: value
+  Content-Type: application/json
+Response Body: (empty)
+`)
+		actual := reportErrorFromResponse(response)
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("with body", func(t *testing.T) {
+		response := &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Header: http.Header{
+				"Content-Type":   []string{"application/json"},
+				"Another-Header": []string{"some", "value"},
+			},
+			Body: io.NopCloser(bytes.NewBufferString(`{"message": "some error"}`)),
+		}
+
+		expected := errors.New(`An unknown error was returned while testing Radius API status:
+Status Code: 502
+Response Headers:
+  Another-Header: some
+  Another-Header: value
+  Content-Type: application/json
+Response Body:
+{"message": "some error"}
+`)
+		actual := reportErrorFromResponse(response)
+		require.Equal(t, expected, actual)
+	})
+}


### PR DESCRIPTION
# Description

Cherry-picked the following two fixes into release 0.23.

https://github.com/project-radius/radius/pull/5989
https://github.com/project-radius/radius/pull/5990


## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 09a9cf1</samp>

### Summary
:recycle::white_check_mark::sparkles:

<!--
1.  :recycle: This emoji represents the refactoring of the `ControlPlane` constant to `ControlPlanePartOfLabelValue` in the `kubernetes` package. It conveys the idea of improving the code quality and consistency without changing the functionality.
2. :white_check_mark: This emoji represents the addition of the `pkg/sdk/health_test.go` file to the `sdk` package. It conveys the idea of testing and verifying the code functionality and quality.
3. :sparkles: This emoji represents the enhancement of the `debugLogs` function in `cmd/rad/cmd/debuglogs.go` and the addition of the `reportErrorFromResponse` function to the `sdk` package. It conveys the idea of adding new features and improving the user experience.
-->
This pull request improves the debug logging and error reporting features of the Radius CLI and SDK. It updates the `debugLogs` command to use the new pod label and handle edge cases. It adds a new `reportErrorFromResponse` function to the `sdk` package to create detailed error messages from HTTP responses. It also adds unit tests for this function and updates the `kubernetes` package to use the new pod label constant.

> _Sing, O Muse, of the valiant pull request_
> _That changed the code of the Radius project_
> _With skill and care they fixed the `ControlPlane`_
> _And made it match the label of F0L75R75_

### Walkthrough
*  Update label selector for Radius control plane pods to use new constant `ControlPlanePartOfLabelValue` ([link](https://github.com/project-radius/radius/pull/5992/files?diff=unified&w=0#diff-3abc8210264132b6c7c39842e1f0e9cfc67d8bcffc0dc82370261d4a83005a71L77-R77), [link](https://github.com/project-radius/radius/pull/5992/files?diff=unified&w=0#diff-047ae86eebcf4fe6b0552e33dfae04d8e3aed6ab8051060dbc3fe8dcd01c2fbdL40-R44))
*  Add function `reportErrorFromResponse` to `sdk` package to construct detailed error messages from HTTP responses ([link](https://github.com/project-radius/radius/pull/5992/files?diff=unified&w=0#diff-286bfd2cd8d008b26e9a187ac18b7b5946b4c6119330a9ddc02a8c6a20dba4d1R79-R115))
*  Use `reportErrorFromResponse` function in `TestConnection` function to improve error reporting for Radius API status ([link](https://github.com/project-radius/radius/pull/5992/files?diff=unified&w=0#diff-286bfd2cd8d008b26e9a187ac18b7b5946b4c6119330a9ddc02a8c6a20dba4d1L60-R64))
*  Add unit tests for `reportErrorFromResponse` function in `pkg/sdk/health_test.go` ([link](https://github.com/project-radius/radius/pull/5992/files?diff=unified&w=0#diff-9e33bed466fff65b47b845df6f308235a215257300ec9c7b424fe5c4e344a953R1-R74))
*  Move `defer os.RemoveAll(tmpdir)` statement to earlier position in `debugLogs` function to ensure cleanup of temporary directory ([link](https://github.com/project-radius/radius/pull/5992/files?diff=unified&w=0#diff-3abc8210264132b6c7c39842e1f0e9cfc67d8bcffc0dc82370261d4a83005a71L104-L105))
*  Add warning message and suggestions in `debugLogs` function if no Radius control plane pods are found ([link](https://github.com/project-radius/radius/pull/5992/files?diff=unified&w=0#diff-3abc8210264132b6c7c39842e1f0e9cfc67d8bcffc0dc82370261d4a83005a71L84-R99))


