### PR TITLE
Fix errata in Kubernetes controllers

### DIFF
--- a/pkg/controller/reconciler/recipe_reconciler_test.go
+++ b/pkg/controller/reconciler/recipe_reconciler_test.go
@@ -97,15 +97,15 @@ func Test_RecipeReconciler_WithoutSecret(t *testing.T) {
 
 	// Recipe will be waiting for extender to complete provisioning.
 	status := waitForRecipeStateUpdating(t, client, name, nil)
-	require.Equal(t, "/planes/radius/local/resourceGroups/default-recipe-without-secret", status.Scope)
+	require.Equal(t, "/planes/radius/local/resourcegroups/default-recipe-without-secret", status.Scope)
 	require.Equal(t, "/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default", status.Environment)
-	require.Equal(t, "/planes/radius/local/resourceGroups/default-recipe-without-secret/providers/Applications.Core/applications/recipe-without-secret", status.Application)
+	require.Equal(t, "/planes/radius/local/resourcegroups/default-recipe-without-secret/providers/Applications.Core/applications/recipe-without-secret", status.Application)
 
 	radius.CompleteOperation(status.Operation.ResumeToken, nil)
 
 	// Recipe will update after operation completes
 	status = waitForRecipeStateReady(t, client, name)
-	require.Equal(t, "/planes/radius/local/resourceGroups/default-recipe-without-secret/providers/Applications.Core/extenders/test-recipe-withoutsecret", status.Resource)
+	require.Equal(t, "/planes/radius/local/resourcegroups/default-recipe-without-secret/providers/Applications.Core/extenders/test-recipe-withoutsecret", status.Resource)
 
 	extender, err := radius.Resources(status.Scope, "Applications.Core/extenders").Get(ctx, name.Name)
 	require.NoError(t, err)
@@ -139,15 +139,15 @@ func Test_RecipeReconciler_ChangeEnvironmentAndApplication(t *testing.T) {
 
 	// Recipe will be waiting for extender to complete provisioning.
 	status := waitForRecipeStateUpdating(t, client, name, nil)
-	require.Equal(t, "/planes/radius/local/resourceGroups/default-recipe-change-envapp", status.Scope)
+	require.Equal(t, "/planes/radius/local/resourcegroups/default-recipe-change-envapp", status.Scope)
 	require.Equal(t, "/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default", status.Environment)
-	require.Equal(t, "/planes/radius/local/resourceGroups/default-recipe-change-envapp/providers/Applications.Core/applications/recipe-change-envapp", status.Application)
+	require.Equal(t, "/planes/radius/local/resourcegroups/default-recipe-change-envapp/providers/Applications.Core/applications/recipe-change-envapp", status.Application)
 
 	radius.CompleteOperation(status.Operation.ResumeToken, nil)
 
 	// Recipe will update after operation completes
 	status = waitForRecipeStateReady(t, client, name)
-	require.Equal(t, "/planes/radius/local/resourceGroups/default-recipe-change-envapp/providers/Applications.Core/extenders/test-recipe-change-envapp", status.Resource)
+	require.Equal(t, "/planes/radius/local/resourcegroups/default-recipe-change-envapp/providers/Applications.Core/extenders/test-recipe-change-envapp", status.Resource)
 
 	createEnvironment(radius, "new-environment")
 
@@ -173,14 +173,14 @@ func Test_RecipeReconciler_ChangeEnvironmentAndApplication(t *testing.T) {
 
 	// Recipe will be waiting for extender to complete provisioning.
 	status = waitForRecipeStateUpdating(t, client, name, nil)
-	require.Equal(t, "/planes/radius/local/resourceGroups/new-environment-new-application", status.Scope)
+	require.Equal(t, "/planes/radius/local/resourcegroups/new-environment-new-application", status.Scope)
 	require.Equal(t, "/planes/radius/local/resourceGroups/new-environment/providers/Applications.Core/environments/new-environment", status.Environment)
-	require.Equal(t, "/planes/radius/local/resourceGroups/new-environment-new-application/providers/Applications.Core/applications/new-application", status.Application)
+	require.Equal(t, "/planes/radius/local/resourcegroups/new-environment-new-application/providers/Applications.Core/applications/new-application", status.Application)
 	radius.CompleteOperation(status.Operation.ResumeToken, nil)
 
 	// Recipe will update after operation completes
 	status = waitForRecipeStateReady(t, client, name)
-	require.Equal(t, "/planes/radius/local/resourceGroups/new-environment-new-application/providers/Applications.Core/extenders/test-recipe-change-envapp", status.Resource)
+	require.Equal(t, "/planes/radius/local/resourcegroups/new-environment-new-application/providers/Applications.Core/extenders/test-recipe-change-envapp", status.Resource)
 
 	// Now delete the recipe.
 	err = client.Delete(ctx, recipe)

--- a/pkg/controller/reconciler/util.go
+++ b/pkg/controller/reconciler/util.go
@@ -41,7 +41,9 @@ func resolveDependencies(ctx context.Context, radius RadiusClient, scope string,
 
 	environmentID = *found
 
-	resourceGroupID = fmt.Sprintf("/planes/radius/local/resourceGroups/%s-%s", environmentName, applicationName)
+	// NOTE: using resource groups with lowercase here is a workaround for a casing bug in `rad app graph`.
+	// When https://github.com/radius-project/radius/issues/6422 is fixed we can use the more correct casing.
+	resourceGroupID = fmt.Sprintf("/planes/radius/local/resourcegroups/%s-%s", environmentName, applicationName)
 	err = createResourceGroupIfNotExists(ctx, radius, resourceGroupID)
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to create resource group: %w", err)

--- a/pkg/kubernetes/secrets.go
+++ b/pkg/kubernetes/secrets.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"sort"
+)
+
+// HashSecretData hashes the data in a secret to produce a deterministic hash.
+//
+// This can be used as a Kubernetes annotation to force a Deployment to redeploy pods
+// when the secret changes.
+func HashSecretData(secretData map[string][]byte) string {
+	// Sort keys so we can hash deterministically
+	keys := []string{}
+	for k := range secretData {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	hash := sha1.New()
+
+	for _, k := range keys {
+		// Using | as a delimiter
+		_, _ = hash.Write([]byte("|" + k + "|"))
+		_, _ = hash.Write(secretData[k])
+	}
+
+	sum := hash.Sum(nil)
+	return fmt.Sprintf("%x", sum)
+}


### PR DESCRIPTION

# Description

This change fixes the minor issues I encountered walking through the tutorial.

There are three issues:

- Radius injects a connection secret even when there are no connections (#6493)
- Radius does not rollout new pods when connections change
- `rad app graph` doesn't deal well with mixed casing

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #6493

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cf76096</samp>

### Summary
:memo::recycle::hammer:

<!--
1.  :memo: This emoji represents the addition of a comment to explain the workaround for the casing bug. It is commonly used for documentation changes.
2.  :recycle: This emoji represents the refactoring of the `hashSecretData` function to a different package and the removal of unused code. It is commonly used for code improvements and cleanup.
3.  :hammer: This emoji represents the update of the `reconciler` package to handle secrets more efficiently and consistently. It is commonly used for bug fixes and feature enhancements.
-->
This pull request improves the handling of secrets for deployments in the `reconciler` package and adds a `kubernetes` package with a utility function to hash secret data. It also fixes some casing issues in the tests and documents a workaround for a `rad app graph` bug.

> _Sing, O Muse, of the skillful coder who changed the reconciler_
> _To handle secrets with care and grace, avoiding duplication and error_
> _He moved the `hashSecretData` function to the `kubernetes` package_
> _Like Zeus who moved the thunderbolt to his mighty hand from the forge of Hephaestus_

### Walkthrough
*  Move the `hashSecretData` function from the `container` package to the `kubernetes` package and make it public as `HashSecretData` ([link](https://github.com/radius-project/radius/pull/6494/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L21), [link](https://github.com/radius-project/radius/pull/6494/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L656-R655), [link](https://github.com/radius-project/radius/pull/6494/files?diff=unified&w=0#diff-3da981bf20df07918a646eafcd867d6c95abac1f3aef1ed1b50a29f3f4cc8636L845-L864), [link](https://github.com/radius-project/radius/pull/6494/files?diff=unified&w=0#diff-5d6c3370ac092d779d7f74cb9e6371c114df3d684a99870dd58f288f02026a9aR1-R47)). This is done to provide a common utility function to hash the data in a secret and use it as a Kubernetes annotation to force a deployment to redeploy pods when the secret changes.


