### PR TITLE
Test1

### DIFF
--- a/.github/actions/download-pr-data-artifact/action.yaml
+++ b/.github/actions/download-pr-data-artifact/action.yaml
@@ -1,0 +1,43 @@
+name: "Download PR number saved as an artifact"
+description: |
+  This action can be used together with save-pr-as-artifact custom action which uploads the PR number as an artifact.
+  This action downloads the artifact to retrieve the PR number.
+outputs:
+  "pr_number":
+    value: ${{ steps.set-pr-number.outputs.pr_number }}
+    description: The PR number downloaded from the artifact
+runs:
+  using: "composite"
+  steps:
+    - name: Download artifact
+      uses: actions/github-script@v6
+      with:
+        script: |
+          let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+          });
+          let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == "pr_number"
+          })[0];
+          let download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+          });
+          let fs = require('fs');
+          fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(download.data));
+    - name: 'Unzip artifact'
+      shell: bash
+      run: unzip pr_number.zip
+    - name: Set PR number
+      id: set-pr-number
+      uses: actions/github-script@v6
+      with:
+        script: |
+          let fs = require('fs');
+          PR_NUMBER=fs.readFileSync('./pr_number').toString();
+          console.log(`Setting output: pr_number=${PR_NUMBER}`);
+          core.setOutput('pr_number', PR_NUMBER);

--- a/.github/actions/save-pr-as-artifact/action.yaml
+++ b/.github/actions/save-pr-as-artifact/action.yaml
@@ -1,0 +1,17 @@
+name: "Save PR number as artifact"
+description: "Save PR number as artifact"
+runs:
+  using: "composite"
+  steps:
+    - name: Save PR number
+      shell: bash
+      env:
+        PR_NUMBER: ${{ github.event.number }}
+      run: |
+          mkdir -p ./pr
+          echo $PR_NUMBER > ./pr/pr_number
+    - uses: actions/upload-artifact@v3
+      with:
+        name: pr_number
+        path: pr/
+

--- a/.github/scripts/radius-bot.js
+++ b/.github/scripts/radius-bot.js
@@ -44,9 +44,6 @@ async function handleIssueCommentCreate({ github, context }) {
         case '/assign':
             await cmdAssign(github, issue, isFromPulls, username);
             break;
-        case '/ok-to-test':
-            await cmdOkToTest(github, issue, isFromPulls, username);
-            break;
         default:
             console.log(`[handleIssueCommentCreate] command ${command} not found, exiting.`);
             break;
@@ -75,70 +72,4 @@ async function cmdAssign(github, issue, isFromPulls, username) {
         issue_number: issue.number,
         assignees: [username],
     });
-}
-
-/**
- * Trigger e2e test for the pull request.
- * @param {*} github GitHub object reference
- * @param {*} issue GitHub issue object
- * @param {boolean} isFromPulls is the workflow triggered by a pull request?
- * @param {string} username is the user who trigger the command
- */
-async function cmdOkToTest(github, issue, isFromPulls, username) {
-    if (!isFromPulls) {
-        console.log('[cmdOkToTest] only pull requests supported, skipping command execution.');
-        return;
-    }
-
-    // Check if the user has permission to trigger e2e test with an issue comment
-    const org = 'radius-project';
-    console.log(`Checking team membership for: ${username}`);
-    const isMember = await checkTeamMembership(github, org, process.env.TEAM_SLUG, username);
-    if (!isMember) {
-        console.log(`${username} is not a member of the ${teamSlug} team.`);
-        return;
-    }
-
-    // Get pull request
-    const pull = await github.rest.pulls.get({
-        owner: issue.owner,
-        repo: issue.repo,
-        pull_number: issue.number,
-    });
-
-    if (pull && pull.data) {
-        // Get commit id and repo from pull head
-        const testPayload = {
-            pull_head_ref: pull.data.head.sha,
-            pull_head_repo: pull.data.head.repo.full_name,
-            command: 'ok-to-test',
-            issue: issue,
-        };
-
-        console.log('Creating repository dispatch event for e2e test');
-
-        // Fire repository_dispatch event to trigger e2e test
-        await github.rest.repos.createDispatchEvent({
-            owner: issue.owner,
-            repo: issue.repo,
-            event_type: 'functional-tests',
-            client_payload: testPayload,
-        });
-
-        console.log(`[cmdOkToTest] triggered E2E test for ${JSON.stringify(testPayload)}`);
-    }
-}
-
-async function checkTeamMembership(github, org, teamSlug, username) {
-    try {
-        const response = await github.rest.teams.getMembershipForUserInOrg({
-            org: org,
-            team_slug: teamSlug,
-            username: username,
-        });
-        return response.data.state === 'active';
-    } catch (error) {
-        console.log(`error: ${error}`)
-        return false;
-    }
 }

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -23,7 +23,11 @@ on:
     - cron: "30 0,12 * * 0,6"
   # Dispatch on external events
   repository_dispatch:
-    types: [functional-tests, de-functional-test]
+    types: [de-functional-test]
+  workflow_run:
+    workflows: ['Approve Functional Tests']
+    types:
+      - completed
 
 env:
   # Go version
@@ -94,22 +98,23 @@ jobs:
             echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
             echo "CHECKOUT_REF=${{ github.ref }}" >> $GITHUB_ENV
             echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-      - name: Set up checkout target (repository_dispatch from /ok-to-test)
-        if: github.event_name == 'repository_dispatch'
+      - name: 'Download PR data artifacts'
+        if: github.event_name == 'workflow_run'
+        uses: ./.github/actions/download-pr-data-artifact
+        id: get-pr-number
+      - name: 'Set PR context (workflow_run)'
+        if: github.event_name == 'workflow_run'
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const testPayload = context.payload.client_payload;
-            if (testPayload && testPayload.command === `ok-to-test`) {
-              var fs = require('fs');
-              // Set environment variables
-              fs.appendFileSync(process.env.GITHUB_ENV,
-                `CHECKOUT_REPO=${testPayload.pull_head_repo}\n`+
-                `CHECKOUT_REF=${testPayload.pull_head_ref}\n`+
-                `PR_NUMBER=${testPayload.issue.number}`
-              );
-            }
+            const payload = context.payload.workflow_run;
+            let fs = require('fs');
+            // Set environment variables
+            fs.appendFileSync(process.env.GITHUB_ENV,
+              `CHECKOUT_REPO=${payload.head_repository.full_name}\n`+
+              `CHECKOUT_REF=${payload.head_sha}\n` +
+              `PR_NUMBER=${{ steps.get-pr-number.outputs.pr_number }}\n`);
       - name: Set DE image and tag (repository_dispatch from de-functional-test)
         if: github.event_name == 'repository_dispatch'
         uses: actions/github-script@v6

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -98,6 +98,8 @@ jobs:
             echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
             echo "CHECKOUT_REF=${{ github.ref }}" >> $GITHUB_ENV
             echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+      - name: Use custom actions
+        uses: actions/checkout@v3
       - name: 'Download PR data artifacts'
         if: github.event_name == 'workflow_run'
         uses: ./.github/actions/download-pr-data-artifact

--- a/.github/workflows/functional-tests-approval.yaml
+++ b/.github/workflows/functional-tests-approval.yaml
@@ -1,0 +1,17 @@
+name: 'Approve Functional Tests'
+on:
+  pull_request:
+    branches:
+      - main
+      - features/*
+      - release/*
+jobs:
+  approve-functional-tests-run:
+    name: 'Approve Functional Tests'
+    runs-on: ubuntu-latest
+    environment: functional-tests
+    steps:
+    - name: Use custom actions
+      uses: actions/checkout@v3
+    - name: Save PR number
+      uses: ./.github/actions/save-pr-as-artifact

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Radius
+# Radius..
 
 Radius is a cloud-native application platform that enables developers and the platform engineers that support them to collaborate on delivering and managing cloud-native applications that follow organizational best practices for cost, operations and security, by default. Radius is an open-source project that supports deploying applications across private cloud, Microsoft Azure, and Amazon Web Services, with more cloud providers to come.
 


### PR DESCRIPTION
# Description

_Please explain the changes you've made._

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 71620bf</samp>

### Summary
:floppy_disk::white_check_mark::wastebasket:

<!--
1.  :floppy_disk: - This emoji represents the custom actions to save and download the PR number as an artifact, which is a way of storing and transferring data between workflows.
2.  :white_check_mark: - This emoji represents the approval workflow and the functional-test workflow, which are used to verify the quality and functionality of the PR changes.
3.  :wastebasket: - This emoji represents the removal of the unused /ok-to-test command and its related functions, which is a way of cleaning up and simplifying the code.
-->
This pull request improves the security and reliability of running functional tests on PRs by using a workflow_run event with approval and custom actions. It also removes the obsolete /ok-to-test command from the `radius-bot` script and makes a minor change to the `README.md` file.

> _To run functional tests on PRs_
> _We need some custom actions and vars_
> _We save and download `pr_number`_
> _With approval, we trigger `workflow_run`_
> _And remove the old `radius-bot` scars_

### Walkthrough
*  Add a new workflow to require approval for running functional tests on PRs ([link](https://github.com/radius-project/radius/pull/6804/files?diff=unified&w=0#diff-336842f9ad3be6e33759449fb701d721641268b444401b71c63a4e371ae91598R1-R17))
* Modify the functional-test workflow to use the workflow_run event instead of the /ok-to-test command ([link](https://github.com/radius-project/radius/pull/6804/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL26-R30), [link](https://github.com/radius-project/radius/pull/6804/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL97-R119))
* Remove the /ok-to-test command and related functions from the radius-bot script ([link](https://github.com/radius-project/radius/pull/6804/files?diff=unified&w=0#diff-b94c0e124b5b65fb6fa8785928c5331547c124a96ecc225f93df9445a29a5109L47-L49), [link](https://github.com/radius-project/radius/pull/6804/files?diff=unified&w=0#diff-b94c0e124b5b65fb6fa8785928c5331547c124a96ecc225f93df9445a29a5109L79-L144))
* Add a newline at the end of the `.github/workflows/functional-test.yaml` file ([link](https://github.com/radius-project/radius/pull/6804/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL578-L577))
* Add a dot at the end of the first line of the `README.md` file ([link](https://github.com/radius-project/radius/pull/6804/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1))


