### PR TITLE
Increase `maxOperationConcurrency`: 3 -> 10

### DIFF
--- a/cmd/applications-rp/portableresource-dev.yaml
+++ b/cmd/applications-rp/portableresource-dev.yaml
@@ -28,7 +28,7 @@ server:
   port: 8081
   enableArmAuth: false
 workerServer:
-  maxOperationConcurrency: 3
+  maxOperationConcurrency: 10
   maxOperationRetryCount: 2
 ucp:
   kind: kubernetes

--- a/cmd/applications-rp/portableresource-self-hosted.yaml
+++ b/cmd/applications-rp/portableresource-self-hosted.yaml
@@ -38,7 +38,7 @@ server:
   port: 8081
   enableArmAuth: false
 workerServer:
-  maxOperationConcurrency: 3
+  maxOperationConcurrency: 10
   maxOperationRetryCount: 2
 ucp:
   kind: direct

--- a/cmd/applications-rp/radius-cloud.yaml
+++ b/cmd/applications-rp/radius-cloud.yaml
@@ -34,7 +34,7 @@ server:
   enableArmAuth: true
   armMetadataEndpoint: "https://admin.api-dogfood.resources.windows-int.net/metadata/authentication?api-version=2015-01-01"
 workerServer:
-  maxOperationConcurrency: 3
+  maxOperationConcurrency: 10
   maxOperationRetryCount: 2
 metricsProvider:
   prometheus:

--- a/cmd/applications-rp/radius-dev.yaml
+++ b/cmd/applications-rp/radius-dev.yaml
@@ -28,7 +28,7 @@ server:
   port: 8080
   enableArmAuth: false
 workerServer:
-  maxOperationConcurrency: 3
+  maxOperationConcurrency: 10
   maxOperationRetryCount: 2
 ucp:
   kind: kubernetes

--- a/cmd/applications-rp/radius-self-hosted.yaml
+++ b/cmd/applications-rp/radius-self-hosted.yaml
@@ -38,7 +38,7 @@ server:
   port: 8080
   enableArmAuth: false
 workerServer:
-  maxOperationConcurrency: 3
+  maxOperationConcurrency: 10
   maxOperationRetryCount: 2
 ucp:
   kind: direct

--- a/deploy/Chart/templates/rp/configmaps.yaml
+++ b/deploy/Chart/templates/rp/configmaps.yaml
@@ -38,7 +38,7 @@ data:
       host: "0.0.0.0"
       port: 5443
     workerServer:
-      maxOperationConcurrency: 3
+      maxOperationConcurrency: 10
       maxOperationRetryCount: 2
     ucp:
       kind: kubernetes
@@ -88,7 +88,7 @@ data:
       host: "0.0.0.0"
       port: 5444
     workerServer:
-      maxOperationConcurrency: 3
+      maxOperationConcurrency: 10
       maxOperationRetryCount: 2
     ucp:
       kind: kubernetes

--- a/docs/contributing/contributing-code/contributing-code-control-plane/configSettings.md
+++ b/docs/contributing/contributing-code/contributing-code-control-plane/configSettings.md
@@ -96,7 +96,7 @@ The following are properties that can be specified for UCP:
 | Key | Description | Example |
 |-----|-------------|---------|
 | port | the localhost port which provides system-level info | `2222` |
-| maxOperationConcurrency | The maximum concurrency to process async request operations | `3` |
+| maxOperationConcurrency | The maximum concurrency to process async request operations | `10` |
 | maxOperationRetryCount | The maximum retry count to process async request operation | `2` |
 
 ### metricsProvider
@@ -210,7 +210,7 @@ server:
   host: "0.0.0.0"
   port: 5443
 workerServer:
-  maxOperationConcurrency: 3
+  maxOperationConcurrency: 10
   maxOperationRetryCount: 2
 ucp:
   kind: kubernetes

--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	// defaultMaxOperationConcurrency is the default maximum concurrency to process async request operation.
-	defaultMaxOperationConcurrency = 3
+	defaultMaxOperationConcurrency = 10
 
 	// defaultMaxOperationRetryCount is the default maximum retry count to process async operation.
 	defaultMaxOperationRetryCount = 3


### PR DESCRIPTION
# Description

* Increasing `maxOperationConcurrency` for async workers

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Partially addresses: https://github.com/radius-project/radius/issues/6259

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 78d7473</samp>

### Summary
🔧🚀📝

<!--
1.  🔧 - This emoji represents a wrench or a tool, and can be used to indicate changes related to configuration, settings, or performance tuning.
2.  🚀 - This emoji represents a rocket or a launch, and can be used to indicate changes related to deployment, scaling, or cloud environments.
3.  📝 - This emoji represents a memo or a document, and can be used to indicate changes related to documentation, comments, or annotations.
-->
This pull request introduces a new variable for the secondary port of the portable resource provider in the `configmaps.yaml` template file, and updates the documentation and configuration files accordingly. It also increases the `maxOperationConcurrency` setting for the worker server component in various configuration files, and updates the default value in the `worker.go` file, as part of a performance tuning effort.

> _`maxOperationConcurrency`_
> _Tuned for performance and scale_
> _Worker server breathes_

### Walkthrough
*  Increase the `maxOperationConcurrency` setting for the `workerServer` component in various configuration files, to improve the performance and scalability of the radius and portable resource providers. ([link](https://github.com/radius-project/radius/pull/6433/files?diff=unified&w=0#diff-5b57e9314a18299dc316a8cfec855ae859078a6b3baaf8a9d9205f4d1e26e665L31-R31), [link](https://github.com/radius-project/radius/pull/6433/files?diff=unified&w=0#diff-a9312f9d13becb76eeb2cba6b9a0f78cc182ae1c203e3f3db5899f3aec534940L41-R41), [link](https://github.com/radius-project/radius/pull/6433/files?diff=unified&w=0#diff-cdbd007d23572be9425f931432181ce0b9468a548a9c28999d0943277a424c7bL37-R37), [link](https://github.com/radius-project/radius/pull/6433/files?diff=unified&w=0#diff-9976f6e926619046569a25ece5f0cd16adfe3413b6334097c6f736e83cda58caL31-R31), [link](https://github.com/radius-project/radius/pull/6433/files?diff=unified&w=0#diff-4df28288cb6f2d9e8e1c520e2a82d7382058acaeebae8882c92b1634882efc43L41-R41), [link](https://github.com/radius-project/radius/pull/6433/files?diff=unified&w=0#diff-58d6d96c3a9a74e33fc72e9a458a3e9f4c463287d906985725fddb0398081126L41-R41), [link](https://github.com/radius-project/radius/pull/6433/files?diff=unified&w=0#diff-58d6d96c3a9a74e33fc72e9a458a3e9f4c463287d906985725fddb0398081126L91-R91))
* Update the constant value of `defaultMaxOperationConcurrency` in the `worker.go` file, to ensure consistency with the configuration files. ([link](https://github.com/radius-project/radius/pull/6433/files?diff=unified&w=0#diff-5d9b9964242d77606f4868e3fe049978ea1c3f1903afcfeb60c76e19d9785fc5L46-R46))
* Update the documentation for the `workerServer` settings in the `configSettings.md` file, to reflect the new default and example values of `maxOperationConcurrency`. ([link](https://github.com/radius-project/radius/pull/6433/files?diff=unified&w=0#diff-c5a6e900bac29ec26476b731e62862ee9afb8f9f67225da0aa8fd1d052f8183fL99-R99), [link](https://github.com/radius-project/radius/pull/6433/files?diff=unified&w=0#diff-c5a6e900bac29ec26476b731e62862ee9afb8f9f67225da0aa8fd1d052f8183fL213-R213))


