### PR TITLE
Refactoring unmarshal time string

### DIFF
--- a/pkg/armrpc/api/v1/time_util.go
+++ b/pkg/armrpc/api/v1/time_util.go
@@ -17,13 +17,9 @@ limitations under the License.
 package v1
 
 import (
-	"context"
-	"fmt"
 	"regexp"
 	"strings"
 	"time"
-
-	"github.com/radius-project/radius/pkg/ucp/ucplog"
 )
 
 const (
@@ -74,12 +70,8 @@ func (t *timeRFC3339) UnmarshalText(data []byte) (err error) {
 
 // UnmarshalTimeString unmarshals a string representation of a time in RFC3339 format into a time.Time object.
 func UnmarshalTimeString(ts string) *time.Time {
-	logger := ucplog.FromContextOrDiscard(context.Background())
 	var tt timeRFC3339
-	err := tt.UnmarshalText([]byte(ts))
-	if err != nil {
-		logger.Info(fmt.Sprintf("Invalid time string: '%s'. Using default value", ts))
-	}
+	_ = tt.UnmarshalText([]byte(ts))
 	return (*time.Time)(&tt)
 }
 

--- a/pkg/armrpc/api/v1/time_util.go
+++ b/pkg/armrpc/api/v1/time_util.go
@@ -17,9 +17,13 @@ limitations under the License.
 package v1
 
 import (
+	"context"
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/radius-project/radius/pkg/ucp/ucplog"
 )
 
 const (
@@ -70,8 +74,12 @@ func (t *timeRFC3339) UnmarshalText(data []byte) (err error) {
 
 // UnmarshalTimeString unmarshals a string representation of a time in RFC3339 format into a time.Time object.
 func UnmarshalTimeString(ts string) *time.Time {
+	logger := ucplog.FromContextOrDiscard(context.Background())
 	var tt timeRFC3339
-	_ = tt.UnmarshalText([]byte(ts))
+	err := tt.UnmarshalText([]byte(ts))
+	if err != nil {
+		logger.Info(fmt.Sprintf("Invalid time string: '%s'. Using default value", ts))
+	}
 	return (*time.Time)(&tt)
 }
 

--- a/pkg/corerp/api/v20220315privatepreview/util.go
+++ b/pkg/corerp/api/v20220315privatepreview/util.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v20220315privatepreview
 
 import (
-	"time"
-
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/recipes"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
@@ -71,20 +69,14 @@ func fromProvisioningStateDataModel(state v1.ProvisioningState) *ProvisioningSta
 	return &converted
 }
 
-func unmarshalTimeString(ts string) *time.Time {
-	var tt timeRFC3339
-	_ = tt.UnmarshalText([]byte(ts))
-	return (*time.Time)(&tt)
-}
-
 func fromSystemDataModel(s v1.SystemData) *SystemData {
 	return &SystemData{
 		CreatedBy:          to.Ptr(s.CreatedBy),
 		CreatedByType:      (*CreatedByType)(to.Ptr(s.CreatedByType)),
-		CreatedAt:          unmarshalTimeString(s.CreatedAt),
+		CreatedAt:          v1.UnmarshalTimeString(s.CreatedAt),
 		LastModifiedBy:     to.Ptr(s.LastModifiedBy),
 		LastModifiedByType: (*CreatedByType)(to.Ptr(s.LastModifiedByType)),
-		LastModifiedAt:     unmarshalTimeString(s.LastModifiedAt),
+		LastModifiedAt:     v1.UnmarshalTimeString(s.LastModifiedAt),
 	}
 }
 

--- a/pkg/corerp/api/v20220315privatepreview/util_test.go
+++ b/pkg/corerp/api/v20220315privatepreview/util_test.go
@@ -66,14 +66,14 @@ func TestFromProvisioningStateDataModel(t *testing.T) {
 }
 
 func TestUnmarshalTimeString(t *testing.T) {
-	parsedTime := unmarshalTimeString("2021-09-24T19:09:00.000000Z")
+	parsedTime := v1.UnmarshalTimeString("2021-09-24T19:09:00.000000Z")
 	require.NotNil(t, parsedTime)
 
 	require.Equal(t, 2021, parsedTime.Year())
 	require.Equal(t, time.Month(9), parsedTime.Month())
 	require.Equal(t, 24, parsedTime.Day())
 
-	parsedTime = unmarshalTimeString("")
+	parsedTime = v1.UnmarshalTimeString("")
 	require.NotNil(t, parsedTime)
 	require.Equal(t, 1, parsedTime.Year())
 }


### PR DESCRIPTION
# Description

Refactors UnmarshalTimeString to have a single instance

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius #5685 .

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #5685

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 380e724</samp>

### Summary
🪵🔧♻️

<!--
1.  🪵 - This emoji can be used to represent the addition of logging and error handling to the `UnmarshalTimeString` function, as it suggests the creation of log entries or wood-like structures.
2.  🔧 - This emoji can be used to represent the update of a test function to use a public function instead of a private one, as it suggests a minor adjustment or fix.
3.  ♻️ - This emoji can be used to represent the removal of unused and redundant code and the refactoring of the time parsing logic to use a common function, as it suggests recycling or reusing existing resources.
-->
Refactored and improved time parsing logic across different API packages. Removed unused code and added logging and error handling to `UnmarshalTimeString` in `pkg/armrpc/api/v1`.

> _Oh we're the coders of the azure sea_
> _We refactor and we log with glee_
> _We use the `v1` package for time_
> _And we sing this shanty in our prime_

### Walkthrough
*  Update imports and add logging to `UnmarshalTimeString` function in `pkg/armrpc/api/v1/time_util.go` ([link](https://github.com/radius-project/radius/pull/6330/files?diff=unified&w=0#diff-11a2914e60769d287a5b7bf84ede141399ce0dc6020b0d89afff000e5a40f799L20-R26), [link](https://github.com/radius-project/radius/pull/6330/files?diff=unified&w=0#diff-11a2914e60769d287a5b7bf84ede141399ce0dc6020b0d89afff000e5a40f799L73-R82))
*  Remove unused `time` import from `pkg/corerp/api/v20220315privatepreview/util.go` ([link](https://github.com/radius-project/radius/pull/6330/files?diff=unified&w=0#diff-48542b3be6d72db57f2adfbf2c59d32397027cbfb7765a01fded291f1cb8e7c9L20-L21))
*  Replace `unmarshalTimeString` function with `v1.UnmarshalTimeString` function in `pkg/corerp/api/v20220315privatepreview/util.go` to avoid code duplication and ensure consistency ([link](https://github.com/radius-project/radius/pull/6330/files?diff=unified&w=0#diff-48542b3be6d72db57f2adfbf2c59d32397027cbfb7765a01fded291f1cb8e7c9L74-R79))
*  Update test function `TestUnmarshalTimeString` in `pkg/corerp/api/v20220315privatepreview/util_test.go` to use `v1.UnmarshalTimeString` function instead of the removed `unmarshalTimeString` function ([link](https://github.com/radius-project/radius/pull/6330/files?diff=unified&w=0#diff-5c2787580738d116817000e3357891d244ab5129a47b53062d15683d181ca532L69-R69), [link](https://github.com/radius-project/radius/pull/6330/files?diff=unified&w=0#diff-5c2787580738d116817000e3357891d244ab5129a47b53062d15683d181ca532L76-R76))


