### PR TITLE
Fix issue with rad install

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -167,7 +167,7 @@ installFile() {
     if [ -f "$RADIUS_CLI_FILE" ]; then
         runAsRoot rm "$RADIUS_CLI_FILE"
     fi
-    chmod o+x $tmp_root_radius_cli
+    chmod a+x $tmp_root_radius_cli
     mkdir -p $RADIUS_INSTALL_DIR
     runAsRoot cp "$tmp_root_radius_cli" "$RADIUS_INSTALL_DIR"
     runAsRoot mv "${RADIUS_INSTALL_DIR}/${RADIUS_CLI_ARTIFACT}" "${RADIUS_INSTALL_DIR}/${RADIUS_CLI_FILENAME}"


### PR DESCRIPTION
# Description

Fixes issue below in #6597 
curl -fsSL "https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh" | /bin/bash
Getting the latest Radius CLI...
Your system is darwin_arm64
/bin/bash: line 91: /usr/local/bin/rad: Permission denied

Radius CLI is detected. Current version:
Reinstalling Radius CLI - /usr/local/bin/rad...

Installing v0.26.8 Radius CLI...
Downloading https://github.com/radius-project/radius/releases/download/v0.26.8/rad_darwin_arm64...
Password:
rad installed into /usr/local/bin successfully
Installing rad-bicep ("rad bicep download")...
/bin/bash: line 179: /usr/local/bin/rad: Permission denied
Failed to install rad-bicep
Failed to install Radius CLI
For support, go to https://github.com/radius-project/radius

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #6597 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b284307</samp>

### Summary
🛠️🔐🚀

<!--
1.  🛠️ - This emoji represents a tool or a fix, and can be used to indicate that the change was made to resolve a bug or improve functionality.
2.  🔐 - This emoji represents a lock or security, and can be used to indicate that the change was related to permissions or access control.
3.  🚀 - This emoji represents a rocket or launch, and can be used to indicate that the change was made to enhance the user experience or performance of the CLI.
-->
Fix permission issue with radius CLI installation. Make `deploy/install.sh` script more robust by allowing any user to execute the temporary `radius` binary.

> _`chmod` for all users_
> _Fixes permission issue_
> _Winter of discontent_

### Walkthrough
*  Make the radius CLI executable by all users after installation ([link](https://github.com/radius-project/radius/pull/6618/files?diff=unified&w=0#diff-ed1191c237ea4ba8f2011568f4ed0208c8d0ca36cbde1285828a61b4ff2128b4L170-R170))


