### PR TITLE
Fix rad recipe show example

### DIFF
--- a/pkg/cli/clivalidation.go
+++ b/pkg/cli/clivalidation.go
@@ -549,7 +549,8 @@ func RequireRecipeNameArgs(cmd *cobra.Command, args []string) (string, error) {
 func GetResourceType(cmd *cobra.Command) (string, error) {
 	resourceType, err := cmd.Flags().GetString(ResourceTypeFlag)
 	if err != nil {
-		return resourceType, err
+		return "", err
 	}
+
 	return resourceType, nil
 }

--- a/pkg/cli/cmd/recipe/show/show.go
+++ b/pkg/cli/cmd/recipe/show/show.go
@@ -53,13 +53,13 @@ By default, the command is scoped to the resource group and environment defined 
 By default, the command outputs a human-readable table. You can customize the output format with the output flag.`,
 		Example: `
 # show the details of a recipe
-rad recipe show redis-prod
+rad recipe show redis-prod --resource-type Applications.Datastores/redisCaches
 
 # show the details of a recipe, with a JSON output
-rad recipe show redis-prod --output json
+rad recipe show redis-prod --resource-type Applications.Datastores/redisCaches --output json
 	
 # show the details of a recipe, with a specified environment and group
-rad recipe show redis-dev --group dev --environment dev`,
+rad recipe show redis-dev --resource-type Applications.Datastores/redisCaches --group dev --environment dev`,
 		RunE: framework.RunCommand(runner),
 		Args: cobra.ExactArgs(1),
 	}

--- a/pkg/cli/cmd/recipe/show/show_test.go
+++ b/pkg/cli/cmd/recipe/show/show_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
-	ds_ctrl "github.com/radius-project/radius/pkg/datastoresrp/frontend/controller"
+	datastorerp "github.com/radius-project/radius/pkg/datastoresrp/frontend/controller"
 	"github.com/radius-project/radius/pkg/recipes"
 	"github.com/radius-project/radius/pkg/to"
 	"github.com/radius-project/radius/test/radcli"
@@ -46,7 +46,7 @@ func Test_Validate(t *testing.T) {
 	testcases := []radcli.ValidateInput{
 		{
 			Name:          "Valid Show Command",
-			Input:         []string{"recipeName", "--resource-type", "resource-type"},
+			Input:         []string{"recipeName", "--resource-type", datastorerp.RedisCachesResourceType},
 			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
@@ -55,7 +55,7 @@ func Test_Validate(t *testing.T) {
 		},
 		{
 			Name:          "Show Command with incorrect fallback workspace",
-			Input:         []string{"-e", "my-env", "-g", "my-env", "recipeName", "--resource-type", "resource-type"},
+			Input:         []string{"-e", "my-env", "-g", "my-env", "recipeName", "--resource-type", datastorerp.RedisCachesResourceType},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
@@ -64,7 +64,7 @@ func Test_Validate(t *testing.T) {
 		},
 		{
 			Name:          "Show Command with too many positional args",
-			Input:         []string{"recipeName", "arg2", "--resource-type", "resource-type"},
+			Input:         []string{"recipeName", "arg2", "--resource-type", datastorerp.RedisCachesResourceType},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
@@ -73,7 +73,7 @@ func Test_Validate(t *testing.T) {
 		},
 		{
 			Name:          "Show Command with fallback workspace",
-			Input:         []string{"-e", "my-env", "-w", "test-workspace", "recipeName", "--resource-type", "resource-type"},
+			Input:         []string{"-e", "my-env", "-w", "test-workspace", "recipeName", "--resource-type", datastorerp.RedisCachesResourceType},
 			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
@@ -111,7 +111,7 @@ func Test_Run(t *testing.T) {
 		}
 		recipe := types.EnvironmentRecipe{
 			Name:         "cosmosDB",
-			ResourceType: ds_ctrl.MongoDatabasesResourceType,
+			ResourceType: datastorerp.MongoDatabasesResourceType,
 			TemplateKind: recipes.TemplateKindBicep,
 			TemplatePath: "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
 		}
@@ -145,7 +145,7 @@ func Test_Run(t *testing.T) {
 			Workspace:         &workspaces.Workspace{},
 			Format:            "table",
 			RecipeName:        "cosmosDB",
-			ResourceType:      ds_ctrl.MongoDatabasesResourceType,
+			ResourceType:      datastorerp.MongoDatabasesResourceType,
 		}
 
 		err := runner.Run(context.Background())
@@ -187,7 +187,7 @@ func Test_Run(t *testing.T) {
 		}
 		recipe := types.EnvironmentRecipe{
 			Name:            "cosmosDB",
-			ResourceType:    ds_ctrl.MongoDatabasesResourceType,
+			ResourceType:    datastorerp.MongoDatabasesResourceType,
 			TemplateKind:    recipes.TemplateKindTerraform,
 			TemplatePath:    "Azure/cosmosdb/azurerm",
 			TemplateVersion: "1.1.0",
@@ -222,7 +222,7 @@ func Test_Run(t *testing.T) {
 			Workspace:         &workspaces.Workspace{},
 			Format:            "table",
 			RecipeName:        "cosmosDB",
-			ResourceType:      ds_ctrl.MongoDatabasesResourceType,
+			ResourceType:      datastorerp.MongoDatabasesResourceType,
 		}
 
 		err := runner.Run(context.Background())


### PR DESCRIPTION
# Description

Fix the example to include all required inputs. More details in https://github.com/radius-project/radius/issues/6442

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

https://github.com/radius-project/radius/issues/6442

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7bf4dcd</samp>

### Summary
🐛📝✅

<!--
1.  🐛 for fixing a bug in the `GetResourceType` function.
2. 📝 for updating the example usage of the `rad recipe show` command.
3. ✅ for updating the tests for the `show` command.
-->
This pull request improves the `rad recipe show` command and its tests. It fixes a bug in the `resourceType` validation, updates the example usage and the test data, and uses more descriptive package names.

> _Sing, O Muse, of the valiant code review_
> _That fixed the bug in `GetResourceType`_
> _And made the `rad recipe show` command true_
> _To the resource's nature and aspect._

### Walkthrough
* Fix bug in `GetResourceType` function to return empty string on error ([link](https://github.com/radius-project/radius/pull/6453/files?diff=unified&w=0#diff-bf4e917446c73565ee6967f28bdd8e619c0d4fa40b215f195b840c021dd36ce9L552-R554))
* Update example usage of `rad recipe show` command to include `--resource-type` flag and valid value ([link](https://github.com/radius-project/radius/pull/6453/files?diff=unified&w=0#diff-a6f10a0125ba5ff86166bb7dd0369942834185ce5533c250891f995dae6ed236L56-R62))
* Modify test cases and data for `Test_Validate` and `Test_Run` functions in `show_test.go` to use valid resource type values ([link](https://github.com/radius-project/radius/pull/6453/files?diff=unified&w=0#diff-13fc0c59e89a1fa92926d4fdd0ef9a6ef372c9816c6c43ec6b003427b63e0852L49-R49), [link](https://github.com/radius-project/radius/pull/6453/files?diff=unified&w=0#diff-13fc0c59e89a1fa92926d4fdd0ef9a6ef372c9816c6c43ec6b003427b63e0852L58-R58), [link](https://github.com/radius-project/radius/pull/6453/files?diff=unified&w=0#diff-13fc0c59e89a1fa92926d4fdd0ef9a6ef372c9816c6c43ec6b003427b63e0852L67-R67), [link](https://github.com/radius-project/radius/pull/6453/files?diff=unified&w=0#diff-13fc0c59e89a1fa92926d4fdd0ef9a6ef372c9816c6c43ec6b003427b63e0852L76-R76), [link](https://github.com/radius-project/radius/pull/6453/files?diff=unified&w=0#diff-13fc0c59e89a1fa92926d4fdd0ef9a6ef372c9816c6c43ec6b003427b63e0852L114-R114), [link](https://github.com/radius-project/radius/pull/6453/files?diff=unified&w=0#diff-13fc0c59e89a1fa92926d4fdd0ef9a6ef372c9816c6c43ec6b003427b63e0852L148-R148), [link](https://github.com/radius-project/radius/pull/6453/files?diff=unified&w=0#diff-13fc0c59e89a1fa92926d4fdd0ef9a6ef372c9816c6c43ec6b003427b63e0852L190-R190), [link](https://github.com/radius-project/radius/pull/6453/files?diff=unified&w=0#diff-13fc0c59e89a1fa92926d4fdd0ef9a6ef372c9816c6c43ec6b003427b63e0852L225-R225))


