### PR TITLE
Update resource group deletion status code check

### DIFF
--- a/pkg/cli/clients/management.go
+++ b/pkg/cli/clients/management.go
@@ -568,7 +568,7 @@ func (amc *UCPApplicationsManagementClient) DeleteUCPGroup(ctx context.Context, 
 		return false, err
 	}
 
-	return respFromCtx.StatusCode == 204, nil
+	return respFromCtx.StatusCode == 200 || respFromCtx.StatusCode == 204, nil
 
 }
 


### PR DESCRIPTION
# Description

In the UCP client for the resource group delete function, we return a boolean to indicate if the resource group was successfully deleted. This is set to true if the return status code is 204 No Content. 

However, a resource group deletion currently returns a 200 Ok instead of a 204 No Content when a resource group is successfully deleted. This lines up with the Swagger spec which shows the delete API returning either a 200 or 204 for a successful delete.

This PR updates the management client logic for resource group delete to return true for either 200 or 204, so that we display the correct message to the user.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #5283

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5ba0f2d</samp>

### Summary
:wrench::sparkles::package:

<!--
1.  :wrench: - This emoji represents a fix or improvement to an existing feature or functionality. The change to the `DeleteUCPGroup` function is a fix for a compatibility issue with different UCP versions, so it falls under this category.
2.  :sparkles: - This emoji represents a new feature or enhancement that adds value or functionality to the project. The change is part of a larger pull request that adds support for UCP 3.4.0, which is a new feature for the radius CLI, so it falls under this category.
3.  :package: - This emoji represents a change that affects the distribution or deployment of the project, such as adding or updating dependencies, configuration files, or build scripts. The change may require updating the radius CLI binary or its dependencies to work with UCP 3.4.0, so it falls under this category.
-->
Support UCP 3.4.0 in radius CLI by handling different status codes for group deletion. Modify `DeleteUCPGroup` in `pkg/cli/clients/management.go` to accept 200 and 204 as success codes.

> _`DeleteUCPGroup`_
> _Handles two status codes now_
> _Winter of UCP_

### Walkthrough
*  Handle different status codes for deleting UCP groups ([link](https://github.com/project-radius/radius/pull/6165/files?diff=unified&w=0#diff-23443c20f46bfbb5ffda2f87efc0e56ecaea1ef964ed4fc9ee06fe584fcfedcaL571-R571))


