### PR TITLE
Revert "Switch ACR Helm chart to GHCR for rad init (#6510)"

### DIFF
--- a/pkg/cli/helm/helm.go
+++ b/pkg/cli/helm/helm.go
@@ -29,7 +29,6 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli"
-	"helm.sh/helm/v3/pkg/registry"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -80,6 +79,7 @@ func locateChartFile(dirPath string) (string, error) {
 
 func helmChartFromContainerRegistry(version string, config *helm.Configuration, repoUrl string, releaseName string) (*chart.Chart, error) {
 	pull := helm.NewPull()
+	pull.RepoURL = repoUrl
 	pull.Settings = &cli.EnvSettings{}
 	pullopt := helm.WithConfig(config)
 	pullopt(pull)
@@ -101,24 +101,7 @@ func helmChartFromContainerRegistry(version string, config *helm.Configuration, 
 
 	pull.DestDir = dir
 
-	var chartRef string
-
-	if !registry.IsOCI(repoUrl) {
-		// For non-OCI registries (like contour), we need to set the repo URL
-		// to the registry URL. The chartRef is the release name.
-		// ex.
-		// pull.RepoURL = https://charts.bitnami.com/bitnami
-		// pull.Run("contour")
-		pull.RepoURL = repoUrl
-		chartRef = releaseName
-	} else {
-		// For OCI registries (like radius), we will use the
-		// repo URL + the releaseName as the chartRef.
-		// pull.Run("oci://ghcr.io/radius-project/helm-chart/radius")
-		chartRef = fmt.Sprintf("%s/%s", repoUrl, releaseName)
-	}
-
-	_, err = pull.Run(chartRef)
+	_, err = pull.Run(releaseName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/helm/radiusclient.go
+++ b/pkg/cli/helm/radiusclient.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	radiusReleaseName     = "radius"
-	radiusHelmRepo        = "oci://ghcr.io/radius-project/helm-chart"
+	radiusHelmRepo        = "https://radius.azurecr.io/helm/v1/repo"
 	RadiusSystemNamespace = "radius-system"
 )
 


### PR DESCRIPTION
This reverts commit 9830c13db5cebc2c644b4e4a8ae60ae5979426f7.

# Description

@kachawla  and I found that Radius installs on amd64 are broken with this change. reverting.
## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f75f123</samp>

### Summary
🚀🐛♻️

<!--
1.  🚀 for the configuration change that enables the use of the new helm repository
2. 🐛 for the bug fix in pulling helm charts from container registries
3. ♻️ for the refactoring and code simplification
-->
This pull request fixes a helm chart bug, refactors a helm function, and updates the helm configuration for the radius project. It changes the files `pkg/cli/helm/helm.go` and `pkg/cli/helm/radiusclient.go` to use the new helm repository at `radius.azurecr.io`.

> _Sing, O Muse, of the valiant radius project_
> _That changed its helm repository with skill and intellect_
> _From ghcr.io, the swift and vast, to radius.azurecr.io, the new and fast_
> _And fixed a bug that plagued the charts, refactoring code with clever arts_

### Walkthrough
* Fix bug in pulling helm chart from container registry by setting `RepoURL` field of `pull` struct ([link](https://github.com/radius-project/radius/pull/6668/files?diff=unified&w=0#diff-35b8f26ef00e63853d6a8303dfdb8755355d7cb6d48ba9449d5a04af62a723cbR82))
* Refactor `helmChartFromContainerRegistry` function to simplify logic and assume valid chart format ([link](https://github.com/radius-project/radius/pull/6668/files?diff=unified&w=0#diff-35b8f26ef00e63853d6a8303dfdb8755355d7cb6d48ba9449d5a04af62a723cbL104-R104))
* Remove unused import of `registry` package from `helm` package ([link](https://github.com/radius-project/radius/pull/6668/files?diff=unified&w=0#diff-35b8f26ef00e63853d6a8303dfdb8755355d7cb6d48ba9449d5a04af62a723cbL32))
* Update release name, helm repository, and system namespace constants for radius project in `radiusclient.go` ([link](https://github.com/radius-project/radius/pull/6668/files?diff=unified&w=0#diff-7f93f7a0f0c6c2329155f30e6a4cc6928277acabefab4c28826cb143a23ce90eL36-R36))


