### PR TITLE
Validating labels of k8s resources in functional tests

### DIFF
--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -25,7 +25,6 @@ import (
 const (
 	LabelRadiusApplication  = "radius.dev/application"
 	LabelRadiusResource     = "radius.dev/resource"
-	LabelRadiusDeployment   = "radius.dev/deployment"
 	LabelRadiusRouteFmt     = "radius.dev/route-%s-%s"
 	LabelRadiusResourceType = "radius.dev/resource-type"
 	LabelPartOf             = "app.kubernetes.io/part-of"
@@ -105,8 +104,9 @@ func MakeSelectorLabels(application string, resource string) map[string]string {
 			LabelRadiusResource:    NormalizeResourceName(resource),
 		}
 	}
+
 	return map[string]string{
-		LabelRadiusApplication: application,
+		LabelRadiusApplication: NormalizeResourceName(application),
 	}
 }
 

--- a/pkg/recipes/terraform/config/config.go
+++ b/pkg/recipes/terraform/config/config.go
@@ -78,6 +78,7 @@ func (cfg *TerraformConfig) Save(ctx context.Context, workingDir string) error {
 	if err = os.WriteFile(getMainConfigFilePath(workingDir), jsonData, modeConfigFile); err != nil {
 		return fmt.Errorf("error creating file: %w", err)
 	}
+
 	return nil
 }
 

--- a/pkg/ucp/store/apiserverstore/apiserverclient.go
+++ b/pkg/ucp/store/apiserverstore/apiserverclient.go
@@ -413,15 +413,15 @@ func resourceName(id resources.ID) string {
 		prefix = store.UCPScopePrefix
 	}
 
-	noramlizedName := normalizeName(id.Name())
+	normalizedName := normalizeName(id.Name())
 	// 211 = 253 (max length of Kubernetes Object name) - 40 (hex hash length) - 2 (dot separators)
 	maxResourceNameLen := 211 - len(prefix)
-	if len(noramlizedName) >= maxResourceNameLen {
-		noramlizedName = noramlizedName[:maxResourceNameLen]
+	if len(normalizedName) >= maxResourceNameLen {
+		normalizedName = normalizedName[:maxResourceNameLen]
 	}
 
 	// example: resource.resource1.ec291e26078b7ea8a74abfac82530005a0ecbf15
-	return fmt.Sprintf("%s.%s.%x", prefix, noramlizedName, hash)
+	return fmt.Sprintf("%s.%s.%x", prefix, normalizedName, hash)
 }
 
 func assignLabels(resource *ucpv1alpha1.Resource) labels.Set {

--- a/test/functional/daprrp/resources/dapr_pubsub_test.go
+++ b/test/functional/daprrp/resources/dapr_pubsub_test.go
@@ -56,14 +56,14 @@ func Test_DaprPubSubBroker_Manual(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dpsb-manual-app-ctnr"),
-						validation.NewK8sPodForResource(name, "dpsb-manual-redis").
-							ValidateLabels(false),
-						validation.NewK8sServiceForResource(name, "dpsb-manual-redis").
-							ValidateLabels(false),
-
-						validation.NewDaprComponent(name, "dpsb-manual").
-							ValidateLabels(false),
+						validation.NewK8sPodForResource(validation.SourceRadius, "dpsb-manual-app-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sPodForResource(validation.SourceRadius, "dpsb-manual-redis",
+							"Applications.Core/containers", name),
+						validation.NewK8sServiceForResource(validation.SourceK8sExtensibility, "dpsb-manual-redis",
+							"Applications.Datastores/redisCaches", name),
+						validation.NewK8sDaprComponent(validation.SourceRadius, "dpsb-manual",
+							"Applications.Dapr/pubSubBrokers", name),
 					},
 				},
 			},
@@ -113,11 +113,10 @@ func Test_DaprPubSubBroker_Recipe(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dpsb-recipe-ctnr").
-							ValidateLabels(false),
-
-						validation.NewDaprComponent(name, "dpsb-recipe").
-							ValidateLabels(false),
+						validation.NewK8sPodForResource(validation.SourceRadius, "dpsb-recipe-app-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sDaprComponent(validation.SourceRecipeEngine, "dpsb-recipe",
+							"Applications.Dapr/pubSubBrokers", name),
 					},
 				},
 			},

--- a/test/functional/daprrp/resources/dapr_secretstore_test.go
+++ b/test/functional/daprrp/resources/dapr_secretstore_test.go
@@ -55,11 +55,10 @@ func Test_DaprSecretStore_Manual(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "gnrc-scs-ctnr"),
-
-						// Not sure why we skip validating the labels
-						validation.NewDaprComponent(name, "gnrc-scs-manual").
-							ValidateLabels(false),
+						validation.NewK8sPodForResource(validation.SourceRadius, "gnrc-scs-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sDaprComponent(validation.SourceRadius, "gnrc-scs-manual",
+							"Applications.Dapr/secretStores", name),
 					},
 				},
 			},
@@ -104,11 +103,10 @@ func Test_DaprSecretStore_Recipe(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "gnrc-scs-ctnr-recipe").
-							ValidateLabels(false),
-
-						validation.NewDaprComponent(name, "gnrc-scs-recipe").
-							ValidateLabels(false),
+						validation.NewK8sPodForResource(validation.SourceRadius, "gnrc-scs-ctnr-recipe",
+							"Applications.Core/containers", name),
+						validation.NewK8sDaprComponent(validation.SourceRecipeEngine, "gnrc-scs-recipe",
+							"Applications.Dapr/secretStores", name),
 					},
 				},
 			},

--- a/test/functional/daprrp/resources/dapr_serviceinvocation_test.go
+++ b/test/functional/daprrp/resources/dapr_serviceinvocation_test.go
@@ -54,8 +54,10 @@ func Test_DaprServiceInvocation(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dapr-frontend"),
-						validation.NewK8sPodForResource(name, "dapr-backend"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "dapr-frontend",
+							"Applications.Core/containers", name),
+						validation.NewK8sPodForResource(validation.SourceRadius, "dapr-backend",
+							"Applications.Core/containers", name),
 					},
 				},
 			},

--- a/test/functional/daprrp/resources/dapr_statestore_test.go
+++ b/test/functional/daprrp/resources/dapr_statestore_test.go
@@ -56,16 +56,17 @@ func Test_DaprStateStore_Manual(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dapr-sts-manual-ctnr"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "dapr-sts-manual-ctnr",
+							"Applications.Core/containers", name),
 
 						// Deployed as supporting resources using Kubernetes Bicep extensibility.
-						validation.NewK8sPodForResource(name, "dapr-sts-manual-redis").
-							ValidateLabels(false),
-						validation.NewK8sServiceForResource(name, "dapr-sts-manual-redis").
-							ValidateLabels(false),
+						validation.NewK8sPodForResource(validation.SourceK8sExtensibility, "dapr-sts-manual-redis",
+							"Applications.Core/containers", name),
+						validation.NewK8sServiceForResource(validation.SourceK8sExtensibility, "dapr-sts-manual-redis",
+							"Applications.Datastores/redisCaches", name),
 
-						validation.NewDaprComponent(name, "dapr-sts-manual").
-							ValidateLabels(false),
+						validation.NewK8sDaprComponent(validation.SourceRadius, "dapr-sts-manual",
+							"Applications.Dapr/stateStores", name),
 					},
 				},
 			},
@@ -115,11 +116,10 @@ func Test_DaprStateStore_Recipe(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "dapr-sts-recipe-ctnr").
-							ValidateLabels(false),
-
-						validation.NewDaprComponent(name, "dapr-sts-recipe").
-							ValidateLabels(false),
+						validation.NewK8sPodForResource(validation.SourceRecipeEngine, "dapr-sts-recipe-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sDaprComponent(validation.SourceRecipeEngine, "dapr-sts-recipe",
+							"Applications.Dapr/stateStores", name),
 					},
 				},
 			},

--- a/test/functional/datastoresrp/resources/microsoftsql_test.go
+++ b/test/functional/datastoresrp/resources/microsoftsql_test.go
@@ -68,7 +68,8 @@ func Test_MicrosoftSQL_Manual(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "mssql-app-ctnr"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "mssql-app-ctnr",
+							"Applications.Core/containers", name),
 					},
 				},
 			},

--- a/test/functional/datastoresrp/resources/mongodb_test.go
+++ b/test/functional/datastoresrp/resources/mongodb_test.go
@@ -66,9 +66,12 @@ func Test_MongoDB_Manual(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "mdb-us-app-ctnr").ValidateLabels(false),
-						validation.NewK8sPodForResource(name, "mdb-us-ctnr").ValidateLabels(false),
-						validation.NewK8sServiceForResource(name, "mdb-us-rte").ValidateLabels(false),
+						validation.NewK8sPodForResource(validation.SourceRadius, "mdb-us-app-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sPodForResource(validation.SourceRadius, "mdb-us-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sServiceForResource(validation.SourceRadius, "mdb-us-rte",
+							"Applications.Core/httpRoutes", name),
 					},
 				},
 			},
@@ -114,7 +117,8 @@ func Test_MongoDB_Recipe(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "mongodb-app-ctnr").ValidateLabels(false),
+						validation.NewK8sPodForResource(validation.SourceRecipeEngine, "mongodb-app-ctnr",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -170,7 +174,8 @@ func Test_MongoDB_RecipeParameters(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "mdb-param-ctnr").ValidateLabels(false),
+						validation.NewK8sPodForResource(validation.SourceRecipeEngine, "mdb-param-ctnr",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -225,7 +230,8 @@ func Test_MongoDB_Recipe_ContextParameter(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "mdb-ctx-ctnr").ValidateLabels(false),
+						validation.NewK8sPodForResource(validation.SourceRecipeEngine, "mdb-ctx-ctnr",
+							"Applications.Core/containers", name),
 					},
 				},
 			},

--- a/test/functional/datastoresrp/resources/redis_test.go
+++ b/test/functional/datastoresrp/resources/redis_test.go
@@ -64,9 +64,12 @@ func Test_Redis_Manual(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "rds-app-ctnr"),
-						validation.NewK8sPodForResource(name, "rds-ctnr"),
-						validation.NewK8sServiceForResource(name, "rds-rte"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "rds-app-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sPodForResource(validation.SourceRadius, "rds-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sServiceForResource(validation.SourceRadius, "rds-rte",
+							"Applications.Core/httpRoutes", name),
 					},
 				},
 			},

--- a/test/functional/datastoresrp/resources/sql_test.go
+++ b/test/functional/datastoresrp/resources/sql_test.go
@@ -69,9 +69,12 @@ func Test_SQLDatabase_Manual(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "sql-app-ctnr"),
-						validation.NewK8sPodForResource(name, "sql-ctnr"),
-						validation.NewK8sServiceForResource(name, "sql-rte"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "sql-app-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sPodForResource(validation.SourceRadius, "sql-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sServiceForResource(validation.SourceRadius, "sql-rte",
+							"Applications.Core/httpRoutes", name),
 					},
 				},
 			},
@@ -112,8 +115,10 @@ func Test_SQLDatabase_Recipe(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "sql-recipe-app-ctnr").ValidateLabels(false),
-						validation.NewK8sPodForResource(name, "sql-recipe-resource").ValidateLabels(false),
+						validation.NewK8sPodForResource(validation.SourceRecipeEngine, "sql-recipe-app-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sPodForResource(validation.SourceRecipeEngine, "sql-recipe-resource",
+							"Applications.Core/containers", name),
 					},
 				},
 			},

--- a/test/functional/datastoresrp/resources/testdata/datastoresrp-resources-redis-manual.bicep
+++ b/test/functional/datastoresrp/resources/testdata/datastoresrp-resources-redis-manual.bicep
@@ -53,7 +53,7 @@ resource redisContainer 'Applications.Core/containers@2023-10-01-preview' = {
   }
 }
 
-resource redisRoute 'Applications.Core/httproutes@2023-10-01-preview' = {
+resource redisRoute 'Applications.Core/httpRoutes@2023-10-01-preview' = {
   name: 'rds-rte'
   location: 'global'
   properties: {

--- a/test/functional/datastoresrp/resources/testdata/datastoresrp-rs-mongodb-manual.bicep
+++ b/test/functional/datastoresrp/resources/testdata/datastoresrp-rs-mongodb-manual.bicep
@@ -60,7 +60,7 @@ resource mongoContainer 'Applications.Core/containers@2023-10-01-preview' = {
   }
 }
 
-resource mongoRoute 'Applications.Core/httproutes@2023-10-01-preview' = {
+resource mongoRoute 'Applications.Core/httpRoutes@2023-10-01-preview' = {
   name: 'mdb-us-rte'
   location: 'global'
   properties: {

--- a/test/functional/messagingrp/resources/rabbitmq_test.go
+++ b/test/functional/messagingrp/resources/rabbitmq_test.go
@@ -64,9 +64,12 @@ func Test_RabbitMQ_Manual(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "rmq-app-ctnr"),
-						validation.NewK8sPodForResource(name, "rmq-ctnr"),
-						validation.NewK8sServiceForResource(name, "rmq-rte"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "rmq-app-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sPodForResource(validation.SourceRadius, "rmq-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sServiceForResource(validation.SourceRadius, "rmq-rte",
+							"Applications.Core/httpRoutes", name),
 					},
 				},
 			},
@@ -104,8 +107,10 @@ func Test_RabbitMQ_Recipe(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "rmq-recipe-app-ctnr").ValidateLabels(false),
-						validation.NewK8sPodForResource(name, "rmq-recipe-resource").ValidateLabels(false),
+						validation.NewK8sPodForResource(validation.SourceRecipeEngine, "rmq-recipe-app-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sPodForResource(validation.SourceRecipeEngine, "rmq-recipe-resource",
+							"Applications.Core/containers", name),
 					},
 				},
 			},

--- a/test/functional/samples/tutorial_test.go
+++ b/test/functional/samples/tutorial_test.go
@@ -110,7 +110,8 @@ func Test_FirstApplicationSample(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(appName, "demo"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "demo",
+							"Applications.Core/containers", appName),
 					},
 				},
 			},

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -441,8 +441,10 @@ func Test_CLI(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					"default-kubernetes-cli": {
-						validation.NewK8sPodForResource(name, "containera"),
-						validation.NewK8sPodForResource(name, "containerb"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "containera",
+							"Applications.Core/containers", name),
+						validation.NewK8sPodForResource(validation.SourceRadius, "containerb",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -481,8 +483,10 @@ func Test_CLI_JSON(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					"default-kubernetes-cli-json": {
-						validation.NewK8sPodForResource(name, "containera-json"),
-						validation.NewK8sPodForResource(name, "containerb-json"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "containera-json",
+							"Applications.Core/containers", name),
+						validation.NewK8sPodForResource(validation.SourceRadius, "containerb-json",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -521,8 +525,10 @@ func Test_CLI_Delete(t *testing.T) {
 		validation.ValidateObjectsRunning(ctx, t, options.K8sClient, options.DynamicClient, validation.K8sObjectSet{
 			Namespaces: map[string][]validation.K8sObject{
 				"default-kubernetes-cli-with-resources": {
-					validation.NewK8sPodForResource(appName, "containera-app-with-resources"),
-					validation.NewK8sPodForResource(appName, "containerb-app-with-resources"),
+					validation.NewK8sPodForResource(validation.SourceRadius, "containera-app-with-resources",
+						"Applications.Core/containers", appName),
+					validation.NewK8sPodForResource(validation.SourceRadius, "containerb-app-with-resources",
+						"Applications.Core/containers", appName),
 				},
 			},
 		})
@@ -555,8 +561,10 @@ func Test_CLI_Delete(t *testing.T) {
 		validation.ValidateObjectsRunning(ctx, t, options.K8sClient, options.DynamicClient, validation.K8sObjectSet{
 			Namespaces: map[string][]validation.K8sObject{
 				"default-kubernetes-cli-with-resources": {
-					validation.NewK8sPodForResource(appName, "containera-app-with-resources"),
-					validation.NewK8sPodForResource(appName, "containerb-app-with-resources"),
+					validation.NewK8sPodForResource(validation.SourceRadius, "containera-app-with-resources",
+						"Applications.Core/containers", appName),
+					validation.NewK8sPodForResource(validation.SourceRadius, "containerb-app-with-resources",
+						"Applications.Core/containers", appName),
 				},
 			},
 		})
@@ -615,8 +623,10 @@ func Test_CLI_DeploymentParameters(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					"default-kubernetes-cli-params": {
-						validation.NewK8sPodForResource(name, "containerc"),
-						validation.NewK8sPodForResource(name, "containerd"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "containerc",
+							"Applications.Core/containers", name),
+						validation.NewK8sPodForResource(validation.SourceRadius, "containerd",
+							"Applications.Core/containers", name),
 					},
 				},
 			},

--- a/test/functional/shared/mechanics/mechanics_test.go
+++ b/test/functional/shared/mechanics/mechanics_test.go
@@ -82,7 +82,8 @@ func Test_RedeployWithAnotherResource(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "mechanicsa"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "mechanicsa",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -110,8 +111,10 @@ func Test_RedeployWithAnotherResource(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "mechanicsb"),
-						validation.NewK8sPodForResource(name, "mechanicsc"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "mechanicsb",
+							"Applications.Core/containers", name),
+						validation.NewK8sPodForResource(validation.SourceRadius, "mechanicsc",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -145,7 +148,8 @@ func Test_RedeployWithUpdatedResourceUpdatesResource(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "mechanicsd"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "mechanicsd",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -168,7 +172,8 @@ func Test_RedeployWithUpdatedResourceUpdatesResource(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "mechanicsd"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "mechanicsd",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -215,7 +220,8 @@ func Test_RedeployWithTwoSeparateResourcesKeepsResource(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "mechanicse"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "mechanicse",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -243,8 +249,10 @@ func Test_RedeployWithTwoSeparateResourcesKeepsResource(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "mechanicse"),
-						validation.NewK8sPodForResource(name, "mechanicsf"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "mechanicse",
+							"Applications.Core/containers", name),
+						validation.NewK8sPodForResource(validation.SourceRadius, "mechanicsf",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -293,8 +301,10 @@ func Test_CommunicationCycle(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "mechanicsg"),
-						validation.NewK8sPodForResource(name, "cyclea"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "mechanicsg",
+							"Applications.Core/containers", name),
+						validation.NewK8sPodForResource(validation.SourceRadius, "cyclea",
+							"Applications.Core/containers", name),
 					},
 				},
 			},

--- a/test/functional/shared/resources/azure_connections_test.go
+++ b/test/functional/shared/resources/azure_connections_test.go
@@ -56,7 +56,8 @@ func Test_AzureConnections(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, containerResourceName),
+						validation.NewK8sPodForResource(validation.SourceRadius, containerResourceName,
+							"Applications.Core/containers", name),
 					},
 				},
 			},

--- a/test/functional/shared/resources/container_runtimes_test.go
+++ b/test/functional/shared/resources/container_runtimes_test.go
@@ -60,7 +60,8 @@ func Test_Container_YAMLManifest(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "ctnr-manifest"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "ctnr-manifest",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -126,7 +127,8 @@ func Test_Container_YAMLManifest_SideCar(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "ctnr-sidecar"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "ctnr-sidecar",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -172,7 +174,8 @@ func Test_Container_pod_patching(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "ctnr-podpatch"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "ctnr-podpatch",
+							"Applications.Core/containers", name),
 					},
 				},
 			},

--- a/test/functional/shared/resources/container_test.go
+++ b/test/functional/shared/resources/container_test.go
@@ -53,7 +53,8 @@ func Test_Container(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "ctnr-ctnr"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "ctnr-ctnr",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -92,8 +93,10 @@ func Test_ContainerHttpRoute(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "ctnr-rte-ctnr"),
-						validation.NewK8sServiceForResource(name, "ctnr-rte-rte"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "ctnr-rte-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sServiceForResource(validation.SourceRadius, "ctnr-rte-rte",
+							"Applications.Core/httpRoutes", name),
 					},
 				},
 			},
@@ -132,9 +135,10 @@ func Test_ContainerDNSSD_TwoContainersDNS(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "containerad"),
-						validation.NewK8sPodForResource(name, "containeraf"),
-						validation.NewK8sServiceForResource(name, "containeraf"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "containerad",
+							"Applications.Core/containers", name),
+						validation.NewK8sPodForResource(validation.SourceRadius, "containeraf",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -178,12 +182,12 @@ func Test_ContainerDNSSD_OptionalPortScheme(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "containerqy"),
-						validation.NewK8sPodForResource(name, "containerqu"),
-						validation.NewK8sPodForResource(name, "containerqi"),
-						validation.NewK8sServiceForResource(name, "containerqy"),
-						validation.NewK8sServiceForResource(name, "containerqu"),
-						validation.NewK8sServiceForResource(name, "containerqi"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "containerqy",
+							"Applications.Core/containers", name),
+						validation.NewK8sPodForResource(validation.SourceRadius, "containerqu",
+							"Applications.Core/containers", name),
+						validation.NewK8sPodForResource(validation.SourceRadius, "containerqi",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -217,7 +221,8 @@ func Test_ContainerReadinessLiveness(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "ctnr-live-ready"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "ctnr-live-ready",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -251,7 +256,8 @@ func Test_ContainerManualScale(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "ctnr-manualscale"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "ctnr-manualscale",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -285,7 +291,8 @@ func Test_ContainerWithCommandAndArgs(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "ctnr-cmd-args"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "ctnr-cmd-args",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -350,7 +357,8 @@ func Test_Container_FailDueToNonExistentImage(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "ctnr-cntr-badimage"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "ctnr-cntr-badimage",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -385,7 +393,8 @@ func Test_Container_FailDueToBadHealthProbe(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "ctnr-cntr-bad-healthprobe"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "ctnr-cntr-bad-healthprobe",
+							"Applications.Core/containers", name),
 					},
 				},
 			},

--- a/test/functional/shared/resources/container_versioning_test.go
+++ b/test/functional/shared/resources/container_versioning_test.go
@@ -56,7 +56,8 @@ func Test_ContainerVersioning(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "friendly-ctnr"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "friendly-ctnr",
+							"Applications.Core/containers", name),
 					},
 				},
 			},
@@ -88,7 +89,8 @@ func Test_ContainerVersioning(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "friendly-ctnr"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "friendly-ctnr",
+							"Applications.Core/containers", name),
 					},
 				},
 			},

--- a/test/functional/shared/resources/extender_test.go
+++ b/test/functional/shared/resources/extender_test.go
@@ -56,7 +56,8 @@ func Test_Extender_Manual(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "extr-ctnr"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "extr-ctnr",
+							"Applications.Core/containers", name),
 					},
 				},
 			},

--- a/test/functional/shared/resources/gateway_test.go
+++ b/test/functional/shared/resources/gateway_test.go
@@ -92,13 +92,18 @@ func Test_Gateway(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "http-gtwy-front-ctnr"),
-						validation.NewK8sPodForResource(name, "http-gtwy-back-ctnr"),
-						validation.NewK8sHTTPProxyForResource(name, "http-gtwy-gtwy"),
-						validation.NewK8sHTTPProxyForResource(name, "http-gtwy-front-rte"),
-						validation.NewK8sServiceForResource(name, "http-gtwy-front-rte"),
-						validation.NewK8sHTTPProxyForResource(name, "http-gtwy-back-rte"),
-						validation.NewK8sServiceForResource(name, "http-gtwy-back-rte"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "http-gtwy-front-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sHTTPProxyForResource(validation.SourceRadius, "http-gtwy-front-rte",
+							"Applications.Core/httpRoutes", name),
+
+						validation.NewK8sPodForResource(validation.SourceRadius, "http-gtwy-back-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sHTTPProxyForResource(validation.SourceRadius, "http-gtwy-back-rte",
+							"Applications.Core/httpRoutes", name),
+
+						validation.NewK8sHTTPProxyForResource(validation.SourceRadius, "http-gtwy-gtwy",
+							"Applications.Core/gateways", name),
 					},
 				},
 			},
@@ -179,13 +184,26 @@ func Test_GatewayDNS(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "frontendcontainerdns"),
-						validation.NewK8sPodForResource(name, "backendcontainerdns"),
-						validation.NewK8sServiceForResource(name, "frontendcontainerdns"),
-						validation.NewK8sServiceForResource(name, "backendcontainerdns"),
-						validation.NewK8sHTTPProxyForResource(name, "http-gtwy-gtwy-dns"),
-						validation.NewK8sHTTPProxyForResource(name, "frontendcontainerdns"),
-						validation.NewK8sHTTPProxyForResource(name, "backendcontainerdns"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "frontendcontainerdns",
+							"Applications.Core/containers", name),
+						// In bicep file there is only the container. How would HTTPProxy be created?
+						validation.NewK8sServiceForResource(validation.SourceRadius, "frontendcontainerdns",
+							"Applications.Core/httpRoutes", name),
+						// How would gateway be created? If the container has a specific property, then the gateway is created?
+						validation.NewK8sHTTPProxyForResource(validation.SourceRadius, "frontendcontainerdns",
+							"Applications.Core/gateways", name),
+
+						validation.NewK8sPodForResource(validation.SourceRadius, "backendcontainerdns",
+							"Applications.Core/containers", name),
+						// In bicep file there is only the container. How would HTTPProxy be created?
+						validation.NewK8sServiceForResource(validation.SourceRadius, "backendcontainerdns",
+							"Applications.Core/httpRoutes", name),
+						// How would gateway be created? If the container has a specific property, then the gateway is created?
+						validation.NewK8sHTTPProxyForResource(validation.SourceRadius, "backendcontainerdns",
+							"Applications.Core/gateways", name),
+
+						validation.NewK8sHTTPProxyForResource(validation.SourceRadius, "http-gtwy-gtwy-dns",
+							"Applications.Core/gateways", name),
 					},
 				},
 			},
@@ -258,10 +276,16 @@ func Test_Gateway_SSLPassthrough(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "ssl-gtwy-front-ctnr"),
-						validation.NewK8sHTTPProxyForResource(name, "ssl-gtwy-gtwy"),
-						validation.NewK8sHTTPProxyForResource(name, "ssl-gtwy-front-rte"),
-						validation.NewK8sServiceForResource(name, "ssl-gtwy-front-rte"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "ssl-gtwy-front-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sHTTPProxyForResource(validation.SourceRadius, "ssl-gtwy-front-rte",
+							"Applications.Core/httpRoutes", name),
+						// Would an HTTPRoute also create a gateway?
+						validation.NewK8sServiceForResource(validation.SourceRadius, "ssl-gtwy-front-rte",
+							"Applications.Core/gateways", name),
+
+						validation.NewK8sHTTPProxyForResource(validation.SourceRadius, "ssl-gtwy-gtwy",
+							"Applications.Core/gateways", name),
 					},
 				},
 			},
@@ -334,11 +358,18 @@ func Test_Gateway_TLSTermination(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "tls-gtwy-front-ctnr"),
-						validation.NewK8sHTTPProxyForResource(name, "tls-gtwy-gtwy"),
-						validation.NewK8sHTTPProxyForResource(name, "tls-gtwy-front-rte"),
-						validation.NewK8sServiceForResource(name, "tls-gtwy-front-rte"),
-						validation.NewK8sSecretForResource(name, "tls-gtwy-cert"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "tls-gtwy-front-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sHTTPProxyForResource(validation.SourceRadius, "tls-gtwy-gtwy",
+							"Applications.Core/gateways", name),
+
+						validation.NewK8sHTTPProxyForResource(validation.SourceRadius, "tls-gtwy-front-rte",
+							"Applications.Core/httpRoutes", name),
+						validation.NewK8sServiceForResource(validation.SourceRadius, "tls-gtwy-front-rte",
+							"Applications.Core/gateways", name),
+
+						validation.NewK8sSecretForResource(validation.SourceRadius, "tls-gtwy-cert",
+							"Applications.Core/secretStores", name),
 					},
 				},
 			},

--- a/test/functional/shared/resources/kubemetadata_container_test.go
+++ b/test/functional/shared/resources/kubemetadata_container_test.go
@@ -67,7 +67,8 @@ func Test_KubeMetadataContainer(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "corerp-kmd-ctnr"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "corerp-kmd-ctnr",
+							"Applications.Core/containers", name),
 					},
 				},
 			},

--- a/test/functional/shared/resources/kubemetadata_gateway_test.go
+++ b/test/functional/shared/resources/kubemetadata_gateway_test.go
@@ -75,13 +75,24 @@ func Test_Gateway_KubernetesMetadata(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "http-gtwy-front-ctnr-kme"),
-						validation.NewK8sPodForResource(name, "http-gtwy-back-ctnr-kme"),
-						validation.NewK8sHTTPProxyForResource(name, "http-gtwy-kme"),
-						validation.NewK8sHTTPProxyForResource(name, "http-gtwy-front-rte-kme"),
-						validation.NewK8sServiceForResource(name, "http-gtwy-front-rte-kme"),
-						validation.NewK8sHTTPProxyForResource(name, "http-gtwy-back-rte-kme"),
-						validation.NewK8sServiceForResource(name, "http-gtwy-back-rte-kme"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "http-gtwy-front-ctnr-kme",
+							"Applications.Core/containers", name),
+
+						validation.NewK8sPodForResource(validation.SourceRadius, "http-gtwy-back-ctnr-kme",
+							"Applications.Core/containers", name),
+
+						validation.NewK8sHTTPProxyForResource(validation.SourceRadius, "http-gtwy-kme",
+							"Applications.Core/httpRoutes", name),
+
+						validation.NewK8sHTTPProxyForResource(validation.SourceRadius, "http-gtwy-front-rte-kme",
+							"Applications.Core/httpRoutes", name),
+						validation.NewK8sServiceForResource(validation.SourceRadius, "http-gtwy-front-rte-kme",
+							"Applications.Core/gateways", name),
+
+						validation.NewK8sHTTPProxyForResource(validation.SourceRadius, "http-gtwy-back-rte-kme",
+							"Applications.Core/httpRoutes", name),
+						validation.NewK8sServiceForResource(validation.SourceRadius, "http-gtwy-back-rte-kme",
+							"Applications.Core/gateways", name),
 					},
 				},
 			},

--- a/test/functional/shared/resources/kubemetadata_httproute_test.go
+++ b/test/functional/shared/resources/kubemetadata_httproute_test.go
@@ -73,8 +73,10 @@ func Test_KubeMetadataHTTPRoute(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "ctnr-rte-kme-ctnr"),
-						validation.NewK8sServiceForResource(name, "ctnr-rte-kme"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "ctnr-rte-kme-ctnr",
+							"Applications.Core/containers", name),
+						validation.NewK8sServiceForResource(validation.SourceRadius, "ctnr-rte-kme",
+							"Applications.Core/httpRoutes", name),
 					},
 				},
 			},

--- a/test/functional/shared/resources/kubmetadata_cascade_test.go
+++ b/test/functional/shared/resources/kubmetadata_cascade_test.go
@@ -91,7 +91,8 @@ func Test_KubeMetadataCascade(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "corerp-kmd-cascade-ctnr"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "corerp-kmd-cascade-ctnr",
+							"Applications.Core/containers", name),
 					},
 				},
 			},

--- a/test/functional/shared/resources/persistent_volume_test.go
+++ b/test/functional/shared/resources/persistent_volume_test.go
@@ -58,7 +58,8 @@ func Test_PersistentVolume(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "volume-azkv-ctnr"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "volume-azkv-ctnr",
+							"Applications.Core/containers", name),
 					},
 				},
 			},

--- a/test/functional/shared/resources/recipe_terraform_test.go
+++ b/test/functional/shared/resources/recipe_terraform_test.go
@@ -90,12 +90,12 @@ func Test_TerraformRecipe_KubernetesRedis(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appName: {
-						validation.NewK8sServiceForResource(appName, redisCacheName).
-							ValidateLabels(false),
+						validation.NewK8sServiceForResource(validation.SourceRecipeEngine, redisCacheName,
+							"Applications.Core/extenders", appName),
 					},
 					secretNamespace: {
-						validation.NewK8sSecretForResourceWithResourceName(secretPrefix + secretSuffix).
-							ValidateLabels(false),
+						validation.NewK8sSecretForResource(validation.SourceK8sExtensibility, secretPrefix+secretSuffix,
+							"", appName),
 					},
 				},
 			},
@@ -143,11 +143,12 @@ func Test_TerraformRecipe_Context(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sSecretForResource(name, name),
+						validation.NewK8sSecretForResource(validation.SourceRecipeEngine, name,
+							"Applications.Core/extenders", name),
 					},
 					secretNamespace: {
-						validation.NewK8sSecretForResourceWithResourceName(secretPrefix + secretSuffix).
-							ValidateLabels(false),
+						validation.NewK8sSecretForResource(validation.SourceK8sExtensibility, secretPrefix+secretSuffix,
+							"", name),
 					},
 				},
 			},

--- a/test/functional/shared/resources/storage_test.go
+++ b/test/functional/shared/resources/storage_test.go
@@ -54,7 +54,8 @@ func Test_Storage(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "azstorage-ctnr"),
+						validation.NewK8sPodForResource(validation.SourceRadius, "azstorage-ctnr",
+							"Applications.Core/containers", name),
 					},
 				},
 			},

--- a/test/functional/shared/resources/testdata/corerp-resources-container-optional-port-scheme.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-container-optional-port-scheme.bicep
@@ -78,7 +78,6 @@ resource containerqi 'Applications.Core/containers@2023-10-01-preview' = {
           containerPort: 3000
         }
       }
-      
     }
   }
 }

--- a/test/functional/shared/resources/testdata/corerp-resources-gateway-sslpassthrough.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-gateway-sslpassthrough.bicep
@@ -1,7 +1,3 @@
-import kubernetes as kubernetes {
-  kubeConfig: ''
-  namespace: 'default'
-}
 import radius as radius
 
 @description('Specifies the location for resources.')

--- a/test/functional/shared/resources/testdata/corerp-resources-gateway-tlstermination.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-gateway-tlstermination.bicep
@@ -22,6 +22,7 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
   }
 }
 
+// This is not being referenced by any other resource. Should it be deleted?
 resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
   name: 'tls-gtwy-gtwy'
   properties: {

--- a/test/functional/shared/resources/testdata/modules/redis-selfhost.bicep
+++ b/test/functional/shared/resources/testdata/modules/redis-selfhost.bicep
@@ -25,7 +25,7 @@ resource redis 'apps/Deployment@v1' = {
           resource: name
 
           // Label pods with the application name so `rad run` can find the logs.
-          'radius.dev/application': application == '' ? '' : application
+          'radius.dev/application': application
         }
       }
       spec: {
@@ -66,6 +66,11 @@ resource svc 'core/Service@v1' = {
     selector: {
       app: 'redis'
       resource: name
+
+      // Label pods with the application name so `rad run` can find the logs.
+      'radius.dev/application': application
+      'radius.dev/resource': name
+      'radius.dev/resource-type': 'applications.datastores-rediscaches'
     }
     ports: [
       {

--- a/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/dapr-pubsub-broker.bicep
+++ b/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/dapr-pubsub-broker.bicep
@@ -18,6 +18,11 @@ resource dapr 'dapr.io/Component@v1alpha1' = {
   metadata: {
     name: context.resource.name
     namespace: context.runtime.kubernetes.namespace
+    labels: {
+      'radius.dev/application': context.application.name
+      'radius.dev/resource': context.resource.name
+      'radius.dev/resource-type': 'applications.dapr-pubsubbrokers'
+    }
   }
   spec: {
     type: 'pubsub.redis'

--- a/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/dapr-secret-store.bicep
+++ b/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/dapr-secret-store.bicep
@@ -9,6 +9,11 @@ resource dapr 'dapr.io/Component@v1alpha1' = {
   metadata: {
     name: context.resource.name
     namespace: context.runtime.kubernetes.namespace
+    labels: {
+      'radius.dev/application': context.application.name
+      'radius.dev/resource': context.resource.name
+      'radius.dev/resource-type': 'applications.dapr-secretstores'
+    }
   }
   spec: {
     type: 'secretstores.kubernetes'

--- a/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/dapr-state-store.bicep
+++ b/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/dapr-state-store.bicep
@@ -18,6 +18,11 @@ resource dapr 'dapr.io/Component@v1alpha1' = {
   metadata: {
     name: context.resource.name
     namespace: context.runtime.kubernetes.namespace
+    labels: {
+      'radius.dev/application': context.application.name
+      'radius.dev/resource': context.resource.name
+      'radius.dev/resource-type': 'applications.dapr-statestores'
+    }
   }
   spec: {
     type: 'state.redis'

--- a/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/extender-recipe.bicep
+++ b/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/extender-recipe.bicep
@@ -44,6 +44,11 @@ resource extender 'apps/Deployment@v1' = {
 resource svc 'core/Service@v1' = {
   metadata: {
     name: 'extender-${uniqueString(context.resource.id)}'
+    labels: {
+      'radius.dev/application': context.application.name
+      'radius.dev/resource': context.resource.name
+      'radius.dev/resource-type': 'applications.core-extenders'
+    }
   }
   spec: {
     type: 'ClusterIP'

--- a/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/rabbitmq-recipe.bicep
+++ b/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/rabbitmq-recipe.bicep
@@ -59,7 +59,12 @@ resource rabbitmq 'apps/Deployment@v1' = {
 
 resource svc 'core/Service@v1' = {
   metadata: {
-    name: 'rabbitmq-${uniqueString(context.resource.id)}'
+    name: context.resource.name
+    labels: {
+      'radius.dev/application': context.application.name
+      'radius.dev/resource': context.resource.name
+      'radius.dev/resource-type': 'applications.messaging-rabbitmqqueues'
+    }
   }
   spec: {
     type: 'ClusterIP'

--- a/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/redis-recipe-value-backed.bicep
+++ b/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/redis-recipe-value-backed.bicep
@@ -43,6 +43,11 @@ resource redis 'apps/Deployment@v1' = {
 resource svc 'core/Service@v1' = {
   metadata: {
     name: 'redis-${uniqueString(context.resource.id)}'
+    labels: {
+      'radius.dev/application': context.application.name
+      'radius.dev/resource': context.resource.name
+      'radius.dev/resource-type': 'applications.datastores-rediscaches'
+    }
   }
   spec: {
     type: 'ClusterIP'

--- a/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/sqldb-recipe.bicep
+++ b/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/sqldb-recipe.bicep
@@ -76,6 +76,11 @@ resource sql 'apps/Deployment@v1' = {
 resource svc 'core/Service@v1' = {
   metadata: {
     name: 'sql-${uniqueString(context.resource.id)}'
+    labels: {
+      'radius.dev/application': context.application.name
+      'radius.dev/resource': context.resource.name
+      'radius.dev/resource-type': 'applications.datastores-sqldatabases'
+    }
   }
   spec: {
     type: 'ClusterIP'

--- a/test/functional/shared/resources/testdata/recipes/test-terraform-recipes/k8ssecret-context/main.tf
+++ b/test/functional/shared/resources/testdata/recipes/test-terraform-recipes/k8ssecret-context/main.tf
@@ -16,6 +16,7 @@ resource "kubernetes_secret" "recipe-context" {
     labels = {
       "radius.dev/application" = var.context.application.name
       "radius.dev/resource" =  var.context.resource.name
+      "radius.dev/resource-type" = "applications.core-extenders"
     }
   }
 

--- a/test/functional/shared/resources/testdata/recipes/test-terraform-recipes/kubernetes-redis/main.tf
+++ b/test/functional/shared/resources/testdata/recipes/test-terraform-recipes/kubernetes-redis/main.tf
@@ -49,6 +49,11 @@ resource "kubernetes_service" "redis" {
   metadata {
     name = var.redis_cache_name
     namespace = var.context.runtime.kubernetes.namespace
+    labels = {
+      "radius.dev/application" = var.context.application.name
+      "radius.dev/resource" = var.redis_cache_name
+      "radius.dev/resource-type" = "applications.core-extenders"
+    }
   }
 
   spec {

--- a/test/validation/k8s_test.go
+++ b/test/validation/k8s_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package validation
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func Test_compareActualAndExpectedResources(t *testing.T) {
+	type args struct {
+		expectedResources []K8sObject
+		actualResources   []unstructured.Unstructured
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Dapr Pub Sub Broker Manual Deployment - Success",
+			args: args{
+				expectedResources: []K8sObject{
+					{
+						GroupVersionResource: schema.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Kind:         "Pod",
+						ResourceName: "dpsb-manual-app-ctnr",
+						Labels: map[string]string{
+							"radius.dev/application":   "dpsb-manual-app",
+							"radius.dev/resource":      "dpsb-manual-app-ctnr",
+							"radius.dev/resource-type": "applications.core-containers",
+						},
+						Source: SourceRadius,
+					},
+					{
+						GroupVersionResource: schema.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Kind:         "Pod",
+						ResourceName: "dpsb-manual-redis",
+						Source:       SourceRadius,
+					},
+					{
+						GroupVersionResource: schema.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "services",
+						},
+						Kind:         "Service",
+						ResourceName: "dpsb-manual-redis",
+						Source:       SourceRadius,
+					},
+					{
+						GroupVersionResource: schema.GroupVersionResource{
+							Group:    "dapr.io",
+							Version:  "v1alpha1",
+							Resource: "components",
+						},
+						Kind:         "Component",
+						ResourceName: "dpsb-manual",
+						Source:       SourceRadius,
+					},
+				},
+				actualResources: []unstructured.Unstructured{
+					{
+						Object: map[string]any{
+							"kind":       "Pod",
+							"apiVersion": "v1",
+							"metadata": map[string]any{
+								"name":      "dpsb-manual-app-ctnr-f57c99cbd-gk2sw",
+								"namespace": "default",
+								"labels": map[string]any{
+									"radius.dev/application":   "dpsb-manual-app",
+									"radius.dev/resource":      "dpsb-manual-app-ctnr",
+									"radius.dev/resource-type": "applications.core-containers",
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]any{
+							"kind":       "Pod",
+							"apiVersion": "v1",
+							"metadata": map[string]any{
+								"name":      "dpsb-manual-redis",
+								"namespace": "default",
+							},
+						},
+					},
+					{
+						Object: map[string]any{
+							"kind":       "Service",
+							"apiVersion": "v1",
+							"metadata": map[string]any{
+								"name":      "dpsb-manual-redis",
+								"namespace": "default",
+							},
+						},
+					},
+					{
+						Object: map[string]any{
+							"kind":       "Component",
+							"apiVersion": "dapr.io/v1alpha1",
+							"metadata": map[string]any{
+								"name":      "dpsb-manual",
+								"namespace": "default",
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Dapr Pub Sub Broker Manual Deployment - Missing Resource",
+			args: args{
+				expectedResources: []K8sObject{
+					{
+						GroupVersionResource: schema.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Kind:         "Pod",
+						ResourceName: "dpsb-manual-app-ctnr",
+						Labels: map[string]string{
+							"radius.dev/application":   "dpsb-manual-app",
+							"radius.dev/resource":      "dpsb-manual-app-ctnr",
+							"radius.dev/resource-type": "applications.core-containers",
+						},
+						Source: SourceRadius,
+					},
+					{
+						GroupVersionResource: schema.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "pods",
+						},
+						Kind:         "Pod",
+						ResourceName: "dpsb-manual-redis",
+						Source:       SourceRadius,
+					},
+					{
+						GroupVersionResource: schema.GroupVersionResource{
+							Group:    "",
+							Version:  "v1",
+							Resource: "services",
+						},
+						Kind:         "Service",
+						ResourceName: "dpsb-manual-redis",
+						Source:       SourceRadius,
+					},
+					{
+						GroupVersionResource: schema.GroupVersionResource{
+							Group:    "dapr.io",
+							Version:  "v1alpha1",
+							Resource: "components",
+						},
+						Kind:         "Component",
+						ResourceName: "dpsb-manual",
+						Source:       SourceRadius,
+					},
+				},
+				actualResources: []unstructured.Unstructured{
+					{
+						Object: map[string]any{
+							"kind":       "Pod",
+							"apiVersion": "v1",
+							"metadata": map[string]any{
+								"name":      "dpsb-manual-app-ctnr-f57c99cbd-gk2sw",
+								"namespace": "default",
+								"labels": map[string]any{
+									"radius.dev/application":   "dpsb-manual-app",
+									"radius.dev/resource":      "dpsb-manual-app-ctnr",
+									"radius.dev/resource-type": "applications.core-containers",
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]any{
+							"kind":       "Pod",
+							"apiVersion": "v1",
+							"metadata": map[string]any{
+								"name":      "dpsb-manual-redis",
+								"namespace": "default",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compareActualAndExpectedResources(tt.args.expectedResources, tt.args.actualResources); got != tt.want {
+				t.Errorf("compareActualAndExpectedResources() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description
Validating labels of k8s resources in functional tests.

**Updating this task based on the discussion with @rynowak and @vishwahiremat.**

When writing functional tests for Radius, we should keep in mind that there are 3 ways of creating an object. These are:

Objects that are created by the Radius RP,
Objects that are created by the Recipe Engine,
Objects that are created by the functional test itself by using Kubernetes Extensibility.

During the validation phase of a functional test, we need to make sure that the resources that are created, the actual resources, should have some certain labels. We have decided that the labels that the functional test should look for during validation are:

Resource Name (key for this label is radius.dev/resource),
Application Name (key for this label is radius.dev/application),
Resource Type (key for this label is radius.dev/resource-type).

We should look for all three of these labels when we are validating the resources that are created by the Radius RP and the Recipe Engine but only validate the resource name for the resources that are created by the functional test itself.

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #6136 

## Auto-generated summary

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a7e1917</samp>

### Summary
🏷️🧪📈

<!--
1.  🏷️ - This emoji represents the label validation that is enabled by these changes. It also conveys the idea of tagging or categorizing the resources with the `radius.io/managed-by` label.
2.  🧪 - This emoji represents the testing and validation that is performed by these changes. It also conveys the idea of experimentation and discovery of the resource functionality.
3.  📈 - This emoji represents the improvement and enhancement that these changes bring to the test coverage and consistency. It also conveys the idea of growth and progress of the resource quality.
-->
This pull request removes the code that disabled label validation for various resources in the functional tests. The goal is to improve the test coverage and consistency for the `radius.io/managed-by` label across different resource types and scenarios. The affected files are `dapr_pubsub_test.go`, `dapr_secretstore_test.go`, `dapr_statestore_test.go`, `mongodb_test.go`, `recipe_terraform_test.go`, `sql_test.go`, and `rabbitmq_test.go`.

> _Oh we are the `radius` crew and we sail the code sea_
> _We test our labels every time, we don't skip them, no siree_
> _So heave away, me hearties, heave away with glee_
> _We'll make our code more consistent with every `ValidateLabels` we free_

### Walkthrough
*  Enable label validation for Dapr PubSub Broker resources in manual and recipe tests ([link](https://github.com/radius-project/radius/pull/6279/files?diff=unified&w=0#diff-ff5eda5a82d6f745eb41d6b3c9fa5c8905ddf5a53afb464c04ae69b363186d6cL60-R62), [link](https://github.com/radius-project/radius/pull/6279/files?diff=unified&w=0#diff-ff5eda5a82d6f745eb41d6b3c9fa5c8905ddf5a53afb464c04ae69b363186d6cL116-R113))
*  Enable label validation for Dapr Secret Store resources in manual and recipe tests ([link](https://github.com/radius-project/radius/pull/6279/files?diff=unified&w=0#diff-83abcb90756fde07a7163fb12a1c3418edd97afae0e6803e5d91fc72529db36dL59-R59), [link](https://github.com/radius-project/radius/pull/6279/files?diff=unified&w=0#diff-83abcb90756fde07a7163fb12a1c3418edd97afae0e6803e5d91fc72529db36dL107-R105))
*  Enable label validation for Dapr State Store resources in manual and recipe tests ([link](https://github.com/radius-project/radius/pull/6279/files?diff=unified&w=0#diff-76b95c6cdc2b6c63edfb330450c6fe417de962651ae89502e88af3b31555272aL60-R63), [link](https://github.com/radius-project/radius/pull/6279/files?diff=unified&w=0#diff-76b95c6cdc2b6c63edfb330450c6fe417de962651ae89502e88af3b31555272aL118-R114))
*  Enable label validation for MongoDB resources in manual and recipe tests, including parameters and context ([link](https://github.com/radius-project/radius/pull/6279/files?diff=unified&w=0#diff-3537a95d4323706fe81435869ceaee11338952061d8f3c4d4c0dd526d761b440L69-R71), [link](https://github.com/radius-project/radius/pull/6279/files?diff=unified&w=0#diff-3537a95d4323706fe81435869ceaee11338952061d8f3c4d4c0dd526d761b440L117-R117), [link](https://github.com/radius-project/radius/pull/6279/files?diff=unified&w=0#diff-3537a95d4323706fe81435869ceaee11338952061d8f3c4d4c0dd526d761b440L173-R173), [link](https://github.com/radius-project/radius/pull/6279/files?diff=unified&w=0#diff-3537a95d4323706fe81435869ceaee11338952061d8f3c4d4c0dd526d761b440L228-R228))
*  Enable label validation for SQL Database resources in recipe test ([link](https://github.com/radius-project/radius/pull/6279/files?diff=unified&w=0#diff-61544cabd23b93b06160db8c149184ecef9601bfc914d7c095e623243cce34ecL115-R116))
*  Enable label validation for RabbitMQ resources in recipe test ([link](https://github.com/radius-project/radius/pull/6279/files?diff=unified&w=0#diff-e16f5cab974f71f4df44663630ca48bc4230cf6d4ecccef1e4f494322a63677bL107-R108))
*  Enable label validation for Terraform Recipe resources in Kubernetes Redis and context tests ([link](https://github.com/radius-project/radius/pull/6279/files?diff=unified&w=0#diff-94178e873ad0fe96b700c75fe85d086b4ad1a4dae5f448e6f5bcc5f706b89995L93-R96), [link](https://github.com/radius-project/radius/pull/6279/files?diff=unified&w=0#diff-94178e873ad0fe96b700c75fe85d086b4ad1a4dae5f448e6f5bcc5f706b89995L149-R147))


