### PR TITLE
Disable rad CLI autogen footer

### DIFF
--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -23,7 +23,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/project-radius/radius/cmd/rad/cmd"
 	"github.com/spf13/cobra/doc"
@@ -53,7 +52,6 @@ func main() {
 
 const template = `---
 type: docs
-date: %s
 title: "%s CLI reference"
 linkTitle: "%s"
 slug: %s
@@ -63,12 +61,11 @@ description: "Details on the %s Radius CLI command"
 `
 
 func frontmatter(filename string) string {
-	now := time.Now().Format(time.RFC3339)
 	name := filepath.Base(filename)
 	base := strings.TrimSuffix(name, path.Ext(name))
 	command := strings.Replace(base, "_", " ", -1)
 	url := "/reference/cli/" + strings.ToLower(base) + "/"
-	return fmt.Sprintf(template, now, command, command, base, url, command)
+	return fmt.Sprintf(template, command, command, base, url, command)
 }
 
 func link(name string) string {

--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -86,11 +86,12 @@ import (
 
 // RootCmd is the root command of the rad CLI. This is exported so we can generate docs for it.
 var RootCmd = &cobra.Command{
-	Use:           "rad",
-	Short:         "Radius CLI",
-	Long:          `Radius CLI`,
-	SilenceErrors: true,
-	SilenceUsage:  true,
+	Use:               "rad",
+	Short:             "Radius CLI",
+	Long:              `Radius CLI`,
+	SilenceErrors:     true,
+	SilenceUsage:      true,
+	DisableAutoGenTag: true,
 }
 
 const (


### PR DESCRIPTION
# Description

The rad CLI reference documentation is auto-generated within the radius repo and a PR is auto created in the docs repo.

There's currently an issue where _any_ change to the Radius repo creates a PR that updates the timestamps of every single reference doc, even if the CLI command didn't change.

This PR removes the timestamps from the reference docs so there is no diff on the PR when the content didn't change. This is aligned with our other docs pages that don't have timestamps on generation time.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2108a6c</samp>

### Summary
:gear::wastebasket::memo:

<!--
1.  :gear: - This emoji represents the addition of the `DisableAutoGenTag` field, which is a configuration option for the cobra library that generates the docs. This emoji conveys the idea of setting up or adjusting a tool or system.
2. :wastebasket: - This emoji represents the removal of the date from the docs frontmatter and the simplification of the code. This emoji conveys the idea of deleting or discarding something that is no longer needed or useful.
3. :memo: - This emoji represents the overall effect of the changes on the docs, which is to make them more consistent and avoid unnecessary diffs. This emoji conveys the idea of writing or documenting something.
-->
Removed timestamps from generated docs to avoid noise in diffs. Added a field to `RootCmd` to disable cobra's auto-gen tag and modified `cmd/docgen/main.go` accordingly.

> _To generate docs for `RootCmd`_
> _We used cobra but it was dumb_
> _It added a date_
> _That we had to negate_
> _So we set `DisableAutoGenTag` to true and it was done_

### Walkthrough
* Remove date from frontmatter of generated docs to avoid unnecessary diffs ([link](https://github.com/project-radius/radius/pull/6103/files?diff=unified&w=0#diff-5cbeb7cfadad016c4132ee13ed10ee37351e02f8182b435bc5edd1a050f01733L26), [link](https://github.com/project-radius/radius/pull/6103/files?diff=unified&w=0#diff-5cbeb7cfadad016c4132ee13ed10ee37351e02f8182b435bc5edd1a050f01733L56), [link](https://github.com/project-radius/radius/pull/6103/files?diff=unified&w=0#diff-5cbeb7cfadad016c4132ee13ed10ee37351e02f8182b435bc5edd1a050f01733L66-R68))
* Disable cobra auto-gen tag to prevent timestamp comment in generated docs ([link](https://github.com/project-radius/radius/pull/6103/files?diff=unified&w=0#diff-d36b7b4d04f01a6cf60c50dd9c01da8fb8c190231ea4c59cbbfbe070178b510bL89-R94))
* Simplify `frontmatter` function in `cmd/docgen/main.go` by removing unused `time` package and `now` variable ([link](https://github.com/project-radius/radius/pull/6103/files?diff=unified&w=0#diff-5cbeb7cfadad016c4132ee13ed10ee37351e02f8182b435bc5edd1a050f01733L26), [link](https://github.com/project-radius/radius/pull/6103/files?diff=unified&w=0#diff-5cbeb7cfadad016c4132ee13ed10ee37351e02f8182b435bc5edd1a050f01733L66-R68))


