### PR TITLE
Patch release for 0.26

### DIFF
--- a/docs/release-notes/v0.26.9.md
+++ b/docs/release-notes/v0.26.9.md
@@ -1,0 +1,7 @@
+## Radius v0.26.9
+
+This release addresses an issue with the Bicep Download Flow. Check out the [changelog](#changelog) for more details of what was addressed in this patch.
+
+## Changelog
+
+- Remove bicep download authentication credentials by @sk593 in <https://github.com/radius-project/radius/pull/6615>

--- a/pkg/cli/tools/binary_tools.go
+++ b/pkg/cli/tools/binary_tools.go
@@ -23,13 +23,10 @@ import (
 	"path"
 	"runtime"
 
-	credentials "github.com/oras-project/oras-credentials-go"
 	"github.com/radius-project/radius/pkg/version"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/registry/remote"
-	"oras.land/oras-go/v2/registry/remote/auth"
-	retry_lib "oras.land/oras-go/v2/registry/remote/retry"
 )
 
 const (
@@ -152,20 +149,6 @@ func DownloadToFolder(filepath string) error {
 	repo, err := remote.NewRepository(binaryRepo + platform)
 	if err != nil {
 		return err
-	}
-
-	// Create credentials to authenticate to repository
-	ds, err := credentials.NewStoreFromDocker(credentials.StoreOptions{
-		AllowPlaintextPut: true,
-	})
-	if err != nil {
-		return err
-	}
-
-	repo.Client = &auth.Client{
-		Client:     retry_lib.DefaultClient,
-		Cache:      auth.DefaultCache,
-		Credential: ds.Get,
 	}
 
 	// Copy the artifact from the registry into the file store

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 supported:
   - channel: '0.26'
-    version: 'v0.26.8'
+    version: 'v0.26.9'
 deprecated:
   - channel: '0.25'
     version: 'v0.25.0'


### PR DESCRIPTION
# Description
Patch release for 0.26

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
Fixes: #issue_number

## Auto-generated summary
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 034730b</samp>

### Summary
📝🚀🔥

<!--
1.  📝 for adding a new release note document.
2.  🚀 for updating the supported version of Radius.
3.  🔥 for simplifying and removing code.
-->
This pull request fixes a security issue in the bicep download flow, adds a release note for v0.26.9, and updates the versions.yaml file to match the latest supported version of Radius.

> _`Radius` patch note_
> _Summarizes the fix, links_
> _To the changelog_

### Walkthrough
* Add a new release note document for v0.26.9 of Radius ([link](https://github.com/radius-project/radius/pull/6621/files?diff=unified&w=0#diff-df24727dcef95a821112a984738537651886df0e2abf039105b0574dfe8ee3b5R1-R7))
* Remove unnecessary and insecure authentication credentials for bicep download flow ([link](https://github.com/radius-project/radius/pull/6621/files?diff=unified&w=0#diff-0bb0df6a87062e6fad23c5f50750cb65e5e6e03112e526341f38a0e42ee06d6bL26-R29), [link](https://github.com/radius-project/radius/pull/6621/files?diff=unified&w=0#diff-0bb0df6a87062e6fad23c5f50750cb65e5e6e03112e526341f38a0e42ee06d6bL157-L170))
* Update the supported version of Radius in `versions.yaml` file ([link](https://github.com/radius-project/radius/pull/6621/files?diff=unified&w=0#diff-1c4cd801df522f4a92edbfb0fea95364ed074a391ea47c284ddc078f512f7b6aL3-R3))


