### PR TITLE
Add '/assign' command to Radius bot

### DIFF
--- a/.github/scripts/radius-bot.js
+++ b/.github/scripts/radius-bot.js
@@ -41,6 +41,9 @@ async function handleIssueCommentCreate({ github, context }) {
     const command = commandParts.shift();
 
     switch (command) {
+        case '/assign':
+            await cmdAssign(github, issue, isFromPulls, username);
+            break;
         case '/ok-to-test':
             await cmdOkToTest(github, issue, isFromPulls, username);
             break;
@@ -48,6 +51,30 @@ async function handleIssueCommentCreate({ github, context }) {
             console.log(`[handleIssueCommentCreate] command ${command} not found, exiting.`);
             break;
     }
+}
+
+/**
+ * Assign issue to the user who commented.
+ * @param {*} github GitHub object reference
+ * @param {*} issue GitHub issue object
+ * @param {*} isFromPulls is the workflow triggered by a pull request?
+ * @param {*} username is the user who trigger the command
+ */
+async function cmdAssign(github, issue, isFromPulls, username) {
+    if (isFromPulls) {
+        console.log('[cmdAssign] pull requests not supported, skipping command execution.');
+        return;
+    } else if (issue.assignees && issue.assignees.length !== 0) {
+        console.log('[cmdAssign] issue already has assignees, skipping command execution.');
+        return;
+    }
+
+    await github.rest.issues.addAssignees({
+        owner: issue.owner,
+        repo: issue.repo,
+        issue_number: issue.number,
+        assignees: [username],
+    })
 }
 
 /**

--- a/.github/scripts/radius-bot.js
+++ b/.github/scripts/radius-bot.js
@@ -74,7 +74,7 @@ async function cmdAssign(github, issue, isFromPulls, username) {
         repo: issue.repo,
         issue_number: issue.number,
         assignees: [username],
-    })
+    });
 }
 
 /**


### PR DESCRIPTION
# Description

Adds support to assign issues via Radius bot with the `/assign` command. Any contributor can issue the command and assign an unassigned issue to themself.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #6549

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 10558f5</samp>

### Summary
🤖🙋🎯

<!--
1.  🤖 - This emoji represents the radius bot itself, as well as the automation and functionality that it provides to the users.
2.  🙋 - This emoji represents the self-assignment feature, as well as the user's intention and initiative to take on an issue.
3.  🎯 - This emoji represents the issue that is being assigned, as well as the focus and goal that the user has for working on it.
-->
Add `/assign` command to `radius-bot.js` to enable self-assignment of issues.

> _Sing, O Muse, of the mighty radius bot_
> _That heeds the users' wishes with `/assign`_
> _And grants them issues to resolve with skill and thought_
> _Unless by pull request or prior claim they're bound._

### Walkthrough
*  Add a new command `/assign` to the issue comment handler in `radius-bot.js` ([link](https://github.com/radius-project/radius/pull/6550/files?diff=unified&w=0#diff-b94c0e124b5b65fb6fa8785928c5331547c124a96ecc225f93df9445a29a5109R44-R46), [link](https://github.com/radius-project/radius/pull/6550/files?diff=unified&w=0#diff-b94c0e124b5b65fb6fa8785928c5331547c124a96ecc225f93df9445a29a5109R57-R80))


