### PR TITLE
Remove bicep download authentication credentials

### DIFF
--- a/pkg/cli/tools/binary_tools.go
+++ b/pkg/cli/tools/binary_tools.go
@@ -23,13 +23,10 @@ import (
 	"path"
 	"runtime"
 
-	credentials "github.com/oras-project/oras-credentials-go"
 	"github.com/radius-project/radius/pkg/version"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/registry/remote"
-	"oras.land/oras-go/v2/registry/remote/auth"
-	retry_lib "oras.land/oras-go/v2/registry/remote/retry"
 )
 
 const (
@@ -152,20 +149,6 @@ func DownloadToFolder(filepath string) error {
 	repo, err := remote.NewRepository(binaryRepo + platform)
 	if err != nil {
 		return err
-	}
-
-	// Create credentials to authenticate to repository
-	ds, err := credentials.NewStoreFromDocker(credentials.StoreOptions{
-		AllowPlaintextPut: true,
-	})
-	if err != nil {
-		return err
-	}
-
-	repo.Client = &auth.Client{
-		Client:     retry_lib.DefaultClient,
-		Cache:      auth.DefaultCache,
-		Credential: ds.Get,
 	}
 
 	// Copy the artifact from the registry into the file store


### PR DESCRIPTION
# Description

This removes authentication to GHCR since anonymous pulls are enabled. 

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue #6597 

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Partially addresses: #6597 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 96b31bb</samp>

### Summary
🗑️🔐📥

<!--
1.  🗑️ - This emoji means waste basket or trash can, and it can be used to indicate that something was removed or deleted. In this case, it represents the removal of unnecessary imports and credential code from the function.
2.  🔐 - This emoji means locked with key or secure, and it can be used to indicate that something was encrypted, protected, or authenticated. In this case, it represents the simplification and improvement of the authentication process for pulling binaries from the repository.
3.  📥 - This emoji means inbox tray or download, and it can be used to indicate that something was received, transferred, or stored. In this case, it represents the main functionality of the function, which is to download binaries to a folder.
-->
Refactored and enhanced binary download functionality in `pkg/cli/tools/binary_tools.go`. Removed unused code and streamlined authentication.

> _`DownloadToFolder`_
> _Cleans imports, auth, and code_
> _A fresh spring refactor_

### Walkthrough
* Remove unnecessary imports of `oras-credentials-go` and `auth` packages ([link](https://github.com/radius-project/radius/pull/6615/files?diff=unified&w=0#diff-0bb0df6a87062e6fad23c5f50750cb65e5e6e03112e526341f38a0e42ee06d6bL26-R29)) to simplify dependencies and reduce code complexity


