### PR TITLE
Fix misuse of log verbosity

### DIFF
--- a/pkg/armrpc/api/v1/armrequestcontext.go
+++ b/pkg/armrpc/api/v1/armrequestcontext.go
@@ -192,13 +192,13 @@ func FromARMRequest(r *http.Request, pathBase, location string) (*ARMRequestCont
 	path := strings.TrimPrefix(refererURL.Path, pathBase)
 	rID, err := resources.ParseByMethod(path, r.Method)
 	if err != nil {
-		log.V(ucplog.Debug).Info(fmt.Sprintf("URL was not a valid resource id: %v", refererURL.Path))
+		log.V(ucplog.LevelDebug).Info(fmt.Sprintf("URL was not a valid resource id: %v", refererURL.Path))
 		// do not stop extracting headers. handler needs to care invalid resource id.
 	}
 
 	queryItemCount, err := getQueryItemCount(r.URL.Query().Get(TopParameterName))
 	if err != nil {
-		log.V(ucplog.Debug).Info(fmt.Sprintf("Error parsing top query parameter: %v", r.URL.Query()))
+		log.V(ucplog.LevelDebug).Info(fmt.Sprintf("Error parsing top query parameter: %v", r.URL.Query()))
 		return nil, err
 	}
 

--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -173,7 +173,7 @@ func (w *AsyncRequestProcessWorker) Start(ctx context.Context) error {
 
 			asyncCtrl := w.registry.Get(armReqCtx.OperationType)
 			if asyncCtrl == nil {
-				opLogger.V(ucplog.Error).Info("cannot process the unknown operation: " + armReqCtx.OperationType.String())
+				opLogger.Error(nil, "cannot process unknown operation: "+armReqCtx.OperationType.String())
 				if err := w.requestQueue.FinishMessage(reqCtx, msgreq); err != nil {
 					opLogger.Error(err, "failed to finish the message")
 				}
@@ -182,7 +182,7 @@ func (w *AsyncRequestProcessWorker) Start(ctx context.Context) error {
 
 			if msgreq.DequeueCount > w.options.MaxOperationRetryCount {
 				errMsg := fmt.Sprintf("exceeded max retry count to process async operation message: %d", msgreq.DequeueCount)
-				opLogger.V(ucplog.Error).Info(errMsg)
+				opLogger.Error(nil, errMsg)
 				failed := ctrl.NewFailedResult(v1.ErrorDetails{
 					Code:    v1.CodeInternal,
 					Message: errMsg,
@@ -201,7 +201,7 @@ func (w *AsyncRequestProcessWorker) Start(ctx context.Context) error {
 				return
 			}
 			if dup {
-				opLogger.V(ucplog.Warn).Info("duplicated message detected")
+				opLogger.Info("duplicated message detected")
 				return
 			}
 
@@ -241,8 +241,8 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 		defer func(done chan struct{}) {
 			close(done)
 			if err := recover(); err != nil {
-				msg := fmt.Sprintf("recovering from panic %v: %s", err, debug.Stack())
-				logger.V(ucplog.Error).Info(msg)
+				msg := fmt.Errorf("recovering from panic %v: %s", err, debug.Stack())
+				logger.Error(msg, "recovering from panic")
 				// When backend controller has a critical bug such as nil reference, asyncCtrl.Run() is panicking.
 				// If this happens, the message is requeued after message lock time (5 mins).
 				// After message lock is expired, message will be reprocessed 'w.options.MaxOperationRetryCount' times and

--- a/pkg/armrpc/authentication/certvalidator.go
+++ b/pkg/armrpc/authentication/certvalidator.go
@@ -45,13 +45,13 @@ func ClientCertValidator(armCertMgr *ArmCertManager) func(http.Handler) http.Han
 			}
 			clientRequestThumbprint := r.Header.Get(IngressCertThumbprintHeader)
 			if clientRequestThumbprint == "" {
-				log.V(ucplog.Debug).Info("X-SSL-Client-Thumbprint header is missing")
+				log.V(ucplog.LevelDebug).Info("X-SSL-Client-Thumbprint header is missing")
 				handleErr(r.Context(), w, r)
 				return
 			}
 			isValid := IsValidThumbprint(clientRequestThumbprint)
 			if !isValid {
-				log.V(ucplog.Debug).Info("Thumbprint validating failed")
+				log.V(ucplog.LevelDebug).Info("Thumbprint validating failed")
 				handleErr(r.Context(), w, r)
 				return
 			}

--- a/pkg/armrpc/frontend/server/handler.go
+++ b/pkg/armrpc/frontend/server/handler.go
@@ -157,7 +157,7 @@ func RegisterHandler(ctx context.Context, opts HandlerOptions, ctrlOpts ctrl.Opt
 	// Ensure that the current route is not registered before. We logs the warning message if the route is registered before.
 	duplicated := opts.ParentRouter.Match(chi.NewRouteContext(), opts.Method.HTTPMethod(), opts.Path)
 	if duplicated {
-		logger.V(ucplog.Error).Info(fmt.Sprintf("Warning: skipping handler registration because '%s %s' has been registered before.", opts.Method, opts.Path))
+		logger.Info(fmt.Sprintf("Warning: skipping handler registration because '%s %s' has been registered before.", opts.Method, opts.Path))
 		return nil
 	}
 

--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -385,7 +385,7 @@ func (dp *deploymentProcessor) getEnvOptions(ctx context.Context, env *corerp_dm
 	// Extract identity info.
 	envOpts.Identity = env.Properties.Compute.Identity
 	if envOpts.Identity == nil {
-		logger.V(ucplog.Debug).Info("environment identity is not specified.")
+		logger.V(ucplog.LevelDebug).Info("environment identity is not specified.")
 	}
 
 	// Get Environment KubernetesMetadata Info

--- a/pkg/middleware/recoverer.go
+++ b/pkg/middleware/recoverer.go
@@ -27,7 +27,7 @@ import (
 )
 
 // # Function Explanation
-// 
+//
 // Recoverer handles panics and logs the error, returning an Internal Server Error response.
 func Recoverer(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -35,8 +35,8 @@ func Recoverer(h http.Handler) http.Handler {
 			if err := recover(); err != nil {
 				log := ucplog.FromContextOrDiscard(r.Context())
 
-				msg := fmt.Sprintf("recovering from panic %v: %s", err, debug.Stack())
-				log.V(ucplog.Error).Info(msg)
+				msg := fmt.Errorf("recovering from panic %v: %s", err, debug.Stack())
+				log.Error(msg, "recovering from panic")
 
 				resp := rest.NewInternalServerErrorARMResponse(v1.ErrorResponse{
 					Error: v1.ErrorDetails{

--- a/pkg/ucp/frontend/controller/planes/proxyplane.go
+++ b/pkg/ucp/frontend/controller/planes/proxyplane.go
@@ -63,7 +63,7 @@ func (p *ProxyPlane) Run(ctx context.Context, w http.ResponseWriter, req *http.R
 
 	logger.Info("starting proxy request")
 	for key, value := range req.Header {
-		logger.V(ucplog.Debug).Info("incoming request header", "key", key, "value", value)
+		logger.V(ucplog.LevelDebug).Info("incoming request header", "key", key, "value", value)
 	}
 
 	refererURL := url.URL{

--- a/pkg/ucp/ucplog/log.go
+++ b/pkg/ucp/ucplog/log.go
@@ -42,15 +42,19 @@ const (
 
 // Log levels
 const (
-	// More details on verbosity levels can be found here: https://pkg.go.dev/go.uber.org/zap@v1.20.0/zapcore#DebugLevel
-	// We do not want to support levels that introduce a new control flow
-	Error int = 1
-	Warn  int = 2
-	Info  int = 3
-	//Verbose = 4
-	Debug int = 9
-	//Trace   = 10
-	DefaultLogLevel int = Info
+	// These log levels can be used with `logger.V(...)` to **add** verbosity to a log message.
+	// These DO NOT map to the underlying Zap log levels.
+	//
+	// Please read the documentation of logger.V(...) before modifying these values.
+	//
+	// You CANNOT use these levels to make a log message more severe, which is why we don't
+	// define log levels for warning or error. Use logger.Error() for errors.
+
+	// LevelInfo is the default.
+	LevelInfo int = 0
+
+	// LevelDebug should be used for messages that should not be shown in production.
+	LevelDebug int = 1
 )
 
 const (

--- a/pkg/ucp/ucplog/log_test.go
+++ b/pkg/ucp/ucplog/log_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ucplog
+
+import (
+	"testing"
+
+	"github.com/go-logr/zapr"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func Test_LogConstants(t *testing.T) {
+	type write struct {
+		Level   zapcore.Level
+		Message string
+	}
+	tests := []struct {
+		desiredLevel zapcore.Level
+		expected     []write
+	}{
+		{
+			desiredLevel: zapcore.ErrorLevel,
+			expected:     []write{},
+		},
+		{
+			desiredLevel: zapcore.WarnLevel,
+			expected:     []write{},
+		},
+		{
+			desiredLevel: zapcore.InfoLevel,
+			expected: []write{
+				{Level: 0, Message: "Default"},
+				{Level: 0, Message: "Info"},
+			},
+		},
+		{
+			desiredLevel: zapcore.DebugLevel,
+			expected: []write{
+				{Level: 0, Message: "Default"},
+				{Level: 0, Message: "Info"},
+				{Level: -1, Message: "Debug"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desiredLevel.String(), func(t *testing.T) {
+			t.Logf("Desired Level is %s - %d", test.desiredLevel.String(), test.desiredLevel)
+			sink := &testCore{DesiredLevel: test.desiredLevel}
+			zap := zap.New(sink)
+
+			logger := zapr.NewLogger(zap)
+
+			// NOTE: we only need to test Info() here. Using Error() ignores the V() call.
+			logger.Info("Default")
+			logger.V(LevelInfo).Info("Info")
+			logger.V(LevelDebug).Info("Debug")
+
+			// We only want to compare the level and message.
+			actual := []write{}
+			for i := range sink.Writes {
+				actual = append(actual, write{Level: sink.Writes[i].Level, Message: sink.Writes[i].Message})
+			}
+
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+var _ zapcore.Core = (*testCore)(nil)
+
+type testCore struct {
+	DesiredLevel zapcore.Level
+	Writes       []zapcore.Entry
+}
+
+func (c *testCore) Enabled(level zapcore.Level) bool {
+	return level >= c.DesiredLevel
+}
+
+func (c *testCore) With([]zap.Field) zapcore.Core {
+	return c
+}
+
+func (c *testCore) Check(entry zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(entry.Level) {
+		return ce.AddCore(entry, c)
+	}
+
+	return ce
+}
+
+func (c *testCore) Write(entry zapcore.Entry, _ []zapcore.Field) error {
+	c.Writes = append(c.Writes, entry)
+	return nil
+}
+
+func (c *testCore) Sync() error {
+	return nil
+}

--- a/pkg/validator/loader.go
+++ b/pkg/validator/loader.go
@@ -115,7 +115,7 @@ func LoadSpec(ctx context.Context, providerName string, specs fs.FS, rootScopePr
 		// Check if specification file pathname is valid and skip global.json.
 		parsed := parseSpecFilePath(path)
 		if parsed == nil {
-			log.V(ucplog.Warn).Info(fmt.Sprintf("failed to parse %s", path))
+			log.Error(nil, fmt.Sprintf("failed to parse OpenAPI spec %s", path))
 			return nil
 		}
 


### PR DESCRIPTION
# Description

I found this issue as part of another ongoing RP, and this is the cleanup. I reviewed all of our uses of `logger.V()`.

What I found is that panics in our codebase were not being logged. Any code that was using the pattern of `logger.V(ucplog.Error).Info(...)` was broken, which meant that a lot of really important logging would never happen.

The problem is with the meaning of `logger.V(...)`. It is NOT possible to use `logger.V(...)` to decrease the verbosity of a message, only to increase it. SO when we were doing `logger.V(ucplog.Error)` we were actually turning it into a debug message and it was being filtered out. Verbosity levels in Logr are additive, you can only add to the default level.

With this in mind, I remove the `ucplog.Error` and `ucplog.Warn` levels because they have the opposite of the desired effect. I also want to say that I really dislike this API design. It's overly complex without being flexible. We should migrate to slog soon, as this API is too difficult to use correctly.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4d16b58</samp>

### Summary
📝🐛🔄

<!--
1.  📝 - This emoji represents the documentation and comment changes that were made to explain the logging system and the usage of the log level constants.
2.  🐛 - This emoji represents the bug fixes and error handling improvements that were made to the logging code and the middleware function.
3.  🔄 - This emoji represents the refactoring and renaming of the logging constants and functions to use the `go-logr` interface and to improve consistency and clarity.
-->
This pull request refactors the logging system of the project to use the `go-logr` interface and to improve the consistency and clarity of log messages and error handling. It also adds a unit test for the log level constants and updates the documentation and naming of some logging functions and constants. The main files affected are `pkg/armrpc/*`, `pkg/middleware/recoverer.go`, `pkg/ucp/ucplog/*`, and `pkg/validator/loader.go`.

> _`ucplog` changes_
> _logging with `go-logr` now_
> _autumn of errors_

### Walkthrough
*  Refactor log level constants to match `go-logr` interface and avoid confusion with Zap log levels ([link](https://github.com/project-radius/radius/pull/6050/files?diff=unified&w=0#diff-d467735d13613b59d7644368aa68280b91ee003b21872edea14fdce1316ca7c1L195-R195), [link](https://github.com/project-radius/radius/pull/6050/files?diff=unified&w=0#diff-d467735d13613b59d7644368aa68280b91ee003b21872edea14fdce1316ca7c1L201-R201), [link](https://github.com/project-radius/radius/pull/6050/files?diff=unified&w=0#diff-107e2e0b513c8b47567d694fdd229ac7256584435045e0b3bdd53b20512ecd01L48-R48), [link](https://github.com/project-radius/radius/pull/6050/files?diff=unified&w=0#diff-107e2e0b513c8b47567d694fdd229ac7256584435045e0b3bdd53b20512ecd01L54-R54), [link](https://github.com/project-radius/radius/pull/6050/files?diff=unified&w=0#diff-2f71b55e0dceaf541f852a86c0b54060819c6266f5257474fa863826d4043815L388-R388), [link](https://github.com/project-radius/radius/pull/6050/files?diff=unified&w=0#diff-91df495d7b1c21622f09be9a9f6e3c0e18f2f7f3d25874c5bd6f0ce35e7c37c0L66-R66), [link](https://github.com/project-radius/radius/pull/6050/files?diff=unified&w=0#diff-9569d7a0c657ca96dc20c7ba231526313604215a17ac55d0ff1ef2522b29875bL45-R57), [link](https://github.com/project-radius/radius/pull/6050/files?diff=unified&w=0#diff-6037e60976cfd81dc45190e47747e324b9d27121d02dce00c9fd02e533ae8b1dR1-R116))
*  Change log messages to use `logger.Error` instead of `logger.V` when logging errors and include error objects instead of strings ([link](https://github.com/project-radius/radius/pull/6050/files?diff=unified&w=0#diff-5d9b9964242d77606f4868e3fe049978ea1c3f1903afcfeb60c76e19d9785fc5L176-R176), [link](https://github.com/project-radius/radius/pull/6050/files?diff=unified&w=0#diff-5d9b9964242d77606f4868e3fe049978ea1c3f1903afcfeb60c76e19d9785fc5L185-R185), [link](https://github.com/project-radius/radius/pull/6050/files?diff=unified&w=0#diff-5d9b9964242d77606f4868e3fe049978ea1c3f1903afcfeb60c76e19d9785fc5L244-R245), [link](https://github.com/project-radius/radius/pull/6050/files?diff=unified&w=0#diff-6adb0a7157a2a28e3007aae36bc06aac41496f5b09fa973449b68c1aa3bd919eL38-R39), [link](https://github.com/project-radius/radius/pull/6050/files?diff=unified&w=0#diff-9e26da263135bed45f84fb809a604e09c7b6b4fe84a9348d08058b1eb212afb2L118-R118))
*  Change log messages to use `logger.Info` instead of `logger.V` when logging warnings or non-fatal errors ([link](https://github.com/project-radius/radius/pull/6050/files?diff=unified&w=0#diff-5d9b9964242d77606f4868e3fe049978ea1c3f1903afcfeb60c76e19d9785fc5L204-R204), [link](https://github.com/project-radius/radius/pull/6050/files?diff=unified&w=0#diff-396513193f1b5b9c9b3a0095d03ef768cf67732757091f664bf7142812b10d75L160-R160))
*  Reformat comment in `pkg/middleware/recoverer.go` to follow Go style guidelines ([link](https://github.com/project-radius/radius/pull/6050/files?diff=unified&w=0#diff-6adb0a7157a2a28e3007aae36bc06aac41496f5b09fa973449b68c1aa3bd919eL30-R30))
*  Add unit test for log level constants and their mapping to Zap log levels in `pkg/ucp/ucplog/log_test.go` ([link](https://github.com/project-radius/radius/pull/6050/files?diff=unified&w=0#diff-6037e60976cfd81dc45190e47747e324b9d27121d02dce00c9fd02e533ae8b1dR1-R116))


