### PR TITLE
Update check for application in manual processing of Dapr Components

### DIFF
--- a/pkg/daprrp/processors/pubsubbrokers/processor.go
+++ b/pkg/daprrp/processors/pubsubbrokers/processor.go
@@ -63,7 +63,7 @@ func (p *Processor) Process(ctx context.Context, resource *datamodel.DaprPubSubB
 	// Let's do this now.
 
 	applicationID, err := resources.ParseResource(resource.Properties.Application)
-	if err != nil {
+	if err != nil && resource.Properties.Application != "" {
 		return err // This should already be validated by this point.
 	}
 
@@ -114,7 +114,7 @@ func (p *Processor) Delete(ctx context.Context, resource *datamodel.DaprPubSubBr
 	}
 
 	applicationID, err := resources.ParseResource(resource.Properties.Application)
-	if err != nil {
+	if err != nil && resource.Properties.Application != "" {
 		return err // This should already be validated by this point.
 	}
 

--- a/pkg/daprrp/processors/pubsubbrokers/processor.go
+++ b/pkg/daprrp/processors/pubsubbrokers/processor.go
@@ -62,9 +62,16 @@ func (p *Processor) Process(ctx context.Context, resource *datamodel.DaprPubSubB
 	// If the resource is being provisioned manually then *we* are responsible for creating the Dapr Component.
 	// Let's do this now.
 
-	applicationID, err := resources.ParseResource(resource.Properties.Application)
-	if err != nil && resource.Properties.Application != "" {
-		return err // This should already be validated by this point.
+	// DaprPubSubBroker resources may or may not be application scoped.
+	// Some Dapr Components can be specific to a single application, they would be application scoped and have
+	// resource.Properties.Application populated, while others could be shared across multiple applications and
+	// would not have resource.Properties.Application populated.
+	var applicationID resources.ID
+	if resource.Properties.Application != "" {
+		applicationID, err = resources.ParseResource(resource.Properties.Application)
+		if err != nil {
+			return err // This should already be validated by this point.
+		}
 	}
 
 	component, err := dapr.ConstructDaprGeneric(
@@ -113,9 +120,17 @@ func (p *Processor) Delete(ctx context.Context, resource *datamodel.DaprPubSubBr
 		return nil
 	}
 
-	applicationID, err := resources.ParseResource(resource.Properties.Application)
-	if err != nil && resource.Properties.Application != "" {
-		return err // This should already be validated by this point.
+	// DaprPubSubBroker resources may or may not be application scoped.
+	// Some Dapr Components can be specific to a single application, they would be application scoped and have
+	// resource.Properties.Application populated, while others could be shared across multiple applications and
+	// would not have resource.Properties.Application populated.
+	var err error
+	var applicationID resources.ID
+	if resource.Properties.Application != "" {
+		applicationID, err = resources.ParseResource(resource.Properties.Application)
+		if err != nil {
+			return err
+		}
 	}
 
 	component := unstructured.Unstructured{

--- a/pkg/daprrp/processors/pubsubbrokers/processor_test.go
+++ b/pkg/daprrp/processors/pubsubbrokers/processor_test.go
@@ -205,6 +205,95 @@ func Test_Process(t *testing.T) {
 		require.Equal(t, []unstructured.Unstructured{*generated}, components.Items)
 	})
 
+	t.Run("success - manual (no application)", func(t *testing.T) {
+		processor := Processor{
+			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}),
+		}
+
+		resource := &datamodel.DaprPubSubBroker{
+			BaseResource: v1.BaseResource{
+				TrackedResource: v1.TrackedResource{
+					Name: "some-other-name",
+				},
+			},
+			Properties: datamodel.DaprPubSubBrokerProperties{
+				BasicResourceProperties: rpv1.BasicResourceProperties{
+					Environment: envID,
+				},
+				BasicDaprResourceProperties: rpv1.BasicDaprResourceProperties{
+					ComponentName: componentName,
+				},
+				ResourceProvisioning: portableresources.ResourceProvisioningManual,
+				Metadata: map[string]any{
+					"config": "extrasecure",
+				},
+				Resources: []*portableresources.ResourceReference{{ID: externalResourceID1}},
+				Type:      "pubsub.redis",
+				Version:   "v1",
+			},
+		}
+
+		options := processors.Options{
+			RuntimeConfiguration: recipes.RuntimeConfiguration{
+				Kubernetes: &recipes.KubernetesRuntime{
+					Namespace: "test-namespace",
+				},
+			},
+		}
+
+		err := processor.Process(context.Background(), resource, options)
+		require.NoError(t, err)
+
+		require.Equal(t, componentName, resource.Properties.ComponentName)
+
+		expectedValues := map[string]any{
+			"componentName": componentName,
+		}
+		expectedSecrets := map[string]rpv1.SecretValueReference{}
+
+		expectedOutputResources, err := processors.GetOutputResourcesFromResourcesField(resource.Properties.Resources)
+
+		generated := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": dapr.DaprAPIVersion,
+				"kind":       dapr.DaprKind,
+				"metadata": map[string]any{
+					"namespace":       "test-namespace",
+					"name":            "test-dapr-pubsub-broker",
+					"labels":          kubernetes.MakeDescriptiveDaprLabels("", "some-other-name", portableresources.DaprPubSubBrokersResourceType),
+					"resourceVersion": "1",
+				},
+				"spec": map[string]any{
+					"type":    "pubsub.redis",
+					"version": "v1",
+					"metadata": []any{
+						map[string]any{
+							"name":  "config",
+							"value": "extrasecure",
+						},
+					},
+				},
+			},
+		}
+
+		component := rpv1.NewKubernetesOutputResource("Component", generated, metav1.ObjectMeta{Name: generated.GetName(), Namespace: generated.GetNamespace()})
+		component.RadiusManaged = to.Ptr(true)
+		expectedOutputResources = append(expectedOutputResources, component)
+		require.NoError(t, err)
+
+		require.Equal(t, expectedValues, resource.ComputedValues)
+		require.Equal(t, expectedSecrets, resource.SecretValues)
+		require.Equal(t, expectedOutputResources, resource.Properties.Status.OutputResources)
+
+		components := unstructured.UnstructuredList{}
+		components.SetAPIVersion("dapr.io/v1alpha1")
+		components.SetKind("Component")
+		err = processor.Client.List(context.Background(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
+		require.NoError(t, err)
+		require.NotEmpty(t, components.Items)
+		require.Equal(t, []unstructured.Unstructured{*generated}, components.Items)
+	})
+
 	t.Run("success - recipe with overrides", func(t *testing.T) {
 		processor := Processor{
 			Client: k8sutil.NewFakeKubeClient(scheme.Scheme),

--- a/pkg/daprrp/processors/secretstores/processor.go
+++ b/pkg/daprrp/processors/secretstores/processor.go
@@ -60,7 +60,7 @@ func (p *Processor) Process(ctx context.Context, resource *datamodel.DaprSecretS
 	// Let's do this now.
 
 	applicationID, err := resources.ParseResource(resource.Properties.Application)
-	if err != nil {
+	if err != nil && resource.Properties.Application != "" {
 		return err // This should already be validated by this point.
 	}
 
@@ -111,7 +111,7 @@ func (p *Processor) Delete(ctx context.Context, resource *datamodel.DaprSecretSt
 	}
 
 	applicationID, err := resources.ParseResource(resource.Properties.Application)
-	if err != nil {
+	if err != nil && resource.Properties.Application != "" {
 		return err // This should already be validated by this point.
 	}
 

--- a/pkg/daprrp/processors/secretstores/processor.go
+++ b/pkg/daprrp/processors/secretstores/processor.go
@@ -59,9 +59,16 @@ func (p *Processor) Process(ctx context.Context, resource *datamodel.DaprSecretS
 	// If the resource is being provisioned manually then *we* are responsible for creating the Dapr Component.
 	// Let's do this now.
 
-	applicationID, err := resources.ParseResource(resource.Properties.Application)
-	if err != nil && resource.Properties.Application != "" {
-		return err // This should already be validated by this point.
+	// DaprSecretStore resources may or may not be application scoped.
+	// Some Dapr Components can be specific to a single application, they would be application scoped and have
+	// resource.Properties.Application populated, while others could be shared across multiple applications and
+	// would not have resource.Properties.Application populated.
+	var applicationID resources.ID
+	if resource.Properties.Application != "" {
+		applicationID, err = resources.ParseResource(resource.Properties.Application)
+		if err != nil {
+			return err // This should already be validated by this point.
+		}
 	}
 
 	component, err := dapr.ConstructDaprGeneric(
@@ -110,9 +117,17 @@ func (p *Processor) Delete(ctx context.Context, resource *datamodel.DaprSecretSt
 		return nil
 	}
 
-	applicationID, err := resources.ParseResource(resource.Properties.Application)
-	if err != nil && resource.Properties.Application != "" {
-		return err // This should already be validated by this point.
+	// DaprSecretStore resources may or may not be application scoped.
+	// Some Dapr Components can be specific to a single application, they would be application scoped and have
+	// resource.Properties.Application populated, while others could be shared across multiple applications and
+	// would not have resource.Properties.Application populated.
+	var err error
+	var applicationID resources.ID
+	if resource.Properties.Application != "" {
+		applicationID, err = resources.ParseResource(resource.Properties.Application)
+		if err != nil {
+			return err
+		}
 	}
 
 	component := unstructured.Unstructured{

--- a/pkg/daprrp/processors/statestores/processor.go
+++ b/pkg/daprrp/processors/statestores/processor.go
@@ -62,9 +62,16 @@ func (p *Processor) Process(ctx context.Context, resource *datamodel.DaprStateSt
 	// If the resource is being provisioned manually then *we* are responsible for creating the Dapr Component.
 	// Let's do this now.
 
-	applicationID, err := resources.ParseResource(resource.Properties.Application)
-	if err != nil && resource.Properties.Application != "" {
-		return err // This should already be validated by this point.
+	// DaprStateStore resources may or may not be application scoped.
+	// Some Dapr Components can be specific to a single application, they would be application scoped and have
+	// resource.Properties.Application populated, while others could be shared across multiple applications and
+	// would not have resource.Properties.Application populated.
+	var applicationID resources.ID
+	if resource.Properties.Application != "" {
+		applicationID, err = resources.ParseResource(resource.Properties.Application)
+		if err != nil {
+			return err // This should already be validated by this point.
+		}
 	}
 
 	component, err := dapr.ConstructDaprGeneric(
@@ -113,9 +120,17 @@ func (p *Processor) Delete(ctx context.Context, resource *datamodel.DaprStateSto
 		return nil
 	}
 
-	applicationID, err := resources.ParseResource(resource.Properties.Application)
-	if err != nil && resource.Properties.Application != "" {
-		return err // This should already be validated by this point.
+	// DaprStateStore resources may or may not be application scoped.
+	// Some Dapr Components can be specific to a single application, they would be application scoped and have
+	// resource.Properties.Application populated, while others could be shared across multiple applications and
+	// would not have resource.Properties.Application populated.
+	var err error
+	var applicationID resources.ID
+	if resource.Properties.Application != "" {
+		applicationID, err = resources.ParseResource(resource.Properties.Application)
+		if err != nil {
+			return err
+		}
 	}
 
 	component := unstructured.Unstructured{

--- a/pkg/daprrp/processors/statestores/processor.go
+++ b/pkg/daprrp/processors/statestores/processor.go
@@ -63,7 +63,7 @@ func (p *Processor) Process(ctx context.Context, resource *datamodel.DaprStateSt
 	// Let's do this now.
 
 	applicationID, err := resources.ParseResource(resource.Properties.Application)
-	if err != nil {
+	if err != nil && resource.Properties.Application != "" {
 		return err // This should already be validated by this point.
 	}
 
@@ -114,7 +114,7 @@ func (p *Processor) Delete(ctx context.Context, resource *datamodel.DaprStateSto
 	}
 
 	applicationID, err := resources.ParseResource(resource.Properties.Application)
-	if err != nil {
+	if err != nil && resource.Properties.Application != "" {
 		return err // This should already be validated by this point.
 	}
 

--- a/pkg/daprrp/processors/statestores/processor_test.go
+++ b/pkg/daprrp/processors/statestores/processor_test.go
@@ -45,6 +45,7 @@ func Test_Process(t *testing.T) {
 	const externalResourceID2 = "/subscriptions/0000/resourceGroups/test-group/providers/Microsoft.Cache/redis/myredis2"
 	const kubernetesResource = "/planes/kubernetes/local/namespaces/test-namespace/providers/dapr.io/Component/test-component"
 	const applicationID = "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Core/applications/test-app"
+	const envID = "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Core/environments/test-env"
 	const componentName = "test-component"
 
 	t.Run("success - recipe", func(t *testing.T) {
@@ -164,6 +165,93 @@ func Test_Process(t *testing.T) {
 					"namespace":       "test-namespace",
 					"name":            "test-component",
 					"labels":          kubernetes.MakeDescriptiveDaprLabels("test-app", "some-other-name", portableresources.DaprStateStoresResourceType),
+					"resourceVersion": "1",
+				},
+				"spec": map[string]any{
+					"type":    "state.redis",
+					"version": "v1",
+					"metadata": []any{
+						map[string]any{
+							"name":  "config",
+							"value": "extrasecure",
+						},
+					},
+				},
+			},
+		}
+
+		component := rpv1.NewKubernetesOutputResource("Component", generated, metav1.ObjectMeta{Name: generated.GetName(), Namespace: generated.GetNamespace()})
+		component.RadiusManaged = to.Ptr(true)
+		expectedOutputResources = append(expectedOutputResources, component)
+		require.NoError(t, err)
+
+		require.Equal(t, expectedValues, resource.ComputedValues)
+		require.Equal(t, expectedSecrets, resource.SecretValues)
+		require.Equal(t, expectedOutputResources, resource.Properties.Status.OutputResources)
+
+		components := unstructured.UnstructuredList{}
+		components.SetAPIVersion("dapr.io/v1alpha1")
+		components.SetKind("Component")
+		err = processor.Client.List(context.Background(), &components, &client.ListOptions{Namespace: options.RuntimeConfiguration.Kubernetes.Namespace})
+		require.NoError(t, err)
+		require.NotEmpty(t, components.Items)
+		require.Equal(t, []unstructured.Unstructured{*generated}, components.Items)
+	})
+
+	t.Run("success - manual (no application)", func(t *testing.T) {
+		processor := Processor{
+			Client: k8sutil.NewFakeKubeClient(scheme.Scheme, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-namespace"}}),
+		}
+
+		resource := &datamodel.DaprStateStore{
+			BaseResource: v1.BaseResource{
+				TrackedResource: v1.TrackedResource{
+					Name: "some-other-name",
+				},
+			},
+			Properties: datamodel.DaprStateStoreProperties{
+				BasicResourceProperties: rpv1.BasicResourceProperties{
+					Environment: envID,
+				},
+				BasicDaprResourceProperties: rpv1.BasicDaprResourceProperties{
+					ComponentName: componentName,
+				},
+				ResourceProvisioning: portableresources.ResourceProvisioningManual,
+				Metadata:             map[string]any{"config": "extrasecure"},
+				Resources:            []*portableresources.ResourceReference{{ID: externalResourceID1}},
+				Type:                 "state.redis",
+				Version:              "v1",
+			},
+		}
+
+		options := processors.Options{
+			RuntimeConfiguration: recipes.RuntimeConfiguration{
+				Kubernetes: &recipes.KubernetesRuntime{
+					Namespace: "test-namespace",
+				},
+			},
+		}
+
+		err := processor.Process(context.Background(), resource, options)
+		require.NoError(t, err)
+
+		require.Equal(t, componentName, resource.Properties.ComponentName)
+
+		expectedValues := map[string]any{
+			"componentName": componentName,
+		}
+		expectedSecrets := map[string]rpv1.SecretValueReference{}
+
+		expectedOutputResources, err := processors.GetOutputResourcesFromResourcesField(resource.Properties.Resources)
+
+		generated := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": dapr.DaprAPIVersion,
+				"kind":       dapr.DaprKind,
+				"metadata": map[string]any{
+					"namespace":       "test-namespace",
+					"name":            "test-component",
+					"labels":          kubernetes.MakeDescriptiveDaprLabels("", "some-other-name", portableresources.DaprStateStoresResourceType),
 					"resourceVersion": "1",
 				},
 				"spec": map[string]any{


### PR DESCRIPTION
# Description

Updated check to allow manual processing if Application is not populated in Dapr components.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue #6233 

Fixes: #6233 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d891a88</samp>

### Summary
🧪🐛📝

<!--
1.  🧪 for adding new test cases and improving test coverage.
2.  🐛 for fixing bugs and avoiding errors in the processors.
3.  📝 for improving code readability and documentation.
-->
This pull request improves the error handling and testing of the Dapr resource processors for pubsub brokers, secret stores, and state stores. It avoids errors when processing resources that do not have an associated application, and adds test cases to cover those scenarios. It also improves code readability by using constants and verifying expected outputs.

> _`Dapr` processors_
> _handle empty application_
> _better with tests - fall_

### Walkthrough
*  Add conditions to check for empty application in DaprPubSubBroker, DaprSecretStore, and DaprStateStore processors, to support manual provisioning without an application ([link](https://github.com/radius-project/radius/pull/6282/files?diff=unified&w=0#diff-bf8a78c7378e6a331ec0c801e36be87e57f6945ee11d458a1767db0b13d08f7cL66-R66), [link](https://github.com/radius-project/radius/pull/6282/files?diff=unified&w=0#diff-bf8a78c7378e6a331ec0c801e36be87e57f6945ee11d458a1767db0b13d08f7cL117-R117), [link](https://github.com/radius-project/radius/pull/6282/files?diff=unified&w=0#diff-addd14a36eed15509082e77643885cab58e37813c3a65af56e8ac735b0429304L63-R63), [link](https://github.com/radius-project/radius/pull/6282/files?diff=unified&w=0#diff-addd14a36eed15509082e77643885cab58e37813c3a65af56e8ac735b0429304L114-R114), [link](https://github.com/radius-project/radius/pull/6282/files?diff=unified&w=0#diff-8af049b18ee28c2c796d0c6f2750948e33de96362d2621dc7f8af8aaa0988de5L66-R66), [link](https://github.com/radius-project/radius/pull/6282/files?diff=unified&w=0#diff-8af049b18ee28c2c796d0c6f2750948e33de96362d2621dc7f8af8aaa0988de5L117-R117))
*  Add test cases to verify the valid generation of Dapr components and the update of resource properties for manual provisioning without an application in `processor_test.go` files for each processor ([link](https://github.com/radius-project/radius/pull/6282/files?diff=unified&w=0#diff-7719d5215f11ba5c57f772020e0320bbd6f776624446f041c6dd54fa89187c42R208-R296), [link](https://github.com/radius-project/radius/pull/6282/files?diff=unified&w=0#diff-f96cf0bc558cf3145838a9217e0b66e2ae4131266486e612965b58f31f3c24b5R193-R275), [link](https://github.com/radius-project/radius/pull/6282/files?diff=unified&w=0#diff-8bb476ee511fdbd2aa100c459f9933736d440a17d8238161d18796d2af2f6c2cR201-R287))
*  Extract environment ID constant in `processor_test.go` files for DaprSecretStore and DaprStateStore processors, to avoid repetition ([link](https://github.com/radius-project/radius/pull/6282/files?diff=unified&w=0#diff-f96cf0bc558cf3145838a9217e0b66e2ae4131266486e612965b58f31f3c24b5R45), [link](https://github.com/radius-project/radius/pull/6282/files?diff=unified&w=0#diff-8bb476ee511fdbd2aa100c459f9933736d440a17d8238161d18796d2af2f6c2cR48))


