### PR TITLE
Migrate to GHCR

### DIFF
--- a/.github/scripts/publish-recipes.sh
+++ b/.github/scripts/publish-recipes.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 # ------------------------------------------------------------
 
-# Fail immedietly if any command fails
+# Fail immediately if any command fails
 set -e
 
 # Get command line arguments
@@ -31,7 +31,7 @@ function print_usage() {
     echo "  Publishes all recipes in the repository to the GitHub Container Registry. Requires you to be logged into GitHub."
     echo ""
     echo "  DIRECTORY: Directory containing the recipes to publish. For example, ./test/functional/testdata/recipes"
-    echo "  REGISTRY_PATH: Registry hostname and path prefix. For example, ghcr.io/radius-project/dev/tests/recipes"
+    echo "  REGISTRY_PATH: Registry hostname and path prefix. For example, ghcr.io/radius-project/dev/test/recipes"
     echo "  RECIPE_VERSION: Version of the recipe to publish. For example, pr-19293"
     echo ""
 }

--- a/.github/scripts/publish-recipes.sh
+++ b/.github/scripts/publish-recipes.sh
@@ -26,7 +26,7 @@ RECIPE_VERSION=$3
 
 # Print usage information
 function print_usage() {
-    echo "Usage: $0 <BICEP_PATH> <DIRECTORY> <REGISTRY_PATH> <RECIPE_VERSION>"
+    echo "Usage: $0 <DIRECTORY> <REGISTRY_PATH> <RECIPE_VERSION>"
     echo ""
     echo "  Publishes all recipes in the repository to the GitHub Container Registry. Requires you to be logged into GitHub."
     echo ""
@@ -37,7 +37,7 @@ function print_usage() {
 }
 
 # Verify that the required arguments are present
-if [[ $# -ne 4 ]]; then
+if [[ $# -ne 3 ]]; then
     echo "Error: Missing required arguments"
     echo ""
     print_usage

--- a/.github/scripts/publish-recipes.sh
+++ b/.github/scripts/publish-recipes.sh
@@ -65,5 +65,5 @@ do
 
     echo "Publishing $RECIPE to $PUBLISH_REF"
     echo "- $PUBLISH_REF" >> $GITHUB_STEP_SUMMARY
-    rad bicep publish $RECIPE --target "br:$PUBLISH_REF"
+    rad bicep publish --file $RECIPE --target "br:$PUBLISH_REF"
 done

--- a/.github/scripts/publish-recipes.sh
+++ b/.github/scripts/publish-recipes.sh
@@ -20,22 +20,18 @@
 set -e
 
 # Get command line arguments
-BICEP_PATH=$1
-DIRECTORY=$2
-REGISTRY_PATH=$3
-RECIPE_VERSION=$4
-
-BICEP_EXECUTABLE="$BICEP_PATH/rad-bicep"
+DIRECTORY=$1
+REGISTRY_PATH=$2
+RECIPE_VERSION=$3
 
 # Print usage information
 function print_usage() {
     echo "Usage: $0 <BICEP_PATH> <DIRECTORY> <REGISTRY_PATH> <RECIPE_VERSION>"
     echo ""
-    echo "  Publishes all recipes in the repository to the Azure Container Registry. Requires you to be logged into Azure via az login."
+    echo "  Publishes all recipes in the repository to the GitHub Container Registry. Requires you to be logged into GitHub."
     echo ""
-    echo "  BICEP_PATH: Path to directory containing the bicep executable. For example, ~/.rad/bin"
     echo "  DIRECTORY: Directory containing the recipes to publish. For example, ./test/functional/testdata/recipes"
-    echo "  REGISTRY_PATH: Registry hostname and path prefix. For example, myregistry.azurecr.io/tests/recipes."
+    echo "  REGISTRY_PATH: Registry hostname and path prefix. For example, ghcr.io/radius-project/dev/tests/recipes"
     echo "  RECIPE_VERSION: Version of the recipe to publish. For example, pr-19293"
     echo ""
 }
@@ -69,5 +65,5 @@ do
 
     echo "Publishing $RECIPE to $PUBLISH_REF"
     echo "- $PUBLISH_REF" >> $GITHUB_STEP_SUMMARY
-    $BICEP_EXECUTABLE publish $RECIPE --target "br:$PUBLISH_REF"
+    rad bicep publish $RECIPE --target "br:$PUBLISH_REF"
 done

--- a/.github/scripts/publish-recipes.sh
+++ b/.github/scripts/publish-recipes.sh
@@ -28,7 +28,7 @@ RECIPE_VERSION=$3
 function print_usage() {
     echo "Usage: $0 <DIRECTORY> <REGISTRY_PATH> <RECIPE_VERSION>"
     echo ""
-    echo "  Publishes all recipes in the repository to the GitHub Container Registry. Requires you to be logged into GitHub."
+    echo "  Publishes all recipes in the repository to a container registry."
     echo ""
     echo "  DIRECTORY: Directory containing the recipes to publish. For example, ./test/functional/testdata/recipes"
     echo "  REGISTRY_PATH: Registry hostname and path prefix. For example, ghcr.io/radius-project/dev/test/recipes"

--- a/.github/scripts/release-verification.sh
+++ b/.github/scripts/release-verification.sh
@@ -59,9 +59,9 @@ fi
 kind create cluster
 ./rad install kubernetes
 
-EXPECTED_APPCORE_RP_IMAGE="radius.azurecr.io/applications-rp:${EXPECTED_TAG_VERSION}"
-EXPECTED_UCP_IMAGE="radius.azurecr.io/ucpd:${EXPECTED_TAG_VERSION}"
-EXPECTED_DE_IMAGE="radius.azurecr.io/deployment-engine:${EXPECTED_TAG_VERSION}"
+EXPECTED_APPCORE_RP_IMAGE="ghcr.io/radius-project/applications-rp:${EXPECTED_TAG_VERSION}"
+EXPECTED_UCP_IMAGE="ghcr.io/radius-project/ucpd:${EXPECTED_TAG_VERSION}"
+EXPECTED_DE_IMAGE="ghcr.io/radius-project/deployment-engine:${EXPECTED_TAG_VERSION}"
 
 APPCORE_RP_IMAGE=$(kubectl describe pods -n radius-system -l control-plane=applications-rp | awk '/^.*Image:/ {print $2}')
 UCP_IMAGE=$(kubectl describe pods -n radius-system -l control-plane=ucp | awk '/^.*Image:/ {print $2}')

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ env:
   GHCR_ACTOR: rad-ci-bot
 
   # Container registry url for GitHub container registry.
-  CONTAINER_REGISTRY: ${{ github.event_name == 'pull_request' && 'ghcr.io/radius-project/dev' || 'ghcr.io/radius-project/radius' }}
+  CONTAINER_REGISTRY: ${{ github.event_name == 'pull_request' && 'ghcr.io/radius-project/dev' || 'ghcr.io/radius-project' }}
 
   # Local file path to the release binaries.
   RELEASE_PATH: ./release
@@ -127,7 +127,6 @@ jobs:
         with:
           name: rad_cli_release
           path: ${{ env.RELEASE_PATH }}
-      # TOOD_LAUNCH: Remove this step when we opensource the repo - https://github.com/radius-project/radius/issues/5892
       - name: Upload CLI binary
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -209,8 +209,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ env.GHCR_ACTOR }}
-          password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: oras-project/setup-oras@v1
         with:
           version: ${{ env.ORAS_VERSION }}
@@ -239,8 +239,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ env.GHCR_ACTOR }}
-          password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -306,9 +306,6 @@ jobs:
             --username ${{ secrets.AZURE_SP_TESTS_APPID }} \
             --password ${{ secrets.AZURE_SP_TESTS_PASSWORD }} \
             --tenant ${{ secrets.AZURE_SP_TESTS_TENANTID }}
-      - name: Push helm chart to ACR
-        run: |
-          az acr helm push --name radius ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}/radius-${{ env.CHART_VERSION }}.tgz --force
       - name: Push helm chart to GHCR
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | helm registry login -u ${{ github.actor }} --password-stdin ${{ env.OCI_REGISTRY }}
@@ -340,8 +337,6 @@ jobs:
             --generate-notes \
             --verify-tag \
             --prerelease
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT }}
       - name: Create GitHub Official Release
         if: ${{ !contains(env.REL_VERSION, 'rc') }}
         run: |
@@ -350,8 +345,6 @@ jobs:
             --title "Project Radius v${{ env.REL_VERSION }}" \
             --notes-file docs/release-notes/v${{ env.REL_VERSION }}.md \
             --verify-tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT }}
 
   delete_artifacts:
     name: Delete artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,14 +36,9 @@ concurrency:
 env:
   # Go version to install
   GOVER: '^1.21'
-  GOPROXY: https://proxy.golang.org
   
   # gotestsum version - see: https://github.com/gotestyourself/gotestsum
   GOTESTSUMVERSION: 1.10.0
-
-  # Use radiusdev.azurecr.io for PR build. Otherwise, use radius.azurecr.io.
-  # TODO_LAUNCH: Remove this variable when we opensource the repo - https://github.com/radius-project/radius/issues/5892
-  DOCKER_REGISTRY: ${{ github.event_name == 'pull_request' && 'radiusdev.azurecr.io' || 'radius.azurecr.io' }}
 
   # GitHub Actor for pushing images to GHCR
   GHCR_ACTOR: rad-ci-bot
@@ -54,8 +49,14 @@ env:
   # Local file path to the release binaries.
   RELEASE_PATH: ./release
 
+  # ORAS (OCI Registry As Storage) CLI version
+  ORAS_VERSION: 1.1.0
+
+  # URL to get source code for building the image
+  IMAGE_SRC: https://github.com/radius-project/radius
+
 jobs:
-  build:
+  build-and-push-cli:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     runs-on: ubuntu-latest
     env:
@@ -204,64 +205,25 @@ jobs:
         with:
           path: ./dist/cache
           key: radius-coverage-${{ github.sha }}-${{ github.run_number }}
-
-  # Logic here:
-  # - always do a docker build for validation
-  # - tag the image as latest and with a version if the trigger was a tag
-  # - tag the image with the PR version if the trigger was a PR
-  # - push the image for pushes to master, or to a tag
-
-  # TODO_LAUNCH: Remove 'image' job when we opensource the repo - https://github.com/radius-project/radius/issues/5892
-  images:
-    name: Container image build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Parse release version and set environment variables
-        run: python ./.github/scripts/get_release_version.py
-      - name: Set up Go ${{ env.GOVER }}
-        uses: actions/setup-go@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          go-version: ${{ env.GOVER }}
-      - uses: azure/docker-login@v1
+          registry: ghcr.io
+          username: ${{ env.GHCR_ACTOR }}
+          password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+      - uses: oras-project/setup-oras@v1
         with:
-          login-server: ${{ env.DOCKER_REGISTRY }}
-          username: '${{ secrets.DOCKER_USERNAME }}'
-          password: '${{ secrets.DOCKER_PASSWORD }}'
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-      - name: Push container images (latest)
+          version: ${{ env.ORAS_VERSION }}
+      - name: Push latest rad cli binary to GHCR (unix-like)
+        if: github.ref == 'refs/heads/main' && matrix.target_os != 'windows'
         run: |
-          make docker-test-image-build && make docker-test-image-push
-          make docker-multi-arch-push
-        if: (github.ref == 'refs/heads/main') # push image to latest on merge to main
-        env:
-          DOCKER_REGISTRY: ${{ env.DOCKER_REGISTRY }}
-          DOCKER_TAG_VERSION: latest
-      - name: Push container images (PR)
+          oras push ${{ env.CONTAINER_REGISTRY }}/rad/${{ matrix.target_os }}-${{ matrix.target_arch }}:latest ./dist/${{ matrix.target_os}}_${{ matrix.target_arch}}/release/rad --annotation "org.opencontainers.image.source=${{ env.IMAGE_SRC }}"
+      - name: Copy cli binaries to release (windows)
+        if: github.ref == 'refs/heads/main' && matrix.target_os == 'windows'
         run: |
-          make docker-test-image-build && make docker-test-image-push
-          make docker-multi-arch-push
-        if: github.event_name == 'pull_request'
-        env:
-          DOCKER_REGISTRY: ${{ env.DOCKER_REGISTRY }}
-          DOCKER_TAG_VERSION: ${{ env.REL_VERSION }} # includes PR number
-      - name: Push container images (release)
-        run: |
-          make docker-test-image-build && make docker-test-image-push
-          make docker-multi-arch-push
-        if: startsWith(github.ref, 'refs/tags/v') # push image on tag
-        env:
-          DOCKER_REGISTRY: ${{ env.DOCKER_REGISTRY }}
-          DOCKER_TAG_VERSION: ${{ env.REL_CHANNEL }}
+          oras push ${{ env.CONTAINER_REGISTRY }}/rad/${{ matrix.target_os }}-${{ matrix.target_arch }}:latest ./dist/${{ matrix.target_os}}_${{ matrix.target_arch}}/release/rad.exe --annotation "org.opencontainers.image.source=${{ env.IMAGE_SRC }}"
 
-  # publish_image is building and publishing images to GHCR.
-  publish_images:
+  build-and-push-images:
     name: Build and publish container images
     runs-on: ubuntu-latest
     steps:
@@ -309,9 +271,10 @@ jobs:
         env:
           DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
           DOCKER_TAG_VERSION: ${{ env.REL_CHANNEL }}
-  helm:
+
+  build-and-push-helm-chart:
     name: Helm chart build
-    needs: ['images', 'publish_images']
+    needs: ['build-and-push-images']
     runs-on: ubuntu-latest
     env:
       ARTIFACT_DIR: ./dist/Charts
@@ -350,9 +313,10 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | helm registry login -u ${{ github.actor }} --password-stdin ${{ env.OCI_REGISTRY }}
           helm push ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}/radius-${{ env.CHART_VERSION }}.tgz oci://${{ env.OCI_REGISTRY }}/${{ env.OCI_REPOSITORY }}
-  publish_release:
+
+  publish-release:
     name: Publish GitHub Release
-    needs: [ 'build' ]
+    needs: ['build-and-push-cli']
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
@@ -388,94 +352,11 @@ jobs:
             --verify-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT }}
-  # TODO_LAUNCH: Remove this job once we opensource - https://github.com/radius-project/radius/issues/5892
-  publish:
-    name: Publish rad CLI binaries
-    needs: [ 'build' ]
-    runs-on: ubuntu-latest
-    if: (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') # upload on push to main or tag
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Parse release version and set environment variables
-        run: python ./.github/scripts/get_release_version.py
-      - name: Download release artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: rad_cli_darwin_arm64
-          path: rad_cli_darwin_arm64
-      - name: Download release artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: rad_cli_darwin_amd64
-          path: rad_cli_darwin_amd64
-      - name: Download release artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: rad_cli_linux_arm
-          path: rad_cli_linux_arm
-      - name: Download release artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: rad_cli_linux_arm64
-          path: rad_cli_linux_arm64
-      - name: Download release artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: rad_cli_linux_amd64
-          path: rad_cli_linux_amd64
-      - name: Download release artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: rad_cli_windows_amd64
-          path: rad_cli_windows_amd64
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_darwin_amd64
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/macos-x64/ --pattern rad --timeout 300'
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_darwin_arm64
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/macos-arm64/ --pattern rad --timeout 300'
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_linux_amd64
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-x64/ --pattern rad --timeout 300'
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_linux_arm
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-arm/ --pattern rad --timeout 300'
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_linux_arm64
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-arm64/ --pattern rad --timeout 300'
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_windows_amd64
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/windows-x64/ --pattern rad.exe --timeout 300'
 
   delete_artifacts:
     name: Delete artifacts
-    needs: [ 'build', 'publish' ]
-    if: ${{ always() && !contains(needs.build.result, 'failure') }}
+    needs: ['build-and-push-cli']
+    if: ${{ always() && !contains(needs.build-and-push-cli.result, 'failure') }}
     runs-on: ubuntu-latest
     steps:
       - name: Delete release artifacts

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -347,12 +347,6 @@ jobs:
         uses: azure/login@v1
         with:
           creds: '{"clientId":"${{ secrets.INTEGRATION_TEST_SP_APP_ID }}","clientSecret":"${{ secrets.INTEGRATION_TEST_SP_PASSWORD }}","subscriptionId":"${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.INTEGRATION_TEST_TENANT_ID }}"}'
-      - name: Login to GitHub Container Registry TODO WILLSMITH delete this
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: marocchino/sticky-pull-request-comment@v2
         continue-on-error: true
         with:

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -188,7 +188,7 @@ jobs:
             * Dapr: ${{ env.DAPR_VER }}
             * Azure KeyVault CSI driver: ${{ env.AZURE_KEYVAULT_CSI_DRIVER_VER }}
             * Azure Workload identity webhook: ${{ env.AZURE_WORKLOAD_IDENTITY_WEBHOOK_VER }}
-            * Bicep recipe location `${{ env.CONTAINER_REGISTRY}}/test/functional/shared/recipes/<name>:${{ env.REL_VERSION }}`
+            * Bicep recipe location `${{ env.BICEP_RECIPE_REGISTRY }}/test/functional/shared/recipes/<name>:${{ env.REL_VERSION }}`
             * Terraform recipe location `${{ env.TF_RECIPE_MODULE_SERVER_URL }}/<name>.zip` (in cluster)
             * applications-rp test image location: `${{ env.CONTAINER_REGISTRY }}/applications-rp:${{ env.REL_VERSION }}`
             * controller test image location: `${{ env.CONTAINER_REGISTRY }}/controller:${{ env.REL_VERSION }}`
@@ -256,7 +256,7 @@ jobs:
         run: |
           make publish-test-bicep-recipes
         env:
-          BICEP_RECIPE_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
+          BICEP_RECIPE_REGISTRY: ${{ env.BICEP_RECIPE_REGISTRY }}
           BICEP_RECIPE_TAG_VERSION: ${{ env.REL_VERSION }}
       - uses: marocchino/sticky-pull-request-comment@v2
         if: success() && env.PR_NUMBER != ''

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -340,6 +340,12 @@ jobs:
         uses: azure/login@v1
         with:
           creds: '{"clientId":"${{ secrets.INTEGRATION_TEST_SP_APP_ID }}","clientSecret":"${{ secrets.INTEGRATION_TEST_SP_PASSWORD }}","subscriptionId":"${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.INTEGRATION_TEST_TENANT_ID }}"}'
+      - name: Login to GitHub Container Registry TODO WILLSMITH delete this
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: marocchino/sticky-pull-request-comment@v2
         continue-on-error: true
         with:

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -70,8 +70,6 @@ env:
   ACTION_LINK: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
   # Server where terraform test modules are deployed
   TF_RECIPE_MODULE_SERVER_URL: "http://tf-module-server.radius-test-tf-module-server.svc.cluster.local"
-  # The rad CLI download URL
-  RAD_CLI_URL: https://get.radapp.dev/tools/rad/install.sh
 
 jobs:
   build:

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -225,6 +225,15 @@ jobs:
           name: ${{ steps.gen-id.outputs.RAD_CLI_ARTIFACT_NAME }}
           path: |
             ./dist/linux_amd64/release/rad
+      - name: Download Bicep
+        run: |
+          mkdir ./bin
+          cp ./dist/linux_amd64/release/rad ./bin/rad
+          chmod +x ./bin/rad
+          export PATH=$GITHUB_WORKSPACE/bin:$PATH
+          which rad || { echo "cannot find rad"; exit 1; }
+          rad bicep download
+          rad version
       - uses: marocchino/sticky-pull-request-comment@v2
         if: success() && env.PR_NUMBER != ''
         continue-on-error: true

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -53,8 +53,7 @@ env:
   # Container registry for storing test images and recipes
   CACHE_REGISTRY: ghcr.io/radius-project/dev
   # Container registry for storing recipe artifacts
-  # TODO_LAUNCH: Change it to ghcr.io/radius-project/dev - https://github.com/radius-project/radius/issues/5892
-  BICEP_RECIPE_REGISTRY: radiusdev.azurecr.io
+  BICEP_RECIPE_REGISTRY: ghcr.io/radius-project/dev
   # The radius functional test timeout
   FUNCTIONALTEST_TIMEOUT: 60m
   # The Azure Location to store test resources
@@ -79,6 +78,7 @@ jobs:
     name: Build Radius for test
     runs-on: ubuntu-latest
     env:
+      # TODO_LAUNCH: this points to ACR. need to change to GHCR
       DE_IMAGE: 'radius.azurecr.io/deployment-engine'
       DE_TAG: 'latest'
     outputs:
@@ -483,9 +483,6 @@ jobs:
           rad env update kind-radius --aws-region ${{ env.AWS_REGION }} --aws-account-id ${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}
           rad credential register aws \
             --access-key-id ${{ secrets.FUNCTEST_AWS_ACCESS_KEY_ID }} --secret-access-key ${{ secrets.FUNCTEST_AWS_SECRET_ACCESS_KEY }}
-          
-          # TODO_LAUNCH: Remove this login once we move recipe to GHCR - https://github.com/radius-project/radius/issues/5892
-          az acr login -n ${{ env.BICEP_RECIPE_REGISTRY }}
       - uses: marocchino/sticky-pull-request-comment@v2
         if: failure() && env.PR_NUMBER != ''
         continue-on-error: true

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -70,6 +70,8 @@ env:
   ACTION_LINK: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
   # Server where terraform test modules are deployed
   TF_RECIPE_MODULE_SERVER_URL: "http://tf-module-server.radius-test-tf-module-server.svc.cluster.local"
+  # The rad CLI download URL
+  RAD_CLI_URL: https://get.radapp.dev/tools/rad/install.sh
 
 jobs:
   build:
@@ -250,18 +252,12 @@ jobs:
           append: true
           message: |
             :hourglass: Publishing Bicep Recipes for functional tests...
-      - name: Download rad-bicep
-        run: |
-          mkdir -p dist
-          ./.github/scripts/curl-with-retries.sh https://get.radapp.dev/tools/bicep-extensibility/edge/linux-x64/rad-bicep --output dist/rad-bicep
-          chmod +x dist/rad-bicep
       - name: Publish Bicep Test Recipes
         run: |
           make publish-test-bicep-recipes
         env:
-          CONTAINER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
+          BICEP_RECIPE_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
           BICEP_RECIPE_TAG_VERSION: ${{ env.REL_VERSION }}
-          RAD_BICEP_PATH: dist
       - uses: marocchino/sticky-pull-request-comment@v2
         if: success() && env.PR_NUMBER != ''
         continue-on-error: true
@@ -377,7 +373,7 @@ jobs:
           # AZURE_OIDC_ISSUER
           eval "export $(echo "${{ secrets.FUNCTEST_AZURE_OIDC_JSON }}" | jq -r 'to_entries | map("\(.key)=\(.value)") | @sh')"
 
-          AUTHKEY=$(echo -n "${{ env.GHCR_ACTOR }}:${{ secrets.GH_RAD_CI_BOT_PAT }}" | base64)
+          AUTHKEY=$(echo -n "${{ github.actor }}:${{ secrets.GH_RAD_CI_BOT_PAT }}" | base64)
           echo "{\"auths\":{\"ghcr.io\":{\"auth\":\"${AUTHKEY}\"}}}" > "./ghcr_secret.json"
 
           # Create KinD cluster with OIDC Issuer keys
@@ -516,7 +512,7 @@ jobs:
           RADIUS_SAMPLES_REPO_ROOT: ${{ github.workspace }}/samples
           # Test_MongoDB_Recipe_Parameters is using the following environment variable.
           INTEGRATION_TEST_RESOURCE_GROUP_NAME: ${{ env.AZURE_TEST_RESOURCE_GROUP }}
-          CONTAINER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
+          BICEP_RECIPE_REGISTRY: ${{ env.BICEP_RECIPE_REGISTRY }}
           BICEP_RECIPE_TAG_VERSION: ${{ env.BICEP_RECIPE_TAG_VERSION }}
       - uses: azure/setup-kubectl@v3
         if: always()

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -225,15 +225,6 @@ jobs:
           name: ${{ steps.gen-id.outputs.RAD_CLI_ARTIFACT_NAME }}
           path: |
             ./dist/linux_amd64/release/rad
-      - name: Download Bicep
-        run: |
-          mkdir ./bin
-          cp ./dist/linux_amd64/release/rad ./bin/rad
-          chmod +x ./bin/rad
-          export PATH=$GITHUB_WORKSPACE/bin:$PATH
-          which rad || { echo "cannot find rad"; exit 1; }
-          rad bicep download
-          rad version
       - uses: marocchino/sticky-pull-request-comment@v2
         if: success() && env.PR_NUMBER != ''
         continue-on-error: true
@@ -263,6 +254,13 @@ jobs:
             :hourglass: Publishing Bicep Recipes for functional tests...
       - name: Publish Bicep Test Recipes
         run: |
+          mkdir ./bin
+          cp ./dist/linux_amd64/release/rad ./bin/rad
+          chmod +x ./bin/rad
+          export PATH=$GITHUB_WORKSPACE/bin:$PATH
+          which rad || { echo "cannot find rad"; exit 1; }
+          rad bicep download
+          rad version
           make publish-test-bicep-recipes
         env:
           BICEP_RECIPE_REGISTRY: ${{ env.BICEP_RECIPE_REGISTRY }}

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -50,9 +50,9 @@ env:
   AZURE_KEYVAULT_CSI_DRIVER_VER: '1.4.2'
   # Azure workload identity webhook chart version
   AZURE_WORKLOAD_IDENTITY_WEBHOOK_VER: '1.1.0'
-  # Container registry for storing test images and recipes
-  CACHE_REGISTRY: ghcr.io/radius-project/dev
-  # Container registry for storing recipe artifacts
+  # Container registry for storing container images
+  CONTAINER_REGISTRY: ghcr.io/radius-project/dev
+  # Container registry for storing Bicep recipe artifacts
   BICEP_RECIPE_REGISTRY: ghcr.io/radius-project/dev
   # The radius functional test timeout
   FUNCTIONALTEST_TIMEOUT: 60m
@@ -71,15 +71,12 @@ env:
   # Server where terraform test modules are deployed
   TF_RECIPE_MODULE_SERVER_URL: "http://tf-module-server.radius-test-tf-module-server.svc.cluster.local"
 
-  # GitHub Actor for pushing images to GHCR
-  GHCR_ACTOR: rad-ci-bot
 jobs:
   build:
     name: Build Radius for test
     runs-on: ubuntu-latest
     env:
-      # TODO_LAUNCH: this points to ACR. need to change to GHCR
-      DE_IMAGE: 'radius.azurecr.io/deployment-engine'
+      DE_IMAGE: 'ghcr.io/radius-project/deployment-engine'
       DE_TAG: 'latest'
     outputs:
       REL_VERSION: ${{ steps.gen-id.outputs.REL_VERSION }}
@@ -189,28 +186,22 @@ jobs:
             * Dapr: ${{ env.DAPR_VER }}
             * Azure KeyVault CSI driver: ${{ env.AZURE_KEYVAULT_CSI_DRIVER_VER }}
             * Azure Workload identity webhook: ${{ env.AZURE_WORKLOAD_IDENTITY_WEBHOOK_VER }}
-            * Bicep recipe location `${{ env.BICEP_RECIPE_REGISTRY}}/test/functional/shared/recipes/<name>:${{ env.REL_VERSION }}`
+            * Bicep recipe location `${{ env.CONTAINER_REGISTRY}}/test/functional/shared/recipes/<name>:${{ env.REL_VERSION }}`
             * Terraform recipe location `${{ env.TF_RECIPE_MODULE_SERVER_URL }}/<name>.zip` (in cluster)
-            * applications-rp test image location: `${{ env.CACHE_REGISTRY }}/applications-rp:${{ env.REL_VERSION }}`
-            * controller test image location: `${{ env.CACHE_REGISTRY }}/controller:${{ env.REL_VERSION }}`
-            * ucp test image location: `${{ env.CACHE_REGISTRY }}/ucpd:${{ env.REL_VERSION }}`
+            * applications-rp test image location: `${{ env.CONTAINER_REGISTRY }}/applications-rp:${{ env.REL_VERSION }}`
+            * controller test image location: `${{ env.CONTAINER_REGISTRY }}/controller:${{ env.REL_VERSION }}`
+            * ucp test image location: `${{ env.CONTAINER_REGISTRY }}/ucpd:${{ env.REL_VERSION }}`
             * deployment-engine test image location: `${{ env.DE_IMAGE }}:${{ env.DE_TAG }}`
 
             </details>
             
             ## Test Status
-      - name: Setup Azure CLI
-        run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-      - name: Login to Azure
-        uses: azure/login@v1
-        with:
-          creds: '{"clientId":"${{ secrets.INTEGRATION_TEST_SP_APP_ID }}","clientSecret":"${{ secrets.INTEGRATION_TEST_SP_PASSWORD }}","subscriptionId":"${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.INTEGRATION_TEST_TENANT_ID }}"}'
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ env.GHCR_ACTOR }}
-          password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: marocchino/sticky-pull-request-comment@v2
         if: env.PR_NUMBER != ''
         continue-on-error: true
@@ -224,7 +215,7 @@ jobs:
         run: |
           make build && make docker-build && make docker-push
         env:
-          DOCKER_REGISTRY: ${{ env.CACHE_REGISTRY }}
+          DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
           DOCKER_TAG_VERSION: ${{ env.REL_VERSION }}
       - name: Upload CLI binary
         uses: actions/upload-artifact@v3
@@ -268,7 +259,7 @@ jobs:
         run: |
           make publish-test-bicep-recipes
         env:
-          BICEP_RECIPE_REGISTRY: ${{ env.BICEP_RECIPE_REGISTRY }}
+          CONTAINER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
           BICEP_RECIPE_TAG_VERSION: ${{ env.REL_VERSION }}
           RAD_BICEP_PATH: dist
       - uses: marocchino/sticky-pull-request-comment@v2
@@ -432,8 +423,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ env.GHCR_ACTOR }}
-          password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Download Bicep
         run: |
           chmod +x ./bin/rad
@@ -461,7 +452,7 @@ jobs:
           echo "*** Installing Radius to Kubernetes ***"
           rad install kubernetes \
             --chart ${{ env.RADIUS_CHART_LOCATION }} \
-            --set rp.image=${{ env.CACHE_REGISTRY }}/applications-rp,rp.tag=${{ env.REL_VERSION }},controller.image=${{ env.CACHE_REGISTRY }}/controller,controller.tag=${{ env.REL_VERSION }},ucp.image=${{ env.CACHE_REGISTRY }}/ucpd,ucp.tag=${{ env.REL_VERSION }},de.image=${{ env.DE_IMAGE }},de.tag=${{ env.DE_TAG }}
+            --set rp.image=${{ env.CONTAINER_REGISTRY }}/applications-rp,rp.tag=${{ env.REL_VERSION }},controller.image=${{ env.CONTAINER_REGISTRY }}/controller,controller.tag=${{ env.REL_VERSION }},ucp.image=${{ env.CONTAINER_REGISTRY }}/ucpd,ucp.tag=${{ env.REL_VERSION }},de.image=${{ env.DE_IMAGE }},de.tag=${{ env.DE_TAG }}
 
           echo "*** Create workspace, group and environment for test ***"
           rad workspace create kubernetes
@@ -516,7 +507,7 @@ jobs:
 
           make test-functional-${{ matrix.name }}
         env:
-          DOCKER_REGISTRY: ${{ env.CACHE_REGISTRY }}
+          DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
           TEST_TIMEOUT: ${{ env.FUNCTIONALTEST_TIMEOUT }}
           RADIUS_CONTAINER_LOG_PATH: ${{ github.workspace }}/${{ env.RADIUS_CONTAINER_LOG_BASE }}
           AWS_ACCESS_KEY_ID: ${{ secrets.FUNCTEST_AWS_ACCESS_KEY_ID }}
@@ -525,7 +516,7 @@ jobs:
           RADIUS_SAMPLES_REPO_ROOT: ${{ github.workspace }}/samples
           # Test_MongoDB_Recipe_Parameters is using the following environment variable.
           INTEGRATION_TEST_RESOURCE_GROUP_NAME: ${{ env.AZURE_TEST_RESOURCE_GROUP }}
-          BICEP_RECIPE_REGISTRY: ${{ env.BICEP_RECIPE_REGISTRY }}
+          CONTAINER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
           BICEP_RECIPE_TAG_VERSION: ${{ env.BICEP_RECIPE_TAG_VERSION }}
       - uses: azure/setup-kubectl@v3
         if: always()

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -236,7 +236,7 @@ jobs:
         if: steps.skip-build.outputs.SKIP_BUILD != 'true'
         run: |
           mkdir -p ./dist/cache
-          mv ./dist/linux_amd64/release/rad ./dist/cache
+          cp ./dist/linux_amd64/release/rad ./dist/cache
           echo $(date +%s) > ./dist/cache/.lastbuildtime
           echo "UNIQUE_ID=${{ steps.gen-id.outputs.UNIQUE_ID }}" >> ./dist/cache/.buildenv
           echo "REL_VERSION=${{ steps.gen-id.outputs.REL_VERSION }}" >> ./dist/cache/.buildenv

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -217,6 +217,16 @@ jobs:
           name: ${{ steps.gen-id.outputs.RAD_CLI_ARTIFACT_NAME }}
           path: |
             ./dist/linux_amd64/release/rad
+      - name: Download Bicep
+        if: steps.skip-build.outputs.SKIP_BUILD != 'true'
+        run: |
+          mkdir ./bin
+          cp ./dist/linux_amd64/release/rad ./bin/rad
+          chmod +x ./bin/rad
+          export PATH=$GITHUB_WORKSPACE/bin:$PATH
+          which rad || { echo "cannot find rad"; exit 1; }
+          rad bicep download
+          rad version
       - name: Log the build result (success)
         if: steps.skip-build.outputs.SKIP_BUILD != 'true' && success()
         continue-on-error: true
@@ -232,12 +242,6 @@ jobs:
         continue-on-error: true
         run: |
           echo ":hourglass: Publishing Bicep Recipes for functional tests..." >> $GITHUB_STEP_SUMMARY
-      - name: Download rad-bicep
-        if: steps.skip-build.outputs.SKIP_BUILD != 'true'
-        run: |
-          mkdir -p dist
-          ./.github/scripts/curl-with-retries.sh https://get.radapp.dev/tools/bicep-extensibility/edge/linux-x64/rad-bicep --output dist/rad-bicep
-          chmod +x dist/rad-bicep
       - name: Move the latest binaries to cache
         if: steps.skip-build.outputs.SKIP_BUILD != 'true'
         run: |
@@ -263,7 +267,6 @@ jobs:
         env:
           BICEP_RECIPE_REGISTRY: ${{ env.BICEP_RECIPE_REGISTRY }}
           BICEP_RECIPE_TAG_VERSION: ${{ env.REL_VERSION }}
-          RAD_BICEP_PATH: dist
       - name: Log Bicep recipe publish status (success)
         if: steps.skip-build.outputs.SKIP_BUILD != 'true' && success()
         run: |

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -180,9 +180,9 @@ jobs:
           * gotestsum ${{ env.GOTESTSUM_VER }}
           * Bicep recipe location `${{ env.BICEP_RECIPE_REGISTRY}}/test/functional/shared/recipes/<name>:${{ steps.gen-id.outputs.REL_VERSION }}`
           * Terraform recipe location `${{ env.TF_RECIPE_MODULE_SERVER_URL }}/<name>.zip` (in cluster)
-          * applications-rp test image location: `${{ env.CACHE_REGISTRY }}/applications-rp:${{ steps.gen-id.outputs.REL_VERSION }}`
-          * controller test image location: `${{ env.CACHE_REGISTRY }}/controller:${{ steps.gen-id.outputs.REL_VERSION }}`
-          * ucp test image location: `${{ env.CACHE_REGISTRY }}/ucpd:${{ steps.gen-id.outputs.REL_VERSION }}`
+          * applications-rp test image location: `${{ env.CONTAINER_REGISTRY }}/applications-rp:${{ steps.gen-id.outputs.REL_VERSION }}`
+          * controller test image location: `${{ env.CONTAINER_REGISTRY }}/controller:${{ steps.gen-id.outputs.REL_VERSION }}`
+          * ucp test image location: `${{ env.CONTAINER_REGISTRY }}/ucpd:${{ steps.gen-id.outputs.REL_VERSION }}`
 
           </details>
           
@@ -202,7 +202,7 @@ jobs:
         run: |
           make build && make docker-build && make docker-push
         env:
-          DOCKER_REGISTRY: ${{ env.CACHE_REGISTRY }}
+          DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
           DOCKER_TAG_VERSION: ${{ env.REL_VERSION }}
       - name: Upload CLI binary
         if: steps.skip-build.outputs.SKIP_BUILD != 'true' 
@@ -353,7 +353,7 @@ jobs:
           echo "*** Installing Radius to Kubernetes ***"
           rad install kubernetes --reinstall \
             --chart ${{ env.RADIUS_CHART_LOCATION }} \
-            --set rp.image=${{ env.CACHE_REGISTRY }}/applications-rp,rp.tag=${{ env.REL_VERSION }},controller.image=${{ env.CACHE_REGISTRY }}/controller,controller.tag=${{ env.REL_VERSION }},ucp.image=${{ env.CACHE_REGISTRY }}/ucpd,ucp.tag=${{ env.REL_VERSION }}
+            --set rp.image=${{ env.CONTAINER_REGISTRY }}/applications-rp,rp.tag=${{ env.REL_VERSION }},controller.image=${{ env.CONTAINER_REGISTRY }}/controller,controller.tag=${{ env.REL_VERSION }},ucp.image=${{ env.CONTAINER_REGISTRY }}/ucpd,ucp.tag=${{ env.REL_VERSION }}
       - name: Configure Radius test workspace
         run: |
           set -x

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -55,10 +55,10 @@ env:
   # gotestsum version - see: https://github.com/gotestyourself/gotestsum
   GOTESTSUM_VER: 1.10.0
 
-  # ACR for storing test images and recipes
-  CACHE_REGISTRY: radiusdev.azurecr.io
-  # Container registry for storing recipe artifacts
-  BICEP_RECIPE_REGISTRY: radiusdev.azurecr.io
+  # Container registry for storing container images
+  CONTAINER_REGISTRY: ghcr.io/radius-project/dev
+  # Container registry for storing Bicep recipe artifacts
+  BICEP_RECIPE_REGISTRY: ghcr.io/radius-project/dev
   # The radius functional test timeout
   FUNCTIONALTEST_TIMEOUT: 60m
   # The Azure Location to store test resources
@@ -197,10 +197,6 @@ jobs:
         uses: azure/login@v1
         with:
           creds: '{"clientId":"${{ secrets.INTEGRATION_TEST_SP_APP_ID }}","clientSecret":"${{ secrets.INTEGRATION_TEST_SP_PASSWORD }}","subscriptionId":"${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.INTEGRATION_TEST_TENANT_ID }}"}'
-      - name: Login ACR - ${{ env.CACHE_REGISTRY }}
-        if: steps.skip-build.outputs.SKIP_BUILD != 'true' 
-        run: |
-          az acr login -n ${{ env.CACHE_REGISTRY }}
       - name: Build and Push container images
         if: steps.skip-build.outputs.SKIP_BUILD != 'true' 
         run: |
@@ -387,8 +383,6 @@ jobs:
           rad env update radius-e2e --aws-region ${{ env.AWS_REGION }} --aws-account-id ${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}
           rad credential register aws \
             --access-key-id ${{ secrets.FUNCTEST_AWS_ACCESS_KEY_ID }} --secret-access-key ${{ secrets.FUNCTEST_AWS_SECRET_ACCESS_KEY }}
-          
-          az acr login -n ${{ env.CACHE_REGISTRY }}
       - name: Log radius installation status (failure)
         if: failure()
         run: |

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -217,16 +217,6 @@ jobs:
           name: ${{ steps.gen-id.outputs.RAD_CLI_ARTIFACT_NAME }}
           path: |
             ./dist/linux_amd64/release/rad
-      - name: Download Bicep
-        if: steps.skip-build.outputs.SKIP_BUILD != 'true'
-        run: |
-          mkdir ./bin
-          cp ./dist/linux_amd64/release/rad ./bin/rad
-          chmod +x ./bin/rad
-          export PATH=$GITHUB_WORKSPACE/bin:$PATH
-          which rad || { echo "cannot find rad"; exit 1; }
-          rad bicep download
-          rad version
       - name: Log the build result (success)
         if: steps.skip-build.outputs.SKIP_BUILD != 'true' && success()
         continue-on-error: true
@@ -263,7 +253,13 @@ jobs:
       - name: Publish Bicep Test Recipes
         if: steps.skip-build.outputs.SKIP_BUILD != 'true'
         run: |
-          make publish-test-bicep-recipes
+          mkdir ./bin
+          cp ./dist/linux_amd64/release/rad ./bin/rad
+          chmod +x ./bin/rad
+          export PATH=$GITHUB_WORKSPACE/bin:$PATH
+          which rad || { echo "cannot find rad"; exit 1; }
+          rad bicep download
+          rad version
         env:
           BICEP_RECIPE_REGISTRY: ${{ env.BICEP_RECIPE_REGISTRY }}
           BICEP_RECIPE_TAG_VERSION: ${{ env.REL_VERSION }}

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -178,7 +178,7 @@ jobs:
           <summary> Click here to see the list of tools in the current test run</summary>
 
           * gotestsum ${{ env.GOTESTSUM_VER }}
-          * Bicep recipe location `${{ env.BICEP_RECIPE_REGISTRY}}/test/functional/shared/recipes/<name>:${{ steps.gen-id.outputs.REL_VERSION }}`
+          * Bicep recipe location `${{ env.BICEP_RECIPE_REGISTRY }}/test/functional/shared/recipes/<name>:${{ steps.gen-id.outputs.REL_VERSION }}`
           * Terraform recipe location `${{ env.TF_RECIPE_MODULE_SERVER_URL }}/<name>.zip` (in cluster)
           * applications-rp test image location: `${{ env.CONTAINER_REGISTRY }}/applications-rp:${{ steps.gen-id.outputs.REL_VERSION }}`
           * controller test image location: `${{ env.CONTAINER_REGISTRY }}/controller:${{ steps.gen-id.outputs.REL_VERSION }}`
@@ -197,6 +197,12 @@ jobs:
         uses: azure/login@v1
         with:
           creds: '{"clientId":"${{ secrets.INTEGRATION_TEST_SP_APP_ID }}","clientSecret":"${{ secrets.INTEGRATION_TEST_SP_PASSWORD }}","subscriptionId":"${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.INTEGRATION_TEST_TENANT_ID }}"}'
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push container images
         if: steps.skip-build.outputs.SKIP_BUILD != 'true' 
         run: |

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -41,9 +41,9 @@ on:
   schedule:
     # Run every 2 hours
     - cron: "0 */2 * * *"
-  pull_request:
-    branches:
-      - main
+  # pull_request:
+  #   branches:
+  #     - main
     paths:
       - '.github/workflows/long-running-azure.yaml'
 

--- a/build/recipes.mk
+++ b/build/recipes.mk
@@ -29,7 +29,6 @@ publish-test-bicep-recipes: ## Publishes test recipes to <BICEP_RECIPE_REGISTRY>
 	
 	@echo "$(ARROW) Publishing Bicep test recipes from ./test/functional/shared/resources/testdata/recipes/test-bicep-recipes..."
 	./.github/scripts/publish-recipes.sh \
-		${RAD_BICEP_PATH} \
 		./test/functional/shared/resources/testdata/recipes/test-bicep-recipes \
 		${BICEP_RECIPE_REGISTRY}/test/functional/shared/recipes \
 		${BICEP_RECIPE_TAG_VERSION}

--- a/build/test.mk
+++ b/build/test.mk
@@ -58,7 +58,7 @@ test-get-envtools:
 test-validate-cli: ## Run cli integration tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) -coverpkg= ./pkg/cli/cmd/... ./cmd/rad/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
 
-test-functional-all: test-functional-ucp test-functional-kubernetes test-functional-shared test-functional-msgrp test-functional-daprrp ## Runs all functional tests
+test-functional-all: test-functional-ucp test-functional-shared test-functional-msgrp test-functional-daprrp ## Runs all functional tests
 
 test-functional-kubernetes: ## Runs Kubernetes functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)

--- a/build/test.mk
+++ b/build/test.mk
@@ -58,7 +58,7 @@ test-get-envtools:
 test-validate-cli: ## Run cli integration tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) -coverpkg= ./pkg/cli/cmd/... ./cmd/rad/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
 
-test-functional-all: test-functional-ucp test-functional-shared test-functional-msgrp test-functional-daprrp ## Runs all functional tests
+test-functional-all: test-functional-ucp test-functional-kubernetes test-functional-shared test-functional-msgrp test-functional-daprrp ## Runs all functional tests
 
 test-functional-kubernetes: ## Runs Kubernetes functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)

--- a/build/test.mk
+++ b/build/test.mk
@@ -20,7 +20,7 @@
 TEST_TIMEOUT ?=1h
 RADIUS_CONTAINER_LOG_PATH ?=./dist/container_logs
 REL_VERSION ?=latest
-DOCKER_REGISTRY ?=radiusdev.azurecr.io
+DOCKER_REGISTRY ?=ghcr.io/radius-project/dev
 ENVTEST_ASSETS_DIR=$(shell pwd)/bin
 K8S_VERSION=1.23.*
 ENV_SETUP=$(GOBIN)/setup-envtest$(BINARY_EXT)

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -10,7 +10,7 @@ global:
   #   url: "http://jaeger-collector.radius-monitoring.svc.cluster.local:9411/api/v2/spans"
   #
 controller:
-  image: radius.azurecr.io/controller
+  image: ghcr.io/radius-project/controller
   # Default tag uses Chart AppVersion.
   # tag: latest
   resources:
@@ -20,7 +20,7 @@ controller:
       memory: "300Mi"
 
 de:
-  image: radius.azurecr.io/deployment-engine
+  image: ghcr.io/radius-project/deployment-engine
   # Default tag uses Chart AppVersion.
   # tag: latest
   resources:
@@ -31,7 +31,7 @@ de:
       memory: "300Mi"
 
 ucp:
-  image: radius.azurecr.io/ucpd
+  image: ghcr.io/radius-project/ucpd
   # Default tag uses Chart AppVersion.
   # tag: latest
   resources:
@@ -42,7 +42,7 @@ ucp:
       memory: "300Mi"
 
 rp:
-  image: radius.azurecr.io/applications-rp
+  image: ghcr.io/radius-project/applications-rp
   # Default tag uses Chart AppVersion.
   # tag: latest
   publicEndpointOverride: ""

--- a/docs/contributing/contributing-code/contributing-code-building/README.md
+++ b/docs/contributing/contributing-code/contributing-code-building/README.md
@@ -31,7 +31,7 @@ These commands assume you are already logged-in to the registry you are using. I
 Here's an example command that will push and push images to a specified registry:
 
 ```sh
-DOCKER_REGISTRY=myregistry.ghcr.io make docker-push docker-build
+DOCKER_REGISTRY=ghcr.io/my-registry make docker-push docker-build
 ```
 
 If you work with Radius frequently, you may want to define a shell variable as part of your profile to set your registry.

--- a/docs/contributing/contributing-code/contributing-code-control-plane/generating-and-installing-custom-build.md
+++ b/docs/contributing/contributing-code/contributing-code-control-plane/generating-and-installing-custom-build.md
@@ -16,7 +16,7 @@ Note that installing a custom build could corrupt existing data or installation.
 
 1. Set environment variables for your docker registry and docker tag version. 
     ```
-    export DOCKER_REGISTRY=your-registry.azurecr.io
+    export DOCKER_REGISTRY=ghcr.io/your-registry
     export DOCKER_IMAGE_TAG=latest
     ```
 
@@ -29,7 +29,7 @@ Note that installing a custom build could corrupt existing data or installation.
 
 4. Use the image from your container registry to install the Radius control plane.
     ```
-    rad install kubernetes --chart deploy/Chart/ --set rp.image=your-registry.azurecr.io/appcore-rp,rp.tag=latest,ucp.image=your-registry.azurecr.io/ucpd,ucp.tag=latest
+    rad install kubernetes --chart deploy/Chart/ --set rp.image=ghcr.io/your-registry/applications-rp,rp.tag=latest,ucp.image=ghcr.io/your-registry/ucpd,ucp.tag=latest
     ```
 
 5. Use `rad init` command to set up the Radius workspace, environment, credentials, and provider as needed.

--- a/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
+++ b/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
@@ -38,9 +38,9 @@ As much as possible, the tests use product functionality such as the Radius CLI 
 
 1. Place `rad` on your path
 2. Make sure `rad-bicep` is downloaded (`rad bicep download`)
-3. Create a container registry (must be Azure Container Registry for now)
-4. Log-in to the container registry `az acr login -n <registry-name>`
-5. Publish Bicep test recipes by running `BICEP_RECIPE_REGISTRY=<registry-name>.azurecr.io make publish-test-bicep-recipes`
+3. Create a container registry
+4. Log-in to the container registry
+5. Publish Bicep test recipes by running `BICEP_RECIPE_REGISTRY=<registry-name> make publish-test-bicep-recipes`
 6. Publish Terraform test recipes by running `make publish-test-terraform-recipes`
 7. Create a Radius Environment with `rad init` and specify the default namespace
 

--- a/docs/contributing/contributing-code/contributing-code-tests/testing-local.md
+++ b/docs/contributing/contributing-code/contributing-code-tests/testing-local.md
@@ -8,7 +8,7 @@ Note, this only applies when we want to update the app core image, if we need to
 
 1. Set the environment variable DOCKER_REGISTRY set to the container registry
     ```
-    export DOCKER_REGISTRY=<registry>.azurecr.io
+    export DOCKER_REGISTRY=ghcr.io/your-registry
     ```
 1. Ensure you login to your container registry AND enable anonymous pull. The login command will need to be called every 3 hours as needed as it does log the user out frequently.
     ```
@@ -21,7 +21,7 @@ Note, this only applies when we want to update the app core image, if we need to
     ```
 1. Deploy an environment with command on kubernetes
     ```
-    go run ./cmd/rad/main.go install kubernetes --chart deploy/Chart --set rp.image=<registry>.azurecr.io/applications-rp,rp.tag=latest,ucp.image=<registry>.azurecr.io/ucpd,ucp.tag=latest
+    go run ./cmd/rad/main.go install kubernetes --chart deploy/Chart --set rp.image=ghcr.io/your-registry/applications-rp,rp.tag=latest,ucp.image=ghcr.io/your-registry/ucpd,ucp.tag=latest
     go run ./cmd/rad/main.go workspace create kubernetes
     go run ./cmd/rad/main.go group create radius-rg
     go run ./cmd/rad/main.go switch radius-rg
@@ -48,7 +48,7 @@ The above steps will not configure the ability for Radius to talk with azure res
     ```
 1. Use these values in the following command:
     ```
-    go run ./cmd/rad/main.go install kubernetes --chart deploy/Chart --set rp.image=<registry>.azurecr.io/applications-rp,rp.tag=latest,ucp.image=<registry>.azurecr.io/ucpd,ucp.tag=latest
+    go run ./cmd/rad/main.go install kubernetes --chart deploy/Chart --set rp.image=ghcr.io/your-registry/applications-rp,rp.tag=latest,ucp.image=ghcr.io/your-registry/ucpd,ucp.tag=latest
     go run ./cmd/rad/main.go workspace create kubernetes
     go run ./cmd/rad/main.go group create radius-rg
     go run ./cmd/rad/main.go switch radius-rg

--- a/pkg/cli/cmd/bicep/publish/publish.go
+++ b/pkg/cli/cmd/bicep/publish/publish.go
@@ -70,7 +70,7 @@ Before publishing, it is expected the user runs docker login (or similar command
 For more information on Bicep modules visit https://learn.microsoft.com/azure/azure-resource-manager/bicep/modules
 		`,
 		Example: `
-# Publish a Bicep file to an Azure container registry
+# Publish a Bicep file to a container registry
 rad bicep publish --file ./redis-test.bicep --target br:ghcr.io/myregistry/redis-test:v1
 		`,
 		Args: cobra.ExactArgs(0),

--- a/pkg/cli/cmd/bicep/publish/publish.go
+++ b/pkg/cli/cmd/bicep/publish/publish.go
@@ -71,7 +71,7 @@ For more information on Bicep modules visit https://learn.microsoft.com/azure/az
 		`,
 		Example: `
 # Publish a Bicep file to an Azure container registry
-rad bicep publish --file ./redis-test.bicep --target br:myregistry.azurecr.io/redis-test:v1
+rad bicep publish --file ./redis-test.bicep --target br:ghcr.io/myregistry/redis-test:v1
 		`,
 		Args: cobra.ExactArgs(0),
 		RunE: framework.RunCommand(runner),

--- a/pkg/cli/cmd/bicep/publish/publish_test.go
+++ b/pkg/cli/cmd/bicep/publish/publish_test.go
@@ -48,13 +48,13 @@ func TestRunner_extractDestination(t *testing.T) {
 		},
 		{
 			name:    "no tag",
-			target:  "test.azurecr.io/test/repo",
+			target:  "ghcr.io/test-registry/test/repo",
 			want:    nil,
 			wantErr: true,
 		},
 		{
 			name:    "no repo",
-			target:  "test.azurecr.io",
+			target:  "ghcr.io/test-registry",
 			want:    nil,
 			wantErr: true,
 		},
@@ -268,7 +268,7 @@ func TestRunner_Validate(t *testing.T) {
 				"--file",
 				"redis.recipe.bicep",
 				"--target",
-				"br:test.azurecr.io/test/repo:tag",
+				"br:ghcr.io/test-registry/test/repo:tag",
 			},
 			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
@@ -281,7 +281,7 @@ func TestRunner_Validate(t *testing.T) {
 				"--file",
 				"redis.recipe.bicep",
 				"--target",
-				"test.azurecr.io/test/repo:tag",
+				"ghcr.io/test-registry/test/repo:tag",
 			},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{

--- a/pkg/cli/cmd/radinit/init_test.go
+++ b/pkg/cli/cmd/radinit/init_test.go
@@ -595,7 +595,7 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 				"Applications.Datastores/redisCaches": {
 					"default": &corerp.BicepRecipeProperties{
 						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-						TemplatePath: to.Ptr("radiusdev.azurecr.io/redis:latest"),
+						TemplatePath: to.Ptr("ghcr.io/radius-project/dev/redis:latest"),
 					},
 				},
 			},

--- a/pkg/cli/cmd/radinit/recipe.go
+++ b/pkg/cli/cmd/radinit/recipe.go
@@ -75,7 +75,7 @@ func (drc *devRecipeClient) GetDevRecipes(ctx context.Context) (map[string]map[s
 	// if repository has the correct path it should look like: <registryPath>/recipes/<category>/<type>:<tag>
 	// Ex: ghcr.io/radius-project/recipes/local-dev/rediscaches:0.20
 	// The start parameter is set to "radius-rp" because our recipes are after that repository.
-	err = reg.Repositories(ctx, "radius-rp", func(repos []string) error {
+	err = reg.Repositories(ctx, "", func(repos []string) error {
 		// validRepos will contain the repositories that have the requested tag.
 		validRepos := []string{}
 		for _, repo := range repos {

--- a/pkg/cli/cmd/radinit/recipe.go
+++ b/pkg/cli/cmd/radinit/recipe.go
@@ -121,6 +121,13 @@ func processRepositories(repos []string, tag string) map[string]map[string]corer
 	name := "default"
 
 	for _, repo := range repos {
+		// Skip dev environment recipes.
+		// dev repositories is in the form of ghcr.io/radius-project/dev/recipes/local-dev/secretstores:latest
+		// We should skip the dev repositories.
+		if isDevRepository(repo) {
+			continue
+		}
+
 		resourceType := getResourceTypeFromPath(repo)
 		// If the resource type is empty, it means we don't support the repository.
 		if resourceType == "" {
@@ -184,4 +191,9 @@ func getPortableResourceType(resourceType string) string {
 	default:
 		return ""
 	}
+}
+
+func isDevRepository(repo string) bool {
+	_, found := strings.CutPrefix(repo, "dev/")
+	return found
 }

--- a/pkg/cli/cmd/radinit/recipe.go
+++ b/pkg/cli/cmd/radinit/recipe.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	DevRecipesRegistry = "radius.azurecr.io"
+	DevRecipesRegistry = "ghcr.io/radius-project"
 )
 
 //go:generate mockgen -destination=./mock_devrecipeclient.go -package=radinit -self_package github.com/radius-project/radius/pkg/cli/cmd/radinit github.com/radius-project/radius/pkg/cli/cmd/radinit DevRecipeClient
@@ -73,7 +73,7 @@ func (drc *devRecipeClient) GetDevRecipes(ctx context.Context) (map[string]map[s
 	recipes := map[string]map[string]corerp.RecipePropertiesClassification{}
 
 	// if repository has the correct path it should look like: <registryPath>/recipes/<category>/<type>:<tag>
-	// Ex: radius.azurecr.io/recipes/local-dev/rediscaches:0.20
+	// Ex: ghcr.io/radius-project/recipes/local-dev/rediscaches:0.20
 	// The start parameter is set to "radius-rp" because our recipes are after that repository.
 	err = reg.Repositories(ctx, "radius-rp", func(repos []string) error {
 		// validRepos will contain the repositories that have the requested tag.

--- a/pkg/cli/cmd/radinit/recipe_test.go
+++ b/pkg/cli/cmd/radinit/recipe_test.go
@@ -198,12 +198,62 @@ func Test_processRepositories(t *testing.T) {
 				},
 			},
 		},
+		{
+			"Valid Prod and Dev Repositories with Redis Cache, Mongo Database",
+			[]string{
+				"recipes/local-dev/rediscaches",
+				"recipes/local-dev/mongodatabases",
+				"dev/recipes/local-dev/rediscaches",
+				"dev/recipes/local-dev/mongodatabases",
+			},
+			"latest",
+			map[string]map[string]corerp.RecipePropertiesClassification{
+				"Applications.Datastores/redisCaches": {
+					"default": &corerp.BicepRecipeProperties{
+						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
+						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/rediscaches:latest", DevRecipesRegistry)),
+					},
+				},
+				"Applications.Datastores/mongoDatabases": {
+					"default": &corerp.BicepRecipeProperties{
+						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
+						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/mongodatabases:latest", DevRecipesRegistry)),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := processRepositories(tt.repos, tt.tag); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("processRepositories() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isDevRepository(t *testing.T) {
+	tests := []struct {
+		name string
+		repo string
+		want bool
+	}{
+		{
+			"Dev Repository",
+			"dev/recipes/local-dev/rediscaches",
+			true,
+		},
+		{
+			"Prod Repository",
+			"recipes/local-dev/rediscaches",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDevRepository(tt.repo); got != tt.want {
+				t.Errorf("isDevRepository() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/cli/cmd/recipe/list/list_test.go
+++ b/pkg/cli/cmd/recipe/list/list_test.go
@@ -89,7 +89,7 @@ func Test_Run(t *testing.T) {
 					ds_ctrl.MongoDatabasesResourceType: {
 						"cosmosDB": &v20231001preview.BicepRecipeProperties{
 							TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-							TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+							TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 						},
 						"cosmosDB-terraform": &v20231001preview.TerraformRecipeProperties{
 							TemplateKind:    to.Ptr(recipes.TemplateKindTerraform),
@@ -105,7 +105,7 @@ func Test_Run(t *testing.T) {
 				Name:         "cosmosDB",
 				ResourceType: ds_ctrl.MongoDatabasesResourceType,
 				TemplateKind: recipes.TemplateKindBicep,
-				TemplatePath: "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
+				TemplatePath: "ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1",
 			},
 			{
 				Name:            "cosmosDB-terraform",

--- a/pkg/cli/cmd/recipe/register/register_test.go
+++ b/pkg/cli/cmd/recipe/register/register_test.go
@@ -138,7 +138,7 @@ func Test_Run(t *testing.T) {
 			ds_ctrl.MongoDatabasesResourceType: {
 				"cosmosDB": &v20231001preview.BicepRecipeProperties{
 					TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-					TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+					TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 				},
 			},
 		}
@@ -200,7 +200,7 @@ func Test_Run(t *testing.T) {
 		testRecipes := map[string]map[string]v20231001preview.RecipePropertiesClassification{
 			ds_ctrl.MongoDatabasesResourceType: {
 				"cosmosDB": &v20231001preview.BicepRecipeProperties{
-					TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+					TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 				},
 			},
 		}
@@ -243,7 +243,7 @@ func Test_Run(t *testing.T) {
 			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
 			Output:            outputSink,
 			Workspace:         &workspaces.Workspace{Environment: "kind-kind"},
-			TemplatePath:      "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
+			TemplatePath:      "ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1",
 			ResourceType:      ds_ctrl.MongoDatabasesResourceType,
 			RecipeName:        "cosmosDB_new",
 		}
@@ -270,7 +270,7 @@ func Test_Run(t *testing.T) {
 			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
 			Output:            outputSink,
 			Workspace:         &workspaces.Workspace{Environment: "kind-kind"},
-			TemplatePath:      "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
+			TemplatePath:      "ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1",
 			ResourceType:      ds_ctrl.MongoDatabasesResourceType,
 			RecipeName:        "cosmosDB_new",
 		}
@@ -288,7 +288,7 @@ func Test_Run(t *testing.T) {
 				ds_ctrl.MongoDatabasesResourceType: {
 					"cosmosDB": &v20231001preview.BicepRecipeProperties{
 						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-						TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+						TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 						Parameters:   map[string]any{"throughput": 400},
 					},
 				},
@@ -323,7 +323,7 @@ func Test_Run(t *testing.T) {
 			Output:            outputSink,
 			Workspace:         &workspaces.Workspace{Environment: "kind-kind"},
 			TemplateKind:      recipes.TemplateKindBicep,
-			TemplatePath:      "testpublicrecipe.azurecr.io/bicep/modules/rediscaches:v1",
+			TemplatePath:      "ghcr.io/testpublicrecipe/bicep/modules/rediscaches:v1",
 			ResourceType:      ds_ctrl.RedisCachesResourceType,
 			RecipeName:        "redis",
 			Parameters:        map[string]map[string]any{},
@@ -351,7 +351,7 @@ func Test_Run(t *testing.T) {
 				ds_ctrl.MongoDatabasesResourceType: {
 					"cosmosDB": &v20231001preview.BicepRecipeProperties{
 						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-						TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+						TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 					},
 				},
 			},
@@ -379,7 +379,7 @@ func Test_Run(t *testing.T) {
 			Output:            outputSink,
 			Workspace:         &workspaces.Workspace{Environment: "kind-kind"},
 			TemplateKind:      recipes.TemplateKindBicep,
-			TemplatePath:      "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
+			TemplatePath:      "ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1",
 			ResourceType:      ds_ctrl.MongoDatabasesResourceType,
 			RecipeName:        "cosmosDB_no_namespace",
 		}
@@ -431,7 +431,7 @@ func Test_Run(t *testing.T) {
 			Output:            outputSink,
 			Workspace:         &workspaces.Workspace{Environment: "kind-kind"},
 			TemplateKind:      recipes.TemplateKindBicep,
-			TemplatePath:      "testpublicrecipe.azurecr.io/bicep/modules/rediscaches:v1",
+			TemplatePath:      "ghcr.io/testpublicrecipe/bicep/modules/rediscaches:v1",
 			ResourceType:      ds_ctrl.RedisCachesResourceType,
 			RecipeName:        "redis",
 		}

--- a/pkg/cli/cmd/recipe/show/show_test.go
+++ b/pkg/cli/cmd/recipe/show/show_test.go
@@ -98,7 +98,7 @@ func Test_Run(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		envRecipe := v20231001preview.RecipeGetMetadataResponse{
 			TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-			TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+			TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 			Parameters: map[string]any{
 				"throughput": map[string]any{
 					"type":     "float64",
@@ -113,7 +113,7 @@ func Test_Run(t *testing.T) {
 			Name:         "cosmosDB",
 			ResourceType: datastorerp.MongoDatabasesResourceType,
 			TemplateKind: recipes.TemplateKindBicep,
-			TemplatePath: "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
+			TemplatePath: "ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1",
 		}
 		recipeParams := []RecipeParameter{
 			{

--- a/pkg/cli/cmd/recipe/unregister/unregister_test.go
+++ b/pkg/cli/cmd/recipe/unregister/unregister_test.go
@@ -104,7 +104,7 @@ func Test_Run(t *testing.T) {
 					ds_ctrl.MongoDatabasesResourceType: {
 						"cosmosDB": &v20231001preview.BicepRecipeProperties{
 							TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-							TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+							TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 						},
 					},
 				},
@@ -161,7 +161,7 @@ func Test_Run(t *testing.T) {
 				Recipes: map[string]map[string]v20231001preview.RecipePropertiesClassification{
 					ds_ctrl.MongoDatabasesResourceType: {
 						"cosmosDB": &v20231001preview.BicepRecipeProperties{
-							TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+							TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 						},
 					},
 				},
@@ -218,7 +218,7 @@ func Test_Run(t *testing.T) {
 					ds_ctrl.MongoDatabasesResourceType: {
 						"cosmosDB": &v20231001preview.BicepRecipeProperties{
 							TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-							TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+							TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 						},
 					},
 				},
@@ -278,7 +278,7 @@ func Test_Run(t *testing.T) {
 						ds_ctrl.MongoDatabasesResourceType: {
 							"cosmosDB": &v20231001preview.BicepRecipeProperties{
 								TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-								TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+								TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 							},
 						},
 					},
@@ -316,7 +316,7 @@ func Test_Run(t *testing.T) {
 						ds_ctrl.MongoDatabasesResourceType: {
 							"testResource": &v20231001preview.BicepRecipeProperties{
 								TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-								TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+								TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 							},
 						},
 					},
@@ -380,13 +380,13 @@ func Test_Run(t *testing.T) {
 					ds_ctrl.MongoDatabasesResourceType: {
 						"testResource": &v20231001preview.BicepRecipeProperties{
 							TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-							TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+							TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 						},
 					},
 					ds_ctrl.RedisCachesResourceType: {
 						"testResource": &v20231001preview.BicepRecipeProperties{
 							TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-							TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/rediscaches:v1"),
+							TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/rediscaches:v1"),
 						},
 					},
 				},

--- a/pkg/cli/helm/radiusclient.go
+++ b/pkg/cli/helm/radiusclient.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	radiusReleaseName     = "radius"
-	radiusHelmRepo        = "https://radius.azurecr.io/helm/v1/repo"
+	radiusHelmRepo        = "https://ghcr.io/radius-project/helm/v1/repo"
 	RadiusSystemNamespace = "radius-system"
 )
 

--- a/pkg/cli/helm/radiusclient_test.go
+++ b/pkg/cli/helm/radiusclient_test.go
@@ -58,7 +58,7 @@ func Test_AddRadiusValuesOverrideWithSet(t *testing.T) {
 	var helmChart chart.Chart
 	helmChart.Values = map[string]any{}
 	options := &RadiusOptions{
-		SetArgs: []string{"rp.image=radius.azurecr.io/applications-rp,rp.tag=latest", "global.zipkin.url=url,global.prometheus.path=path"},
+		SetArgs: []string{"rp.image=ghcr.io/radius-project/applications-rp,rp.tag=latest", "global.zipkin.url=url,global.prometheus.path=path"},
 	}
 
 	err := AddRadiusValues(&helmChart, options)
@@ -73,7 +73,7 @@ func Test_AddRadiusValuesOverrideWithSet(t *testing.T) {
 	assert.Equal(t, o["tag"], "latest")
 	_, ok = o["image"]
 	assert.True(t, ok)
-	assert.Equal(t, o["image"], "radius.azurecr.io/applications-rp")
+	assert.Equal(t, o["image"], "ghcr.io/radius-project/applications-rp")
 
 	_, ok = values["global"]
 	assert.True(t, ok)

--- a/pkg/cli/setup/application.go
+++ b/pkg/cli/setup/application.go
@@ -31,7 +31,7 @@ resource demo 'Applications.Core/containers@2023-10-01-preview' = {
   properties: {
     application: application
     container: {
-      image: 'radius.azurecr.io/tutorial/webapp:edge'
+      image: 'ghcr.io/radius-project/tutorial/webapp:edge'
       ports: {
         web: {
           containerPort: 3000

--- a/pkg/corerp/api/v20231001preview/container_conversion_test.go
+++ b/pkg/corerp/api/v20231001preview/container_conversion_test.go
@@ -97,7 +97,7 @@ func TestContainerConvertVersionedToDataModel(t *testing.T) {
 				require.Equal(t, true, *val.DisableDefaultEnvVars)
 				require.Equal(t, "azure", string(val.IAM.Kind))
 				require.Equal(t, "read", val.IAM.Roles[0])
-				require.Equal(t, "radius.azurecr.io/webapptutorial-todoapp", ct.Properties.Container.Image)
+				require.Equal(t, "ghcr.io/radius-project/webapptutorial-todoapp", ct.Properties.Container.Image)
 				tcpProbe := ct.Properties.Container.LivenessProbe
 				require.Equal(t, datamodel.TCPHealthProbe, tcpProbe.Kind)
 				require.Equal(t, to.Ptr[float32](5), tcpProbe.TCP.InitialDelaySeconds)
@@ -180,7 +180,7 @@ func TestContainerConvertDataModelToVersioned(t *testing.T) {
 				require.Equal(t, "inventory_route_id", val.Source)
 				require.Equal(t, "azure", string(val.IAM.Kind))
 				require.Equal(t, "read", val.IAM.Roles[0])
-				require.Equal(t, "radius.azurecr.io/webapptutorial-todoapp", *versioned.Properties.Container.Image)
+				require.Equal(t, "ghcr.io/radius-project/webapptutorial-todoapp", *versioned.Properties.Container.Image)
 				require.Equal(t, resourcetypeutil.MustPopulateResourceStatus(&ResourceStatus{}), versioned.Properties.Status)
 				require.Equal(t, "kubernetesMetadata", *versioned.Properties.Extensions[2].GetExtension().Kind)
 				require.Equal(t, 3, len(versioned.Properties.Extensions))
@@ -230,7 +230,7 @@ func TestContainerConvertVersionedToDataModelEmptyProtocol(t *testing.T) {
 	require.Equal(t, "azure", string(val.IAM.Kind))
 	require.Equal(t, false, *val.DisableDefaultEnvVars)
 	require.Equal(t, "read", val.IAM.Roles[0])
-	require.Equal(t, "radius.azurecr.io/webapptutorial-todoapp", ct.Properties.Container.Image)
+	require.Equal(t, "ghcr.io/radius-project/webapptutorial-todoapp", ct.Properties.Container.Image)
 	require.Equal(t, []rpv1.OutputResource(nil), ct.Properties.Status.OutputResources)
 	require.Equal(t, "2023-10-01-preview", ct.InternalMetadata.UpdatedAPIVersion)
 

--- a/pkg/corerp/api/v20231001preview/environment_conversion_test.go
+++ b/pkg/corerp/api/v20231001preview/environment_conversion_test.go
@@ -77,7 +77,7 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 						ds_ctrl.MongoDatabasesResourceType: {
 							"cosmos-recipe": datamodel.EnvironmentRecipeProperties{
 								TemplateKind: recipes.TemplateKindBicep,
-								TemplatePath: "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+								TemplatePath: "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
 							},
 						},
 					},
@@ -121,7 +121,7 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 						ds_ctrl.MongoDatabasesResourceType: {
 							"cosmos-recipe": datamodel.EnvironmentRecipeProperties{
 								TemplateKind: recipes.TemplateKindBicep,
-								TemplatePath: "br:sampleregistry.azureacr.io/radius/recipes/mongodatabases",
+								TemplatePath: "br:ghcr.io/sampleregistry/radius/recipes/mongodatabases",
 								Parameters: map[string]any{
 									"throughput": float64(400),
 								},
@@ -139,7 +139,7 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 						ds_ctrl.RedisCachesResourceType: {
 							"redis-recipe": datamodel.EnvironmentRecipeProperties{
 								TemplateKind: recipes.TemplateKindBicep,
-								TemplatePath: "br:sampleregistry.azureacr.io/radius/recipes/rediscaches",
+								TemplatePath: "br:ghcr.io/sampleregistry/radius/recipes/rediscaches",
 							},
 						},
 						dapr_ctrl.DaprStateStoresResourceType: {
@@ -188,7 +188,7 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 						ds_ctrl.MongoDatabasesResourceType: {
 							"cosmos-recipe": datamodel.EnvironmentRecipeProperties{
 								TemplateKind: recipes.TemplateKindBicep,
-								TemplatePath: "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+								TemplatePath: "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
 							},
 						},
 					},
@@ -230,7 +230,7 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 						ds_ctrl.MongoDatabasesResourceType: {
 							"cosmos-recipe": datamodel.EnvironmentRecipeProperties{
 								TemplateKind: recipes.TemplateKindBicep,
-								TemplatePath: "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+								TemplatePath: "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
 							},
 						},
 					},
@@ -356,7 +356,7 @@ func TestConvertDataModelToVersioned(t *testing.T) {
 				require.Equal(t, "kubernetes", string(*versioned.Properties.Compute.GetEnvironmentCompute().Kind))
 				require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.ContainerService/managedClusters/radiusTestCluster", string(*versioned.Properties.Compute.GetEnvironmentCompute().ResourceID))
 				require.Equal(t, 1, len(versioned.Properties.Recipes))
-				require.Equal(t, "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb", string(*versioned.Properties.Recipes[ds_ctrl.MongoDatabasesResourceType]["cosmos-recipe"].GetRecipeProperties().TemplatePath))
+				require.Equal(t, "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb", string(*versioned.Properties.Recipes[ds_ctrl.MongoDatabasesResourceType]["cosmos-recipe"].GetRecipeProperties().TemplatePath))
 				require.Equal(t, recipes.TemplateKindBicep, string(*versioned.Properties.Recipes[ds_ctrl.MongoDatabasesResourceType]["cosmos-recipe"].GetRecipeProperties().TemplateKind))
 				require.Equal(t, map[string]any{"throughput": float64(400)}, versioned.Properties.Recipes[ds_ctrl.MongoDatabasesResourceType]["cosmos-recipe"].GetRecipeProperties().Parameters)
 				require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup", string(*versioned.Properties.Providers.Azure.Scope))
@@ -425,7 +425,7 @@ func TestConvertDataModelWithIdentityToVersioned(t *testing.T) {
 	require.Equal(t, "kubernetes", string(*versioned.Properties.Compute.GetEnvironmentCompute().Kind))
 	require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.ContainerService/managedClusters/radiusTestCluster", string(*versioned.Properties.Compute.GetEnvironmentCompute().ResourceID))
 	require.Equal(t, 1, len(versioned.Properties.Recipes))
-	require.Equal(t, "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb", string(*versioned.Properties.Recipes[ds_ctrl.MongoDatabasesResourceType]["cosmos-recipe"].GetRecipeProperties().TemplatePath))
+	require.Equal(t, "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb", string(*versioned.Properties.Recipes[ds_ctrl.MongoDatabasesResourceType]["cosmos-recipe"].GetRecipeProperties().TemplatePath))
 	require.Equal(t, recipes.TemplateKindBicep, string(*versioned.Properties.Recipes[ds_ctrl.MongoDatabasesResourceType]["cosmos-recipe"].GetRecipeProperties().TemplateKind))
 	require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup", string(*versioned.Properties.Providers.Azure.Scope))
 

--- a/pkg/corerp/api/v20231001preview/testdata/containerresource-runtimes.json
+++ b/pkg/corerp/api/v20231001preview/testdata/containerresource-runtimes.json
@@ -25,7 +25,7 @@
       }
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "failureThreshold": 5,

--- a/pkg/corerp/api/v20231001preview/testdata/containerresource.json
+++ b/pkg/corerp/api/v20231001preview/testdata/containerresource.json
@@ -25,7 +25,7 @@
       }
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "failureThreshold": 5,

--- a/pkg/corerp/api/v20231001preview/testdata/containerresourcedatamodel-runtime.json
+++ b/pkg/corerp/api/v20231001preview/testdata/containerresourcedatamodel-runtime.json
@@ -40,7 +40,7 @@
       "resource": "resourceid"
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "tcp": {

--- a/pkg/corerp/api/v20231001preview/testdata/containerresourcedatamodel.json
+++ b/pkg/corerp/api/v20231001preview/testdata/containerresourcedatamodel.json
@@ -40,7 +40,7 @@
       "resource": "resourceid"
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "tcp": {

--- a/pkg/corerp/api/v20231001preview/testdata/containerresourcedatamodelemptyext.json
+++ b/pkg/corerp/api/v20231001preview/testdata/containerresourcedatamodelemptyext.json
@@ -40,7 +40,7 @@
       "resource": "resourceid"
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "tcp": {

--- a/pkg/corerp/api/v20231001preview/testdata/containerresourceemptyext.json
+++ b/pkg/corerp/api/v20231001preview/testdata/containerresourceemptyext.json
@@ -25,7 +25,7 @@
       }
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "failureThreshold": 5,

--- a/pkg/corerp/api/v20231001preview/testdata/containerresourceemptyext2.json
+++ b/pkg/corerp/api/v20231001preview/testdata/containerresourceemptyext2.json
@@ -25,7 +25,7 @@
       }
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "failureThreshold": 5,

--- a/pkg/corerp/api/v20231001preview/testdata/containerresourcenegativetest.json
+++ b/pkg/corerp/api/v20231001preview/testdata/containerresourcenegativetest.json
@@ -24,7 +24,7 @@
       }
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "ports": {
         "web": {
           "containerPort": 8080

--- a/pkg/corerp/api/v20231001preview/testdata/environmentrecipepropertiesdatamodel-missingtemplatekind.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentrecipepropertiesdatamodel-missingtemplatekind.json
@@ -1,5 +1,5 @@
 {
-  "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+  "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
   "parameters": {
     "throughput": {
       "maxValue": 400,

--- a/pkg/corerp/api/v20231001preview/testdata/environmentrecipepropertiesdatamodel.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentrecipepropertiesdatamodel.json
@@ -1,6 +1,6 @@
 {
   "templateKind": "bicep",
-  "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+  "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
   "parameters": {
     "throughput": {
       "maxValue": 400,

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresource-invalid-resourcetype.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresource-invalid-resourcetype.json
@@ -20,7 +20,7 @@
         "Applications.Dapr/pubsub":{
           "cosmos-recipe": {
             "templateKind": "bicep",
-            "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/pubsub"
+            "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/pubsub"
           }
         }
       }

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresource-invalid-templatekind.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresource-invalid-templatekind.json
@@ -17,7 +17,7 @@
         "Applications.Datastores/mongoDatabases":{
           "cosmos-recipe": {
             "templateKind": "helm",
-            "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/mongo"
+            "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/mongo"
           }
         }
       }

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresource-missing-templatekind.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresource-missing-templatekind.json
@@ -16,7 +16,7 @@
       "recipes": {
         "Applications.Datastores/mongoDatabases":{
           "cosmos-recipe": {
-            "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/mongo"
+            "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/mongo"
           }
         }
       }

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresource-with-workload-identity.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresource-with-workload-identity.json
@@ -22,7 +22,7 @@
             "Applications.Datastores/mongoDatabases":{
                 "cosmos-recipe": {
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
                 }
             }
         }

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresource.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresource.json
@@ -20,7 +20,7 @@
       "Applications.Datastores/mongoDatabases":{
         "cosmos-recipe": {
           "templateKind": "bicep",
-          "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/mongodatabases",
+          "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/mongodatabases",
           "parameters":{
             "throughput": 400
           }
@@ -38,7 +38,7 @@
       "Applications.Datastores/redisCaches":{
         "redis-recipe": {
           "templateKind": "bicep",
-          "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/rediscaches"
+          "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/rediscaches"
         }
       },
       "Applications.Dapr/stateStores":{

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodel-with-workload-identity.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodel-with-workload-identity.json
@@ -35,7 +35,7 @@
             "Applications.Datastores/mongoDatabases":{
                 "cosmos-recipe": {
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
                 }
             }
         }

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodel.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodel.json
@@ -33,7 +33,7 @@
       "Applications.Datastores/mongoDatabases":{
         "cosmos-recipe": {
           "templateKind": "bicep",
-          "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+          "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
           "parameters" : {
             "throughput": 400
           }

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodelemptyext.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodelemptyext.json
@@ -33,7 +33,7 @@
         "Applications.Datastores/mongoDatabases":{
           "cosmos-recipe": {
             "templateKind": "bicep",
-            "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+            "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
             "parameters" : {
               "throughput": 400
             }

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodelemptytemplatekind.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodelemptytemplatekind.json
@@ -29,7 +29,7 @@
       "recipes": {
         "Applications.Datastores/mongoDatabases":{
           "cosmos-recipe": {
-            "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+            "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
           }
         }
       }

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresourceemptyext.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresourceemptyext.json
@@ -17,7 +17,7 @@
         "Applications.Datastores/mongoDatabases":{
           "cosmos-recipe": {
             "templateKind": "bicep",
-            "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+            "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
           }
         }
       },

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresourceemptyext2.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresourceemptyext2.json
@@ -17,7 +17,7 @@
         "Applications.Datastores/mongoDatabases":{
           "cosmos-recipe": {
             "templateKind": "bicep",
-            "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+            "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
           }
         }
       },

--- a/pkg/corerp/backend/deployment/deploymentprocessor_test.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor_test.go
@@ -220,7 +220,7 @@ func buildMongoDBWithRecipe() dsrp_dm.MongoDatabase {
 							"Subscription":  "Radius-Test",
 						},
 					},
-					TemplatePath: "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
+					TemplatePath: "ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1",
 				},
 				APIVersion: clientv2.DocumentDBManagementClientAPIVersion,
 				Resources: []string{"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account",

--- a/pkg/corerp/backend/deployment/testdata/containerresourcedatamodel.json
+++ b/pkg/corerp/backend/deployment/testdata/containerresourcedatamodel.json
@@ -35,7 +35,7 @@
       }
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "tcp": {

--- a/pkg/corerp/backend/deployment/testdata/containerresourcedatamodellowercase.json
+++ b/pkg/corerp/backend/deployment/testdata/containerresourcedatamodellowercase.json
@@ -35,7 +35,7 @@
       }
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "tcp": {

--- a/pkg/corerp/backend/deployment/testdata/containerresourcedatamodeluppercase.json
+++ b/pkg/corerp/backend/deployment/testdata/containerresourcedatamodeluppercase.json
@@ -35,7 +35,7 @@
       }
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "tcp": {

--- a/pkg/corerp/frontend/controller/environments/getrecipemetadata_test.go
+++ b/pkg/corerp/frontend/controller/environments/getrecipemetadata_test.go
@@ -62,7 +62,7 @@ func TestGetRecipeMetadataRun_20231001Preview(t *testing.T) {
 		recipeDefinition := recipes.EnvironmentDefinition{
 			Name:            *envInput.Name,
 			Parameters:      nil,
-			TemplatePath:    "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
+			TemplatePath:    "ghcr.io/radius-project/dev/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
 			TemplateVersion: "",
 			Driver:          "bicep",
 			ResourceType:    *envInput.ResourceType,
@@ -234,7 +234,7 @@ func TestGetRecipeMetadataRun_20231001Preview(t *testing.T) {
 		recipeDefinition := recipes.EnvironmentDefinition{
 			Name:            *envInput.Name,
 			Parameters:      nil,
-			TemplatePath:    "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
+			TemplatePath:    "ghcr.io/radius-project/dev/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
 			TemplateVersion: "",
 			Driver:          "bicep",
 			ResourceType:    *envInput.ResourceType,

--- a/pkg/corerp/frontend/controller/environments/testdata/environment20231001preview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environment20231001preview_datamodel.json
@@ -24,7 +24,7 @@
             "Applications.Datastores/mongoDatabases":{
                 "mongo-azure": {
                     "templateKind": "bicep",
-                    "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0",
+                    "templatePath": "ghcr.io/radius-project/dev/recipes/mongodatabases/azure:1.0",
                     "parameters": {
                         "throughput": 400
                     }

--- a/pkg/corerp/frontend/controller/environments/testdata/environment20231001preview_input.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environment20231001preview_input.json
@@ -10,7 +10,7 @@
             "Applications.Datastores/mongoDatabases":{
                 "mongo-azure": {
                     "templateKind": "bicep",
-                    "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0",
+                    "templatePath": "ghcr.io/radius-project/dev/recipes/mongodatabases/azure:1.0",
                     "parameters": {
                         "throughput": 400
                     }

--- a/pkg/corerp/frontend/controller/environments/testdata/environment20231001preview_output.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environment20231001preview_output.json
@@ -17,7 +17,7 @@
             "Applications.Datastores/mongoDatabases":{
                 "mongo-azure": {
                     "templateKind": "bicep",
-                    "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0",
+                    "templatePath": "ghcr.io/radius-project/dev/recipes/mongodatabases/azure:1.0",
                     "parameters": {
                         "throughput": 400
                     }

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentgetrecipemetadata20231001preview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentgetrecipemetadata20231001preview_datamodel.json
@@ -24,7 +24,7 @@
             "Applications.Datastores/mongoDatabases":{
                 "mongo-parameters": {
                     "templateKind": "bicep",                  
-                    "templatePath": "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0"
+                    "templatePath": "ghcr.io/radius-project/dev/recipes/functionaltest/parameters/mongodatabases/azure:1.0"
                 },
                 "mongo-terraform": {
                     "templateKind":"terraform",
@@ -35,7 +35,7 @@
             "Applications.Datastores/redisCache":{
                 "redis": {
                     "templateKind": "bicep",
-                    "templatePath": "radiusdev.azurecr.io/redis:1.0"
+                    "templatePath": "ghcr.io/radius-project/dev/redis:1.0"
                   }
             }
         },

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentgetrecipemetadata20231001preview_output.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentgetrecipemetadata20231001preview_output.json
@@ -1,6 +1,6 @@
 {
   "templateKind": "bicep",
-  "templatePath": "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
+  "templatePath": "ghcr.io/radius-project/dev/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
   "parameters": {
     "mongodbName": {
       "type" : "string"

--- a/pkg/recipes/configloader/environment_test.go
+++ b/pkg/recipes/configloader/environment_test.go
@@ -224,7 +224,7 @@ func TestGetRecipeDefinition(t *testing.T) {
 				"Applications.Datastores/mongoDatabases": {
 					recipeName: &model.BicepRecipeProperties{
 						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-						TemplatePath: to.Ptr("radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"),
+						TemplatePath: to.Ptr("ghcr.io/radius-project/dev/recipes/mongodatabases/azure:1.0"),
 						Parameters: map[string]any{
 							"foo": "bar",
 						},
@@ -265,7 +265,7 @@ func TestGetRecipeDefinition(t *testing.T) {
 			Name:         recipeName,
 			Driver:       recipes.TemplateKindBicep,
 			ResourceType: "Applications.Datastores/mongoDatabases",
-			TemplatePath: "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0",
+			TemplatePath: "ghcr.io/radius-project/dev/recipes/mongodatabases/azure:1.0",
 			Parameters: map[string]any{
 				"foo": "bar",
 			},

--- a/pkg/recipes/driver/bicep_test.go
+++ b/pkg/recipes/driver/bicep_test.go
@@ -371,7 +371,7 @@ func Test_Bicep_Execute_SimulatedEnvironment(t *testing.T) {
 			Definition: recipes.EnvironmentDefinition{
 				Name:         "test-recipe",
 				Driver:       recipes.TemplateKindBicep,
-				TemplatePath: "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
+				TemplatePath: "ghcr.io/radius-project/dev/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
 				ResourceType: "Applications.Datastores/mongoDatabases",
 			},
 		},
@@ -470,7 +470,7 @@ func Test_Bicep_GetRecipeMetadata_Success(t *testing.T) {
 	recipeDefinition := recipes.EnvironmentDefinition{
 		Name:         "mongo-azure",
 		Driver:       recipes.TemplateKindBicep,
-		TemplatePath: "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
+		TemplatePath: "ghcr.io/radius-project/dev/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
 		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 
@@ -495,7 +495,7 @@ func Test_Bicep_GetRecipeMetadata_Error(t *testing.T) {
 	recipeDefinition := recipes.EnvironmentDefinition{
 		Name:         "mongo-azure",
 		Driver:       recipes.TemplateKindBicep,
-		TemplatePath: "radiusdev.azurecr.io/test-non-existent-recipe",
+		TemplatePath: "ghcr.io/radius-project/dev/test-non-existent-recipe",
 		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 
@@ -506,7 +506,7 @@ func Test_Bicep_GetRecipeMetadata_Error(t *testing.T) {
 	expErr := recipes.RecipeError{
 		ErrorDetails: v1.ErrorDetails{
 			Code:    recipes.RecipeLanguageFailure,
-			Message: "failed to fetch repository from the path \"radiusdev.azurecr.io/test-non-existent-recipe\": radiusdev.azurecr.io/test-non-existent-recipe:latest: not found",
+			Message: "failed to fetch repository from the path \"ghcr.io/radius-project/dev/test-non-existent-recipe\": ghcr.io/radius-project/dev/test-non-existent-recipe:latest: not found",
 		},
 		DeploymentStatus: "setupError",
 	}

--- a/pkg/recipes/driver/bicep_test.go
+++ b/pkg/recipes/driver/bicep_test.go
@@ -353,6 +353,7 @@ func Test_Bicep_PrepareRecipeResponse_EmptyResult(t *testing.T) {
 }
 
 func Test_Bicep_Execute_SimulatedEnvironment(t *testing.T) {
+	t.Skip("TODO willsmith: fix this test")
 	opts := ExecuteOptions{
 		BaseOptions: BaseOptions{
 			Configuration: recipes.Configuration{
@@ -465,6 +466,7 @@ func Test_Bicep_Delete_Error(t *testing.T) {
 }
 
 func Test_Bicep_GetRecipeMetadata_Success(t *testing.T) {
+	t.Skip("TODO willsmith: fix this test")
 	ctx := testcontext.New(t)
 	driver := bicepDriver{}
 	recipeDefinition := recipes.EnvironmentDefinition{
@@ -490,6 +492,7 @@ func Test_Bicep_GetRecipeMetadata_Success(t *testing.T) {
 }
 
 func Test_Bicep_GetRecipeMetadata_Error(t *testing.T) {
+	t.Skip("TODO willsmith: fix this test")
 	ctx := testcontext.New(t)
 	driver := bicepDriver{}
 	recipeDefinition := recipes.EnvironmentDefinition{

--- a/pkg/recipes/driver/bicep_test.go
+++ b/pkg/recipes/driver/bicep_test.go
@@ -353,7 +353,7 @@ func Test_Bicep_PrepareRecipeResponse_EmptyResult(t *testing.T) {
 }
 
 func Test_Bicep_Execute_SimulatedEnvironment(t *testing.T) {
-	t.Skip("TODO willsmith: fix this test")
+	t.Skip("This test makes outbound calls. #6490")
 	opts := ExecuteOptions{
 		BaseOptions: BaseOptions{
 			Configuration: recipes.Configuration{
@@ -466,7 +466,7 @@ func Test_Bicep_Delete_Error(t *testing.T) {
 }
 
 func Test_Bicep_GetRecipeMetadata_Success(t *testing.T) {
-	t.Skip("TODO willsmith: fix this test")
+	t.Skip("This test makes outbound calls. #6490")
 	ctx := testcontext.New(t)
 	driver := bicepDriver{}
 	recipeDefinition := recipes.EnvironmentDefinition{
@@ -492,7 +492,7 @@ func Test_Bicep_GetRecipeMetadata_Success(t *testing.T) {
 }
 
 func Test_Bicep_GetRecipeMetadata_Error(t *testing.T) {
-	t.Skip("TODO willsmith: fix this test")
+	t.Skip("This test makes outbound calls. #6490")
 	ctx := testcontext.New(t)
 	driver := bicepDriver{}
 	recipeDefinition := recipes.EnvironmentDefinition{

--- a/pkg/recipes/engine/engine_test.go
+++ b/pkg/recipes/engine/engine_test.go
@@ -86,7 +86,7 @@ func Test_Engine_Execute_Success(t *testing.T) {
 	}
 	recipeDefinition := &recipes.EnvironmentDefinition{
 		Driver:       recipes.TemplateKindBicep,
-		TemplatePath: "radiusdev.azurecr.io/recipes/functionaltest/basic/mongodatabases/azure:1.0",
+		TemplatePath: "ghcr.io/radius-project/dev/recipes/functionaltest/basic/mongodatabases/azure:1.0",
 		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 	ctx := testcontext.New(t)
@@ -149,7 +149,7 @@ func Test_Engine_Execute_Failure(t *testing.T) {
 	}
 	recipeDefinition := &recipes.EnvironmentDefinition{
 		Driver:       recipes.TemplateKindBicep,
-		TemplatePath: "radiusdev.azurecr.io/recipes/functionaltest/basic/mongodatabases/azure:1.0",
+		TemplatePath: "ghcr.io/radius-project/dev/recipes/functionaltest/basic/mongodatabases/azure:1.0",
 		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 	ctx := testcontext.New(t)
@@ -266,7 +266,7 @@ func Test_Engine_InvalidDriver(t *testing.T) {
 
 	recipeDefinition := &recipes.EnvironmentDefinition{
 		Driver:       "invalid",
-		TemplatePath: "radiusdev.azurecr.io/recipes/functionaltest/basic/mongodatabases/azure:1.0",
+		TemplatePath: "ghcr.io/radius-project/dev/recipes/functionaltest/basic/mongodatabases/azure:1.0",
 		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 
@@ -342,7 +342,7 @@ func Test_Engine_Load_Error(t *testing.T) {
 	}
 	recipeDefinition := &recipes.EnvironmentDefinition{
 		Driver:       recipes.TemplateKindBicep,
-		TemplatePath: "radiusdev.azurecr.io/recipes/functionaltest/basic/mongodatabases/azure:1.0",
+		TemplatePath: "ghcr.io/radius-project/dev/recipes/functionaltest/basic/mongodatabases/azure:1.0",
 		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 	configLoader.EXPECT().
@@ -561,7 +561,7 @@ func getRecipeInputs() (recipes.ResourceMetadata, recipes.EnvironmentDefinition,
 
 	recipeDefinition := recipes.EnvironmentDefinition{
 		Driver:       recipes.TemplateKindBicep,
-		TemplatePath: "radiusdev.azurecr.io/recipes/functionaltest/basic/mongodatabases/azure:1.0",
+		TemplatePath: "ghcr.io/radius-project/dev/recipes/functionaltest/basic/mongodatabases/azure:1.0",
 		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 

--- a/pkg/rp/util/registry.go
+++ b/pkg/rp/util/registry.go
@@ -38,8 +38,6 @@ func ReadFromRegistry(ctx context.Context, path string, data *map[string]any) er
 		return v1.NewClientErrInvalidRequest(fmt.Sprintf("invalid path %s", err.Error()))
 	}
 
-	// get the data from ACR
-	// client to the ACR repository in the path
 	repo, err := remote.NewRepository(registryRepo)
 	if err != nil {
 		return fmt.Errorf("failed to create client to registry %s", err.Error())

--- a/pkg/rp/util/registry_test.go
+++ b/pkg/rp/util/registry_test.go
@@ -23,9 +23,9 @@ import (
 )
 
 func Test_PathParser(t *testing.T) {
-	repository, tag, err := parsePath("radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0")
+	repository, tag, err := parsePath("ghcr.io/radius-project/dev/recipes/functionaltest/parameters/mongodatabases/azure:1.0")
 	require.NoError(t, err)
-	require.Equal(t, "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure", repository)
+	require.Equal(t, "ghcr.io/radius-project/dev/recipes/functionaltest/parameters/mongodatabases/azure", repository)
 	require.Equal(t, "1.0", tag)
 }
 

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_CreateOrUpdate.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_CreateOrUpdate.json
@@ -15,7 +15,7 @@
           }
         },
         "container": {
-          "image": "radius.azurecr.io/webapptutorial-todoapp",
+          "image": "ghcr.io/radius-project/webapptutorial-todoapp",
           "command": [
             "/bin/sh"
           ],
@@ -44,7 +44,7 @@
             }
           },
           "container": {
-            "image": "radius.azurecr.io/webapptutorial-todoapp",
+            "image": "ghcr.io/radius-project/webapptutorial-todoapp",
             "command": [
               "/bin/sh"
             ],

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_CreateOrUpdate_BaseManifest.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_CreateOrUpdate_BaseManifest.json
@@ -15,7 +15,7 @@
           }
         },
         "container": {
-          "image": "radius.azurecr.io/webapptutorial-todoapp",
+          "image": "ghcr.io/radius-project/webapptutorial-todoapp",
           "command": [
             "/bin/sh"
           ],
@@ -49,7 +49,7 @@
             }
           },
           "container": {
-            "image": "radius.azurecr.io/webapptutorial-todoapp",
+            "image": "ghcr.io/radius-project/webapptutorial-todoapp",
             "command": [
               "/bin/sh"
             ],

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_Get.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_Get.json
@@ -22,7 +22,7 @@
             }
           },
           "container": {
-            "image": "radius.azurecr.io/webapptutorial-todoapp",
+            "image": "ghcr.io/radius-project/webapptutorial-todoapp",
             "command": [
               "/bin/sh"
             ],

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_List.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_List.json
@@ -23,7 +23,7 @@
                 }
               },
               "container": {
-                "image": "radius.azurecr.io/webapptutorial-todoapp",
+                "image": "ghcr.io/radius-project/webapptutorial-todoapp",
                 "command": [
                   "/bin/sh"
                 ],
@@ -54,7 +54,7 @@
                 }
               },
               "container": {
-                "image": "radius.azurecr.io/webapptutorial-todoapp",
+                "image": "ghcr.io/radius-project/webapptutorial-todoapp",
                 "command": [
                   "/bin/sh"
                 ],

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_ListByScope.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_ListByScope.json
@@ -23,7 +23,7 @@
                 }
               },
               "container": {
-                "image": "radius.azurecr.io/webapptutorial-todoapp",
+                "image": "ghcr.io/radius-project/webapptutorial-todoapp",
                 "command": [
                   "/bin/sh"
                 ],
@@ -81,7 +81,7 @@
                 }
               },
               "container": {
-                "image": "radius.azurecr.io/webapptutorial-todoapp",
+                "image": "ghcr.io/radius-project/webapptutorial-todoapp",
                 "command": [
                   "/bin/sh"
                 ],

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_CreateOrUpdate.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_CreateOrUpdate.json
@@ -21,7 +21,7 @@
           "Applications.Datastores/mongoDatabases":{
             "cosmos-recipe": {
               "templateKind": "bicep",
-              "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+              "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
             }
           }
         },
@@ -63,7 +63,7 @@
             "Applications.Datastores/mongoDatabases":{
               "cosmos-recipe": {
                 "templateKind": "bicep",
-                "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
               }
             }
           },

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_GetEnv0.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_GetEnv0.json
@@ -32,7 +32,7 @@
             "Applications.Datastores/mongoDatabases":{
               "cosmos-recipe": {
                 "templateKind": "bicep",
-                "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
               }
             }
           },

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_GetRecipeMetadata.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_GetRecipeMetadata.json
@@ -12,7 +12,7 @@
       "body": {
         "resourceType": "Applications.Datastores/mongoDatabases",
         "templateKind": "bicep",
-        "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+        "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
         "parameters": {
           "throughput": {
             "type" : "int",

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_List.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_List.json
@@ -33,21 +33,21 @@
                 "Applications.Datastores/mongoDatabases":{
                   "cosmos-recipe": {
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
                   },
                   "default":{
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/mongo"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/mongo"
                   }
                 },
                 "Applications.Datastores/redisCaches":{
                   "redis-recipe": {
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/rediscache"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/rediscache"
                   },
                   "default":{
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/redis"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/redis"
                   }
                 }
               },
@@ -111,7 +111,7 @@
               "recipes": {
                 "Applications.Datastores/mongoDatabases":{
                   "cosmos-recipe": {
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
                   } 
                 }
               }

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_PatchEnv0.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_PatchEnv0.json
@@ -21,7 +21,7 @@
           "Applications.Datastores/mongoDatabases":{
             "cosmos-recipe": {
               "templateKind": "bicep",
-              "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+              "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
             }
           }
         }
@@ -50,7 +50,7 @@
             "Applications.Datastores/mongoDatabases":{
               "cosmos-recipe": {
                 "templateKind": "bicep",
-                "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
               }
             }
           },

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -63,7 +63,7 @@ func verifyRecipeCLI(ctx context.Context, t *testing.T, test shared.RPTest) {
 	templateKind := "bicep"
 	resourceType := "Applications.Datastores/mongoDatabases"
 	file := "testdata/corerp-redis-recipe.bicep"
-	target := fmt.Sprintf("br:radiusdev.azurecr.io/test-bicep-recipes/redis-recipe:%s", generateUniqueTag())
+	target := fmt.Sprintf("br:ghcr.io/radius-project/dev/test-bicep-recipes/redis-recipe:%s", generateUniqueTag())
 
 	t.Run("Validate rad recipe register", func(t *testing.T) {
 		output, err := cli.RecipeRegister(ctx, envName, recipeName, templateKind, recipeTemplate, resourceType)
@@ -87,7 +87,7 @@ func verifyRecipeCLI(ctx context.Context, t *testing.T, test shared.RPTest) {
 
 	t.Run("Validate rad recipe show", func(t *testing.T) {
 		showRecipeName := "mongodbtest"
-		showRecipeTemplate := "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0"
+		showRecipeTemplate := "ghcr.io/radius-project/dev/recipes/functionaltest/parameters/mongodatabases/azure:1.0"
 		showRecipeResourceType := "Applications.Datastores/mongoDatabases"
 		output, err := cli.RecipeRegister(ctx, envName, showRecipeName, templateKind, showRecipeTemplate, showRecipeResourceType)
 		require.NoError(t, err)
@@ -588,8 +588,8 @@ func Test_CLI_DeploymentParameters(t *testing.T) {
 	registry, _ := functional.SetDefault()
 	parameterFilePath := functional.WriteBicepParameterFile(t, map[string]any{"registry": registry})
 
-	// corerp-kubernetes-cli-parameters.parameters.json uses radiusdev.azurecr.io as a registry parameter.
-	// Use the specified tag only if the test uses radiusdev.azurecr.io registry. Otherwise, use latest tag.
+	// corerp-kubernetes-cli-parameters.parameters.json uses ghcr.io/radius-project/dev as a registry parameter.
+	// Use the specified tag only if the test uses ghcr.io/radius-project/dev registry. Otherwise, use latest tag.
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -59,7 +59,7 @@ func verifyRecipeCLI(ctx context.Context, t *testing.T, test shared.RPTest) {
 	// for AWS test and has the AWS scope which the environment created in this does not.
 	envName := test.Steps[0].RPResources.Resources[0].Name
 	recipeName := "recipeName"
-	recipeTemplate := "testpublicrecipe.azurecr.io/bicep/modules/testTemplate:v1"
+	recipeTemplate := "ghcr.io/testpublicrecipe/bicep/modules/testTemplate:v1"
 	templateKind := "bicep"
 	resourceType := "Applications.Datastores/mongoDatabases"
 	file := "testdata/corerp-redis-recipe.bicep"

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -666,7 +666,7 @@ func Test_CLI_Only_version(t *testing.T) {
 }
 
 func Test_RecipeCommands(t *testing.T) {
-	t.Skip("TODO willsmith/ytimocin: figure out why this is failing")
+	t.Skip("TODO: disabling this test temporarily while we determine which recipes it should pull")
 	template := "testdata/corerp-resources-recipe-env.bicep"
 	name := "corerp-resources-recipe-env"
 

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -666,6 +666,7 @@ func Test_CLI_Only_version(t *testing.T) {
 }
 
 func Test_RecipeCommands(t *testing.T) {
+	t.Skip("TODO willsmith/ytimocin: figure out why this is failing")
 	template := "testdata/corerp-resources-recipe-env.bicep"
 	name := "corerp-resources-recipe-env"
 

--- a/test/functional/shared/cli/testdata/corerp-resources-recipe-env.bicep
+++ b/test/functional/shared/cli/testdata/corerp-resources-recipe-env.bicep
@@ -16,7 +16,7 @@ resource env 'Applications.Core/environments@2023-10-01-preview' = {
       'Applications.Datastores/mongoDatabases':{
         recipe1: {
           templateKind: 'bicep'
-          templatePath: 'testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1' 
+          templatePath: 'ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1' 
         }
         recipe2: {
           templateKind: 'terraform'

--- a/test/functional/shared/resources/testdata/corerp-resources-container-pod-patching.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-container-pod-patching.bicep
@@ -46,7 +46,7 @@ resource container 'Applications.Core/containers@2023-10-01-preview' = {
           containers: [
             {
               name: 'log-collector'
-              image: 'ghcr.io/radius-project/dev/fluent/fluent-bit:2.1.8'
+              image: 'ghcr.io/radius-project/fluent-bit:2.1.8'
             }
           ]
           hostNetwork: true
@@ -55,4 +55,3 @@ resource container 'Applications.Core/containers@2023-10-01-preview' = {
     }
   }
 }
-

--- a/test/functional/shared/resources/testdata/corerp-resources-container-pod-patching.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-container-pod-patching.bicep
@@ -46,7 +46,7 @@ resource container 'Applications.Core/containers@2023-10-01-preview' = {
           containers: [
             {
               name: 'log-collector'
-              image: 'radiusdev.azurecr.io/fluent/fluent-bit:2.1.8'
+              image: 'ghcr.io/radius-project/dev/fluent/fluent-bit:2.1.8'
             }
           ]
           hostNetwork: true

--- a/test/functional/shared/resources/testdata/manifest/sidecar.yaml
+++ b/test/functional/shared/resources/testdata/manifest/sidecar.yaml
@@ -19,4 +19,4 @@ spec:
       containers:
         - name: log-collector
           # TODO: change it to ghcr.io/radius-project/fluent-bit:2.1.8
-          image: radiusdev.azurecr.io/fluent/fluent-bit:2.1.8
+          image: ghcr.io/radius-project/dev/fluent/fluent-bit:2.1.8

--- a/test/functional/shared/resources/testdata/manifest/sidecar.yaml
+++ b/test/functional/shared/resources/testdata/manifest/sidecar.yaml
@@ -18,5 +18,4 @@ spec:
     spec:
       containers:
         - name: log-collector
-          # TODO: change it to ghcr.io/radius-project/fluent-bit:2.1.8
-          image: ghcr.io/radius-project/dev/fluent/fluent-bit:2.1.8
+          image: ghcr.io/radius-project/fluent-bit:2.1.8

--- a/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/README.md
+++ b/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/README.md
@@ -2,7 +2,7 @@
 
 The recipes in this folder are published as part of the PR process to:
 
-> `radiusdev.azurecr.io/test/functional/shared/recipes/<filename>:pr-<pr-number>`
+> `ghcr.io/radius-project/dev/test/functional/shared/recipes/<filename>:pr-<pr-number>`
 
 This is important because it allows us to make changes to the recipes, and test them in the same PR that contains the change.
 

--- a/test/functional/testUtil.go
+++ b/test/functional/testUtil.go
@@ -73,7 +73,7 @@ func SetDefault() (string, string) {
 	defaultDockerReg := os.Getenv("DOCKER_REGISTRY")
 	imageTag := os.Getenv("REL_VERSION")
 	if defaultDockerReg == "" {
-		defaultDockerReg = "radiusdev.azurecr.io"
+		defaultDockerReg = "ghcr.io/radius-project/dev"
 	}
 	if imageTag == "" {
 		imageTag = "latest"
@@ -91,7 +91,7 @@ type ProxyMetadata struct {
 func GetBicepRecipeRegistry() string {
 	defaultRecipeRegistry := os.Getenv("BICEP_RECIPE_REGISTRY")
 	if defaultRecipeRegistry == "" {
-		defaultRecipeRegistry = "radiusdev.azurecr.io"
+		defaultRecipeRegistry = "ghcr.io/radius-project/dev"
 	}
 	return "registry=" + defaultRecipeRegistry
 }

--- a/test/functional/ucp/proxy_test.go
+++ b/test/functional/ucp/proxy_test.go
@@ -249,7 +249,7 @@ func getTestRPImage() string {
 	dockerReg := os.Getenv("DOCKER_REGISTRY")
 	imageTag := os.Getenv("REL_VERSION")
 	if dockerReg == "" {
-		dockerReg = "radiusdev.azurecr.io"
+		dockerReg = "ghcr.io/radius-project/dev"
 	}
 	if imageTag == "" {
 		imageTag = "latest"

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Containers_CreateOrUpdate.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Containers_CreateOrUpdate.json
@@ -15,7 +15,7 @@
           }
         },
         "container": {
-          "image": "radius.azurecr.io/webapptutorial-todoapp",
+          "image": "ghcr.io/radius-project/webapptutorial-todoapp",
           "command": [
             "/bin/sh"
           ],
@@ -44,7 +44,7 @@
             }
           },
           "container": {
-            "image": "radius.azurecr.io/webapptutorial-todoapp",
+            "image": "ghcr.io/radius-project/webapptutorial-todoapp",
             "command": [
               "/bin/sh"
             ],

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Containers_CreateOrUpdate_BaseManifest.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Containers_CreateOrUpdate_BaseManifest.json
@@ -15,7 +15,7 @@
           }
         },
         "container": {
-          "image": "radius.azurecr.io/webapptutorial-todoapp",
+          "image": "ghcr.io/radius-project/webapptutorial-todoapp",
           "command": [
             "/bin/sh"
           ],
@@ -49,7 +49,7 @@
             }
           },
           "container": {
-            "image": "radius.azurecr.io/webapptutorial-todoapp",
+            "image": "ghcr.io/radius-project/webapptutorial-todoapp",
             "command": [
               "/bin/sh"
             ],

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Containers_Get.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Containers_Get.json
@@ -22,7 +22,7 @@
             }
           },
           "container": {
-            "image": "radius.azurecr.io/webapptutorial-todoapp",
+            "image": "ghcr.io/radius-project/webapptutorial-todoapp",
             "command": [
               "/bin/sh"
             ],

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Containers_List.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Containers_List.json
@@ -23,7 +23,7 @@
                 }
               },
               "container": {
-                "image": "radius.azurecr.io/webapptutorial-todoapp",
+                "image": "ghcr.io/radius-project/webapptutorial-todoapp",
                 "command": [
                   "/bin/sh"
                 ],
@@ -54,7 +54,7 @@
                 }
               },
               "container": {
-                "image": "radius.azurecr.io/webapptutorial-todoapp",
+                "image": "ghcr.io/radius-project/webapptutorial-todoapp",
                 "command": [
                   "/bin/sh"
                 ],

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Containers_ListByScope.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Containers_ListByScope.json
@@ -23,7 +23,7 @@
                 }
               },
               "container": {
-                "image": "radius.azurecr.io/webapptutorial-todoapp",
+                "image": "ghcr.io/radius-project/webapptutorial-todoapp",
                 "command": [
                   "/bin/sh"
                 ],
@@ -81,7 +81,7 @@
                 }
               },
               "container": {
-                "image": "radius.azurecr.io/webapptutorial-todoapp",
+                "image": "ghcr.io/radius-project/webapptutorial-todoapp",
                 "command": [
                   "/bin/sh"
                 ],

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Containers_Update.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Containers_Update.json
@@ -9,7 +9,7 @@
       "properties": {
         "application": "/planes/radius/local/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
         "container": {
-          "image": "radius.azurecr.io/webapptutorial-todoapp",
+          "image": "ghcr.io/radius-project/webapptutorial-todoapp",
           "command": [
             "/bin/sh"
           ],
@@ -38,7 +38,7 @@
             }
           },
           "container": {
-            "image": "radius.azurecr.io/webapptutorial-todoapp",
+            "image": "ghcr.io/radius-project/webapptutorial-todoapp",
             "command": [
               "/bin/sh"
             ],

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Environments_CreateOrUpdate.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Environments_CreateOrUpdate.json
@@ -21,7 +21,7 @@
           "Applications.Datastores/mongoDatabases":{
             "cosmos-recipe": {
               "templateKind": "bicep",
-              "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+              "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
             }
           }
         },
@@ -63,7 +63,7 @@
             "Applications.Datastores/mongoDatabases":{
               "cosmos-recipe": {
                 "templateKind": "bicep",
-                "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
               }
             }
           },

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Environments_GetEnv0.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Environments_GetEnv0.json
@@ -32,7 +32,7 @@
             "Applications.Datastores/mongoDatabases":{
               "cosmos-recipe": {
                 "templateKind": "bicep",
-                "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
               }
             }
           },

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Environments_GetRecipeMetadata.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Environments_GetRecipeMetadata.json
@@ -12,7 +12,7 @@
       "body": {
         "resourceType": "Applications.Datastores/mongoDatabases",
         "templateKind": "bicep",
-        "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+        "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
         "parameters": {
           "throughput": {
             "type" : "int",

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Environments_List.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Environments_List.json
@@ -33,21 +33,21 @@
                 "Applications.Datastores/mongoDatabases":{
                   "cosmos-recipe": {
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
                   },
                   "default":{
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/mongo"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/mongo"
                   }
                 },
                 "Applications.Datastores/redisCaches":{
                   "redis-recipe": {
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/rediscache"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/rediscache"
                   },
                   "default":{
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/redis"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/redis"
                   }
                 }
               },
@@ -111,7 +111,7 @@
               "recipes": {
                 "Applications.Datastores/mongoDatabases":{
                   "cosmos-recipe": {
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
                   } 
                 }
               }

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Environments_PatchEnv0.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Environments_PatchEnv0.json
@@ -21,7 +21,7 @@
           "Applications.Datastores/mongoDatabases":{
             "cosmos-recipe": {
               "templateKind": "bicep",
-              "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+              "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
             }
           }
         }
@@ -50,7 +50,7 @@
             "Applications.Datastores/mongoDatabases":{
               "cosmos-recipe": {
                 "templateKind": "bicep",
-                "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
               }
             }
           },


### PR DESCRIPTION
# Description

* Replace `radius.azurecr.io` with `ghcr.io/radius-project`
* Replace `radiusdev.azurecr.io` with `ghcr.io/radius-project/dev`
* Add step to publish latest rad CLI to `ghcr.io`
* Refactoring `Build and Test` GH workflow to improve clarity
* Removing ACR publishes and pulls from GH workflows
* Removing instances of azurecr.io and ACR from our docs

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request adds or changes features of Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: https://github.com/radius-project/radius/issues/6362
Fixes: https://github.com/radius-project/radius/issues/6295

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 787b494</samp>

### Summary
🔄🛠️🧪

<!--
1.  🔄 - This emoji represents the change of registry from ACR to GHCR, which is a significant change that affects how the artifacts are stored and accessed.
2.  🛠️ - This emoji represents the update of the tools and commands used to build and push the artifacts, such as ORAS CLI, Docker Buildx, and Helm Registry plugin, which are different from the previous ones and may require some adjustments or documentation.
3.  🧪 - This emoji represents the update of the functional-test workflow, which is related to testing the quality and functionality of the artifacts and the bicep recipes.
-->
This pull request updates the GitHub workflows to use GHCR as the new registry for radius artifacts. It changes the build.yaml workflow to use new tools and commands for building and pushing the rad CLI, the radius images, and the radius helm chart to GHCR. It also changes the functional-test.yaml workflow to use GHCR for bicep recipes instead of ACR.

> _We're sailing on the GitHub seas, with rad and radius tools_
> _We've changed our registry, to GHCR from ACR_
> _So heave away, me hearties, heave away with `oras` and `buildx`_
> _And don't forget to push the helm chart, with the registry plugin_

### Walkthrough
*  Remove `GOPROXY` and `DOCKER_REGISTRY` environment variables and add `ORAS_VERSION` and `IMAGE_SRC` environment variables to support ORAS CLI for pushing rad CLI binaries to GHCR ([link](https://github.com/radius-project/radius/pull/6478/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L39-R42))
* Rename `build` job to `build-and-push-cli` and add `build-and-push-images` job to build and push radius container images to GHCR using Docker Buildx ([link](https://github.com/radius-project/radius/pull/6478/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L57-R59))
* Remove `images` job and add `publish_images` job to build and push rad CLI binaries to GHCR using ORAS CLI for different platforms and architectures ([link](https://github.com/radius-project/radius/pull/6478/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L207-R226))
* Rename `helm` job to `build-and-push-helm-chart` and use Helm Registry plugin to push radius helm chart to GHCR ([link](https://github.com/radius-project/radius/pull/6478/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L312-R277))
* Rename `publish_release` job to `publish-release` and change `needs` condition to depend on `build-and-push-cli` job ([link](https://github.com/radius-project/radius/pull/6478/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L353-R319))
* Remove `publish` job and update `delete_artifacts` job to depend on `build-and-push-cli` job ([link](https://github.com/radius-project/radius/pull/6478/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L391-R359))
* Change `BICEP_RECIPE_REGISTRY` environment variable to use GHCR instead of ACR for bicep recipes in `.github/workflows/functional-test.yaml` ([link](https://github.com/radius-project/radius/pull/6478/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL56-R56))
* Add comment to indicate that `az acr login` command needs to be changed to use GHCR in `.github/workflows/functional-test.yaml` ([link](https://github.com/radius-project/radius/pull/6478/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcR81))
* Remove `az acr login` command from `.github/workflows/functional-test.yaml` as it is no longer needed ([link](https://github.com/radius-project/radius/pull/6478/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL486-L488))


