### PR TITLE
Lower polling frequency for async operations

### DIFF
--- a/pkg/corerp/frontend/handler/routes.go
+++ b/pkg/corerp/frontend/handler/routes.go
@@ -18,6 +18,7 @@ package handler
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -43,6 +44,9 @@ import (
 
 const (
 	ProviderNamespaceName = "Applications.Core"
+
+	// AsyncOperationRetryAfter is polling interval for async create/update or delete resource operations.
+	AsyncOperationRetryAfter = time.Duration(5) * time.Second
 )
 
 // # Function Explanation
@@ -217,8 +221,9 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncPut(opt,
 					frontend_ctrl.ResourceOptions[datamodel.HTTPRoute]{
-						RequestConverter:  converter.HTTPRouteDataModelFromVersioned,
-						ResponseConverter: converter.HTTPRouteDataModelToVersioned,
+						RequestConverter:         converter.HTTPRouteDataModelFromVersioned,
+						ResponseConverter:        converter.HTTPRouteDataModelToVersioned,
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -230,8 +235,9 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncPut(opt,
 					frontend_ctrl.ResourceOptions[datamodel.HTTPRoute]{
-						RequestConverter:  converter.HTTPRouteDataModelFromVersioned,
-						ResponseConverter: converter.HTTPRouteDataModelToVersioned,
+						RequestConverter:         converter.HTTPRouteDataModelFromVersioned,
+						ResponseConverter:        converter.HTTPRouteDataModelToVersioned,
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -243,8 +249,9 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.HTTPRoute]{
-						RequestConverter:  converter.HTTPRouteDataModelFromVersioned,
-						ResponseConverter: converter.HTTPRouteDataModelToVersioned,
+						RequestConverter:         converter.HTTPRouteDataModelFromVersioned,
+						ResponseConverter:        converter.HTTPRouteDataModelToVersioned,
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -307,6 +314,7 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 							rp_frontend.PrepareRadiusResource[*datamodel.ContainerResource],
 							ctr_ctrl.ValidateAndMutateRequest,
 						},
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -324,6 +332,7 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 							rp_frontend.PrepareRadiusResource[*datamodel.ContainerResource],
 							ctr_ctrl.ValidateAndMutateRequest,
 						},
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -335,8 +344,9 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.ContainerResource]{
-						RequestConverter:  converter.ContainerDataModelFromVersioned,
-						ResponseConverter: converter.ContainerDataModelToVersioned,
+						RequestConverter:         converter.ContainerDataModelFromVersioned,
+						ResponseConverter:        converter.ContainerDataModelToVersioned,
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -492,6 +502,7 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 							rp_frontend.PrepareRadiusResource[*datamodel.Gateway],
 							gtwy_ctrl.ValidateAndMutateRequest,
 						},
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -509,6 +520,7 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 							rp_frontend.PrepareRadiusResource[*datamodel.Gateway],
 							gtwy_ctrl.ValidateAndMutateRequest,
 						},
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -520,8 +532,9 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.Gateway]{
-						RequestConverter:  converter.GatewayDataModelFromVersioned,
-						ResponseConverter: converter.GatewayDataModelToVersioned,
+						RequestConverter:         converter.GatewayDataModelFromVersioned,
+						ResponseConverter:        converter.GatewayDataModelToVersioned,
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -586,6 +599,7 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 							rp_frontend.PrepareRadiusResource[*datamodel.VolumeResource],
 							vol_ctrl.ValidateRequest,
 						},
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -603,6 +617,7 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 							rp_frontend.PrepareRadiusResource[*datamodel.VolumeResource],
 							vol_ctrl.ValidateRequest,
 						},
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -614,8 +629,9 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.VolumeResource]{
-						RequestConverter:  converter.VolumeResourceModelFromVersioned,
-						ResponseConverter: converter.VolumeResourceModelToVersioned,
+						RequestConverter:         converter.VolumeResourceModelFromVersioned,
+						ResponseConverter:        converter.VolumeResourceModelToVersioned,
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
 					},
 				)
 			},

--- a/pkg/linkrp/frontend/controller/types.go
+++ b/pkg/linkrp/frontend/controller/types.go
@@ -21,6 +21,9 @@ import (
 )
 
 var (
+	// AsyncOperationRetryAfter is polling interval for async create/update or delete resource operations.
+	AsyncOperationRetryAfter = time.Duration(5) * time.Second
+
 	// AsyncCreateOrUpdateMongoDatabaseTimeout is the timeout for async create or update mongo database
 	AsyncCreateOrUpdateMongoDatabaseTimeout = time.Duration(10) * time.Minute
 	// AsyncDeleteMongoDatabaseTimeout is the timeout for async delete mongo database

--- a/pkg/linkrp/frontend/handler/routes.go
+++ b/pkg/linkrp/frontend/handler/routes.go
@@ -176,7 +176,8 @@ func AddMessagingRoutes(ctx context.Context, r chi.Router, rootScopePath string,
 						UpdateFilters: []frontend_ctrl.UpdateFilter[msg_dm.RabbitMQQueue]{
 							rp_frontend.PrepareRadiusResource[*msg_dm.RabbitMQQueue],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -193,7 +194,8 @@ func AddMessagingRoutes(ctx context.Context, r chi.Router, rootScopePath string,
 						UpdateFilters: []frontend_ctrl.UpdateFilter[msg_dm.RabbitMQQueue]{
 							rp_frontend.PrepareRadiusResource[*msg_dm.RabbitMQQueue],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -205,9 +207,10 @@ func AddMessagingRoutes(ctx context.Context, r chi.Router, rootScopePath string,
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[msg_dm.RabbitMQQueue]{
-						RequestConverter:      msg_conv.RabbitMQQueueDataModelFromVersioned,
-						ResponseConverter:     msg_conv.RabbitMQQueueDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteRabbitMQTimeout,
+						RequestConverter:         msg_conv.RabbitMQQueueDataModelFromVersioned,
+						ResponseConverter:        msg_conv.RabbitMQQueueDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteRabbitMQTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -312,7 +315,8 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[dapr_dm.DaprPubSubBroker]{
 							rp_frontend.PrepareRadiusResource[*dapr_dm.DaprPubSubBroker],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -329,7 +333,8 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[dapr_dm.DaprPubSubBroker]{
 							rp_frontend.PrepareRadiusResource[*dapr_dm.DaprPubSubBroker],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -341,9 +346,10 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[dapr_dm.DaprPubSubBroker]{
-						RequestConverter:      dapr_conv.PubSubBrokerDataModelFromVersioned,
-						ResponseConverter:     dapr_conv.PubSubBrokerDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						RequestConverter:         dapr_conv.PubSubBrokerDataModelFromVersioned,
+						ResponseConverter:        dapr_conv.PubSubBrokerDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -404,7 +410,8 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[dapr_dm.DaprSecretStore]{
 							rp_frontend.PrepareRadiusResource[*dapr_dm.DaprSecretStore],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprSecretStoreTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprSecretStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -421,7 +428,8 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[dapr_dm.DaprSecretStore]{
 							rp_frontend.PrepareRadiusResource[*dapr_dm.DaprSecretStore],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprSecretStoreTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprSecretStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -433,9 +441,10 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[dapr_dm.DaprSecretStore]{
-						RequestConverter:      dapr_conv.SecretStoreDataModelFromVersioned,
-						ResponseConverter:     dapr_conv.SecretStoreDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteDaprSecretStoreTimeout,
+						RequestConverter:         dapr_conv.SecretStoreDataModelFromVersioned,
+						ResponseConverter:        dapr_conv.SecretStoreDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteDaprSecretStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -496,7 +505,8 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[dapr_dm.DaprStateStore]{
 							rp_frontend.PrepareRadiusResource[*dapr_dm.DaprStateStore],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprStateStoreTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprStateStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -513,7 +523,8 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[dapr_dm.DaprStateStore]{
 							rp_frontend.PrepareRadiusResource[*dapr_dm.DaprStateStore],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprStateStoreTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprStateStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -525,9 +536,10 @@ func AddDaprRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[dapr_dm.DaprStateStore]{
-						RequestConverter:      dapr_conv.StateStoreDataModelFromVersioned,
-						ResponseConverter:     dapr_conv.StateStoreDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteDaprStateStoreTimeout,
+						RequestConverter:         dapr_conv.StateStoreDataModelFromVersioned,
+						ResponseConverter:        dapr_conv.StateStoreDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteDaprStateStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -625,7 +637,8 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 						UpdateFilters: []frontend_ctrl.UpdateFilter[ds_dm.MongoDatabase]{
 							rp_frontend.PrepareRadiusResource[*ds_dm.MongoDatabase],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -642,7 +655,8 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.MongoDatabase]{
 							rp_frontend.PrepareRadiusResource[*datamodel.MongoDatabase],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -654,9 +668,10 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[ds_dm.MongoDatabase]{
-						RequestConverter:      ds_conv.MongoDatabaseDataModelFromVersioned,
-						ResponseConverter:     ds_conv.MongoDatabaseDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteMongoDatabaseTimeout,
+						RequestConverter:         ds_conv.MongoDatabaseDataModelFromVersioned,
+						ResponseConverter:        ds_conv.MongoDatabaseDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteMongoDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -724,7 +739,8 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 						UpdateFilters: []frontend_ctrl.UpdateFilter[ds_dm.RedisCache]{
 							rp_frontend.PrepareRadiusResource[*ds_dm.RedisCache],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -741,7 +757,8 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 						UpdateFilters: []frontend_ctrl.UpdateFilter[ds_dm.RedisCache]{
 							rp_frontend.PrepareRadiusResource[*ds_dm.RedisCache],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -753,9 +770,10 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[ds_dm.RedisCache]{
-						RequestConverter:      ds_conv.RedisCacheDataModelFromVersioned,
-						ResponseConverter:     ds_conv.RedisCacheDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteRedisCacheTimeout,
+						RequestConverter:         ds_conv.RedisCacheDataModelFromVersioned,
+						ResponseConverter:        ds_conv.RedisCacheDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteRedisCacheTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -823,7 +841,8 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 						UpdateFilters: []frontend_ctrl.UpdateFilter[ds_dm.SqlDatabase]{
 							rp_frontend.PrepareRadiusResource[*ds_dm.SqlDatabase],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateSqlDatabaseTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateSqlDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -840,7 +859,8 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 						UpdateFilters: []frontend_ctrl.UpdateFilter[ds_dm.SqlDatabase]{
 							rp_frontend.PrepareRadiusResource[*ds_dm.SqlDatabase],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateSqlDatabaseTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateSqlDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -852,9 +872,10 @@ func AddDatastoresRoutes(ctx context.Context, r chi.Router, rootScopePath string
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[ds_dm.SqlDatabase]{
-						RequestConverter:      ds_conv.SqlDatabaseDataModelFromVersioned,
-						ResponseConverter:     ds_conv.SqlDatabaseDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteSqlDatabaseTimeout,
+						RequestConverter:         ds_conv.SqlDatabaseDataModelFromVersioned,
+						ResponseConverter:        ds_conv.SqlDatabaseDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteSqlDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -952,7 +973,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.MongoDatabase]{
 							rp_frontend.PrepareRadiusResource[*datamodel.MongoDatabase],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -969,7 +991,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.MongoDatabase]{
 							rp_frontend.PrepareRadiusResource[*datamodel.MongoDatabase],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -981,9 +1004,10 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.MongoDatabase]{
-						RequestConverter:      converter.MongoDatabaseDataModelFromVersioned,
-						ResponseConverter:     converter.MongoDatabaseDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteMongoDatabaseTimeout,
+						RequestConverter:         converter.MongoDatabaseDataModelFromVersioned,
+						ResponseConverter:        converter.MongoDatabaseDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteMongoDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1051,7 +1075,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.DaprPubSubBroker]{
 							rp_frontend.PrepareRadiusResource[*datamodel.DaprPubSubBroker],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1068,7 +1093,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.DaprPubSubBroker]{
 							rp_frontend.PrepareRadiusResource[*datamodel.DaprPubSubBroker],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1080,9 +1106,10 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.DaprPubSubBroker]{
-						RequestConverter:      converter.DaprPubSubBrokerDataModelFromVersioned,
-						ResponseConverter:     converter.DaprPubSubBrokerDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						RequestConverter:         converter.DaprPubSubBrokerDataModelFromVersioned,
+						ResponseConverter:        converter.DaprPubSubBrokerDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprPubSubBrokerTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1143,7 +1170,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.DaprSecretStore]{
 							rp_frontend.PrepareRadiusResource[*datamodel.DaprSecretStore],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprSecretStoreTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprSecretStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1160,7 +1188,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.DaprSecretStore]{
 							rp_frontend.PrepareRadiusResource[*datamodel.DaprSecretStore],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprSecretStoreTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprSecretStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1172,9 +1201,10 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.DaprSecretStore]{
-						RequestConverter:      converter.DaprSecretStoreDataModelFromVersioned,
-						ResponseConverter:     converter.DaprSecretStoreDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteDaprSecretStoreTimeout,
+						RequestConverter:         converter.DaprSecretStoreDataModelFromVersioned,
+						ResponseConverter:        converter.DaprSecretStoreDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteDaprSecretStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1235,7 +1265,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.DaprStateStore]{
 							rp_frontend.PrepareRadiusResource[*datamodel.DaprStateStore],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprStateStoreTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprStateStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1252,7 +1283,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.DaprStateStore]{
 							rp_frontend.PrepareRadiusResource[*datamodel.DaprStateStore],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateDaprStateStoreTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateDaprStateStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1264,9 +1296,10 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.DaprStateStore]{
-						RequestConverter:      converter.DaprStateStoreDataModelFromVersioned,
-						ResponseConverter:     converter.DaprStateStoreDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteDaprStateStoreTimeout,
+						RequestConverter:         converter.DaprStateStoreDataModelFromVersioned,
+						ResponseConverter:        converter.DaprStateStoreDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteDaprStateStoreTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1327,7 +1360,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.RedisCache]{
 							rp_frontend.PrepareRadiusResource[*datamodel.RedisCache],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1344,7 +1378,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.RedisCache]{
 							rp_frontend.PrepareRadiusResource[*datamodel.RedisCache],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1356,9 +1391,10 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.RedisCache]{
-						RequestConverter:      converter.RedisCacheDataModelFromVersioned,
-						ResponseConverter:     converter.RedisCacheDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteRedisCacheTimeout,
+						RequestConverter:         converter.RedisCacheDataModelFromVersioned,
+						ResponseConverter:        converter.RedisCacheDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteRedisCacheTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1427,7 +1463,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.RabbitMQMessageQueue]{
 							rp_frontend.PrepareRadiusResource[*datamodel.RabbitMQMessageQueue],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1444,7 +1481,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.RabbitMQMessageQueue]{
 							rp_frontend.PrepareRadiusResource[*datamodel.RabbitMQMessageQueue],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1456,9 +1494,10 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.RabbitMQMessageQueue]{
-						RequestConverter:      converter.RabbitMQMessageQueueDataModelFromVersioned,
-						ResponseConverter:     converter.RabbitMQMessageQueueDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteRabbitMQTimeout,
+						RequestConverter:         converter.RabbitMQMessageQueueDataModelFromVersioned,
+						ResponseConverter:        converter.RabbitMQMessageQueueDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteRabbitMQTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1526,7 +1565,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.SqlDatabase]{
 							rp_frontend.PrepareRadiusResource[*datamodel.SqlDatabase],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateSqlDatabaseTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateSqlDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1543,7 +1583,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.SqlDatabase]{
 							rp_frontend.PrepareRadiusResource[*datamodel.SqlDatabase],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateSqlDatabaseTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateSqlDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1555,9 +1596,10 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.SqlDatabase]{
-						RequestConverter:      converter.SqlDatabaseDataModelFromVersioned,
-						ResponseConverter:     converter.SqlDatabaseDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteSqlDatabaseTimeout,
+						RequestConverter:         converter.SqlDatabaseDataModelFromVersioned,
+						ResponseConverter:        converter.SqlDatabaseDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteSqlDatabaseTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1625,7 +1667,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.Extender]{
 							rp_frontend.PrepareRadiusResource[*datamodel.Extender],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateExtenderTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateExtenderTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1642,7 +1685,8 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 						UpdateFilters: []frontend_ctrl.UpdateFilter[datamodel.Extender]{
 							rp_frontend.PrepareRadiusResource[*datamodel.Extender],
 						},
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncCreateOrUpdateExtenderTimeout,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncCreateOrUpdateExtenderTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},
@@ -1654,9 +1698,10 @@ func AddLinkRoutes(ctx context.Context, r chi.Router, rootScopePath string, pref
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
 				return defaultoperation.NewDefaultAsyncDelete(opt,
 					frontend_ctrl.ResourceOptions[datamodel.Extender]{
-						RequestConverter:      converter.ExtenderDataModelFromVersioned,
-						ResponseConverter:     converter.ExtenderDataModelToVersioned,
-						AsyncOperationTimeout: link_frontend_ctrl.AsyncDeleteExtenderTimeout,
+						RequestConverter:         converter.ExtenderDataModelFromVersioned,
+						ResponseConverter:        converter.ExtenderDataModelToVersioned,
+						AsyncOperationTimeout:    link_frontend_ctrl.AsyncDeleteExtenderTimeout,
+						AsyncOperationRetryAfter: link_frontend_ctrl.AsyncOperationRetryAfter,
 					},
 				)
 			},


### PR DESCRIPTION
# Description

This change updates our async operations for all of our resources to set a lower value.

Based on my investigation of the issue we're experiencing long delete times because the polling frequency of these operations is set to 60 seconds. They actually complete very quickly but the CLI doesn't check the status for 60 seconds.

We're changing this value to 5 seconds for all of our async operations. Based on feedback we have no reason NOT to optimize for speed right now. We can tweak values additionally in the future.

This change has a big (positive) impact on the speed of our functional tests. Results here: https://github.com/project-radius/radius/pull/6016#issuecomment-1667056285

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #5164

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 40f9279</samp>

### Summary
🕒🔄🚦

<!--
1.  🕒 - This emoji represents the concept of time or duration, which is relevant for the `AsyncOperationRetryAfter` constant and the `Retry-After` header.
2.  🔄 - This emoji represents the concept of repetition or looping, which is relevant for the polling mechanism that checks the status of async resource operations.
3.  🚦 - This emoji represents the concept of signaling or controlling, which is relevant for the async resource operations that depend on the `Gateway` resource.
-->
This pull request adds support for polling intervals for async resource operations in the frontend handler and controller packages. It defines a constant `AsyncOperationRetryAfter` and uses it to set the `Retry-After` header in the response for the `HTTPRoute`, `ContainerResource`, `Gateway`, and `VolumeResource` resources. The changes affect the files `pkg/corerp/frontend/handler/routes.go`, `pkg/linkrp/frontend/handler/routes.go`, and `pkg/linkrp/frontend/controller/types.go`.

> _We're sailing on the cloud with async ops_
> _We need to check the status of our props_
> _We use the `Retry-After` header and the `AsyncOperationRetryAfter` const_
> _To poll the resources on the count of three_

### Walkthrough
*  Add `AsyncOperationRetryAfter` constant to specify polling interval for async resource operations ([link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6R21), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-f2917d2c692a615ad7bd04dc17bc79dc9081a4b72f5d9a82f676c16b1684f531R24-R26))
*  Pass `AsyncOperationRetryAfter` to `NewDefaultAsyncPut` and `NewDefaultAsyncDelete` functions for various resources in `corerp` and `linkrp` packages ([link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6R47-R49), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L220-R226), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L233-R240), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L246-R254), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6R317), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6R335), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L338-R349), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6R505), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6R523), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L523-R537), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6R602), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6R620), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L617-R634), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL179-R180), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL196-R198), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL208-R213), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL315-R319), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL332-R337), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL344-R352), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL407-R414), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL424-R432), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL436-R447), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL499-R509), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL516-R527), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL528-R542), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL628-R641), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL645-R659), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL657-R674), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL727-R743), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL744-R761), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL756-R776), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL826-R845), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL843-R863), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL855-R878), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL955-R977), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL972-R995), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL984-R1010), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1054-R1079), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1071-R1097), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1083-R1112), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1146-R1174), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1163-R1192), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1175-R1207), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1238-R1269), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1255-R1287), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1267-R1302), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1330-R1364), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1347-R1382), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1359-R1397), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1430-R1467), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1447-R1485), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1459-R1500), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1529-R1569), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1546-R1587), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1558-R1602), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1628-R1671), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1645-R1689), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1657-R1704))
*  Set `Retry-After` header in response for async resource operations using `AsyncOperationRetryAfter` value ([link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L220-R226), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L233-R240), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L246-R254), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6R317), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6R335), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L338-R349), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6R505), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6R523), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L523-R537), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6R602), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6R620), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L617-R634), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL179-R180), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL196-R198), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL208-R213), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL315-R319), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL332-R337), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL344-R352), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL407-R414), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL424-R432), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL436-R447), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL499-R509), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL516-R527), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL528-R542), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL628-R641), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL645-R659), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL657-R674), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL727-R743), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL744-R761), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL756-R776), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL826-R845), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL843-R863), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL855-R878), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL955-R977), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL972-R995), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL984-R1010), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1054-R1079), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1071-R1097), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1083-R1112), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1146-R1174), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1163-R1192), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1175-R1207), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1238-R1269), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1255-R1287), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1267-R1302), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1330-R1364), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1347-R1382), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1359-R1397), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1430-R1467), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1447-R1485), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1459-R1500), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1529-R1569), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1546-R1587), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1558-R1602), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1628-R1671), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1645-R1689), [link](https://github.com/project-radius/radius/pull/6019/files?diff=unified&w=0#diff-35a42847397e63ce68849a6460524de6b1e7d1758aad42fb75864bdfe7a0b94aL1657-R1704))


