### PR TITLE
Updating Functional Test to Validate Deletion in Absence of Terraform State File

### DIFF
--- a/test/functional/shared/resources/recipe_terraform_test.go
+++ b/test/functional/shared/resources/recipe_terraform_test.go
@@ -119,14 +119,14 @@ func Test_TerraformRecipe_KubernetesRedis(t *testing.T) {
 				require.Equal(t, expectedTemplatePath, recipe["templatePath"].(string))
 				// At present, it is not possible to verify the template version in functional tests
 				// This is verified by UTs though
+
+				// Force delete the kubernetes secret for terraform state file.
+				// This is done to validate that the application/portable resource deletion is not blocked if the Terraform state file backend is deleted.
+				err = test.Options.K8sClient.CoreV1().Secrets(secretNamespace).Delete(ctx, secretPrefix+secretSuffix, metav1.DeleteOptions{})
+				require.NoError(t, err)
 			},
 		},
 	})
-
-	test.PostDeleteVerify = func(ctx context.Context, t *testing.T, test shared.RPTest) {
-		resourceID := "/planes/radius/local/resourcegroups/kind-radius/providers/Applications.Core/extenders/" + name
-		testSecretDeletion(t, ctx, test, appName, envName, resourceID)
-	}
 
 	test.Test(t)
 }


### PR DESCRIPTION
# Description

Updating functional test to validate deletion of application/resource in absence of Terraform state file backend.

Validated that the expected info is being logged when the deletion is skipped for the test -

```
{"severity":"info","timestamp":"2023-11-15T01:58:53.487Z","name":"radius.radiusasyncworker","caller":"terraform/execute.go:144","message":"Skipping deletion of recipe resources: Terraform state file backend does not exist.","serviceName":"radius","version":"edge","hostName":"applications-rp-656797b9f7-wsbzl","resourceId":"/planes/radius/local/resourcegroups/kind-radius/providers/Applications.Core/extenders/corerp-resources-terraform-redis","operationId":"4452b732-8284-4ea4-832c-e8b6ec60e332","operationType":"APPLICATIONS.CORE/EXTENDERS|DELETE","dequeueCount":1,"traceId":"b42826b4c29565abae2aeef5b2aa5e28","spanId":"64f4fa786698b55c"}
```

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: https://github.com/radius-project/radius/issues/6257

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 142495c</samp>

### Summary
🗑️🧪🌐

<!--
1.  🗑️ - This emoji represents the deletion of the kubernetes secret and the terraform state file backend, as well as the concept of force deleting or cleaning up resources.
2.  🧪 - This emoji represents the testing or experimentation aspect of the change, as it is part of a test case for a new feature and involves validating the expected behavior of the terraform extender.
3.  🌐 - This emoji represents the terraform resource and the portable resource, which are both related to deploying and managing infrastructure across different cloud platforms and environments.
-->
Added a test step to verify terraform resource deletion when state file backend is gone. This is for the `terraform extender` feature in `test/functional/shared/resources/recipe_terraform_test.go`.

> _`terraform` state_
> _force deleted in secret_
> _autumn leaves fall_

### Walkthrough
* Add a step to force delete the kubernetes secret for the terraform state file ([link](https://github.com/radius-project/radius/pull/6741/files?diff=unified&w=0#diff-94178e873ad0fe96b700c75fe85d086b4ad1a4dae5f448e6f5bcc5f706b89995L122-R130))


