### PR TITLE
[wip] Add logs for kubernetes events

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -480,6 +480,7 @@ jobs:
           message: |
             :x: Failed to install Radius for ${{ matrix.name }} functional test. Please check [the logs](${{ env.ACTION_LINK }}) for more details
       - name: Publish Terraform test recipes
+        id: publish-tf-recipes
         run: |
           make publish-test-terraform-recipes
       - name: Run functional tests
@@ -576,3 +577,27 @@ jobs:
               labels: ['bug', 'test-failure'],
               body: `## Bug information \n\nThis bug is generated automatically if the scheduled functional test fails. The Radius functional test operates on a schedule of every 4 hours during weekdays and every 12 hours over the weekend. It's important to understand that the test may fail due to workflow infrastructure issues, like network problems, rather than the flakiness of the test itself. For the further investigation, please visit [here](${process.env.ACTION_LINK}).`
             })
+      - name: Get pod logs for recipe publishing failure
+        id: get-pod-logs
+        if: failure() && steps.publish-tf-recipes.outcome == 'failure' 
+        run: |
+          # Create pod-logs directory
+          mkdir -p recipes/pod-logs
+          # Get pod logs and save to file
+          namespace="radius-test-tf-module-server"
+          label="app.kubernetes.io/name=tf-module-server"
+          pod_names=($(kubectl get pods -l $label -n $namespace -o jsonpath='{.items[*].metadata.name}'))
+          for pod_name in "${pod_names[@]}"; do
+            kubectl logs $pod_name -n $namespace > recipes/pod-logs//${pod_name}.txt
+          done
+          echo "Pod logs saved to playwright/pod-logs/"
+          # Get kubernetes events and save to file
+          kubectl get events -n $namespace > playwright/pod-logs/events.txt
+      - name: Upload Pod logs for failed steps
+        uses: actions/upload-artifact@v3
+        if: failure() && steps.publish-tf-recipes.outcome.outcome == 'success'
+        with:
+          name: recipes-pod-logs
+          path: recipes/pod-logs
+          retention-days: 30
+          if-no-files-found: error


### PR DESCRIPTION
# Description

Adding logs to track pod failures during schedule func test runs 

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4b779ec</samp>

### Summary
🐛🚀🔧

<!--
1.  🐛 - This emoji represents bug fixes or error handling, which is the main purpose of this pull request.
2.  🚀 - This emoji represents performance improvements or optimizations, which are achieved by uploading pod logs and events as an artifact instead of printing them to the console.
3.  🔧 - This emoji represents configuration or tooling changes, which are required to assign an `id` to the `publish-tf-recipes` step and use the `upload-artifact` action.
-->
Add error handling and debugging to functional-test workflow. Upload pod logs and events as an artifact if `.github/workflows/functional-test.yaml` fails.

> _When the test workflow fails_
> _We don't give up or bail_
> _We grab the logs and events_
> _From the `publish-tf-recipes` step_

### Walkthrough
* Add an `id` to the recipe publishing step to enable conditional execution of subsequent steps ([link](https://github.com/radius-project/radius/pull/6655/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcR483))
* Add two steps to collect and upload pod logs and events as an artifact if the recipe publishing step fails ([link](https://github.com/radius-project/radius/pull/6655/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcR580-R603))


