### PR TITLE
Release v0.25.0

### DIFF
--- a/docs/release-notes/v0.25.0.md
+++ b/docs/release-notes/v0.25.0.md
@@ -1,0 +1,115 @@
+## Announcing Radius v0.25.0
+
+Today we're happy to announce the release of Radius v0.25.0. Check out the [highlights](#highlights) below, along with the [full changelog](#full-changelog) for more details.
+
+We would like to extend our thanks to all the [new](#new-contributors) and existing contributors who helped make this release possible!
+
+## Intro to Radius
+
+If you're new to Radius, check out our website, [radapp.dev](https://radapp.dev), for more information. Also visit our [getting started guide](https://docs.radapp.dev/getting-started/) to learn how to install Radius and create your first app.
+
+## Highlights
+
+## Breaking changes
+
+## Upgrading to Radius v0.25.0
+
+During our preview stage, an upgrade to Radius v0.25.0 requires a full reinstallation of the Radius control-plane, rad CLI, and all Radius apps. Stay tuned for an in-place upgrade path in the future.
+
+1. Delete any environments you have created:
+   ```bash
+   rad env delete <env-name>
+   ```
+1. Uninstall the previous version of the Radius control-plane:
+   ```bash
+   rad uninstall kubernetes
+   ```
+1. Visit the [Radius installation guide](https://docs.radapp.dev/getting-started/install/) to install the latest CLI, or download a binary below
+1. Install the latest version of the Radius control-plane:
+   ```bash
+   rad install kubernetes
+   ```
+
+## Full changelog
+
+* Remove Function Explanation heading from comments by @rynowak in https://github.com/radius-project/radius/pull/6075
+* Implement Terraform Recipe Outputs by @kachawla in https://github.com/radius-project/radius/pull/6062
+* Fix failures of GitHub Release by @youngbupark in https://github.com/radius-project/radius/pull/6084
+* Use Kubernetes Secret as backend  by @vishwahiremat in https://github.com/radius-project/radius/pull/6038
+* Add the step to publish chart to GHCR by @youngbupark in https://github.com/radius-project/radius/pull/6071
+* Update `rad init` strings by @AaronCrawfis in https://github.com/radius-project/radius/pull/6088
+* SplitNamespace: New Extenders type in corerp should allow for optional applicationid ip in ExtenderProperties by @lakshmimsft in https://github.com/radius-project/radius/pull/6079
+* Upgrade Go 1.20 to Go 1.21 by @youngbupark in https://github.com/radius-project/radius/pull/6098
+* Add Actions workflow to auto-generate CLI docs by @AaronCrawfis in https://github.com/radius-project/radius/pull/6070
+* Release v0.24.0 by @willdavsmith in https://github.com/radius-project/radius/pull/6092
+* SplitNamespace: Cleanup datamodel_util.go, updating spec examples by @lakshmimsft in https://github.com/radius-project/radius/pull/6080
+* Disable rad CLI autogen footer by @AaronCrawfis in https://github.com/radius-project/radius/pull/6103
+* Recipe Engine metrics updates by @ytimocin in https://github.com/radius-project/radius/pull/6096
+* Add extension resource support for resource ID parser by @rynowak in https://github.com/radius-project/radius/pull/6110
+* Adding recipe error codes  by @vishwahiremat in https://github.com/radius-project/radius/pull/6100
+* Remove ResourceIdentity by @rynowak in https://github.com/radius-project/radius/pull/6089
+* Initial commit of Applications.Core typespec by @youngbupark in https://github.com/radius-project/radius/pull/6097
+* Terraform Delete Logic Implementation by @ytimocin in https://github.com/radius-project/radius/pull/6091
+* SplitNamespace: Application.Core/extenders Functional Tests by @lakshmimsft in https://github.com/radius-project/radius/pull/6094
+* Applications.Core - Regen models and clients from TypeSpec emitted swagger files by @youngbupark in https://github.com/radius-project/radius/pull/6108
+* Return a daprmissing error if we are deploying dapr resource to a cluster which does not have dapr installed. by @nithyatsu in https://github.com/radius-project/radius/pull/5962
+* Install TypeSpec compiler and generate clients in lint action by @youngbupark in https://github.com/radius-project/radius/pull/6122
+* Convert Applications.Dapr CADL to TypeSpec by @youngbupark in https://github.com/radius-project/radius/pull/6115
+* Convert App.Datastores and App.Messaging Cadl to TypeSpec by @youngbupark in https://github.com/radius-project/radius/pull/6121
+* Updating terraform functional tests to verify kubernetes secret  by @vishwahiremat in https://github.com/radius-project/radius/pull/6120
+* Initial commit of YAML manifest based container deployment (frontend controller) by @youngbupark in https://github.com/radius-project/radius/pull/6119
+* Adding a check to the Error.Code before adding as an attribute by @ytimocin in https://github.com/radius-project/radius/pull/6145
+* Fix the flakiness of validateBaseManifest test by @youngbupark in https://github.com/radius-project/radius/pull/6143
+* Fix security vulnerability in npm packages by @youngbupark in https://github.com/radius-project/radius/pull/6142
+* Add image pull policy to containers  by @vinayada1 in https://github.com/radius-project/radius/pull/6093
+* Adding a fix for validating terraform secret in functional test by @vishwahiremat in https://github.com/radius-project/radius/pull/6141
+* Log pod states on failure of PR test run by @willdavsmith in https://github.com/radius-project/radius/pull/5946
+* Update running-controlplane-locally.md by @ytimocin in https://github.com/radius-project/radius/pull/6161
+* Adding Recipe Engine section to Grafana Dashboard by @ytimocin in https://github.com/radius-project/radius/pull/6116
+* Adding new extender details to the required places by @ytimocin in https://github.com/radius-project/radius/pull/6164
+* Adding Post Delete Verify steps to the TF Functional Tests by @ytimocin in https://github.com/radius-project/radius/pull/6137
+* Add GitHub Issues config file by @AaronCrawfis in https://github.com/radius-project/radius/pull/6167
+* Document how to use forked repo to contribute to Radius. by @vinayada1 in https://github.com/radius-project/radius/pull/6168
+* Enable support for recipe type specific garbage collection of resources. by @vishwahiremat in https://github.com/radius-project/radius/pull/6162
+* SplitNamespace: Remove Applications.Link, rename linkrp package to portableresources by @lakshmimsft in https://github.com/radius-project/radius/pull/6130
+* Use Hosted Pool by @youngbupark in https://github.com/radius-project/radius/pull/6169
+* Use basemanifest in Container resource to create k8s resources by @youngbupark in https://github.com/radius-project/radius/pull/6154
+* rename project-radius to radius-project by @nithyatsu in https://github.com/radius-project/radius/pull/6178
+* Clean up CADL and unused swagger files by @youngbupark in https://github.com/radius-project/radius/pull/6181
+* Rename `e2e test on Azure` to `Long-running test on Azure` by @youngbupark in https://github.com/radius-project/radius/pull/6182
+* Use hosted pool for functional tests. by @youngbupark in https://github.com/radius-project/radius/pull/6190
+* Use GVK for resource key in manifest by @youngbupark in https://github.com/radius-project/radius/pull/6184
+* Add Terraform Recipe output functional tests by @kachawla in https://github.com/radius-project/radius/pull/6171
+* Add terraform support for rad recipe show by @sk593 in https://github.com/radius-project/radius/pull/6139
+* Improvements and tests for UCP proxy by @rynowak in https://github.com/radius-project/radius/pull/6194
+* Enable Samples repo test in radius functional tests by @lakshmimsft in https://github.com/radius-project/radius/pull/6193
+* Migrate UCP CADL to TypeSpec by @youngbupark in https://github.com/radius-project/radius/pull/6191
+* Cleanup portableresources/api package by @lakshmimsft in https://github.com/radius-project/radius/pull/6192
+* Initial commit of pod patching  by @youngbupark in https://github.com/radius-project/radius/pull/6188
+* Add test RP for testing resource lifecycle by @rynowak in https://github.com/radius-project/radius/pull/6197
+* Update sudo prompt by @AaronCrawfis in https://github.com/radius-project/radius/pull/6125
+* rad init should use current kube context for its operations by @nithyatsu in https://github.com/radius-project/radius/pull/6212
+* Detect deployment failures with gateway by @vinayada1 in https://github.com/radius-project/radius/pull/6126
+* Add plumbing for tracked resources by @rynowak in https://github.com/radius-project/radius/pull/6199
+* Adding applyDeploymentOutput to the necessary resources by @ytimocin in https://github.com/radius-project/radius/pull/6203
+* Docs cleanup by @vinayada1 in https://github.com/radius-project/radius/pull/6229
+* Add purge AWS resources GitHub workflow by @willdavsmith in https://github.com/radius-project/radius/pull/6160
+* Updating linktype, link-type, linkrecipe, linkmetadata constructs by @lakshmimsft in https://github.com/radius-project/radius/pull/6211
+* Fix inconsistency in connection prefix naming for container connections by @AaronCrawfis in https://github.com/radius-project/radius/pull/6235
+* Adding postDeleteVerify to the Dapr functional tests by @ytimocin in https://github.com/radius-project/radius/pull/6195
+* support servicePort different from containerPort by @nithyatsu in https://github.com/radius-project/radius/pull/6234
+* Move Dapr test files under daprrp/resources by @lakshmimsft in https://github.com/radius-project/radius/pull/6240
+* Adding error codes as attributes to the Recipe Engine and Driver metrics by @ytimocin in https://github.com/radius-project/radius/pull/6205
+* Simplify API route registration by @youngbupark in https://github.com/radius-project/radius/pull/5851
+* Add missing async job controller for corerp and delete dead code. by @youngbupark in https://github.com/radius-project/radius/pull/6243
+* Add more unit-tests to basemanifest renderer by @youngbupark in https://github.com/radius-project/radius/pull/6225
+* Fixing and adding better logging to purge AWS resources workflow by @willdavsmith in https://github.com/radius-project/radius/pull/6246
+* Fix naming example by @AaronCrawfis in https://github.com/radius-project/radius/pull/6253
+* Fix code of conduct link by @AaronCrawfis in https://github.com/radius-project/radius/pull/6254
+* Fix stuck portable resource deletion bug  by @sk593 in https://github.com/radius-project/radius/pull/6247
+* Adding metrics for recipe grabage collection and refactoring engine to take options. by @vishwahiremat in https://github.com/radius-project/radius/pull/6232
+* Release 0.25: Create rc release by @kachawla in https://github.com/radius-project/radius/pull/6260
+* Add new release documentation and release verification workflow by @willdavsmith in https://github.com/radius-project/radius/pull/6113
+
+
+**Full Changelog**: https://github.com/radius-project/radius/compare/v0.24.0...v0.25.0

--- a/docs/release-notes/v0.25.0.md
+++ b/docs/release-notes/v0.25.0.md
@@ -10,7 +10,27 @@ If you're new to Radius, check out our website, [radapp.dev](https://radapp.dev)
 
 ## Highlights
 
+### Terraform Recipes
+
+[Recipes](https://docs.radapp.dev/guides/recipes/overview/) now support Terraform. You can now add a Terraform module to your environment as a Recipe and deploy it with any Recipe-enabled resource. This allows your developers to self-service deploy and manage infrastructure while ensuring security and cost best practices are followed.
+
+### Updated types for portable resources
+
+[Radius portable resources](https://docs.radapp.dev/guides/author-apps/portable-resources/overview/) (_formerly Links_) now have a new look and feel. A new set of namespaces and types are available for you to use in your apps today, including Applications.Datastores, Applications.Messaging, and Applications.Dapr.
+
+### New Kubernetes interoperability features
+
+You can now customize a [Radius container](https://docs.radapp.dev/guides/author-apps/containers/overview/) with Kubernetes properties, or use a Kubernetes YAML file as its base. This allows you to migrate to Radius and/or punch through directly to the Kubernetes pod for when you need to access Kubernetes-specific properties from the Radius container abstraction.
+
+### Renamed GitHub organization
+
+The Radius GitHub organization has been renamed to `radius-project`. This aligns us with our new launch-name: "Radius".
+
 ## Breaking changes
+
+- Previous bookmarks to https://github.com/project-radius will need to be updated to https://github.com/radius-project. We've re-registered the project-radius org to prevent redirect squatting so redirects should work in most cases, but make sure to use the new name when possible.
+- All `Applications.Link` resources need to be moved to the new set of portable resource types (see above)
+
 
 ## Upgrading to Radius v0.25.0
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,9 +1,9 @@
 supported:
   - channel: '0.25'
-    version: 'v0.25.0-rc1'
+    version: 'v0.25.0'
+deprecated:
   - channel: '0.24'
     version: 'v0.24.0'
-deprecated:
   - channel: '0.23'
     version: 'v0.23.1'
   - channel: '0.22'


### PR DESCRIPTION
# Description

* Adding 0.25.0 to the supported versions
* Deprecating v0.24.1

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b905bbb</samp>

### Summary
:arrow_up::leftwards_arrow_with_hook::memo:

<!--
1.  :arrow_up: This emoji indicates that the channel 0.25 was upgraded from a release candidate to a stable version, which is a positive and expected change for users who want to access the latest features and bug fixes.
2. :leftwards_arrow_with_hook: This emoji indicates that the channel 0.24 was moved from supported to deprecated, which is a backward-incompatible change that may affect users who are still using the older version. They may need to migrate to a newer channel or face potential issues with compatibility and security.
3. :memo: This emoji indicates that the documentation and configuration files were updated to reflect the changes in the channels and versions, which is an informative and helpful change for users who want to understand the current status and options of the project.
-->
Update `versions.yaml` to reflect the release of v0.25.0. Change the 0.25 channel to point to the stable version and deprecate the 0.24 channel.

> _`v0.25.0` is out_
> _New channel supported now_
> _Old one deprecated_

### Walkthrough
* Update the supported and deprecated channels and versions for the release of v0.25.0 ([link](https://github.com/radius-project/radius/pull/6270/files?diff=unified&w=0#diff-1c4cd801df522f4a92edbfb0fea95364ed074a391ea47c284ddc078f512f7b6aL3-R6))


