### PR TITLE
Fixing and adding better logging to purge AWS resources workflow

### DIFF
--- a/.github/workflows/purge-aws-test-resources.yaml
+++ b/.github/workflows/purge-aws-test-resources.yaml
@@ -26,7 +26,7 @@ env:
   AWS_RESOURCE_TYPES: 'AWS::Kinesis::Stream,AWS::S3::Bucket,AWS::RDS::DBInstance,AWS::RDS::DBSubnetGroup,AWS::MemoryDB::Cluster,AWS::MemoryDB::SubnetGroup'
 jobs:
   purge_aws_resources:
-    name: AWS resources clean-ups
+    name: Delete all AWS resources created by tests
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
@@ -37,10 +37,13 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
       - name: Filter and delete resources
         run: |
-          for resource_type in ${${{env.AWS_RESOURCE_TYPES}}//,/ }
+          RESOURCE_TYPES=${{env.AWS_RESOURCE_TYPES}}
+          for resource_type in ${RESOURCE_TYPES//,/ }
           do
+            echo "Deleting resources of type $resource_type"
             aws cloudcontrol list-resources --type-name "$resource_type" --query "ResourceDescriptions[].Identifier" --output text | tr '\t' '\n' | while read identifier
             do
+              echo "Deleting resource $identifier of type $resource_type"
               aws cloudcontrol delete-resource --type-name "$resource_type" --identifier "$identifier"
-            done            
+            done
           done


### PR DESCRIPTION
# Description

* Fixing bug in purge AWS resources workflow
* Adding better logging to purge AWS resources workflow

Example workflow run here: https://github.com/radius-project/radius/actions/runs/6145656973/job/16673451217

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).


## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at aa50ee9</samp>

### Summary
🧹🌐🛠️

<!--
1.  🧹 - This emoji represents cleaning or tidying up, which is what the job does by deleting unused AWS resources.
2.  🌐 - This emoji represents the internet or web, which is related to the AWS Cloud Control API that the job uses to interact with AWS services.
3.  🛠️ - This emoji represents tools or fixing, which is related to the improvement and renaming of the job.
-->
Rename and enhance AWS resource cleanup job in `.github/workflows/purge-aws-test-resources.yaml`. Use a local variable and console messages to make the deletion script more readable and informative.

> _`CleanupJob` renamed_
> _Script deletes resources with_
> _Cloud Control API_

### Walkthrough
*  Rename job to purge-aws-test-resources ([link](https://github.com/radius-project/radius/pull/6246/files?diff=unified&w=0#diff-cdbef2239fc7a1aa34d773cb6dae3395193da5015c322ef49bb02025b701a0bcL29-R29))
*  Update script to delete AWS resources by type ([link](https://github.com/radius-project/radius/pull/6246/files?diff=unified&w=0#diff-cdbef2239fc7a1aa34d773cb6dae3395193da5015c322ef49bb02025b701a0bcL40-R48))


