### PR TITLE
Switch to radapp.io

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,4 +21,4 @@ jobs:
             - Swagger changes require reference edge docs to be updated [here](https://github.com/radius-project/docs/tree/edge/docs/content/reference/resource-schema)
             - Make sure to create a branch and submit a PR into the edge branch instead of the default latest branch, as the swagger changes will not be available until the next release.
             
-            For more information on contributing to docs please visit https://docs.radapp.dev/contributing/docs/.
+            For more information on contributing to docs please visit https://docs.radapp.io/contributing/docs/.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ This is an early release of Radius which enables the community to learn about an
 
 ## Getting started
 
-1. Follow the [getting started guide](https://docs.radapp.dev/getting-started/) to install and try out Radius
-1. Visit the [Tutorials](https://docs.radapp.dev/tutorials) and [User Guides](https://docs.radapp.dev/guides) to learn more about Radius and start radifying your apps
+1. Follow the [getting started guide](https://docs.radapp.io/getting-started/) to install and try out Radius
+1. Visit the [Tutorials](https://docs.radapp.io/tutorials) and [User Guides](https://docs.radapp.io/guides) to learn more about Radius and start radifying your apps
 
 ## Getting help
 
@@ -47,8 +47,8 @@ Every month we host a community call to showcase new features, review upcoming m
 ## Contributing to Radius
 
 Visit [Contributing](./CONTRIBUTING.md) for more information on how to contribute to Radius.
-To author Radius Recipes visit [Author Custom Radius Recipes](https://docs.radapp.dev/operations/custom-recipes/).
-To contribute to Radius documentation visit [Radius documentation](https://docs.radapp.dev/contributing/docs/)
+To author Radius Recipes visit [Author Custom Radius Recipes](https://docs.radapp.io/guides/recipes/howto-author-recipes/).
+To contribute to Radius documentation visit [Radius documentation](https://docs.radapp.io/contributing/docs/)
 
 ## Repositories
 

--- a/deploy/Chart/Chart.yaml
+++ b/deploy/Chart/Chart.yaml
@@ -5,13 +5,13 @@ name: radius
 version: '0.42.42-dev'
 # appVersion is the version of Radius, which will be replaced when this chart is packaged.
 appVersion: 'edge'
-home: https://radapp.dev
+home: https://radapp.io
 sources:
   - https://github.com/radius-project/radius/tree/main/deploy/Chart
 maintainers:
   - name: Radius Authors
     url: https://github.com/radius-project/radius
-icon: https://radapp.dev/images/logo.png
+icon: https://radapp.io/images/logo.png
 keywords:
   - radius
   - iac

--- a/deploy/Chart/templates/NOTES.txt
+++ b/deploy/Chart/templates/NOTES.txt
@@ -6,4 +6,4 @@ APP VERSION: {{ .Chart.AppVersion }}
 
   kubectl --namespace {{ $.Release.Namespace }} get pods -l "app.kubernetes.io/part-of=radius"
 
-Visit https://docs.radapp.dev to start Radius.
+Visit https://docs.radapp.io to start Radius.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Radius documentation
 
-The documentation for Radius is at https://radapp.dev, with the source in the [radius-project/docs repo](https://github.com/radius-project/docs).
+The documentation for Radius is at https://docs.radapp.io, with the source in the [radius-project/docs repo](https://github.com/radius-project/docs).
 
 ## Contributing to Radius
 

--- a/docs/contributing/contributing-code/contributing-code-control-plane/generating-and-installing-custom-build.md
+++ b/docs/contributing/contributing-code/contributing-code-control-plane/generating-and-installing-custom-build.md
@@ -9,7 +9,7 @@ by creating a Radius installation with your code changes. For this, you need to:
 
 ## Instructions
 
-Prerequisite: [Supported Kubernetes cluster](https://docs.radapp.dev/operations/platforms/kubernetes-platform/supported-clusters/)
+Prerequisite: [Supported Kubernetes cluster](https://docs.radapp.io/guides/operations/kubernetes/overview)
 
 Note that installing a custom build could corrupt existing data or installation. For these reasons, it might be useful to install the custom build on a clean test cluster.  
 

--- a/docs/contributing/contributing-code/contributing-code-control-plane/troubleshooting-installation.md
+++ b/docs/contributing/contributing-code/contributing-code-control-plane/troubleshooting-installation.md
@@ -33,7 +33,7 @@ Logs with `severity` set to `error` or `warn` could point to why the pods are no
 
 Every rad CLI command outputs a `traceId` in the event of an error. These identifiers correspond to the `traceId` field that appears in the log messages produced by Radius.
 By searching the logs for the `traceId` value, you can find the logs associated with a request that failed.
-You can learn more about observability and logging in Radius in our [observability docs](https://docs.radapp.dev/operations/control-plane/observability/logging/logs/).
+You can learn more about observability and logging in Radius in our [observability docs](https://docs.radapp.io/guides/operations/control-plane/logs/).
 ```json
 {
   "severity": "info",

--- a/docs/release-notes/template.md
+++ b/docs/release-notes/template.md
@@ -8,7 +8,7 @@ We would like to extend our thanks to all the [new](#new-contributors) and exist
 
 ## Intro to Radius
 
-If you're new to Radius, check out our website, [radapp.dev](https://radapp.dev), for more information. Also visit our [getting started guide](https://docs.radapp.dev/getting-started/) to learn how to install Radius and create your first app.
+If you're new to Radius, check out our website, [radapp.io](https://radapp.io), for more information. Also visit our [getting started guide](https://docs.radapp.io/getting-started/) to learn how to install Radius and create your first app.
 
 ## Highlights
 
@@ -38,7 +38,7 @@ During our preview stage, an upgrade to Radius vX.Y.Z requires a full reinstalla
    ```bash
    rad uninstall kubernetes
    ```
-1. Visit the [Radius installation guide](https://docs.radapp.dev/getting-started/install/) to install the latest CLI, or download a binary below
+1. Visit the [Radius installation guide](https://docs.radapp.io/getting-started/install/) to install the latest CLI, or download a binary below
 1. Install the latest version of the Radius control-plane:
    ```bash
    rad install kubernetes

--- a/pkg/cli/cmd/install/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/install/kubernetes/kubernetes.go
@@ -41,9 +41,9 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 		Long: `Install Radius in a Kubernetes cluster using the Radius Helm chart.
 By default 'rad install kubernetes' will install Radius with the version matching the rad CLI version.
 
-Radius will be installed in the 'radius-system' namespace. For more information visit https://docs.radapp.dev/concepts/architecture/
+Radius will be installed in the 'radius-system' namespace. For more information visit https://docs.radapp.io/concepts/architecture/
 
-Overrides can be set by specifying Helm chart values with the '--set' flag. For more information visit https://docs.radapp.dev/operations/platforms/kubernetes/install/.
+Overrides can be set by specifying Helm chart values with the '--set' flag. For more information visit https://docs.radapp.io/operations/platforms/kubernetes/install/.
 `,
 		Example: `# Install Radius with default settings in current Kubernetes context
 rad install kubernetes


### PR DESCRIPTION
Signed-off-by: Aaron Crawfis <Aaron.Crawfis@microsoft.com>

# Description

This PR updates existing instances of radapp.dev to radapp.io

I left existing get.radapp.dev references in place for now until we remove later.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4829c3f</samp>

### Summary
:globe_with_meridians::link::books:

<!--
1.  :globe_with_meridians: This emoji represents the change of the domain name for the docs website, which affects the global accessibility and visibility of the documentation.
2. :link: This emoji represents the change of the URL structure for the docs website, which affects the links and references to the documentation within the project and external sources.
3. :books: This emoji represents the change of the documentation itself, which affects the content and quality of the information provided to the users and contributors of Radius.
-->
This pull request updates various URLs in the codebase, docs, and Helm chart to use the new domain name for the docs website, https://docs.radapp.io. This change aligns the references to the docs website with the current website address and structure.

> _`docs.radapp.dev`_
> _now becomes `docs.radapp.io`_
> _a fresh spring domain_

### Walkthrough
*  Update the URL for the docs website from https://docs.radapp.dev to https://docs.radapp.io in various files and templates ([link](https://github.com/radius-project/radius/pull/6503/files?diff=unified&w=0#diff-d54d69dbb27e75dae25cb4b2384310cb57707e419377cf572d5cb0ecc1f16877L24-R24), [link](https://github.com/radius-project/radius/pull/6503/files?diff=unified&w=0#diff-224fad3e2fb703c2187ec6613ba431a1896e43cb4d4cad00f7433e7f576dd1f3L9-R9), [link](https://github.com/radius-project/radius/pull/6503/files?diff=unified&w=0#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L3-R3), [link](https://github.com/radius-project/radius/pull/6503/files?diff=unified&w=0#diff-f28e9b44bbe12a77bbb3d70fddbb6d5ab266284fedf1aaba5b25e4782dd89b37L12-R12), [link](https://github.com/radius-project/radius/pull/6503/files?diff=unified&w=0#diff-7eb3dd90abb260ec5b1e75d0cff1d3dbddef2422bea1e089bda4c6a52bbec2bfL36-R36), [link](https://github.com/radius-project/radius/pull/6503/files?diff=unified&w=0#diff-4a15cfc9695c95c8be0f3ad0277eebcd970d62cb78c836186db3a7d86c92263eL11-R11), [link](https://github.com/radius-project/radius/pull/6503/files?diff=unified&w=0#diff-4a15cfc9695c95c8be0f3ad0277eebcd970d62cb78c836186db3a7d86c92263eL41-R41), [link](https://github.com/radius-project/radius/pull/6503/files?diff=unified&w=0#diff-969a1495c18d847fc09b31b1e6854e7be42d541513807361aaa5e9497a62e86fL44-R46), [link](https://github.com/radius-project/radius/pull/6503/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R25), [link](https://github.com/radius-project/radius/pull/6503/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L50-R51)). This change reflects the new domain name for the docs website and also updates the URLs for some guides to match the new URL structure of the docs website.


