### PR TITLE
Display HTTP response body on health check failure

### DIFF
--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/acarl005/stripansi"
 	"github.com/project-radius/radius/pkg/azure/clientv2"
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/aws"
@@ -155,7 +156,14 @@ func Execute() error {
 		fmt.Println("") // Output an extra blank line for readability
 		return err
 	} else if err != nil {
-		fmt.Println("Error:", prettyPrintRPError(err))
+		errText := prettyPrintRPError(err)
+
+		// Remove any ANSI escape sequences from the error text. We may be displaying untrusted
+		// data in an error message for an "unhandled" error. This will prevent the error text
+		// from potentially corrupting the terminal.
+		errText = stripansi.Strip(errText)
+
+		fmt.Println("Error:", errText)
 		fmt.Println("\nTraceId: ", span.SpanContext().TraceID().String())
 		fmt.Println("") // Output an extra blank line for readability
 		return err

--- a/pkg/sdk/health.go
+++ b/pkg/sdk/health.go
@@ -101,7 +101,7 @@ func reportErrorFromResponse(resp *http.Response) error {
 
 	if resp.Body == nil {
 		_, _ = message.WriteString("Response Body: (empty)\n")
-	} else if resp.Header.Get("Content-Type") == "application/json" {
+	} else {
 		defer resp.Body.Close()
 
 		_, _ = message.WriteString("Response Body:\n")

--- a/test/functional/daprrp/resources/testdata/daprrp-resources-component-name-conflict.bicep
+++ b/test/functional/daprrp/resources/testdata/daprrp-resources-component-name-conflict.bicep
@@ -2,8 +2,6 @@ import radius as radius
 
 param environment string
 
-param location string = resourceGroup().location
-
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
   name: 'daprrp-rs-component-name-conflict'
   location: 'global'
@@ -20,24 +18,11 @@ resource pubsub 'Applications.Dapr/pubSubBrokers@2022-03-15-privatepreview' = {
     environment: environment
     application: app.id
     resourceProvisioning: 'manual'
-    resources: [
-      {
-        id: namespace.id
-      }
-    ]
     type: 'pubsub.azure.servicebus'
     version: 'v1'
     metadata: {
-      name: namespace.name
+      name: 'test'
     }
-  }
-}
-
-resource namespace 'Microsoft.ServiceBus/namespaces@2017-04-01' = {
-  name: 'dapr-ns-${guid(resourceGroup().name)}'
-  location: location
-  tags: {
-    radiustest: 'daprrp-resources-pubsub-servicebus'
   }
 }
 

--- a/test/step/deployerrorexecutor.go
+++ b/test/step/deployerrorexecutor.go
@@ -18,7 +18,6 @@ package step
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -74,8 +73,7 @@ func (d *DeployErrorExecutor) Execute(ctx context.Context, t *testing.T, options
 	require.Error(t, err, "deployment %s succeeded when it should have failed", d.Description)
 
 	var cliErr *radcli.CLIError
-	ok := errors.As(err, &cliErr)
-	require.True(t, ok)
+	require.ErrorAs(t, err, &cliErr, "error should be a CLIError and it was not")
 	require.Equal(t, d.ExpectedErrorCode, cliErr.GetFirstErrorCode())
 
 	if len(d.ExpectedInnerError) > 0 {


### PR DESCRIPTION
# Description

This change improves the error handling for the CLI and removes the filtering on JSON that was previously applied. My goal in the previous PR was to avoid printing non-textual data to console and possibly corrupt the terminal.

However, for the investigation we're seeing non-JSON data (`text/plain`) which means the previous version of this can't report it. I'm using a bigger hammer here by filtering out ANSI escape sequences. This should allow us to print the message bodies we get back if they are text-based. For non-textual data it won't be useful regardless but this should at least be safe.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #6006

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 43bb657</samp>

### Summary
🐛📝🧹

<!--
1.  🐛 - This emoji represents a bug fix, since the change fixes an issue where some error information was not captured or displayed correctly by the CLI.
2.  📝 - This emoji represents a documentation update, since the change modifies the JSDoc comment for the `reportErrorFromResponse` function to reflect the new behavior and parameters.
3.  🧹 - This emoji represents a code cleanup or refactoring, since the change introduces a new dependency and uses it to simplify and improve the code quality of the CLI `Execute` function.
-->
This pull request enhances the error handling and output of the `rad` CLI tool. It sanitizes the error text to avoid ANSI escape codes, and reads the error information from any content type in the HTTP response.

> _To report errors with more detail_
> _We don't care about the content seal_
> _We read the response body_
> _And strip any ANSI_
> _To make the CLI output more real_

### Walkthrough
* Sanitize error text from ANSI escape sequences to prevent terminal corruption or information hiding ([link](https://github.com/project-radius/radius/pull/6010/files?diff=unified&w=0#diff-d36b7b4d04f01a6cf60c50dd9c01da8fb8c190231ea4c59cbbfbe070178b510bR26),[link](https://github.com/project-radius/radius/pull/6010/files?diff=unified&w=0#diff-d36b7b4d04f01a6cf60c50dd9c01da8fb8c190231ea4c59cbbfbe070178b510bL158-R166))
* Try to read error information from HTTP response body regardless of content type to improve error reporting and debugging ([link](https://github.com/project-radius/radius/pull/6010/files?diff=unified&w=0#diff-286bfd2cd8d008b26e9a187ac18b7b5946b4c6119330a9ddc02a8c6a20dba4d1L104-R104))


