### PR TITLE
Recipe Engine metrics updates

### DIFF
--- a/cmd/applications-rp/radius-self-hosted.yaml
+++ b/cmd/applications-rp/radius-self-hosted.yaml
@@ -24,7 +24,7 @@ secretProvider:
   provider: "kubernetes"
 metricsProvider:
   prometheus:
-    enabled: false
+    enabled: true
     path: "/metrics"
     port: 9092
 profilerProvider:

--- a/pkg/metrics/asyncoperationmetrics.go
+++ b/pkg/metrics/asyncoperationmetrics.go
@@ -137,7 +137,7 @@ func newAsyncOperationCommonAttributes(req *ctrl.Request, res *ctrl.Result) []at
 	}
 
 	if res != nil && res.ProvisioningState() != "" {
-		attrs = append(attrs, operationStateAttrKey.String(normalizeAttrValue(string(res.ProvisioningState()))))
+		attrs = append(attrs, OperationStateAttrKey.String(normalizeAttrValue(string(res.ProvisioningState()))))
 		attrs = append(attrs, operationErrorCodeAttrKey.String(normalizeAttrValue(string(res.Error.Code))))
 	}
 

--- a/pkg/metrics/recipeenginemetrics.go
+++ b/pkg/metrics/recipeenginemetrics.go
@@ -141,11 +141,14 @@ func NewRecipeAttributes(operationType, recipeName string, definition *recipes.E
 
 	if definition != nil && definition.TemplatePath != "" {
 		attrs = append(attrs, recipeTemplatePathAttrKey.String(strings.ToLower(definition.TemplatePath)))
+	}
 
+	if definition != nil && definition.ResourceType != "" {
+		attrs = append(attrs, resourceTypeAttrKey.String(strings.ToLower(definition.ResourceType)))
 	}
 
 	if state != "" {
-		attrs = append(attrs, operationStateAttrKey.String(strings.ToLower(state)))
+		attrs = append(attrs, OperationStateAttrKey.String(strings.ToLower(state)))
 	}
 
 	return attrs

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -27,8 +27,8 @@ const (
 	// operationTypeAttrKey is the attribute name for the operation type.
 	operationTypeAttrKey = attribute.Key("operation_type")
 
-	// operationStateAttrKey is the attribute name for the operation state.
-	operationStateAttrKey = attribute.Key("operation_state")
+	// OperationStateAttrKey is the attribute name for the operation state.
+	OperationStateAttrKey = attribute.Key("operation_state")
 
 	// operationErrorCodeAttrKey is the attribute name for the operation error code.
 	operationErrorCodeAttrKey = attribute.Key("operation_error_code")

--- a/pkg/recipes/driver/bicep.go
+++ b/pkg/recipes/driver/bicep.go
@@ -73,6 +73,8 @@ func (d *bicepDriver) Execute(ctx context.Context, configuration recipes.Configu
 	downloadStartTime := time.Now()
 	err := util.ReadFromRegistry(ctx, definition.TemplatePath, &recipeData)
 	if err != nil {
+		metrics.DefaultRecipeEngineMetrics.RecordRecipeDownloadDuration(ctx, downloadStartTime,
+			metrics.NewRecipeAttributes(metrics.RecipeEngineOperationDownloadRecipe, recipe.Name, &definition, metrics.FailedOperationState))
 		return nil, err
 	}
 	metrics.DefaultRecipeEngineMetrics.RecordRecipeDownloadDuration(ctx, downloadStartTime,


### PR DESCRIPTION
# Description

1. Doing some changes to the Recipe Engine Metrics

![image](https://github.com/project-radius/radius/assets/5220939/83bbb7d6-6287-4227-9f16-4e881cddeb91)


## Type of change
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #issue_number

## Auto-generated summary
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2b39fb7</samp>

### Summary
📊🛠️🌐

<!--
1.  📊 - This emoji represents the addition of the Prometheus metrics provider and the exposure of metrics for monitoring and alerting purposes. It conveys the idea of data analysis and visualization.
2.  🛠️ - This emoji represents the capitalization of the `operationStateAttrKey` variable and the addition of the resource type attribute to the `NewRecipeAttributes` function. It conveys the idea of fixing and improving the code quality and functionality.
3.  🌐 - This emoji represents the metrics recording for the bicep and terraform drivers, which involve downloading and executing recipes from remote sources. It conveys the idea of networking and cloud computing.
-->
This pull request adds and enables metrics recording and monitoring for the radius service, using the `attribute` and `metrics` packages. It records the duration and state of various operations, such as terraform and bicep recipe execution, installation, and resource provisioning. It also exposes the metrics via the Prometheus provider in the `radius-self-hosted.yaml` configuration file.

> _We're sailing on the cloud with metrics in our hand_
> _We're tracking every state and duration of our plan_
> _We're using `attribute` and `operationStateAttrKey`_
> _We're heaving on the line, one, two, three_

### Walkthrough
*  Enable Prometheus metrics provider in radius-self-hosted.yaml configuration file ([link](https://github.com/project-radius/radius/pull/6096/files?diff=unified&w=0#diff-4df28288cb6f2d9e8e1c520e2a82d7382058acaeebae8882c92b1634882efc43L27-R27))
*  Export `operationStateAttrKey` variable in metrics package to make it accessible from other packages ([link](https://github.com/project-radius/radius/pull/6096/files?diff=unified&w=0#diff-0746ff3ed894513244b3843837993bc5f1de5716bb72e8114c0020cc6821a03bL140-R140), [link](https://github.com/project-radius/radius/pull/6096/files?diff=unified&w=0#diff-4f6014ec49684363555a74798cd8e4b653f397288a35abca1d1085c34e67fff4L30-R31))
*  Add resource type attribute to `NewRecipeAttributes` function in metrics package to capture resource type for metrics ([link](https://github.com/project-radius/radius/pull/6096/files?diff=unified&w=0#diff-6403665d6373b7e2a29e5a0e1d8e52b830982dfdce21983cfd83e1c434b19046L144-R151))
*  Record recipe download duration and operation state in bicep and terraform packages using `RecordRecipeDownloadDuration` function from metrics package ([link](https://github.com/project-radius/radius/pull/6096/files?diff=unified&w=0#diff-f12e37706fa75e9e04b8dfa01a45cf9bf2a0463e1962605b2420d0cb343922a0R80-R81), [link](https://github.com/project-radius/radius/pull/6096/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482R207-R209))
*  Record terraform initialization duration and operation state in terraform package using `attribute.RecordDuration` function from metrics package ([link](https://github.com/project-radius/radius/pull/6096/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482L285-R295), [link](https://github.com/project-radius/radius/pull/6096/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482L325-R339))
*  Record terraform installation duration, version, and operation state in terraform package using `attribute.RecordDuration` and `attribute.RecordVersion` functions from metrics package ([link](https://github.com/project-radius/radius/pull/6096/files?diff=unified&w=0#diff-928c8e55e3071403aec24ba60b0f8fd85ed1f95cd4a12aed4ec6da1b3dd659c6R54), [link](https://github.com/project-radius/radius/pull/6096/files?diff=unified&w=0#diff-928c8e55e3071403aec24ba60b0f8fd85ed1f95cd4a12aed4ec6da1b3dd659c6L63-R77))
*  Import `attribute` package in terraform package to use attribute types and functions for metrics recording ([link](https://github.com/project-radius/radius/pull/6096/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482R38))


