### PR TITLE
Fix for Dapr StateStores and SecretStores dev recipes URL casing

### DIFF
--- a/.github/scripts/publish-recipes.sh
+++ b/.github/scripts/publish-recipes.sh
@@ -16,32 +16,28 @@
 # limitations under the License.
 # ------------------------------------------------------------
 
-# Fail immedietly if any command fails
+# Fail immediately if any command fails
 set -e
 
 # Get command line arguments
-BICEP_PATH=$1
-DIRECTORY=$2
-REGISTRY_PATH=$3
-RECIPE_VERSION=$4
-
-BICEP_EXECUTABLE="$BICEP_PATH/rad-bicep"
+DIRECTORY=$1
+REGISTRY_PATH=$2
+RECIPE_VERSION=$3
 
 # Print usage information
 function print_usage() {
-    echo "Usage: $0 <BICEP_PATH> <DIRECTORY> <REGISTRY_PATH> <RECIPE_VERSION>"
+    echo "Usage: $0 <DIRECTORY> <REGISTRY_PATH> <RECIPE_VERSION>"
     echo ""
-    echo "  Publishes all recipes in the repository to the Azure Container Registry. Requires you to be logged into Azure via az login."
+    echo "  Publishes all recipes in the repository to a container registry."
     echo ""
-    echo "  BICEP_PATH: Path to directory containing the bicep executable. For example, ~/.rad/bin"
     echo "  DIRECTORY: Directory containing the recipes to publish. For example, ./test/functional/testdata/recipes"
-    echo "  REGISTRY_PATH: Registry hostname and path prefix. For example, myregistry.azurecr.io/tests/recipes."
+    echo "  REGISTRY_PATH: Registry hostname and path prefix. For example, ghcr.io/radius-project/dev/test/recipes"
     echo "  RECIPE_VERSION: Version of the recipe to publish. For example, pr-19293"
     echo ""
 }
 
 # Verify that the required arguments are present
-if [[ $# -ne 4 ]]; then
+if [[ $# -ne 3 ]]; then
     echo "Error: Missing required arguments"
     echo ""
     print_usage
@@ -69,5 +65,5 @@ do
 
     echo "Publishing $RECIPE to $PUBLISH_REF"
     echo "- $PUBLISH_REF" >> $GITHUB_STEP_SUMMARY
-    $BICEP_EXECUTABLE publish $RECIPE --target "br:$PUBLISH_REF"
+    rad bicep publish --file $RECIPE --target "br:$PUBLISH_REF"
 done

--- a/.github/scripts/release-verification.sh
+++ b/.github/scripts/release-verification.sh
@@ -59,9 +59,9 @@ fi
 kind create cluster
 ./rad install kubernetes
 
-EXPECTED_APPCORE_RP_IMAGE="radius.azurecr.io/applications-rp:${EXPECTED_TAG_VERSION}"
-EXPECTED_UCP_IMAGE="radius.azurecr.io/ucpd:${EXPECTED_TAG_VERSION}"
-EXPECTED_DE_IMAGE="radius.azurecr.io/deployment-engine:${EXPECTED_TAG_VERSION}"
+EXPECTED_APPCORE_RP_IMAGE="ghcr.io/radius-project/applications-rp:${EXPECTED_TAG_VERSION}"
+EXPECTED_UCP_IMAGE="ghcr.io/radius-project/ucpd:${EXPECTED_TAG_VERSION}"
+EXPECTED_DE_IMAGE="ghcr.io/radius-project/deployment-engine:${EXPECTED_TAG_VERSION}"
 
 APPCORE_RP_IMAGE=$(kubectl describe pods -n radius-system -l control-plane=applications-rp | awk '/^.*Image:/ {print $2}')
 UCP_IMAGE=$(kubectl describe pods -n radius-system -l control-plane=ucp | awk '/^.*Image:/ {print $2}')

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,26 +36,27 @@ concurrency:
 env:
   # Go version to install
   GOVER: '^1.21'
-  GOPROXY: https://proxy.golang.org
   
   # gotestsum version - see: https://github.com/gotestyourself/gotestsum
   GOTESTSUMVERSION: 1.10.0
-
-  # Use radiusdev.azurecr.io for PR build. Otherwise, use radius.azurecr.io.
-  # TODO_LAUNCH: Remove this variable when we opensource the repo - https://github.com/radius-project/radius/issues/5892
-  DOCKER_REGISTRY: ${{ github.event_name == 'pull_request' && 'radiusdev.azurecr.io' || 'radius.azurecr.io' }}
 
   # GitHub Actor for pushing images to GHCR
   GHCR_ACTOR: rad-ci-bot
 
   # Container registry url for GitHub container registry.
-  CONTAINER_REGISTRY: ${{ github.event_name == 'pull_request' && 'ghcr.io/radius-project/dev' || 'ghcr.io/radius-project/radius' }}
+  CONTAINER_REGISTRY: ${{ github.event_name == 'pull_request' && 'ghcr.io/radius-project/dev' || 'ghcr.io/radius-project' }}
 
   # Local file path to the release binaries.
   RELEASE_PATH: ./release
 
+  # ORAS (OCI Registry As Storage) CLI version
+  ORAS_VERSION: 1.1.0
+
+  # URL to get source code for building the image
+  IMAGE_SRC: https://github.com/radius-project/radius
+
 jobs:
-  build:
+  build-and-push-cli:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     runs-on: ubuntu-latest
     env:
@@ -126,7 +127,6 @@ jobs:
         with:
           name: rad_cli_release
           path: ${{ env.RELEASE_PATH }}
-      # TOOD_LAUNCH: Remove this step when we opensource the repo - https://github.com/radius-project/radius/issues/5892
       - name: Upload CLI binary
         uses: actions/upload-artifact@v3
         with:
@@ -204,64 +204,25 @@ jobs:
         with:
           path: ./dist/cache
           key: radius-coverage-${{ github.sha }}-${{ github.run_number }}
-
-  # Logic here:
-  # - always do a docker build for validation
-  # - tag the image as latest and with a version if the trigger was a tag
-  # - tag the image with the PR version if the trigger was a PR
-  # - push the image for pushes to master, or to a tag
-
-  # TODO_LAUNCH: Remove 'image' job when we opensource the repo - https://github.com/radius-project/radius/issues/5892
-  images:
-    name: Container image build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Parse release version and set environment variables
-        run: python ./.github/scripts/get_release_version.py
-      - name: Set up Go ${{ env.GOVER }}
-        uses: actions/setup-go@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          go-version: ${{ env.GOVER }}
-      - uses: azure/docker-login@v1
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: oras-project/setup-oras@v1
         with:
-          login-server: ${{ env.DOCKER_REGISTRY }}
-          username: '${{ secrets.DOCKER_USERNAME }}'
-          password: '${{ secrets.DOCKER_PASSWORD }}'
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-      - name: Push container images (latest)
+          version: ${{ env.ORAS_VERSION }}
+      - name: Push latest rad cli binary to GHCR (unix-like)
+        if: github.ref == 'refs/heads/main' && matrix.target_os != 'windows'
         run: |
-          make docker-test-image-build && make docker-test-image-push
-          make docker-multi-arch-push
-        if: (github.ref == 'refs/heads/main') # push image to latest on merge to main
-        env:
-          DOCKER_REGISTRY: ${{ env.DOCKER_REGISTRY }}
-          DOCKER_TAG_VERSION: latest
-      - name: Push container images (PR)
+          oras push ${{ env.CONTAINER_REGISTRY }}/rad/${{ matrix.target_os }}-${{ matrix.target_arch }}:latest ./dist/${{ matrix.target_os}}_${{ matrix.target_arch}}/release/rad --annotation "org.opencontainers.image.source=${{ env.IMAGE_SRC }}"
+      - name: Copy cli binaries to release (windows)
+        if: github.ref == 'refs/heads/main' && matrix.target_os == 'windows'
         run: |
-          make docker-test-image-build && make docker-test-image-push
-          make docker-multi-arch-push
-        if: github.event_name == 'pull_request'
-        env:
-          DOCKER_REGISTRY: ${{ env.DOCKER_REGISTRY }}
-          DOCKER_TAG_VERSION: ${{ env.REL_VERSION }} # includes PR number
-      - name: Push container images (release)
-        run: |
-          make docker-test-image-build && make docker-test-image-push
-          make docker-multi-arch-push
-        if: startsWith(github.ref, 'refs/tags/v') # push image on tag
-        env:
-          DOCKER_REGISTRY: ${{ env.DOCKER_REGISTRY }}
-          DOCKER_TAG_VERSION: ${{ env.REL_CHANNEL }}
+          oras push ${{ env.CONTAINER_REGISTRY }}/rad/${{ matrix.target_os }}-${{ matrix.target_arch }}:latest ./dist/${{ matrix.target_os}}_${{ matrix.target_arch}}/release/rad.exe --annotation "org.opencontainers.image.source=${{ env.IMAGE_SRC }}"
 
-  # publish_image is building and publishing images to GHCR.
-  publish_images:
+  build-and-push-images:
     name: Build and publish container images
     runs-on: ubuntu-latest
     steps:
@@ -277,8 +238,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ env.GHCR_ACTOR }}
-          password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -309,9 +270,10 @@ jobs:
         env:
           DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
           DOCKER_TAG_VERSION: ${{ env.REL_CHANNEL }}
-  helm:
+
+  build-and-push-helm-chart:
     name: Helm chart build
-    needs: ['images', 'publish_images']
+    needs: ['build-and-push-images']
     runs-on: ubuntu-latest
     env:
       ARTIFACT_DIR: ./dist/Charts
@@ -343,16 +305,14 @@ jobs:
             --username ${{ secrets.AZURE_SP_TESTS_APPID }} \
             --password ${{ secrets.AZURE_SP_TESTS_PASSWORD }} \
             --tenant ${{ secrets.AZURE_SP_TESTS_TENANTID }}
-      - name: Push helm chart to ACR
-        run: |
-          az acr helm push --name radius ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}/radius-${{ env.CHART_VERSION }}.tgz --force
       - name: Push helm chart to GHCR
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | helm registry login -u ${{ github.actor }} --password-stdin ${{ env.OCI_REGISTRY }}
           helm push ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}/radius-${{ env.CHART_VERSION }}.tgz oci://${{ env.OCI_REGISTRY }}/${{ env.OCI_REPOSITORY }}
-  publish_release:
+
+  publish-release:
     name: Publish GitHub Release
-    needs: [ 'build' ]
+    needs: ['build-and-push-cli']
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
@@ -376,8 +336,6 @@ jobs:
             --generate-notes \
             --verify-tag \
             --prerelease
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT }}
       - name: Create GitHub Official Release
         if: ${{ !contains(env.REL_VERSION, 'rc') }}
         run: |
@@ -386,96 +344,11 @@ jobs:
             --title "Project Radius v${{ env.REL_VERSION }}" \
             --notes-file docs/release-notes/v${{ env.REL_VERSION }}.md \
             --verify-tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT }}
-  # TODO_LAUNCH: Remove this job once we opensource - https://github.com/radius-project/radius/issues/5892
-  publish:
-    name: Publish rad CLI binaries
-    needs: [ 'build' ]
-    runs-on: ubuntu-latest
-    if: (github.ref == 'refs/heads/main') || startsWith(github.ref, 'refs/tags/v') # upload on push to main or tag
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Parse release version and set environment variables
-        run: python ./.github/scripts/get_release_version.py
-      - name: Download release artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: rad_cli_darwin_arm64
-          path: rad_cli_darwin_arm64
-      - name: Download release artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: rad_cli_darwin_amd64
-          path: rad_cli_darwin_amd64
-      - name: Download release artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: rad_cli_linux_arm
-          path: rad_cli_linux_arm
-      - name: Download release artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: rad_cli_linux_arm64
-          path: rad_cli_linux_arm64
-      - name: Download release artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: rad_cli_linux_amd64
-          path: rad_cli_linux_amd64
-      - name: Download release artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: rad_cli_windows_amd64
-          path: rad_cli_windows_amd64
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_darwin_amd64
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/macos-x64/ --pattern rad --timeout 300'
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_darwin_arm64
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/macos-arm64/ --pattern rad --timeout 300'
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_linux_amd64
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-x64/ --pattern rad --timeout 300'
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_linux_arm
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-arm/ --pattern rad --timeout 300'
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_linux_arm64
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/linux-arm64/ --pattern rad --timeout 300'
-      - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
-        with:
-          source_dir: rad_cli_windows_amd64
-          container_name: 'tools'
-          connection_string: ${{ secrets.ASSETS_STORAGE_CONNECTION_STRING }}
-          overwrite: 'true'
-          extra_args: '--destination-path rad/${{ env.REL_CHANNEL }}/windows-x64/ --pattern rad.exe --timeout 300'
 
   delete_artifacts:
     name: Delete artifacts
-    needs: [ 'build', 'publish' ]
-    if: ${{ always() && !contains(needs.build.result, 'failure') }}
+    needs: ['build-and-push-cli']
+    if: ${{ always() && !contains(needs.build-and-push-cli.result, 'failure') }}
     runs-on: ubuntu-latest
     steps:
       - name: Delete release artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -320,6 +320,8 @@ jobs:
     name: Publish GitHub Release
     needs: ['build-and-push-cli']
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT }}
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout
@@ -338,7 +340,7 @@ jobs:
         run: |
           gh release create v${{ env.REL_VERSION }} \
             ${{ env.RELEASE_PATH }}/* \
-            --title "Project Radius v${{ env.REL_VERSION }}" \
+            --title "Radius v${{ env.REL_VERSION }}" \
             --generate-notes \
             --verify-tag \
             --prerelease
@@ -347,7 +349,7 @@ jobs:
         run: |
           gh release create v${{ env.REL_VERSION }} \
             ${{ env.RELEASE_PATH }}/* \
-            --title "Project Radius v${{ env.REL_VERSION }}" \
+            --title "Radius v${{ env.REL_VERSION }}" \
             --notes-file docs/release-notes/v${{ env.REL_VERSION }}.md \
             --verify-tag
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -280,7 +280,8 @@ jobs:
       HELM_PACKAGE_DIR: helm
       HELM_CHARTS_DIR: deploy/Chart
       OCI_REGISTRY: ghcr.io
-      OCI_REPOSITORY: ${{ startsWith(github.ref, 'refs/tags/v') && 'radius-project/helm-chart' || 'radius-project/dev/helm-chart' }} 
+      # If we are pushing from a tag or from the main branch, push to radius-project/helm-chart. Otherwise, push to radius-project/dev/helm-chart.
+      OCI_REPOSITORY: ${{ (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main') && 'radius-project/helm-chart' || 'radius-project/dev/helm-chart' }} 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -288,8 +289,6 @@ jobs:
         uses: Azure/setup-helm@v3
         with:
           version: 'v3.11.1'
-      - name: Setup Azure CLI
-        run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
       - name: Parse release version and set environment variables
         run: python ./.github/scripts/get_release_version.py
       - name: Run Helm linter
@@ -299,12 +298,19 @@ jobs:
         run: |
           mkdir -p ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
           helm package ${{ env.HELM_CHARTS_DIR }} --version ${{ env.CHART_VERSION }} --app-version ${{ env.REL_VERSION }} --destination ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
+      # TODO: Delete this step once we use GHCR as the helm chart repo.
+      - name: Setup Azure CLI
+        run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
       - name: az CLI login
         run: |
           az login --service-principal \
             --username ${{ secrets.AZURE_SP_TESTS_APPID }} \
             --password ${{ secrets.AZURE_SP_TESTS_PASSWORD }} \
             --tenant ${{ secrets.AZURE_SP_TESTS_TENANTID }}
+      # TODO: Delete this step once we use GHCR as the helm chart repo.
+      - name: Push helm chart to ACR
+        run: |
+          az acr helm push --name radius ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}/radius-${{ env.CHART_VERSION }}.tgz --force
       - name: Push helm chart to GHCR
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | helm registry login -u ${{ github.actor }} --password-stdin ${{ env.OCI_REGISTRY }}

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -50,11 +50,10 @@ env:
   AZURE_KEYVAULT_CSI_DRIVER_VER: '1.4.2'
   # Azure workload identity webhook chart version
   AZURE_WORKLOAD_IDENTITY_WEBHOOK_VER: '1.1.0'
-  # Container registry for storing test images and recipes
-  CACHE_REGISTRY: ghcr.io/radius-project/dev
-  # Container registry for storing recipe artifacts
-  # TODO_LAUNCH: Change it to ghcr.io/radius-project/dev - https://github.com/radius-project/radius/issues/5892
-  BICEP_RECIPE_REGISTRY: radiusdev.azurecr.io
+  # Container registry for storing container images
+  CONTAINER_REGISTRY: ghcr.io/radius-project/dev
+  # Container registry for storing Bicep recipe artifacts
+  BICEP_RECIPE_REGISTRY: ghcr.io/radius-project/dev
   # The radius functional test timeout
   FUNCTIONALTEST_TIMEOUT: 60m
   # The Azure Location to store test resources
@@ -72,14 +71,12 @@ env:
   # Server where terraform test modules are deployed
   TF_RECIPE_MODULE_SERVER_URL: "http://tf-module-server.radius-test-tf-module-server.svc.cluster.local"
 
-  # GitHub Actor for pushing images to GHCR
-  GHCR_ACTOR: rad-ci-bot
 jobs:
   build:
     name: Build Radius for test
     runs-on: ubuntu-latest
     env:
-      DE_IMAGE: 'radius.azurecr.io/deployment-engine'
+      DE_IMAGE: 'ghcr.io/radius-project/deployment-engine'
       DE_TAG: 'latest'
     outputs:
       REL_VERSION: ${{ steps.gen-id.outputs.REL_VERSION }}
@@ -189,28 +186,22 @@ jobs:
             * Dapr: ${{ env.DAPR_VER }}
             * Azure KeyVault CSI driver: ${{ env.AZURE_KEYVAULT_CSI_DRIVER_VER }}
             * Azure Workload identity webhook: ${{ env.AZURE_WORKLOAD_IDENTITY_WEBHOOK_VER }}
-            * Bicep recipe location `${{ env.BICEP_RECIPE_REGISTRY}}/test/functional/shared/recipes/<name>:${{ env.REL_VERSION }}`
+            * Bicep recipe location `${{ env.BICEP_RECIPE_REGISTRY }}/test/functional/shared/recipes/<name>:${{ env.REL_VERSION }}`
             * Terraform recipe location `${{ env.TF_RECIPE_MODULE_SERVER_URL }}/<name>.zip` (in cluster)
-            * applications-rp test image location: `${{ env.CACHE_REGISTRY }}/applications-rp:${{ env.REL_VERSION }}`
-            * controller test image location: `${{ env.CACHE_REGISTRY }}/controller:${{ env.REL_VERSION }}`
-            * ucp test image location: `${{ env.CACHE_REGISTRY }}/ucpd:${{ env.REL_VERSION }}`
+            * applications-rp test image location: `${{ env.CONTAINER_REGISTRY }}/applications-rp:${{ env.REL_VERSION }}`
+            * controller test image location: `${{ env.CONTAINER_REGISTRY }}/controller:${{ env.REL_VERSION }}`
+            * ucp test image location: `${{ env.CONTAINER_REGISTRY }}/ucpd:${{ env.REL_VERSION }}`
             * deployment-engine test image location: `${{ env.DE_IMAGE }}:${{ env.DE_TAG }}`
 
             </details>
             
             ## Test Status
-      - name: Setup Azure CLI
-        run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-      - name: Login to Azure
-        uses: azure/login@v1
-        with:
-          creds: '{"clientId":"${{ secrets.INTEGRATION_TEST_SP_APP_ID }}","clientSecret":"${{ secrets.INTEGRATION_TEST_SP_PASSWORD }}","subscriptionId":"${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.INTEGRATION_TEST_TENANT_ID }}"}'
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ env.GHCR_ACTOR }}
-          password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: marocchino/sticky-pull-request-comment@v2
         if: env.PR_NUMBER != ''
         continue-on-error: true
@@ -224,7 +215,7 @@ jobs:
         run: |
           make build && make docker-build && make docker-push
         env:
-          DOCKER_REGISTRY: ${{ env.CACHE_REGISTRY }}
+          DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
           DOCKER_TAG_VERSION: ${{ env.REL_VERSION }}
       - name: Upload CLI binary
         uses: actions/upload-artifact@v3
@@ -259,18 +250,19 @@ jobs:
           append: true
           message: |
             :hourglass: Publishing Bicep Recipes for functional tests...
-      - name: Download rad-bicep
-        run: |
-          mkdir -p dist
-          ./.github/scripts/curl-with-retries.sh https://get.radapp.dev/tools/bicep-extensibility/edge/linux-x64/rad-bicep --output dist/rad-bicep
-          chmod +x dist/rad-bicep
       - name: Publish Bicep Test Recipes
         run: |
+          mkdir ./bin
+          cp ./dist/linux_amd64/release/rad ./bin/rad
+          chmod +x ./bin/rad
+          export PATH=$GITHUB_WORKSPACE/bin:$PATH
+          which rad || { echo "cannot find rad"; exit 1; }
+          rad bicep download
+          rad version
           make publish-test-bicep-recipes
         env:
           BICEP_RECIPE_REGISTRY: ${{ env.BICEP_RECIPE_REGISTRY }}
           BICEP_RECIPE_TAG_VERSION: ${{ env.REL_VERSION }}
-          RAD_BICEP_PATH: dist
       - uses: marocchino/sticky-pull-request-comment@v2
         if: success() && env.PR_NUMBER != ''
         continue-on-error: true
@@ -386,7 +378,7 @@ jobs:
           # AZURE_OIDC_ISSUER
           eval "export $(echo "${{ secrets.FUNCTEST_AZURE_OIDC_JSON }}" | jq -r 'to_entries | map("\(.key)=\(.value)") | @sh')"
 
-          AUTHKEY=$(echo -n "${{ env.GHCR_ACTOR }}:${{ secrets.GH_RAD_CI_BOT_PAT }}" | base64)
+          AUTHKEY=$(echo -n "${{ github.actor }}:${{ secrets.GH_RAD_CI_BOT_PAT }}" | base64)
           echo "{\"auths\":{\"ghcr.io\":{\"auth\":\"${AUTHKEY}\"}}}" > "./ghcr_secret.json"
 
           # Create KinD cluster with OIDC Issuer keys
@@ -432,8 +424,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ env.GHCR_ACTOR }}
-          password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Download Bicep
         run: |
           chmod +x ./bin/rad
@@ -461,7 +453,7 @@ jobs:
           echo "*** Installing Radius to Kubernetes ***"
           rad install kubernetes \
             --chart ${{ env.RADIUS_CHART_LOCATION }} \
-            --set rp.image=${{ env.CACHE_REGISTRY }}/applications-rp,rp.tag=${{ env.REL_VERSION }},controller.image=${{ env.CACHE_REGISTRY }}/controller,controller.tag=${{ env.REL_VERSION }},ucp.image=${{ env.CACHE_REGISTRY }}/ucpd,ucp.tag=${{ env.REL_VERSION }},de.image=${{ env.DE_IMAGE }},de.tag=${{ env.DE_TAG }}
+            --set rp.image=${{ env.CONTAINER_REGISTRY }}/applications-rp,rp.tag=${{ env.REL_VERSION }},controller.image=${{ env.CONTAINER_REGISTRY }}/controller,controller.tag=${{ env.REL_VERSION }},ucp.image=${{ env.CONTAINER_REGISTRY }}/ucpd,ucp.tag=${{ env.REL_VERSION }},de.image=${{ env.DE_IMAGE }},de.tag=${{ env.DE_TAG }}
 
           echo "*** Create workspace, group and environment for test ***"
           rad workspace create kubernetes
@@ -483,9 +475,6 @@ jobs:
           rad env update kind-radius --aws-region ${{ env.AWS_REGION }} --aws-account-id ${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}
           rad credential register aws \
             --access-key-id ${{ secrets.FUNCTEST_AWS_ACCESS_KEY_ID }} --secret-access-key ${{ secrets.FUNCTEST_AWS_SECRET_ACCESS_KEY }}
-          
-          # TODO_LAUNCH: Remove this login once we move recipe to GHCR - https://github.com/radius-project/radius/issues/5892
-          az acr login -n ${{ env.BICEP_RECIPE_REGISTRY }}
       - uses: marocchino/sticky-pull-request-comment@v2
         if: failure() && env.PR_NUMBER != ''
         continue-on-error: true
@@ -519,7 +508,7 @@ jobs:
 
           make test-functional-${{ matrix.name }}
         env:
-          DOCKER_REGISTRY: ${{ env.CACHE_REGISTRY }}
+          DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
           TEST_TIMEOUT: ${{ env.FUNCTIONALTEST_TIMEOUT }}
           RADIUS_CONTAINER_LOG_PATH: ${{ github.workspace }}/${{ env.RADIUS_CONTAINER_LOG_BASE }}
           AWS_ACCESS_KEY_ID: ${{ secrets.FUNCTEST_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -296,7 +296,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        name: [ucp,shared,msgrp,daprrp,samples]
+        name: [ucp,kubernetes,shared,msgrp,daprrp,samples]
         include:
           # datastorerp functional tests need the larger VM.
           - os: ubuntu-latest-m

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -21,11 +21,6 @@ on:
     - cron: "30 0,4,8,12,16,20 * * 1-5"
     # Run every 12 hours on weekends.
     - cron: "30 0,12 * * 0,6"
-  pull_request:
-    branches:
-      - main
-      - features/*
-      - release/*
   # Dispatch on external events
   repository_dispatch:
     types: [functional-tests, de-functional-test]

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -41,9 +41,9 @@ on:
   schedule:
     # Run every 2 hours
     - cron: "0 */2 * * *"
-  pull_request:
-    branches:
-      - main
+  # pull_request:
+  #   branches:
+  #     - main
     paths:
       - '.github/workflows/long-running-azure.yaml'
 
@@ -55,10 +55,10 @@ env:
   # gotestsum version - see: https://github.com/gotestyourself/gotestsum
   GOTESTSUM_VER: 1.10.0
 
-  # ACR for storing test images and recipes
-  CACHE_REGISTRY: radiusdev.azurecr.io
-  # Container registry for storing recipe artifacts
-  BICEP_RECIPE_REGISTRY: radiusdev.azurecr.io
+  # Container registry for storing container images
+  CONTAINER_REGISTRY: ghcr.io/radius-project/dev
+  # Container registry for storing Bicep recipe artifacts
+  BICEP_RECIPE_REGISTRY: ghcr.io/radius-project/dev
   # The radius functional test timeout
   FUNCTIONALTEST_TIMEOUT: 60m
   # The Azure Location to store test resources
@@ -178,11 +178,11 @@ jobs:
           <summary> Click here to see the list of tools in the current test run</summary>
 
           * gotestsum ${{ env.GOTESTSUM_VER }}
-          * Bicep recipe location `${{ env.BICEP_RECIPE_REGISTRY}}/test/functional/shared/recipes/<name>:${{ steps.gen-id.outputs.REL_VERSION }}`
+          * Bicep recipe location `${{ env.BICEP_RECIPE_REGISTRY }}/test/functional/shared/recipes/<name>:${{ steps.gen-id.outputs.REL_VERSION }}`
           * Terraform recipe location `${{ env.TF_RECIPE_MODULE_SERVER_URL }}/<name>.zip` (in cluster)
-          * applications-rp test image location: `${{ env.CACHE_REGISTRY }}/applications-rp:${{ steps.gen-id.outputs.REL_VERSION }}`
-          * controller test image location: `${{ env.CACHE_REGISTRY }}/controller:${{ steps.gen-id.outputs.REL_VERSION }}`
-          * ucp test image location: `${{ env.CACHE_REGISTRY }}/ucpd:${{ steps.gen-id.outputs.REL_VERSION }}`
+          * applications-rp test image location: `${{ env.CONTAINER_REGISTRY }}/applications-rp:${{ steps.gen-id.outputs.REL_VERSION }}`
+          * controller test image location: `${{ env.CONTAINER_REGISTRY }}/controller:${{ steps.gen-id.outputs.REL_VERSION }}`
+          * ucp test image location: `${{ env.CONTAINER_REGISTRY }}/ucpd:${{ steps.gen-id.outputs.REL_VERSION }}`
 
           </details>
           
@@ -197,16 +197,18 @@ jobs:
         uses: azure/login@v1
         with:
           creds: '{"clientId":"${{ secrets.INTEGRATION_TEST_SP_APP_ID }}","clientSecret":"${{ secrets.INTEGRATION_TEST_SP_PASSWORD }}","subscriptionId":"${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.INTEGRATION_TEST_TENANT_ID }}"}'
-      - name: Login ACR - ${{ env.CACHE_REGISTRY }}
-        if: steps.skip-build.outputs.SKIP_BUILD != 'true' 
-        run: |
-          az acr login -n ${{ env.CACHE_REGISTRY }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push container images
         if: steps.skip-build.outputs.SKIP_BUILD != 'true' 
         run: |
           make build && make docker-build && make docker-push
         env:
-          DOCKER_REGISTRY: ${{ env.CACHE_REGISTRY }}
+          DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
           DOCKER_TAG_VERSION: ${{ env.REL_VERSION }}
       - name: Upload CLI binary
         if: steps.skip-build.outputs.SKIP_BUILD != 'true' 
@@ -230,17 +232,11 @@ jobs:
         continue-on-error: true
         run: |
           echo ":hourglass: Publishing Bicep Recipes for functional tests..." >> $GITHUB_STEP_SUMMARY
-      - name: Download rad-bicep
-        if: steps.skip-build.outputs.SKIP_BUILD != 'true'
-        run: |
-          mkdir -p dist
-          ./.github/scripts/curl-with-retries.sh https://get.radapp.dev/tools/bicep-extensibility/edge/linux-x64/rad-bicep --output dist/rad-bicep
-          chmod +x dist/rad-bicep
       - name: Move the latest binaries to cache
         if: steps.skip-build.outputs.SKIP_BUILD != 'true'
         run: |
           mkdir -p ./dist/cache
-          mv ./dist/linux_amd64/release/rad ./dist/cache
+          cp ./dist/linux_amd64/release/rad ./dist/cache
           echo $(date +%s) > ./dist/cache/.lastbuildtime
           echo "UNIQUE_ID=${{ steps.gen-id.outputs.UNIQUE_ID }}" >> ./dist/cache/.buildenv
           echo "REL_VERSION=${{ steps.gen-id.outputs.REL_VERSION }}" >> ./dist/cache/.buildenv
@@ -257,11 +253,16 @@ jobs:
       - name: Publish Bicep Test Recipes
         if: steps.skip-build.outputs.SKIP_BUILD != 'true'
         run: |
-          make publish-test-bicep-recipes
+          mkdir ./bin
+          cp ./dist/linux_amd64/release/rad ./bin/rad
+          chmod +x ./bin/rad
+          export PATH=$GITHUB_WORKSPACE/bin:$PATH
+          which rad || { echo "cannot find rad"; exit 1; }
+          rad bicep download
+          rad version
         env:
           BICEP_RECIPE_REGISTRY: ${{ env.BICEP_RECIPE_REGISTRY }}
           BICEP_RECIPE_TAG_VERSION: ${{ env.REL_VERSION }}
-          RAD_BICEP_PATH: dist
       - name: Log Bicep recipe publish status (success)
         if: steps.skip-build.outputs.SKIP_BUILD != 'true' && success()
         run: |
@@ -357,7 +358,7 @@ jobs:
           echo "*** Installing Radius to Kubernetes ***"
           rad install kubernetes --reinstall \
             --chart ${{ env.RADIUS_CHART_LOCATION }} \
-            --set rp.image=${{ env.CACHE_REGISTRY }}/applications-rp,rp.tag=${{ env.REL_VERSION }},controller.image=${{ env.CACHE_REGISTRY }}/controller,controller.tag=${{ env.REL_VERSION }},ucp.image=${{ env.CACHE_REGISTRY }}/ucpd,ucp.tag=${{ env.REL_VERSION }}
+            --set rp.image=${{ env.CONTAINER_REGISTRY }}/applications-rp,rp.tag=${{ env.REL_VERSION }},controller.image=${{ env.CONTAINER_REGISTRY }}/controller,controller.tag=${{ env.REL_VERSION }},ucp.image=${{ env.CONTAINER_REGISTRY }}/ucpd,ucp.tag=${{ env.REL_VERSION }}
       - name: Configure Radius test workspace
         run: |
           set -x
@@ -387,8 +388,6 @@ jobs:
           rad env update radius-e2e --aws-region ${{ env.AWS_REGION }} --aws-account-id ${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}
           rad credential register aws \
             --access-key-id ${{ secrets.FUNCTEST_AWS_ACCESS_KEY_ID }} --secret-access-key ${{ secrets.FUNCTEST_AWS_SECRET_ACCESS_KEY }}
-          
-          az acr login -n ${{ env.CACHE_REGISTRY }}
       - name: Log radius installation status (failure)
         if: failure()
         run: |

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,6 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
-
         {
             "name": "Launch Applications RP",
             "type": "go",
@@ -83,11 +82,12 @@
         {
             "name": "Launch Control Plane (all)",
             "configurations": [
-                "Launch UCP", 
+                "Launch UCP",
                 "Launch Applications RP",
                 "Launch Controller",
-                "Launch Deployment Engine"],
+                "Launch Deployment Engine",
+            ],
             "stopAll": true
-          }
-      ]
+        }
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -1,33 +1,28 @@
 # Radius
 
-Radius is a platform for developers and IT operators building cloud-native applications. With Radius, teams can model, deploy, manage, and troubleshoot entire applications across on-premises and multi-cloud environments, with a consistent set of tools and a common experience across it all.
+Radius is a cloud-native application platform that enables developers and the platform engineers that support them to collaborate on delivering and managing cloud-native applications that follow organizational best practices for cost, operations and security, by default. Radius is an open-source project that supports deploying applications across private cloud, Microsoft Azure, and Amazon Web Services, with more cloud providers to come.
 
 ## Overview
 
-Application teams today struggle to build, deploy, and scale cloud-native applications. Not only do developers and IT operators need to model and manage complex app architectures, but they need to do so while balancing portability, organizational best-practices, regulatory requirements, and complex platform requirements. Even after figuring out all this and an app is deployed, teams struggle to communicate, visualize, and troubleshoot their app, often dealing with flat lists of resources that span every layer of the stack. 
+The evolution of cloud computing has increased the speed of innovation for many companies, whether they are building 2 and 3-tier applications, or complex microservice-based applications. Cloud native technologies like Kubernetes have made it easier to build applications that can run anywhere. At the same time, many applications have become more complex, and managing them in the cloud increasingly difficult, as companies build cloud-native applications composed of interconnected services and deploy them to multiple public clouds and their private infrastructure. While Kubernetes is a key enabler, we see many organizations building abstractions over Kubernetes, usually focused on compute, to work around its limitations:  Kubernetes has no formal definition of an application, it mingles infrastructure and application concepts and it is overwhelmingly complex.  Developers also inevitably realize their applications require much more than Kubernetes, including support for dependencies like application programming interface (API) front ends, key/value stores, caches, and observability systems.  Amidst these challenges for developers, their corporate IT counterparts also must enforce an ever-growing matrix of corporate standards, compliance, and security requirements, while enabling rapid application innovation. 
 
-As the pace of innovation increases for cloud-native technologies, so does the need for rapid progress within application teams. Application teams need a platform that can let developers and operators work together, while still maintaining the agility their users and applications require. These are the challenges that Radius is designed to solve.
+Radius was designed to address these distinct but related challenges that arise across development and operations as companies continue their journey to cloud.  Radius meets application teams where they are by supporting proven technologies like Kubernetes, existing infrastructure tools including Terraform and Bicep and by integrating with existing CI/CD systems like GitHub Actions. Radius supports multi-tier web-plus-data to complex microservice applications like eShop, a popular cloud reference application from Microsoft.
 
 Key features of the Radius platform include: 
-
-- *Radius Application graph*: Developers can model their entire application, including the connections and dependencies between services. 
-- *Swappable infrastructure*: Radius resources are platform-agnostic, allowing applications to be written once and deployed to any platform, such as Kubernetes, Microsoft Azure, Amazon Web Services (AWS), or on-premises hardware. 
-- Recipes for infrastructure Provisioning: Radius Recipes automate infrastructure provisioning using infrastructure-as-code templates, ensuring all deployments meet organizational requirements and policies. 
-- *Radius Environments*: IT operators can define policies, security configurations, Recipes, and diagnostics required by their organization, ensuring secure and repeatable infrastructure across local development, testing, and production environments. 
-- *Consistent tooling and experiences*: Radius offers a consistent set of APIs, tools, and experiences that span any cloud or on-premises environment, simplifying and standardizing cloud-native application teams' toolchains and processes.
+- *Team Collaboration*: Radius Applications and Environments allow developers to work with Operations on application definition and delivery.
+- *Infrastructure Recipes*: Swappable infrastructure that complies with organization best practicies and IT policy be default.
+- *Application Graph*: Understand how services and infrastructure in an application are interconnected.
+- *Cloud Neutral*: Deploy across development, on-premises and cloud environments with a consistent experience.
+- *Incremental Adoption*: Integrate Radius into existing workflows and existing catalogs of Infrastructure-as-Code templates.
 
 ## Release status
 
-Radius is currently in an invitation-only private release and we are working hard to get Radius ready for public release in the near future.
+This is an early release of Radius which enables the community to learn about and experiment with the platform. Please let us know what you think and open Issues when you find bugs or want to request a new feature. Radius is not yet ready for production workloads.
 
 ## Getting started
 
-1. Follow the [installation guide](https://docs.radapp.dev/getting-started/install/) to install Radius if you have not done so already.
-1. Then, follow the [first app guide](https://docs.radapp.dev/getting-started/first-app/) to take a tour of Radius by running your first app.
-
-## Quickstarts and samples
-
-See the [Radius quickstarts](https://docs.radapp.dev/getting-started/quickstarts/) and [samples repository](https://github.com/radius-project/samples) for tutorials and code examples that can help you get started with Radius.
+1. Follow the [getting started guide](https://docs.radapp.dev/getting-started/) to install and try out Radius
+1. Visit the [Tutorials](https://docs.radapp.dev/tutorials) and [User Guides](https://docs.radapp.dev/guides) to learn more about Radius and start radifying your apps
 
 ## Getting help
 

--- a/build/recipes.mk
+++ b/build/recipes.mk
@@ -29,7 +29,6 @@ publish-test-bicep-recipes: ## Publishes test recipes to <BICEP_RECIPE_REGISTRY>
 	
 	@echo "$(ARROW) Publishing Bicep test recipes from ./test/functional/shared/resources/testdata/recipes/test-bicep-recipes..."
 	./.github/scripts/publish-recipes.sh \
-		${RAD_BICEP_PATH} \
 		./test/functional/shared/resources/testdata/recipes/test-bicep-recipes \
 		${BICEP_RECIPE_REGISTRY}/test/functional/shared/recipes \
 		${BICEP_RECIPE_TAG_VERSION}

--- a/build/test.mk
+++ b/build/test.mk
@@ -58,7 +58,7 @@ test-get-envtools:
 test-validate-cli: ## Run cli integration tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) -coverpkg= ./pkg/cli/cmd/... ./cmd/rad/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
 
-test-functional-all: test-functional-ucp test-functional-shared test-functional-msgrp test-functional-daprrp ## Runs all functional tests
+test-functional-all: test-functional-ucp test-functional-kubernetes test-functional-shared test-functional-msgrp test-functional-daprrp ## Runs all functional tests
 
 test-functional-kubernetes: ## Runs Kubernetes functional tests
 	CGO_ENABLED=1 $(GOTEST_TOOL) ./test/functional/kubernetes/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)

--- a/build/test.mk
+++ b/build/test.mk
@@ -20,7 +20,7 @@
 TEST_TIMEOUT ?=1h
 RADIUS_CONTAINER_LOG_PATH ?=./dist/container_logs
 REL_VERSION ?=latest
-DOCKER_REGISTRY ?=radiusdev.azurecr.io
+DOCKER_REGISTRY ?=ghcr.io/radius-project/dev
 ENVTEST_ASSETS_DIR=$(shell pwd)/bin
 K8S_VERSION=1.23.*
 ENV_SETUP=$(GOBIN)/setup-envtest$(BINARY_EXT)

--- a/deploy/Chart/crds/radius/radapp.io_recipes.yaml
+++ b/deploy/Chart/crds/radius/radapp.io_recipes.yaml
@@ -51,6 +51,16 @@ spec:
           spec:
             description: RecipeSpec defines the desired state of Recipe
             properties:
+              application:
+                description: Application is the name of the Radius application to
+                  use. If unset the namespace of the Recipe will be used as the application
+                  name.
+                type: string
+              environment:
+                description: Environment is the name of the Radius environment to
+                  use. If unset the value 'default' will be used as the environment
+                  name.
+                type: string
               secretName:
                 description: SecretName is the name of a Kubernetes secret to create
                   once the resource is created.

--- a/deploy/Chart/templates/controller/rbac.yaml
+++ b/deploy/Chart/templates/controller/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: controller
+  name: radius-controller
   labels:
     app.kubernetes.io/name: controller
     app.kubernetes.io/part-of: radius
@@ -11,6 +11,7 @@ rules:
   resources:
   - namespaces
   - secrets
+  - events
   verbs:
   - create
   - delete
@@ -55,14 +56,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: controller
+  name: radius-controller
   labels:
     app.kubernetes.io/name: controller
     app.kubernetes.io/part-of: radius
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: controller
+  name: radius-controller
 subjects:
 - kind: ServiceAccount
   name: controller

--- a/deploy/Chart/templates/controller/rbac.yaml
+++ b/deploy/Chart/templates/controller/rbac.yaml
@@ -33,7 +33,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - rad.app
+  - radapp.io
   resources:
   - recipes
   - recipes/status

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -10,7 +10,7 @@ global:
   #   url: "http://jaeger-collector.radius-monitoring.svc.cluster.local:9411/api/v2/spans"
   #
 controller:
-  image: radius.azurecr.io/controller
+  image: ghcr.io/radius-project/controller
   # Default tag uses Chart AppVersion.
   # tag: latest
   resources:
@@ -20,7 +20,7 @@ controller:
       memory: "300Mi"
 
 de:
-  image: radius.azurecr.io/deployment-engine
+  image: ghcr.io/radius-project/deployment-engine
   # Default tag uses Chart AppVersion.
   # tag: latest
   resources:
@@ -31,7 +31,7 @@ de:
       memory: "300Mi"
 
 ucp:
-  image: radius.azurecr.io/ucpd
+  image: ghcr.io/radius-project/ucpd
   # Default tag uses Chart AppVersion.
   # tag: latest
   resources:
@@ -42,7 +42,7 @@ ucp:
       memory: "300Mi"
 
 rp:
-  image: radius.azurecr.io/applications-rp
+  image: ghcr.io/radius-project/applications-rp
   # Default tag uses Chart AppVersion.
   # tag: latest
   publicEndpointOverride: ""

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -19,11 +19,15 @@
 # Radius CLI location
 : ${RADIUS_INSTALL_DIR:="/usr/local/bin"}
 
-# sudo is required to copy binary to RADIUS_INSTALL_DIR for linux and M1 macs
+# sudo is required to copy binary to RADIUS_INSTALL_DIR for linux
 : ${USE_SUDO:="false"}
 
 # Http request CLI
 RADIUS_HTTP_REQUEST_CLI=curl
+
+# GitHub Organization and repo name to download release
+GITHUB_ORG=radius-project
+GITHUB_REPO=radius
 
 # Radius CLI filename
 RADIUS_CLI_FILENAME=rad
@@ -35,25 +39,19 @@ getSystemInfo() {
     case $ARCH in
         armv7*) ARCH="arm";;
         aarch64) ARCH="arm64";;
-        x86_64) ARCH="x64";;
+        x86_64) ARCH="amd64";;
     esac
 
     OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
 
-    if [ "$OS" == "darwin" ]; then
-        OS="macos"
-    fi
-
     # Most linux distro needs root permission to copy the file to /usr/local/bin
-    # Also, for M1 macs, we also need sudo permission for /usr/local/bin
-    if [[ ("$OS" == "linux" || ( "$OS" == "macos" && ( "$ARCH" == "arm" || "$ARCH" == "arm64" ))) && "$RADIUS_INSTALL_DIR" == "/usr/local/bin"  ]];
-    then
+    if [[ "$OS" == "linux" || "$OS" == "darwin" ]] && [ "$RADIUS_INSTALL_DIR" == "/usr/local/bin" ]; then
         USE_SUDO="true"
     fi
 }
 
 verifySupported() {
-    local supported=(macos-x64 macos-arm64 linux-x64 linux-arm linux-arm64)
+    local supported=(darwin-arm64 darwin-amd64 linux-amd64 linux-arm linux-arm64)
     local current_osarch="${OS}-${ARCH}"
 
     for osarch in "${supported[@]}"; do
@@ -71,7 +69,6 @@ runAsRoot() {
     local CMD="$*"
 
     if [ $EUID -ne 0 -a $USE_SUDO = "true" ]; then
-        echo "Additional permission needed. Please enter your sudo password if prompted..."
         CMD="sudo $CMD"
     fi
 
@@ -100,13 +97,13 @@ checkExistingRadius() {
 }
 
 getLatestRelease() {
-    local releaseUrl="https://get.radapp.dev/version/stable.txt"
+    local radReleaseUrl="https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/releases"
     local latest_release=""
 
     if [ "$RADIUS_HTTP_REQUEST_CLI" == "curl" ]; then
-        latest_release=$(curl -s $releaseUrl)
+        latest_release=$(curl -s $radReleaseUrl | grep \"tag_name\" | grep -v rc | awk 'NR==1{print $2}' |  sed -n 's/\"\(.*\)\",/\1/p')
     else
-        latest_release=$(wget -q -O - $releaseUrl)
+        latest_release=$(wget -q --header="Accept: application/json" -O - $radReleaseUrl | grep \"tag_name\" | grep -v rc | awk 'NR==1{print $2}' |  sed -n 's/\"\(.*\)\",/\1/p')
     fi
 
     ret_val=$latest_release
@@ -115,27 +112,13 @@ getLatestRelease() {
 downloadFile() {
     LATEST_RELEASE_TAG=$1
 
-    OS_ARCH="${OS}-${ARCH}"
-    RADIUS_CLI_ARTIFACT="rad"
-    DOWNLOAD_BASE="https://get.radapp.dev/tools/rad"
-    DOWNLOAD_URL="${DOWNLOAD_BASE}/${LATEST_RELEASE_TAG}/${OS_ARCH}/${RADIUS_CLI_ARTIFACT}"
+    RADIUS_CLI_ARTIFACT="${RADIUS_CLI_FILENAME}_${OS}_${ARCH}"
+    DOWNLOAD_BASE="https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download"
+    DOWNLOAD_URL="${DOWNLOAD_BASE}/${LATEST_RELEASE_TAG}/${RADIUS_CLI_ARTIFACT}"
 
     # Create the temp directory
-    RADIUS_TMP_ROOT=$(mktemp -dt Radius-install-XXXXXX)
+    RADIUS_TMP_ROOT=$(mktemp -dt radius-install-XXXXXX)
     ARTIFACT_TMP_FILE="$RADIUS_TMP_ROOT/$RADIUS_CLI_ARTIFACT"
-
-    if [ "$RADIUS_HTTP_REQUEST_CLI" == "curl" ]; then
-        if ! curl --output /dev/null --silent --head --fail "$DOWNLOAD_URL"; then
-            echo "ERROR: The specified release version: $LATEST_RELEASE_TAG does not exist."
-            exit 1
-        fi
-    else
-        if ! wget --spider "$DOWNLOAD_URL" 2>/dev/null; then
-            echo "ERROR: The specified release version: $LATEST_RELEASE_TAG does not exist."
-            exit 1
-        fi
-    fi
-
 
     echo "Downloading ${DOWNLOAD_URL}..."
     if [ "$RADIUS_HTTP_REQUEST_CLI" == "curl" ]; then
@@ -150,20 +133,48 @@ downloadFile() {
     fi
 }
 
-installFile() {
-    local tmp_root_Radius_cli="$RADIUS_TMP_ROOT/$RADIUS_CLI_FILENAME"
+isReleaseAvailable() {
+    LATEST_RELEASE_TAG=$1
 
-    if [ ! -f "$tmp_root_Radius_cli" ]; then
-        echo "Failed to download Radius CLI executable."
+    RADIUS_CLI_ARTIFACT="${RADIUS_CLI_FILENAME}_${OS}_${ARCH}"
+    DOWNLOAD_BASE="https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download"
+    DOWNLOAD_URL="${DOWNLOAD_BASE}/${LATEST_RELEASE_TAG}/${RADIUS_CLI_ARTIFACT}"
+
+    if [ "$RADIUS_HTTP_REQUEST_CLI" == "curl" ]; then
+        httpstatus=$(curl -sSLI -o /dev/null -w "%{http_code}" "$DOWNLOAD_URL")
+        if [ "$httpstatus" == "200" ]; then
+            return 0
+        fi
+    else
+        wget -q --spider "$DOWNLOAD_URL"
+        exitstatus=$?
+        if [ $exitstatus -eq 0 ]; then
+            return 0
+        fi
+    fi
+    return 1
+}
+
+installFile() {
+    RADIUS_CLI_ARTIFACT="${RADIUS_CLI_FILENAME}_${OS}_${ARCH}"
+    local tmp_root_radius_cli="$RADIUS_TMP_ROOT/$RADIUS_CLI_ARTIFACT"
+
+    if [ ! -f "$tmp_root_radius_cli" ]; then
+        echo "Failed to unpack Radius CLI executable."
         exit 1
     fi
 
-    chmod a+x $tmp_root_Radius_cli
-    runAsRoot cp "$tmp_root_Radius_cli" "$RADIUS_INSTALL_DIR"
+    if [ -f "$RADIUS_CLI_FILE" ]; then
+        runAsRoot rm "$RADIUS_CLI_FILE"
+    fi
+    chmod o+x $tmp_root_radius_cli
+    mkdir -p $RADIUS_INSTALL_DIR
+    runAsRoot cp "$tmp_root_radius_cli" "$RADIUS_INSTALL_DIR"
+    runAsRoot mv "${RADIUS_INSTALL_DIR}/${RADIUS_CLI_ARTIFACT}" "${RADIUS_INSTALL_DIR}/${RADIUS_CLI_FILENAME}"
 
     if [ -f "$RADIUS_CLI_FILE" ]; then
-        echo "$RADIUS_CLI_FILENAME installed into $RADIUS_INSTALL_DIR successfully."
-        
+        echo "$RADIUS_CLI_FILENAME installed into $RADIUS_INSTALL_DIR successfully"
+
         echo "Installing rad-bicep (\"rad bicep download\")..."
         $RADIUS_CLI_FILE bicep download
         result=$?
@@ -198,7 +209,7 @@ cleanup() {
 }
 
 installCompleted() {
-    echo -e "\nTo get started with Radius, please visit https://radapp.dev/getting-started/"
+    echo -e "\nTo get started with Radius, please visit https://docs.radapp.io/getting-started/"
 }
 
 # -----------------------------------------------------------------------------
@@ -207,18 +218,17 @@ installCompleted() {
 trap "fail_trap" EXIT
 
 getSystemInfo
-verifySupported
-checkExistingRadius
 checkHttpRequestCLI
-
 
 if [ -z "$1" ]; then
     echo "Getting the latest Radius CLI..."
     getLatestRelease
 else
-    ret_val=$1
-    echo "Getting the Radius CLI release version: $1..."
+    ret_val=v$1
 fi
+
+verifySupported $ret_val
+checkExistingRadius
 
 echo "Installing $ret_val Radius CLI..."
 

--- a/docs/contributing/contributing-code/contributing-code-building/README.md
+++ b/docs/contributing/contributing-code/contributing-code-building/README.md
@@ -31,7 +31,7 @@ These commands assume you are already logged-in to the registry you are using. I
 Here's an example command that will push and push images to a specified registry:
 
 ```sh
-DOCKER_REGISTRY=myregistry.ghcr.io make docker-push docker-build
+DOCKER_REGISTRY=ghcr.io/my-registry make docker-push docker-build
 ```
 
 If you work with Radius frequently, you may want to define a shell variable as part of your profile to set your registry.

--- a/docs/contributing/contributing-code/contributing-code-control-plane/generating-and-installing-custom-build.md
+++ b/docs/contributing/contributing-code/contributing-code-control-plane/generating-and-installing-custom-build.md
@@ -16,7 +16,7 @@ Note that installing a custom build could corrupt existing data or installation.
 
 1. Set environment variables for your docker registry and docker tag version. 
     ```
-    export DOCKER_REGISTRY=your-registry.azurecr.io
+    export DOCKER_REGISTRY=ghcr.io/your-registry
     export DOCKER_IMAGE_TAG=latest
     ```
 
@@ -29,7 +29,7 @@ Note that installing a custom build could corrupt existing data or installation.
 
 4. Use the image from your container registry to install the Radius control plane.
     ```
-    rad install kubernetes --chart deploy/Chart/ --set rp.image=your-registry.azurecr.io/appcore-rp,rp.tag=latest,ucp.image=your-registry.azurecr.io/ucpd,ucp.tag=latest
+    rad install kubernetes --chart deploy/Chart/ --set rp.image=ghcr.io/your-registry/applications-rp,rp.tag=latest,ucp.image=ghcr.io/your-registry/ucpd,ucp.tag=latest
     ```
 
 5. Use `rad init` command to set up the Radius workspace, environment, credentials, and provider as needed.

--- a/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
+++ b/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
@@ -14,7 +14,7 @@ Radius consists of a few processes that get deployed inside a Kubernetes cluster
 
 The easiest way to get started is to launch Radius using VS Code. This will give you the ability to debug all of the processes. This workflow will run all of the Radius processes locally on your computer without containerizing them.
 
-> ⚠️ The debugging setup provided by these instructions **does NOT** share its database with an installed copy of Radius. It will use a separate namespace to store data. 
+> ⚠️ The debugging setup provided by these instructions **does NOT** share its database with an installed copy of Radius. It will use a separate namespace to store data.
 
 ## Endpoints
 
@@ -27,15 +27,14 @@ If you need to manually test APIs you can reach them at the following endpoints 
 
 ## Prerequisites
 
-1. Create a Kubernetes cluster, or set your current context to a cluster you want to use. The debug configuration will use your current cluster for storing data. 
-2. Clone the `radius-project/radius` and `radius-project/deployment-engine` repo next to each other. 
-3. Run `git submodule update --init` in the `deployment-engine` repo
-4. Install .NET 6.0 SDK - https://dotnet.microsoft.com/en-us/download/dotnet/6.0
-5. Install C# VS Code extension - https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp
-6. (Optional) Configure any cloud provider credentials you want to use for developing Radius. 
+1. Create a Kubernetes cluster, or set your current context to a cluster you want to use. The debug configuration will use your current cluster for storing data.
+2. Clone the `radius-project/radius` and `radius-project/deployment-engine` repo next to each other.
+3. Run `git submodule update --init` in the `deployment-engine` repo.
+4. Install .NET 6.0 SDK - <https://dotnet.microsoft.com/en-us/download/dotnet/6.0>.
+5. Install C# VS Code extension - <https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp>.
+6. (Optional) Configure any cloud provider credentials you want to use for developing Radius.
   
 > 💡 The Bicep deployment engine uses .NET. However you don't need to know C# or .NET to develop locally with Radius.
-
 > 💡 Radius will use your locally configured Azure or AWS credentials. If you are able to use the `az` or `aws` CLI then you don't need to do any additional setup.
 
 ## Setup Step 1: Run `rad init`

--- a/docs/contributing/contributing-code/contributing-code-organization/README.md
+++ b/docs/contributing/contributing-code/contributing-code-organization/README.md
@@ -28,6 +28,7 @@ In general you should ask for guidance before creating a new top-level folder in
 | `aws/`                 | Utility code and library integrations for working with AWS                              |
 | `azure/`               | Utility code and library integrations for working with Azure                            |
 | `cli/`                 | Implementation code for the `rad` CLI                                                   |
+| `controllers/`         | Kubernetes controllers for Radius                                                       |
 | `corerp/`              | Resource Provider implementation for `Applications.Core` resources                      |
 | `daprrp/`              | Resource Provider implementation for `Applications.Dapr` resources                      |
 | `datastoresrp/`        | Resource Provider implementation for `Applications.Datastores` resources                |

--- a/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
+++ b/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
@@ -38,9 +38,9 @@ As much as possible, the tests use product functionality such as the Radius CLI 
 
 1. Place `rad` on your path
 2. Make sure `rad-bicep` is downloaded (`rad bicep download`)
-3. Create a container registry (must be Azure Container Registry for now)
-4. Log-in to the container registry `az acr login -n <registry-name>`
-5. Publish Bicep test recipes by running `BICEP_RECIPE_REGISTRY=<registry-name>.azurecr.io make publish-test-bicep-recipes`
+3. Create a container registry
+4. Log-in to the container registry
+5. Publish Bicep test recipes by running `BICEP_RECIPE_REGISTRY=<registry-name> make publish-test-bicep-recipes`
 6. Publish Terraform test recipes by running `make publish-test-terraform-recipes`
 7. Create a Radius Environment with `rad init` and specify the default namespace
 

--- a/docs/contributing/contributing-code/contributing-code-tests/testing-local.md
+++ b/docs/contributing/contributing-code/contributing-code-tests/testing-local.md
@@ -8,7 +8,7 @@ Note, this only applies when we want to update the app core image, if we need to
 
 1. Set the environment variable DOCKER_REGISTRY set to the container registry
     ```
-    export DOCKER_REGISTRY=<registry>.azurecr.io
+    export DOCKER_REGISTRY=ghcr.io/your-registry
     ```
 1. Ensure you login to your container registry AND enable anonymous pull. The login command will need to be called every 3 hours as needed as it does log the user out frequently.
     ```
@@ -21,7 +21,7 @@ Note, this only applies when we want to update the app core image, if we need to
     ```
 1. Deploy an environment with command on kubernetes
     ```
-    go run ./cmd/rad/main.go install kubernetes --chart deploy/Chart --set rp.image=<registry>.azurecr.io/applications-rp,rp.tag=latest,ucp.image=<registry>.azurecr.io/ucpd,ucp.tag=latest
+    go run ./cmd/rad/main.go install kubernetes --chart deploy/Chart --set rp.image=ghcr.io/your-registry/applications-rp,rp.tag=latest,ucp.image=ghcr.io/your-registry/ucpd,ucp.tag=latest
     go run ./cmd/rad/main.go workspace create kubernetes
     go run ./cmd/rad/main.go group create radius-rg
     go run ./cmd/rad/main.go switch radius-rg
@@ -48,7 +48,7 @@ The above steps will not configure the ability for Radius to talk with azure res
     ```
 1. Use these values in the following command:
     ```
-    go run ./cmd/rad/main.go install kubernetes --chart deploy/Chart --set rp.image=<registry>.azurecr.io/applications-rp,rp.tag=latest,ucp.image=<registry>.azurecr.io/ucpd,ucp.tag=latest
+    go run ./cmd/rad/main.go install kubernetes --chart deploy/Chart --set rp.image=ghcr.io/your-registry/applications-rp,rp.tag=latest,ucp.image=ghcr.io/your-registry/ucpd,ucp.tag=latest
     go run ./cmd/rad/main.go workspace create kubernetes
     go run ./cmd/rad/main.go group create radius-rg
     go run ./cmd/rad/main.go switch radius-rg

--- a/docs/release-notes/v0.26.0.md
+++ b/docs/release-notes/v0.26.0.md
@@ -1,0 +1,98 @@
+## Announcing Radius v0.26.0
+
+Today we're happy to announce the release of Radius v0.26.0. Check out the [highlights](#highlights) below, along with the [full changelog](#full-changelog) for more details.
+
+We would like to extend our thanks to all the [new](#new-contributors) and existing contributors who helped make this release possible!
+
+## Intro to Radius
+
+If you're new to Radius, check out our website, [radapp.dev](https://radapp.dev), for more information. Also visit our [getting started guide](https://docs.radapp.dev/getting-started/) to learn how to install Radius and create your first app.
+
+## Highlights
+
+### New logo
+
+Radius has a new logo! Stay tuned as we work to roll this out to our websites, docs, and repos.
+
+![image](https://github.com/radius-project/radius/assets/54363786/177bc882-7279-4b0b-90f9-a3a61fc00235)
+
+### Updated API version
+
+All Radius resource types now use the API version `2023-10-01-preview`. Please find-and-replace all existing `2022-03-15-privatepreview` strings to the new API version.
+
+## Breaking changes
+
+All Radius resource types have been updated with the API version `2023-10-01-preview`. All apps need to be updated with the new version.
+
+## New contributors
+
+Welcome to our new contributors who have merged their first PR in this release!
+
+* @nicolejms made their first contribution in https://github.com/radius-project/radius/pull/6274
+* @jonvsm made their first contribution in https://github.com/radius-project/radius/pull/6435
+* @Reshrahim made their first contribution in https://github.com/radius-project/radius/pull/6445
+
+## Upgrading to Radius v0.26.0
+
+During our preview stage, an upgrade to Radius v0.26.0 requires a full reinstallation of the Radius control-plane, rad CLI, and all Radius apps. Stay tuned for an in-place upgrade path in the future.
+
+1. Delete any environments you have created:
+   ```bash
+   rad env delete <env-name>
+   ```
+1. Uninstall the previous version of the Radius control-plane:
+   ```bash
+   rad uninstall kubernetes
+   ```
+1. Visit the [Radius installation guide](https://docs.radapp.dev/getting-started/install/) to install the latest CLI, or download a binary below
+1. Install the latest version of the Radius control-plane:
+   ```bash
+   rad install kubernetes
+   ```
+
+## Full changelog
+
+* Add new release documentation and release verification workflow by @willdavsmith in https://github.com/radius-project/radius/pull/6113
+* Release v0.25.0 by @kachawla in https://github.com/radius-project/radius/pull/6270
+* Add code review documentation by @rynowak in https://github.com/radius-project/radius/pull/6250
+* Update release verification workflow by @willdavsmith in https://github.com/radius-project/radius/pull/6268
+* add recipe failure error message by @nithyatsu in https://github.com/radius-project/radius/pull/6276
+* Update Release Verification Workflow Link by @kachawla in https://github.com/radius-project/radius/pull/6272
+* Update error message for missing application by @AaronCrawfis in https://github.com/radius-project/radius/pull/6281
+* Removing TF secret prefix by @sk593 in https://github.com/radius-project/radius/pull/6273
+* Refactoring unmarshal time string by @sk593 in https://github.com/radius-project/radius/pull/6330
+* Fix flaky test: Test_Render_Multiple_Routes by @willdavsmith in https://github.com/radius-project/radius/pull/6333
+* Update apiversion to 2023-10-01-preview by @vinayada1 in https://github.com/radius-project/radius/pull/6332
+* Update codeowners by @AaronCrawfis in https://github.com/radius-project/radius/pull/6117
+* Fixing CodeQL Warnings by @ytimocin in https://github.com/radius-project/radius/pull/6277
+* Update check for application in manual processing of Dapr Components by @lakshmimsft in https://github.com/radius-project/radius/pull/6282
+* Remove temp change to not run samples tests due to dependency on updated API version by @vinayada1 in https://github.com/radius-project/radius/pull/6347
+* Add AWS creation timestamp to test resources by @willdavsmith in https://github.com/radius-project/radius/pull/6262
+* Switch Bicep Recipe deletion logic from sequential to parallel and add retries by @willdavsmith in https://github.com/radius-project/radius/pull/6256
+* Increase timeouts for DatastoresRP resources by @willdavsmith in https://github.com/radius-project/radius/pull/6348
+* `rad deploy`: remove environment validation if `--environment` is not set by @willdavsmith in https://github.com/radius-project/radius/pull/6351
+* Fix 500 panic when generated Kubernetes namespace is too long by @willdavsmith in https://github.com/radius-project/radius/pull/6349
+* Add `--runtime-version` to functional test Dapr install by @willdavsmith in https://github.com/radius-project/radius/pull/6278
+* Add triage process document by @nicolejms in https://github.com/radius-project/radius/pull/6274
+* Moving constants for resourcetypes defined in portableresources package to their respective packages by @lakshmimsft in https://github.com/radius-project/radius/pull/6343
+* Replace `radius.dev` and some instances of `radapp.dev` with `radapp.io` by @willdavsmith in https://github.com/radius-project/radius/pull/6357
+* Add Kubernetes controller plumbing by @rynowak in https://github.com/radius-project/radius/pull/6418
+* Updates to the generic resource client by @rynowak in https://github.com/radius-project/radius/pull/6421
+* Add 'manual' provisioning to containers by @rynowak in https://github.com/radius-project/radius/pull/6423
+* Adding ApplicationGraphResource model API TypeSpec by @nithyatsu in https://github.com/radius-project/radius/pull/6425
+* Add queuemessages to ucp rbac by @vinayada1 in https://github.com/radius-project/radius/pull/6427
+* Fix `rad group show` and `rad group list` by @AaronCrawfis in https://github.com/radius-project/radius/pull/6252
+* Increase `maxOperationConcurrency`: 3 -> 10 by @willdavsmith in https://github.com/radius-project/radius/pull/6433
+* Skip Terraform recipe deletion if Terraform state backend does not exist by @kachawla in https://github.com/radius-project/radius/pull/6437
+* Add recipe controller by @rynowak in https://github.com/radius-project/radius/pull/6438
+* Populate terraform resource ids to recipe response by @vishwahiremat in https://github.com/radius-project/radius/pull/6430
+* Update GitHub SUPPORT.md to point to Radius Discord server by @jonvsm in https://github.com/radius-project/radius/pull/6435
+* Update `rad bicep` to pull binaries from GHCR by @sk593 in https://github.com/radius-project/radius/pull/6426
+* Update path to app.bicep in tutorial_test.go by @lakshmimsft in https://github.com/radius-project/radius/pull/6449
+* Fix rad recipe show example by @kachawla in https://github.com/radius-project/radius/pull/6453
+* Create unique directory for every TF recipe operation by @kachawla in https://github.com/radius-project/radius/pull/6452
+* Ensure consistent casing convention. by @Reshrahim in https://github.com/radius-project/radius/pull/6445
+* Release 0.26: RC release candidate  by @sk593 in https://github.com/radius-project/radius/pull/6455
+* Mock env to deploy without actually creating resources by @vinayada1 in https://github.com/radius-project/radius/pull/6424
+
+**Full Changelog**: https://github.com/radius-project/radius/compare/v0.25.0...v0.26.0

--- a/docs/release-notes/v0.26.4.md
+++ b/docs/release-notes/v0.26.4.md
@@ -1,0 +1,23 @@
+## Radius v0.26.4
+
+This release fully switches us to Github assets in preparation for open-sourcing. Check out the [changelog](#changelog) for more details of what was addressed in this patch.
+
+## Changelog
+
+* Release 0.26.0 by @sk593 in https://github.com/radius-project/radius/pull/6458
+* Release 0.26.1 by @sk593 in https://github.com/radius-project/radius/pull/6460
+* Pagination causing Dev Recipes to not be installed and Controller Pod permission fix by @ytimocin in https://github.com/radius-project/radius/pull/6466
+* patch release v0.26.2 by @sk593 in https://github.com/radius-project/radius/pull/6470
+* Handle 404 as success in recipe deletion by @willdavsmith in https://github.com/radius-project/radius/pull/6467
+* Update release v0.26.3 by @sk593 in https://github.com/radius-project/radius/pull/6475
+* Add Deployment reconciler by @rynowak in https://github.com/radius-project/radius/pull/6444
+* Make application and environment configurable by @rynowak in https://github.com/radius-project/radius/pull/6480
+* Add functional test for Kubernetes interop by @rynowak in https://github.com/radius-project/radius/pull/6488
+* Add `graph` alias for `rad app connections` by @AaronCrawfis in https://github.com/radius-project/radius/pull/6489
+* Update README.md by @jonvsm in https://github.com/radius-project/radius/pull/6482
+* Fix errata in Kubernetes controllers by @rynowak in https://github.com/radius-project/radius/pull/6494
+* Migrate to GHCR by @willdavsmith in https://github.com/radius-project/radius/pull/6478
+* Update installation scripts by @sk593 in https://github.com/radius-project/radius/pull/6495
+* Add `ok-to-test` trigger for functional tests by @willdavsmith in https://github.com/radius-project/radius/pull/6481
+
+**Full Changelog**: https://github.com/radius-project/radius/compare/v0.26.0...v0.26.4

--- a/docs/release-notes/v0.26.5.md
+++ b/docs/release-notes/v0.26.5.md
@@ -1,0 +1,11 @@
+## Radius v0.26.5
+
+This release addresses a CI/CD issue. Check out the [changelog](#changelog) for more details of what was addressed in this patch.
+
+## Changelog
+
+* Update release build by @sk593 in https://github.com/radius-project/radius/pull/6504
+
+**Full Changelog**: https://github.com/radius-project/radius/compare/v0.26.0...v0.26.5
+
+

--- a/docs/release-notes/v0.26.6.md
+++ b/docs/release-notes/v0.26.6.md
@@ -1,0 +1,11 @@
+## Radius v0.26.6
+
+This release addresses a recipe issue. Check out the [changelog](#changelog) for more details of what was addressed in this patch.
+
+## Changelog
+
+* Hard code dev recipes by @ytimocin in https://github.com/radius-project/radius/pull/6507
+
+**Full Changelog**: https://github.com/radius-project/radius/compare/v0.26.5...v0.26.6
+
+

--- a/docs/release-notes/v0.26.7.md
+++ b/docs/release-notes/v0.26.7.md
@@ -1,0 +1,10 @@
+## Radius v0.26.7
+
+This release addresses an issue with the Radius Kubernetes controller. Check out the [changelog](#changelog) for more details of what was addressed in this patch.
+
+## Changelog
+
+* Fix double-encoding of Kubernetes secrets by @rynowak in https://github.com/radius-project/radius/pull/6541
+
+**Full Changelog**: https://github.com/radius-project/radius/compare/v0.26.6...v0.26.7
+

--- a/pkg/cli/clients/errors.go
+++ b/pkg/cli/clients/errors.go
@@ -19,6 +19,7 @@ package clients
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
@@ -28,8 +29,10 @@ import (
 // Is404Error returns true if the error is a 404 payload from an autorest operation.
 //
 
-// "Is404Error" checks if the given error is a 404 error by checking if it is a ResponseError with an ErrorCode of
-// "NotFound" or an ErrorResponse with an Error Code of "NotFound".
+// "Is404Error" checks if the given error is a 404 error by checking if it is one of:
+// a ResponseError with an ErrorCode of "NotFound", or
+// a ResponseError with a StatusCode of 404, or
+// an ErrorResponse with an Error Code of "NotFound".
 func Is404Error(err error) bool {
 	if err == nil {
 		return false
@@ -37,7 +40,7 @@ func Is404Error(err error) bool {
 
 	// The error might already be an ResponseError
 	responseError := &azcore.ResponseError{}
-	if errors.As(err, &responseError) && responseError.ErrorCode == v1.CodeNotFound {
+	if errors.As(err, &responseError) && responseError.ErrorCode == v1.CodeNotFound || responseError.StatusCode == http.StatusNotFound {
 		return true
 	} else if errors.As(err, &responseError) {
 		return false

--- a/pkg/cli/clients/errors_test.go
+++ b/pkg/cli/clients/errors_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clients
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+)
+
+func TestIs404Error(t *testing.T) {
+	var err error
+
+	// Test with a ResponseError with an ErrorCode of "NotFound"
+	err = &azcore.ResponseError{ErrorCode: v1.CodeNotFound}
+	if !Is404Error(err) {
+		t.Errorf("Expected Is404Error to return true for ResponseError with ErrorCode of 'NotFound', but it returned false")
+	}
+
+	// Test with a ResponseError with a StatusCode of 404
+	err = &azcore.ResponseError{StatusCode: http.StatusNotFound}
+	if !Is404Error(err) {
+		t.Errorf("Expected Is404Error to return true for ResponseError with StatusCode of 404, but it returned false")
+	}
+
+	// Test with an ErrorResponse with an Error Code of "NotFound"
+	err = errors.New(`{"error": {"code": "NotFound"}}`)
+	if !Is404Error(err) {
+		t.Errorf("Expected Is404Error to return true for ErrorResponse with Error Code of 'NotFound', but it returned false")
+	}
+
+	// Test with an ErrorResponse with a different Error Code
+	err = errors.New(`{"error": {"code": "SomeOtherCode"}}`)
+	if Is404Error(err) {
+		t.Errorf("Expected Is404Error to return false for ErrorResponse with Error Code of 'SomeOtherCode', but it returned true")
+	}
+
+	// Test with a different error type
+	err = errors.New("Some other error")
+	if Is404Error(err) {
+		t.Errorf("Expected Is404Error to return false for error of type %T, but it returned true", err)
+	}
+
+	// Test with a nil error
+	if Is404Error(nil) {
+		t.Errorf("Expected Is404Error to return false for nil error, but it returned true")
+	}
+}

--- a/pkg/cli/cmd/app/connections/connections.go
+++ b/pkg/cli/cmd/app/connections/connections.go
@@ -24,10 +24,11 @@ import (
 func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	runner := NewRunner(factory)
 	cmd := &cobra.Command{
-		Use:   "connections",
-		Short: "Shows the connections for an application.",
-		Long:  `Shows the connections for an application`,
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "connections",
+		Aliases: []string{"graph"},
+		Short:   "Shows the connections for an application.",
+		Long:    `Shows the connections for an application`,
+		Args:    cobra.MaximumNArgs(1),
 		Example: `
 # Show connections for current application
 rad app connections

--- a/pkg/cli/cmd/bicep/publish/publish.go
+++ b/pkg/cli/cmd/bicep/publish/publish.go
@@ -70,8 +70,8 @@ Before publishing, it is expected the user runs docker login (or similar command
 For more information on Bicep modules visit https://learn.microsoft.com/azure/azure-resource-manager/bicep/modules
 		`,
 		Example: `
-# Publish a Bicep file to an Azure container registry
-rad bicep publish --file ./redis-test.bicep --target br:myregistry.azurecr.io/redis-test:v1
+# Publish a Bicep file to a container registry
+rad bicep publish --file ./redis-test.bicep --target br:ghcr.io/myregistry/redis-test:v1
 		`,
 		Args: cobra.ExactArgs(0),
 		RunE: framework.RunCommand(runner),

--- a/pkg/cli/cmd/bicep/publish/publish_test.go
+++ b/pkg/cli/cmd/bicep/publish/publish_test.go
@@ -48,13 +48,13 @@ func TestRunner_extractDestination(t *testing.T) {
 		},
 		{
 			name:    "no tag",
-			target:  "test.azurecr.io/test/repo",
+			target:  "ghcr.io/test-registry/test/repo",
 			want:    nil,
 			wantErr: true,
 		},
 		{
 			name:    "no repo",
-			target:  "test.azurecr.io",
+			target:  "ghcr.io/test-registry",
 			want:    nil,
 			wantErr: true,
 		},
@@ -268,7 +268,7 @@ func TestRunner_Validate(t *testing.T) {
 				"--file",
 				"redis.recipe.bicep",
 				"--target",
-				"br:test.azurecr.io/test/repo:tag",
+				"br:ghcr.io/test-registry/test/repo:tag",
 			},
 			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
@@ -281,7 +281,7 @@ func TestRunner_Validate(t *testing.T) {
 				"--file",
 				"redis.recipe.bicep",
 				"--target",
-				"test.azurecr.io/test/repo:tag",
+				"ghcr.io/test-registry/test/repo:tag",
 			},
 			ExpectedValid: false,
 			ConfigHolder: framework.ConfigHolder{

--- a/pkg/cli/cmd/radinit/init_test.go
+++ b/pkg/cli/cmd/radinit/init_test.go
@@ -595,7 +595,7 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 				"Applications.Datastores/redisCaches": {
 					"default": &corerp.BicepRecipeProperties{
 						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-						TemplatePath: to.Ptr("radiusdev.azurecr.io/redis:latest"),
+						TemplatePath: to.Ptr("ghcr.io/radius-project/dev/redis:latest"),
 					},
 				},
 			},

--- a/pkg/cli/cmd/radinit/recipe.go
+++ b/pkg/cli/cmd/radinit/recipe.go
@@ -131,13 +131,13 @@ func (drc *devRecipeClient) GetDevRecipes(ctx context.Context) (map[string]map[s
 		"Applications.Dapr/secretStores": {
 			"default": &corerp.BicepRecipeProperties{
 				TemplateKind: to.Ptr(recipe_types.TemplateKindBicep),
-				TemplatePath: to.Ptr(fmt.Sprintf("ghcr.io/radius-project/recipes/local-dev/secretStores:%s", tag)),
+				TemplatePath: to.Ptr(fmt.Sprintf("ghcr.io/radius-project/recipes/local-dev/secretstores:%s", tag)),
 			},
 		},
 		"Applications.Dapr/stateStores": {
 			"default": &corerp.BicepRecipeProperties{
 				TemplateKind: to.Ptr(recipe_types.TemplateKindBicep),
-				TemplatePath: to.Ptr(fmt.Sprintf("ghcr.io/radius-project/recipes/local-dev/stateStores:%s", tag)),
+				TemplatePath: to.Ptr(fmt.Sprintf("ghcr.io/radius-project/recipes/local-dev/statestores:%s", tag)),
 			},
 		},
 		"Applications.Datastores/mongoDatabases": {

--- a/pkg/cli/cmd/radinit/recipe.go
+++ b/pkg/cli/cmd/radinit/recipe.go
@@ -29,11 +29,10 @@ import (
 	recipe_types "github.com/radius-project/radius/pkg/recipes"
 	"github.com/radius-project/radius/pkg/to"
 	"github.com/radius-project/radius/pkg/version"
-	"oras.land/oras-go/v2/registry/remote"
 )
 
 const (
-	DevRecipesRegistry = "ghcr.io/radius-project"
+	DevRecipesRegistry = "ghcr.io"
 )
 
 //go:generate mockgen -destination=./mock_devrecipeclient.go -package=radinit -self_package github.com/radius-project/radius/pkg/cli/cmd/radinit github.com/radius-project/radius/pkg/cli/cmd/radinit DevRecipeClient
@@ -52,10 +51,10 @@ func NewDevRecipeClient() DevRecipeClient {
 // GetDevRecipes is a function that queries a registry for recipes with a specific tag and returns a map of recipes.
 // If an error occurs, an error is returned.
 func (drc *devRecipeClient) GetDevRecipes(ctx context.Context) (map[string]map[string]corerp.RecipePropertiesClassification, error) {
-	reg, err := remote.NewRegistry(DevRecipesRegistry)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create client to registry %s -  %s", DevRecipesRegistry, err.Error())
-	}
+	// reg, err := remote.NewRegistry(DevRecipesRegistry)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("failed to create client to registry %s -  %s", DevRecipesRegistry, err.Error())
+	// }
 
 	// The tag will be the major.minor version of the release.
 	tag := version.Channel()
@@ -68,90 +67,135 @@ func (drc *devRecipeClient) GetDevRecipes(ctx context.Context) (map[string]map[s
 	// We have 104 repositories in the registry as of 12 Oct 2023. That is why processRepositories
 	// function was being called twice and the second call was overwriting all the recipes.
 	// TODO: Remove this once we have a better solution.
-	reg.RepositoryListPageSize = 1000
+	// reg.RepositoryListPageSize = 1000
 
-	recipes := map[string]map[string]corerp.RecipePropertiesClassification{}
+	// recipes := map[string]map[string]corerp.RecipePropertiesClassification{}
 
-	// if repository has the correct path it should look like: <registryPath>/recipes/<category>/<type>:<tag>
-	// Ex: ghcr.io/radius-project/recipes/local-dev/rediscaches:0.20
-	// The start parameter is set to "radius-rp" because our recipes are after that repository.
-	err = reg.Repositories(ctx, "", func(repos []string) error {
-		// validRepos will contain the repositories that have the requested tag.
-		validRepos := []string{}
-		for _, repo := range repos {
-			r, err := reg.Repository(ctx, repo)
-			if err != nil {
-				continue
-			}
+	// // if repository has the correct path it should look like: <registryPath>/recipes/<category>/<type>:<tag>
+	// // Ex: ghcr.io/radius-project/recipes/local-dev/rediscaches:0.20
+	// // The start parameter is set to "radius-rp" because our recipes are after that repository.
+	// err = reg.Repositories(ctx, "radius-project", func(repos []string) error {
+	// 	// validRepos will contain the repositories that have the requested tag.
+	// 	validRepos := []string{}
+	// 	for _, repo := range repos {
+	// 		r, err := reg.Repository(ctx, repo)
+	// 		if err != nil {
+	// 			continue
+	// 		}
 
-			tagExists := false
-			err = r.Tags(ctx, "", func(tags []string) error {
-				for _, t := range tags {
-					if t == tag {
-						tagExists = true
-						break
-					}
-				}
-				return nil
-			})
-			if err != nil {
-				continue
-			}
+	// 		tagExists := false
+	// 		err = r.Tags(ctx, "", func(tags []string) error {
+	// 			for _, t := range tags {
+	// 				if t == tag {
+	// 					tagExists = true
+	// 					break
+	// 				}
+	// 			}
+	// 			return nil
+	// 		})
+	// 		if err != nil {
+	// 			continue
+	// 		}
 
-			if tagExists {
-				validRepos = append(validRepos, repo)
-			}
-		}
+	// 		if tagExists {
+	// 			validRepos = append(validRepos, repo)
+	// 		}
+	// 	}
 
-		recipes = processRepositories(validRepos, tag)
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list recipes available in registry at path  %s -  %s", DevRecipesRegistry, err.Error())
+	// 	recipes = processRepositories(validRepos, tag)
+	// 	return nil
+	// })
+	// if err != nil {
+	// 	return nil, fmt.Errorf("failed to list recipes available in registry at path  %s -  %s", DevRecipesRegistry, err.Error())
+	// }
+
+	recipes := map[string]map[string]corerp.RecipePropertiesClassification{
+		"Applications.Datastores/sqlDatabases": {
+			"default": &corerp.BicepRecipeProperties{
+				TemplateKind: to.Ptr(recipe_types.TemplateKindBicep),
+				TemplatePath: to.Ptr(fmt.Sprintf("ghcr.io/radius-project/recipes/local-dev/sqldatabases:%s", tag)),
+			},
+		},
+		"Applications.Messaging/rabbitMQQueues": {
+			"default": &corerp.BicepRecipeProperties{
+				TemplateKind: to.Ptr(recipe_types.TemplateKindBicep),
+				TemplatePath: to.Ptr(fmt.Sprintf("ghcr.io/radius-project/recipes/local-dev/rabbitmqqueues:%s", tag)),
+			},
+		},
+		"Applications.Dapr/pubSubBrokers": {
+			"default": &corerp.BicepRecipeProperties{
+				TemplateKind: to.Ptr(recipe_types.TemplateKindBicep),
+				TemplatePath: to.Ptr(fmt.Sprintf("ghcr.io/radius-project/recipes/local-dev/pubsubbrokers:%s", tag)),
+			},
+		},
+		"Applications.Dapr/secretStores": {
+			"default": &corerp.BicepRecipeProperties{
+				TemplateKind: to.Ptr(recipe_types.TemplateKindBicep),
+				TemplatePath: to.Ptr(fmt.Sprintf("ghcr.io/radius-project/recipes/local-dev/secretStores:%s", tag)),
+			},
+		},
+		"Applications.Dapr/stateStores": {
+			"default": &corerp.BicepRecipeProperties{
+				TemplateKind: to.Ptr(recipe_types.TemplateKindBicep),
+				TemplatePath: to.Ptr(fmt.Sprintf("ghcr.io/radius-project/recipes/local-dev/stateStores:%s", tag)),
+			},
+		},
+		"Applications.Datastores/mongoDatabases": {
+			"default": &corerp.BicepRecipeProperties{
+				TemplateKind: to.Ptr(recipe_types.TemplateKindBicep),
+				TemplatePath: to.Ptr(fmt.Sprintf("ghcr.io/radius-project/recipes/local-dev/mongodatabases:%s", tag)),
+			},
+		},
+		"Applications.Datastores/redisCaches": {
+			"default": &corerp.BicepRecipeProperties{
+				TemplateKind: to.Ptr(recipe_types.TemplateKindBicep),
+				TemplatePath: to.Ptr(fmt.Sprintf("ghcr.io/radius-project/recipes/local-dev/rediscaches:%s", tag)),
+			},
+		},
 	}
 
 	return recipes, nil
 }
 
 // processRepositories processes the repositories and returns the recipes.
-func processRepositories(repos []string, tag string) map[string]map[string]corerp.RecipePropertiesClassification {
-	recipes := map[string]map[string]corerp.RecipePropertiesClassification{}
+// func processRepositories(repos []string, tag string) map[string]map[string]corerp.RecipePropertiesClassification {
+// 	recipes := map[string]map[string]corerp.RecipePropertiesClassification{}
 
-	// We are using the default recipe.
-	name := "default"
+// 	// We are using the default recipe.
+// 	name := "default"
 
-	for _, repo := range repos {
-		// Skip dev environment recipes.
-		// dev repositories is in the form of ghcr.io/radius-project/dev/recipes/local-dev/secretstores:latest
-		// We should skip the dev repositories.
-		if isDevRepository(repo) {
-			continue
-		}
+// 	for _, repo := range repos {
+// 		// Skip dev environment recipes.
+// 		// dev repositories is in the form of ghcr.io/radius-project/dev/recipes/local-dev/secretstores:latest
+// 		// We should skip the dev repositories.
+// 		if isDevRepository(repo) {
+// 			continue
+// 		}
 
-		resourceType := getResourceTypeFromPath(repo)
-		// If the resource type is empty, it means we don't support the repository.
-		if resourceType == "" {
-			continue
-		}
+// 		resourceType := getResourceTypeFromPath(repo)
+// 		// If the resource type is empty, it means we don't support the repository.
+// 		if resourceType == "" {
+// 			continue
+// 		}
 
-		portableResourceType := getPortableResourceType(resourceType)
-		// If the PortableResource type is empty, it means we don't support the resource type.
-		if portableResourceType == "" {
-			continue
-		}
+// 		portableResourceType := getPortableResourceType(resourceType)
+// 		// If the PortableResource type is empty, it means we don't support the resource type.
+// 		if portableResourceType == "" {
+// 			continue
+// 		}
 
-		repoPath := DevRecipesRegistry + "/" + repo
+// 		repoPath := DevRecipesRegistry + "/" + repo
 
-		recipes[portableResourceType] = map[string]corerp.RecipePropertiesClassification{
-			name: &corerp.BicepRecipeProperties{
-				TemplateKind: to.Ptr(recipe_types.TemplateKindBicep),
-				TemplatePath: to.Ptr(repoPath + ":" + tag),
-			},
-		}
-	}
+// 		recipes[portableResourceType] = map[string]corerp.RecipePropertiesClassification{
+// 			name: &corerp.BicepRecipeProperties{
+// 				TemplateKind: to.Ptr(recipe_types.TemplateKindBicep),
+// 				TemplatePath: to.Ptr(repoPath + ":" + tag),
+// 			},
+// 		}
+// 	}
 
-	return recipes
-}
+// 	return recipes
+// }
 
 // getResourceTypeFromPath parses the repository path to extract the resource type.
 //

--- a/pkg/cli/cmd/radinit/recipe.go
+++ b/pkg/cli/cmd/radinit/recipe.go
@@ -63,11 +63,19 @@ func (drc *devRecipeClient) GetDevRecipes(ctx context.Context) (map[string]map[s
 		tag = "latest"
 	}
 
+	// Temporary solution to get all repositories.
+	// The issue is that if RepositoryListPageSize is not specified the default is 100.
+	// We have 104 repositories in the registry as of 12 Oct 2023. That is why processRepositories
+	// function was being called twice and the second call was overwriting all the recipes.
+	// TODO: Remove this once we have a better solution.
+	reg.RepositoryListPageSize = 1000
+
 	recipes := map[string]map[string]corerp.RecipePropertiesClassification{}
 
 	// if repository has the correct path it should look like: <registryPath>/recipes/<category>/<type>:<tag>
 	// Ex: radius.azurecr.io/recipes/local-dev/rediscaches:0.20
-	err = reg.Repositories(ctx, "", func(repos []string) error {
+	// The start parameter is set to "radius-rp" because our recipes are after that repository.
+	err = reg.Repositories(ctx, "radius-rp", func(repos []string) error {
 		// validRepos will contain the repositories that have the requested tag.
 		validRepos := []string{}
 		for _, repo := range repos {

--- a/pkg/cli/cmd/radinit/recipe_test.go
+++ b/pkg/cli/cmd/radinit/recipe_test.go
@@ -198,12 +198,62 @@ func Test_processRepositories(t *testing.T) {
 				},
 			},
 		},
+		{
+			"Valid Prod and Dev Repositories with Redis Cache, Mongo Database",
+			[]string{
+				"recipes/local-dev/rediscaches",
+				"recipes/local-dev/mongodatabases",
+				"dev/recipes/local-dev/rediscaches",
+				"dev/recipes/local-dev/mongodatabases",
+			},
+			"latest",
+			map[string]map[string]corerp.RecipePropertiesClassification{
+				"Applications.Datastores/redisCaches": {
+					"default": &corerp.BicepRecipeProperties{
+						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
+						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/rediscaches:latest", DevRecipesRegistry)),
+					},
+				},
+				"Applications.Datastores/mongoDatabases": {
+					"default": &corerp.BicepRecipeProperties{
+						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
+						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/mongodatabases:latest", DevRecipesRegistry)),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := processRepositories(tt.repos, tt.tag); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("processRepositories() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isDevRepository(t *testing.T) {
+	tests := []struct {
+		name string
+		repo string
+		want bool
+	}{
+		{
+			"Dev Repository",
+			"dev/recipes/local-dev/rediscaches",
+			true,
+		},
+		{
+			"Prod Repository",
+			"recipes/local-dev/rediscaches",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDevRepository(tt.repo); got != tt.want {
+				t.Errorf("isDevRepository() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/cli/cmd/radinit/recipe_test.go
+++ b/pkg/cli/cmd/radinit/recipe_test.go
@@ -17,13 +17,8 @@ limitations under the License.
 package radinit
 
 import (
-	"fmt"
-	reflect "reflect"
 	"testing"
 
-	corerp "github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
-	"github.com/radius-project/radius/pkg/recipes"
-	"github.com/radius-project/radius/pkg/to"
 	"github.com/stretchr/testify/require"
 )
 
@@ -129,109 +124,109 @@ func Test_getPortableResourceType(t *testing.T) {
 	}
 }
 
-func Test_processRepositories(t *testing.T) {
-	tests := []struct {
-		name  string
-		repos []string
-		tag   string
-		want  map[string]map[string]corerp.RecipePropertiesClassification
-	}{
-		{
-			"Valid Repository with Redis Cache",
-			[]string{
-				"recipes/local-dev/rediscaches",
-			},
-			"0.20",
-			map[string]map[string]corerp.RecipePropertiesClassification{
-				"Applications.Datastores/redisCaches": {
-					"default": &corerp.BicepRecipeProperties{
-						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/rediscaches:0.20", DevRecipesRegistry)),
-					},
-				},
-			},
-		},
-		{
-			"Valid Repository with Redis Cache and Mongo Database",
-			[]string{
-				"recipes/local-dev/rediscaches",
-				"recipes/local-dev/mongodatabases",
-			},
-			"0.20",
-			map[string]map[string]corerp.RecipePropertiesClassification{
-				"Applications.Datastores/redisCaches": {
-					"default": &corerp.BicepRecipeProperties{
-						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/rediscaches:0.20", DevRecipesRegistry)),
-					},
-				},
-				"Applications.Datastores/mongoDatabases": {
-					"default": &corerp.BicepRecipeProperties{
-						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/mongodatabases:0.20", DevRecipesRegistry)),
-					},
-				},
-			},
-		},
-		{
-			"Valid Repository with Redis Cache, Mongo Database, and an unsupported type",
-			[]string{
-				"recipes/local-dev/rediscaches",
-				"recipes/local-dev/mongodatabases",
-				"recipes/local-dev/unsupported",
-				"recipes/unsupported/rediscaches",
-				"recipes/unsupported/unsupported",
-			},
-			"latest",
-			map[string]map[string]corerp.RecipePropertiesClassification{
-				"Applications.Datastores/redisCaches": {
-					"default": &corerp.BicepRecipeProperties{
-						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/rediscaches:latest", DevRecipesRegistry)),
-					},
-				},
-				"Applications.Datastores/mongoDatabases": {
-					"default": &corerp.BicepRecipeProperties{
-						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/mongodatabases:latest", DevRecipesRegistry)),
-					},
-				},
-			},
-		},
-		{
-			"Valid Prod and Dev Repositories with Redis Cache, Mongo Database",
-			[]string{
-				"recipes/local-dev/rediscaches",
-				"recipes/local-dev/mongodatabases",
-				"dev/recipes/local-dev/rediscaches",
-				"dev/recipes/local-dev/mongodatabases",
-			},
-			"latest",
-			map[string]map[string]corerp.RecipePropertiesClassification{
-				"Applications.Datastores/redisCaches": {
-					"default": &corerp.BicepRecipeProperties{
-						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/rediscaches:latest", DevRecipesRegistry)),
-					},
-				},
-				"Applications.Datastores/mongoDatabases": {
-					"default": &corerp.BicepRecipeProperties{
-						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/mongodatabases:latest", DevRecipesRegistry)),
-					},
-				},
-			},
-		},
-	}
+// func Test_processRepositories(t *testing.T) {
+// 	tests := []struct {
+// 		name  string
+// 		repos []string
+// 		tag   string
+// 		want  map[string]map[string]corerp.RecipePropertiesClassification
+// 	}{
+// 		{
+// 			"Valid Repository with Redis Cache",
+// 			[]string{
+// 				"recipes/local-dev/rediscaches",
+// 			},
+// 			"0.20",
+// 			map[string]map[string]corerp.RecipePropertiesClassification{
+// 				"Applications.Datastores/redisCaches": {
+// 					"default": &corerp.BicepRecipeProperties{
+// 						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
+// 						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/rediscaches:0.20", DevRecipesRegistry)),
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			"Valid Repository with Redis Cache and Mongo Database",
+// 			[]string{
+// 				"recipes/local-dev/rediscaches",
+// 				"recipes/local-dev/mongodatabases",
+// 			},
+// 			"0.20",
+// 			map[string]map[string]corerp.RecipePropertiesClassification{
+// 				"Applications.Datastores/redisCaches": {
+// 					"default": &corerp.BicepRecipeProperties{
+// 						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
+// 						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/rediscaches:0.20", DevRecipesRegistry)),
+// 					},
+// 				},
+// 				"Applications.Datastores/mongoDatabases": {
+// 					"default": &corerp.BicepRecipeProperties{
+// 						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
+// 						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/mongodatabases:0.20", DevRecipesRegistry)),
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			"Valid Repository with Redis Cache, Mongo Database, and an unsupported type",
+// 			[]string{
+// 				"recipes/local-dev/rediscaches",
+// 				"recipes/local-dev/mongodatabases",
+// 				"recipes/local-dev/unsupported",
+// 				"recipes/unsupported/rediscaches",
+// 				"recipes/unsupported/unsupported",
+// 			},
+// 			"latest",
+// 			map[string]map[string]corerp.RecipePropertiesClassification{
+// 				"Applications.Datastores/redisCaches": {
+// 					"default": &corerp.BicepRecipeProperties{
+// 						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
+// 						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/rediscaches:latest", DevRecipesRegistry)),
+// 					},
+// 				},
+// 				"Applications.Datastores/mongoDatabases": {
+// 					"default": &corerp.BicepRecipeProperties{
+// 						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
+// 						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/mongodatabases:latest", DevRecipesRegistry)),
+// 					},
+// 				},
+// 			},
+// 		},
+// 		{
+// 			"Valid Prod and Dev Repositories with Redis Cache, Mongo Database",
+// 			[]string{
+// 				"recipes/local-dev/rediscaches",
+// 				"recipes/local-dev/mongodatabases",
+// 				"dev/recipes/local-dev/rediscaches",
+// 				"dev/recipes/local-dev/mongodatabases",
+// 			},
+// 			"latest",
+// 			map[string]map[string]corerp.RecipePropertiesClassification{
+// 				"Applications.Datastores/redisCaches": {
+// 					"default": &corerp.BicepRecipeProperties{
+// 						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
+// 						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/rediscaches:latest", DevRecipesRegistry)),
+// 					},
+// 				},
+// 				"Applications.Datastores/mongoDatabases": {
+// 					"default": &corerp.BicepRecipeProperties{
+// 						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
+// 						TemplatePath: to.Ptr(fmt.Sprintf("%s/recipes/local-dev/mongodatabases:latest", DevRecipesRegistry)),
+// 					},
+// 				},
+// 			},
+// 		},
+// 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := processRepositories(tt.repos, tt.tag); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("processRepositories() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			if got := processRepositories(tt.repos, tt.tag); !reflect.DeepEqual(got, tt.want) {
+// 				t.Errorf("processRepositories() = %v, want %v", got, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
 func Test_isDevRepository(t *testing.T) {
 	tests := []struct {

--- a/pkg/cli/cmd/recipe/list/list_test.go
+++ b/pkg/cli/cmd/recipe/list/list_test.go
@@ -89,7 +89,7 @@ func Test_Run(t *testing.T) {
 					ds_ctrl.MongoDatabasesResourceType: {
 						"cosmosDB": &v20231001preview.BicepRecipeProperties{
 							TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-							TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+							TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 						},
 						"cosmosDB-terraform": &v20231001preview.TerraformRecipeProperties{
 							TemplateKind:    to.Ptr(recipes.TemplateKindTerraform),
@@ -105,7 +105,7 @@ func Test_Run(t *testing.T) {
 				Name:         "cosmosDB",
 				ResourceType: ds_ctrl.MongoDatabasesResourceType,
 				TemplateKind: recipes.TemplateKindBicep,
-				TemplatePath: "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
+				TemplatePath: "ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1",
 			},
 			{
 				Name:            "cosmosDB-terraform",

--- a/pkg/cli/cmd/recipe/register/register_test.go
+++ b/pkg/cli/cmd/recipe/register/register_test.go
@@ -138,7 +138,7 @@ func Test_Run(t *testing.T) {
 			ds_ctrl.MongoDatabasesResourceType: {
 				"cosmosDB": &v20231001preview.BicepRecipeProperties{
 					TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-					TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+					TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 				},
 			},
 		}
@@ -200,7 +200,7 @@ func Test_Run(t *testing.T) {
 		testRecipes := map[string]map[string]v20231001preview.RecipePropertiesClassification{
 			ds_ctrl.MongoDatabasesResourceType: {
 				"cosmosDB": &v20231001preview.BicepRecipeProperties{
-					TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+					TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 				},
 			},
 		}
@@ -243,7 +243,7 @@ func Test_Run(t *testing.T) {
 			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
 			Output:            outputSink,
 			Workspace:         &workspaces.Workspace{Environment: "kind-kind"},
-			TemplatePath:      "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
+			TemplatePath:      "ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1",
 			ResourceType:      ds_ctrl.MongoDatabasesResourceType,
 			RecipeName:        "cosmosDB_new",
 		}
@@ -270,7 +270,7 @@ func Test_Run(t *testing.T) {
 			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
 			Output:            outputSink,
 			Workspace:         &workspaces.Workspace{Environment: "kind-kind"},
-			TemplatePath:      "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
+			TemplatePath:      "ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1",
 			ResourceType:      ds_ctrl.MongoDatabasesResourceType,
 			RecipeName:        "cosmosDB_new",
 		}
@@ -288,7 +288,7 @@ func Test_Run(t *testing.T) {
 				ds_ctrl.MongoDatabasesResourceType: {
 					"cosmosDB": &v20231001preview.BicepRecipeProperties{
 						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-						TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+						TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 						Parameters:   map[string]any{"throughput": 400},
 					},
 				},
@@ -323,7 +323,7 @@ func Test_Run(t *testing.T) {
 			Output:            outputSink,
 			Workspace:         &workspaces.Workspace{Environment: "kind-kind"},
 			TemplateKind:      recipes.TemplateKindBicep,
-			TemplatePath:      "testpublicrecipe.azurecr.io/bicep/modules/rediscaches:v1",
+			TemplatePath:      "ghcr.io/testpublicrecipe/bicep/modules/rediscaches:v1",
 			ResourceType:      ds_ctrl.RedisCachesResourceType,
 			RecipeName:        "redis",
 			Parameters:        map[string]map[string]any{},
@@ -351,7 +351,7 @@ func Test_Run(t *testing.T) {
 				ds_ctrl.MongoDatabasesResourceType: {
 					"cosmosDB": &v20231001preview.BicepRecipeProperties{
 						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-						TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+						TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 					},
 				},
 			},
@@ -379,7 +379,7 @@ func Test_Run(t *testing.T) {
 			Output:            outputSink,
 			Workspace:         &workspaces.Workspace{Environment: "kind-kind"},
 			TemplateKind:      recipes.TemplateKindBicep,
-			TemplatePath:      "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
+			TemplatePath:      "ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1",
 			ResourceType:      ds_ctrl.MongoDatabasesResourceType,
 			RecipeName:        "cosmosDB_no_namespace",
 		}
@@ -431,7 +431,7 @@ func Test_Run(t *testing.T) {
 			Output:            outputSink,
 			Workspace:         &workspaces.Workspace{Environment: "kind-kind"},
 			TemplateKind:      recipes.TemplateKindBicep,
-			TemplatePath:      "testpublicrecipe.azurecr.io/bicep/modules/rediscaches:v1",
+			TemplatePath:      "ghcr.io/testpublicrecipe/bicep/modules/rediscaches:v1",
 			ResourceType:      ds_ctrl.RedisCachesResourceType,
 			RecipeName:        "redis",
 		}

--- a/pkg/cli/cmd/recipe/show/show_test.go
+++ b/pkg/cli/cmd/recipe/show/show_test.go
@@ -98,7 +98,7 @@ func Test_Run(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		envRecipe := v20231001preview.RecipeGetMetadataResponse{
 			TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-			TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+			TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 			Parameters: map[string]any{
 				"throughput": map[string]any{
 					"type":     "float64",
@@ -113,7 +113,7 @@ func Test_Run(t *testing.T) {
 			Name:         "cosmosDB",
 			ResourceType: datastorerp.MongoDatabasesResourceType,
 			TemplateKind: recipes.TemplateKindBicep,
-			TemplatePath: "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
+			TemplatePath: "ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1",
 		}
 		recipeParams := []RecipeParameter{
 			{

--- a/pkg/cli/cmd/recipe/unregister/unregister_test.go
+++ b/pkg/cli/cmd/recipe/unregister/unregister_test.go
@@ -104,7 +104,7 @@ func Test_Run(t *testing.T) {
 					ds_ctrl.MongoDatabasesResourceType: {
 						"cosmosDB": &v20231001preview.BicepRecipeProperties{
 							TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-							TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+							TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 						},
 					},
 				},
@@ -161,7 +161,7 @@ func Test_Run(t *testing.T) {
 				Recipes: map[string]map[string]v20231001preview.RecipePropertiesClassification{
 					ds_ctrl.MongoDatabasesResourceType: {
 						"cosmosDB": &v20231001preview.BicepRecipeProperties{
-							TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+							TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 						},
 					},
 				},
@@ -218,7 +218,7 @@ func Test_Run(t *testing.T) {
 					ds_ctrl.MongoDatabasesResourceType: {
 						"cosmosDB": &v20231001preview.BicepRecipeProperties{
 							TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-							TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+							TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 						},
 					},
 				},
@@ -278,7 +278,7 @@ func Test_Run(t *testing.T) {
 						ds_ctrl.MongoDatabasesResourceType: {
 							"cosmosDB": &v20231001preview.BicepRecipeProperties{
 								TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-								TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+								TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 							},
 						},
 					},
@@ -316,7 +316,7 @@ func Test_Run(t *testing.T) {
 						ds_ctrl.MongoDatabasesResourceType: {
 							"testResource": &v20231001preview.BicepRecipeProperties{
 								TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-								TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+								TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 							},
 						},
 					},
@@ -380,13 +380,13 @@ func Test_Run(t *testing.T) {
 					ds_ctrl.MongoDatabasesResourceType: {
 						"testResource": &v20231001preview.BicepRecipeProperties{
 							TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-							TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1"),
+							TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1"),
 						},
 					},
 					ds_ctrl.RedisCachesResourceType: {
 						"testResource": &v20231001preview.BicepRecipeProperties{
 							TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-							TemplatePath: to.Ptr("testpublicrecipe.azurecr.io/bicep/modules/rediscaches:v1"),
+							TemplatePath: to.Ptr("ghcr.io/testpublicrecipe/bicep/modules/rediscaches:v1"),
 						},
 					},
 				},

--- a/pkg/cli/helm/radiusclient.go
+++ b/pkg/cli/helm/radiusclient.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	radiusReleaseName     = "radius"
-	radiusHelmRepo        = "https://radius.azurecr.io/helm/v1/repo"
+	radiusHelmRepo        = "https://ghcr.io/radius-project/helm/v1/repo"
 	RadiusSystemNamespace = "radius-system"
 )
 

--- a/pkg/cli/helm/radiusclient.go
+++ b/pkg/cli/helm/radiusclient.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	radiusReleaseName     = "radius"
-	radiusHelmRepo        = "https://ghcr.io/radius-project/helm/v1/repo"
+	radiusHelmRepo        = "https://radius.azurecr.io/helm/v1/repo"
 	RadiusSystemNamespace = "radius-system"
 )
 

--- a/pkg/cli/helm/radiusclient_test.go
+++ b/pkg/cli/helm/radiusclient_test.go
@@ -58,7 +58,7 @@ func Test_AddRadiusValuesOverrideWithSet(t *testing.T) {
 	var helmChart chart.Chart
 	helmChart.Values = map[string]any{}
 	options := &RadiusOptions{
-		SetArgs: []string{"rp.image=radius.azurecr.io/applications-rp,rp.tag=latest", "global.zipkin.url=url,global.prometheus.path=path"},
+		SetArgs: []string{"rp.image=ghcr.io/radius-project/applications-rp,rp.tag=latest", "global.zipkin.url=url,global.prometheus.path=path"},
 	}
 
 	err := AddRadiusValues(&helmChart, options)
@@ -73,7 +73,7 @@ func Test_AddRadiusValuesOverrideWithSet(t *testing.T) {
 	assert.Equal(t, o["tag"], "latest")
 	_, ok = o["image"]
 	assert.True(t, ok)
-	assert.Equal(t, o["image"], "radius.azurecr.io/applications-rp")
+	assert.Equal(t, o["image"], "ghcr.io/radius-project/applications-rp")
 
 	_, ok = values["global"]
 	assert.True(t, ok)

--- a/pkg/cli/kubernetes/kubernetes.go
+++ b/pkg/cli/kubernetes/kubernetes.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/radius-project/radius/pkg/cli/output"
+	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
 	"github.com/radius-project/radius/pkg/kubeutil"
 )
 
@@ -49,6 +50,7 @@ func init() {
 	_ = apiextv1.AddToScheme(Scheme)
 	_ = clientgoscheme.AddToScheme(Scheme)
 	_ = contourv1.AddToScheme(Scheme)
+	_ = radappiov1alpha3.AddToScheme(Scheme)
 }
 
 // NewDynamicClient creates a new dynamic client by context name, otherwise returns an error.
@@ -82,13 +84,13 @@ func NewClientset(context string) (*k8s.Clientset, *rest.Config, error) {
 }
 
 // NewRuntimeClient creates a kubernetes client using a given context and scheme.
-func NewRuntimeClient(context string, scheme *k8s_runtime.Scheme) (client.Client, error) {
+func NewRuntimeClient(context string, scheme *k8s_runtime.Scheme) (client.WithWatch, error) {
 	merged, err := NewCLIClientConfig(context)
 	if err != nil {
 		return nil, err
 	}
 
-	c, err := client.New(merged, client.Options{Scheme: scheme})
+	c, err := client.NewWithWatch(merged, client.Options{Scheme: scheme})
 	if err != nil {
 		output.LogInfo("failed to create runtime client due to error: %v", err)
 		return nil, err

--- a/pkg/cli/setup/application.go
+++ b/pkg/cli/setup/application.go
@@ -31,7 +31,7 @@ resource demo 'Applications.Core/containers@2023-10-01-preview' = {
   properties: {
     application: application
     container: {
-      image: 'radius.azurecr.io/tutorial/webapp:edge'
+      image: 'ghcr.io/radius-project/tutorial/webapp:edge'
       ports: {
         web: {
           containerPort: 3000

--- a/pkg/controller/api/radapp.io/v1alpha3/recipe_types.go
+++ b/pkg/controller/api/radapp.io/v1alpha3/recipe_types.go
@@ -32,6 +32,14 @@ type RecipeSpec struct {
 	// SecretName is the name of a Kubernetes secret to create once the resource is created.
 	// +kubebuilder:validation:Optional
 	SecretName string `json:"secretName,omitempty"`
+
+	// Environment is the name of the Radius environment to use. If unset the value 'default' will be
+	// used as the environment name.
+	Environment string `json:"environment,omitempty"`
+
+	// Application is the name of the Radius application to use. If unset the namespace of the
+	// Recipe will be used as the application name.
+	Application string `json:"application,omitempty"`
 }
 
 // RecipePhrase is a string representation of the current status of a Recipe.

--- a/pkg/controller/reconciler/annotations.go
+++ b/pkg/controller/reconciler/annotations.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+type deploymentPhrase string
+
+const (
+	deploymentPhraseWaiting  deploymentPhrase = "Waiting"
+	deploymentPhraseUpdating deploymentPhrase = "Updating"
+	deploymentPhraseReady    deploymentPhrase = "Ready"
+	deploymentPhraseDeleting deploymentPhrase = "Deleting"
+	deploymentPhraseFailed   deploymentPhrase = "Failed"
+)
+
+// deploymentAnnotations represents the user-provided configuration and the status (Radius related status)
+// of the Deployment.
+type deploymentAnnotations struct {
+	// Configuration is the configuration of the Deployment provided by the user via annotations.
+	// This will be nil if Radius is not enabled for the Deployment.
+	Configuration *deploymentConfiguration
+
+	//ConfigurationHash is the hash of the user-provided configuration.
+	// This will be used to diff the configuration and determine if the Deployment needs to be updated.
+	ConfigurationHash string
+
+	// Status is the status of the Deployment (Radius related status).
+	Status *deploymentStatus
+}
+
+// deploymentConfiguration is the configuration of the Deployment provided by the user via annotations.
+type deploymentConfiguration struct {
+	Connections map[string]string
+}
+
+func (c *deploymentConfiguration) computeHash() (string, error) {
+	b, err := json.Marshal(c)
+	if err != nil {
+		return "", err
+	}
+
+	sum := sha1.Sum(b)
+	hash := hex.EncodeToString(sum[:])
+	return hash, nil
+}
+
+type deploymentStatus struct {
+	Scope       string                              `json:"scope,omitempty"`
+	Application string                              `json:"application,omitempty"`
+	Environment string                              `json:"environment,omitempty"`
+	Container   string                              `json:"container,omitempty"`
+	Operation   *radappiov1alpha3.ResourceOperation `json:"operation,omitempty"`
+	Phrase      deploymentPhrase                    `json:"phrase,omitempty"`
+}
+
+// readAnnotations reads the annotations from a Deployment.
+//
+// This includes the configuration specified by the user, the hash of the configuration, and the status.
+func readAnnotations(deployment *appsv1.Deployment) (*deploymentAnnotations, error) {
+	if deployment.Annotations == nil {
+		return nil, nil
+	}
+
+	result := deploymentAnnotations{
+		ConfigurationHash: deployment.Annotations[AnnotationRadiusConfigurationHash],
+	}
+
+	s := deploymentStatus{}
+	status := deployment.Annotations[AnnotationRadiusStatus]
+	if status != "" {
+		err := json.Unmarshal([]byte(status), &s)
+		if err != nil {
+			return &result, fmt.Errorf("failed to unmarshal status annotation: %w", err)
+		}
+	}
+
+	result.Status = &s
+
+	// Note: we need to read and return the configuration even if Radius is not enabled for the Deployment.
+	// This is important so that can clean up previsouly created connections when Radius is disabled.
+	enabled := deployment.Annotations[AnnotationRadiusEnabled]
+	if !strings.EqualFold(enabled, "true") {
+		return &result, nil
+	}
+
+	result.Configuration = &deploymentConfiguration{Connections: map[string]string{}}
+
+	for k, v := range deployment.Annotations {
+		if strings.HasPrefix(k, AnnotationRadiusConnectionPrefix) {
+			result.Configuration.Connections[strings.TrimPrefix(k, AnnotationRadiusConnectionPrefix)] = v
+		}
+	}
+
+	return &result, nil
+}
+
+// ApplyToDeployment applies the configuration and status to a Deployment.
+//
+// This should be used before saving the Deployment's state.
+func (annotations *deploymentAnnotations) ApplyToDeployment(deployment *appsv1.Deployment) error {
+	if deployment.Annotations == nil {
+		deployment.Annotations = map[string]string{}
+	}
+
+	status := ""
+	if annotations.Status != nil {
+		b, err := json.Marshal(annotations.Status)
+		if err != nil {
+			return err
+		}
+
+		status = string(b)
+	}
+
+	deployment.Annotations[AnnotationRadiusStatus] = status
+
+	if annotations.Configuration == nil {
+		deployment.Annotations[AnnotationRadiusEnabled] = "false"
+		return nil
+	}
+
+	hash, err := annotations.Configuration.computeHash()
+	if err != nil {
+		return err
+	}
+
+	deployment.Annotations[AnnotationRadiusConfigurationHash] = hash
+	deployment.Annotations[AnnotationRadiusEnabled] = "true"
+
+	for k, v := range annotations.Configuration.Connections {
+		deployment.Annotations[AnnotationRadiusConnectionPrefix+k] = v
+	}
+
+	return nil
+}
+
+// IsUpToDate returns true if the Deployment is up to date with the configuration.
+//
+// This should be used to determine if the Radius container needs to be updated based
+// on a change made by the user.
+func (annotations *deploymentAnnotations) IsUpToDate() bool {
+	if annotations.ConfigurationHash == "" {
+		return false
+	}
+
+	if annotations.Status == nil {
+		return false
+	}
+
+	hash, err := annotations.Configuration.computeHash()
+	if err != nil {
+		return false // If the hash cannot be computed, we assume the configuration is outdated.
+	}
+
+	return hash == annotations.ConfigurationHash
+}

--- a/pkg/controller/reconciler/annotations.go
+++ b/pkg/controller/reconciler/annotations.go
@@ -54,7 +54,9 @@ type deploymentAnnotations struct {
 
 // deploymentConfiguration is the configuration of the Deployment provided by the user via annotations.
 type deploymentConfiguration struct {
-	Connections map[string]string
+	Application string            `json:"application,omitempty"`
+	Environment string            `json:"environment,omitempty"`
+	Connections map[string]string `json:"connections,omitempty"`
 }
 
 func (c *deploymentConfiguration) computeHash() (string, error) {
@@ -107,7 +109,11 @@ func readAnnotations(deployment *appsv1.Deployment) (*deploymentAnnotations, err
 		return &result, nil
 	}
 
-	result.Configuration = &deploymentConfiguration{Connections: map[string]string{}}
+	result.Configuration = &deploymentConfiguration{
+		Environment: deployment.Annotations[AnnotationRadiusEnvironment],
+		Application: deployment.Annotations[AnnotationRadiusApplication],
+		Connections: map[string]string{},
+	}
 
 	for k, v := range deployment.Annotations {
 		if strings.HasPrefix(k, AnnotationRadiusConnectionPrefix) {

--- a/pkg/controller/reconciler/const.go
+++ b/pkg/controller/reconciler/const.go
@@ -34,6 +34,14 @@ const (
 	// AnnotationRadiusConfigurationHash is the name of the annotation that indicates the hash of the configuration.
 	AnnotationRadiusConfigurationHash = "radapp.io/configuration-hash"
 
+	// AnnotationRadiusEnvionment is the name of the annotation that indicates the name of the environment. If unset,
+	// the value 'default' will be used as the environment name.
+	AnnotationRadiusEnvironment = "radapp.io/environment"
+
+	// AnnotationRadiusApplication is the name of the annotation that indicates the name of the application. If unset,
+	// the namespace of the Deployment will be used as the application name.
+	AnnotationRadiusApplication = "radapp.io/application"
+
 	// DeploymentFinalizer is the name of the finalizer added to Deployments.
 	DeploymentFinalizer = "radapp.io/deployment-finalizer"
 

--- a/pkg/controller/reconciler/const.go
+++ b/pkg/controller/reconciler/const.go
@@ -22,6 +22,21 @@ const (
 	// PollingDelay is the amount of time to wait between polling for the status of a resource.
 	PollingDelay time.Duration = 5 * time.Second
 
+	// AnnotationRadiusEnabled is the name of the annotation that indicates if a Deployment has Radius enabled.
+	AnnotationRadiusEnabled = "radapp.io/enabled"
+
+	// AnnotationRadiusConnectionPrefix is the name of the annotation that indicates the name of the connection to use.
+	AnnotationRadiusConnectionPrefix = "radapp.io/connection-"
+
+	// AnnotationRadiusStatus is the name of the annotation that indicates the status of a Deployment.
+	AnnotationRadiusStatus = "radapp.io/status"
+
+	// AnnotationRadiusConfigurationHash is the name of the annotation that indicates the hash of the configuration.
+	AnnotationRadiusConfigurationHash = "radapp.io/configuration-hash"
+
+	// DeploymentFinalizer is the name of the finalizer added to Deployments.
+	DeploymentFinalizer = "radapp.io/deployment-finalizer"
+
 	// RecipeFinalizer is the name of the finalizer added to Recipes.
 	RecipeFinalizer = "radapp.io/recipe-finalizer"
 )

--- a/pkg/controller/reconciler/deployment_reconciler.go
+++ b/pkg/controller/reconciler/deployment_reconciler.go
@@ -1,0 +1,602 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/go-logr/logr"
+	"github.com/radius-project/radius/pkg/cli/clients"
+	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
+	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
+	"github.com/radius-project/radius/pkg/to"
+	"github.com/radius-project/radius/pkg/ucp/resources"
+	"github.com/radius-project/radius/pkg/ucp/ucplog"
+)
+
+// DeploymentReconciler reconciles a Deployment object.
+type DeploymentReconciler struct {
+	// Client is the Kubernetes client.
+	Client client.Client
+
+	// Scheme is the Kubernetes scheme.
+	Scheme *runtime.Scheme
+
+	// EventRecorder is the Kubernetes event recorder.
+	EventRecorder record.EventRecorder
+
+	// Radius is the Radius client.
+	Radius RadiusClient
+
+	// DelayInterval is the amount of time to wait between operations.
+	DelayInterval time.Duration
+}
+
+// Reconcile is the main reconciliation loop for the Deployment resource.
+func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := ucplog.FromContextOrDiscard(ctx).WithValues("kind", "Deployment", "name", req.Name, "namespace", req.Namespace)
+	ctx = logr.NewContext(ctx, logger)
+
+	deployment := appsv1.Deployment{}
+	err := r.Client.Get(ctx, req.NamespacedName, &deployment)
+	if apierrors.IsNotFound(err) {
+		// This can happen due to a data-race if the deployment is created and then deleted before we can
+		// reconcile it. There's nothing to do here.
+		logger.Info("Deployment has already been deleted.")
+		return ctrl.Result{}, nil
+	} else if err != nil {
+		logger.Error(err, "Unable to fetch resource.")
+		return ctrl.Result{}, err
+	}
+
+	// Our algorithm is as follows:
+	//
+	// 1. Check if we have an "operation" in progress. If so, check it's status.
+	//   a. If the operation is still in progress, then queue another reconcile (polling).
+	//   b. If the operation completed successfully then update the status and continue processing (happy-path).
+	//   c. If the operation failed then update the status and continue processing (retry).
+	// 2. If the deployment is being deleted then process deletion.
+	//   a. This may require us to start a DELETE operation. After that we can continue polling.
+	// 3. If the deployment is not being deleted then process this as a creation or update.
+	//   a. This may require us to start a PUT operation. After that we can continue polling.
+	//
+	// We do it this way because it guarantees that we only have one operation going at a time.
+
+	// Since Deployment is a built-in type in Kubernetes we can't add our own status field to it.
+	// We have to store our status in an annotation.
+	annotations, err := readAnnotations(&deployment)
+	if err != nil {
+		logger.Error(err, "Failed to read deployment status.")
+		deployment.Annotations[AnnotationRadiusStatus] = ""
+
+		// This could happen if someone manually edited the annotations. We can reset it to empty
+		// and repair it on the next reconcile.
+	}
+
+	if annotations.Status.Operation != nil {
+		// NOTE: if reconcileOperation completes successfully, then it will return a "zero" result,
+		// this means the operation has completed and we should continue processing.
+		result, err := r.reconcileOperation(ctx, &deployment, annotations)
+		if err != nil {
+			logger.Error(err, "Unable to reconcile in-progress operation.")
+			return ctrl.Result{}, err
+		} else if result.IsZero() {
+			// NOTE: if reconcileOperation completes successfully, then it will return a "zero" result,
+			// this means the operation has completed and we should continue processing.
+			logger.Info("Operation completed successfully.")
+		} else {
+			logger.Info("Requeueing to continue operation.")
+			return result, nil
+		}
+	}
+
+	// If the Deployment is being deleted **or** if Radius is not enabled, then we should
+	// clean up any Radius state.
+	if deployment.DeletionTimestamp != nil || annotations.Configuration == nil {
+		return r.reconcileDelete(ctx, &deployment, annotations)
+	}
+
+	return r.reconcileUpdate(ctx, &deployment, annotations)
+}
+
+// reconcileOperation reconciles a Deployment that has an operation in progress.
+func (r *DeploymentReconciler) reconcileOperation(ctx context.Context, deployment *appsv1.Deployment, annotations *deploymentAnnotations) (ctrl.Result, error) {
+	logger := ucplog.FromContextOrDiscard(ctx)
+
+	// NOTE: the pollers are actually different types, so we have to duplicate the code
+	// for the PUT and DELETE handling. This makes me sad :( but there isn't a great
+	// solution besides duplicating the code.
+	//
+	// The only difference between these two codepaths is how they handle success.
+	if annotations.Status.Operation.OperationKind == radappiov1alpha3.OperationKindPut {
+		poller, err := r.Radius.Containers(annotations.Status.Scope).ContinueCreateOperation(ctx, annotations.Status.Operation.ResumeToken)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to continue PUT operation: %w", err)
+		}
+
+		_, err = poller.Poll(ctx)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to poll operation status: %w", err)
+		}
+
+		if !poller.Done() {
+			return ctrl.Result{Requeue: true, RequeueAfter: r.requeueDelay()}, nil
+		}
+
+		// If we get here, the operation is complete.
+		_, err = poller.Result(ctx)
+		if err != nil {
+			// Operation failed, reset state and retry.
+			r.EventRecorder.Event(deployment, corev1.EventTypeWarning, "ResourceError", err.Error())
+			logger.Error(err, "Update failed.")
+
+			annotations.Status.Operation = nil
+			annotations.Status.Phrase = deploymentPhraseFailed
+
+			err = r.saveState(ctx, deployment, annotations)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{Requeue: true, RequeueAfter: r.requeueDelay()}, nil
+		}
+
+		// If we get here, the operation was a success. Update the status and continue.
+		//
+		// NOTE: we don't need to save the status here, because we're going to continue reconciling.
+		annotations.Status.Operation = nil
+		annotations.Status.Container = annotations.Status.Scope + "/providers/Applications.Core/containers/" + deployment.Name
+		return ctrl.Result{}, nil
+
+	} else if annotations.Status.Operation.OperationKind == radappiov1alpha3.OperationKindDelete {
+		poller, err := r.Radius.Containers(annotations.Status.Scope).ContinueDeleteOperation(ctx, annotations.Status.Operation.ResumeToken)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to continue DELETE operation: %w", err)
+		}
+
+		_, err = poller.Poll(ctx)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to poll operation status: %w", err)
+		}
+
+		if !poller.Done() {
+			return ctrl.Result{Requeue: true, RequeueAfter: r.requeueDelay()}, nil
+		}
+
+		// If we get here, the operation is complete.
+		_, err = poller.Result(ctx)
+		if err != nil {
+			// Operation failed, reset state and retry.
+			r.EventRecorder.Event(deployment, corev1.EventTypeWarning, "ResourceError", err.Error())
+			logger.Error(err, "Delete failed.")
+
+			annotations.Status.Operation = nil
+			annotations.Status.Phrase = deploymentPhraseFailed
+
+			err = r.saveState(ctx, deployment, annotations)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{Requeue: true, RequeueAfter: r.requeueDelay()}, nil
+		}
+
+		// If we get here, the operation was a success. Update the status and continue.
+		//
+		// NOTE: we don't need to save the status here, because we're going to continue reconciling.
+		annotations.Status.Operation = nil
+		annotations.Status.Container = ""
+		return ctrl.Result{}, nil
+	}
+
+	// If we get here, this was an unknown operation kind. This is a bug in our code, or someone
+	// tampered with the status of the object. Just reset the state and move on.
+	logger.Error(fmt.Errorf("unknown operation kind: %s", annotations.Status.Operation.OperationKind), "Unknown operation kind.")
+
+	annotations.Status.Operation = nil
+	annotations.Status.Phrase = deploymentPhraseFailed
+
+	err := r.saveState(ctx, deployment, annotations)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *DeploymentReconciler) reconcileUpdate(ctx context.Context, deployment *appsv1.Deployment, annotations *deploymentAnnotations) (ctrl.Result, error) {
+	logger := ucplog.FromContextOrDiscard(ctx)
+
+	// Ensure that our finalizer is present before we start any operations.
+	if controllerutil.AddFinalizer(deployment, DeploymentFinalizer) {
+		err := r.Client.Update(ctx, deployment)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// For now the environment name is hardcoded to default.
+	environmentName := "default"
+
+	// For now the application name is hardcoded to the namespace.
+	applicationName := deployment.Namespace
+
+	resourceGroupID, environmentID, applicationID, err := resolveDependencies(ctx, r.Radius, "/planes/radius/local", environmentName, applicationName)
+	if err != nil {
+		r.EventRecorder.Event(deployment, corev1.EventTypeWarning, "DependencyError", err.Error())
+		logger.Error(err, "Unable to resolve dependencies.")
+		return ctrl.Result{}, fmt.Errorf("failed to resolve dependencies: %w", err)
+	}
+
+	annotations.Status.Scope = resourceGroupID
+	annotations.Status.Environment = environmentID
+	annotations.Status.Application = applicationID
+
+	// There are three possible states returned here:
+	//
+	// 1) err != nil - an error happened, this will be retried next reconcile.
+	// 2) waiting == true - we're waiting on dependencies, this will be retried next reconcile.
+	// 3) poller != nil - we've started an operation, this will be checked next reconcile.
+	poller, waiting, err := r.startPutOperationIfNeeded(ctx, deployment, annotations)
+	if err != nil {
+		logger.Error(err, "Unable to create or update resource.")
+		r.EventRecorder.Event(deployment, corev1.EventTypeWarning, "ResourceError", err.Error())
+		return ctrl.Result{}, err
+	} else if waiting {
+		logger.Info("Waiting on dependencies.")
+		r.EventRecorder.Event(deployment, corev1.EventTypeNormal, "DependencyNotReady", "Waiting on dependencies.")
+
+		annotations.Status.Phrase = deploymentPhraseWaiting
+		err = r.saveState(ctx, deployment, annotations)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// We don't need to requeue here because we watch Recipes and will be notified when
+		// the state changes.
+		return ctrl.Result{}, nil
+	} else if poller != nil {
+		// We've successfully started an operation. Update the status and requeue.
+		token, err := poller.ResumeToken()
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get operation token: %w", err)
+		}
+
+		annotations.Status.Operation = &radappiov1alpha3.ResourceOperation{ResumeToken: token, OperationKind: radappiov1alpha3.OperationKindPut}
+		annotations.Status.Phrase = deploymentPhraseUpdating
+		err = r.saveState(ctx, deployment, annotations)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{Requeue: true, RequeueAfter: r.requeueDelay()}, nil
+	}
+
+	// If we get here then it means we can process the result of the operation.
+	logger.Info("Resource is in desired state.", "resourceId", annotations.Status.Container)
+
+	annotations.Status.Phrase = deploymentPhraseReady
+	err = r.updateDeployment(ctx, deployment, annotations)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update deployment: %w", err)
+	}
+
+	err = r.saveState(ctx, deployment, annotations)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *DeploymentReconciler) reconcileDelete(ctx context.Context, deployment *appsv1.Deployment, annotations *deploymentAnnotations) (ctrl.Result, error) {
+	logger := ucplog.FromContextOrDiscard(ctx)
+
+	poller, err := r.startDeleteOperationIfNeeded(ctx, deployment, annotations)
+	if err != nil {
+		logger.Error(err, "Unable to delete resource.")
+		r.EventRecorder.Event(deployment, corev1.EventTypeWarning, "ResourceError", err.Error())
+		return ctrl.Result{}, err
+	} else if poller != nil {
+		// We've successfully started an operation. Update the status and requeue.
+		token, err := poller.ResumeToken()
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to get operation token: %w", err)
+		}
+
+		annotations.Status.Operation = &radappiov1alpha3.ResourceOperation{ResumeToken: token, OperationKind: radappiov1alpha3.OperationKindDelete}
+		annotations.Status.Phrase = deploymentPhraseDeleting
+		err = r.saveState(ctx, deployment, annotations)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{Requeue: true, RequeueAfter: r.requeueDelay()}, nil
+	}
+
+	logger.Info("Resource is deleted.")
+
+	err = r.cleanupDeployment(ctx, deployment)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to cleanup deployment: %w", err)
+	}
+
+	// At this point we've cleaned up everything. We can remove the finalizer which will allow deletion of the
+	// recipe.
+	controllerutil.RemoveFinalizer(deployment, DeploymentFinalizer)
+	err = r.Client.Update(ctx, deployment)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	r.EventRecorder.Event(deployment, corev1.EventTypeNormal, "Reconciled", "Successfully reconciled resource.")
+	return ctrl.Result{}, nil
+}
+
+func (r *DeploymentReconciler) startPutOperationIfNeeded(ctx context.Context, deployment *appsv1.Deployment, annotations *deploymentAnnotations) (Poller[v20231001preview.ContainersClientCreateOrUpdateResponse], bool, error) {
+	logger := ucplog.FromContextOrDiscard(ctx)
+
+	// Check the annotations first to see how the current configuration compares to the desired configuration.
+	if !annotations.IsUpToDate() {
+		logger.Info("Container configuration is out-of-date.")
+	} else if annotations.Status.Container != "" {
+		logger.Info("Container is already created and is up-to-date.")
+		return nil, false, nil
+	}
+
+	logger.Info("Starting PUT operation.")
+	properties := v20231001preview.ContainerProperties{
+		Application:          to.Ptr(annotations.Status.Application),
+		ResourceProvisioning: to.Ptr(v20231001preview.ContainerResourceProvisioningManual),
+		Connections:          map[string]*v20231001preview.ConnectionProperties{},
+		Container: &v20231001preview.Container{
+			Image: to.Ptr("none"),
+		},
+		Resources: []*v20231001preview.ResourceReference{
+			{
+				ID: to.Ptr("/planes/kubernetes/local/namespaces/" + deployment.Namespace + "/providers/apps/Deployment/" + deployment.Name),
+			},
+		},
+	}
+
+	for name, source := range annotations.Configuration.Connections {
+		recipe := radappiov1alpha3.Recipe{}
+		err := r.Client.Get(ctx, client.ObjectKey{Namespace: deployment.Namespace, Name: source}, &recipe)
+		if apierrors.IsNotFound(err) {
+			logger.Info("Recipe does not exist.", "recipe", source)
+			return nil, true, nil
+		} else if err != nil {
+			return nil, false, fmt.Errorf("failed to fetch recipe %s: %w", source, err)
+		} else if recipe.Status.Resource == "" {
+			logger.Info("Recipe is not ready.", "recipe", source)
+			return nil, true, nil
+		}
+
+		properties.Connections[name] = &v20231001preview.ConnectionProperties{
+			Source: to.Ptr(recipe.Status.Resource),
+		}
+	}
+
+	resourceID := annotations.Status.Scope + "/providers/Applications.Core/containers/" + deployment.Name
+	poller, err := createOrUpdateContainer(ctx, r.Radius, resourceID, &properties)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return poller, false, nil
+}
+
+func (r *DeploymentReconciler) startDeleteOperationIfNeeded(ctx context.Context, deployment *appsv1.Deployment, annotations *deploymentAnnotations) (Poller[v20231001preview.ContainersClientDeleteResponse], error) {
+	logger := ucplog.FromContextOrDiscard(ctx)
+	if annotations.Status.Container == "" {
+		logger.Info("Container is already deleted (or was never created).")
+		return nil, nil
+	}
+
+	logger.Info("Starting DELETE operation.")
+	return deleteContainer(ctx, r.Radius, annotations.Status.Container)
+}
+
+func (r *DeploymentReconciler) updateDeployment(ctx context.Context, deployment *appsv1.Deployment, annotations *deploymentAnnotations) error {
+	// We store the connection values in a Kubernetes secret and then use the secret to populate environment variables.
+	secretName := client.ObjectKey{Namespace: deployment.Namespace, Name: fmt.Sprintf("%s-connections", deployment.Name)}
+
+	// First retrieve the secret.
+	createSecret := false
+	secret := corev1.Secret{}
+	err := r.Client.Get(ctx, secretName, &secret)
+	if apierrors.IsNotFound(err) {
+		// It's OK if the secret doesn't exist yet. We'll create it below.
+		createSecret = true
+		secret.Name = secretName.Name
+		secret.Namespace = secretName.Namespace
+		secret.OwnerReferences = []metav1.OwnerReference{
+			*metav1.NewControllerRef(deployment, appsv1.SchemeGroupVersion.WithKind("Deployment")),
+		}
+	} else if err != nil {
+		return fmt.Errorf("failed to fetch secret %s: %w", secretName, err)
+	}
+
+	secret.Data = map[string][]byte{}
+
+	for name, source := range annotations.Configuration.Connections {
+		recipe := radappiov1alpha3.Recipe{}
+		err := r.Client.Get(ctx, client.ObjectKey{Namespace: deployment.Namespace, Name: source}, &recipe)
+		if err != nil {
+			return fmt.Errorf("failed to fetch recipe %s: %w", source, err)
+		}
+
+		if recipe.Status.Resource == "" {
+			return fmt.Errorf("recipe %s is not ready", source)
+		}
+
+		id, err := resources.Parse(recipe.Status.Resource)
+		if err != nil {
+			return err
+		}
+
+		response, err := r.Radius.Resources(id.RootScope(), id.Type()).Get(ctx, id.Name())
+		if err != nil {
+			return fmt.Errorf("failed to fetch resource %s: %w", id, err)
+		}
+
+		secrets, err := r.Radius.Resources(id.RootScope(), id.Type()).ListSecrets(ctx, id.Name())
+		if clients.Is404Error(err) {
+			// This is fine. The resource doesn't have any secrets.
+			secrets.Value = map[string]*string{}
+		} else if err != nil {
+			return fmt.Errorf("failed to fetch secrets for resource %s: %w", id, err)
+		}
+
+		values, err := resourceToConnectionEnvVars(name, response.GenericResource, secrets)
+		if err != nil {
+			return fmt.Errorf("failed to read values resource %s: %w", id, err)
+		}
+
+		// envtest has some quirky behavior around StringData which makes it hard to test. So we're
+		// using Data directly.
+		for k, v := range values {
+			secret.Data[k] = []byte(base64.RawStdEncoding.EncodeToString([]byte(v)))
+		}
+	}
+
+	addSecretReference(deployment, secretName.Name)
+
+	if createSecret {
+		err = r.Client.Create(ctx, &secret)
+		if err != nil {
+			return fmt.Errorf("failed to create secret %s: %w", secretName, err)
+		}
+	} else {
+		err = r.Client.Update(ctx, &secret)
+		if err != nil {
+			return fmt.Errorf("failed to update secret %s: %w", secretName, err)
+		}
+	}
+
+	return nil
+}
+
+func (r *DeploymentReconciler) cleanupDeployment(ctx context.Context, deployment *appsv1.Deployment) error {
+	delete(deployment.Annotations, AnnotationRadiusStatus)
+	delete(deployment.Annotations, AnnotationRadiusConfigurationHash)
+
+	secretName := client.ObjectKey{Namespace: deployment.Namespace, Name: fmt.Sprintf("%s-connections", deployment.Name)}
+	err := r.Client.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: secretName.Namespace, Name: secretName.Name}})
+	if err != nil {
+		return fmt.Errorf("failed to delete secret %s: %w", secretName.Name, err)
+	}
+
+	removeSecretReference(deployment, secretName.Name)
+	return nil
+}
+
+func (r *DeploymentReconciler) saveState(ctx context.Context, deployment *appsv1.Deployment, annotations *deploymentAnnotations) error {
+	err := annotations.ApplyToDeployment(deployment)
+	if err != nil {
+		return fmt.Errorf("unable to apply annotations: %w", err)
+	}
+
+	err = r.Client.Update(ctx, deployment)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *DeploymentReconciler) findDeploymentsForRecipe(ctx context.Context, obj client.Object) []reconcile.Request {
+	recipe := obj.(*radappiov1alpha3.Recipe)
+
+	deployments := &appsv1.DeploymentList{}
+	options := &client.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(indexField, recipe.Name),
+		Namespace:     recipe.Namespace,
+	}
+	err := r.Client.List(ctx, deployments, options)
+	if err != nil {
+		return []reconcile.Request{}
+	}
+
+	requests := []reconcile.Request{}
+	for _, item := range deployments.Items {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      item.GetName(),
+				Namespace: item.GetNamespace(),
+			},
+		})
+	}
+	return requests
+}
+
+func (r *DeploymentReconciler) requeueDelay() time.Duration {
+	delay := r.DelayInterval
+	if delay == 0 {
+		delay = PollingDelay
+	}
+
+	return delay
+}
+
+const indexField = "spec.recipe-reference"
+
+func (r *DeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &appsv1.Deployment{}, indexField, func(rawObj client.Object) []string {
+		deployment := rawObj.(*appsv1.Deployment)
+		annotations, err := readAnnotations(deployment)
+		if err != nil {
+			return []string{}
+		} else if annotations.Configuration == nil {
+			return []string{}
+		}
+
+		recipes := []string{}
+		for _, recipe := range annotations.Configuration.Connections {
+			recipes = append(recipes, recipe)
+		}
+
+		return recipes
+	}); err != nil {
+		return err
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appsv1.Deployment{}).
+		Watches(&radappiov1alpha3.Recipe{}, handler.EnqueueRequestsFromMapFunc(r.findDeploymentsForRecipe), builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
+		Owns(&corev1.Secret{}).
+		Complete(r)
+}

--- a/pkg/controller/reconciler/deployment_reconciler.go
+++ b/pkg/controller/reconciler/deployment_reconciler.go
@@ -18,7 +18,6 @@ package reconciler
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"strings"
 	"time"
@@ -517,6 +516,8 @@ func (r *DeploymentReconciler) updateDeployment(ctx context.Context, deployment 
 		return fmt.Errorf("failed to fetch secret %s: %w", secretName, err)
 	}
 
+	// envtest has some quirky behavior around StringData which makes it hard to test. So we're
+	// using Data directly.
 	secret.Data = map[string][]byte{}
 
 	for name, source := range annotations.Configuration.Connections {
@@ -553,10 +554,8 @@ func (r *DeploymentReconciler) updateDeployment(ctx context.Context, deployment 
 			return fmt.Errorf("failed to read values resource %s: %w", id, err)
 		}
 
-		// envtest has some quirky behavior around StringData which makes it hard to test. So we're
-		// using Data directly.
 		for k, v := range values {
-			secret.Data[k] = []byte(base64.RawStdEncoding.EncodeToString([]byte(v)))
+			secret.Data[k] = []byte(v)
 		}
 	}
 

--- a/pkg/controller/reconciler/deployment_reconciler_test.go
+++ b/pkg/controller/reconciler/deployment_reconciler_test.go
@@ -1,0 +1,518 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
+	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
+	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
+	"github.com/radius-project/radius/pkg/to"
+	"github.com/radius-project/radius/test/testcontext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	deploymentTestWaitDuration            = time.Second * 10
+	deploymentTestWaitInterval            = time.Second * 1
+	deploymentTestControllerDelayInterval = time.Millisecond * 100
+)
+
+func SetupDeploymentTest(t *testing.T) (*mockRadiusClient, client.Client) {
+	SkipWithoutEnvironment(t)
+
+	// For debugging, you can set uncomment this to see logs from the controller. This will cause tests to fail
+	// because the logging will continue after the test completes.
+	//
+	// Add runtimelog "sigs.k8s.io/controller-runtime/pkg/log" to imports.
+	//
+	// runtimelog.SetLogger(ucplog.FromContextOrDiscard(testcontext.New(t)))
+
+	// Shut down the manager when the test exits.
+	ctx, cancel := testcontext.NewWithCancel(t)
+	t.Cleanup(cancel)
+
+	mgr, err := ctrl.NewManager(config, ctrl.Options{
+		Scheme: scheme,
+
+		// Suppress metrics in tests to avoid conflicts.
+		MetricsBindAddress: "0",
+	})
+	require.NoError(t, err)
+
+	radius := NewMockRadiusClient()
+	err = (&DeploymentReconciler{
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		EventRecorder: mgr.GetEventRecorderFor("recipe-controller"),
+		Radius:        radius,
+		DelayInterval: deploymentTestControllerDelayInterval,
+	}).SetupWithManager(mgr)
+	require.NoError(t, err)
+
+	go func() {
+		err := mgr.Start(ctx)
+		require.NoError(t, err)
+	}()
+
+	return radius, mgr.GetClient()
+}
+
+// Creates a deployment with Radius enabled.
+//
+// Then exercises the cleanup path by deleting the deployment.
+func Test_DeploymentReconciler_RadiusEnabled_ThenDeploymentDeleted(t *testing.T) {
+	ctx := testcontext.New(t)
+	radius, client := SetupDeploymentTest(t)
+
+	name := types.NamespacedName{Namespace: "deployment-enabled-deleted", Name: "test-deployment-enabled-deleted"}
+	err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	require.NoError(t, err)
+
+	deployment := makeDeployment(name)
+	deployment.Annotations[AnnotationRadiusEnabled] = "true"
+	err = client.Create(ctx, deployment)
+	require.NoError(t, err)
+
+	// Deployment will be waiting for environment to be created.
+	createEnvironment(radius)
+
+	// Deployment will be waiting for container to complete deployment.
+	annotations := waitForStateUpdating(t, client, name)
+
+	radius.CompleteOperation(annotations.Status.Operation.ResumeToken, nil)
+
+	// Deployment will update after operation completes
+	annotations = waitForStateReady(t, client, name)
+
+	container, err := radius.Containers(annotations.Status.Scope).Get(ctx, deployment.Name, nil)
+	require.NoError(t, err)
+	require.Equal(t, "manual", string(*container.Properties.ResourceProvisioning))
+	require.Equal(t, []*v20231001preview.ResourceReference{{ID: to.Ptr("/planes/kubernetes/local/namespaces/deployment-enabled-deleted/providers/apps/Deployment/" + deployment.Name)}}, container.Properties.Resources)
+
+	err = client.Delete(ctx, deployment)
+	require.NoError(t, err)
+
+	// Deletion of the container is in progress.
+	annotations = waitForStateDeleting(t, client, name)
+	radius.CompleteOperation(annotations.Status.Operation.ResumeToken, nil)
+
+	// Now deleting of the deployment object can complete.
+	waitForDeploymentDeleted(t, client, name)
+}
+
+// Creates a deployment with Radius enabled.
+//
+// Then exercises the cleanup path by disabling Radius.
+func Test_DeploymentReconciler_RadiusEnabled_ThenRadiusDisabled(t *testing.T) {
+	ctx := testcontext.New(t)
+	radius, client := SetupDeploymentTest(t)
+
+	name := types.NamespacedName{Namespace: "deployment-enabled-disabled", Name: "test-deployment-enabled-disabled"}
+	err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	require.NoError(t, err)
+
+	deployment := makeDeployment(name)
+	deployment.Annotations[AnnotationRadiusEnabled] = "true"
+	err = client.Create(ctx, deployment)
+	require.NoError(t, err)
+
+	// Deployment will be waiting for environment to be created.
+	createEnvironment(radius)
+
+	// Deployment will be waiting for container to complete deployment.
+	annotations := waitForStateUpdating(t, client, name)
+
+	radius.CompleteOperation(annotations.Status.Operation.ResumeToken, nil)
+
+	// Deployment will update after operation completes
+	annotations = waitForStateReady(t, client, name)
+
+	container, err := radius.Containers(annotations.Status.Scope).Get(ctx, deployment.Name, nil)
+	require.NoError(t, err)
+	require.Equal(t, "manual", string(*container.Properties.ResourceProvisioning))
+	require.Equal(t, []*v20231001preview.ResourceReference{{ID: to.Ptr("/planes/kubernetes/local/namespaces/deployment-enabled-disabled/providers/apps/Deployment/" + deployment.Name)}}, container.Properties.Resources)
+
+	// Trigger cleanup by disabling Radius.
+	err = client.Get(ctx, name, deployment)
+	require.NoError(t, err)
+	deployment.Annotations[AnnotationRadiusEnabled] = "false"
+	err = client.Update(ctx, deployment)
+	require.NoError(t, err)
+
+	// Deletion of the container is in progress.
+	annotations = waitForStateDeleting(t, client, name)
+	radius.CompleteOperation(annotations.Status.Operation.ResumeToken, nil)
+
+	waitForRadiusContainerDeleted(t, client, name)
+}
+
+// Creates a deployment with Radius enabled and connections to two recipes.
+//
+// Then makes those recipes Ready so connections can be enabled.
+//
+// Then changes the configuration to *drop* one of the connections.
+//
+// Then exercises the cleanup path by disabling Radius - and shows that we can revert
+// the changes Radius made to the deployment.
+func Test_DeploymentReconciler_Connections(t *testing.T) {
+	ctx := testcontext.New(t)
+	radius, client := SetupDeploymentTest(t)
+
+	name := types.NamespacedName{Namespace: "deployment-connections", Name: "test-deployment-connections"}
+	secretName := types.NamespacedName{Namespace: name.Namespace, Name: fmt.Sprintf("%s-connections", name.Name)}
+	err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+	require.NoError(t, err)
+
+	deployment := makeDeployment(name)
+	deployment.Annotations[AnnotationRadiusEnabled] = "true"
+	deployment.Annotations[AnnotationRadiusConnectionPrefix+"a"] = "recipe-a"
+	deployment.Annotations[AnnotationRadiusConnectionPrefix+"b"] = "recipe-b"
+
+	err = client.Create(ctx, deployment)
+	require.NoError(t, err)
+
+	// Deployment will be waiting for environment to be created.
+	createEnvironment(radius)
+
+	// Deployment will be waiting for recipe resources to be created
+	_ = waitForStateWaiting(t, client, name)
+
+	// Create the recipes, but don't mark them as provisioned yet.
+	recipeA := makeRecipe(types.NamespacedName{Namespace: name.Namespace, Name: "recipe-a"}, "Applications.Core/extenders")
+	recipeB := makeRecipe(types.NamespacedName{Namespace: name.Namespace, Name: "recipe-b"}, "Applications.Core/extenders")
+
+	err = client.Create(ctx, recipeA)
+	require.NoError(t, err)
+	err = client.Create(ctx, recipeB)
+	require.NoError(t, err)
+
+	// Deployment will be waiting for recipe resources to be created.
+	annotations := waitForStateWaiting(t, client, name)
+
+	// Create the radius resources associated with the recipes
+	extenderA := generated.GenericResource{
+		Properties: map[string]any{
+			"a-value": "a",
+			"secrets": map[string]string{
+				"a-secret": "a",
+			},
+		},
+	}
+	poller, err := radius.Resources(annotations.Status.Scope, "Applications.Core/extenders").BeginCreateOrUpdate(ctx, recipeA.Name, extenderA, nil)
+	require.NoError(t, err)
+	token, err := poller.ResumeToken()
+	require.NoError(t, err)
+	radius.CompleteOperation(token, nil)
+
+	extenderB := generated.GenericResource{
+		Properties: map[string]any{
+			"b-value": "b",
+			"secrets": map[string]string{
+				"b-secret": "b",
+			},
+		},
+	}
+	poller, err = radius.Resources(annotations.Status.Scope, "Applications.Core/extenders").BeginCreateOrUpdate(ctx, recipeB.Name, extenderB, nil)
+	require.NoError(t, err)
+	token, err = poller.ResumeToken()
+	require.NoError(t, err)
+	radius.CompleteOperation(token, nil)
+
+	recipeA.Status = radappiov1alpha3.RecipeStatus{
+		Resource: annotations.Status.Scope + "/providers/Applications.Core/extenders/" + recipeA.Name,
+	}
+	recipeB.Status = radappiov1alpha3.RecipeStatus{
+		Resource: annotations.Status.Scope + "/providers/Applications.Core/extenders/" + recipeB.Name,
+	}
+
+	// Mark the recipes as provisioned.
+	err = client.Status().Update(ctx, recipeA)
+	require.NoError(t, err)
+	err = client.Status().Update(ctx, recipeB)
+	require.NoError(t, err)
+
+	// Now we can create the container
+	annotations = waitForStateUpdating(t, client, name)
+
+	radius.CompleteOperation(annotations.Status.Operation.ResumeToken, nil)
+
+	// Deployment will update after operation completes
+	annotations = waitForStateReady(t, client, name)
+
+	container, err := radius.Containers(annotations.Status.Scope).Get(ctx, deployment.Name, nil)
+	require.NoError(t, err)
+	require.Equal(t, "manual", string(*container.Properties.ResourceProvisioning))
+	require.Equal(t, map[string]*v20231001preview.ConnectionProperties{
+		"a": {
+			Source: to.Ptr(annotations.Status.Scope + "/providers/Applications.Core/extenders/" + recipeA.Name),
+		},
+		"b": {
+			Source: to.Ptr(annotations.Status.Scope + "/providers/Applications.Core/extenders/" + recipeB.Name),
+		},
+	}, container.Properties.Connections)
+	require.Equal(t, []*v20231001preview.ResourceReference{{ID: to.Ptr("/planes/kubernetes/local/namespaces/deployment-connections/providers/apps/Deployment/" + deployment.Name)}}, container.Properties.Resources)
+
+	err = client.Get(ctx, name, deployment)
+	require.NoError(t, err)
+
+	// Secret should have been created.
+	secret := corev1.Secret{}
+	err = client.Get(ctx, secretName, &secret)
+	require.NoError(t, err)
+
+	expectedSecretData := map[string][]byte{
+		"CONNECTION_A_A-SECRET": []byte(base64.RawStdEncoding.EncodeToString([]byte("a"))),
+		"CONNECTION_A_A-VALUE":  []byte(base64.RawStdEncoding.EncodeToString([]byte("a"))),
+		"CONNECTION_B_B-SECRET": []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
+		"CONNECTION_B_B-VALUE":  []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
+	}
+	require.Equal(t, expectedSecretData, secret.Data)
+
+	// Secret should be mapped as env-vars
+	expectedEnvFrom := []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-connections", deployment.Name)},
+				Optional:             to.Ptr(false),
+			},
+		},
+	}
+
+	require.Equal(t, expectedEnvFrom, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
+
+	// Trigger a change by removing one of the connections.
+	err = client.Get(ctx, name, deployment)
+	require.NoError(t, err)
+	delete(deployment.Annotations, AnnotationRadiusConnectionPrefix+"a")
+	err = client.Update(ctx, deployment)
+	require.NoError(t, err)
+
+	// Container will be updated.
+	annotations = waitForStateUpdating(t, client, name)
+
+	radius.CompleteOperation(annotations.Status.Operation.ResumeToken, nil)
+
+	// Deployment will update after operation completes
+	_ = waitForStateReady(t, client, name)
+
+	// Secret should have been updated.
+	err = client.Get(ctx, secretName, &secret)
+	require.NoError(t, err)
+
+	expectedSecretData = map[string][]byte{
+		"CONNECTION_B_B-SECRET": []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
+		"CONNECTION_B_B-VALUE":  []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
+	}
+	require.Equal(t, expectedSecretData, secret.Data)
+
+	// Secret should be mapped as env-vars
+	require.Equal(t, expectedEnvFrom, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
+
+	// Trigger cleanup by disabling Radius.
+	err = client.Get(ctx, name, deployment)
+	require.NoError(t, err)
+	deployment.Annotations[AnnotationRadiusEnabled] = "false"
+	err = client.Update(ctx, deployment)
+	require.NoError(t, err)
+
+	// Deletion of the container is in progress.
+	annotations = waitForStateDeleting(t, client, name)
+	radius.CompleteOperation(annotations.Status.Operation.ResumeToken, nil)
+
+	waitForRadiusContainerDeleted(t, client, name)
+
+	// Deployment should have Radius changes reverted.
+	err = client.Get(ctx, name, deployment)
+	require.NoError(t, err)
+	require.Empty(t, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
+
+	// Secret should be gone
+	err = client.Get(ctx, secretName, &secret)
+	require.Error(t, err)
+	require.True(t, apierrors.IsNotFound(err))
+}
+
+func makeDeployment(name types.NamespacedName) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name.Name,
+			Namespace:   name.Namespace,
+			Annotations: map[string]string{},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": name.Name,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": name.Name,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  name.Name,
+							Image: "nginx:latest",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func waitForStateWaiting(t *testing.T, client client.Client, name types.NamespacedName) *deploymentAnnotations {
+	ctx := testcontext.New(t)
+
+	logger := t
+	var annotations *deploymentAnnotations
+	require.EventuallyWithTf(t, func(t *assert.CollectT) {
+		logger.Logf("Fetching Deployment: %+v", name)
+		current := &appsv1.Deployment{}
+		err := client.Get(ctx, name, current)
+		require.NoError(t, err)
+
+		annotations, err = readAnnotations(current)
+		require.NoError(t, err)
+		assert.NotNil(t, annotations)
+		logger.Logf("Annotations.Status: %+v", annotations.Status)
+
+		if assert.NotNil(t, annotations.Status) && assert.Equal(t, deploymentPhraseWaiting, annotations.Status.Phrase) {
+			assert.Empty(t, annotations.Status.Operation)
+		}
+	}, deploymentTestWaitDuration, deploymentTestWaitInterval, "waiting for state to be Waiting")
+
+	return annotations
+}
+
+func waitForStateUpdating(t *testing.T, client client.Client, name types.NamespacedName) *deploymentAnnotations {
+	ctx := testcontext.New(t)
+
+	logger := t
+	var annotations *deploymentAnnotations
+	require.EventuallyWithTf(t, func(t *assert.CollectT) {
+		logger.Logf("Fetching Deployment: %+v", name)
+		current := &appsv1.Deployment{}
+		err := client.Get(ctx, name, current)
+		require.NoError(t, err)
+
+		annotations, err = readAnnotations(current)
+		require.NoError(t, err)
+		assert.NotNil(t, annotations)
+		logger.Logf("Annotations.Status: %+v", annotations.Status)
+
+		if assert.NotNil(t, annotations.Status) && assert.Equal(t, deploymentPhraseUpdating, annotations.Status.Phrase) {
+			assert.NotEmpty(t, annotations.Status.Operation)
+		}
+	}, deploymentTestWaitDuration, deploymentTestWaitInterval, "waiting for state to be Updating")
+
+	return annotations
+}
+
+func waitForStateReady(t *testing.T, client client.Client, name types.NamespacedName) *deploymentAnnotations {
+	ctx := testcontext.New(t)
+
+	logger := t
+	var annotations *deploymentAnnotations
+	require.EventuallyWithTf(t, func(t *assert.CollectT) {
+		logger.Logf("Fetching Deployment: %+v", name)
+		current := &appsv1.Deployment{}
+		err := client.Get(ctx, name, current)
+		require.NoError(t, err)
+
+		annotations, err = readAnnotations(current)
+		require.NoError(t, err)
+		assert.NotNil(t, annotations)
+		logger.Logf("Annotations.Status: %+v", annotations.Status)
+
+		if assert.NotNil(t, annotations.Status) && assert.Equal(t, deploymentPhraseReady, annotations.Status.Phrase) {
+			assert.Empty(t, annotations.Status.Operation)
+		}
+	}, deploymentTestWaitDuration, deploymentTestWaitInterval, "waiting for state to be Ready")
+
+	return annotations
+}
+
+func waitForStateDeleting(t *testing.T, client client.Client, name types.NamespacedName) *deploymentAnnotations {
+	ctx := testcontext.New(t)
+
+	logger := t
+	var annotations *deploymentAnnotations
+	require.EventuallyWithTf(t, func(t *assert.CollectT) {
+		logger.Logf("Fetching Deployment: %+v", name)
+		current := &appsv1.Deployment{}
+		err := client.Get(ctx, name, current)
+		require.NoError(t, err)
+
+		annotations, err = readAnnotations(current)
+		require.NoError(t, err)
+		assert.NotNil(t, annotations)
+		logger.Logf("Annotations.Status: %+v", annotations.Status)
+
+		if assert.NotNil(t, annotations.Status) && assert.Equal(t, deploymentPhraseDeleting, annotations.Status.Phrase) {
+			assert.NotEmpty(t, annotations.Status.Operation)
+		}
+	}, deploymentTestWaitDuration, deploymentTestWaitInterval, "waiting for state to be Deleting")
+
+	return annotations
+}
+
+func waitForRadiusContainerDeleted(t *testing.T, client client.Client, name types.NamespacedName) *deploymentAnnotations {
+	ctx := testcontext.New(t)
+
+	logger := t
+	var annotations *deploymentAnnotations
+	require.EventuallyWithTf(t, func(t *assert.CollectT) {
+		logger.Logf("Fetching Deployment: %+v", name)
+		current := &appsv1.Deployment{}
+		err := client.Get(ctx, name, current)
+		require.NoError(t, err)
+
+		logger.Logf("Annotations: %+v", current.Annotations)
+		assert.NotContains(t, current.Annotations, AnnotationRadiusStatus)
+		assert.NotContains(t, current.Annotations, AnnotationRadiusConfigurationHash)
+	}, deploymentTestWaitDuration, deploymentTestWaitInterval, "waiting for state to be Deleting")
+
+	return annotations
+}
+
+func waitForDeploymentDeleted(t *testing.T, client client.Client, name types.NamespacedName) {
+	ctx := testcontext.New(t)
+
+	logger := t
+	require.Eventuallyf(t, func() bool {
+		logger.Logf("Fetching Deployment: %+v", name)
+		err := client.Get(ctx, name, &appsv1.Deployment{})
+		return apierrors.IsNotFound(err)
+	}, deploymentTestWaitDuration, deploymentTestWaitInterval, "waiting for deployment to be deleted")
+}

--- a/pkg/controller/reconciler/deployment_reconciler_test.go
+++ b/pkg/controller/reconciler/deployment_reconciler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package reconciler
 
 import (
-	"encoding/base64"
 	"fmt"
 	"testing"
 	"time"
@@ -366,10 +365,10 @@ func Test_DeploymentReconciler_Connections(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedSecretData := map[string][]byte{
-		"CONNECTION_A_A-SECRET": []byte(base64.RawStdEncoding.EncodeToString([]byte("a"))),
-		"CONNECTION_A_A-VALUE":  []byte(base64.RawStdEncoding.EncodeToString([]byte("a"))),
-		"CONNECTION_B_B-SECRET": []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
-		"CONNECTION_B_B-VALUE":  []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
+		"CONNECTION_A_A-SECRET": []byte("a"),
+		"CONNECTION_A_A-VALUE":  []byte("a"),
+		"CONNECTION_B_B-SECRET": []byte("b"),
+		"CONNECTION_B_B-VALUE":  []byte("b"),
 	}
 	require.Equal(t, expectedSecretData, secret.Data)
 
@@ -412,8 +411,8 @@ func Test_DeploymentReconciler_Connections(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedSecretData = map[string][]byte{
-		"CONNECTION_B_B-SECRET": []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
-		"CONNECTION_B_B-VALUE":  []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
+		"CONNECTION_B_B-SECRET": []byte("b"),
+		"CONNECTION_B_B-VALUE":  []byte("b"),
 	}
 	require.Equal(t, expectedSecretData, secret.Data)
 

--- a/pkg/controller/reconciler/deployment_util.go
+++ b/pkg/controller/reconciler/deployment_util.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"github.com/radius-project/radius/pkg/to"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// addSecretReference adds a secret reference to the deployment. Returns true if the secret was added, and false if it already exists.
+//
+// This function is idempotent and will not add the secret reference if it already exists.
+func addSecretReference(deployment *appsv1.Deployment, secretName string) bool {
+	// For now we're just interested in the first container.
+	container := &deployment.Spec.Template.Spec.Containers[0]
+
+	index := -1
+	for i := range deployment.Spec.Template.Spec.Containers[0].EnvFrom {
+		if container.EnvFrom[i].SecretRef != nil && container.EnvFrom[i].SecretRef.Name == secretName {
+			index = i
+			break
+		}
+	}
+
+	if index != -1 {
+		return false // Already present
+	}
+
+	from := corev1.EnvFromSource{
+		SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+			Optional:             to.Ptr(false),
+		},
+	}
+
+	container.EnvFrom = append(container.EnvFrom, from)
+	return true
+}
+
+// removeSecretReference removes the secret reference from the deployment. Returns true if the secret was removed, and false if it was not found.
+func removeSecretReference(deployment *appsv1.Deployment, secretName string) bool {
+
+	// For now we're just interested in the first container.
+	container := &deployment.Spec.Template.Spec.Containers[0]
+
+	index := -1
+	for i := range deployment.Spec.Template.Spec.Containers[0].EnvFrom {
+		if container.EnvFrom[i].SecretRef != nil && container.EnvFrom[i].SecretRef.Name == secretName {
+			index = i
+			break
+		}
+	}
+
+	if index == -1 {
+		return false
+	}
+
+	// Remove the secret from the deployment.
+	container.EnvFrom = append(container.EnvFrom[0:index], container.EnvFrom[index+1:]...)
+	return true
+}

--- a/pkg/controller/reconciler/deployment_util_test.go
+++ b/pkg/controller/reconciler/deployment_util_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/radius-project/radius/pkg/to"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func Test_addSecretReference_AlreadyPresent(t *testing.T) {
+	expected := []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "secret"}},
+		},
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+		},
+		{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+		},
+	}
+
+	deployment := makeDeployment(types.NamespacedName{})
+	deployment.Spec.Template.Spec.Containers[0].EnvFrom = expected
+
+	result := addSecretReference(deployment, "secret")
+	require.False(t, result)
+	require.Equal(t, expected, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
+}
+
+func Test_addSecretReference_ReferenceAdded(t *testing.T) {
+	expected := []corev1.EnvFromSource{
+
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+		},
+		{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+		},
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "secret"}, Optional: to.Ptr(false)},
+		},
+	}
+
+	deployment := makeDeployment(types.NamespacedName{})
+	deployment.Spec.Template.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+		},
+		{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+		},
+	}
+
+	result := addSecretReference(deployment, "secret")
+	require.True(t, result)
+	require.Equal(t, expected, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
+}
+
+func Test_removeSecretReference_AlreadyRemoved(t *testing.T) {
+	expected := []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+		},
+		{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+		},
+	}
+
+	deployment := makeDeployment(types.NamespacedName{})
+	deployment.Spec.Template.Spec.Containers[0].EnvFrom = expected
+
+	result := removeSecretReference(deployment, "secret")
+	require.False(t, result)
+	require.Equal(t, expected, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
+}
+
+func Test_removeSecretReference_ReferenceRemoved(t *testing.T) {
+	expected := []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+		},
+		{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+		},
+	}
+
+	deployment := makeDeployment(types.NamespacedName{})
+	deployment.Spec.Template.Spec.Containers[0].EnvFrom = []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "secret"}},
+		},
+		{
+			SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "another"}},
+		},
+		{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "config"}},
+		},
+	}
+
+	result := removeSecretReference(deployment, "secret")
+	require.True(t, result)
+	require.Equal(t, expected, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
+}

--- a/pkg/controller/reconciler/recipe_reconciler.go
+++ b/pkg/controller/reconciler/recipe_reconciler.go
@@ -18,7 +18,6 @@ package reconciler
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"strings"
 	"time"
@@ -503,8 +502,7 @@ func (r *RecipeReconciler) updateSecret(ctx context.Context, recipe *radappiov1a
 	}
 
 	for k, v := range values {
-		encoded := base64.RawStdEncoding.EncodeToString([]byte(v))
-		secret.Data[k] = []byte(encoded)
+		secret.Data[k] = []byte(v)
 	}
 
 	secrets, err := r.Radius.Resources(recipe.Status.Scope, recipe.Spec.Type).ListSecrets(ctx, recipe.Name)
@@ -514,8 +512,7 @@ func (r *RecipeReconciler) updateSecret(ctx context.Context, recipe *radappiov1a
 		return fmt.Errorf("failed to list secrets: %w", err)
 	} else {
 		for k, v := range secrets.Value {
-			encoded := base64.RawStdEncoding.EncodeToString([]byte(*v))
-			secret.Data[k] = []byte(encoded)
+			secret.Data[k] = []byte(*v)
 		}
 	}
 

--- a/pkg/controller/reconciler/recipe_reconciler_test.go
+++ b/pkg/controller/reconciler/recipe_reconciler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package reconciler
 
 import (
-	"encoding/base64"
 	"errors"
 	"testing"
 	"time"
@@ -303,8 +302,8 @@ func Test_RecipeReconciler_WithSecret(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedData := map[string][]byte{
-		"a-value":  []byte(base64.RawStdEncoding.EncodeToString([]byte("a"))),
-		"b-secret": []byte(base64.RawStdEncoding.EncodeToString([]byte("b"))),
+		"a-value":  []byte("a"),
+		"b-secret": []byte("b"),
 	}
 
 	require.Equal(t, expectedData, secret.Data)

--- a/pkg/controller/reconciler/recipe_reconciler_test.go
+++ b/pkg/controller/reconciler/recipe_reconciler_test.go
@@ -97,15 +97,15 @@ func Test_RecipeReconciler_WithoutSecret(t *testing.T) {
 
 	// Recipe will be waiting for extender to complete provisioning.
 	status := waitForRecipeStateUpdating(t, client, name, nil)
-	require.Equal(t, "/planes/radius/local/resourceGroups/default-recipe-without-secret", status.Scope)
+	require.Equal(t, "/planes/radius/local/resourcegroups/default-recipe-without-secret", status.Scope)
 	require.Equal(t, "/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default", status.Environment)
-	require.Equal(t, "/planes/radius/local/resourceGroups/default-recipe-without-secret/providers/Applications.Core/applications/recipe-without-secret", status.Application)
+	require.Equal(t, "/planes/radius/local/resourcegroups/default-recipe-without-secret/providers/Applications.Core/applications/recipe-without-secret", status.Application)
 
 	radius.CompleteOperation(status.Operation.ResumeToken, nil)
 
 	// Recipe will update after operation completes
 	status = waitForRecipeStateReady(t, client, name)
-	require.Equal(t, "/planes/radius/local/resourceGroups/default-recipe-without-secret/providers/Applications.Core/extenders/test-recipe-withoutsecret", status.Resource)
+	require.Equal(t, "/planes/radius/local/resourcegroups/default-recipe-without-secret/providers/Applications.Core/extenders/test-recipe-withoutsecret", status.Resource)
 
 	extender, err := radius.Resources(status.Scope, "Applications.Core/extenders").Get(ctx, name.Name)
 	require.NoError(t, err)
@@ -139,15 +139,15 @@ func Test_RecipeReconciler_ChangeEnvironmentAndApplication(t *testing.T) {
 
 	// Recipe will be waiting for extender to complete provisioning.
 	status := waitForRecipeStateUpdating(t, client, name, nil)
-	require.Equal(t, "/planes/radius/local/resourceGroups/default-recipe-change-envapp", status.Scope)
+	require.Equal(t, "/planes/radius/local/resourcegroups/default-recipe-change-envapp", status.Scope)
 	require.Equal(t, "/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default", status.Environment)
-	require.Equal(t, "/planes/radius/local/resourceGroups/default-recipe-change-envapp/providers/Applications.Core/applications/recipe-change-envapp", status.Application)
+	require.Equal(t, "/planes/radius/local/resourcegroups/default-recipe-change-envapp/providers/Applications.Core/applications/recipe-change-envapp", status.Application)
 
 	radius.CompleteOperation(status.Operation.ResumeToken, nil)
 
 	// Recipe will update after operation completes
 	status = waitForRecipeStateReady(t, client, name)
-	require.Equal(t, "/planes/radius/local/resourceGroups/default-recipe-change-envapp/providers/Applications.Core/extenders/test-recipe-change-envapp", status.Resource)
+	require.Equal(t, "/planes/radius/local/resourcegroups/default-recipe-change-envapp/providers/Applications.Core/extenders/test-recipe-change-envapp", status.Resource)
 
 	createEnvironment(radius, "new-environment")
 
@@ -173,14 +173,14 @@ func Test_RecipeReconciler_ChangeEnvironmentAndApplication(t *testing.T) {
 
 	// Recipe will be waiting for extender to complete provisioning.
 	status = waitForRecipeStateUpdating(t, client, name, nil)
-	require.Equal(t, "/planes/radius/local/resourceGroups/new-environment-new-application", status.Scope)
+	require.Equal(t, "/planes/radius/local/resourcegroups/new-environment-new-application", status.Scope)
 	require.Equal(t, "/planes/radius/local/resourceGroups/new-environment/providers/Applications.Core/environments/new-environment", status.Environment)
-	require.Equal(t, "/planes/radius/local/resourceGroups/new-environment-new-application/providers/Applications.Core/applications/new-application", status.Application)
+	require.Equal(t, "/planes/radius/local/resourcegroups/new-environment-new-application/providers/Applications.Core/applications/new-application", status.Application)
 	radius.CompleteOperation(status.Operation.ResumeToken, nil)
 
 	// Recipe will update after operation completes
 	status = waitForRecipeStateReady(t, client, name)
-	require.Equal(t, "/planes/radius/local/resourceGroups/new-environment-new-application/providers/Applications.Core/extenders/test-recipe-change-envapp", status.Resource)
+	require.Equal(t, "/planes/radius/local/resourcegroups/new-environment-new-application/providers/Applications.Core/extenders/test-recipe-change-envapp", status.Resource)
 
 	// Now delete the recipe.
 	err = client.Delete(ctx, recipe)

--- a/pkg/controller/reconciler/recipe_reconciler_test.go
+++ b/pkg/controller/reconciler/recipe_reconciler_test.go
@@ -22,11 +22,8 @@ import (
 	"testing"
 	"time"
 
-	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
 	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
-	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
-	"github.com/radius-project/radius/pkg/to"
 	"github.com/radius-project/radius/test/testcontext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -96,13 +93,7 @@ func Test_RecipeReconciler_WithoutSecret(t *testing.T) {
 	require.NoError(t, err)
 
 	// Recipe will be waiting for environment to be created.
-	radius.Update(func() {
-		radius.environments["/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"] = v20231001preview.EnvironmentResource{
-			ID:       to.Ptr("/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"),
-			Name:     to.Ptr("default"),
-			Location: to.Ptr(v1.LocationGlobal),
-		}
-	})
+	createEnvironment(radius)
 
 	// Recipe will be waiting for extender to complete provisioning.
 	status := waitForRecipeStateUpdating(t, client, name, nil)
@@ -149,13 +140,7 @@ func Test_RecipeReconciler_FailureRecovery(t *testing.T) {
 	require.NoError(t, err)
 
 	// Recipe will be waiting for environment to be created.
-	radius.Update(func() {
-		radius.environments["/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"] = v20231001preview.EnvironmentResource{
-			ID:       to.Ptr("/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"),
-			Name:     to.Ptr("default"),
-			Location: to.Ptr(v1.LocationGlobal),
-		}
-	})
+	createEnvironment(radius)
 
 	// Recipe will be waiting for extender to complete provisioning.
 	status := waitForRecipeStateUpdating(t, client, name, nil)
@@ -221,13 +206,7 @@ func Test_RecipeReconciler_WithSecret(t *testing.T) {
 	require.NoError(t, err)
 
 	// Recipe will be waiting for environment to be created.
-	radius.Update(func() {
-		radius.environments["/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"] = v20231001preview.EnvironmentResource{
-			ID:       to.Ptr("/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"),
-			Name:     to.Ptr("default"),
-			Location: to.Ptr(v1.LocationGlobal),
-		}
-	})
+	createEnvironment(radius)
 
 	// Recipe will be waiting for extender to complete provisioning.
 	status := waitForRecipeStateUpdating(t, client, name, nil)
@@ -298,18 +277,6 @@ func Test_RecipeReconciler_WithSecret(t *testing.T) {
 	err = client.Get(ctx, name, &secret)
 	require.Error(t, err)
 	require.True(t, apierrors.IsNotFound(err))
-}
-
-func makeRecipe(name types.NamespacedName, resourceType string) *radappiov1alpha3.Recipe {
-	return &radappiov1alpha3.Recipe{
-		ObjectMeta: ctrl.ObjectMeta{
-			Namespace: name.Namespace,
-			Name:      name.Name,
-		},
-		Spec: radappiov1alpha3.RecipeSpec{
-			Type: resourceType,
-		},
-	}
 }
 
 func waitForRecipeStateUpdating(t *testing.T, client client.Client, name types.NamespacedName, oldOperation *radappiov1alpha3.ResourceOperation) *radappiov1alpha3.RecipeStatus {

--- a/pkg/controller/reconciler/shared_test.go
+++ b/pkg/controller/reconciler/shared_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
+	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
+	"github.com/radius-project/radius/pkg/to"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func createEnvironment(radius *mockRadiusClient) {
+	radius.Update(func() {
+		radius.environments["/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"] = v20231001preview.EnvironmentResource{
+			ID:       to.Ptr("/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"),
+			Name:     to.Ptr("default"),
+			Location: to.Ptr(v1.LocationGlobal),
+		}
+	})
+}
+
+func makeRecipe(name types.NamespacedName, resourceType string) *radappiov1alpha3.Recipe {
+	return &radappiov1alpha3.Recipe{
+		ObjectMeta: ctrl.ObjectMeta{
+			Namespace: name.Namespace,
+			Name:      name.Name,
+		},
+		Spec: radappiov1alpha3.RecipeSpec{
+			Type: resourceType,
+		},
+	}
+}

--- a/pkg/controller/reconciler/shared_test.go
+++ b/pkg/controller/reconciler/shared_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package reconciler
 
 import (
+	"fmt"
+
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
 	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
@@ -25,11 +27,12 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func createEnvironment(radius *mockRadiusClient) {
+func createEnvironment(radius *mockRadiusClient, name string) {
+	id := fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Applications.Core/environments/%s", name, name)
 	radius.Update(func() {
-		radius.environments["/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"] = v20231001preview.EnvironmentResource{
-			ID:       to.Ptr("/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default"),
-			Name:     to.Ptr("default"),
+		radius.environments[id] = v20231001preview.EnvironmentResource{
+			ID:       to.Ptr(id),
+			Name:     to.Ptr(name),
 			Location: to.Ptr(v1.LocationGlobal),
 		}
 	})

--- a/pkg/controller/reconciler/util.go
+++ b/pkg/controller/reconciler/util.go
@@ -41,7 +41,9 @@ func resolveDependencies(ctx context.Context, radius RadiusClient, scope string,
 
 	environmentID = *found
 
-	resourceGroupID = fmt.Sprintf("/planes/radius/local/resourceGroups/%s-%s", environmentName, applicationName)
+	// NOTE: using resource groups with lowercase here is a workaround for a casing bug in `rad app graph`.
+	// When https://github.com/radius-project/radius/issues/6422 is fixed we can use the more correct casing.
+	resourceGroupID = fmt.Sprintf("/planes/radius/local/resourcegroups/%s-%s", environmentName, applicationName)
 	err = createResourceGroupIfNotExists(ctx, radius, resourceGroupID)
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to create resource group: %w", err)

--- a/pkg/controller/reconciler/util.go
+++ b/pkg/controller/reconciler/util.go
@@ -163,7 +163,17 @@ func deleteResource(ctx context.Context, radius RadiusClient, resourceID string)
 		return nil, err
 	}
 
-	return poller, nil
+	if !poller.Done() {
+		return poller, nil
+	}
+
+	// Handle synchronous completion
+	_, err = poller.Result(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
 }
 
 func createOrUpdateResource(ctx context.Context, radius RadiusClient, resourceID string, properties map[string]any) (Poller[generated.GenericResourcesClientCreateOrUpdateResponse], error) {
@@ -185,7 +195,17 @@ func createOrUpdateResource(ctx context.Context, radius RadiusClient, resourceID
 		return nil, err
 	}
 
-	return poller, nil
+	if !poller.Done() {
+		return poller, nil
+	}
+
+	// Handle synchronous completion
+	_, err = poller.Result(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
 }
 
 func fetchResource(ctx context.Context, radius RadiusClient, resourceID string) (generated.GenericResourcesClientGetResponse, error) {
@@ -214,7 +234,17 @@ func deleteContainer(ctx context.Context, radius RadiusClient, containerID strin
 		return nil, err
 	}
 
-	return poller, nil
+	if !poller.Done() {
+		return poller, nil
+	}
+
+	// Handle synchronous completion
+	_, err = poller.Result(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
 }
 
 func createOrUpdateContainer(ctx context.Context, radius RadiusClient, containerID string, properties *corerpv20231001preview.ContainerProperties) (Poller[corerpv20231001preview.ContainersClientCreateOrUpdateResponse], error) {
@@ -236,5 +266,15 @@ func createOrUpdateContainer(ctx context.Context, radius RadiusClient, container
 		return nil, err
 	}
 
-	return poller, nil
+	if !poller.Done() {
+		return poller, nil
+	}
+
+	// Handle synchronous completion
+	_, err = poller.Result(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
 }

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -92,6 +92,15 @@ func (s *Service) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to setup %s controller: %w", "Recipe", err)
 	}
+	err = (&reconciler.DeploymentReconciler{
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		EventRecorder: mgr.GetEventRecorderFor("radius-deployment-controller"),
+		Radius:        reconciler.NewClient(s.Options.UCPConnection),
+	}).SetupWithManager(mgr)
+	if err != nil {
+		return fmt.Errorf("failed to setup %s controller: %w", "Deployment", err)
+	}
 
 	if s.TLSCertDir == "" {
 		logger.Info("Webhooks will be skipped. TLS certificates not present.")

--- a/pkg/corerp/api/v20231001preview/container_conversion_test.go
+++ b/pkg/corerp/api/v20231001preview/container_conversion_test.go
@@ -97,7 +97,7 @@ func TestContainerConvertVersionedToDataModel(t *testing.T) {
 				require.Equal(t, true, *val.DisableDefaultEnvVars)
 				require.Equal(t, "azure", string(val.IAM.Kind))
 				require.Equal(t, "read", val.IAM.Roles[0])
-				require.Equal(t, "radius.azurecr.io/webapptutorial-todoapp", ct.Properties.Container.Image)
+				require.Equal(t, "ghcr.io/radius-project/webapptutorial-todoapp", ct.Properties.Container.Image)
 				tcpProbe := ct.Properties.Container.LivenessProbe
 				require.Equal(t, datamodel.TCPHealthProbe, tcpProbe.Kind)
 				require.Equal(t, to.Ptr[float32](5), tcpProbe.TCP.InitialDelaySeconds)
@@ -180,7 +180,7 @@ func TestContainerConvertDataModelToVersioned(t *testing.T) {
 				require.Equal(t, "inventory_route_id", val.Source)
 				require.Equal(t, "azure", string(val.IAM.Kind))
 				require.Equal(t, "read", val.IAM.Roles[0])
-				require.Equal(t, "radius.azurecr.io/webapptutorial-todoapp", *versioned.Properties.Container.Image)
+				require.Equal(t, "ghcr.io/radius-project/webapptutorial-todoapp", *versioned.Properties.Container.Image)
 				require.Equal(t, resourcetypeutil.MustPopulateResourceStatus(&ResourceStatus{}), versioned.Properties.Status)
 				require.Equal(t, "kubernetesMetadata", *versioned.Properties.Extensions[2].GetExtension().Kind)
 				require.Equal(t, 3, len(versioned.Properties.Extensions))
@@ -230,7 +230,7 @@ func TestContainerConvertVersionedToDataModelEmptyProtocol(t *testing.T) {
 	require.Equal(t, "azure", string(val.IAM.Kind))
 	require.Equal(t, false, *val.DisableDefaultEnvVars)
 	require.Equal(t, "read", val.IAM.Roles[0])
-	require.Equal(t, "radius.azurecr.io/webapptutorial-todoapp", ct.Properties.Container.Image)
+	require.Equal(t, "ghcr.io/radius-project/webapptutorial-todoapp", ct.Properties.Container.Image)
 	require.Equal(t, []rpv1.OutputResource(nil), ct.Properties.Status.OutputResources)
 	require.Equal(t, "2023-10-01-preview", ct.InternalMetadata.UpdatedAPIVersion)
 

--- a/pkg/corerp/api/v20231001preview/environment_conversion_test.go
+++ b/pkg/corerp/api/v20231001preview/environment_conversion_test.go
@@ -77,7 +77,7 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 						ds_ctrl.MongoDatabasesResourceType: {
 							"cosmos-recipe": datamodel.EnvironmentRecipeProperties{
 								TemplateKind: recipes.TemplateKindBicep,
-								TemplatePath: "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+								TemplatePath: "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
 							},
 						},
 					},
@@ -121,7 +121,7 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 						ds_ctrl.MongoDatabasesResourceType: {
 							"cosmos-recipe": datamodel.EnvironmentRecipeProperties{
 								TemplateKind: recipes.TemplateKindBicep,
-								TemplatePath: "br:sampleregistry.azureacr.io/radius/recipes/mongodatabases",
+								TemplatePath: "br:ghcr.io/sampleregistry/radius/recipes/mongodatabases",
 								Parameters: map[string]any{
 									"throughput": float64(400),
 								},
@@ -139,7 +139,7 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 						ds_ctrl.RedisCachesResourceType: {
 							"redis-recipe": datamodel.EnvironmentRecipeProperties{
 								TemplateKind: recipes.TemplateKindBicep,
-								TemplatePath: "br:sampleregistry.azureacr.io/radius/recipes/rediscaches",
+								TemplatePath: "br:ghcr.io/sampleregistry/radius/recipes/rediscaches",
 							},
 						},
 						dapr_ctrl.DaprStateStoresResourceType: {
@@ -188,7 +188,7 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 						ds_ctrl.MongoDatabasesResourceType: {
 							"cosmos-recipe": datamodel.EnvironmentRecipeProperties{
 								TemplateKind: recipes.TemplateKindBicep,
-								TemplatePath: "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+								TemplatePath: "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
 							},
 						},
 					},
@@ -230,7 +230,7 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 						ds_ctrl.MongoDatabasesResourceType: {
 							"cosmos-recipe": datamodel.EnvironmentRecipeProperties{
 								TemplateKind: recipes.TemplateKindBicep,
-								TemplatePath: "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+								TemplatePath: "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
 							},
 						},
 					},
@@ -327,7 +327,7 @@ func TestConvertDataModelToVersioned(t *testing.T) {
 				require.Equal(t, "kubernetes", string(*versioned.Properties.Compute.GetEnvironmentCompute().Kind))
 				require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.ContainerService/managedClusters/radiusTestCluster", string(*versioned.Properties.Compute.GetEnvironmentCompute().ResourceID))
 				require.Equal(t, 1, len(versioned.Properties.Recipes))
-				require.Equal(t, "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb", string(*versioned.Properties.Recipes[ds_ctrl.MongoDatabasesResourceType]["cosmos-recipe"].GetRecipeProperties().TemplatePath))
+				require.Equal(t, "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb", string(*versioned.Properties.Recipes[ds_ctrl.MongoDatabasesResourceType]["cosmos-recipe"].GetRecipeProperties().TemplatePath))
 				require.Equal(t, recipes.TemplateKindBicep, string(*versioned.Properties.Recipes[ds_ctrl.MongoDatabasesResourceType]["cosmos-recipe"].GetRecipeProperties().TemplateKind))
 				require.Equal(t, map[string]any{"throughput": float64(400)}, versioned.Properties.Recipes[ds_ctrl.MongoDatabasesResourceType]["cosmos-recipe"].GetRecipeProperties().Parameters)
 				require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup", string(*versioned.Properties.Providers.Azure.Scope))
@@ -396,7 +396,7 @@ func TestConvertDataModelWithIdentityToVersioned(t *testing.T) {
 	require.Equal(t, "kubernetes", string(*versioned.Properties.Compute.GetEnvironmentCompute().Kind))
 	require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/providers/Microsoft.ContainerService/managedClusters/radiusTestCluster", string(*versioned.Properties.Compute.GetEnvironmentCompute().ResourceID))
 	require.Equal(t, 1, len(versioned.Properties.Recipes))
-	require.Equal(t, "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb", string(*versioned.Properties.Recipes[ds_ctrl.MongoDatabasesResourceType]["cosmos-recipe"].GetRecipeProperties().TemplatePath))
+	require.Equal(t, "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb", string(*versioned.Properties.Recipes[ds_ctrl.MongoDatabasesResourceType]["cosmos-recipe"].GetRecipeProperties().TemplatePath))
 	require.Equal(t, recipes.TemplateKindBicep, string(*versioned.Properties.Recipes[ds_ctrl.MongoDatabasesResourceType]["cosmos-recipe"].GetRecipeProperties().TemplateKind))
 	require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup", string(*versioned.Properties.Providers.Azure.Scope))
 

--- a/pkg/corerp/api/v20231001preview/testdata/containerresource-runtimes.json
+++ b/pkg/corerp/api/v20231001preview/testdata/containerresource-runtimes.json
@@ -25,7 +25,7 @@
       }
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "failureThreshold": 5,

--- a/pkg/corerp/api/v20231001preview/testdata/containerresource.json
+++ b/pkg/corerp/api/v20231001preview/testdata/containerresource.json
@@ -25,7 +25,7 @@
       }
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "failureThreshold": 5,

--- a/pkg/corerp/api/v20231001preview/testdata/containerresourcedatamodel-runtime.json
+++ b/pkg/corerp/api/v20231001preview/testdata/containerresourcedatamodel-runtime.json
@@ -40,7 +40,7 @@
       "resource": "resourceid"
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "tcp": {

--- a/pkg/corerp/api/v20231001preview/testdata/containerresourcedatamodel.json
+++ b/pkg/corerp/api/v20231001preview/testdata/containerresourcedatamodel.json
@@ -40,7 +40,7 @@
       "resource": "resourceid"
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "tcp": {

--- a/pkg/corerp/api/v20231001preview/testdata/containerresourcedatamodelemptyext.json
+++ b/pkg/corerp/api/v20231001preview/testdata/containerresourcedatamodelemptyext.json
@@ -40,7 +40,7 @@
       "resource": "resourceid"
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "tcp": {

--- a/pkg/corerp/api/v20231001preview/testdata/containerresourceemptyext.json
+++ b/pkg/corerp/api/v20231001preview/testdata/containerresourceemptyext.json
@@ -25,7 +25,7 @@
       }
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "failureThreshold": 5,

--- a/pkg/corerp/api/v20231001preview/testdata/containerresourceemptyext2.json
+++ b/pkg/corerp/api/v20231001preview/testdata/containerresourceemptyext2.json
@@ -25,7 +25,7 @@
       }
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "failureThreshold": 5,

--- a/pkg/corerp/api/v20231001preview/testdata/containerresourcenegativetest.json
+++ b/pkg/corerp/api/v20231001preview/testdata/containerresourcenegativetest.json
@@ -24,7 +24,7 @@
       }
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "ports": {
         "web": {
           "containerPort": 8080

--- a/pkg/corerp/api/v20231001preview/testdata/environmentrecipepropertiesdatamodel-missingtemplatekind.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentrecipepropertiesdatamodel-missingtemplatekind.json
@@ -1,5 +1,5 @@
 {
-  "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+  "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
   "parameters": {
     "throughput": {
       "maxValue": 400,

--- a/pkg/corerp/api/v20231001preview/testdata/environmentrecipepropertiesdatamodel.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentrecipepropertiesdatamodel.json
@@ -1,6 +1,6 @@
 {
   "templateKind": "bicep",
-  "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+  "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
   "parameters": {
     "throughput": {
       "maxValue": 400,

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresource-invalid-resourcetype.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresource-invalid-resourcetype.json
@@ -20,7 +20,7 @@
         "Applications.Dapr/pubsub":{
           "cosmos-recipe": {
             "templateKind": "bicep",
-            "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/pubsub"
+            "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/pubsub"
           }
         }
       }

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresource-invalid-templatekind.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresource-invalid-templatekind.json
@@ -17,7 +17,7 @@
         "Applications.Datastores/mongoDatabases":{
           "cosmos-recipe": {
             "templateKind": "helm",
-            "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/mongo"
+            "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/mongo"
           }
         }
       }

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresource-missing-templatekind.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresource-missing-templatekind.json
@@ -16,7 +16,7 @@
       "recipes": {
         "Applications.Datastores/mongoDatabases":{
           "cosmos-recipe": {
-            "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/mongo"
+            "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/mongo"
           }
         }
       }

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresource-with-workload-identity.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresource-with-workload-identity.json
@@ -22,7 +22,7 @@
             "Applications.Datastores/mongoDatabases":{
                 "cosmos-recipe": {
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
                 }
             }
         }

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresource.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresource.json
@@ -20,7 +20,7 @@
       "Applications.Datastores/mongoDatabases":{
         "cosmos-recipe": {
           "templateKind": "bicep",
-          "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/mongodatabases",
+          "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/mongodatabases",
           "parameters":{
             "throughput": 400
           }
@@ -38,7 +38,7 @@
       "Applications.Datastores/redisCaches":{
         "redis-recipe": {
           "templateKind": "bicep",
-          "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/rediscaches"
+          "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/rediscaches"
         }
       },
       "Applications.Dapr/stateStores":{

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodel-with-workload-identity.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodel-with-workload-identity.json
@@ -35,7 +35,7 @@
             "Applications.Datastores/mongoDatabases":{
                 "cosmos-recipe": {
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
                 }
             }
         }

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodel.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodel.json
@@ -33,7 +33,7 @@
       "Applications.Datastores/mongoDatabases":{
         "cosmos-recipe": {
           "templateKind": "bicep",
-          "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+          "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
           "parameters" : {
             "throughput": 400
           }

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodelemptyext.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodelemptyext.json
@@ -33,7 +33,7 @@
         "Applications.Datastores/mongoDatabases":{
           "cosmos-recipe": {
             "templateKind": "bicep",
-            "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+            "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
             "parameters" : {
               "throughput": 400
             }

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodelemptytemplatekind.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodelemptytemplatekind.json
@@ -29,7 +29,7 @@
       "recipes": {
         "Applications.Datastores/mongoDatabases":{
           "cosmos-recipe": {
-            "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+            "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
           }
         }
       }

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresourceemptyext.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresourceemptyext.json
@@ -17,7 +17,7 @@
         "Applications.Datastores/mongoDatabases":{
           "cosmos-recipe": {
             "templateKind": "bicep",
-            "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+            "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
           }
         }
       },

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresourceemptyext2.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresourceemptyext2.json
@@ -17,7 +17,7 @@
         "Applications.Datastores/mongoDatabases":{
           "cosmos-recipe": {
             "templateKind": "bicep",
-            "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+            "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
           }
         }
       },

--- a/pkg/corerp/backend/deployment/deploymentprocessor_test.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor_test.go
@@ -185,7 +185,7 @@ func buildMongoDBWithRecipe() dsrp_dm.MongoDatabase {
 							"Subscription":  "Radius-Test",
 						},
 					},
-					TemplatePath: "testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1",
+					TemplatePath: "ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1",
 				},
 				APIVersion: clientv2.DocumentDBManagementClientAPIVersion,
 				Resources: []string{"/subscriptions/test-sub/resourceGroups/test-group/providers/Microsoft.DocumentDB/databaseAccounts/test-account",

--- a/pkg/corerp/backend/deployment/testdata/containerresourcedatamodel.json
+++ b/pkg/corerp/backend/deployment/testdata/containerresourcedatamodel.json
@@ -35,7 +35,7 @@
       }
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "tcp": {

--- a/pkg/corerp/backend/deployment/testdata/containerresourcedatamodellowercase.json
+++ b/pkg/corerp/backend/deployment/testdata/containerresourcedatamodellowercase.json
@@ -35,7 +35,7 @@
       }
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "tcp": {

--- a/pkg/corerp/backend/deployment/testdata/containerresourcedatamodeluppercase.json
+++ b/pkg/corerp/backend/deployment/testdata/containerresourcedatamodeluppercase.json
@@ -35,7 +35,7 @@
       }
     },
     "container": {
-      "image": "radius.azurecr.io/webapptutorial-todoapp",
+      "image": "ghcr.io/radius-project/webapptutorial-todoapp",
       "livenessProbe": {
         "kind": "tcp",
         "tcp": {

--- a/pkg/corerp/frontend/controller/environments/getrecipemetadata_test.go
+++ b/pkg/corerp/frontend/controller/environments/getrecipemetadata_test.go
@@ -62,7 +62,7 @@ func TestGetRecipeMetadataRun_20231001Preview(t *testing.T) {
 		recipeDefinition := recipes.EnvironmentDefinition{
 			Name:            *envInput.Name,
 			Parameters:      nil,
-			TemplatePath:    "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
+			TemplatePath:    "ghcr.io/radius-project/dev/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
 			TemplateVersion: "",
 			Driver:          "bicep",
 			ResourceType:    *envInput.ResourceType,
@@ -234,7 +234,7 @@ func TestGetRecipeMetadataRun_20231001Preview(t *testing.T) {
 		recipeDefinition := recipes.EnvironmentDefinition{
 			Name:            *envInput.Name,
 			Parameters:      nil,
-			TemplatePath:    "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
+			TemplatePath:    "ghcr.io/radius-project/dev/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
 			TemplateVersion: "",
 			Driver:          "bicep",
 			ResourceType:    *envInput.ResourceType,

--- a/pkg/corerp/frontend/controller/environments/testdata/environment20231001preview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environment20231001preview_datamodel.json
@@ -24,7 +24,7 @@
             "Applications.Datastores/mongoDatabases":{
                 "mongo-azure": {
                     "templateKind": "bicep",
-                    "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0",
+                    "templatePath": "ghcr.io/radius-project/dev/recipes/mongodatabases/azure:1.0",
                     "parameters": {
                         "throughput": 400
                     }

--- a/pkg/corerp/frontend/controller/environments/testdata/environment20231001preview_input.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environment20231001preview_input.json
@@ -10,7 +10,7 @@
             "Applications.Datastores/mongoDatabases":{
                 "mongo-azure": {
                     "templateKind": "bicep",
-                    "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0",
+                    "templatePath": "ghcr.io/radius-project/dev/recipes/mongodatabases/azure:1.0",
                     "parameters": {
                         "throughput": 400
                     }

--- a/pkg/corerp/frontend/controller/environments/testdata/environment20231001preview_output.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environment20231001preview_output.json
@@ -17,7 +17,7 @@
             "Applications.Datastores/mongoDatabases":{
                 "mongo-azure": {
                     "templateKind": "bicep",
-                    "templatePath": "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0",
+                    "templatePath": "ghcr.io/radius-project/dev/recipes/mongodatabases/azure:1.0",
                     "parameters": {
                         "throughput": 400
                     }

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentgetrecipemetadata20231001preview_datamodel.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentgetrecipemetadata20231001preview_datamodel.json
@@ -24,7 +24,7 @@
             "Applications.Datastores/mongoDatabases":{
                 "mongo-parameters": {
                     "templateKind": "bicep",                  
-                    "templatePath": "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0"
+                    "templatePath": "ghcr.io/radius-project/dev/recipes/functionaltest/parameters/mongodatabases/azure:1.0"
                 },
                 "mongo-terraform": {
                     "templateKind":"terraform",
@@ -35,7 +35,7 @@
             "Applications.Datastores/redisCache":{
                 "redis": {
                     "templateKind": "bicep",
-                    "templatePath": "radiusdev.azurecr.io/redis:1.0"
+                    "templatePath": "ghcr.io/radius-project/dev/redis:1.0"
                   }
             }
         },

--- a/pkg/corerp/frontend/controller/environments/testdata/environmentgetrecipemetadata20231001preview_output.json
+++ b/pkg/corerp/frontend/controller/environments/testdata/environmentgetrecipemetadata20231001preview_output.json
@@ -1,6 +1,6 @@
 {
   "templateKind": "bicep",
-  "templatePath": "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
+  "templatePath": "ghcr.io/radius-project/dev/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
   "parameters": {
     "mongodbName": {
       "type" : "string"

--- a/pkg/corerp/handlers/kubernetes_http_proxy_waiter.go
+++ b/pkg/corerp/handlers/kubernetes_http_proxy_waiter.go
@@ -137,7 +137,7 @@ func (handler *httpProxyWaiter) checkHTTPProxyStatus(ctx context.Context, dynami
 
 		if len(p.Spec.Includes) == 0 && len(p.Spec.Routes) > 0 {
 			// This is a route HTTP proxy. We will not validate deployment completion for it and return success here
-			logger.Info("Not validating the deployment of route HTTP proxy for ", p.Name)
+			logger.Info(fmt.Sprintf("Not validating the deployment of route HTTP proxy for %s", p.Name))
 			doneCh <- nil
 			return true
 		}

--- a/pkg/kubernetes/secrets.go
+++ b/pkg/kubernetes/secrets.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"sort"
+)
+
+// HashSecretData hashes the data in a secret to produce a deterministic hash.
+//
+// This can be used as a Kubernetes annotation to force a Deployment to redeploy pods
+// when the secret changes.
+func HashSecretData(secretData map[string][]byte) string {
+	// Sort keys so we can hash deterministically
+	keys := []string{}
+	for k := range secretData {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	hash := sha1.New()
+
+	for _, k := range keys {
+		// Using | as a delimiter
+		_, _ = hash.Write([]byte("|" + k + "|"))
+		_, _ = hash.Write(secretData[k])
+	}
+
+	sum := hash.Sum(nil)
+	return fmt.Sprintf("%x", sum)
+}

--- a/pkg/portableresources/processors/resourceclient.go
+++ b/pkg/portableresources/processors/resourceclient.go
@@ -26,6 +26,7 @@ import (
 	"github.com/radius-project/radius/pkg/azure/armauth"
 	"github.com/radius-project/radius/pkg/azure/clientv2"
 	aztoken "github.com/radius-project/radius/pkg/azure/tokencredentials"
+	"github.com/radius-project/radius/pkg/cli/clients"
 	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
 	"github.com/radius-project/radius/pkg/sdk"
 	"github.com/radius-project/radius/pkg/trace"
@@ -117,11 +118,21 @@ func (c *resourceClient) deleteAzureResource(ctx context.Context, id resources.I
 
 	poller, err := client.BeginDeleteByID(ctx, id.String(), apiVersion, &armresources.ClientBeginDeleteByIDOptions{})
 	if err != nil {
+		if clients.Is404Error(err) {
+			// If the resource that we want to delete doesn't exist, we don't need to delete it.
+			return nil
+		}
+
 		return err
 	}
 
 	_, err = poller.PollUntilDone(ctx, nil)
 	if err != nil {
+		if clients.Is404Error(err) {
+			// If the resource that we want to delete doesn't exist, we don't need to delete it.
+			return nil
+		}
+
 		return err
 	}
 
@@ -175,11 +186,21 @@ func (c *resourceClient) deleteUCPResource(ctx context.Context, id resources.ID)
 
 	poller, err := client.BeginDelete(ctx, id.Name(), nil)
 	if err != nil {
+		if clients.Is404Error(err) {
+			// If the resource that we want to delete doesn't exist, we don't need to delete it.
+			return nil
+		}
+
 		return err
 	}
 
 	_, err = poller.PollUntilDone(ctx, nil)
 	if err != nil {
+		if clients.Is404Error(err) {
+			// If the resource that we want to delete doesn't exist, we don't need to delete it.
+			return nil
+		}
+
 		return err
 	}
 

--- a/pkg/portableresources/processors/resourceclient_test.go
+++ b/pkg/portableresources/processors/resourceclient_test.go
@@ -126,6 +126,33 @@ func Test_Delete_ARM(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("success - deletion returns 404", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc(ARMResourceID, handleNotFound(t))
+		mux.HandleFunc(ARMProviderPath, handleJSONResponse(t, armresources.Provider{
+			Namespace: to.Ptr("Microsoft.Compute"),
+			ResourceTypes: []*armresources.ProviderResourceType{
+				{
+					ResourceType: to.Ptr("anotherType"),
+					APIVersions:  []*string{},
+				},
+				{
+					ResourceType:      to.Ptr("virtualMachines"),
+					DefaultAPIVersion: to.Ptr(ARMAPIVersion),
+				},
+			},
+		}, 200))
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		c := NewResourceClient(newArmOptions(server.URL), nil, nil, nil)
+		c.armClientOptions = newClientOptions(server.Client(), server.URL)
+
+		err := c.Delete(context.Background(), ARMResourceID)
+		require.NoError(t, err)
+	})
+
 	t.Run("failure - lookup API Version - provider not found", func(t *testing.T) {
 		mux := http.NewServeMux()
 		mux.HandleFunc(ARMProviderPath, handleNotFound(t))
@@ -269,6 +296,22 @@ func Test_Delete_UCP(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mux := http.NewServeMux()
 		mux.HandleFunc(AWSResourceID, handleDeleteSuccess(t))
+
+		server := httptest.NewServer(mux)
+		defer server.Close()
+
+		connection, err := sdk.NewDirectConnection(server.URL)
+		require.NoError(t, err)
+
+		c := NewResourceClient(nil, connection, nil, nil)
+
+		err = c.Delete(context.Background(), AWSResourceID)
+		require.NoError(t, err)
+	})
+
+	t.Run("success - delete returns 404", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc(AWSResourceID, handleNotFound(t))
 
 		server := httptest.NewServer(mux)
 		defer server.Close()

--- a/pkg/recipes/configloader/environment_test.go
+++ b/pkg/recipes/configloader/environment_test.go
@@ -224,7 +224,7 @@ func TestGetRecipeDefinition(t *testing.T) {
 				"Applications.Datastores/mongoDatabases": {
 					recipeName: &model.BicepRecipeProperties{
 						TemplateKind: to.Ptr(recipes.TemplateKindBicep),
-						TemplatePath: to.Ptr("radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0"),
+						TemplatePath: to.Ptr("ghcr.io/radius-project/dev/recipes/mongodatabases/azure:1.0"),
 						Parameters: map[string]any{
 							"foo": "bar",
 						},
@@ -265,7 +265,7 @@ func TestGetRecipeDefinition(t *testing.T) {
 			Name:         recipeName,
 			Driver:       recipes.TemplateKindBicep,
 			ResourceType: "Applications.Datastores/mongoDatabases",
-			TemplatePath: "radiusdev.azurecr.io/recipes/mongodatabases/azure:1.0",
+			TemplatePath: "ghcr.io/radius-project/dev/recipes/mongodatabases/azure:1.0",
 			Parameters: map[string]any{
 				"foo": "bar",
 			},

--- a/pkg/recipes/driver/bicep_test.go
+++ b/pkg/recipes/driver/bicep_test.go
@@ -434,12 +434,13 @@ func Test_Bicep_Delete_Error(t *testing.T) {
 }
 
 func Test_Bicep_GetRecipeMetadata_Success(t *testing.T) {
+	t.Skip("This test makes outbound calls. #6490")
 	ctx := testcontext.New(t)
 	driver := bicepDriver{}
 	recipeDefinition := recipes.EnvironmentDefinition{
 		Name:         "mongo-azure",
 		Driver:       recipes.TemplateKindBicep,
-		TemplatePath: "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
+		TemplatePath: "ghcr.io/radius-project/dev/recipes/functionaltest/parameters/mongodatabases/azure:1.0",
 		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 
@@ -459,12 +460,13 @@ func Test_Bicep_GetRecipeMetadata_Success(t *testing.T) {
 }
 
 func Test_Bicep_GetRecipeMetadata_Error(t *testing.T) {
+	t.Skip("This test makes outbound calls. #6490")
 	ctx := testcontext.New(t)
 	driver := bicepDriver{}
 	recipeDefinition := recipes.EnvironmentDefinition{
 		Name:         "mongo-azure",
 		Driver:       recipes.TemplateKindBicep,
-		TemplatePath: "radiusdev.azurecr.io/test-non-existent-recipe",
+		TemplatePath: "ghcr.io/radius-project/dev/test-non-existent-recipe",
 		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 
@@ -475,7 +477,7 @@ func Test_Bicep_GetRecipeMetadata_Error(t *testing.T) {
 	expErr := recipes.RecipeError{
 		ErrorDetails: v1.ErrorDetails{
 			Code:    recipes.RecipeLanguageFailure,
-			Message: "failed to fetch repository from the path \"radiusdev.azurecr.io/test-non-existent-recipe\": radiusdev.azurecr.io/test-non-existent-recipe:latest: not found",
+			Message: "failed to fetch repository from the path \"ghcr.io/radius-project/dev/test-non-existent-recipe\": ghcr.io/radius-project/dev/test-non-existent-recipe:latest: not found",
 		},
 		DeploymentStatus: "setupError",
 	}

--- a/pkg/recipes/engine/engine_test.go
+++ b/pkg/recipes/engine/engine_test.go
@@ -86,7 +86,7 @@ func Test_Engine_Execute_Success(t *testing.T) {
 	}
 	recipeDefinition := &recipes.EnvironmentDefinition{
 		Driver:       recipes.TemplateKindBicep,
-		TemplatePath: "radiusdev.azurecr.io/recipes/functionaltest/basic/mongodatabases/azure:1.0",
+		TemplatePath: "ghcr.io/radius-project/dev/recipes/functionaltest/basic/mongodatabases/azure:1.0",
 		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 	ctx := testcontext.New(t)
@@ -149,7 +149,7 @@ func Test_Engine_Execute_Failure(t *testing.T) {
 	}
 	recipeDefinition := &recipes.EnvironmentDefinition{
 		Driver:       recipes.TemplateKindBicep,
-		TemplatePath: "radiusdev.azurecr.io/recipes/functionaltest/basic/mongodatabases/azure:1.0",
+		TemplatePath: "ghcr.io/radius-project/dev/recipes/functionaltest/basic/mongodatabases/azure:1.0",
 		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 	ctx := testcontext.New(t)
@@ -266,7 +266,7 @@ func Test_Engine_InvalidDriver(t *testing.T) {
 
 	recipeDefinition := &recipes.EnvironmentDefinition{
 		Driver:       "invalid",
-		TemplatePath: "radiusdev.azurecr.io/recipes/functionaltest/basic/mongodatabases/azure:1.0",
+		TemplatePath: "ghcr.io/radius-project/dev/recipes/functionaltest/basic/mongodatabases/azure:1.0",
 		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 
@@ -342,7 +342,7 @@ func Test_Engine_Load_Error(t *testing.T) {
 	}
 	recipeDefinition := &recipes.EnvironmentDefinition{
 		Driver:       recipes.TemplateKindBicep,
-		TemplatePath: "radiusdev.azurecr.io/recipes/functionaltest/basic/mongodatabases/azure:1.0",
+		TemplatePath: "ghcr.io/radius-project/dev/recipes/functionaltest/basic/mongodatabases/azure:1.0",
 		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 	configLoader.EXPECT().
@@ -561,7 +561,7 @@ func getRecipeInputs() (recipes.ResourceMetadata, recipes.EnvironmentDefinition,
 
 	recipeDefinition := recipes.EnvironmentDefinition{
 		Driver:       recipes.TemplateKindBicep,
-		TemplatePath: "radiusdev.azurecr.io/recipes/functionaltest/basic/mongodatabases/azure:1.0",
+		TemplatePath: "ghcr.io/radius-project/dev/recipes/functionaltest/basic/mongodatabases/azure:1.0",
 		ResourceType: "Applications.Datastores/mongoDatabases",
 	}
 

--- a/pkg/rp/util/registry.go
+++ b/pkg/rp/util/registry.go
@@ -38,8 +38,6 @@ func ReadFromRegistry(ctx context.Context, path string, data *map[string]any) er
 		return v1.NewClientErrInvalidRequest(fmt.Sprintf("invalid path %s", err.Error()))
 	}
 
-	// get the data from ACR
-	// client to the ACR repository in the path
 	repo, err := remote.NewRepository(registryRepo)
 	if err != nil {
 		return fmt.Errorf("failed to create client to registry %s", err.Error())

--- a/pkg/rp/util/registry_test.go
+++ b/pkg/rp/util/registry_test.go
@@ -23,9 +23,9 @@ import (
 )
 
 func Test_PathParser(t *testing.T) {
-	repository, tag, err := parsePath("radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0")
+	repository, tag, err := parsePath("ghcr.io/radius-project/dev/recipes/functionaltest/parameters/mongodatabases/azure:1.0")
 	require.NoError(t, err)
-	require.Equal(t, "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure", repository)
+	require.Equal(t, "ghcr.io/radius-project/dev/recipes/functionaltest/parameters/mongodatabases/azure", repository)
 	require.Equal(t, "1.0", tag)
 }
 

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_CreateOrUpdate.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_CreateOrUpdate.json
@@ -15,7 +15,7 @@
           }
         },
         "container": {
-          "image": "radius.azurecr.io/webapptutorial-todoapp",
+          "image": "ghcr.io/radius-project/webapptutorial-todoapp",
           "command": [
             "/bin/sh"
           ],
@@ -44,7 +44,7 @@
             }
           },
           "container": {
-            "image": "radius.azurecr.io/webapptutorial-todoapp",
+            "image": "ghcr.io/radius-project/webapptutorial-todoapp",
             "command": [
               "/bin/sh"
             ],

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_CreateOrUpdate_BaseManifest.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_CreateOrUpdate_BaseManifest.json
@@ -15,7 +15,7 @@
           }
         },
         "container": {
-          "image": "radius.azurecr.io/webapptutorial-todoapp",
+          "image": "ghcr.io/radius-project/webapptutorial-todoapp",
           "command": [
             "/bin/sh"
           ],
@@ -49,7 +49,7 @@
             }
           },
           "container": {
-            "image": "radius.azurecr.io/webapptutorial-todoapp",
+            "image": "ghcr.io/radius-project/webapptutorial-todoapp",
             "command": [
               "/bin/sh"
             ],

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_Get.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_Get.json
@@ -22,7 +22,7 @@
             }
           },
           "container": {
-            "image": "radius.azurecr.io/webapptutorial-todoapp",
+            "image": "ghcr.io/radius-project/webapptutorial-todoapp",
             "command": [
               "/bin/sh"
             ],

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_List.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_List.json
@@ -23,7 +23,7 @@
                 }
               },
               "container": {
-                "image": "radius.azurecr.io/webapptutorial-todoapp",
+                "image": "ghcr.io/radius-project/webapptutorial-todoapp",
                 "command": [
                   "/bin/sh"
                 ],
@@ -54,7 +54,7 @@
                 }
               },
               "container": {
-                "image": "radius.azurecr.io/webapptutorial-todoapp",
+                "image": "ghcr.io/radius-project/webapptutorial-todoapp",
                 "command": [
                   "/bin/sh"
                 ],

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_ListByScope.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Containers_ListByScope.json
@@ -23,7 +23,7 @@
                 }
               },
               "container": {
-                "image": "radius.azurecr.io/webapptutorial-todoapp",
+                "image": "ghcr.io/radius-project/webapptutorial-todoapp",
                 "command": [
                   "/bin/sh"
                 ],
@@ -81,7 +81,7 @@
                 }
               },
               "container": {
-                "image": "radius.azurecr.io/webapptutorial-todoapp",
+                "image": "ghcr.io/radius-project/webapptutorial-todoapp",
                 "command": [
                   "/bin/sh"
                 ],

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_CreateOrUpdate.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_CreateOrUpdate.json
@@ -21,7 +21,7 @@
           "Applications.Datastores/mongoDatabases":{
             "cosmos-recipe": {
               "templateKind": "bicep",
-              "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+              "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
             }
           }
         },
@@ -63,7 +63,7 @@
             "Applications.Datastores/mongoDatabases":{
               "cosmos-recipe": {
                 "templateKind": "bicep",
-                "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
               }
             }
           },

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_GetEnv0.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_GetEnv0.json
@@ -32,7 +32,7 @@
             "Applications.Datastores/mongoDatabases":{
               "cosmos-recipe": {
                 "templateKind": "bicep",
-                "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
               }
             }
           },

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_GetRecipeMetadata.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_GetRecipeMetadata.json
@@ -12,7 +12,7 @@
       "body": {
         "resourceType": "Applications.Datastores/mongoDatabases",
         "templateKind": "bicep",
-        "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+        "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
         "parameters": {
           "throughput": {
             "type" : "int",

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_List.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_List.json
@@ -33,21 +33,21 @@
                 "Applications.Datastores/mongoDatabases":{
                   "cosmos-recipe": {
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
                   },
                   "default":{
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/mongo"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/mongo"
                   }
                 },
                 "Applications.Datastores/redisCaches":{
                   "redis-recipe": {
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/rediscache"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/rediscache"
                   },
                   "default":{
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/redis"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/redis"
                   }
                 }
               },
@@ -111,7 +111,7 @@
               "recipes": {
                 "Applications.Datastores/mongoDatabases":{
                   "cosmos-recipe": {
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
                   } 
                 }
               }

--- a/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_PatchEnv0.json
+++ b/swagger/specification/applications/resource-manager/Applications.Core/preview/2023-10-01-preview/examples/Environments_PatchEnv0.json
@@ -21,7 +21,7 @@
           "Applications.Datastores/mongoDatabases":{
             "cosmos-recipe": {
               "templateKind": "bicep",
-              "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+              "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
             }
           }
         }
@@ -50,7 +50,7 @@
             "Applications.Datastores/mongoDatabases":{
               "cosmos-recipe": {
                 "templateKind": "bicep",
-                "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
               }
             }
           },

--- a/test/functional/kubernetes/kubernetes_test.go
+++ b/test/functional/kubernetes/kubernetes_test.go
@@ -1,0 +1,282 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	aztoken "github.com/radius-project/radius/pkg/azure/tokencredentials"
+	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
+	radappiov1alpha3 "github.com/radius-project/radius/pkg/controller/api/radapp.io/v1alpha3"
+	"github.com/radius-project/radius/pkg/controller/reconciler"
+	"github.com/radius-project/radius/pkg/sdk"
+	"github.com/radius-project/radius/test/functional"
+	"github.com/radius-project/radius/test/functional/shared"
+	"github.com/radius-project/radius/test/radcli"
+	"github.com/radius-project/radius/test/testcontext"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+	controller_runtime "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func Test_TutorialApplication_KubernetesManifests(t *testing.T) {
+	ctx := testcontext.New(t)
+	opts := shared.NewRPTestOptions(t)
+
+	namespace := "kubernetes-interop-tutorial"
+	environmentName := namespace + "-env"
+	applicationName := namespace
+
+	// Create the namespace, if it already exists we can ignore the error.
+	_, err := opts.K8sClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}, metav1.CreateOptions{})
+	require.NoError(t, controller_runtime.IgnoreAlreadyExists(err))
+
+	cli := radcli.NewCLI(t, "")
+
+	params := []string{
+		functional.GetBicepRecipeRegistry(),
+		functional.GetBicepRecipeVersion(),
+
+		// Avoid a conflict between app namespace and env namespace.
+		fmt.Sprintf("name=%s", environmentName),
+		fmt.Sprintf("namespace=%s", environmentName),
+	}
+
+	err = cli.Deploy(ctx, "testdata/tutorial-environment.bicep", "", "", params...)
+	require.NoError(t, err)
+
+	deployment := makeDeployment(types.NamespacedName{Name: "demo", Namespace: namespace}, environmentName, applicationName)
+	recipe := makeRecipe(types.NamespacedName{Name: "db", Namespace: namespace}, environmentName, applicationName)
+
+	t.Run("Deploy", func(t *testing.T) {
+		t.Log("Creating recipe")
+		err = opts.Client.Create(ctx, deployment)
+		require.NoError(t, err)
+
+		t.Log("Creating deployment")
+		err = opts.Client.Create(ctx, recipe)
+		require.NoError(t, err)
+	})
+
+	t.Run("Check Recipe status", func(t *testing.T) {
+		ctx, cancel := testcontext.NewWithCancel(t)
+		defer cancel()
+
+		// Get resource version
+		err = opts.Client.Get(ctx, types.NamespacedName{Name: "db", Namespace: namespace}, recipe)
+		require.NoError(t, err)
+
+		t.Log("Waiting for recipe ready")
+		recipe, err = waitForRecipeReady(t, ctx, types.NamespacedName{Name: "db", Namespace: namespace}, opts.Client, recipe.ResourceVersion)
+		require.NoError(t, err)
+
+		// Doing a basic check that the recipe has a resource provisioned.
+		require.NotEmpty(t, recipe.Status.Resource)
+
+		client, err := generated.NewGenericResourcesClient(recipe.Status.Scope, recipe.Spec.Type, &aztoken.AnonymousCredential{}, sdk.NewClientOptions(opts.Connection))
+		require.NoError(t, err)
+
+		_, err = client.Get(ctx, recipe.Name, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("Check Deployment status", func(t *testing.T) {
+		ctx, cancel := testcontext.NewWithCancel(t)
+		defer cancel()
+
+		// Get resource version
+		err = opts.Client.Get(ctx, types.NamespacedName{Name: "demo", Namespace: namespace}, deployment)
+		require.NoError(t, err)
+
+		t.Log("Waiting for deployment ready")
+		deployment, err = waitForDeploymentReady(t, ctx, types.NamespacedName{Name: "demo", Namespace: namespace}, opts.K8sClient, deployment.ResourceVersion)
+		require.NoError(t, err)
+
+		// Doing a basic check that the Deployment has environment variables set.
+		require.NotEmpty(t, deployment.Spec.Template.Spec.Containers[0].EnvFrom)
+
+		// Doing a basic check that the deployment has a resource provisioned.
+		client, err := generated.NewGenericResourcesClient(recipe.Status.Scope, "Applications.Core/containers", &aztoken.AnonymousCredential{}, sdk.NewClientOptions(opts.Connection))
+		require.NoError(t, err)
+
+		_, err = client.Get(ctx, deployment.Name, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		t.Log("Deleting recipe")
+		err = opts.Client.Delete(ctx, recipe)
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			err = opts.Client.Get(ctx, types.NamespacedName{Name: "db", Namespace: namespace}, recipe)
+			return apierrors.IsNotFound(err)
+		}, time.Second*60, time.Second*5, "waiting for recipe to be deleted")
+
+		t.Log("Deleting deployment")
+		err = opts.Client.Delete(ctx, deployment)
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			err = opts.Client.Get(ctx, types.NamespacedName{Name: "demo", Namespace: namespace}, deployment)
+			return apierrors.IsNotFound(err)
+		}, time.Second*60, time.Second*5, "waiting for deployment to be deleted")
+	})
+}
+
+func makeDeployment(name types.NamespacedName, environmentName string, applicationName string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+			Annotations: map[string]string{
+				"radapp.io/enabled":          "true",
+				"radapp.io/connection-redis": "db",
+				"radapp.io/environment":      environmentName,
+				"radapp.io/application":      applicationName,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "demo"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "demo"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "demo",
+							Image: "radius.azurecr.io/tutorial/webapp:edge",
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: 3000,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func makeRecipe(name types.NamespacedName, environmentName string, applicationName string) *radappiov1alpha3.Recipe {
+	return &radappiov1alpha3.Recipe{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.Name,
+			Namespace: name.Namespace,
+			Annotations: map[string]string{
+				"radapp.io/enabled":          "true",
+				"radapp.io/connection-redis": "db",
+			},
+		},
+		Spec: radappiov1alpha3.RecipeSpec{
+			Type:        "Applications.Datastores/redisCaches",
+			Environment: environmentName,
+			Application: applicationName,
+		},
+	}
+}
+
+func waitForRecipeReady(t *testing.T, ctx context.Context, name types.NamespacedName, client controller_runtime.WithWatch, initialVersion string) (*radappiov1alpha3.Recipe, error) {
+	// Based on https://gist.github.com/PrasadG193/52faed6499d2ec739f9630b9d044ffdc
+	lister := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			listOptions := &controller_runtime.ListOptions{Raw: &options, Namespace: name.Namespace, FieldSelector: fields.ParseSelectorOrDie("metadata.name=" + name.Name)}
+			recipes := &radappiov1alpha3.RecipeList{}
+			err := client.List(ctx, recipes, listOptions)
+			if err != nil {
+				return nil, err
+			}
+
+			return recipes, nil
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			listOptions := &controller_runtime.ListOptions{Raw: &options, Namespace: name.Namespace, FieldSelector: fields.ParseSelectorOrDie("metadata.name=" + name.Name)}
+			recipes := &radappiov1alpha3.RecipeList{}
+			return client.Watch(ctx, recipes, listOptions)
+		},
+	}
+	watcher, err := watchtools.NewRetryWatcher(initialVersion, lister)
+	require.NoError(t, err)
+	defer watcher.Stop()
+
+	for {
+		event := <-watcher.ResultChan()
+		r, ok := event.Object.(*radappiov1alpha3.Recipe)
+		if !ok {
+			// Not a recipe, likely an event.
+			t.Logf("Received event: %+v", event)
+			continue
+		}
+
+		t.Logf("Received recipe. Status: %+v", r.Status)
+		if r.Status.Phrase == radappiov1alpha3.PhraseReady {
+			return r, nil
+		}
+	}
+}
+
+func waitForDeploymentReady(t *testing.T, ctx context.Context, name types.NamespacedName, client *kubernetes.Clientset, initialVersion string) (*appsv1.Deployment, error) {
+	// Based on https://gist.github.com/PrasadG193/52faed6499d2ec739f9630b9d044ffdc
+	watcher, err := watchtools.NewRetryWatcher(initialVersion, cache.NewFilteredListWatchFromClient(client.AppsV1().RESTClient(), "deployments", name.Namespace, func(options *metav1.ListOptions) {
+		options.FieldSelector = "metadata.name=" + name.Name
+	}))
+	require.NoError(t, err)
+	defer watcher.Stop()
+
+	for {
+		event := <-watcher.ResultChan()
+		d, ok := event.Object.(*appsv1.Deployment)
+		if !ok {
+			// Not a deployment, likely an event.
+			t.Logf("Received event: %+v", event)
+			continue
+		}
+
+		t.Logf("Received deployment. Annotations: %+v", d.Annotations)
+
+		data, ok := d.Annotations[reconciler.AnnotationRadiusStatus]
+		if !ok || data == "" {
+			continue
+		}
+
+		status := map[string]any{}
+		err := json.Unmarshal([]byte(data), &status)
+		require.NoError(t, err)
+
+		if d.Status.ObservedGeneration == d.Generation && d.Status.ReadyReplicas == 1 && status["phrase"] == "Ready" {
+			return d, nil
+		}
+	}
+}

--- a/test/functional/kubernetes/testdata/tutorial-environment.bicep
+++ b/test/functional/kubernetes/testdata/tutorial-environment.bicep
@@ -1,0 +1,25 @@
+import radius as radius
+
+param name string
+param namespace string
+param registry string
+param version string
+
+resource env 'Applications.Core/environments@2023-10-01-preview' = {
+  name: name
+  properties: {
+    compute: {
+      kind: 'kubernetes'
+      resourceId: 'self'
+      namespace: namespace
+    }
+    recipes: {
+      'Applications.Datastores/redisCaches': {
+        default: {
+          templateKind: 'bicep'
+          templatePath: '${registry}/test/functional/shared/recipes/redis-recipe-value-backed:${version}'
+        }
+      }
+    }
+  }
+}

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -59,11 +59,11 @@ func verifyRecipeCLI(ctx context.Context, t *testing.T, test shared.RPTest) {
 	// for AWS test and has the AWS scope which the environment created in this does not.
 	envName := test.Steps[0].RPResources.Resources[0].Name
 	recipeName := "recipeName"
-	recipeTemplate := "testpublicrecipe.azurecr.io/bicep/modules/testTemplate:v1"
+	recipeTemplate := "ghcr.io/testpublicrecipe/bicep/modules/testTemplate:v1"
 	templateKind := "bicep"
 	resourceType := "Applications.Datastores/mongoDatabases"
 	file := "testdata/corerp-redis-recipe.bicep"
-	target := fmt.Sprintf("br:radiusdev.azurecr.io/test-bicep-recipes/redis-recipe:%s", generateUniqueTag())
+	target := fmt.Sprintf("br:ghcr.io/radius-project/dev/test-bicep-recipes/redis-recipe:%s", generateUniqueTag())
 
 	t.Run("Validate rad recipe register", func(t *testing.T) {
 		output, err := cli.RecipeRegister(ctx, envName, recipeName, templateKind, recipeTemplate, resourceType)
@@ -87,7 +87,7 @@ func verifyRecipeCLI(ctx context.Context, t *testing.T, test shared.RPTest) {
 
 	t.Run("Validate rad recipe show", func(t *testing.T) {
 		showRecipeName := "mongodbtest"
-		showRecipeTemplate := "radiusdev.azurecr.io/recipes/functionaltest/parameters/mongodatabases/azure:1.0"
+		showRecipeTemplate := "ghcr.io/radius-project/dev/recipes/functionaltest/parameters/mongodatabases/azure:1.0"
 		showRecipeResourceType := "Applications.Datastores/mongoDatabases"
 		output, err := cli.RecipeRegister(ctx, envName, showRecipeName, templateKind, showRecipeTemplate, showRecipeResourceType)
 		require.NoError(t, err)
@@ -588,8 +588,8 @@ func Test_CLI_DeploymentParameters(t *testing.T) {
 	registry, _ := functional.SetDefault()
 	parameterFilePath := functional.WriteBicepParameterFile(t, map[string]any{"registry": registry})
 
-	// corerp-kubernetes-cli-parameters.parameters.json uses radiusdev.azurecr.io as a registry parameter.
-	// Use the specified tag only if the test uses radiusdev.azurecr.io registry. Otherwise, use latest tag.
+	// corerp-kubernetes-cli-parameters.parameters.json uses ghcr.io/radius-project/dev as a registry parameter.
+	// Use the specified tag only if the test uses ghcr.io/radius-project/dev registry. Otherwise, use latest tag.
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{
 		{
@@ -666,6 +666,7 @@ func Test_CLI_Only_version(t *testing.T) {
 }
 
 func Test_RecipeCommands(t *testing.T) {
+	t.Skip("TODO: disabling this test temporarily while we determine which recipes it should pull")
 	template := "testdata/corerp-resources-recipe-env.bicep"
 	name := "corerp-resources-recipe-env"
 

--- a/test/functional/shared/cli/testdata/corerp-resources-recipe-env.bicep
+++ b/test/functional/shared/cli/testdata/corerp-resources-recipe-env.bicep
@@ -16,7 +16,7 @@ resource env 'Applications.Core/environments@2023-10-01-preview' = {
       'Applications.Datastores/mongoDatabases':{
         recipe1: {
           templateKind: 'bicep'
-          templatePath: 'testpublicrecipe.azurecr.io/bicep/modules/mongodatabases:v1' 
+          templatePath: 'ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1' 
         }
         recipe2: {
           templateKind: 'terraform'

--- a/test/functional/shared/resources/testdata/corerp-resources-container-pod-patching.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-container-pod-patching.bicep
@@ -46,7 +46,7 @@ resource container 'Applications.Core/containers@2023-10-01-preview' = {
           containers: [
             {
               name: 'log-collector'
-              image: 'radiusdev.azurecr.io/fluent/fluent-bit:2.1.8'
+              image: 'ghcr.io/radius-project/fluent-bit:2.1.8'
             }
           ]
           hostNetwork: true
@@ -55,4 +55,3 @@ resource container 'Applications.Core/containers@2023-10-01-preview' = {
     }
   }
 }
-

--- a/test/functional/shared/resources/testdata/manifest/sidecar.yaml
+++ b/test/functional/shared/resources/testdata/manifest/sidecar.yaml
@@ -18,5 +18,4 @@ spec:
     spec:
       containers:
         - name: log-collector
-          # TODO: change it to ghcr.io/radius-project/fluent-bit:2.1.8
-          image: radiusdev.azurecr.io/fluent/fluent-bit:2.1.8
+          image: ghcr.io/radius-project/fluent-bit:2.1.8

--- a/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/README.md
+++ b/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/README.md
@@ -2,7 +2,7 @@
 
 The recipes in this folder are published as part of the PR process to:
 
-> `radiusdev.azurecr.io/test/functional/shared/recipes/<filename>:pr-<pr-number>`
+> `ghcr.io/radius-project/dev/test/functional/shared/recipes/<filename>:pr-<pr-number>`
 
 This is important because it allows us to make changes to the recipes, and test them in the same PR that contains the change.
 

--- a/test/functional/shared/test.go
+++ b/test/functional/shared/test.go
@@ -84,6 +84,7 @@ func NewRPTestOptions(t *testing.T) RPTestOptions {
 		CustomAction:     customAction,
 		ManagementClient: client,
 		AWSClient:        awsClient,
+		Connection:       connection,
 	}
 }
 
@@ -92,4 +93,7 @@ type RPTestOptions struct {
 	CustomAction     *clientv2.CustomActionClient
 	ManagementClient clients.ApplicationsManagementClient
 	AWSClient        aws.AWSCloudControlClient
+
+	// Connection gets access to the Radius connection which can be used to create API clients.
+	Connection sdk.Connection
 }

--- a/test/functional/testUtil.go
+++ b/test/functional/testUtil.go
@@ -73,7 +73,7 @@ func SetDefault() (string, string) {
 	defaultDockerReg := os.Getenv("DOCKER_REGISTRY")
 	imageTag := os.Getenv("REL_VERSION")
 	if defaultDockerReg == "" {
-		defaultDockerReg = "radiusdev.azurecr.io"
+		defaultDockerReg = "ghcr.io/radius-project/dev"
 	}
 	if imageTag == "" {
 		imageTag = "latest"
@@ -91,7 +91,7 @@ type ProxyMetadata struct {
 func GetBicepRecipeRegistry() string {
 	defaultRecipeRegistry := os.Getenv("BICEP_RECIPE_REGISTRY")
 	if defaultRecipeRegistry == "" {
-		defaultRecipeRegistry = "radiusdev.azurecr.io"
+		defaultRecipeRegistry = "ghcr.io/radius-project/dev"
 	}
 	return "registry=" + defaultRecipeRegistry
 }

--- a/test/functional/ucp/proxy_test.go
+++ b/test/functional/ucp/proxy_test.go
@@ -249,7 +249,7 @@ func getTestRPImage() string {
 	dockerReg := os.Getenv("DOCKER_REGISTRY")
 	imageTag := os.Getenv("REL_VERSION")
 	if dockerReg == "" {
-		dockerReg = "radiusdev.azurecr.io"
+		dockerReg = "ghcr.io/radius-project/dev"
 	}
 	if imageTag == "" {
 		imageTag = "latest"

--- a/test/options.go
+++ b/test/options.go
@@ -34,7 +34,7 @@ type TestOptions struct {
 	K8sClient      *k8s.Clientset
 	K8sConfig      *rest.Config
 	DynamicClient  dynamic.Interface
-	Client         client.Client
+	Client         client.WithWatch
 }
 
 // NewTestOptions creates a TestOptions struct with the necessary clients and configs for testing.

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Containers_CreateOrUpdate.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Containers_CreateOrUpdate.json
@@ -15,7 +15,7 @@
           }
         },
         "container": {
-          "image": "radius.azurecr.io/webapptutorial-todoapp",
+          "image": "ghcr.io/radius-project/webapptutorial-todoapp",
           "command": [
             "/bin/sh"
           ],
@@ -44,7 +44,7 @@
             }
           },
           "container": {
-            "image": "radius.azurecr.io/webapptutorial-todoapp",
+            "image": "ghcr.io/radius-project/webapptutorial-todoapp",
             "command": [
               "/bin/sh"
             ],

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Containers_CreateOrUpdate_BaseManifest.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Containers_CreateOrUpdate_BaseManifest.json
@@ -15,7 +15,7 @@
           }
         },
         "container": {
-          "image": "radius.azurecr.io/webapptutorial-todoapp",
+          "image": "ghcr.io/radius-project/webapptutorial-todoapp",
           "command": [
             "/bin/sh"
           ],
@@ -49,7 +49,7 @@
             }
           },
           "container": {
-            "image": "radius.azurecr.io/webapptutorial-todoapp",
+            "image": "ghcr.io/radius-project/webapptutorial-todoapp",
             "command": [
               "/bin/sh"
             ],

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Containers_Get.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Containers_Get.json
@@ -22,7 +22,7 @@
             }
           },
           "container": {
-            "image": "radius.azurecr.io/webapptutorial-todoapp",
+            "image": "ghcr.io/radius-project/webapptutorial-todoapp",
             "command": [
               "/bin/sh"
             ],

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Containers_List.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Containers_List.json
@@ -23,7 +23,7 @@
                 }
               },
               "container": {
-                "image": "radius.azurecr.io/webapptutorial-todoapp",
+                "image": "ghcr.io/radius-project/webapptutorial-todoapp",
                 "command": [
                   "/bin/sh"
                 ],
@@ -54,7 +54,7 @@
                 }
               },
               "container": {
-                "image": "radius.azurecr.io/webapptutorial-todoapp",
+                "image": "ghcr.io/radius-project/webapptutorial-todoapp",
                 "command": [
                   "/bin/sh"
                 ],

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Containers_ListByScope.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Containers_ListByScope.json
@@ -23,7 +23,7 @@
                 }
               },
               "container": {
-                "image": "radius.azurecr.io/webapptutorial-todoapp",
+                "image": "ghcr.io/radius-project/webapptutorial-todoapp",
                 "command": [
                   "/bin/sh"
                 ],
@@ -81,7 +81,7 @@
                 }
               },
               "container": {
-                "image": "radius.azurecr.io/webapptutorial-todoapp",
+                "image": "ghcr.io/radius-project/webapptutorial-todoapp",
                 "command": [
                   "/bin/sh"
                 ],

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Containers_Update.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Containers_Update.json
@@ -9,7 +9,7 @@
       "properties": {
         "application": "/planes/radius/local/resourceGroups/testGroup/providers/Applications.Core/applications/app0",
         "container": {
-          "image": "radius.azurecr.io/webapptutorial-todoapp",
+          "image": "ghcr.io/radius-project/webapptutorial-todoapp",
           "command": [
             "/bin/sh"
           ],
@@ -38,7 +38,7 @@
             }
           },
           "container": {
-            "image": "radius.azurecr.io/webapptutorial-todoapp",
+            "image": "ghcr.io/radius-project/webapptutorial-todoapp",
             "command": [
               "/bin/sh"
             ],

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Environments_CreateOrUpdate.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Environments_CreateOrUpdate.json
@@ -21,7 +21,7 @@
           "Applications.Datastores/mongoDatabases":{
             "cosmos-recipe": {
               "templateKind": "bicep",
-              "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+              "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
             }
           }
         },
@@ -63,7 +63,7 @@
             "Applications.Datastores/mongoDatabases":{
               "cosmos-recipe": {
                 "templateKind": "bicep",
-                "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
               }
             }
           },

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Environments_GetEnv0.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Environments_GetEnv0.json
@@ -32,7 +32,7 @@
             "Applications.Datastores/mongoDatabases":{
               "cosmos-recipe": {
                 "templateKind": "bicep",
-                "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
               }
             }
           },

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Environments_GetRecipeMetadata.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Environments_GetRecipeMetadata.json
@@ -12,7 +12,7 @@
       "body": {
         "resourceType": "Applications.Datastores/mongoDatabases",
         "templateKind": "bicep",
-        "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb",
+        "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb",
         "parameters": {
           "throughput": {
             "type" : "int",

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Environments_List.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Environments_List.json
@@ -33,21 +33,21 @@
                 "Applications.Datastores/mongoDatabases":{
                   "cosmos-recipe": {
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
                   },
                   "default":{
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/mongo"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/mongo"
                   }
                 },
                 "Applications.Datastores/redisCaches":{
                   "redis-recipe": {
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/rediscache"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/rediscache"
                   },
                   "default":{
                     "templateKind": "bicep",
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/redis"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/redis"
                   }
                 }
               },
@@ -111,7 +111,7 @@
               "recipes": {
                 "Applications.Datastores/mongoDatabases":{
                   "cosmos-recipe": {
-                    "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                    "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
                   } 
                 }
               }

--- a/typespec/Applications.Core/examples/2023-10-01-preview/Environments_PatchEnv0.json
+++ b/typespec/Applications.Core/examples/2023-10-01-preview/Environments_PatchEnv0.json
@@ -21,7 +21,7 @@
           "Applications.Datastores/mongoDatabases":{
             "cosmos-recipe": {
               "templateKind": "bicep",
-              "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+              "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
             }
           }
         }
@@ -50,7 +50,7 @@
             "Applications.Datastores/mongoDatabases":{
               "cosmos-recipe": {
                 "templateKind": "bicep",
-                "templatePath": "br:sampleregistry.azureacr.io/radius/recipes/cosmosdb"
+                "templatePath": "br:ghcr.io/sampleregistry/radius/recipes/cosmosdb"
               }
             }
           },

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 supported:
   - channel: '0.26'
-    version: 'v0.26.6'
+    version: 'v0.26.7'
 deprecated:
   - channel: '0.25'
     version: 'v0.25.0'

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 supported:
   - channel: '0.26'
-    version: 'v0.26.3'
+    version: 'v0.26.4'
 deprecated:
   - channel: '0.25'
     version: 'v0.25.0'

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 supported:
   - channel: '0.26'
-    version: 'v0.26.5'
+    version: 'v0.26.6'
 deprecated:
   - channel: '0.25'
     version: 'v0.25.0'

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,9 +1,9 @@
 supported:
   - channel: '0.26'
-    version: 'v0.26.0-rc1'
+    version: 'v0.26.0'
+deprecated:
   - channel: '0.25'
     version: 'v0.25.0'
-deprecated:
   - channel: '0.24'
     version: 'v0.24.0'
   - channel: '0.23'

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 supported:
   - channel: '0.26'
-    version: 'v0.26.4'
+    version: 'v0.26.5'
 deprecated:
   - channel: '0.25'
     version: 'v0.25.0'

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 supported:
   - channel: '0.26'
-    version: 'v0.26.0'
+    version: 'v0.26.1'
 deprecated:
   - channel: '0.25'
     version: 'v0.25.0'

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 supported:
   - channel: '0.26'
-    version: 'v0.26.1'
+    version: 'v0.26.2'
 deprecated:
   - channel: '0.25'
     version: 'v0.25.0'

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 supported:
   - channel: '0.26'
-    version: 'v0.26.2'
+    version: 'v0.26.3'
 deprecated:
   - channel: '0.25'
     version: 'v0.25.0'

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 supported:
   - channel: '0.26'
-    version: 'v0.26.1'
+    version: 'v0.26.0'
 deprecated:
   - channel: '0.25'
     version: 'v0.25.0'


### PR DESCRIPTION
# Description

Fixing Fix for Dapr StateStores and SecretStores dev recipes URL casing

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #6575 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7581d05</samp>

### Summary
🔄🧹🚀

<!--
1.  🔄 for the migration to GHCR as the default container registry
2.  🧹 for the simplification and cleanup of the publish-recipes.sh script
3.  🚀 for the improvement of the build workflow and the use of the GitHub Actions runner's credentials
-->
This pull request migrates the Radius project from using ACR to GHCR as the default container registry for images and helm charts. It updates the build and release verification scripts to use GHCR and the rad CLI binary, and simplifies the publish-recipes.sh script.

> _Oh we're the crew of the Radius ship, and we sail the GitHub sea_
> _We push and pull and build and test, and we do it all with GHCR_
> _We've left behind the ACR, and we've learned to use the rad_
> _So heave away, me hearties, heave away, and publish those Bicep recipes_

### Walkthrough
* Reduce the number of arguments and use the rad CLI binary for publishing Bicep recipes in the `publish-recipes.sh` script ([link](https://github.com/radius-project/radius/pull/6577/files?diff=unified&w=0#diff-52f187b75cadbd36c18130331e4916e5165d7581ece299adff243212970a9434L19-R34), [link](https://github.com/radius-project/radius/pull/6577/files?diff=unified&w=0#diff-52f187b75cadbd36c18130331e4916e5165d7581ece299adff243212970a9434L44-R40), [link](https://github.com/radius-project/radius/pull/6577/files?diff=unified&w=0#diff-52f187b75cadbd36c18130331e4916e5165d7581ece299adff243212970a9434L72-R68))
* Use GHCR instead of ACR as the default container registry for the build workflow and the release verification script ([link](https://github.com/radius-project/radius/pull/6577/files?diff=unified&w=0#diff-e7011f75526faa24b25c444f9296b6c4172655dc99ad4e21f61fbbf9f137e586L62-R64), [link](https://github.com/radius-project/radius/pull/6577/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L39-R59), [link](https://github.com/radius-project/radius/pull/6577/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L280-R242), [link](https://github.com/radius-project/radius/pull/6577/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L321-R284))
* Rename the jobs and steps for building and pushing images and helm chart in the `build.yaml` workflow ([link](https://github.com/radius-project/radius/pull/6577/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L207-R225), [link](https://github.com/radius-project/radius/pull/6577/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L312-R276))
* Use the GitHub Actions runner's credentials for logging into GHCR ([link](https://github.com/radius-project/radius/pull/6577/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L280-R242))
* Remove the Azure CLI setup step for pushing the helm chart to GHCR ([link](https://github.com/radius-project/radius/pull/6577/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L329-L330))
* Add back the Azure CLI setup step for pushing the helm chart to ACR with a comment to delete it later ([link](https://github.com/radius-project/radius/pull/6577/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R301-R303), [link](https://github.com/radius-project/radius/pull/6577/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R310))
* Update the helm push command for pushing the helm chart to GHCR ([link](https://github.com/radius-project/radius/pull/6577/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L353-R324))
* Remove the comment for removing the image job when the repo is open-sourced ([link](https://github.com/radius-project/radius/pull/6577/files?diff=unified&w=0#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L129))


