### PR TITLE
fix:typos

### DIFF
--- a/pkg/cli/bicep/build.go
+++ b/pkg/cli/bicep/build.go
@@ -59,7 +59,7 @@ func runBicepRaw(args ...string) ([]byte, error) {
 		return nil, fmt.Errorf("failed executing %q: %w", fullCmd, err)
 	}
 
-	// asyncronously copy to our buffer, we don't really need to observe
+	// asynchronously copy to our buffer, we don't really need to observe
 	// errors here since it's copying into memory
 	buf := bytes.Buffer{}
 	go func() {

--- a/pkg/cli/clivalidation.go
+++ b/pkg/cli/clivalidation.go
@@ -359,7 +359,7 @@ func RequireWorkspace(cmd *cobra.Command, config *viper.Viper, dc *config.Direct
 	return ws, nil
 }
 
-// RequireUCPResourceGroup is used by commands that require specifying a UCP resouce group name using flag or positional args
+// RequireUCPResourceGroup is used by commands that require specifying a UCP resource group name using flag or positional args
 //
 
 // RequireUCPResourceGroup reads the resource group name from the command line arguments and returns an error if the name

--- a/pkg/cli/kubernetes/portforward/doc.go
+++ b/pkg/cli/kubernetes/portforward/doc.go
@@ -15,6 +15,6 @@ limitations under the License.
 */
 
 // portforward contains functionality for port-forwarding an entire application from
-// Kubernetes. This functionality is based on the kubenetes client APIs and implemented
+// Kubernetes. This functionality is based on the kubernetes client APIs and implemented
 // inside this package.
 package portforward

--- a/pkg/cli/setup/application.go
+++ b/pkg/cli/setup/application.go
@@ -60,7 +60,7 @@ func ScaffoldApplication(directory string, name string) error {
 		return err
 	}
 
-	// We NEVER overwite app.bicep if it exists. We assume the user might have changed it, and don't
+	// We NEVER overwrite app.bicep if it exists. We assume the user might have changed it, and don't
 	// want them to lose their content.
 	//
 	// On the other hand, we ALWAYS overwrite rad.yaml if it exists. We assume that the reason why

--- a/pkg/controller/reconciler/annotations.go
+++ b/pkg/controller/reconciler/annotations.go
@@ -103,7 +103,7 @@ func readAnnotations(deployment *appsv1.Deployment) (*deploymentAnnotations, err
 	result.Status = &s
 
 	// Note: we need to read and return the configuration even if Radius is not enabled for the Deployment.
-	// This is important so that can clean up previsouly created connections when Radius is disabled.
+	// This is important so that can clean up previously created connections when Radius is disabled.
 	enabled := deployment.Annotations[AnnotationRadiusEnabled]
 	if !strings.EqualFold(enabled, "true") {
 		return &result, nil

--- a/pkg/controller/reconciler/const.go
+++ b/pkg/controller/reconciler/const.go
@@ -34,7 +34,7 @@ const (
 	// AnnotationRadiusConfigurationHash is the name of the annotation that indicates the hash of the configuration.
 	AnnotationRadiusConfigurationHash = "radapp.io/configuration-hash"
 
-	// AnnotationRadiusEnvionment is the name of the annotation that indicates the name of the environment. If unset,
+	// AnnotationRadiusEnvironment is the name of the annotation that indicates the name of the environment. If unset,
 	// the value 'default' will be used as the environment name.
 	AnnotationRadiusEnvironment = "radapp.io/environment"
 

--- a/pkg/corerp/api/v20231001preview/container_conversion_test.go
+++ b/pkg/corerp/api/v20231001preview/container_conversion_test.go
@@ -111,7 +111,7 @@ func TestContainerConvertVersionedToDataModel(t *testing.T) {
 				require.Equal(t, "Always", ct.Properties.RestartPolicy)
 				require.Equal(t, "/app", ct.Properties.Container.WorkingDir)
 				if tt.emptyExt {
-					require.Equal(t, getTestContainerEmptyKuberenetesMetadataExt(t), ct.Properties.Extensions)
+					require.Equal(t, getTestContainerEmptyKubernetesMetadataExt(t), ct.Properties.Extensions)
 				} else {
 					require.Equal(t, getTestContainerExtensions(t), ct.Properties.Extensions)
 				}
@@ -296,7 +296,7 @@ func getTestContainerExtensions(t *testing.T) []datamodel.Extension {
 	return extensions
 }
 
-func getTestContainerEmptyKuberenetesMetadataExt(t *testing.T) []datamodel.Extension {
+func getTestContainerEmptyKubernetesMetadataExt(t *testing.T) []datamodel.Extension {
 	var replicavalue int32 = 2
 	ptrreplicaval := &replicavalue
 	extensions := []datamodel.Extension{

--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -629,7 +629,7 @@ func (dp *deploymentProcessor) getRendererDependency(ctx context.Context, depend
 		computedValues[k] = v
 	}
 
-	// Now build the renderer dependecy out of these collected dependencies
+	// Now build the renderer dependency out of these collected dependencies
 	rendererDependency := renderers.RendererDependency{
 		ResourceID:      dependency.ID,
 		Resource:        dependency.Resource,

--- a/pkg/corerp/frontend/controller/applications/graph_util.go
+++ b/pkg/corerp/frontend/controller/applications/graph_util.go
@@ -425,7 +425,7 @@ func outputResourcesFromAPIData(resource generated.GenericResource) []*corerpv20
 	// The data is returned as an array of JSON objects. We need to convert each object from a map[string]any
 	// to the strongly-typed format we understand.
 	//
-	// If we enounter an error processing this data, just and an "invalid" output resource entry.
+	// If we encounter an error processing this data, just and an "invalid" output resource entry.
 	entries := []*corerpv20231001preview.ApplicationGraphOutputResource{}
 	for _, or := range ors {
 		// This is the wire format returned by the API for an output resource.

--- a/pkg/corerp/frontend/controller/containers/validator_test.go
+++ b/pkg/corerp/frontend/controller/containers/validator_test.go
@@ -103,7 +103,7 @@ func TestValidateAndMutateRequest_IdentityProperty(t *testing.T) {
 				Properties: datamodel.ContainerProperties{
 					Runtimes: &datamodel.RuntimeProperties{
 						Kubernetes: &datamodel.KubernetesRuntime{
-							Base: strings.Join([]string{fakeDeployment, fakeService, fakeServiceAccount}, k8sutil.YAMLSeparater),
+							Base: strings.Join([]string{fakeDeployment, fakeService, fakeServiceAccount}, k8sutil.YAMLSeparator),
 						},
 					},
 				},
@@ -117,7 +117,7 @@ func TestValidateAndMutateRequest_IdentityProperty(t *testing.T) {
 				Properties: datamodel.ContainerProperties{
 					Runtimes: &datamodel.RuntimeProperties{
 						Kubernetes: &datamodel.KubernetesRuntime{
-							Base: strings.Join([]string{fakeDeployment, fakeService, fakeServiceAccount}, k8sutil.YAMLSeparater),
+							Base: strings.Join([]string{fakeDeployment, fakeService, fakeServiceAccount}, k8sutil.YAMLSeparator),
 						},
 					},
 				},
@@ -216,25 +216,25 @@ func TestValidateManifest(t *testing.T) {
 	}{
 		{
 			name:     "valid manifest with deployments/services/serviceaccounts",
-			manifest: strings.Join([]string{fakeDeployment, fakeService, fakeServiceAccount}, k8sutil.YAMLSeparater),
+			manifest: strings.Join([]string{fakeDeployment, fakeService, fakeServiceAccount}, k8sutil.YAMLSeparator),
 			resource: validResource,
 			err:      nil,
 		},
 		{
 			name:     "valid manifest with deployments/services/secrets/configmaps",
-			manifest: strings.Join([]string{fakeDeployment, fakeService, fakeSecret, fakeSecret}, k8sutil.YAMLSeparater),
+			manifest: strings.Join([]string{fakeDeployment, fakeService, fakeSecret, fakeSecret}, k8sutil.YAMLSeparator),
 			resource: validResource,
 			err:      nil,
 		},
 		{
 			name:     "valid manifest with multiple secrets and multiple configmaps",
-			manifest: strings.Join([]string{fakeDeployment, fakeService, fakeSecret, fakeSecret, fakeSecret, fakeConfigMap, fakeConfigMap}, k8sutil.YAMLSeparater),
+			manifest: strings.Join([]string{fakeDeployment, fakeService, fakeSecret, fakeSecret, fakeSecret, fakeConfigMap, fakeConfigMap}, k8sutil.YAMLSeparator),
 			resource: validResource,
 			err:      nil,
 		},
 		{
 			name:     "invalid manifest with multiple deployments",
-			manifest: strings.Join([]string{fakeDeployment, fakeDeployment}, k8sutil.YAMLSeparater),
+			manifest: strings.Join([]string{fakeDeployment, fakeDeployment}, k8sutil.YAMLSeparator),
 			resource: validResource,
 			err: v1.ErrorDetails{
 				Code:    v1.CodeInvalidRequestContent,
@@ -251,7 +251,7 @@ func TestValidateManifest(t *testing.T) {
 		},
 		{
 			name:     "invalid manifest with multiple services",
-			manifest: strings.Join([]string{fakeDeployment, fakeService, fakeService}, k8sutil.YAMLSeparater),
+			manifest: strings.Join([]string{fakeDeployment, fakeService, fakeService}, k8sutil.YAMLSeparator),
 			resource: validResource,
 			err: v1.ErrorDetails{
 				Code:    v1.CodeInvalidRequestContent,
@@ -268,7 +268,7 @@ func TestValidateManifest(t *testing.T) {
 		},
 		{
 			name:     "invalid manifest with multiple serviceaccounts",
-			manifest: strings.Join([]string{fakeDeployment, fakeService, fakeServiceAccount, fakeServiceAccount}, k8sutil.YAMLSeparater),
+			manifest: strings.Join([]string{fakeDeployment, fakeService, fakeServiceAccount, fakeServiceAccount}, k8sutil.YAMLSeparator),
 			resource: validResource,
 			err: v1.ErrorDetails{
 				Code:    v1.CodeInvalidRequestContent,
@@ -285,7 +285,7 @@ func TestValidateManifest(t *testing.T) {
 		},
 		{
 			name:     "invalid manifest with resource including namespace",
-			manifest: strings.Join([]string{fakeDeployment, fakeServiceWithNamespace, fakeServiceAccount}, k8sutil.YAMLSeparater),
+			manifest: strings.Join([]string{fakeDeployment, fakeServiceWithNamespace, fakeServiceAccount}, k8sutil.YAMLSeparator),
 			resource: validResource,
 			err: v1.ErrorDetails{
 				Code:    v1.CodeInvalidRequestContent,
@@ -302,7 +302,7 @@ func TestValidateManifest(t *testing.T) {
 		},
 		{
 			name:     "invalid manifest with unmatched deployment name",
-			manifest: strings.Join([]string{fmt.Sprintf(k8sutil.FakeDeploymentTemplate, "pie", "", "magpie"), fakeService, fakeServiceAccount}, k8sutil.YAMLSeparater),
+			manifest: strings.Join([]string{fmt.Sprintf(k8sutil.FakeDeploymentTemplate, "pie", "", "magpie"), fakeService, fakeServiceAccount}, k8sutil.YAMLSeparator),
 			resource: validResource,
 			err: v1.ErrorDetails{
 				Code:    v1.CodeInvalidRequestContent,
@@ -319,7 +319,7 @@ func TestValidateManifest(t *testing.T) {
 		},
 		{
 			name:     "invalid manifest with unmatched service name",
-			manifest: strings.Join([]string{fakeDeployment, fmt.Sprintf(k8sutil.FakeServiceTemplate, "pie", ""), fakeServiceAccount}, k8sutil.YAMLSeparater),
+			manifest: strings.Join([]string{fakeDeployment, fmt.Sprintf(k8sutil.FakeServiceTemplate, "pie", ""), fakeServiceAccount}, k8sutil.YAMLSeparator),
 			resource: validResource,
 			err: v1.ErrorDetails{
 				Code:    v1.CodeInvalidRequestContent,
@@ -336,7 +336,7 @@ func TestValidateManifest(t *testing.T) {
 		},
 		{
 			name:     "invalid manifest with unmatched serviceaccount name",
-			manifest: strings.Join([]string{fakeDeployment, fakeService, fmt.Sprintf(k8sutil.FakeServiceAccountTemplate, "pie")}, k8sutil.YAMLSeparater),
+			manifest: strings.Join([]string{fakeDeployment, fakeService, fmt.Sprintf(k8sutil.FakeServiceAccountTemplate, "pie")}, k8sutil.YAMLSeparator),
 			resource: validResource,
 			err: v1.ErrorDetails{
 				Code:    v1.CodeInvalidRequestContent,
@@ -358,7 +358,7 @@ func TestValidateManifest(t *testing.T) {
 		},
 		{
 			name:     "invalid manifest with multiple errors",
-			manifest: strings.Join([]string{fakeDeployment, fakeService, fakeService, fmt.Sprintf(k8sutil.FakeServiceAccountTemplate, "pie")}, k8sutil.YAMLSeparater),
+			manifest: strings.Join([]string{fakeDeployment, fakeService, fakeService, fmt.Sprintf(k8sutil.FakeServiceAccountTemplate, "pie")}, k8sutil.YAMLSeparator),
 			resource: validResource,
 			err: v1.ErrorDetails{
 				Code:    v1.CodeInvalidRequestContent,

--- a/pkg/corerp/renderers/container/manifest_test.go
+++ b/pkg/corerp/renderers/container/manifest_test.go
@@ -592,7 +592,7 @@ func TestPopulateAllBaseResources(t *testing.T) {
 		fakeConfigMap0 := fmt.Sprintf(k8sutil.FakeConfigMapTemplate, "configmap0")
 		fakeConfigMap1 := fmt.Sprintf(k8sutil.FakeConfigMapTemplate, "configmap1")
 
-		baseString := strings.Join([]string{fakeDeployment, fakeService, fakeServiceAccount, fakeSecret0, fakeConfigMap0, fakeSecret1, fakeConfigMap1}, k8sutil.YAMLSeparater)
+		baseString := strings.Join([]string{fakeDeployment, fakeService, fakeServiceAccount, fakeSecret0, fakeConfigMap0, fakeSecret1, fakeConfigMap1}, k8sutil.YAMLSeparator)
 		manifest, err := kubeutil.ParseManifest([]byte(baseString))
 		require.NoError(t, err)
 

--- a/pkg/corerp/renderers/container/render_test.go
+++ b/pkg/corerp/renderers/container/render_test.go
@@ -264,7 +264,7 @@ func Test_GetDependencyIDs_InvalidAzureResourceId(t *testing.T) {
 }
 
 // This test verifies most of the 'basics' of rendering a deployment. These verifications are not
-// repeated in other tests becase the code is simple for these cases.
+// repeated in other tests because the code is simple for these cases.
 //
 // If you add minor features, add them here.
 func Test_Render_Basic(t *testing.T) {
@@ -1696,7 +1696,7 @@ func Test_Render_ImagePullPolicySpecified(t *testing.T) {
 }
 
 func Test_Render_StrategicPatchMerge(t *testing.T) {
-	const contianerPatchObject = `
+	const containerPatchObject = `
 {
 	"containers": [
 		{
@@ -1730,7 +1730,7 @@ func Test_Render_StrategicPatchMerge(t *testing.T) {
 		},
 		Runtimes: &datamodel.RuntimeProperties{
 			Kubernetes: &datamodel.KubernetesRuntime{
-				Pod: contianerPatchObject,
+				Pod: containerPatchObject,
 			},
 		},
 	}

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -113,7 +113,7 @@ func MakeSelectorLabels(application string, resource string) map[string]string {
 // MakeRouteSelectorLabels returns a map of labels suitable for a Kubernetes selector to identify a labeled Radius-managed
 // Kubernetes object.
 //
-// This function differs from MakeSelectorLablels in that it's intended to *cross* resources. eg: The Service created by
+// This function differs from MakeRouteSelectorLabels in that it's intended to *cross* resources. eg: The Service created by
 // an HttpRoute and the Deployment created by a Container.
 func MakeRouteSelectorLabels(application string, resourceType string, route string) map[string]string {
 	return map[string]string{

--- a/pkg/kubernetes/labels_test.go
+++ b/pkg/kubernetes/labels_test.go
@@ -112,7 +112,7 @@ func TestNormalizeResoureName(t *testing.T) {
 	}
 }
 
-func TestNormalizeResoureNameDapr(t *testing.T) {
+func TestNormalizeResourceNameDapr(t *testing.T) {
 	nameTests := []struct {
 		in    string
 		out   string

--- a/pkg/sdk/clients/providerconfig.go
+++ b/pkg/sdk/clients/providerconfig.go
@@ -28,7 +28,7 @@ const (
 )
 
 // NewDefaultProviderConfig creates a ProviderConfig instance with two fields, Deployments and Radius, and sets their values
-// based on the resourceGroup parameter. The default config will include configuration for Radius resources, Kuberenetes resources,
+// based on the resourceGroup parameter. The default config will include configuration for Radius resources, Kubernetes resources,
 // and Bicep modules. AWS and Azure resources must be added separately.
 func NewDefaultProviderConfig(resourceGroup string) ProviderConfig {
 	config := ProviderConfig{

--- a/pkg/server/asyncworker.go
+++ b/pkg/server/asyncworker.go
@@ -29,14 +29,14 @@ import (
 	"github.com/radius-project/radius/pkg/kubeutil"
 )
 
-// AsyncWorker is a service to run AsyncReqeustProcessWorker.
+// AsyncWorker is a service to run AsyncRequestProcessWorker.
 type AsyncWorker struct {
 	worker.Service
 
 	handlerBuilder []builder.Builder
 }
 
-// NewAsyncWorker creates new service instance to run AsyncReqeustProcessWorker.
+// NewAsyncWorker creates new service instance to run AsyncRequestProcessWorker.
 func NewAsyncWorker(options hostoptions.HostOptions, builder []builder.Builder) *AsyncWorker {
 	return &AsyncWorker{
 		Service: worker.Service{

--- a/test/k8sutil/fakeresources.go
+++ b/test/k8sutil/fakeresources.go
@@ -16,8 +16,8 @@ limitations under the License.
 
 package k8sutil
 
-// YAMLSeparater is the separater for fake YAML.
-const YAMLSeparater = "\n---\n"
+// YAMLSeparator is the separator for fake YAML.
+const YAMLSeparator = "\n---\n"
 
 // FakeDeploymentTemplate is the template for fake deployment.
 const FakeDeploymentTemplate = `


### PR DESCRIPTION
# Description

fix typos

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c2be2f3</samp>

### Summary
:pencil2::memo::books:

<!--
1.  :pencil2: - This emoji is often used to indicate a minor correction or improvement, such as fixing a typo or a spelling error. It can also suggest writing or editing something.
2.  :memo: - This emoji is also related to writing or editing, and can imply documentation, notes, or comments. It can be used to indicate changes that affect the readability or clarity of the code or its documentation.
3.  :books: - This emoji is associated with learning, studying, or reading. It can be used to indicate changes that improve the quality or accuracy of the code or its documentation, or that follow best practices or standards.
-->
This pull request fixes various typos in comments, variable names, and function names across multiple files in the radius-project/radius repository. These changes improve the readability, consistency, and accuracy of the code and documentation. The files affected are mostly related to container, Kubernetes, and deployment features.

> _Some comments and names had a flaw_
> _They misspelled some words that they saw_
> _Like `YAMLSeparater`_
> _And `MakeSelectorLablels`_
> _This pull request fixes them all_

### Walkthrough
* Fix typos in comments and function names related to spelling "asynchronously", "resource", "kubernetes", "overwrite", "previously", "environment", and "dependency" ([link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-aef8bc089aee4d8a81586b222f3724c7c1d2359d27980f00dba80f4d9e84d800L62-R62), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-bf4e917446c73565ee6967f28bdd8e619c0d4fa40b215f195b840c021dd36ce9L362-R362), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-9902cb1ba466c0457732e4543bb4c38abcede1cdee2fb363b491d027929738e6L18-R18), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-1b0ac5c011aaaf6673a23365f05fe4d2ebdc793c135984d7b3410e59ef92fa75L63-R63), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-73b7f11d4ca1032a9f2f6001f455c2f6622633ba1ff91373c9e6299e7439c468L106-R106), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-1c5d9f9f2bd3272c714eba486f899cd6e053bc2fd950dac921bc328d789568b1L37-R37), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-4183e8fa58766ff3187ebf888b8266b181dd6b4f11a23debac68833bde480edbL114-R114), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-4183e8fa58766ff3187ebf888b8266b181dd6b4f11a23debac68833bde480edbL299-R299), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-2f71b55e0dceaf541f852a86c0b54060819c6266f5257474fa863826d4043815L632-R632))
* Fix typos in variable names related to spelling "separator" and "container" ([link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-fc19d513d0bf2fdd0bc405a7bbfe1ca9ce18e1bb6219d27675e807d46ef3de01L106-R106), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-fc19d513d0bf2fdd0bc405a7bbfe1ca9ce18e1bb6219d27675e807d46ef3de01L120-R120), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-fc19d513d0bf2fdd0bc405a7bbfe1ca9ce18e1bb6219d27675e807d46ef3de01L219-R219), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-fc19d513d0bf2fdd0bc405a7bbfe1ca9ce18e1bb6219d27675e807d46ef3de01L225-R225), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-fc19d513d0bf2fdd0bc405a7bbfe1ca9ce18e1bb6219d27675e807d46ef3de01L231-R231), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-fc19d513d0bf2fdd0bc405a7bbfe1ca9ce18e1bb6219d27675e807d46ef3de01L237-R237), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-fc19d513d0bf2fdd0bc405a7bbfe1ca9ce18e1bb6219d27675e807d46ef3de01L254-R254), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-fc19d513d0bf2fdd0bc405a7bbfe1ca9ce18e1bb6219d27675e807d46ef3de01L271-R271), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-fc19d513d0bf2fdd0bc405a7bbfe1ca9ce18e1bb6219d27675e807d46ef3de01L288-R288), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-fc19d513d0bf2fdd0bc405a7bbfe1ca9ce18e1bb6219d27675e807d46ef3de01L305-R305), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-fc19d513d0bf2fdd0bc405a7bbfe1ca9ce18e1bb6219d27675e807d46ef3de01L322-R322), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-fc19d513d0bf2fdd0bc405a7bbfe1ca9ce18e1bb6219d27675e807d46ef3de01L339-R339), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-fc19d513d0bf2fdd0bc405a7bbfe1ca9ce18e1bb6219d27675e807d46ef3de01L361-R361), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-464b567399407ca08de3c0341b37b7f7a9eb047020323802dba3bc90acc63613L595-R595), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-6f1219f263ab06a1493ac76960e2ab8cbe647e83e926bff7d13988f393334f94L1699-R1699), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-6f1219f263ab06a1493ac76960e2ab8cbe647e83e926bff7d13988f393334f94L1733-R1733), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-1b6e97dcb8ad393f2b7cb6aa6145cba33a91e5ee3761d892f3845342815fd2aeL19-R20))
* Fix typos in function names related to spelling "labels" and "resource" ([link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-047ae86eebcf4fe6b0552e33dfae04d8e3aed6ab8051060dbc3fe8dcd01c2fbdL116-R116), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-0ed3106914c765be24ebab5a569823821d59d872e4ef02a1ca3c109bc2615e7eL115-R115))
* Fix typos in comments related to spelling "encounter" and "because" ([link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-22a021280064553a167148d57b149611b97686195be62addc09e1fc4fa2c1bb0L428-R428), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-6f1219f263ab06a1493ac76960e2ab8cbe647e83e926bff7d13988f393334f94L267-R267))
* Fix typos in comments related to spelling "AsyncRequestProcessWorker" and "Kubernetes" ([link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-f0953e4b019539f4c62a6c24c9837a07212a3effb5ce22931abb09fc7d90d1aeL31-R31), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-0d8522466cd60aa335c74f53b18be7dfa7ba7cf052d3cd8deb44b3d08646af6bL32-R32), [link](https://github.com/radius-project/radius/pull/6797/files?diff=unified&w=0#diff-0d8522466cd60aa335c74f53b18be7dfa7ba7cf052d3cd8deb44b3d08646af6bL39-R39))


