### PR TITLE
Enable support for recipe type specific garbage collection of resources.

### DIFF
--- a/pkg/linkrp/backend/controller/createorupdateresource_test.go
+++ b/pkg/linkrp/backend/controller/createorupdateresource_test.go
@@ -341,7 +341,13 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 					"p1": "v1",
 				},
 			}
-
+			id := resources.MustParse(oldOutputResourceResourceID)
+			//require.NoError(t, err)
+			outputResources := []rpv1.OutputResource{
+				{
+					ID: id,
+				},
+			}
 			if stillPassing && tt.recipeErr != nil {
 				stillPassing = false
 				eng.EXPECT().
@@ -391,13 +397,12 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 
 			if stillPassing && tt.resourceClientErr != nil {
 				stillPassing = false
-				client.EXPECT().
-					Delete(gomock.Any(), oldOutputResourceResourceID).
+				eng.EXPECT().GarbageCollectResources(gomock.Any(), recipeMetadata, outputResources).
 					Return(tt.resourceClientErr).
 					Times(1)
 			} else if stillPassing {
-				client.EXPECT().
-					Delete(gomock.Any(), oldOutputResourceResourceID).
+				eng.EXPECT().
+					GarbageCollectResources(gomock.Any(), recipeMetadata, outputResources).
 					Return(nil).
 					Times(1)
 			}

--- a/pkg/recipes/driver/bicep.go
+++ b/pkg/recipes/driver/bicep.go
@@ -276,3 +276,17 @@ func (d *bicepDriver) prepareRecipeResponse(outputs any, resources []*deployment
 
 	return recipeResponse, nil
 }
+
+func (d *bicepDriver) GarbageCollectResources(ctx context.Context, diff []rpv1.OutputResource) error {
+	logger := ucplog.FromContextOrDiscard(ctx)
+	for _, resource := range diff {
+		logger.Info(fmt.Sprintf("Deleting output resource: %q", resource.ID), ucplog.LogFieldTargetResourceID, resource.ID)
+		err := d.ResourceClient.Delete(ctx, resource.ID.String())
+		if err != nil {
+			return recipes.NewRecipeError(recipes.RecipeGarbageCollectionFailed, err.Error(), nil)
+		}
+		logger.Info(fmt.Sprintf("Deleted output resource: %q", resource.ID), ucplog.LogFieldTargetResourceID, resource.ID)
+	}
+
+	return nil
+}

--- a/pkg/recipes/driver/bicep.go
+++ b/pkg/recipes/driver/bicep.go
@@ -277,6 +277,7 @@ func (d *bicepDriver) prepareRecipeResponse(outputs any, resources []*deployment
 	return recipeResponse, nil
 }
 
+// GarbageCollectResources handles the clean up of any obsolete resources.
 func (d *bicepDriver) GarbageCollectResources(ctx context.Context, diff []rpv1.OutputResource) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
 	for _, resource := range diff {

--- a/pkg/recipes/driver/mock_driver.go
+++ b/pkg/recipes/driver/mock_driver.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	recipes "github.com/project-radius/radius/pkg/recipes"
+	v1 "github.com/project-radius/radius/pkg/rp/v1"
 )
 
 // MockDriver is a mock of Driver interface.
@@ -62,4 +63,18 @@ func (m *MockDriver) Execute(arg0 context.Context, arg1 ExecuteOptions) (*recipe
 func (mr *MockDriverMockRecorder) Execute(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockDriver)(nil).Execute), arg0, arg1)
+}
+
+// GarbageCollectResources mocks base method.
+func (m *MockDriver) GarbageCollectResources(arg0 context.Context, arg1 []v1.OutputResource) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GarbageCollectResources", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GarbageCollectResources indicates an expected call of GarbageCollectResources.
+func (mr *MockDriverMockRecorder) GarbageCollectResources(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollectResources", reflect.TypeOf((*MockDriver)(nil).GarbageCollectResources), arg0, arg1)
 }

--- a/pkg/recipes/driver/terraform.go
+++ b/pkg/recipes/driver/terraform.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/uuid"
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	"github.com/project-radius/radius/pkg/recipes"
+	rpv1 "github.com/project-radius/radius/pkg/rp/v1"
 
 	"github.com/project-radius/radius/pkg/recipes/terraform"
 	"github.com/project-radius/radius/pkg/sdk"
@@ -172,4 +173,8 @@ func (d *terraformDriver) createExecutionDirectory(ctx context.Context, recipe r
 	}
 
 	return requestDirPath, nil
+}
+
+func (d *terraformDriver) GarbageCollectResources(ctx context.Context, diff []rpv1.OutputResource) error {
+	return nil
 }

--- a/pkg/recipes/driver/types.go
+++ b/pkg/recipes/driver/types.go
@@ -30,6 +30,8 @@ type Driver interface {
 
 	// Delete handles deletion of output resources for the recipe deployment.
 	Delete(ctx context.Context, opts DeleteOptions) error
+
+	GarbageCollectResources(ctx context.Context, diff []rpv1.OutputResource) error
 }
 
 // BaseOptions is the base options for the driver operations.

--- a/pkg/recipes/driver/types.go
+++ b/pkg/recipes/driver/types.go
@@ -31,6 +31,7 @@ type Driver interface {
 	// Delete handles deletion of output resources for the recipe deployment.
 	Delete(ctx context.Context, opts DeleteOptions) error
 
+	// GarbageCollectResources handles the clean up of any obsolete resources.
 	GarbageCollectResources(ctx context.Context, diff []rpv1.OutputResource) error
 }
 

--- a/pkg/recipes/engine/engine.go
+++ b/pkg/recipes/engine/engine.go
@@ -137,6 +137,7 @@ func (e *engine) deleteCore(ctx context.Context, recipe recipes.ResourceMetadata
 	return definition, nil
 }
 
+// GarbageCollectResources get the kind of the driver used in recipe deployment and uses that driver to call GarbageCollectResources() driver function to cleanup any obsolete resources.
 func (e *engine) GarbageCollectResources(ctx context.Context, recipe recipes.ResourceMetadata, diff []rpv1.OutputResource) error {
 	if reflect.DeepEqual(recipes.ResourceMetadata{}, recipe) {
 		return nil

--- a/pkg/recipes/engine/mock_engine.go
+++ b/pkg/recipes/engine/mock_engine.go
@@ -64,3 +64,17 @@ func (mr *MockEngineMockRecorder) Execute(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockEngine)(nil).Execute), arg0, arg1)
 }
+
+// GarbageCollectResources mocks base method.
+func (m *MockEngine) GarbageCollectResources(arg0 context.Context, arg1 recipes.ResourceMetadata, arg2 []v1.OutputResource) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GarbageCollectResources", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GarbageCollectResources indicates an expected call of GarbageCollectResources.
+func (mr *MockEngineMockRecorder) GarbageCollectResources(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollectResources", reflect.TypeOf((*MockEngine)(nil).GarbageCollectResources), arg0, arg1, arg2)
+}

--- a/pkg/recipes/engine/types.go
+++ b/pkg/recipes/engine/types.go
@@ -30,6 +30,6 @@ type Engine interface {
 	Execute(ctx context.Context, recipe recipes.ResourceMetadata) (*recipes.RecipeOutput, error)
 	// Delete handles deletion of output resources for the recipe deployment.
 	Delete(ctx context.Context, recipe recipes.ResourceMetadata, outputResources []rpv1.OutputResource) error
-
+	// GarbageCollectResources handles the clean up of any obsolete resources.
 	GarbageCollectResources(ctx context.Context, recipe recipes.ResourceMetadata, outputResources []rpv1.OutputResource) error
 }

--- a/pkg/recipes/engine/types.go
+++ b/pkg/recipes/engine/types.go
@@ -30,4 +30,6 @@ type Engine interface {
 	Execute(ctx context.Context, recipe recipes.ResourceMetadata) (*recipes.RecipeOutput, error)
 	// Delete handles deletion of output resources for the recipe deployment.
 	Delete(ctx context.Context, recipe recipes.ResourceMetadata, outputResources []rpv1.OutputResource) error
+
+	GarbageCollectResources(ctx context.Context, recipe recipes.ResourceMetadata, outputResources []rpv1.OutputResource) error
 }

--- a/pkg/recipes/errorcodes.go
+++ b/pkg/recipes/errorcodes.go
@@ -28,4 +28,7 @@ const (
 
 	// Used for errors encountered while reading a recipe from registry.
 	RecipeLanguageFailure = "RecipeLanguageFailure"
+
+	//Used for errors encountered while cleaning up of obsolete resources during patch operation.
+	RecipeGarbageCollectionFailed = "RecipeGarbageCollectionFailed"
 )


### PR DESCRIPTION
# Description
- Moving the logic of garbage collection of resources inside driver.
- Updating the unit tests


## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f5b5fd7</samp>

### Summary
🗑️🧹🛠️

<!--
1.  🗑️ - This emoji represents the garbage collection feature that was added to the driver and engine packages, and the controller logic that uses it. It also conveys the idea of deleting obsolete resources.
2.  🧹 - This emoji represents the cleanup and refactoring of the code, such as removing unused imports, simplifying logic, and extracting helper functions. It also conveys the idea of improving the code quality and readability.
3.  🛠️ - This emoji represents the addition of new methods and interfaces to the driver and engine packages, and the test functions that verify them. It also conveys the idea of enhancing the functionality and testability of the code.
-->
Added garbage collection feature for output resources to the recipe engine and drivers. Refactored the controller and engine packages to use the new feature and simplify the code. Updated and added test cases for the new logic. Added a new error code for garbage collection failures.

> _Oh we are the coders of the `engine` package_
> _We clean up the resources with a garbage collect_
> _We use the `driver` interface to delegate the task_
> _And we test our logic with a mock and a mask_

### Walkthrough
*  Add garbage collection logic for output resources managed by recipes ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-b93ba441d82b7bf92f0027d1e366830b87ca7d768ce1d9d21c54bc4f3c2ede07L97-R96), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-f12e37706fa75e9e04b8dfa01a45cf9bf2a0463e1962605b2420d0cb343922a0R279-R292), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-1b98bc9b02b96687752860c11c68d87d99ad99f24ecdfc5497fda6823abc0612R177-R180), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-a95d80e21fb522c60702dad150fe92099ac96749fd90a452abd92867b40d069dR33-R34), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59R139-R164), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-3fdb9931c1f2ddfc5b14d87f47b4124f2bdc1da187219fa1ad9cbe79fc326528R460-R520), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-2dee9fa8b594b7a0e0783bd6587b452223eb5f7ba7c28a1dc0178c121a2509f0R67-R80), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-11be7ca47327363d5edeaff3c6ac6389a462ff9111e1fc03ccb3a98123cd939fR33-R34), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-4811c2c3581e1effba7ad029717fa82713a8e3a58b848b3845cfaf7d6a44fbacR31-R33))
  * Implement `GarbageCollectResources` method for `bicepDriver` and `terraformDriver` structs in `bicep.go` and `terraform.go` ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-f12e37706fa75e9e04b8dfa01a45cf9bf2a0463e1962605b2420d0cb343922a0R279-R292), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-1b98bc9b02b96687752860c11c68d87d99ad99f24ecdfc5497fda6823abc0612R177-R180))
  * Implement `GarbageCollectResources` method for `Driver` interface in `types.go` ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-a95d80e21fb522c60702dad150fe92099ac96749fd90a452abd92867b40d069dR33-R34))
  * Implement `GarbageCollectResources` and `getRecipeDefinitionAndDriver` functions for `engine` struct in `engine.go` ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59R139-R164))
  * Implement `GarbageCollectResources` method for `Engine` interface in `types.go` ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-11be7ca47327363d5edeaff3c6ac6389a462ff9111e1fc03ccb3a98123cd939fR33-R34))
  * Implement `GarbageCollectResources` method for `MockDriver` and `MockEngine` structs in `mock_driver.go` and `mock_engine.go` ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-ede26839223dbf77d6c86d51fd2eea9bf3720aabf7d404d331f1a0ff4e359f64R67-R80), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-2dee9fa8b594b7a0e0783bd6587b452223eb5f7ba7c28a1dc0178c121a2509f0R67-R80))
  * Add `RecipeGarbageCollectionFailed` error code in `errorcodes.go` ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-4811c2c3581e1effba7ad029717fa82713a8e3a58b848b3845cfaf7d6a44fbacR31-R33))
  * Add test cases for `GarbageCollectResources` method in `bicep_test.go` and `engine_test.go` ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-a0a208a111e71713a21b404fdb3b31fd13f668e5716ab4331584027cc3d98debR432-R479), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-3fdb9931c1f2ddfc5b14d87f47b4124f2bdc1da187219fa1ad9cbe79fc326528R460-R520))
* Refactor recipe execution and deletion logic in `controller` and `engine` packages ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-b93ba441d82b7bf92f0027d1e366830b87ca7d768ce1d9d21c54bc4f3c2ede07L22-R22), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-b93ba441d82b7bf92f0027d1e366830b87ca7d768ce1d9d21c54bc4f3c2ede07L32), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-b93ba441d82b7bf92f0027d1e366830b87ca7d768ce1d9d21c54bc4f3c2ede07L123-R125), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-b93ba441d82b7bf92f0027d1e366830b87ca7d768ce1d9d21c54bc4f3c2ede07L154-R156), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59R22), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59L70-R75), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59L120-R119))
  * Import `reflect` package in `createorupdateresource.go` and `engine.go` to use `DeepEqual` function ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-b93ba441d82b7bf92f0027d1e366830b87ca7d768ce1d9d21c54bc4f3c2ede07L22-R22), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59R22))
  * Remove `ucplog` package from `createorupdateresource.go` as it is no longer used ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-b93ba441d82b7bf92f0027d1e366830b87ca7d768ce1d9d21c54bc4f3c2ede07L32))
  * Simplify `executeRecipeIfNeeded` function in `createorupdateresource.go` by using `getResourceMetadata` function ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-b93ba441d82b7bf92f0027d1e366830b87ca7d768ce1d9d21c54bc4f3c2ede07L123-R125))
  * Add `getResourceMetadata` function in `createorupdateresource.go` to extract recipe metadata from data model ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-b93ba441d82b7bf92f0027d1e366830b87ca7d768ce1d9d21c54bc4f3c2ede07L154-R156))
  * Refactor `executeCore` and `deleteCore` functions in `engine.go` by using `getRecipeDefinitionAndDriver` function ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59L70-R75), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59L120-R119))
* Update test cases in `controller` package to match garbage collection logic ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-9bdc7e92b6a746c8b205c08b733880545415d6f58933b3d36b44b37181f1ce1dL344-R350), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-9bdc7e92b6a746c8b205c08b733880545415d6f58933b3d36b44b37181f1ce1dL394-R405))
  * Add `outputResources` variable to simulate obsolete resources in `createorupdateresource_test.go` ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-9bdc7e92b6a746c8b205c08b733880545415d6f58933b3d36b44b37181f1ce1dL344-R350))
  * Replace `client.Delete` expectations by `eng.GarbageCollectResources` expectations in `createorupdateresource_test.go` ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-9bdc7e92b6a746c8b205c08b733880545415d6f58933b3d36b44b37181f1ce1dL394-R405))
* Import additional packages in `driver` and `engine` packages to support test cases ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-a0a208a111e71713a21b404fdb3b31fd13f668e5716ab4331584027cc3d98debR20), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-ede26839223dbf77d6c86d51fd2eea9bf3720aabf7d404d331f1a0ff4e359f64R13), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-3fdb9931c1f2ddfc5b14d87f47b4124f2bdc1da187219fa1ad9cbe79fc326528L30-R32))
  * Import `errors` package in `bicep_test.go` to create error values ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-a0a208a111e71713a21b404fdb3b31fd13f668e5716ab4331584027cc3d98debR20))
  * Import `rpv1` package in `mock_driver.go` and `terraform.go` to use `OutputResource` type ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-ede26839223dbf77d6c86d51fd2eea9bf3720aabf7d404d331f1a0ff4e359f64R13), [link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-1b98bc9b02b96687752860c11c68d87d99ad99f24ecdfc5497fda6823abc0612R29))
  * Import `to` and `resources_kubernetes` packages in `engine_test.go` to use `Ptr` and `IDFromParts` functions ([link](https://github.com/project-radius/radius/pull/6155/files?diff=unified&w=0#diff-3fdb9931c1f2ddfc5b14d87f47b4124f2bdc1da187219fa1ad9cbe79fc326528L30-R32))


