### PR TITLE
rad init should use current kube context for its operations

### DIFF
--- a/pkg/cli/cmd/radinit/options.go
+++ b/pkg/cli/cmd/radinit/options.go
@@ -111,8 +111,11 @@ func (r *Runner) enterInitOptions(ctx context.Context) (*initOptions, *workspace
 
 	options.Recipes.DevRecipes = !r.Full
 
+	// If the user has a current workspace we should overwrite it.
+	// If the user does not have a current workspace we should create a new one called default and set it as current
+	// If the user does not have a current workspace and has an existing one called default we should overwrite it and set it as current
 	if ws == nil {
-		workspace.Name = options.Environment.Name
+		workspace.Name = "default"
 	} else {
 		workspace.Name = ws.Name
 	}

--- a/pkg/cli/cmd/radinit/options.go
+++ b/pkg/cli/cmd/radinit/options.go
@@ -112,15 +112,12 @@ func (r *Runner) enterInitOptions(ctx context.Context) (*initOptions, *workspace
 	options.Recipes.DevRecipes = !r.Full
 
 	if ws == nil {
-		// Update the workspace with the information we captured about the environment.
 		workspace.Name = options.Environment.Name
-		workspace.Environment = fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Applications.Core/environments/%s", options.Environment.Name, options.Environment.Name)
-		workspace.Scope = fmt.Sprintf("/planes/radius/local/resourceGroups/%s", options.Environment.Name)
-		return &options, workspace, nil
+	} else {
+		workspace.Name = ws.Name
 	}
+	workspace.Environment = fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Applications.Core/environments/%s", options.Environment.Name, options.Environment.Name)
+	workspace.Scope = fmt.Sprintf("/planes/radius/local/resourceGroups/%s", options.Environment.Name)
+	return &options, workspace, nil
 
-	ws.Environment = fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Applications.Core/environments/%s", options.Environment.Name, options.Environment.Name)
-	ws.Scope = fmt.Sprintf("/planes/radius/local/resourceGroups/%s", options.Environment.Name)
-
-	return &options, ws, nil
 }

--- a/pkg/cli/cmd/radinit/options_test.go
+++ b/pkg/cli/cmd/radinit/options_test.go
@@ -157,12 +157,11 @@ workspaces:
 		expectedWorkspace := workspaces.Workspace{
 			Name: "abc",
 			Connection: map[string]any{
-				"context": "cool-beans",
+				"context": "kind-kind",
 				"kind":    workspaces.KindKubernetes,
 			},
 			Environment: "/planes/radius/local/resourceGroups/test-env/providers/Applications.Core/environments/test-env",
 			Scope:       "/planes/radius/local/resourceGroups/test-env",
-			Source:      "userconfig",
 		}
 		require.Equal(t, expectedWorkspace, *workspace)
 

--- a/pkg/cli/cmd/radinit/options_test.go
+++ b/pkg/cli/cmd/radinit/options_test.go
@@ -96,7 +96,7 @@ func Test_enterInitOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedWorkspace := workspaces.Workspace{
-			Name: "test-env",
+			Name: "default",
 			Connection: map[string]any{
 				"context": "kind-kind",
 				"kind":    workspaces.KindKubernetes,


### PR DESCRIPTION
# Description

If there was an existing workspace, rad init was using the kube context from this file, instead of current kube context.
This caused init to fail. We should use current kube context for rad init and also update workspace to reflect the correct context. 

## Type of change


- This pull request fixes a bug in Radius and has an approved issue (issue link required).
Fixes: radius-project/core-team#1256 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f048585</samp>

### Summary
🐛🧪♻️

<!--
1.  🐛 - This emoji represents a bug fix, since the change fixes a test failure that was caused by a previous change in the function.
2.  🧪 - This emoji represents a test update, since the change modifies the expected value of a test case to match the actual behavior of the function.
3.  ♻️ - This emoji represents a code refactor, since the change simplifies and improves the logic of setting the workspace name in the function.
-->
This pull request fixes a test failure and simplifies the code in the `radinit` package. It updates the expected value for the `workspace.Connection` field in the `test case for the `enterInitOptions` function and moves some assignments outside an `if` statement in the same function.

> _`enterInitOptions`_
> _Fix test, simplify logic_
> _Autumn of refactor_

### Walkthrough
*  Simplify workspace name assignment in `enterInitOptions` function ([link](https://github.com/radius-project/radius/pull/6212/files?diff=unified&w=0#diff-a786a8b7ff8510f7a22696b1be6f2a304c325c404b381caff53b758e8e1ec482L115-R122))
*  Update test case for `enterInitOptions` function in `options_test.go` to match the new logic of selecting Kubernetes context ([link](https://github.com/radius-project/radius/pull/6212/files?diff=unified&w=0#diff-8ade53961f66c9f7818a671656cdac5de7967ea3c6dcb1d54a6b63b13e27f653L160-R164))


