### PR TITLE
Fix inconsistency in connection prefix naming for container connections

### DIFF
--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -692,9 +692,9 @@ func getEnvVarsAndSecretData(resource *datamodel.ContainerResource, applicationN
 					return map[string]corev1.EnvVar{}, map[string][]byte{}, fmt.Errorf("failed to parse source URL: %w", err)
 				}
 
-				env["CONNECTIONS_"+name+"_SCHEME"] = corev1.EnvVar{Name: "CONNECTIONS_" + name + "_SCHEME", Value: scheme}
-				env["CONNECTIONS_"+name+"_HOSTNAME"] = corev1.EnvVar{Name: "CONNECTIONS_" + name + "_HOSTNAME", Value: hostname}
-				env["CONNECTIONS_"+name+"_PORT"] = corev1.EnvVar{Name: "CONNECTIONS_" + name + "_PORT", Value: port}
+				env["CONNECTION_"+name+"_SCHEME"] = corev1.EnvVar{Name: "CONNECTION_" + name + "_SCHEME", Value: scheme}
+				env["CONNECTION_"+name+"_HOSTNAME"] = corev1.EnvVar{Name: "CONNECTION_" + name + "_HOSTNAME", Value: hostname}
+				env["CONNECTION_"+name+"_PORT"] = corev1.EnvVar{Name: "CONNECTION_" + name + "_PORT", Value: port}
 
 				continue
 			}

--- a/pkg/corerp/renderers/container/render.go
+++ b/pkg/corerp/renderers/container/render.go
@@ -692,9 +692,13 @@ func getEnvVarsAndSecretData(resource *datamodel.ContainerResource, applicationN
 					return map[string]corev1.EnvVar{}, map[string][]byte{}, fmt.Errorf("failed to parse source URL: %w", err)
 				}
 
-				env["CONNECTION_"+name+"_SCHEME"] = corev1.EnvVar{Name: "CONNECTION_" + name + "_SCHEME", Value: scheme}
-				env["CONNECTION_"+name+"_HOSTNAME"] = corev1.EnvVar{Name: "CONNECTION_" + name + "_HOSTNAME", Value: hostname}
-				env["CONNECTION_"+name+"_PORT"] = corev1.EnvVar{Name: "CONNECTION_" + name + "_PORT", Value: port}
+				schemeKey := fmt.Sprintf("%s_%s_%s", "CONNECTION", strings.ToUpper(name), "SCHEME")
+				hostnameKey := fmt.Sprintf("%s_%s_%s", "CONNECTION", strings.ToUpper(name), "HOSTNAME")
+				portKey := fmt.Sprintf("%s_%s_%s", "CONNECTION", strings.ToUpper(name), "PORT")
+
+				env[schemeKey] = corev1.EnvVar{Name: schemeKey, Value: scheme}
+				env[hostnameKey] = corev1.EnvVar{Name: hostnameKey, Value: hostname}
+				env[portKey] = corev1.EnvVar{Name: portKey, Value: port}
 
 				continue
 			}

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -497,6 +497,10 @@ func Test_Render_PortConnectedToRoute(t *testing.T) {
 }
 
 func Test_Render_Connections(t *testing.T) {
+	containerConnectionHostname := "containerB"
+	containerConnectionScheme := "http"
+	containerConnectionPort := "80"
+
 	properties := datamodel.ContainerProperties{
 		BasicResourceProperties: rpv1.BasicResourceProperties{
 			Application: applicationResourceID,
@@ -507,6 +511,9 @@ func Test_Render_Connections(t *testing.T) {
 				IAM: datamodel.IAMProperties{
 					Kind: datamodel.KindHTTP,
 				},
+			},
+			"containerB": {
+				Source: fmt.Sprintf("%s://%s:%s", containerConnectionScheme, containerConnectionHostname, containerConnectionPort),
 			},
 		},
 		Container: datamodel.Container{
@@ -570,6 +577,18 @@ func Test_Render_Connections(t *testing.T) {
 						Key: "CONNECTION_A_COMPUTEDKEY2",
 					},
 				},
+			},
+			{
+				Name:  "CONNECTION_CONTAINERB_HOSTNAME",
+				Value: containerConnectionHostname,
+			},
+			{
+				Name:  "CONNECTION_CONTAINERB_PORT",
+				Value: containerConnectionPort,
+			},
+			{
+				Name:  "CONNECTION_CONTAINERB_SCHEME",
+				Value: containerConnectionScheme,
 			},
 			{Name: envVarName1, Value: envVarValue1},
 			{Name: envVarName2, Value: envVarValue2},


### PR DESCRIPTION
# Description

This PR fixes a bug in the naming convention for connections to other containers. Instead of "CONNECTIONS_" it should be "CONNECTION".

This PR also adds a unit test for this change.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ba2d0ed</samp>

### Summary
🔧🚚🧪

<!--
1.  🔧 - This emoji represents refactoring or fixing something, which is what the first change does to the code.
2.  🚚 - This emoji represents adding or moving something, which is what the second change does to the test cases.
3.  🧪 - This emoji represents testing or experimenting, which is what the second change also does to the test cases.
-->
This pull request adds a test case for container-to-container routing and refactors the environment variable keys for connection information in `render.go` and `render_test.go`.

> _We forge the keys of connection_
> _With the power of `fmt.Sprintf`_
> _We test the routes of rendering_
> _With mock and assert in `render_test.go`_

### Walkthrough
*  Refactor environment variable keys for connection information to use consistent format ([link](https://github.com/radius-project/radius/pull/6235/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L695-R702))
*  Add variables for connection to containerB in test function Test_Render_PortConnectedToRoute ([link](https://github.com/radius-project/radius/pull/6235/files?diff=unified&w=0#diff-6f1219f263ab06a1493ac76960e2ab8cbe647e83e926bff7d13988f393334f94R500-R503))
*  Pass connection entry for containerB to Render function in test function Test_Render_Connections ([link](https://github.com/radius-project/radius/pull/6235/files?diff=unified&w=0#diff-6f1219f263ab06a1493ac76960e2ab8cbe647e83e926bff7d13988f393334f94R515-R517))
*  Assert expected environment variables for connection to containerB in test function Test_Render_Connections ([link](https://github.com/radius-project/radius/pull/6235/files?diff=unified&w=0#diff-6f1219f263ab06a1493ac76960e2ab8cbe647e83e926bff7d13988f393334f94R581-R592))


