### PR TITLE
Test PR please ignore

### DIFF
--- a/pkg/corerp/frontend/handler/routes.go
+++ b/pkg/corerp/frontend/handler/routes.go
@@ -18,6 +18,7 @@ package handler
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -43,6 +44,9 @@ import (
 
 const (
 	ProviderNamespaceName = "Applications.Core"
+
+	// AsyncOperationRetryAfter is polling interval for async create/update or delete resource operations.
+	AsyncOperationRetryAfter = time.Duration(5) * time.Second
 )
 
 // # Function Explanation
@@ -217,8 +221,9 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncPut(opt,
 					frontend_ctrl.ResourceOptions[datamodel.HTTPRoute]{
-						RequestConverter:  converter.HTTPRouteDataModelFromVersioned,
-						ResponseConverter: converter.HTTPRouteDataModelToVersioned,
+						RequestConverter:         converter.HTTPRouteDataModelFromVersioned,
+						ResponseConverter:        converter.HTTPRouteDataModelToVersioned,
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -230,8 +235,9 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncPut(opt,
 					frontend_ctrl.ResourceOptions[datamodel.HTTPRoute]{
-						RequestConverter:  converter.HTTPRouteDataModelFromVersioned,
-						ResponseConverter: converter.HTTPRouteDataModelToVersioned,
+						RequestConverter:         converter.HTTPRouteDataModelFromVersioned,
+						ResponseConverter:        converter.HTTPRouteDataModelToVersioned,
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -243,8 +249,9 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.HTTPRoute]{
-						RequestConverter:  converter.HTTPRouteDataModelFromVersioned,
-						ResponseConverter: converter.HTTPRouteDataModelToVersioned,
+						RequestConverter:         converter.HTTPRouteDataModelFromVersioned,
+						ResponseConverter:        converter.HTTPRouteDataModelToVersioned,
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -307,6 +314,7 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 							rp_frontend.PrepareRadiusResource[*datamodel.ContainerResource],
 							ctr_ctrl.ValidateAndMutateRequest,
 						},
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -324,6 +332,7 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 							rp_frontend.PrepareRadiusResource[*datamodel.ContainerResource],
 							ctr_ctrl.ValidateAndMutateRequest,
 						},
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -335,8 +344,9 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.ContainerResource]{
-						RequestConverter:  converter.ContainerDataModelFromVersioned,
-						ResponseConverter: converter.ContainerDataModelToVersioned,
+						RequestConverter:         converter.ContainerDataModelFromVersioned,
+						ResponseConverter:        converter.ContainerDataModelToVersioned,
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -492,6 +502,7 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 							rp_frontend.PrepareRadiusResource[*datamodel.Gateway],
 							gtwy_ctrl.ValidateAndMutateRequest,
 						},
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -509,6 +520,7 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 							rp_frontend.PrepareRadiusResource[*datamodel.Gateway],
 							gtwy_ctrl.ValidateAndMutateRequest,
 						},
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -520,8 +532,9 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.Gateway]{
-						RequestConverter:  converter.GatewayDataModelFromVersioned,
-						ResponseConverter: converter.GatewayDataModelToVersioned,
+						RequestConverter:         converter.GatewayDataModelFromVersioned,
+						ResponseConverter:        converter.GatewayDataModelToVersioned,
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -586,6 +599,7 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 							rp_frontend.PrepareRadiusResource[*datamodel.VolumeResource],
 							vol_ctrl.ValidateRequest,
 						},
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -603,6 +617,7 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 							rp_frontend.PrepareRadiusResource[*datamodel.VolumeResource],
 							vol_ctrl.ValidateRequest,
 						},
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -614,8 +629,9 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.VolumeResource]{
-						RequestConverter:  converter.VolumeResourceModelFromVersioned,
-						ResponseConverter: converter.VolumeResourceModelToVersioned,
+						RequestConverter:         converter.VolumeResourceModelFromVersioned,
+						ResponseConverter:        converter.VolumeResourceModelToVersioned,
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},

--- a/pkg/linkrp/frontend/controller/types.go
+++ b/pkg/linkrp/frontend/controller/types.go
@@ -21,6 +21,9 @@ import (
 )
 
 var (
+	// AsyncOperationRetryAfter is polling interval for async create/update or delete resource operations.
+	AsyncOperationRetryAfter = time.Duration(5) * time.Second
+
 	// AsyncCreateOrUpdateMongoDatabaseTimeout is the timeout for async create or update mongo database
 	AsyncCreateOrUpdateMongoDatabaseTimeout = time.Duration(10) * time.Minute
 	// AsyncDeleteMongoDatabaseTimeout is the timeout for async delete mongo database

--- a/pkg/linkrp/frontend/handler/routes.go
+++ b/pkg/linkrp/frontend/handler/routes.go
@@ -176,7 +176,8 @@ func AddMessagingRoutes(ctx context.Context, r chi.Router, rootScopePath string,
 						UpdateFilters: []frontend_ctrl.UpdateFilter[msg_dm.RabbitMQQueue]{
 							rp_frontend.PrepareRadiusResource[*msg_dm.RabbitMQQueue],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -193,7 +194,8 @@ func AddMessagingRoutes(ctx context.Context, r chi.Router, rootScopePath string,
 						UpdateFilters: []frontend_ctrl.UpdateFilter[msg_dm.RabbitMQQueue]{
 							rp_frontend.PrepareRadiusResource[*msg_dm.RabbitMQQueue],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -205,9 +207,10 @@ func AddMessagingRoutes(ctx context.Context, r chi.Router, rootScopePath string,
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[msg_dm.RabbitMQQueue]{
-						RequestConverter:      msg_conv.RabbitMQQueueDataModelFromVersioned,
-						ResponseConverter:     msg_conv.RabbitMQQueueDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteRabbitMQTimeout,
+						RequestConverter:         msg_conv.RabbitMQQueueDataModelFromVersioned,
+						ResponseConverter:        msg_conv.RabbitMQQueueDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteRabbitMQTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -312,7 +315,8 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[dapr_dm.DaprPubSubBroker]{
 							rp_frontend.PrepareRadiusResource[*dapr_dm.DaprPubSubBroker],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -329,7 +333,8 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[dapr_dm.DaprPubSubBroker]{
 							rp_frontend.PrepareRadiusResource[*dapr_dm.DaprPubSubBroker],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -341,9 +346,10 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[dapr_dm.DaprPubSubBroker]{
-						RequestConverter:      dapr_conv.PubSubBrokerDataModelFromVersioned,
-						ResponseConverter:     dapr_conv.PubSubBrokerDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						RequestConverter:         dapr_conv.PubSubBrokerDataModelFromVersioned,
+						ResponseConverter:        dapr_conv.PubSubBrokerDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -404,7 +410,8 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[dapr_dm.DaprSecretStore]{
 							rp_frontend.PrepareRadiusResource[*dapr_dm.DaprSecretStore],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprSecretStoreTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprSecretStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -421,7 +428,8 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[dapr_dm.DaprSecretStore]{
 							rp_frontend.PrepareRadiusResource[*dapr_dm.DaprSecretStore],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprSecretStoreTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprSecretStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -433,9 +441,10 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[dapr_dm.DaprSecretStore]{
-						RequestConverter:      dapr_conv.SecretStoreDataModelFromVersioned,
-						ResponseConverter:     dapr_conv.SecretStoreDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteDaprSecretStoreTimeout,
+						RequestConverter:         dapr_conv.SecretStoreDataModelFromVersioned,
+						ResponseConverter:        dapr_conv.SecretStoreDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteDaprSecretStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -496,7 +505,8 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[dapr_dm.DaprStateStore]{
 							rp_frontend.PrepareRadiusResource[*dapr_dm.DaprStateStore],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprStateStoreTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprStateStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -513,7 +523,8 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[dapr_dm.DaprStateStore]{
 							rp_frontend.PrepareRadiusResource[*dapr_dm.DaprStateStore],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprStateStoreTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprStateStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -525,9 +536,10 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[dapr_dm.DaprStateStore]{
-						RequestConverter:      dapr_conv.StateStoreDataModelFromVersioned,
-						ResponseConverter:     dapr_conv.StateStoreDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteDaprStateStoreTimeout,
+						RequestConverter:         dapr_conv.StateStoreDataModelFromVersioned,
+						ResponseConverter:        dapr_conv.StateStoreDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteDaprStateStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -625,7 +637,8 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 						UpdateFilters: []frontend_ctrl.UpdateFilter[ds_dm.MongoDatabase]{
 							rp_frontend.PrepareRadiusResource[*ds_dm.MongoDatabase],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -642,7 +655,8 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.MongoDatabase]{
 							rp_frontend.PrepareRadiusResource[*datamodel.MongoDatabase],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -654,9 +668,10 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[ds_dm.MongoDatabase]{
-						RequestConverter:      ds_conv.MongoDatabaseDataModelFromVersioned,
-						ResponseConverter:     ds_conv.MongoDatabaseDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteMongoDatabaseTimeout,
+						RequestConverter:         ds_conv.MongoDatabaseDataModelFromVersioned,
+						ResponseConverter:        ds_conv.MongoDatabaseDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteMongoDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -724,7 +739,8 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 						UpdateFilters: []frontend_ctrl.UpdateFilter[ds_dm.RedisCache]{
 							rp_frontend.PrepareRadiusResource[*ds_dm.RedisCache],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -741,7 +757,8 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 						UpdateFilters: []frontend_ctrl.UpdateFilter[ds_dm.RedisCache]{
 							rp_frontend.PrepareRadiusResource[*ds_dm.RedisCache],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -753,9 +770,10 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[ds_dm.RedisCache]{
-						RequestConverter:      ds_conv.RedisCacheDataModelFromVersioned,
-						ResponseConverter:     ds_conv.RedisCacheDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteRedisCacheTimeout,
+						RequestConverter:         ds_conv.RedisCacheDataModelFromVersioned,
+						ResponseConverter:        ds_conv.RedisCacheDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteRedisCacheTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -823,7 +841,8 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 						UpdateFilters: []frontend_ctrl.UpdateFilter[ds_dm.SqlDatabase]{
 							rp_frontend.PrepareRadiusResource[*ds_dm.SqlDatabase],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateSqlDatabaseTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateSqlDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -840,7 +859,8 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 						UpdateFilters: []frontend_ctrl.UpdateFilter[ds_dm.SqlDatabase]{
 							rp_frontend.PrepareRadiusResource[*ds_dm.SqlDatabase],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateSqlDatabaseTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateSqlDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -852,9 +872,10 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[ds_dm.SqlDatabase]{
-						RequestConverter:      ds_conv.SqlDatabaseDataModelFromVersioned,
-						ResponseConverter:     ds_conv.SqlDatabaseDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteSqlDatabaseTimeout,
+						RequestConverter:         ds_conv.SqlDatabaseDataModelFromVersioned,
+						ResponseConverter:        ds_conv.SqlDatabaseDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteSqlDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -952,7 +973,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.MongoDatabase]{
 							rp_frontend.PrepareRadiusResource[*datamodel.MongoDatabase],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -969,7 +991,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.MongoDatabase]{
 							rp_frontend.PrepareRadiusResource[*datamodel.MongoDatabase],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -981,9 +1004,10 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.MongoDatabase]{
-						RequestConverter:      converter.MongoDatabaseDataModelFromVersioned,
-						ResponseConverter:     converter.MongoDatabaseDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteMongoDatabaseTimeout,
+						RequestConverter:         converter.MongoDatabaseDataModelFromVersioned,
+						ResponseConverter:        converter.MongoDatabaseDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteMongoDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1051,7 +1075,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.DaprPubSubBroker]{
 							rp_frontend.PrepareRadiusResource[*datamodel.DaprPubSubBroker],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1068,7 +1093,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.DaprPubSubBroker]{
 							rp_frontend.PrepareRadiusResource[*datamodel.DaprPubSubBroker],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1080,9 +1106,10 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.DaprPubSubBroker]{
-						RequestConverter:      converter.DaprPubSubBrokerDataModelFromVersioned,
-						ResponseConverter:     converter.DaprPubSubBrokerDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						RequestConverter:         converter.DaprPubSubBrokerDataModelFromVersioned,
+						ResponseConverter:        converter.DaprPubSubBrokerDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1143,7 +1170,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.DaprSecretStore]{
 							rp_frontend.PrepareRadiusResource[*datamodel.DaprSecretStore],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprSecretStoreTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprSecretStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1160,7 +1188,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.DaprSecretStore]{
 							rp_frontend.PrepareRadiusResource[*datamodel.DaprSecretStore],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprSecretStoreTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprSecretStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1172,9 +1201,10 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.DaprSecretStore]{
-						RequestConverter:      converter.DaprSecretStoreDataModelFromVersioned,
-						ResponseConverter:     converter.DaprSecretStoreDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteDaprSecretStoreTimeout,
+						RequestConverter:         converter.DaprSecretStoreDataModelFromVersioned,
+						ResponseConverter:        converter.DaprSecretStoreDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteDaprSecretStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1235,7 +1265,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.DaprStateStore]{
 							rp_frontend.PrepareRadiusResource[*datamodel.DaprStateStore],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprStateStoreTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprStateStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1252,7 +1283,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.DaprStateStore]{
 							rp_frontend.PrepareRadiusResource[*datamodel.DaprStateStore],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprStateStoreTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprStateStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1264,9 +1296,10 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.DaprStateStore]{
-						RequestConverter:      converter.DaprStateStoreDataModelFromVersioned,
-						ResponseConverter:     converter.DaprStateStoreDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteDaprStateStoreTimeout,
+						RequestConverter:         converter.DaprStateStoreDataModelFromVersioned,
+						ResponseConverter:        converter.DaprStateStoreDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteDaprStateStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1327,7 +1360,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.RedisCache]{
 							rp_frontend.PrepareRadiusResource[*datamodel.RedisCache],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1344,7 +1378,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.RedisCache]{
 							rp_frontend.PrepareRadiusResource[*datamodel.RedisCache],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1356,9 +1391,10 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.RedisCache]{
-						RequestConverter:      converter.RedisCacheDataModelFromVersioned,
-						ResponseConverter:     converter.RedisCacheDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteRedisCacheTimeout,
+						RequestConverter:         converter.RedisCacheDataModelFromVersioned,
+						ResponseConverter:        converter.RedisCacheDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteRedisCacheTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1427,7 +1463,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.RabbitMQMessageQueue]{
 							rp_frontend.PrepareRadiusResource[*datamodel.RabbitMQMessageQueue],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1444,7 +1481,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.RabbitMQMessageQueue]{
 							rp_frontend.PrepareRadiusResource[*datamodel.RabbitMQMessageQueue],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1456,9 +1494,10 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.RabbitMQMessageQueue]{
-						RequestConverter:      converter.RabbitMQMessageQueueDataModelFromVersioned,
-						ResponseConverter:     converter.RabbitMQMessageQueueDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteRabbitMQTimeout,
+						RequestConverter:         converter.RabbitMQMessageQueueDataModelFromVersioned,
+						ResponseConverter:        converter.RabbitMQMessageQueueDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteRabbitMQTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1526,7 +1565,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.SqlDatabase]{
 							rp_frontend.PrepareRadiusResource[*datamodel.SqlDatabase],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateSqlDatabaseTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateSqlDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1543,7 +1583,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.SqlDatabase]{
 							rp_frontend.PrepareRadiusResource[*datamodel.SqlDatabase],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateSqlDatabaseTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateSqlDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1555,9 +1596,10 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.SqlDatabase]{
-						RequestConverter:      converter.SqlDatabaseDataModelFromVersioned,
-						ResponseConverter:     converter.SqlDatabaseDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteSqlDatabaseTimeout,
+						RequestConverter:         converter.SqlDatabaseDataModelFromVersioned,
+						ResponseConverter:        converter.SqlDatabaseDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteSqlDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1625,7 +1667,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.Extender]{
 							rp_frontend.PrepareRadiusResource[*datamodel.Extender],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateExtenderTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateExtenderTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1642,7 +1685,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.Extender]{
 							rp_frontend.PrepareRadiusResource[*datamodel.Extender],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateExtenderTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateExtenderTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1654,9 +1698,10 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.Extender]{
-						RequestConverter:      converter.ExtenderDataModelFromVersioned,
-						ResponseConverter:     converter.ExtenderDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteExtenderTimeout,
+						RequestConverter:         converter.ExtenderDataModelFromVersioned,
+						ResponseConverter:        converter.ExtenderDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteExtenderTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},


### PR DESCRIPTION
# Description

_Please explain the changes you've made._

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1f4ae6d</samp>

### Summary
🚀🎨🛠️

<!--
1.  🚀 - This emoji can be used to indicate a performance improvement or a feature enhancement, which is the case for the reduced values of the Retry-After header and the polling frequency. This change makes the CLI commands faster and more responsive, which is a positive outcome for the users.
2.  🎨 - This emoji can be used to indicate a code improvement or a cosmetic change, which is the case for the added import statements and the print statements. These changes make the code more readable and consistent, and also provide some feedback to the users about the status of the delete operations.
3.  🛠️ - This emoji can be used to indicate a bug fix or a minor change, which is the case for the added polling option. This change fixes a potential issue where the delete operations could fail or hang if the default polling duration was too long or too short. The polling option allows the users to customize the polling frequency according to their needs.
-->
The pull request enhances the CLI delete commands for resources and applications by adding polling and printing options, and by reducing the default polling intervals for long-running operations. The changes affect the files `./pkg/cli/clients/management.go` and `./pkg/armrpc/api/v1/types.go`.

> _We are the masters of deletion_
> _We tear down the resources of doom_
> _With `PollUntilDone` we unleash the beast_
> _We slash the `Retry-After` and the polling time_

### Walkthrough
* Reduce the default polling frequency and the Retry-After header value for long-running operations to 5 seconds ([link](https://github.com/project-radius/radius/pull/6016/files?diff=unified&w=0#diff-66f19d316ddd07d63870a3dc89d97bb120b10b462eaa0c5dd168eb95f3b2aa29L30-R35))
* Import `fmt` and `time` packages to enable printing and measuring the duration of delete operations in `management.go` ([link](https://github.com/project-radius/radius/pull/6016/files?diff=unified&w=0#diff-23443c20f46bfbb5ffda2f87efc0e56ecaea1ef964ed4fc9ee06fe584fcfedcaL21-R24))
* Specify the polling frequency as 5 seconds in the `PollUntilDoneOptions` struct for the `PollUntilDone` method call in `management.go` ([link](https://github.com/project-radius/radius/pull/6016/files?diff=unified&w=0#diff-23443c20f46bfbb5ffda2f87efc0e56ecaea1ef964ed4fc9ee06fe584fcfedcaL211-R213))
* Print the resource ID and the elapsed time before and after deleting a resource in `management.go` ([link](https://github.com/project-radius/radius/pull/6016/files?diff=unified&w=0#diff-23443c20f46bfbb5ffda2f87efc0e56ecaea1ef964ed4fc9ee06fe584fcfedcaL298-R308))
* Print the application name and the elapsed time before and after deleting an application in `management.go` ([link](https://github.com/project-radius/radius/pull/6016/files?diff=unified&w=0#diff-23443c20f46bfbb5ffda2f87efc0e56ecaea1ef964ed4fc9ee06fe584fcfedcaR326-R327), [link](https://github.com/project-radius/radius/pull/6016/files?diff=unified&w=0#diff-23443c20f46bfbb5ffda2f87efc0e56ecaea1ef964ed4fc9ee06fe584fcfedcaR333))


