### PR TITLE
Update Helm Chart Download Error Message

### DIFF
--- a/pkg/cli/helm/helm.go
+++ b/pkg/cli/helm/helm.go
@@ -103,7 +103,7 @@ func helmChartFromContainerRegistry(version string, config *helm.Configuration, 
 
 	_, err = pull.Run(releaseName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error downloading helm chart from the registry for version: %s, release name: %s. Error: %w", version, releaseName, err)
 	}
 
 	chartPath, err := locateChartFile(dir)


### PR DESCRIPTION
# Description

Include additional information in the error message for easier debugging.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 85cb02a</samp>

### Summary
🐛💬📝

<!--
1.  🐛 - This emoji represents a bug fix, since the error message was not very helpful before and did not provide enough context to the user or the developer.
2.  💬 - This emoji represents an improvement to the user interface or user experience, since the error message is now more informative and friendly, and can help the user to understand what went wrong and how to fix it.
3.  📝 - This emoji represents a documentation update, since the error message is part of the documentation that the function provides to the user, and it has been updated to reflect the new behavior and functionality of the function.
-->
Improve error message for helm chart download failure in `helm.go`. Include version and release name details in the message to aid debugging.

> _`helmChart` error_
> _More details in the message_
> _Winter of debugging_

### Walkthrough
* Improve error message for helm chart download failure ([link](https://github.com/radius-project/radius/pull/6671/files?diff=unified&w=0#diff-35b8f26ef00e63853d6a8303dfdb8755355d7cb6d48ba9449d5a04af62a723cbL106-R106))


