### PR TITLE
Increase memory limit for applications-rp

### DIFF
--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -42,6 +42,8 @@ rp:
       # request memory is the average memory usage + 10% buffer.
       memory: "160Mi"
     limits:
-      memory: "300Mi"
+      # limit is higher for applications-rp because the Terraform execution
+      # can spike memory usage.
+      memory: "500Mi"
   terraform:
     path: "/terraform"


### PR DESCRIPTION
# Description

We're seeing restarts due to memory usage in long-haul tests. This is due to execution of Terraform recipes, which can cause a spike in memory usage while the recipe is executing.

Based on the data we're seeing an increase of at least 200mb of working set during recipe execution. We don't have metrics in place yet for Terraform so it's not clear how many Terraform processes this represents (maximum of 3 due to concurrency limit of the background worker).

We may need to make future adjustments here as we add more sophisticated tests, and we will iterate based on data from the long haul tests.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).


## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 517799f</samp>

### Summary
🚀🛠️📈

<!--
1.  🚀 This emoji can be used to indicate a performance improvement or a speed boost for the pod.
2.  🛠️ This emoji can be used to indicate a bug fix or a stability enhancement for the pod.
3.  📈 This emoji can be used to indicate an increase or a growth in a resource or a metric, such as memory.
-->
Increased memory limit for `applications-rp` pod in `deploy/Chart/values.yaml`. This improves stability and performance when running Terraform commands.

> _`applications-rp`_
> _Needs more memory to run_
> _Terraform in fall_

### Walkthrough
* Increase memory limit for applications-rp pod to 500Mi ([link](https://github.com/project-radius/radius/pull/6067/files?diff=unified&w=0#diff-344923809e38a5b4c75b67a576228cf7573194fac37e773cd54334f2be49d297L45-R47))


