### PR TITLE
Enable Samples repo test in radius functional tests

### DIFF
--- a/test/functional/samples/tutorial_test.go
+++ b/test/functional/samples/tutorial_test.go
@@ -52,10 +52,6 @@ var samplesRepoAbsPath, samplesRepoEnvVarSet = os.LookupEnv("RADIUS_SAMPLES_REPO
 // You can set the variables used by vscode codelens (e.g. 'debug test', 'run test') using 'go.testEnvVars' in vscode settings.json
 // Ex: export PROJECT_RADIUS_SAMPLES_REPO_ABS_PATH=/home/uname/src/samples
 func Test_FirstApplicationSample(t *testing.T) {
-	// TODO: Remove the following statement
-	// LJ: Skipping this test to test pipeline for this PR: https://github.com/radius-project/radius/pull/6130
-	t.Skipf("Temporary: Skip samples test execution, samples repo still contains Applications.Links resources, which is deprecated in this PR")
-
 	if !samplesRepoEnvVarSet {
 		t.Skipf("Skip samples test execution, to enable you must set env var PROJECT_RADIUS_SAMPLES_REPO_ABS_PATH to the absolute path of the radius-project/samples repository")
 	}


### PR DESCRIPTION
# Description

Enabling test in radius repo which had been skipped to help coordinate merging of PRs for splitnamespace work across repos.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: Part of #3499 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3536a0c</samp>

### Summary
🚫✅🧪

<!--
1.  🚫 - This emoji represents the removal of something, such as the `t.Skipf` statement that was removed from the test function. It can also be used to indicate that something is no longer allowed or supported, such as the deprecated `Applications.Links` resources.
2.  ✅ - This emoji represents the completion or success of something, such as the pull request that updated the samples repository and the test function that passed after the removal of the `t.Skipf` statement. It can also be used to indicate that something is correct or verified, such as the test results or the code quality.
3.  🧪 - This emoji represents the testing or experimentation of something, such as the `TestSamples` function that checks the validity of the samples in the repository. It can also be used to indicate that something is new or innovative, such as a feature or a solution.
-->
Removed a temporary test skip statement from the `samples` package. The statement was used to bypass a test that depended on a deprecated resource that was removed in another pull request.

> _`TestSamples` runs_
> _No more `t.Skipf` needed_
> _Winter of old code_

### Walkthrough
* Remove temporary skip statement from `TestSamples` function ([link](https://github.com/radius-project/radius/pull/6193/files?diff=unified&w=0#diff-a6eb33222335c5ca5618a71aa2c65413c4baafa31c91ed3523dd19ea43839a4eL55-L58))


