### PR TITLE
Add functional tests for Bicep driver

### DIFF
--- a/.github/scripts/publish-recipes.sh
+++ b/.github/scripts/publish-recipes.sh
@@ -62,7 +62,7 @@ do
     
     # Skip files that start with _. These are not recipes, they are modules that are
     # used by the recipes.
-    if [[ $RECIPE = _* ]]; then
+    if [[ $(basename $RECIPE) =~ ^_.* ]]; then
         echo "Skipping $RECIPE"
         continue
     fi

--- a/.github/workflows/validate-bicep.yaml
+++ b/.github/workflows/validate-bicep.yaml
@@ -66,4 +66,4 @@ jobs:
       - name: Verify Bicep files
         run: ./build/validate-bicep.sh
         env:
-          BICEP_PATH: .
+          BICEP_PATH: './rad-bicep-corerp'

--- a/build/test.mk
+++ b/build/test.mk
@@ -78,7 +78,7 @@ test-functional-ucp: ## Runs UCP functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/ucp/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
 
 test-validate-bicep: ## Validates that all .bicep files compile cleanly
-	BICEP_PATH="${HOME}/.rad/bin" ./build/validate-bicep.sh
+	BICEP_PATH="${HOME}/.rad/bin/rad-bicep" ./build/validate-bicep.sh
 
 .PHONY: oav-installed
 oav-installed:

--- a/build/validate-bicep.sh
+++ b/build/validate-bicep.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
-BICEP_EXECUTABLE_CORERP="rad-bicep-corerp"
-if [[ ! -z $BICEP_PATH ]]
+if [[ -z $BICEP_PATH ]]
 then
-    BICEP_EXECUTABLE_CORERP="$BICEP_PATH/$BICEP_EXECUTABLE_CORERP"
+    echo "usage: BICEP_PATH=path/to/bicep ./build/validate-bicep.sh"
+    exit 1
 fi
 
 FILES=$(find . -type f -name "*.bicep")
@@ -23,7 +23,8 @@ do
     if grep -q "import radius as radius" $F
     then
         exec 3>&1
-        STDERR=$($BICEP_EXECUTABLE_CORERP build $F --stdout 2>&1 1>/dev/null)
+        echo "running: $BICEP_PATH build $F"
+        STDERR=$($BICEP_PATH build $F --stdout 2>&1 1>/dev/null)
         EXITCODE=$?
         exec 3>&-
     fi

--- a/pkg/azure/clientv2/clients.go
+++ b/pkg/azure/clientv2/clients.go
@@ -68,18 +68,22 @@ func NewUserAssignedIdentityClient(subscriptionID string, options *Options) (*ar
 //
 // NewCustomActionClient creates a new CustomActionClient with the provided subscriptionID and Options, and returns an
 // error if one occurs.
-func NewCustomActionClient(subscriptionID string, options *Options) (*CustomActionClient, error) {
+func NewCustomActionClient(subscriptionID string, options *Options, clientOptions *arm.ClientOptions) (*CustomActionClient, error) {
 	baseURI := DefaultBaseURI
 	if options.BaseURI != "" {
 		baseURI = options.BaseURI
 	}
 
-	client, err := armresources.NewClient(subscriptionID, options.Cred, defaultClientOptions)
+	if clientOptions == nil {
+		clientOptions = defaultClientOptions
+	}
+
+	client, err := armresources.NewClient(subscriptionID, options.Cred, clientOptions)
 	if err != nil {
 		return nil, err
 	}
 
-	pipeline, err := armruntime.NewPipeline(ModuleName, ModuleVersion, options.Cred, runtime.PipelineOptions{}, defaultClientOptions)
+	pipeline, err := armruntime.NewPipeline(ModuleName, ModuleVersion, options.Cred, runtime.PipelineOptions{}, clientOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/azure/clientv2/customaction.go
+++ b/pkg/azure/clientv2/customaction.go
@@ -87,7 +87,9 @@ func (client *CustomActionClient) customActionCreateRequest(ctx context.Context,
 		return nil, errors.New("action cannot be empty")
 	}
 
-	urlPath := runtime.JoinPaths(client.baseURI, url.PathEscape(resourceID), url.PathEscape(action))
+	// resourceID contains slashes, and only allows characters allowed in a URL path, so
+	// it must not be escaped.
+	urlPath := runtime.JoinPaths(client.baseURI, resourceID, url.PathEscape(action))
 	req, err := runtime.NewRequest(ctx, http.MethodPost, urlPath)
 	if err != nil {
 		return nil, err

--- a/pkg/cli/cmd/app/connections/compute.go
+++ b/pkg/cli/cmd/app/connections/compute.go
@@ -257,6 +257,8 @@ func outputResourcesFromAPIData(resource generated.GenericResource) []outputReso
 		switch data.Provider {
 		case resourcemodel.ProviderAzure:
 			fallthrough
+		case resourcemodel.ProviderRadius:
+			fallthrough
 		case resourcemodel.ProviderAWS:
 			entry = outputResourceEntryFromID(data.Identity["id"])
 			entry.Provider = data.Provider

--- a/pkg/linkrp/processors/util.go
+++ b/pkg/linkrp/processors/util.go
@@ -41,6 +41,10 @@ func GetOutputResourcesFromResourcesField(field []*linkrp.ResourceReference) ([]
 		}
 
 		identity := resourcemodel.FromUCPID(id, "")
+		if (identity == resourcemodel.ResourceIdentity{}) {
+			return nil, &ValidationError{Message: fmt.Sprintf("resource id %q is invalid", resource)}
+		}
+
 		result := rpv1.OutputResource{
 			LocalID:       fmt.Sprintf("Resource%d", i), // The dependency sorting code requires unique LocalIDs
 			Identity:      identity,
@@ -66,6 +70,10 @@ func GetOutputResourcesFromRecipe(output *recipes.RecipeOutput) ([]rpv1.OutputRe
 		}
 
 		identity := resourcemodel.FromUCPID(id, "")
+		if (identity == resourcemodel.ResourceIdentity{}) {
+			return nil, &ValidationError{Message: fmt.Sprintf("resource id %q returned by recipe is invalid", resource)}
+		}
+
 		result := rpv1.OutputResource{
 			LocalID:       fmt.Sprintf("RecipeResource%d", i), // The dependency sorting code requires unique LocalIDs
 			Identity:      identity,

--- a/pkg/recipes/driver/bicep.go
+++ b/pkg/recipes/driver/bicep.go
@@ -88,7 +88,7 @@ func (d *bicepDriver) Execute(ctx context.Context, configuration recipes.Configu
 
 	// get the parameters after resolving the conflict between developer and operator parameters
 	// if the recipe template also has the context parameter defined then add it to the parameter for deployment
-	_, isContextParameterDefined := recipeData[recipeParameters].(map[string]any)[datamodel.RecipeContextParameter]
+	isContextParameterDefined := hasContextParameter(recipeData)
 	parameters := createRecipeParameters(recipe.Parameters, definition.Parameters, isContextParameterDefined, recipeContext)
 
 	deploymentName := deploymentPrefix + strconv.FormatInt(time.Now().UnixNano(), 10)
@@ -171,6 +171,21 @@ func (d *bicepDriver) Delete(ctx context.Context, outputResources []rpv1.OutputR
 	}
 
 	return nil
+}
+
+func hasContextParameter(recipeData map[string]any) bool {
+	parametersAny, ok := recipeData[recipeParameters]
+	if !ok {
+		return false
+	}
+
+	parameters, ok := parametersAny.(map[string]any)
+	if !ok {
+		return false
+	}
+
+	_, ok = parameters[datamodel.RecipeContextParameter]
+	return ok
 }
 
 // createRecipeParameters creates the parameters to be passed for recipe deployment after handling conflicts in parameters set by operator and developer.

--- a/pkg/recipes/driver/bicep_test.go
+++ b/pkg/recipes/driver/bicep_test.go
@@ -35,6 +35,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_NoContext(t *testing.T) {
+	devParams := map[string]any{}
+	operatorParams := map[string]any{}
+	expectedParams := map[string]any{}
+
+	actualParams := createRecipeParameters(devParams, operatorParams, false, nil)
+	require.Equal(t, expectedParams, actualParams)
+}
+
 func Test_ParameterConflict(t *testing.T) {
 	devParams := map[string]any{
 		"throughput": 400,

--- a/pkg/resourcemodel/identity_test.go
+++ b/pkg/resourcemodel/identity_test.go
@@ -113,6 +113,19 @@ var values = []struct {
 			},
 		},
 	},
+	{
+		Description: "Radius",
+		ExpectedID:  "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/applications/myapp",
+		Identity: ResourceIdentity{
+			ResourceType: &ResourceType{
+				Type:     "Applications.Core/applications",
+				Provider: ProviderRadius,
+			},
+			Data: UCPIdentity{
+				ID: "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/applications/myapp",
+			},
+		},
+	},
 }
 
 // Test that all formats of ResourceIdentifier round-trip with BSON

--- a/test/functional/daprrp/dapr_component_name_conflict_test.go
+++ b/test/functional/daprrp/dapr_component_name_conflict_test.go
@@ -29,9 +29,19 @@ func Test_DaprComponentNameConflict(t *testing.T) {
 	template := "resources/testdata/daprrp-resources-component-name-conflict.bicep"
 	name := "daprrp-rs-component-name-conflict"
 
+	validate := step.ValidateSingleDetail("DeploymentFailed", step.DeploymentErrorDetail{
+		Code: "ResourceDeploymentFailure",
+		Details: []step.DeploymentErrorDetail{
+			{
+				Code:            v1.CodeInternal,
+				MessageContains: "the Dapr component name '\"dapr-component\"' is already in use by another resource. Dapr component and resource names must be unique across all Dapr types (eg: StateStores, PubSubBrokers, SecretStores, etc.). Please select a new name and try again",
+			},
+		},
+	})
+
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor:                               step.NewDeployErrorExecutor(template, v1.CodeInternal, nil),
+			Executor:                               step.NewDeployErrorExecutor(template, validate),
 			SkipKubernetesOutputResourceValidation: true,
 			K8sObjects:                             &validation.K8sObjectSet{},
 		},

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -561,42 +561,12 @@ func Test_CLI_Delete(t *testing.T) {
 	})
 }
 
-func createParametersFile(t *testing.T) (string, func()) {
-	paramFile, err := os.CreateTemp("./testdata", "tmp-*-parameters.json")
-	require.NoError(t, err)
-
-	registryVal, _ := functional.SetDefault()
-	paramFileBody := `
-{
-	"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
-	"contentVersion": "1.0.0.0",
-	"parameters": {
-		"registry": {
-			"value": "%s"
-		}
-	}
-}`
-	paramJSONBody := fmt.Sprintf(paramFileBody, registryVal)
-	t.Log(paramJSONBody)
-
-	err = os.WriteFile(paramFile.Name(), []byte(paramJSONBody), os.FileMode(0755))
-	require.NoError(t, err)
-
-	return paramFile.Name(), func() {
-		os.Remove(paramFile.Name())
-	}
-}
-
 func Test_CLI_DeploymentParameters(t *testing.T) {
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-
 	template := "testdata/corerp-kubernetes-cli-parameters.bicep"
 	name := "kubernetes-cli-params"
 
-	paramFile, cleanup := createParametersFile(t)
-	defer cleanup()
-	parameterFilePath := filepath.Join(cwd, paramFile)
+	registry, _ := functional.SetDefault()
+	parameterFilePath := functional.WriteBicepParameterFile(t, map[string]any{"registry": registry})
 
 	// corerp-kubernetes-cli-parameters.parameters.json uses radiusdev.azurecr.io as a registry parameter.
 	// Use the specified tag only if the test uses radiusdev.azurecr.io registry. Otherwise, use latest tag.

--- a/test/functional/shared/mechanics/mechanics_test.go
+++ b/test/functional/shared/mechanics/mechanics_test.go
@@ -23,7 +23,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/kubernetes"
 	"github.com/project-radius/radius/test/functional"
 	"github.com/project-radius/radius/test/functional/shared"
@@ -309,9 +308,41 @@ func Test_InvalidResourceIDs(t *testing.T) {
 	name := "corerp-mechanics-invalid-resourceids"
 	template := "testdata/corerp-mechanics-invalid-resourceids.bicep"
 
+	// We've avoiding including resource IDs here because they can change depending on how the run is
+	// configured.
+	validate := step.ValidateAllDetails("DeploymentFailed", []step.DeploymentErrorDetail{
+		{
+			Code: "ResourceDeploymentFailure",
+			Details: []step.DeploymentErrorDetail{
+				{
+					Code:            "BadRequest",
+					MessageContains: "has invalid Applications.Core/applications resource type.",
+				},
+			},
+		},
+		{
+			Code: "ResourceDeploymentFailure",
+			Details: []step.DeploymentErrorDetail{
+				{
+					Code:            "BadRequest",
+					MessageContains: "application ID \"not_an_id\" for the resource",
+				},
+			},
+		},
+		{
+			Code: "ResourceDeploymentFailure",
+			Details: []step.DeploymentErrorDetail{
+				{
+					Code:            "BadRequest",
+					MessageContains: "application ID \"global\" for the resource",
+				},
+			},
+		},
+	})
+
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
-			Executor: step.NewDeployErrorExecutor(template, v1.CodeInvalid, nil, functional.GetMagpieImage()),
+			Executor: step.NewDeployErrorExecutor(template, validate, functional.GetMagpieImage()),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{

--- a/test/functional/shared/resources/recipe_bicep_test.go
+++ b/test/functional/shared/resources/recipe_bicep_test.go
@@ -1,0 +1,432 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
+	"github.com/project-radius/radius/pkg/ucp/resources"
+	"github.com/project-radius/radius/test/functional"
+	"github.com/project-radius/radius/test/functional/shared"
+	"github.com/project-radius/radius/test/step"
+	"github.com/project-radius/radius/test/validation"
+	"github.com/stretchr/testify/require"
+)
+
+// This file contains tests for Bicep recipes functionality - covering general behaviors that should
+// be consistent across all resource types. These tests mostly use the extender resource type and mostly
+// avoid cloud resources to avoid unnecessary coupling and reliability issues.
+//
+// Tests in this file should only use cloud resources if absolutely necessary.
+//
+// Tests in this file should be kept *roughly* in sync with recipe_terraform_test and any other drivers.
+
+// This tests parameters on the input side and values/secrets on the output side.
+func Test_BicepRecipe_ParametersAndOutputs(t *testing.T) {
+	template := "testdata/corerp-resources-recipe-bicep.bicep"
+	name := "corerp-resources-recipe-bicep-parametersandoutputs"
+
+	// Best way to pass complex parameters is to use JSON.
+	parametersFilePath := functional.WriteBicepParameterFile(t, map[string]any{
+		// These will be set on the environment as part of the recipe
+		"environmentParameters": map[string]any{
+			"a": "environment",
+			"d": "environment",
+		},
+
+		// These will be set on the extender resource
+		"resourceParameters": map[string]any{
+			"c": 42,
+			"d": "resource",
+		},
+	})
+
+	parameters := []string{
+		functional.GetBicepRecipeRegistry(),
+		functional.GetBicepRecipeVersion(),
+		fmt.Sprintf("basename=%s", name),
+		fmt.Sprintf("recipe=%s", "parameters-outputs"),
+		"@" + parametersFilePath,
+	}
+
+	test := shared.NewRPTest(t, name, []shared.TestStep{
+		{
+			Executor: step.NewDeployExecutor(template, parameters...),
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{
+					{
+						Name: name,
+						Type: validation.ApplicationsResource,
+					},
+					{
+						Name: name,
+						Type: validation.ExtendersResource,
+					},
+				},
+			},
+			K8sObjects: &validation.K8sObjectSet{},
+			PostStepVerify: func(ctx context.Context, t *testing.T, test shared.RPTest) {
+				resource, err := test.Options.ManagementClient.ShowResource(ctx, "Applications.Link/extenders", name)
+				require.NoError(t, err)
+
+				text, err := json.MarshalIndent(resource, "", "  ")
+				require.NoError(t, err)
+				t.Logf("resource data:\n %s", text)
+
+				require.Equal(t, "environment", resource.Properties["a"])
+				require.Equal(t, "default value", resource.Properties["b"])
+				require.Equal(t, 42.0, resource.Properties["c"])
+				require.Equal(t, "resource", resource.Properties["d"])
+
+				response, err := test.Options.CustomAction.InvokeCustomAction(ctx, *resource.ID, "2022-03-15-privatepreview", "listSecrets")
+				require.NoError(t, err)
+
+				t.Logf("secret data:\n %+v", response.Body)
+
+				expected := map[string]any{"e": "so secret"}
+				require.Equal(t, expected, response.Body)
+			},
+		},
+	})
+	test.Test(t)
+}
+
+// This test actually creates a Radius resource using a recipe (yeah, not a real user scenario).
+//
+// The purpose of this test is to test creation and behavior of **output resources**. This way we
+// can test the behavior of the output resource without having to create a real cloud resource.
+//
+// The reason we test both a Radius resource and a Kubernetes resource is that the deployment
+// engine has different behaviors for these cases. For Kubernetes resources (at the time of writing)
+// users need to manually include them in the output resources. For a Radius resource (or any UCP/Azure)
+// resource type including it in output resources is automatic.
+//
+// There are four cases we want to test (determined by open-box analysis):
+//
+// - Creating a UCP resource
+// - Creating a Kubernetes resource and manually including it in output resources
+// - Creating a resource in a module
+// - Referencing an existing resource
+//
+// Each of these cases requires a distinct behavior from the driver.
+func Test_BicepRecipe_ResourceCreation(t *testing.T) {
+	templateFmt := "testdata/corerp-resources-recipe-bicep-resourcecreation.%s.bicep"
+	name := "corerp-resources-recipe-bicep-resourcecreation"
+
+	parametersStep0 := []string{
+		functional.GetBicepRecipeRegistry(),
+		functional.GetBicepRecipeVersion(),
+		fmt.Sprintf("basename=%s", name),
+		fmt.Sprintf("recipe=%s", "resource-creation"),
+	}
+
+	parametersStep1 := []string{
+		fmt.Sprintf("basename=%s", name),
+	}
+
+	test := shared.NewRPTest(t, name, []shared.TestStep{
+		{
+			Executor: step.NewDeployExecutor(fmt.Sprintf(templateFmt, "step0"), parametersStep0...),
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{
+					{
+						Name: name,
+						Type: validation.ApplicationsResource,
+					},
+					{
+						Name: name + "-existing",
+						Type: validation.ExtendersResource,
+					},
+				},
+			},
+			SkipResourceDeletion: true,
+			K8sObjects:           &validation.K8sObjectSet{},
+		},
+		{
+			Executor: step.NewDeployExecutor(fmt.Sprintf(templateFmt, "step1"), parametersStep1...),
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{
+					{
+						Name: name,
+						Type: validation.ApplicationsResource,
+					},
+					{
+						Name: name + "-existing",
+						Type: validation.ExtendersResource,
+					},
+					{
+						Name: name, // Using a recipe
+						Type: validation.ExtendersResource,
+					},
+					{
+						Name: name + "-created", // Created inside the recipe
+						Type: validation.ExtendersResource,
+					},
+					{
+						Name: name + "-module", // Created inside the recipe using a module
+						Type: validation.ExtendersResource,
+					},
+				},
+			},
+			K8sObjects: &validation.K8sObjectSet{},
+			// Trying to delete the resources can cause multiple concurrent delete requests.
+			// This currently fails.
+			SkipResourceDeletion: true,
+			PostStepVerify: func(ctx context.Context, t *testing.T, test shared.RPTest) {
+				resource, err := test.Options.ManagementClient.ShowResource(ctx, "Applications.Link/extenders", name)
+				require.NoError(t, err)
+
+				text, err := json.MarshalIndent(resource, "", "  ")
+				require.NoError(t, err)
+				t.Logf("resource data:\n %s", text)
+
+				// Let's verify the output resources.
+				parsed, err := resources.ParseResource(*resource.ID)
+				require.NoError(t, err)
+
+				scope := strings.ReplaceAll(parsed.RootScope(), "resourcegroups", "resourceGroups")
+				expected := []any{
+					map[string]any{
+						"Identity": map[string]any{
+							"apiVersion": "unknown",
+							"kind":       "Secret",
+							"name":       name,
+							"namespace":  name + "-app",
+						},
+						"LocalID":  "RecipeResource0",
+						"Provider": "kubernetes",
+					},
+					map[string]any{
+						"Identity": map[string]interface{}{
+							"id": scope + "/providers/Applications.Link/extenders/" + name + "-created",
+						},
+						"LocalID":  "RecipeResource1",
+						"Provider": "radius",
+					}, map[string]interface{}{
+						"Identity": map[string]interface{}{
+							"id": scope + "/providers/Applications.Link/extenders/" + name + "-module",
+						},
+						"LocalID":  "RecipeResource2",
+						"Provider": "radius",
+					},
+				}
+				actual := resource.Properties["status"].(map[string]any)["outputResources"].([]any)
+				require.Equal(t, expected, actual)
+			},
+		},
+	})
+	test.Test(t)
+}
+
+func Test_BicepRecipe_ParameterNotDefined(t *testing.T) {
+	template := "testdata/corerp-resources-recipe-bicep.bicep"
+	name := "corerp-resources-recipe-bicep-parameternotdefined"
+
+	// Best way to pass complex parameters is to use JSON.
+	parametersFilePath := functional.WriteBicepParameterFile(t, map[string]any{
+		// These will be set on the environment as part of the recipe
+		"environmentParameters": map[string]any{
+			"a": "environment",
+		},
+
+		// These will be set on the extender resource
+		"resourceParameters": map[string]any{
+			"b": "resource",
+		},
+	})
+
+	parameters := []string{
+		functional.GetBicepRecipeRegistry(),
+		functional.GetBicepRecipeVersion(),
+		fmt.Sprintf("basename=%s", name),
+		fmt.Sprintf("recipe=%s", "empty-recipe"),
+		"@" + parametersFilePath,
+	}
+
+	validate := step.ValidateSingleDetail("DeploymentFailed", step.DeploymentErrorDetail{
+		Code: "ResourceDeploymentFailure",
+		Details: []step.DeploymentErrorDetail{
+			{
+				Code: v1.CodeInternal,
+				// NOTE: There is a bug in our error handling for deployements. We return the JSON text of the deployment error inside the message
+				// of our error. This is wrong.
+				//
+				// See: https://github.com/project-radius/radius/issues/6045
+
+				MessageContains: "Deployment template validation failed: 'The template parameters 'a, b' in the parameters file are not valid",
+			},
+		},
+	})
+
+	test := shared.NewRPTest(t, name, []shared.TestStep{
+		{
+			Executor: step.NewDeployErrorExecutor(template, validate, parameters...),
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{
+					{
+						Name: name,
+						Type: validation.ApplicationsResource,
+					},
+					{
+						Name: name,
+						Type: validation.ExtendersResource,
+					},
+				},
+			},
+			K8sObjects: &validation.K8sObjectSet{},
+		},
+	})
+	test.Test(t)
+}
+
+func Test_BicepRecipe_WrongOutput(t *testing.T) {
+	template := "testdata/corerp-resources-recipe-bicep.bicep"
+	name := "corerp-resources-recipe-bicep-wrongoutput"
+	parameters := []string{
+		functional.GetBicepRecipeRegistry(),
+		functional.GetBicepRecipeVersion(),
+		fmt.Sprintf("basename=%s", name),
+		fmt.Sprintf("recipe=%s", "wrong-output"),
+	}
+
+	validate := step.ValidateSingleDetail("DeploymentFailed", step.DeploymentErrorDetail{
+		Code: "ResourceDeploymentFailure",
+		Details: []step.DeploymentErrorDetail{
+			{
+				Code:            v1.CodeInternal,
+				MessageContains: "failed to read the recipe output \"result\": json: unknown field \"error\"",
+			},
+		},
+	})
+
+	test := shared.NewRPTest(t, name, []shared.TestStep{
+		{
+			Executor: step.NewDeployErrorExecutor(template, validate, parameters...),
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{
+					{
+						Name: name,
+						Type: validation.ApplicationsResource,
+					},
+					{
+						Name: name,
+						Type: validation.ExtendersResource,
+					},
+				},
+			},
+			K8sObjects: &validation.K8sObjectSet{},
+		},
+	})
+	test.Test(t)
+}
+
+func Test_BicepRecipe_LanguageFailure(t *testing.T) {
+	template := "testdata/corerp-resources-recipe-bicep.bicep"
+	name := "corerp-resources-recipe-bicep-langugagefailure"
+	parameters := []string{
+		functional.GetBicepRecipeRegistry(),
+		functional.GetBicepRecipeVersion(),
+		fmt.Sprintf("basename=%s", name),
+		fmt.Sprintf("recipe=%s", "language-failure"),
+	}
+
+	validate := step.ValidateSingleDetail("DeploymentFailed", step.DeploymentErrorDetail{
+		Code: "ResourceDeploymentFailure",
+		Details: []step.DeploymentErrorDetail{
+			{
+				Code: v1.CodeInternal,
+				// NOTE: There is a bug in our error handling for deployements. We return the JSON text of the deployment error inside the message
+				// of our error. This is wrong.
+				//
+				// See: https://github.com/project-radius/radius/issues/6046
+
+				MessageContains: "Unable to process template language expressions for resource",
+			},
+		},
+	})
+
+	test := shared.NewRPTest(t, name, []shared.TestStep{
+		{
+			Executor: step.NewDeployErrorExecutor(template, validate, parameters...),
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{
+					{
+						Name: name,
+						Type: validation.ApplicationsResource,
+					},
+					{
+						Name: name,
+						Type: validation.ExtendersResource,
+					},
+				},
+			},
+			K8sObjects: &validation.K8sObjectSet{},
+		},
+	})
+	test.Test(t)
+}
+
+func Test_BicepRecipe_ResourceCreationFailure(t *testing.T) {
+	template := "testdata/corerp-resources-recipe-bicep.bicep"
+	name := "corerp-resources-recipe-bicep-resourcecreationfailure"
+	parameters := []string{
+		functional.GetBicepRecipeRegistry(),
+		functional.GetBicepRecipeVersion(),
+		fmt.Sprintf("basename=%s", name),
+		fmt.Sprintf("recipe=%s", "resource-creation-failure"),
+	}
+
+	validate := step.ValidateSingleDetail("DeploymentFailed", step.DeploymentErrorDetail{
+		Code: "ResourceDeploymentFailure",
+		Details: []step.DeploymentErrorDetail{
+			{
+				Code: v1.CodeInternal,
+				// NOTE: There is a bug in our error handling for deployements. We return the JSON text of the deployment error inside the message
+				// of our error. This is wrong.
+				//
+				// See: https://github.com/project-radius/radius/issues/6047
+
+				MessageContains: "'not an id, just deal with it' is not a valid resource id",
+			},
+		},
+	})
+
+	test := shared.NewRPTest(t, name, []shared.TestStep{
+		{
+			Executor: step.NewDeployErrorExecutor(template, validate, parameters...),
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{
+					{
+						Name: name,
+						Type: validation.ApplicationsResource,
+					},
+					{
+						Name: name,
+						Type: validation.ExtendersResource,
+					},
+				},
+			},
+			K8sObjects: &validation.K8sObjectSet{},
+		},
+	})
+	test.Test(t)
+}

--- a/test/functional/shared/resources/recipe_terraform_test.go
+++ b/test/functional/shared/resources/recipe_terraform_test.go
@@ -16,6 +16,14 @@ limitations under the License.
 
 package resource_test
 
+// This file contains tests for Terraform recipes functionality - covering general behaviors that should
+// be consistent across all resource types. These tests mostly use the extender resource type and mostly
+// avoid cloud resources to avoid unnecessary coupling and reliability issues.
+//
+// Tests in this file should only use cloud resources if absolutely necessary.
+//
+// Tests in this file should be kept *roughly* in sync with recipe_bicep_test and any other drivers.
+
 import (
 	"context"
 	"encoding/base64"

--- a/test/functional/shared/resources/testdata/corerp-resources-dapr-component-name-conflict.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-dapr-component-name-conflict.bicep
@@ -2,8 +2,6 @@ import radius as radius
 
 param environment string
 
-param location string = resourceGroup().location
-
 resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
   name: 'corerp-resources-dcnc-old'
   location: 'global'
@@ -20,24 +18,11 @@ resource pubsub 'Applications.Link/daprPubSubBrokers@2022-03-15-privatepreview' 
     environment: environment
     application: app.id
     resourceProvisioning: 'manual'
-    resources: [
-      {
-        id: namespace.id
-      }
-    ]
     type: 'pubsub.azure.servicebus'
     version: 'v1'
     metadata: {
-      name: namespace.name
+      name: 'example'
     }
-  }
-}
-
-resource namespace 'Microsoft.ServiceBus/namespaces@2017-04-01' = {
-  name: 'dapr-ns-${guid(resourceGroup().name)}'
-  location: location
-  tags: {
-    radiustest: 'corerp-resources-dapr-pubsub-servicebus'
   }
 }
 

--- a/test/functional/shared/resources/testdata/corerp-resources-recipe-bicep-resourcecreation.step0.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-recipe-bicep-resourcecreation.step0.bicep
@@ -1,0 +1,60 @@
+import radius as radius
+
+@description('The OCI registry for test Bicep recipes.')
+param registry string
+@description('The OCI tag for test Bicep recipes.')
+param version string
+
+@description('The base name of the test, used to qualify resources and namespaces. eg: corerp-resources-terraform-helloworld')
+param basename string
+@description('The recipe to test. eg: hello-world')
+param recipe string
+@description('The recipe name used to register the recipe. eg: default')
+param environmentRecipeName string = 'default'
+@description('The environment parameters to pass to the recipe. eg: {"message": "Hello World"}')
+param environmentParameters object = {}
+
+resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
+  name: basename
+  properties: {
+    compute: {
+      kind: 'kubernetes'
+      resourceId: 'self'
+      namespace: '${basename}-env'
+    }
+    recipes: {
+      'Applications.Link/extenders': {
+        '${environmentRecipeName}': {
+          templateKind: 'bicep'
+          templatePath: '${registry}/test/functional/shared/recipes/${recipe}:${version}'
+          parameters: environmentParameters
+        }
+      }
+    }
+  }
+}
+
+resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
+  name: basename
+  properties: {
+    environment: env.id
+    extensions: [
+      {
+        kind: 'kubernetesNamespace'
+        namespace: '${basename}-app'
+      }
+    ]
+  }
+}
+
+// This resources is intentionally NOT using a recipe. It's being created so we can reference
+// it inside a recipe in the next step.
+resource extender 'Applications.Link/extenders@2022-03-15-privatepreview' = {
+  name: '${basename}-existing'
+  properties: {
+    application: app.id
+    environment: env.id
+    resourceProvisioning: 'manual'
+    message: 'hello from existing resource'
+  }
+}

--- a/test/functional/shared/resources/testdata/corerp-resources-recipe-bicep-resourcecreation.step1.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-recipe-bicep-resourcecreation.step1.bicep
@@ -1,0 +1,25 @@
+import radius as radius
+
+@description('The base name of the test, used to qualify resources and namespaces. eg: corerp-resources-terraform-helloworld')
+param basename string
+@description('The recipe name used to register the recipe. eg: default')
+param environmentRecipeName string = 'default'
+
+resource env 'Applications.Core/environments@2022-03-15-privatepreview' existing = {
+  name: basename
+}
+
+resource app 'Applications.Core/applications@2022-03-15-privatepreview' existing = {
+  name: basename
+}
+
+resource extender 'Applications.Link/extenders@2022-03-15-privatepreview' = {
+  name: basename
+  properties: {
+    application: app.id
+    environment: env.id
+    recipe: {
+      name: environmentRecipeName
+    }
+  }
+}

--- a/test/functional/shared/resources/testdata/corerp-resources-recipe-bicep.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-recipe-bicep.bicep
@@ -1,0 +1,64 @@
+import radius as radius
+
+@description('The OCI registry for test Bicep recipes.')
+param registry string
+@description('The OCI tag for test Bicep recipes.')
+param version string
+
+@description('The base name of the test, used to qualify resources and namespaces. eg: corerp-resources-terraform-helloworld')
+param basename string
+@description('The recipe to test. eg: hello-world')
+param recipe string
+@description('The recipe name used to register the recipe. eg: default')
+param environmentRecipeName string = 'default'
+@description('The recipe name used to invoke the recipe. eg: default')
+param resourceRecipeName string = 'default'
+@description('The environment parameters to pass to the recipe. eg: {"message": "Hello World"}')
+param environmentParameters object = {}
+@description('The resource parameters to pass to the recipe. eg: {"name": "hello-world"}')
+param resourceParameters object = {}
+
+resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
+  name: basename
+  properties: {
+    compute: {
+      kind: 'kubernetes'
+      resourceId: 'self'
+      namespace: '${basename}-env'
+    }
+    recipes: {
+      'Applications.Link/extenders': {
+        '${environmentRecipeName}': {
+          templateKind: 'bicep'
+          templatePath: '${registry}/test/functional/shared/recipes/${recipe}:${version}'
+          parameters: environmentParameters
+        }
+      }
+    }
+  }
+}
+
+resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
+  name: basename
+  properties: {
+    environment: env.id
+    extensions: [
+      {
+        kind: 'kubernetesNamespace'
+        namespace: '${basename}-app'
+      }
+    ]
+  }
+}
+
+resource extender 'Applications.Link/extenders@2022-03-15-privatepreview' = {
+  name: basename
+  properties: {
+    application: app.id
+    environment: env.id
+    recipe: {
+      name: resourceRecipeName
+      parameters: resourceParameters
+    }
+  }
+}

--- a/test/functional/shared/resources/testdata/corerp-resources-recipe-notfound.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-recipe-notfound.bicep
@@ -1,0 +1,41 @@
+import radius as radius
+
+@description('The base name of the test, used to qualify resources and namespaces. eg: corerp-resources-terraform-helloworld')
+param basename string
+
+resource env 'Applications.Core/environments@2022-03-15-privatepreview' = {
+  name: basename
+  properties: {
+    compute: {
+      kind: 'kubernetes'
+      resourceId: 'self'
+      namespace: '${basename}-env'
+    }
+    recipes: { // No recipes!
+    }
+  }
+}
+
+resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
+  name: basename
+  properties: {
+    environment: env.id
+    extensions: [
+      {
+        kind: 'kubernetesNamespace'
+        namespace: '${basename}-app'
+      }
+    ]
+  }
+}
+
+resource extender 'Applications.Link/extenders@2022-03-15-privatepreview' = {
+  name: basename
+  properties: {
+    application: app.id
+    environment: env.id
+    recipe: {
+      name: 'not found!'
+    }
+  }
+}

--- a/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/_resource-creation.bicep
+++ b/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/_resource-creation.bicep
@@ -1,0 +1,17 @@
+import radius as radius
+
+param context object
+
+var basename = context.resource.name
+
+// This is not a realistic user scenario (creating a Radius resource in a recipe). We're
+// doing things this way to test the UCP functionality without using cloud resources.
+resource extender 'Applications.Link/extenders@2022-03-15-privatepreview' = {
+  name: '${basename}-module'
+  properties: {
+    application: context.application.id
+    environment: context.environment.id
+    resourceProvisioning: 'manual'
+    message: 'hello from module resource'
+  }
+}

--- a/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/empty-recipe.bicep
+++ b/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/empty-recipe.bicep
@@ -1,0 +1,1 @@
+// This is the simplest possible Bicep recipe. It doesn't do anything useful or return anything.

--- a/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/language-failure.bicep
+++ b/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/language-failure.bicep
@@ -1,0 +1,18 @@
+import radius as radius
+
+param context object
+
+var basename = context.resource.name
+
+// This is not a realistic user scenario (creating a Radius resource in a recipe). We're
+// doing things this way to test a bicep language failure without using cloud resources.
+resource extender 'Applications.Link/extenders@2022-03-15-privatepreview' = {
+  name: '${basename}-failure'
+  properties: {
+    application: context.application.id
+    environment: context.environment.id
+    resourceProvisioning: 'manual'
+    #disable-next-line BCP234
+    message: substring('abcd', 10, 2929999) // YOLO
+  }
+}

--- a/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/parameters-outputs.bicep
+++ b/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/parameters-outputs.bicep
@@ -1,0 +1,21 @@
+// This is the simplest possible Bicep recipe. It doesn't do anything useful.
+
+#disable-next-line no-unused-params
+param context object
+
+param a string
+param b string = 'default value'
+param c int
+param d string = 'default value'
+
+output result object = {
+  values: {
+    a: a
+    b: b
+    c: c
+    d: d
+  }
+  secrets: {
+    e: 'so secret'
+  }
+}

--- a/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/resource-creation-failure.bicep
+++ b/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/resource-creation-failure.bicep
@@ -1,0 +1,17 @@
+import radius as radius
+
+param context object
+
+var basename = context.resource.name
+
+// This is not a realistic user scenario (creating a Radius resource in a recipe). We're
+// doing things this way to test a provisioning failure without using cloud resources.
+resource extender 'Applications.Link/extenders@2022-03-15-privatepreview' = {
+  name: '${basename}-failure'
+  properties: {
+    application: 'not an id, just deal with it'
+    environment: context.environment.id
+    resourceProvisioning: 'manual'
+    message: 'hello from recipe resource'
+  }
+}

--- a/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/resource-creation.bicep
+++ b/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/resource-creation.bicep
@@ -1,0 +1,37 @@
+import radius as radius
+
+param context object
+
+var basename = context.resource.name
+
+// This is not a realistic user scenario (creating a Radius resource in a recipe). We're
+// doing things this way to test the UCP functionality without using cloud resources.
+resource extender 'Applications.Link/extenders@2022-03-15-privatepreview' = {
+  name: '${basename}-created'
+  properties: {
+    application: context.application.id
+    environment: context.environment.id
+    resourceProvisioning: 'manual'
+    message: 'hello from recipe resource'
+  }
+}
+
+#disable-next-line no-unused-existing-resources
+resource existing 'Applications.Link/extenders@2022-03-15-privatepreview' existing = {
+  name: '${basename}-existing'
+}
+
+module mod '_resource-creation.bicep' = {
+  name: '${basename}-module'
+  params: {
+    context: context
+  }
+}
+
+output result object = {
+  resources: [
+    // We don't actually need to create this, just to make sure the recipe engine
+    // processes it. 
+    '/planes/kubernetes/local/namespaces/${context.runtime.kubernetes.namespace}/providers/core/Secret/${context.resource.name}'
+  ]
+}

--- a/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/wrong-output.bicep
+++ b/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/wrong-output.bicep
@@ -1,0 +1,5 @@
+output result object = {
+  error: {
+    message: 'not allowed!'
+  }
+}

--- a/test/functional/shared/test.go
+++ b/test/functional/shared/test.go
@@ -24,9 +24,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/project-radius/radius/pkg/azure/clientv2"
+	aztoken "github.com/project-radius/radius/pkg/azure/tokencredentials"
 	"github.com/project-radius/radius/pkg/cli"
 	"github.com/project-radius/radius/pkg/cli/clients"
 	"github.com/project-radius/radius/pkg/cli/connections"
+	"github.com/project-radius/radius/pkg/sdk"
 	"github.com/project-radius/radius/pkg/ucp/aws"
 	"github.com/project-radius/radius/test"
 	"github.com/project-radius/radius/test/functional"
@@ -34,8 +37,8 @@ import (
 )
 
 // # Function Explanation
-// 
-// NewRPTestOptions sets up the test environment by loading configs, creating a test context, creating an 
+//
+// NewRPTestOptions sets up the test environment by loading configs, creating a test context, creating an
 // ApplicationsManagementClient, creating an AWSCloudControlClient, and returning an RPTestOptions struct.
 func NewRPTestOptions(t *testing.T) RPTestOptions {
 	registry, tag := functional.SetDefault()
@@ -58,11 +61,21 @@ func NewRPTestOptions(t *testing.T) RPTestOptions {
 
 	workspace, err := cli.GetWorkspace(config, "")
 	require.NoError(t, err, "failed to read default workspace")
+	require.NotNil(t, workspace, "default workspace is not set")
 
 	t.Logf("Loaded workspace: %s (%s)", workspace.Name, workspace.FmtConnection())
 
 	client, err := connections.DefaultFactory.CreateApplicationsManagementClient(ctx, *workspace)
 	require.NoError(t, err, "failed to create ApplicationsManagementClient")
+
+	connection, err := workspace.Connect()
+	require.NoError(t, err, "failed to connect to workspace")
+
+	customAction, err := clientv2.NewCustomActionClient("", &clientv2.Options{
+		BaseURI: strings.TrimRight(connection.Endpoint(), "/"),
+		Cred:    &aztoken.AnonymousCredential{},
+	}, sdk.NewClientOptions(connection))
+	require.NoError(t, err, "failed to create CustomActionClient")
 
 	cfg, err := awsconfig.LoadDefaultConfig(ctx)
 	require.NoError(t, err)
@@ -70,6 +83,7 @@ func NewRPTestOptions(t *testing.T) RPTestOptions {
 
 	return RPTestOptions{
 		TestOptions:      test.NewTestOptions(t),
+		CustomAction:     customAction,
 		ManagementClient: client,
 		AWSClient:        awsClient,
 	}
@@ -77,6 +91,7 @@ func NewRPTestOptions(t *testing.T) RPTestOptions {
 
 type RPTestOptions struct {
 	test.TestOptions
+	CustomAction     *clientv2.CustomActionClient
 	ManagementClient clients.ApplicationsManagementClient
 	AWSClient        aws.AWSCloudControlClient
 }

--- a/test/step/deployexecutor.go
+++ b/test/step/deployexecutor.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -76,22 +75,6 @@ func (d *DeployExecutor) WithEnvironment(environment string) *DeployExecutor {
 // GetDescription returns the Description field of the DeployExecutor instance.
 func (d *DeployExecutor) GetDescription() string {
 	return d.Description
-}
-
-func unpackErrorAndMatch(err error, failWithAny []string) bool {
-	for _, errString := range failWithAny {
-		cliErr := err.(*radcli.CLIError)
-		for _, detail := range cliErr.ErrorResponse.Error.Details {
-			if detail.Code != "OK" {
-				for _, innerDetail := range detail.Details {
-					if strings.Contains(innerDetail.Message, errString) {
-						return true
-					}
-				}
-			}
-		}
-	}
-	return false
 }
 
 // # Function Explanation


### PR DESCRIPTION
# Description

This change improves our negative functional testing generally as well as adding some missing functional tests for Recipes and the bicep recipe driver.

I found a few minor blocking bugs along the way and added fixes for these.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c212ea7</samp>

### Summary
🛠️🧪🆕

<!--
1.  🛠️ - This emoji represents the changes that modify or fix the existing code, such as the publish-recipes.sh script, the error handling in the worker.go file, the urlPath variable in the customaction.go file, and the validation checks in the util.go file.
2.  🧪 - This emoji represents the changes that add or modify the test code, such as the test functions in the recipe_test.go, dapr_component_name_conflict_test.go, cli_test.go, and mechanics_test.go files, and the bicep templates in the testdata folder.
3.  🆕 - This emoji represents the changes that add new features or functionality, such as the support for Radius resources in the identity.go file, and the new parameter for the NewCustomActionClient function in the clients.go file.
-->
This pull request adds support for Radius resources in the identity and CLI packages, improves the error handling and validation for deployment scenarios, simplifies and refactors some test and recipe code, and fixes some bugs in the ARM and custom action clients.

> _We are the masters of the code, we shape it as we please_
> _We fix the bugs, we add the tests, we make the recipes_
> _We use the tools, we write the scripts, we handle the errors_
> _We are the masters of the code, we are the engineers_

### Walkthrough
*  Modify publish-recipes.sh script to use basename and regex for skipping files with _ prefix ([link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-52f187b75cadbd36c18130331e4916e5165d7581ece299adff243212970a9434L65-R65))
*  Add clientOptions parameter to NewCustomActionClient function and pass it to NewClient and NewPipeline functions ([link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-30b3c068407e2879a004117b19f540d5ab6e4a28daa61365a315cb6d5f5c7ca2L71-R71), [link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-30b3c068407e2879a004117b19f540d5ab6e4a28daa61365a315cb6d5f5c7ca2L77-R86))
*  Remove url.PathEscape from resourceID argument in customActionCreateRequest function to fix double-escaping bug ([link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-28d9c33a9ea4c136250fa8e8690c381d78cff8fd4b75414fde25996d03fe2ca2L90-R92))
*  Add case for resourcemodel.ProviderRadius constant in outputResourcesFromAPIData function and return resource ID from RequireRadius method ([link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-ef65dc502b1e82b84929bb88995888d432dfcd5b22bae9617db4cc9e62c3ea75R260))
*  Add validation check for empty identity struct in GetOutputResourcesFromResourcesField and GetOutputResourcesFromRecipe functions and return ValidationError with resource ID ([link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-25bf55298f2a9bfe20922841e4e1f17800329e38d36f2768f4c08e9fdac95bdbR44-R47), [link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-25bf55298f2a9bfe20922841e4e1f17800329e38d36f2768f4c08e9fdac95bdbR73-R76))
*  Assign isContextParameterDefined variable to return value of hasContextParameter function and add hasContextParameter function to bicep.go file ([link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-f12e37706fa75e9e04b8dfa01a45cf9bf2a0463e1962605b2420d0cb343922a0L91-R91), [link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-f12e37706fa75e9e04b8dfa01a45cf9bf2a0463e1962605b2420d0cb343922a0R176-R190))
*  Add ProviderRadius constant, case for ProviderRadius in GetID function, RequireRadius function, and case for "radius" first scope in FromUCPID function to identity.go file ([link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-c3a3d1182bee28b6b780bd8b794d6c0b34743fe7a48db45b4f0904a034026cf4R40), [link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-c3a3d1182bee28b6b780bd8b794d6c0b34743fe7a48db45b4f0904a034026cf4R173-R175), [link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-c3a3d1182bee28b6b780bd8b794d6c0b34743fe7a48db45b4f0904a034026cf4R231-R248), [link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-c3a3d1182bee28b6b780bd8b794d6c0b34743fe7a48db45b4f0904a034026cf4R499-R503))
*  Add Test_Recipe_NotFound function to identity_test.go file to test scenario where recipe name is not found in environment ([link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-8f0866d8a988d65eb6bf2e59736523e914a9abc9757a60197403a49107c91e22R116-R128))
*  Modify Test_DaprComponentNameConflict function in dapr_component_name_conflict_test.go file to use step.ValidateSingleDetail function for error details and specify expected message and RP resource ([link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-1afbf56aa926ed8a7c8f200587712e77b9677b08904b6eacbaee522fff0927f6L32-R44), [link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-c4523dc3ad460dc3baaaa98429900f8e43efdb6fce8ab40e8f368d82b79db387L32-R54))
*  Modify Test_CLI_DeploymentParameters function in cli_test.go file to use functional.WriteBicepParameterFile function instead of createParametersFile function ([link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-9f50fd192c3de42201f2c910d3f4ba78ec369dd7c50ea61ba500fa7518f4e81dL564-R569))
*  Remove unused import statement for v1 package from mechanics_test.go file ([link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-d38a59fddb3034eb8c0448c1fed4cabfdfc8f134dfb427656ad969ea6f647f9cL26))
*  Modify Test_InvalidResourceIDs function in mechanics_test.go file to use step.ValidateAllDetails function for error details and pass functional.GetMagpieImage function to step.NewDeployErrorExecutor function ([link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-d38a59fddb3034eb8c0448c1fed4cabfdfc8f134dfb427656ad969ea6f647f9cL312-R343))
*  Modify Test_Container_FailDueToNonExistentImage and Test_Container_FailDueToBadHealthProbe functions in container_test.go file to use step.ValidateAnyDetails and step.ValidateSingleDetail functions for error details and remove innerError argument from step.NewDeployErrorExecutor function ([link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-9442e1a784d8aba972917e5cfd69a85102d0b1393b88dc2be87e84a47c794970L319-R344), [link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-9442e1a784d8aba972917e5cfd69a85102d0b1393b88dc2be87e84a47c794970L347-R379))
*  Add comment to recipe_terraform_test.go file to explain purpose of file and refer to other driver-specific tests ([link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-94178e873ad0fe96b700c75fe85d086b4ad1a4dae5f448e6f5bcc5f706b89995R19-R24))
*  Add recipe_test.go file with tests for general recipe engine functionality and Test_Recipe_NotFound function to test scenario where recipe name is not found in environment ([link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-51075c55b01bbd2dc496d976f66acecf933a7726fc3cd5897263b1a8da45e9ccR1-R67))
*  Simplify bicep template in corerp-resources-dapr-component-name-conflict.bicep file by removing unnecessary properties and changing metadata name to "example" ([link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-f6be69c9b36bf2b68f2fdcc0baf0c49e514cebbaf2b9e345dd06923320def5e7L23-R30))
*  Add bicep templates for testing resource creation behavior of Bicep recipe in corerp-resources-recipe-bicep-resourcecreation.step0.bicep and corerp-resources-recipe-bicep-resourcecreation.step1.bicep files ([link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-86a1fa3f6521a3f229498f14f3ab6d37af6e055fadf815a646b3eeee693bae36R1-R60), [link](https://github.com/project-radius/radius/pull/6048/files?diff=unified&w=0#diff-b623663e1cc8e8a27dbc78821a9451ce52cb2d00e5490ca4dc1dc38106759718R1-R25))


