### PR TITLE
Fix long-running azure workflow syntax and re-enable for pull requests

### DIFF
--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -41,9 +41,9 @@ on:
   schedule:
     # Run every 2 hours
     - cron: "0 */2 * * *"
-  # pull_request:
-  #   branches:
-  #     - main
+  pull_request:
+    branches:
+      - main
     paths:
       - '.github/workflows/long-running-azure.yaml'
 


### PR DESCRIPTION
# Description

This PR fixes the YAML syntax error in https://github.com/radius-project/radius/actions/workflows/long-running-azure.yaml and re-enables running the workflow on pull requests whenever the workflow file is itself edited.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #6497

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 552ebbc</samp>

### Summary
🚀🧪🔒

<!--
1.  🚀 This emoji represents the pull_request trigger, which enables the workflow to run on pull requests and launch the CI/CD pipeline.
2.  🧪 This emoji represents the testing and reviewing of the workflow changes, which can help catch and fix any errors or bugs before merging.
3.  🔒 This emoji represents the security and protection of the main branch, which can prevent unwanted or harmful changes from being deployed.
-->
Enable pull request trigger for long-running Azure workflow. This allows testing the `.github/workflows/long-running-azure.yaml` file changes before merging.

> _`pull_request` runs_
> _workflow on branch changes_
> _autumn leaves falling_

### Walkthrough
*  Enable workflow to run on pull requests that modify it ([link](https://github.com/radius-project/radius/pull/6547/files?diff=unified&w=0#diff-85cd86e7ae6da973e4808fe57f4fea7892ab78a499ba5aec72c0b3751a2cc226L44-R46))


