### PR TITLE
Update release verification workflow

### DIFF
--- a/.github/scripts/release-verification.sh
+++ b/.github/scripts/release-verification.sh
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ------------------------------------------------------------
 
+set -ex
+
 # RELEASE_VERSION_NUMBER is the Radius release version number
 # (e.g. 0.24.0, 0.24.0-rc1)
 RELEASE_VERSION_NUMBER=$1
@@ -64,7 +66,6 @@ EXPECTED_DE_IMAGE="radius.azurecr.io/deployment-engine:${EXPECTED_TAG_VERSION}"
 APPCORE_RP_IMAGE=$(kubectl describe pods -n radius-system -l control-plane=applications-rp | awk '/^.*Image:/ {print $2}')
 UCP_IMAGE=$(kubectl describe pods -n radius-system -l control-plane=ucp | awk '/^.*Image:/ {print $2}')
 DE_IMAGE=$(kubectl describe pods -n radius-system -l control-plane=bicep-de | awk '/^.*Image:/ {print $2}')
-
 
 if [[ "${APPCORE_RP_IMAGE}" != "${EXPECTED_APPCORE_RP_IMAGE}" ]]; then
     echo "Error: Applications RP image: ${APPCORE_RP_IMAGE} does not match the desired image: ${EXPECTED_APPCORE_RP_IMAGE}."

--- a/.github/scripts/release-verification.sh
+++ b/.github/scripts/release-verification.sh
@@ -17,7 +17,7 @@
 set -ex
 
 # RELEASE_VERSION_NUMBER is the Radius release version number
-# (e.g. 0.24, 0.24.0, 0.24.0-rc1)
+# (e.g. 0.24.0, 0.24.0-rc1)
 RELEASE_VERSION_NUMBER=$1
 
 if [[ -z "${RELEASE_VERSION_NUMBER}" ]]; then
@@ -25,30 +25,43 @@ if [[ -z "${RELEASE_VERSION_NUMBER}" ]]; then
     exit 1
 fi
 
-echo "RELEASE_VERSION_NUMBER: ${RELEASE_VERSION_NUMBER}"
+# EXPECTED_CLI_VERSION is the same as the RELEASE_VERSION_NUMBER
+EXPECTED_CLI_VERSION=$RELEASE_VERSION_NUMBER
 
-curl https://get.radapp.dev/tools/rad/$RELEASE_VERSION_NUMBER/linux-x64/rad --output rad
+EXPECTED_TAG_VERSION=$RELEASE_VERSION_NUMBER
+# if RELEASE_VERSION_NUMBER contains -rc, then it is a prerelease.
+# In that case, we need to set expected tag version to the major.minor of the 
+# release version number
+if [[ $RELEASE_VERSION_NUMBER != *"rc"* ]]; then
+    EXPECTED_TAG_VERSION=$(echo $RELEASE_VERSION_NUMBER | cut -d '.' -f 1,2)
+fi
+
+echo "RELEASE_VERSION_NUMBER: ${RELEASE_VERSION_NUMBER}"
+echo "EXPECTED_CLI_VERSION: ${EXPECTED_CLI_VERSION}"
+echo "EXPECTED_TAG_VERSION: ${EXPECTED_TAG_VERSION}"
+
+curl https://get.radapp.dev/tools/rad/$EXPECTED_TAG_VERSION/linux-x64/rad --output rad
 chmod +x ./rad
 
 RELEASE_FROM_RAD_VERSION=$(./rad version -o json | jq -r '.release')
 VERSION_FROM_RAD_VERSION=$(./rad version -o json | jq -r '.version')
 
-if [[ "${RELEASE_FROM_RAD_VERSION}" != "${RELEASE_VERSION_NUMBER}" ]]; then
-    echo "Error: Release: ${RELEASE_FROM_RAD_VERSION} from rad version does not match the desired release: ${RELEASE_VERSION_NUMBER}."
+if [[ "${RELEASE_FROM_RAD_VERSION}" != "${EXPECTED_CLI_VERSION}" ]]; then
+    echo "Error: Release: ${RELEASE_FROM_RAD_VERSION} from rad version does not match the desired release: ${EXPECTED_CLI_VERSION}."
     exit 1
 fi
 
-if [[ "${VERSION_FROM_RAD_VERSION}" != "v${RELEASE_VERSION_NUMBER}" ]]; then
-    echo "Error: Version: ${VERSION_FROM_RAD_VERSION} from rad version does not match the desired version: v${RELEASE_VERSION_NUMBER}."
+if [[ "${VERSION_FROM_RAD_VERSION}" != "v${EXPECTED_CLI_VERSION}" ]]; then
+    echo "Error: Version: ${VERSION_FROM_RAD_VERSION} from rad version does not match the desired version: v${EXPECTED_CLI_VERSION}."
     exit 1
 fi
 
 kind create cluster
 ./rad install kubernetes
 
-EXPECTED_APPCORE_RP_IMAGE="radius.azurecr.io/applications-rp:${RELEASE_VERSION_NUMBER}"
-EXPECTED_UCP_IMAGE="radius.azurecr.io/ucpd:${RELEASE_VERSION_NUMBER}"
-EXPECTED_DE_IMAGE="radius.azurecr.io/deployment-engine:${RELEASE_VERSION_NUMBER}"
+EXPECTED_APPCORE_RP_IMAGE="radius.azurecr.io/applications-rp:${EXPECTED_TAG_VERSION}"
+EXPECTED_UCP_IMAGE="radius.azurecr.io/ucpd:${EXPECTED_TAG_VERSION}"
+EXPECTED_DE_IMAGE="radius.azurecr.io/deployment-engine:${EXPECTED_TAG_VERSION}"
 
 APPCORE_RP_IMAGE=$(kubectl describe pods -n radius-system -l control-plane=applications-rp | awk '/^.*Image:/ {print $2}')
 UCP_IMAGE=$(kubectl describe pods -n radius-system -l control-plane=ucp | awk '/^.*Image:/ {print $2}')

--- a/.github/scripts/validate_semver.py
+++ b/.github/scripts/validate_semver.py
@@ -26,7 +26,7 @@ def main():
         sys.exit(1)
 
     # From https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-    SEMVER_REGEX = r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+    SEMVER_REGEX = r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)(\.(?P<patch>0|[1-9]\d*))*(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
 
     pattern = re.compile(SEMVER_REGEX)
 

--- a/.github/scripts/validate_semver.py
+++ b/.github/scripts/validate_semver.py
@@ -26,7 +26,7 @@ def main():
         sys.exit(1)
 
     # From https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-    SEMVER_REGEX = r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)(\.(?P<patch>0|[1-9]\d*))*(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+    SEMVER_REGEX = r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
 
     pattern = re.compile(SEMVER_REGEX)
 

--- a/.github/workflows/release-verification.yaml
+++ b/.github/workflows/release-verification.yaml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Radius version number to use (e.g. 0.24, 0.24.0, 0.24.0-rc1)'
+        description: 'Radius version number to use (e.g. 0.24.0, 0.24.0-rc1)'
         required: true
         default: ''
         type: string

--- a/.github/workflows/release-verification.yaml
+++ b/.github/workflows/release-verification.yaml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Radius version number to use (e.g. 0.24.0, 0.24.0-rc1)'
+        description: 'Radius version number to use (e.g. 0.1.0, 0.1.0-rc1)'
         required: true
         default: ''
         type: string


### PR DESCRIPTION
# Description

* Release verification workflow will log everything and exit on error now
* Release verification workflow will now use the correct version in the case of being a final release

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2a88496</samp>

### Summary
🛠️🚨🗑️

<!--
1.  🛠️ - This emoji can be used to represent the improvement or fixing of the release-verification.sh script, as it suggests a tool or a repair.
2.  🚨 - This emoji can be used to represent the addition of error checking and tracing, as it suggests an alert or a warning for potential issues or failures.
3.  🗑️ - This emoji can be used to represent the removal of an unnecessary blank line, as it suggests a deletion or a cleanup.
-->
Improved the `release-verification.sh` script by adding error and trace flags and removing a blank line. This enhances the reliability and readability of the release verification process.

> _Oh we're the crew of the `release-verification.sh`_
> _We check for errors and we trace every bash_
> _We don't need no blank lines in our tidy script_
> _So haul away and sing with us, we'll make this ship go swift_

### Walkthrough
* Add `set -ex` command to exit on failure and print commands ([link](https://github.com/radius-project/radius/pull/6268/files?diff=unified&w=0#diff-e7011f75526faa24b25c444f9296b6c4172655dc99ad4e21f61fbbf9f137e586R17-R18))
* Remove empty line at end of script ([link](https://github.com/radius-project/radius/pull/6268/files?diff=unified&w=0#diff-e7011f75526faa24b25c444f9296b6c4172655dc99ad4e21f61fbbf9f137e586L68))


