### PR TITLE
[DO NOT MERGE] Debugging unusual Dapr Test issue in CLI Error PR

### DIFF
--- a/pkg/cli/cmd/radinit/recipe.go
+++ b/pkg/cli/cmd/radinit/recipe.go
@@ -175,12 +175,6 @@ func getLinkType(resourceType string) string {
 		return linkrp.SqlDatabasesResourceType
 	case "rabbitmqqueues":
 		return linkrp.N_RabbitMQQueuesResourceType
-	case "pubsubbrokers":
-		return linkrp.N_DaprPubSubBrokersResourceType
-	case "secretstores":
-		return linkrp.N_DaprSecretStoresResourceType
-	case "statestores":
-		return linkrp.N_DaprStateStoresResourceType
 	default:
 		return ""
 	}

--- a/pkg/sdk/health.go
+++ b/pkg/sdk/health.go
@@ -101,7 +101,7 @@ func reportErrorFromResponse(resp *http.Response) error {
 
 	if resp.Body == nil {
 		_, _ = message.WriteString("Response Body: (empty)\n")
-	} else if resp.Header.Get("Content-Type") == "application/json" {
+	} else {
 		defer resp.Body.Close()
 
 		_, _ = message.WriteString("Response Body:\n")

--- a/pkg/sdk/health.go
+++ b/pkg/sdk/health.go
@@ -101,7 +101,7 @@ func reportErrorFromResponse(resp *http.Response) error {
 
 	if resp.Body == nil {
 		_, _ = message.WriteString("Response Body: (empty)\n")
-	} else {
+	} else if resp.Header.Get("Content-Type") == "application/json" {
 		defer resp.Body.Close()
 
 		_, _ = message.WriteString("Response Body:\n")


### PR DESCRIPTION
# Description

daprrp-resources-component-name-conflict.bicep Test runs locally and on other PRs but not in https://github.com/project-radius/radius/pull/6010. 
Trying to debug underlying issue.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8ba202d</samp>

### Summary
🐛📝🚿

<!--
1.  🐛 - This emoji represents a bug fix, as the change to the `reportErrorFromResponse` function fixes a potential issue where the response body would be ignored even if it contained useful information about the error.
2.  📝 - This emoji represents a documentation or logging improvement, as the change to the `Execute` function adds more details to the error output that can help developers and testers understand what went wrong.
3.  🚿 - This emoji represents a sanitization or cleanup, as the change to the `Execute` function uses the `stripansi` package to remove any ANSI escape sequences from the error text that could interfere with the terminal display.
-->
Improve error handling and reporting in `rad` tool and test framework. Sanitize error text in `cmd/rad/cmd/root.go`, read response body in `pkg/sdk/health.go`, and add logging statements in `test/step/deployerrorexecutor.go`.

> _To improve the `rad` tool's error reporting_
> _We changed how it reads the response sorting_
> _We added more logging_
> _To help with debugging_
> _And sanitized the text with `stripansi` importing_

### Walkthrough
* Sanitize error text from ANSI escape sequences to prevent terminal corruption ([link](https://github.com/project-radius/radius/pull/6013/files?diff=unified&w=0#diff-d36b7b4d04f01a6cf60c50dd9c01da8fb8c190231ea4c59cbbfbe070178b510bR26), [link](https://github.com/project-radius/radius/pull/6013/files?diff=unified&w=0#diff-d36b7b4d04f01a6cf60c50dd9c01da8fb8c190231ea4c59cbbfbe070178b510bL158-R166))
* Improve error reporting by reading response body regardless of content type ([link](https://github.com/project-radius/radius/pull/6013/files?diff=unified&w=0#diff-286bfd2cd8d008b26e9a187ac18b7b5946b4c6119330a9ddc02a8c6a20dba4d1L104-R104))
* Add logging statements to test framework for debugging `rad` command failures ([link](https://github.com/project-radius/radius/pull/6013/files?diff=unified&w=0#diff-080ae4c3111a76dd50048a311bc3c6ec238797dc4e599b9d6f06146fe1f0774aL78-R83))


