### PR TITLE
Fix naming example

### DIFF
--- a/pkg/cli/cmd/resource/list/list.go
+++ b/pkg/cli/cmd/resource/list/list.go
@@ -44,7 +44,7 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 		Short: "Lists resources",
 		Long:  "List all resources of specified type",
 		Example: `
-	sample list of resourceType: containers, gateways, httpRoutes, daprPubSubBrokers, extenders, mongoDatabases, rabbitMQMessageQueues, redisCaches, sqlDatabases, daprStateStores, daprSecretStores
+	sample list of resourceType: containers, gateways, httpRoutes, pubSubBrokers, extenders, mongoDatabases, rabbitMQMessageQueues, redisCaches, sqlDatabases, stateStores, secretStores
 
 	# list all resources of a specified type in the default environment
 


### PR DESCRIPTION
# Description

Update the short name of types to remove "dapr" now that these resources are under "Applications.Dapr" and do not need "dapr" in the resource name. 
## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #6198

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c4c766e</samp>

### Summary
🚚🧹📝

<!--
1.  🚚 This emoji can be used to indicate that something was moved or renamed, as in the case of the resourceType values that lost the `dapr` prefix.
2.  🧹 This emoji can be used to indicate that something was cleaned up or simplified, as in the case of the resourceType naming convention that became more consistent and concise.
3.  📝 This emoji can be used to indicate that something was documented or explained, as in the case of the example of resourceType that was updated to reflect the changes.
-->
Refactor resourceType naming convention in `pkg/cli/cmd/resource/list/list.go`. Remove `dapr` prefix from some types to make them consistent and concise.

> _`resourceType` changed_
> _No more `dapr` prefix_
> _Simpler and clearer_

### Walkthrough
*  Simplify the resourceType naming convention by removing the `dapr` prefix from some of the types ([link](https://github.com/radius-project/radius/pull/6253/files?diff=unified&w=0#diff-b21dcd67dbc0d24e0f8bba90701dfcfb5736cf40427547c7a7ccb91478f262cfL47-R47))
* Update the example of resourceType in the list command to reflect the new naming convention ([link](https://github.com/radius-project/radius/pull/6253/files?diff=unified&w=0#diff-b21dcd67dbc0d24e0f8bba90701dfcfb5736cf40427547c7a7ccb91478f262cfL47-R47))


