### PR TITLE
Upload rad cli edge/latest version to GHCR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,6 +54,9 @@ env:
   # Local file path to the release binaries.
   RELEASE_PATH: ./release
 
+  # ORAS (OCI Registry As Storage) CLI version
+  ORAS_VERSION: 1.1.0
+
 jobs:
   build:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
@@ -388,12 +391,76 @@ jobs:
             --verify-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+  publish-ghcr:
+    name: Publish rad CLI latest binaries to GHCR
+    needs: [ 'build' ]
+    runs-on: ubuntu-latest
+    if: (github.ref == 'refs/heads/main')
+    steps:
+      - name: Download release artifacts (darwin_arm64)
+        uses: actions/download-artifact@v3
+        with:
+          name: rad_cli_darwin_arm64
+          path: rad_cli_darwin_arm64
+      - name: Download release artifacts (darwin_amd64)
+        uses: actions/download-artifact@v3
+        with:
+          name: rad_cli_darwin_amd64
+          path: rad_cli_darwin_amd64
+      - name: Download release artifacts (linux_arm)
+        uses: actions/download-artifact@v3
+        with:
+          name: rad_cli_linux_arm
+          path: rad_cli_linux_arm
+      - name: Download release artifacts (linux_arm64)
+        uses: actions/download-artifact@v3
+        with:
+          name: rad_cli_linux_arm64
+          path: rad_cli_linux_arm64
+      - name: Download release artifacts (linux_amd64)
+        uses: actions/download-artifact@v3
+        with:
+          name: rad_cli_linux_amd64
+          path: rad_cli_linux_amd64
+      - name: Download release artifacts (windows_amd64)
+        uses: actions/download-artifact@v3
+        with:
+          name: rad_cli_windows_amd64
+          path: rad_cli_windows_amd64
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ env.GHCR_ACTOR }}
+          password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+      - uses: oras-project/setup-oras@v1
+        with:
+          version: ${{ env.ORAS_VERSION }}
+      - run: oras version
+      - name: Push rad cli binaries to GHCR (macos-x64:latest)
+        run: |
+          oras push ${{ env.CONTAINER_REGISTRY }}/rad/macos-x64:latest rad_cli_darwin_amd64/rad
+      - name: Push rad cli binaries to GHCR (macos-arm64:latest)
+        run: |
+          oras push ${{ env.CONTAINER_REGISTRY }}/rad/macos-arm64:latest rad_cli_darwin_arm64/rad
+      - name: Push rad cli binaries to GHCR (linux-x64:latest)
+        run: |
+          oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-x64:latest rad_cli_linux_amd64/rad
+      - name: Push rad cli binaries to GHCR (linux-arm:latest)
+        run: |
+          oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-arm:latest rad_cli_linux_arm/rad
+      - name: Push rad cli binaries to GHCR (linux-arm64:latest)
+        run: |
+          oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-arm64:latest rad_cli_linux_arm64/rad
+      - name: Push rad cli binaries to GHCR (windows-x64:latest)
+        run: |
+          oras push ${{ env.CONTAINER_REGISTRY }}/rad/windows-x64:latest rad_cli_windows_amd64/rad.exe
   # TODO_LAUNCH: Remove this job once we opensource - https://github.com/radius-project/radius/issues/5892
-  publish:
+  publish-acr:
     name: Publish rad CLI binaries
     needs: [ 'build' ]
     runs-on: ubuntu-latest
-    # if: (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') # upload on push to main or tag
+    if: (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') # upload on push to main or tag
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -429,80 +496,52 @@ jobs:
         with:
           name: rad_cli_windows_amd64
           path: rad_cli_windows_amd64
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
         with:
-          registry: ghcr.io
-          username: ${{ env.GHCR_ACTOR }}
-          password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
-      - uses: oras-project/setup-oras@v1
+          source_dir: rad_cli_darwin_amd64
+          container_name: 'tools'
+          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
+          overwrite: 'true'
+          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/macos-x64/ --pattern rad --timeout 300'
+      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
         with:
-          version: 1.1.0
-      - run: oras version
-      - name: Push rad cli binaries to GHCR (macos-x64:latest)
-        run: |
-          oras push ${{ env.CONTAINER_REGISTRY }}/rad/macos-x64:latest rad_cli_darwin_amd64/rad
-      - name: Push rad cli binaries to GHCR (macos-arm64:latest)
-        run: |
-          oras push ${{ env.CONTAINER_REGISTRY }}/rad/macos-arm64:latest rad_cli_darwin_arm64/rad
-      - name: Push rad cli binaries to GHCR (linux-x64:latest)
-        run: |
-          oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-x64:latest rad_cli_linux_amd64/rad
-      - name: Push rad cli binaries to GHCR (linux-arm:latest)
-        run: |
-          oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-arm:latest rad_cli_linux_arm/rad
-      - name: Push rad cli binaries to GHCR (linux-arm64:latest)
-        run: |
-          oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-arm64:latest rad_cli_linux_arm64/rad
-      - name: Push rad cli binaries to GHCR (windows-x64:latest)
-        run: |
-          oras push ${{ env.CONTAINER_REGISTRY }}/rad/windows-x64:latest rad_cli_windows_amd64/rad.exe
-      # - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-      #   with:
-      #     source_dir: rad_cli_darwin_amd64
-      #     container_name: 'tools'
-      #     connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-      #     overwrite: 'true'
-      #     extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/macos-x64/ --pattern rad --timeout 300'
-      # - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-      #   with:
-      #     source_dir: rad_cli_darwin_arm64
-      #     container_name: 'tools'
-      #     connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-      #     overwrite: 'true'
-      #     extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/macos-arm64/ --pattern rad --timeout 300'
-      # - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-      #   with:
-      #     source_dir: rad_cli_linux_amd64
-      #     container_name: 'tools'
-      #     connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-      #     overwrite: 'true'
-      #     extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-x64/ --pattern rad --timeout 300'
-      # - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-      #   with:
-      #     source_dir: rad_cli_linux_arm
-      #     container_name: 'tools'
-      #     connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-      #     overwrite: 'true'
-      #     extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-arm/ --pattern rad --timeout 300'
-      # - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-      #   with:
-      #     source_dir: rad_cli_linux_arm64
-      #     container_name: 'tools'
-      #     connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-      #     overwrite: 'true'
-      #     extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-arm64/ --pattern rad --timeout 300'
-      # - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-      #   with:
-      #     source_dir: rad_cli_windows_amd64
-      #     container_name: 'tools'
-      #     connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-      #     overwrite: 'true'
-      #     extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/windows-x64/ --pattern rad.exe --timeout 300'
+          source_dir: rad_cli_darwin_arm64
+          container_name: 'tools'
+          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
+          overwrite: 'true'
+          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/macos-arm64/ --pattern rad --timeout 300'
+      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
+        with:
+          source_dir: rad_cli_linux_amd64
+          container_name: 'tools'
+          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
+          overwrite: 'true'
+          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-x64/ --pattern rad --timeout 300'
+      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
+        with:
+          source_dir: rad_cli_linux_arm
+          container_name: 'tools'
+          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
+          overwrite: 'true'
+          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-arm/ --pattern rad --timeout 300'
+      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
+        with:
+          source_dir: rad_cli_linux_arm64
+          container_name: 'tools'
+          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
+          overwrite: 'true'
+          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-arm64/ --pattern rad --timeout 300'
+      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
+        with:
+          source_dir: rad_cli_windows_amd64
+          container_name: 'tools'
+          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
+          overwrite: 'true'
+          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/windows-x64/ --pattern rad.exe --timeout 300'
 
   delete_artifacts:
     name: Delete artifacts
-    needs: [ 'build', 'publish' ]
+    needs: [ 'build', 'publish-acr', 'publish-ghcr' ]
     if: ${{ always() && !contains(needs.build.result, 'failure') }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -441,19 +441,19 @@ jobs:
       - run: oras version
       - name: Push rad cli binaries to GHCR (macos-x64:latest)
         run: |
-          ./oras push ${{ env.CONTAINER_REGISTRY }}/rad/macos-x64:latest rad_cli_darwin_amd64/rad
+          oras push ${{ env.CONTAINER_REGISTRY }}/rad/macos-x64:latest rad_cli_darwin_amd64/rad
       - name: Push rad cli binaries to GHCR (macos-arm64:latest)
         run: |
-          ./oras push ${{ env.CONTAINER_REGISTRY }}/rad/macos-arm64:latest rad_cli_darwin_arm64/rad
+          oras push ${{ env.CONTAINER_REGISTRY }}/rad/macos-arm64:latest rad_cli_darwin_arm64/rad
       - name: Push rad cli binaries to GHCR (linux-x64:latest)
         run: |
-          ./oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-x64:latest rad_cli_linux_amd64/rad
+          oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-x64:latest rad_cli_linux_amd64/rad
       - name: Push rad cli binaries to GHCR (linux-arm:latest)
         run: |
-          ./oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-arm:latest rad_cli_linux_arm/rad
+          oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-arm:latest rad_cli_linux_arm/rad
       - name: Push rad cli binaries to GHCR (linux-arm64:latest)
         run: |
-          ./oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-arm64:latest rad_cli_linux_arm64/rad
+          oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-arm64:latest rad_cli_linux_arm64/rad
       - name: Push rad cli binaries to GHCR (windows-x64:latest)
         run: |
           oras push ${{ env.CONTAINER_REGISTRY }}/rad/windows-x64:latest rad_cli_windows_amd64/rad.exe

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -393,7 +393,7 @@ jobs:
     name: Publish rad CLI binaries
     needs: [ 'build' ]
     runs-on: ubuntu-latest
-    if: (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') # upload on push to main or tag
+    # if: (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') # upload on push to main or tag
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -440,71 +440,65 @@ jobs:
           version: 1.1.0
       - run: oras version
       - name: Push rad cli binaries to GHCR (macos-x64:latest)
-        # if: (github.ref == 'refs/heads/main')
         run: |
           ./oras push ${{ env.CONTAINER_REGISTRY }}/rad/macos-x64:latest rad_cli_darwin_amd64/rad
       - name: Push rad cli binaries to GHCR (macos-arm64:latest)
-        # if: (github.ref == 'refs/heads/main')
         run: |
           ./oras push ${{ env.CONTAINER_REGISTRY }}/rad/macos-arm64:latest rad_cli_darwin_arm64/rad
       - name: Push rad cli binaries to GHCR (linux-x64:latest)
-        # if: (github.ref == 'refs/heads/main')
         run: |
           ./oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-x64:latest rad_cli_linux_amd64/rad
       - name: Push rad cli binaries to GHCR (linux-arm:latest)
-        # if: (github.ref == 'refs/heads/main')
         run: |
           ./oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-arm:latest rad_cli_linux_arm/rad
       - name: Push rad cli binaries to GHCR (linux-arm64:latest)
-        # if: (github.ref == 'refs/heads/main')
         run: |
           ./oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-arm64:latest rad_cli_linux_arm64/rad
       - name: Push rad cli binaries to GHCR (windows-x64:latest)
-        # if: (github.ref == 'refs/heads/main')
         run: |
           oras push ${{ env.CONTAINER_REGISTRY }}/rad/windows-x64:latest rad_cli_windows_amd64/rad.exe
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_darwin_amd64
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/macos-x64/ --pattern rad --timeout 300'
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_darwin_arm64
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/macos-arm64/ --pattern rad --timeout 300'
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_linux_amd64
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-x64/ --pattern rad --timeout 300'
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_linux_arm
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-arm/ --pattern rad --timeout 300'
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_linux_arm64
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-arm64/ --pattern rad --timeout 300'
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_windows_amd64
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/windows-x64/ --pattern rad.exe --timeout 300'
+      # - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
+      #   with:
+      #     source_dir: rad_cli_darwin_amd64
+      #     container_name: 'tools'
+      #     connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
+      #     overwrite: 'true'
+      #     extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/macos-x64/ --pattern rad --timeout 300'
+      # - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
+      #   with:
+      #     source_dir: rad_cli_darwin_arm64
+      #     container_name: 'tools'
+      #     connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
+      #     overwrite: 'true'
+      #     extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/macos-arm64/ --pattern rad --timeout 300'
+      # - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
+      #   with:
+      #     source_dir: rad_cli_linux_amd64
+      #     container_name: 'tools'
+      #     connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
+      #     overwrite: 'true'
+      #     extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-x64/ --pattern rad --timeout 300'
+      # - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
+      #   with:
+      #     source_dir: rad_cli_linux_arm
+      #     container_name: 'tools'
+      #     connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
+      #     overwrite: 'true'
+      #     extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-arm/ --pattern rad --timeout 300'
+      # - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
+      #   with:
+      #     source_dir: rad_cli_linux_arm64
+      #     container_name: 'tools'
+      #     connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
+      #     overwrite: 'true'
+      #     extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-arm64/ --pattern rad --timeout 300'
+      # - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
+      #   with:
+      #     source_dir: rad_cli_windows_amd64
+      #     container_name: 'tools'
+      #     connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
+      #     overwrite: 'true'
+      #     extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/windows-x64/ --pattern rad.exe --timeout 300'
 
   delete_artifacts:
     name: Delete artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -429,6 +429,40 @@ jobs:
         with:
           name: rad_cli_windows_amd64
           path: rad_cli_windows_amd64
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ env.GHCR_ACTOR }}
+          password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+      - uses: oras-project/setup-oras@v1
+        with:
+          version: 1.1.0
+      - run: oras version
+      - name: Push rad cli binaries to GHCR (macos-x64:latest)
+        # if: (github.ref == 'refs/heads/main')
+        run: |
+          ./oras push ${{ env.CONTAINER_REGISTRY }}/rad/macos-x64:latest rad_cli_darwin_amd64/rad
+      - name: Push rad cli binaries to GHCR (macos-arm64:latest)
+        # if: (github.ref == 'refs/heads/main')
+        run: |
+          ./oras push ${{ env.CONTAINER_REGISTRY }}/rad/macos-arm64:latest rad_cli_darwin_arm64/rad
+      - name: Push rad cli binaries to GHCR (linux-x64:latest)
+        # if: (github.ref == 'refs/heads/main')
+        run: |
+          ./oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-x64:latest rad_cli_linux_amd64/rad
+      - name: Push rad cli binaries to GHCR (linux-arm:latest)
+        # if: (github.ref == 'refs/heads/main')
+        run: |
+          ./oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-arm:latest rad_cli_linux_arm/rad
+      - name: Push rad cli binaries to GHCR (linux-arm64:latest)
+        # if: (github.ref == 'refs/heads/main')
+        run: |
+          ./oras push ${{ env.CONTAINER_REGISTRY }}/rad/linux-arm64:latest rad_cli_linux_arm64/rad
+      - name: Push rad cli binaries to GHCR (windows-x64:latest)
+        # if: (github.ref == 'refs/heads/main')
+        run: |
+          oras push ${{ env.CONTAINER_REGISTRY }}/rad/windows-x64:latest rad_cli_windows_amd64/rad.exe
       - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
         with:
           source_dir: rad_cli_darwin_amd64


### PR DESCRIPTION
# Description

* Updating build.yaml workflow to publish rad cli edge version to GHCR

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request adds or changes features of Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Partially addresses: #6295

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1ba4f9a</samp>

### Summary
🚀🐳🛠️

<!--
1.  🚀 This emoji conveys the idea of launching or deploying something new, which fits with the goal of distributing the rad cli tool to a wider audience through GHCR.
2.  🐳 This emoji is often used to represent Docker or containers in general, which relates to the use of GHCR as a container registry and oras as a tool for working with OCI artifacts.
3.  🛠️ This emoji signifies tools or building something, which matches the theme of the build workflow and the rad cli tool itself.
-->
This change updates the build workflow to publish the `rad` cli tool as OCI artifacts on GHCR. This allows users to download and install the tool using `oras`.

> _`rad cli` as OCI_
> _Pushed to GHCR by oras_
> _Autumn of binaries_

### Walkthrough
*  Add steps to login to GHCR, setup oras, and push rad cli binaries as OCI artifacts ([link](https://github.com/radius-project/radius/pull/6352/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R432-R465))


