### PR TITLE
support servicePort different from containerPort

### DIFF
--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -248,7 +248,6 @@ func (r Renderer) Render(ctx context.Context, dm v1.DataModelInterface, options 
 
 	// If the container has an exposed port and uses DNS-SD, generate a service for it.
 	if needsServiceGeneration {
-
 		for portName, port := range resource.Properties.Container.Ports {
 			// store portNames and portValues for use in service generation.
 			servicePort := corev1.ServicePort{
@@ -266,7 +265,6 @@ func (r Renderer) Render(ctx context.Context, dm v1.DataModelInterface, options 
 		if err != nil {
 			return renderers.RendererOutput{}, err
 		}
-
 		outputResources = append(outputResources, serviceResource)
 	}
 

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -1538,7 +1538,8 @@ func Test_ParseURL(t *testing.T) {
 }
 
 func Test_DNS_Service_Generation(t *testing.T) {
-	var containerPortNumber int32 = 80
+	var containerPortNumber int32 = 3000
+	var servicePortNumber int32 = 80
 	t.Run("verify service generation", func(t *testing.T) {
 		properties := datamodel.ContainerProperties{
 			BasicResourceProperties: rpv1.BasicResourceProperties{
@@ -1549,6 +1550,7 @@ func Test_DNS_Service_Generation(t *testing.T) {
 				Ports: map[string]datamodel.ContainerPort{
 					"web": {
 						ContainerPort: int32(containerPortNumber),
+						Port:          int32(servicePortNumber),
 					},
 				},
 			},
@@ -1565,8 +1567,8 @@ func Test_DNS_Service_Generation(t *testing.T) {
 
 		expectedServicePort := corev1.ServicePort{
 			Name:       "web",
-			Port:       containerPortNumber,
-			TargetPort: intstr.FromInt(80),
+			Port:       80,
+			TargetPort: intstr.FromInt(int(containerPortNumber)),
 			Protocol:   "TCP",
 		}
 


### PR DESCRIPTION
# Description

Add support for "port" in 

```
ports: {
        web: {
          containerPort: 5000
          port: 80 // optional: only needs to be set when a value different from containerPort is desired
          protocol: 'TCP' // optional: defaults to TCP
          scheme: 'http' // optional: used to build URLs, defaults to http or https based on port
        }
      }
```

ref: https://github.com/radius-project/radius/issues/6375
## Type of change
- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 33de0af</samp>

### Summary
🧪🐛✨

<!--
1.  🧪 for modifying a test function
2.  🐛 for fixing a typo in an error message
3.  ✨ for adding a new feature to the `corerp` package
-->
This pull request adds support for service port values for container ports in the `corerp` package. It updates the `containerPorts` struct and the `generateService` function to render the `Port` and `TargetPort` fields in the service spec. It also modifies a test function in `render_test.go` to cover this feature.

> _Sing, O Muse, of the skillful coder who devised_
> _A clever way to render service ports for containers_
> _And tested well his work with inputs and outputs wise_
> _To please the gods of Kubernetes, the cloud maintainers._

### Walkthrough
* Fix typo in error message for invalid ports definition ([link](https://github.com/radius-project/radius/pull/6234/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L186-R197))
* Add service port values to container ports struct and append them from input map ([link](https://github.com/radius-project/radius/pull/6234/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L245-R252), [link](https://github.com/radius-project/radius/pull/6234/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636R259), [link](https://github.com/radius-project/radius/pull/6234/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L275-R284))
* Use service port values instead of container port values for service port field in `generateService` function and add debug print ([link](https://github.com/radius-project/radius/pull/6234/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L288-R299))
* Update test values and expected output for container port and service port in `Test_DNS_Service_Generation` function in `render_test.go` ([link](https://github.com/radius-project/radius/pull/6234/files?diff=unified&w=0#diff-6f1219f263ab06a1493ac76960e2ab8cbe647e83e926bff7d13988f393334f94L1522-R1523), [link](https://github.com/radius-project/radius/pull/6234/files?diff=unified&w=0#diff-6f1219f263ab06a1493ac76960e2ab8cbe647e83e926bff7d13988f393334f94R1534), [link](https://github.com/radius-project/radius/pull/6234/files?diff=unified&w=0#diff-6f1219f263ab06a1493ac76960e2ab8cbe647e83e926bff7d13988f393334f94L1549-R1552))


