### PR TITLE
Update running-controlplane-locally.md

### DIFF
--- a/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
+++ b/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
@@ -44,10 +44,10 @@ Run one of the following two commands:
 
 ```sh
 # Choose this by default
-rad init --dev
+rad init
 
 # Choose this if you want to do advanced setup
-rad init
+rad init --full
 ```
 
 This will install Radius and configure an environment for you. The database that's used **will NOT** be shared with your debug setup, so it mostly doesn't matter what choices you make.


### PR DESCRIPTION
# Description

https://github.com/project-radius/radius/issues/6159

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #6159 

## Auto-generated summary


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c149c7f</samp>

### Summary
🛠️🏠🔢

<!--
1.  🛠️ - This emoji represents the idea of fixing or improving something, which is what the simplification of the `rad init` command and the improved error message aim to do.
2.  🏠 - This emoji represents the idea of a local or home environment, which is what the `rad init` command sets up for the user.
3.  🔢 - This emoji represents the idea of numbers or versions, which is what the .NET SDK version requirement is related to.
-->
Updated the documentation for setting up and running the control plane locally. Made the `rad init` command easier to use and clarified the .NET SDK version error.

> _Oh, we're the raddest crew that ever sailed the net_
> _We don't need no fancy tools to get our project set_
> _We just run `rad init` and it does the job for us_
> _And if your SDK is old, it tells you with a fuss_

### Walkthrough
*  Simplify the `rad init` command to use default options and add the `--full` flag for advanced setup ([link](https://github.com/project-radius/radius/pull/6161/files?diff=unified&w=0#diff-9e2fd80b379a42830faf06edccddb5228ec9ade05d089345244394619fb9e805L47-R50))
*  Improve the error message for .NET SDK version requirement ([link](https://github.com/project-radius/radius/pull/6161/files?diff=unified&w=0#diff-9e2fd80b379a42830faf06edccddb5228ec9ade05d089345244394619fb9e805L168-R168))


