### PR TITLE
update gateway for dns functionality

### DIFF
--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -288,7 +288,7 @@ func (r Renderer) makeService(resource *datamodel.ContainerResource, options ren
 		ports = append(ports, corev1.ServicePort{
 			Name:       containerPorts.names[i],
 			Port:       port,
-			TargetPort: intstr.FromString(containerPorts.names[i]),
+			TargetPort: intstr.FromInt(int(containerPorts.values[i])),
 			Protocol:  corev1.ProtocolTCP,
 		})
 	}

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -1565,7 +1565,7 @@ func Test_DNS_Service_Generation(t *testing.T) {
 		expectedServicePort := corev1.ServicePort{
 			Name:       "web",
 			Port:       containerPortNumber,
-			TargetPort: intstr.FromString("web"),
+			TargetPort: intstr.FromInt(80),
 			Protocol:   "TCP",
 		}
 

--- a/pkg/corerp/renderers/gateway/render.go
+++ b/pkg/corerp/renderers/gateway/render.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/corerp/renderers/gateway/render.go
+++ b/pkg/corerp/renderers/gateway/render.go
@@ -325,10 +325,10 @@ func MakeHttpRoutes(ctx context.Context, options renderers.RenderOptions, resour
 				return []rpv1.OutputResource{}, err
 			}
 
-			// // bound check intURLport
-			// if intURLport < 0 || intURLport > 65535 {
-			// 	return []rpv1.OutputResource{}, fmt.Errorf("port %d is out of range", intURLport)
-			// }
+			// bound check intURLport
+			if intURLport < 0 || intURLport > 65535 {
+				return []rpv1.OutputResource{}, fmt.Errorf("port %d is out of range", intURLport)
+			}
 
 			port = int32(intURLport)
 
@@ -539,7 +539,7 @@ func parseURL(sourceURL string) (scheme, hostname, port string, err error) {
 	if err != nil {
 		return "", "", "", err
 	}
-	
+
 	if portInt < 0 || portInt > 65535 {
 		return "", "", "", fmt.Errorf("port %s is out of range", port)
 	}

--- a/pkg/corerp/renderers/gateway/render.go
+++ b/pkg/corerp/renderers/gateway/render.go
@@ -325,13 +325,13 @@ func MakeHttpRoutes(ctx context.Context, options renderers.RenderOptions, resour
 				return []rpv1.OutputResource{}, err
 			}
 
-			// bound check intURLport
-			if intURLport < 0 || intURLport > 65535 {
-				return []rpv1.OutputResource{}, fmt.Errorf("port %d is out of range", intURLport)
-			}
+			// // bound check intURLport
+			// if intURLport < 0 || intURLport > 65535 {
+			// 	return []rpv1.OutputResource{}, fmt.Errorf("port %d is out of range", intURLport)
+			// }
 
 			port = int32(intURLport)
-			
+
 		} else {
 			routeProperties := dependencies[route.Destination]
 			routePort, ok := routeProperties.ComputedValues["port"].(float64)
@@ -532,6 +532,16 @@ func parseURL(sourceURL string) (scheme, hostname, port string, err error) {
 	hostname, port, err = net.SplitHostPort(host)
 	if err != nil {
 		return "", "", "", err
+	}
+
+	// bound check port
+	portInt, err := strconv.Atoi(port)
+	if err != nil {
+		return "", "", "", err
+	}
+	
+	if portInt < 0 || portInt > 65535 {
+		return "", "", "", fmt.Errorf("port %s is out of range", port)
 	}
 
 	return scheme, hostname, port, nil

--- a/pkg/corerp/renderers/gateway/render.go
+++ b/pkg/corerp/renderers/gateway/render.go
@@ -17,22 +17,24 @@ limitations under the License.
 package gateway
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"net"
-	"strings"
+    "context"
+    "errors"
+    "fmt"
+    "net"
+    "net/url"
+    "strings"
+    "strconv"
 
-	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
-	"github.com/project-radius/radius/pkg/corerp/datamodel"
-	"github.com/project-radius/radius/pkg/corerp/renderers"
-	"github.com/project-radius/radius/pkg/kubernetes"
-	"github.com/project-radius/radius/pkg/resourcekinds"
-	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
-	"github.com/project-radius/radius/pkg/ucp/resources"
+    v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+    "github.com/project-radius/radius/pkg/corerp/datamodel"
+    "github.com/project-radius/radius/pkg/corerp/renderers"
+    "github.com/project-radius/radius/pkg/kubernetes"
+    "github.com/project-radius/radius/pkg/resourcekinds"
+    rpv1 "github.com/project-radius/radius/pkg/rp/v1"
+    "github.com/project-radius/radius/pkg/ucp/resources"
 )
 
 type Renderer struct {
@@ -43,33 +45,38 @@ type Renderer struct {
 // GetDependencyIDs parses the gateway data model to get the resource IDs of the httpRoutes and the secretStore resource ID
 // from the certificateFrom property, and returns them as two slices of resource IDs.
 func (r Renderer) GetDependencyIDs(ctx context.Context, dm v1.DataModelInterface) (radiusResourceIDs []resources.ID, azureResourceIDs []resources.ID, err error) {
-	gateway, ok := dm.(*datamodel.Gateway)
-	if !ok {
-		return nil, nil, v1.ErrInvalidModelConversion
-	}
-	gtwyProperties := gateway.Properties
+    gateway, ok := dm.(*datamodel.Gateway)
+    if !ok {
+        return nil, nil, v1.ErrInvalidModelConversion
+    }
+    gtwyProperties := gateway.Properties
 
-	// Get all httpRoutes that are used by this gateway
-	for _, httpRoute := range gtwyProperties.Routes {
-		resourceID, err := resources.ParseResource(httpRoute.Destination)
-		if err != nil {
-			return nil, nil, v1.NewClientErrInvalidRequest(err.Error())
-		}
+    // Get all httpRoutes that are used by this gateway
+    for _, route := range gtwyProperties.Routes {
+        // Skip if destination is a URL. DNS-SD will resolve the route.
+        if (isURL(route.Destination)) {
+            continue
+        }
 
-		radiusResourceIDs = append(radiusResourceIDs, resourceID)
-	}
+        resourceID, err := resources.ParseResource(route.Destination)
+        if err != nil {
+            return nil, nil, v1.NewClientErrInvalidRequest(err.Error())
+        }
 
-	// Get secretStore resource ID from certificateFrom property
-	if gtwyProperties.TLS != nil && gtwyProperties.TLS.CertificateFrom != "" {
-		resourceID, err := resources.ParseResource(gtwyProperties.TLS.CertificateFrom)
-		if err != nil {
-			return nil, nil, v1.NewClientErrInvalidRequest(err.Error())
-		}
+        radiusResourceIDs = append(radiusResourceIDs, resourceID)
+    }
 
-		radiusResourceIDs = append(radiusResourceIDs, resourceID)
-	}
+    // Get secretStore resource ID from certificateFrom property
+    if gtwyProperties.TLS != nil && gtwyProperties.TLS.CertificateFrom != "" {
+        resourceID, err := resources.ParseResource(gtwyProperties.TLS.CertificateFrom)
+        if err != nil {
+            return nil, nil, v1.NewClientErrInvalidRequest(err.Error())
+        }
 
-	return radiusResourceIDs, azureResourceIDs, nil
+        radiusResourceIDs = append(radiusResourceIDs, resourceID)
+    }
+
+    return radiusResourceIDs, azureResourceIDs, nil
 }
 
 // # Function Explanation
@@ -77,52 +84,52 @@ func (r Renderer) GetDependencyIDs(ctx context.Context, dm v1.DataModelInterface
 // Render creates a gateway object and http route objects based on the given parameters, and returns them along
 // with a computed value for the gateway's public endpoint.
 func (r Renderer) Render(ctx context.Context, dm v1.DataModelInterface, options renderers.RenderOptions) (renderers.RendererOutput, error) {
-	outputResources := []rpv1.OutputResource{}
-	gateway, ok := dm.(*datamodel.Gateway)
-	if !ok {
-		return renderers.RendererOutput{}, v1.ErrInvalidModelConversion
-	}
-	appId, err := resources.ParseResource(gateway.Properties.Application)
-	if err != nil {
-		return renderers.RendererOutput{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("invalid application id: %s. id: %s", err.Error(), gateway.Properties.Application))
-	}
-	applicationName := appId.Name()
-	gatewayName := kubernetes.NormalizeResourceName(gateway.Name)
-	hostname, err := getHostname(*gateway, &gateway.Properties, applicationName, options.Environment.Gateway)
+    outputResources := []rpv1.OutputResource{}
+    gateway, ok := dm.(*datamodel.Gateway)
+    if !ok {
+        return renderers.RendererOutput{}, v1.ErrInvalidModelConversion
+    }
+    appId, err := resources.ParseResource(gateway.Properties.Application)
+    if err != nil {
+        return renderers.RendererOutput{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("invalid application id: %s. id: %s", err.Error(), gateway.Properties.Application))
+    }
+    applicationName := appId.Name()
+    gatewayName := kubernetes.NormalizeResourceName(gateway.Name)
+    hostname, err := getHostname(*gateway, &gateway.Properties, applicationName, options.Environment.Gateway)
 
-	var publicEndpoint string
-	if errors.Is(err, &ErrNoPublicEndpoint{}) {
-		publicEndpoint = "unknown"
-	} else if err != nil {
-		return renderers.RendererOutput{}, fmt.Errorf("getting hostname failed with error: %s", err)
-	} else {
-		isHttps := gateway.Properties.TLS != nil && (gateway.Properties.TLS.SSLPassthrough || gateway.Properties.TLS.CertificateFrom != "")
-		publicEndpoint = getPublicEndpoint(hostname, options.Environment.Gateway.Port, isHttps)
-	}
+    var publicEndpoint string
+    if errors.Is(err, &ErrNoPublicEndpoint{}) {
+        publicEndpoint = "unknown"
+    } else if err != nil {
+        return renderers.RendererOutput{}, fmt.Errorf("getting hostname failed with error: %s", err)
+    } else {
+        isHttps := gateway.Properties.TLS != nil && (gateway.Properties.TLS.SSLPassthrough || gateway.Properties.TLS.CertificateFrom != "")
+        publicEndpoint = getPublicEndpoint(hostname, options.Environment.Gateway.Port, isHttps)
+    }
 
-	gatewayObject, err := MakeGateway(ctx, options, gateway, gateway.Name, applicationName, hostname)
-	if err != nil {
-		return renderers.RendererOutput{}, err
-	}
+    gatewayObject, err := MakeGateway(ctx, options, gateway, gateway.Name, applicationName, hostname)
+    if err != nil {
+        return renderers.RendererOutput{}, err
+    }
 
-	outputResources = append(outputResources, gatewayObject)
+    outputResources = append(outputResources, gatewayObject)
 
-	computedValues := map[string]rpv1.ComputedValueReference{
-		"url": {
-			Value: publicEndpoint,
-		},
-	}
+    computedValues := map[string]rpv1.ComputedValueReference{
+        "url": {
+            Value: publicEndpoint,
+        },
+    }
 
-	httpRouteObjects, err := MakeHttpRoutes(ctx, options, *gateway, &gateway.Properties, gatewayName, applicationName)
-	if err != nil {
-		return renderers.RendererOutput{}, err
-	}
-	outputResources = append(outputResources, httpRouteObjects...)
+    httpRouteObjects, err := MakeHttpRoutes(ctx, options, *gateway, &gateway.Properties, gatewayName, applicationName)
+    if err != nil {
+        return renderers.RendererOutput{}, err
+    }
+    outputResources = append(outputResources, httpRouteObjects...)
 
-	return renderers.RendererOutput{
-		Resources:      outputResources,
-		ComputedValues: computedValues,
-	}, nil
+    return renderers.RendererOutput{
+        Resources:      outputResources,
+        ComputedValues: computedValues,
+    }, nil
 }
 
 // # Function Explanation
@@ -130,168 +137,170 @@ func (r Renderer) Render(ctx context.Context, dm v1.DataModelInterface, options 
 // MakeGateway validates the Gateway resource and its dependencies, and creates a Contour HTTPProxy resource
 // to act as the Gateway.
 func MakeGateway(ctx context.Context, options renderers.RenderOptions, gateway *datamodel.Gateway, resourceName string, applicationName string, hostname string) (rpv1.OutputResource, error) {
-	includes := []contourv1.Include{}
-	dependencies := options.Dependencies
+    includes := []contourv1.Include{}
+    dependencies := options.Dependencies
 
-	if len(gateway.Properties.Routes) < 1 {
-		return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("must have at least one route when declaring a Gateway resource")
-	}
+    if len(gateway.Properties.Routes) < 1 {
+        return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("must have at least one route when declaring a Gateway resource")
+    }
 
-	sslPassthrough := false
-	var contourTLSConfig *contourv1.TLS
-	if gateway.Properties.TLS != nil {
-		sslPassthrough = gateway.Properties.TLS.SSLPassthrough
+    sslPassthrough := false
+    var contourTLSConfig *contourv1.TLS
 
-		if gateway.Properties.TLS.CertificateFrom != "" {
-			secretStoreResourceId := gateway.Properties.TLS.CertificateFrom
-			secretStoreResource, ok := dependencies[secretStoreResourceId]
-			if !ok {
-				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
-			}
+    // configure TLS if it is enabled
+    if gateway.Properties.TLS != nil {
+        sslPassthrough = gateway.Properties.TLS.SSLPassthrough
 
-			referencedResource := dependencies[secretStoreResourceId].Resource
-			if !strings.EqualFold(referencedResource.ResourceTypeName(), datamodel.SecretStoreResourceType) {
-				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource")
-			}
+        if gateway.Properties.TLS.CertificateFrom != "" {
+            secretStoreResourceId := gateway.Properties.TLS.CertificateFrom
+            secretStoreResource, ok := dependencies[secretStoreResourceId]
+            if !ok {
+                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
+            }
 
-			// Validate the secretStore resource: it must be of type certificate and have tls.crt and tls.key
-			secretStore, ok := referencedResource.(*datamodel.SecretStore)
-			if !ok {
-				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource")
-			}
+            referencedResource := dependencies[secretStoreResourceId].Resource
+            if !strings.EqualFold(referencedResource.ResourceTypeName(), datamodel.SecretStoreResourceType) {
+                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource")
+            }
 
-			if secretStore.Properties.Type != datamodel.SecretTypeCert {
-				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource with type certificate")
-			}
+            // Validate the secretStore resource: it must be of type certificate and have tls.crt and tls.key
+            secretStore, ok := referencedResource.(*datamodel.SecretStore)
+            if !ok {
+                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource")
+            }
 
-			if secretStore.Properties.Data["tls.crt"] == nil {
-				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource with tls.crt")
-			}
+            if secretStore.Properties.Type != datamodel.SecretTypeCert {
+                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource with type certificate")
+            }
 
-			if secretStore.Properties.Data["tls.key"] == nil {
-				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource with tls.key")
-			}
+            if secretStore.Properties.Data["tls.crt"] == nil {
+                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource with tls.crt")
+            }
 
-			// Get the name and namespace of the Kubernetes secret resource from the secretStore OutputResources
-			if secretStoreResource.OutputResources == nil {
-				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
-			}
+            if secretStore.Properties.Data["tls.key"] == nil {
+                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource with tls.key")
+            }
 
-			secretResource := secretStoreResource.OutputResources[rpv1.LocalIDSecret].Data
-			secretResourceData, ok := secretResource.(map[string]any)
-			if !ok {
-				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
-			}
+            // Get the name and namespace of the Kubernetes secret resource from the secretStore OutputResources
+            if secretStoreResource.OutputResources == nil {
+                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
+            }
 
-			secretName, ok := secretResourceData["name"]
-			if !ok {
-				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
-			}
+            secretResource := secretStoreResource.OutputResources[rpv1.LocalIDSecret].Data
+            secretResourceData, ok := secretResource.(map[string]any)
+            if !ok {
+                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
+            }
 
-			secretNamespace, ok := secretResourceData["namespace"]
-			if !ok {
-				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
-			}
+            secretName, ok := secretResourceData["name"]
+            if !ok {
+                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
+            }
 
-			contourTLSConfig = &contourv1.TLS{
-				SecretName:             fmt.Sprintf("%s/%s", secretNamespace, secretName),
-				MinimumProtocolVersion: string(gateway.Properties.TLS.MinimumProtocolVersion),
-			}
-		}
-	}
+            secretNamespace, ok := secretResourceData["namespace"]
+            if !ok {
+                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
+            }
 
-	// If SSL Passthrough is enabled, then we can only have one route
-	if sslPassthrough && len(gateway.Properties.Routes) > 1 {
-		return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("cannot support multiple routes with sslPassthrough set to true")
-	}
+            contourTLSConfig = &contourv1.TLS{
+                SecretName:             fmt.Sprintf("%s/%s", secretNamespace, secretName),
+                MinimumProtocolVersion: string(gateway.Properties.TLS.MinimumProtocolVersion),
+            }
+        }
+    }
 
-	var route datamodel.GatewayRoute //route will hold the one sslPassthrough route, if sslPassthrough is true
-	for _, route = range gateway.Properties.Routes {
-		if sslPassthrough && (route.Path != "" || route.ReplacePrefix != "") {
-			return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("cannot support `path` or `replacePrefix` in routes with sslPassthrough set to true")
-		}
-		routeName, err := getRouteName(&route)
-		if err != nil {
-			return rpv1.OutputResource{}, err
-		}
+    // If SSL Passthrough is enabled, then we can only have one route
+    if sslPassthrough && len(gateway.Properties.Routes) > 1 {
+        return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("cannot support multiple routes with sslPassthrough set to true")
+    }
 
-		routeResourceName := kubernetes.NormalizeResourceName(routeName)
-		prefix := route.Path
-		if sslPassthrough {
-			prefix = "/"
-		}
-		includes = append(includes, contourv1.Include{
-			Name: routeResourceName,
-			Conditions: []contourv1.MatchCondition{
-				{
-					Prefix: prefix,
-				},
-			},
-		})
-	}
+    var route datamodel.GatewayRoute //route will hold the one sslPassthrough route, if sslPassthrough is true
+    for _, route = range gateway.Properties.Routes {
+        if sslPassthrough && (route.Path != "" || route.ReplacePrefix != "") {
+            return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("cannot support `path` or `replacePrefix` in routes with sslPassthrough set to true")
+        }
+        routeName, err := getRouteName(&route)
+        if err != nil {
+            return rpv1.OutputResource{}, err
+        }
 
-	virtualHostname := hostname
-	if hostname == "" {
-		// If the given hostname is empty, use the application name
-		// in order to make sure that this resource is seen as a root proxy.
-		virtualHostname = applicationName
-	}
+        routeResourceName := kubernetes.NormalizeResourceName(routeName)
+        prefix := route.Path
+        if sslPassthrough {
+            prefix = "/"
+        }
+        includes = append(includes, contourv1.Include{
+            Name: routeResourceName,
+            Conditions: []contourv1.MatchCondition{
+                {
+                    Prefix: prefix,
+                },
+            },
+        })
+    }
 
-	virtualHost := &contourv1.VirtualHost{
-		Fqdn: virtualHostname,
-		TLS:  contourTLSConfig,
-	}
+    virtualHostname := hostname
+    if hostname == "" {
+        // If the given hostname is empty, use the application name
+        // in order to make sure that this resource is seen as a root proxy.
+        virtualHostname = applicationName
+    }
 
-	var tcpProxy *contourv1.TCPProxy
-	if sslPassthrough {
-		virtualHost.TLS = &contourv1.TLS{
-			Passthrough: true,
-		}
+    virtualHost := &contourv1.VirtualHost{
+        Fqdn: virtualHostname,
+        TLS:  contourTLSConfig,
+    }
 
-		routeProperties := options.Dependencies[route.Destination]
-		port := renderers.DefaultSecurePort
-		routePort, ok := routeProperties.ComputedValues["port"].(float64)
-		if ok {
-			port = int32(routePort)
-		}
+    var tcpProxy *contourv1.TCPProxy
+    if sslPassthrough {
+        virtualHost.TLS = &contourv1.TLS{
+            Passthrough: true,
+        }
 
-		routeName, err := getRouteName(&route)
-		if err != nil {
-			return rpv1.OutputResource{}, err
-		}
+        routeProperties := options.Dependencies[route.Destination]
+        port := renderers.DefaultSecurePort
+        routePort, ok := routeProperties.ComputedValues["port"].(float64)
+        if ok {
+            port = int32(routePort)
+        }
 
-		tcpProxy = &contourv1.TCPProxy{
-			Services: []contourv1.Service{
-				{
-					Name: kubernetes.NormalizeResourceName(routeName),
-					Port: int(port),
-				},
-			},
-		}
-	}
+        routeName, err := getRouteName(&route)
+        if err != nil {
+            return rpv1.OutputResource{}, err
+        }
 
-	// The root HTTPProxy object acts as the Gateway
-	rootHTTPProxy := &contourv1.HTTPProxy{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "HTTPProxy",
-			APIVersion: contourv1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        kubernetes.NormalizeResourceName(resourceName),
-			Namespace:   options.Environment.Namespace,
-			Labels:      renderers.GetLabels(ctx, options, applicationName, resourceName, gateway.ResourceTypeName()),
-			Annotations: renderers.GetAnnotations(ctx, options),
-		},
-		Spec: contourv1.HTTPProxySpec{
-			VirtualHost: virtualHost,
-			Includes:    includes,
-		},
-	}
-	if sslPassthrough {
-		rootHTTPProxy.Spec.TCPProxy = tcpProxy
-	}
+        tcpProxy = &contourv1.TCPProxy{
+            Services: []contourv1.Service{
+                {
+                    Name: kubernetes.NormalizeResourceName(routeName),
+                    Port: int(port),
+                },
+            },
+        }
+    }
 
-	return rpv1.NewKubernetesOutputResource(resourcekinds.Gateway, rpv1.LocalIDGateway, rootHTTPProxy, rootHTTPProxy.ObjectMeta), nil
+    // The root HTTPProxy object acts as the Gateway
+    rootHTTPProxy := &contourv1.HTTPProxy{
+        TypeMeta: metav1.TypeMeta{
+            Kind:       "HTTPProxy",
+            APIVersion: contourv1.SchemeGroupVersion.String(),
+        },
+        ObjectMeta: metav1.ObjectMeta{
+            Name:        kubernetes.NormalizeResourceName(resourceName),
+            Namespace:   options.Environment.Namespace,
+            Labels:      renderers.GetLabels(ctx, options, applicationName, resourceName, gateway.ResourceTypeName()),
+            Annotations: renderers.GetAnnotations(ctx, options),
+        },
+        Spec: contourv1.HTTPProxySpec{
+            VirtualHost: virtualHost,
+            Includes:    includes,
+        },
+    }
+    if sslPassthrough {
+        rootHTTPProxy.Spec.TCPProxy = tcpProxy
+    }
+
+    return rpv1.NewKubernetesOutputResource(resourcekinds.Gateway, rpv1.LocalIDGateway, rootHTTPProxy, rootHTTPProxy.ObjectMeta), nil
 }
 
 // # Function Explanation
@@ -299,171 +308,231 @@ func MakeGateway(ctx context.Context, options renderers.RenderOptions, gateway *
 // MakeHttpRoutes creates HTTPProxy objects for each route in the gateway and returns them as OutputResources. It returns
 // an error if it fails to get the route name.
 func MakeHttpRoutes(ctx context.Context, options renderers.RenderOptions, resource datamodel.Gateway, gateway *datamodel.GatewayProperties, gatewayName string, applicationName string) ([]rpv1.OutputResource, error) {
-	dependencies := options.Dependencies
-	objects := make(map[string]*contourv1.HTTPProxy)
+    dependencies := options.Dependencies
+    objects := make(map[string]*contourv1.HTTPProxy)
 
-	for _, route := range gateway.Routes {
-		routeProperties := dependencies[route.Destination]
-		port := renderers.DefaultPort
-		routePort, ok := routeProperties.ComputedValues["port"].(float64)
-		if ok {
-			port = int32(routePort)
-		}
+    for _, route := range gateway.Routes {
+        routeProperties := dependencies[route.Destination]
+        port := renderers.DefaultPort
+        routePort, ok := routeProperties.ComputedValues["port"].(float64)
+        if ok {
+            port = int32(routePort)
+        }
 
-		routeName, err := getRouteName(&route)
-		if err != nil {
-			return []rpv1.OutputResource{}, err
-		}
+        // if the route destination is a URL, then we need to parse the port from the URL
+        if isURL(route.Destination) {
+            _, _, urlPort, err := parseURL(route.Destination)
+            if err != nil {
+                return []rpv1.OutputResource{}, err
+            }
 
-		// Create unique localID for dependency graph
-		localID := fmt.Sprintf("%s-%s", rpv1.LocalIDHttpRoute, routeName)
-		routeResourceName := kubernetes.NormalizeResourceName(routeName)
+            intURLport, err := strconv.Atoi(urlPort)
+            if err != nil {
+                return []rpv1.OutputResource{}, err
+            }
 
-		var pathRewritePolicy *contourv1.PathRewritePolicy
-		if route.ReplacePrefix != "" {
-			pathRewritePolicy = &contourv1.PathRewritePolicy{
-				ReplacePrefix: []contourv1.ReplacePrefix{
-					{
-						Prefix:      route.Path,
-						Replacement: route.ReplacePrefix,
-					},
-				},
-			}
-		}
+            // bound check intURLport
+            if intURLport < 0 || intURLport > 65535 {
+                return []rpv1.OutputResource{}, fmt.Errorf("port %d is out of range", intURLport)
+            }
+            
+            port = int32(intURLport)
+        }
 
-		// If this route already exists, append to it
-		if object, exists := objects[localID]; exists {
-			if pathRewritePolicy != nil {
-			outer:
-				for i := range object.Spec.Routes {
-					for _, service := range object.Spec.Routes[i].Services {
-						if service.Name == routeResourceName {
-							if object.Spec.Routes[i].PathRewritePolicy == nil {
-								object.Spec.Routes[i].PathRewritePolicy = pathRewritePolicy
-							} else {
-								object.Spec.Routes[i].PathRewritePolicy.ReplacePrefix = append(object.Spec.Routes[i].PathRewritePolicy.ReplacePrefix, pathRewritePolicy.ReplacePrefix[0])
-							}
+        routeName, err := getRouteName(&route)
+        if err != nil {
+            return []rpv1.OutputResource{}, err
+        }
 
-							break outer
-						}
-					}
-				}
-			}
+        // Create unique localID for dependency graph
+        localID := fmt.Sprintf("%s-%s", rpv1.LocalIDHttpRoute, routeName)
+        routeResourceName := kubernetes.NormalizeResourceName(routeName)
 
-			continue
-		}
+        var pathRewritePolicy *contourv1.PathRewritePolicy
+        if route.ReplacePrefix != "" {
+            pathRewritePolicy = &contourv1.PathRewritePolicy{
+                ReplacePrefix: []contourv1.ReplacePrefix{
+                    {
+                        Prefix:      route.Path,
+                        Replacement: route.ReplacePrefix,
+                    },
+                },
+            }
+        }
 
-		httpProxyObject := &contourv1.HTTPProxy{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "HTTPProxy",
-				APIVersion: contourv1.SchemeGroupVersion.String(),
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        routeResourceName,
-				Namespace:   options.Environment.Namespace,
-				Labels:      renderers.GetLabels(ctx, options, applicationName, routeName, resource.ResourceTypeName()),
-				Annotations: renderers.GetAnnotations(ctx, options),
-			},
-			Spec: contourv1.HTTPProxySpec{
-				Routes: []contourv1.Route{
-					{
-						Services: []contourv1.Service{
-							{
-								Name: routeResourceName,
-								Port: int(port),
-							},
-						},
-						PathRewritePolicy: pathRewritePolicy,
-					},
-				},
-			},
-		}
+        // If this route already exists, append to it
+        if object, exists := objects[localID]; exists {
+            if pathRewritePolicy != nil {
+            outer:
+                for i := range object.Spec.Routes {
+                    for _, service := range object.Spec.Routes[i].Services {
+                        if service.Name == routeResourceName {
+                            if object.Spec.Routes[i].PathRewritePolicy == nil {
+                                object.Spec.Routes[i].PathRewritePolicy = pathRewritePolicy
+                            } else {
+                                object.Spec.Routes[i].PathRewritePolicy.ReplacePrefix = append(object.Spec.Routes[i].PathRewritePolicy.ReplacePrefix, pathRewritePolicy.ReplacePrefix[0])
+                            }
 
-		objects[localID] = httpProxyObject
-	}
+                            break outer
+                        }
+                    }
+                }
+            }
 
-	var outputResources []rpv1.OutputResource
-	for localID, object := range objects {
-		outputResources = append(outputResources, rpv1.NewKubernetesOutputResource(resourcekinds.KubernetesHTTPRoute, localID, object, object.ObjectMeta))
-	}
+            continue
+        }
 
-	return outputResources, nil
+        httpProxyObject := &contourv1.HTTPProxy{
+            TypeMeta: metav1.TypeMeta{
+                Kind:       "HTTPProxy",
+                APIVersion: contourv1.SchemeGroupVersion.String(),
+            },
+            ObjectMeta: metav1.ObjectMeta{
+                Name:        routeResourceName,
+                Namespace:   options.Environment.Namespace,
+                Labels:      renderers.GetLabels(ctx, options, applicationName, routeName, resource.ResourceTypeName()),
+                Annotations: renderers.GetAnnotations(ctx, options),
+            },
+            Spec: contourv1.HTTPProxySpec{
+                Routes: []contourv1.Route{
+                    {
+                        Services: []contourv1.Service{
+                            {
+                                Name: routeResourceName,
+                                Port: int(port),
+                            },
+                        },
+                        PathRewritePolicy: pathRewritePolicy,
+                    },
+                },
+            },
+        }
+
+        objects[localID] = httpProxyObject
+    }
+
+    var outputResources []rpv1.OutputResource
+    for localID, object := range objects {
+        outputResources = append(outputResources, rpv1.NewKubernetesOutputResource(resourcekinds.KubernetesHTTPRoute, localID, object, object.ObjectMeta))
+    }
+
+    return outputResources, nil
 }
 
 func getRouteName(route *datamodel.GatewayRoute) (string, error) {
-	resourceID, err := resources.ParseResource(route.Destination)
-	if err != nil {
-		return "", v1.NewClientErrInvalidRequest(err.Error())
-	}
+    // if isURL, then name is hostname (DNS-SD case)
+    if isURL(route.Destination) {
+        u, err := url.Parse(route.Destination)
+        if err != nil {
+            return "", v1.NewClientErrInvalidRequest(err.Error())
+        }
 
-	return resourceID.Name(), nil
+        return u.Hostname(), nil
+    }
+
+    // if not URL, then name is the resourceID (HTTProute case)
+    resourceID, err := resources.ParseResource(route.Destination)
+    if err != nil {
+        return "", v1.NewClientErrInvalidRequest(err.Error())
+    }
+
+    return resourceID.Name(), nil
 }
 
 // getHostname returns the hostname of the public endpoint of the Gateway.
 // This sometimes involves transforming the external IP of the cluster into
 // a hostname that's unique to this Gateway and Application.
 func getHostname(resource datamodel.Gateway, gateway *datamodel.GatewayProperties, applicationName string, options renderers.GatewayOptions) (string, error) {
-	// Handle the explicit override case (return)
-	// Handle the explicit FQDN case (return)
-	// Select the 'base' hostname (convert IP to hostname)
-	// If a prefix is not specified and the LoadBalancer provided an IP, then prepend with the gateway name
-	// Prepend the prefix, if one is specified
-	// Return the (possibly altered) hostname
+    // Handle the explicit override case (return)
+    // Handle the explicit FQDN case (return)
+    // Select the 'base' hostname (convert IP to hostname)
+    // If a prefix is not specified and the LoadBalancer provided an IP, then prepend with the gateway name
+    // Prepend the prefix, if one is specified
+    // Return the (possibly altered) hostname
 
-	if options.PublicEndpointOverride {
-		// Specified from --public-endpoint-override CLI flag
-		return options.Hostname, nil
-	} else if gateway.Hostname != nil && gateway.Hostname.FullyQualifiedHostname != "" {
-		// Trust that the provided FullyQualifiedHostname actually works
-		return gateway.Hostname.FullyQualifiedHostname, nil
-	}
+    if options.PublicEndpointOverride {
+        // Specified from --public-endpoint-override CLI flag
+        return options.Hostname, nil
+    } else if gateway.Hostname != nil && gateway.Hostname.FullyQualifiedHostname != "" {
+        // Trust that the provided FullyQualifiedHostname actually works
+        return gateway.Hostname.FullyQualifiedHostname, nil
+    }
 
-	// baseHostname represents the base hostname that may be prepended with the given prefix
-	// or gateway name. After this block, baseHostname looks like either:
-	// 1. a hostname from the LoadBalancer
-	// 2. appname.IP.nip.io
-	var baseHostname string
-	if options.ExternalIP != "" {
-		baseHostname = fmt.Sprintf("%s.%s.nip.io", applicationName, options.ExternalIP)
+    // baseHostname represents the base hostname that may be prepended with the given prefix
+    // or gateway name. After this block, baseHostname looks like either:
+    // 1. a hostname from the LoadBalancer
+    // 2. appname.IP.nip.io
+    var baseHostname string
+    if options.ExternalIP != "" {
+        baseHostname = fmt.Sprintf("%s.%s.nip.io", applicationName, options.ExternalIP)
 
-		// If no prefix was specified, and the LoadBalancer provided us an ExternalIP,
-		// prepend the hostname with the Gateway name (for uniqueness)
-		if gateway.Hostname == nil {
-			// Auto-assign hostname: gatewayname.appname.ip.nip.io
-			return fmt.Sprintf("%s.%s", resource.Name, baseHostname), nil
-		}
-	} else if options.Hostname != "" {
-		baseHostname = options.Hostname
-	} else {
-		// In the case of no public endpoint, use the application name as the hostname
-		return applicationName, &ErrNoPublicEndpoint{}
-	}
+        // If no prefix was specified, and the LoadBalancer provided us an ExternalIP,
+        // prepend the hostname with the Gateway name (for uniqueness)
+        if gateway.Hostname == nil {
+            // Auto-assign hostname: gatewayname.appname.ip.nip.io
+            return fmt.Sprintf("%s.%s", resource.Name, baseHostname), nil
+        }
+    } else if options.Hostname != "" {
+        baseHostname = options.Hostname
+    } else {
+        // In the case of no public endpoint, use the application name as the hostname
+        return applicationName, &ErrNoPublicEndpoint{}
+    }
 
-	// Prepend the prefix, if the user specified one
-	if gateway.Hostname != nil {
-		// Generate a hostname using the external IP
-		if gateway.Hostname.Prefix != "" {
-			// Auto-assign hostname: prefix.appname.ip.nip.io
-			return fmt.Sprintf("%s.%s", gateway.Hostname.Prefix, baseHostname), nil
-		} else {
-			return "", &ErrFQDNOrPrefixRequired{}
-		}
-	}
+    // Prepend the prefix, if the user specified one
+    if gateway.Hostname != nil {
+        // Generate a hostname using the external IP
+        if gateway.Hostname.Prefix != "" {
+            // Auto-assign hostname: prefix.appname.ip.nip.io
+            return fmt.Sprintf("%s.%s", gateway.Hostname.Prefix, baseHostname), nil
+        } else {
+            return "", &ErrFQDNOrPrefixRequired{}
+        }
+    }
 
-	return baseHostname, nil
+    return baseHostname, nil
 }
 
 // getPublicEndpoint adds http:// or https:// and the port (if it exists) to the given hostname
 func getPublicEndpoint(hostname string, port string, isHttps bool) string {
-	authority := hostname
-	if port != "" {
-		authority = net.JoinHostPort(hostname, port)
-	}
+    authority := hostname
+    if port != "" {
+        authority = net.JoinHostPort(hostname, port)
+    }
 
-	scheme := "http"
-	if isHttps {
-		scheme = "https"
-	}
+    scheme := "http"
+    if isHttps {
+        scheme = "https"
+    }
 
-	return fmt.Sprintf("%s://%s", scheme, authority)
+    return fmt.Sprintf("%s://%s", scheme, authority)
 }
+
+func isURL(input string) bool {
+    _, err := url.ParseRequestURI(input)
+    fmt.Println(err)
+    fmt.Println(input)
+    // if first character is a slash, it's not a URL. It's a path.
+    if (err != nil || input[0] == '/') {
+        return false
+    }
+    return true
+}
+
+func parseURL(sourceURL string) (scheme, hostname, port string, err error) {
+    u, err := url.Parse(sourceURL)
+    if err != nil {
+        return "", "", "", err
+    }
+
+    scheme = u.Scheme
+    host := u.Host
+
+    hostname, port, err = net.SplitHostPort(host)
+    if err != nil {
+        return "", "", "", err
+    }
+
+    return scheme, hostname, port, nil
+}
+

--- a/pkg/corerp/renderers/gateway/render.go
+++ b/pkg/corerp/renderers/gateway/render.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,24 +17,24 @@ limitations under the License.
 package gateway
 
 import (
-    "context"
-    "errors"
-    "fmt"
-    "net"
-    "net/url"
-    "strings"
-    "strconv"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"strconv"
 
-    contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-    v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
-    "github.com/project-radius/radius/pkg/corerp/datamodel"
-    "github.com/project-radius/radius/pkg/corerp/renderers"
-    "github.com/project-radius/radius/pkg/kubernetes"
-    "github.com/project-radius/radius/pkg/resourcekinds"
-    rpv1 "github.com/project-radius/radius/pkg/rp/v1"
-    "github.com/project-radius/radius/pkg/ucp/resources"
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	"github.com/project-radius/radius/pkg/corerp/datamodel"
+	"github.com/project-radius/radius/pkg/corerp/renderers"
+	"github.com/project-radius/radius/pkg/kubernetes"
+	"github.com/project-radius/radius/pkg/resourcekinds"
+	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
+	"github.com/project-radius/radius/pkg/ucp/resources"
 )
 
 type Renderer struct {
@@ -45,38 +45,38 @@ type Renderer struct {
 // GetDependencyIDs parses the gateway data model to get the resource IDs of the httpRoutes and the secretStore resource ID
 // from the certificateFrom property, and returns them as two slices of resource IDs.
 func (r Renderer) GetDependencyIDs(ctx context.Context, dm v1.DataModelInterface) (radiusResourceIDs []resources.ID, azureResourceIDs []resources.ID, err error) {
-    gateway, ok := dm.(*datamodel.Gateway)
-    if !ok {
-        return nil, nil, v1.ErrInvalidModelConversion
-    }
-    gtwyProperties := gateway.Properties
+	gateway, ok := dm.(*datamodel.Gateway)
+	if !ok {
+		return nil, nil, v1.ErrInvalidModelConversion
+	}
+	gtwyProperties := gateway.Properties
 
-    // Get all httpRoutes that are used by this gateway
-    for _, route := range gtwyProperties.Routes {
-        // Skip if destination is a URL. DNS-SD will resolve the route.
-        if (isURL(route.Destination)) {
-            continue
-        }
+	// Get all httpRoutes that are used by this gateway
+	for _, route := range gtwyProperties.Routes {
+		// Skip if destination is a URL. DNS-SD will resolve the route.
+		if (isURL(route.Destination)) {
+			continue
+		}
 
-        resourceID, err := resources.ParseResource(route.Destination)
-        if err != nil {
-            return nil, nil, v1.NewClientErrInvalidRequest(err.Error())
-        }
+		resourceID, err := resources.ParseResource(route.Destination)
+		if err != nil {
+			return nil, nil, v1.NewClientErrInvalidRequest(err.Error())
+		}
 
-        radiusResourceIDs = append(radiusResourceIDs, resourceID)
-    }
+		radiusResourceIDs = append(radiusResourceIDs, resourceID)
+	}
 
-    // Get secretStore resource ID from certificateFrom property
-    if gtwyProperties.TLS != nil && gtwyProperties.TLS.CertificateFrom != "" {
-        resourceID, err := resources.ParseResource(gtwyProperties.TLS.CertificateFrom)
-        if err != nil {
-            return nil, nil, v1.NewClientErrInvalidRequest(err.Error())
-        }
+	// Get secretStore resource ID from certificateFrom property
+	if gtwyProperties.TLS != nil && gtwyProperties.TLS.CertificateFrom != "" {
+		resourceID, err := resources.ParseResource(gtwyProperties.TLS.CertificateFrom)
+		if err != nil {
+			return nil, nil, v1.NewClientErrInvalidRequest(err.Error())
+		}
 
-        radiusResourceIDs = append(radiusResourceIDs, resourceID)
-    }
+		radiusResourceIDs = append(radiusResourceIDs, resourceID)
+	}
 
-    return radiusResourceIDs, azureResourceIDs, nil
+	return radiusResourceIDs, azureResourceIDs, nil
 }
 
 // # Function Explanation
@@ -84,52 +84,52 @@ func (r Renderer) GetDependencyIDs(ctx context.Context, dm v1.DataModelInterface
 // Render creates a gateway object and http route objects based on the given parameters, and returns them along
 // with a computed value for the gateway's public endpoint.
 func (r Renderer) Render(ctx context.Context, dm v1.DataModelInterface, options renderers.RenderOptions) (renderers.RendererOutput, error) {
-    outputResources := []rpv1.OutputResource{}
-    gateway, ok := dm.(*datamodel.Gateway)
-    if !ok {
-        return renderers.RendererOutput{}, v1.ErrInvalidModelConversion
-    }
-    appId, err := resources.ParseResource(gateway.Properties.Application)
-    if err != nil {
-        return renderers.RendererOutput{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("invalid application id: %s. id: %s", err.Error(), gateway.Properties.Application))
-    }
-    applicationName := appId.Name()
-    gatewayName := kubernetes.NormalizeResourceName(gateway.Name)
-    hostname, err := getHostname(*gateway, &gateway.Properties, applicationName, options.Environment.Gateway)
+	outputResources := []rpv1.OutputResource{}
+	gateway, ok := dm.(*datamodel.Gateway)
+	if !ok {
+		return renderers.RendererOutput{}, v1.ErrInvalidModelConversion
+	}
+	appId, err := resources.ParseResource(gateway.Properties.Application)
+	if err != nil {
+		return renderers.RendererOutput{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("invalid application id: %s. id: %s", err.Error(), gateway.Properties.Application))
+	}
+	applicationName := appId.Name()
+	gatewayName := kubernetes.NormalizeResourceName(gateway.Name)
+	hostname, err := getHostname(*gateway, &gateway.Properties, applicationName, options.Environment.Gateway)
 
-    var publicEndpoint string
-    if errors.Is(err, &ErrNoPublicEndpoint{}) {
-        publicEndpoint = "unknown"
-    } else if err != nil {
-        return renderers.RendererOutput{}, fmt.Errorf("getting hostname failed with error: %s", err)
-    } else {
-        isHttps := gateway.Properties.TLS != nil && (gateway.Properties.TLS.SSLPassthrough || gateway.Properties.TLS.CertificateFrom != "")
-        publicEndpoint = getPublicEndpoint(hostname, options.Environment.Gateway.Port, isHttps)
-    }
+	var publicEndpoint string
+	if errors.Is(err, &ErrNoPublicEndpoint{}) {
+		publicEndpoint = "unknown"
+	} else if err != nil {
+		return renderers.RendererOutput{}, fmt.Errorf("getting hostname failed with error: %s", err)
+	} else {
+		isHttps := gateway.Properties.TLS != nil && (gateway.Properties.TLS.SSLPassthrough || gateway.Properties.TLS.CertificateFrom != "")
+		publicEndpoint = getPublicEndpoint(hostname, options.Environment.Gateway.Port, isHttps)
+	}
 
-    gatewayObject, err := MakeGateway(ctx, options, gateway, gateway.Name, applicationName, hostname)
-    if err != nil {
-        return renderers.RendererOutput{}, err
-    }
+	gatewayObject, err := MakeGateway(ctx, options, gateway, gateway.Name, applicationName, hostname)
+	if err != nil {
+		return renderers.RendererOutput{}, err
+	}
 
-    outputResources = append(outputResources, gatewayObject)
+	outputResources = append(outputResources, gatewayObject)
 
-    computedValues := map[string]rpv1.ComputedValueReference{
-        "url": {
-            Value: publicEndpoint,
-        },
-    }
+	computedValues := map[string]rpv1.ComputedValueReference{
+		"url": {
+			Value: publicEndpoint,
+		},
+	}
 
-    httpRouteObjects, err := MakeHttpRoutes(ctx, options, *gateway, &gateway.Properties, gatewayName, applicationName)
-    if err != nil {
-        return renderers.RendererOutput{}, err
-    }
-    outputResources = append(outputResources, httpRouteObjects...)
+	httpRouteObjects, err := MakeHttpRoutes(ctx, options, *gateway, &gateway.Properties, gatewayName, applicationName)
+	if err != nil {
+		return renderers.RendererOutput{}, err
+	}
+	outputResources = append(outputResources, httpRouteObjects...)
 
-    return renderers.RendererOutput{
-        Resources:      outputResources,
-        ComputedValues: computedValues,
-    }, nil
+	return renderers.RendererOutput{
+		Resources:      outputResources,
+		ComputedValues: computedValues,
+	}, nil
 }
 
 // # Function Explanation
@@ -137,170 +137,170 @@ func (r Renderer) Render(ctx context.Context, dm v1.DataModelInterface, options 
 // MakeGateway validates the Gateway resource and its dependencies, and creates a Contour HTTPProxy resource
 // to act as the Gateway.
 func MakeGateway(ctx context.Context, options renderers.RenderOptions, gateway *datamodel.Gateway, resourceName string, applicationName string, hostname string) (rpv1.OutputResource, error) {
-    includes := []contourv1.Include{}
-    dependencies := options.Dependencies
+	includes := []contourv1.Include{}
+	dependencies := options.Dependencies
 
-    if len(gateway.Properties.Routes) < 1 {
-        return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("must have at least one route when declaring a Gateway resource")
-    }
+	if len(gateway.Properties.Routes) < 1 {
+		return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("must have at least one route when declaring a Gateway resource")
+	}
 
-    sslPassthrough := false
-    var contourTLSConfig *contourv1.TLS
+	sslPassthrough := false
+	var contourTLSConfig *contourv1.TLS
 
-    // configure TLS if it is enabled
-    if gateway.Properties.TLS != nil {
-        sslPassthrough = gateway.Properties.TLS.SSLPassthrough
+	// configure TLS if it is enabled
+	if gateway.Properties.TLS != nil {
+		sslPassthrough = gateway.Properties.TLS.SSLPassthrough
 
-        if gateway.Properties.TLS.CertificateFrom != "" {
-            secretStoreResourceId := gateway.Properties.TLS.CertificateFrom
-            secretStoreResource, ok := dependencies[secretStoreResourceId]
-            if !ok {
-                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
-            }
+		if gateway.Properties.TLS.CertificateFrom != "" {
+			secretStoreResourceId := gateway.Properties.TLS.CertificateFrom
+			secretStoreResource, ok := dependencies[secretStoreResourceId]
+			if !ok {
+				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
+			}
 
-            referencedResource := dependencies[secretStoreResourceId].Resource
-            if !strings.EqualFold(referencedResource.ResourceTypeName(), datamodel.SecretStoreResourceType) {
-                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource")
-            }
+			referencedResource := dependencies[secretStoreResourceId].Resource
+			if !strings.EqualFold(referencedResource.ResourceTypeName(), datamodel.SecretStoreResourceType) {
+				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource")
+			}
 
-            // Validate the secretStore resource: it must be of type certificate and have tls.crt and tls.key
-            secretStore, ok := referencedResource.(*datamodel.SecretStore)
-            if !ok {
-                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource")
-            }
+			// Validate the secretStore resource: it must be of type certificate and have tls.crt and tls.key
+			secretStore, ok := referencedResource.(*datamodel.SecretStore)
+			if !ok {
+				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource")
+			}
 
-            if secretStore.Properties.Type != datamodel.SecretTypeCert {
-                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource with type certificate")
-            }
+			if secretStore.Properties.Type != datamodel.SecretTypeCert {
+				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource with type certificate")
+			}
 
-            if secretStore.Properties.Data["tls.crt"] == nil {
-                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource with tls.crt")
-            }
+			if secretStore.Properties.Data["tls.crt"] == nil {
+				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource with tls.crt")
+			}
 
-            if secretStore.Properties.Data["tls.key"] == nil {
-                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource with tls.key")
-            }
+			if secretStore.Properties.Data["tls.key"] == nil {
+				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("certificateFrom must reference a secretStore resource with tls.key")
+			}
 
-            // Get the name and namespace of the Kubernetes secret resource from the secretStore OutputResources
-            if secretStoreResource.OutputResources == nil {
-                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
-            }
+			// Get the name and namespace of the Kubernetes secret resource from the secretStore OutputResources
+			if secretStoreResource.OutputResources == nil {
+				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
+			}
 
-            secretResource := secretStoreResource.OutputResources[rpv1.LocalIDSecret].Data
-            secretResourceData, ok := secretResource.(map[string]any)
-            if !ok {
-                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
-            }
+			secretResource := secretStoreResource.OutputResources[rpv1.LocalIDSecret].Data
+			secretResourceData, ok := secretResource.(map[string]any)
+			if !ok {
+				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
+			}
 
-            secretName, ok := secretResourceData["name"]
-            if !ok {
-                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
-            }
+			secretName, ok := secretResourceData["name"]
+			if !ok {
+				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
+			}
 
-            secretNamespace, ok := secretResourceData["namespace"]
-            if !ok {
-                return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
-            }
+			secretNamespace, ok := secretResourceData["namespace"]
+			if !ok {
+				return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("secretStore resource %s not found", secretStoreResourceId))
+			}
 
-            contourTLSConfig = &contourv1.TLS{
-                SecretName:             fmt.Sprintf("%s/%s", secretNamespace, secretName),
-                MinimumProtocolVersion: string(gateway.Properties.TLS.MinimumProtocolVersion),
-            }
-        }
-    }
+			contourTLSConfig = &contourv1.TLS{
+				SecretName:             fmt.Sprintf("%s/%s", secretNamespace, secretName),
+				MinimumProtocolVersion: string(gateway.Properties.TLS.MinimumProtocolVersion),
+			}
+		}
+	}
 
-    // If SSL Passthrough is enabled, then we can only have one route
-    if sslPassthrough && len(gateway.Properties.Routes) > 1 {
-        return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("cannot support multiple routes with sslPassthrough set to true")
-    }
+	// If SSL Passthrough is enabled, then we can only have one route
+	if sslPassthrough && len(gateway.Properties.Routes) > 1 {
+		return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("cannot support multiple routes with sslPassthrough set to true")
+	}
 
-    var route datamodel.GatewayRoute //route will hold the one sslPassthrough route, if sslPassthrough is true
-    for _, route = range gateway.Properties.Routes {
-        if sslPassthrough && (route.Path != "" || route.ReplacePrefix != "") {
-            return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("cannot support `path` or `replacePrefix` in routes with sslPassthrough set to true")
-        }
-        routeName, err := getRouteName(&route)
-        if err != nil {
-            return rpv1.OutputResource{}, err
-        }
+	var route datamodel.GatewayRoute //route will hold the one sslPassthrough route, if sslPassthrough is true
+	for _, route = range gateway.Properties.Routes {
+		if sslPassthrough && (route.Path != "" || route.ReplacePrefix != "") {
+			return rpv1.OutputResource{}, v1.NewClientErrInvalidRequest("cannot support `path` or `replacePrefix` in routes with sslPassthrough set to true")
+		}
+		routeName, err := getRouteName(&route)
+		if err != nil {
+			return rpv1.OutputResource{}, err
+		}
 
-        routeResourceName := kubernetes.NormalizeResourceName(routeName)
-        prefix := route.Path
-        if sslPassthrough {
-            prefix = "/"
-        }
-        includes = append(includes, contourv1.Include{
-            Name: routeResourceName,
-            Conditions: []contourv1.MatchCondition{
-                {
-                    Prefix: prefix,
-                },
-            },
-        })
-    }
+		routeResourceName := kubernetes.NormalizeResourceName(routeName)
+		prefix := route.Path
+		if sslPassthrough {
+			prefix = "/"
+		}
+		includes = append(includes, contourv1.Include{
+			Name: routeResourceName,
+			Conditions: []contourv1.MatchCondition{
+				{
+					Prefix: prefix,
+				},
+			},
+		})
+	}
 
-    virtualHostname := hostname
-    if hostname == "" {
-        // If the given hostname is empty, use the application name
-        // in order to make sure that this resource is seen as a root proxy.
-        virtualHostname = applicationName
-    }
+	virtualHostname := hostname
+	if hostname == "" {
+		// If the given hostname is empty, use the application name
+		// in order to make sure that this resource is seen as a root proxy.
+		virtualHostname = applicationName
+	}
 
-    virtualHost := &contourv1.VirtualHost{
-        Fqdn: virtualHostname,
-        TLS:  contourTLSConfig,
-    }
+	virtualHost := &contourv1.VirtualHost{
+		Fqdn: virtualHostname,
+		TLS:  contourTLSConfig,
+	}
 
-    var tcpProxy *contourv1.TCPProxy
-    if sslPassthrough {
-        virtualHost.TLS = &contourv1.TLS{
-            Passthrough: true,
-        }
+	var tcpProxy *contourv1.TCPProxy
+	if sslPassthrough {
+		virtualHost.TLS = &contourv1.TLS{
+			Passthrough: true,
+		}
 
-        routeProperties := options.Dependencies[route.Destination]
-        port := renderers.DefaultSecurePort
-        routePort, ok := routeProperties.ComputedValues["port"].(float64)
-        if ok {
-            port = int32(routePort)
-        }
+		routeProperties := options.Dependencies[route.Destination]
+		port := renderers.DefaultSecurePort
+		routePort, ok := routeProperties.ComputedValues["port"].(float64)
+		if ok {
+			port = int32(routePort)
+		}
 
-        routeName, err := getRouteName(&route)
-        if err != nil {
-            return rpv1.OutputResource{}, err
-        }
+		routeName, err := getRouteName(&route)
+		if err != nil {
+			return rpv1.OutputResource{}, err
+		}
 
-        tcpProxy = &contourv1.TCPProxy{
-            Services: []contourv1.Service{
-                {
-                    Name: kubernetes.NormalizeResourceName(routeName),
-                    Port: int(port),
-                },
-            },
-        }
-    }
+		tcpProxy = &contourv1.TCPProxy{
+			Services: []contourv1.Service{
+				{
+					Name: kubernetes.NormalizeResourceName(routeName),
+					Port: int(port),
+				},
+			},
+		}
+	}
 
-    // The root HTTPProxy object acts as the Gateway
-    rootHTTPProxy := &contourv1.HTTPProxy{
-        TypeMeta: metav1.TypeMeta{
-            Kind:       "HTTPProxy",
-            APIVersion: contourv1.SchemeGroupVersion.String(),
-        },
-        ObjectMeta: metav1.ObjectMeta{
-            Name:        kubernetes.NormalizeResourceName(resourceName),
-            Namespace:   options.Environment.Namespace,
-            Labels:      renderers.GetLabels(ctx, options, applicationName, resourceName, gateway.ResourceTypeName()),
-            Annotations: renderers.GetAnnotations(ctx, options),
-        },
-        Spec: contourv1.HTTPProxySpec{
-            VirtualHost: virtualHost,
-            Includes:    includes,
-        },
-    }
-    if sslPassthrough {
-        rootHTTPProxy.Spec.TCPProxy = tcpProxy
-    }
+	// The root HTTPProxy object acts as the Gateway
+	rootHTTPProxy := &contourv1.HTTPProxy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HTTPProxy",
+			APIVersion: contourv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        kubernetes.NormalizeResourceName(resourceName),
+			Namespace:   options.Environment.Namespace,
+			Labels:      renderers.GetLabels(ctx, options, applicationName, resourceName, gateway.ResourceTypeName()),
+			Annotations: renderers.GetAnnotations(ctx, options),
+		},
+		Spec: contourv1.HTTPProxySpec{
+			VirtualHost: virtualHost,
+			Includes:    includes,
+		},
+	}
+	if sslPassthrough {
+		rootHTTPProxy.Spec.TCPProxy = tcpProxy
+	}
 
-    return rpv1.NewKubernetesOutputResource(resourcekinds.Gateway, rpv1.LocalIDGateway, rootHTTPProxy, rootHTTPProxy.ObjectMeta), nil
+	return rpv1.NewKubernetesOutputResource(resourcekinds.Gateway, rpv1.LocalIDGateway, rootHTTPProxy, rootHTTPProxy.ObjectMeta), nil
 }
 
 // # Function Explanation
@@ -308,231 +308,231 @@ func MakeGateway(ctx context.Context, options renderers.RenderOptions, gateway *
 // MakeHttpRoutes creates HTTPProxy objects for each route in the gateway and returns them as OutputResources. It returns
 // an error if it fails to get the route name.
 func MakeHttpRoutes(ctx context.Context, options renderers.RenderOptions, resource datamodel.Gateway, gateway *datamodel.GatewayProperties, gatewayName string, applicationName string) ([]rpv1.OutputResource, error) {
-    dependencies := options.Dependencies
-    objects := make(map[string]*contourv1.HTTPProxy)
+	dependencies := options.Dependencies
+	objects := make(map[string]*contourv1.HTTPProxy)
 
-    for _, route := range gateway.Routes {
-        routeProperties := dependencies[route.Destination]
-        port := renderers.DefaultPort
-        routePort, ok := routeProperties.ComputedValues["port"].(float64)
-        if ok {
-            port = int32(routePort)
-        }
+	for _, route := range gateway.Routes {
+		routeProperties := dependencies[route.Destination]
+		port := renderers.DefaultPort
+		routePort, ok := routeProperties.ComputedValues["port"].(float64)
+		if ok {
+			port = int32(routePort)
+		}
 
-        // if the route destination is a URL, then we need to parse the port from the URL
-        if isURL(route.Destination) {
-            _, _, urlPort, err := parseURL(route.Destination)
-            if err != nil {
-                return []rpv1.OutputResource{}, err
-            }
+		// if the route destination is a URL, then we need to parse the port from the URL
+		if isURL(route.Destination) {
+			_, _, urlPort, err := parseURL(route.Destination)
+			if err != nil {
+				return []rpv1.OutputResource{}, err
+			}
 
-            intURLport, err := strconv.Atoi(urlPort)
-            if err != nil {
-                return []rpv1.OutputResource{}, err
-            }
+			intURLport, err := strconv.Atoi(urlPort)
+			if err != nil {
+				return []rpv1.OutputResource{}, err
+			}
 
-            // bound check intURLport
-            if intURLport < 0 || intURLport > 65535 {
-                return []rpv1.OutputResource{}, fmt.Errorf("port %d is out of range", intURLport)
-            }
-            
-            port = int32(intURLport)
-        }
+			// bound check intURLport
+			if intURLport < 0 || intURLport > 65535 {
+				return []rpv1.OutputResource{}, fmt.Errorf("port %d is out of range", intURLport)
+			}
+			
+			port = int32(intURLport)
+		}
 
-        routeName, err := getRouteName(&route)
-        if err != nil {
-            return []rpv1.OutputResource{}, err
-        }
+		routeName, err := getRouteName(&route)
+		if err != nil {
+			return []rpv1.OutputResource{}, err
+		}
 
-        // Create unique localID for dependency graph
-        localID := fmt.Sprintf("%s-%s", rpv1.LocalIDHttpRoute, routeName)
-        routeResourceName := kubernetes.NormalizeResourceName(routeName)
+		// Create unique localID for dependency graph
+		localID := fmt.Sprintf("%s-%s", rpv1.LocalIDHttpRoute, routeName)
+		routeResourceName := kubernetes.NormalizeResourceName(routeName)
 
-        var pathRewritePolicy *contourv1.PathRewritePolicy
-        if route.ReplacePrefix != "" {
-            pathRewritePolicy = &contourv1.PathRewritePolicy{
-                ReplacePrefix: []contourv1.ReplacePrefix{
-                    {
-                        Prefix:      route.Path,
-                        Replacement: route.ReplacePrefix,
-                    },
-                },
-            }
-        }
+		var pathRewritePolicy *contourv1.PathRewritePolicy
+		if route.ReplacePrefix != "" {
+			pathRewritePolicy = &contourv1.PathRewritePolicy{
+				ReplacePrefix: []contourv1.ReplacePrefix{
+					{
+						Prefix:      route.Path,
+						Replacement: route.ReplacePrefix,
+					},
+				},
+			}
+		}
 
-        // If this route already exists, append to it
-        if object, exists := objects[localID]; exists {
-            if pathRewritePolicy != nil {
-            outer:
-                for i := range object.Spec.Routes {
-                    for _, service := range object.Spec.Routes[i].Services {
-                        if service.Name == routeResourceName {
-                            if object.Spec.Routes[i].PathRewritePolicy == nil {
-                                object.Spec.Routes[i].PathRewritePolicy = pathRewritePolicy
-                            } else {
-                                object.Spec.Routes[i].PathRewritePolicy.ReplacePrefix = append(object.Spec.Routes[i].PathRewritePolicy.ReplacePrefix, pathRewritePolicy.ReplacePrefix[0])
-                            }
+		// If this route already exists, append to it
+		if object, exists := objects[localID]; exists {
+			if pathRewritePolicy != nil {
+			outer:
+				for i := range object.Spec.Routes {
+					for _, service := range object.Spec.Routes[i].Services {
+						if service.Name == routeResourceName {
+							if object.Spec.Routes[i].PathRewritePolicy == nil {
+								object.Spec.Routes[i].PathRewritePolicy = pathRewritePolicy
+							} else {
+								object.Spec.Routes[i].PathRewritePolicy.ReplacePrefix = append(object.Spec.Routes[i].PathRewritePolicy.ReplacePrefix, pathRewritePolicy.ReplacePrefix[0])
+							}
 
-                            break outer
-                        }
-                    }
-                }
-            }
+							break outer
+						}
+					}
+				}
+			}
 
-            continue
-        }
+			continue
+		}
 
-        httpProxyObject := &contourv1.HTTPProxy{
-            TypeMeta: metav1.TypeMeta{
-                Kind:       "HTTPProxy",
-                APIVersion: contourv1.SchemeGroupVersion.String(),
-            },
-            ObjectMeta: metav1.ObjectMeta{
-                Name:        routeResourceName,
-                Namespace:   options.Environment.Namespace,
-                Labels:      renderers.GetLabels(ctx, options, applicationName, routeName, resource.ResourceTypeName()),
-                Annotations: renderers.GetAnnotations(ctx, options),
-            },
-            Spec: contourv1.HTTPProxySpec{
-                Routes: []contourv1.Route{
-                    {
-                        Services: []contourv1.Service{
-                            {
-                                Name: routeResourceName,
-                                Port: int(port),
-                            },
-                        },
-                        PathRewritePolicy: pathRewritePolicy,
-                    },
-                },
-            },
-        }
+		httpProxyObject := &contourv1.HTTPProxy{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "HTTPProxy",
+				APIVersion: contourv1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        routeResourceName,
+				Namespace:   options.Environment.Namespace,
+				Labels:      renderers.GetLabels(ctx, options, applicationName, routeName, resource.ResourceTypeName()),
+				Annotations: renderers.GetAnnotations(ctx, options),
+			},
+			Spec: contourv1.HTTPProxySpec{
+				Routes: []contourv1.Route{
+					{
+						Services: []contourv1.Service{
+							{
+								Name: routeResourceName,
+								Port: int(port),
+							},
+						},
+						PathRewritePolicy: pathRewritePolicy,
+					},
+				},
+			},
+		}
 
-        objects[localID] = httpProxyObject
-    }
+		objects[localID] = httpProxyObject
+	}
 
-    var outputResources []rpv1.OutputResource
-    for localID, object := range objects {
-        outputResources = append(outputResources, rpv1.NewKubernetesOutputResource(resourcekinds.KubernetesHTTPRoute, localID, object, object.ObjectMeta))
-    }
+	var outputResources []rpv1.OutputResource
+	for localID, object := range objects {
+		outputResources = append(outputResources, rpv1.NewKubernetesOutputResource(resourcekinds.KubernetesHTTPRoute, localID, object, object.ObjectMeta))
+	}
 
-    return outputResources, nil
+	return outputResources, nil
 }
 
 func getRouteName(route *datamodel.GatewayRoute) (string, error) {
-    // if isURL, then name is hostname (DNS-SD case)
-    if isURL(route.Destination) {
-        u, err := url.Parse(route.Destination)
-        if err != nil {
-            return "", v1.NewClientErrInvalidRequest(err.Error())
-        }
+	// if isURL, then name is hostname (DNS-SD case)
+	if isURL(route.Destination) {
+		u, err := url.Parse(route.Destination)
+		if err != nil {
+			return "", v1.NewClientErrInvalidRequest(err.Error())
+		}
 
-        return u.Hostname(), nil
-    }
+		return u.Hostname(), nil
+	}
 
-    // if not URL, then name is the resourceID (HTTProute case)
-    resourceID, err := resources.ParseResource(route.Destination)
-    if err != nil {
-        return "", v1.NewClientErrInvalidRequest(err.Error())
-    }
+	// if not URL, then name is the resourceID (HTTProute case)
+	resourceID, err := resources.ParseResource(route.Destination)
+	if err != nil {
+		return "", v1.NewClientErrInvalidRequest(err.Error())
+	}
 
-    return resourceID.Name(), nil
+	return resourceID.Name(), nil
 }
 
 // getHostname returns the hostname of the public endpoint of the Gateway.
 // This sometimes involves transforming the external IP of the cluster into
 // a hostname that's unique to this Gateway and Application.
 func getHostname(resource datamodel.Gateway, gateway *datamodel.GatewayProperties, applicationName string, options renderers.GatewayOptions) (string, error) {
-    // Handle the explicit override case (return)
-    // Handle the explicit FQDN case (return)
-    // Select the 'base' hostname (convert IP to hostname)
-    // If a prefix is not specified and the LoadBalancer provided an IP, then prepend with the gateway name
-    // Prepend the prefix, if one is specified
-    // Return the (possibly altered) hostname
+	// Handle the explicit override case (return)
+	// Handle the explicit FQDN case (return)
+	// Select the 'base' hostname (convert IP to hostname)
+	// If a prefix is not specified and the LoadBalancer provided an IP, then prepend with the gateway name
+	// Prepend the prefix, if one is specified
+	// Return the (possibly altered) hostname
 
-    if options.PublicEndpointOverride {
-        // Specified from --public-endpoint-override CLI flag
-        return options.Hostname, nil
-    } else if gateway.Hostname != nil && gateway.Hostname.FullyQualifiedHostname != "" {
-        // Trust that the provided FullyQualifiedHostname actually works
-        return gateway.Hostname.FullyQualifiedHostname, nil
-    }
+	if options.PublicEndpointOverride {
+		// Specified from --public-endpoint-override CLI flag
+		return options.Hostname, nil
+	} else if gateway.Hostname != nil && gateway.Hostname.FullyQualifiedHostname != "" {
+		// Trust that the provided FullyQualifiedHostname actually works
+		return gateway.Hostname.FullyQualifiedHostname, nil
+	}
 
-    // baseHostname represents the base hostname that may be prepended with the given prefix
-    // or gateway name. After this block, baseHostname looks like either:
-    // 1. a hostname from the LoadBalancer
-    // 2. appname.IP.nip.io
-    var baseHostname string
-    if options.ExternalIP != "" {
-        baseHostname = fmt.Sprintf("%s.%s.nip.io", applicationName, options.ExternalIP)
+	// baseHostname represents the base hostname that may be prepended with the given prefix
+	// or gateway name. After this block, baseHostname looks like either:
+	// 1. a hostname from the LoadBalancer
+	// 2. appname.IP.nip.io
+	var baseHostname string
+	if options.ExternalIP != "" {
+		baseHostname = fmt.Sprintf("%s.%s.nip.io", applicationName, options.ExternalIP)
 
-        // If no prefix was specified, and the LoadBalancer provided us an ExternalIP,
-        // prepend the hostname with the Gateway name (for uniqueness)
-        if gateway.Hostname == nil {
-            // Auto-assign hostname: gatewayname.appname.ip.nip.io
-            return fmt.Sprintf("%s.%s", resource.Name, baseHostname), nil
-        }
-    } else if options.Hostname != "" {
-        baseHostname = options.Hostname
-    } else {
-        // In the case of no public endpoint, use the application name as the hostname
-        return applicationName, &ErrNoPublicEndpoint{}
-    }
+		// If no prefix was specified, and the LoadBalancer provided us an ExternalIP,
+		// prepend the hostname with the Gateway name (for uniqueness)
+		if gateway.Hostname == nil {
+			// Auto-assign hostname: gatewayname.appname.ip.nip.io
+			return fmt.Sprintf("%s.%s", resource.Name, baseHostname), nil
+		}
+	} else if options.Hostname != "" {
+		baseHostname = options.Hostname
+	} else {
+		// In the case of no public endpoint, use the application name as the hostname
+		return applicationName, &ErrNoPublicEndpoint{}
+	}
 
-    // Prepend the prefix, if the user specified one
-    if gateway.Hostname != nil {
-        // Generate a hostname using the external IP
-        if gateway.Hostname.Prefix != "" {
-            // Auto-assign hostname: prefix.appname.ip.nip.io
-            return fmt.Sprintf("%s.%s", gateway.Hostname.Prefix, baseHostname), nil
-        } else {
-            return "", &ErrFQDNOrPrefixRequired{}
-        }
-    }
+	// Prepend the prefix, if the user specified one
+	if gateway.Hostname != nil {
+		// Generate a hostname using the external IP
+		if gateway.Hostname.Prefix != "" {
+			// Auto-assign hostname: prefix.appname.ip.nip.io
+			return fmt.Sprintf("%s.%s", gateway.Hostname.Prefix, baseHostname), nil
+		} else {
+			return "", &ErrFQDNOrPrefixRequired{}
+		}
+	}
 
-    return baseHostname, nil
+	return baseHostname, nil
 }
 
 // getPublicEndpoint adds http:// or https:// and the port (if it exists) to the given hostname
 func getPublicEndpoint(hostname string, port string, isHttps bool) string {
-    authority := hostname
-    if port != "" {
-        authority = net.JoinHostPort(hostname, port)
-    }
+	authority := hostname
+	if port != "" {
+		authority = net.JoinHostPort(hostname, port)
+	}
 
-    scheme := "http"
-    if isHttps {
-        scheme = "https"
-    }
+	scheme := "http"
+	if isHttps {
+		scheme = "https"
+	}
 
-    return fmt.Sprintf("%s://%s", scheme, authority)
+	return fmt.Sprintf("%s://%s", scheme, authority)
 }
 
 func isURL(input string) bool {
-    _, err := url.ParseRequestURI(input)
-    fmt.Println(err)
-    fmt.Println(input)
-    // if first character is a slash, it's not a URL. It's a path.
-    if (err != nil || input[0] == '/') {
-        return false
-    }
-    return true
+	_, err := url.ParseRequestURI(input)
+	fmt.Println(err)
+	fmt.Println(input)
+	// if first character is a slash, it's not a URL. It's a path.
+	if (err != nil || input[0] == '/') {
+		return false
+	}
+	return true
 }
 
 func parseURL(sourceURL string) (scheme, hostname, port string, err error) {
-    u, err := url.Parse(sourceURL)
-    if err != nil {
-        return "", "", "", err
-    }
+	u, err := url.Parse(sourceURL)
+	if err != nil {
+		return "", "", "", err
+	}
 
-    scheme = u.Scheme
-    host := u.Host
+	scheme = u.Scheme
+	host := u.Host
 
-    hostname, port, err = net.SplitHostPort(host)
-    if err != nil {
-        return "", "", "", err
-    }
+	hostname, port, err = net.SplitHostPort(host)
+	if err != nil {
+		return "", "", "", err
+	}
 
-    return scheme, hostname, port, nil
+	return scheme, hostname, port, nil
 }
 

--- a/pkg/corerp/renderers/gateway/render_test.go
+++ b/pkg/corerp/renderers/gateway/render_test.go
@@ -1224,6 +1224,113 @@ func Test_Render_WithEnvironmentApplication_KubernetesMetadata(t *testing.T) {
 	validateHttpRoute(t, output.Resources, routeName, 80, nil, envAppKubeMetadata)
 }
 
+func Test_RenderDNS_WithEnvironmentApplication_KubernetesMetadata(t *testing.T) {
+	r := &Renderer{}
+
+	routePathA := "/routea"
+    validPortDestination := "http://test-cntr:3234"
+    routeA := datamodel.GatewayRoute{
+        Destination: validPortDestination,
+        Path:        routePathA,
+    }
+
+	var routes []datamodel.GatewayRoute
+	routeName := "test-cntr"
+	path := "/routea"
+	routes = append(routes, routeA)
+	properties := datamodel.GatewayProperties{
+		BasicResourceProperties: rpv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		},
+		Routes: routes,
+	}
+	resource := makeResource(t, properties)
+	dependencies := map[string]renderers.RendererDependency{}
+	environmentOptions := getEnvironmentOptions("", testExternalIP, "", false, true)
+	applicationOptions := getApplicationOptions(true)
+	expectedHostname := fmt.Sprintf("%s.%s.%s.nip.io", resourceName, applicationName, testExternalIP)
+	expectedURL := "http://" + expectedHostname
+
+	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions, Application: applicationOptions})
+	require.NoError(t, err)
+	require.Len(t, output.Resources, 2)
+	require.Empty(t, output.SecretValues)
+	require.Equal(t, expectedURL, output.ComputedValues["url"].Value)
+
+	expectedIncludes := []contourv1.Include{
+		{
+			Name: kubernetes.NormalizeResourceName(routeName),
+			Conditions: []contourv1.MatchCondition{
+				{
+					Prefix: path,
+				},
+			},
+		},
+	}
+
+	expectedGatewaySpec := &contourv1.HTTPProxySpec{
+		VirtualHost: &contourv1.VirtualHost{
+			Fqdn: expectedHostname,
+		},
+		Includes: expectedIncludes,
+	}
+
+	validateGateway(t, output.Resources, expectedGatewaySpec, envAppKubeMetadata)
+}
+
+func Test_RenderDNS_WithEnvironment_KubernetesMetadata(t *testing.T) {
+	r := &Renderer{}
+
+	routePathA := "/routea"
+    validPortDestination := "http://test-cntr:3234"
+    routeA := datamodel.GatewayRoute{
+        Destination: validPortDestination,
+        Path:        routePathA,
+    }
+
+	var routes []datamodel.GatewayRoute
+	routeName := "test-cntr"
+	path := "/routea"
+	routes = append(routes, routeA)
+	properties := datamodel.GatewayProperties{
+		BasicResourceProperties: rpv1.BasicResourceProperties{
+			Application: "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-application",
+		},
+		Routes: routes,
+	}
+	resource := makeResource(t, properties)
+	dependencies := map[string]renderers.RendererDependency{}
+	environmentOptions := getEnvironmentOptions("", testExternalIP, "", false, true)
+	expectedHostname := fmt.Sprintf("%s.%s.%s.nip.io", resourceName, applicationName, testExternalIP)
+	expectedURL := "http://" + expectedHostname
+
+	output, err := r.Render(context.Background(), resource, renderers.RenderOptions{Dependencies: dependencies, Environment: environmentOptions})
+	require.NoError(t, err)
+	require.Len(t, output.Resources, 2)
+	require.Empty(t, output.SecretValues)
+	require.Equal(t, expectedURL, output.ComputedValues["url"].Value)
+
+	expectedIncludes := []contourv1.Include{
+		{
+			Name: kubernetes.NormalizeResourceName(routeName),
+			Conditions: []contourv1.MatchCondition{
+				{
+					Prefix: path,
+				},
+			},
+		},
+	}
+
+	expectedGatewaySpec := &contourv1.HTTPProxySpec{
+		VirtualHost: &contourv1.VirtualHost{
+			Fqdn: expectedHostname,
+		},
+		Includes: expectedIncludes,
+	}
+
+	validateGateway(t, output.Resources, expectedGatewaySpec, envKubeMetadata)
+}
+
 func Test_Render_With_TLSTermination(t *testing.T) {
 	r := &Renderer{}
 
@@ -1303,12 +1410,14 @@ func Test_ParseURL(t *testing.T) {
 	const valid_url = "http://examplehost:80"
 	const invalid_url = "http://abc:def"
 	const invalid_port_url = "http://examplehost:99999"
+	const valid_default_http_url = "http://examplehost"
+	const valid_default_https_url = "https://examplehost"
 
 	t.Run("valid URL test", func(t *testing.T) {
 		scheme, hostname, port, err := parseURL(valid_url)
 		require.Equal(t, scheme, "http")
 		require.Equal(t, hostname, "examplehost")
-		require.Equal(t, port, "80")
+		require.Equal(t, port, int32(80))
 		require.Equal(t, err, nil)
 	})
 
@@ -1316,7 +1425,7 @@ func Test_ParseURL(t *testing.T) {
 		scheme, hostname, port, err := parseURL(invalid_url)
 		require.Equal(t, scheme, "")
 		require.Equal(t, hostname, "")
-		require.Equal(t, port, "")
+		require.Equal(t, port, int32(0))
 		require.NotEqual(t, err, nil)
 	})
 
@@ -1324,9 +1433,40 @@ func Test_ParseURL(t *testing.T) {
 		scheme, hostname, port, err := parseURL(invalid_port_url)
 		require.Equal(t, scheme, "")
 		require.Equal(t, hostname, "")
-		require.Equal(t, port, "")
-		require.Equal(t, err, fmt.Errorf("port 99999 is out of range"))
+		require.Equal(t, port, int32(0))
+		require.Equal(t, err, fmt.Errorf("port 0 is out of range"))
 	})
+
+	t.Run("valid default http URL test", func(t *testing.T) {
+		scheme, hostname, port, err := parseURL(valid_default_http_url)
+		require.Equal(t, err, nil)
+		require.Equal(t, scheme, "http")
+		require.Equal(t, hostname, "examplehost")
+		require.Equal(t, port, int32(80))
+		require.Equal(t, err, nil)
+	})
+
+	t.Run("valid default https URL test", func(t *testing.T) {
+		scheme, hostname, port, err := parseURL(valid_default_https_url)
+		require.Equal(t, scheme, "https")
+		require.Equal(t, hostname, "examplehost")
+		require.Equal(t, port, int32(443))
+		require.Equal(t, err, nil)
+	})
+}
+
+func Test_IsURL(t *testing.T) {
+	const valid_url = "http://examplehost:80"
+	const invalid_url = "http://abc:def"
+	const valid_default_http_url = "http://examplehost"
+	const valid_default_https_url = "https://examplehost"
+	const path = "/testpath/testfolder/testfile.txt"
+
+	require.True(t, isURL(valid_url))
+	require.False(t, isURL(invalid_url))
+	require.False(t, isURL(path))
+	require.True(t, isURL(valid_default_http_url))
+	require.True(t, isURL(valid_default_https_url))
 }
 
 func validateGateway(t *testing.T, outputResources []rpv1.OutputResource, expectedGatewaySpec *contourv1.HTTPProxySpec, kmeOption string) {

--- a/pkg/corerp/renderers/gateway/render_test.go
+++ b/pkg/corerp/renderers/gateway/render_test.go
@@ -1228,11 +1228,11 @@ func Test_RenderDNS_WithEnvironmentApplication_KubernetesMetadata(t *testing.T) 
 	r := &Renderer{}
 
 	routePathA := "/routea"
-    validPortDestination := "http://test-cntr:3234"
-    routeA := datamodel.GatewayRoute{
-        Destination: validPortDestination,
-        Path:        routePathA,
-    }
+	validURL := "http://test-cntr:3234"
+	routeA := datamodel.GatewayRoute{
+		Destination: validURL,
+		Path:        routePathA,
+	}
 
 	var routes []datamodel.GatewayRoute
 	routeName := "test-cntr"
@@ -1282,11 +1282,11 @@ func Test_RenderDNS_WithEnvironment_KubernetesMetadata(t *testing.T) {
 	r := &Renderer{}
 
 	routePathA := "/routea"
-    validPortDestination := "http://test-cntr:3234"
-    routeA := datamodel.GatewayRoute{
-        Destination: validPortDestination,
-        Path:        routePathA,
-    }
+	validPortDestination := "http://test-cntr:3234"
+	routeA := datamodel.GatewayRoute{
+		Destination: validPortDestination,
+		Path:        routePathA,
+	}
 
 	var routes []datamodel.GatewayRoute
 	routeName := "test-cntr"

--- a/pkg/corerp/renderers/gateway/render_test.go
+++ b/pkg/corerp/renderers/gateway/render_test.go
@@ -1299,6 +1299,36 @@ func Test_Render_With_TLSTermination(t *testing.T) {
 	validateGateway(t, output.Resources, expectedGatewaySpec, "")
 }
 
+func Test_ParseURL(t *testing.T) {
+	const valid_url = "http://examplehost:80"
+	const invalid_url = "http://abc:def"
+	const invalid_port_url = "http://examplehost:99999"
+
+	t.Run("valid URL test", func(t *testing.T) {
+		scheme, hostname, port, err := parseURL(valid_url)
+		require.Equal(t, scheme, "http")
+		require.Equal(t, hostname, "examplehost")
+		require.Equal(t, port, "80")
+		require.Equal(t, err, nil)
+	})
+
+	t.Run("invalid URL test", func(t *testing.T) {
+		scheme, hostname, port, err := parseURL(invalid_url)
+		require.Equal(t, scheme, "")
+		require.Equal(t, hostname, "")
+		require.Equal(t, port, "")
+		require.NotEqual(t, err, nil)
+	})
+
+	t.Run("invalid port URL test", func(t *testing.T) {
+		scheme, hostname, port, err := parseURL(invalid_port_url)
+		require.Equal(t, scheme, "")
+		require.Equal(t, hostname, "")
+		require.Equal(t, port, "")
+		require.Equal(t, err, fmt.Errorf("port 99999 is out of range"))
+	})
+}
+
 func validateGateway(t *testing.T, outputResources []rpv1.OutputResource, expectedGatewaySpec *contourv1.HTTPProxySpec, kmeOption string) {
 	gateway, gatewayOutputResource := kubernetes.FindGateway(outputResources)
 

--- a/test/functional/shared/resources/gateway_test.go
+++ b/test/functional/shared/resources/gateway_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/functional/shared/resources/gateway_test.go
+++ b/test/functional/shared/resources/gateway_test.go
@@ -212,9 +212,8 @@ func Test_GatewayDNS(t *testing.T) {
 						ExpectedStatusCode: http.StatusNotFound,
 					},
 				})
-				
+
 				require.NoError(t, err)
-				require.Fail(t, "Gateway tests failed")
 			},
 		},
 	})

--- a/test/functional/shared/resources/gateway_test.go
+++ b/test/functional/shared/resources/gateway_test.go
@@ -157,7 +157,7 @@ func Test_GatewayDNS(t *testing.T) {
                         Type: validation.ApplicationsResource,
                     },
                     {
-                        Name: "http-gtwy-gtwy",
+                        Name: "http-gtwy-gtwy-dns",
                         Type: validation.GatewaysResource,
                         App:  name,
                     },
@@ -180,7 +180,7 @@ func Test_GatewayDNS(t *testing.T) {
                         validation.NewK8sPodForResource(name, "backendcontainerdns"),
                         validation.NewK8sServiceForResource(name, "frontendcontainerdns"),
                         validation.NewK8sServiceForResource(name, "backendcontainerdns"),
-                        validation.NewK8sHTTPProxyForResource(name, "http-gtwy-gtwy"),
+                        validation.NewK8sHTTPProxyForResource(name, "http-gtwy-gtwy-dns"),
                         validation.NewK8sHTTPProxyForResource(name, "frontendcontainerdns"),
                         validation.NewK8sHTTPProxyForResource(name, "backendcontainerdns"),
                     },

--- a/test/functional/shared/resources/gateway_test.go
+++ b/test/functional/shared/resources/gateway_test.go
@@ -212,13 +212,8 @@ func Test_GatewayDNS(t *testing.T) {
 						ExpectedStatusCode: http.StatusNotFound,
 					},
 				})
-				if err != nil {
-					t.Logf("Failed to test Gateway via portforward with error: %s", err)
-				} else {
-					// Successfully ran tests
-					return
-				}
-
+				
+				require.NoError(t, err)
 				require.Fail(t, "Gateway tests failed")
 			},
 		},

--- a/test/functional/shared/resources/gateway_test.go
+++ b/test/functional/shared/resources/gateway_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,447 +17,447 @@ limitations under the License.
 package resource_test
 
 import (
-    "context"
-    "crypto/tls"
-    "fmt"
-    "net"
-    "net/http"
-    "strings"
-    "testing"
-    "time"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
 
-    "github.com/project-radius/radius/test/functional"
-    "github.com/project-radius/radius/test/functional/shared"
-    "github.com/project-radius/radius/test/step"
-    "github.com/project-radius/radius/test/validation"
-    "github.com/stretchr/testify/require"
+	"github.com/project-radius/radius/test/functional"
+	"github.com/project-radius/radius/test/functional/shared"
+	"github.com/project-radius/radius/test/step"
+	"github.com/project-radius/radius/test/validation"
+	"github.com/stretchr/testify/require"
 )
 
 const (
-    retries         = 3
-    httpRemotePort  = 8080
-    httpsRemotePort = 8443
-    retryTimeout    = 1 * time.Minute
-    retryBackoff    = 1 * time.Second
+	retries         = 3
+	httpRemotePort  = 8080
+	httpsRemotePort = 8443
+	retryTimeout    = 1 * time.Minute
+	retryBackoff    = 1 * time.Second
 )
 
 // GatewayTestConfig is a struct that contains the configuration for a Gateway test
 type GatewayTestConfig struct {
-    Path               string
-    ExpectedStatusCode int
+	Path               string
+	ExpectedStatusCode int
 }
 
 func Test_Gateway(t *testing.T) {
-    template := "testdata/corerp-resources-gateway.bicep"
-    name := "corerp-resources-gateway"
-    appNamespace := "default-corerp-resources-gateway"
+	template := "testdata/corerp-resources-gateway.bicep"
+	name := "corerp-resources-gateway"
+	appNamespace := "default-corerp-resources-gateway"
 
-    test := shared.NewRPTest(t, name, []shared.TestStep{
-        {
-            Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
-            RPResources: &validation.RPResourceSet{
-                Resources: []validation.RPResource{
-                    {
-                        Name: name,
-                        Type: validation.ApplicationsResource,
-                    },
-                    {
-                        Name: "http-gtwy-gtwy",
-                        Type: validation.GatewaysResource,
-                        App:  name,
-                    },
-                    {
-                        Name: "http-gtwy-front-rte",
-                        Type: validation.HttpRoutesResource,
-                        App:  name,
-                    },
-                    {
-                        Name: "http-gtwy-front-ctnr",
-                        Type: validation.ContainersResource,
-                        App:  name,
-                    },
-                    {
-                        Name: "http-gtwy-back-rte",
-                        Type: validation.HttpRoutesResource,
-                        App:  name,
-                    },
-                    {
-                        Name: "http-gtwy-back-ctnr",
-                        Type: validation.ContainersResource,
-                        App:  name,
-                    },
-                },
-            },
-            K8sObjects: &validation.K8sObjectSet{
-                Namespaces: map[string][]validation.K8sObject{
-                    appNamespace: {
-                        validation.NewK8sPodForResource(name, "http-gtwy-front-ctnr"),
-                        validation.NewK8sPodForResource(name, "http-gtwy-back-ctnr"),
-                        validation.NewK8sHTTPProxyForResource(name, "http-gtwy-gtwy"),
-                        validation.NewK8sHTTPProxyForResource(name, "http-gtwy-front-rte"),
-                        validation.NewK8sServiceForResource(name, "http-gtwy-front-rte"),
-                        validation.NewK8sHTTPProxyForResource(name, "http-gtwy-back-rte"),
-                        validation.NewK8sServiceForResource(name, "http-gtwy-back-rte"),
-                    },
-                },
-            },
-            PostStepVerify: func(ctx context.Context, t *testing.T, ct shared.RPTest) {
-                // Get hostname from root HTTPProxy in application namespace
-                metadata, err := functional.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
-                require.NoError(t, err)
-                t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
+	test := shared.NewRPTest(t, name, []shared.TestStep{
+		{
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{
+					{
+						Name: name,
+						Type: validation.ApplicationsResource,
+					},
+					{
+						Name: "http-gtwy-gtwy",
+						Type: validation.GatewaysResource,
+						App:  name,
+					},
+					{
+						Name: "http-gtwy-front-rte",
+						Type: validation.HttpRoutesResource,
+						App:  name,
+					},
+					{
+						Name: "http-gtwy-front-ctnr",
+						Type: validation.ContainersResource,
+						App:  name,
+					},
+					{
+						Name: "http-gtwy-back-rte",
+						Type: validation.HttpRoutesResource,
+						App:  name,
+					},
+					{
+						Name: "http-gtwy-back-ctnr",
+						Type: validation.ContainersResource,
+						App:  name,
+					},
+				},
+			},
+			K8sObjects: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					appNamespace: {
+						validation.NewK8sPodForResource(name, "http-gtwy-front-ctnr"),
+						validation.NewK8sPodForResource(name, "http-gtwy-back-ctnr"),
+						validation.NewK8sHTTPProxyForResource(name, "http-gtwy-gtwy"),
+						validation.NewK8sHTTPProxyForResource(name, "http-gtwy-front-rte"),
+						validation.NewK8sServiceForResource(name, "http-gtwy-front-rte"),
+						validation.NewK8sHTTPProxyForResource(name, "http-gtwy-back-rte"),
+						validation.NewK8sServiceForResource(name, "http-gtwy-back-rte"),
+					},
+				},
+			},
+			PostStepVerify: func(ctx context.Context, t *testing.T, ct shared.RPTest) {
+				// Get hostname from root HTTPProxy in application namespace
+				metadata, err := functional.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
+				require.NoError(t, err)
+				t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
 
-                // Set up pod port-forwarding for contour-envoy
-                t.Logf("Setting up portforward")
+				// Set up pod port-forwarding for contour-envoy
+				t.Logf("Setting up portforward")
 
-                err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpRemotePort, false, []GatewayTestConfig{
-                    // /healthz is exposed on frontend container
-                    {
-                        Path:               "healthz",
-                        ExpectedStatusCode: http.StatusOK,
-                    },
-                    // /backend2 uses 'replacePrefix', so it can access /healthz on backend container
-                    {
-                        Path:               "backend2/healthz",
-                        ExpectedStatusCode: http.StatusOK,
-                    },
-                    // since /backend1/healthz is not exposed on frontend container, it should return 404
-                    {
-                        Path:               "backend1/healthz",
-                        ExpectedStatusCode: http.StatusNotFound,
-                    },
-                })
-                if err != nil {
-                    t.Logf("Failed to test Gateway via portforward with error: %s", err)
-                } else {
-                    // Successfully ran tests
-                    return
-                }
+				err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpRemotePort, false, []GatewayTestConfig{
+					// /healthz is exposed on frontend container
+					{
+						Path:               "healthz",
+						ExpectedStatusCode: http.StatusOK,
+					},
+					// /backend2 uses 'replacePrefix', so it can access /healthz on backend container
+					{
+						Path:               "backend2/healthz",
+						ExpectedStatusCode: http.StatusOK,
+					},
+					// since /backend1/healthz is not exposed on frontend container, it should return 404
+					{
+						Path:               "backend1/healthz",
+						ExpectedStatusCode: http.StatusNotFound,
+					},
+				})
+				if err != nil {
+					t.Logf("Failed to test Gateway via portforward with error: %s", err)
+				} else {
+					// Successfully ran tests
+					return
+				}
 
-                require.Fail(t, "Gateway tests failed")
-            },
-        },
-    })
+				require.Fail(t, "Gateway tests failed")
+			},
+		},
+	})
 
-    test.Test(t)
+	test.Test(t)
 }
 
 func Test_GatewayDNS(t *testing.T) {
-    template := "testdata/corerp-resources-gateway-dns.bicep"
-    name := "corerp-resources-gateway-dns"
-    appNamespace := "default-corerp-resources-gateway-dns"
+	template := "testdata/corerp-resources-gateway-dns.bicep"
+	name := "corerp-resources-gateway-dns"
+	appNamespace := "default-corerp-resources-gateway-dns"
 
-    test := shared.NewRPTest(t, name, []shared.TestStep{
-        {
-            Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
-            RPResources: &validation.RPResourceSet{
-                Resources: []validation.RPResource{
-                    {
-                        Name: name,
-                        Type: validation.ApplicationsResource,
-                    },
-                    {
-                        Name: "http-gtwy-gtwy-dns",
-                        Type: validation.GatewaysResource,
-                        App:  name,
-                    },
-                    {
-                        Name: "frontendcontainerdns",
-                        Type: validation.ContainersResource,
-                        App:  name,
-                    },
-                    {
-                        Name: "backendcontainerdns",
-                        Type: validation.ContainersResource,
-                        App:  name,
-                    },
-                },
-            },
-            K8sObjects: &validation.K8sObjectSet{
-                Namespaces: map[string][]validation.K8sObject{
-                    appNamespace: {
-                        validation.NewK8sPodForResource(name, "frontendcontainerdns"),
-                        validation.NewK8sPodForResource(name, "backendcontainerdns"),
-                        validation.NewK8sServiceForResource(name, "frontendcontainerdns"),
-                        validation.NewK8sServiceForResource(name, "backendcontainerdns"),
-                        validation.NewK8sHTTPProxyForResource(name, "http-gtwy-gtwy-dns"),
-                        validation.NewK8sHTTPProxyForResource(name, "frontendcontainerdns"),
-                        validation.NewK8sHTTPProxyForResource(name, "backendcontainerdns"),
-                    },
-                },
-            },
-            PostStepVerify: func(ctx context.Context, t *testing.T, ct shared.RPTest) {
-                // Get hostname from root HTTPProxy in application namespace
-                metadata, err := functional.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
-                require.NoError(t, err)
-                t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
+	test := shared.NewRPTest(t, name, []shared.TestStep{
+		{
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{
+					{
+						Name: name,
+						Type: validation.ApplicationsResource,
+					},
+					{
+						Name: "http-gtwy-gtwy-dns",
+						Type: validation.GatewaysResource,
+						App:  name,
+					},
+					{
+						Name: "frontendcontainerdns",
+						Type: validation.ContainersResource,
+						App:  name,
+					},
+					{
+						Name: "backendcontainerdns",
+						Type: validation.ContainersResource,
+						App:  name,
+					},
+				},
+			},
+			K8sObjects: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					appNamespace: {
+						validation.NewK8sPodForResource(name, "frontendcontainerdns"),
+						validation.NewK8sPodForResource(name, "backendcontainerdns"),
+						validation.NewK8sServiceForResource(name, "frontendcontainerdns"),
+						validation.NewK8sServiceForResource(name, "backendcontainerdns"),
+						validation.NewK8sHTTPProxyForResource(name, "http-gtwy-gtwy-dns"),
+						validation.NewK8sHTTPProxyForResource(name, "frontendcontainerdns"),
+						validation.NewK8sHTTPProxyForResource(name, "backendcontainerdns"),
+					},
+				},
+			},
+			PostStepVerify: func(ctx context.Context, t *testing.T, ct shared.RPTest) {
+				// Get hostname from root HTTPProxy in application namespace
+				metadata, err := functional.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
+				require.NoError(t, err)
+				t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
 
-                // Set up pod port-forwarding for contour-envoy
-                t.Logf("Setting up portforward")
+				// Set up pod port-forwarding for contour-envoy
+				t.Logf("Setting up portforward")
 
-                err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpRemotePort, false, []GatewayTestConfig{
-                    // /healthz is exposed on frontend container
-                    {
-                        Path:               "healthz",
-                        ExpectedStatusCode: http.StatusOK,
-                    },
-                    // /backend2 uses 'replacePrefix', so it can access /healthz on backend container
-                    {
-                        Path:               "backend2/healthz",
-                        ExpectedStatusCode: http.StatusOK,
-                    },
-                    // since /backend1/healthz is not exposed on frontend container, it should return 404
-                    {
-                        Path:               "backend1/healthz",
-                        ExpectedStatusCode: http.StatusNotFound,
-                    },
-                })
-                if err != nil {
-                    t.Logf("Failed to test Gateway via portforward with error: %s", err)
-                } else {
-                    // Successfully ran tests
-                    return
-                }
+				err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpRemotePort, false, []GatewayTestConfig{
+					// /healthz is exposed on frontend container
+					{
+						Path:               "healthz",
+						ExpectedStatusCode: http.StatusOK,
+					},
+					// /backend2 uses 'replacePrefix', so it can access /healthz on backend container
+					{
+						Path:               "backend2/healthz",
+						ExpectedStatusCode: http.StatusOK,
+					},
+					// since /backend1/healthz is not exposed on frontend container, it should return 404
+					{
+						Path:               "backend1/healthz",
+						ExpectedStatusCode: http.StatusNotFound,
+					},
+				})
+				if err != nil {
+					t.Logf("Failed to test Gateway via portforward with error: %s", err)
+				} else {
+					// Successfully ran tests
+					return
+				}
 
-                require.Fail(t, "Gateway tests failed")
-            },
-        },
-    })
+				require.Fail(t, "Gateway tests failed")
+			},
+		},
+	})
 
-    test.Test(t)
+	test.Test(t)
 }
 
 func Test_Gateway_SSLPassthrough(t *testing.T) {
-    template := "testdata/corerp-resources-gateway-sslpassthrough.bicep"
-    name := "corerp-resources-gateway-sslpassthrough"
-    appNamespace := "default-corerp-resources-gateway-sslpassthrough"
+	template := "testdata/corerp-resources-gateway-sslpassthrough.bicep"
+	name := "corerp-resources-gateway-sslpassthrough"
+	appNamespace := "default-corerp-resources-gateway-sslpassthrough"
 
-    test := shared.NewRPTest(t, name, []shared.TestStep{
-        {
-            Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), "@testdata/parameters/test-tls-cert.parameters.json"),
-            RPResources: &validation.RPResourceSet{
-                Resources: []validation.RPResource{
-                    {
-                        Name: name,
-                        Type: validation.ApplicationsResource,
-                    },
-                    {
-                        Name: "ssl-gtwy-gtwy",
-                        Type: validation.GatewaysResource,
-                        App:  name,
-                    },
-                    {
-                        Name: "ssl-gtwy-front-rte",
-                        Type: validation.HttpRoutesResource,
-                        App:  name,
-                    },
-                    {
-                        Name: "ssl-gtwy-front-ctnr",
-                        Type: validation.ContainersResource,
-                        App:  name,
-                    },
-                },
-            },
-            K8sObjects: &validation.K8sObjectSet{
-                Namespaces: map[string][]validation.K8sObject{
-                    appNamespace: {
-                        validation.NewK8sPodForResource(name, "ssl-gtwy-front-ctnr"),
-                        validation.NewK8sHTTPProxyForResource(name, "ssl-gtwy-gtwy"),
-                        validation.NewK8sHTTPProxyForResource(name, "ssl-gtwy-front-rte"),
-                        validation.NewK8sServiceForResource(name, "ssl-gtwy-front-rte"),
-                    },
-                },
-            },
-            PostStepVerify: func(ctx context.Context, t *testing.T, ct shared.RPTest) {
-                // Get hostname from root HTTPProxy in application namespace
-                metadata, err := functional.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
-                require.NoError(t, err)
-                t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
+	test := shared.NewRPTest(t, name, []shared.TestStep{
+		{
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), "@testdata/parameters/test-tls-cert.parameters.json"),
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{
+					{
+						Name: name,
+						Type: validation.ApplicationsResource,
+					},
+					{
+						Name: "ssl-gtwy-gtwy",
+						Type: validation.GatewaysResource,
+						App:  name,
+					},
+					{
+						Name: "ssl-gtwy-front-rte",
+						Type: validation.HttpRoutesResource,
+						App:  name,
+					},
+					{
+						Name: "ssl-gtwy-front-ctnr",
+						Type: validation.ContainersResource,
+						App:  name,
+					},
+				},
+			},
+			K8sObjects: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					appNamespace: {
+						validation.NewK8sPodForResource(name, "ssl-gtwy-front-ctnr"),
+						validation.NewK8sHTTPProxyForResource(name, "ssl-gtwy-gtwy"),
+						validation.NewK8sHTTPProxyForResource(name, "ssl-gtwy-front-rte"),
+						validation.NewK8sServiceForResource(name, "ssl-gtwy-front-rte"),
+					},
+				},
+			},
+			PostStepVerify: func(ctx context.Context, t *testing.T, ct shared.RPTest) {
+				// Get hostname from root HTTPProxy in application namespace
+				metadata, err := functional.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
+				require.NoError(t, err)
+				t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
 
-                // Set up pod port-forwarding for contour-envoy
-                t.Logf("Setting up portforward")
-                err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpsRemotePort, true, []GatewayTestConfig{
-                    // /healthz is exposed on frontend container
-                    {
-                        Path:               "healthz",
-                        ExpectedStatusCode: http.StatusOK,
-                    },
-                })
-                if err != nil {
-                    t.Logf("Failed to test Gateway via portforward with error: %s", err)
-                } else {
-                    // Successfully ran tests
-                    return
-                }
+				// Set up pod port-forwarding for contour-envoy
+				t.Logf("Setting up portforward")
+				err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpsRemotePort, true, []GatewayTestConfig{
+					// /healthz is exposed on frontend container
+					{
+						Path:               "healthz",
+						ExpectedStatusCode: http.StatusOK,
+					},
+				})
+				if err != nil {
+					t.Logf("Failed to test Gateway via portforward with error: %s", err)
+				} else {
+					// Successfully ran tests
+					return
+				}
 
-                require.Fail(t, "Gateway tests failed")
-            },
-        },
-    })
+				require.Fail(t, "Gateway tests failed")
+			},
+		},
+	})
 
-    test.Test(t)
+	test.Test(t)
 }
 
 func Test_Gateway_TLSTermination(t *testing.T) {
-    template := "testdata/corerp-resources-gateway-tlstermination.bicep"
-    name := "corerp-resources-gateway-tlstermination"
-    appNamespace := "default-corerp-resources-gateway-tlstermination"
+	template := "testdata/corerp-resources-gateway-tlstermination.bicep"
+	name := "corerp-resources-gateway-tlstermination"
+	appNamespace := "default-corerp-resources-gateway-tlstermination"
 
-    test := shared.NewRPTest(t, name, []shared.TestStep{
-        {
-            Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), "@testdata/parameters/test-tls-cert.parameters.json"),
-            RPResources: &validation.RPResourceSet{
-                Resources: []validation.RPResource{
-                    {
-                        Name: name,
-                        Type: validation.ApplicationsResource,
-                    },
-                    {
-                        Name: "tls-gtwy-gtwy",
-                        Type: validation.GatewaysResource,
-                        App:  name,
-                    },
-                    {
-                        Name: "tls-gtwy-cert",
-                        Type: validation.SecretStoresResource,
-                        App:  name,
-                    },
-                    {
-                        Name: "tls-gtwy-front-rte",
-                        Type: validation.HttpRoutesResource,
-                        App:  name,
-                    },
-                    {
-                        Name: "tls-gtwy-front-ctnr",
-                        Type: validation.ContainersResource,
-                        App:  name,
-                    },
-                },
-            },
-            K8sObjects: &validation.K8sObjectSet{
-                Namespaces: map[string][]validation.K8sObject{
-                    appNamespace: {
-                        validation.NewK8sPodForResource(name, "tls-gtwy-front-ctnr"),
-                        validation.NewK8sHTTPProxyForResource(name, "tls-gtwy-gtwy"),
-                        validation.NewK8sHTTPProxyForResource(name, "tls-gtwy-front-rte"),
-                        validation.NewK8sServiceForResource(name, "tls-gtwy-front-rte"),
-                        validation.NewK8sSecretForResource(name, "tls-gtwy-cert"),
-                    },
-                },
-            },
-            PostStepVerify: func(ctx context.Context, t *testing.T, ct shared.RPTest) {
-                // Get hostname from root HTTPProxy in application namespace
-                metadata, err := functional.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
-                require.NoError(t, err)
-                t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
+	test := shared.NewRPTest(t, name, []shared.TestStep{
+		{
+			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), "@testdata/parameters/test-tls-cert.parameters.json"),
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{
+					{
+						Name: name,
+						Type: validation.ApplicationsResource,
+					},
+					{
+						Name: "tls-gtwy-gtwy",
+						Type: validation.GatewaysResource,
+						App:  name,
+					},
+					{
+						Name: "tls-gtwy-cert",
+						Type: validation.SecretStoresResource,
+						App:  name,
+					},
+					{
+						Name: "tls-gtwy-front-rte",
+						Type: validation.HttpRoutesResource,
+						App:  name,
+					},
+					{
+						Name: "tls-gtwy-front-ctnr",
+						Type: validation.ContainersResource,
+						App:  name,
+					},
+				},
+			},
+			K8sObjects: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					appNamespace: {
+						validation.NewK8sPodForResource(name, "tls-gtwy-front-ctnr"),
+						validation.NewK8sHTTPProxyForResource(name, "tls-gtwy-gtwy"),
+						validation.NewK8sHTTPProxyForResource(name, "tls-gtwy-front-rte"),
+						validation.NewK8sServiceForResource(name, "tls-gtwy-front-rte"),
+						validation.NewK8sSecretForResource(name, "tls-gtwy-cert"),
+					},
+				},
+			},
+			PostStepVerify: func(ctx context.Context, t *testing.T, ct shared.RPTest) {
+				// Get hostname from root HTTPProxy in application namespace
+				metadata, err := functional.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
+				require.NoError(t, err)
+				t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
 
-                // Set up pod port-forwarding for contour-envoy
-                t.Logf("Setting up portforward")
-                err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpsRemotePort, true, []GatewayTestConfig{
-                    // /healthz is exposed on frontend container
-                    {
-                        Path:               "healthz",
-                        ExpectedStatusCode: http.StatusOK,
-                    },
-                })
-                if err != nil {
-                    t.Logf("Failed to test Gateway via portforward with error: %s", err)
-                } else {
-                    // Successfully ran tests
-                    return
-                }
+				// Set up pod port-forwarding for contour-envoy
+				t.Logf("Setting up portforward")
+				err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpsRemotePort, true, []GatewayTestConfig{
+					// /healthz is exposed on frontend container
+					{
+						Path:               "healthz",
+						ExpectedStatusCode: http.StatusOK,
+					},
+				})
+				if err != nil {
+					t.Logf("Failed to test Gateway via portforward with error: %s", err)
+				} else {
+					// Successfully ran tests
+					return
+				}
 
-                require.Fail(t, "Gateway tests failed")
-            },
-        },
-    })
+				require.Fail(t, "Gateway tests failed")
+			},
+		},
+	})
 
-    test.Test(t)
+	test.Test(t)
 }
 
 func testGatewayWithPortForward(t *testing.T, ctx context.Context, at shared.RPTest, hostname string, remotePort int, isHttps bool, tests []GatewayTestConfig) error {
-    // stopChan will close the port-forward connection on close
-    stopChan := make(chan struct{})
+	// stopChan will close the port-forward connection on close
+	stopChan := make(chan struct{})
 
-    // portChan will be populated with the assigned port once the port-forward connection is opened on it
-    portChan := make(chan int)
+	// portChan will be populated with the assigned port once the port-forward connection is opened on it
+	portChan := make(chan int)
 
-    // errorChan will contain any errors created from initializing the port-forwarding session
-    errorChan := make(chan error)
+	// errorChan will contain any errors created from initializing the port-forwarding session
+	errorChan := make(chan error)
 
-    go functional.ExposeIngress(t, ctx, at.Options.K8sClient, at.Options.K8sConfig, remotePort, stopChan, portChan, errorChan)
+	go functional.ExposeIngress(t, ctx, at.Options.K8sClient, at.Options.K8sConfig, remotePort, stopChan, portChan, errorChan)
 
-    select {
-    case err := <-errorChan:
-        return fmt.Errorf("portforward failed with error: %s", err)
-    case localPort := <-portChan:
-        protocol := "http"
-        if isHttps {
-            protocol = "https"
-        }
-        baseURL := fmt.Sprintf("%s://localhost:%d", protocol, localPort)
+	select {
+	case err := <-errorChan:
+		return fmt.Errorf("portforward failed with error: %s", err)
+	case localPort := <-portChan:
+		protocol := "http"
+		if isHttps {
+			protocol = "https"
+		}
+		baseURL := fmt.Sprintf("%s://localhost:%d", protocol, localPort)
 
-        t.Logf("Portforward session active at %s", baseURL)
+		t.Logf("Portforward session active at %s", baseURL)
 
-        for _, test := range tests {
-            if err := testGatewayAvailability(hostname, baseURL, test.Path, test.ExpectedStatusCode, isHttps); err != nil {
-                close(stopChan)
-                return err
-            }
-        }
+		for _, test := range tests {
+			if err := testGatewayAvailability(hostname, baseURL, test.Path, test.ExpectedStatusCode, isHttps); err != nil {
+				close(stopChan)
+				return err
+			}
+		}
 
-        // All of the requests were successful
-        t.Logf("All requests encountered the correct status code")
-        return nil
-    }
+		// All of the requests were successful
+		t.Logf("All requests encountered the correct status code")
+		return nil
+	}
 }
 
 func testGatewayAvailability(hostname, baseURL, path string, expectedStatusCode int, isHttps bool) error {
-    urlPath := strings.TrimSuffix(baseURL, "/") + "/" + strings.TrimPrefix(path, "/")
-    req, err := http.NewRequest(http.MethodGet, urlPath, nil)
-    if err != nil {
-        return err
-    }
+	urlPath := strings.TrimSuffix(baseURL, "/") + "/" + strings.TrimPrefix(path, "/")
+	req, err := http.NewRequest(http.MethodGet, urlPath, nil)
+	if err != nil {
+		return err
+	}
 
-    req.Host = hostname
+	req.Host = hostname
 
-    client := newTestHTTPClient(isHttps, hostname)
-    res, err := client.Do(req)
-    if err != nil {
-        return err
-    }
+	client := newTestHTTPClient(isHttps, hostname)
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
 
-    if res.StatusCode != expectedStatusCode {
-        return fmt.Errorf("expected status code %d, got %d", expectedStatusCode, res.StatusCode)
-    }
+	if res.StatusCode != expectedStatusCode {
+		return fmt.Errorf("expected status code %d, got %d", expectedStatusCode, res.StatusCode)
+	}
 
-    // Encountered the correct status code
-    return nil
+	// Encountered the correct status code
+	return nil
 }
 
 func newTestHTTPClient(isHttps bool, hostname string) *http.Client {
-    transport := &http.Transport{
-        DialContext: (&net.Dialer{
-            Timeout:   30 * time.Second,
-            KeepAlive: 30 * time.Second,
-        }).DialContext,
-        ForceAttemptHTTP2:     true,
-        MaxIdleConns:          100,
-        IdleConnTimeout:       90 * time.Second,
-        TLSHandshakeTimeout:   10 * time.Second,
-        ExpectContinueTimeout: 1 * time.Second,
-    }
+	transport := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
 
-    if isHttps {
-        transport.TLSClientConfig = &tls.Config{
-            InsecureSkipVerify: true, //ignore certificate verification errors; needed since we use self-signed cert for magpie
-            MinVersion:         tls.VersionTLS12,
-            ServerName:         hostname,
-        }
-    }
+	if isHttps {
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true, //ignore certificate verification errors; needed since we use self-signed cert for magpie
+			MinVersion:         tls.VersionTLS12,
+			ServerName:         hostname,
+		}
+	}
 
-    return &http.Client{
-        Transport: transport,
-    }
+	return &http.Client{
+		Transport: transport,
+	}
 }
 

--- a/test/functional/shared/resources/gateway_test.go
+++ b/test/functional/shared/resources/gateway_test.go
@@ -195,7 +195,7 @@ func Test_GatewayDNS(t *testing.T) {
                 // Set up pod port-forwarding for contour-envoy
                 t.Logf("Setting up portforward")
 
-                err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpRemotePort, false, []GatewayTestConfig{
+                err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, 3000, false, []GatewayTestConfig{
                     // /healthz is exposed on frontend container
                     {
                         Path:               "healthz",

--- a/test/functional/shared/resources/gateway_test.go
+++ b/test/functional/shared/resources/gateway_test.go
@@ -17,361 +17,447 @@ limitations under the License.
 package resource_test
 
 import (
-	"context"
-	"crypto/tls"
-	"fmt"
-	"net"
-	"net/http"
-	"strings"
-	"testing"
-	"time"
+    "context"
+    "crypto/tls"
+    "fmt"
+    "net"
+    "net/http"
+    "strings"
+    "testing"
+    "time"
 
-	"github.com/project-radius/radius/test/functional"
-	"github.com/project-radius/radius/test/functional/shared"
-	"github.com/project-radius/radius/test/step"
-	"github.com/project-radius/radius/test/validation"
-	"github.com/stretchr/testify/require"
+    "github.com/project-radius/radius/test/functional"
+    "github.com/project-radius/radius/test/functional/shared"
+    "github.com/project-radius/radius/test/step"
+    "github.com/project-radius/radius/test/validation"
+    "github.com/stretchr/testify/require"
 )
 
 const (
-	retries         = 3
-	httpRemotePort  = 8080
-	httpsRemotePort = 8443
-	retryTimeout    = 1 * time.Minute
-	retryBackoff    = 1 * time.Second
+    retries         = 3
+    httpRemotePort  = 8080
+    httpsRemotePort = 8443
+    retryTimeout    = 1 * time.Minute
+    retryBackoff    = 1 * time.Second
 )
 
 // GatewayTestConfig is a struct that contains the configuration for a Gateway test
 type GatewayTestConfig struct {
-	Path               string
-	ExpectedStatusCode int
+    Path               string
+    ExpectedStatusCode int
 }
 
 func Test_Gateway(t *testing.T) {
-	template := "testdata/corerp-resources-gateway.bicep"
-	name := "corerp-resources-gateway"
-	appNamespace := "default-corerp-resources-gateway"
+    template := "testdata/corerp-resources-gateway.bicep"
+    name := "corerp-resources-gateway"
+    appNamespace := "default-corerp-resources-gateway"
 
-	test := shared.NewRPTest(t, name, []shared.TestStep{
-		{
-			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
-			RPResources: &validation.RPResourceSet{
-				Resources: []validation.RPResource{
-					{
-						Name: name,
-						Type: validation.ApplicationsResource,
-					},
-					{
-						Name: "http-gtwy-gtwy",
-						Type: validation.GatewaysResource,
-						App:  name,
-					},
-					{
-						Name: "http-gtwy-front-rte",
-						Type: validation.HttpRoutesResource,
-						App:  name,
-					},
-					{
-						Name: "http-gtwy-front-ctnr",
-						Type: validation.ContainersResource,
-						App:  name,
-					},
-					{
-						Name: "http-gtwy-back-rte",
-						Type: validation.HttpRoutesResource,
-						App:  name,
-					},
-					{
-						Name: "http-gtwy-back-ctnr",
-						Type: validation.ContainersResource,
-						App:  name,
-					},
-				},
-			},
-			K8sObjects: &validation.K8sObjectSet{
-				Namespaces: map[string][]validation.K8sObject{
-					appNamespace: {
-						validation.NewK8sPodForResource(name, "http-gtwy-front-ctnr"),
-						validation.NewK8sPodForResource(name, "http-gtwy-back-ctnr"),
-						validation.NewK8sHTTPProxyForResource(name, "http-gtwy-gtwy"),
-						validation.NewK8sHTTPProxyForResource(name, "http-gtwy-front-rte"),
-						validation.NewK8sServiceForResource(name, "http-gtwy-front-rte"),
-						validation.NewK8sHTTPProxyForResource(name, "http-gtwy-back-rte"),
-						validation.NewK8sServiceForResource(name, "http-gtwy-back-rte"),
-					},
-				},
-			},
-			PostStepVerify: func(ctx context.Context, t *testing.T, ct shared.RPTest) {
-				// Get hostname from root HTTPProxy in application namespace
-				metadata, err := functional.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
-				require.NoError(t, err)
-				t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
+    test := shared.NewRPTest(t, name, []shared.TestStep{
+        {
+            Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
+            RPResources: &validation.RPResourceSet{
+                Resources: []validation.RPResource{
+                    {
+                        Name: name,
+                        Type: validation.ApplicationsResource,
+                    },
+                    {
+                        Name: "http-gtwy-gtwy",
+                        Type: validation.GatewaysResource,
+                        App:  name,
+                    },
+                    {
+                        Name: "http-gtwy-front-rte",
+                        Type: validation.HttpRoutesResource,
+                        App:  name,
+                    },
+                    {
+                        Name: "http-gtwy-front-ctnr",
+                        Type: validation.ContainersResource,
+                        App:  name,
+                    },
+                    {
+                        Name: "http-gtwy-back-rte",
+                        Type: validation.HttpRoutesResource,
+                        App:  name,
+                    },
+                    {
+                        Name: "http-gtwy-back-ctnr",
+                        Type: validation.ContainersResource,
+                        App:  name,
+                    },
+                },
+            },
+            K8sObjects: &validation.K8sObjectSet{
+                Namespaces: map[string][]validation.K8sObject{
+                    appNamespace: {
+                        validation.NewK8sPodForResource(name, "http-gtwy-front-ctnr"),
+                        validation.NewK8sPodForResource(name, "http-gtwy-back-ctnr"),
+                        validation.NewK8sHTTPProxyForResource(name, "http-gtwy-gtwy"),
+                        validation.NewK8sHTTPProxyForResource(name, "http-gtwy-front-rte"),
+                        validation.NewK8sServiceForResource(name, "http-gtwy-front-rte"),
+                        validation.NewK8sHTTPProxyForResource(name, "http-gtwy-back-rte"),
+                        validation.NewK8sServiceForResource(name, "http-gtwy-back-rte"),
+                    },
+                },
+            },
+            PostStepVerify: func(ctx context.Context, t *testing.T, ct shared.RPTest) {
+                // Get hostname from root HTTPProxy in application namespace
+                metadata, err := functional.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
+                require.NoError(t, err)
+                t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
 
-				// Set up pod port-forwarding for contour-envoy
-				t.Logf("Setting up portforward")
+                // Set up pod port-forwarding for contour-envoy
+                t.Logf("Setting up portforward")
 
-				err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpRemotePort, false, []GatewayTestConfig{
-					// /healthz is exposed on frontend container
-					{
-						Path:               "healthz",
-						ExpectedStatusCode: http.StatusOK,
-					},
-					// /backend2 uses 'replacePrefix', so it can access /healthz on backend container
-					{
-						Path:               "backend2/healthz",
-						ExpectedStatusCode: http.StatusOK,
-					},
-					// since /backend1/healthz is not exposed on frontend container, it should return 404
-					{
-						Path:               "backend1/healthz",
-						ExpectedStatusCode: http.StatusNotFound,
-					},
-				})
-				if err != nil {
-					t.Logf("Failed to test Gateway via portforward with error: %s", err)
-				} else {
-					// Successfully ran tests
-					return
-				}
+                err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpRemotePort, false, []GatewayTestConfig{
+                    // /healthz is exposed on frontend container
+                    {
+                        Path:               "healthz",
+                        ExpectedStatusCode: http.StatusOK,
+                    },
+                    // /backend2 uses 'replacePrefix', so it can access /healthz on backend container
+                    {
+                        Path:               "backend2/healthz",
+                        ExpectedStatusCode: http.StatusOK,
+                    },
+                    // since /backend1/healthz is not exposed on frontend container, it should return 404
+                    {
+                        Path:               "backend1/healthz",
+                        ExpectedStatusCode: http.StatusNotFound,
+                    },
+                })
+                if err != nil {
+                    t.Logf("Failed to test Gateway via portforward with error: %s", err)
+                } else {
+                    // Successfully ran tests
+                    return
+                }
 
-				require.Fail(t, "Gateway tests failed")
-			},
-		},
-	})
+                require.Fail(t, "Gateway tests failed")
+            },
+        },
+    })
 
-	test.Test(t)
+    test.Test(t)
+}
+
+func Test_GatewayDNS(t *testing.T) {
+    template := "testdata/corerp-resources-gateway-dns.bicep"
+    name := "corerp-resources-gateway-dns"
+    appNamespace := "default-corerp-resources-gateway-dns"
+
+    test := shared.NewRPTest(t, name, []shared.TestStep{
+        {
+            Executor: step.NewDeployExecutor(template, functional.GetMagpieImage()),
+            RPResources: &validation.RPResourceSet{
+                Resources: []validation.RPResource{
+                    {
+                        Name: name,
+                        Type: validation.ApplicationsResource,
+                    },
+                    {
+                        Name: "http-gtwy-gtwy",
+                        Type: validation.GatewaysResource,
+                        App:  name,
+                    },
+                    {
+                        Name: "frontendcontainerdns",
+                        Type: validation.ContainersResource,
+                        App:  name,
+                    },
+                    {
+                        Name: "backendcontainerdns",
+                        Type: validation.ContainersResource,
+                        App:  name,
+                    },
+                },
+            },
+            K8sObjects: &validation.K8sObjectSet{
+                Namespaces: map[string][]validation.K8sObject{
+                    appNamespace: {
+                        validation.NewK8sPodForResource(name, "frontendcontainerdns"),
+                        validation.NewK8sPodForResource(name, "backendcontainerdns"),
+                        validation.NewK8sServiceForResource(name, "frontendcontainerdns"),
+                        validation.NewK8sServiceForResource(name, "backendcontainerdns"),
+                        validation.NewK8sHTTPProxyForResource(name, "http-gtwy-gtwy"),
+                        validation.NewK8sHTTPProxyForResource(name, "frontendcontainerdns"),
+                        validation.NewK8sHTTPProxyForResource(name, "backendcontainerdns"),
+                    },
+                },
+            },
+            PostStepVerify: func(ctx context.Context, t *testing.T, ct shared.RPTest) {
+                // Get hostname from root HTTPProxy in application namespace
+                metadata, err := functional.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
+                require.NoError(t, err)
+                t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
+
+                // Set up pod port-forwarding for contour-envoy
+                t.Logf("Setting up portforward")
+
+                err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpRemotePort, false, []GatewayTestConfig{
+                    // /healthz is exposed on frontend container
+                    {
+                        Path:               "healthz",
+                        ExpectedStatusCode: http.StatusOK,
+                    },
+                    // /backend2 uses 'replacePrefix', so it can access /healthz on backend container
+                    {
+                        Path:               "backend2/healthz",
+                        ExpectedStatusCode: http.StatusOK,
+                    },
+                    // since /backend1/healthz is not exposed on frontend container, it should return 404
+                    {
+                        Path:               "backend1/healthz",
+                        ExpectedStatusCode: http.StatusNotFound,
+                    },
+                })
+                if err != nil {
+                    t.Logf("Failed to test Gateway via portforward with error: %s", err)
+                } else {
+                    // Successfully ran tests
+                    return
+                }
+
+                require.Fail(t, "Gateway tests failed")
+            },
+        },
+    })
+
+    test.Test(t)
 }
 
 func Test_Gateway_SSLPassthrough(t *testing.T) {
-	template := "testdata/corerp-resources-gateway-sslpassthrough.bicep"
-	name := "corerp-resources-gateway-sslpassthrough"
-	appNamespace := "default-corerp-resources-gateway-sslpassthrough"
+    template := "testdata/corerp-resources-gateway-sslpassthrough.bicep"
+    name := "corerp-resources-gateway-sslpassthrough"
+    appNamespace := "default-corerp-resources-gateway-sslpassthrough"
 
-	test := shared.NewRPTest(t, name, []shared.TestStep{
-		{
-			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), "@testdata/parameters/test-tls-cert.parameters.json"),
-			RPResources: &validation.RPResourceSet{
-				Resources: []validation.RPResource{
-					{
-						Name: name,
-						Type: validation.ApplicationsResource,
-					},
-					{
-						Name: "ssl-gtwy-gtwy",
-						Type: validation.GatewaysResource,
-						App:  name,
-					},
-					{
-						Name: "ssl-gtwy-front-rte",
-						Type: validation.HttpRoutesResource,
-						App:  name,
-					},
-					{
-						Name: "ssl-gtwy-front-ctnr",
-						Type: validation.ContainersResource,
-						App:  name,
-					},
-				},
-			},
-			K8sObjects: &validation.K8sObjectSet{
-				Namespaces: map[string][]validation.K8sObject{
-					appNamespace: {
-						validation.NewK8sPodForResource(name, "ssl-gtwy-front-ctnr"),
-						validation.NewK8sHTTPProxyForResource(name, "ssl-gtwy-gtwy"),
-						validation.NewK8sHTTPProxyForResource(name, "ssl-gtwy-front-rte"),
-						validation.NewK8sServiceForResource(name, "ssl-gtwy-front-rte"),
-					},
-				},
-			},
-			PostStepVerify: func(ctx context.Context, t *testing.T, ct shared.RPTest) {
-				// Get hostname from root HTTPProxy in application namespace
-				metadata, err := functional.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
-				require.NoError(t, err)
-				t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
+    test := shared.NewRPTest(t, name, []shared.TestStep{
+        {
+            Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), "@testdata/parameters/test-tls-cert.parameters.json"),
+            RPResources: &validation.RPResourceSet{
+                Resources: []validation.RPResource{
+                    {
+                        Name: name,
+                        Type: validation.ApplicationsResource,
+                    },
+                    {
+                        Name: "ssl-gtwy-gtwy",
+                        Type: validation.GatewaysResource,
+                        App:  name,
+                    },
+                    {
+                        Name: "ssl-gtwy-front-rte",
+                        Type: validation.HttpRoutesResource,
+                        App:  name,
+                    },
+                    {
+                        Name: "ssl-gtwy-front-ctnr",
+                        Type: validation.ContainersResource,
+                        App:  name,
+                    },
+                },
+            },
+            K8sObjects: &validation.K8sObjectSet{
+                Namespaces: map[string][]validation.K8sObject{
+                    appNamespace: {
+                        validation.NewK8sPodForResource(name, "ssl-gtwy-front-ctnr"),
+                        validation.NewK8sHTTPProxyForResource(name, "ssl-gtwy-gtwy"),
+                        validation.NewK8sHTTPProxyForResource(name, "ssl-gtwy-front-rte"),
+                        validation.NewK8sServiceForResource(name, "ssl-gtwy-front-rte"),
+                    },
+                },
+            },
+            PostStepVerify: func(ctx context.Context, t *testing.T, ct shared.RPTest) {
+                // Get hostname from root HTTPProxy in application namespace
+                metadata, err := functional.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
+                require.NoError(t, err)
+                t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
 
-				// Set up pod port-forwarding for contour-envoy
-				t.Logf("Setting up portforward")
-				err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpsRemotePort, true, []GatewayTestConfig{
-					// /healthz is exposed on frontend container
-					{
-						Path:               "healthz",
-						ExpectedStatusCode: http.StatusOK,
-					},
-				})
-				if err != nil {
-					t.Logf("Failed to test Gateway via portforward with error: %s", err)
-				} else {
-					// Successfully ran tests
-					return
-				}
+                // Set up pod port-forwarding for contour-envoy
+                t.Logf("Setting up portforward")
+                err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpsRemotePort, true, []GatewayTestConfig{
+                    // /healthz is exposed on frontend container
+                    {
+                        Path:               "healthz",
+                        ExpectedStatusCode: http.StatusOK,
+                    },
+                })
+                if err != nil {
+                    t.Logf("Failed to test Gateway via portforward with error: %s", err)
+                } else {
+                    // Successfully ran tests
+                    return
+                }
 
-				require.Fail(t, "Gateway tests failed")
-			},
-		},
-	})
+                require.Fail(t, "Gateway tests failed")
+            },
+        },
+    })
 
-	test.Test(t)
+    test.Test(t)
 }
 
 func Test_Gateway_TLSTermination(t *testing.T) {
-	template := "testdata/corerp-resources-gateway-tlstermination.bicep"
-	name := "corerp-resources-gateway-tlstermination"
-	appNamespace := "default-corerp-resources-gateway-tlstermination"
+    template := "testdata/corerp-resources-gateway-tlstermination.bicep"
+    name := "corerp-resources-gateway-tlstermination"
+    appNamespace := "default-corerp-resources-gateway-tlstermination"
 
-	test := shared.NewRPTest(t, name, []shared.TestStep{
-		{
-			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), "@testdata/parameters/test-tls-cert.parameters.json"),
-			RPResources: &validation.RPResourceSet{
-				Resources: []validation.RPResource{
-					{
-						Name: name,
-						Type: validation.ApplicationsResource,
-					},
-					{
-						Name: "tls-gtwy-gtwy",
-						Type: validation.GatewaysResource,
-						App:  name,
-					},
-					{
-						Name: "tls-gtwy-cert",
-						Type: validation.SecretStoresResource,
-						App:  name,
-					},
-					{
-						Name: "tls-gtwy-front-rte",
-						Type: validation.HttpRoutesResource,
-						App:  name,
-					},
-					{
-						Name: "tls-gtwy-front-ctnr",
-						Type: validation.ContainersResource,
-						App:  name,
-					},
-				},
-			},
-			K8sObjects: &validation.K8sObjectSet{
-				Namespaces: map[string][]validation.K8sObject{
-					appNamespace: {
-						validation.NewK8sPodForResource(name, "tls-gtwy-front-ctnr"),
-						validation.NewK8sHTTPProxyForResource(name, "tls-gtwy-gtwy"),
-						validation.NewK8sHTTPProxyForResource(name, "tls-gtwy-front-rte"),
-						validation.NewK8sServiceForResource(name, "tls-gtwy-front-rte"),
-						validation.NewK8sSecretForResource(name, "tls-gtwy-cert"),
-					},
-				},
-			},
-			PostStepVerify: func(ctx context.Context, t *testing.T, ct shared.RPTest) {
-				// Get hostname from root HTTPProxy in application namespace
-				metadata, err := functional.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
-				require.NoError(t, err)
-				t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
+    test := shared.NewRPTest(t, name, []shared.TestStep{
+        {
+            Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), "@testdata/parameters/test-tls-cert.parameters.json"),
+            RPResources: &validation.RPResourceSet{
+                Resources: []validation.RPResource{
+                    {
+                        Name: name,
+                        Type: validation.ApplicationsResource,
+                    },
+                    {
+                        Name: "tls-gtwy-gtwy",
+                        Type: validation.GatewaysResource,
+                        App:  name,
+                    },
+                    {
+                        Name: "tls-gtwy-cert",
+                        Type: validation.SecretStoresResource,
+                        App:  name,
+                    },
+                    {
+                        Name: "tls-gtwy-front-rte",
+                        Type: validation.HttpRoutesResource,
+                        App:  name,
+                    },
+                    {
+                        Name: "tls-gtwy-front-ctnr",
+                        Type: validation.ContainersResource,
+                        App:  name,
+                    },
+                },
+            },
+            K8sObjects: &validation.K8sObjectSet{
+                Namespaces: map[string][]validation.K8sObject{
+                    appNamespace: {
+                        validation.NewK8sPodForResource(name, "tls-gtwy-front-ctnr"),
+                        validation.NewK8sHTTPProxyForResource(name, "tls-gtwy-gtwy"),
+                        validation.NewK8sHTTPProxyForResource(name, "tls-gtwy-front-rte"),
+                        validation.NewK8sServiceForResource(name, "tls-gtwy-front-rte"),
+                        validation.NewK8sSecretForResource(name, "tls-gtwy-cert"),
+                    },
+                },
+            },
+            PostStepVerify: func(ctx context.Context, t *testing.T, ct shared.RPTest) {
+                // Get hostname from root HTTPProxy in application namespace
+                metadata, err := functional.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
+                require.NoError(t, err)
+                t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
 
-				// Set up pod port-forwarding for contour-envoy
-				t.Logf("Setting up portforward")
-				err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpsRemotePort, true, []GatewayTestConfig{
-					// /healthz is exposed on frontend container
-					{
-						Path:               "healthz",
-						ExpectedStatusCode: http.StatusOK,
-					},
-				})
-				if err != nil {
-					t.Logf("Failed to test Gateway via portforward with error: %s", err)
-				} else {
-					// Successfully ran tests
-					return
-				}
+                // Set up pod port-forwarding for contour-envoy
+                t.Logf("Setting up portforward")
+                err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpsRemotePort, true, []GatewayTestConfig{
+                    // /healthz is exposed on frontend container
+                    {
+                        Path:               "healthz",
+                        ExpectedStatusCode: http.StatusOK,
+                    },
+                })
+                if err != nil {
+                    t.Logf("Failed to test Gateway via portforward with error: %s", err)
+                } else {
+                    // Successfully ran tests
+                    return
+                }
 
-				require.Fail(t, "Gateway tests failed")
-			},
-		},
-	})
+                require.Fail(t, "Gateway tests failed")
+            },
+        },
+    })
 
-	test.Test(t)
+    test.Test(t)
 }
 
 func testGatewayWithPortForward(t *testing.T, ctx context.Context, at shared.RPTest, hostname string, remotePort int, isHttps bool, tests []GatewayTestConfig) error {
-	// stopChan will close the port-forward connection on close
-	stopChan := make(chan struct{})
+    // stopChan will close the port-forward connection on close
+    stopChan := make(chan struct{})
 
-	// portChan will be populated with the assigned port once the port-forward connection is opened on it
-	portChan := make(chan int)
+    // portChan will be populated with the assigned port once the port-forward connection is opened on it
+    portChan := make(chan int)
 
-	// errorChan will contain any errors created from initializing the port-forwarding session
-	errorChan := make(chan error)
+    // errorChan will contain any errors created from initializing the port-forwarding session
+    errorChan := make(chan error)
 
-	go functional.ExposeIngress(t, ctx, at.Options.K8sClient, at.Options.K8sConfig, remotePort, stopChan, portChan, errorChan)
+    go functional.ExposeIngress(t, ctx, at.Options.K8sClient, at.Options.K8sConfig, remotePort, stopChan, portChan, errorChan)
 
-	select {
-	case err := <-errorChan:
-		return fmt.Errorf("portforward failed with error: %s", err)
-	case localPort := <-portChan:
-		protocol := "http"
-		if isHttps {
-			protocol = "https"
-		}
-		baseURL := fmt.Sprintf("%s://localhost:%d", protocol, localPort)
+    select {
+    case err := <-errorChan:
+        return fmt.Errorf("portforward failed with error: %s", err)
+    case localPort := <-portChan:
+        protocol := "http"
+        if isHttps {
+            protocol = "https"
+        }
+        baseURL := fmt.Sprintf("%s://localhost:%d", protocol, localPort)
 
-		t.Logf("Portforward session active at %s", baseURL)
+        t.Logf("Portforward session active at %s", baseURL)
 
-		for _, test := range tests {
-			if err := testGatewayAvailability(hostname, baseURL, test.Path, test.ExpectedStatusCode, isHttps); err != nil {
-				close(stopChan)
-				return err
-			}
-		}
+        for _, test := range tests {
+            if err := testGatewayAvailability(hostname, baseURL, test.Path, test.ExpectedStatusCode, isHttps); err != nil {
+                close(stopChan)
+                return err
+            }
+        }
 
-		// All of the requests were successful
-		t.Logf("All requests encountered the correct status code")
-		return nil
-	}
+        // All of the requests were successful
+        t.Logf("All requests encountered the correct status code")
+        return nil
+    }
 }
 
 func testGatewayAvailability(hostname, baseURL, path string, expectedStatusCode int, isHttps bool) error {
-	urlPath := strings.TrimSuffix(baseURL, "/") + "/" + strings.TrimPrefix(path, "/")
-	req, err := http.NewRequest(http.MethodGet, urlPath, nil)
-	if err != nil {
-		return err
-	}
+    urlPath := strings.TrimSuffix(baseURL, "/") + "/" + strings.TrimPrefix(path, "/")
+    req, err := http.NewRequest(http.MethodGet, urlPath, nil)
+    if err != nil {
+        return err
+    }
 
-	req.Host = hostname
+    req.Host = hostname
 
-	client := newTestHTTPClient(isHttps, hostname)
-	res, err := client.Do(req)
-	if err != nil {
-		return err
-	}
+    client := newTestHTTPClient(isHttps, hostname)
+    res, err := client.Do(req)
+    if err != nil {
+        return err
+    }
 
-	if res.StatusCode != expectedStatusCode {
-		return fmt.Errorf("expected status code %d, got %d", expectedStatusCode, res.StatusCode)
-	}
+    if res.StatusCode != expectedStatusCode {
+        return fmt.Errorf("expected status code %d, got %d", expectedStatusCode, res.StatusCode)
+    }
 
-	// Encountered the correct status code
-	return nil
+    // Encountered the correct status code
+    return nil
 }
 
 func newTestHTTPClient(isHttps bool, hostname string) *http.Client {
-	transport := &http.Transport{
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-	}
+    transport := &http.Transport{
+        DialContext: (&net.Dialer{
+            Timeout:   30 * time.Second,
+            KeepAlive: 30 * time.Second,
+        }).DialContext,
+        ForceAttemptHTTP2:     true,
+        MaxIdleConns:          100,
+        IdleConnTimeout:       90 * time.Second,
+        TLSHandshakeTimeout:   10 * time.Second,
+        ExpectContinueTimeout: 1 * time.Second,
+    }
 
-	if isHttps {
-		transport.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true, //ignore certificate verification errors; needed since we use self-signed cert for magpie
-			MinVersion:         tls.VersionTLS12,
-			ServerName:         hostname,
-		}
-	}
+    if isHttps {
+        transport.TLSClientConfig = &tls.Config{
+            InsecureSkipVerify: true, //ignore certificate verification errors; needed since we use self-signed cert for magpie
+            MinVersion:         tls.VersionTLS12,
+            ServerName:         hostname,
+        }
+    }
 
-	return &http.Client{
-		Transport: transport,
-	}
+    return &http.Client{
+        Transport: transport,
+    }
 }
+

--- a/test/functional/shared/resources/gateway_test.go
+++ b/test/functional/shared/resources/gateway_test.go
@@ -195,7 +195,7 @@ func Test_GatewayDNS(t *testing.T) {
                 // Set up pod port-forwarding for contour-envoy
                 t.Logf("Setting up portforward")
 
-                err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, 3000, false, []GatewayTestConfig{
+                err = testGatewayWithPortForward(t, ctx, ct, metadata.Hostname, httpRemotePort, false, []GatewayTestConfig{
                     // /healthz is exposed on frontend container
                     {
                         Path:               "healthz",

--- a/test/functional/shared/resources/testdata/corerp-resources-gateway-dns.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-gateway-dns.bicep
@@ -13,85 +13,85 @@ param port int = 3000
 param magpieimage string
 
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
-  name: 'corerp-resources-gateway-dns'
-  location: location
-  properties: {
-    environment: environment
-  }
+	name: 'corerp-resources-gateway-dns'
+	location: location
+	properties: {
+		environment: environment
+	}
 }
 
 resource gateway 'Applications.Core/gateways@2022-03-15-privatepreview' = {
-  name: 'http-gtwy-gtwy-dns'
-  location: location
-  properties: {
-    application: app.id
-    routes: [
-      {
-        path: '/'
-        destination: 'http://frontendcontainerdns:3000'
-      }
-      {
-        path: '/backend1'
-        destination: 'http://backendcontainerdns:3000'
-      }
-      {
-        // Route /backend2 requests to the backend, and
-        // transform the request to /
-        path: '/backend2'
-        destination: 'http://backendcontainerdns:3000'
-        replacePrefix: '/'
-      }
-    ]
-  }
+	name: 'http-gtwy-gtwy-dns'
+	location: location
+	properties: {
+		application: app.id
+		routes: [
+			{
+				path: '/'
+				destination: 'http://frontendcontainerdns:3000'
+			}
+			{
+				path: '/backend1'
+				destination: 'http://backendcontainerdns:3000'
+			}
+			{
+				// Route /backend2 requests to the backend, and
+				// transform the request to /
+				path: '/backend2'
+				destination: 'http://backendcontainerdns:3000'
+				replacePrefix: '/'
+			}
+		]
+	}
 }
 
 resource frontendcontainerdns 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'frontendcontainerdns'
-  location: location
-  properties: {
-    application: app.id
-    container: {
-      image: magpieimage
-      ports: {
-        web: {
-          containerPort: port
-        }
-      }
-      readinessProbe: {
-        kind: 'httpGet'
-        containerPort: port
-        path: '/healthz'
-      }
-    }
-    connections: {
-      backendcontainerdns: {
-        source: 'http://backendcontainerdns:3000'
-      }
-    }
-  }
+	name: 'frontendcontainerdns'
+	location: location
+	properties: {
+		application: app.id
+		container: {
+			image: magpieimage
+			ports: {
+				web: {
+					containerPort: port
+				}
+			}
+			readinessProbe: {
+				kind: 'httpGet'
+				containerPort: port
+				path: '/healthz'
+			}
+		}
+		connections: {
+			backendcontainerdns: {
+				source: 'http://backendcontainerdns:3000'
+			}
+		}
+	}
 }
 
 resource backendcontainerdns 'Applications.Core/containers@2022-03-15-privatepreview' = {
-  name: 'backendcontainerdns'
-  location: location
-  properties: {
-    application: app.id
-    container: {
-      image: magpieimage
-      env: {
-        gatewayUrl: gateway.properties.url
-      }
-      ports: {
-        web: {
-          containerPort: port
-        }
-      }
-      readinessProbe: {
-        kind: 'httpGet'
-        containerPort: port
-        path: '/healthz'
-      }
-    }
-  }
+	name: 'backendcontainerdns'
+	location: location
+	properties: {
+		application: app.id
+		container: {
+			image: magpieimage
+			env: {
+				gatewayUrl: gateway.properties.url
+			}
+			ports: {
+				web: {
+					containerPort: port
+				}
+			}
+			readinessProbe: {
+				kind: 'httpGet'
+				containerPort: port
+				path: '/healthz'
+			}
+		}
+	}
 }
 

--- a/test/functional/shared/resources/testdata/corerp-resources-gateway-dns.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-gateway-dns.bicep
@@ -21,7 +21,7 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 }
 
 resource gateway 'Applications.Core/gateways@2022-03-15-privatepreview' = {
-  name: 'http-gtwy-gtwy'
+  name: 'http-gtwy-gtwy-dns'
   location: location
   properties: {
     application: app.id

--- a/test/functional/shared/resources/testdata/corerp-resources-gateway-dns.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-gateway-dns.bicep
@@ -1,0 +1,97 @@
+import radius as radius
+
+@description('Specifies the location for resources.')
+param location string = 'local'
+
+@description('Specifies the environment for resources.')
+param environment string
+
+@description('Specifies the port for the container resource.')
+param port int = 3000
+
+@description('Specifies the image for the container resource.')
+param magpieimage string
+
+resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
+  name: 'corerp-resources-gateway-dns'
+  location: location
+  properties: {
+    environment: environment
+  }
+}
+
+resource gateway 'Applications.Core/gateways@2022-03-15-privatepreview' = {
+  name: 'http-gtwy-gtwy'
+  location: location
+  properties: {
+    application: app.id
+    routes: [
+      {
+        path: '/'
+        destination: 'http://frontendcontainerdns:3000'
+      }
+      {
+        path: '/backend1'
+        destination: 'http://backendcontainerdns:3000'
+      }
+      {
+        // Route /backend2 requests to the backend, and
+        // transform the request to /
+        path: '/backend2'
+        destination: 'http://backendcontainerdns:3000'
+        replacePrefix: '/'
+      }
+    ]
+  }
+}
+
+resource frontendcontainerdns 'Applications.Core/containers@2022-03-15-privatepreview' = {
+  name: 'frontendcontainerdns'
+  location: location
+  properties: {
+    application: app.id
+    container: {
+      image: magpieimage
+      ports: {
+        web: {
+          containerPort: port
+        }
+      }
+      readinessProbe: {
+        kind: 'httpGet'
+        containerPort: port
+        path: '/healthz'
+      }
+    }
+    connections: {
+      backendcontainerdns: {
+        source: 'http://backendcontainerdns:3000'
+      }
+    }
+  }
+}
+
+resource backendcontainerdns 'Applications.Core/containers@2022-03-15-privatepreview' = {
+  name: 'backendcontainerdns'
+  location: location
+  properties: {
+    application: app.id
+    container: {
+      image: magpieimage
+      env: {
+        gatewayUrl: gateway.properties.url
+      }
+      ports: {
+        web: {
+          containerPort: port
+        }
+      }
+      readinessProbe: {
+        kind: 'httpGet'
+        containerPort: port
+        path: '/healthz'
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
# Description

Updated the gateway render.go file to accept URL-type destinations. This will allow users to specify container routes in a DNS-SD fashion, as opposed to the previous HTTProute fashion where they needed to specify resourceIDs. This change is linked to https://github.com/project-radius/radius/pull/5857 and https://github.com/project-radius/radius/issues/3865.

Next steps include the removal of HTTProutes altogether. Right now, users can still choose to use either DNS-SD or HTTProutes to define their container resource communication.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request adds or changes features of Radius and has an approved issue.

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: radius-project/radius#6375
## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ca9c923</samp>

### Summary
🐳🌐🚀

<!--
1.  🐳 - This emoji represents the containers and the Docker image used by the application. It is a common symbol for containerization and Docker in general.
2.  🌐 - This emoji represents the gateway and the DNS name functionality. It is a symbol for the web, networking, and domain names.
3.  🚀 - This emoji represents the new feature and the deployment of the application. It is a symbol for launching, innovation, and speed.
-->
Add a new bicep file `test/functional/shared/resources/testdata/corerp-resources-gateway-dns.bicep` that defines an application with a gateway and two containers using DNS names. This is part of adding DNS support for containers in Applications.Core.

> _`corerp` app grows_
> _two containers and gateway_
> _autumn of magpie_

### Walkthrough
*  Add a new bicep file that defines an application with two containers and a gateway ([link](https://github.com/project-radius/radius/pull/6024/files?diff=unified&w=0#diff-24904a85de1aedc7e2c9c378b012a0abfcbbec3f9ef713ac60e1125eef393aa0R1-R97))


