### PR TITLE
Bicep PR is failing the DCO check

### DIFF
--- a/.github/workflows/publish-bicep.yaml
+++ b/.github/workflows/publish-bicep.yaml
@@ -63,7 +63,7 @@ jobs:
           token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
           committer: rad-ci-bot <rad-ci-bot@users.noreply.github.com>
           author: rad-ci-bot <rad-ci-bot@users.noreply.github.com>
-          signoff: false
+          signoff: true
           branch: radius-types/patch-${{ github.event.pull_request.number }}
           delete-branch: true
           title: |


### PR DESCRIPTION
# Description
The PR that is created on the Bicep repo is failing the DCO check. Enabling the signoff on create PR step of the publish-bicep workflow.

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
Fixes: #issue_number

## Auto-generated summary
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c678499</samp>

### Summary
:memo::sparkles::white_check_mark:

<!--
1.  :memo: This emoji represents documentation or writing, and it can be used to indicate the change in the commit message format due to the `signoff` option.
2. :sparkles: This emoji represents new features or enhancements, and it can be used to indicate the addition of the `signoff` option as part of the automated publishing feature.
3. :white_check_mark: This emoji represents tests or quality assurance, and it can be used to indicate the compliance with the DCO requirement by the radius project.
-->
Enable sign-off for git-push action in publish-bicep workflow. This ensures compliance with the DCO for bicep file contributions.

> _`git-push` action_
> _signs off commits with DCO_
> _autumn of bicep_

### Walkthrough
* Enable commit sign-off for git-push action to comply with DCO ([link](https://github.com/radius-project/radius/pull/6605/files?diff=unified&w=0#diff-5dda38c017a17c459b16104779239cf891ceac425018e4b63263f4c7d773e061L66-R66))


