### PR TITLE
Fix flaky TF recipe tests

### DIFF
--- a/pkg/metrics/recipeenginemetrics.go
+++ b/pkg/metrics/recipeenginemetrics.go
@@ -43,6 +43,9 @@ const (
 	// terraformInitializationDuration is the metric name for the Terraform initialization duration.
 	terraformInitializationDuration = "recipe.tf.init.duration"
 
+	// terraformVerficiationDuration is the metric name for the Terraform installation verification duration.
+	terraformInstallVerficiationDuration = "recipe.tf.install.verification.duration"
+
 	// RecipeEngineOperationExecute represents the Execute operation of the Recipe Engine.
 	RecipeEngineOperationExecute = "execute"
 
@@ -118,6 +121,14 @@ func (m *recipeEngineMetrics) RecordTerraformInstallationDuration(ctx context.Co
 	if m.valueRecorders[terraformInstallationDuration] != nil {
 		elapsedTime := float64(time.Since(startTime)) / float64(time.Millisecond)
 		m.valueRecorders[terraformInstallationDuration].Record(ctx, elapsedTime, metric.WithAttributes(attrs...))
+	}
+}
+
+// RecordTerraformInstallVerificationDuration records the duration of the Terraform installation verification with the given attributes.
+func (m *recipeEngineMetrics) RecordTerraformInstallVerificationDuration(ctx context.Context, startTime time.Time, attrs []attribute.KeyValue) {
+	if m.valueRecorders[terraformInstallVerficiationDuration] != nil {
+		elapsedTime := float64(time.Since(startTime)) / float64(time.Millisecond)
+		m.valueRecorders[terraformInstallVerficiationDuration].Record(ctx, elapsedTime, metric.WithAttributes(attrs...))
 	}
 }
 

--- a/pkg/metrics/recipeenginemetrics.go
+++ b/pkg/metrics/recipeenginemetrics.go
@@ -43,8 +43,8 @@ const (
 	// terraformInitializationDuration is the metric name for the Terraform initialization duration.
 	terraformInitializationDuration = "recipe.tf.init.duration"
 
-	// terraformInstallVerficiationDuration is the metric name for the Terraform installation verification duration.
-	terraformInstallVerficiationDuration = "recipe.tf.install.verification.duration"
+	// terraformInstallVerificationDuration is the metric name for verifying the completion of a Terraform installation duration.
+	terraformInstallVerificationDuration = "recipe.tf.install.verification.duration"
 
 	// RecipeEngineOperationExecute represents the Execute operation of the Recipe Engine.
 	RecipeEngineOperationExecute = "execute"
@@ -126,9 +126,9 @@ func (m *recipeEngineMetrics) RecordTerraformInstallationDuration(ctx context.Co
 
 // RecordTerraformInstallVerificationDuration records the duration of the Terraform installation verification with the given attributes.
 func (m *recipeEngineMetrics) RecordTerraformInstallVerificationDuration(ctx context.Context, startTime time.Time, attrs []attribute.KeyValue) {
-	if m.valueRecorders[terraformInstallVerficiationDuration] != nil {
+	if m.valueRecorders[terraformInstallVerificationDuration] != nil {
 		elapsedTime := float64(time.Since(startTime)) / float64(time.Millisecond)
-		m.valueRecorders[terraformInstallVerficiationDuration].Record(ctx, elapsedTime, metric.WithAttributes(attrs...))
+		m.valueRecorders[terraformInstallVerificationDuration].Record(ctx, elapsedTime, metric.WithAttributes(attrs...))
 	}
 }
 

--- a/pkg/metrics/recipeenginemetrics.go
+++ b/pkg/metrics/recipeenginemetrics.go
@@ -43,7 +43,7 @@ const (
 	// terraformInitializationDuration is the metric name for the Terraform initialization duration.
 	terraformInitializationDuration = "recipe.tf.init.duration"
 
-	// terraformVerficiationDuration is the metric name for the Terraform installation verification duration.
+	// terraformInstallVerficiationDuration is the metric name for the Terraform installation verification duration.
 	terraformInstallVerficiationDuration = "recipe.tf.install.verification.duration"
 
 	// RecipeEngineOperationExecute represents the Execute operation of the Recipe Engine.

--- a/pkg/recipes/terraform/execute.go
+++ b/pkg/recipes/terraform/execute.go
@@ -24,6 +24,7 @@ import (
 
 	install "github.com/hashicorp/hc-install"
 	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/hashicorp/terraform-exec/tfexec"
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/radius-project/radius/pkg/metrics"
 	"github.com/radius-project/radius/pkg/recipes"
@@ -70,7 +71,7 @@ func (e *executor) Deploy(ctx context.Context, options Options) (*tfjson.State, 
 
 	// Install Terraform
 	i := install.NewInstaller()
-	execPath, err := Install(ctx, i, options.RootDir)
+	tf, err := Install(ctx, i, options.RootDir)
 	// The terraform zip for installation is downloaded in a location outside of the install directory and is only accessible through the installer.Remove function -
 	// stored in latestVersion.pathsToRemove. So this needs to be called for complete cleanup even if the root terraform directory is deleted.
 	defer func() {
@@ -78,12 +79,6 @@ func (e *executor) Deploy(ctx context.Context, options Options) (*tfjson.State, 
 			logger.Info(fmt.Sprintf("Failed to cleanup Terraform installation: %s", err.Error()))
 		}
 	}()
-	if err != nil {
-		return nil, err
-	}
-
-	// Create a new instance of tfexec.Terraform with current Terraform installation path
-	tf, err := NewTerraform(ctx, options.RootDir, execPath)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +114,7 @@ func (e *executor) Delete(ctx context.Context, options Options) error {
 
 	// Install Terraform
 	i := install.NewInstaller()
-	execPath, err := Install(ctx, i, options.RootDir)
+	tf, err := Install(ctx, i, options.RootDir)
 	// The terraform zip for installation is downloaded in a location outside of the install directory and is only accessible through the installer.Remove function -
 	// stored in latestVersion.pathsToRemove. So this needs to be called for complete cleanup even if the root terraform directory is deleted.
 	defer func() {
@@ -127,12 +122,6 @@ func (e *executor) Delete(ctx context.Context, options Options) error {
 			logger.Info(fmt.Sprintf("Failed to cleanup Terraform installation: %s", err.Error()))
 		}
 	}()
-	if err != nil {
-		return err
-	}
-
-	// Create a new instance of tfexec.Terraform with current Terraform installation path
-	tf, err := NewTerraform(ctx, options.RootDir, execPath)
 	if err != nil {
 		return err
 	}
@@ -179,7 +168,7 @@ func (e *executor) GetRecipeMetadata(ctx context.Context, options Options) (map[
 
 	// Install Terraform
 	i := install.NewInstaller()
-	execPath, err := Install(ctx, i, options.RootDir)
+	tf, err := Install(ctx, i, options.RootDir)
 	// The terraform zip for installation is downloaded in a location outside of the install directory and is only accessible through the installer.Remove function -
 	// stored in latestVersion.pathsToRemove. So this needs to be called for complete cleanup even if the root terraform directory is deleted.
 	defer func() {
@@ -187,12 +176,6 @@ func (e *executor) GetRecipeMetadata(ctx context.Context, options Options) (map[
 			logger.Info(fmt.Sprintf("Failed to cleanup Terraform installation: %s", err.Error()))
 		}
 	}()
-	if err != nil {
-		return nil, err
-	}
-
-	// Create a new instance of tfexec.Terraform with current Terraform installation path
-	tf, err := NewTerraform(ctx, options.RootDir, execPath)
 	if err != nil {
 		return nil, err
 	}
@@ -213,6 +196,7 @@ func (e *executor) GetRecipeMetadata(ctx context.Context, options Options) (map[
 }
 
 // generateConfig generates Terraform configuration with required inputs for the module, providers and backend to be initialized and applied.
+func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, options Options) (string, error) {
 func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, options Options) (string, error) {
 	logger := ucplog.FromContextOrDiscard(ctx)
 	workingDir := tf.WorkingDir()

--- a/pkg/recipes/terraform/execute.go
+++ b/pkg/recipes/terraform/execute.go
@@ -24,7 +24,6 @@ import (
 
 	install "github.com/hashicorp/hc-install"
 	"github.com/hashicorp/terraform-exec/tfexec"
-	"github.com/hashicorp/terraform-exec/tfexec"
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/radius-project/radius/pkg/metrics"
 	"github.com/radius-project/radius/pkg/recipes"
@@ -196,7 +195,6 @@ func (e *executor) GetRecipeMetadata(ctx context.Context, options Options) (map[
 }
 
 // generateConfig generates Terraform configuration with required inputs for the module, providers and backend to be initialized and applied.
-func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, options Options) (string, error) {
 func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, options Options) (string, error) {
 	logger := ucplog.FromContextOrDiscard(ctx)
 	workingDir := tf.WorkingDir()

--- a/pkg/recipes/terraform/install.go
+++ b/pkg/recipes/terraform/install.go
@@ -89,11 +89,10 @@ func Install(ctx context.Context, installer *install.Installer, tfDir string) (*
 
 	// Verify Terraform installation is complete before proceeding
 	for attempt := 0; attempt <= installRetryCount; attempt++ {
-		errMsg := "Failed to verify Terraform installation: %s. Retrying after %d seconds"
 		_, _, err = tf.Version(ctx, false)
 		if err != nil {
 			if attempt < installRetryCount {
-				logger.Info(fmt.Sprintf(errMsg, err.Error(), retryDelaySecs))
+				logger.Info(fmt.Sprintf("Failed to verify Terraform installation: %s. Retrying after %d seconds", err.Error(), retryDelaySecs))
 				metrics.DefaultRecipeEngineMetrics.RecordTerraformInstallVerificationDuration(ctx, installStartTime,
 					[]attribute.KeyValue{
 						metrics.TerraformVersionAttrKey.String("latest"),
@@ -103,7 +102,7 @@ func Install(ctx context.Context, installer *install.Installer, tfDir string) (*
 				time.Sleep(time.Duration(retryDelaySecs) * time.Second)
 				continue
 			}
-			return nil, fmt.Errorf(errMsg, err.Error(), retryDelaySecs)
+			return nil, err
 		}
 	}
 

--- a/pkg/recipes/terraform/install.go
+++ b/pkg/recipes/terraform/install.go
@@ -90,6 +90,9 @@ func Install(ctx context.Context, installer *install.Installer, tfDir string) (*
 	// Verify Terraform installation is complete before proceeding
 	for attempt := 0; attempt <= installRetryCount; attempt++ {
 		_, _, err = tf.Version(ctx, false)
+		if err == nil {
+			break
+		}
 		if err != nil {
 			if attempt < installRetryCount {
 				logger.Info(fmt.Sprintf("Failed to verify Terraform installation: %s. Retrying after %d seconds", err.Error(), retryDelaySecs))

--- a/pkg/recipes/terraform/install.go
+++ b/pkg/recipes/terraform/install.go
@@ -99,20 +99,18 @@ func Install(ctx context.Context, installer *install.Installer, tfDir string) (*
 			)
 			break
 		}
-		if err != nil {
-			if attempt < installVerificationRetryCount {
-				logger.Info(fmt.Sprintf("Failed to verify Terraform installation completion: %s. Retrying after %d seconds", err.Error(), installVerificationRetryDelaySecs))
-				metrics.DefaultRecipeEngineMetrics.RecordTerraformInstallVerificationDuration(ctx, installStartTime,
-					[]attribute.KeyValue{
-						metrics.TerraformVersionAttrKey.String("latest"),
-						metrics.OperationStateAttrKey.String(metrics.FailedOperationState),
-					},
-				)
-				time.Sleep(time.Duration(installVerificationRetryDelaySecs) * time.Second)
-				continue
-			}
-			return nil, fmt.Errorf("failed to verify Terraform installation completion after %d attempts. Error: %s", installVerificationRetryCount, err.Error())
+		if attempt < installVerificationRetryCount {
+			logger.Info(fmt.Sprintf("Failed to verify Terraform installation completion: %s. Retrying after %d seconds", err.Error(), installVerificationRetryDelaySecs))
+			metrics.DefaultRecipeEngineMetrics.RecordTerraformInstallVerificationDuration(ctx, installStartTime,
+				[]attribute.KeyValue{
+					metrics.TerraformVersionAttrKey.String("latest"),
+					metrics.OperationStateAttrKey.String(metrics.FailedOperationState),
+				},
+			)
+			time.Sleep(time.Duration(installVerificationRetryDelaySecs) * time.Second)
+			continue
 		}
+		return nil, fmt.Errorf("failed to verify Terraform installation completion after %d attempts. Error: %s", installVerificationRetryCount, err.Error())
 	}
 
 	// Configure Terraform logs once Terraform installation is complete

--- a/pkg/recipes/terraform/types.go
+++ b/pkg/recipes/terraform/types.go
@@ -74,8 +74,6 @@ func NewTerraform(ctx context.Context, tfRootDir, execPath string) (*tfexec.Terr
 		return nil, fmt.Errorf("failed to initialize Terraform: %w", err)
 	}
 
-	configureTerraformLogs(ctx, tf)
-
 	return tf, nil
 }
 


### PR DESCRIPTION
# Description

This fixes flaky Terraform tests by adding retries to verify that the TF installation is compete. The problem seems to be occurring when the TF installation hasn't completed but we proceed with calling the executable anyway  

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue #6564 

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #6564 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f1969ab</samp>

### Summary
🗑️🕑🔄

<!--
1.  🗑️ - This emoji represents the removal of the redundant call to configureTerraformLogs from the NewTerraform function. It implies that the code is cleaner and simpler after the change.
2.  🕑 - This emoji represents the addition of the new metric and function to record the duration of Terraform installation verification. It implies that the code is more observant and measurable after the change.
3.  🔄 - This emoji represents the refactoring of the terraform package to use the *tfexec.Terraform instance returned by the Install function instead of creating a new one with the installation path. It implies that the code is more consistent and efficient after the change.
-->
This pull request improves the terraform package by using the tfexec library for installing and executing Terraform. It also adds a new metric to measure the verification time of the installation and refactors some variable names and function calls. The changes affect the files `pkg/metrics/recipeenginemetrics.go`, `pkg/recipes/terraform/execute.go`, `pkg/recipes/terraform/install.go`, and `pkg/recipes/terraform/types.go`.

> _`terraform` package_
> _refactored with tfexec_
> _cutting duplication_

### Walkthrough
*  Add and record metric for Terraform installation verification duration ([link](https://github.com/radius-project/radius/pull/6644/files?diff=unified&w=0#diff-6403665d6373b7e2a29e5a0e1d8e52b830982dfdce21983cfd83e1c434b19046R46-R48), [link](https://github.com/radius-project/radius/pull/6644/files?diff=unified&w=0#diff-6403665d6373b7e2a29e5a0e1d8e52b830982dfdce21983cfd83e1c434b19046R127-R134))
*  Return and use *tfexec.Terraform instance instead of string path from Install function ([link](https://github.com/radius-project/radius/pull/6644/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482L73-R73), [link](https://github.com/radius-project/radius/pull/6644/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482L85-L90), [link](https://github.com/radius-project/radius/pull/6644/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482L122-R116), [link](https://github.com/radius-project/radius/pull/6644/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482L134-L139), [link](https://github.com/radius-project/radius/pull/6644/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482L182-R170), [link](https://github.com/radius-project/radius/pull/6644/files?diff=unified&w=0#diff-41ec31c0ceb8bd50c0329b55a8d27aeba69648059faef4e785302155f4e97482L194-L199), [link](https://github.com/radius-project/radius/pull/6644/files?diff=unified&w=0#diff-928c8e55e3071403aec24ba60b0f8fd85ed1f95cd4a12aed4ec6da1b3dd659c6R30), [link](https://github.com/radius-project/radius/pull/6644/files?diff=unified&w=0#diff-928c8e55e3071403aec24ba60b0f8fd85ed1f95cd4a12aed4ec6da1b3dd659c6L36-R39), [link](https://github.com/radius-project/radius/pull/6644/files?diff=unified&w=0#diff-928c8e55e3071403aec24ba60b0f8fd85ed1f95cd4a12aed4ec6da1b3dd659c6L42-R45), [link](https://github.com/radius-project/radius/pull/6644/files?diff=unified&w=0#diff-928c8e55e3071403aec24ba60b0f8fd85ed1f95cd4a12aed4ec6da1b3dd659c6L48-R51), [link](https://github.com/radius-project/radius/pull/6644/files?diff=unified&w=0#diff-928c8e55e3071403aec24ba60b0f8fd85ed1f95cd4a12aed4ec6da1b3dd659c6L69-R72), [link](https://github.com/radius-project/radius/pull/6644/files?diff=unified&w=0#diff-928c8e55e3071403aec24ba60b0f8fd85ed1f95cd4a12aed4ec6da1b3dd659c6L81-R120), [link](https://github.com/radius-project/radius/pull/6644/files?diff=unified&w=0#diff-0ad85ed086350c77c3e366408120b4c3020d1cec542671ab3586fd0c34dafe6fL77-L78))


