### PR TITLE
Fix Docs Workflow when run from fork

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -45,7 +45,6 @@ jobs:
           repository: radius-project/docs
           path: docs
           ref: ${{ env.DOCS_BRANCH }}
-          token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
       # Setup dependencies
       - name: Set up Go ${{ env.GOVER }}
         uses: actions/setup-go@v4


### PR DESCRIPTION
# Description



This change fixes the docs publishing workflow when running from a fork. The workflow triggers onPR to do a 'dry-run' of docs changes. It's failing because the PAT we are using to clone the docs repo won't be set on a fork.

The solution is not to use a PAT since the repo is public.



_Please explain the changes you've made._

## Type of change


- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->
Fixes: #6778

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at bc26bf8</samp>

### Summary
:wastebasket::lock::memo:

<!--
1.  :wastebasket: This emoji can be used to indicate that something was removed or deleted, such as the `token` parameter. It conveys the idea of cleaning up or simplifying the code.
2.  :lock: This emoji can be used to indicate that something was related to security or permissions, such as the `GITHUB_TOKEN` and the potential issues with forks. It conveys the idea of protecting or restricting access to the code.
3.  :memo: This emoji can be used to indicate that something was related to documentation, such as the workflow for publishing the docs of the radius project. It conveys the idea of writing or updating information about the code.
-->
Remove unnecessary `token` parameter from `actions/checkout@v2` step in `.github/workflows/publish-docs.yaml`. This simplifies the workflow and avoids potential permission issues for public repositories.

> _`token` removed_
> _checkout is simpler and safer_
> _autumn leaves fall fast_

### Walkthrough
* Remove `token` parameter from `actions/checkout@v2` step to avoid permission issues and use default `GITHUB_TOKEN` ([link](https://github.com/radius-project/radius/pull/6786/files?diff=unified&w=0#diff-69250281a3f8b6ed9c93d9d9d8d92aa49e2105c37fe83fd22168ec5ab85250bdL48))


