### PR TITLE
Add Deployment reconciler

### DIFF
--- a/pkg/controller/reconciler/annotations.go
+++ b/pkg/controller/reconciler/annotations.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+type deploymentPhrase string
+
+const (
+	deploymentPhraseWaiting  deploymentPhrase = "Waiting"
+	deploymentPhraseUpdating deploymentPhrase = "Updating"
+	deploymentPhraseReady    deploymentPhrase = "Ready"
+	deploymentPhraseDeleting deploymentPhrase = "Deleting"
+	deploymentPhraseFailed   deploymentPhrase = "Failed"
+)
+
+// deploymentAnnotations represents the user-provided configuration and the status (Radius related status)
+// of the Deployment.
+type deploymentAnnotations struct {
+	// Configuration is the configuration of the Deployment provided by the user via annotations.
+	// This will be nil if Radius is not enabled for the Deployment.
+	Configuration *deploymentConfiguration
+
+	//ConfigurationHash is the hash of the user-provided configuration.
+	// This will be used to diff the configuration and determine if the Deployment needs to be updated.
+	ConfigurationHash string
+
+	// Status is the status of the Deployment (Radius related status).
+	Status *deploymentStatus
+}
+
+// deploymentConfiguration is the configuration of the Deployment provided by the user via annotations.
+type deploymentConfiguration struct {
+	Connections map[string]string
+}
+
+func (c *deploymentConfiguration) computeHash() (string, error) {
+	b, err := json.Marshal(c)
+	if err != nil {
+		return "", err
+	}
+
+	sum := sha1.Sum(b)
+	hash := hex.EncodeToString(sum[:])
+	return hash, nil
+}
+
+type deploymentStatus struct {
+	Scope       string                              `json:"scope,omitempty"`
+	Application string                              `json:"application,omitempty"`
+	Environment string                              `json:"environment,omitempty"`
+	Container   string                              `json:"container,omitempty"`
+	Operation   *radappiov1alpha3.ResourceOperation `json:"operation,omitempty"`
+	Phrase      deploymentPhrase                    `json:"phrase,omitempty"`
+}
+
+// readAnnotations reads the annotations from a Deployment.
+//
+// This includes the configuration specified by the user, the hash of the configuration, and the status.
+func readAnnotations(deployment *appsv1.Deployment) (*deploymentAnnotations, error) {
+	if deployment.Annotations == nil {
+		return nil, nil
+	}
+
+	result := deploymentAnnotations{
+		ConfigurationHash: deployment.Annotations[AnnotationRadiusConfigurationHash],
+	}
+
+	s := deploymentStatus{}
+	status := deployment.Annotations[AnnotationRadiusStatus]
+	if status != "" {
+		err := json.Unmarshal([]byte(status), &s)
+		if err != nil {
+			return &result, fmt.Errorf("failed to unmarshal status annotation: %w", err)
+		}
+	}
+
+	result.Status = &s
+
+	// Note: we need to read and return the configuration even if Radius is not enabled for the Deployment.
+	// This is important so that can clean up previsouly created connections when Radius is disabled.
+	enabled := deployment.Annotations[AnnotationRadiusEnabled]
+	if !strings.EqualFold(enabled, "true") {
+		return &result, nil
+	}
+
+	result.Configuration = &deploymentConfiguration{Connections: map[string]string{}}
+
+	for k, v := range deployment.Annotations {
+		if strings.HasPrefix(k, AnnotationRadiusConnectionPrefix) {
+			result.Configuration.Connections[strings.TrimPrefix(k, AnnotationRadiusConnectionPrefix)] = v
+		}
+	}
+
+	return &result, nil
+}
+
+// ApplyToDeployment applies the configuration and status to a Deployment.
+//
+// This should be used before saving the Deployment's state.
+func (annotations *deploymentAnnotations) ApplyToDeployment(deployment *appsv1.Deployment) error {
+	if deployment.Annotations == nil {
+		deployment.Annotations = map[string]string{}
+	}
+
+	status := ""
+	if annotations.Status != nil {
+		b, err := json.Marshal(annotations.Status)
+		if err != nil {
+			return err
+		}
+
+		status = string(b)
+	}
+
+	deployment.Annotations[AnnotationRadiusStatus] = status
+
+	if annotations.Configuration == nil {
+		deployment.Annotations[AnnotationRadiusEnabled] = "false"
+		return nil
+	}
+
+	hash, err := annotations.Configuration.computeHash()
+	if err != nil {
+		return err
+	}
+
+	deployment.Annotations[AnnotationRadiusConfigurationHash] = hash
+	deployment.Annotations[AnnotationRadiusEnabled] = "true"
+
+	for k, v := range annotations.Configuration.Connections {
+		deployment.Annotations[AnnotationRadiusConnectionPrefix+k] = v
+	}
+
+	return nil
+}
+
+// IsUpToDate returns true if the Deployment is up to date with the configuration.
+//
+// This should be used to determine if the Radius container needs to be updated based
+// on a change made by the user.
+func (annotations *deploymentAnnotations) IsUpToDate() bool {
+	if annotations.ConfigurationHash == "" {
+		return false
+	}
+
+	if annotations.Status == nil {
+		return false
+	}
+
+	hash, err := annotations.Configuration.computeHash()
+	if err != nil {
+		return false // If the hash cannot be computed, we assume the configuration is outdated.
+	}
+
+	return hash == annotations.ConfigurationHash
+}

--- a/pkg/controller/reconciler/const.go
+++ b/pkg/controller/reconciler/const.go
@@ -22,6 +22,21 @@ const (
 	// PollingDelay is the amount of time to wait between polling for the status of a resource.
 	PollingDelay time.Duration = 5 * time.Second
 
+	// AnnotationRadiusEnabled is the name of the annotation that indicates if a Deployment has Radius enabled.
+	AnnotationRadiusEnabled = "radapp.io/enabled"
+
+	// AnnotationRadiusConnectionPrefix is the name of the annotation that indicates the name of the connection to use.
+	AnnotationRadiusConnectionPrefix = "radapp.io/connection-"
+
+	// AnnotationRadiusStatus is the name of the annotation that indicates the status of a Deployment.
+	AnnotationRadiusStatus = "radapp.io/status"
+
+	// AnnotationRadiusConfigurationHash is the name of the annotation that indicates the hash of the configuration.
+	AnnotationRadiusConfigurationHash = "radapp.io/configuration-hash"
+
+	// DeploymentFinalizer is the name of the finalizer added to Deployments.
+	DeploymentFinalizer = "radapp.io/deployment-finalizer"
+
 	// RecipeFinalizer is the name of the finalizer added to Recipes.
 	RecipeFinalizer = "radapp.io/recipe-finalizer"
 )

--- a/pkg/controller/reconciler/deployment_reconciler.go
+++ b/pkg/controller/reconciler/deployment_reconciler.go
@@ -1,0 +1,602 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/go-logr/logr"
+	"github.com/radius-project/radius/pkg/cli/clients"
+	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
+	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
+	"github.com/radius-project/radius/pkg/to"
+	"github.com/radius-project/radius/pkg/ucp/resources"
+	"github.com/radius-project/radius/pkg/ucp/ucplog"
+)
+
+// DeploymentReconciler reconciles a Deployment object.
+type DeploymentReconciler struct {
+	// Client is the Kubernetes client.
+	Client client.Client
+
+	// Scheme is the Kubernetes scheme.
+	Scheme *runtime.Scheme
+
+	// EventRecorder is the Kubernetes event recorder.
+	EventRecorder record.EventRecorder
+
+	// Radius is the Radius client.
+	Radius RadiusClient
+
+	// DelayInterval is the amount of time to wait between operations.
+	DelayInterval time.Duration
+}
+
+// Reconcile is the main reconciliation loop for the Deployment resource.
+func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := ucplog.FromContextOrDiscard(ctx).WithValues("kind", "Deployment", "name", req.Name, "namespace", req.Namespace)
+	ctx = logr.NewContext(ctx, logger)
+
+	deployment := appsv1.Deployment{}
+	err := r.Client.Get(ctx, req.NamespacedName, &deployment)
+	if apierrors.IsNotFound(err) {
+		// This can happen due to a data-race if the deployment is created and then deleted before we can
+		// reconcile it. There's nothing to do here.
+		logger.Info("Deployment has already been deleted.")
+		return ctrl.Result{}, nil
+	} else if err != nil {
+		logger.Error(err, "Unable to fetch resource.")
+		return ctrl.Result{}, err
+	}
+
+	// Our algorithm is as follows:
+	//
+	// 1. Check if we have an "operation" in progress. If so, check it's status.
+	//   a. If the operation is still in progress, then queue another reconcile (polling).
+	//   b. If the operation completed successfully then update the status and continue processing (happy-path).
+	//   c. If the operation failed then update the status and continue processing (retry).
+	// 2. If the deployment is being deleted then process deletion.
+	//   a. This may require us to start a DELETE operation. After that we can continue polling.
+	// 3. If the deployment is not being deleted then process this as a creation or update.
+	//   a. This may require us to start a PUT operation. After that we can continue polling.
+	//
+	// We do it this way because it guarantees that we only have one operation going at a time.
+
+	// Since Deployment is a built-in type in Kubernetes we can't add our own status field to it.
+	// We have to store our status in an annotation.
+	annotations, err := readAnnotations(&deployment)
+	if err != nil {
+		logger.Error(err, "Failed to read deployment status.")
+		deployment.Annotations[AnnotationRadiusStatus] = ""
+
+		// This could happen if someone manually edited the annotations. We can reset it to empty
+		// and repair it on the next reconcile.
+	}
+
+	if annotations.Status.Operation != nil {
+		// NOTE: if reconcileOperation completes successfully, then it will return a "zero" result,
+		// this means the operation has completed and we should continue processing.
+		result, err := r.reconcileOperation(ctx, &deployment, annotations)
+		if err != nil {
+			logger.Error(err, "Unable to reconcile in-progress operation.")
+			return ctrl.Result{}, err
+		} else if result.IsZero() {
+			// NOTE: if reconcileOperation completes successfully, then it will return a "zero" result,
+			// this means the operation has completed and we should continue processing.
+			logger.Info("Operation completed successfully.")
+		} else {
+			logger.Info("Requeueing to continue operation.")
+			return result, nil
+		}
+	}
+
+	// If the Deployment is being deleted **or** if Radius is not enabled, then we should
+	// clean up any Radius state.
+	if deployment.DeletionTimestamp != nil || annotations.Configuration == nil {
+		return r.reconcileDelete(ctx, &deployment, annotations)
+	}
+
+	return r.reconcileUpdate(ctx, &deployment, annotations)
+}
+
+// reconcileOperation reconciles a Deployment that has an operation in progress.
+func (r *DeploymentReconciler) reconcileOperation(ctx context.Context, deployment *appsv1.Deployment, annotations *deploymentAnnotations) (ctrl.Result, error) {
+	logger := ucplog.FromContextOrDiscard(ctx)
+
+	// NOTE: the pollers are actually different types, so we have to duplicate the code
+	// for the PUT and DELETE handling. This makes me sad :( but there isn't a great
+	// solution besides duplicating the code.
+	//
+	// The only difference between these two codepaths is how they handle success.
+	if annotations.Status.Operation.OperationKind == radappiov1alpha3.OperationKindPut {
+		poller, err := r.Radius.Containers(annotations.Status.Scope).ContinueCreateOperation(ctx, annotations.Status.Operation.ResumeToken)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to continue PUT operation: %w", err)
+		}
+
+		_, err = poller.Poll(ctx)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to poll operation status: %w", err)
+		}
+
+		if !poller.Done() {
+			return ctrl.Result{Requeue: true, RequeueAfter: r.requeueDelay()}, nil
+		}
+
+		// If we get here, the operation is complete.
+		_, err = poller.Result(ctx)
+		if err != nil {
+			// Operation failed, reset state and retry.
+			r.EventRecorder.Event(deployment, corev1.EventTypeWarning, "ResourceError", err.Error())
+			logger.Error(err, "Update failed.")
+
+			annotations.Status.Operation = nil
+			annotations.Status.Phrase = deploymentPhraseFailed
+
+			err = r.saveState(ctx, deployment, annotations)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{Requeue: true, RequeueAfter: r.requeueDelay()}, nil
+		}
+
+		// If we get here, the operation was a success. Update the status and continue.
+		//
+		// NOTE: we don't need to save the status here, because we're going to continue reconciling.
+		annotations.Status.Operation = nil
+		annotations.Status.Container = annotations.Status.Scope + "/providers/Applications.Core/containers/" + deployment.Name
+		return ctrl.Result{}, nil
+
+	} else if annotations.Status.Operation.OperationKind == radappiov1alpha3.OperationKindDelete {
+		poller, err := r.Radius.Containers(annotations.Status.Scope).ContinueDeleteOperation(ctx, annotations.Status.Operation.ResumeToken)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to continue DELETE operation: %w", err)
+		}
+
+		_, err = poller.Poll(ctx)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to poll operation status: %w", err)
+		}
+
+		if !poller.Done() {
+			return ctrl.Result{Requeue: true, RequeueAfter: r.requeueDelay()}, nil
+		}
+
+		// If we get here, the operation is complete.
+		_, err = poller.Result(ctx)
+		if err != nil {
+			// Operation failed, reset state and retry.
+			r.EventRecorder.Event(deployment, corev1.EventTypeWarning, "ResourceError", err.Error())
+			logger.Error(err, "Delete failed.")
+
+			annotations.Status.Operation = nil
+			annotations.Status.Phrase = deploymentPhraseFailed
+
+			err = r.saveState(ctx, deployment, annotations)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{Requeue: true, RequeueAfter: r.requeueDelay()}, nil
+		}
+
+		// If we get here, the operation was a success. Update the status and continue.
+		//
+		// NOTE: we don't need to save the status here, because we're going to continue reconciling.
+		annotations.Status.Operation = nil
+		annotations.Status.Container = ""
+		return ctrl.Result{}, nil
+	}
+
+	// If we get here, this was an unknown operation kind. This is a bug in our code, or someone
+	// tampered with the status of the object. Just reset the state and move on.
+	logger.Error(fmt.Errorf("unknown operation kind: %s", annotations.Status.Operation.OperationKind), "Unknown operation kind.")
+
+	annotations.Status.Operation = nil
+	annotations.Status.Phrase = deploymentPhraseFailed
+
+	err := r.saveState(ctx, deployment, annotations)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *DeploymentReconciler) reconcileUpdate(ctx context.Context, deployment *appsv1.Deployment, annotations *deploymentAnnotations) (ctrl.Result, error) {
+	logger := ucplog.FromContextOrDiscard(ctx)
+
+	// Ensure that our finalizer is present before we start any operations.
+	if controllerutil.AddFinalizer(deployment, DeploymentFinalizer) {
+		err := r.Client.Update(ctx, deployment)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// For now the environment name is hardcoded to default.
+	environmentName := "default"
+
+	// For now the application name is hardcoded to the namespace.
+	applicationName := deployment.Namespace
+
+	resourceGroupID, environmentID, applicationID, err := resolveDependencies(ctx, r.Radius, "/planes/radius/local", environmentName, applicationName)
+	if err != nil {
+		r.EventRecorder.Event(deployment, corev1.EventTypeWarning, "DependencyError", err.Error())
+		logger.Error(err, "Unable to resolve dependencies.")
+		return ctrl.Result{}, fmt.Errorf("failed to resolve dependencies: %w", err)
+	}
+
+	annotations.Status.Scope = resourceGroupID
+	annotations.Status.Environment = environmentID
+	annotations.Status.Application = applicationID
+
+	// There are three possible states returned here:
+	//
+	// 1) err != nil - an error happened, this will be retried next reconcile.
+	// 2) waiting == true - we're waiting on dependencies, this will be retried next reconcile.
+	// 3) poller != nil - we've started an operation, this will be checked next reconcile.
+	poller, waiting, err := r.startPutOperationIfNeeded(ctx, deployment, annotations)
+	if err != nil {
+		logger.Error(err, "Unable to create or update resource.")
+		r.EventRecorder.Event(deployment, corev1.EventTypeWarning, "ResourceError", err.Error())
+		return ctrl.Result{}, err
+	} else if waiting {
+		logger.Info("Waiting on dependencies.")
+		r.EventRecorder.Event(deployment, corev1.EventTypeNormal, "DependencyNotReady", "Waiting on dependencies.")
+
+		annotations.Status.Phrase = deploymentPhraseWaiting
+		err = r.saveState(ctx, deployment, annotations)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// We don't need to requeue here because we watch Recipes and will be notified when
+		// the state changes.
+		return ctrl.Result{}, nil
+	} else if poller != nil {
+		// We've successfully started an operation. Update the status and requeue.
+		token, err := poller.ResumeToken()
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get operation token: %w", err)
+		}
+
+		annotations.Status.Operation = &radappiov1alpha3.ResourceOperation{ResumeToken: token, OperationKind: radappiov1alpha3.OperationKindPut}
+		annotations.Status.Phrase = deploymentPhraseUpdating
+		err = r.saveState(ctx, deployment, annotations)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{Requeue: true, RequeueAfter: r.requeueDelay()}, nil
+	}
+
+	// If we get here then it means we can process the result of the operation.
+	logger.Info("Resource is in desired state.", "resourceId", annotations.Status.Container)
+
+	annotations.Status.Phrase = deploymentPhraseReady
+	err = r.updateDeployment(ctx, deployment, annotations)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update deployment: %w", err)
+	}
+
+	err = r.saveState(ctx, deployment, annotations)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *DeploymentReconciler) reconcileDelete(ctx context.Context, deployment *appsv1.Deployment, annotations *deploymentAnnotations) (ctrl.Result, error) {
+	logger := ucplog.FromContextOrDiscard(ctx)
+
+	poller, err := r.startDeleteOperationIfNeeded(ctx, deployment, annotations)
+	if err != nil {
+		logger.Error(err, "Unable to delete resource.")
+		r.EventRecorder.Event(deployment, corev1.EventTypeWarning, "ResourceError", err.Error())
+		return ctrl.Result{}, err
+	} else if poller != nil {
+		// We've successfully started an operation. Update the status and requeue.
+		token, err := poller.ResumeToken()
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get operation token: %w", err)
+		}
+
+		annotations.Status.Operation = &radappiov1alpha3.ResourceOperation{ResumeToken: token, OperationKind: radappiov1alpha3.OperationKindDelete}
+		annotations.Status.Phrase = deploymentPhraseDeleting
+		err = r.saveState(ctx, deployment, annotations)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{Requeue: true, RequeueAfter: r.requeueDelay()}, nil
+	}
+
+	logger.Info("Resource is deleted.")
+
+	err = r.cleanupDeployment(ctx, deployment)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to cleanup deployment: %w", err)
+	}
+
+	// At this point we've cleaned up everything. We can remove the finalizer which will allow deletion of the
+	// recipe.
+	controllerutil.RemoveFinalizer(deployment, DeploymentFinalizer)
+	err = r.Client.Update(ctx, deployment)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	r.EventRecorder.Event(deployment, corev1.EventTypeNormal, "Reconciled", "Successfully reconciled resource.")
+	return ctrl.Result{}, nil
+}
+
+func (r *DeploymentReconciler) startPutOperationIfNeeded(ctx context.Context, deployment *appsv1.Deployment, annotations *deploymentAnnotations) (Poller[v20231001preview.ContainersClientCreateOrUpdateResponse], bool, error) {
+	logger := ucplog.FromContextOrDiscard(ctx)
+
+	// Check the annotations first to see how the current configuration compares to the desired configuration.
+	if !annotations.IsUpToDate() {
+		logger.Info("Container configuration is out-of-date.")
+	} else if annotations.Status.Container != "" {
+		logger.Info("Container is already created and is up-to-date.")
+		return nil, false, nil
+	}
+
+	logger.Info("Starting PUT operation.")
+	properties := v20231001preview.ContainerProperties{
+		Application:          to.Ptr(annotations.Status.Application),
+		ResourceProvisioning: to.Ptr(v20231001preview.ContainerResourceProvisioningManual),
+		Connections:          map[string]*v20231001preview.ConnectionProperties{},
+		Container: &v20231001preview.Container{
+			Image: to.Ptr("none"),
+		},
+		Resources: []*v20231001preview.ResourceReference{
+			{
+				ID: to.Ptr("/planes/kubernetes/local/namespaces/" + deployment.Namespace + "/providers/apps/Deployment/" + deployment.Name),
+			},
+		},
+	}
+
+	for name, source := range annotations.Configuration.Connections {
+		recipe := radappiov1alpha3.Recipe{}
+		err := r.Client.Get(ctx, client.ObjectKey{Namespace: deployment.Namespace, Name: source}, &recipe)
+		if apierrors.IsNotFound(err) {
+			logger.Info("Recipe does not exist.", "recipe", source)
+			return nil, true, nil
+		} else if err != nil {
+			return nil, false, fmt.Errorf("failed to fetch recipe %s: %w", source, err)
+		} else if recipe.Status.Resource == "" {
+			logger.Info("Recipe is not ready.", "recipe", source)
+			return nil, true, nil
+		}
+
+		properties.Connections[name] = &v20231001preview.ConnectionProperties{
+			Source: to.Ptr(recipe.Status.Resource),
+		}
+	}
+
+	resourceID := annotations.Status.Scope + "/providers/Applications.Core/containers/" + deployment.Name
+	poller, err := createOrUpdateContainer(ctx, r.Radius, resourceID, &properties)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return poller, false, nil
+}
+
+func (r *DeploymentReconciler) startDeleteOperationIfNeeded(ctx context.Context, deployment *appsv1.Deployment, annotations *deploymentAnnotations) (Poller[v20231001preview.ContainersClientDeleteResponse], error) {
+	logger := ucplog.FromContextOrDiscard(ctx)
+	if annotations.Status.Container == "" {
+		logger.Info("Container is already deleted (or was never created).")
+		return nil, nil
+	}
+
+	logger.Info("Starting DELETE operation.")
+	return deleteContainer(ctx, r.Radius, annotations.Status.Container)
+}
+
+func (r *DeploymentReconciler) updateDeployment(ctx context.Context, deployment *appsv1.Deployment, annotations *deploymentAnnotations) error {
+	// We store the connection values in a Kubernetes secret and then use the secret to populate environment variables.
+	secretName := client.ObjectKey{Namespace: deployment.Namespace, Name: fmt.Sprintf("%s-connections", deployment.Name)}
+
+	// First retrieve the secret.
+	createSecret := false
+	secret := corev1.Secret{}
+	err := r.Client.Get(ctx, secretName, &secret)
+	if apierrors.IsNotFound(err) {
+		// It's OK if the secret doesn't exist yet. We'll create it below.
+		createSecret = true
+		secret.Name = secretName.Name
+		secret.Namespace = secretName.Namespace
+		secret.OwnerReferences = []metav1.OwnerReference{
+			*metav1.NewControllerRef(deployment, appsv1.SchemeGroupVersion.WithKind("Deployment")),
+		}
+	} else if err != nil {
+		return fmt.Errorf("failed to fetch secret %s: %w", secretName, err)
+	}
+
+	secret.Data = map[string][]byte{}
+
+	for name, source := range annotations.Configuration.Connections {
+		recipe := radappiov1alpha3.Recipe{}
+		err := r.Client.Get(ctx, client.ObjectKey{Namespace: deployment.Namespace, Name: source}, &recipe)
+		if err != nil {
+			return fmt.Errorf("failed to fetch recipe %s: %w", source, err)
+		}
+
+		if recipe.Status.Resource == "" {
+			return fmt.Errorf("recipe %s is not ready", source)
+		}
+
+		id, err := resources.Parse(recipe.Status.Resource)
+		if err != nil {
+			return err
+		}
+
+		response, err := r.Radius.Resources(id.RootScope(), id.Type()).Get(ctx, id.Name())
+		if err != nil {
+			return fmt.Errorf("failed to fetch resource %s: %w", id, err)
+		}
+
+		secrets, err := r.Radius.Resources(id.RootScope(), id.Type()).ListSecrets(ctx, id.Name())
+		if clients.Is404Error(err) {
+			// This is fine. The resource doesn't have any secrets.
+			secrets.Value = map[string]*string{}
+		} else if err != nil {
+			return fmt.Errorf("failed to fetch secrets for resource %s: %w", id, err)
+		}
+
+		values, err := resourceToConnectionEnvVars(name, response.GenericResource, secrets)
+		if err != nil {
+			return fmt.Errorf("failed to read values resource %s: %w", id, err)
+		}
+
+		// envtest has some quirky behavior around StringData which makes it hard to test. So we're
+		// using Data directly.
+		for k, v := range values {
+			secret.Data[k] = []byte(base64.RawStdEncoding.EncodeToString([]byte(v)))
+		}
+	}
+
+	addSecretReference(deployment, secretName.Name)
+
+	if createSecret {
+		err = r.Client.Create(ctx, &secret)
+		if err != nil {
+			return fmt.Errorf("failed to create secret %s: %w", secretName, err)
+		}
+	} else {
+		err = r.Client.Update(ctx, &secret)
+		if err != nil {
+			return fmt.Errorf("failed to update secret %s: %w", secretName, err)
+		}
+	}
+
+	return nil
+}
+
+func (r *DeploymentReconciler) cleanupDeployment(ctx context.Context, deployment *appsv1.Deployment) error {
+	delete(deployment.Annotations, AnnotationRadiusStatus)
+	delete(deployment.Annotations, AnnotationRadiusConfigurationHash)
+
+	secretName := client.ObjectKey{Namespace: deployment.Namespace, Name: fmt.Sprintf("%s-connections", deployment.Name)}
+	err := r.Client.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: secretName.Namespace, Name: secretName.Name}})
+	if err != nil {
+		return fmt.Errorf("failed to delete secret %s: %w", secretName.Name, err)
+	}
+
+	removeSecretReference(deployment, secretName.Name)
+	return nil
+}
+
+func (r *DeploymentReconciler) saveState(ctx context.Context, deployment *appsv1.Deployment, annotations *deploymentAnnotations) error {
+	err := annotations.ApplyToDeployment(deployment)
+	if err != nil {
+		return fmt.Errorf("unable to apply annotations: %w", err)
+	}
+
+	err = r.Client.Update(ctx, deployment)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *DeploymentReconciler) findDeploymentsForRecipe(ctx context.Context, obj client.Object) []reconcile.Request {
+	recipe := obj.(*radappiov1alpha3.Recipe)
+
+	deployments := &appsv1.DeploymentList{}
+	options := &client.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(indexField, recipe.Name),
+		Namespace:     recipe.Namespace,
+	}
+	err := r.Client.List(ctx, deployments, options)
+	if err != nil {
+		return []reconcile.Request{}
+	}
+
+	requests := []reconcile.Request{}
+	for _, item := range deployments.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      item.GetName(),
+				Namespace: item.GetNamespace(),
+			},
+		})
+	}
+	return requests
+}
+
+func (r *DeploymentReconciler) requeueDelay() time.Duration {
+	delay := r.DelayInterval
+	if delay == 0 {
+		delay = PollingDelay
+	}
+
+	return delay
+}
+
+const indexField = "spec.recipe-reference"
+
+func (r *DeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &appsv1.Deployment{}, indexField, func(rawObj client.Object) []string {
+		deployment := rawObj.(*appsv1.Deployment)
+		annotations, err := readAnnotations(deployment)
+		if err != nil {
+			return []string{}
+		} else if annotations.Configuration == nil {
+			return []string{}
+		}
+
+		recipes := []string{}
+		for _, recipe := range annotations.Configuration.Connections {
+			recipes = append(recipes, recipe)
+		}
+
+		return recipes
+	}); err != nil {
+		return err
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appsv1.Deployment{}).
+		Watches(&radappiov1alpha3.Recipe{}, handler.EnqueueRequestsFromMapFunc(r.findDeploymentsForRecipe), builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
+		Owns(&corev1.Secret{}).
+		Complete(r)
+}

--- a/pkg/controller/reconciler/deployment_reconciler_test.go
+++ b/pkg/controller/reconciler/deployment_reconciler_test.go
@@ -1,0 +1,518 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
+	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
+	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
+	"github.com/radius-project/radius/pkg/to"
+	"github.com/radius-project/radius/test/testcontext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	deploymentTestWaitDuration            = time.Second * 10
+	deploymentTestWaitInterval            = time.Second * 1
+	deploymentTestControllerDelayInterval = time.Millisecond * 100
+)
+
+func SetupDeploymentTest(t *testing.T) (*mockRadiusClient, client.Client) {
+	SkipWithoutEnvironment(t)
+
+	// For debugging, you can set uncomment this to see logs from the controller. This will cause tests to fail
+	// because the logging will continue after the test completes.
+	//
+	// Add runtimelog "sigs.k8s.io/controller-runtime/pkg/log" to imports.
+	//
+	// runtimelog.SetLogger(ucplog.FromContextOrDiscard(testcontext.New(t)))
+
+	// Shut down the manager when the test exits.
+	ctx, cancel := testcontext.NewWithCancel(t)
+	t.Cleanup(cancel)
+
+	mgr, err := ctrl.NewManager(config, ctrl.Options{
+		Scheme: scheme,
+
+		// Suppress metrics in tests to avoid conflicts.
+		MetricsBindAddress: "0",
+	})
+	require.NoError(t, err)
+
+	radius := NewMockRadiusClient()
+	err = (&DeploymentReconciler{
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		EventRecorder: mgr.GetEventRecorderFor("recipe-controller"),
+		Radius:        radius,
+		DelayInterval: deploymentTestControllerDelayInterval,
+	}).SetupWithManager(mgr)
+	require.NoError(t, err)
+
+	go func() {
+		err := mgr.Start(ctx)
+		require.NoError(t, err)
+	}()
+
+	return radius, mgr.GetClient()
+}
+
+// Creates a deployment with Radius enabled.
+//
+// Then exercises the cleanup path by deleting the deployment.
+func Test_DeploymentReconciler_RadiusEnabled_ThenDeploymentDeleted(t *testing.T) {
+	ctx := testcontext.New(t)
+	radius, client := SetupDeploymentTest(t)
+
+	name := types.NamespacedName{Namespace: "deployment-enabled-deleted", Name: "test-deployment-enabled-deleted"}
+	err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	require.NoError(t, err)
+
+	deployment := makeDeployment(name)
+	deployment.Annotations[AnnotationRadiusEnabled] = "true"
+	err = client.Create(ctx, deployment)
+	require.NoError(t, err)
+
+	// Deployment will be waiting for environment to be created.
+	createEnvironment(radius)
+
+	// Deployment will be waiting for container to complete deployment.
+	annotations := waitForStateUpdating(t, client, name)
+
+	radius.CompleteOperation(annotations.Status.Operation.ResumeToken, nil)
+
+	// Deployment will update after operation completes
+	annotations = waitForStateReady(t, client, name)
+
+	container, err := radius.Containers(annotations.Status.Scope).Get(ctx, deployment.Name, nil)
+	require.NoError(t, err)
+	require.Equal(t, "manual", string(*container.Properties.ResourceProvisioning))
+	require.Equal(t, []*v20231001preview.ResourceReference{{ID: to.Ptr("/planes/kubernetes/local/namespaces/deployment-enabled-deleted/providers/apps/Deployment/" + deployment.Name)}}, container.Properties.Resources)
+
+	err = client.Delete(ctx, deployment)
+	require.NoError(t, err)
+
+	// Deletion of the container is in progress.
+	annotations = waitForStateDeleting(t, client, name)
+	radius.CompleteOperation(annotations.Status.Operation.ResumeToken, nil)
+
+	// Now deleting of the deployment object can complete.
+	waitForDeploymentDeleted(t, client, name)
+}
+
+// Creates a deployment with Radius enabled.
+//
+// Then exercises the cleanup path by disabling Radius.
+func Test_DeploymentReconciler_RadiusEnabled_ThenRadiusDisabled(t *testing.T) {
+	ctx := testcontext.New(t)
+	radius, client := SetupDeploymentTest(t)
+
+	name := types.NamespacedName{Namespace: "deployment-enabled-disabled", Name: "test-deployment-enabled-disabled"}
+	err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	require.NoError(t, err)
+
+	deployment := makeDeployment(name)
+	deployment.Annotations[AnnotationRadiusEnabled] = "true"
+	err = client.Create(ctx, deployment)
+	require.NoError(t, err)
+
+	// Deployment will be waiting for environment to be created.
+	createEnvironment(radius)
+
+	// Deployment will be waiting for container to complete deployment.
+	annotations := waitForStateUpdating(t, client, name)
+
+	radius.CompleteOperation(annotations.Status.Operation.ResumeToken, nil)
+
+	// Deployment will update after operation completes
+	annotations = waitForStateReady(t, client, name)
+
+	container, err := radius.Containers(annotations.Status.Scope).Get(ctx, deployment.Name, nil)
+	require.NoError(t, err)
+	require.Equal(t, "manual", string(*container.Properties.ResourceProvisioning))
+	require.Equal(t, []*v20231001preview.ResourceReference{{ID: to.Ptr("/planes/kubernetes/local/namespaces/deployment-enabled-disabled/providers/apps/Deployment/" + deployment.Name)}}, container.Properties.Resources)
+
+	// Trigger cleanup by disabling Radius.
+	err = client.Get(ctx, name, deployment)
+	require.NoError(t, err)
+	deployment.Annotations[AnnotationRadiusEnabled] = "false"
+	err = client.Update(ctx, deployment)
+	require.NoError(t, err)
+
+	// Deletion of the container is in progress.
+	annotations = waitForStateDeleting(t, client, name)
+	radius.CompleteOperation(annotations.Status.Operation.ResumeToken, nil)
+
+	waitForRadiusContainerDeleted(t, client, name)
+}
+
+// Creates a deployment with Radius enabled and connections to two recipes.
+//
+// Then makes those recipes Ready so connections can be enabled.
+//
+// Then changes the configuration to *drop* one of the connections.
+//
+// Then exercises the cleanup path by disabling Radius - and shows that we can revert
+// the changes Radius made to the deployment.
+func Test_DeploymentReconciler_Connections(t *testing.T) {
+	ctx := testcontext.New(t)
+	radius, client := SetupDeploymentTest(t)
+
+	name := types.NamespacedName{Namespace: "deployment-connections", Name: "test-deployment-connections"}
+	secretName := types.NamespacedName{Namespace: name.Namespace, Name: fmt.Sprintf("%s-connections", name.Name)}
+	err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	require.NoError(t, err)
+
+	deployment := makeDeployment(name)
+	deployment.Annotations[AnnotationRadiusEnabled] = "true"
+	deployment.Annotations[AnnotationRadiusConnectionPrefix+"a"] = "recipe-a"
+	deployment.Annotations[AnnotationRadiusConnectionPrefix+"b"] = "recipe-b"
+
+	err = client.Create(ctx, deployment)
+	require.NoError(t, err)
+
+	// Deployment will be waiting for environment to be created.
+	createEnvironment(radius)
+
+	// Deployment will be waiting for recipe resources to be created
+	_ = waitForStateWaiting(t, client, name)
+
+	// Create the recipes, but don't mark them as provisioned yet.
+	recipeA := makeRecipe(types.NamespacedName{Namespace: name.Namespace, Name: "recipe-a"}, "Applications.Core/extenders")
+	recipeB := makeRecipe(types.NamespacedName{Namespace: name.Namespace, Name: "recipe-b"}, "Applications.Core/extenders")
+
+	err = client.Create(ctx, recipeA)
+	require.NoError(t, err)
+	err = client.Create(ctx, recipeB)
+	require.NoError(t, err)
+
+	// Deployment will be waiting for recipe resources to be created.
+	annotations := waitForStateWaiting(t, client, name)
+
+	// Create the radius resources associated with the recipes
+	extenderA := generated.GenericResource{
+		Properties: map[string]any{
+			"a-value": "a",
+			"secrets": map[string]string{
+				"a-secret": "a",
+			},
+		},
+	}
+	poller, err := radius.Resources(annotations.Status.Scope, "Applications.Core/extenders").BeginCreateOrUpdate(ctx, recipeA.Name, extenderA, nil)
+	require.NoError(t, err)
+	token, err := poller.ResumeToken()
+	require.NoError(t, err)
+	radius.CompleteOperation(token, nil)
+
+	extenderB := generated.GenericResource{
+		Properties: map[string]any{
+			"b-value": "b",
+			"secrets": map[string]string{
+				"b-secret": "b",
+			},
+		},
+	}
+	poller, err = radius.Resources(annotations.Status.Scope, "Applications.Core/extenders").BeginCreateOrUpdate(ctx, recipeB.Name, extenderB, nil)
+	require.NoError(t, err)
+	token, err = poller.ResumeToken()
+	require.NoError(t, err)
+	radius.CompleteOperation(token, nil)
+
+	recipeA.Status = radappiov1alpha3.RecipeStatus{
+		Resource: annotations.Status.Scope + "/providers/Applications.Core/extenders/" + recipeA.Name,
+	}
+	recipeB.Status = radappiov1alpha3.RecipeStatus{
+		Resource: annotations.Status.Scope + "/providers/Applications.Core/extenders/" + recipeB.Name,
+	}
+
+	// Mark the recipes as provisioned.
+	err = client.Status().Update(ctx, recipeA)
+	require.NoError(t, err)
+	err = client.Status().Update(ctx, recipeB)
+	require.NoError(t, err)
+
+	// Now we can create the container
+	annotations = waitForStateUpdating(t, client, name)
+
+	radius.CompleteOperation(annotations.Status.Operation.ResumeToken, nil)
+
+	// Deployment will update after operation completes
+	annotations = waitForStateReady(t, client, name)
+
+	container, err := radius.Containers(annotations.Status.Scope).Get(ctx, deployment.Name, nil)
+	require.NoError(t, err)
+	require.Equal(t, "manual", string(*container.Properties.ResourceProvisioning))
+	require.Equal(t, map[string]*v20231001preview.ConnectionProperties{
+		"a": {
+			Source: to.Ptr(annotations.Status.Scope + "/providers/Applications.Core/extenders/" + recipeA.Name),
+		},
+		"b": {
+			Source: to.Ptr(annotations.Status.Scope + "/providers/Applications.Core/extenders/" + recipeB.Name),
+		},
+	}, container.Properties.Connections)
+	require.Equal(t, []*v20231001preview.ResourceReference{{ID: to.Ptr("/planes/kubernetes/local/namespaces/deployment-connections/providers/apps/Deployment/" + deployment.Name)}}, container.Properties.Resources)
+
+	err = client.Get(ctx, name, deployment)
+	require.NoError(t, err)
+
+	// Secret should have been created.
+	secret := corev1.Secret{}
+	err = client.Get(ctx, secretName, &secret)
+	require.NoError(t, err)
+
+	expectedSecretData := map[string][]byte{
+		"CONNECTION_A_A-SECRET": []byte(base64.RawStdEncoding.EncodeToString([]byte("a"))),
+		"CONNECTION_A_A-VALUE":  []byte(base64.RawStdEncoding.EncodeToString([]byte("a"))),
+		"CONNECTION_B_B-SECRET": []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
+		"CONNECTION_B_B-VALUE":  []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
+	}
+	require.Equal(t, expectedSecretData, secret.Data)
+
+	// Secret should be mapped as env-vars
+	expectedEnvFrom := []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-connections", deployment.Name)},
+				Optional:             to.Ptr(false),
+			},
+		},
+	}
+
+	require.Equal(t, expectedEnvFrom, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
+
+	// Trigger a change by removing one of the connections.
+	err = client.Get(ctx, name, deployment)
+	require.NoError(t, err)
+	delete(deployment.Annotations, AnnotationRadiusConnectionPrefix+"a")
+	err = client.Update(ctx, deployment)
+	require.NoError(t, err)
+
+	// Container will be updated.
+	annotations = waitForStateUpdating(t, client, name)
+
+	radius.CompleteOperation(annotations.Status.Operation.ResumeToken, nil)
+
+	// Deployment will update after operation completes
+	_ = waitForStateReady(t, client, name)
+
+	// Secret should have been updated.
+	err = client.Get(ctx, secretName, &secret)
+	require.NoError(t, err)
+
+	expectedSecretData = map[string][]byte{
+		"CONNECTION_B_B-SECRET": []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
+		"CONNECTION_B_B-VALUE":  []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
+	}
+	require.Equal(t, expectedSecretData, secret.Data)
+
+	// Secret should be mapped as env-vars
+	require.Equal(t, expectedEnvFrom, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
+
+	// Trigger cleanup by disabling Radius.
+	err = client.Get(ctx, name, deployment)
+	require.NoError(t, err)
+	deployment.Annotations[AnnotationRadiusEnabled] = "false"
+	err = client.Update(ctx, deployment)
+	require.NoError(t, err)
+
+	// Deletion of the container is in progress.
+	annotations = waitForStateDeleting(t, client, name)
+	radius.CompleteOperation(annotations.Status.Operation.ResumeToken, nil)
+
+	waitForRadiusContainerDeleted(t, client, name)
+
+	// Deployment should have Radius changes reverted.
+	err = client.Get(ctx, name, deployment)
+	require.NoError(t, err)
+	require.Empty(t, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
+
+	// Secret should be gone
+	err = client.Get(ctx, secretName, &secret)
+	require.Error(t, err)
+	require.True(t, apierrors.IsNotFound(err))
+}
+
+func makeDeployment(name types.NamespacedName) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name.Name,
+			Namespace:   name.Namespace,
+			Annotations: map[string]string{},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": name.Name,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": name.Name,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  name.Name,
+							Image: "nginx:latest",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func waitForStateWaiting(t *testing.T, client client.Client, name types.NamespacedName) *deploymentAnnotations {
+	ctx := testcontext.New(t)
+
+	logger := t
+	var annotations *deploymentAnnotations
+	require.EventuallyWithTf(t, func(t *assert.CollectT) {
+		logger.Logf("Fetching Deployment: %+v", name)
+		current := &appsv1.Deployment{}
+		err := client.Get(ctx, name, current)
+		require.NoError(t, err)
+
+		annotations, err = readAnnotations(current)
+		require.NoError(t, err)
+		assert.NotNil(t, annotations)
+		logger.Logf("Annotations.Status: %+v", annotations.Status)
+
+		if assert.NotNil(t, annotations.Status) && assert.Equal(t, deploymentPhraseWaiting, annotations.Status.Phrase) {
+			assert.Empty(t, annotations.Status.Operation)
+		}
+	}, deploymentTestWaitDuration, deploymentTestWaitInterval, "waiting for state to be Waiting")
+
+	return annotations
+}
+
+func waitForStateUpdating(t *testing.T, client client.Client, name types.NamespacedName) *deploymentAnnotations {
+	ctx := testcontext.New(t)
+
+	logger := t
+	var annotations *deploymentAnnotations
+	require.EventuallyWithTf(t, func(t *assert.CollectT) {
+		logger.Logf("Fetching Deployment: %+v", name)
+		current := &appsv1.Deployment{}
+		err := client.Get(ctx, name, current)
+		require.NoError(t, err)
+
+		annotations, err = readAnnotations(current)
+		require.NoError(t, err)
+		assert.NotNil(t, annotations)
+		logger.Logf("Annotations.Status: %+v", annotations.Status)
+
+		if assert.NotNil(t, annotations.Status) && assert.Equal(t, deploymentPhraseUpdating, annotations.Status.Phrase) {
+			assert.NotEmpty(t, annotations.Status.Operation)
+		}
+	}, deploymentTestWaitDuration, deploymentTestWaitInterval, "waiting for state to be Updating")
+
+	return annotations
+}
+
+func waitForStateReady(t *testing.T, client client.Client, name types.NamespacedName) *deploymentAnnotations {
+	ctx := testcontext.New(t)
+
+	logger := t
+	var annotations *deploymentAnnotations
+	require.EventuallyWithTf(t, func(t *assert.CollectT) {
+		logger.Logf("Fetching Deployment: %+v", name)
+		current := &appsv1.Deployment{}
+		err := client.Get(ctx, name, current)
+		require.NoError(t, err)
+
+		annotations, err = readAnnotations(current)
+		require.NoError(t, err)
+		assert.NotNil(t, annotations)
+		logger.Logf("Annotations.Status: %+v", annotations.Status)
+
+		if assert.NotNil(t, annotations.Status) && assert.Equal(t, deploymentPhraseReady, annotations.Status.Phrase) {
+			assert.Empty(t, annotations.Status.Operation)
+		}
+	}, deploymentTestWaitDuration, deploymentTestWaitInterval, "waiting for state to be Ready")
+
+	return annotations
+}
+
+func waitForStateDeleting(t *testing.T, client client.Client, name types.NamespacedName) *deploymentAnnotations {
+	ctx := testcontext.New(t)
+
+	logger := t
+	var annotations *deploymentAnnotations
+	require.EventuallyWithTf(t, func(t *assert.CollectT) {
+		logger.Logf("Fetching Deployment: %+v", name)
+		current := &appsv1.Deployment{}
+		err := client.Get(ctx, name, current)
+		require.NoError(t, err)
+
+		annotations, err = readAnnotations(current)
+		require.NoError(t, err)
+		assert.NotNil(t, annotations)
+		logger.Logf("Annotations.Status: %+v", annotations.Status)
+
+		if assert.NotNil(t, annotations.Status) && assert.Equal(t, deploymentPhraseDeleting, annotations.Status.Phrase) {
+			assert.NotEmpty(t, annotations.Status.Operation)
+		}
+	}, deploymentTestWaitDuration, deploymentTestWaitInterval, "waiting for state to be Deleting")
+
+	return annotations
+}
+
+func waitForRadiusContainerDeleted(t *testing.T, client client.Client, name types.NamespacedName) *deploymentAnnotations {
+	ctx := testcontext.New(t)
+
+	logger := t
+	var annotations *deploymentAnnotations
+	require.EventuallyWithTf(t, func(t *assert.CollectT) {
+		logger.Logf("Fetching Deployment: %+v", name)
+		current := &appsv1.Deployment{}
+		err := client.Get(ctx, name, current)
+		require.NoError(t, err)
+
+		logger.Logf("Annotations: %+v", current.Annotations)
+		assert.NotContains(t, current.Annotations, AnnotationRadiusStatus)
+		assert.NotContains(t, current.Annotations, AnnotationRadiusConfigurationHash)
+	}, deploymentTestWaitDuration, deploymentTestWaitInterval, "waiting for state to be Deleting")
+
+	return annotations
+}
+
+func waitForDeploymentDeleted(t *testing.T, client client.Client, name types.NamespacedName) {
+	ctx := testcontext.New(t)
+
+	logger := t
+	require.Eventuallyf(t, func() bool {
+		logger.Logf("Fetching Deployment: %+v", name)
+		err := client.Get(ctx, name, &appsv1.Deployment{})
+		return apierrors.IsNotFound(err)
+	}, deploymentTestWaitDuration, deploymentTestWaitInterval, "waiting for deployment to be deleted")
+}

--- a/pkg/controller/reconciler/deployment_util.go
+++ b/pkg/controller/reconciler/deployment_util.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"github.com/radius-project/radius/pkg/to"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// addSecretReference adds a secret reference to the deployment. Returns true if the secret was added, and false if it already exists.
+//
+// This function is idempotent and will not add the secret reference if it already exists.
+func addSecretReference(deployment *appsv1.Deployment, secretName string) bool {
+	// For now we're just interested in the first container.
+	container := &deployment.Spec.Template.Spec.Containers[0]
+
+	index := -1
+	for i := range deployment.Spec.Template.Spec.Containers[0].EnvFrom {
+		if container.EnvFrom[i].SecretRef != nil && container.EnvFrom[i].SecretRef.Name == secretName {
+			index = i
+			break
+		}
+	}
+
+	if index != -1 {
+		return false // Already present
+	}
+
+	from := corev1.EnvFromSource{
+		SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+			Optional:             to.Ptr(false),
+		},
+	}
+
+	container.EnvFrom = append(container.EnvFrom, from)
+	return true
+}
+
+// removeSecretReference removes the secret reference from the deployment. Returns true if the secret was removed, and false if it was not found.
+func removeSecretReference(deployment *appsv1.Deployment, secretName string) bool {
+
+	// For now we're just interested in the first container.
+	container := &deployment.Spec.Template.Spec.Containers[0]
+
+	index := -1
+	for i := range deployment.Spec.Template.Spec.Containers[0].EnvFrom {
+		if container.EnvFrom[i].SecretRef != nil && container.EnvFrom[i].SecretRef.Name == secretName {
+			index = i
+			break
+		}
+	}
+
+	if index == -1 {
+		return false
+	}
+
+	// Remove the secret from the deployment.
+	container.EnvFrom = append(container.EnvFrom[0:index], container.EnvFrom[index+1:]...)
+	return true
+}

--- a/pkg/controller/reconciler/deployment_util_test.go
+++ b/pkg/controller/reconciler/deployment_util_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/radius-project/radius/pkg/to"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func Test_addSecretReference_AlreadyPresent(t *testing.T) {
+	expected := []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "secret"}},
+		},
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+		},
+		{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+		},
+	}
+
+	deployment := makeDeployment(types.NamespacedName{})
+	deployment.Spec.Template.Spec.Containers[0].EnvFrom = expected
+
+	result := addSecretReference(deployment, "secret")
+	require.False(t, result)
+	require.Equal(t, expected, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
+}
+
+func Test_addSecretReference_ReferenceAdded(t *testing.T) {
+	expected := []corev1.EnvFromSource{
+
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+		},
+		{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+		},
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "secret"}, Optional: to.Ptr(false)},
+		},
+	}
+
+	deployment := makeDeployment(types.NamespacedName{})
+	deployment.Spec.Template.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+		},
+		{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+		},
+	}
+
+	result := addSecretReference(deployment, "secret")
+	require.True(t, result)
+	require.Equal(t, expected, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
+}
+
+func Test_removeSecretReference_AlreadyRemoved(t *testing.T) {
+	expected := []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+		},
+		{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+		},
+	}
+
+	deployment := makeDeployment(types.NamespacedName{})
+	deployment.Spec.Template.Spec.Containers[0].EnvFrom = expected
+
+	result := removeSecretReference(deployment, "secret")
+	require.False(t, result)
+	require.Equal(t, expected, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
+}
+
+func Test_removeSecretReference_ReferenceRemoved(t *testing.T) {
+	expected := []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+		},
+		{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+		},
+	}
+
+	deployment := makeDeployment(types.NamespacedName{})
+	deployment.Spec.Template.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "secret"}},
+		},
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+		},
+		{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+		},
+	}
+
+	result := removeSecretReference(deployment, "secret")
+	require.True(t, result)
+	require.Equal(t, expected, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
+}

--- a/pkg/controller/reconciler/recipe_reconciler_test.go
+++ b/pkg/controller/reconciler/recipe_reconciler_test.go
@@ -22,11 +22,8 @@ import (
 	"testing"
 	"time"
 
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
 	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
-	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
-	"github.com/radius-project/radius/pkg/to"
 	"github.com/radius-project/radius/test/testcontext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -96,13 +93,7 @@ func Test_RecipeReconciler_WithoutSecret(t *testing.T) {
 	require.NoError(t, err)
 
 	// Recipe will be waiting for environment to be created.
-	radius.Update(func() {
-		radius.environments["/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"] = v20231001preview.EnvironmentResource{
-			ID:       to.Ptr("/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"),
-			Name:     to.Ptr("default"),
-			Location: to.Ptr(v1.LocationGlobal),
-		}
-	})
+	createEnvironment(radius)
 
 	// Recipe will be waiting for extender to complete provisioning.
 	status := waitForRecipeStateUpdating(t, client, name, nil)
@@ -149,13 +140,7 @@ func Test_RecipeReconciler_FailureRecovery(t *testing.T) {
 	require.NoError(t, err)
 
 	// Recipe will be waiting for environment to be created.
-	radius.Update(func() {
-		radius.environments["/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"] = v20231001preview.EnvironmentResource{
-			ID:       to.Ptr("/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"),
-			Name:     to.Ptr("default"),
-			Location: to.Ptr(v1.LocationGlobal),
-		}
-	})
+	createEnvironment(radius)
 
 	// Recipe will be waiting for extender to complete provisioning.
 	status := waitForRecipeStateUpdating(t, client, name, nil)
@@ -221,13 +206,7 @@ func Test_RecipeReconciler_WithSecret(t *testing.T) {
 	require.NoError(t, err)
 
 	// Recipe will be waiting for environment to be created.
-	radius.Update(func() {
-		radius.environments["/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"] = v20231001preview.EnvironmentResource{
-			ID:       to.Ptr("/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"),
-			Name:     to.Ptr("default"),
-			Location: to.Ptr(v1.LocationGlobal),
-		}
-	})
+	createEnvironment(radius)
 
 	// Recipe will be waiting for extender to complete provisioning.
 	status := waitForRecipeStateUpdating(t, client, name, nil)
@@ -298,18 +277,6 @@ func Test_RecipeReconciler_WithSecret(t *testing.T) {
 	err = client.Get(ctx, name, &secret)
 	require.Error(t, err)
 	require.True(t, apierrors.IsNotFound(err))
-}
-
-func makeRecipe(name types.NamespacedName, resourceType string) *radappiov1alpha3.Recipe {
-	return &radappiov1alpha3.Recipe{
-		ObjectMeta: ctrl.ObjectMeta{
-			Namespace: name.Namespace,
-			Name:      name.Name,
-		},
-		Spec: radappiov1alpha3.RecipeSpec{
-			Type: resourceType,
-		},
-	}
 }
 
 func waitForRecipeStateUpdating(t *testing.T, client client.Client, name types.NamespacedName, oldOperation *radappiov1alpha3.ResourceOperation) *radappiov1alpha3.RecipeStatus {

--- a/pkg/controller/reconciler/shared_test.go
+++ b/pkg/controller/reconciler/shared_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
+	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
+	"github.com/radius-project/radius/pkg/to"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func createEnvironment(radius *mockRadiusClient) {
+	radius.Update(func() {
+		radius.environments["/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"] = v20231001preview.EnvironmentResource{
+			ID:       to.Ptr("/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"),
+			Name:     to.Ptr("default"),
+			Location: to.Ptr(v1.LocationGlobal),
+		}
+	})
+}
+
+func makeRecipe(name types.NamespacedName, resourceType string) *radappiov1alpha3.Recipe {
+	return &radappiov1alpha3.Recipe{
+		ObjectMeta: ctrl.ObjectMeta{
+			Namespace: name.Namespace,
+			Name:      name.Name,
+		},
+		Spec: radappiov1alpha3.RecipeSpec{
+			Type: resourceType,
+		},
+	}
+}

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -92,6 +92,15 @@ func (s *Service) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to setup %s controller: %w", "Recipe", err)
 	}
+	err = (&reconciler.DeploymentReconciler{
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		EventRecorder: mgr.GetEventRecorderFor("radius-deployment-controller"),
+		Radius:        reconciler.NewClient(s.Options.UCPConnection),
+	}).SetupWithManager(mgr)
+	if err != nil {
+		return fmt.Errorf("failed to setup %s controller: %w", "Deployment", err)
+	}
 
 	if s.TLSCertDir == "" {
 		logger.Info("Webhooks will be skipped. TLS certificates not present.")


### PR DESCRIPTION
# Description

This change adds the deployment reconciler for Radius. With this change it's possible to annotate a `Deployment` in Kubernetes and use features like connections.

## Type of change


- This pull request adds or changes features of Radius and has an approved issue (issue link required).



## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fd087bb</samp>

### Summary
📝🐳🔌

<!--
1.  📝 - This emoji represents the addition of a new file `annotations.go` that contains types and functions for managing annotations on Deployments. It also represents the addition of some constants to the `const.go` file that define the names of the annotations used by Radius. The emoji suggests that these changes are related to documentation and metadata.
2.  🐳 - This emoji represents the addition of two new functions `deleteContainer` and `createOrUpdateContainer` to the `util.go` file that are used to perform operations on container resources using the Radius client. It also represents the addition of a new reconciler `DeploymentReconciler` to the `service.go` file that is responsible for reconciling Deployments that are managed by Radius. The emoji suggests that these changes are related to containerization and orchestration.
3.  🔌 - This emoji represents the addition of a new feature to the radius controller that allows it to inject connection environment variables into Deployments based on resources and secrets. It also represents the refactoring of some test code in `recipe_reconciler_test.go` to reduce duplication and improve readability. The emoji suggests that these changes are related to connectivity and integration.
-->
This pull request adds a new feature to the radius controller that enables it to inject connection environment variables into Deployments based on resources and secrets. It also refactors some test code, adds new types and functions for managing annotations and containers, and introduces a new reconciler for Deployments. The changes affect the files `connections.go`, `recipe_reconciler_test.go`, `annotations.go`, `const.go`, `shared_test.go`, `util.go`, and `service.go` in the `reconciler` package.

> _`DeploymentReconciler`_
> _Injects connection env vars_
> _Spring of annotations_

### Walkthrough
*  Add new reconciler for Deployments ([link](https://github.com/radius-project/radius/pull/6444/files?diff=unified&w=0#diff-b31c03e05358c6faab6e77c96909e14e14eeb0dc09412ede3329625adc197fa9R95-R103))
   * Use annotations to store and update Deployment status, configuration, and connections ([link](https://github.com/radius-project/radius/pull/6444/files?diff=unified&w=0#diff-73b7f11d4ca1032a9f2f6001f455c2f6622633ba1ff91373c9e6299e7439c468R1-R156), [link](https://github.com/radius-project/radius/pull/6444/files?diff=unified&w=0#diff-1c5d9f9f2bd3272c714eba486f899cd6e053bc2fd950dac921bc328d789568b1R25-R39))
   * Use helper functions to convert resources and secrets to connection environment variables ([link](https://github.com/radius-project/radius/pull/6444/files?diff=unified&w=0#diff-b7077d6be67d0defe31f8815da3903198ab33557fc278d9294ea636c09e4eb3dR29-R55), [link](https://github.com/radius-project/radius/pull/6444/files?diff=unified&w=0#diff-b7077d6be67d0defe31f8815da3903198ab33557fc278d9294ea636c09e4eb3dR22))
   * Use helper functions to delete and create or update containers using Radius client ([link](https://github.com/radius-project/radius/pull/6444/files?diff=unified&w=0#diff-b2622e855cc3c8af44551c69c158d0400b6b2df3e3ebaefef18f7db96c6b66bbR202-R240))
* Refactor test functions and types to a shared file `shared_test.go` ([link](https://github.com/radius-project/radius/pull/6444/files?diff=unified&w=0#diff-8474e0158b0dd7b2711f19a4b9ae592ae62195fe7426e453a8d4faf2f0a8f2e9R1-R48))
   * Move `createEnvironment` and `makeRecipe` functions from `recipe_reconciler_test.go` to `shared_test.go` ([link](https://github.com/radius-project/radius/pull/6444/files?diff=unified&w=0#diff-2b3aa3c5be32be791c9069d44213d653090aed157026f3d37f187ccded049cacL99-R96), [link](https://github.com/radius-project/radius/pull/6444/files?diff=unified&w=0#diff-2b3aa3c5be32be791c9069d44213d653090aed157026f3d37f187ccded049cacL152-R143), [link](https://github.com/radius-project/radius/pull/6444/files?diff=unified&w=0#diff-2b3aa3c5be32be791c9069d44213d653090aed157026f3d37f187ccded049cacL224-R209), [link](https://github.com/radius-project/radius/pull/6444/files?diff=unified&w=0#diff-2b3aa3c5be32be791c9069d44213d653090aed157026f3d37f187ccded049cacL303-L314))
* Remove unused imports from `recipe_reconciler_test.go` ([link](https://github.com/radius-project/radius/pull/6444/files?diff=unified&w=0#diff-2b3aa3c5be32be791c9069d44213d653090aed157026f3d37f187ccded049cacL25-R26))


