### PR TITLE
Add functional tests instructions to setup local dev environment work with ghcr

### DIFF
--- a/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
+++ b/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
@@ -41,8 +41,10 @@ As much as possible, the tests use product functionality such as the Radius CLI 
 3. Make sure 
 4. Make sure your [local dev environment is setup](../contributing-code-control-plane/running-controlplane-locally.md)
 5. Log-in to the container registry of your Github organization. 
+   ```
     export CR_PAT=<your_pat>
     echo $CR_PAT | docker login ghcr.io -u <your_username> --password-stdin
+   ```
 6. Publish Bicep test recipes by running `BICEP_RECIPE_REGISTRY=<registry-name> make publish-test-bicep-recipes`
 7. Publish Terraform test recipes by running `make publish-test-terraform-recipes`
 8. Change the visibility of the published packages to 'public'

--- a/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
+++ b/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
@@ -38,11 +38,15 @@ As much as possible, the tests use product functionality such as the Radius CLI 
 
 1. Place `rad` on your path
 2. Make sure `rad-bicep` is downloaded (`rad bicep download`)
-3. Create a container registry
-4. Log-in to the container registry
-5. Publish Bicep test recipes by running `BICEP_RECIPE_REGISTRY=<registry-name> make publish-test-bicep-recipes`
-6. Publish Terraform test recipes by running `make publish-test-terraform-recipes`
-7. Create a Radius Environment with `rad init` and specify the default namespace
+3. Make sure 
+4. Make sure your [local dev environment is setup](../contributing-code-control-plane/running-controlplane-locally.md)
+5. Log-in to the container registry of your Github organization. 
+    export CR_PAT=<your_pat>
+    echo $CR_PAT | docker login ghcr.io -u <your_username> --password-stdin
+6. Publish Bicep test recipes by running `BICEP_RECIPE_REGISTRY=<registry-name> make publish-test-bicep-recipes`
+7. Publish Terraform test recipes by running `make publish-test-terraform-recipes`
+8. Change the visibility of the published packages to 'public'
+   
 
 > ⚠️ The tests assume the Kubernetes namespace in use is `default`. If your environment is set up differently you will see
 > test failures.
@@ -70,7 +74,7 @@ You can also run/debug individual tests from VSCode.
 ### Tips
 
 > 💡 If you make changes to recipes, make sure to re-run the *publish test recipe* step from prerequisites.
-
+> 💡 Make sure the packages published to your organization have their visibility set to "public"
 > 💡 If you make changes to the `rad` CLI make sure to copy it to your path. 
 
 ### Seeing log output

--- a/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
+++ b/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
@@ -41,10 +41,11 @@ As much as possible, the tests use product functionality such as the Radius CLI 
 3. Make sure 
 4. Make sure your [local dev environment is setup](../contributing-code-control-plane/running-controlplane-locally.md)
 5. Log-in to the container registry of your Github organization. 
-   ```
-    export CR_PAT=<your_pat>
-    echo $CR_PAT | docker login ghcr.io -u <your_username> --password-stdin
-   ```
+   
+    `export CR_PAT=<your_pat>`
+    
+    `echo $CR_PAT | docker login ghcr.io -u <your_username> --password-stdin`
+
 6. Publish Bicep test recipes by running `BICEP_RECIPE_REGISTRY=<registry-name> make publish-test-bicep-recipes`
 7. Publish Terraform test recipes by running `make publish-test-terraform-recipes`
 8. Change the visibility of the published packages to 'public'

--- a/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
+++ b/docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md
@@ -38,8 +38,8 @@ As much as possible, the tests use product functionality such as the Radius CLI 
 
 1. Place `rad` on your path
 2. Make sure `rad-bicep` is downloaded (`rad bicep download`)
-3. Make sure 
-4. Make sure your [local dev environment is setup](../contributing-code-control-plane/running-controlplane-locally.md)
+3. Make sure your [local dev environment is setup](../contributing-code-control-plane/running-controlplane-locally.md)
+4. Log into your Github account and [Generate PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
 5. Log-in to the container registry of your Github organization. 
    
     `export CR_PAT=<your_pat>`


### PR DESCRIPTION
# Description

Add instructions to use GHCR from user's organization to run recipe functional tests.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).


Fixes: #6603 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at dffc0cc</samp>

### Summary
📝🔑🌐

<!--
1.  📝 - This emoji represents documentation or writing, and can be used for the first change of updating the documentation for running functional tests locally.
2.  🔑 - This emoji represents security or authentication, and can be used for the second change of logging in to the registry.
3.  🌐 - This emoji represents the internet or global access, and can be used for the third change of making the packages public.
-->
Improved the documentation for functional testing. Added steps for `dev` setup, registry login, and package visibility in `docs/contributing/contributing-code/contributing-code-tests/running-functional-tests.md`.

> _`Dev environment` is the battlefield_
> _We fight for `functional tests` to pass_
> _We log in to the `registry` of doom_
> _We make the `packages` public at last_

### Walkthrough
*  Update prerequisites for running functional tests locally ([link](https://github.com/radius-project/radius/pull/6717/files?diff=unified&w=0#diff-e286d51f1368685af6439c0bd568dc2cbee5c7c3806112b211a8844754c0b1c6L41-R49))
*  Add tip to make packages public after publishing them ([link](https://github.com/radius-project/radius/pull/6717/files?diff=unified&w=0#diff-e286d51f1368685af6439c0bd568dc2cbee5c7c3806112b211a8844754c0b1c6L73-R77))


