### PR TITLE
Terraform Delete Logic Implementation

### DIFF
--- a/pkg/recipes/driver/bicep_test.go
+++ b/pkg/recipes/driver/bicep_test.go
@@ -391,7 +391,9 @@ func Test_Bicep_Delete_Success(t *testing.T) {
 	}
 	client.EXPECT().Delete(ctx, "/planes/kubernetes/local/namespaces/recipe-app/providers/apps/Deployment/redis").Times(1).Return(nil)
 
-	err := driver.Delete(ctx, outputResources)
+	err := driver.Delete(ctx, DeleteOptions{
+		OutputResources: outputResources,
+	})
 	require.NoError(t, err)
 }
 
@@ -420,7 +422,9 @@ func Test_Bicep_Delete_Error(t *testing.T) {
 		Return(fmt.Errorf("could not find API version for type %q, no supported API versions", outputResources[0].GetResourceType().Type)).
 		Times(1)
 
-	err := driver.Delete(ctx, outputResources)
+	err := driver.Delete(ctx, DeleteOptions{
+		OutputResources: outputResources,
+	})
 	require.Error(t, err)
 	require.Equal(t, err, &recipeError)
 }

--- a/pkg/recipes/driver/mock_driver.go
+++ b/pkg/recipes/driver/mock_driver.go
@@ -10,7 +10,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	recipes "github.com/project-radius/radius/pkg/recipes"
-	v1 "github.com/project-radius/radius/pkg/rp/v1"
 )
 
 // MockDriver is a mock of Driver interface.
@@ -37,7 +36,7 @@ func (m *MockDriver) EXPECT() *MockDriverMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockDriver) Delete(arg0 context.Context, arg1 []v1.OutputResource) error {
+func (m *MockDriver) Delete(arg0 context.Context, arg1 DeleteOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -51,16 +50,16 @@ func (mr *MockDriverMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // Execute mocks base method.
-func (m *MockDriver) Execute(arg0 context.Context, arg1 recipes.Configuration, arg2 recipes.ResourceMetadata, arg3 recipes.EnvironmentDefinition) (*recipes.RecipeOutput, error) {
+func (m *MockDriver) Execute(arg0 context.Context, arg1 ExecuteOptions) (*recipes.RecipeOutput, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Execute", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Execute", arg0, arg1)
 	ret0, _ := ret[0].(*recipes.RecipeOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Execute indicates an expected call of Execute.
-func (mr *MockDriverMockRecorder) Execute(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockDriverMockRecorder) Execute(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockDriver)(nil).Execute), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockDriver)(nil).Execute), arg0, arg1)
 }

--- a/pkg/recipes/driver/types.go
+++ b/pkg/recipes/driver/types.go
@@ -26,8 +26,33 @@ import (
 // Driver is an interface to implement recipe deployment and recipe resources deletion.
 type Driver interface {
 	// Execute fetches the recipe contents and deploys the recipe and returns deployed resources, secrets and values.
-	Execute(ctx context.Context, configuration recipes.Configuration, recipe recipes.ResourceMetadata, definition recipes.EnvironmentDefinition) (*recipes.RecipeOutput, error)
+	Execute(ctx context.Context, opts ExecuteOptions) (*recipes.RecipeOutput, error)
 
 	// Delete handles deletion of output resources for the recipe deployment.
-	Delete(ctx context.Context, outputResources []rpv1.OutputResource) error
+	Delete(ctx context.Context, opts DeleteOptions) error
+}
+
+// BaseOptions is the base options for the driver operations.
+type BaseOptions struct {
+	// Configuration is the configuration for the recipe.
+	Configuration recipes.Configuration
+
+	// Recipe is the recipe metadata.
+	Recipe recipes.ResourceMetadata
+
+	// Definition is the environment definition for the recipe.
+	Definition recipes.EnvironmentDefinition
+}
+
+// ExecuteOptions is the options for the Execute method.
+type ExecuteOptions struct {
+	BaseOptions
+}
+
+// DeleteOptions is the options for the Delete method.
+type DeleteOptions struct {
+	BaseOptions
+
+	// OutputResources is the list of output resources for the recipe.
+	OutputResources []rpv1.OutputResource
 }

--- a/pkg/recipes/engine/engine_test.go
+++ b/pkg/recipes/engine/engine_test.go
@@ -25,20 +25,20 @@ import (
 	"github.com/project-radius/radius/pkg/corerp/datamodel"
 	"github.com/project-radius/radius/pkg/recipes"
 	"github.com/project-radius/radius/pkg/recipes/configloader"
-	"github.com/project-radius/radius/pkg/recipes/driver"
+	recipedriver "github.com/project-radius/radius/pkg/recipes/driver"
 	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 	"github.com/project-radius/radius/pkg/ucp/resources"
 	"github.com/project-radius/radius/test/testcontext"
 	"github.com/stretchr/testify/require"
 )
 
-func setup(t *testing.T) (engine, configloader.MockConfigurationLoader, driver.MockDriver) {
+func setup(t *testing.T) (engine, configloader.MockConfigurationLoader, recipedriver.MockDriver) {
 	ctrl := gomock.NewController(t)
 	configLoader := configloader.NewMockConfigurationLoader(ctrl)
-	mDriver := driver.NewMockDriver(ctrl)
+	mDriver := recipedriver.NewMockDriver(ctrl)
 	options := Options{
 		ConfigurationLoader: configLoader,
-		Drivers: map[string]driver.Driver{
+		Drivers: map[string]recipedriver.Driver{
 			recipes.TemplateKindBicep:     mDriver,
 			recipes.TemplateKindTerraform: mDriver,
 		},
@@ -89,9 +89,24 @@ func Test_Engine_Execute_Success(t *testing.T) {
 	ctx := testcontext.New(t)
 	engine, configLoader, driver := setup(t)
 
-	configLoader.EXPECT().LoadConfiguration(gomock.Any(), gomock.Any()).Times(1).Return(envConfig, nil)
-	configLoader.EXPECT().LoadRecipe(gomock.Any(), gomock.Any()).Times(1).Return(recipeDefinition, nil)
-	driver.EXPECT().Execute(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(recipeResult, nil)
+	configLoader.EXPECT().
+		LoadConfiguration(ctx, recipeMetadata).
+		Times(1).
+		Return(envConfig, nil)
+	configLoader.EXPECT().
+		LoadRecipe(ctx, &recipeMetadata).
+		Times(1).
+		Return(recipeDefinition, nil)
+	driver.EXPECT().
+		Execute(ctx, recipedriver.ExecuteOptions{
+			BaseOptions: recipedriver.BaseOptions{
+				Configuration: *envConfig,
+				Recipe:        recipeMetadata,
+				Definition:    *recipeDefinition,
+			},
+		}).
+		Times(1).
+		Return(recipeResult, nil)
 
 	result, err := engine.Execute(ctx, recipeMetadata)
 	require.NoError(t, err)
@@ -128,9 +143,24 @@ func Test_Engine_Execute_Failure(t *testing.T) {
 	ctx := testcontext.New(t)
 	engine, configLoader, driver := setup(t)
 
-	configLoader.EXPECT().LoadConfiguration(gomock.Any(), gomock.Any()).Times(1).Return(envConfig, nil)
-	configLoader.EXPECT().LoadRecipe(gomock.Any(), gomock.Any()).Times(1).Return(recipeDefinition, nil)
-	driver.EXPECT().Execute(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil, errors.New("failed to execute recipe"))
+	configLoader.EXPECT().
+		LoadConfiguration(ctx, recipeMetadata).
+		Times(1).
+		Return(envConfig, nil)
+	configLoader.EXPECT().
+		LoadRecipe(ctx, &recipeMetadata).
+		Times(1).
+		Return(recipeDefinition, nil)
+	driver.EXPECT().
+		Execute(ctx, recipedriver.ExecuteOptions{
+			BaseOptions: recipedriver.BaseOptions{
+				Configuration: *envConfig,
+				Recipe:        recipeMetadata,
+				Definition:    *recipeDefinition,
+			},
+		}).
+		Times(1).
+		Return(nil, errors.New("failed to execute recipe"))
 
 	result, err := engine.Execute(ctx, recipeMetadata)
 	require.Nil(t, result)
@@ -179,9 +209,24 @@ func Test_Engine_Terraform_Success(t *testing.T) {
 	ctx := testcontext.New(t)
 	engine, configLoader, driver := setup(t)
 
-	configLoader.EXPECT().LoadConfiguration(gomock.Any(), gomock.Any()).Times(1).Return(envConfig, nil)
-	configLoader.EXPECT().LoadRecipe(gomock.Any(), gomock.Any()).Times(1).Return(recipeDefinition, nil)
-	driver.EXPECT().Execute(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(recipeResult, nil)
+	configLoader.EXPECT().
+		LoadConfiguration(ctx, recipeMetadata).
+		Times(1).
+		Return(envConfig, nil)
+	configLoader.EXPECT().
+		LoadRecipe(ctx, &recipeMetadata).
+		Times(1).
+		Return(recipeDefinition, nil)
+	driver.EXPECT().
+		Execute(ctx, recipedriver.ExecuteOptions{
+			BaseOptions: recipedriver.BaseOptions{
+				Configuration: *envConfig,
+				Recipe:        recipeMetadata,
+				Definition:    *recipeDefinition,
+			},
+		}).
+		Times(1).
+		Return(recipeResult, nil)
 
 	result, err := engine.Execute(ctx, recipeMetadata)
 	require.NoError(t, err)
@@ -208,7 +253,10 @@ func Test_Engine_InvalidDriver(t *testing.T) {
 		},
 	}
 
-	configLoader.EXPECT().LoadRecipe(gomock.Any(), gomock.Any()).Times(1).Return(recipeDefinition, nil)
+	configLoader.EXPECT().
+		LoadRecipe(ctx, &recipeMetadata).
+		Times(1).
+		Return(recipeDefinition, nil)
 	_, err := engine.Execute(ctx, recipeMetadata)
 	require.Error(t, err)
 	require.Equal(t, err.Error(), "could not find driver invalid")
@@ -226,7 +274,10 @@ func Test_Engine_Lookup_Error(t *testing.T) {
 			"resourceName": "resource1",
 		},
 	}
-	configLoader.EXPECT().LoadRecipe(gomock.Any(), gomock.Any()).Times(1).Return(nil, errors.New("could not find recipe mongo-azure in environment env1"))
+	configLoader.EXPECT().
+		LoadRecipe(ctx, &recipeMetadata).
+		Times(1).
+		Return(nil, errors.New("could not find recipe mongo-azure in environment env1"))
 	_, err := engine.Execute(ctx, recipeMetadata)
 	require.Error(t, err)
 }
@@ -248,8 +299,14 @@ func Test_Engine_Load_Error(t *testing.T) {
 		TemplatePath: "radiusdev.azurecr.io/recipes/functionaltest/basic/mongodatabases/azure:1.0",
 		ResourceType: "Applications.Link/mongoDatabases",
 	}
-	configLoader.EXPECT().LoadRecipe(gomock.Any(), gomock.Any()).Times(1).Return(recipeDefinition, nil)
-	configLoader.EXPECT().LoadConfiguration(gomock.Any(), gomock.Any()).Times(1).Return(nil, errors.New("unable to fetch namespace information"))
+	configLoader.EXPECT().
+		LoadRecipe(ctx, &recipeMetadata).
+		Times(1).
+		Return(recipeDefinition, nil)
+	configLoader.EXPECT().
+		LoadConfiguration(ctx, recipeMetadata).
+		Times(1).
+		Return(nil, errors.New("unable to fetch namespace information"))
 	_, err := engine.Execute(ctx, recipeMetadata)
 	require.Error(t, err)
 }
@@ -257,11 +314,43 @@ func Test_Engine_Load_Error(t *testing.T) {
 func Test_Engine_Delete_Success(t *testing.T) {
 	recipeMetadata, recipeDefinition, outputResources := getDeleteInputs()
 
+	envConfig := &recipes.Configuration{
+		Runtime: recipes.RuntimeConfiguration{
+			Kubernetes: &recipes.KubernetesRuntime{
+				Namespace: "default",
+			},
+		},
+		Providers: datamodel.Providers{
+			Azure: datamodel.ProvidersAzure{
+				Scope: "scope",
+			},
+		},
+	}
+
 	ctx := testcontext.New(t)
 	engine, configLoader, driver := setup(t)
 
-	configLoader.EXPECT().LoadRecipe(gomock.Any(), gomock.Any()).Times(1).Return(&recipeDefinition, nil)
-	driver.EXPECT().Delete(ctx, outputResources).Times(1).Return(nil)
+	configLoader.EXPECT().
+		LoadRecipe(ctx, &recipeMetadata).
+		Times(1).
+		Return(&recipeDefinition, nil)
+
+	configLoader.EXPECT().
+		LoadConfiguration(ctx, recipeMetadata).
+		Times(1).
+		Return(envConfig, nil)
+
+	driver.EXPECT().
+		Delete(ctx, recipedriver.DeleteOptions{
+			BaseOptions: recipedriver.BaseOptions{
+				Configuration: *envConfig,
+				Recipe:        recipeMetadata,
+				Definition:    recipeDefinition,
+			},
+			OutputResources: outputResources,
+		}).
+		Times(1).
+		Return(nil)
 
 	err := engine.Delete(ctx, recipeMetadata, outputResources)
 	require.NoError(t, err)
@@ -270,11 +359,44 @@ func Test_Engine_Delete_Success(t *testing.T) {
 func Test_Engine_Delete_Error(t *testing.T) {
 	recipeMetadata, recipeDefinition, outputResources := getDeleteInputs()
 
+	envConfig := &recipes.Configuration{
+		Runtime: recipes.RuntimeConfiguration{
+			Kubernetes: &recipes.KubernetesRuntime{
+				Namespace: "default",
+			},
+		},
+		Providers: datamodel.Providers{
+			Azure: datamodel.ProvidersAzure{
+				Scope: "scope",
+			},
+		},
+	}
+
 	ctx := testcontext.New(t)
 	engine, configLoader, driver := setup(t)
 
-	configLoader.EXPECT().LoadRecipe(gomock.Any(), gomock.Any()).Times(1).Return(&recipeDefinition, nil)
-	driver.EXPECT().Delete(ctx, outputResources).Times(1).Return(fmt.Errorf("could not find API version for type %q, no supported API versions", outputResources[0].ID))
+	configLoader.EXPECT().
+		LoadRecipe(ctx, &recipeMetadata).
+		Times(1).
+		Return(&recipeDefinition, nil)
+
+	configLoader.EXPECT().
+		LoadConfiguration(ctx, recipeMetadata).
+		Times(1).
+		Return(envConfig, nil)
+
+	driver.EXPECT().
+		Delete(ctx, recipedriver.DeleteOptions{
+			BaseOptions: recipedriver.BaseOptions{
+				Configuration: *envConfig,
+				Recipe:        recipeMetadata,
+				Definition:    recipeDefinition,
+			},
+			OutputResources: outputResources,
+		}).
+		Times(1).
+		Return(fmt.Errorf("could not find API version for type %q, no supported API versions",
+			outputResources[0].ID))
 
 	err := engine.Delete(ctx, recipeMetadata, outputResources)
 	require.Error(t, err)
@@ -287,7 +409,10 @@ func Test_Delete_InvalidDriver(t *testing.T) {
 	ctx := testcontext.New(t)
 	engine, configLoader, _ := setup(t)
 
-	configLoader.EXPECT().LoadRecipe(gomock.Any(), gomock.Any()).Times(1).Return(&recipeDefinition, nil)
+	configLoader.EXPECT().
+		LoadRecipe(ctx, &recipeMetadata).
+		Times(1).
+		Return(&recipeDefinition, nil)
 	err := engine.Delete(ctx, recipeMetadata, outputResources)
 	require.Error(t, err)
 	require.Equal(t, err.Error(), "could not find driver invalid")
@@ -298,7 +423,10 @@ func Test_Delete_Lookup_Error(t *testing.T) {
 	engine, configLoader, _ := setup(t)
 	recipeMetadata, _, outputResources := getDeleteInputs()
 
-	configLoader.EXPECT().LoadRecipe(gomock.Any(), gomock.Any()).Times(1).Return(nil, errors.New("could not find recipe mongo-azure in environment env1"))
+	configLoader.EXPECT().
+		LoadRecipe(ctx, &recipeMetadata).
+		Times(1).
+		Return(nil, errors.New("could not find recipe mongo-azure in environment env1"))
 	err := engine.Delete(ctx, recipeMetadata, outputResources)
 	require.Error(t, err)
 }

--- a/pkg/recipes/terraform/mock_executor.go
+++ b/pkg/recipes/terraform/mock_executor.go
@@ -35,6 +35,20 @@ func (m *MockTerraformExecutor) EXPECT() *MockTerraformExecutorMockRecorder {
 	return m.recorder
 }
 
+// Delete mocks base method.
+func (m *MockTerraformExecutor) Delete(arg0 context.Context, arg1 Options) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockTerraformExecutorMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockTerraformExecutor)(nil).Delete), arg0, arg1)
+}
+
 // Deploy mocks base method.
 func (m *MockTerraformExecutor) Deploy(arg0 context.Context, arg1 Options) (*terraform_json.State, error) {
 	m.ctrl.T.Helper()

--- a/pkg/recipes/terraform/types.go
+++ b/pkg/recipes/terraform/types.go
@@ -31,6 +31,10 @@ import (
 type TerraformExecutor interface {
 	// Deploy installs terraform and runs terraform init and apply on the terraform module referenced by the recipe using terraform-exec.
 	Deploy(ctx context.Context, options Options) (*tfjson.State, error)
+
+	// Delete installs terraform and runs terraform destroy on the terraform module referenced by the recipe using terraform-exec,
+	// and deletes the Kubernetes secret created for terraform state store.
+	Delete(ctx context.Context, options Options) error
 }
 
 // Options represents the options required to build inputs to interact with Terraform.


### PR DESCRIPTION
# Description
This PR adds the following:
1. BaseOptions, ExecuteOptions, and DeleteOptions for the Driver operations.
2. Implementation of Terraform Delete logic.
3. Adding and updating unit tests.
4. Updating one of the Terraform functional tests to do the deletion.
5. Adding Secret Deletion verification to one of the functional tests.

## Type of change
- This pull request adds or changes features of Radius and has an approved issue (issue link required).

Fixes: #issue_number

## Auto-generated summary

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2dd0d17</samp>

### Summary
🗑️🧪🚧

<!--
1.  🗑️ - This emoji represents the deletion of resources, which is the main functionality of the `Delete` method for the `terraformDriver` and the `terraformExecutor` interface.
6.  🧪 - This emoji represents the testing of the `Delete` method using the `MockTerraformExecutor`, which is a mock implementation of the `terraformExecutor` interface for testing purposes.
7.  🚧 - This emoji represents the extension of the `terraformExecutor` interface to support the deletion of resources, which is a new feature that requires some changes to the existing code.
-->
Added `Delete` method to `terraformExecutor` interface and its implementations in `terraformDriver` and `MockTerraformExecutor`. This enables the deletion of resources provisioned by the Terraform driver in the Radius project.

> _Oh, we are the drivers of Terraform_
> _We create and delete with skill and charm_
> _When the recipe is done, we don't leave a trace_
> _We call the `Delete` method and destroy the place_

### Walkthrough
*  Implement the `Delete` method for the `terraformDriver` struct to delete the resources created by the Terraform recipe using the `terraformExecutor` interface ([link](https://github.com/project-radius/radius/pull/6091/files?diff=unified&w=0#diff-1b98bc9b02b96687752860c11c68d87d99ad99f24ecdfc5497fda6823abc0612L115-R148))
*  Extend the `terraformExecutor` interface to define the `Delete` method that takes the `Options` struct and deletes the Terraform resources ([link](https://github.com/project-radius/radius/pull/6091/files?diff=unified&w=0#diff-0ad85ed086350c77c3e366408120b4c3020d1cec542671ab3586fd0c34dafe6fR34-R36))
*  Provide the implementation of the `Delete` method for the `executor` struct that installs Terraform, creates a working directory, generates a config, and runs Terraform destroy using the `destroy` helper function ([link](https://github.com/project-radius/radius/pull/6091/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482R99-R133), [link](https://github.com/project-radius/radius/pull/6091/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482R252-R269))
*  Provide a mock implementation of the `Delete` method for the `MockTerraformExecutor` struct that simulates the deletion of the Terraform resources for testing purposes ([link](https://github.com/project-radius/radius/pull/6091/files?diff=unified&w=0#diff-0b4cf4663fdbba1f4b6a80956c645dca9c402e48fc2e7965c35faa12c36680a2R38-R51))


