### PR TITLE
Correct dapr dashboard version

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -39,6 +39,7 @@ env:
   KIND_VER: 'v0.20.0'
   # Dapr version
   DAPR_VER: '1.11.0'
+  DAPR_DASHBOARD_VER: '0.14.0'
   # Kubectl version
   KUBECTL_VER: 'v1.25.0'
   # Azure Keyvault CSI driver chart version
@@ -406,7 +407,7 @@ jobs:
       - name: Install dapr into cluster
         run: |
           wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash -s ${{ env.DAPR_VER }}
-          dapr init -k --wait --timeout 600 --runtime-version ${{ env.DAPR_VER }} --dashboard-version ${{ env.DAPR_VER }}
+          dapr init -k --wait --timeout 600 --runtime-version ${{ env.DAPR_VER }} --dashboard-version ${{ env.DAPR_DASHBOARD_VER }}
       - name: Install Azure Keyvault CSI driver chart
         run: |
           helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts


### PR DESCRIPTION
# Description

The Dapr Dashboard version is separate from the runtime version.


## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->


- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).


## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7bb09c2</samp>

### Summary
🎛️🆕🧪

<!--
1.  🎛️ - This emoji represents the addition of a new environment variable, which is a way of controlling or adjusting something.
2.  🆕 - This emoji represents the use of a new version of the Dapr dashboard, which is a new feature or improvement.
3.  🧪 - This emoji represents the functional tests, which are a way of verifying the functionality or behavior of something.
-->
Add Dapr dashboard version variable and use it in functional tests. This allows testing different dashboard versions with the same Dapr runtime and ensures consistent results.

> _`Dapr init` unleashes the dashboard of doom_
> _Control the version with the env var of gloom_
> _Functional tests will never fail or crash_
> _Stability and compatibility in a flash_

### Walkthrough
* Add a new environment variable `DAPR_DASHBOARD_VER` to specify the Dapr dashboard version ([link](https://github.com/radius-project/radius/pull/6818/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcR42))
* Use `DAPR_DASHBOARD_VER` instead of `DAPR_VER` for the dashboard version in the `dapr init` command ([link](https://github.com/radius-project/radius/pull/6818/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL409-R410))


