### PR TITLE
Add `graph` alias for `rad app connections`

### DIFF
--- a/pkg/cli/cmd/app/connections/connections.go
+++ b/pkg/cli/cmd/app/connections/connections.go
@@ -24,10 +24,11 @@ import (
 func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	runner := NewRunner(factory)
 	cmd := &cobra.Command{
-		Use:   "connections",
-		Short: "Shows the connections for an application.",
-		Long:  `Shows the connections for an application`,
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "connections",
+		Aliases: []string{"graph"},
+		Short:   "Shows the connections for an application.",
+		Long:    `Shows the connections for an application`,
+		Args:    cobra.MaximumNArgs(1),
 		Example: `
 # Show connections for current application
 rad app connections

--- a/pkg/cli/cmd/app/connections/connections.go
+++ b/pkg/cli/cmd/app/connections/connections.go
@@ -24,7 +24,8 @@ import (
 func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	runner := NewRunner(factory)
 	cmd := &cobra.Command{
-		Use:     "connections",
+		Use: "connections",
+		// TODO: Add alias for this command until we completely rename
 		Aliases: []string{"graph"},
 		Short:   "Shows the connections for an application.",
 		Long:    `Shows the connections for an application`,

--- a/pkg/cli/cmd/app/connections/connections.go
+++ b/pkg/cli/cmd/app/connections/connections.go
@@ -24,8 +24,7 @@ import (
 func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	runner := NewRunner(factory)
 	cmd := &cobra.Command{
-		Use: "connections",
-		// TODO: Add alias for this command until we completely rename
+		Use:     "connections",
 		Aliases: []string{"graph"},
 		Short:   "Shows the connections for an application.",
 		Long:    `Shows the connections for an application`,


### PR DESCRIPTION
# Description

This PR adds an alias for `rad app graph` that points to `rad app connections`.

It is a temporary update until we permanently update the command.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Partially addresses: #6473

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b5b8f0c</samp>

### Summary
:sparkles::recycle::memo:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement, and can be used to highlight the main purpose of the pull request, which is to implement a graphical view of the connections.
2.  :recycle: This emoji represents the refactoring or improvement of existing code, and can be used to indicate the modification of the `NewCommand` function to add an alias for the existing command.
3.  :memo: This emoji represents the addition or update of documentation, and can be used to indicate the changes to the command help text and the README file that explain the new alias and feature.
-->
Add "graph" alias for "connections" command in `pkg/cli/cmd/app/connections/connections.go`. This enables users to view a graphical representation of the connections for an application.

> _`NewCommand` adds_
> _alias for connections_
> _graph in the spring_

### Walkthrough
*  Add an alias "graph" for the "connections" command ([link](https://github.com/radius-project/radius/pull/6489/files?diff=unified&w=0#diff-eb0083d8df9479acb2d5b36bf150aa410e371a26a01619d09c933a73994aa563L27-R31))


