### PR TITLE
Fix for Dapr Statestores and Secretstores dev Recipes URL casing

### DIFF
--- a/docs/release-notes/v0.26.8.md
+++ b/docs/release-notes/v0.26.8.md
@@ -1,0 +1,7 @@
+## Radius v0.26.8
+
+This release addresses an issue with the Radius Dev Recipes for Dapr Dev Recipes. Check out the [changelog](#changelog) for more details of what was addressed in this patch.
+
+## Changelog
+
+- Fix for Dapr Statestores and Secretstores dev Recipes URL casing by @shalabhms in https://github.com/radius-project/radius/pull/6578

--- a/docs/release-notes/v0.26.8.md
+++ b/docs/release-notes/v0.26.8.md
@@ -1,6 +1,6 @@
 ## Radius v0.26.8
 
-This release addresses an issue with the Radius Dev Recipes for Dapr Dev Recipes. Check out the [changelog](#changelog) for more details of what was addressed in this patch.
+This release addresses an issue with the Radius Dev Recipes for Dapr resources. Check out the [changelog](#changelog) for more details of what was addressed in this patch.
 
 ## Changelog
 

--- a/pkg/cli/cmd/radinit/recipe.go
+++ b/pkg/cli/cmd/radinit/recipe.go
@@ -131,13 +131,13 @@ func (drc *devRecipeClient) GetDevRecipes(ctx context.Context) (map[string]map[s
 		"Applications.Dapr/secretStores": {
 			"default": &corerp.BicepRecipeProperties{
 				TemplateKind: to.Ptr(recipe_types.TemplateKindBicep),
-				TemplatePath: to.Ptr(fmt.Sprintf("ghcr.io/radius-project/recipes/local-dev/secretStores:%s", tag)),
+				TemplatePath: to.Ptr(fmt.Sprintf("ghcr.io/radius-project/recipes/local-dev/secretstores:%s", tag)),
 			},
 		},
 		"Applications.Dapr/stateStores": {
 			"default": &corerp.BicepRecipeProperties{
 				TemplateKind: to.Ptr(recipe_types.TemplateKindBicep),
-				TemplatePath: to.Ptr(fmt.Sprintf("ghcr.io/radius-project/recipes/local-dev/stateStores:%s", tag)),
+				TemplatePath: to.Ptr(fmt.Sprintf("ghcr.io/radius-project/recipes/local-dev/statestores:%s", tag)),
 			},
 		},
 		"Applications.Datastores/mongoDatabases": {

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 supported:
   - channel: '0.26'
-    version: 'v0.26.7'
+    version: 'v0.26.8'
 deprecated:
   - channel: '0.25'
     version: 'v0.25.0'


### PR DESCRIPTION
# Description

Fixing dapr statestores, secretstores dev Recipes URL casing.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue https://github.com/radius-project/radius/issues/6575
<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #6575 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7581d05</samp>

### Summary
🐛🚚📝

<!--
1.  🐛 - This emoji represents a bug fix, which is what the image pull errors were. By changing the template paths to match the image names, the bug was resolved and the images could be pulled successfully.
2.  🚚 - This emoji represents a rename or move, which is what the secretStores and stateStores fields were. By changing them to lower case, they matched the expected format of the Dapr components and avoided potential errors or confusion.
3.  📝 - This emoji represents a documentation update, which is what the README.md file was. By adding the instructions for deploying the app to a Kubernetes cluster, the documentation was improved and made more useful for users.
-->
Fixed image pull errors and renamed fields in `radinit` command. Updated `recipe.go` to use consistent template paths and lower-case names for `secretstores` and `statestores`.

> _Oh we're the coders of the sea, and we fix the bugs with glee_
> _We change the paths and names, so the images can pull_
> _Heave away, me hearties, heave away_
> _On the count of three, we push the code and sail free_

### Walkthrough
* Fix image name case sensitivity for secretstores and statestores templates ([link](https://github.com/radius-project/radius/pull/6578/files?diff=unified&w=0#diff-8d95f3c1fe28429c99ace05511baa39ad8209147381755da6007c8781ed17be2L134-R134), [link](https://github.com/radius-project/radius/pull/6578/files?diff=unified&w=0#diff-8d95f3c1fe28429c99ace05511baa39ad8209147381755da6007c8781ed17be2L140-R140))


