### PR TITLE
Add unit test for JSON Terraform config validation

### DIFF
--- a/pkg/recipes/terraform/config/config_test.go
+++ b/pkg/recipes/terraform/config/config_test.go
@@ -122,6 +122,13 @@ func TestGenerateTFConfigFile(t *testing.T) {
 
 	// Assert that generated config contains the expected data.
 	require.Equal(t, expectedTFConfig, tfConfig)
+
+	// Assert generated config matches expected in JSON format.
+	expectedJSON, err := os.ReadFile("testdata/tfconfig.json")
+	require.NoError(t, err)
+	generatedJSON, err := os.ReadFile(configFilePath)
+	require.NoError(t, err)
+	require.JSONEq(t, string(expectedJSON), string(generatedJSON))
 }
 
 func TestGenerateTFConfig_EmptyParameters(t *testing.T) {

--- a/pkg/recipes/terraform/config/testdata/tfconfig.json
+++ b/pkg/recipes/terraform/config/testdata/tfconfig.json
@@ -1,0 +1,11 @@
+{
+    "module": {
+      "redis-azure": {
+        "source": "Azure/redis/azurerm",
+        "version": "1.1.0",
+        "resource_group_name": "test-rg",
+        "redis_cache_name":    "redis-test",
+        "sku":                 "P"
+      }
+    }
+  }


### PR DESCRIPTION
# Description

Updating Terraform config unit test to add assertion on the generated JSON data so that we can catch any drifts from the expected format.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 914c7d5</samp>

### Summary
🧪📝☁️

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate a change that adds or modifies a test case or a test framework.
2.  📝 - This emoji represents writing, documentation, or notes, and can be used to indicate a change that adds or modifies a JSON file or any other text-based file that is not code.
3.  ☁️ - This emoji represents cloud computing, services, or platforms, and can be used to indicate a change that relates to Azure or any other cloud provider.
-->
Add a test case for Terraform config generation. The test uses a JSON file as the expected output for a Redis module on Azure and compares it with the config file created by the `config` package.

> _`Terraform` config_
> _Tested against JSON file_
> _Autumn leaves fall fast_

### Walkthrough
* Add a test assertion to verify Terraform config generation ([link](https://github.com/project-radius/radius/pull/6000/files?diff=unified&w=0#diff-c5c89506f1ba2fe9bd8ecf4eedc856e93714c251c295c32a15d875f5924df3bdR125-R131))
  - Use `testdata/tfconfig.json` as the expected output ([link](https://github.com/project-radius/radius/pull/6000/files?diff=unified&w=0#diff-77abf5c76c57f6b0a551aba9de03bcff2f585370fe4c661297af2ee6282ef60aL1-R10))


