### PR TITLE
add recipe failure error message

### DIFF
--- a/pkg/portableresources/backend/controller/createorupdateresource.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource.go
@@ -84,7 +84,7 @@ func (c *CreateOrUpdateResource[P, T]) Run(ctx context.Context, req *ctrl.Reques
 	if err != nil {
 		if recipeError, ok := err.(*recipes.RecipeError); ok {
 			logger := ucplog.FromContextOrDiscard(ctx)
-			logger.Error(err, fmt.Sprintf("failed to execute recipe. Encounted error while processing %s ", recipeError.ErrorDetails.Target))
+			logger.Error(err, fmt.Sprintf("failed to execute recipe. Encountered error while processing %s ", recipeError.ErrorDetails.Target))
 			// Set the deployment status to the recipe error code.
 			recipeDataModel.Recipe().DeploymentStatus = util.RecipeDeploymentStatus(recipeError.DeploymentStatus)
 			update := &store.Object{

--- a/pkg/portableresources/backend/controller/createorupdateresource.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource.go
@@ -98,10 +98,8 @@ func (c *CreateOrUpdateResource[P, T]) Run(ctx context.Context, req *ctrl.Reques
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-
 			return ctrl.NewFailedResult(recipeError.ErrorDetails), nil
 		}
-
 		return ctrl.Result{}, err
 	}
 

--- a/pkg/portableresources/backend/controller/createorupdateresource.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	ctrl "github.com/radius-project/radius/pkg/armrpc/asyncoperation/controller"
 	"github.com/radius-project/radius/pkg/portableresources/datamodel"
@@ -29,6 +30,7 @@ import (
 	"github.com/radius-project/radius/pkg/recipes/util"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 	"github.com/radius-project/radius/pkg/ucp/store"
+	"github.com/radius-project/radius/pkg/ucp/ucplog"
 )
 
 // CreateOrUpdateResource is the async operation controller to create or update portable resources.
@@ -81,6 +83,8 @@ func (c *CreateOrUpdateResource[P, T]) Run(ctx context.Context, req *ctrl.Reques
 	recipeOutput, err := c.executeRecipeIfNeeded(ctx, data, previousOutputResources)
 	if err != nil {
 		if recipeError, ok := err.(*recipes.RecipeError); ok {
+			logger := ucplog.FromContextOrDiscard(ctx)
+			logger.Error(err, fmt.Sprintf("failed to execute recipe. Encounted error while processing %s ", recipeError.ErrorDetails.Target))
 			// Set the deployment status to the recipe error code.
 			recipeDataModel.Recipe().DeploymentStatus = util.RecipeDeploymentStatus(recipeError.DeploymentStatus)
 			update := &store.Object{
@@ -94,8 +98,10 @@ func (c *CreateOrUpdateResource[P, T]) Run(ctx context.Context, req *ctrl.Reques
 			if err != nil {
 				return ctrl.Result{}, err
 			}
+
 			return ctrl.NewFailedResult(recipeError.ErrorDetails), nil
 		}
+
 		return ctrl.Result{}, err
 	}
 

--- a/pkg/recipes/engine/engine.go
+++ b/pkg/recipes/engine/engine.go
@@ -27,6 +27,7 @@ import (
 	recipedriver "github.com/radius-project/radius/pkg/recipes/driver"
 	"github.com/radius-project/radius/pkg/recipes/util"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
+	"github.com/radius-project/radius/pkg/ucp/ucplog"
 )
 
 // NewEngine creates a new Engine to deploy recipe.
@@ -50,11 +51,13 @@ type engine struct {
 // configuration associated with the recipe, and then executes the recipe using the driver. It returns a RecipeOutput and
 // an error if one occurs.
 func (e *engine) Execute(ctx context.Context, opts ExecuteOptions) (*recipes.RecipeOutput, error) {
+	logger := ucplog.FromContextOrDiscard(ctx)
 	executionStart := time.Now()
 	result := metrics.SuccessfulOperationState
 
 	recipeOutput, definition, err := e.executeCore(ctx, opts.Recipe, opts.PreviousState)
 	if err != nil {
+		logger.Error(err, fmt.Sprintf("failed to execute recipe %s ", opts.Recipe.Name))
 		result = metrics.FailedOperationState
 		if recipes.GetRecipeErrorDetails(err) != nil {
 			result = recipes.GetRecipeErrorDetails(err).Code

--- a/pkg/recipes/engine/engine.go
+++ b/pkg/recipes/engine/engine.go
@@ -27,7 +27,6 @@ import (
 	recipedriver "github.com/radius-project/radius/pkg/recipes/driver"
 	"github.com/radius-project/radius/pkg/recipes/util"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
-	"github.com/radius-project/radius/pkg/ucp/ucplog"
 )
 
 // NewEngine creates a new Engine to deploy recipe.
@@ -51,13 +50,11 @@ type engine struct {
 // configuration associated with the recipe, and then executes the recipe using the driver. It returns a RecipeOutput and
 // an error if one occurs.
 func (e *engine) Execute(ctx context.Context, opts ExecuteOptions) (*recipes.RecipeOutput, error) {
-	logger := ucplog.FromContextOrDiscard(ctx)
 	executionStart := time.Now()
 	result := metrics.SuccessfulOperationState
 
 	recipeOutput, definition, err := e.executeCore(ctx, opts.Recipe, opts.PreviousState)
 	if err != nil {
-		logger.Error(err, fmt.Sprintf("failed to execute recipe %s ", opts.Recipe.Name))
 		result = metrics.FailedOperationState
 		if recipes.GetRecipeErrorDetails(err) != nil {
 			result = recipes.GetRecipeErrorDetails(err).Code


### PR DESCRIPTION
# Description

Add a log capturing error encountered while executing a recipe along with trace and span IDs.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4332061</samp>

### Summary
📝🚫🍽️

<!--
1.  📝 This emoji can be used to indicate logging or writing something down, as well as documenting or reporting something. It could represent the improvement of logging in the recipe engine using the `ucplog` package.
2.  🚫 This emoji can be used to indicate something that is forbidden, blocked, stopped, or failed. It could represent the logging of recipe failures with the recipe name and other metadata.
3.  🍽️ This emoji can be used to indicate something related to food, cooking, or eating. It could represent the recipe engine or the recipes themselves.
-->
Enhance recipe engine logging with `ucplog`. Include recipe name and metadata in failure logs.

> _Sing, O Muse, of the valiant code review_
> _That improved the logging of the recipe engine_
> _With the `ucplog` package, a gift from Zeus_
> _To record the failures and the triumphs of the chefs._

### Walkthrough
*  Import `ucplog` package and create logger instance from context or default ([link](https://github.com/radius-project/radius/pull/6276/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59R30), [link](https://github.com/radius-project/radius/pull/6276/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59R54))
* Log error message with recipe name if recipe execution fails ([link](https://github.com/radius-project/radius/pull/6276/files?diff=unified&w=0#diff-06702c6df95f9efe532b70614e1341244f575e5cbc030db57af268ecbfcd8c59R60))


