### PR TITLE
[do not review] wip - update messaging rp routes

### DIFF
--- a/cmd/applications-rp/main.go
+++ b/cmd/applications-rp/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/radius-project/radius/pkg/ucp/ucplog"
 
 	corerp_setup "github.com/radius-project/radius/pkg/corerp/setup"
+	messagingrp_setup "github.com/radius-project/radius/pkg/messagingrp/setup"
 )
 
 const serviceName = "radius"
@@ -187,6 +188,7 @@ func builders(options hostoptions.HostOptions) ([]builder.Builder, error) {
 
 	return []builder.Builder{
 		corerp_setup.SetupNamespace(config).GenerateBuilder(),
+		messagingrp_setup.SetupNamespace(config).GenerateBuilder(),
 		// Add resource provider builders...
 	}, nil
 }

--- a/cmd/ucpd/ucp-self-hosted-dev.yaml
+++ b/cmd/ucpd/ucp-self-hosted-dev.yaml
@@ -39,7 +39,7 @@ planes:
     properties:
       resourceProviders:
         Applications.Core: "http://localhost:8080"
-        Applications.Messaging: "http://localhost:8081"
+        Applications.Messaging: "http://localhost:8080"
         Applications.Dapr: "http://localhost:8081"
         Applications.Datastores: "http://localhost:8081"
         Microsoft.Resources: "http://localhost:5017"

--- a/pkg/messagingrp/setup/operations.go
+++ b/pkg/messagingrp/setup/operations.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package setup
+
+import v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+
+var operationList = []v1.Operation{
+	{
+		Name: "Applications.Messaging/operations/read",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Messaging",
+			Resource:    "operations",
+			Operation:   "Get operations",
+			Description: "Get the list of operations",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Messaging/rabbitmqqueues/read",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Messaging",
+			Resource:    "rabbitmqqueues",
+			Operation:   "List RabbitMQ",
+			Description: "Get the list of RabbitMQ.",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Messaging/rabbitmqqueues/write",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Messaging",
+			Resource:    "rabbitmqqueues",
+			Operation:   "Create/Update RabbitMQ",
+			Description: "Create or update RabbitMQ.",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Messaging/rabbitmqqueues/delete",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Core",
+			Resource:    "rabbitmqqueues",
+			Operation:   "Delete RabbitMQ",
+			Description: "Delete RabbitMQ.",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Messaging/rabbitmqqueues/listsecrets/action",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Messaging",
+			Resource:    "rabbitmqqueues",
+			Operation:   "List secrets",
+			Description: "Lists RabbitMQ secrets.",
+		},
+		IsDataAction: false,
+	},
+}

--- a/pkg/messagingrp/setup/setup.go
+++ b/pkg/messagingrp/setup/setup.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package setup
+
+import (
+	"time"
+
+	"github.com/radius-project/radius/pkg/armrpc/builder"
+	"github.com/radius-project/radius/pkg/armrpc/frontend/defaultoperation"
+	"github.com/radius-project/radius/pkg/recipes/controllerconfig"
+
+	frontend_ctrl "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
+	"github.com/radius-project/radius/pkg/messagingrp/datamodel"
+	msg_dm "github.com/radius-project/radius/pkg/messagingrp/datamodel"
+	"github.com/radius-project/radius/pkg/messagingrp/datamodel/converter"
+	msg_ctrl "github.com/radius-project/radius/pkg/messagingrp/frontend/controller"
+	rmq_ctrl "github.com/radius-project/radius/pkg/messagingrp/frontend/controller/rabbitmqqueues"
+	rp_frontend "github.com/radius-project/radius/pkg/rp/frontend"
+)
+
+const (
+	// AsyncOperationRetryAfter is polling interval for async create/update or delete resource operations.
+	AsyncOperationRetryAfter = time.Duration(5) * time.Second
+)
+
+// SetupNamespace builds the namespace for core resource provider.
+func SetupNamespace(recipeControllerConfig *controllerconfig.RecipeControllerConfig) *builder.Namespace {
+	ns := builder.NewNamespace("Applications.Messaging")
+
+	_ = ns.AddResource("rabbitmqqueues", &builder.ResourceOption[*datamodel.RabbitMQQueue, datamodel.RabbitMQQueue]{
+		RequestConverter:  converter.RabbitMQQueueDataModelFromVersioned,
+		ResponseConverter: converter.RabbitMQQueueDataModelToVersioned,
+
+		Put: builder.Operation[datamodel.RabbitMQQueue]{
+			APIController: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
+				return defaultoperation.NewDefaultAsyncPut(opt,
+					frontend_ctrl.ResourceOptions[msg_dm.RabbitMQQueue]{
+						RequestConverter:  converter.RabbitMQQueueDataModelFromVersioned,
+						ResponseConverter: converter.RabbitMQQueueDataModelToVersioned,
+						UpdateFilters: []frontend_ctrl.UpdateFilter[msg_dm.RabbitMQQueue]{
+							rp_frontend.PrepareRadiusResource[*msg_dm.RabbitMQQueue],
+						},
+						AsyncOperationTimeout:    msg_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
+					},
+				)
+			},
+		},
+		Patch: builder.Operation[datamodel.RabbitMQQueue]{
+			APIController: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
+				return defaultoperation.NewDefaultAsyncPut(opt,
+					frontend_ctrl.ResourceOptions[msg_dm.RabbitMQQueue]{
+						RequestConverter:  converter.RabbitMQQueueDataModelFromVersioned,
+						ResponseConverter: converter.RabbitMQQueueDataModelToVersioned,
+						UpdateFilters: []frontend_ctrl.UpdateFilter[msg_dm.RabbitMQQueue]{
+							rp_frontend.PrepareRadiusResource[*msg_dm.RabbitMQQueue],
+						},
+						AsyncOperationTimeout:    msg_ctrl.AsyncCreateOrUpdateRabbitMQTimeout,
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
+					},
+				)
+			},
+		},
+		Delete: builder.Operation[datamodel.RabbitMQQueue]{
+			APIController: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
+				return defaultoperation.NewDefaultAsyncDelete(opt,
+					frontend_ctrl.ResourceOptions[msg_dm.RabbitMQQueue]{
+						RequestConverter:         converter.RabbitMQQueueDataModelFromVersioned,
+						ResponseConverter:        converter.RabbitMQQueueDataModelToVersioned,
+						AsyncOperationTimeout:    msg_ctrl.AsyncDeleteRabbitMQTimeout,
+						AsyncOperationRetryAfter: AsyncOperationRetryAfter,
+					},
+				)
+			},
+		},
+		List: builder.Operation[datamodel.RabbitMQQueue]{
+			APIController: func(opt frontend_ctrl.Options) (frontend_ctrl.Controller, error) {
+				return defaultoperation.NewListResources(opt,
+					frontend_ctrl.ResourceOptions[msg_dm.RabbitMQQueue]{
+						RequestConverter:   converter.RabbitMQQueueDataModelFromVersioned,
+						ResponseConverter:  converter.RabbitMQQueueDataModelToVersioned,
+						ListRecursiveQuery: true,
+					})
+			},
+		},
+		Custom: map[string]builder.Operation[datamodel.RabbitMQQueue]{
+			"listsecrets": {
+				APIController: rmq_ctrl.NewListSecretsRabbitMQQueue,
+			},
+		},
+	})
+
+	// Optional
+	ns.SetAvailableOperations(operationList)
+
+	return ns
+}

--- a/pkg/messagingrp/setup/setup_test.go
+++ b/pkg/messagingrp/setup/setup_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package setup
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/golang/mock/gomock"
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	"github.com/radius-project/radius/pkg/armrpc/builder"
+	apictrl "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
+	"github.com/radius-project/radius/pkg/armrpc/rpctest"
+	"github.com/radius-project/radius/pkg/recipes/controllerconfig"
+	"github.com/radius-project/radius/pkg/ucp/dataprovider"
+	"github.com/radius-project/radius/pkg/ucp/store"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ResourceTypeName = "Applications.Messaging/rabbitmqqueues"
+)
+
+var handlerTests = []rpctest.HandlerTestSpec{
+	{
+		OperationType: v1.OperationType{Type: ResourceTypeName, Method: v1.OperationPlaneScopeList},
+		Path:          "/providers/applications.messaging/rabbitmqqueues",
+		Method:        http.MethodGet,
+	}, {
+		OperationType: v1.OperationType{Type: ResourceTypeName, Method: v1.OperationList},
+		Path:          "/resourcegroups/testrg/providers/applications.messaging/rabbitmqqueues",
+		Method:        http.MethodGet,
+	}, {
+		OperationType: v1.OperationType{Type: ResourceTypeName, Method: v1.OperationGet},
+		Path:          "/resourcegroups/testrg/providers/applications.messaging/rabbitmqqueues/rmq0",
+		Method:        http.MethodGet,
+	}, {
+		OperationType: v1.OperationType{Type: ResourceTypeName, Method: v1.OperationPut},
+		Path:          "/resourcegroups/testrg/providers/applications.messaging/rabbitmqqueues/rmq0",
+		Method:        http.MethodPut,
+	},
+}
+
+func TestRouter(t *testing.T) {
+	mctrl := gomock.NewController(t)
+
+	mockSP := dataprovider.NewMockDataStorageProvider(mctrl)
+	mockSC := store.NewMockStorageClient(mctrl)
+
+	mockSC.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&store.Object{}, nil).AnyTimes()
+	mockSC.EXPECT().Save(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockSP.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Return(store.StorageClient(mockSC), nil).AnyTimes()
+
+	cfg := &controllerconfig.RecipeControllerConfig{}
+	ns := SetupNamespace(cfg)
+	nsBuilder := ns.GenerateBuilder()
+
+	rpctest.AssertRouters(t, handlerTests, "/api.ucp.dev", "/planes/radius/local", func(ctx context.Context) (chi.Router, error) {
+		r := chi.NewRouter()
+		validator, err := builder.NewOpenAPIValidator(ctx, "/api.ucp.dev", "applications.messaging")
+		require.NoError(t, err)
+		return r, nsBuilder.ApplyAPIHandlers(ctx, r, apictrl.Options{PathBase: "/api.ucp.dev", DataProvider: mockSP}, validator)
+	})
+}

--- a/pkg/portableresources/frontend/handler/getoperations.go
+++ b/pkg/portableresources/frontend/handler/getoperations.go
@@ -254,46 +254,46 @@ func (opctrl *GetOperations) availableOperationsV1() *v1.PaginatedList {
 				},
 				IsDataAction: false,
 			},
-			&v1.Operation{
-				Name: "Applications.Messaging/rabbitMQQueues/read",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    MessagingProviderNamespace,
-					Resource:    "rabbitMQQueues",
-					Operation:   "Get/List rabbitMQQueues",
-					Description: "Gets/Lists rabbitMQQueue resource(s).",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Messaging/rabbitMQQueues/write",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    MessagingProviderNamespace,
-					Resource:    "rabbitMQQueues",
-					Operation:   "Create/Update rabbitMQQueues",
-					Description: "Creates or updates a rabbitMQQueue resource.",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Messaging/rabbitMQQueues/delete",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    MessagingProviderNamespace,
-					Resource:    "rabbitMQQueues",
-					Operation:   "Delete rabbitMQQueue",
-					Description: "Deletes a rabbitMQQueue resource.",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Messaging/rabbitMQQueues/listsecrets/action",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    MessagingProviderNamespace,
-					Resource:    "rabbitMQQueues",
-					Operation:   "List secrets",
-					Description: "Lists rabbitMQQueue secrets.",
-				},
-				IsDataAction: false,
-			},
+			// &v1.Operation{
+			// 	Name: "Applications.Messaging/rabbitMQQueues/read",
+			// 	Display: &v1.OperationDisplayProperties{
+			// 		Provider:    MessagingProviderNamespace,
+			// 		Resource:    "rabbitMQQueues",
+			// 		Operation:   "Get/List rabbitMQQueues",
+			// 		Description: "Gets/Lists rabbitMQQueue resource(s).",
+			// 	},
+			// 	IsDataAction: false,
+			// },
+			// &v1.Operation{
+			// 	Name: "Applications.Messaging/rabbitMQQueues/write",
+			// 	Display: &v1.OperationDisplayProperties{
+			// 		Provider:    MessagingProviderNamespace,
+			// 		Resource:    "rabbitMQQueues",
+			// 		Operation:   "Create/Update rabbitMQQueues",
+			// 		Description: "Creates or updates a rabbitMQQueue resource.",
+			// 	},
+			// 	IsDataAction: false,
+			// },
+			// &v1.Operation{
+			// 	Name: "Applications.Messaging/rabbitMQQueues/delete",
+			// 	Display: &v1.OperationDisplayProperties{
+			// 		Provider:    MessagingProviderNamespace,
+			// 		Resource:    "rabbitMQQueues",
+			// 		Operation:   "Delete rabbitMQQueue",
+			// 		Description: "Deletes a rabbitMQQueue resource.",
+			// 	},
+			// 	IsDataAction: false,
+			// },
+			// &v1.Operation{
+			// 	Name: "Applications.Messaging/rabbitMQQueues/listsecrets/action",
+			// 	Display: &v1.OperationDisplayProperties{
+			// 		Provider:    MessagingProviderNamespace,
+			// 		Resource:    "rabbitMQQueues",
+			// 		Operation:   "List secrets",
+			// 		Description: "Lists rabbitMQQueue secrets.",
+			// 	},
+			// 	IsDataAction: false,
+			// },
 			&v1.Operation{
 				Name: "Applications.Dapr/secretStores/read",
 				Display: &v1.OperationDisplayProperties{

--- a/pkg/portableresources/frontend/handler/routes.go
+++ b/pkg/portableresources/frontend/handler/routes.go
@@ -78,12 +78,12 @@ func AddRoutes(ctx context.Context, router chi.Router, isARM bool, ctrlOpts fron
 		rootScopePath,
 	}
 
-	err := AddMessagingRoutes(ctx, router, rootScopePath, prefixes, isARM, ctrlOpts)
-	if err != nil {
-		return err
-	}
+	// err := AddMessagingRoutes(ctx, router, rootScopePath, prefixes, isARM, ctrlOpts)
+	// if err != nil {
+	// 	return err
+	// }
 
-	err = AddDaprRoutes(ctx, router, rootScopePath, prefixes, isARM, ctrlOpts)
+	err := AddDaprRoutes(ctx, router, rootScopePath, prefixes, isARM, ctrlOpts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

_Please explain the changes you've made._

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1619d5a</samp>

### Summary
🐰🚀🧪

<!--
1.  🐰 - This emoji represents the rabbitmqqueues resource, which is the main resource of the Applications.Messaging namespace. It also conveys the idea of messaging and communication, which are the core features of the namespace.
2.  🚀 - This emoji represents the improvement and enhancement of the applications-rp command, which can now serve both the Applications.Core and Applications.Messaging namespaces. It also conveys the idea of speed and performance, which are important aspects of the unified control plane.
3.  🧪 - This emoji represents the testing and verification of the namespace setup and its handlers, which are done by the setup_test.go file. It also conveys the idea of experimentation and development, which are the goals of the ucp-self-hosted-dev.yaml file.
-->
This pull request adds support for the Applications.Messaging namespace to the applications-rp command, which serves as a resource provider for the Radius platform. It does this by creating a new package `messagingrp_setup` that defines and registers the namespace, its resources, and its operations. It also updates the `ucpd` and `portableresources` packages to use the new package and avoid duplication.

> _We are the messengers of doom_
> _We unleash the rabbitmqqueues_
> _We set up the namespace of gloom_
> _We register the operations of death_

### Walkthrough
*  Import the messagingrp_setup package and use its SetupNamespace function to register the Applications.Messaging namespace and its resources in the applications-rp command ([link](https://github.com/radius-project/radius/pull/6346/files?diff=unified&w=0#diff-667f05aa16f6dfd1d55d0ca1392411a09981560434524889a6dfe768679673fcR48), [link](https://github.com/radius-project/radius/pull/6346/files?diff=unified&w=0#diff-667f05aa16f6dfd1d55d0ca1392411a09981560434524889a6dfe768679673fcR191))
* Update the Applications.Messaging provider URL in the ucp-self-hosted-dev.yaml file to use the same port as the Applications.Core provider, since the applications-rp command will serve both namespaces ([link](https://github.com/radius-project/radius/pull/6346/files?diff=unified&w=0#diff-ceba0600c7e49ffd65b0a2fd7bf1798d9f6f6f531db64e051bb00ff29c7dcd93L42-R42))
* Implement the SetupNamespace function for the Applications.Messaging namespace in the `setup.go` file, which creates a namespace builder and registers the rabbitmqqueues resource with its options and controllers ([link](https://github.com/radius-project/radius/pull/6346/files?diff=unified&w=0#diff-b30407415dd2a84746f6d50dd44a5cbad71eb44630df88c735e715edfb852ac4R1-R111))
* Define the list of available operations for the Applications.Messaging namespace in the `operations.go` file, such as read, write, delete, and listsecrets for the rabbitmqqueues resource ([link](https://github.com/radius-project/radius/pull/6346/files?diff=unified&w=0#diff-d5a626f9259dd5b3c41f58ce71fdc82afd0c54be8a9835bf80e1a54fa2011f04R1-R72))
* Test the router generated by the SetupNamespace function for the Applications.Messaging namespace in the `setup_test.go` file, using the rpctest package ([link](https://github.com/radius-project/radius/pull/6346/files?diff=unified&w=0#diff-d98a4356c6f2a78c5c9723a3306ff155039b5b2e69e156c91e738de0a7deb7aeR1-R80))
* Comment out the operations and routes related to the Applications.Messaging namespace in the portable resources API, since they are now handled by the messagingrp_setup package ([link](https://github.com/radius-project/radius/pull/6346/files?diff=unified&w=0#diff-72c62c901d96d8731589a498aa8646bb01aeefafd5dbcc0b56781120b151b14aL257-R297), [link](https://github.com/radius-project/radius/pull/6346/files?diff=unified&w=0#diff-56d7c0ab8720204bebac59bab3fcfadd0edfac6944a88c61d3188285a57d3c80L81-R86))


