### PR TITLE
Adding new extender details to the required places

### DIFF
--- a/pkg/cli/clients/management.go
+++ b/pkg/cli/clients/management.go
@@ -56,6 +56,7 @@ var (
 		"Applications.Core/httpRoutes",
 		"Applications.Core/containers",
 		"Applications.Core/secretStores",
+		"Applications.Core/extenders",
 		// Resource Types after Splitting Linkrp Namespace
 		linkrp.N_RabbitMQQueuesResourceType,
 		linkrp.N_DaprStateStoresResourceType,

--- a/pkg/linkrp/backend/controller/deleteresource.go
+++ b/pkg/linkrp/backend/controller/deleteresource.go
@@ -23,6 +23,7 @@ import (
 
 	v1 "github.com/project-radius/radius/pkg/armrpc/api/v1"
 	ctrl "github.com/project-radius/radius/pkg/armrpc/asyncoperation/controller"
+	corerp_dm "github.com/project-radius/radius/pkg/corerp/datamodel"
 	dapr_dm "github.com/project-radius/radius/pkg/daprrp/datamodel"
 	ds_dm "github.com/project-radius/radius/pkg/datastoresrp/datamodel"
 	"github.com/project-radius/radius/pkg/linkrp"
@@ -135,6 +136,8 @@ func getDataModel(id resources.ID) (v1.ResourceDataModel, error) {
 		return &dapr_dm.DaprSecretStore{}, nil
 	case strings.ToLower(linkrp.N_DaprPubSubBrokersResourceType):
 		return &dapr_dm.DaprPubSubBroker{}, nil
+	case strings.ToLower(linkrp.N_ExtendersResourceType):
+		return &corerp_dm.Extender{}, nil
 	default:
 		return nil, fmt.Errorf("async delete operation unsupported on resource type: %q. Resource ID: %q", resourceType, id.String())
 	}


### PR DESCRIPTION
# Description
Most of our recipes use `Applications.Core/extenders` and the delete flow needs to be triggered for the new extender.

Please see this PR: https://github.com/project-radius/radius/pull/6137. In this PR, I added a [PostDeleteVerify](https://github.com/project-radius/radius/pull/6137/files#diff-94178e873ad0fe96b700c75fe85d086b4ad1a4dae5f448e6f5bcc5f706b89995R110) which is failing because delete logic needs to be updated for the `Applications.Core/extenders`.

Let me know if any other place needs to be updated.

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #6163 

## Auto-generated summary

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e6a541f</samp>

### Summary
:sparkles::wastebasket::package:

<!--
1.  :sparkles: - This emoji represents the addition of a new feature or resource type, which is the `Applications.Core/extenders` resource type in this case.
2.  :wastebasket: - This emoji represents the deletion of a resource or data, which is the extender resource in this case.
3.  :package: - This emoji represents the addition or modification of a dependency or package, which is the `corerp/datamodel` package in this case.
-->
This pull request adds support for managing extenders, which are custom resources that extend the core platform. It updates the `controller` and `clients` packages to handle the new resource type `Applications.Core/extenders`.

> _We are the extenders, we defy the core_
> _We create our own resources, we demand more_
> _But they try to delete us, they import the `datamodel`_
> _They add a case for us, they think they can control_

### Walkthrough
*  Add support for extender resource type in clients package ([link](https://github.com/project-radius/radius/pull/6164/files?diff=unified&w=0#diff-23443c20f46bfbb5ffda2f87efc0e56ecaea1ef964ed4fc9ee06fe584fcfedcaR59))
*  Import corerp/datamodel package as corerp_dm in controller package ([link](https://github.com/project-radius/radius/pull/6164/files?diff=unified&w=0#diff-f369203c896ae38d9f447bf905fa1566b36a31b235e99de6742f243f0e37269cR26))
*  Return pointer to extender data model in getDataModel function ([link](https://github.com/project-radius/radius/pull/6164/files?diff=unified&w=0#diff-f369203c896ae38d9f447bf905fa1566b36a31b235e99de6742f243f0e37269cR139-R140))
*  Delete extender resource in deleteResource function using corerp_dm.Extender struct ([link](https://github.com/project-radius/radius/pull/6164/files?diff=unified&w=0#diff-f369203c896ae38d9f447bf905fa1566b36a31b235e99de6742f243f0e37269cR139-R140))


