### PR TITLE
Make application and environment configurable

### DIFF
--- a/deploy/Chart/crds/radius/radapp.io_recipes.yaml
+++ b/deploy/Chart/crds/radius/radapp.io_recipes.yaml
@@ -51,6 +51,16 @@ spec:
           spec:
             description: RecipeSpec defines the desired state of Recipe
             properties:
+              application:
+                description: Application is the name of the Radius application to
+                  use. If unset the namespace of the Recipe will be used as the application
+                  name.
+                type: string
+              environment:
+                description: Environment is the name of the Radius environment to
+                  use. If unset the value 'default' will be used as the environment
+                  name.
+                type: string
               secretName:
                 description: SecretName is the name of a Kubernetes secret to create
                   once the resource is created.

--- a/pkg/controller/api/radapp.io/v1alpha3/recipe_types.go
+++ b/pkg/controller/api/radapp.io/v1alpha3/recipe_types.go
@@ -32,6 +32,14 @@ type RecipeSpec struct {
 	// SecretName is the name of a Kubernetes secret to create once the resource is created.
 	// +kubebuilder:validation:Optional
 	SecretName string `json:"secretName,omitempty"`
+
+	// Environment is the name of the Radius environment to use. If unset the value 'default' will be
+	// used as the environment name.
+	Environment string `json:"environment,omitempty"`
+
+	// Application is the name of the Radius application to use. If unset the namespace of the
+	// Recipe will be used as the application name.
+	Application string `json:"application,omitempty"`
 }
 
 // RecipePhrase is a string representation of the current status of a Recipe.

--- a/pkg/controller/reconciler/annotations.go
+++ b/pkg/controller/reconciler/annotations.go
@@ -54,7 +54,9 @@ type deploymentAnnotations struct {
 
 // deploymentConfiguration is the configuration of the Deployment provided by the user via annotations.
 type deploymentConfiguration struct {
-	Connections map[string]string
+	Application string            `json:"application,omitempty"`
+	Environment string            `json:"environment,omitempty"`
+	Connections map[string]string `json:"connections,omitempty"`
 }
 
 func (c *deploymentConfiguration) computeHash() (string, error) {
@@ -107,7 +109,11 @@ func readAnnotations(deployment *appsv1.Deployment) (*deploymentAnnotations, err
 		return &result, nil
 	}
 
-	result.Configuration = &deploymentConfiguration{Connections: map[string]string{}}
+	result.Configuration = &deploymentConfiguration{
+		Environment: deployment.Annotations[AnnotationRadiusEnvironment],
+		Application: deployment.Annotations[AnnotationRadiusApplication],
+		Connections: map[string]string{},
+	}
 
 	for k, v := range deployment.Annotations {
 		if strings.HasPrefix(k, AnnotationRadiusConnectionPrefix) {

--- a/pkg/controller/reconciler/const.go
+++ b/pkg/controller/reconciler/const.go
@@ -34,6 +34,14 @@ const (
 	// AnnotationRadiusConfigurationHash is the name of the annotation that indicates the hash of the configuration.
 	AnnotationRadiusConfigurationHash = "radapp.io/configuration-hash"
 
+	// AnnotationRadiusEnvionment is the name of the annotation that indicates the name of the environment. If unset,
+	// the value 'default' will be used as the environment name.
+	AnnotationRadiusEnvironment = "radapp.io/environment"
+
+	// AnnotationRadiusApplication is the name of the annotation that indicates the name of the application. If unset,
+	// the namespace of the Deployment will be used as the application name.
+	AnnotationRadiusApplication = "radapp.io/application"
+
 	// DeploymentFinalizer is the name of the finalizer added to Deployments.
 	DeploymentFinalizer = "radapp.io/deployment-finalizer"
 

--- a/pkg/controller/reconciler/shared_test.go
+++ b/pkg/controller/reconciler/shared_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package reconciler
 
 import (
+	"fmt"
+
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
 	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
@@ -25,11 +27,12 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func createEnvironment(radius *mockRadiusClient) {
+func createEnvironment(radius *mockRadiusClient, name string) {
+	id := fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Applications.Core/environments/%s", name, name)
 	radius.Update(func() {
-		radius.environments["/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"] = v20231001preview.EnvironmentResource{
-			ID:       to.Ptr("/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"),
-			Name:     to.Ptr("default"),
+		radius.environments[id] = v20231001preview.EnvironmentResource{
+			ID:       to.Ptr(id),
+			Name:     to.Ptr(name),
 			Location: to.Ptr(v1.LocationGlobal),
 		}
 	})


### PR DESCRIPTION
# Description

This change makes the application and environment of a Recipe or Deployment configurable through the Kubernetes API.

This includes the logic and tests to handle the case where the application or environment change after creation. For this case we need to delete the existing paired resource for two reasons:

- This will result in a different deployment scope (resource group name is computed).
- It is forbidden in our API to change the application or environment of an existing resource.

This PR does not address the case where a Deployment reacts to a Recipe changing its environment or application. That will be handled in a follow-up.

This change is a prerequisite to enabling a functional test for the Kubernetes controllers. That's my next project.

## Type of change


- This pull request adds or changes features of Radius and has an approved issue (issue link required).


<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7827e4f</samp>

### Summary
🚀🛠️📝

<!--
1.  🚀 - This emoji represents the new feature of allowing the user to specify the Radius application and environment for the recipe and deployment resources. It also implies that this feature can improve the performance and scalability of the Radius platform.
2.  🛠️ - This emoji represents the enhancement and improvement of the existing reconciliation logic and test functions. It also implies that this change fixes some issues and bugs in the previous code.
3.  📝 - This emoji represents the documentation and annotation of the new schema fields, struct fields, and constants. It also implies that this change provides clear and helpful information for the user and the developer.
-->
This pull request adds support for changing the name of the Radius application and environment for recipe and deployment resources. It updates the reconciler logic, the CRD schema, and the test functions to handle the new fields and annotations. It also improves the string comparison and default value handling for the resource IDs.

> _To manage recipes and deployments with ease_
> _We added some fields for app and env keys_
> _They trigger operations_
> _With annotations_
> _And reconcile resources with IDs_

### Walkthrough
*  Add application and environment fields to RecipeSpec schema and struct ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-4a45f7894d7cc49e41ed3ace50b10c4a0e26da6489ec2dd4e8ab9a06978ea0f3R54-R63), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-5e52978508d6b18ab3b5a2ebd856c3c26372fc6bdefed4542bb1904fa209ae3aR35-R42))
*  Add application and environment fields to deploymentConfiguration struct and assign them from deployment annotations ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-73b7f11d4ca1032a9f2f6001f455c2f6622633ba1ff91373c9e6299e7439c468L57-R59), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-73b7f11d4ca1032a9f2f6001f455c2f6622633ba1ff91373c9e6299e7439c468L110-R116))
*  Define constants for deployment annotation names for application and environment ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-1c5d9f9f2bd3272c714eba486f899cd6e053bc2fd950dac921bc328d789568b1R37-R44))
*  Modify startPutOperationIfNeeded function to startPutOrDeleteOperationIfNeeded function that returns two pollers, one for PUT and one for DELETE operations, and checks for changes in application or environment names ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L369-R412), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-565f9bf43f08d107a3218cdeb8b17eab13363d0661a65535e80ec4ef114f09e5L351-R389))
*  Modify startPutOrDeleteOperationIfNeeded function to start a DELETE operation for the old resource if the application or environment name has changed, and return a deletePoller ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L272-R279), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-565f9bf43f08d107a3218cdeb8b17eab13363d0661a65535e80ec4ef114f09e5L252-R264))
*  Modify startPutOrDeleteOperationIfNeeded function to return nil for both pollers and false for waiting if the resource does not exist yet ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L272-R279), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-565f9bf43f08d107a3218cdeb8b17eab13363d0661a65535e80ec4ef114f09e5L252-R264))
*  Modify startPutOrDeleteOperationIfNeeded function to return an error if the createOrUpdateContainer or createOrUpdateResource functions fail ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L413-R453), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-565f9bf43f08d107a3218cdeb8b17eab13363d0661a65535e80ec4ef114f09e5L365-R404))
*  Modify reconciliation logic to check for the deletePoller and update the status and phrase of the resource accordingly ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195R312-R326), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-565f9bf43f08d107a3218cdeb8b17eab13363d0661a65535e80ec4ef114f09e5R277-R291))
*  Modify reconciliation logic to check for the updatePoller instead of the poller and update the variable name and logging statements accordingly ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L291-R299), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L400-R440), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-565f9bf43f08d107a3218cdeb8b17eab13363d0661a65535e80ec4ef114f09e5L277-R297))
*  Assign the values of the application and environment fields from the recipe spec or the deployment annotations to local variables and add default values if not provided ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L251-R260), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-565f9bf43f08d107a3218cdeb8b17eab13363d0661a65535e80ec4ef114f09e5L235-R244))
*  Use the local variables for the application and environment names to resolve the dependencies for the resource ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L272-R279), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-565f9bf43f08d107a3218cdeb8b17eab13363d0661a65535e80ec4ef114f09e5L252-R264))
*  Use the strings.EqualFold function to compare the resource IDs in a case-insensitive way ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L369-R412), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-565f9bf43f08d107a3218cdeb8b17eab13363d0661a65535e80ec4ef114f09e5L351-R389))
*  Add the strings package to the import statement of `deployment_reconciler.go` and `recipe_reconciler.go` ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195R23), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-565f9bf43f08d107a3218cdeb8b17eab13363d0661a65535e80ec4ef114f09e5R23))
*  Modify the createEnvironment function in `shared_test.go` to accept a name parameter and create an environment resource with that name and ID ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-8474e0158b0dd7b2711f19a4b9ae592ae62195fe7426e453a8d4faf2f0a8f2e9L28-R35))
*  Add the fmt package to the import statement of `shared_test.go` to format the environment resource ID with the name parameter ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-8474e0158b0dd7b2711f19a4b9ae592ae62195fe7426e453a8d4faf2f0a8f2e9R20-R21))
*  Modify the createEnvironment function calls in the test functions of `deployment_reconciler_test.go` and `recipe_reconciler_test.go` to pass the name of the environment as an argument ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-9d66db7eb311e875d019923b0892c9b51b9520295624cc0b6a0197cdbd04527cL104-R104), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-9d66db7eb311e875d019923b0892c9b51b9520295624cc0b6a0197cdbd04527cL147-R218), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-9d66db7eb311e875d019923b0892c9b51b9520295624cc0b6a0197cdbd04527cL202-R273), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-2b3aa3c5be32be791c9069d44213d653090aed157026f3d37f187ccded049cacL96-R96), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-2b3aa3c5be32be791c9069d44213d653090aed157026f3d37f187ccded049cacL143-R215), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-2b3aa3c5be32be791c9069d44213d653090aed157026f3d37f187ccded049cacL209-R281))
*  Add new test functions in `deployment_reconciler_test.go` and `recipe_reconciler_test.go` to check the scenario where the user changes the environment and application name of the resource via annotations or spec fields ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-9d66db7eb311e875d019923b0892c9b51b9520295624cc0b6a0197cdbd04527cR130-R200), [link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-2b3aa3c5be32be791c9069d44213d653090aed157026f3d37f187ccded049cacR125-R196))
*  Modify the updateSecret function in `recipe_reconciler.go` to remove the poller parameter that was not used ([link](https://github.com/radius-project/radius/pull/6480/files?diff=unified&w=0#diff-565f9bf43f08d107a3218cdeb8b17eab13363d0661a65535e80ec4ef114f09e5L380-R418))


