### PR TITLE
Use GHCR for Radius Helm repository (#6672)

### DIFF
--- a/pkg/cli/helm/helm.go
+++ b/pkg/cli/helm/helm.go
@@ -29,6 +29,7 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/registry"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -79,7 +80,6 @@ func locateChartFile(dirPath string) (string, error) {
 
 func helmChartFromContainerRegistry(version string, config *helm.Configuration, repoUrl string, releaseName string) (*chart.Chart, error) {
 	pull := helm.NewPull()
-	pull.RepoURL = repoUrl
 	pull.Settings = &cli.EnvSettings{}
 	pullopt := helm.WithConfig(config)
 	pullopt(pull)
@@ -101,7 +101,32 @@ func helmChartFromContainerRegistry(version string, config *helm.Configuration, 
 
 	pull.DestDir = dir
 
-	_, err = pull.Run(releaseName)
+	var chartRef string
+
+	if !registry.IsOCI(repoUrl) {
+		// For non-OCI registries (like contour), we need to set the repo URL
+		// to the registry URL. The chartRef is the release name.
+		// ex.
+		// pull.RepoURL = https://charts.bitnami.com/bitnami
+		// pull.Run("contour")
+		pull.RepoURL = repoUrl
+		chartRef = releaseName
+	} else {
+		// For OCI registries (like radius), we will use the
+		// repo URL + the releaseName as the chartRef.
+		// pull.Run("oci://ghcr.io/radius-project/helm-chart/radius")
+		chartRef = fmt.Sprintf("%s/%s", repoUrl, releaseName)
+
+		// Since we are using an OCI registry, we need to set the registry client
+		registryClient, err := registry.NewClient()
+		if err != nil {
+			return nil, err
+		}
+
+		pull.SetRegistryClient(registryClient)
+	}
+
+	_, err = pull.Run(chartRef)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/helm/radiusclient.go
+++ b/pkg/cli/helm/radiusclient.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	radiusReleaseName     = "radius"
-	radiusHelmRepo        = "https://radius.azurecr.io/helm/v1/repo"
+	radiusHelmRepo        = "oci://ghcr.io/radius-project/helm-chart"
 	RadiusSystemNamespace = "radius-system"
 )
 


### PR DESCRIPTION
# Description

* Use GHCR for Radius Helm repository

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now.

-->

- This pull request adds or changes features of Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: https://github.com/radius-project/radius/issues/6502

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at df0ce00</samp>

### Summary
🚚🆕🛠️

<!--
1.  🚚 for moving the constants from one file to another
2.  🆕 for adding support for a new feature (OCI registry)
3.  🛠️ for fixing the pull operation to work with different formats -->
This pull request adds support for pulling Helm charts from OCI registries and updates the Radius Helm chart location to use an OCI registry. It also refactors some constants related to Helm operations in the `pkg/cli/helm` package.

> _Sing, O Muse, of the valiant deeds of the Radius CLI,_
> _The swift and skillful tool that deploys the cloud-born chart_
> _From the new and shining registry, where GitHub hosts the art_
> _Of Helm, the master of the helm, who guides the ships at sea._

### Walkthrough
* Add support for pulling Helm charts from OCI registries ([link](https://github.com/radius-project/radius/pull/6672/files?diff=unified&w=0#diff-35b8f26ef00e63853d6a8303dfdb8755355d7cb6d48ba9449d5a04af62a723cbR32),[link](https://github.com/radius-project/radius/pull/6672/files?diff=unified&w=0#diff-35b8f26ef00e63853d6a8303dfdb8755355d7cb6d48ba9449d5a04af62a723cbL104-R129))
* Import the `registry` package from the Helm library to interact with OCI registries
([link](https://github.com/radius-project/radius/pull/6672/files?diff=unified&w=0#diff-35b8f26ef00e63853d6a8303dfdb8755355d7cb6d48ba9449d5a04af62a723cbR32))
* Check if the `repoUrl` is an OCI registry or not, and set the `pull.RepoURL` and the `chartRef` accordingly
([link](https://github.com/radius-project/radius/pull/6672/files?diff=unified&w=0#diff-35b8f26ef00e63853d6a8303dfdb8755355d7cb6d48ba9449d5a04af62a723cbL104-R129))
* Set the `registryClient` for the `pull` operation to enable pulling from OCI registries
([link](https://github.com/radius-project/radius/pull/6672/files?diff=unified&w=0#diff-35b8f26ef00e63853d6a8303dfdb8755355d7cb6d48ba9449d5a04af62a723cbL104-R129))
* Remove the unnecessary assignment of `pull.RepoURL` to `repoUrl` for non-OCI registries
([link](https://github.com/radius-project/radius/pull/6672/files?diff=unified&w=0#diff-35b8f26ef00e63853d6a8303dfdb8755355d7cb6d48ba9449d5a04af62a723cbL82))
* Update the constants for the Radius Helm chart location and move them to the `helm.go` file
([link](https://github.com/radius-project/radius/pull/6672/files?diff=unified&w=0#diff-7f93f7a0f0c6c2329155f30e6a4cc6928277acabefab4c28826cb143a23ce90eL36-R36))
* Change the `radiusReleaseName` and the `radiusHelmRepo` to point to the new OCI registry on GitHub Container Registry
([link](https://github.com/radius-project/radius/pull/6672/files?diff=unified&w=0#diff-7f93f7a0f0c6c2329155f30e6a4cc6928277acabefab4c28826cb143a23ce90eL36-R36))
* Move the constants from the `radiusclient.go` file to the `helm.go` file, as they are more relevant to the general Helm operations ([link](https://github.com/radius-project/radius/pull/6672/files?diff=unified&w=0#diff-7f93f7a0f0c6c2329155f30e6a4cc6928277acabefab4c28826cb143a23ce90eL36-R36))

Signed-off-by: willdavsmith <willdavsmith@gmail.com>
Co-authored-by: Karishma Chawla <kachawla@microsoft.com>
(cherry picked from commit c0accc62ac3791d5c5ee90958749a395db51877b)

# Description

_Please explain the changes you've made._

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 33fb5d9</samp>

### Summary
🚀🔄🛠️

<!--
1.  🚀 - This emoji represents the migration of the Radius Helm chart from ACR to GHCR, which is a faster and more reliable way to distribute the chart.
2.  🔄 - This emoji represents the change of the Helm repo URL in the `radiusclient.go` file, which requires updating the references and constants in the code.
3.  🛠️ - This emoji represents the support for installing Helm charts from OCI registries, which is a new feature that requires importing and using a new package and adjusting the logic in the `helmChartFromContainerRegistry` function.
-->
Support installing Helm charts from OCI registries and update the Radius Helm repo URL. This allows the `helmChartFromContainerRegistry` function to handle different registry types, and reflects the migration of the Radius Helm chart from ACR to GHCR.

> _Sing, O Muse, of the valiant deeds of the Radius team_
> _Who changed their Helm repo from ACR to GHCR with skill and esteem_
> _They updated their constants in the `radiusclient.go` file_
> _And made their charts OCI-compatible with the `registry` package, agile and versatile_

### Walkthrough
*  Support installing Helm charts from OCI registries, such as GHCR ([link](https://github.com/radius-project/radius/pull/6674/files?diff=unified&w=0#diff-35b8f26ef00e63853d6a8303dfdb8755355d7cb6d48ba9449d5a04af62a723cbR32), [link](https://github.com/radius-project/radius/pull/6674/files?diff=unified&w=0#diff-35b8f26ef00e63853d6a8303dfdb8755355d7cb6d48ba9449d5a04af62a723cbL82), [link](https://github.com/radius-project/radius/pull/6674/files?diff=unified&w=0#diff-35b8f26ef00e63853d6a8303dfdb8755355d7cb6d48ba9449d5a04af62a723cbL104-R129), [link](https://github.com/radius-project/radius/pull/6674/files?diff=unified&w=0#diff-7f93f7a0f0c6c2329155f30e6a4cc6928277acabefab4c28826cb143a23ce90eL36-R36))
  - Import `registry` package from Helm library in `helm.go` ([link](https://github.com/radius-project/radius/pull/6674/files?diff=unified&w=0#diff-35b8f26ef00e63853d6a8303dfdb8755355d7cb6d48ba9449d5a04af62a723cbR32))
  - Remove assignment of `pull.RepoURL` to `repoUrl` in `helmChartFromContainerRegistry` function in `helm.go` ([link](https://github.com/radius-project/radius/pull/6674/files?diff=unified&w=0#diff-35b8f26ef00e63853d6a8303dfdb8755355d7cb6d48ba9449d5a04af62a723cbL82))
  - Add conditional branch based on registry type in `helmChartFromContainerRegistry` function in `helm.go` ([link](https://github.com/radius-project/radius/pull/6674/files?diff=unified&w=0#diff-35b8f26ef00e63853d6a8303dfdb8755355d7cb6d48ba9449d5a04af62a723cbL104-R129))
  - Update constants for Radius release name and Helm repo in `radiusclient.go` ([link](https://github.com/radius-project/radius/pull/6674/files?diff=unified&w=0#diff-7f93f7a0f0c6c2329155f30e6a4cc6928277acabefab4c28826cb143a23ce90eL36-R36))


