### PR TITLE
Fix flaky test: Test_Render_Multiple_Routes

### DIFF
--- a/pkg/corerp/renderers/gateway/render_test.go
+++ b/pkg/corerp/renderers/gateway/render_test.go
@@ -34,6 +34,7 @@ import (
 	resources_kubernetes "github.com/radius-project/radius/pkg/ucp/resources/kubernetes"
 	"github.com/radius-project/radius/test/testcontext"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -1472,6 +1473,10 @@ func validateHTTPProxy(t *testing.T, outputResources []rpv1.OutputResource, expe
 			expectedHTTPProxyOutputResource.CreateResource.Dependencies = append(expectedHTTPProxyOutputResource.CreateResource.Dependencies, r.LocalID)
 		}
 	}
+
+	// Sort the dependencies so that tests aren't flaky
+	slices.Sort(expectedHTTPProxyOutputResource.CreateResource.Dependencies)
+	slices.Sort(httpProxyOutputResource.CreateResource.Dependencies)
 
 	require.Equal(t, expectedHTTPProxyOutputResource, httpProxyOutputResource)
 	require.Equal(t, kubernetes.NormalizeResourceName(resourceName), httpProxy.Name)


### PR DESCRIPTION
# Description

* Fixing flaky gateway test

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #6263

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2a9b619</samp>

### Summary
📦🔧🧪

<!--
1.  📦 - This emoji represents the import of a new package, which is the `slices` package in this case.
2.  🔧 - This emoji represents the use of a tool or utility to improve something, which is the `slices.Sort` function in this case.
3.  🧪 - This emoji represents the testing or experimentation of something, which is the `validateHTTPProxy` function tests in this case.
-->
Improved test reliability for `validateHTTPProxy` function by sorting dependencies with `slices.Sort` in `render_test.go`.

> _Sing, O Muse, of the cunning code review_
> _That sorted the dependencies of proxies_
> _With the help of `slices`, a package new_
> _And improved the tests of `validateHTTPProxy`._

### Walkthrough
* Import the `slices` package from the `x/exp` module to sort slices of any type ([link](https://github.com/radius-project/radius/pull/6333/files?diff=unified&w=0#diff-ec18995e697107d252ed17ccd8be4bfa5c62cd32b37b75e34379a9053cd39166R37))
* Use the `slices.Sort` function to sort the dependencies of the expected and actual HTTPProxy resources in the `validateHTTPProxy` test function ([link](https://github.com/radius-project/radius/pull/6333/files?diff=unified&w=0#diff-ec18995e697107d252ed17ccd8be4bfa5c62cd32b37b75e34379a9053cd39166R1477-R1480))


