### PR TITLE
Adding ApplicationGraphResource model API TypeSpec

### DIFF
--- a/pkg/corerp/api/v20231001preview/zz_generated_applications_client.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_applications_client.go
@@ -195,6 +195,62 @@ func (client *ApplicationsClient) getHandleResponse(resp *http.Response) (Applic
 	return result, nil
 }
 
+// GetGraph - Gets the application graph and resources.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-10-01-preview
+//   - applicationName - The application name
+//   - body - The content of the action request
+//   - options - ApplicationsClientGetGraphOptions contains the optional parameters for the ApplicationsClient.GetGraph method.
+func (client *ApplicationsClient) GetGraph(ctx context.Context, applicationName string, body map[string]any, options *ApplicationsClientGetGraphOptions) (ApplicationsClientGetGraphResponse, error) {
+	var err error
+	req, err := client.getGraphCreateRequest(ctx, applicationName, body, options)
+	if err != nil {
+		return ApplicationsClientGetGraphResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return ApplicationsClientGetGraphResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
+		err = runtime.NewResponseError(httpResp)
+		return ApplicationsClientGetGraphResponse{}, err
+	}
+	resp, err := client.getGraphHandleResponse(httpResp)
+	return resp, err
+}
+
+// getGraphCreateRequest creates the GetGraph request.
+func (client *ApplicationsClient) getGraphCreateRequest(ctx context.Context, applicationName string, body map[string]any, options *ApplicationsClientGetGraphOptions) (*policy.Request, error) {
+	urlPath := "/{rootScope}/providers/Applications.Core/applications/{applicationName}/getGraph"
+	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
+	if applicationName == "" {
+		return nil, errors.New("parameter applicationName cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{applicationName}", url.PathEscape(applicationName))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api-version", "2023-10-01-preview")
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	if err := runtime.MarshalAsJSON(req, body); err != nil {
+	return nil, err
+}
+	return req, nil
+}
+
+// getGraphHandleResponse handles the GetGraph response.
+func (client *ApplicationsClient) getGraphHandleResponse(resp *http.Response) (ApplicationsClientGetGraphResponse, error) {
+	result := ApplicationsClientGetGraphResponse{}
+	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGraphResponse); err != nil {
+		return ApplicationsClientGetGraphResponse{}, err
+	}
+	return result, nil
+}
+
 // NewListByScopePager - List ApplicationResource resources by Scope
 //
 // Generated from API version 2023-10-01-preview

--- a/pkg/corerp/api/v20231001preview/zz_generated_constants.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_constants.go
@@ -127,17 +127,18 @@ func PossibleDaprSidecarExtensionProtocolValues() []DaprSidecarExtensionProtocol
 type Direction string
 
 const (
-	// DirectionFrom - From
-	DirectionFrom Direction = "From"
-	// DirectionTo - To
-	DirectionTo Direction = "To"
+	// DirectionInbound - The resource defining this connection accepts inbound connections from the resource specified by this
+// id.
+	DirectionInbound Direction = "Inbound"
+	// DirectionOutbound - The resource defining this connection makes an outbound connection resource specified by this id.
+	DirectionOutbound Direction = "Outbound"
 )
 
 // PossibleDirectionValues returns the possible values for the Direction const type.
 func PossibleDirectionValues() []Direction {
 	return []Direction{	
-		DirectionFrom,
-		DirectionTo,
+		DirectionInbound,
+		DirectionOutbound,
 	}
 }
 

--- a/pkg/corerp/api/v20231001preview/zz_generated_constants.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_constants.go
@@ -123,6 +123,24 @@ func PossibleDaprSidecarExtensionProtocolValues() []DaprSidecarExtensionProtocol
 	}
 }
 
+// Direction - The direction of a connection.
+type Direction string
+
+const (
+	// DirectionFrom - From
+	DirectionFrom Direction = "From"
+	// DirectionTo - To
+	DirectionTo Direction = "To"
+)
+
+// PossibleDirectionValues returns the possible values for the Direction const type.
+func PossibleDirectionValues() []Direction {
+	return []Direction{	
+		DirectionFrom,
+		DirectionTo,
+	}
+}
+
 // IAMKind - The kind of IAM provider to configure
 type IAMKind string
 

--- a/pkg/corerp/api/v20231001preview/zz_generated_models.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_models.go
@@ -9,6 +9,51 @@ package v20231001preview
 
 import "time"
 
+// ApplicationGraphConnection - Describes the connection between two resources.
+type ApplicationGraphConnection struct {
+	// REQUIRED; The direction of the connection. To indicates the id is destination and From indicates the id is source
+	Direction *Direction
+
+	// REQUIRED; The resource ID
+	ID *string
+}
+
+// ApplicationGraphOutputResource - Describes an output resource that comprises an application graph resource.
+type ApplicationGraphOutputResource struct {
+	// REQUIRED; The resource ID.
+	ID *string
+
+	// REQUIRED; The resource name.
+	Name *string
+
+	// REQUIRED; The resource type.
+	Type *string
+}
+
+// ApplicationGraphResource - Describes a resource in the application graph.
+type ApplicationGraphResource struct {
+	// REQUIRED; The connections between resources in the application graph.
+	Connections []*ApplicationGraphConnection
+
+	// REQUIRED; The resource ID.
+	ID *string
+
+	// REQUIRED; The resource name.
+	Name *string
+
+	// REQUIRED; The resources that comprise this resource.
+	Resources []*ApplicationGraphOutputResource
+
+	// REQUIRED; The resource type.
+	Type *string
+}
+
+// ApplicationGraphResponse - Describes the application architecture and its dependencies.
+type ApplicationGraphResponse struct {
+	// REQUIRED; The resources in the application graph.
+	Resources []*ApplicationGraphResource
+}
+
 // ApplicationProperties - Application properties
 type ApplicationProperties struct {
 	// REQUIRED; Fully qualified resource ID for the environment that the portable resource is linked to

--- a/pkg/corerp/api/v20231001preview/zz_generated_models.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_models.go
@@ -11,7 +11,8 @@ import "time"
 
 // ApplicationGraphConnection - Describes the connection between two resources.
 type ApplicationGraphConnection struct {
-	// REQUIRED; The direction of the connection. To indicates the id is destination and From indicates the id is source
+	// REQUIRED; The direction of the connection. 'Outbound' indicates this connection specifies the ID of the destination and
+// 'Inbound' indicates indicates this connection specifies the ID of the source.
 	Direction *Direction
 
 	// REQUIRED; The resource ID

--- a/pkg/corerp/api/v20231001preview/zz_generated_models_serde.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_models_serde.go
@@ -14,6 +14,142 @@ import (
 	"reflect"
 )
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGraphConnection.
+func (a ApplicationGraphConnection) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "direction", a.Direction)
+	populate(objectMap, "id", a.ID)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type ApplicationGraphConnection.
+func (a *ApplicationGraphConnection) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", a, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "direction":
+				err = unpopulate(val, "Direction", &a.Direction)
+			delete(rawMsg, key)
+		case "id":
+				err = unpopulate(val, "ID", &a.ID)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", a, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGraphOutputResource.
+func (a ApplicationGraphOutputResource) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "id", a.ID)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type ApplicationGraphOutputResource.
+func (a *ApplicationGraphOutputResource) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", a, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "id":
+				err = unpopulate(val, "ID", &a.ID)
+			delete(rawMsg, key)
+		case "name":
+				err = unpopulate(val, "Name", &a.Name)
+			delete(rawMsg, key)
+		case "type":
+				err = unpopulate(val, "Type", &a.Type)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", a, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGraphResource.
+func (a ApplicationGraphResource) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "connections", a.Connections)
+	populate(objectMap, "id", a.ID)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "resources", a.Resources)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type ApplicationGraphResource.
+func (a *ApplicationGraphResource) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", a, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "connections":
+				err = unpopulate(val, "Connections", &a.Connections)
+			delete(rawMsg, key)
+		case "id":
+				err = unpopulate(val, "ID", &a.ID)
+			delete(rawMsg, key)
+		case "name":
+				err = unpopulate(val, "Name", &a.Name)
+			delete(rawMsg, key)
+		case "resources":
+				err = unpopulate(val, "Resources", &a.Resources)
+			delete(rawMsg, key)
+		case "type":
+				err = unpopulate(val, "Type", &a.Type)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", a, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGraphResponse.
+func (a ApplicationGraphResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "resources", a.Resources)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type ApplicationGraphResponse.
+func (a *ApplicationGraphResponse) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", a, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "resources":
+				err = unpopulate(val, "Resources", &a.Resources)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", a, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type ApplicationProperties.
 func (a ApplicationProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)

--- a/pkg/corerp/api/v20231001preview/zz_generated_options.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_options.go
@@ -17,6 +17,11 @@ type ApplicationsClientDeleteOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ApplicationsClientGetGraphOptions contains the optional parameters for the ApplicationsClient.GetGraph method.
+type ApplicationsClientGetGraphOptions struct {
+	// placeholder for future optional parameters
+}
+
 // ApplicationsClientGetOptions contains the optional parameters for the ApplicationsClient.Get method.
 type ApplicationsClientGetOptions struct {
 	// placeholder for future optional parameters

--- a/pkg/corerp/api/v20231001preview/zz_generated_response_types.go
+++ b/pkg/corerp/api/v20231001preview/zz_generated_response_types.go
@@ -18,6 +18,12 @@ type ApplicationsClientDeleteResponse struct {
 	// placeholder for future response values
 }
 
+// ApplicationsClientGetGraphResponse contains the response from method ApplicationsClient.GetGraph.
+type ApplicationsClientGetGraphResponse struct {
+	// Describes the application architecture and its dependencies.
+	ApplicationGraphResponse
+}
+
 // ApplicationsClientGetResponse contains the response from method ApplicationsClient.Get.
 type ApplicationsClientGetResponse struct {
 	// Radius Application resource

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/openapi.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/openapi.json
@@ -2529,7 +2529,7 @@
         },
         "direction": {
           "$ref": "#/definitions/Direction",
-          "description": "The direction of the connection. To indicates the id is destination and From indicates the id is source"
+          "description": "The direction of the connection. 'Outbound' indicates this connection specifies the ID of the destination and 'Inbound' indicates indicates this connection specifies the ID of the source."
         }
       },
       "required": [
@@ -3379,22 +3379,22 @@
       "type": "string",
       "description": "The direction of a connection.",
       "enum": [
-        "To",
-        "From"
+        "Outbound",
+        "Inbound"
       ],
       "x-ms-enum": {
         "name": "Direction",
         "modelAsString": true,
         "values": [
           {
-            "name": "To",
-            "value": "To",
-            "description": "To"
+            "name": "Outbound",
+            "value": "Outbound",
+            "description": "The resource defining this connection makes an outbound connection resource specified by this id."
           },
           {
-            "name": "From",
-            "value": "From",
-            "description": "From"
+            "name": "Inbound",
+            "value": "Inbound",
+            "description": "The resource defining this connection accepts inbound connections from the resource specified by this id."
           }
         ]
       }

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/openapi.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/openapi.json
@@ -308,6 +308,56 @@
         }
       }
     },
+    "/{rootScope}/providers/Applications.Core/applications/{applicationName}/getGraph": {
+      "post": {
+        "operationId": "Applications_GetGraph",
+        "tags": [
+          "Applications"
+        ],
+        "description": "Gets the application graph and resources.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/RootScopeParameter"
+          },
+          {
+            "name": "applicationName",
+            "in": "path",
+            "description": "The application name",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[A-Za-z]([-A-Za-z0-9]*[A-Za-z0-9])?$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The content of the action request",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ARM operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGraphResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
     "/{rootScope}/providers/Applications.Core/containers": {
       "get": {
         "operationId": "Containers_ListByScope",
@@ -2469,6 +2519,109 @@
     }
   },
   "definitions": {
+    "ApplicationGraphConnection": {
+      "type": "object",
+      "description": "Describes the connection between two resources.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The resource ID "
+        },
+        "direction": {
+          "$ref": "#/definitions/Direction",
+          "description": "The direction of the connection. To indicates the id is destination and From indicates the id is source"
+        }
+      },
+      "required": [
+        "id",
+        "direction"
+      ]
+    },
+    "ApplicationGraphOutputResource": {
+      "type": "object",
+      "description": "Describes an output resource that comprises an application graph resource.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The resource ID."
+        },
+        "type": {
+          "type": "string",
+          "description": "The resource type."
+        },
+        "name": {
+          "type": "string",
+          "description": "The resource name."
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "name"
+      ]
+    },
+    "ApplicationGraphResource": {
+      "type": "object",
+      "description": "Describes a resource in the application graph.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The resource ID."
+        },
+        "type": {
+          "type": "string",
+          "description": "The resource type."
+        },
+        "name": {
+          "type": "string",
+          "description": "The resource name."
+        },
+        "resources": {
+          "type": "array",
+          "description": "The resources that comprise this resource.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGraphOutputResource"
+          },
+          "x-ms-identifiers": [
+            "id"
+          ]
+        },
+        "connections": {
+          "type": "array",
+          "description": "The connections between resources in the application graph.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGraphConnection"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "name",
+        "resources",
+        "connections"
+      ]
+    },
+    "ApplicationGraphResponse": {
+      "type": "object",
+      "description": "Describes the application architecture and its dependencies.",
+      "properties": {
+        "resources": {
+          "type": "array",
+          "description": "The resources in the application graph.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGraphResource"
+          },
+          "x-ms-identifiers": [
+            "id"
+          ]
+        }
+      },
+      "required": [
+        "resources"
+      ]
+    },
     "ApplicationProperties": {
       "type": "object",
       "description": "Application properties",
@@ -3218,6 +3371,30 @@
             "name": "grpc",
             "value": "grpc",
             "description": "gRPC protocol"
+          }
+        ]
+      }
+    },
+    "Direction": {
+      "type": "string",
+      "description": "The direction of a connection.",
+      "enum": [
+        "To",
+        "From"
+      ],
+      "x-ms-enum": {
+        "name": "Direction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "To",
+            "value": "To",
+            "description": "To"
+          },
+          {
+            "name": "From",
+            "value": "From",
+            "description": "From"
           }
         ]
       }

--- a/test/functional/shared/resources/testdata/corerp-resources-application.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-application.bicep
@@ -6,7 +6,7 @@ param location string = 'local'
 @description('Specifies the environment for resources.')
 param environment string = 'test'
 
-resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
+resource app 'Applications.Core/applications@2023-10-01-preview' = {
   name: 'corerp-resources-application-app'
   location: location
   properties: {

--- a/test/functional/shared/resources/testdata/corerp-resources-application.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-application.bicep
@@ -6,7 +6,7 @@ param location string = 'local'
 @description('Specifies the environment for resources.')
 param environment string = 'test'
 
-resource app 'Applications.Core/applications@2023-10-01-preview' = {
+resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
   name: 'corerp-resources-application-app'
   location: location
   properties: {

--- a/typespec/Applications.Core/applications.tsp
+++ b/typespec/Applications.Core/applications.tsp
@@ -64,6 +64,63 @@ model ApplicationProperties {
   status?: ResourceStatus;
 }
 
+@doc("Describes the application architecture and its dependencies.")
+model ApplicationGraphResponse {
+  @doc("The resources in the application graph.")
+  @extension("x-ms-identifiers", ["id"])
+  resources: Array<ApplicationGraphResource>;
+}
+
+@doc("Describes the connection between two resources.")
+model ApplicationGraphConnection {
+  @doc("The resource ID ")
+  id: string;
+
+  @doc("The direction of the connection. To indicates the id is destination and From indicates the id is source")
+  direction: Direction;
+}
+
+@doc("The direction of a connection.")
+enum Direction {
+  @doc("To")
+  To,
+
+  @doc("From")
+  From,
+}
+
+@doc("Describes a resource in the application graph.")
+model ApplicationGraphResource {
+  @doc("The resource ID.")
+  id: string;
+
+  @doc("The resource type.")
+  type: string;
+
+  @doc("The resource name.")
+  name: string;
+
+  @doc("The resources that comprise this resource.")
+  @extension("x-ms-identifiers", ["id"])
+  resources: Array<ApplicationGraphOutputResource>;
+
+  @doc("The connections between resources in the application graph.")
+  @extension("x-ms-identifiers",[])
+  connections: Array<ApplicationGraphConnection>;
+}
+
+@doc("Describes an output resource that comprises an application graph resource.")
+model ApplicationGraphOutputResource {
+  @doc("The resource ID.")
+  id: string;
+
+  @doc("The resource type.")
+  type: string;
+
+  @doc("The resource name.")
+  name: string;
+}
+
 #suppress "@azure-tools/typespec-azure-core/casing-style"
 @armResourceOperations
 interface Applications {
@@ -93,5 +150,14 @@ interface Applications {
     UCPBaseParameters<ApplicationResource>,
     "Scope",
     "Scope"
+  >;
+
+  @doc("Gets the application graph and resources.")
+  @action("getGraph")
+  getGraph is ArmResourceActionSync<
+    ApplicationResource,
+    {},
+    ApplicationGraphResponse,
+    UCPBaseParameters<ApplicationResource>
   >;
 }

--- a/typespec/Applications.Core/applications.tsp
+++ b/typespec/Applications.Core/applications.tsp
@@ -76,17 +76,17 @@ model ApplicationGraphConnection {
   @doc("The resource ID ")
   id: string;
 
-  @doc("The direction of the connection. To indicates the id is destination and From indicates the id is source")
+  @doc("The direction of the connection. 'Outbound' indicates this connection specifies the ID of the destination and 'Inbound' indicates indicates this connection specifies the ID of the source.")
   direction: Direction;
 }
 
 @doc("The direction of a connection.")
 enum Direction {
-  @doc("To")
-  To,
+  @doc("The resource defining this connection makes an outbound connection resource specified by this id.")
+  Outbound,
 
-  @doc("From")
-  From,
+  @doc("The resource defining this connection accepts inbound connections from the resource specified by this id.")
+  Inbound,
 }
 
 @doc("Describes a resource in the application graph.")


### PR DESCRIPTION
# Description

Update ApplicationGraphResource model 
- to be able to support for pagination
- to include ApplicationGraphOutputResource
 

## Type of change

- This pull request adds or changes features of Radius and has an approved issue (issue link required).

Partially Fixes: #[6337](https://github.com/radius-project/radius/issues/6337)

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ad299e2</samp>

### Summary
📊🌐🛠️

<!--
1.  📊 - This emoji represents the new feature of getting the application graph and resources, which is a visual and analytical tool for users to understand the architecture and dependencies of their application resource.
2.  🌐 - This emoji represents the new models and types that describe the resources and connections in the application graph, which are network-related concepts that show how the components of the application interact with each other and with external resources.
3.  🛠️ - This emoji represents the new functions and methods that implement the serialization and deserialization of the graph objects, as well as the creation and handling of the request and response for the new operation, which are technical and functional aspects of the code change.
-->
This pull request adds a new feature to the Applications.Core resource provider that allows users to query the application graph and resources of an application resource. It updates the `openapi.json` specification and the `applications.tsp` file to document the new feature and models. It also generates new types, methods, and functions in the `v20231001preview` package to implement the feature and handle the request and response. Additionally, it fixes a test failure by changing the API version in the `corerp-resources-application.bicep` file.

> _We are the masters of the graph, we see the connections of the core_
> _We send the post request to the endpoint, we get the response with the `ApplicationGraphResponse`_
> _We marshal and unmarshal the JSON, we use the `ApplicationsClientGetGraphOptions`_
> _We are the masters of the graph, we rule the `v20231001preview`_

### Walkthrough
*  Add a new feature to query the application graph and resources of an application resource ([link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-09b86d89a837246f3822cca8ee43e4a308f6b4c529c30754e84846d2af008e52R198-R253), [link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-ac35cdfa65680d5d2be2d0513a686f4651b9a41eb951d05dcd446bc927090d68R311-R360), [link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-b8dc4ae8a464360dbbf745e5af8f383d89a314c1958792a8adf3dc6f82e9d823R154-R162))
  - Implement a new method `GetGraph` in the `ApplicationsClient` struct that sends a POST request to the `/getGraph` endpoint and returns an `ApplicationGraphResponse` struct ([link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-09b86d89a837246f3822cca8ee43e4a308f6b4c529c30754e84846d2af008e52R198-R253))
  - Document the new operation in the `openapi.json` specification with the path parameters, the request body, and the response body ([link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-ac35cdfa65680d5d2be2d0513a686f4651b9a41eb951d05dcd446bc927090d68R311-R360))
  - Define a new action `getGraph` in the `typespec/Applications.Core/applications.tsp` file with the input and output parameters and the documentation ([link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-b8dc4ae8a464360dbbf745e5af8f383d89a314c1958792a8adf3dc6f82e9d823R154-R162))
* Define new models for the resources and connections in the application graph ([link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-21034b9d798fa570ecae4b7d54142c7f94d9d0f1b39c5f45f0c4c859674b19fbR12-R56), [link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-ac35cdfa65680d5d2be2d0513a686f4651b9a41eb951d05dcd446bc927090d68R2522-R2624), [link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-b8dc4ae8a464360dbbf745e5af8f383d89a314c1958792a8adf3dc6f82e9d823R67-R123))
  - Add new types `ApplicationGraphConnection`, `ApplicationGraphOutputResource`, `ApplicationGraphResource`, and `ApplicationGraphResponse` to the `v20231001preview` package and the `openapi.json` specification ([link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-21034b9d798fa570ecae4b7d54142c7f94d9d0f1b39c5f45f0c4c859674b19fbR12-R56), [link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-ac35cdfa65680d5d2be2d0513a686f4651b9a41eb951d05dcd446bc927090d68R2522-R2624))
  - Add new type `Direction` to the `v20231001preview` package and the `openapi.json` specification as a string enum for the connection direction ([link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-07cd8284519deaa5e625f1fe393cb48bdd1cc621c9a4656ca43cc6049dfe7962R106-R123), [link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-ac35cdfa65680d5d2be2d0513a686f4651b9a41eb951d05dcd446bc927090d68R3332-R3355))
  - Add new types `ApplicationGraphResponse`, `ApplicationGraphConnection`, `Direction`, `ApplicationGraphResource`, and `ApplicationGraphOutputResource` to the `typespec/Applications.Core/applications.tsp` file with the documentation and the extensions ([link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-b8dc4ae8a464360dbbf745e5af8f383d89a314c1958792a8adf3dc6f82e9d823R67-R123))
* Enable the encoding and decoding of the new models as JSON objects ([link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-bc1502ced9e29d6d61dc028d22603e863f59a981bbc54a59879ba3177d8e62e9R17-R152))
  - Add new functions `MarshalJSON` and `UnmarshalJSON` to the types `ApplicationGraphConnection`, `ApplicationGraphOutputResource`, `ApplicationGraphResource`, and `ApplicationGraphResponse` in the `v20231001preview` package ([link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-bc1502ced9e29d6d61dc028d22603e863f59a981bbc54a59879ba3177d8e62e9R17-R152))
* Provide placeholders for future optional parameters and response types for the `GetGraph` method ([link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-e40562ef9d9abc12ef551ab7651a5f8b079b6b88a55c13e8b66792e8509b7503R20-R24), [link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-d3bed90c8d082ba05ab113150f5afa6c51cabd0db1523e00da63e4f11d54692aR21-R26))
  - Add new type `ApplicationsClientGetGraphOptions` to the `v20231001preview` package as a struct for the optional parameters ([link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-e40562ef9d9abc12ef551ab7651a5f8b079b6b88a55c13e8b66792e8509b7503R20-R24))
  - Add new type `ApplicationsClientGetGraphResponse` to the `v20231001preview` package as a struct for the response that embeds the `ApplicationGraphResponse` struct ([link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-d3bed90c8d082ba05ab113150f5afa6c51cabd0db1523e00da63e4f11d54692aR21-R26))
* Fix a test failure due to the mismatch between the API versions in the bicep file and the `openapi.json` specification ([link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-c93997d341207e085433657b16d3435da09e63c442e5b2ec35e06362684673a8L9-R9))
  - Update the `test/functional/shared/resources/testdata/corerp-resources-application.bicep` file to use the `2022-03-15-privatepreview` API version instead of the `2023-10-01-preview` API version for the application resource ([link](https://github.com/radius-project/radius/pull/6425/files?diff=unified&w=0#diff-c93997d341207e085433657b16d3435da09e63c442e5b2ec35e06362684673a8L9-R9))


