### PR TITLE
Adding a check to the Error.Code before adding as an attribute

### DIFF
--- a/pkg/metrics/asyncoperationmetrics.go
+++ b/pkg/metrics/asyncoperationmetrics.go
@@ -138,6 +138,9 @@ func newAsyncOperationCommonAttributes(req *ctrl.Request, res *ctrl.Result) []at
 
 	if res != nil && res.ProvisioningState() != "" {
 		attrs = append(attrs, OperationStateAttrKey.String(normalizeAttrValue(string(res.ProvisioningState()))))
+	}
+
+	if res != nil && res.Error != nil && res.Error.Code != "" {
 		attrs = append(attrs, operationErrorCodeAttrKey.String(normalizeAttrValue(string(res.Error.Code))))
 	}
 


### PR DESCRIPTION
# Description
Adding a check to the Error.Code before adding as an attribute

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #6144 

## Auto-generated summary
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2f63662</samp>

### Summary
🛠️📊🚀

<!--
1.  🛠️ - This emoji represents a fix or improvement to existing code or functionality. The change adds a condition to check for an error code, which is a fix for a potential issue with setting an empty string as the error code.
2.  📊 - This emoji represents a change related to metrics or analytics. The change is part of a larger refactor to improve the async operation metrics and logging, which are important for monitoring and debugging the system performance and behavior.
3.  🚀 - This emoji represents a change that enhances or speeds up the system or its features. The change is part of a larger refactor that aims to improve the async operation handling, which could result in faster and more reliable operations for the users.
-->
Refactor async operation metrics and logging to handle error codes better. Avoid setting `error_code` attribute to empty string in `pkg/metrics/asyncoperationmetrics.go`.

> _`error_code` checked_
> _refactor for better metrics_
> _autumn of async_

### Walkthrough
*  Add a condition to check for error codes in async operation responses ([link](https://github.com/project-radius/radius/pull/6145/files?diff=unified&w=0#diff-0746ff3ed894513244b3843837993bc5f1de5716bb72e8114c0020cc6821a03bR141-R143))


