### PR TITLE
Fix string formatting in pod status check assertion

### DIFF
--- a/test/validation/k8s.go
+++ b/test/validation/k8s.go
@@ -491,13 +491,13 @@ func (pm PodMonitor) ValidateRunning(ctx context.Context, t *testing.T) {
 					return
 				}
 				if attempt >= MaxRetryAttempts {
-					assert.Failf(t, "pod %v failed readiness checks", pod.Name)
+					assert.Failf(t, "pod failed readiness checks.", "Pod Name: %v", pod.Name)
 				} else {
 					t.Logf("Readiness check failed. Retrying - attempt %d", attempt)
 					attempt++
 				}
 			} else if pod.Status.Phase == corev1.PodFailed {
-				assert.Failf(t, "pod %v entered a failing state", pod.Name)
+				assert.Failf(t, "pod entered a failing state", "Pod Name: %v", pod.Name)
 				return
 			}
 


### PR DESCRIPTION
# Description

Corrected the string formatting argument in assert.Failf to properly display the pod name in pod status check retries. This ensures pod name is displayed instead of the format specifier by correctly ordering the arguments in the assert.Failf call.

Current formatting is resulting into this output: `pod %v entered a failing state`

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->
## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 940f891</samp>

### Summary
🌟📝🎛️

<!--
1.  🌟 This emoji could be used to indicate that the logging was improved or enhanced, as stars often signify quality or excellence.
2.  📝 This emoji could be used to indicate that the error messages were changed or edited, as a pencil or a document often signify writing or editing.
3.  🎛️ This emoji could be used to indicate that the pod name was made a separate argument instead of interpolating it into the message string, as a control knob or a dial often signify adjusting or fine-tuning something.
-->
Enhanced logging and error reporting for pod validation tests. Used structured logging to separate pod name from error message in `test/validation/k8s.go`.

> _To make logging more clear and concise_
> _We changed how we handle pod slice_
> _We use `pod name` as arg_
> _Not in the message's larg_
> _In `./test/validation/k8s.go` we made this nice_

### Walkthrough
*  Modify error messages for pod failures to use structured logging ([link](https://github.com/radius-project/radius/pull/6656/files?diff=unified&w=0#diff-a52153bfeb452a3dd497767a98db0dc1a0621e012f6e6d8dd9d4b5ec758b4dc2L494-R494), [link](https://github.com/radius-project/radius/pull/6656/files?diff=unified&w=0#diff-a52153bfeb452a3dd497767a98db0dc1a0621e012f6e6d8dd9d4b5ec758b4dc2L500-R500))


