### PR TITLE
Create unique directory for every TF recipe operation

### DIFF
--- a/pkg/recipes/driver/terraform.go
+++ b/pkg/recipes/driver/terraform.go
@@ -176,16 +176,16 @@ func (d *terraformDriver) createExecutionDirectory(ctx context.Context, recipe r
 	}
 
 	// We need a unique directory per execution of terraform. We generate this using the unique operation id of the async request so that names are always unique,
-	// but we can also trace them to the resource we were working on through operationID.
+	// but we can also trace them to the resource we were working on through operationID. UUID is added to the path to prevent overwrite across retries for same ARM request.
 	dirID := ""
 	armCtx := v1.ARMRequestContextFromContext(ctx)
 	if armCtx.OperationID != uuid.Nil {
-		dirID = armCtx.OperationID.String()
+		dirID = armCtx.OperationID.String() + "-" + uuid.NewString()
 	} else {
 		// If the operationID is nil, we generate a new UUID for unique directory name combined with resource id so that we can trace it to the resource.
 		// Ideally operationID should not be nil.
 		logger.Info("Empty operation ID provided in the request context, using uuid to generate a unique directory name")
-		dirID = util.NormalizeStringToLower(recipe.ResourceID) + "/" + uuid.NewString()
+		dirID = util.NormalizeStringToLower(recipe.ResourceID) + "-" + uuid.NewString()
 	}
 	requestDirPath := filepath.Join(d.options.Path, dirID)
 

--- a/pkg/recipes/terraform/execute.go
+++ b/pkg/recipes/terraform/execute.go
@@ -304,7 +304,7 @@ func downloadAndInspect(ctx context.Context, workingDir string, execPath string,
 	// Download the Terraform module to the working directory.
 	logger.Info(fmt.Sprintf("Downloading Terraform module: %s", options.EnvRecipe.TemplatePath))
 	downloadStartTime := time.Now()
-	if err := downloadModule(ctx, workingDir, execPath); err != nil {
+	if err := downloadModule(ctx, workingDir, execPath, options.EnvRecipe.TemplatePath); err != nil {
 		metrics.DefaultRecipeEngineMetrics.RecordRecipeDownloadDuration(ctx, downloadStartTime,
 			metrics.NewRecipeAttributes(metrics.RecipeEngineOperationDownloadRecipe, options.EnvRecipe.Name,
 				options.EnvRecipe, recipes.RecipeDownloadFailed))
@@ -325,7 +325,7 @@ func downloadAndInspect(ctx context.Context, workingDir string, execPath string,
 	return loadedModule, nil
 }
 
-// getTerraformConfig generates the Terraform json config and saves it
+// getTerraformConfig initializes the Terraform json config with provided module source and saves it
 func getTerraformConfig(ctx context.Context, workingDir string, options Options) (*config.TerraformConfig, error) {
 	// Generate Terraform json config in the working directory
 	// Use recipe name as a local reference to the module.
@@ -345,6 +345,7 @@ func getTerraformConfig(ctx context.Context, workingDir string, options Options)
 	if err := tfConfig.Save(ctx, workingDir); err != nil {
 		return nil, err
 	}
+
 	return tfConfig, nil
 }
 

--- a/pkg/recipes/terraform/module.go
+++ b/pkg/recipes/terraform/module.go
@@ -98,14 +98,14 @@ func inspectModule(workingDir, localModuleName string) (*moduleInspectResult, er
 // downloadModule downloads the module to the workingDir from the module source specified in the Terraform configuration.
 // It uses Terraform's Get command to download the module using the Terraform executable available at execPath.
 // An error is returned if the module could not be downloaded.
-func downloadModule(ctx context.Context, workingDir, execPath string) error {
+func downloadModule(ctx context.Context, workingDir, execPath, templatePath string) error {
 	tf, err := NewTerraform(ctx, workingDir, execPath)
 	if err != nil {
 		return err
 	}
 
 	if err = tf.Get(ctx); err != nil {
-		return err
+		return fmt.Errorf("failed to run terraform get to download the module from source %q: %w", templatePath, err)
 	}
 
 	return nil

--- a/pkg/recipes/terraform/module_test.go
+++ b/pkg/recipes/terraform/module_test.go
@@ -95,7 +95,7 @@ func Test_DownloadModule_EmptyWorkingDirPath_Error(t *testing.T) {
 	testDir := t.TempDir()
 	execPath := filepath.Join(testDir, "terraform")
 
-	err := downloadModule(testcontext.New(t), "", execPath)
+	err := downloadModule(testcontext.New(t), "", execPath, "test/module/source")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Terraform cannot be initialised with empty workdir")
 }

--- a/pkg/recipes/terraform/types.go
+++ b/pkg/recipes/terraform/types.go
@@ -18,6 +18,7 @@ package terraform
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/terraform-exec/tfexec"
@@ -59,12 +60,12 @@ type Options struct {
 func NewTerraform(ctx context.Context, workingDir, execPath string) (*tfexec.Terraform, error) {
 	tf, err := tfexec.NewTerraform(workingDir, execPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize Terraform: %w", err)
 	}
 
 	configureTerraformLogs(ctx, tf)
 
-	return tf, err
+	return tf, nil
 }
 
 // tfLogWrapper is a wrapper around the Terraform logger to stream the logs to the Radius logger.


### PR DESCRIPTION
# Description

Use UUID along with ARM request operation id in the Terraform recipe execution directory name to make the directory unique per attempt. More background context can be found in https://github.com/radius-project/radius/issues/6447

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: https://github.com/radius-project/radius/issues/6447

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 58c6c2f</samp>

### Summary
🐛🛠️♻️

<!--
1.  🐛 for the bug fix in the `createExecutionDirectory` function.
2.  🛠️ for the test code modification in the `Test_DownloadModule_EmptyWorkingDirPath_Error` function.
3.  ♻️ for the refactoring and enhancement of the `terraform` driver test file and package.
-->
This pull request refactors and enhances the `terraform` driver and package in the `radius` project. It simplifies the test setup, improves the code formatting and error handling, and fixes a bug related to the terraform state file. It also updates the function signatures and test code to match the new logic. The files affected are `pkg/recipes/driver/terraform_test.go`, `pkg/recipes/terraform/execute.go`, `pkg/recipes/terraform/module.go`, `pkg/recipes/terraform/types.go`, `pkg/recipes/driver/terraform.go`, and `pkg/recipes/terraform/module_test.go`.

> _Sing, O Muse, of the `terraform` driver's skillful deeds,_
> _How it shaped the cloud with `createExecutionDirectory`,_
> _Adding a unique ID to each resource's name,_
> _To avoid the wrath of the retrying gods._

### Walkthrough
*  Fix a bug where the terraform state file could be corrupted or lost due to concurrent or retrying operations on the same resource by appending a UUID to the execution directory name based on the operation ID ([link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-1b98bc9b02b96687752860c11c68d87d99ad99f24ecdfc5497fda6823abc0612L179-R188))
*  Improve the user experience and troubleshooting of the module download process by providing the module source information to the `downloadModule` function for logging and error handling ([link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482L307-R307), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-4f4cb2009f77e8f5e252eee95f3ed880148fc285798ef4b7bbeb970525ad7b5aL101-R101), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-4f4cb2009f77e8f5e252eee95f3ed880148fc285798ef4b7bbeb970525ad7b5aL108-R108), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-35f143c273df8b35733ba5b5e44bc5bb5e4dbe8467aeabc3e861b5e19354791bL98-R98))
*  Update the comment for the `getTerraformConfig` function to reflect the new behavior of the function ([link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482L328-R328))
*  Improve the code formatting and readability by adding or removing blank lines ([link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92R223), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92L248), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482R348), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-0ad85ed086350c77c3e366408120b4c3020d1cec542671ab3586fd0c34dafe6fR21))
*  Improve the user experience and troubleshooting of the Terraform initialization process by wrapping the original error with the `fmt.Errorf` function ([link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-0ad85ed086350c77c3e366408120b4c3020d1cec542671ab3586fd0c34dafe6fL62-R68))
  * Adding a new function `verifyDirectoryCleanup` to check that the execution directory created by the driver is removed after each test case ([link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92R78-R87))
  * Removing the code that creates the `tfDir` and `options` variables in the test functions and relying on the driver logic instead ([link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92L87-R97), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92L143-L149), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92L182-L188), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92L325), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92L379-L385))
  * Using `gomock.Any()` as the argument matcher for the mock expectations instead of the `options` variable to make the tests more flexible and avoid depending on the specific implementation details of the driver ([link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92L118-R122), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92L157-R152), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92L212-R198), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92L331-R314), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92L392-R361))
  * Replacing the code that checks the existence of the `tfDir` with a call to the `verifyDirectoryCleanup` function in the test functions to reuse the common logic and avoid repeating the same code ([link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92L129-R133), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92L168-R163), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92L223-R209), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92L344-R322), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92L400-R382), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92R393), [link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92R450))
  * Providing a valid operation ID in the request context for the driver to use in the `Test_Terraform_Delete_Failure` test function to make the test consistent with the other test functions that use the operation ID to create the execution directory ([link](https://github.com/radius-project/radius/pull/6452/files?diff=unified&w=0#diff-ae6e6fdc3b9219f2f1b2dbfd1cfaff3ff2d941a2a4d58fd33b910bd1fbf31e92L451-R430))


