### PR TITLE
[do not review] Adding terraform support to rad recipe show

### DIFF
--- a/pkg/armrpc/frontend/controller/controller.go
+++ b/pkg/armrpc/frontend/controller/controller.go
@@ -25,6 +25,7 @@ import (
 	sm "github.com/radius-project/radius/pkg/armrpc/asyncoperation/statusmanager"
 	"github.com/radius-project/radius/pkg/armrpc/hostoptions"
 	"github.com/radius-project/radius/pkg/armrpc/rest"
+	"github.com/radius-project/radius/pkg/recipes/engine"
 	"github.com/radius-project/radius/pkg/ucp/dataprovider"
 	"github.com/radius-project/radius/pkg/ucp/store"
 
@@ -67,6 +68,9 @@ type Options struct {
 
 	// StatusManager is the async operation status manager.
 	StatusManager sm.StatusManager
+
+	// Engine is the Recipe engine to handle Recipe commands
+	Engine engine.Engine
 }
 
 // ResourceOptions represents the options and filters for resource.

--- a/pkg/armrpc/frontend/controller/controller.go
+++ b/pkg/armrpc/frontend/controller/controller.go
@@ -25,7 +25,6 @@ import (
 	sm "github.com/radius-project/radius/pkg/armrpc/asyncoperation/statusmanager"
 	"github.com/radius-project/radius/pkg/armrpc/hostoptions"
 	"github.com/radius-project/radius/pkg/armrpc/rest"
-	"github.com/radius-project/radius/pkg/recipes/engine"
 	"github.com/radius-project/radius/pkg/ucp/dataprovider"
 	"github.com/radius-project/radius/pkg/ucp/store"
 
@@ -68,9 +67,6 @@ type Options struct {
 
 	// StatusManager is the async operation status manager.
 	StatusManager sm.StatusManager
-
-	// Engine is the Recipe engine to handle Recipe commands
-	Engine engine.Engine
 }
 
 // ResourceOptions represents the options and filters for resource.

--- a/pkg/corerp/frontend/controller/environments/getrecipemetadata.go
+++ b/pkg/corerp/frontend/controller/environments/getrecipemetadata.go
@@ -29,6 +29,7 @@ import (
 	"github.com/radius-project/radius/pkg/corerp/datamodel/converter"
 	pr_dm "github.com/radius-project/radius/pkg/portableresources/datamodel"
 	"github.com/radius-project/radius/pkg/recipes"
+	"github.com/radius-project/radius/pkg/recipes/engine"
 	"golang.org/x/exp/maps"
 )
 
@@ -37,10 +38,11 @@ var _ ctrl.Controller = (*GetRecipeMetadata)(nil)
 // GetRecipeMetadata is the controller implementation to get recipe metadata such as parameters and the details of those parameters(type/minValue/etc.).
 type GetRecipeMetadata struct {
 	ctrl.Operation[*datamodel.Environment, datamodel.Environment]
+	engine.Engine
 }
 
 // NewGetRecipeMetadata creates a new controller for retrieving recipe metadata from an environment.
-func NewGetRecipeMetadata(opts ctrl.Options) (ctrl.Controller, error) {
+func NewGetRecipeMetadata(opts ctrl.Options, engine engine.Engine) (ctrl.Controller, error) {
 	return &GetRecipeMetadata{
 		ctrl.NewOperation(opts,
 			ctrl.ResourceOptions[datamodel.Environment]{
@@ -48,6 +50,7 @@ func NewGetRecipeMetadata(opts ctrl.Options) (ctrl.Controller, error) {
 				ResponseConverter: converter.EnvironmentDataModelToVersioned,
 			},
 		),
+		engine,
 	}, nil
 }
 
@@ -110,7 +113,7 @@ func (r *GetRecipeMetadata) GetRecipeMetadataFromRegistry(ctx context.Context, r
 	}
 
 	recipeParameters = make(map[string]any)
-	recipeData, err := r.Options().Engine.GetRecipeMetadata(ctx, recipeMetadata)
+	recipeData, err := r.Engine.GetRecipeMetadata(ctx, recipeMetadata)
 	if err != nil {
 		return recipeParameters, err
 	}

--- a/pkg/corerp/frontend/controller/environments/getrecipemetadata.go
+++ b/pkg/corerp/frontend/controller/environments/getrecipemetadata.go
@@ -102,18 +102,17 @@ func (r *GetRecipeMetadata) Run(ctx context.Context, w http.ResponseWriter, req 
 }
 
 func (r *GetRecipeMetadata) GetRecipeMetadataFromRegistry(ctx context.Context, recipeProperties datamodel.EnvironmentRecipeProperties, recipeDataModel *datamodel.Recipe) (recipeParameters map[string]any, err error) {
-	serviceCtx := v1.ARMRequestContextFromContext(ctx)
-
-	recipeMetadata := recipes.ResourceMetadata{
-		Name:          recipeDataModel.Name,
-		EnvironmentID: serviceCtx.ResourceID.String(),
-		Parameters:    recipeProperties.Parameters,
-		ResourceID:    serviceCtx.ResourceID.String(),
-		ResourceType:  recipeDataModel.LinkType,
+	recipeDefinition := recipes.EnvironmentDefinition{
+		Name:            recipeDataModel.Name,
+		Driver:          recipeProperties.TemplateKind,
+		Parameters:      recipeProperties.Parameters,
+		TemplatePath:    recipeProperties.TemplatePath,
+		TemplateVersion: recipeProperties.TemplateVersion,
+		ResourceType:    recipeDataModel.LinkType,
 	}
 
 	recipeParameters = make(map[string]any)
-	recipeData, err := r.Engine.GetRecipeMetadata(ctx, recipeMetadata)
+	recipeData, err := r.Engine.GetRecipeMetadata(ctx, recipeDefinition)
 	if err != nil {
 		return recipeParameters, err
 	}

--- a/pkg/corerp/frontend/controller/environments/getrecipemetadata_test.go
+++ b/pkg/corerp/frontend/controller/environments/getrecipemetadata_test.go
@@ -77,9 +77,8 @@ func TestGetRecipeMetadataRun_20220315PrivatePreview(t *testing.T) {
 
 		opts := ctrl.Options{
 			StorageClient: mStorageClient,
-			Engine:        mEngine,
 		}
-		ctl, err := NewGetRecipeMetadata(opts)
+		ctl, err := NewGetRecipeMetadata(opts, mEngine)
 		require.NoError(t, err)
 		resp, err := ctl.Run(ctx, w, req)
 		require.NoError(t, err)
@@ -125,9 +124,8 @@ func TestGetRecipeMetadataRun_20220315PrivatePreview(t *testing.T) {
 
 		opts := ctrl.Options{
 			StorageClient: mStorageClient,
-			Engine:        mEngine,
 		}
-		ctl, err := NewGetRecipeMetadata(opts)
+		ctl, err := NewGetRecipeMetadata(opts, mEngine)
 		require.NoError(t, err)
 		resp, err := ctl.Run(ctx, w, req)
 		require.NoError(t, err)
@@ -153,9 +151,8 @@ func TestGetRecipeMetadataRun_20220315PrivatePreview(t *testing.T) {
 			})
 		opts := ctrl.Options{
 			StorageClient: mStorageClient,
-			Engine:        mEngine,
 		}
-		ctl, err := NewGetRecipeMetadata(opts)
+		ctl, err := NewGetRecipeMetadata(opts, mEngine)
 		require.NoError(t, err)
 		resp, err := ctl.Run(ctx, w, req)
 		require.NoError(t, err)
@@ -195,9 +192,8 @@ func TestGetRecipeMetadataRun_20220315PrivatePreview(t *testing.T) {
 
 		opts := ctrl.Options{
 			StorageClient: mStorageClient,
-			Engine:        mEngine,
 		}
-		ctl, err := NewGetRecipeMetadata(opts)
+		ctl, err := NewGetRecipeMetadata(opts, mEngine)
 		require.NoError(t, err)
 		resp, err := ctl.Run(ctx, w, req)
 		require.NoError(t, err)
@@ -245,9 +241,8 @@ func TestGetRecipeMetadataRun_20220315PrivatePreview(t *testing.T) {
 
 		opts := ctrl.Options{
 			StorageClient: mStorageClient,
-			Engine:        mEngine,
 		}
-		ctl, err := NewGetRecipeMetadata(opts)
+		ctl, err := NewGetRecipeMetadata(opts, mEngine)
 		require.NoError(t, err)
 		_, err = ctl.Run(ctx, w, req)
 		require.Error(t, err)

--- a/pkg/corerp/frontend/controller/environments/getrecipemetadata_test.go
+++ b/pkg/corerp/frontend/controller/environments/getrecipemetadata_test.go
@@ -44,7 +44,7 @@ func TestGetRecipeMetadataRun_20220315PrivatePreview(t *testing.T) {
 	ctx := context.Background()
 	t.Parallel()
 	t.Run("get recipe metadata run", func(t *testing.T) {
-		envInput, _, envDataModel, expectedOutput := getTestModelsGetRecipeMetadata20220315privatepreview()
+		envInput, _, envDataModel, expectedOutput, _ := getTestModelsGetRecipeMetadata20220315privatepreview()
 		w := httptest.NewRecorder()
 		req, err := rpctest.NewHTTPRequestFromJSON(ctx, v1.OperationPost.HTTPMethod(), testHeaderfilegetrecipemetadata, envInput)
 		require.NoError(t, err)
@@ -59,12 +59,13 @@ func TestGetRecipeMetadataRun_20220315PrivatePreview(t *testing.T) {
 				}, nil
 			})
 		ctx := rpctest.NewARMRequestContext(req)
-		recipeMetadata := recipes.ResourceMetadata{
-			Name:          *envInput.Name,
-			EnvironmentID: envDataModel.ID,
-			Parameters:    nil,
-			ResourceID:    envDataModel.ID,
-			ResourceType:  "Applications.Datastores/mongoDatabases",
+		recipeDefinition := recipes.EnvironmentDefinition{
+			Name:            *envInput.Name,
+			Parameters:      nil,
+			TemplatePath:    "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
+			TemplateVersion: "",
+			Driver:          "bicep",
+			ResourceType:    "Applications.Datastores/mongoDatabases",
 		}
 		recipeData := map[string]any{
 			"parameters": map[string]any{
@@ -73,7 +74,7 @@ func TestGetRecipeMetadataRun_20220315PrivatePreview(t *testing.T) {
 				"mongodbName":    map[string]any{"type": "string"},
 			},
 		}
-		mEngine.EXPECT().GetRecipeMetadata(ctx, recipeMetadata).Return(recipeData, nil)
+		mEngine.EXPECT().GetRecipeMetadata(ctx, recipeDefinition).Return(recipeData, nil)
 
 		opts := ctrl.Options{
 			StorageClient: mStorageClient,
@@ -91,7 +92,7 @@ func TestGetRecipeMetadataRun_20220315PrivatePreview(t *testing.T) {
 	})
 
 	t.Run("get recipe metadata run -- terraform", func(t *testing.T) {
-		_, envInput, envDataModel, expectedOutput := getTestModelsGetRecipeMetadata20220315privatepreview()
+		_, envInput, envDataModel, _, expectedOutput := getTestModelsGetRecipeMetadata20220315privatepreview()
 		w := httptest.NewRecorder()
 		req, err := rpctest.NewHTTPRequestFromJSON(ctx, v1.OperationPost.HTTPMethod(), testHeaderfilegetrecipemetadata, envInput)
 		require.NoError(t, err)
@@ -106,12 +107,13 @@ func TestGetRecipeMetadataRun_20220315PrivatePreview(t *testing.T) {
 				}, nil
 			})
 		ctx := rpctest.NewARMRequestContext(req)
-		recipeMetadata := recipes.ResourceMetadata{
-			Name:          *envInput.Name,
-			EnvironmentID: envDataModel.ID,
-			Parameters:    nil,
-			ResourceID:    envDataModel.ID,
-			ResourceType:  "Applications.Datastores/mongoDatabases",
+		recipeDefinition := recipes.EnvironmentDefinition{
+			Name:            *envInput.Name,
+			Parameters:      nil,
+			TemplatePath:    "Azure/cosmosdb/azurerm",
+			TemplateVersion: "1.1.0",
+			Driver:          "terraform",
+			ResourceType:    *envInput.LinkType,
 		}
 		recipeData := map[string]any{
 			"parameters": map[string]any{
@@ -120,7 +122,7 @@ func TestGetRecipeMetadataRun_20220315PrivatePreview(t *testing.T) {
 				"mongodbName":    map[string]any{"type": "string"},
 			},
 		}
-		mEngine.EXPECT().GetRecipeMetadata(ctx, recipeMetadata).Return(recipeData, nil)
+		mEngine.EXPECT().GetRecipeMetadata(ctx, recipeDefinition).Return(recipeData, nil)
 
 		opts := ctrl.Options{
 			StorageClient: mStorageClient,
@@ -214,7 +216,7 @@ func TestGetRecipeMetadataRun_20220315PrivatePreview(t *testing.T) {
 	})
 
 	t.Run("get recipe metadata engine failure", func(t *testing.T) {
-		envInput, _, envDataModel, _ := getTestModelsGetRecipeMetadata20220315privatepreview()
+		envInput, _, envDataModel, _, _ := getTestModelsGetRecipeMetadata20220315privatepreview()
 		w := httptest.NewRecorder()
 		req, err := rpctest.NewHTTPRequestFromJSON(ctx, v1.OperationPost.HTTPMethod(), testHeaderfilegetrecipemetadata, envInput)
 		require.NoError(t, err)
@@ -229,15 +231,16 @@ func TestGetRecipeMetadataRun_20220315PrivatePreview(t *testing.T) {
 				}, nil
 			})
 		ctx := rpctest.NewARMRequestContext(req)
-		recipeMetadata := recipes.ResourceMetadata{
-			Name:          *envInput.Name,
-			EnvironmentID: envDataModel.ID,
-			Parameters:    nil,
-			ResourceID:    envDataModel.ID,
-			ResourceType:  "Applications.Datastores/mongoDatabases",
+		recipeDefinition := recipes.EnvironmentDefinition{
+			Name:            *envInput.Name,
+			Parameters:      nil,
+			TemplatePath:    "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
+			TemplateVersion: "",
+			Driver:          "bicep",
+			ResourceType:    "Applications.Datastores/mongoDatabases",
 		}
 		engineErr := fmt.Errorf("could not find driver %s", "invalidDriver")
-		mEngine.EXPECT().GetRecipeMetadata(ctx, recipeMetadata).Return(nil, engineErr)
+		mEngine.EXPECT().GetRecipeMetadata(ctx, recipeDefinition).Return(nil, engineErr)
 
 		opts := ctrl.Options{
 			StorageClient: mStorageClient,

--- a/pkg/corerp/frontend/controller/environments/getrecipemetadata_test.go
+++ b/pkg/corerp/frontend/controller/environments/getrecipemetadata_test.go
@@ -64,7 +64,7 @@ func TestGetRecipeMetadataRun_20220315PrivatePreview(t *testing.T) {
 			EnvironmentID: envDataModel.ID,
 			Parameters:    nil,
 			ResourceID:    envDataModel.ID,
-			ResourceType:  "Applications.Link/mongoDatabases",
+			ResourceType:  "Applications.Datastores/mongoDatabases",
 		}
 		recipeData := map[string]any{
 			"parameters": map[string]any{
@@ -112,7 +112,7 @@ func TestGetRecipeMetadataRun_20220315PrivatePreview(t *testing.T) {
 			EnvironmentID: envDataModel.ID,
 			Parameters:    nil,
 			ResourceID:    envDataModel.ID,
-			ResourceType:  "Applications.Link/mongoDatabases",
+			ResourceType:  "Applications.Datastores/mongoDatabases",
 		}
 		recipeData := map[string]any{
 			"parameters": map[string]any{
@@ -238,7 +238,7 @@ func TestGetRecipeMetadataRun_20220315PrivatePreview(t *testing.T) {
 			EnvironmentID: envDataModel.ID,
 			Parameters:    nil,
 			ResourceID:    envDataModel.ID,
-			ResourceType:  "Applications.Link/mongoDatabases",
+			ResourceType:  "Applications.Datastores/mongoDatabases",
 		}
 		engineErr := fmt.Errorf("could not find driver %s", "invalidDriver")
 		mEngine.EXPECT().GetRecipeMetadata(ctx, recipeMetadata).Return(nil, engineErr)

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentgetrecipemetadata20220315privatepreview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentgetrecipemetadata20220315privatepreview_datamodel.json
@@ -32,7 +32,7 @@
                     "templateVersion": "1.1.0"
                 }
             },
-            "Applications.Datastores/redisCaches":{
+            "Applications.Datastores/redisCache":{
                 "redis": {
                     "templateKind": "bicep",
                     "templatePath": "radiusdev.azurecr.io/redis:1.0"

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentgetrecipemetadata20220315privatepreview_input_terraform.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentgetrecipemetadata20220315privatepreview_input_terraform.json
@@ -1,0 +1,4 @@
+{
+    "name":"mongo-terraform",
+    "linkType":"Applications.Link/mongoDatabases"
+}

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentgetrecipemetadata20220315privatepreview_input_terraform.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentgetrecipemetadata20220315privatepreview_input_terraform.json
@@ -1,4 +1,4 @@
 {
     "name":"mongo-terraform",
-    "linkType":"Applications.Link/mongoDatabases"
+    "linkType":"Applications.Datastores/mongoDatabases"
 }

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentgetrecipemetadata20220315privatepreview_output_terraform.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentgetrecipemetadata20220315privatepreview_output_terraform.json
@@ -1,0 +1,17 @@
+{
+    "templateKind": "terraform",
+    "templatePath": "Azure/cosmosdb/azurerm",
+    "templateVersion": "1.1.0",
+    "parameters": {
+      "mongodbName": {
+        "type" : "string"
+      },
+      "documentdbName":  {
+        "type" : "string"
+      },
+      "location": {
+        "type" : "string",
+        "defaultValue" : "[resourceGroup().location]"
+      }
+    }
+  }

--- a/pkg/corerp/frontend/controller/environments/v20220315privatepreview_test.go
+++ b/pkg/corerp/frontend/controller/environments/v20220315privatepreview_test.go
@@ -44,10 +44,14 @@ func getTestModels20220315privatepreview() (*v20220315privatepreview.Environment
 	return envInput, envDataModel, expectedOutput
 }
 
-func getTestModelsGetRecipeMetadata20220315privatepreview() (*v20220315privatepreview.RecipeGetMetadata, *datamodel.Environment, *v20220315privatepreview.RecipeGetMetadataResponse) {
+func getTestModelsGetRecipeMetadata20220315privatepreview() (*v20220315privatepreview.RecipeGetMetadata, *v20220315privatepreview.RecipeGetMetadata, *datamodel.Environment, *v20220315privatepreview.RecipeGetMetadataResponse) {
 	rawInput := testutil.ReadFixture("environmentgetrecipemetadata20220315privatepreview_input.json")
 	envInput := &v20220315privatepreview.RecipeGetMetadata{}
 	_ = json.Unmarshal(rawInput, envInput)
+
+	rawTFInput := testutil.ReadFixture("environmentgetrecipemetadata20220315privatepreview_input.json")
+	envTFInput := &v20220315privatepreview.RecipeGetMetadata{}
+	_ = json.Unmarshal(rawTFInput, envTFInput)
 
 	rawExistingDataModel := testutil.ReadFixture("environmentgetrecipemetadata20220315privatepreview_datamodel.json")
 	envExistingDataModel := &datamodel.Environment{}
@@ -57,7 +61,7 @@ func getTestModelsGetRecipeMetadata20220315privatepreview() (*v20220315privatepr
 	expectedOutput := &v20220315privatepreview.RecipeGetMetadataResponse{}
 	_ = json.Unmarshal(rawExpectedOutput, expectedOutput)
 
-	return envInput, envExistingDataModel, expectedOutput
+	return envInput, envTFInput, envExistingDataModel, expectedOutput
 }
 
 func getTestModelsGetRecipeMetadataForNonExistingRecipe20220315privatepreview() (*v20220315privatepreview.RecipeGetMetadata, *datamodel.Environment) {

--- a/pkg/corerp/frontend/controller/environments/v20220315privatepreview_test.go
+++ b/pkg/corerp/frontend/controller/environments/v20220315privatepreview_test.go
@@ -44,12 +44,12 @@ func getTestModels20220315privatepreview() (*v20220315privatepreview.Environment
 	return envInput, envDataModel, expectedOutput
 }
 
-func getTestModelsGetRecipeMetadata20220315privatepreview() (*v20220315privatepreview.RecipeGetMetadata, *v20220315privatepreview.RecipeGetMetadata, *datamodel.Environment, *v20220315privatepreview.RecipeGetMetadataResponse) {
+func getTestModelsGetRecipeMetadata20220315privatepreview() (*v20220315privatepreview.RecipeGetMetadata, *v20220315privatepreview.RecipeGetMetadata, *datamodel.Environment, *v20220315privatepreview.RecipeGetMetadataResponse, *v20220315privatepreview.RecipeGetMetadataResponse) {
 	rawInput := testutil.ReadFixture("environmentgetrecipemetadata20220315privatepreview_input.json")
 	envInput := &v20220315privatepreview.RecipeGetMetadata{}
 	_ = json.Unmarshal(rawInput, envInput)
 
-	rawTFInput := testutil.ReadFixture("environmentgetrecipemetadata20220315privatepreview_input.json")
+	rawTFInput := testutil.ReadFixture("environmentgetrecipemetadata20220315privatepreview_input_terraform.json")
 	envTFInput := &v20220315privatepreview.RecipeGetMetadata{}
 	_ = json.Unmarshal(rawTFInput, envTFInput)
 
@@ -61,7 +61,11 @@ func getTestModelsGetRecipeMetadata20220315privatepreview() (*v20220315privatepr
 	expectedOutput := &v20220315privatepreview.RecipeGetMetadataResponse{}
 	_ = json.Unmarshal(rawExpectedOutput, expectedOutput)
 
-	return envInput, envTFInput, envExistingDataModel, expectedOutput
+	rawExpectedTFOutput := testutil.ReadFixture("environmentgetrecipemetadata20220315privatepreview_output_terraform.json")
+	expectedTFOutput := &v20220315privatepreview.RecipeGetMetadataResponse{}
+	_ = json.Unmarshal(rawExpectedTFOutput, expectedTFOutput)
+
+	return envInput, envTFInput, envExistingDataModel, expectedOutput, expectedTFOutput
 }
 
 func getTestModelsGetRecipeMetadataForNonExistingRecipe20220315privatepreview() (*v20220315privatepreview.RecipeGetMetadata, *datamodel.Environment) {

--- a/pkg/corerp/frontend/handler/routes.go
+++ b/pkg/corerp/frontend/handler/routes.go
@@ -26,6 +26,7 @@ import (
 	frontend_ctrl "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
 	"github.com/radius-project/radius/pkg/armrpc/frontend/defaultoperation"
 	"github.com/radius-project/radius/pkg/armrpc/frontend/server"
+	"github.com/radius-project/radius/pkg/recipes/engine"
 	rp_frontend "github.com/radius-project/radius/pkg/rp/frontend"
 	"github.com/radius-project/radius/pkg/validator"
 	"github.com/radius-project/radius/swagger"
@@ -52,7 +53,7 @@ const (
 
 // AddRoutes registers handlers for Container, Application, Gateway, Volume and Secret Store resources, allowing for
 // operations such as List, Get, Put, Patch and Delete.
-func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_ctrl.Options) error {
+func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_ctrl.Options, engine engine.Engine) error {
 	rootScopePath := ctrlOpts.PathBase
 	if isARM {
 		rootScopePath += "/subscriptions/{subscriptionID}"
@@ -167,7 +168,7 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 			ResourceType: env_ctrl.ResourceTypeName,
 			Method:       env_ctrl.OperationGetRecipeMetadata,
 			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
-				return env_ctrl.NewGetRecipeMetadata(opt)
+				return env_ctrl.NewGetRecipeMetadata(opt, engine)
 			},
 		},
 	}

--- a/pkg/corerp/frontend/handler/routes.go
+++ b/pkg/corerp/frontend/handler/routes.go
@@ -162,11 +162,13 @@ func AddRoutes(ctx context.Context, r chi.Router, isARM bool, ctrlOpts frontend_
 			},
 		},
 		{
-			ParentRouter:      envResourceRouter,
-			Path:              "/getmetadata",
-			ResourceType:      env_ctrl.ResourceTypeName,
-			Method:            env_ctrl.OperationGetRecipeMetadata,
-			ControllerFactory: env_ctrl.NewGetRecipeMetadata,
+			ParentRouter: envResourceRouter,
+			Path:         "/getmetadata",
+			ResourceType: env_ctrl.ResourceTypeName,
+			Method:       env_ctrl.OperationGetRecipeMetadata,
+			ControllerFactory: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
+				return env_ctrl.NewGetRecipeMetadata(opt)
+			},
 		},
 	}
 

--- a/pkg/corerp/frontend/handler/routes_test.go
+++ b/pkg/corerp/frontend/handler/routes_test.go
@@ -26,6 +26,7 @@ import (
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	ctrl "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
 	"github.com/radius-project/radius/pkg/armrpc/rpctest"
+	"github.com/radius-project/radius/pkg/recipes/engine"
 	"github.com/radius-project/radius/pkg/ucp/dataprovider"
 	"github.com/radius-project/radius/pkg/ucp/store"
 
@@ -231,6 +232,7 @@ func TestHandlers(t *testing.T) {
 
 	mockSP := dataprovider.NewMockDataStorageProvider(mctrl)
 	mockSC := store.NewMockStorageClient(mctrl)
+	mockEngine := engine.NewMockEngine(mctrl)
 
 	mockSC.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&store.Object{}, nil).AnyTimes()
 	mockSC.EXPECT().Save(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
@@ -240,7 +242,7 @@ func TestHandlers(t *testing.T) {
 		// Test handlers for UCP resources.
 		rpctest.AssertRouters(t, handlerTests, "/api.ucp.dev", "/planes/radius/local", func(ctx context.Context) (chi.Router, error) {
 			r := chi.NewRouter()
-			return r, AddRoutes(ctx, r, false, ctrl.Options{PathBase: "/api.ucp.dev", DataProvider: mockSP})
+			return r, AddRoutes(ctx, r, false, ctrl.Options{PathBase: "/api.ucp.dev", DataProvider: mockSP}, mockEngine)
 		})
 	})
 
@@ -257,7 +259,7 @@ func TestHandlers(t *testing.T) {
 		// Test handlers for Azure resources
 		rpctest.AssertRouters(t, azureHandlerTests, "", "/subscriptions/00000000-0000-0000-0000-000000000000", func(ctx context.Context) (chi.Router, error) {
 			r := chi.NewRouter()
-			return r, AddRoutes(ctx, r, true, ctrl.Options{PathBase: "", DataProvider: mockSP})
+			return r, AddRoutes(ctx, r, true, ctrl.Options{PathBase: "", DataProvider: mockSP}, mockEngine)
 		})
 	})
 }

--- a/pkg/corerp/frontend/service.go
+++ b/pkg/corerp/frontend/service.go
@@ -102,7 +102,6 @@ func (s *Service) Run(ctx context.Context) error {
 		DataProvider:  s.StorageProvider,
 		KubeClient:    s.KubeClient,
 		StatusManager: s.OperationStatusManager,
-		Engine:        engine,
 	}
 
 	err = s.Start(ctx, server.Options{
@@ -114,7 +113,7 @@ func (s *Service) Run(ctx context.Context) error {
 		ArmCertMgr:    s.ARMCertManager,
 		EnableArmAuth: s.Options.Config.Server.EnableArmAuth, // when enabled the client cert validation will be done
 		Configure: func(router chi.Router) error {
-			err := handler.AddRoutes(ctx, router, !hostoptions.IsSelfHosted(), opts)
+			err := handler.AddRoutes(ctx, router, !hostoptions.IsSelfHosted(), opts, engine)
 			if err != nil {
 				return err
 			}

--- a/pkg/corerp/frontend/service.go
+++ b/pkg/corerp/frontend/service.go
@@ -89,7 +89,7 @@ func (s *Service) Run(ctx context.Context) error {
 			recipes.TemplateKindTerraform: driver.NewTerraformDriver(s.Options.UCPConnection, provider.NewSecretProvider(s.Options.Config.SecretProvider),
 				driver.TerraformOptions{
 					Path: s.Options.Config.Terraform.Path,
-				}),
+				}, nil),
 		},
 	})
 

--- a/pkg/corerp/frontend/service.go
+++ b/pkg/corerp/frontend/service.go
@@ -24,6 +24,7 @@ import (
 	ctrl "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
 	"github.com/radius-project/radius/pkg/armrpc/frontend/server"
 	"github.com/radius-project/radius/pkg/armrpc/hostoptions"
+	aztoken "github.com/radius-project/radius/pkg/azure/tokencredentials"
 	"github.com/radius-project/radius/pkg/corerp/frontend/handler"
 	"github.com/radius-project/radius/pkg/kubeutil"
 	"github.com/radius-project/radius/pkg/portableresources/processors"

--- a/pkg/corerp/frontend/service.go
+++ b/pkg/corerp/frontend/service.go
@@ -81,6 +81,9 @@ func (s *Service) Run(ctx context.Context) error {
 		BaseURI:          s.Options.UCPConnection.Endpoint(),
 		ARMClientOptions: sdk.NewClientOptions(s.Options.UCPConnection),
 	})
+	if err != nil {
+		return err
+	}
 
 	engine := engine.NewEngine(engine.Options{
 		ConfigurationLoader: configLoader,

--- a/pkg/portableresources/backend/service.go
+++ b/pkg/portableresources/backend/service.go
@@ -82,7 +82,7 @@ func (s *Service) Run(ctx context.Context) error {
 	deploymentEngineClient, err := clients.NewResourceDeploymentsClient(&clients.Options{
 		Cred:             &aztoken.AnonymousCredential{},
 		BaseURI:          s.Options.UCPConnection.Endpoint(),
-		ARMClientOptions: sdk.NewClientOptions(s.Options.UCPConnection),
+		ARMClientOptions: clientOptions,
 	})
 	if err != nil {
 		return err

--- a/pkg/recipes/configloader/environment.go
+++ b/pkg/recipes/configloader/environment.go
@@ -132,7 +132,11 @@ func getRecipeDefinition(environment *v20220315privatepreview.EnvironmentResourc
 		return nil, fmt.Errorf("failed to parse resourceID: %q %w", recipe.ResourceID, err)
 	}
 	recipeName := recipe.Name
-	found, ok := environment.Properties.Recipes[resource.Type()][recipeName]
+	resourceType := resource.Type()
+	if recipe.ResourceType != "" {
+		resourceType = recipe.ResourceType
+	}
+	found, ok := environment.Properties.Recipes[resourceType][recipeName]
 	if !ok {
 		return nil, &recipes.ErrRecipeNotFound{Name: recipe.Name, Environment: recipe.EnvironmentID}
 	}

--- a/pkg/recipes/driver/bicep.go
+++ b/pkg/recipes/driver/bicep.go
@@ -185,6 +185,7 @@ func (d *bicepDriver) Delete(ctx context.Context, opts DeleteOptions) error {
 	return nil
 }
 
+// GetRecipeMetadata gets the parameter information from the Bicep registry
 func (d *bicepDriver) GetRecipeMetadata(ctx context.Context, opts ExecuteOptions) (map[string]any, error) {
 	recipeData := make(map[string]any)
 	err := util.ReadFromRegistry(ctx, opts.BaseOptions.Definition.TemplatePath, &recipeData)

--- a/pkg/recipes/driver/bicep.go
+++ b/pkg/recipes/driver/bicep.go
@@ -185,9 +185,9 @@ func (d *bicepDriver) Delete(ctx context.Context, opts DeleteOptions) error {
 	return nil
 }
 
-func (d *bicepDriver) GetRecipeMetadata(ctx context.Context, recipe recipes.EnvironmentDefinition, recipeMetadata recipes.ResourceMetadata) (map[string]any, error) {
+func (d *bicepDriver) GetRecipeMetadata(ctx context.Context, opts ExecuteOptions) (map[string]any, error) {
 	recipeData := make(map[string]any)
-	err := util.ReadFromRegistry(ctx, recipe.TemplatePath, &recipeData)
+	err := util.ReadFromRegistry(ctx, opts.BaseOptions.Definition.TemplatePath, &recipeData)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/recipes/driver/bicep.go
+++ b/pkg/recipes/driver/bicep.go
@@ -185,6 +185,15 @@ func (d *bicepDriver) Delete(ctx context.Context, opts DeleteOptions) error {
 	return nil
 }
 
+func (d *bicepDriver) GetRecipeMetadata(ctx context.Context, recipe recipes.EnvironmentDefinition, recipeMetadata recipes.ResourceMetadata) (map[string]any, error) {
+	recipeData := make(map[string]any)
+	err := util.ReadFromRegistry(ctx, recipe.TemplatePath, &recipeData)
+	if err != nil {
+		return nil, err
+	}
+	return recipeData, nil
+}
+
 func hasContextParameter(recipeData map[string]any) bool {
 	parametersAny, ok := recipeData[recipeParameters]
 	if !ok {

--- a/pkg/recipes/driver/bicep.go
+++ b/pkg/recipes/driver/bicep.go
@@ -186,9 +186,9 @@ func (d *bicepDriver) Delete(ctx context.Context, opts DeleteOptions) error {
 }
 
 // GetRecipeMetadata gets the parameter information from the Bicep registry
-func (d *bicepDriver) GetRecipeMetadata(ctx context.Context, opts ExecuteOptions) (map[string]any, error) {
+func (d *bicepDriver) GetRecipeMetadata(ctx context.Context, opts BaseOptions) (map[string]any, error) {
 	recipeData := make(map[string]any)
-	err := util.ReadFromRegistry(ctx, opts.BaseOptions.Definition.TemplatePath, &recipeData)
+	err := util.ReadFromRegistry(ctx, opts.Definition.TemplatePath, &recipeData)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/recipes/driver/bicep_test.go
+++ b/pkg/recipes/driver/bicep_test.go
@@ -440,29 +440,15 @@ func Test_Bicep_GetRecipeMetadata_Success(t *testing.T) {
 		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 
-	recipe := recipes.ResourceMetadata{
-		Name:          "redis-azure",
-		ApplicationID: "/planes/radius/local/resourcegroups/test-rg/providers/applications.core/applications/app1",
-		EnvironmentID: "/planes/radius/local/resourcegroups/test-rg/providers/applications.core/environments/env1",
-		ResourceID:    "/planes/radius/local/resourceGroups/test-rg/providers/applications.datastores/mongoDatabases/test-mongo-recipe",
-		Parameters: map[string]any{
-			"documentdbName": "documentName",
-			"location":       "eastus",
-			"mongodbName":    "test-mongo-db",
-		},
-	}
-
 	expectedOutput := map[string]any{
 		"documentdbName": map[string]any{"type": "string"},
 		"location":       map[string]any{"defaultValue": "[resourceGroup().location]", "type": "string"},
 		"mongodbName":    map[string]any{"type": "string"},
 	}
 
-	recipeData, err := driver.GetRecipeMetadata(ctx, ExecuteOptions{
-		BaseOptions: BaseOptions{
-			Recipe:     recipe,
-			Definition: recipeDefinition,
-		},
+	recipeData, err := driver.GetRecipeMetadata(ctx, BaseOptions{
+		Recipe:     recipes.ResourceMetadata{},
+		Definition: recipeDefinition,
 	})
 
 	require.NoError(t, err)
@@ -479,23 +465,9 @@ func Test_Bicep_GetRecipeMetadata_Error(t *testing.T) {
 		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 
-	recipe := recipes.ResourceMetadata{
-		Name:          "redis-azure",
-		ApplicationID: "/planes/radius/local/resourcegroups/test-rg/providers/applications.core/applications/app1",
-		EnvironmentID: "/planes/radius/local/resourcegroups/test-rg/providers/applications.core/environments/env1",
-		ResourceID:    "/planes/radius/local/resourceGroups/test-rg/providers/applications.datastores/mongoDatabases/test-mongo-recipe",
-		Parameters: map[string]any{
-			"documentdbName": "documentName",
-			"location":       "eastus",
-			"mongodbName":    "test-mongo-db",
-		},
-	}
-
-	_, err := driver.GetRecipeMetadata(ctx, ExecuteOptions{
-		BaseOptions: BaseOptions{
-			Recipe:     recipe,
-			Definition: recipeDefinition,
-		},
+	_, err := driver.GetRecipeMetadata(ctx, BaseOptions{
+		Recipe:     recipes.ResourceMetadata{},
+		Definition: recipeDefinition,
 	})
 	expErr := recipes.RecipeError{
 		ErrorDetails: v1.ErrorDetails{

--- a/pkg/recipes/driver/bicep_test.go
+++ b/pkg/recipes/driver/bicep_test.go
@@ -437,14 +437,14 @@ func Test_Bicep_GetRecipeMetadata_Success(t *testing.T) {
 		Name:         "mongo-azure",
 		Driver:       recipes.TemplateKindBicep,
 		TemplatePath: "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
-		ResourceType: "Applications.Link/mongoDatabases",
+		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 
 	recipe := recipes.ResourceMetadata{
 		Name:          "redis-azure",
 		ApplicationID: "/planes/radius/local/resourcegroups/test-rg/providers/applications.core/applications/app1",
 		EnvironmentID: "/planes/radius/local/resourcegroups/test-rg/providers/applications.core/environments/env1",
-		ResourceID:    "/planes/radius/local/resourceGroups/test-rg/providers/applications.link/mongoDatabases/test-mongo-recipe",
+		ResourceID:    "/planes/radius/local/resourceGroups/test-rg/providers/applications.datastores/mongoDatabases/test-mongo-recipe",
 		Parameters: map[string]any{
 			"documentdbName": "documentName",
 			"location":       "eastus",
@@ -476,14 +476,14 @@ func Test_Bicep_GetRecipeMetadata_Error(t *testing.T) {
 		Name:         "mongo-azure",
 		Driver:       recipes.TemplateKindBicep,
 		TemplatePath: "radiusdev.azurecr.io/test-non-existent-recipe",
-		ResourceType: "Applications.Link/mongoDatabases",
+		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 
 	recipe := recipes.ResourceMetadata{
 		Name:          "redis-azure",
 		ApplicationID: "/planes/radius/local/resourcegroups/test-rg/providers/applications.core/applications/app1",
 		EnvironmentID: "/planes/radius/local/resourcegroups/test-rg/providers/applications.core/environments/env1",
-		ResourceID:    "/planes/radius/local/resourceGroups/test-rg/providers/applications.link/mongoDatabases/test-mongo-recipe",
+		ResourceID:    "/planes/radius/local/resourceGroups/test-rg/providers/applications.datastores/mongoDatabases/test-mongo-recipe",
 		Parameters: map[string]any{
 			"documentdbName": "documentName",
 			"location":       "eastus",

--- a/pkg/recipes/driver/mock_driver.go
+++ b/pkg/recipes/driver/mock_driver.go
@@ -65,16 +65,16 @@ func (mr *MockDriverMockRecorder) Execute(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // GetRecipeMetadata mocks base method.
-func (m *MockDriver) GetRecipeMetadata(arg0 context.Context, arg1 recipes.EnvironmentDefinition, arg2 recipes.ResourceMetadata) (map[string]interface{}, error) {
+func (m *MockDriver) GetRecipeMetadata(arg0 context.Context, arg1 ExecuteOptions) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRecipeMetadata", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetRecipeMetadata", arg0, arg1)
 	ret0, _ := ret[0].(map[string]interface{})
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRecipeMetadata indicates an expected call of GetRecipeMetadata.
-func (mr *MockDriverMockRecorder) GetRecipeMetadata(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockDriverMockRecorder) GetRecipeMetadata(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecipeMetadata", reflect.TypeOf((*MockDriver)(nil).GetRecipeMetadata), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecipeMetadata", reflect.TypeOf((*MockDriver)(nil).GetRecipeMetadata), arg0, arg1)
 }

--- a/pkg/recipes/driver/mock_driver.go
+++ b/pkg/recipes/driver/mock_driver.go
@@ -63,3 +63,18 @@ func (mr *MockDriverMockRecorder) Execute(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockDriver)(nil).Execute), arg0, arg1)
 }
+
+// GetRecipeMetadata mocks base method.
+func (m *MockDriver) GetRecipeMetadata(arg0 context.Context, arg1 recipes.EnvironmentDefinition, arg2 recipes.ResourceMetadata) (map[string]interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRecipeMetadata", arg0, arg1, arg2)
+	ret0, _ := ret[0].(map[string]interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRecipeMetadata indicates an expected call of GetRecipeMetadata.
+func (mr *MockDriverMockRecorder) GetRecipeMetadata(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecipeMetadata", reflect.TypeOf((*MockDriver)(nil).GetRecipeMetadata), arg0, arg1, arg2)
+}

--- a/pkg/recipes/driver/mock_driver.go
+++ b/pkg/recipes/driver/mock_driver.go
@@ -65,7 +65,7 @@ func (mr *MockDriverMockRecorder) Execute(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // GetRecipeMetadata mocks base method.
-func (m *MockDriver) GetRecipeMetadata(arg0 context.Context, arg1 ExecuteOptions) (map[string]interface{}, error) {
+func (m *MockDriver) GetRecipeMetadata(arg0 context.Context, arg1 BaseOptions) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRecipeMetadata", arg0, arg1)
 	ret0, _ := ret[0].(map[string]interface{})

--- a/pkg/recipes/driver/terraform.go
+++ b/pkg/recipes/driver/terraform.go
@@ -174,8 +174,6 @@ func (d *terraformDriver) createExecutionDirectory(ctx context.Context, recipe r
 	return requestDirPath, nil
 }
 
-// # Function Explanation
-//
 // GetRecipeMetadata returns the Terraform Recipe parameters and metadata
 func (d *terraformDriver) GetRecipeMetadata(ctx context.Context, opts ExecuteOptions) (map[string]any, error) {
 	// TODO: to be implemented in follow up PR

--- a/pkg/recipes/driver/terraform.go
+++ b/pkg/recipes/driver/terraform.go
@@ -175,7 +175,7 @@ func (d *terraformDriver) createExecutionDirectory(ctx context.Context, recipe r
 }
 
 // GetRecipeMetadata returns the Terraform Recipe parameters and metadata
-func (d *terraformDriver) GetRecipeMetadata(ctx context.Context, opts ExecuteOptions) (map[string]any, error) {
+func (d *terraformDriver) GetRecipeMetadata(ctx context.Context, opts BaseOptions) (map[string]any, error) {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
 	requestDirPath, err := d.createExecutionDirectory(ctx, opts.Recipe, opts.Definition)

--- a/pkg/recipes/driver/terraform.go
+++ b/pkg/recipes/driver/terraform.go
@@ -176,7 +176,6 @@ func (d *terraformDriver) createExecutionDirectory(ctx context.Context, recipe r
 
 // GetRecipeMetadata returns the Terraform Recipe parameters and metadata
 func (d *terraformDriver) GetRecipeMetadata(ctx context.Context, opts ExecuteOptions) (map[string]any, error) {
-	// TODO: to be implemented in follow up PR
 	logger := ucplog.FromContextOrDiscard(ctx)
 
 	requestDirPath, err := d.createExecutionDirectory(ctx, opts.Recipe, opts.Definition)

--- a/pkg/recipes/driver/terraform.go
+++ b/pkg/recipes/driver/terraform.go
@@ -173,3 +173,32 @@ func (d *terraformDriver) createExecutionDirectory(ctx context.Context, recipe r
 
 	return requestDirPath, nil
 }
+
+// # Function Explanation
+//
+// GetRecipeMetadata returns the Terraform Recipe parameters and metadata
+func (d *terraformDriver) GetRecipeMetadata(ctx context.Context, recipe recipes.EnvironmentDefinition, recipeMetadata recipes.ResourceMetadata) (map[string]any, error) {
+	// TODO: to be implemented in follow up PR
+	logger := ucplog.FromContextOrDiscard(ctx)
+
+	requestDirPath, err := d.createExecutionDirectory(ctx, recipeMetadata, recipe)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := os.RemoveAll(requestDirPath); err != nil {
+			logger.Info(fmt.Sprintf("Failed to cleanup Terraform execution directory %q. Err: %s", requestDirPath, err.Error()))
+		}
+	}()
+
+	recipeData, err := d.terraformExecutor.GetRecipeMetadata(ctx, terraform.Options{
+		RootDir:        requestDirPath,
+		ResourceRecipe: &recipeMetadata,
+		EnvRecipe:      &recipe,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return recipeData, nil
+}

--- a/pkg/recipes/driver/terraform.go
+++ b/pkg/recipes/driver/terraform.go
@@ -177,13 +177,13 @@ func (d *terraformDriver) createExecutionDirectory(ctx context.Context, recipe r
 // # Function Explanation
 //
 // GetRecipeMetadata returns the Terraform Recipe parameters and metadata
-func (d *terraformDriver) GetRecipeMetadata(ctx context.Context, recipe recipes.EnvironmentDefinition, recipeMetadata recipes.ResourceMetadata) (map[string]any, error) {
+func (d *terraformDriver) GetRecipeMetadata(ctx context.Context, opts ExecuteOptions) (map[string]any, error) {
 	// TODO: to be implemented in follow up PR
 	logger := ucplog.FromContextOrDiscard(ctx)
 
-	requestDirPath, err := d.createExecutionDirectory(ctx, recipeMetadata, recipe)
+	requestDirPath, err := d.createExecutionDirectory(ctx, opts.Recipe, opts.Definition)
 	if err != nil {
-		return nil, err
+		return nil, recipes.NewRecipeError(recipes.RecipeDownloadFailed, err.Error(), recipes.GetRecipeErrorDetails(err))
 	}
 	defer func() {
 		if err := os.RemoveAll(requestDirPath); err != nil {
@@ -193,8 +193,8 @@ func (d *terraformDriver) GetRecipeMetadata(ctx context.Context, recipe recipes.
 
 	recipeData, err := d.terraformExecutor.GetRecipeMetadata(ctx, terraform.Options{
 		RootDir:        requestDirPath,
-		ResourceRecipe: &recipeMetadata,
-		EnvRecipe:      &recipe,
+		ResourceRecipe: &opts.Recipe,
+		EnvRecipe:      &opts.Definition,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/recipes/driver/types.go
+++ b/pkg/recipes/driver/types.go
@@ -30,6 +30,9 @@ type Driver interface {
 
 	// Delete handles deletion of output resources for the recipe deployment.
 	Delete(ctx context.Context, opts DeleteOptions) error
+
+	// Gets the Recipe metadata and parameters from the Bicep registry or TF modules
+	GetRecipeMetadata(ctx context.Context, recipeDefinition recipes.EnvironmentDefinition, resourceMetadata recipes.ResourceMetadata) (map[string]any, error)
 }
 
 // BaseOptions is the base options for the driver operations.

--- a/pkg/recipes/driver/types.go
+++ b/pkg/recipes/driver/types.go
@@ -32,7 +32,7 @@ type Driver interface {
 	Delete(ctx context.Context, opts DeleteOptions) error
 
 	// Gets the Recipe metadata and parameters from the Bicep registry or TF modules
-	GetRecipeMetadata(ctx context.Context, recipeDefinition recipes.EnvironmentDefinition, resourceMetadata recipes.ResourceMetadata) (map[string]any, error)
+	GetRecipeMetadata(ctx context.Context, opts ExecuteOptions) (map[string]any, error)
 }
 
 // BaseOptions is the base options for the driver operations.

--- a/pkg/recipes/driver/types.go
+++ b/pkg/recipes/driver/types.go
@@ -32,7 +32,7 @@ type Driver interface {
 	Delete(ctx context.Context, opts DeleteOptions) error
 
 	// Gets the Recipe metadata and parameters from the Bicep registry or TF modules
-	GetRecipeMetadata(ctx context.Context, opts ExecuteOptions) (map[string]any, error)
+	GetRecipeMetadata(ctx context.Context, opts BaseOptions) (map[string]any, error)
 }
 
 // BaseOptions is the base options for the driver operations.

--- a/pkg/recipes/engine/engine.go
+++ b/pkg/recipes/engine/engine.go
@@ -152,6 +152,24 @@ func (e *engine) deleteCore(ctx context.Context, recipe recipes.ResourceMetadata
 
 // GetRecipeMetadata gets the Recipe metadata and parameters from the Bicep registry or TF modules
 func (e *engine) GetRecipeMetadata(ctx context.Context, recipeMetadata recipes.ResourceMetadata) (map[string]any, error) {
+	getMetadata := time.Now()
+	result := metrics.SuccessfulOperationState
+
+	recipeData, err := e.getRecipeMetadataCore(ctx, recipeMetadata)
+	if err != nil {
+		result = metrics.FailedOperationState
+	}
+
+	metrics.DefaultRecipeEngineMetrics.RecordRecipeOperationDuration(ctx, getMetadata,
+		metrics.NewRecipeAttributes(metrics.RecipeEngineOperationDownloadRecipe, recipeMetadata.Name,
+			nil, result))
+
+	return recipeData, err
+}
+
+// getRecipeMetadataCore function is the core logic of the GetRecipeMetadata function.
+// Any changes to the core logic of the GetRecipeMetadata function should be made here.
+func (e *engine) getRecipeMetadataCore(ctx context.Context, recipeMetadata recipes.ResourceMetadata) (map[string]any, error) {
 	// Load Recipe Definition from the environment.
 	definition, err := e.options.ConfigurationLoader.LoadRecipe(ctx, &recipeMetadata)
 	if err != nil {

--- a/pkg/recipes/engine/engine.go
+++ b/pkg/recipes/engine/engine.go
@@ -164,5 +164,10 @@ func (e *engine) GetRecipeMetadata(ctx context.Context, recipeMetadata recipes.R
 		return nil, fmt.Errorf("could not find driver %s", definition.Driver)
 	}
 
-	return driver.GetRecipeMetadata(ctx, *definition, recipeMetadata)
+	return driver.GetRecipeMetadata(ctx, recipedriver.ExecuteOptions{
+		BaseOptions: recipedriver.BaseOptions{
+			Definition: *definition,
+			Recipe:     recipeMetadata,
+		},
+	})
 }

--- a/pkg/recipes/engine/engine.go
+++ b/pkg/recipes/engine/engine.go
@@ -149,3 +149,20 @@ func (e *engine) deleteCore(ctx context.Context, recipe recipes.ResourceMetadata
 
 	return definition, nil
 }
+
+// TODO
+func (e *engine) GetRecipeMetadata(ctx context.Context, recipeMetadata recipes.ResourceMetadata) (map[string]any, error) {
+	// Load Recipe Definition from the environment.
+	definition, err := e.options.ConfigurationLoader.LoadRecipe(ctx, &recipeMetadata)
+	if err != nil {
+		return nil, err
+	}
+
+	// Determine Recipe driver type
+	driver, ok := e.options.Drivers[definition.Driver]
+	if !ok {
+		return nil, fmt.Errorf("could not find driver %s", definition.Driver)
+	}
+
+	return driver.GetRecipeMetadata(ctx, *definition, recipeMetadata)
+}

--- a/pkg/recipes/engine/engine.go
+++ b/pkg/recipes/engine/engine.go
@@ -150,7 +150,7 @@ func (e *engine) deleteCore(ctx context.Context, recipe recipes.ResourceMetadata
 	return definition, nil
 }
 
-// TODO
+// GetRecipeMetadata gets the Recipe metadata and parameters from the Bicep registry or TF modules
 func (e *engine) GetRecipeMetadata(ctx context.Context, recipeMetadata recipes.ResourceMetadata) (map[string]any, error) {
 	// Load Recipe Definition from the environment.
 	definition, err := e.options.ConfigurationLoader.LoadRecipe(ctx, &recipeMetadata)

--- a/pkg/recipes/engine/engine_test.go
+++ b/pkg/recipes/engine/engine_test.go
@@ -452,51 +452,34 @@ func Test_Delete_Lookup_Error(t *testing.T) {
 }
 
 func Test_Engine_GetRecipeMetadata_Success(t *testing.T) {
-	recipeMetadata, recipeDefinition, _ := getDeleteInputs()
+	_, recipeDefinition, _ := getDeleteInputs()
 
 	ctx := testcontext.New(t)
-	engine, configLoader, driver := setup(t)
-	outputParams := map[string]any{"parameters": recipeMetadata.Parameters}
+	engine, _, driver := setup(t)
+	outputParams := map[string]any{"parameters": recipeDefinition.Parameters}
 
-	configLoader.EXPECT().LoadRecipe(gomock.Any(), gomock.Any()).Times(1).Return(&recipeDefinition, nil)
-	driver.EXPECT().GetRecipeMetadata(ctx, recipedriver.ExecuteOptions{
-		BaseOptions: recipedriver.BaseOptions{
-			Recipe:     recipeMetadata,
-			Definition: recipeDefinition,
-		},
+	driver.EXPECT().GetRecipeMetadata(ctx, recipedriver.BaseOptions{
+		Recipe:     recipes.ResourceMetadata{},
+		Definition: recipeDefinition,
 	}).Times(1).Return(outputParams, nil)
 
-	recipeData, err := engine.GetRecipeMetadata(ctx, recipeMetadata)
+	recipeData, err := engine.GetRecipeMetadata(ctx, recipeDefinition)
 	require.NoError(t, err)
 	require.Equal(t, outputParams, recipeData)
 }
 
 func Test_GetRecipeMetadata_Driver_Error(t *testing.T) {
-	recipeMetadata, recipeDefinition, _ := getDeleteInputs()
+	_, recipeDefinition, _ := getDeleteInputs()
 
 	ctx := testcontext.New(t)
-	engine, configLoader, driver := setup(t)
+	engine, _, driver := setup(t)
 
-	configLoader.EXPECT().LoadRecipe(gomock.Any(), gomock.Any()).Times(1).Return(&recipeDefinition, nil)
-	driver.EXPECT().GetRecipeMetadata(ctx, recipedriver.ExecuteOptions{
-		BaseOptions: recipedriver.BaseOptions{
-			Recipe:     recipeMetadata,
-			Definition: recipeDefinition,
-		},
+	driver.EXPECT().GetRecipeMetadata(ctx, recipedriver.BaseOptions{
+		Recipe:     recipes.ResourceMetadata{},
+		Definition: recipeDefinition,
 	}).Times(1).Return(nil, errors.New("driver failure"))
 
-	_, err := engine.GetRecipeMetadata(ctx, recipeMetadata)
-	require.Error(t, err)
-}
-
-func Test_GetRecipeMetadata_Lookup_Error(t *testing.T) {
-	recipeMetadata, _, _ := getDeleteInputs()
-
-	ctx := testcontext.New(t)
-	engine, configLoader, _ := setup(t)
-
-	configLoader.EXPECT().LoadRecipe(gomock.Any(), gomock.Any()).Times(1).Return(nil, errors.New("could not find recipe mongo-azure in environment env1"))
-	_, err := engine.GetRecipeMetadata(ctx, recipeMetadata)
+	_, err := engine.GetRecipeMetadata(ctx, recipeDefinition)
 	require.Error(t, err)
 }
 

--- a/pkg/recipes/engine/mock_engine.go
+++ b/pkg/recipes/engine/mock_engine.go
@@ -64,3 +64,18 @@ func (mr *MockEngineMockRecorder) Execute(arg0, arg1, arg2 interface{}) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockEngine)(nil).Execute), arg0, arg1, arg2)
 }
+
+// GetRecipeMetadata mocks base method.
+func (m *MockEngine) GetRecipeMetadata(arg0 context.Context, arg1 recipes.ResourceMetadata) (map[string]interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRecipeMetadata", arg0, arg1)
+	ret0, _ := ret[0].(map[string]interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRecipeMetadata indicates an expected call of GetRecipeMetadata.
+func (mr *MockEngineMockRecorder) GetRecipeMetadata(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecipeMetadata", reflect.TypeOf((*MockEngine)(nil).GetRecipeMetadata), arg0, arg1)
+}

--- a/pkg/recipes/engine/mock_engine.go
+++ b/pkg/recipes/engine/mock_engine.go
@@ -66,7 +66,7 @@ func (mr *MockEngineMockRecorder) Execute(arg0, arg1, arg2 interface{}) *gomock.
 }
 
 // GetRecipeMetadata mocks base method.
-func (m *MockEngine) GetRecipeMetadata(arg0 context.Context, arg1 recipes.ResourceMetadata) (map[string]interface{}, error) {
+func (m *MockEngine) GetRecipeMetadata(arg0 context.Context, arg1 recipes.EnvironmentDefinition) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRecipeMetadata", arg0, arg1)
 	ret0, _ := ret[0].(map[string]interface{})

--- a/pkg/recipes/engine/types.go
+++ b/pkg/recipes/engine/types.go
@@ -31,4 +31,6 @@ type Engine interface {
 	Execute(ctx context.Context, recipe recipes.ResourceMetadata, prevState []string) (*recipes.RecipeOutput, error)
 	// Delete handles deletion of output resources for the recipe deployment.
 	Delete(ctx context.Context, recipe recipes.ResourceMetadata, outputResources []rpv1.OutputResource) error
+	// Gets the Recipe metadata and parameters from the Bicep registry or TF modules
+	GetRecipeMetadata(ctx context.Context, recipeMetadata recipes.ResourceMetadata) (map[string]any, error)
 }

--- a/pkg/recipes/engine/types.go
+++ b/pkg/recipes/engine/types.go
@@ -32,5 +32,5 @@ type Engine interface {
 	// Delete handles deletion of output resources for the recipe deployment.
 	Delete(ctx context.Context, recipe recipes.ResourceMetadata, outputResources []rpv1.OutputResource) error
 	// Gets the Recipe metadata and parameters from the Bicep registry or TF modules
-	GetRecipeMetadata(ctx context.Context, recipeMetadata recipes.ResourceMetadata) (map[string]any, error)
+	GetRecipeMetadata(ctx context.Context, recipeDefinition recipes.EnvironmentDefinition) (map[string]any, error)
 }

--- a/pkg/recipes/terraform/config/config_test.go
+++ b/pkg/recipes/terraform/config/config_test.go
@@ -159,6 +159,17 @@ func Test_AddRecipeContext(t *testing.T) {
 			expectedConfigFile: "testdata/main-noparams.tf.json",
 		},
 		{
+			name: "recipe context with empty resource metadata",
+			envdef: &recipes.EnvironmentDefinition{
+				Name:            testRecipeName,
+				TemplatePath:    testTemplatePath,
+				TemplateVersion: testTemplateVersion,
+			},
+			metadata:           &recipes.ResourceMetadata{},
+			recipeContext:      getTestRecipeContext(),
+			expectedConfigFile: "testdata/main-noparams.tf.json",
+		},
+		{
 			name: "recipe context and env params are given",
 			envdef: &recipes.EnvironmentDefinition{
 				Name:            testRecipeName,

--- a/pkg/recipes/terraform/execute.go
+++ b/pkg/recipes/terraform/execute.go
@@ -205,7 +205,7 @@ func (e *executor) GetRecipeMetadata(ctx context.Context, options Options) (map[
 
 	logger.Info(fmt.Sprintf("Inspecting downloaded recipe: %s", options.ResourceRecipe.Name))
 	// Get the inspection result from downloaded module to extract recipecontext existency and providers.
-	result, err := inspectTFModuleConfig(workingDir, localModuleName)
+	result, err := inspectModule(workingDir, localModuleName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/recipes/terraform/execute.go
+++ b/pkg/recipes/terraform/execute.go
@@ -210,7 +210,9 @@ func (e *executor) GetRecipeMetadata(ctx context.Context, options Options) (map[
 		return nil, err
 	}
 
-	return result.Parameters, nil
+	return map[string]any{
+		"parameters": result.Parameters,
+	}, nil
 }
 
 func createWorkingDir(ctx context.Context, tfDir string) (string, error) {

--- a/pkg/recipes/terraform/execute_test.go
+++ b/pkg/recipes/terraform/execute_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/radius-project/radius/pkg/recipes"
+	"github.com/radius-project/radius/pkg/recipes/terraform/config"
 	"github.com/radius-project/radius/test/testcontext"
 	"github.com/stretchr/testify/require"
 )
@@ -118,4 +119,27 @@ func TestGeneratedConfig(t *testing.T) {
 			require.ErrorContains(t, err, tc.err)
 		})
 	}
+}
+
+func Test_GetTerraformConfig(t *testing.T) {
+	// Create a temporary directory for testing.
+	testDir := t.TempDir()
+
+	workingDir, err := createWorkingDir(testcontext.New(t), testDir)
+	require.NoError(t, err)
+	options := Options{
+		EnvRecipe: &recipes.EnvironmentDefinition{
+			Name:         "test-recipe",
+			TemplatePath: "test/module/source",
+		},
+		ResourceRecipe: &recipes.ResourceMetadata{},
+	}
+
+	expectedConfig := config.TerraformConfig{
+		Module: map[string]config.TFModuleConfig{
+			"test-recipe": {"source": "test/module/source"}},
+	}
+	tfConfig, err := getTerraformConfig(testcontext.New(t), workingDir, options)
+	require.NoError(t, err)
+	require.Equal(t, &expectedConfig, tfConfig)
 }

--- a/pkg/recipes/terraform/mock_executor.go
+++ b/pkg/recipes/terraform/mock_executor.go
@@ -63,3 +63,18 @@ func (mr *MockTerraformExecutorMockRecorder) Deploy(arg0, arg1 interface{}) *gom
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Deploy", reflect.TypeOf((*MockTerraformExecutor)(nil).Deploy), arg0, arg1)
 }
+
+// GetRecipeMetadata mocks base method.
+func (m *MockTerraformExecutor) GetRecipeMetadata(arg0 context.Context, arg1 Options) (map[string]interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRecipeMetadata", arg0, arg1)
+	ret0, _ := ret[0].(map[string]interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRecipeMetadata indicates an expected call of GetRecipeMetadata.
+func (mr *MockTerraformExecutorMockRecorder) GetRecipeMetadata(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecipeMetadata", reflect.TypeOf((*MockTerraformExecutor)(nil).GetRecipeMetadata), arg0, arg1)
+}

--- a/pkg/recipes/terraform/module.go
+++ b/pkg/recipes/terraform/module.go
@@ -51,7 +51,7 @@ type moduleInspectResult struct {
 // It uses terraform-config-inspect to load the module from the directory. An error is returned if the module
 // could not be loaded.
 func inspectModule(workingDir, localModuleName string) (*moduleInspectResult, error) {
-	result := &moduleInspectResult{ContextVarExists: false, RequiredProviders: []string{}, ResultOutputExists: false}
+	result := &moduleInspectResult{ContextVarExists: false, RequiredProviders: []string{}, ResultOutputExists: false, Parameters: map[string]any{}}
 
 	// Modules are downloaded in a subdirectory in the working directory.
 	// Name of the module specified in the configuration is used as subdirectory name.

--- a/pkg/recipes/terraform/module.go
+++ b/pkg/recipes/terraform/module.go
@@ -78,7 +78,16 @@ func inspectModule(workingDir, localModuleName string) (*moduleInspectResult, er
 
 	// Extract the list of parameters.
 	for variable, value := range mod.Variables {
-		result.Parameters[variable] = value
+		tfVar := map[string]any{
+			"Name":        value.Name,
+			"Type":        value.Type,
+			"Description": value.Description,
+			"Default":     value.Default,
+			"Required":    value.Required,
+			"Sensitive":   value.Sensitive,
+			"Pos":         value.Pos,
+		}
+		result.Parameters[variable] = tfVar
 	}
 
 	return result, nil

--- a/pkg/recipes/terraform/module.go
+++ b/pkg/recipes/terraform/module.go
@@ -42,6 +42,7 @@ type moduleInspectResult struct {
 	ResultOutputExists bool
 
 	// Any other module information required in the future can be added here.
+	Parameters map[string]any
 }
 
 // inspectModule inspects the module present at workingDir/.terraform/modules/<localModuleName> directory
@@ -75,10 +76,15 @@ func inspectModule(workingDir, localModuleName string) (*moduleInspectResult, er
 		result.ResultOutputExists = true
 	}
 
+	// Extract the list of parameters.
+	for variable, value := range mod.Variables {
+		result.Parameters[variable] = value
+	}
+
 	return result, nil
 }
 
-// downloadModule downloads the module to the workingDir from the module source specified in the Terraform configuration.
+// DownloadModule downloads the module to the workingDir from the module source specified in the Terraform configuration.
 // It uses Terraform's Get command to download the module using the Terraform executable available at execPath.
 // An error is returned if the module could not be downloaded.
 func downloadModule(ctx context.Context, workingDir, execPath string) error {

--- a/pkg/recipes/terraform/module.go
+++ b/pkg/recipes/terraform/module.go
@@ -79,13 +79,13 @@ func inspectModule(workingDir, localModuleName string) (*moduleInspectResult, er
 	// Extract the list of parameters.
 	for variable, value := range mod.Variables {
 		tfVar := map[string]any{
-			"Name":        value.Name,
-			"Type":        value.Type,
-			"Description": value.Description,
-			"Default":     value.Default,
-			"Required":    value.Required,
-			"Sensitive":   value.Sensitive,
-			"Pos":         value.Pos,
+			"name":         value.Name,
+			"type":         value.Type,
+			"description":  value.Description,
+			"defaultValue": value.Default,
+			"required":     value.Required,
+			"sensitive":    value.Sensitive,
+			"pos":          value.Pos,
 		}
 		result.Parameters[variable] = tfVar
 	}

--- a/pkg/recipes/terraform/module_test.go
+++ b/pkg/recipes/terraform/module_test.go
@@ -40,8 +40,10 @@ func Test_InspectTFModuleConfig(t *testing.T) {
 				ContextVarExists:   false,
 				RequiredProviders:  []string{"aws"},
 				ResultOutputExists: false,
+				Parameters:         map[string]any{},
 			},
-		}, {
+		},
+		{
 			name:       "aws provider with recipe context variable and output",
 			workingDir: "testdata",
 			moduleName: "test-module-recipe-context-outputs",
@@ -49,8 +51,12 @@ func Test_InspectTFModuleConfig(t *testing.T) {
 				ContextVarExists:   true,
 				RequiredProviders:  []string{"aws"},
 				ResultOutputExists: true,
+				Parameters: map[string]any{
+					"context": "contextInformation",
+				},
 			},
-		}, {
+		},
+		{
 			name:       "invalid module name - non existent module directory",
 			workingDir: "testdata",
 			moduleName: "invalid-module",
@@ -65,6 +71,10 @@ func Test_InspectTFModuleConfig(t *testing.T) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.err)
 				return
+			}
+			// Context parameters aren't treated as user-set parameters so we check for it's existence, but not its value
+			if result.Parameters["context"] != nil {
+				result.Parameters["context"] = "contextInformation"
 			}
 			require.NoError(t, err)
 			require.Equal(t, tc.result, result)

--- a/pkg/recipes/terraform/types.go
+++ b/pkg/recipes/terraform/types.go
@@ -35,6 +35,9 @@ type TerraformExecutor interface {
 	// Delete installs terraform and runs terraform destroy on the terraform module referenced by the recipe using terraform-exec,
 	// and deletes the Kubernetes secret created for terraform state store.
 	Delete(ctx context.Context, options Options) error
+
+	// Get
+	GetRecipeMetadata(ctx context.Context, options Options) (map[string]any, error)
 }
 
 // Options represents the options required to build inputs to interact with Terraform.

--- a/pkg/recipes/terraform/types.go
+++ b/pkg/recipes/terraform/types.go
@@ -36,7 +36,7 @@ type TerraformExecutor interface {
 	// and deletes the Kubernetes secret created for terraform state store.
 	Delete(ctx context.Context, options Options) error
 
-	// Get
+	// GetRecipeMetadata installs terraform and runs terraform get to retrieve information on the terraform module
 	GetRecipeMetadata(ctx context.Context, options Options) (map[string]any, error)
 }
 

--- a/pkg/recipes/types.go
+++ b/pkg/recipes/types.go
@@ -73,6 +73,8 @@ type ResourceMetadata struct {
 	ResourceID string
 	// Parameters represents key/value pairs to pass into the recipe template. Overrides any parameters set by the environment.
 	Parameters map[string]any
+	// ResourceType represents the type of the link this recipe can be consumed by.
+	ResourceType string
 }
 
 const (

--- a/test/functional/samples/tutorial_test.go
+++ b/test/functional/samples/tutorial_test.go
@@ -54,7 +54,7 @@ var samplesRepoAbsPath, samplesRepoEnvVarSet = os.LookupEnv("RADIUS_SAMPLES_REPO
 func Test_FirstApplicationSample(t *testing.T) {
 	// TODO: Remove the following statement
 	// LJ: Skipping this test to test pipeline for this PR: https://github.com/radius-project/radius/pull/6130
-	t.Skipf("Temporary: Skip samples test execution, samples repo still contains Applications.Links resources, which is deprecated in this PR")
+	t.Skipf("Temporary: Skip samples test execution, samples repo still contains Applications.PortableResources resources, which is deprecated in this PR")
 
 	if !samplesRepoEnvVarSet {
 		t.Skipf("Skip samples test execution, to enable you must set env var PROJECT_RADIUS_SAMPLES_REPO_ABS_PATH to the absolute path of the radius-project/samples repository")

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -104,6 +104,22 @@ func verifyRecipeCLI(ctx context.Context, t *testing.T, test shared.RPTest) {
 		require.Contains(t, output, "resourceGroup().location]")
 	})
 
+	t.Run("Validate rad recipe show - terraform recipe", func(t *testing.T) {
+		showRecipeName := "redistesttf"
+		moduleServer := functional.GetTerraformRecipeModuleServerURL()
+		showRecipeTemplate := fmt.Sprintf("%s/kubernetes-redis.zip", moduleServer)
+		showRecipeLinkType := "Applications.Link/redisCaches"
+		output, err := cli.RecipeRegister(ctx, envName, showRecipeName, "terraform", showRecipeTemplate, showRecipeLinkType)
+		require.NoError(t, err)
+		require.Contains(t, output, "Successfully linked recipe")
+		output, err = cli.RecipeShow(ctx, envName, showRecipeName, linkType)
+		require.NoError(t, err)
+		require.Contains(t, output, showRecipeName)
+		require.Contains(t, output, showRecipeTemplate)
+		require.Contains(t, output, showRecipeLinkType)
+		require.Contains(t, output, "redis_cache_name")
+	})
+
 	t.Run("Validate `rad bicep publish` is publishing the file to the given target", func(t *testing.T) {
 		output, err := cli.BicepPublish(ctx, file, target)
 		require.NoError(t, err)

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -112,7 +112,7 @@ func verifyRecipeCLI(ctx context.Context, t *testing.T, test shared.RPTest) {
 		output, err := cli.RecipeRegister(ctx, envName, showRecipeName, "terraform", showRecipeTemplate, showRecipeLinkType)
 		require.NoError(t, err)
 		require.Contains(t, output, "Successfully linked recipe")
-		output, err = cli.RecipeShow(ctx, envName, showRecipeName, linkType)
+		output, err = cli.RecipeShow(ctx, envName, showRecipeName, showRecipeLinkType)
 		require.NoError(t, err)
 		require.Contains(t, output, showRecipeName)
 		require.Contains(t, output, showRecipeTemplate)

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -106,7 +106,10 @@ func verifyRecipeCLI(ctx context.Context, t *testing.T, test shared.RPTest) {
 
 	t.Run("Validate rad recipe show - terraform recipe", func(t *testing.T) {
 		showRecipeName := "redistesttf"
-		moduleServer := functional.GetTerraformRecipeModuleServerURL()
+		moduleServer := os.Getenv("TF_RECIPE_MODULE_SERVER_URL")
+		if moduleServer == "" {
+			moduleServer = "http://localhost:8999"
+		}
 		showRecipeTemplate := fmt.Sprintf("%s/kubernetes-redis.zip", moduleServer)
 		showRecipeLinkType := "Applications.Link/redisCaches"
 		output, err := cli.RecipeRegister(ctx, envName, showRecipeName, "terraform", showRecipeTemplate, showRecipeLinkType)

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -121,6 +121,7 @@ func verifyRecipeCLI(ctx context.Context, t *testing.T, test shared.RPTest) {
 		require.Contains(t, output, showRecipeTemplate)
 		require.Contains(t, output, showRecipeLinkType)
 		require.Contains(t, output, "redis_cache_name")
+		require.Contains(t, output, "string")
 	})
 
 	t.Run("Validate `rad bicep publish` is publishing the file to the given target", func(t *testing.T) {

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -111,7 +111,7 @@ func verifyRecipeCLI(ctx context.Context, t *testing.T, test shared.RPTest) {
 			moduleServer = "http://localhost:8999"
 		}
 		showRecipeTemplate := fmt.Sprintf("%s/kubernetes-redis.zip", moduleServer)
-		showRecipeLinkType := "Applications.Link/redisCaches"
+		showRecipeLinkType := "Applications.Datastores/redisCaches"
 		output, err := cli.RecipeRegister(ctx, envName, showRecipeName, "terraform", showRecipeTemplate, showRecipeLinkType)
 		require.NoError(t, err)
 		require.Contains(t, output, "Successfully linked recipe")


### PR DESCRIPTION
# Description

This adds Terraform support for rad recipe show. This also abstracts the GetRecipeMetadata controller to use the Engine and driver-specific implementations for Bicep and Terraform

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request adds or changes features of Radius and has an approved issue radius-project/radius#6356 .


<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: Part of radius-project/radius#6356 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e70140f</samp>

### Summary
🐛🧪🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is the case for the typo correction in the `environmentgetrecipemetadata20220315privatepreview_datamodel.json` file.
2.  🧪 - This emoji represents a test, which is the case for the new test files, test cases, and mock methods that were added for the `GetRecipeMetadata` method and the `driver` and `engine` interfaces.
3.  🚀 - This emoji represents a feature, which is the case for the new `GetRecipeMetadata` method and the `driver` and `engine` interfaces that were implemented for the Terraform and Bicep templates.
-->
This pull request adds support for getting recipe metadata from Terraform and Bicep templates using the `engine` and `driver` packages. It also updates the `frontend` and `handler` packages to use the `engine` for the `GetRecipeMetadata` controller and its tests. It fixes some typos and adds some test data and cases.

> _We're the masters of the engine, we control the recipe_
> _We extract the metadata from the registry or the module_
> _We use the driver interface to handle Bicep or Terraform_
> _We're the masters of the engine, we unleash the power of the code_

### Walkthrough
*  Implement the `GetRecipeMetadata` method for the `driver` interface and its implementations for the `bicepDriver` and `terraformDriver` structs. The method returns the parameter information from the registry or the module for a given recipe definition. ([link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-f12e37706fa75e9e04b8dfa01a45cf9bf2a0463e1962605b2420d0cb343922a0R188-R197),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-1b98bc9b02b96687752860c11c68d87d99ad99f24ecdfc5497fda6823abc0612R176-R201),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-a95d80e21fb522c60702dad150fe92099ac96749fd90a452abd92867b40d069dR33-R35),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-a0a208a111e71713a21b404fdb3b31fd13f668e5716ab4331584027cc3d98debR433-R482),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92R311-R392))
* Implement the `GetRecipeMetadata` method for the `engine` interface and its implementation for the `engine` struct. The method calls the `driver` interface method with the appropriate driver instance based on the recipe definition. The method also refactors the common logic of getting the recipe definition and the driver instance into a separate `getDriver` method. ([link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59R139-R185),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-3fdb9931c1f2ddfc5b14d87f47b4124f2bdc1da187219fa1ad9cbe79fc326528R454-R485))
* Add the `engine` field to the `GetRecipeMetadata` controller struct and pass the `engine` instance to the constructor. Replace the `getRecipeMetadataFromRegistry` function with the `GetRecipeMetadataFromRegistry` method that wraps the `engine` logic. Construct a `recipes.EnvironmentDefinition` from the input parameters and pass it to the `engine` instance. ([link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-bcda78402ab93b01aeec72741f0cf3732642cd9f2feccf79d75579e77e079ceeL40-R45),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-bcda78402ab93b01aeec72741f0cf3732642cd9f2feccf79d75579e77e079ceeR53),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-bcda78402ab93b01aeec72741f0cf3732642cd9f2feccf79d75579e77e079ceeL82-R85),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-bcda78402ab93b01aeec72741f0cf3732642cd9f2feccf79d75579e77e079ceeL101-R115))
* Pass the `engine` instance to the `AddRoutes` function that registers the handlers for the `GetRecipeMetadata` controller. Create and configure the `engine` instance in the `Run` function of the `frontend` package. ([link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L55-R56),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-2bdfa10a8abd451bfb18e729290e9182d1b8e6280d8a9e47dd0ce70f6e8d48d6L165-R172),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-0710457d98e776f97314721f5e8bfba29a045f6181aa8e48214744abe0bf7ed7L243-R245),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-0710457d98e776f97314721f5e8bfba29a045f6181aa8e48214744abe0bf7ed7L260-R262),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-7ea25eedbaa97be92839b34529ce6c828e50f74b8845eaefc02832c23cd6d833R66-R99),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-7ea25eedbaa97be92839b34529ce6c828e50f74b8845eaefc02832c23cd6d833L72-R117))
* Add the `engine` parameter to the `NewGetRecipeMetadata` function calls in the test cases. Add a new test case for the `GetRecipeMetadata` controller with Terraform input. Remove the redundant test case for the old function that was replaced by the `GetRecipeMetadataFromRegistry` method. ([link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-b0b2e17db6a713c000a5f3843b75bc43896032e2aed99b0a99a4279aca3713e1R22),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-b0b2e17db6a713c000a5f3843b75bc43896032e2aed99b0a99a4279aca3713e1R32-R33),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-b0b2e17db6a713c000a5f3843b75bc43896032e2aed99b0a99a4279aca3713e1L40-R47),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-b0b2e17db6a713c000a5f3843b75bc43896032e2aed99b0a99a4279aca3713e1L59-R82),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-b0b2e17db6a713c000a5f3843b75bc43896032e2aed99b0a99a4279aca3713e1R94-R141),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-b0b2e17db6a713c000a5f3843b75bc43896032e2aed99b0a99a4279aca3713e1L90-R157),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-b0b2e17db6a713c000a5f3843b75bc43896032e2aed99b0a99a4279aca3713e1L131-R198),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-b0b2e17db6a713c000a5f3843b75bc43896032e2aed99b0a99a4279aca3713e1L150-R252),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-65b4a3a6b2482bca618d94791287132ec134e5ccb062da1cfcb3025345f58b87L47-R55),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-65b4a3a6b2482bca618d94791287132ec134e5ccb062da1cfcb3025345f58b87L60-R68),[link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-0710457d98e776f97314721f5e8bfba29a045f6181aa8e48214744abe0bf7ed7R235))
* Add the `Name` field to the `recipes.EnvironmentDefinition` struct in the `buildTestInputs` function of the `terraformDriver` test file. ([link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92R68))
* Add a `resourceType` variable to the `configloader` package to support the case where the recipe has a different resource type than the resource itself. ([link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-0b45f6a08490c2a47c6ead052f97e5b5be965617c8ab927d9b0a297088a92a6eL135-R139))
* Reuse the existing `clientOptions` variable in the `Run` function of the `portableresources` package. ([link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-2779f210632b96e2b7717b9cfae7f667d7f8f5d4053a67d9e796c00d39e34ce1L85-R85))
* Fix a typo in the `environmentgetrecipemetadata20220315privatepreview_datamodel.json` file. ([link](https://github.com/radius-project/radius/pull/6185/files?diff=unified&w=0#diff-30d54efb53ca20cd9777b3fa44115b01fff62e2d7ddc844751d452b63b52ca5eL35-R35))


