### PR TITLE
Specify Dapr dashboard version on installation

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -406,7 +406,7 @@ jobs:
       - name: Install dapr into cluster
         run: |
           wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s ${{ env.DAPR_VER }}
-          dapr init -k --wait --timeout 600 --runtime-version ${{ env.DAPR_VER }}
+          dapr init -k --wait --timeout 600 --runtime-version ${{ env.DAPR_VER }} --dashboard-version ${{ env.DAPR_VER }}
       - name: Install Azure Keyvault CSI driver chart
         run: |
           helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts


### PR DESCRIPTION
# Description


I started investigating this issue more deeply and opened https://github.com/dapr/cli/issues/1365 on the Dapr side. It appears that the lookup is happening for the installation of the dashboard, which has it's own command line parameter. 

This change also specifies the dashboard version, so we can avoid the usage of the Github Releases API.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->


- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #6213

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d41f296</samp>

### Summary
🆕🔄🐛

<!--
1.  🆕 - This emoji indicates that a new feature or option was added to the command.
2.  🔄 - This emoji indicates that the version of a dependency or component was updated or synchronized with another one.
3.  🐛 - This emoji indicates that a potential bug or issue was fixed or prevented by the change.
-->
Updated Dapr version and dashboard compatibility in functional tests. Added `--dashboard-version` flag to `dapr init` in `.github/workflows/functional-test.yaml` to match the Dapr runtime version.

> _`dapr init` flag_
> _sets dashboard and runtime_
> _harmony in spring_

### Walkthrough
* Add `--dashboard-version` flag to `dapr init` command to ensure compatibility with Dapr runtime ([link](https://github.com/radius-project/radius/pull/6814/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL409-R409))


