### PR TITLE
Update scaffolded application with correct image

### DIFF
--- a/pkg/cli/setup/application.go
+++ b/pkg/cli/setup/application.go
@@ -24,6 +24,8 @@ import (
 
 const (
 	appBicepTemplate = `import radius as radius
+
+@description('The Radius Application ID. Injected automatically by the rad CLI.')
 param application string
 
 resource demo 'Applications.Core/containers@2023-10-01-preview' = {
@@ -31,7 +33,7 @@ resource demo 'Applications.Core/containers@2023-10-01-preview' = {
   properties: {
     application: application
     container: {
-      image: 'ghcr.io/radius-project/tutorial/webapp:edge'
+      image: 'ghcr.io/radius-project/samples/demo:latest'
       ports: {
         web: {
           containerPort: 3000


### PR DESCRIPTION
# Description

This PR updates the image for the scaffolded application to use the new webapp image convention.

Does not require a patch release as the old format has been published to the container registry.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #6518

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9641bd9</samp>

### Summary
📝🚀🐳

<!--
1.  📝 - This emoji can be used to represent documentation improvements, as it is often associated with writing or editing text.
2.  🚀 - This emoji can be used to represent usability enhancements, as it is often associated with launching or deploying something quickly and easily.
3.  🐳 - This emoji can be used to represent changes related to container images, as it is a common symbol for Docker or other container technologies.
-->
Improve `setup` package documentation and sample application. Add description for `application` parameter and use `radius-project/samples/hello-world` image in `pkg/cli/setup/application.go`.

> _`setup` package docs_
> _better description and image_
> _autumn of usability_

### Walkthrough
* Add a description annotation to the `application` parameter of the `setup` package ([link](https://github.com/radius-project/radius/pull/6520/files?diff=unified&w=0#diff-1b0ac5c011aaaf6673a23365f05fe4d2ebdc793c135984d7b3410e59ef92fa75R27-R28)). This helps document the package and its usage for users and developers.


