### PR TITLE
Update TF Logs Writer

### DIFF
--- a/pkg/recipes/terraform/types.go
+++ b/pkg/recipes/terraform/types.go
@@ -18,7 +18,6 @@ package terraform
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/terraform-exec/tfexec"
@@ -60,23 +59,19 @@ func NewTerraform(ctx context.Context, workingDir, execPath string) (*tfexec.Ter
 	return tf, err
 }
 
-// StreamingWriter is a writer that processes data in a streaming manner.
-type StreamingWriter struct {
-	logger logr.Logger
+// tfLogWrapper is a wrapper around the Terraform logger to stream the logs to the Radius logger.
+type tfLogWrapper struct {
+	logger   logr.Logger
+	isStdErr bool
 }
 
-// Write processes the data in a streaming manner.
-func (w *StreamingWriter) Write(p []byte) (n int, err error) {
-	w.logger.Info(string(p))
-	return len(p), nil
-}
-
-type StreamingErrorWriter struct {
-	logger logr.Logger
-}
-
-func (w *StreamingErrorWriter) Write(p []byte) (n int, err error) {
-	w.logger.Error(fmt.Errorf(string(p)), string(p))
+// Write implements the io.Writer interface to stream the Terraform logs to the Radius logger.
+func (w *tfLogWrapper) Write(p []byte) (n int, err error) {
+	if w.isStdErr {
+		w.logger.Error(nil, string(p))
+	} else {
+		w.logger.Info(string(p))
+	}
 	return len(p), nil
 }
 
@@ -90,13 +85,6 @@ func configureTerraformLogs(ctx context.Context, tf *tfexec.Terraform) {
 		return
 	}
 
-	streamingWriter := &StreamingWriter{
-		logger: logger,
-	}
-	tf.SetStdout(streamingWriter)
-
-	streamingErrorWriter := &StreamingErrorWriter{
-		logger: logger,
-	}
-	tf.SetStderr(streamingErrorWriter)
+	tf.SetStdout(&tfLogWrapper{logger: logger})
+	tf.SetStderr(&tfLogWrapper{logger: logger, isStdErr: true})
 }


### PR DESCRIPTION
# Description
Updating the TF Logs Writer.

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #issue_number

## Auto-generated summary

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at eaee33b</samp>

### Summary
🎁🎧🚀

<!--
1.  🎁 - This emoji could represent the simplification of the streaming of Terraform logs, as it suggests a gift or a benefit for the users or developers of the Radius logger. It could also imply that the code is more concise and elegant after the change.
2.  🎧 - This emoji could represent the use of a single `tfLogWrapper` type instead of separate types for standard output and standard error, as it suggests a unified or harmonized way of listening or handling different sources of audio or data. It could also imply that the code is more consistent and coherent after the change.
3.  🚀 - This emoji could represent the improvement of the performance or speed of the streaming of Terraform logs, as it suggests a fast or powerful launch or execution. It could also imply that the code is more efficient and optimized after the change.
-->
Improved logging of Terraform output in `pkg/recipes/terraform` package. Used a single type to wrap and stream both standard output and standard error logs.

> _To log Terraform output with ease_
> _They used a single `tfLogWrapper` type, please_
> _No more separate streams_
> _For stdout and stderr means_
> _A simpler and cleaner codebase to appease_

### Walkthrough
*  Simplify Terraform log streaming by using a single `tfLogWrapper` type instead of separate `StreamingWriter` and `StreamingErrorWriter` types ([link](https://github.com/project-radius/radius/pull/6076/files?diff=unified&w=0#diff-0ad85ed086350c77c3e366408120b4c3020d1cec542671ab3586fd0c34dafe6fL63-R78), [link](https://github.com/project-radius/radius/pull/6076/files?diff=unified&w=0#diff-0ad85ed086350c77c3e366408120b4c3020d1cec542671ab3586fd0c34dafe6fL93-R90))
* Update `configureTerraformLogs` function to use the `tfLogWrapper` type and reduce the number of variables and structs needed ([link](https://github.com/project-radius/radius/pull/6076/files?diff=unified&w=0#diff-0ad85ed086350c77c3e366408120b4c3020d1cec542671ab3586fd0c34dafe6fL93-R90))
* Modify the file `pkg/recipes/terraform/types.go` to reflect these changes ([link](https://github.com/project-radius/radius/pull/6076/files?diff=unified&w=0#diff-0ad85ed086350c77c3e366408120b4c3020d1cec542671ab3586fd0c34dafe6fL63-R78), [link](https://github.com/project-radius/radius/pull/6076/files?diff=unified&w=0#diff-0ad85ed086350c77c3e366408120b4c3020d1cec542671ab3586fd0c34dafe6fL93-R90))


