### PR TITLE
[Do Not Merge]  Populate Terraform recipe deployed resource IDs in recipe output

### DIFF
--- a/pkg/corerp/processors/extenders/processor.go
+++ b/pkg/corerp/processors/extenders/processor.go
@@ -53,7 +53,7 @@ func (p *Processor) Delete(ctx context.Context, resource *datamodel.Extender, op
 	return nil
 }
 
-func mergeOutputValues(properties map[string]any, recipeOutput *recipes.RecipeOutput, secret bool) map[string]any {
+func mergeOutputValues(properties map[string]any, recipeOutput *recipes.RecipeOutputResponse, secret bool) map[string]any {
 	values := make(map[string]any)
 	for k, val := range properties {
 		values[k] = val

--- a/pkg/corerp/processors/extenders/processor_test.go
+++ b/pkg/corerp/processors/extenders/processor_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/radius-project/radius/pkg/portableresources/processors"
 	"github.com/radius-project/radius/pkg/recipes"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
+	"github.com/radius-project/radius/pkg/to"
+	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,11 +39,19 @@ func Test_Process(t *testing.T) {
 	processor := Processor{}
 	t.Run("success - recipe", func(t *testing.T) {
 		resource := &datamodel.Extender{}
+		outputResources := []rpv1.OutputResource{}
+		for _, resource := range []string{extenderResourceID1} {
+			id, err := resources.ParseResource(resource)
+			require.NoError(t, err)
+			result := rpv1.OutputResource{
+				ID:            id,
+				RadiusManaged: to.Ptr(true),
+			}
+			outputResources = append(outputResources, result)
+		}
 		options := processors.Options{
 			RecipeOutput: &recipes.RecipeOutput{
-				Resources: []string{
-					extenderResourceID1,
-				},
+				OutputResources: outputResources,
 				Values: map[string]any{
 					"bucketName": "myBucket",
 					"region":     "westus",
@@ -74,7 +84,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		expectedOutputResources, err := processors.GetOutputResourcesFromRecipe(options.RecipeOutput)
+		expectedOutputResources := options.RecipeOutput.OutputResources
 		require.NoError(t, err)
 
 		require.Equal(t, expectedValues, resource.ComputedValues)
@@ -123,11 +133,19 @@ func Test_Process(t *testing.T) {
 				},
 			},
 		}
+		outputResources := []rpv1.OutputResource{}
+		for _, resource := range []string{extenderResourceID2} {
+			id, err := resources.ParseResource(resource)
+			require.NoError(t, err)
+			result := rpv1.OutputResource{
+				ID:            id,
+				RadiusManaged: to.Ptr(true),
+			}
+			outputResources = append(outputResources, result)
+		}
 		options := processors.Options{
 			RecipeOutput: &recipes.RecipeOutput{
-				Resources: []string{
-					extenderResourceID2,
-				},
+				OutputResources: outputResources,
 				// Values and secrets will be overridden by the resource.
 				Values: map[string]any{
 					"bucketName": "myBucket2",
@@ -155,7 +173,7 @@ func Test_Process(t *testing.T) {
 
 		expectedOutputResources := []rpv1.OutputResource{}
 
-		recipeOutputResources, err := processors.GetOutputResourcesFromRecipe(options.RecipeOutput)
+		recipeOutputResources := options.RecipeOutput.OutputResources
 		require.NoError(t, err)
 		expectedOutputResources = append(expectedOutputResources, recipeOutputResources...)
 
@@ -196,11 +214,19 @@ func Test_MergeOutputValues(t *testing.T) {
 	secretsMap := mergeOutputValues(resource.Properties.Secrets, nil, true)
 	require.Equal(t, resource.Properties.Secrets, secretsMap)
 
+	outputResources := []rpv1.OutputResource{}
+	for _, resource := range []string{extenderResourceID1} {
+		id, err := resources.ParseResource(resource)
+		require.NoError(t, err)
+		result := rpv1.OutputResource{
+			ID:            id,
+			RadiusManaged: to.Ptr(true),
+		}
+		outputResources = append(outputResources, result)
+	}
 	options := processors.Options{
 		RecipeOutput: &recipes.RecipeOutput{
-			Resources: []string{
-				extenderResourceID1,
-			},
+			OutputResources: outputResources,
 			Values: map[string]any{
 				"region": "westus",
 			},

--- a/pkg/corerp/processors/extenders/processor_test.go
+++ b/pkg/corerp/processors/extenders/processor_test.go
@@ -50,7 +50,7 @@ func Test_Process(t *testing.T) {
 			outputResources = append(outputResources, result)
 		}
 		options := processors.Options{
-			RecipeOutput: &recipes.RecipeOutput{
+			RecipeOutput: &recipes.RecipeOutputResponse{
 				OutputResources: outputResources,
 				Values: map[string]any{
 					"bucketName": "myBucket",
@@ -144,7 +144,7 @@ func Test_Process(t *testing.T) {
 			outputResources = append(outputResources, result)
 		}
 		options := processors.Options{
-			RecipeOutput: &recipes.RecipeOutput{
+			RecipeOutput: &recipes.RecipeOutputResponse{
 				OutputResources: outputResources,
 				// Values and secrets will be overridden by the resource.
 				Values: map[string]any{
@@ -190,7 +190,7 @@ func Test_Process(t *testing.T) {
 				},
 			},
 		}
-		options := processors.Options{RecipeOutput: &recipes.RecipeOutput{}}
+		options := processors.Options{RecipeOutput: &recipes.RecipeOutputResponse{}}
 
 		err := processor.Process(context.Background(), resource, options)
 		require.Error(t, err)
@@ -225,7 +225,7 @@ func Test_MergeOutputValues(t *testing.T) {
 		outputResources = append(outputResources, result)
 	}
 	options := processors.Options{
-		RecipeOutput: &recipes.RecipeOutput{
+		RecipeOutput: &recipes.RecipeOutputResponse{
 			OutputResources: outputResources,
 			Values: map[string]any{
 				"region": "westus",

--- a/pkg/daprrp/processors/pubsubbrokers/processor_test.go
+++ b/pkg/daprrp/processors/pubsubbrokers/processor_test.go
@@ -85,7 +85,7 @@ func Test_Process(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			RecipeOutput: &recipes.RecipeOutput{
+			RecipeOutput: &recipes.RecipeOutputResponse{
 				OutputResources: outputResources,
 				Values:          map[string]any{}, // Component name will be computed for resource name.
 				Secrets:         map[string]any{},
@@ -246,7 +246,7 @@ func Test_Process(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			RecipeOutput: &recipes.RecipeOutput{
+			RecipeOutput: &recipes.RecipeOutputResponse{
 				OutputResources: outputResources,
 
 				// Values and secrets will be overridden by the resource.

--- a/pkg/daprrp/processors/pubsubbrokers/processor_test.go
+++ b/pkg/daprrp/processors/pubsubbrokers/processor_test.go
@@ -42,7 +42,6 @@ import (
 
 func Test_Process(t *testing.T) {
 	const externalResourceID1 = "/subscriptions/0000/resourceGroups/test-group/providers/Microsoft.Cache/redis/myredis1"
-	const externalResourceID2 = "/subscriptions/0000/resourceGroups/test-group/providers/Microsoft.Cache/redis/myredis2"
 	const kubernetesResource = "/planes/kubernetes/local/namespaces/test-namespace/providers/dapr.io/Component/test-component"
 	const appID = "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Core/applications/test-app"
 	const envID = "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Core/environments/test-env"

--- a/pkg/daprrp/processors/pubsubbrokers/processor_test.go
+++ b/pkg/daprrp/processors/pubsubbrokers/processor_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/radius-project/radius/pkg/recipes"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 	"github.com/radius-project/radius/pkg/to"
+	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/radius-project/radius/test/k8sutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,6 +68,16 @@ func Test_Process(t *testing.T) {
 				},
 			},
 		}
+		outputResources := []rpv1.OutputResource{}
+		for _, resource := range []string{externalResourceID1, kubernetesResource} {
+			id, err := resources.ParseResource(resource)
+			require.NoError(t, err)
+			result := rpv1.OutputResource{
+				ID:            id,
+				RadiusManaged: to.Ptr(true),
+			}
+			outputResources = append(outputResources, result)
+		}
 
 		options := processors.Options{
 			RuntimeConfiguration: recipes.RuntimeConfiguration{
@@ -75,12 +86,9 @@ func Test_Process(t *testing.T) {
 				},
 			},
 			RecipeOutput: &recipes.RecipeOutput{
-				Resources: []string{
-					externalResourceID1,
-					kubernetesResource,
-				},
-				Values:  map[string]any{}, // Component name will be computed for resource name.
-				Secrets: map[string]any{},
+				OutputResources: outputResources,
+				Values:          map[string]any{}, // Component name will be computed for resource name.
+				Secrets:         map[string]any{},
 			},
 		}
 
@@ -94,7 +102,7 @@ func Test_Process(t *testing.T) {
 		}
 		expectedSecrets := map[string]rpv1.SecretValueReference{}
 
-		expectedOutputResources, err := processors.GetOutputResourcesFromRecipe(options.RecipeOutput)
+		expectedOutputResources := options.RecipeOutput.OutputResources
 		require.NoError(t, err)
 
 		require.Equal(t, expectedValues, resource.ComputedValues)
@@ -222,7 +230,16 @@ func Test_Process(t *testing.T) {
 				},
 			},
 		}
-
+		outputResources := []rpv1.OutputResource{}
+		for _, resource := range []string{externalResourceID1, kubernetesResource} {
+			id, err := resources.ParseResource(resource)
+			require.NoError(t, err)
+			result := rpv1.OutputResource{
+				ID:            id,
+				RadiusManaged: to.Ptr(true),
+			}
+			outputResources = append(outputResources, result)
+		}
 		options := processors.Options{
 			RuntimeConfiguration: recipes.RuntimeConfiguration{
 				Kubernetes: &recipes.KubernetesRuntime{
@@ -230,10 +247,7 @@ func Test_Process(t *testing.T) {
 				},
 			},
 			RecipeOutput: &recipes.RecipeOutput{
-				Resources: []string{
-					externalResourceID2,
-					kubernetesResource,
-				},
+				OutputResources: outputResources,
 
 				// Values and secrets will be overridden by the resource.
 				Values: map[string]any{
@@ -254,7 +268,7 @@ func Test_Process(t *testing.T) {
 		expectedSecrets := map[string]rpv1.SecretValueReference{}
 		expectedOutputResources := []rpv1.OutputResource{}
 
-		recipeOutputResources, err := processors.GetOutputResourcesFromRecipe(options.RecipeOutput)
+		recipeOutputResources := options.RecipeOutput.OutputResources
 		require.NoError(t, err)
 		expectedOutputResources = append(expectedOutputResources, recipeOutputResources...)
 

--- a/pkg/daprrp/processors/secretstores/processor_test.go
+++ b/pkg/daprrp/processors/secretstores/processor_test.go
@@ -81,7 +81,7 @@ func Test_Process(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			RecipeOutput: &recipes.RecipeOutput{
+			RecipeOutput: &recipes.RecipeOutputResponse{
 				OutputResources: outputResources,
 				Values:          map[string]any{}, // Component name will be computed for resource name.
 				Secrets:         map[string]any{},
@@ -231,7 +231,7 @@ func Test_Process(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			RecipeOutput: &recipes.RecipeOutput{
+			RecipeOutput: &recipes.RecipeOutputResponse{
 				OutputResources: outputResources,
 
 				// Values and secrets will be overridden by the resource.

--- a/pkg/daprrp/processors/secretstores/processor_test.go
+++ b/pkg/daprrp/processors/secretstores/processor_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/radius-project/radius/pkg/recipes"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 	"github.com/radius-project/radius/pkg/to"
+	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/radius-project/radius/test/k8sutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -64,6 +65,16 @@ func Test_Process(t *testing.T) {
 				},
 			},
 		}
+		outputResources := []rpv1.OutputResource{}
+		for _, resource := range []string{kubernetesResource} {
+			id, err := resources.ParseResource(resource)
+			require.NoError(t, err)
+			result := rpv1.OutputResource{
+				ID:            id,
+				RadiusManaged: to.Ptr(true),
+			}
+			outputResources = append(outputResources, result)
+		}
 		options := processors.Options{
 			RuntimeConfiguration: recipes.RuntimeConfiguration{
 				Kubernetes: &recipes.KubernetesRuntime{
@@ -71,11 +82,9 @@ func Test_Process(t *testing.T) {
 				},
 			},
 			RecipeOutput: &recipes.RecipeOutput{
-				Resources: []string{
-					kubernetesResource,
-				},
-				Values:  map[string]any{}, // Component name will be computed for resource name.
-				Secrets: map[string]any{},
+				OutputResources: outputResources,
+				Values:          map[string]any{}, // Component name will be computed for resource name.
+				Secrets:         map[string]any{},
 			},
 		}
 
@@ -89,7 +98,7 @@ func Test_Process(t *testing.T) {
 		}
 		expectedSecrets := map[string]rpv1.SecretValueReference{}
 
-		expectedOutputResources, err := processors.GetOutputResourcesFromRecipe(options.RecipeOutput)
+		expectedOutputResources := options.RecipeOutput.OutputResources
 		require.NoError(t, err)
 
 		require.Equal(t, expectedValues, resource.ComputedValues)
@@ -206,6 +215,16 @@ func Test_Process(t *testing.T) {
 				},
 			},
 		}
+		outputResources := []rpv1.OutputResource{}
+		for _, resource := range []string{kubernetesResource} {
+			id, err := resources.ParseResource(resource)
+			require.NoError(t, err)
+			result := rpv1.OutputResource{
+				ID:            id,
+				RadiusManaged: to.Ptr(true),
+			}
+			outputResources = append(outputResources, result)
+		}
 		options := processors.Options{
 			RuntimeConfiguration: recipes.RuntimeConfiguration{
 				Kubernetes: &recipes.KubernetesRuntime{
@@ -213,9 +232,7 @@ func Test_Process(t *testing.T) {
 				},
 			},
 			RecipeOutput: &recipes.RecipeOutput{
-				Resources: []string{
-					kubernetesResource,
-				},
+				OutputResources: outputResources,
 
 				// Values and secrets will be overridden by the resource.
 				Values: map[string]any{
@@ -237,7 +254,7 @@ func Test_Process(t *testing.T) {
 
 		expectedOutputResources := []rpv1.OutputResource{}
 
-		recipeOutputResources, err := processors.GetOutputResourcesFromRecipe(options.RecipeOutput)
+		recipeOutputResources := options.RecipeOutput.OutputResources
 		require.NoError(t, err)
 		expectedOutputResources = append(expectedOutputResources, recipeOutputResources...)
 		require.Equal(t, expectedValues, resource.ComputedValues)

--- a/pkg/daprrp/processors/statestores/processor_test.go
+++ b/pkg/daprrp/processors/statestores/processor_test.go
@@ -43,7 +43,6 @@ import (
 func Test_Process(t *testing.T) {
 
 	const externalResourceID1 = "/subscriptions/0000/resourceGroups/test-group/providers/Microsoft.Cache/redis/myredis1"
-	const externalResourceID2 = "/subscriptions/0000/resourceGroups/test-group/providers/Microsoft.Cache/redis/myredis2"
 	const kubernetesResource = "/planes/kubernetes/local/namespaces/test-namespace/providers/dapr.io/Component/test-component"
 	const applicationID = "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Core/applications/test-app"
 	const componentName = "test-component"

--- a/pkg/daprrp/processors/statestores/processor_test.go
+++ b/pkg/daprrp/processors/statestores/processor_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/radius-project/radius/pkg/recipes"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 	"github.com/radius-project/radius/pkg/to"
+	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/radius-project/radius/test/k8sutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,6 +68,16 @@ func Test_Process(t *testing.T) {
 				},
 			},
 		}
+		outputResources := []rpv1.OutputResource{}
+		for _, resource := range []string{externalResourceID1, kubernetesResource} {
+			id, err := resources.ParseResource(resource)
+			require.NoError(t, err)
+			result := rpv1.OutputResource{
+				ID:            id,
+				RadiusManaged: to.Ptr(true),
+			}
+			outputResources = append(outputResources, result)
+		}
 		options := processors.Options{
 			RuntimeConfiguration: recipes.RuntimeConfiguration{
 				Kubernetes: &recipes.KubernetesRuntime{
@@ -74,12 +85,9 @@ func Test_Process(t *testing.T) {
 				},
 			},
 			RecipeOutput: &recipes.RecipeOutput{
-				Resources: []string{
-					externalResourceID1,
-					kubernetesResource,
-				},
-				Values:  map[string]any{}, // Component name will be computed for resource name.
-				Secrets: map[string]any{},
+				OutputResources: outputResources,
+				Values:          map[string]any{}, // Component name will be computed for resource name.
+				Secrets:         map[string]any{},
 			},
 		}
 
@@ -93,7 +101,7 @@ func Test_Process(t *testing.T) {
 		}
 		expectedSecrets := map[string]rpv1.SecretValueReference{}
 
-		expectedOutputResources, err := processors.GetOutputResourcesFromRecipe(options.RecipeOutput)
+		expectedOutputResources := options.RecipeOutput.OutputResources
 		require.NoError(t, err)
 
 		require.Equal(t, expectedValues, resource.ComputedValues)
@@ -214,6 +222,16 @@ func Test_Process(t *testing.T) {
 				},
 			},
 		}
+		outputResources := []rpv1.OutputResource{}
+		for _, resource := range []string{externalResourceID1, kubernetesResource} {
+			id, err := resources.ParseResource(resource)
+			require.NoError(t, err)
+			result := rpv1.OutputResource{
+				ID:            id,
+				RadiusManaged: to.Ptr(true),
+			}
+			outputResources = append(outputResources, result)
+		}
 		options := processors.Options{
 			RuntimeConfiguration: recipes.RuntimeConfiguration{
 				Kubernetes: &recipes.KubernetesRuntime{
@@ -221,10 +239,7 @@ func Test_Process(t *testing.T) {
 				},
 			},
 			RecipeOutput: &recipes.RecipeOutput{
-				Resources: []string{
-					externalResourceID2,
-					kubernetesResource,
-				},
+				OutputResources: outputResources,
 
 				// Values and secrets will be overridden by the resource.
 				Values: map[string]any{
@@ -246,7 +261,7 @@ func Test_Process(t *testing.T) {
 
 		expectedOutputResources := []rpv1.OutputResource{}
 
-		recipeOutputResources, err := processors.GetOutputResourcesFromRecipe(options.RecipeOutput)
+		recipeOutputResources := options.RecipeOutput.OutputResources
 		require.NoError(t, err)
 		expectedOutputResources = append(expectedOutputResources, recipeOutputResources...)
 

--- a/pkg/daprrp/processors/statestores/processor_test.go
+++ b/pkg/daprrp/processors/statestores/processor_test.go
@@ -84,7 +84,7 @@ func Test_Process(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			RecipeOutput: &recipes.RecipeOutput{
+			RecipeOutput: &recipes.RecipeOutputResponse{
 				OutputResources: outputResources,
 				Values:          map[string]any{}, // Component name will be computed for resource name.
 				Secrets:         map[string]any{},
@@ -238,7 +238,7 @@ func Test_Process(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			RecipeOutput: &recipes.RecipeOutput{
+			RecipeOutput: &recipes.RecipeOutputResponse{
 				OutputResources: outputResources,
 
 				// Values and secrets will be overridden by the resource.

--- a/pkg/datastoresrp/processors/mongodatabases/processor_test.go
+++ b/pkg/datastoresrp/processors/mongodatabases/processor_test.go
@@ -56,7 +56,7 @@ func Test_Process(t *testing.T) {
 			outputResources = append(outputResources, result)
 		}
 		options := processors.Options{
-			RecipeOutput: &recipes.RecipeOutput{
+			RecipeOutput: &recipes.RecipeOutputResponse{
 				OutputResources: outputResources,
 				Values: map[string]any{
 					"host":     host,
@@ -179,7 +179,7 @@ func Test_Process(t *testing.T) {
 			outputResources = append(outputResources, result)
 		}
 		options := processors.Options{
-			RecipeOutput: &recipes.RecipeOutput{
+			RecipeOutput: &recipes.RecipeOutputResponse{
 				OutputResources: outputResources,
 				// Values and secrets will be overridden by the resource.
 				Values: map[string]any{
@@ -241,7 +241,7 @@ func Test_Process(t *testing.T) {
 
 	t.Run("failure - missing required values", func(t *testing.T) {
 		resource := &datamodel.MongoDatabase{}
-		options := processors.Options{RecipeOutput: &recipes.RecipeOutput{}}
+		options := processors.Options{RecipeOutput: &recipes.RecipeOutputResponse{}}
 
 		err := processor.Process(context.Background(), resource, options)
 		require.Error(t, err)

--- a/pkg/datastoresrp/processors/mongodatabases/processor_test.go
+++ b/pkg/datastoresrp/processors/mongodatabases/processor_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/radius-project/radius/pkg/portableresources/processors"
 	"github.com/radius-project/radius/pkg/recipes"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
+	"github.com/radius-project/radius/pkg/to"
+	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,11 +45,19 @@ func Test_Process(t *testing.T) {
 
 	t.Run("success - recipe", func(t *testing.T) {
 		resource := &datamodel.MongoDatabase{}
+		outputResources := []rpv1.OutputResource{}
+		for _, resource := range []string{azureMongoResourceID1} {
+			id, err := resources.ParseResource(resource)
+			require.NoError(t, err)
+			result := rpv1.OutputResource{
+				ID:            id,
+				RadiusManaged: to.Ptr(true),
+			}
+			outputResources = append(outputResources, result)
+		}
 		options := processors.Options{
 			RecipeOutput: &recipes.RecipeOutput{
-				Resources: []string{
-					azureMongoResourceID1,
-				},
+				OutputResources: outputResources,
 				Values: map[string]any{
 					"host":     host,
 					"port":     port,
@@ -85,7 +95,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		expectedOutputResources, err := processors.GetOutputResourcesFromRecipe(options.RecipeOutput)
+		expectedOutputResources := options.RecipeOutput.OutputResources
 		require.NoError(t, err)
 
 		require.Equal(t, expectedValues, resource.ComputedValues)
@@ -158,11 +168,19 @@ func Test_Process(t *testing.T) {
 				},
 			},
 		}
+		outputResources := []rpv1.OutputResource{}
+		for _, resource := range []string{azureMongoResourceID2} {
+			id, err := resources.ParseResource(resource)
+			require.NoError(t, err)
+			result := rpv1.OutputResource{
+				ID:            id,
+				RadiusManaged: to.Ptr(true),
+			}
+			outputResources = append(outputResources, result)
+		}
 		options := processors.Options{
 			RecipeOutput: &recipes.RecipeOutput{
-				Resources: []string{
-					azureMongoResourceID2,
-				},
+				OutputResources: outputResources,
 				// Values and secrets will be overridden by the resource.
 				Values: map[string]any{
 					"host":     "asdf",
@@ -204,7 +222,7 @@ func Test_Process(t *testing.T) {
 
 		expectedOutputResources := []rpv1.OutputResource{}
 
-		recipeOutputResources, err := processors.GetOutputResourcesFromRecipe(options.RecipeOutput)
+		recipeOutputResources := options.RecipeOutput.OutputResources
 		require.NoError(t, err)
 		expectedOutputResources = append(expectedOutputResources, recipeOutputResources...)
 

--- a/pkg/datastoresrp/processors/rediscaches/processor_test.go
+++ b/pkg/datastoresrp/processors/rediscaches/processor_test.go
@@ -56,7 +56,7 @@ func Test_Process(t *testing.T) {
 			outputResources = append(outputResources, result)
 		}
 		options := processors.Options{
-			RecipeOutput: &recipes.RecipeOutput{
+			RecipeOutput: &recipes.RecipeOutputResponse{
 				OutputResources: outputResources,
 				Values: map[string]any{
 					"host":     host,
@@ -189,7 +189,7 @@ func Test_Process(t *testing.T) {
 			outputResources = append(outputResources, result)
 		}
 		options := processors.Options{
-			RecipeOutput: &recipes.RecipeOutput{
+			RecipeOutput: &recipes.RecipeOutputResponse{
 				OutputResources: outputResources,
 				// Values and secrets will be overridden by the resource.
 				Values: map[string]any{
@@ -254,7 +254,7 @@ func Test_Process(t *testing.T) {
 
 	t.Run("failure - missing required values", func(t *testing.T) {
 		resource := &datamodel.RedisCache{}
-		options := processors.Options{RecipeOutput: &recipes.RecipeOutput{}}
+		options := processors.Options{RecipeOutput: &recipes.RecipeOutputResponse{}}
 
 		err := processor.Process(context.Background(), resource, options)
 		require.Error(t, err)

--- a/pkg/datastoresrp/processors/rediscaches/processor_test.go
+++ b/pkg/datastoresrp/processors/rediscaches/processor_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/radius-project/radius/pkg/portableresources/processors"
 	"github.com/radius-project/radius/pkg/recipes"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
+	"github.com/radius-project/radius/pkg/to"
+	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,11 +45,19 @@ func Test_Process(t *testing.T) {
 
 	t.Run("success - recipe", func(t *testing.T) {
 		resource := &datamodel.RedisCache{}
+		outputResources := []rpv1.OutputResource{}
+		for _, resource := range []string{azureRedisResourceID1} {
+			id, err := resources.ParseResource(resource)
+			require.NoError(t, err)
+			result := rpv1.OutputResource{
+				ID:            id,
+				RadiusManaged: to.Ptr(true),
+			}
+			outputResources = append(outputResources, result)
+		}
 		options := processors.Options{
 			RecipeOutput: &recipes.RecipeOutput{
-				Resources: []string{
-					azureRedisResourceID1,
-				},
+				OutputResources: outputResources,
 				Values: map[string]any{
 					"host":     host,
 					"port":     RedisNonSSLPort,
@@ -90,7 +100,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		expectedOutputResources, err := processors.GetOutputResourcesFromRecipe(options.RecipeOutput)
+		expectedOutputResources := options.RecipeOutput.OutputResources
 		require.NoError(t, err)
 
 		require.Equal(t, expectedValues, resource.ComputedValues)
@@ -168,11 +178,19 @@ func Test_Process(t *testing.T) {
 				},
 			},
 		}
+		outputResources := []rpv1.OutputResource{}
+		for _, resource := range []string{azureRedisResourceID2} {
+			id, err := resources.ParseResource(resource)
+			require.NoError(t, err)
+			result := rpv1.OutputResource{
+				ID:            id,
+				RadiusManaged: to.Ptr(true),
+			}
+			outputResources = append(outputResources, result)
+		}
 		options := processors.Options{
 			RecipeOutput: &recipes.RecipeOutput{
-				Resources: []string{
-					azureRedisResourceID2,
-				},
+				OutputResources: outputResources,
 				// Values and secrets will be overridden by the resource.
 				Values: map[string]any{
 					"host":     "asdf",
@@ -217,7 +235,7 @@ func Test_Process(t *testing.T) {
 
 		expectedOutputResources := []rpv1.OutputResource{}
 
-		recipeOutputResources, err := processors.GetOutputResourcesFromRecipe(options.RecipeOutput)
+		recipeOutputResources := options.RecipeOutput.OutputResources
 		require.NoError(t, err)
 		expectedOutputResources = append(expectedOutputResources, recipeOutputResources...)
 

--- a/pkg/datastoresrp/processors/sqldatabases/processor_test.go
+++ b/pkg/datastoresrp/processors/sqldatabases/processor_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/radius-project/radius/pkg/portableresources/processors"
 	"github.com/radius-project/radius/pkg/recipes"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
+	"github.com/radius-project/radius/pkg/to"
+	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,11 +32,19 @@ func Test_Process(t *testing.T) {
 
 	t.Run("success - recipe", func(t *testing.T) {
 		resource := &datamodel.SqlDatabase{}
+		outputResources := []rpv1.OutputResource{}
+		for _, resource := range []string{azureSqlResourceID} {
+			id, err := resources.ParseResource(resource)
+			require.NoError(t, err)
+			result := rpv1.OutputResource{
+				ID:            id,
+				RadiusManaged: to.Ptr(true),
+			}
+			outputResources = append(outputResources, result)
+		}
 		options := processors.Options{
 			RecipeOutput: &recipes.RecipeOutput{
-				Resources: []string{
-					azureSqlResourceID,
-				},
+				OutputResources: outputResources,
 				Values: map[string]any{
 					"database": database,
 					"server":   server,
@@ -72,7 +82,7 @@ func Test_Process(t *testing.T) {
 			},
 		}
 
-		expectedOutputResources, err := processors.GetOutputResourcesFromRecipe(options.RecipeOutput)
+		expectedOutputResources := options.RecipeOutput.OutputResources
 		require.NoError(t, err)
 
 		require.Equal(t, expectedValues, resource.ComputedValues)
@@ -145,11 +155,19 @@ func Test_Process(t *testing.T) {
 				},
 			},
 		}
+		outputResources := []rpv1.OutputResource{}
+		for _, resource := range []string{azureSqlResourceID} {
+			id, err := resources.ParseResource(resource)
+			require.NoError(t, err)
+			result := rpv1.OutputResource{
+				ID:            id,
+				RadiusManaged: to.Ptr(true),
+			}
+			outputResources = append(outputResources, result)
+		}
 		options := processors.Options{
 			RecipeOutput: &recipes.RecipeOutput{
-				Resources: []string{
-					azureSqlResourceID,
-				},
+				OutputResources: outputResources,
 				// Values and secrets will be overridden by the resource.
 				Values: map[string]any{
 					"database": "override-database",
@@ -190,7 +208,7 @@ func Test_Process(t *testing.T) {
 		}
 		expectedOutputResources := []rpv1.OutputResource{}
 
-		recipeOutputResources, err := processors.GetOutputResourcesFromRecipe(options.RecipeOutput)
+		recipeOutputResources := options.RecipeOutput.OutputResources
 		require.NoError(t, err)
 		expectedOutputResources = append(expectedOutputResources, recipeOutputResources...)
 

--- a/pkg/datastoresrp/processors/sqldatabases/processor_test.go
+++ b/pkg/datastoresrp/processors/sqldatabases/processor_test.go
@@ -43,7 +43,7 @@ func Test_Process(t *testing.T) {
 			outputResources = append(outputResources, result)
 		}
 		options := processors.Options{
-			RecipeOutput: &recipes.RecipeOutput{
+			RecipeOutput: &recipes.RecipeOutputResponse{
 				OutputResources: outputResources,
 				Values: map[string]any{
 					"database": database,
@@ -166,7 +166,7 @@ func Test_Process(t *testing.T) {
 			outputResources = append(outputResources, result)
 		}
 		options := processors.Options{
-			RecipeOutput: &recipes.RecipeOutput{
+			RecipeOutput: &recipes.RecipeOutputResponse{
 				OutputResources: outputResources,
 				// Values and secrets will be overridden by the resource.
 				Values: map[string]any{
@@ -227,7 +227,7 @@ func Test_Process(t *testing.T) {
 
 	t.Run("failure - missing required values", func(t *testing.T) {
 		resource := &datamodel.SqlDatabase{}
-		options := processors.Options{RecipeOutput: &recipes.RecipeOutput{}}
+		options := processors.Options{RecipeOutput: &recipes.RecipeOutputResponse{}}
 
 		err := processor.Process(context.Background(), resource, options)
 		require.Error(t, err)

--- a/pkg/messagingrp/processors/rabbitmqqueues/processor_test.go
+++ b/pkg/messagingrp/processors/rabbitmqqueues/processor_test.go
@@ -55,7 +55,7 @@ func Test_Process(t *testing.T) {
 			outputResources = append(outputResources, result)
 		}
 		options := processors.Options{
-			RecipeOutput: &recipes.RecipeOutput{
+			RecipeOutput: &recipes.RecipeOutputResponse{
 				OutputResources: outputResources,
 				Values: map[string]any{
 					"queue":    queue,
@@ -148,7 +148,7 @@ func Test_Process(t *testing.T) {
 			outputResources = append(outputResources, result)
 		}
 		options := processors.Options{
-			RecipeOutput: &recipes.RecipeOutput{
+			RecipeOutput: &recipes.RecipeOutputResponse{
 				OutputResources: outputResources,
 				// Values and secrets will be overridden by the resource.
 				Values: map[string]any{
@@ -196,7 +196,7 @@ func Test_Process(t *testing.T) {
 
 	t.Run("failure - missing required values", func(t *testing.T) {
 		resource := &datamodel.RabbitMQQueue{}
-		options := processors.Options{RecipeOutput: &recipes.RecipeOutput{}}
+		options := processors.Options{RecipeOutput: &recipes.RecipeOutputResponse{}}
 
 		err := processor.Process(context.Background(), resource, options)
 		require.Error(t, err)

--- a/pkg/messagingrp/processors/rabbitmqqueues/processor_test.go
+++ b/pkg/messagingrp/processors/rabbitmqqueues/processor_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/radius-project/radius/pkg/portableresources/processors"
 	"github.com/radius-project/radius/pkg/recipes"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
+	"github.com/radius-project/radius/pkg/to"
+	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,9 +44,19 @@ func Test_Process(t *testing.T) {
 
 	t.Run("success - recipe", func(t *testing.T) {
 		resource := &datamodel.RabbitMQQueue{}
+		outputResources := []rpv1.OutputResource{}
+		for _, resource := range rabbitMQOutputResources {
+			id, err := resources.ParseResource(resource)
+			require.NoError(t, err)
+			result := rpv1.OutputResource{
+				ID:            id,
+				RadiusManaged: to.Ptr(true),
+			}
+			outputResources = append(outputResources, result)
+		}
 		options := processors.Options{
 			RecipeOutput: &recipes.RecipeOutput{
-				Resources: rabbitMQOutputResources,
+				OutputResources: outputResources,
 				Values: map[string]any{
 					"queue":    queue,
 					"host":     host,
@@ -79,7 +91,7 @@ func Test_Process(t *testing.T) {
 				Value: "amqps://test-user:test-password@test-host:5672/test-vHost",
 			},
 		}
-		expectedOutputResources, err := processors.GetOutputResourcesFromRecipe(options.RecipeOutput)
+		expectedOutputResources := options.RecipeOutput.OutputResources
 		require.NoError(t, err)
 
 		require.Equal(t, expectedValues, resource.ComputedValues)
@@ -125,9 +137,19 @@ func Test_Process(t *testing.T) {
 				},
 			},
 		}
+		outputResources := []rpv1.OutputResource{}
+		for _, resource := range rabbitMQOutputResources {
+			id, err := resources.ParseResource(resource)
+			require.NoError(t, err)
+			result := rpv1.OutputResource{
+				ID:            id,
+				RadiusManaged: to.Ptr(true),
+			}
+			outputResources = append(outputResources, result)
+		}
 		options := processors.Options{
 			RecipeOutput: &recipes.RecipeOutput{
-				Resources: rabbitMQOutputResources,
+				OutputResources: outputResources,
 				// Values and secrets will be overridden by the resource.
 				Values: map[string]any{
 					"queue":    queue,
@@ -163,7 +185,7 @@ func Test_Process(t *testing.T) {
 		}
 		expectedOutputResources := []rpv1.OutputResource{}
 
-		recipeOutputResources, err := processors.GetOutputResourcesFromRecipe(options.RecipeOutput)
+		recipeOutputResources := options.RecipeOutput.OutputResources
 		require.NoError(t, err)
 		expectedOutputResources = append(expectedOutputResources, recipeOutputResources...)
 

--- a/pkg/portableresources/backend/controller/createorupdateresource.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource.go
@@ -136,7 +136,7 @@ func (c *CreateOrUpdateResource[P, T]) copyOutputResources(data P) []string {
 	return previousOutputResources
 }
 
-func (c *CreateOrUpdateResource[P, T]) executeRecipeIfNeeded(ctx context.Context, data P, prevState []string) (*recipes.RecipeOutput, error) {
+func (c *CreateOrUpdateResource[P, T]) executeRecipeIfNeeded(ctx context.Context, data P, prevState []string) (*recipes.RecipeOutputResponse, error) {
 	// 'any' is required here to convert to an interface type, only then can we use a type assertion.
 	recipeDataModel, supportsRecipes := any(data).(datamodel.RecipeDataModel)
 	if !supportsRecipes {

--- a/pkg/portableresources/backend/controller/createorupdateresource_test.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource_test.go
@@ -350,7 +350,7 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 						},
 						PreviousState: prevState,
 					}).
-					Return(&recipes.RecipeOutput{}, tt.recipeErr).
+					Return(&recipes.RecipeOutputResponse{}, tt.recipeErr).
 					Times(1)
 			} else if stillPassing {
 				eng.EXPECT().
@@ -360,7 +360,7 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 						},
 						PreviousState: prevState,
 					}).
-					Return(&recipes.RecipeOutput{}, nil).
+					Return(&recipes.RecipeOutputResponse{}, nil).
 					Times(1)
 			}
 

--- a/pkg/portableresources/processors/types.go
+++ b/pkg/portableresources/processors/types.go
@@ -45,7 +45,7 @@ type Options struct {
 	RuntimeConfiguration recipes.RuntimeConfiguration
 
 	// RecipeOutput represents the output of executing a recipe (may be nil).
-	RecipeOutput *recipes.RecipeOutput
+	RecipeOutput *recipes.RecipeOutputResponse
 }
 
 // ValidationError represents a user-facing validation message reported by the processor.

--- a/pkg/portableresources/processors/util.go
+++ b/pkg/portableresources/processors/util.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/radius-project/radius/pkg/portableresources"
-	"github.com/radius-project/radius/pkg/recipes"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 	"github.com/radius-project/radius/pkg/to"
 	"github.com/radius-project/radius/pkg/ucp/resources"
@@ -49,21 +48,21 @@ func GetOutputResourcesFromResourcesField(field []*portableresources.ResourceRef
 
 // GetOutputResourcesFromRecipe parses the output resources from a recipe and returns a slice of OutputResource objects,
 // returning an error if any of the resources are invalid.
-func GetOutputResourcesFromRecipe(output *recipes.RecipeOutput) ([]rpv1.OutputResource, error) {
-	results := []rpv1.OutputResource{}
-	for _, resource := range output.Resources {
-		id, err := resources.ParseResource(resource)
-		if err != nil {
-			return nil, &ValidationError{Message: fmt.Sprintf("resource id %q returned by recipe is invalid", resource)}
-		}
+// func GetOutputResourcesFromRecipe(output *recipes.RecipeOutput) ([]rpv1.OutputResource, error) {
+// 	results := []rpv1.OutputResource{}
+// 	for _, resource := range output.Resources {
+// 		id, err := resources.ParseResource(resource)
+// 		if err != nil {
+// 			return nil, &ValidationError{Message: fmt.Sprintf("resource id %q returned by recipe is invalid", resource)}
+// 		}
 
-		result := rpv1.OutputResource{
-			ID:            id,
-			RadiusManaged: to.Ptr(true),
-		}
+// 		result := rpv1.OutputResource{
+// 			ID:            id,
+// 			RadiusManaged: to.Ptr(true),
+// 		}
 
-		results = append(results, result)
-	}
+// 		results = append(results, result)
+// 	}
 
-	return results, nil
-}
+// 	return results, nil
+// }

--- a/pkg/portableresources/processors/util_test.go
+++ b/pkg/portableresources/processors/util_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/radius-project/radius/pkg/portableresources"
-	"github.com/radius-project/radius/pkg/recipes"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 	"github.com/radius-project/radius/pkg/to"
 	"github.com/radius-project/radius/pkg/ucp/resources"
@@ -61,44 +60,4 @@ func Test_GetOutputResourceFromResourceID_Invalid(t *testing.T) {
 	require.Empty(t, actual)
 	require.IsType(t, &ValidationError{}, err)
 	require.Equal(t, "resource id \"/////asdf////\" is invalid", err.Error())
-}
-
-func Test_GetOutputResourcesFromRecipe(t *testing.T) {
-	output := recipes.RecipeOutput{
-		Resources: []string{
-			"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Cache/redis/test-resource1",
-			"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Cache/redis/test-resource2",
-		},
-	}
-
-	expected := []rpv1.OutputResource{
-		{
-			LocalID:       "",
-			ID:            resources.MustParse(output.Resources[0]),
-			RadiusManaged: to.Ptr(true),
-		},
-		{
-			LocalID:       "",
-			ID:            resources.MustParse(output.Resources[1]),
-			RadiusManaged: to.Ptr(true),
-		},
-	}
-
-	actual, err := GetOutputResourcesFromRecipe(&output)
-	require.NoError(t, err)
-	require.Equal(t, expected, actual)
-}
-
-func Test_GetOutputResourcesFromRecipe_Invalid(t *testing.T) {
-	output := recipes.RecipeOutput{
-		Resources: []string{
-			"/////asdf////",
-		},
-	}
-
-	actual, err := GetOutputResourcesFromRecipe(&output)
-	require.Error(t, err)
-	require.Empty(t, actual)
-	require.IsType(t, &ValidationError{}, err)
-	require.Equal(t, "resource id \"/////asdf////\" returned by recipe is invalid", err.Error())
 }

--- a/pkg/portableresources/processors/validator.go
+++ b/pkg/portableresources/processors/validator.go
@@ -41,8 +41,8 @@ const (
 // - Apply values and secrets from the recipe output to the resource data model.
 type Validator struct {
 	resourcesField *[]*portableresources.ResourceReference
-	fields         []func(output *recipes.RecipeOutput) string
-	computedFields []func(output *recipes.RecipeOutput) string
+	fields         []func(output *recipes.RecipeOutputResponse) string
+	computedFields []func(output *recipes.RecipeOutputResponse) string
 
 	// ConnectionValues stores the connection values extracted from the data model and recipe output.
 	ConnectionValues map[string]any
@@ -150,7 +150,7 @@ func (v *Validator) AddComputedSecretField(name string, ref *string, compute fun
 // This function returns *ValidationError for validation failures.
 //
 // After calling SetAndValidate, the connection values/secrets and output resources will be populated.
-func (v *Validator) SetAndValidate(output *recipes.RecipeOutput) error {
+func (v *Validator) SetAndValidate(output *recipes.RecipeOutputResponse) error {
 	msgs := []string{}
 
 	if output != nil {
@@ -201,8 +201,8 @@ func (v *Validator) SetAndValidate(output *recipes.RecipeOutput) error {
 	return nil
 }
 
-func bind[T any](v *Validator, name string, ref *T, required bool, secret bool, typeName string, convert func(value any) (T, bool), compute func() (T, *ValidationError)) func(output *recipes.RecipeOutput) string {
-	return func(output *recipes.RecipeOutput) string {
+func bind[T any](v *Validator, name string, ref *T, required bool, secret bool, typeName string, convert func(value any) (T, bool), compute func() (T, *ValidationError)) func(output *recipes.RecipeOutputResponse) string {
+	return func(output *recipes.RecipeOutputResponse) string {
 		valueKind := kindConnectionValue
 		propertyPath := fmt.Sprintf(".properties.%v", name)
 		if secret {

--- a/pkg/portableresources/processors/validator.go
+++ b/pkg/portableresources/processors/validator.go
@@ -154,12 +154,12 @@ func (v *Validator) SetAndValidate(output *recipes.RecipeOutput) error {
 	msgs := []string{}
 
 	if output != nil {
-		recipeResources, err := GetOutputResourcesFromRecipe(output)
-		if err != nil {
-			return err
-		}
+		// recipeResources, err := GetOutputResourcesFromRecipe(output)
+		// if err != nil {
+		// 	return err
+		// }
 
-		*v.OutputResources = append(*v.OutputResources, recipeResources...)
+		*v.OutputResources = append(*v.OutputResources, output.OutputResources...)
 	}
 
 	if v.resourcesField != nil {

--- a/pkg/portableresources/processors/validator_test.go
+++ b/pkg/portableresources/processors/validator_test.go
@@ -123,7 +123,7 @@ func Test_Validator_SetAndValidate_OutputResources(t *testing.T) {
 
 		v := NewValidator(&values, &secrets, &outputResources)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{})
 		require.NoError(t, err)
 
 		require.Empty(t, outputResources)
@@ -156,7 +156,7 @@ func Test_Validator_SetAndValidate_OutputResources(t *testing.T) {
 			},
 		}
 		or := []rpv1.OutputResource{}
-		for _, resource := range []string{"/planes/aws/aws/accounts/1234/regions/us-west-1/providers/AWS.Kinesis/Stream/my-stream2"} {
+		for _, resource := range []string{"/planes/aws/aws/accounts/1234/regions/us-west-1/providers/AWS.Kinesis/Stream/my-stream1"} {
 			id, err := resources.ParseResource(resource)
 			require.NoError(t, err)
 			result := rpv1.OutputResource{
@@ -165,7 +165,7 @@ func Test_Validator_SetAndValidate_OutputResources(t *testing.T) {
 			}
 			or = append(or, result)
 		}
-		output := recipes.RecipeOutput{
+		output := recipes.RecipeOutputResponse{
 			OutputResources: or,
 		}
 
@@ -200,7 +200,7 @@ func Test_Validator_SetAndValidate_Required_Strings(t *testing.T) {
 
 		v.AddRequiredStringField("test", &model.StringField)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": "ignored"}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Values: map[string]any{"test": "ignored"}})
 		require.NoError(t, err)
 		require.Equal(t, "existing", model.StringField)
 		require.Equal(t, "existing", v.ConnectionValues["test"])
@@ -216,7 +216,7 @@ func Test_Validator_SetAndValidate_Required_Strings(t *testing.T) {
 
 		v.AddRequiredSecretField("test", &model.StringField)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Secrets: map[string]any{"test": "ignored"}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Secrets: map[string]any{"test": "ignored"}})
 		require.NoError(t, err)
 		require.Equal(t, "existing", model.StringField)
 		require.Equal(t, rpv1.SecretValueReference{Value: "existing"}, v.ConnectionSecrets["test"])
@@ -231,7 +231,7 @@ func Test_Validator_SetAndValidate_Required_Strings(t *testing.T) {
 		}
 		v.AddRequiredStringField("test", &model.StringField)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": "new"}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Values: map[string]any{"test": "new"}})
 		require.NoError(t, err)
 		require.Equal(t, "new", model.StringField)
 		require.Equal(t, "new", v.ConnectionValues["test"])
@@ -246,7 +246,7 @@ func Test_Validator_SetAndValidate_Required_Strings(t *testing.T) {
 		}
 		v.AddRequiredSecretField("test", &model.StringField)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Secrets: map[string]any{"test": "new"}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Secrets: map[string]any{"test": "new"}})
 		require.NoError(t, err)
 		require.Equal(t, "new", model.StringField)
 		require.Equal(t, rpv1.SecretValueReference{Value: "new"}, v.ConnectionSecrets["test"])
@@ -261,7 +261,7 @@ func Test_Validator_SetAndValidate_Required_Strings(t *testing.T) {
 		}
 		v.AddRequiredStringField("test", &model.StringField)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{})
 		require.Error(t, err)
 		require.IsType(t, &ValidationError{}, err)
 		require.Equal(t, "the connection value \"test\" should be provided by the recipe, set '.properties.test' to provide a value manually", err.Error())
@@ -289,7 +289,7 @@ func Test_Validator_SetAndValidate_Required_Strings(t *testing.T) {
 		}
 		v.AddRequiredSecretField("test", &model.StringField)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{})
 		require.Error(t, err)
 		require.IsType(t, &ValidationError{}, err)
 		require.Equal(t, "the connection secret \"test\" should be provided by the recipe, set '.properties.secrets.test' to provide a value manually", err.Error())
@@ -320,7 +320,7 @@ func Test_Validator_SetAndValidate_Optional_Strings(t *testing.T) {
 
 		v.AddOptionalStringField("test", &model.StringField)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": "ignored"}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Values: map[string]any{"test": "ignored"}})
 		require.NoError(t, err)
 		require.Equal(t, "existing", model.StringField)
 		require.Equal(t, "existing", v.ConnectionValues["test"])
@@ -336,7 +336,7 @@ func Test_Validator_SetAndValidate_Optional_Strings(t *testing.T) {
 
 		v.AddOptionalSecretField("test", &model.StringField)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Secrets: map[string]any{"test": "ignored"}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Secrets: map[string]any{"test": "ignored"}})
 		require.NoError(t, err)
 		require.Equal(t, "existing", model.StringField)
 		require.Equal(t, rpv1.SecretValueReference{Value: "existing"}, v.ConnectionSecrets["test"])
@@ -351,7 +351,7 @@ func Test_Validator_SetAndValidate_Optional_Strings(t *testing.T) {
 		}
 		v.AddOptionalStringField("test", &model.StringField)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": "new"}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Values: map[string]any{"test": "new"}})
 		require.NoError(t, err)
 		require.Equal(t, "new", model.StringField)
 		require.Equal(t, "new", v.ConnectionValues["test"])
@@ -366,7 +366,7 @@ func Test_Validator_SetAndValidate_Optional_Strings(t *testing.T) {
 		}
 		v.AddOptionalSecretField("test", &model.StringField)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Secrets: map[string]any{"test": "new"}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Secrets: map[string]any{"test": "new"}})
 		require.NoError(t, err)
 		require.Equal(t, "new", model.StringField)
 		require.Equal(t, rpv1.SecretValueReference{Value: "new"}, v.ConnectionSecrets["test"])
@@ -381,7 +381,7 @@ func Test_Validator_SetAndValidate_Optional_Strings(t *testing.T) {
 		}
 		v.AddOptionalStringField("test", &model.StringField)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{})
 		require.NoError(t, err)
 		require.Equal(t, "", model.StringField)
 		require.Empty(t, v.ConnectionValues)
@@ -411,7 +411,7 @@ func Test_Validator_SetAndValidate_Optional_Strings(t *testing.T) {
 		}
 		v.AddOptionalSecretField("test", &model.StringField)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{})
 		require.NoError(t, err)
 		require.Equal(t, "", model.StringField)
 		require.Empty(t, v.ConnectionValues)
@@ -449,7 +449,7 @@ func Test_Validator_SetAndValidate_Computed_Strings(t *testing.T) {
 		})
 		v.AddOptionalStringField("regular", &model.StringField)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"regular": "YO"}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Values: map[string]any{"regular": "YO"}})
 		require.NoError(t, err)
 		require.Equal(t, "YO", model.StringField)
 		require.Equal(t, "YO-computed", model.AnotherCoolStringField)
@@ -490,7 +490,7 @@ func Test_Validator_SetAndValidate_Computed_Strings(t *testing.T) {
 		})
 		v.AddOptionalStringField("regular", &model.StringField)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"regular": "YO"}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Values: map[string]any{"regular": "YO"}})
 		require.Error(t, err)
 		require.IsType(t, &ValidationError{}, err)
 		require.Equal(t, "OH NO!", err.Error())
@@ -531,7 +531,7 @@ func Test_Validator_SetAndValidate_Computed_Boolean(t *testing.T) {
 		})
 		v.AddOptionalInt32Field("regular", &model.Int32Field)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"regular": 6380}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Values: map[string]any{"regular": 6380}})
 		require.NoError(t, err)
 		require.Equal(t, true, model.BooleanField)
 		require.Equal(t, map[string]any{"regular": int32(6380), "computed": true}, v.ConnectionValues)
@@ -550,7 +550,7 @@ func Test_Validator_SetAndValidate_Computed_Boolean(t *testing.T) {
 		})
 		v.AddOptionalInt32Field("regular", &model.Int32Field)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"regular": 6380}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Values: map[string]any{"regular": 6380}})
 		require.NoError(t, err)
 		require.Equal(t, false, model.BooleanField)
 		require.Equal(t, map[string]any{"regular": int32(6379), "computed": false}, v.ConnectionValues)
@@ -569,7 +569,7 @@ func Test_Validator_SetAndValidate_Computed_Boolean(t *testing.T) {
 		})
 		v.AddOptionalInt32Field("regular", &model.Int32Field)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"regular": 6380}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Values: map[string]any{"regular": 6380}})
 		require.NoError(t, err)
 		require.Equal(t, true, model.BooleanField)
 		require.Equal(t, map[string]any{"regular": int32(6380), "computed": true}, v.ConnectionValues)
@@ -587,7 +587,7 @@ func Test_Validator_SetAndValidate_TypeMismatch_Strings(t *testing.T) {
 
 		v.AddRequiredStringField("test", &model.StringField)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": 3}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Values: map[string]any{"test": 3}})
 		require.Error(t, err)
 		require.IsType(t, &ValidationError{}, err)
 		require.Equal(t, "the connection value \"test\" provided by the recipe is expected to be a string, got int", err.Error())
@@ -604,7 +604,7 @@ func Test_Validator_SetAndValidate_Required_Int32(t *testing.T) {
 
 		v.AddRequiredInt32Field("test", &model.Int32Field)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": int32(43)}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Values: map[string]any{"test": int32(43)}})
 		require.NoError(t, err)
 		require.Equal(t, int32(47), model.Int32Field)
 		require.Equal(t, int32(47), v.ConnectionValues["test"])
@@ -619,7 +619,7 @@ func Test_Validator_SetAndValidate_Required_Int32(t *testing.T) {
 		}
 		v.AddRequiredInt32Field("test", &model.Int32Field)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": int32(43)}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Values: map[string]any{"test": int32(43)}})
 		require.NoError(t, err)
 		require.Equal(t, int32(43), model.Int32Field)
 		require.Equal(t, int32(43), v.ConnectionValues["test"])
@@ -634,7 +634,7 @@ func Test_Validator_SetAndValidate_Required_Int32(t *testing.T) {
 		}
 		v.AddRequiredInt32Field("test", &model.Int32Field)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{})
 		require.Error(t, err)
 		require.IsType(t, &ValidationError{}, err)
 		require.Equal(t, "the connection value \"test\" should be provided by the recipe, set '.properties.test' to provide a value manually", err.Error())
@@ -665,7 +665,7 @@ func Test_Validator_SetAndValidate_Optional_Int32(t *testing.T) {
 
 		v.AddOptionalInt32Field("test", &model.Int32Field)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": int32(43)}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Values: map[string]any{"test": int32(43)}})
 		require.NoError(t, err)
 		require.Equal(t, int32(47), model.Int32Field)
 		require.Equal(t, int32(47), v.ConnectionValues["test"])
@@ -680,7 +680,7 @@ func Test_Validator_SetAndValidate_Optional_Int32(t *testing.T) {
 		}
 		v.AddOptionalInt32Field("test", &model.Int32Field)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": int32(43)}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Values: map[string]any{"test": int32(43)}})
 		require.NoError(t, err)
 		require.Equal(t, int32(43), model.Int32Field)
 		require.Equal(t, int32(43), v.ConnectionValues["test"])
@@ -695,7 +695,7 @@ func Test_Validator_SetAndValidate_Optional_Int32(t *testing.T) {
 		}
 		v.AddOptionalInt32Field("test", &model.Int32Field)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{})
 		require.NoError(t, err)
 		require.Equal(t, int32(0), model.Int32Field)
 		require.Empty(t, v.ConnectionValues)
@@ -727,7 +727,7 @@ func Test_Validator_TypeConversions_Int32(t *testing.T) {
 		}
 		v.AddOptionalInt32Field("test", &model.Int32Field)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": int(43)}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Values: map[string]any{"test": int(43)}})
 		require.NoError(t, err)
 		require.Equal(t, int32(43), model.Int32Field)
 		require.Equal(t, int32(43), v.ConnectionValues["test"])
@@ -742,7 +742,7 @@ func Test_Validator_TypeConversions_Int32(t *testing.T) {
 		}
 		v.AddOptionalInt32Field("test", &model.Int32Field)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": float64(43.1)}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Values: map[string]any{"test": float64(43.1)}})
 		require.NoError(t, err)
 		require.Equal(t, int32(43), model.Int32Field)
 		require.Equal(t, int32(43), v.ConnectionValues["test"])
@@ -757,7 +757,7 @@ func Test_Validator_TypeConversions_Int32(t *testing.T) {
 		}
 		v.AddOptionalInt32Field("test", &model.Int32Field)
 
-		err := v.SetAndValidate(&recipes.RecipeOutput{Values: map[string]any{"test": "heyyyyy"}})
+		err := v.SetAndValidate(&recipes.RecipeOutputResponse{Values: map[string]any{"test": "heyyyyy"}})
 		require.Error(t, err)
 		require.IsType(t, &ValidationError{}, err)
 		require.Equal(t, "the connection value \"test\" provided by the recipe is expected to be a int32, got string", err.Error())

--- a/pkg/recipes/driver/bicep_test.go
+++ b/pkg/recipes/driver/bicep_test.go
@@ -266,14 +266,17 @@ func Test_Bicep_PrepareRecipeResponse_Success(t *testing.T) {
 
 	resources := []*armresources.ResourceReference{
 		{
-			ID: to.Ptr("outputResourceId"),
+			ID: to.Ptr("/planes/radius/local/resourceGroups/test-rg/providers/Microsoft.Resources/deployments/outputResourceId"),
 		},
 	}
 
 	response := map[string]any{}
 	value := map[string]any{}
 
-	value["outputResources"] = []any{"testId1", "testId2"}
+	value["resources"] = []any{
+		"/planes/radius/local/resourceGroups/test-rg/providers/Microsoft.Resources/deployments/testId1",
+		"/planes/radius/local/resourceGroups/test-rg/providers/Microsoft.Resources/deployments/testId2",
+	}
 	value["secrets"] = map[string]any{
 		"username":         "testUser",
 		"password":         "testPassword",
@@ -287,9 +290,11 @@ func Test_Bicep_PrepareRecipeResponse_Success(t *testing.T) {
 		"value": value,
 	}
 	outputResources := []rpv1.OutputResource{}
-	for _, resource := range []string{"/planes/kubernetes/local/namespaces/test-namespace/providers/dapr.io/Component/testId1",
-		"/planes/kubernetes/local/namespaces/test-namespace/providers/dapr.io/Component/testId2",
-		"/planes/kubernetes/local/namespaces/test-namespace/providers/dapr.io/Component/outputResourceId"} {
+	for _, resource := range []string{
+		"/planes/radius/local/resourceGroups/test-rg/providers/Microsoft.Resources/deployments/testId1",
+		"/planes/radius/local/resourceGroups/test-rg/providers/Microsoft.Resources/deployments/testId2",
+		"/planes/radius/local/resourceGroups/test-rg/providers/Microsoft.Resources/deployments/outputResourceId",
+	} {
 		id, err := ucp_resources.ParseResource(resource)
 		require.NoError(t, err)
 		result := rpv1.OutputResource{
@@ -298,7 +303,7 @@ func Test_Bicep_PrepareRecipeResponse_Success(t *testing.T) {
 		}
 		outputResources = append(outputResources, result)
 	}
-	expectedResponse := &recipes.RecipeOutput{
+	expectedResponse := &recipes.RecipeOutputResponse{
 		OutputResources: outputResources,
 		Secrets: map[string]any{
 			"username":         "testUser",
@@ -321,13 +326,13 @@ func Test_Bicep_PrepareRecipeResponse_EmptySecret(t *testing.T) {
 
 	resources := []*armresources.ResourceReference{
 		{
-			ID: to.Ptr("outputResourceId"),
+			ID: to.Ptr("/planes/radius/local/resourceGroups/test-rg/providers/Microsoft.Resources/deployments/outputResourceId"),
 		},
 	}
 
 	response := map[string]any{}
 	value := map[string]any{}
-	value["resources"] = []any{"testId1", "testId2"}
+	value["resources"] = []any{"/planes/radius/local/resourceGroups/test-rg/providers/Microsoft.Resources/deployments/testId1", "/planes/radius/local/resourceGroups/test-rg/providers/Microsoft.Resources/deployments/testId2"}
 	value["values"] = map[string]any{
 		"host": "myrediscache.redis.cache.windows.net",
 		"port": float64(6379), // This will be a float64 not an int in real scenarios, it's read from JSON.
@@ -336,7 +341,10 @@ func Test_Bicep_PrepareRecipeResponse_EmptySecret(t *testing.T) {
 		"value": value,
 	}
 	outputResources := []rpv1.OutputResource{}
-	for _, resource := range []string{"testId1", "testId2", "outputResourceId"} {
+	for _, resource := range []string{
+		"/planes/radius/local/resourceGroups/test-rg/providers/Microsoft.Resources/deployments/testId1",
+		"/planes/radius/local/resourceGroups/test-rg/providers/Microsoft.Resources/deployments/testId2",
+		"/planes/radius/local/resourceGroups/test-rg/providers/Microsoft.Resources/deployments/outputResourceId"} {
 		id, err := ucp_resources.ParseResource(resource)
 		require.NoError(t, err)
 		result := rpv1.OutputResource{
@@ -345,7 +353,7 @@ func Test_Bicep_PrepareRecipeResponse_EmptySecret(t *testing.T) {
 		}
 		outputResources = append(outputResources, result)
 	}
-	expectedResponse := &recipes.RecipeOutput{
+	expectedResponse := &recipes.RecipeOutputResponse{
 		OutputResources: outputResources,
 		Secrets:         map[string]any{},
 		Values: map[string]any{
@@ -364,12 +372,12 @@ func Test_Bicep_PrepareRecipeResponse_EmptyResult(t *testing.T) {
 
 	resources := []*armresources.ResourceReference{
 		{
-			ID: to.Ptr("outputResourceId"),
+			ID: to.Ptr("/planes/radius/local/resourceGroups/test-rg/providers/Microsoft.Resources/deployments/outputResourceId"),
 		},
 	}
 	response := map[string]any{}
 	outputResources := []rpv1.OutputResource{}
-	for _, resource := range []string{"outputResourceId"} {
+	for _, resource := range []string{"/planes/radius/local/resourceGroups/test-rg/providers/Microsoft.Resources/deployments/outputResourceId"} {
 		id, err := ucp_resources.ParseResource(resource)
 		require.NoError(t, err)
 		result := rpv1.OutputResource{
@@ -378,7 +386,7 @@ func Test_Bicep_PrepareRecipeResponse_EmptyResult(t *testing.T) {
 		}
 		outputResources = append(outputResources, result)
 	}
-	expectedResponse := &recipes.RecipeOutput{
+	expectedResponse := &recipes.RecipeOutputResponse{
 		OutputResources: outputResources,
 	}
 

--- a/pkg/recipes/driver/mock_driver.go
+++ b/pkg/recipes/driver/mock_driver.go
@@ -50,10 +50,10 @@ func (mr *MockDriverMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // Execute mocks base method.
-func (m *MockDriver) Execute(arg0 context.Context, arg1 ExecuteOptions) (*recipes.RecipeOutput, error) {
+func (m *MockDriver) Execute(arg0 context.Context, arg1 ExecuteOptions) (*recipes.RecipeOutputResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Execute", arg0, arg1)
-	ret0, _ := ret[0].(*recipes.RecipeOutput)
+	ret0, _ := ret[0].(*recipes.RecipeOutputResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/recipes/driver/terraform_test.go
+++ b/pkg/recipes/driver/terraform_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/radius-project/radius/pkg/corerp/datamodel"
 	"github.com/radius-project/radius/pkg/recipes"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
+	"github.com/radius-project/radius/pkg/to"
+	ucp_resources "github.com/radius-project/radius/pkg/ucp/resources"
 
 	"github.com/radius-project/radius/pkg/recipes/terraform"
 	"github.com/radius-project/radius/test/testcontext"
@@ -95,8 +97,8 @@ func Test_Terraform_Execute_Success(t *testing.T) {
 			"host": "myrediscache.redis.cache.windows.net",
 			"port": float64(6379),
 		},
-		Secrets:   map[string]any{},
-		Resources: []string{},
+		Secrets:         map[string]any{},
+		OutputResources: []rpv1.OutputResource{},
 	}
 
 	expectedTFState := &tfjson.State{
@@ -258,8 +260,8 @@ func Test_Terraform_Execute_EmptyOperationID_Success(t *testing.T) {
 			"host": "myrediscache.redis.cache.windows.net",
 			"port": float64(6379),
 		},
-		Secrets:   map[string]any{},
-		Resources: []string{},
+		Secrets:         map[string]any{},
+		OutputResources: []rpv1.OutputResource{},
 	}
 
 	expectedTFState := &tfjson.State{
@@ -478,6 +480,16 @@ func Test_Terraform_Delete_Failure(t *testing.T) {
 
 func Test_Terraform_PrepareRecipeResponse(t *testing.T) {
 	d := &terraformDriver{}
+	outputResources := []rpv1.OutputResource{}
+	for _, resource := range []string{"outputResourceId1"} {
+		id, err := ucp_resources.ParseResource(resource)
+		require.NoError(t, err)
+		result := rpv1.OutputResource{
+			ID:            id,
+			RadiusManaged: to.Ptr(true),
+		}
+		outputResources = append(outputResources, result)
+	}
 	tests := []struct {
 		desc             string
 		state            *tfjson.State
@@ -525,7 +537,7 @@ func Test_Terraform_PrepareRecipeResponse(t *testing.T) {
 				Secrets: map[string]any{
 					"connectionString": "testConnectionString",
 				},
-				Resources: []string{"outputResourceId1"},
+				OutputResources: outputResources,
 			},
 		},
 		{

--- a/pkg/recipes/driver/terraform_test.go
+++ b/pkg/recipes/driver/terraform_test.go
@@ -481,7 +481,7 @@ func Test_Terraform_Delete_Failure(t *testing.T) {
 func Test_Terraform_PrepareRecipeResponse(t *testing.T) {
 	d := &terraformDriver{}
 	outputResources := []rpv1.OutputResource{}
-	for _, resource := range []string{"outputResourceId1"} {
+	for _, resource := range []string{"outputResourceId1", "outputResourceId2"} {
 		id := ucp_resources.ParseTerraformResource(resource)
 		result := rpv1.OutputResource{
 			ID:            id,

--- a/pkg/recipes/driver/terraform_test.go
+++ b/pkg/recipes/driver/terraform_test.go
@@ -92,7 +92,7 @@ func Test_Terraform_Execute_Success(t *testing.T) {
 		ResourceRecipe: &recipeMetadata,
 		EnvRecipe:      &envRecipe,
 	}
-	expectedOutput := &recipes.RecipeOutput{
+	expectedOutput := &recipes.RecipeOutputResponse{
 		Values: map[string]any{
 			"host": "myrediscache.redis.cache.windows.net",
 			"port": float64(6379),
@@ -255,7 +255,7 @@ func Test_Terraform_Execute_EmptyOperationID_Success(t *testing.T) {
 
 	tfExecutor, driver := setup(t)
 	envConfig, recipeMetadata, envRecipe := buildTestInputs()
-	expectedOutput := &recipes.RecipeOutput{
+	expectedOutput := &recipes.RecipeOutputResponse{
 		Values: map[string]any{
 			"host": "myrediscache.redis.cache.windows.net",
 			"port": float64(6379),
@@ -482,8 +482,7 @@ func Test_Terraform_PrepareRecipeResponse(t *testing.T) {
 	d := &terraformDriver{}
 	outputResources := []rpv1.OutputResource{}
 	for _, resource := range []string{"outputResourceId1"} {
-		id, err := ucp_resources.ParseResource(resource)
-		require.NoError(t, err)
+		id := ucp_resources.ParseTerraformResource(resource)
 		result := rpv1.OutputResource{
 			ID:            id,
 			RadiusManaged: to.Ptr(true),
@@ -493,7 +492,7 @@ func Test_Terraform_PrepareRecipeResponse(t *testing.T) {
 	tests := []struct {
 		desc             string
 		state            *tfjson.State
-		expectedResponse *recipes.RecipeOutput
+		expectedResponse *recipes.RecipeOutputResponse
 		expectedErr      error
 	}{
 		{
@@ -529,7 +528,7 @@ func Test_Terraform_PrepareRecipeResponse(t *testing.T) {
 					},
 				},
 			},
-			expectedResponse: &recipes.RecipeOutput{
+			expectedResponse: &recipes.RecipeOutputResponse{
 				Values: map[string]any{
 					"host": "testhost",
 					"port": float64(6379),
@@ -574,19 +573,19 @@ func Test_Terraform_PrepareRecipeResponse(t *testing.T) {
 					},
 				},
 			},
-			expectedResponse: &recipes.RecipeOutput{},
+			expectedResponse: &recipes.RecipeOutputResponse{},
 			expectedErr:      errors.New("json: unknown field \"outputs\""),
 		},
 		{
 			desc:             "nil state",
 			state:            nil,
-			expectedResponse: &recipes.RecipeOutput{},
+			expectedResponse: &recipes.RecipeOutputResponse{},
 			expectedErr:      errors.New("terraform state is empty"),
 		},
 		{
 			desc:             "empty state",
 			state:            &tfjson.State{},
-			expectedResponse: &recipes.RecipeOutput{},
+			expectedResponse: &recipes.RecipeOutputResponse{},
 			expectedErr:      errors.New("terraform state is empty"),
 		},
 	}

--- a/pkg/recipes/driver/types.go
+++ b/pkg/recipes/driver/types.go
@@ -26,7 +26,7 @@ import (
 // Driver is an interface to implement recipe deployment and recipe resources deletion.
 type Driver interface {
 	// Execute fetches the recipe contents and deploys the recipe and returns deployed resources, secrets and values.
-	Execute(ctx context.Context, opts ExecuteOptions) (*recipes.RecipeOutput, error)
+	Execute(ctx context.Context, opts ExecuteOptions) (*recipes.RecipeOutputResponse, error)
 
 	// Delete handles deletion of output resources for the recipe deployment.
 	Delete(ctx context.Context, opts DeleteOptions) error

--- a/pkg/recipes/engine/engine.go
+++ b/pkg/recipes/engine/engine.go
@@ -49,7 +49,7 @@ type engine struct {
 // Execute loads the recipe definition from the environment, finds the driver associated with the recipe, loads the
 // configuration associated with the recipe, and then executes the recipe using the driver. It returns a RecipeOutput and
 // an error if one occurs.
-func (e *engine) Execute(ctx context.Context, opts ExecuteOptions) (*recipes.RecipeOutput, error) {
+func (e *engine) Execute(ctx context.Context, opts ExecuteOptions) (*recipes.RecipeOutputResponse, error) {
 	executionStart := time.Now()
 	result := metrics.SuccessfulOperationState
 
@@ -70,7 +70,7 @@ func (e *engine) Execute(ctx context.Context, opts ExecuteOptions) (*recipes.Rec
 
 // executeCore function is the core logic of the Execute function.
 // Any changes to the core logic of the Execute function should be made here.
-func (e *engine) executeCore(ctx context.Context, recipe recipes.ResourceMetadata, prevState []string) (*recipes.RecipeOutput, *recipes.EnvironmentDefinition, error) {
+func (e *engine) executeCore(ctx context.Context, recipe recipes.ResourceMetadata, prevState []string) (*recipes.RecipeOutputResponse, *recipes.EnvironmentDefinition, error) {
 	definition, driver, err := e.getDriver(ctx, recipe)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/recipes/engine/engine_test.go
+++ b/pkg/recipes/engine/engine_test.go
@@ -76,7 +76,7 @@ func Test_Engine_Execute_Success(t *testing.T) {
 		},
 	}
 	outputResources := []rpv1.OutputResource{}
-	for _, resource := range []string{"mongoStorageAccount", "mongoDatabase"} {
+	for _, resource := range []string{"/planes/radius/local/resourceGroups/test-rg/providers/Applications.Datastores/mongoDatabases/mongoStorageAccount", "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Datastores/mongoDatabases/mongoDatabase"} {
 		id, err := resources.ParseResource(resource)
 		require.NoError(t, err)
 		result := rpv1.OutputResource{
@@ -85,7 +85,7 @@ func Test_Engine_Execute_Success(t *testing.T) {
 		}
 		outputResources = append(outputResources, result)
 	}
-	recipeResult := &recipes.RecipeOutput{
+	recipeResult := &recipes.RecipeOutputResponse{
 		OutputResources: outputResources,
 		Secrets: map[string]any{
 			"connectionString": "mongodb://testUser:testPassword@testAccount1.mongo.cosmos.azure.com:10255",
@@ -224,15 +224,14 @@ func Test_Engine_Terraform_Success(t *testing.T) {
 	}
 	outputResources := []rpv1.OutputResource{}
 	for _, resource := range []string{"mongoStorageAccount", "mongoDatabase"} {
-		id, err := resources.ParseResource(resource)
-		require.NoError(t, err)
+		id := resources.ParseTerraformResource(resource)
 		result := rpv1.OutputResource{
 			ID:            id,
 			RadiusManaged: to.Ptr(true),
 		}
 		outputResources = append(outputResources, result)
 	}
-	recipeResult := &recipes.RecipeOutput{
+	recipeResult := &recipes.RecipeOutputResponse{
 		OutputResources: outputResources,
 		Secrets: map[string]any{
 			"connectionString": "mongodb://testUser:testPassword@testAccount1.mongo.cosmos.azure.com:10255",

--- a/pkg/recipes/engine/engine_test.go
+++ b/pkg/recipes/engine/engine_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/radius-project/radius/pkg/recipes/configloader"
 	recipedriver "github.com/radius-project/radius/pkg/recipes/driver"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
+	"github.com/radius-project/radius/pkg/to"
 	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/radius-project/radius/test/testcontext"
 	"github.com/stretchr/testify/require"
@@ -74,8 +75,18 @@ func Test_Engine_Execute_Success(t *testing.T) {
 			},
 		},
 	}
+	outputResources := []rpv1.OutputResource{}
+	for _, resource := range []string{"mongoStorageAccount", "mongoDatabase"} {
+		id, err := resources.ParseResource(resource)
+		require.NoError(t, err)
+		result := rpv1.OutputResource{
+			ID:            id,
+			RadiusManaged: to.Ptr(true),
+		}
+		outputResources = append(outputResources, result)
+	}
 	recipeResult := &recipes.RecipeOutput{
-		Resources: []string{"mongoStorageAccount", "mongoDatabase"},
+		OutputResources: outputResources,
 		Secrets: map[string]any{
 			"connectionString": "mongodb://testUser:testPassword@testAccount1.mongo.cosmos.azure.com:10255",
 		},
@@ -211,8 +222,18 @@ func Test_Engine_Terraform_Success(t *testing.T) {
 			},
 		},
 	}
+	outputResources := []rpv1.OutputResource{}
+	for _, resource := range []string{"mongoStorageAccount", "mongoDatabase"} {
+		id, err := resources.ParseResource(resource)
+		require.NoError(t, err)
+		result := rpv1.OutputResource{
+			ID:            id,
+			RadiusManaged: to.Ptr(true),
+		}
+		outputResources = append(outputResources, result)
+	}
 	recipeResult := &recipes.RecipeOutput{
-		Resources: []string{"mongoStorageAccount", "mongoDatabase"},
+		OutputResources: outputResources,
 		Secrets: map[string]any{
 			"connectionString": "mongodb://testUser:testPassword@testAccount1.mongo.cosmos.azure.com:10255",
 		},

--- a/pkg/recipes/engine/mock_engine.go
+++ b/pkg/recipes/engine/mock_engine.go
@@ -50,10 +50,10 @@ func (mr *MockEngineMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // Execute mocks base method.
-func (m *MockEngine) Execute(arg0 context.Context, arg1 ExecuteOptions) (*recipes.RecipeOutput, error) {
+func (m *MockEngine) Execute(arg0 context.Context, arg1 ExecuteOptions) (*recipes.RecipeOutputResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Execute", arg0, arg1)
-	ret0, _ := ret[0].(*recipes.RecipeOutput)
+	ret0, _ := ret[0].(*recipes.RecipeOutputResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/recipes/engine/types.go
+++ b/pkg/recipes/engine/types.go
@@ -28,7 +28,7 @@ import (
 type Engine interface {
 	// Execute gathers environment configuration, recipe definition and calls the driver to deploy the recipe.
 	// prevState is added to the driver execute options, which is used to get the obsolete resources for cleanup. It consists list of recipe output resource IDs that were created in the previous deployment.
-	Execute(ctx context.Context, opts ExecuteOptions) (*recipes.RecipeOutput, error)
+	Execute(ctx context.Context, opts ExecuteOptions) (*recipes.RecipeOutputResponse, error)
 
 	// Delete handles deletion of output resources for the recipe deployment.
 	Delete(ctx context.Context, opts DeleteOptions) error

--- a/pkg/recipes/types.go
+++ b/pkg/recipes/types.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 
 	"github.com/radius-project/radius/pkg/corerp/datamodel"
+	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 )
 
 // Configuration represents kubernetes runtime and cloud provider configuration, which is used by the driver while deploying recipes.
@@ -89,7 +90,9 @@ var (
 // RecipeOutput represents recipe deployment output.
 type RecipeOutput struct {
 	// Resources represents the list of output resources deployed recipe.
-	Resources []string
+	//Resources []string
+
+	OutputResources []rpv1.OutputResource
 
 	// Secrets represents the key/value pairs of secret values of the deployed resource.
 	Secrets map[string]any
@@ -121,8 +124,8 @@ func (ro *RecipeOutput) PrepareRecipeResponse(resultValue map[string]any) error 
 	if ro.Values == nil {
 		ro.Values = map[string]any{}
 	}
-	if ro.Resources == nil {
-		ro.Resources = []string{}
+	if ro.OutputResources == nil {
+		ro.OutputResources = []rpv1.OutputResource{}
 	}
 
 	return nil

--- a/pkg/recipes/types.go
+++ b/pkg/recipes/types.go
@@ -92,6 +92,20 @@ type RecipeOutput struct {
 	// Resources represents the list of output resources deployed recipe.
 	//Resources []string
 
+	Resources []string
+
+	// Secrets represents the key/value pairs of secret values of the deployed resource.
+	Secrets map[string]any
+
+	// Values represents the key/value pairs of properties of the deployed resource.
+	Values map[string]any
+}
+
+// RecipeOutput represents recipe deployment output.
+type RecipeOutputResponse struct {
+	// Resources represents the list of output resources deployed recipe.
+	//Resources []string
+
 	OutputResources []rpv1.OutputResource
 
 	// Secrets represents the key/value pairs of secret values of the deployed resource.
@@ -124,8 +138,8 @@ func (ro *RecipeOutput) PrepareRecipeResponse(resultValue map[string]any) error 
 	if ro.Values == nil {
 		ro.Values = map[string]any{}
 	}
-	if ro.OutputResources == nil {
-		ro.OutputResources = []rpv1.OutputResource{}
+	if ro.Resources == nil {
+		ro.Resources = []string{}
 	}
 
 	return nil

--- a/pkg/recipes/types_test.go
+++ b/pkg/recipes/types_test.go
@@ -64,11 +64,11 @@ func TestRecipeOutput_PrepareRecipeResponse(t *testing.T) {
 				if tt.result["values"] != nil {
 					require.Equal(t, tt.result["values"], ro.Values)
 					require.Equal(t, tt.result["secrets"], ro.Secrets)
-					require.Equal(t, tt.result["resources"], ro.Resources)
+					require.Equal(t, tt.result["resources"], ro.OutputResources)
 				} else {
 					require.Equal(t, map[string]any{}, ro.Values)
 					require.Equal(t, map[string]any{}, ro.Secrets)
-					require.Equal(t, []string{}, ro.Resources)
+					require.Equal(t, []string{}, ro.OutputResources)
 				}
 			} else {
 				err := ro.PrepareRecipeResponse(tt.result)

--- a/pkg/recipes/types_test.go
+++ b/pkg/recipes/types_test.go
@@ -64,11 +64,11 @@ func TestRecipeOutput_PrepareRecipeResponse(t *testing.T) {
 				if tt.result["values"] != nil {
 					require.Equal(t, tt.result["values"], ro.Values)
 					require.Equal(t, tt.result["secrets"], ro.Secrets)
-					require.Equal(t, tt.result["resources"], ro.OutputResources)
+					require.Equal(t, tt.result["resources"], ro.Resources)
 				} else {
 					require.Equal(t, map[string]any{}, ro.Values)
 					require.Equal(t, map[string]any{}, ro.Secrets)
-					require.Equal(t, []string{}, ro.OutputResources)
+					require.Equal(t, []string{}, ro.Resources)
 				}
 			} else {
 				err := ro.PrepareRecipeResponse(tt.result)

--- a/pkg/ucp/resources/id.go
+++ b/pkg/ucp/resources/id.go
@@ -529,7 +529,7 @@ func (id ID) MarshalText() ([]byte, error) {
 func (id *ID) UnmarshalText(data []byte) error {
 	parsed, err := Parse(string(data))
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal text, value was not a valid resource ID: %w", err)
+		parsed = ParseTerraformResource(string(data))
 	}
 
 	// Assign fields into self.

--- a/pkg/ucp/resources/id.go
+++ b/pkg/ucp/resources/id.go
@@ -610,7 +610,7 @@ func ParseResource(id string) (ID, error) {
 	return parsed, err
 }
 
-func ParseTerrafornResource(id string) ID {
+func ParseTerraformResource(id string) ID {
 	return ID{
 		id: id,
 	}

--- a/pkg/ucp/resources/id.go
+++ b/pkg/ucp/resources/id.go
@@ -46,6 +46,8 @@ type ID struct {
 	extensionSegments []TypeSegment
 }
 
+// Handle Terraform IDs
+
 // ScopeSegment represents one of the root-scope pairs of a resource ID.
 type ScopeSegment struct {
 	// Type is the type of the scope.

--- a/pkg/ucp/resources/id.go
+++ b/pkg/ucp/resources/id.go
@@ -610,6 +610,12 @@ func ParseResource(id string) (ID, error) {
 	return parsed, err
 }
 
+func ParseTerrafornResource(id string) ID {
+	return ID{
+		id: id,
+	}
+}
+
 // Parse parses a resource ID. Parse will parse ALL valid resource IDs in the most permissive way.
 // Most code should use a more specific function like ParseResource to parse the specific kind of ID
 // they want to handle.

--- a/pkg/ucp/store/map_test.go
+++ b/pkg/ucp/store/map_test.go
@@ -124,13 +124,14 @@ func TestDecodeMap_WithResourceIDs(t *testing.T) {
 		require.Equal(t, data["ID"], out.ID.String())
 	})
 
-	t.Run("invalid", func(t *testing.T) {
+	t.Run("terraform id", func(t *testing.T) {
 		data := map[string]any{
-			"ID": "asdf",
+			"ID": "terraform-id",
 		}
 
 		out := datatype{}
 		err := DecodeMap(data, &out)
-		require.Error(t, err)
+		require.NoError(t, err)
+		require.Equal(t, data["ID"], out.ID.String())
 	})
 }


### PR DESCRIPTION
# Description

Added changed to populate Terraform recipe deployed resource IDs in recipe output.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2984d12</samp>

### Summary

No summary available (Limit exceeded: required to process 51960 tokens, but only 50000 are allowed per call)



### Walkthrough
No walkthrough available (Limit exceeded: required to process 51960 tokens, but only 50000 are allowed per call)


