### PR TITLE
Removing TF secret prefix

### DIFF
--- a/pkg/recipes/terraform/config/backends/kubernetes.go
+++ b/pkg/recipes/terraform/config/backends/kubernetes.go
@@ -46,16 +46,16 @@ func NewKubernetesBackend() Backend {
 // in-cluster config is not present.
 // https://developer.hashicorp.com/terraform/language/settings/backends/kubernetes
 func (p *kubernetesBackend) BuildBackend(resourceRecipe *recipes.ResourceMetadata) (map[string]any, error) {
-	secretSuffix, err := generateSecret(resourceRecipe)
+	secretSuffix, err := generateSecretSuffix(resourceRecipe)
 	if err != nil {
 		return nil, err
 	}
 	return generateKubernetesBackendConfig(secretSuffix)
 }
 
-// generateSecret returns a unique string from the resourceID, environmentID, and applicationID
+// generateSecretSuffix returns a unique string from the resourceID, environmentID, and applicationID
 // which is used as key for kubernetes secret in defining terraform backend.
-func generateSecret(resourceRecipe *recipes.ResourceMetadata) (string, error) {
+func generateSecretSuffix(resourceRecipe *recipes.ResourceMetadata) (string, error) {
 	parsedResourceID, err := resources.Parse(resourceRecipe.ResourceID)
 	if err != nil {
 		return "", err

--- a/pkg/recipes/terraform/config/backends/kubernetes.go
+++ b/pkg/recipes/terraform/config/backends/kubernetes.go
@@ -46,16 +46,16 @@ func NewKubernetesBackend() Backend {
 // in-cluster config is not present.
 // https://developer.hashicorp.com/terraform/language/settings/backends/kubernetes
 func (p *kubernetesBackend) BuildBackend(resourceRecipe *recipes.ResourceMetadata) (map[string]any, error) {
-	secretSuffix, err := generateSecretSuffix(resourceRecipe)
+	secretSuffix, err := generateSecret(resourceRecipe)
 	if err != nil {
 		return nil, err
 	}
 	return generateKubernetesBackendConfig(secretSuffix)
 }
 
-// generateSecretSuffix returns a unique string from the resourceID, environmentID, and applicationID
+// generateSecret returns a unique string from the resourceID, environmentID, and applicationID
 // which is used as key for kubernetes secret in defining terraform backend.
-func generateSecretSuffix(resourceRecipe *recipes.ResourceMetadata) (string, error) {
+func generateSecret(resourceRecipe *recipes.ResourceMetadata) (string, error) {
 	parsedResourceID, err := resources.Parse(resourceRecipe.ResourceID)
 	if err != nil {
 		return "", err

--- a/pkg/recipes/terraform/config/backends/kubernetes.go
+++ b/pkg/recipes/terraform/config/backends/kubernetes.go
@@ -77,6 +77,7 @@ func generateSecretSuffix(resourceRecipe *recipes.ResourceMetadata) (string, err
 		return "", err
 	}
 	hash := hasher.Sum(nil)
+
 	return fmt.Sprintf("%x", hash), nil
 }
 

--- a/pkg/recipes/terraform/config/backends/kubernetes.go
+++ b/pkg/recipes/terraform/config/backends/kubernetes.go
@@ -71,24 +71,13 @@ func generateSecretSuffix(resourceRecipe *recipes.ResourceMetadata) (string, err
 		return "", err
 	}
 
-	prefix := fmt.Sprintf("%s-%s-%s", parsedEnvID.Name(), parsedAppID.Name(), parsedResourceID.Name())
-
-	// Kubernetes enforces a character limit of 63 characters on the suffix for state file stored in kubernetes secret.
-	// 22 = 63 (max length of Kubernetes secret suffix) - 40 (hex hash length) - 1 (dot separator)
-	maxResourceNameLen := 22
-	if len(prefix) >= maxResourceNameLen {
-		prefix = prefix[:maxResourceNameLen]
-	}
-
 	hasher := sha1.New()
 	_, err = hasher.Write([]byte(strings.ToLower(fmt.Sprintf("%s-%s-%s", parsedEnvID.Name(), parsedAppID.Name(), parsedResourceID.String()))))
 	if err != nil {
 		return "", err
 	}
 	hash := hasher.Sum(nil)
-
-	// example: env-app-redis.ec291e26078b7ea8a74abfac82530005a0ecbf15
-	return fmt.Sprintf("%s.%x", prefix, hash), nil
+	return fmt.Sprintf("%x", hash), nil
 }
 
 // generateKubernetesBackendConfig returns Terraform backend configuration to store Terraform state file for the deployment.

--- a/pkg/recipes/terraform/config/backends/kubernetes_test.go
+++ b/pkg/recipes/terraform/config/backends/kubernetes_test.go
@@ -100,7 +100,7 @@ func Test_GenerateSecretSuffix(t *testing.T) {
 	_, err := hasher.Write([]byte(strings.ToLower(fmt.Sprintf("%s-%s-%s", envName, appName, resourceRecipe.ResourceID))))
 	require.NoError(t, err)
 	expSecret := fmt.Sprintf("%x", hasher.Sum(nil))
-	secret, err := generateSecretSuffix(&resourceRecipe)
+	secret, err := generateSecret(&resourceRecipe)
 	require.NoError(t, err)
 	require.Equal(t, expSecret, secret)
 }
@@ -108,20 +108,20 @@ func Test_GenerateSecretSuffix(t *testing.T) {
 func Test_GenerateSecretSuffix_invalid_resourceid(t *testing.T) {
 	_, resourceRecipe := getTestInputs()
 	resourceRecipe.ResourceID = "invalid"
-	_, err := generateSecretSuffix(&resourceRecipe)
+	_, err := generateSecret(&resourceRecipe)
 	require.Equal(t, err.Error(), "'invalid' is not a valid resource id")
 }
 
 func Test_GenerateSecretSuffix_invalid_envid(t *testing.T) {
 	_, resourceRecipe := getTestInputs()
 	resourceRecipe.EnvironmentID = "invalid"
-	_, err := generateSecretSuffix(&resourceRecipe)
+	_, err := generateSecret(&resourceRecipe)
 	require.Equal(t, err.Error(), "'invalid' is not a valid resource id")
 }
 
 func Test_GenerateSecretSuffix_invalid_appid(t *testing.T) {
 	_, resourceRecipe := getTestInputs()
 	resourceRecipe.ApplicationID = "invalid"
-	_, err := generateSecretSuffix(&resourceRecipe)
+	_, err := generateSecret(&resourceRecipe)
 	require.Equal(t, err.Error(), "'invalid' is not a valid resource id")
 }

--- a/pkg/recipes/terraform/config/backends/kubernetes_test.go
+++ b/pkg/recipes/terraform/config/backends/kubernetes_test.go
@@ -100,7 +100,7 @@ func Test_GenerateSecretSuffix(t *testing.T) {
 	_, err := hasher.Write([]byte(strings.ToLower(fmt.Sprintf("%s-%s-%s", envName, appName, resourceRecipe.ResourceID))))
 	require.NoError(t, err)
 	expSecret := fmt.Sprintf("%x", hasher.Sum(nil))
-	secret, err := generateSecret(&resourceRecipe)
+	secret, err := generateSecretSuffix(&resourceRecipe)
 	require.NoError(t, err)
 	require.Equal(t, expSecret, secret)
 }
@@ -108,20 +108,20 @@ func Test_GenerateSecretSuffix(t *testing.T) {
 func Test_GenerateSecretSuffix_invalid_resourceid(t *testing.T) {
 	_, resourceRecipe := getTestInputs()
 	resourceRecipe.ResourceID = "invalid"
-	_, err := generateSecret(&resourceRecipe)
+	_, err := generateSecretSuffix(&resourceRecipe)
 	require.Equal(t, err.Error(), "'invalid' is not a valid resource id")
 }
 
 func Test_GenerateSecretSuffix_invalid_envid(t *testing.T) {
 	_, resourceRecipe := getTestInputs()
 	resourceRecipe.EnvironmentID = "invalid"
-	_, err := generateSecret(&resourceRecipe)
+	_, err := generateSecretSuffix(&resourceRecipe)
 	require.Equal(t, err.Error(), "'invalid' is not a valid resource id")
 }
 
 func Test_GenerateSecretSuffix_invalid_appid(t *testing.T) {
 	_, resourceRecipe := getTestInputs()
 	resourceRecipe.ApplicationID = "invalid"
-	_, err := generateSecret(&resourceRecipe)
+	_, err := generateSecretSuffix(&resourceRecipe)
 	require.Equal(t, err.Error(), "'invalid' is not a valid resource id")
 }

--- a/test/functional/shared/resources/recipe_terraform_test.go
+++ b/test/functional/shared/resources/recipe_terraform_test.go
@@ -387,12 +387,6 @@ func getSecretSuffix(resourceID, envName, appName string) (string, error) {
 		return "", err
 	}
 
-	prefix := fmt.Sprintf("%s-%s-%s", envName, appName, parsedResourceID.Name())
-	maxResourceNameLen := 22
-	if len(prefix) >= maxResourceNameLen {
-		prefix = prefix[:maxResourceNameLen]
-	}
-
 	hasher := sha1.New()
 	_, err = hasher.Write([]byte(strings.ToLower(fmt.Sprintf("%s-%s-%s", envName, appName, parsedResourceID.String()))))
 	if err != nil {
@@ -400,6 +394,5 @@ func getSecretSuffix(resourceID, envName, appName string) (string, error) {
 	}
 	hash := hasher.Sum(nil)
 
-	// example: env-app-redis.ec291e26078b7ea8a74abfac82530005a0ecbf15
-	return fmt.Sprintf("%s.%x", prefix, hash), nil
+	return fmt.Sprintf("%x", hash), nil
 }


### PR DESCRIPTION
# Description

This updates the kubernetes secret generation for TF to only use the hash based on the env, app, and resource names (previously we prefixed the hash with the env/app/resource name as well)

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->


- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius #6237.

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #6237

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at eea0445</samp>

### Summary
:white_check_mark::wrench::whale:

<!--
1.  :white_check_mark: - This emoji represents the addition and removal of test cases, as well as the fact that the changes improve the test coverage and quality of the `terraform` package.
2.  :wrench: - This emoji represents the simplification and standardization of the secret suffix generation logic, as well as the fact that the changes fix some potential issues with the previous implementation, such as collisions or truncation errors.
3.  :whale: - This emoji represents the Kubernetes context of the changes, as well as the fact that the changes affect the Terraform backend configuration and secret management for Kubernetes resources.
-->
This pull request improves the testing and implementation of the `terraform` package's Kubernetes backend. It updates the test cases in `kubernetes_test.go` and simplifies the secret suffix generation in `kubernetes.go` by using a hex hash.

> _Sing, O Muse, of the skillful engineers who changed_
> _The code of Terraform, the mighty tool of cloud_
> _They tested well their work, and added and removed_
> _The cases that would prove their backend sound and proud_

### Walkthrough
*  Simplify and improve secret suffix generation for Kubernetes backend ([link](https://github.com/radius-project/radius/pull/6273/files?diff=unified&w=0#diff-8cfcf199134239080517722934e076294829b01cc0c3dbd971f22f75818e6ed2L74-L82), [link](https://github.com/radius-project/radius/pull/6273/files?diff=unified&w=0#diff-8cfcf199134239080517722934e076294829b01cc0c3dbd971f22f75818e6ed2L89-R80), [link](https://github.com/radius-project/radius/pull/6273/files?diff=unified&w=0#diff-98512ebd0fd586cfa9b266a18f807392d48df130f68f8d483ff71f002c1e6e0cL92-R126))
  - Remove truncation logic and use only hex hash of lowercased names ([link](https://github.com/radius-project/radius/pull/6273/files?diff=unified&w=0#diff-8cfcf199134239080517722934e076294829b01cc0c3dbd971f22f75818e6ed2L74-L82), [link](https://github.com/radius-project/radius/pull/6273/files?diff=unified&w=0#diff-8cfcf199134239080517722934e076294829b01cc0c3dbd971f22f75818e6ed2L89-R80))
  - Remove obsolete test case and add new ones for error scenarios ([link](https://github.com/radius-project/radius/pull/6273/files?diff=unified&w=0#diff-98512ebd0fd586cfa9b266a18f807392d48df130f68f8d483ff71f002c1e6e0cL92-R126))
* Add constants and new test cases for Kubernetes backend config ([link](https://github.com/radius-project/radius/pull/6273/files?diff=unified&w=0#diff-98512ebd0fd586cfa9b266a18f807392d48df130f68f8d483ff71f002c1e6e0cR34-R36), [link](https://github.com/radius-project/radius/pull/6273/files?diff=unified&w=0#diff-98512ebd0fd586cfa9b266a18f807392d48df130f68f8d483ff71f002c1e6e0cR88-R107))
  - Define constants for environment, application and resource names ([link](https://github.com/radius-project/radius/pull/6273/files?diff=unified&w=0#diff-98512ebd0fd586cfa9b266a18f807392d48df130f68f8d483ff71f002c1e6e0cR34-R36))
  - Test error scenario when service host and port are not set ([link](https://github.com/radius-project/radius/pull/6273/files?diff=unified&w=0#diff-98512ebd0fd586cfa9b266a18f807392d48df130f68f8d483ff71f002c1e6e0cR88-R107))
  - Test happy path scenario when secret suffix is generated correctly ([link](https://github.com/radius-project/radius/pull/6273/files?diff=unified&w=0#diff-98512ebd0fd586cfa9b266a18f807392d48df130f68f8d483ff71f002c1e6e0cR88-R107))


