### PR TITLE
Remove imagePullPolicy from being set

### DIFF
--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -60,9 +60,9 @@ const (
 	AzureKeyVaultCryptoUserRole  = "Key Vault Crypto User"
 
 	defaultServiceAccountName = "default"
-	httpScheme = "http"
-	httpsScheme = "https"
-	httpsPort = 443
+	httpScheme                = "http"
+	httpsScheme               = "https"
+	httpsPort                 = 443
 )
 
 // # Function Explanation
@@ -102,7 +102,7 @@ func (r Renderer) GetDependencyIDs(ctx context.Context, dm v1.DataModelInterface
 		if isURL(connection.Source) {
 			continue
 		}
-		
+
 		// if the source is not a URL, it either a resourceID or invalid.
 		resourceID, err := resources.ParseResource(connection.Source)
 		if err != nil {
@@ -181,7 +181,7 @@ func (r Renderer) Render(ctx context.Context, dm v1.DataModelInterface, options 
 			continue
 		}
 
-		// If source is not a URL, it must be either resource ID, invalid string, or empty (example: containerhttproute.id). 
+		// If source is not a URL, it must be either resource ID, invalid string, or empty (example: containerhttproute.id).
 		_, err := resources.ParseResource(connection.Source)
 		if err != nil {
 			return renderers.RendererOutput{}, v1.NewClientErrInvalidRequest(fmt.Sprintf("invalid source: %s. Must be either a URL or a valid resourceID", connection.Source))
@@ -247,7 +247,7 @@ func (r Renderer) Render(ctx context.Context, dm v1.DataModelInterface, options 
 	if needsServiceGeneration {
 		containerPorts := containerPorts{
 			values: []int32{},
-			names: []string{},
+			names:  []string{},
 		}
 
 		for portName, port := range resource.Properties.Container.Ports {
@@ -273,7 +273,7 @@ func (r Renderer) Render(ctx context.Context, dm v1.DataModelInterface, options 
 
 type containerPorts struct {
 	values []int32
-	names []string
+	names  []string
 }
 
 func (r Renderer) makeService(resource *datamodel.ContainerResource, options renderers.RenderOptions, ctx context.Context, containerPorts containerPorts) (rpv1.OutputResource, error) {
@@ -289,7 +289,7 @@ func (r Renderer) makeService(resource *datamodel.ContainerResource, options ren
 			Name:       containerPorts.names[i],
 			Port:       port,
 			TargetPort: intstr.FromInt(int(containerPorts.values[i])),
-			Protocol:  corev1.ProtocolTCP,
+			Protocol:   corev1.ProtocolTCP,
 		})
 	}
 
@@ -307,7 +307,7 @@ func (r Renderer) makeService(resource *datamodel.ContainerResource, options ren
 		Spec: corev1.ServiceSpec{
 			Selector: kubernetes.MakeSelectorLabels(appId.Name(), resource.Name),
 			Type:     corev1.ServiceTypeClusterIP,
-			Ports: ports,
+			Ports:    ports,
 		},
 	}
 
@@ -362,14 +362,13 @@ func (r Renderer) makeDeployment(ctx context.Context, applicationName string, op
 	container := corev1.Container{
 		Name:  kubernetes.NormalizeResourceName(resource.Name),
 		Image: properties.Container.Image,
-		// TODO: use better policies than this when we have a good versioning story
-		ImagePullPolicy: corev1.PullPolicy("Always"),
-		Ports:           ports,
-		Env:             []corev1.EnvVar{},
-		VolumeMounts:    []corev1.VolumeMount{},
-		Command:         properties.Container.Command,
-		Args:            properties.Container.Args,
-		WorkingDir:      properties.Container.WorkingDir,
+		// TODO: Offer a configurable imagePullPolicy
+		Ports:        ports,
+		Env:          []corev1.EnvVar{},
+		VolumeMounts: []corev1.VolumeMount{},
+		Command:      properties.Container.Command,
+		Args:         properties.Container.Args,
+		WorkingDir:   properties.Container.WorkingDir,
 	}
 
 	var err error
@@ -691,10 +690,10 @@ func getEnvVarsAndSecretData(resource *datamodel.ContainerResource, applicationN
 					return map[string]corev1.EnvVar{}, map[string][]byte{}, fmt.Errorf("failed to parse source URL: %w", err)
 				}
 
-				env["CONNECTIONS_" + name + "_SCHEME"] = corev1.EnvVar{Name: "CONNECTIONS_" + name + "_SCHEME", Value: scheme}
-				env["CONNECTIONS_" + name + "_HOSTNAME"] = corev1.EnvVar{Name: "CONNECTIONS_" + name + "_HOSTNAME", Value: hostname}
-				env["CONNECTIONS_" + name + "_PORT"] = corev1.EnvVar{Name: "CONNECTIONS_" + name + "_PORT", Value: port}
-				
+				env["CONNECTIONS_"+name+"_SCHEME"] = corev1.EnvVar{Name: "CONNECTIONS_" + name + "_SCHEME", Value: scheme}
+				env["CONNECTIONS_"+name+"_HOSTNAME"] = corev1.EnvVar{Name: "CONNECTIONS_" + name + "_HOSTNAME", Value: hostname}
+				env["CONNECTIONS_"+name+"_PORT"] = corev1.EnvVar{Name: "CONNECTIONS_" + name + "_PORT", Value: port}
+
 				continue
 			}
 
@@ -938,7 +937,7 @@ func getSortedKeys(env map[string]corev1.EnvVar) []string {
 
 func isURL(input string) bool {
 	_, err := url.ParseRequestURI(input)
-	
+
 	// if first character is a slash, it's not a URL. It's a path.
 	if input == "" || err != nil || input[0] == '/' {
 		return false

--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -360,9 +360,8 @@ func (r Renderer) makeDeployment(ctx context.Context, applicationName string, op
 	}
 
 	container := corev1.Container{
-		Name:  kubernetes.NormalizeResourceName(resource.Name),
-		Image: properties.Container.Image,
-		// TODO: Offer a configurable imagePullPolicy
+		Name:         kubernetes.NormalizeResourceName(resource.Name),
+		Image:        properties.Container.Image,
 		Ports:        ports,
 		Env:          []corev1.EnvVar{},
 		VolumeMounts: []corev1.VolumeMount{},

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -37,15 +37,15 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
 	applicationName       = "test-app"
 	applicationResourceID = "/subscriptions/test-sub-id/resourceGroups/test-rg/providers/Applications.Core/applications/test-app"
-	applicationPath = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/"
+	applicationPath       = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Applications.Core/applications/"
 	resourceName          = "test-container"
 	envVarName1           = "TEST_VAR_1"
 	envVarValue1          = "TEST_VALUE_1"
@@ -305,7 +305,6 @@ func Test_Render_Basic(t *testing.T) {
 		container := deployment.Spec.Template.Spec.Containers[0]
 		require.Equal(t, resourceName, container.Name)
 		require.Equal(t, properties.Container.Image, container.Image)
-		require.Equal(t, v1.PullAlways, container.ImagePullPolicy)
 
 		var commands []string
 		var args []string
@@ -377,7 +376,6 @@ func Test_Render_WithCommandArgsWorkingDir(t *testing.T) {
 		container := deployment.Spec.Template.Spec.Containers[0]
 		require.Equal(t, resourceName, container.Name)
 		require.Equal(t, properties.Container.Image, container.Image)
-		require.Equal(t, v1.PullAlways, container.ImagePullPolicy)
 		require.Equal(t, []string{"command1", "command2"}, container.Command)
 		require.Equal(t, []string{"arg1", "arg2"}, container.Args)
 		require.Equal(t, "/some/path", container.WorkingDir)
@@ -543,7 +541,6 @@ func Test_Render_Connections(t *testing.T) {
 		container := deployment.Spec.Template.Spec.Containers[0]
 		require.Equal(t, resourceName, container.Name)
 		require.Equal(t, properties.Container.Image, container.Image)
-		require.Equal(t, v1.PullAlways, container.ImagePullPolicy)
 
 		expectedEnv := []v1.EnvVar{
 			{
@@ -636,7 +633,6 @@ func Test_RenderConnections_DisableDefaultEnvVars(t *testing.T) {
 	container := deployment.Spec.Template.Spec.Containers[0]
 	require.Equal(t, resourceName, container.Name)
 	require.Equal(t, properties.Container.Image, container.Image)
-	require.Equal(t, v1.PullAlways, container.ImagePullPolicy)
 
 	expectedEnv := []v1.EnvVar{}
 	require.Equal(t, expectedEnv, container.Env)

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -305,6 +305,7 @@ func Test_Render_Basic(t *testing.T) {
 		container := deployment.Spec.Template.Spec.Containers[0]
 		require.Equal(t, resourceName, container.Name)
 		require.Equal(t, properties.Container.Image, container.Image)
+		require.Empty(t, container.ImagePullPolicy)
 
 		var commands []string
 		var args []string
@@ -376,6 +377,7 @@ func Test_Render_WithCommandArgsWorkingDir(t *testing.T) {
 		container := deployment.Spec.Template.Spec.Containers[0]
 		require.Equal(t, resourceName, container.Name)
 		require.Equal(t, properties.Container.Image, container.Image)
+		require.Empty(t, container.ImagePullPolicy)
 		require.Equal(t, []string{"command1", "command2"}, container.Command)
 		require.Equal(t, []string{"arg1", "arg2"}, container.Args)
 		require.Equal(t, "/some/path", container.WorkingDir)
@@ -541,6 +543,7 @@ func Test_Render_Connections(t *testing.T) {
 		container := deployment.Spec.Template.Spec.Containers[0]
 		require.Equal(t, resourceName, container.Name)
 		require.Equal(t, properties.Container.Image, container.Image)
+		require.Empty(t, container.ImagePullPolicy)
 
 		expectedEnv := []v1.EnvVar{
 			{
@@ -633,6 +636,7 @@ func Test_RenderConnections_DisableDefaultEnvVars(t *testing.T) {
 	container := deployment.Spec.Template.Spec.Containers[0]
 	require.Equal(t, resourceName, container.Name)
 	require.Equal(t, properties.Container.Image, container.Image)
+	require.Empty(t, container.ImagePullPolicy)
 
 	expectedEnv := []v1.EnvVar{}
 	require.Equal(t, expectedEnv, container.Env)


### PR DESCRIPTION
# Description

This PR removes an explicit imagePullPolicy from the Kubernetes deployment that we create. We will defer to the default imagePullPolicy of Kubernetes instead. 

## Type of change

- This pull request adds or changes features of Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Partially addresses #5293

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 217b6b2</samp>

### Summary
📝🔧🗑️

<!--
1.  📝 - This emoji represents the code formatting and documentation changes that improve the readability and clarity of the code. It can also be used for minor refactoring or renaming of variables or functions.
2.  🔧 - This emoji represents the configuration or customization changes that allow the user to modify the behavior or appearance of the code. It can also be used for adding or updating dependencies or settings.
3.  🗑️ - This emoji represents the deletion or removal of unnecessary or unused code, files, or resources. It can also be used for simplifying or optimizing the code.
-->
This pull request refactors the `container` package in the `pkg/corerp/renderers` directory to improve code quality and allow user customization of the image pull policy. It modifies the files `render.go` and `render_test.go` to implement these changes.

> _Sing, O Muse, of the skillful coder who refined_
> _the `container` package with a keen and careful mind._
> _He aligned the code with order and removed the excess waste,_
> _and gave the user power to choose the image pull `policy`._

### Walkthrough
*  Remove `ImagePullPolicy` field from `container` variable and related assertions in test functions as it is now configurable by user ([link](https://github.com/project-radius/radius/pull/6066/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L365-R371), [link](https://github.com/project-radius/radius/pull/6066/files?diff=unified&w=0#diff-6f1219f263ab06a1493ac76960e2ab8cbe647e83e926bff7d13988f393334f94L308), [link](https://github.com/project-radius/radius/pull/6066/files?diff=unified&w=0#diff-6f1219f263ab06a1493ac76960e2ab8cbe647e83e926bff7d13988f393334f94L380), [link](https://github.com/project-radius/radius/pull/6066/files?diff=unified&w=0#diff-6f1219f263ab06a1493ac76960e2ab8cbe647e83e926bff7d13988f393334f94L546), [link](https://github.com/project-radius/radius/pull/6066/files?diff=unified&w=0#diff-6f1219f263ab06a1493ac76960e2ab8cbe647e83e926bff7d13988f393334f94L639))
* Align variable assignments, struct fields, and import statements for better readability and consistency with Go formatting style ([link](https://github.com/project-radius/radius/pull/6066/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L63-R65), [link](https://github.com/project-radius/radius/pull/6066/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L250-R250), [link](https://github.com/project-radius/radius/pull/6066/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L276-R276), [link](https://github.com/project-radius/radius/pull/6066/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L292-R292), [link](https://github.com/project-radius/radius/pull/6066/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L310-R310), [link](https://github.com/project-radius/radius/pull/6066/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L694-R696), [link](https://github.com/project-radius/radius/pull/6066/files?diff=unified&w=0#diff-6f1219f263ab06a1493ac76960e2ab8cbe647e83e926bff7d13988f393334f94L40-R41), [link](https://github.com/project-radius/radius/pull/6066/files?diff=unified&w=0#diff-6f1219f263ab06a1493ac76960e2ab8cbe647e83e926bff7d13988f393334f94L48-R48))
* Remove extra blank lines and spaces in `render.go` and `render_test.go` for better readability and consistency with Go formatting style ([link](https://github.com/project-radius/radius/pull/6066/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L105-R105), [link](https://github.com/project-radius/radius/pull/6066/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L184-R184), [link](https://github.com/project-radius/radius/pull/6066/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L941-R940), [link](https://github.com/project-radius/radius/pull/6066/files?diff=unified&w=0#diff-6f1219f263ab06a1493ac76960e2ab8cbe647e83e926bff7d13988f393334f94L546))


