### PR TITLE
Add `ok-to-test` trigger for functional tests

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -294,7 +294,7 @@ jobs:
         name: [ucp,shared,msgrp,daprrp,samples]
         include:
           # datastorerp functional tests need the larger VM.
-          - os: ubuntu-latest
+          - os: ubuntu-latest-m
             name: datastoresrp
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -294,7 +294,7 @@ jobs:
         name: [ucp,shared,msgrp,daprrp,samples]
         include:
           # datastorerp functional tests need the larger VM.
-          - os: ubuntu-latest-m
+          - os: ubuntu-latest
             name: datastoresrp
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -21,14 +21,9 @@ on:
     - cron: "30 0,4,8,12,16,20 * * 1-5"
     # Run every 12 hours on weekends.
     - cron: "30 0,12 * * 0,6"
-  pull_request:
-    branches:
-      - main
-      - features/*
-      - release/*
   # Dispatch on external events
   repository_dispatch:
-    types: [functional-tests, de-functional-test]
+    types: [functional-tests, de-functional-test, ok-to-test]
 
 env:
   # Go version

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -23,7 +23,7 @@ on:
     - cron: "30 0,12 * * 0,6"
   # Dispatch on external events
   repository_dispatch:
-    types: [functional-tests, de-functional-test, ok-to-test]
+    types: [functional-tests, de-functional-test]
 
 env:
   # Go version


### PR DESCRIPTION
# Description

* Re-adding `ok-to-test` to trigger functional tests

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #5632

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fcbb71f</samp>

### Summary
:no_entry_sign::clock1::point_right:

<!--
1.  :no_entry_sign: This emoji represents the removal of the `pull_request` trigger, which means that the functional tests are no longer automatically triggered by every pull request.
2. :clock1: This emoji represents the addition of the `schedule` trigger, which means that the functional tests are now run periodically on a fixed interval (in this case, every 15 minutes).
3. :point_right: This emoji represents the addition of the `ok-to-test` event type to the `repository_dispatch` trigger, which means that the functional tests can be manually triggered by the repository maintainers on a specific pull request.
-->
Remove `pull_request` trigger and add `ok-to-test` event for functional tests. This allows maintainers to manually run the tests on a pull request by sending a `repository_dispatch` event with the pull request number.

> _`pull_request` gone_
> _functional tests run on demand_
> _`ok-to-test` cuts_

### Walkthrough
* Remove `pull_request` trigger and add `ok-to-test` event type for `repository_dispatch` trigger in functional test workflow ([link](https://github.com/radius-project/radius/pull/6481/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL24-R26)). This allows maintainers to manually run the functional tests on a pull request by sending a `repository_dispatch` event with the `ok-to-test` type and the pull request number as the payload. The workflow file is `.github/workflows/functional-test.yaml`.


