### PR TITLE
[DO NOT REVIEW] Simplify API Registration - Applications.Datastores

### DIFF
--- a/cmd/applications-rp/main.go
+++ b/cmd/applications-rp/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/radius-project/radius/pkg/ucp/ucplog"
 
 	corerp_setup "github.com/radius-project/radius/pkg/corerp/setup"
+	dsrp_setup "github.com/radius-project/radius/pkg/datastoresrp/setup"
 )
 
 const serviceName = "radius"
@@ -187,6 +188,7 @@ func builders(options hostoptions.HostOptions) ([]builder.Builder, error) {
 
 	return []builder.Builder{
 		corerp_setup.SetupNamespace(config).GenerateBuilder(),
+		dsrp_setup.SetupNamespace(config).GenerateBuilder(),
 		// Add resource provider builders...
 	}, nil
 }

--- a/cmd/ucpd/ucp-self-hosted-dev.yaml
+++ b/cmd/ucpd/ucp-self-hosted-dev.yaml
@@ -41,7 +41,7 @@ planes:
         Applications.Core: "http://localhost:8080"
         Applications.Messaging: "http://localhost:8081"
         Applications.Dapr: "http://localhost:8081"
-        Applications.Datastores: "http://localhost:8081"
+        Applications.Datastores: "http://localhost:8080"
         Microsoft.Resources: "http://localhost:5017"
       kind: "UCPNative"
 

--- a/deploy/Chart/templates/ucp/configmaps.yaml
+++ b/deploy/Chart/templates/ucp/configmaps.yaml
@@ -36,7 +36,7 @@ data:
           resourceProviders:
             Applications.Core: "http://applications-rp.radius-system:5443"
             Applications.Dapr: "http://applications-rp.radius-system:5444"
-            Applications.Datastores: "http://applications-rp.radius-system:5444"
+            Applications.Datastores: "http://applications-rp.radius-system:5443"
             Applications.Messaging: "http://applications-rp.radius-system:5444"
             Microsoft.Resources: "http://bicep-de.radius-system:6443"
           kind: "UCPNative"

--- a/docs/contributing/contributing-code/contributing-code-control-plane/configSettings.md
+++ b/docs/contributing/contributing-code/contributing-code-control-plane/configSettings.md
@@ -231,7 +231,7 @@ planes:
       resourceProviders:
         Applications.Core: "http://applications-rp.radius-system:5443"
         Applications.Dapr: "http://applications-rp.radius-system:5444"
-        Applications.Datastores: "http://applications-rp.radius-system:5444"
+        Applications.Datastores: "http://applications-rp.radius-system:5443"
         Applications.Messaging: "http://applications-rp.radius-system:5444"
         Microsoft.Resources: "http://bicep-de.radius-system:6443"
       kind: "UCPNative"

--- a/pkg/datastoresrp/setup/operations.go
+++ b/pkg/datastoresrp/setup/operations.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package setup
+
+import v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+
+var operationList = []v1.Operation{
+	{
+		Name: "Applications.Datastores/operations/read",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Datastores",
+			Resource:    "operations",
+			Operation:   "Get operations",
+			Description: "Get the list of operations",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Datastores/redisCaches/read",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Datastores",
+			Resource:    "redisCaches",
+			Operation:   "List redisCaches",
+			Description: "List Redis cache resource(s).",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Datastores/redisCaches/write",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Datastores",
+			Resource:    "redisCaches",
+			Operation:   "Create/Update redisCaches",
+			Description: "Create or update an Redis cache resource.",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Datastores/redisCaches/delete",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Datastores",
+			Resource:    "redisCaches",
+			Operation:   "Delete redisCache",
+			Description: "Delete a Redis cache resource.",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Datastores/redisCaches/getmetadata/action",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Datastores",
+			Resource:    "redisCaches",
+			Operation:   "Get recipe metadata",
+			Description: "Get recipe metadata.",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Datastores/redisCaches/listsecrets/action",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Datastores",
+			Resource:    "redisCaches",
+			Operation:   "List secrets",
+			Description: "Lists Redis cache secrets.",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Datastores/register/action",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Datastores",
+			Resource:    "Applications.Datastores",
+			Operation:   "Register Applications.Datastores",
+			Description: "Register the subscription for Applications.Datastores.",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Datastores/unregister/action",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Datastores",
+			Resource:    "Applications.Datastores",
+			Operation:   "Unregister Applications.Datastores",
+			Description: "Unregister the subscription for Applications.Datastores.",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Datastores/mongoDatabases/read",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Datastores",
+			Resource:    "mongoDatabases",
+			Operation:   "List mongoDatabases",
+			Description: "List Mongo database resource(s).",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Datastores/mongoDatabases/write",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Datastores",
+			Resource:    "mongoDatabases",
+			Operation:   "Create/Update mongoDatabases",
+			Description: "Create or update a Mongo database resource.",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Datastores/mongoDatabases/delete",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Datastores",
+			Resource:    "mongoDatabases",
+			Operation:   "Delete mongoDatabases",
+			Description: "Delete a Mongo databases resource.",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Datastores/mongoDatabases/listsecrets/action",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Datastore",
+			Resource:    "mongoDatabases",
+			Operation:   "List secrets",
+			Description: "List secret(s) of Mongo database resource.",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Datastores/sqlDatabases/read",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Datastores",
+			Resource:    "sqlDatabases",
+			Operation:   "List sqlDatabases",
+			Description: "List SQL database resource(s).",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Datastores/sqlDatabases/write",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Datastores",
+			Resource:    "sqlDatabases",
+			Operation:   "Create/Update sqlDatabases",
+			Description: "Create or update a SQL database resource.",
+		},
+		IsDataAction: false,
+	},
+	{
+		Name: "Applications.Datastores/sqlDatabases/delete",
+		Display: &v1.OperationDisplayProperties{
+			Provider:    "Applications.Datastores",
+			Resource:    "sqlDatabases",
+			Operation:   "Delete sqlDatabases",
+			Description: "Delete a SQL database resource.",
+		},
+		IsDataAction: false,
+	},
+}

--- a/pkg/datastoresrp/setup/setup.go
+++ b/pkg/datastoresrp/setup/setup.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package setup
+
+import (
+	"time"
+
+	asyncctrl "github.com/radius-project/radius/pkg/armrpc/asyncoperation/controller"
+	"github.com/radius-project/radius/pkg/armrpc/builder"
+	apictrl "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
+	"github.com/radius-project/radius/pkg/datastoresrp/datamodel"
+	"github.com/radius-project/radius/pkg/datastoresrp/datamodel/converter"
+	"github.com/radius-project/radius/pkg/recipes/controllerconfig"
+
+	ds_ctrl "github.com/radius-project/radius/pkg/datastoresrp/frontend/controller"
+	mongo_ctrl "github.com/radius-project/radius/pkg/datastoresrp/frontend/controller/mongodatabases"
+	rds_ctrl "github.com/radius-project/radius/pkg/datastoresrp/frontend/controller/rediscaches"
+	sql_ctrl "github.com/radius-project/radius/pkg/datastoresrp/frontend/controller/sqldatabases"
+	mongo_proc "github.com/radius-project/radius/pkg/datastoresrp/processors/mongodatabases"
+	rds_proc "github.com/radius-project/radius/pkg/datastoresrp/processors/rediscaches"
+	sql_proc "github.com/radius-project/radius/pkg/datastoresrp/processors/sqldatabases"
+	pr_ctrl "github.com/radius-project/radius/pkg/portableresources/backend/controller"
+	rp_frontend "github.com/radius-project/radius/pkg/rp/frontend"
+)
+
+const (
+	// AsyncOperationRetryAfter is polling interval for async create/update or delete resource operations.
+	AsyncOperationRetryAfter = time.Duration(5) * time.Second
+)
+
+// SetupNamespace builds the namespace for core resource provider.
+func SetupNamespace(recipeControllerConfig *controllerconfig.RecipeControllerConfig) *builder.Namespace {
+	ns := builder.NewNamespace("Applications.Datastores")
+
+	_ = ns.AddResource("redisCaches", &builder.ResourceOption[*datamodel.RedisCache, datamodel.RedisCache]{
+		RequestConverter:  converter.RedisCacheDataModelFromVersioned,
+		ResponseConverter: converter.RedisCacheDataModelToVersioned,
+
+		Put: builder.Operation[datamodel.RedisCache]{
+			UpdateFilters: []apictrl.UpdateFilter[datamodel.RedisCache]{
+				rp_frontend.PrepareRadiusResource[*datamodel.RedisCache],
+			},
+			AsyncJobController: func(options asyncctrl.Options) (asyncctrl.Controller, error) {
+				return pr_ctrl.NewCreateOrUpdateResource[*datamodel.RedisCache, datamodel.RedisCache](options, &rds_proc.Processor{}, recipeControllerConfig.Engine, recipeControllerConfig.ResourceClient, recipeControllerConfig.ConfigLoader)
+			},
+			AsyncOperationTimeout:    ds_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+			AsyncOperationRetryAfter: AsyncOperationRetryAfter,
+		},
+		Patch: builder.Operation[datamodel.RedisCache]{
+			UpdateFilters: []apictrl.UpdateFilter[datamodel.RedisCache]{
+				rp_frontend.PrepareRadiusResource[*datamodel.RedisCache],
+			},
+			AsyncJobController: func(options asyncctrl.Options) (asyncctrl.Controller, error) {
+				return pr_ctrl.NewCreateOrUpdateResource[*datamodel.RedisCache, datamodel.RedisCache](options, &rds_proc.Processor{}, recipeControllerConfig.Engine, recipeControllerConfig.ResourceClient, recipeControllerConfig.ConfigLoader)
+			},
+			AsyncOperationTimeout:    ds_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+			AsyncOperationRetryAfter: AsyncOperationRetryAfter,
+		},
+		Delete: builder.Operation[datamodel.RedisCache]{
+			AsyncJobController: func(options asyncctrl.Options) (asyncctrl.Controller, error) {
+				return pr_ctrl.NewDeleteResource[*datamodel.RedisCache, datamodel.RedisCache](options, &rds_proc.Processor{}, recipeControllerConfig.Engine, recipeControllerConfig.ConfigLoader)
+			},
+			AsyncOperationTimeout:    ds_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+			AsyncOperationRetryAfter: AsyncOperationRetryAfter,
+		},
+		Custom: map[string]builder.Operation[datamodel.RedisCache]{
+			"listsecrets": {
+				APIController: rds_ctrl.NewListSecretsRedisCache,
+			},
+		},
+	})
+
+	_ = ns.AddResource("mongoDatabases", &builder.ResourceOption[*datamodel.MongoDatabase, datamodel.MongoDatabase]{
+		RequestConverter:  converter.MongoDatabaseDataModelFromVersioned,
+		ResponseConverter: converter.MongoDatabaseDataModelToVersioned,
+
+		Put: builder.Operation[datamodel.MongoDatabase]{
+			UpdateFilters: []apictrl.UpdateFilter[datamodel.MongoDatabase]{
+				rp_frontend.PrepareRadiusResource[*datamodel.MongoDatabase],
+			},
+			AsyncJobController: func(options asyncctrl.Options) (asyncctrl.Controller, error) {
+				return pr_ctrl.NewCreateOrUpdateResource[*datamodel.MongoDatabase, datamodel.MongoDatabase](options, &mongo_proc.Processor{}, recipeControllerConfig.Engine, recipeControllerConfig.ResourceClient, recipeControllerConfig.ConfigLoader)
+			},
+			AsyncOperationTimeout:    ds_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+			AsyncOperationRetryAfter: AsyncOperationRetryAfter,
+		},
+		Patch: builder.Operation[datamodel.MongoDatabase]{
+			UpdateFilters: []apictrl.UpdateFilter[datamodel.MongoDatabase]{
+				rp_frontend.PrepareRadiusResource[*datamodel.MongoDatabase],
+			},
+			AsyncJobController: func(options asyncctrl.Options) (asyncctrl.Controller, error) {
+				return pr_ctrl.NewCreateOrUpdateResource[*datamodel.MongoDatabase, datamodel.MongoDatabase](options, &mongo_proc.Processor{}, recipeControllerConfig.Engine, recipeControllerConfig.ResourceClient, recipeControllerConfig.ConfigLoader)
+			},
+			AsyncOperationTimeout:    ds_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+			AsyncOperationRetryAfter: AsyncOperationRetryAfter,
+		},
+		Delete: builder.Operation[datamodel.MongoDatabase]{
+			AsyncJobController: func(options asyncctrl.Options) (asyncctrl.Controller, error) {
+				return pr_ctrl.NewDeleteResource[*datamodel.MongoDatabase, datamodel.MongoDatabase](options, &mongo_proc.Processor{}, recipeControllerConfig.Engine, recipeControllerConfig.ConfigLoader)
+			},
+			AsyncOperationTimeout:    ds_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+			AsyncOperationRetryAfter: AsyncOperationRetryAfter,
+		},
+		Custom: map[string]builder.Operation[datamodel.MongoDatabase]{
+			"listsecrets": {
+				APIController: mongo_ctrl.NewListSecretsMongoDatabase,
+			},
+		},
+	})
+
+	_ = ns.AddResource("sqldatabases", &builder.ResourceOption[*datamodel.SqlDatabase, datamodel.SqlDatabase]{
+		RequestConverter:  converter.SqlDatabaseDataModelFromVersioned,
+		ResponseConverter: converter.SqlDatabaseDataModelToVersioned,
+
+		Put: builder.Operation[datamodel.SqlDatabase]{
+			UpdateFilters: []apictrl.UpdateFilter[datamodel.SqlDatabase]{
+				rp_frontend.PrepareRadiusResource[*datamodel.SqlDatabase],
+			},
+			AsyncJobController: func(options asyncctrl.Options) (asyncctrl.Controller, error) {
+				return pr_ctrl.NewCreateOrUpdateResource[*datamodel.SqlDatabase, datamodel.SqlDatabase](options, &sql_proc.Processor{}, recipeControllerConfig.Engine, recipeControllerConfig.ResourceClient, recipeControllerConfig.ConfigLoader)
+			},
+			AsyncOperationTimeout:    ds_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+			AsyncOperationRetryAfter: AsyncOperationRetryAfter,
+		},
+		Patch: builder.Operation[datamodel.SqlDatabase]{
+			UpdateFilters: []apictrl.UpdateFilter[datamodel.SqlDatabase]{
+				rp_frontend.PrepareRadiusResource[*datamodel.SqlDatabase],
+			},
+			AsyncJobController: func(options asyncctrl.Options) (asyncctrl.Controller, error) {
+				return pr_ctrl.NewCreateOrUpdateResource[*datamodel.SqlDatabase, datamodel.SqlDatabase](options, &sql_proc.Processor{}, recipeControllerConfig.Engine, recipeControllerConfig.ResourceClient, recipeControllerConfig.ConfigLoader)
+			},
+			AsyncOperationTimeout:    ds_ctrl.AsyncCreateOrUpdateMongoDatabaseTimeout,
+			AsyncOperationRetryAfter: AsyncOperationRetryAfter,
+		},
+		Delete: builder.Operation[datamodel.SqlDatabase]{
+			AsyncJobController: func(options asyncctrl.Options) (asyncctrl.Controller, error) {
+				return pr_ctrl.NewDeleteResource[*datamodel.SqlDatabase, datamodel.SqlDatabase](options, &sql_proc.Processor{}, recipeControllerConfig.Engine, recipeControllerConfig.ConfigLoader)
+			},
+			AsyncOperationTimeout:    ds_ctrl.AsyncCreateOrUpdateRedisCacheTimeout,
+			AsyncOperationRetryAfter: AsyncOperationRetryAfter,
+		},
+		Custom: map[string]builder.Operation[datamodel.SqlDatabase]{
+			"listsecrets": {
+				APIController: sql_ctrl.NewListSecretsSqlDatabase,
+			},
+		},
+	})
+
+	// Optional
+	ns.SetAvailableOperations(operationList)
+
+	return ns
+}

--- a/pkg/datastoresrp/setup/setup_test.go
+++ b/pkg/datastoresrp/setup/setup_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package setup
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	"github.com/radius-project/radius/pkg/armrpc/builder"
+	apictrl "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
+	"github.com/radius-project/radius/pkg/armrpc/rpctest"
+	ds_ctrl "github.com/radius-project/radius/pkg/datastoresrp/frontend/controller"
+	"github.com/radius-project/radius/pkg/portableresources"
+	"github.com/radius-project/radius/pkg/recipes/controllerconfig"
+	"github.com/radius-project/radius/pkg/ucp/dataprovider"
+	"github.com/radius-project/radius/pkg/ucp/store"
+)
+
+var handlerTests = []rpctest.HandlerTestSpec{
+	{
+		OperationType: v1.OperationType{Type: portableresources.MongoDatabasesResourceType, Method: v1.OperationPlaneScopeList},
+		Path:          "/providers/applications.datastores/mongodatabases",
+		Method:        http.MethodGet,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.MongoDatabasesResourceType, Method: v1.OperationList},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/mongodatabases",
+		Method:        http.MethodGet,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.MongoDatabasesResourceType, Method: v1.OperationGet},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/mongodatabases/mongo",
+		Method:        http.MethodGet,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.MongoDatabasesResourceType, Method: v1.OperationPut},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/mongodatabases/mongo",
+		Method:        http.MethodPut,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.MongoDatabasesResourceType, Method: v1.OperationPatch},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/mongodatabases/mongo",
+		Method:        http.MethodPatch,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.MongoDatabasesResourceType, Method: v1.OperationDelete},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/mongodatabases/mongo",
+		Method:        http.MethodDelete,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.MongoDatabasesResourceType, Method: ds_ctrl.OperationListSecret},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/mongodatabases/mongo/listsecrets",
+		Method:        http.MethodPost,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.RedisCachesResourceType, Method: v1.OperationPlaneScopeList},
+		Path:          "/providers/applications.datastores/rediscaches",
+		Method:        http.MethodGet,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.RedisCachesResourceType, Method: v1.OperationList},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/rediscaches",
+		Method:        http.MethodGet,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.RedisCachesResourceType, Method: v1.OperationGet},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/rediscaches/redis",
+		Method:        http.MethodGet,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.RedisCachesResourceType, Method: v1.OperationPut},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/rediscaches/redis",
+		Method:        http.MethodPut,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.RedisCachesResourceType, Method: v1.OperationPatch},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/rediscaches/redis",
+		Method:        http.MethodPatch,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.RedisCachesResourceType, Method: v1.OperationDelete},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/rediscaches/redis",
+		Method:        http.MethodDelete,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.RedisCachesResourceType, Method: ds_ctrl.OperationListSecret},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/rediscaches/redis/listsecrets",
+		Method:        http.MethodPost,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.SqlDatabasesResourceType, Method: v1.OperationPlaneScopeList},
+		Path:          "/providers/applications.datastores/sqldatabases",
+		Method:        http.MethodGet,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.SqlDatabasesResourceType, Method: v1.OperationList},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/sqldatabases",
+		Method:        http.MethodGet,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.SqlDatabasesResourceType, Method: v1.OperationGet},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/sqldatabases/sql",
+		Method:        http.MethodGet,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.SqlDatabasesResourceType, Method: v1.OperationPut},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/sqldatabases/sql",
+		Method:        http.MethodPut,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.SqlDatabasesResourceType, Method: v1.OperationPatch},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/sqldatabases/sql",
+		Method:        http.MethodPatch,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.SqlDatabasesResourceType, Method: v1.OperationDelete},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/sqldatabases/sql",
+		Method:        http.MethodDelete,
+	}, {
+		OperationType: v1.OperationType{Type: portableresources.SqlDatabasesResourceType, Method: ds_ctrl.OperationListSecret},
+		Path:          "/resourcegroups/testrg/providers/applications.datastores/sqldatabases/sql/listsecrets",
+		Method:        http.MethodPost,
+	},
+}
+
+func TestRouter(t *testing.T) {
+	mctrl := gomock.NewController(t)
+
+	mockSP := dataprovider.NewMockDataStorageProvider(mctrl)
+	mockSC := store.NewMockStorageClient(mctrl)
+
+	mockSC.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&store.Object{}, nil).AnyTimes()
+	mockSC.EXPECT().Save(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockSP.EXPECT().GetStorageClient(gomock.Any(), gomock.Any()).Return(store.StorageClient(mockSC), nil).AnyTimes()
+
+	cfg := &controllerconfig.RecipeControllerConfig{}
+	ns := SetupNamespace(cfg)
+	nsBuilder := ns.GenerateBuilder()
+
+	rpctest.AssertRouters(t, handlerTests, "/api.ucp.dev", "/planes/radius/local", func(ctx context.Context) (chi.Router, error) {
+		r := chi.NewRouter()
+		validator, err := builder.NewOpenAPIValidator(ctx, "/api.ucp.dev", "applications.datastores")
+		require.NoError(t, err)
+		return r, nsBuilder.ApplyAPIHandlers(ctx, r, apictrl.Options{PathBase: "/api.ucp.dev", DataProvider: mockSP}, validator)
+	})
+}

--- a/pkg/portableresources/frontend/handler/getoperations.go
+++ b/pkg/portableresources/frontend/handler/getoperations.go
@@ -65,72 +65,12 @@ func (opctrl *GetOperations) availableOperationsV1() *v1.PaginatedList {
 				IsDataAction: false,
 			},
 			&v1.Operation{
-				Name: "Applications.Datastores/operations/read",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    DatastoresProviderNamespace,
-					Resource:    "operations",
-					Operation:   "Get operations",
-					Description: "Get the list of operations.",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
 				Name: "Applications.Messaging/operations/read",
 				Display: &v1.OperationDisplayProperties{
 					Provider:    MessagingProviderNamespace,
 					Resource:    "operations",
 					Operation:   "Get operations",
 					Description: "Get the list of operations.",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Datastores/mongoDatabases/read",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    DatastoresProviderNamespace,
-					Resource:    "mongoDatabases",
-					Operation:   "Get/List mongoDatabases",
-					Description: "Gets/Lists mongoDatabase resource(s).",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Datastores/mongoDatabases/write",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    DatastoresProviderNamespace,
-					Resource:    "mongoDatabases",
-					Operation:   "Create/Update mongoDatabases",
-					Description: "Creates or updates a mongo database resource.",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Datastores/mongoDatabases/delete",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    DatastoresProviderNamespace,
-					Resource:    "mongoDatabases",
-					Operation:   "Delete mongoDatabase",
-					Description: "Deletes a mongoDatabase resource.",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Datastores/mongoDatabases/listsecrets/action",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    DatastoresProviderNamespace,
-					Resource:    "mongoDatabases",
-					Operation:   "List secrets",
-					Description: "Lists mongoDatabase secrets.",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Datastores/register/action",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    DatastoresProviderNamespace,
-					Resource:    DatastoresProviderNamespace,
-					Operation:   "Register Applications.Datastores resource provider",
-					Description: "Registers 'Applications.Datastores' resource provider with a subscription.",
 				},
 				IsDataAction: false,
 			},
@@ -151,106 +91,6 @@ func (opctrl *GetOperations) availableOperationsV1() *v1.PaginatedList {
 					Resource:    MessagingProviderNamespace,
 					Operation:   "Register Applications.Messaging resource provider",
 					Description: "Registers 'Applications.Messaging' resource provider with a subscription.",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Datastores/unregister/action",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    DatastoresProviderNamespace,
-					Resource:    "Applications.Datastores",
-					Operation:   "Unregister 'Applications.Datastores' resource provider",
-					Description: "Unregisters 'Applications.Datastores' resource provider with a subscription.",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Dapr/unregister/action",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    DaprProviderNamespace,
-					Resource:    "Applications.Datastores",
-					Operation:   "Unregister 'Applications.Dapr' resource provider",
-					Description: "Unregisters 'Applications.Dapr' resource provider with a subscription.",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Messaging/unregister/action",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    MessagingProviderNamespace,
-					Resource:    "Applications.Datastores",
-					Operation:   "Unregister 'Applications.Messaging' resource provider",
-					Description: "Unregisters 'Applications.Messaging' resource provider with a subscription.",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Datastores/sqlDatabases/read",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    DatastoresProviderNamespace,
-					Resource:    "sqlDatabases",
-					Operation:   "Get/List sqlDatabases",
-					Description: "Gets/Lists sqlDatabase resource(s).",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Datastores/sqlDatabases/write",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    DatastoresProviderNamespace,
-					Resource:    "sqlDatabases",
-					Operation:   "Create/Update sqlDatabases",
-					Description: "Creates or updates a sql database resource.",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Datastores/sqlDatabases/delete",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    DatastoresProviderNamespace,
-					Resource:    "sqlDatabases",
-					Operation:   "Delete sqlDatabase",
-					Description: "Deletes a sqlDatabase resource.",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Datastores/redisCaches/read",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    DatastoresProviderNamespace,
-					Resource:    "redisCaches",
-					Operation:   "Get/List redisCaches",
-					Description: "Gets/Lists redisCache resource(s).",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Datastores/redisCaches/write",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    DatastoresProviderNamespace,
-					Resource:    "redisCaches",
-					Operation:   "Create/Update redisCaches",
-					Description: "Creates or updates a redisCache resource.",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Datastores/redisCaches/delete",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    DatastoresProviderNamespace,
-					Resource:    "redisCaches",
-					Operation:   "Delete redisCache",
-					Description: "Deletes a redisCache resource.",
-				},
-				IsDataAction: false,
-			},
-			&v1.Operation{
-				Name: "Applications.Datastores/redisCaches/listsecrets/action",
-				Display: &v1.OperationDisplayProperties{
-					Provider:    DatastoresProviderNamespace,
-					Resource:    "redisCaches",
-					Operation:   "List secrets",
-					Description: "Lists redisCache secrets.",
 				},
 				IsDataAction: false,
 			},

--- a/pkg/portableresources/frontend/handler/getoperations_test.go
+++ b/pkg/portableresources/frontend/handler/getoperations_test.go
@@ -47,7 +47,7 @@ func TestRunWith20231001Preview(t *testing.T) {
 	case *rest.OKResponse:
 		pagination, ok := v.Body.(*v1.PaginatedList)
 		require.True(t, ok)
-		require.Equal(t, 33, len(pagination.Value))
+		require.Equal(t, 17, len(pagination.Value))
 	default:
 		require.Truef(t, false, "should not return error")
 	}

--- a/pkg/portableresources/frontend/handler/routes_test.go
+++ b/pkg/portableresources/frontend/handler/routes_test.go
@@ -26,7 +26,6 @@ import (
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	ctrl "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
 	"github.com/radius-project/radius/pkg/armrpc/rpctest"
-	ds_ctrl "github.com/radius-project/radius/pkg/datastoresrp/frontend/controller"
 	rabbitmq_ctrl "github.com/radius-project/radius/pkg/messagingrp/frontend/controller/rabbitmqqueues"
 	"github.com/radius-project/radius/pkg/portableresources"
 	"github.com/radius-project/radius/pkg/ucp/dataprovider"
@@ -134,7 +133,7 @@ var handlerTests = []rpctest.HandlerTestSpec{
 		OperationType: v1.OperationType{Type: portableresources.DaprStateStoresResourceType, Method: v1.OperationDelete},
 		Path:          "/resourcegroups/testrg/providers/applications.dapr/statestores/daprstatestore",
 		Method:        http.MethodDelete,
-	}, {
+	}, /*{
 		OperationType: v1.OperationType{Type: portableresources.MongoDatabasesResourceType, Method: v1.OperationList},
 		Path:          "/providers/applications.datastores/mongodatabases",
 		Method:        http.MethodGet,
@@ -218,7 +217,7 @@ var handlerTests = []rpctest.HandlerTestSpec{
 		OperationType: v1.OperationType{Type: portableresources.SqlDatabasesResourceType, Method: ds_ctrl.OperationListSecret},
 		Path:          "/resourcegroups/testrg/providers/applications.datastores/sqldatabases/sql/listsecrets",
 		Method:        http.MethodPost,
-	}, {
+	},*/{
 		OperationType: v1.OperationType{Type: "Applications.Messaging/operationStatuses", Method: v1.OperationGet},
 		Path:          "/providers/applications.messaging/locations/global/operationstatuses/00000000-0000-0000-0000-000000000000",
 		Method:        http.MethodGet,
@@ -270,13 +269,6 @@ func TestHandlers(t *testing.T) {
 			{
 				OperationType:               v1.OperationType{Type: "Applications.Dapr/providers", Method: v1.OperationGet},
 				Path:                        "/providers/applications.dapr/operations",
-				Method:                      http.MethodGet,
-				WithoutRootScope:            true,
-				SkipOperationTypeValidation: true,
-			},
-			{
-				OperationType:               v1.OperationType{Type: "Applications.Datastores/providers", Method: v1.OperationGet},
-				Path:                        "/providers/applications.datastores/operations",
 				Method:                      http.MethodGet,
 				WithoutRootScope:            true,
 				SkipOperationTypeValidation: true,


### PR DESCRIPTION
# Description

Updating routes, operations and resource provider registration to be inline with recent updates for Applications.Core resource provider

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius #6269 .

Fixes: Part of #6269 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0db6559</samp>

### Summary
🔄🚀🧹

<!--
1.  🔄 - This emoji represents the changes that modify the port numbers for the `Applications.Datastores` endpoint, as they are changing the configuration and alignment of the service.
2.  🚀 - This emoji represents the changes that add new files and functions for the `datastoresrp/setup` package, as they are launching a new feature and functionality for the `Applications.Datastores` resource provider.
3.  🧹 - This emoji represents the changes that remove or skip redundant or irrelevant operations and test cases, as they are cleaning up the code and improving the quality and performance of the service.
-->
This pull request adds support for `Applications.Datastores` resources to the `applications-rp` command and the `datastoresrp` package. It also removes redundant or obsolete operations and tests from the `portableresources` package and updates the port numbers for the `Applications.Datastores` endpoint in various files.

> _We're setting up the datastores for the applications_
> _We're changing ports and operations for the `applications-rp`_
> _We're testing all the routers and the converters_
> _We're heaving on the line on the count of three_

### Walkthrough
*  Register and set up the `Applications.Datastores` resource provider namespace and its resources using the `datastoresrp/setup` package ([link](https://github.com/radius-project/radius/pull/6414/files?diff=unified&w=0#diff-667f05aa16f6dfd1d55d0ca1392411a09981560434524889a6dfe768679673fcR48), [link](https://github.com/radius-project/radius/pull/6414/files?diff=unified&w=0#diff-667f05aa16f6dfd1d55d0ca1392411a09981560434524889a6dfe768679673fcR191), [link](https://github.com/radius-project/radius/pull/6414/files?diff=unified&w=0#diff-dac7ca2c8cbe7fd5eab5fd3fe83ed18ddd07d7f6d55ba46b8917b24e7b24bfa1R1-R167), [link](https://github.com/radius-project/radius/pull/6414/files?diff=unified&w=0#diff-038ee92ede58f35d8401332288f5068780baac643f71ed0671b493bcd38ac4d0R1-R172))
*  Test the routers for the `Applications.Datastores` resource provider using mock objects and the `rpctest` package ([link](https://github.com/radius-project/radius/pull/6414/files?diff=unified&w=0#diff-1270518f609b8ce321ca0dd5f5cda6979baa5b0dd4dc70f616f655be1e70bd3cR1-R147))
*  Remove the `Applications.Datastores` operations from the `portableresources/frontend/handler/getoperations.go` file to avoid duplication ([link](https://github.com/radius-project/radius/pull/6414/files?diff=unified&w=0#diff-72c62c901d96d8731589a498aa8646bb01aeefafd5dbcc0b56781120b151b14aL68-L77), [link](https://github.com/radius-project/radius/pull/6414/files?diff=unified&w=0#diff-72c62c901d96d8731589a498aa8646bb01aeefafd5dbcc0b56781120b151b14aL88-L137), [link](https://github.com/radius-project/radius/pull/6414/files?diff=unified&w=0#diff-72c62c901d96d8731589a498aa8646bb01aeefafd5dbcc0b56781120b151b14aL158-L257))
*  Update the expected number of operations in the `portableresources/frontend/handler/getoperations_test.go` file ([link](https://github.com/radius-project/radius/pull/6414/files?diff=unified&w=0#diff-935e98a3e7f642c3133e7514a00b6b326bc1a321b9a266fac3912ca49fbd4ca5L50-R50))
*  Remove or comment out the test cases for the `Applications.Datastores` operations from the `portableresources/frontend/handler/routes_test.go` file, as they are handled by the `datastoresrp` handler ([link](https://github.com/radius-project/radius/pull/6414/files?diff=unified&w=0#diff-2792dae138ce1d90b14d02d5f207e29a4a144886ca9ece6faab8e8effc47e851L29), [link](https://github.com/radius-project/radius/pull/6414/files?diff=unified&w=0#diff-2792dae138ce1d90b14d02d5f207e29a4a144886ca9ece6faab8e8effc47e851L137-R136), [link](https://github.com/radius-project/radius/pull/6414/files?diff=unified&w=0#diff-2792dae138ce1d90b14d02d5f207e29a4a144886ca9ece6faab8e8effc47e851L221-R220), [link](https://github.com/radius-project/radius/pull/6414/files?diff=unified&w=0#diff-2792dae138ce1d90b14d02d5f207e29a4a144886ca9ece6faab8e8effc47e851L277-L283))
*  Align the port for the `Applications.Datastores` endpoint with the `applications-rp` command in the `ucpd/ucp-self-hosted-dev.yaml` and `deploy/Chart/templates/ucp/configmaps.yaml` files ([link](https://github.com/radius-project/radius/pull/6414/files?diff=unified&w=0#diff-ceba0600c7e49ffd65b0a2fd7bf1798d9f6f6f531db64e051bb00ff29c7dcd93L44-R44), [link](https://github.com/radius-project/radius/pull/6414/files?diff=unified&w=0#diff-be9c0b61a26165c87503e667cec005520aea94da66f0dd1eedfff863efd266acL39-R39))
*  Update the port for the `Applications.Datastores` endpoint in the `docs/contributing/contributing-code/contributing-code-control-plane/configSettings.md` file ([link](https://github.com/radius-project/radius/pull/6414/files?diff=unified&w=0#diff-c5a6e900bac29ec26476b731e62862ee9afb8f9f67225da0aa8fd1d052f8183fL234-R234))


