### PR TITLE
[DONOTMERGE] deployment test

### DIFF
--- a/pkg/corerp/renderers/container/azure/identity.go
+++ b/pkg/corerp/renderers/container/azure/identity.go
@@ -193,7 +193,7 @@ func MakeFederatedIdentitySA(appName, name, namespace string, resource *datamode
 	}
 
 	s, _ := json.Marshal(sa)
-	fmt.Printf("sa: %s", string(s))
+	fmt.Printf("\n\n ### serviceaccount: %s", string(s))
 
 	or := rpv1.NewKubernetesOutputResource(rpv1.LocalIDServiceAccount, sa, sa.ObjectMeta)
 	or.CreateResource.Dependencies = []string{rpv1.LocalIDFederatedIdentity}

--- a/pkg/corerp/renderers/container/azure/identity.go
+++ b/pkg/corerp/renderers/container/azure/identity.go
@@ -18,6 +18,7 @@ package azure
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -190,6 +191,9 @@ func MakeFederatedIdentitySA(appName, name, namespace string, resource *datamode
 			},
 		},
 	}
+
+	s, _ := json.Marshal(sa)
+	fmt.Printf("sa: %s", string(s))
 
 	or := rpv1.NewKubernetesOutputResource(rpv1.LocalIDServiceAccount, sa, sa.ObjectMeta)
 	or.CreateResource.Dependencies = []string{rpv1.LocalIDFederatedIdentity}

--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -19,6 +19,7 @@ package container
 import (
 	"context"
 	"crypto/sha1"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -305,6 +306,9 @@ func (r Renderer) makeService(resource *datamodel.ContainerResource, options ren
 			Ports:    ports,
 		},
 	}
+
+	s, _ := json.Marshal(service)
+	fmt.Printf("service: %s", string(s))
 
 	return rpv1.NewKubernetesOutputResource(rpv1.LocalIDService, service, service.ObjectMeta), nil
 }
@@ -653,6 +657,9 @@ func (r Renderer) makeDeployment(ctx context.Context, applicationName string, op
 
 	deploymentOutput := rpv1.NewKubernetesOutputResource(rpv1.LocalIDDeployment, &deployment, deployment.ObjectMeta)
 	deploymentOutput.CreateResource.Dependencies = deps
+
+	s, _ := json.Marshal(deployment)
+	fmt.Printf("deployment: %s", string(s))
 
 	outputResources = append(outputResources, deploymentOutput)
 	return outputResources, secretData, nil

--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -308,7 +308,7 @@ func (r Renderer) makeService(resource *datamodel.ContainerResource, options ren
 	}
 
 	s, _ := json.Marshal(service)
-	fmt.Printf("service: %s", string(s))
+	fmt.Printf("\n\n ### service: %s\n", string(s))
 
 	return rpv1.NewKubernetesOutputResource(rpv1.LocalIDService, service, service.ObjectMeta), nil
 }
@@ -659,7 +659,7 @@ func (r Renderer) makeDeployment(ctx context.Context, applicationName string, op
 	deploymentOutput.CreateResource.Dependencies = deps
 
 	s, _ := json.Marshal(deployment)
-	fmt.Printf("deployment: %s", string(s))
+	fmt.Printf("\n\n ### deployment: %s", string(s))
 
 	outputResources = append(outputResources, deploymentOutput)
 	return outputResources, secretData, nil


### PR DESCRIPTION
# Description

_Please explain the changes you've made._

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e114f99</samp>

### Summary
🚧🐛📦

<!--
1.  🚧 This emoji means "construction" or "work in progress" and can be used to indicate that the changes are part of an ongoing development or improvement process. It can also imply that the changes are not final or stable and may be subject to further modifications or revisions.
2.  🐛 This emoji means "bug" or "issue" and can be used to indicate that the changes are related to fixing, finding, or preventing errors or problems in the code. It can also imply that the changes are motivated by testing or debugging purposes and may involve adding or removing logging, printing, or tracing statements.
3.  📦 This emoji means "package" or "dependency" and can be used to indicate that the changes are related to importing, exporting, updating, or installing external or internal modules, libraries, or frameworks. It can also imply that the changes are motivated by enhancing or simplifying the code's functionality, compatibility, or performance.
-->
Added JSON encoding and printing to the `container` and `azure` packages to debug the service account and Kubernetes resource creation.

> _`azure` encodes JSON_
> _service account for the cloud_
> _debugging in spring_

### Walkthrough
*  Import `encoding/json` package to enable JSON encoding and decoding of service account, service, and deployment objects ([link](https://github.com/project-radius/radius/pull/6166/files?diff=unified&w=0#diff-901a92f8517371b86a8148aa840dbca987300619ae93d6db5380a90d4db3e773R21), [link](https://github.com/project-radius/radius/pull/6166/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636R22))
*  Marshal and print service account object to standard output for debugging purposes in `identity.go` ([link](https://github.com/project-radius/radius/pull/6166/files?diff=unified&w=0#diff-901a92f8517371b86a8148aa840dbca987300619ae93d6db5380a90d4db3e773R195-R197))
*  Marshal and print service object to standard output for debugging purposes in `render.go` ([link](https://github.com/project-radius/radius/pull/6166/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636R310-R312))
*  Marshal and print deployment object to standard output for debugging purposes in `render.go` ([link](https://github.com/project-radius/radius/pull/6166/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636R661-R663))


