### PR TITLE
Add functional test for Kubernetes interop

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -296,7 +296,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        name: [ucp,shared,msgrp,daprrp,samples]
+        name: [ucp,kubernetes,shared,msgrp,daprrp,samples]
         include:
           # datastorerp functional tests need the larger VM.
           - os: ubuntu-latest-m

--- a/build/test.mk
+++ b/build/test.mk
@@ -58,7 +58,7 @@ test-get-envtools:
 test-validate-cli: ## Run cli integration tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) -coverpkg= ./pkg/cli/cmd/... ./cmd/rad/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
 
-test-functional-all: test-functional-ucp test-functional-shared test-functional-msgrp test-functional-daprrp ## Runs all functional tests
+test-functional-all: test-functional-ucp test-functional-kubernetes test-functional-shared test-functional-msgrp test-functional-daprrp ## Runs all functional tests
 
 test-functional-kubernetes: ## Runs Kubernetes functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)

--- a/deploy/Chart/templates/controller/rbac.yaml
+++ b/deploy/Chart/templates/controller/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: controller
+  name: radius-controller
   labels:
     app.kubernetes.io/name: controller
     app.kubernetes.io/part-of: radius
@@ -11,6 +11,7 @@ rules:
   resources:
   - namespaces
   - secrets
+  - events
   verbs:
   - create
   - delete
@@ -55,14 +56,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: controller
+  name: radius-controller
   labels:
     app.kubernetes.io/name: controller
     app.kubernetes.io/part-of: radius
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: controller
+  name: radius-controller
 subjects:
 - kind: ServiceAccount
   name: controller

--- a/docs/contributing/contributing-code/contributing-code-organization/README.md
+++ b/docs/contributing/contributing-code/contributing-code-organization/README.md
@@ -28,6 +28,7 @@ In general you should ask for guidance before creating a new top-level folder in
 | `aws/`                 | Utility code and library integrations for working with AWS                              |
 | `azure/`               | Utility code and library integrations for working with Azure                            |
 | `cli/`                 | Implementation code for the `rad` CLI                                                   |
+| `controllers/`         | Kubernetes controllers for Radius                                                       |
 | `corerp/`              | Resource Provider implementation for `Applications.Core` resources                      |
 | `daprrp/`              | Resource Provider implementation for `Applications.Dapr` resources                      |
 | `datastoresrp/`        | Resource Provider implementation for `Applications.Datastores` resources                |

--- a/pkg/cli/kubernetes/kubernetes.go
+++ b/pkg/cli/kubernetes/kubernetes.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/radius-project/radius/pkg/cli/output"
+	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
 	"github.com/radius-project/radius/pkg/kubeutil"
 )
 
@@ -49,6 +50,7 @@ func init() {
 	_ = apiextv1.AddToScheme(Scheme)
 	_ = clientgoscheme.AddToScheme(Scheme)
 	_ = contourv1.AddToScheme(Scheme)
+	_ = radappiov1alpha3.AddToScheme(Scheme)
 }
 
 // NewDynamicClient creates a new dynamic client by context name, otherwise returns an error.
@@ -82,13 +84,13 @@ func NewClientset(context string) (*k8s.Clientset, *rest.Config, error) {
 }
 
 // NewRuntimeClient creates a kubernetes client using a given context and scheme.
-func NewRuntimeClient(context string, scheme *k8s_runtime.Scheme) (client.Client, error) {
+func NewRuntimeClient(context string, scheme *k8s_runtime.Scheme) (client.WithWatch, error) {
 	merged, err := NewCLIClientConfig(context)
 	if err != nil {
 		return nil, err
 	}
 
-	c, err := client.New(merged, client.Options{Scheme: scheme})
+	c, err := client.NewWithWatch(merged, client.Options{Scheme: scheme})
 	if err != nil {
 		output.LogInfo("failed to create runtime client due to error: %v", err)
 		return nil, err

--- a/pkg/controller/reconciler/util.go
+++ b/pkg/controller/reconciler/util.go
@@ -163,7 +163,17 @@ func deleteResource(ctx context.Context, radius RadiusClient, resourceID string)
 		return nil, err
 	}
 
-	return poller, nil
+	if !poller.Done() {
+		return poller, nil
+	}
+
+	// Handle synchronous completion
+	_, err = poller.Result(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
 }
 
 func createOrUpdateResource(ctx context.Context, radius RadiusClient, resourceID string, properties map[string]any) (Poller[generated.GenericResourcesClientCreateOrUpdateResponse], error) {
@@ -185,7 +195,17 @@ func createOrUpdateResource(ctx context.Context, radius RadiusClient, resourceID
 		return nil, err
 	}
 
-	return poller, nil
+	if !poller.Done() {
+		return poller, nil
+	}
+
+	// Handle synchronous completion
+	_, err = poller.Result(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
 }
 
 func fetchResource(ctx context.Context, radius RadiusClient, resourceID string) (generated.GenericResourcesClientGetResponse, error) {
@@ -214,7 +234,17 @@ func deleteContainer(ctx context.Context, radius RadiusClient, containerID strin
 		return nil, err
 	}
 
-	return poller, nil
+	if !poller.Done() {
+		return poller, nil
+	}
+
+	// Handle synchronous completion
+	_, err = poller.Result(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
 }
 
 func createOrUpdateContainer(ctx context.Context, radius RadiusClient, containerID string, properties *corerpv20231001preview.ContainerProperties) (Poller[corerpv20231001preview.ContainersClientCreateOrUpdateResponse], error) {
@@ -236,5 +266,15 @@ func createOrUpdateContainer(ctx context.Context, radius RadiusClient, container
 		return nil, err
 	}
 
-	return poller, nil
+	if !poller.Done() {
+		return poller, nil
+	}
+
+	// Handle synchronous completion
+	_, err = poller.Result(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
 }

--- a/test/functional/kubernetes/kubernetes_test.go
+++ b/test/functional/kubernetes/kubernetes_test.go
@@ -1,0 +1,282 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	aztoken "github.com/radius-project/radius/pkg/azure/tokencredentials"
+	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
+	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
+	"github.com/radius-project/radius/pkg/controller/reconciler"
+	"github.com/radius-project/radius/pkg/sdk"
+	"github.com/radius-project/radius/test/functional"
+	"github.com/radius-project/radius/test/functional/shared"
+	"github.com/radius-project/radius/test/radcli"
+	"github.com/radius-project/radius/test/testcontext"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+	controller_runtime "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func Test_TutorialApplication_KubernetesManifests(t *testing.T) {
+	ctx := testcontext.New(t)
+	opts := shared.NewRPTestOptions(t)
+
+	namespace := "kubernetes-interop-tutorial"
+	environmentName := namespace + "-env"
+	applicationName := namespace
+
+	// Create the namespace, if it already exists we can ignore the error.
+	_, err := opts.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}, metav1.CreateOptions{})
+	require.NoError(t, controller_runtime.IgnoreAlreadyExists(err))
+
+	cli := radcli.NewCLI(t, "")
+
+	params := []string{
+		functional.GetBicepRecipeRegistry(),
+		functional.GetBicepRecipeVersion(),
+
+		// Avoid a conflict between app namespace and env namespace.
+		fmt.Sprintf("name=%s", environmentName),
+		fmt.Sprintf("namespace=%s", environmentName),
+	}
+
+	err = cli.Deploy(ctx, "testdata/tutorial-environment.bicep", "", "", params...)
+	require.NoError(t, err)
+
+	deployment := makeDeployment(types.NamespacedName{Name: "demo", Namespace: namespace}, environmentName, applicationName)
+	recipe := makeRecipe(types.NamespacedName{Name: "db", Namespace: namespace}, environmentName, applicationName)
+
+	t.Run("Deploy", func(t *testing.T) {
+		t.Log("Creating recipe")
+		err = opts.Client.Create(ctx, deployment)
+		require.NoError(t, err)
+
+		t.Log("Creating deployment")
+		err = opts.Client.Create(ctx, recipe)
+		require.NoError(t, err)
+	})
+
+	t.Run("Check Recipe status", func(t *testing.T) {
+		ctx, cancel := testcontext.NewWithCancel(t)
+		defer cancel()
+
+		// Get resource version
+		err = opts.Client.Get(ctx, types.NamespacedName{Name: "db", Namespace: namespace}, recipe)
+		require.NoError(t, err)
+
+		t.Log("Waiting for recipe ready")
+		recipe, err = waitForRecipeReady(t, ctx, types.NamespacedName{Name: "db", Namespace: namespace}, opts.Client, recipe.ResourceVersion)
+		require.NoError(t, err)
+
+		// Doing a basic check that the recipe has a resource provisioned.
+		require.NotEmpty(t, recipe.Status.Resource)
+
+		client, err := generated.NewGenericResourcesClient(recipe.Status.Scope, recipe.Spec.Type, &aztoken.AnonymousCredential{}, sdk.NewClientOptions(opts.Connection))
+		require.NoError(t, err)
+
+		_, err = client.Get(ctx, recipe.Name, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("Check Deployment status", func(t *testing.T) {
+		ctx, cancel := testcontext.NewWithCancel(t)
+		defer cancel()
+
+		// Get resource version
+		err = opts.Client.Get(ctx, types.NamespacedName{Name: "demo", Namespace: namespace}, deployment)
+		require.NoError(t, err)
+
+		t.Log("Waiting for deployment ready")
+		deployment, err = waitForDeploymentReady(t, ctx, types.NamespacedName{Name: "demo", Namespace: namespace}, opts.K8sClient, deployment.ResourceVersion)
+		require.NoError(t, err)
+
+		// Doing a basic check that the Deployment has environment variables set.
+		require.NotEmpty(t, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
+
+		// Doing a basic check that the deployment has a resource provisioned.
+		client, err := generated.NewGenericResourcesClient(recipe.Status.Scope, "Applications.Core/containers", &aztoken.AnonymousCredential{}, sdk.NewClientOptions(opts.Connection))
+		require.NoError(t, err)
+
+		_, err = client.Get(ctx, deployment.Name, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		t.Log("Deleting recipe")
+		err = opts.Client.Delete(ctx, recipe)
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			err = opts.Client.Get(ctx, types.NamespacedName{Name: "db", Namespace: namespace}, recipe)
+			return apierrors.IsNotFound(err)
+		}, time.Second*60, time.Second*5, "waiting for recipe to be deleted")
+
+		t.Log("Deleting deployment")
+		err = opts.Client.Delete(ctx, deployment)
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			err = opts.Client.Get(ctx, types.NamespacedName{Name: "demo", Namespace: namespace}, deployment)
+			return apierrors.IsNotFound(err)
+		}, time.Second*60, time.Second*5, "waiting for deployment to be deleted")
+	})
+}
+
+func makeDeployment(name types.NamespacedName, environmentName string, applicationName string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+			Annotations: map[string]string{
+				"radapp.io/enabled":          "true",
+				"radapp.io/connection-redis": "db",
+				"radapp.io/environment":      environmentName,
+				"radapp.io/application":      applicationName,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "demo"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "demo"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "demo",
+							Image: "radius.azurecr.io/tutorial/webapp:edge",
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: 3000,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func makeRecipe(name types.NamespacedName, environmentName string, applicationName string) *radappiov1alpha3.Recipe {
+	return &radappiov1alpha3.Recipe{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+			Annotations: map[string]string{
+				"radapp.io/enabled":          "true",
+				"radapp.io/connection-redis": "db",
+			},
+		},
+		Spec: radappiov1alpha3.RecipeSpec{
+			Type:        "Applications.Datastores/redisCaches",
+			Environment: environmentName,
+			Application: applicationName,
+		},
+	}
+}
+
+func waitForRecipeReady(t *testing.T, ctx context.Context, name types.NamespacedName, client controller_runtime.WithWatch, initialVersion string) (*radappiov1alpha3.Recipe, error) {
+	// Based on https://gist.github.com/PrasadG193/52faed6499d2ec739f9630b9d044ffdc
+	lister := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			listOptions := &controller_runtime.ListOptions{Raw: &options, Namespace: name.Namespace, FieldSelector: fields.ParseSelectorOrDie("metadata.name=" + name.Name)}
+			recipes := &radappiov1alpha3.RecipeList{}
+			err := client.List(ctx, recipes, listOptions)
+			if err != nil {
+				return nil, err
+			}
+
+			return recipes, nil
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			listOptions := &controller_runtime.ListOptions{Raw: &options, Namespace: name.Namespace, FieldSelector: fields.ParseSelectorOrDie("metadata.name=" + name.Name)}
+			recipes := &radappiov1alpha3.RecipeList{}
+			return client.Watch(ctx, recipes, listOptions)
+		},
+	}
+	watcher, err := watchtools.NewRetryWatcher(initialVersion, lister)
+	require.NoError(t, err)
+	defer watcher.Stop()
+
+	for {
+		event := <-watcher.ResultChan()
+		r, ok := event.Object.(*radappiov1alpha3.Recipe)
+		if !ok {
+			// Not a recipe, likely an event.
+			t.Logf("Received event: %+v", event)
+			continue
+		}
+
+		t.Logf("Received recipe. Status: %+v", r.Status)
+		if r.Status.Phrase == radappiov1alpha3.PhraseReady {
+			return r, nil
+		}
+	}
+}
+
+func waitForDeploymentReady(t *testing.T, ctx context.Context, name types.NamespacedName, client *kubernetes.Clientset, initialVersion string) (*appsv1.Deployment, error) {
+	// Based on https://gist.github.com/PrasadG193/52faed6499d2ec739f9630b9d044ffdc
+	watcher, err := watchtools.NewRetryWatcher(initialVersion, cache.NewFilteredListWatchFromClient(client.AppsV1().RESTClient(), "deployments", name.Namespace, func(options *metav1.ListOptions) {
+		options.FieldSelector = "metadata.name=" + name.Name
+	}))
+	require.NoError(t, err)
+	defer watcher.Stop()
+
+	for {
+		event := <-watcher.ResultChan()
+		d, ok := event.Object.(*appsv1.Deployment)
+		if !ok {
+			// Not a deployment, likely an event.
+			t.Logf("Received event: %+v", event)
+			continue
+		}
+
+		t.Logf("Received deployment. Annotations: %+v", d.Annotations)
+
+		data, ok := d.Annotations[reconciler.AnnotationRadiusStatus]
+		if !ok || data == "" {
+			continue
+		}
+
+		status := map[string]any{}
+		err := json.Unmarshal([]byte(data), &status)
+		require.NoError(t, err)
+
+		if d.Status.ObservedGeneration == d.Generation && d.Status.ReadyReplicas == 1 && status["phrase"] == "Ready" {
+			return d, nil
+		}
+	}
+}

--- a/test/functional/kubernetes/testdata/tutorial-environment.bicep
+++ b/test/functional/kubernetes/testdata/tutorial-environment.bicep
@@ -1,0 +1,25 @@
+import radius as radius
+
+param name string
+param namespace string
+param registry string
+param version string
+
+resource env 'Applications.Core/environments@2023-10-01-preview' = {
+  name: name
+  properties: {
+    compute: {
+      kind: 'kubernetes'
+      resourceId: 'self'
+      namespace: namespace
+    }
+    recipes: {
+      'Applications.Datastores/redisCaches': {
+        default: {
+          templateKind: 'bicep'
+          templatePath: '${registry}/test/functional/shared/recipes/redis-recipe-value-backed:${version}'
+        }
+      }
+    }
+  }
+}

--- a/test/functional/shared/test.go
+++ b/test/functional/shared/test.go
@@ -84,6 +84,7 @@ func NewRPTestOptions(t *testing.T) RPTestOptions {
 		CustomAction:     customAction,
 		ManagementClient: client,
 		AWSClient:        awsClient,
+		Connection:       connection,
 	}
 }
 
@@ -92,4 +93,7 @@ type RPTestOptions struct {
 	CustomAction     *clientv2.CustomActionClient
 	ManagementClient clients.ApplicationsManagementClient
 	AWSClient        aws.AWSCloudControlClient
+
+	// Connection gets access to the Radius connection which can be used to create API clients.
+	Connection sdk.Connection
 }

--- a/test/options.go
+++ b/test/options.go
@@ -34,7 +34,7 @@ type TestOptions struct {
 	K8sClient      *k8s.Clientset
 	K8sConfig      *rest.Config
 	DynamicClient  dynamic.Interface
-	Client         client.Client
+	Client         client.WithWatch
 }
 
 // NewTestOptions creates a TestOptions struct with the necessary clients and configs for testing.


### PR DESCRIPTION
# Description

This change adds a new function test for Kubernetes interop.

As part of this PR I added a new functional test run for the Kubernetes interop tests. It didn't feel like these belonged in our of our existing categories, and it's likely we'll add more in the future.

The major change in this PR is to handle synchronous operations correctly. The APIs we call are documented as asychronous, but can complete synchronously, which requires different handling in the code. I was able to address this without significantly complicating the logic.

There were a few other small fixes needed to get the tutorial code passing.

## Type of change

- This pull request adds or changes features of Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1bfbbe5</samp>

### Summary
🧪🚀🛠️

<!--
1.  🧪 - This emoji represents testing, experimentation, and science. It can be used to indicate the addition of new functional tests, especially for a new platform like Kubernetes.
2.  🚀 - This emoji represents launching, deploying, and scaling. It can be used to indicate the improvement of the deployment reconciler, which manages the Radius configuration and status of Kubernetes Deployments.
3.  🛠️ - This emoji represents tools, fixing, and building. It can be used to indicate the enhancement of the error handling, edge cases, and synchronous operations of the reconciler, as well as the CLI interaction with the custom resources.
-->
This pull request adds Kubernetes support to Radius, by implementing Kubernetes controllers, custom resources, and functional tests. It also updates the documentation, the deployment chart, the CLI, and the error handling of the reconciler.

> _The pull request has many changes_
> _To test and improve Radius ranges_
> _It adds `kubernetes` tests_
> _And handles edge cases best_
> _With reconcilers and controllers exchanges_

### Walkthrough
*  Add Kubernetes functional tests and the environment template to verify the interoperation between Kubernetes manifests and Radius resources ([link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-f1b21adc52462ef91afa8e2bfa7927ab7c7ab2c25b6b29785aba25345bf9ccf8R1-R282), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-7ff04db92b609e2614cff7761401720302926bfb6b40f08908bd1ac3e9c8ae5dR1-R25))
*  Add the `kubernetes` name to the functional test matrix and the `test-functional-kubernetes` target to run the new tests ([link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL299-R299), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-607e82dd7ce2736355a7703fb1a4a832dddb294c3683c4b51a5118218e379712L61-R61))
*  Add the `Connection` field to the `TestOptions` and `RPTestOptions` structs and change the type of the `Client` field to `client.WithWatch` to enable the functional tests to create API clients and watch custom resources ([link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-ca65669bbb1ffbb902e1e73c239e499e677a3efd9ab7e9f63ff826d14e604057R87), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-ca65669bbb1ffbb902e1e73c239e499e677a3efd9ab7e9f63ff826d14e604057R96-R98), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-415520be4a4b2230377a0f9c0625016d65206ef0768d9cfa76313be4387699ceL37-R37))
*  Import the `radapp.io/v1alpha3` API package and add the API group to the Kubernetes scheme in the `kubernetes` CLI package to enable the CLI to use the custom resources ([link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-bd86a3bd62b2c24bd445b9d7c4fbb5e48aa1aef0b3d137e992d80e129d6b5db1R37), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-bd86a3bd62b2c24bd445b9d7c4fbb5e48aa1aef0b3d137e992d80e129d6b5db1R53))
*  Change the return type of the `NewRuntimeClient` function and the call to `client.New` to support the `Watch` method in the `kubernetes` CLI package ([link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-bd86a3bd62b2c24bd445b9d7c4fbb5e48aa1aef0b3d137e992d80e129d6b5db1L85-R87), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-bd86a3bd62b2c24bd445b9d7c4fbb5e48aa1aef0b3d137e992d80e129d6b5db1L91-R93))
*  Rename the `controller` ClusterRole to `radius-controller` and add the `events` resource to avoid conflicts and enable event creation in the `deploy/Chart/templates/controller/rbac.yaml` file ([link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-0eb83f283dad161ea34486e10ead98d0c74fcaa93a13e8d182113ebb8de66c63L4-R4), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-0eb83f283dad161ea34486e10ead98d0c74fcaa93a13e8d182113ebb8de66c63R14))
*  Add the `controllers/` folder to the documentation of the code organization in the `docs/contributing/contributing-code/contributing-code-organization/README.md` file ([link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-5d21ae7061cfc67f297efd6dff13a428d728e4773925f3510f60c8e6d9e37783R31))
*  Handle the case where the delete, create, or update operation completes synchronously and update the annotations and status accordingly in the `reconcileDelete`, `reconcileUpdate`, `startPutOrDeleteOperationIfNeeded`, `startDeleteOperationIfNeeded`, `deleteResource`, `createOrUpdateResource`, `deleteContainer`, and `createOrUpdateContainer` functions in the `pkg/controller/reconciler` package ([link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L127-R129), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L301-R301), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L316-R316), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L358-R358), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L405-R414), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L451-R462), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L464-R483), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L553-R572), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-565f9bf43f08d107a3218cdeb8b17eab13363d0661a65535e80ec4ef114f09e5L384-R393), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-565f9bf43f08d107a3218cdeb8b17eab13363d0661a65535e80ec4ef114f09e5L402-R414), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-565f9bf43f08d107a3218cdeb8b17eab13363d0661a65535e80ec4ef114f09e5L415-R435), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-b2622e855cc3c8af44551c69c158d0400b6b2df3e3ebaefef18f7db96c6b66bbL166-R176), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-b2622e855cc3c8af44551c69c158d0400b6b2df3e3ebaefef18f7db96c6b66bbL188-R208), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-b2622e855cc3c8af44551c69c158d0400b6b2df3e3ebaefef18f7db96c6b66bbL217-R247), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-b2622e855cc3c8af44551c69c158d0400b6b2df3e3ebaefef18f7db96c6b66bbL239-R279))
*  Add suffixes to the error messages to distinguish between the errors from the `ResumeToken` and the `Result` methods of the pollers in the `reconcileDelete` and `reconcileUpdate` functions in the `pkg/controller/reconciler` package ([link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L301-R301), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L316-R316), [link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L358-R358))
*  Ignore the error if the secret to be deleted does not exist in the `cleanupDeployment` function in the `pkg/controller/reconciler` package ([link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L553-R572))
*  Handle the case where the annotations are nil in the `SetupWithManager` function in the `pkg/controller/reconciler` package ([link](https://github.com/radius-project/radius/pull/6488/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L617-R636))


