### PR TITLE
Configuring Terraform Driver logs

### DIFF
--- a/pkg/recipes/terraform/execute.go
+++ b/pkg/recipes/terraform/execute.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 
 	install "github.com/hashicorp/hc-install"
-	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/project-radius/radius/pkg/recipes"
 	"github.com/project-radius/radius/pkg/recipes/recipecontext"
 	"github.com/project-radius/radius/pkg/recipes/terraform/config"
@@ -183,7 +182,7 @@ func (e *executor) generateConfig(ctx context.Context, workingDir, execPath stri
 func initAndApply(ctx context.Context, workingDir, execPath string) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
-	tf, err := tfexec.NewTerraform(workingDir, execPath)
+	tf, err := NewTerraform(ctx, workingDir, execPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/recipes/terraform/module.go
+++ b/pkg/recipes/terraform/module.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
-	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/project-radius/radius/pkg/recipes/recipecontext"
 )
 
@@ -74,7 +73,7 @@ func inspectTFModuleConfig(workingDir, localModuleName string) (*moduleInspectRe
 // It uses Terraform's Get command to download the module using the Terraform executable available at execPath.
 // An error is returned if the module could not be downloaded.
 func downloadModule(ctx context.Context, workingDir, execPath string) error {
-	tf, err := tfexec.NewTerraform(workingDir, execPath)
+	tf, err := NewTerraform(ctx, workingDir, execPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/recipes/terraform/types.go
+++ b/pkg/recipes/terraform/types.go
@@ -48,7 +48,7 @@ type Options struct {
 	ResourceRecipe *recipes.ResourceMetadata
 }
 
-// NewTerraform creates a new Terraform executor.
+// NewTerraform creates a new Terraform executor with Terraform logs enabled.
 func NewTerraform(ctx context.Context, workingDir, execPath string) (*tfexec.Terraform, error) {
 	tf, err := tfexec.NewTerraform(workingDir, execPath)
 	if err != nil {


### PR DESCRIPTION
# Description
This change adds log configuration for the Terraform libraries we use in the Terraform Driver.

INFO
![image](https://github.com/project-radius/radius/assets/5220939/848572b1-55e9-4e52-9b60-7c3f420c4e1d)

ERROR
![image](https://github.com/project-radius/radius/assets/5220939/a2f6b2ad-9ebe-4864-b0de-ea60dae31e52)

## Type of change
- This pull request adds or changes features of Radius and has an approved issue (issue link required).

Fixes: #issue_number

## Auto-generated summary

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7e38f70</samp>

### Summary
📝🌐🛠️

<!--
1.  📝 - This emoji represents the change of adding streaming Terraform logs to the `terraform` package. It suggests that the change involves writing or documenting something.
2.  🌐 - This emoji represents the change of calling the `configureTerraformLogs` function in the `initAndApply` and `downloadModule` functions. It suggests that the change involves networking or web-related functionality.
3.  🛠️ - This emoji represents the change of enabling streaming Terraform logs to the Radius logs. It suggests that the change involves fixing or improving something.
-->
This pull request adds streaming Terraform logs to the `terraform` package. It modifies the `initAndApply` and `downloadModule` functions to call the `configureTerraformLogs` function, which writes the Terraform output and error messages to the Radius logger.

> _To stream Terraform logs to Radius_
> _They added a function that aids us_
> _They called it in `initAndApply`_
> _And also in `downloadModule`, why?_
> _To capture the output that sways us_

### Walkthrough
*  Enable streaming the Terraform logs to the Radius logs by calling the `configureTerraformLogs` function in the `initAndApply` and `downloadModule` functions ([link](https://github.com/project-radius/radius/pull/6037/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482R191-R192), [link](https://github.com/project-radius/radius/pull/6037/files?diff=unified&w=0#diff-4f4cb2009f77e8f5e252eee95f3ed880148fc285798ef4b7bbeb970525ad7b5aR82-R83))
* Define the `configureTerraformLogs` function and the `StreamingWriter` and `StreamingErrorWriter` types in the `terraform` package ([link](https://github.com/project-radius/radius/pull/6037/files?diff=unified&w=0#diff-0ad85ed086350c77c3e366408120b4c3020d1cec542671ab3586fd0c34dafe6fR50-R90))
* Import the packages needed by the `configureTerraformLogs` function and the streaming writers in the `types.go` file ([link](https://github.com/project-radius/radius/pull/6037/files?diff=unified&w=0#diff-0ad85ed086350c77c3e366408120b4c3020d1cec542671ab3586fd0c34dafe6fL21-R26))


