### PR TITLE
Update release branch for 0.26.7

### DIFF
--- a/docs/release-notes/v0.26.7.md
+++ b/docs/release-notes/v0.26.7.md
@@ -1,0 +1,10 @@
+## Radius v0.26.7
+
+This release addresses an issue with the Radius Kubernetes controller. Check out the [changelog](#changelog) for more details of what was addressed in this patch.
+
+## Changelog
+
+* Fix double-encoding of Kubernetes secrets by @rynowak in https://github.com/radius-project/radius/pull/6541
+
+**Full Changelog**: https://github.com/radius-project/radius/compare/v0.26.6...v0.26.7
+

--- a/pkg/controller/reconciler/deployment_reconciler.go
+++ b/pkg/controller/reconciler/deployment_reconciler.go
@@ -18,7 +18,6 @@ package reconciler
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"strings"
 	"time"
@@ -517,6 +516,8 @@ func (r *DeploymentReconciler) updateDeployment(ctx context.Context, deployment 
 		return fmt.Errorf("failed to fetch secret %s: %w", secretName, err)
 	}
 
+	// envtest has some quirky behavior around StringData which makes it hard to test. So we're
+	// using Data directly.
 	secret.Data = map[string][]byte{}
 
 	for name, source := range annotations.Configuration.Connections {
@@ -553,10 +554,8 @@ func (r *DeploymentReconciler) updateDeployment(ctx context.Context, deployment 
 			return fmt.Errorf("failed to read values resource %s: %w", id, err)
 		}
 
-		// envtest has some quirky behavior around StringData which makes it hard to test. So we're
-		// using Data directly.
 		for k, v := range values {
-			secret.Data[k] = []byte(base64.RawStdEncoding.EncodeToString([]byte(v)))
+			secret.Data[k] = []byte(v)
 		}
 	}
 

--- a/pkg/controller/reconciler/deployment_reconciler_test.go
+++ b/pkg/controller/reconciler/deployment_reconciler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package reconciler
 
 import (
-	"encoding/base64"
 	"fmt"
 	"testing"
 	"time"
@@ -366,10 +365,10 @@ func Test_DeploymentReconciler_Connections(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedSecretData := map[string][]byte{
-		"CONNECTION_A_A-SECRET": []byte(base64.RawStdEncoding.EncodeToString([]byte("a"))),
-		"CONNECTION_A_A-VALUE":  []byte(base64.RawStdEncoding.EncodeToString([]byte("a"))),
-		"CONNECTION_B_B-SECRET": []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
-		"CONNECTION_B_B-VALUE":  []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
+		"CONNECTION_A_A-SECRET": []byte("a"),
+		"CONNECTION_A_A-VALUE":  []byte("a"),
+		"CONNECTION_B_B-SECRET": []byte("b"),
+		"CONNECTION_B_B-VALUE":  []byte("b"),
 	}
 	require.Equal(t, expectedSecretData, secret.Data)
 
@@ -412,8 +411,8 @@ func Test_DeploymentReconciler_Connections(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedSecretData = map[string][]byte{
-		"CONNECTION_B_B-SECRET": []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
-		"CONNECTION_B_B-VALUE":  []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
+		"CONNECTION_B_B-SECRET": []byte("b"),
+		"CONNECTION_B_B-VALUE":  []byte("b"),
 	}
 	require.Equal(t, expectedSecretData, secret.Data)
 

--- a/pkg/controller/reconciler/recipe_reconciler.go
+++ b/pkg/controller/reconciler/recipe_reconciler.go
@@ -18,7 +18,6 @@ package reconciler
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"strings"
 	"time"
@@ -503,8 +502,7 @@ func (r *RecipeReconciler) updateSecret(ctx context.Context, recipe *radappiov1a
 	}
 
 	for k, v := range values {
-		encoded := base64.RawStdEncoding.EncodeToString([]byte(v))
-		secret.Data[k] = []byte(encoded)
+		secret.Data[k] = []byte(v)
 	}
 
 	secrets, err := r.Radius.Resources(recipe.Status.Scope, recipe.Spec.Type).ListSecrets(ctx, recipe.Name)
@@ -514,8 +512,7 @@ func (r *RecipeReconciler) updateSecret(ctx context.Context, recipe *radappiov1a
 		return fmt.Errorf("failed to list secrets: %w", err)
 	} else {
 		for k, v := range secrets.Value {
-			encoded := base64.RawStdEncoding.EncodeToString([]byte(*v))
-			secret.Data[k] = []byte(encoded)
+			secret.Data[k] = []byte(*v)
 		}
 	}
 

--- a/pkg/controller/reconciler/recipe_reconciler_test.go
+++ b/pkg/controller/reconciler/recipe_reconciler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package reconciler
 
 import (
-	"encoding/base64"
 	"errors"
 	"testing"
 	"time"
@@ -303,8 +302,8 @@ func Test_RecipeReconciler_WithSecret(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedData := map[string][]byte{
-		"a-value":  []byte(base64.RawStdEncoding.EncodeToString([]byte("a"))),
-		"b-secret": []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
+		"a-value":  []byte("a"),
+		"b-secret": []byte("b"),
 	}
 
 	require.Equal(t, expectedData, secret.Data)

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 supported:
   - channel: '0.26'
-    version: 'v0.26.6'
+    version: 'v0.26.7'
 deprecated:
   - channel: '0.25'
     version: 'v0.25.0'


### PR DESCRIPTION
# Description

Cherry-picked: https://github.com/radius-project/radius/commit/bf4e6bb1a508902f6d0068cf2a2df251d6ca152e
Cherry-picked: https://github.com/radius-project/radius/pull/6553/commits/24192aa3bdb9f1e9c72f3afabf0bbbe2951de31b

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1f3633a</samp>

### Summary
📝🚀🐛

<!--
1.  📝 - This emoji represents the change that adds the release notes for Radius v0.26.7, as it is a documentation update that summarizes the patch release.
2.  🚀 - This emoji represents the change that updates the `versions.yaml` file to reflect the latest supported version of Radius, as it is a deployment update that marks a new release.
3.  🐛 - This emoji represents the changes that fix the bugs in the Radius Kubernetes controller and the unit tests, as they are bug fixes that improve the functionality and reliability of the code.
-->
This pull request fixes a bug in the Radius Kubernetes controller that affected the encoding of secret values for the Radius agent. It updates the `deployment_reconciler.go` and `recipe_reconciler.go` files and their corresponding unit tests. It also adds the release notes and updates the `versions.yaml` file for Radius v0.26.7.

> _Sing, O Muse, of the valiant deeds of Radius, the cloud-native agent_
> _That swiftly fixes bugs and errors in its Kubernetes deployment_
> _And of the skilled developers who craft the code with care and wisdom_
> _And document the changes in the notes and files for all to see_

### Walkthrough
*  Add release notes for Radius v0.26.7 ([link](https://github.com/radius-project/radius/pull/6554/files?diff=unified&w=0#diff-068b288e2b3c9c5e99acaddd84acdfe2a382c53eb1ee92a465e26b9952004cfaR1-R10))
*  Fix double-encoding of Kubernetes secret values in `deployment_reconciler.go` and `recipe_reconciler.go` ([link](https://github.com/radius-project/radius/pull/6554/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L556-R558), [link](https://github.com/radius-project/radius/pull/6554/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195R519-R520), [link](https://github.com/radius-project/radius/pull/6554/files?diff=unified&w=0#diff-565f9bf43f08d107a3218cdeb8b17eab13363d0661a65535e80ec4ef114f09e5L506-R505), [link](https://github.com/radius-project/radius/pull/6554/files?diff=unified&w=0#diff-565f9bf43f08d107a3218cdeb8b17eab13363d0661a65535e80ec4ef114f09e5L517-R515))
*  Remove unused import of `encoding/base64` package from `deployment_reconciler.go`, `deployment_reconciler_test.go`, `recipe_reconciler.go`, and `recipe_reconciler_test.go` ([link](https://github.com/radius-project/radius/pull/6554/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L21), [link](https://github.com/radius-project/radius/pull/6554/files?diff=unified&w=0#diff-9d66db7eb311e875d019923b0892c9b51b9520295624cc0b6a0197cdbd04527cL20), [link](https://github.com/radius-project/radius/pull/6554/files?diff=unified&w=0#diff-565f9bf43f08d107a3218cdeb8b17eab13363d0661a65535e80ec4ef114f09e5L21), [link](https://github.com/radius-project/radius/pull/6554/files?diff=unified&w=0#diff-2b3aa3c5be32be791c9069d44213d653090aed157026f3d37f187ccded049cacL20))
*  Update unit tests to match the plain string values of secret data in `deployment_reconciler_test.go` and `recipe_reconciler_test.go` ([link](https://github.com/radius-project/radius/pull/6554/files?diff=unified&w=0#diff-9d66db7eb311e875d019923b0892c9b51b9520295624cc0b6a0197cdbd04527cL369-R371), [link](https://github.com/radius-project/radius/pull/6554/files?diff=unified&w=0#diff-9d66db7eb311e875d019923b0892c9b51b9520295624cc0b6a0197cdbd04527cL415-R415), [link](https://github.com/radius-project/radius/pull/6554/files?diff=unified&w=0#diff-2b3aa3c5be32be791c9069d44213d653090aed157026f3d37f187ccded049cacL306-R306))
*  Update `versions.yaml` to reflect the latest supported version of Radius ([link](https://github.com/radius-project/radius/pull/6554/files?diff=unified&w=0#diff-1c4cd801df522f4a92edbfb0fea95364ed074a391ea47c284ddc078f512f7b6aL3-R3))


