### PR TITLE
Fix: Folders with spaces cause the installation script to fail

### DIFF
--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -22,9 +22,6 @@ param (
 Write-Output ""
 $ErrorActionPreference = 'stop'
 
-# Escape space of RadiusRoot path
-$RadiusRoot = $RadiusRoot -replace ' ', '` '
-
 # Constants
 $RadiusCliFileName = "rad.exe"
 $RadiusCliFilePath = "${RadiusRoot}\${RadiusCliFileName}"
@@ -91,7 +88,7 @@ if (Test-Path "C:\radius\rad.exe" -PathType Leaf) {
 if (Test-Path $RadiusCliFilePath -PathType Leaf) {
     Write-Output "Previous rad CLI detected: $RadiusCliFilePath"
     try {
-        $CurrentVersion = Invoke-Expression "$RadiusCliFilePath version -o json | ConvertFrom-JSON | Select-Object -ExpandProperty version"
+        $CurrentVersion = &$RadiusCliFilePath version -o json | ConvertFrom-JSON | Select-Object -ExpandProperty version
         Write-Output "Previous version: $CurrentVersion`r`n"
     }
     catch {
@@ -155,7 +152,7 @@ if (Test-Path $RadiusCliFilePath -PathType Leaf) {
 Rename-Item -Path $exeFilePath -NewName $RadiusCliFileName -Force
 
 # Print the version string of the installed CLI
-Write-Output "rad CLI version: $(Invoke-Expression "$RadiusCliFilePath version -o json | ConvertFrom-JSON | Select-Object -ExpandProperty version")"
+Write-Output "rad CLI version: $(&$RadiusCliFilePath version -o json | ConvertFrom-JSON | Select-Object -ExpandProperty version)"
 
 # Add RadiusRoot directory to User Path environment variable
 $UserPathEnvironmentVar = (Get-Item -Path HKCU:\Environment).GetValue(


### PR DESCRIPTION
# Description

The script fails when you try to run the install script on Windows with user folders that have spaces in the names.

The problem comes from the attempt to escape spaces in the path. It doesn't work in Powershell 5 & 7. There's no need for them either. I modified the invoke-expression calls to handle the situation without escaping spaces.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue 

Fixes: #6528

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1bb18ea</samp>

### Summary
🔒🛠️🚀

<!--
1.  🔒 - This emoji represents security, and is appropriate for the removal of `Invoke-Expression`, which can be a security risk if the input is not trusted or validated.
2.  🛠️ - This emoji represents reliability, and is appropriate for the removal of unnecessary escaping of spaces, which could cause errors or unexpected behavior if the installation path contains spaces.
3.  🚀 - This emoji represents improvement, and is appropriate for the overall enhancement of the PowerShell installation script, which makes it easier and safer for users to install and use the rad CLI.
-->
Improve PowerShell installation script for `rad` CLI. Fix escaping and command execution issues in `deploy/install.ps1`.

> _Oh we're the rad CLI crew and we know what to do_
> _We install it with PowerShell and we make it run well_
> _No more escaping spaces or invoking expressions_
> _We use the call operator `&` and we sail the ocean blue_

### Walkthrough
* Remove unnecessary escaping of spaces in installation path ([link](https://github.com/radius-project/radius/pull/6529/files?diff=unified&w=0#diff-506d53c740958f1f7b269e6b80b68300aeb53417fccb0297240700f1d84811bfL25-L27))
* Replace `Invoke-Expression` with call operator `&` to execute and print rad CLI version ([link](https://github.com/radius-project/radius/pull/6529/files?diff=unified&w=0#diff-506d53c740958f1f7b269e6b80b68300aeb53417fccb0297240700f1d84811bfL94-R91), [link](https://github.com/radius-project/radius/pull/6529/files?diff=unified&w=0#diff-506d53c740958f1f7b269e6b80b68300aeb53417fccb0297240700f1d84811bfL158-R155))


