### PR TITLE
WIP - Updating AKS Cluster and dependent resources definitions

### DIFF
--- a/test/infra/azure/README.md
+++ b/test/infra/azure/README.md
@@ -67,7 +67,7 @@ This directory includes the Bicep templates to deploy the following resources on
     By default, `grafanaEnabled` is false. We do not need to set any parameters unless you need Grafana dashboard. If you want to see Grafana dashboard later, you can redeploy main.bicep with `grafanaEnabled` and `grafanaAdminObjectId` later--bicep will install only Grafana dashboard with your existing cluster.
 
     ```bash
-    az deployment group create --resource-group [Resource Group Name] --template-file main.bicep --parameters grafanaEnabled=[Grafana Dashboard Enabled] grafanaAdminObjectId='[Grafana Admin Object Id]'
+    az deployment group create --resource-group [Resource Group Name] --template-file main.bicep --parameters grafanaEnabled=[Grafana Dashboard Enabled] grafanaAdminObjectId='[Grafana Admin Object Id]' isPrivateClusterSupported=true enablePrivateCluster=true
     ```
 
     * **[Grafana Dashboard Enabled]**: Set `true` if you want to see metrics and its dashboard with Azure managed Prometheus and Grafana dashboard. Otherwise, `false` is recommended to save the cost.

--- a/test/infra/azure/modules/ama-metrics-setting-configmap.bicep
+++ b/test/infra/azure/modules/ama-metrics-setting-configmap.bicep
@@ -25,7 +25,7 @@ var podAnnotationNamespaceRegex = 'podannotationnamespaceregex = "${prefix}.*"'
 import 'kubernetes@1.0.0' with {
   namespace: 'default'
   kubeConfig: kubeConfig
-}
+} as k8s
 
 resource coreConfigMap_amaMetricsSettingsConfigmap 'core/ConfigMap@v1' = {
   metadata: {

--- a/test/infra/azure/modules/vnet-with-firewall.bicep
+++ b/test/infra/azure/modules/vnet-with-firewall.bicep
@@ -1,0 +1,158 @@
+@description('Virtual network name')
+param virtualNetworkName string = 'vnet-${uniqueString(resourceGroup().id)}'
+
+@description('Azure Firewall name')
+param firewallName string = 'fw${uniqueString(resourceGroup().id)}'
+
+@description('Number of public IP addresses for the Azure Firewall')
+@minValue(1)
+@maxValue(100)
+param numberOfPublicIPAddresses int = 2
+
+@description('Zone numbers e.g. 1,2,3.')
+param availabilityZones array = []
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+@description('Specifies the resource tags.')
+param tags object = {
+  'radapp.io': 'radius-infra'
+}
+
+param firewallPolicyName string = '${firewallName}-firewallPolicy'
+
+// Starts with `10.10.0.0` (network address) and ends with `10.10.255.255` (broadcast address).
+// [65536 - 2 = 65534] usable IP addresses for hosts like servers, virtual machines, etc.
+var vnetAddressPrefix = '10.10.0.0/16'
+
+// Starts with `10.10.0.0` (network address) and ends with `10.10.15.255` (broadcast address).
+// [4096 - 2 = 4094] usable IP addresses for hosts.
+var azureFirewallSubnetPrefix = '10.10.0.0/20'
+
+// Starts with `10.10.16.0` (network address) and ends with `10.10.31.255` (broadcast address).
+// [4096 - 2 = 4094] usable IP addresses for hosts.
+var aksPoolsSubnetPrefix = '10.10.16.0/20'
+var aksPoolsSubnetName = 'aks-pools-subnet'
+
+var publicIPNamePrefix = 'publicIP'
+var azurepublicIpname = publicIPNamePrefix
+
+@description('Specify a Network Security Group name.')
+param networkSecurityGroupName string = 'nsg-${uniqueString(resourceGroup().id)}'
+
+@description('Specify a DDoS protection plan name.')
+param ddosProtectionPlanName string = 'ddos-${uniqueString(resourceGroup().id)}'
+
+var azureFirewallSubnetName = 'AzureFirewallSubnet'
+var azureFirewallSubnetId = resourceId('Microsoft.Network/virtualNetworks/subnets', virtualNetworkName, azureFirewallSubnetName)
+var azureFirewallPublicIpId = resourceId('Microsoft.Network/publicIPAddresses', publicIPNamePrefix)
+var azureFirewallIpConfigurations = [for i in range(0, numberOfPublicIPAddresses): {
+  name: 'IpConf${i}'
+  properties: {
+    subnet: ((i == 0) ? json('{"id": "${azureFirewallSubnetId}"}') : json('null'))
+    publicIPAddress: {
+      id: '${azureFirewallPublicIpId}${i + 1}'
+    }
+  }
+}]
+
+var vnetTags = union(tags, {
+    displayName: virtualNetworkName
+  }
+)
+
+resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2022-01-01' = {
+  name: networkSecurityGroupName
+  location: location
+  tags: tags
+}
+
+resource ddosProtectionPlan 'Microsoft.Network/ddosProtectionPlans@2021-05-01' = {
+  name: ddosProtectionPlanName
+  location: location
+}
+
+resource vnet 'Microsoft.Network/virtualNetworks@2022-01-01' = {
+  name: virtualNetworkName
+  location: location
+  tags: vnetTags
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        vnetAddressPrefix
+      ]
+    }
+    subnets: [
+      {
+        name: aksPoolsSubnetName
+        properties: {
+          addressPrefix: aksPoolsSubnetPrefix
+          networkSecurityGroup: {
+            id: networkSecurityGroup.id
+          }
+        }
+      }
+      {
+        name: azureFirewallSubnetName
+        properties: {
+          addressPrefix: azureFirewallSubnetPrefix
+        }
+      }
+    ]
+    enableDdosProtection: true
+    ddosProtectionPlan: {
+      id: ddosProtectionPlan.id
+    }
+  }
+}
+
+resource publicIpAddress 'Microsoft.Network/publicIPAddresses@2022-01-01' = [for i in range(0, numberOfPublicIPAddresses): {
+  name: '${azurepublicIpname}${i + 1}'
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Static'
+    publicIPAddressVersion: 'IPv4'
+  }
+}]
+
+resource firewallPolicy 'Microsoft.Network/firewallPolicies@2022-01-01' = {
+  name: firewallPolicyName
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      tier: 'Premium'
+    }
+    threatIntelMode: 'Alert'
+  }
+}
+
+resource firewall 'Microsoft.Network/azureFirewalls@2021-03-01' = {
+  name: firewallName
+  location: location
+  tags: tags
+  zones: ((length(availabilityZones) == 0) ? null : availabilityZones)
+  dependsOn: [
+    vnet
+    publicIpAddress
+  ]
+  properties: {
+    sku: {
+      tier: 'Premium'
+    }
+    ipConfigurations: azureFirewallIpConfigurations
+    firewallPolicy: {
+      id: firewallPolicy.id
+    }
+  }
+}
+
+// Outputs
+output aksPoolsSubnetID string = vnet.properties.subnets[0].id
+output azureFirewallSubnetID string = vnet.properties.subnets[1].id
+output networkSecurityGroup string = networkSecurityGroup.id


### PR DESCRIPTION
# Description
Initial work on updating the definitions in the **test/infra/azure** folder that defines an AKS Cluster (that we use for long-haul testing) and all the dependents.

As of 24 Nov 2023, after the initial creation of resources here are the policies that fail:
1. **endpoint protection solution should be installed on virtual machine scale sets** => https://ms.portal.azure.com/#view/Microsoft_Azure_Policy/PolicyComplianceDetail.ReactView/assignmentId/%2Fproviders%2Fmicrosoft.management%2Fmanagementgroups%2F48fed3a1-0814-4847-88ce-b766155f2792%2Fproviders%2Fmicrosoft.authorization%2Fpolicyassignments%2Fasb-audit2-initiative-v1/initiativeId/%2Fproviders%2FMicrosoft.Management%2Fmanagementgroups%2F48fed3a1-0814-4847-88ce-b766155f2792%2Fproviders%2FMicrosoft.Authorization%2FpolicySetDefinitions%2F4df59e9ddb1bfd29/policyDefinitionReferenceId/13846729305249179065/policyDefinitionId/%2Fproviders%2Fmicrosoft.management%2Fmanagementgroups%2F48fed3a1-0814-4847-88ce-b766155f2792%2Fproviders%2Fmicrosoft.authorization%2Fpolicydefinitions%2Fd6bd79706f147506/scopes~/%5B%22%2Fsubscriptions%2F66d1209e-1382-45d3-99bb-650e6bf63fc0%2FresourceGroups%2FMC_ytimocin-test-aks-rg_4wakkwmtizec2-aks_westus3%22%5D/isRegulatoryCompliance~/false
2. **endpoint protection solution should be installed on virtual machine scale sets** => https://ms.portal.azure.com/#view/Microsoft_Azure_Policy/PolicyComplianceDetail.ReactView/assignmentId/%2Fproviders%2Fmicrosoft.management%2Fmanagementgroups%2F48fed3a1-0814-4847-88ce-b766155f2792%2Fproviders%2Fmicrosoft.authorization%2Fpolicyassignments%2Fasb-audit2-initiative-v1/initiativeId/%2Fproviders%2FMicrosoft.Management%2Fmanagementgroups%2F48fed3a1-0814-4847-88ce-b766155f2792%2Fproviders%2FMicrosoft.Authorization%2FpolicySetDefinitions%2F4df59e9ddb1bfd29/policyDefinitionReferenceId/13846729305249179065/policyDefinitionId/%2Fproviders%2Fmicrosoft.management%2Fmanagementgroups%2F48fed3a1-0814-4847-88ce-b766155f2792%2Fproviders%2Fmicrosoft.authorization%2Fpolicydefinitions%2Fd6bd79706f147506/scopes~/%5B%22%2Fsubscriptions%2F66d1209e-1382-45d3-99bb-650e6bf63fc0%2FresourceGroups%2FMC_ytimocin-test-aks-rg_4wakkwmtizec2-aks_westus3%22%5D/isRegulatoryCompliance~/false
3. **log analytics agent should be installed on your virtual machine scale sets for azure security center monitoring** => https://ms.portal.azure.com/#view/Microsoft_Azure_Policy/PolicyComplianceDetail.ReactView/assignmentId/%2Fproviders%2Fmicrosoft.management%2Fmanagementgroups%2F48fed3a1-0814-4847-88ce-b766155f2792%2Fproviders%2Fmicrosoft.authorization%2Fpolicyassignments%2Fasb-audit2-initiative-v1/initiativeId/%2Fproviders%2FMicrosoft.Management%2Fmanagementgroups%2F48fed3a1-0814-4847-88ce-b766155f2792%2Fproviders%2FMicrosoft.Authorization%2FpolicySetDefinitions%2F4df59e9ddb1bfd29/policyDefinitionReferenceId/7507843044034395825/policyDefinitionId/%2Fproviders%2Fmicrosoft.management%2Fmanagementgroups%2F48fed3a1-0814-4847-88ce-b766155f2792%2Fproviders%2Fmicrosoft.authorization%2Fpolicydefinitions%2F162a011ddca389e9/scopes~/%5B%22%2Fsubscriptions%2F66d1209e-1382-45d3-99bb-650e6bf63fc0%2FresourceGroups%2FMC_ytimocin-test-aks-rg_4wakkwmtizec2-aks_westus3%22%5D/isRegulatoryCompliance~/false
4. Others: https://ms.portal.azure.com/#view/Microsoft_Azure_Policy/InitiativeComplianceDetail.ReactView/assignmentId/%2Fproviders%2Fmicrosoft.management%2Fmanagementgroups%2F48fed3a1-0814-4847-88ce-b766155f2792%2Fproviders%2Fmicrosoft.authorization%2Fpolicyassignments%2Fasb-audit3-initiative-v1/initiativeId/%2Fproviders%2Fmicrosoft.management%2Fmanagementgroups%2F48fed3a1-0814-4847-88ce-b766155f2792%2Fproviders%2Fmicrosoft.authorization%2Fpolicysetdefinitions%2F47d8e1d3106c85a1/scopes~/%5B%22%2Fsubscriptions%2F66d1209e-1382-45d3-99bb-650e6bf63fc0%2FresourceGroups%2FMC_ytimocin-test-aks-rg_4wakkwmtizec2-aks_westus3%22%5D/isRegulatoryCompliance~/0/showGroups~/null
5. Others: https://ms.portal.azure.com/#view/Microsoft_Azure_Policy/InitiativeComplianceDetail.ReactView/assignmentId/%2Fproviders%2Fmicrosoft.management%2Fmanagementgroups%2F48fed3a1-0814-4847-88ce-b766155f2792%2Fproviders%2Fmicrosoft.authorization%2Fpolicyassignments%2Fasb-audit1-initiative-v1/initiativeId/%2Fproviders%2Fmicrosoft.management%2Fmanagementgroups%2F48fed3a1-0814-4847-88ce-b766155f2792%2Fproviders%2Fmicrosoft.authorization%2Fpolicysetdefinitions%2F160bc010a809a54c/scopes~/%5B%22%2Fsubscriptions%2F66d1209e-1382-45d3-99bb-650e6bf63fc0%2FresourceGroups%2Fytimocin-test-aks-rg%22%5D/isRegulatoryCompliance~/0/showGroups~/null

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
Fixes: #6726 

## Auto-generated summary
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7c0f3aa</samp>

### Summary
🌐🌟🐛

<!--
1.  🌐 - This emoji represents the private cluster feature, which allows the user to isolate the AKS cluster from public internet access and use a private DNS zone for internal name resolution. This enhances the security and privacy of the cluster and its resources.
6.  🌟 - This emoji represents the arc node pool feature, which allows the user to add a dedicated node pool for running Azure Arc-enabled Kubernetes agents and extensions. This enables the user to leverage the benefits of Azure Arc, such as centralized management, governance, and monitoring of the cluster across hybrid and multi-cloud environments.
7.  🐛 - This emoji represents the bug fixes and error removals in the `akscluster.bicep` module, such as removing unused or duplicated parameters and properties, fixing typos, and updating default values. These changes improve the code quality and reliability of the module.
-->
This pull request enhances the Azure test infrastructure by adding private cluster support and arc node pool creation for the AKS cluster. It also fixes some errors and improves the readability and consistency of the `main.bicep` and `akscluster.bicep` templates and the `README.md` file.

> _We're building up the `akscluster` module, me hearties_
> _Adding features and fixing errors as we go_
> _We'll make a private cluster and an arc node pool_
> _And update the README so everyone will know_

### Walkthrough
*  Add parameters and properties to enable private cluster support for AKS cluster ([link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-9bc53c5b194e7560211473c93fe9b226bd3d80795aec67de6b3750f3e55db8adR64-R75), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-9bc53c5b194e7560211473c93fe9b226bd3d80795aec67de6b3750f3e55db8adR122-R125), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-5112e4ffbd5ca641bbb7f5ebfc7bbd6ea1350bfa95b6a5fc687f51d4678438a9R251-R322), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-5112e4ffbd5ca641bbb7f5ebfc7bbd6ea1350bfa95b6a5fc687f51d4678438a9L329-R418), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-5112e4ffbd5ca641bbb7f5ebfc7bbd6ea1350bfa95b6a5fc687f51d4678438a9R607), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-ab02e40d060bb9a71c0d1a0003fc7d70da88feffc027a1bb2192d87f05a87b29L67-R83))
*  Add parameters and properties to enable arc node pool for AKS cluster ([link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-5112e4ffbd5ca641bbb7f5ebfc7bbd6ea1350bfa95b6a5fc687f51d4678438a9R251-R322), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-5112e4ffbd5ca641bbb7f5ebfc7bbd6ea1350bfa95b6a5fc687f51d4678438a9R508-R527))
*  Update `kubernetesVersion` parameter to use latest version ([link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-9bc53c5b194e7560211473c93fe9b226bd3d80795aec67de6b3750f3e55db8adL90-R105))
*  Remove unused and unsupported parameters and properties for diagnostic settings ([link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-5112e4ffbd5ca641bbb7f5ebfc7bbd6ea1350bfa95b6a5fc687f51d4678438a9L296-L298))
*  Add `enableRBAC` property and remove duplicate property for `aksCluster` resource ([link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-5112e4ffbd5ca641bbb7f5ebfc7bbd6ea1350bfa95b6a5fc687f51d4678438a9R465), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-5112e4ffbd5ca641bbb7f5ebfc7bbd6ea1350bfa95b6a5fc687f51d4678438a9L444))
*  Update parameter descriptions and variable names for clarity and consistency ([link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-5112e4ffbd5ca641bbb7f5ebfc7bbd6ea1350bfa95b6a5fc687f51d4678438a9L178-R178), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-5112e4ffbd5ca641bbb7f5ebfc7bbd6ea1350bfa95b6a5fc687f51d4678438a9R251-R322))
*  Add spaces and blank lines to improve readability and follow bicep style guide ([link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-9bc53c5b194e7560211473c93fe9b226bd3d80795aec67de6b3750f3e55db8adL116-R132), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-9bc53c5b194e7560211473c93fe9b226bd3d80795aec67de6b3750f3e55db8adL128-R144), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-9bc53c5b194e7560211473c93fe9b226bd3d80795aec67de6b3750f3e55db8adL142-R158), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-9bc53c5b194e7560211473c93fe9b226bd3d80795aec67de6b3750f3e55db8adL157-R173), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-5112e4ffbd5ca641bbb7f5ebfc7bbd6ea1350bfa95b6a5fc687f51d4678438a9L149-R149), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-5112e4ffbd5ca641bbb7f5ebfc7bbd6ea1350bfa95b6a5fc687f51d4678438a9L344-R449), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-5112e4ffbd5ca641bbb7f5ebfc7bbd6ea1350bfa95b6a5fc687f51d4678438a9R564), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-ab02e40d060bb9a71c0d1a0003fc7d70da88feffc027a1bb2192d87f05a87b29R22), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-ab02e40d060bb9a71c0d1a0003fc7d70da88feffc027a1bb2192d87f05a87b29L56-R64), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-ab02e40d060bb9a71c0d1a0003fc7d70da88feffc027a1bb2192d87f05a87b29L88-R97))
*  Update `README.md` to reflect changes and fix links ([link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-ab02e40d060bb9a71c0d1a0003fc7d70da88feffc027a1bb2192d87f05a87b29L1-R12), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-ab02e40d060bb9a71c0d1a0003fc7d70da88feffc027a1bb2192d87f05a87b29L28-R31), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-ab02e40d060bb9a71c0d1a0003fc7d70da88feffc027a1bb2192d87f05a87b29L67-R83), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-ab02e40d060bb9a71c0d1a0003fc7d70da88feffc027a1bb2192d87f05a87b29L88-R97), [link](https://github.com/radius-project/radius/pull/6821/files?diff=unified&w=0#diff-ab02e40d060bb9a71c0d1a0003fc7d70da88feffc027a1bb2192d87f05a87b29L98-R106))


