### PR TITLE
Update team membership requirement for `/ok-to-test` execution

### DIFF
--- a/.github/workflows/radius-bot.yaml
+++ b/.github/workflows/radius-bot.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Comment analyzer
         uses: actions/github-script@v6
         env:
-          TEAM_SLUG: 'Radius-Eng'
+          TEAM_SLUG: 'approvers-radius'
         with:
           github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
           script: |


### PR DESCRIPTION
# Description

Update `/ok-to-test` command so it can only be triggered by approvers-radius.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: https://github.com/radius-project/radius/issues/6715

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f836107</samp>

### Summary
:recycle::busts_in_silhouette::wrench:

<!--
1.  :recycle: - This emoji can be used to indicate a refactor or update of existing code or configuration, without changing the functionality or behavior. In this case, the environment variable is updated to reflect the new team name, but the workflow logic remains the same.
2. :busts_in_silhouette: - This emoji can be used to indicate a change related to users, groups, teams, or roles. In this case, the team `approvers-radius` is a new group of users who are responsible for reviewing and approving pull requests for the radius project.
3. :wrench: - This emoji can be used to indicate a change related to tools, settings, or configuration. In this case, the environment variable is a setting that controls how the radius-bot workflow operates and interacts with GitHub.
-->
Updated the radius-bot workflow to use the new `approvers-radius` team for pull request approvals. This team includes the core maintainers and reviewers of the radius project.

> _`TEAM_SLUG` changes_
> _New team structure for radius_
> _Autumn of refactor_

### Walkthrough
* Update the team name for approving pull requests in the radius-bot workflow ([link](https://github.com/radius-project/radius/pull/6732/files?diff=unified&w=0#diff-c70ecfd035a4650c141a6b69858c30ad9a9f261099f3c891b6bd44f7021ba9ceL21-R21))


