### PR TITLE
[Do Not Review] Updating terraform functional tests to verify kubernetes secret

### DIFF
--- a/test/functional/shared/resources/recipe_terraform_test.go
+++ b/test/functional/shared/resources/recipe_terraform_test.go
@@ -102,7 +102,8 @@ func Test_TerraformRecipe_Context(t *testing.T) {
 	template := "testdata/corerp-resources-terraform-context.bicep"
 	name := "corerp-resources-terraform-context"
 	appNamespace := "corerp-resources-terraform-context-app"
-
+	secret, err := getSecretSuffix("/planes/radius/local/resourcegroups/default/providers/Applications.Link/extenders/"+name, name, name)
+	require.NoError(t, err)
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
 			Executor: step.NewDeployExecutor(template, functional.GetTerraformRecipeModuleServerURL()),
@@ -122,6 +123,9 @@ func Test_TerraformRecipe_Context(t *testing.T) {
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
 						validation.NewK8sSecretForResource(name, name),
+					},
+					"radius-system": {
+						validation.NewK8sSecretForResourceWithResourceName("tfstate-default-" + secret).ValidateLabels(false),
 					},
 				},
 			},

--- a/test/functional/shared/resources/recipe_terraform_test.go
+++ b/test/functional/shared/resources/recipe_terraform_test.go
@@ -55,6 +55,8 @@ func Test_TerraformRecipe_KubernetesRedis(t *testing.T) {
 	appName := "corerp-resources-terraform-redis-app"
 	envName := "corerp-resources-terraform-redis-env"
 	redisCacheName := "tf-redis-cache"
+	secret, err := getSecretSuffix("/planes/radius/local/resourcegroups/default/providers/Applications.Link/extenders/"+name, envName, appName)
+	require.NoError(t, err)
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -81,6 +83,9 @@ func Test_TerraformRecipe_KubernetesRedis(t *testing.T) {
 				Namespaces: map[string][]validation.K8sObject{
 					appName: {
 						validation.NewK8sServiceForResource(appName, redisCacheName).ValidateLabels(false),
+					},
+					"radius-system": {
+						validation.NewK8sSecretForResourceWithResourceName("tfstate-default-" + secret).ValidateLabels(false),
 					},
 				},
 			},


### PR DESCRIPTION
# Description

Adding changes to verify kubernetes secret verification as part of the k8s object validation
Adding ResourceName to K8s objects so we can validate the secrets object when validate labels is set to false.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2b052df</samp>

### Summary
:sparkles::wrench::package:

<!--
1.  :sparkles: - This emoji represents the new feature of validating secrets with custom names, which is a useful enhancement for users who want more flexibility and control over their secret naming.
2.  :wrench: - This emoji represents the modification of the existing `matchesActualLabels` function, which is a minor change that fixes a bug and improves the logic of the label validation.
3.  :package: - This emoji represents the addition of a new field and function to the `validation` package, which is a code-related change that affects the structure and organization of the package.
-->
Add validation support for custom-named secrets in `test/validation/k8s.go`. This allows testing secrets that do not follow the default naming convention or label validation.

> _To validate secrets with custom names_
> _We added a field and a function with claims_
> _`ResourceName` is the key_
> _And `SkipLabelValidation` we see_
> _In `matchesActualLabels` where we check the frames_

### Walkthrough
*  Add `ResourceName` field to `K8sObject` type to store the name of a Kubernetes resource ([link](https://github.com/project-radius/radius/pull/6129/files?diff=unified&w=0#diff-a52153bfeb452a3dd497767a98db0dc1a0621e012f6e6d8dd9d4b5ec758b4dc2R63))
*  Add `NewK8sSecretForResourceWithResourceName` function to create a `K8sObject` for a secret with a custom name ([link](https://github.com/project-radius/radius/pull/6129/files?diff=unified&w=0#diff-a52153bfeb452a3dd497767a98db0dc1a0621e012f6e6d8dd9d4b5ec758b4dc2R128-R139))
*  Modify `matchesActualLabels` function in `test/validation/k8s.go` to skip label validation for secrets with custom names and compare them by name instead ([link](https://github.com/project-radius/radius/pull/6129/files?diff=unified&w=0#diff-a52153bfeb452a3dd497767a98db0dc1a0621e012f6e6d8dd9d4b5ec758b4dc2L525-R538), [link](https://github.com/project-radius/radius/pull/6129/files?diff=unified&w=0#diff-a52153bfeb452a3dd497767a98db0dc1a0621e012f6e6d8dd9d4b5ec758b4dc2R547-R552))


