### PR TITLE
`rad deploy`: remove environment validation if `--environment` is not set

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,7 +44,7 @@
             "preLaunchTask": "Build Radius (all)",
             "program": "${workspaceFolder}/cmd/rad/main.go",
             "cwd": "${workspaceFolder}",
-            "args": ["deploy", "/Users/willsmith/dev/radius-sandbox/wow/test.bicep", "-g", "test-env-2"],
+            "args": [],
         },
         {
             "name": "Launch Deployment Engine",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,7 +44,7 @@
             "preLaunchTask": "Build Radius (all)",
             "program": "${workspaceFolder}/cmd/rad/main.go",
             "cwd": "${workspaceFolder}",
-            "args": [],
+            "args": ["deploy", "/Users/willsmith/dev/radius-sandbox/wow/test.bicep", "-g", "test-env-2"],
         },
         {
             "name": "Launch Deployment Engine",

--- a/pkg/cli/clivalidation.go
+++ b/pkg/cli/clivalidation.go
@@ -100,6 +100,12 @@ func RequireEnvironmentName(cmd *cobra.Command, args []string, workspace workspa
 	return environmentName, err
 }
 
+// DidSpecifyEnvironmentName checks if an environment name is provided as a flag
+func DidSpecifyEnvironmentName(cmd *cobra.Command, args []string) bool {
+	environmentName, err := cmd.Flags().GetString("environment")
+	return err == nil && environmentName != ""
+}
+
 // RequireKubeContext is used by commands that need a kubernetes context name to be specified using -c flag or has a default kubecontext
 //
 

--- a/pkg/cli/cmd/deploy/deploy.go
+++ b/pkg/cli/cmd/deploy/deploy.go
@@ -163,7 +163,6 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	// does not exist.
 	workspace.Scope = scope
 
-	didSpecifyEnvironment := cli.DidSpecifyEnvironmentName(cmd, args)
 	r.EnvironmentName, err = cli.RequireEnvironmentName(cmd, args, *workspace)
 	if err != nil {
 		return err
@@ -189,7 +188,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 
 		// If the environment doesn't exist, but the user specified it as
 		// a command-line option, return an error
-		if clients.Is404Error(err) && didSpecifyEnvironment {
+		if clients.Is404Error(err) && cli.DidSpecifyEnvironmentName(cmd, args) {
 			return clierrors.Message("The environment %q does not exist in scope %q. Run `rad env create` first.", r.EnvironmentName, r.Workspace.Scope)
 		}
 	}

--- a/pkg/cli/cmd/deploy/deploy.go
+++ b/pkg/cli/cmd/deploy/deploy.go
@@ -182,15 +182,19 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 	env, err := client.GetEnvDetails(cmd.Context(), r.EnvironmentName)
 	if err != nil {
+		// If the error is not a 404, return it
 		if !clients.Is404Error(err) {
 			return err
 		}
 
 		// If the environment doesn't exist, but the user specified it as
 		// a command-line option, return an error
-		if clients.Is404Error(err) && cli.DidSpecifyEnvironmentName(cmd, args) {
+		if cli.DidSpecifyEnvironmentName(cmd, args) {
 			return clierrors.Message("The environment %q does not exist in scope %q. Run `rad env create` first.", r.EnvironmentName, r.Workspace.Scope)
 		}
+
+		// If we got here, it means that the error was a 404 and the user did not specify the environment name.
+		// This is fine, because an environment is not required.
 	}
 
 	r.Providers = &clients.Providers{}
@@ -253,11 +257,13 @@ func (r *Runner) Run(ctx context.Context) error {
 		// Validate that the environment exists already
 		_, err = client.GetEnvDetails(ctx, r.EnvironmentName)
 		if err != nil {
-			if clients.Is404Error(err) {
-				// If the environment is missing, don't create the application
-			} else {
+			// If the error is not a 404, return it
+			if !clients.Is404Error(err) {
 				return err
 			}
+
+			// If the error is a 404, it means that the environment does not exist,
+			// but this is okay. We don't want to create an application though.
 		} else {
 			err = client.CreateApplicationIfNotFound(ctx, r.ApplicationName, v20231001preview.ApplicationResource{
 				Location: to.Ptr(v1.LocationGlobal),

--- a/pkg/cli/cmd/deploy/deploy_test.go
+++ b/pkg/cli/cmd/deploy/deploy_test.go
@@ -444,9 +444,9 @@ func Test_Run(t *testing.T) {
 			Return(map[string]any{}, nil).
 			Times(1)
 
-		// options := deploy.Options{}
-
 		appManagmentMock := clients.NewMockApplicationsManagementClient(ctrl)
+
+		// GetEnvDetails returns a 404 error
 		appManagmentMock.EXPECT().
 			GetEnvDetails(gomock.Any(), "envdoesntexist").
 			Return(v20231001preview.EnvironmentResource{}, radcli.Create404Error()).
@@ -456,8 +456,6 @@ func Test_Run(t *testing.T) {
 		deployMock.EXPECT().
 			DeployWithProgress(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, o deploy.Options) (clients.DeploymentResult, error) {
-				// Capture options for verification
-				// options = o
 				return clients.DeploymentResult{}, nil
 			}).
 			Times(1)
@@ -485,6 +483,8 @@ func Test_Run(t *testing.T) {
 		}
 
 		err := runner.Run(context.Background())
+
+		// Even though GetEnvDetails returns a 404 error, the deployment should still succeed
 		require.NoError(t, err)
 
 		// All of the output in this command is being done by functions that we mock for testing, so this

--- a/pkg/cli/cmd/run/run_test.go
+++ b/pkg/cli/cmd/run/run_test.go
@@ -201,6 +201,10 @@ func Test_Run(t *testing.T) {
 
 	clientMock := clients.NewMockApplicationsManagementClient(ctrl)
 	clientMock.EXPECT().
+		GetEnvDetails(gomock.Any(), "test-environment").
+		Return(v20231001preview.EnvironmentResource{}, nil).
+		Times(1)
+	clientMock.EXPECT().
 		CreateApplicationIfNotFound(gomock.Any(), "test-application", gomock.Any()).
 		Return(nil).
 		Times(1)


### PR DESCRIPTION
# Description

* This fixes the bootstrapping issue where you need an environment to deploy an environment

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #4017

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ef8f68b</samp>

### Summary
🚀🆕🧹

<!--
1.  🚀 - This emoji represents the launch configuration change, which enables the `rad` tool to deploy Bicep files to resource groups. The rocket emoji is often used to indicate deployment or launching of a new feature or service.
2.  🆕 - This emoji represents the addition of a new method to the `ApplicationsManagementClient` interface, which allows creating an environment if it does not exist. The new emoji is commonly used to indicate something new or novel, such as a new feature, functionality, or option.
3.  🧹 - This emoji represents the improvement of the `deploy` subcommand by simplifying the error handling, removing unused code, and adding the default environment creation. The broom emoji is often used to indicate cleaning up, refactoring, or improving existing code or functionality.
-->
This pull request enhances the `deploy` subcommand of the `rad` tool to support creating a default environment from a Bicep file if not specified. It also simplifies the error handling and removes unused code in the `deploy` logic. It updates the launch configuration for debugging the `rad` tool and adds a new method to the `ApplicationsManagementClient` interface and its implementation.

> _Sing, O Muse, of the `rad` tool, the mighty helper of the coders,_
> _Who with skill and craft deploy their Bicep files to Azure's borders._
> _They invoke the `deploy` subcommand, passing arguments with care,_
> _To create or update resources in the environment they declare._

### Walkthrough
*  Simplify the `deploy` subcommand of the `rad` tool to create an environment if not found ([link](https://github.com/radius-project/radius/pull/6351/files?diff=unified&w=0#diff-b18b7839db664b7ea7e3dee7fb9e1fb08f7246f7c6e02bd946e6c60ab9b3f211R159-R161), [link](https://github.com/radius-project/radius/pull/6351/files?diff=unified&w=0#diff-23443c20f46bfbb5ffda2f87efc0e56ecaea1ef964ed4fc9ee06fe584fcfedcaR374-R402), [link](https://github.com/radius-project/radius/pull/6351/files?diff=unified&w=0#diff-d6c61273bc3b207947a07cd5738268086f051aabe22a517620be75dbcb94c83cL184-R183), [link](https://github.com/radius-project/radius/pull/6351/files?diff=unified&w=0#diff-d6c61273bc3b207947a07cd5738268086f051aabe22a517620be75dbcb94c83cR233-R254))
  - Add a new method `CreateEnvironmentIfNotFound` to the `ApplicationsManagementClient` interface and implement it for the `UCPApplicationsManagementClient` struct using the UCP library ([link](https://github.com/radius-project/radius/pull/6351/files?diff=unified&w=0#diff-b18b7839db664b7ea7e3dee7fb9e1fb08f7246f7c6e02bd946e6c60ab9b3f211R159-R161), [link](https://github.com/radius-project/radius/pull/6351/files?diff=unified&w=0#diff-23443c20f46bfbb5ffda2f87efc0e56ecaea1ef964ed4fc9ee06fe584fcfedcaR374-R402))
  - Call the new method in the `Run` method of the `deploy` command, passing the environment name and a default resource definition ([link](https://github.com/radius-project/radius/pull/6351/files?diff=unified&w=0#diff-d6c61273bc3b207947a07cd5738268086f051aabe22a517620be75dbcb94c83cR233-R254))
  - Ignore the 404 error in the `Validate` method of the `deploy` command if the environment does not exist, as it might be created later ([link](https://github.com/radius-project/radius/pull/6351/files?diff=unified&w=0#diff-d6c61273bc3b207947a07cd5738268086f051aabe22a517620be75dbcb94c83cL184-R183))
* Modify the launch configuration for the `rad` tool to pass arguments for deploying a Bicep file to a resource group ([link](https://github.com/radius-project/radius/pull/6351/files?diff=unified&w=0#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L47-R47))
  - Update the `.vscode/launch.json` file to include the `deploy` subcommand, the environment name, and the Bicep file path as arguments ([link](https://github.com/radius-project/radius/pull/6351/files?diff=unified&w=0#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L47-R47))
* Remove unused and extra code from the `deploy` package ([link](https://github.com/radius-project/radius/pull/6351/files?diff=unified&w=0#diff-d6c61273bc3b207947a07cd5738268086f051aabe22a517620be75dbcb94c83cL27), [link](https://github.com/radius-project/radius/pull/6351/files?diff=unified&w=0#diff-d6c61273bc3b207947a07cd5738268086f051aabe22a517620be75dbcb94c83cL228-L229))
  - Delete an unused import from the `deploy.go` file ([link](https://github.com/radius-project/radius/pull/6351/files?diff=unified&w=0#diff-d6c61273bc3b207947a07cd5738268086f051aabe22a517620be75dbcb94c83cL27))
  - Remove an extra blank comment line from the `Run` method of the `deploy` command ([link](https://github.com/radius-project/radius/pull/6351/files?diff=unified&w=0#diff-d6c61273bc3b207947a07cd5738268086f051aabe22a517620be75dbcb94c83cL228-L229))


