### PR TITLE
Adding provisioning state to the result of some commands

### DIFF
--- a/pkg/cli/cmd/app/list/list.go
+++ b/pkg/cli/cmd/app/list/list.go
@@ -118,15 +118,10 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	environments, err := client.ListApplications(ctx)
+	apps, err := client.ListApplications(ctx)
 	if err != nil {
 		return err
 	}
 
-	err = r.Output.WriteFormatted(r.Format, environments, objectformats.GetResourceTableFormat())
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return r.Output.WriteFormatted(r.Format, apps, objectformats.GetResourceTableFormat())
 }

--- a/pkg/cli/cmd/app/show/show.go
+++ b/pkg/cli/cmd/app/show/show.go
@@ -131,17 +131,12 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	application, err := client.ShowApplication(ctx, r.ApplicationName)
+	app, err := client.ShowApplication(ctx, r.ApplicationName)
 	if clients.Is404Error(err) {
 		return clierrors.Message("The application %q was not found or has been deleted.", r.ApplicationName)
 	} else if err != nil {
 		return err
 	}
 
-	err = r.Output.WriteFormatted(r.Format, application, objectformats.GetResourceTableFormat())
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return r.Output.WriteFormatted(r.Format, app, objectformats.GetResourceTableFormat())
 }

--- a/pkg/cli/cmd/env/list/list.go
+++ b/pkg/cli/cmd/env/list/list.go
@@ -120,10 +120,5 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	err = r.Output.WriteFormatted(r.Format, environments, objectformats.GetGenericEnvironmentTableFormat())
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return r.Output.WriteFormatted(r.Format, environments, objectformats.GetResourceTableFormat())
 }

--- a/pkg/cli/cmd/env/list/list_test.go
+++ b/pkg/cli/cmd/env/list/list_test.go
@@ -87,10 +87,10 @@ func Test_Run(t *testing.T) {
 	defer ctrl.Finish()
 
 	environments := []v20231001preview.EnvironmentResource{
-		v20231001preview.EnvironmentResource{
+		{
 			Name: to.Ptr("A"),
 		},
-		v20231001preview.EnvironmentResource{
+		{
 			Name: to.Ptr("B"),
 		},
 	}
@@ -124,7 +124,7 @@ func Test_Run(t *testing.T) {
 		output.FormattedOutput{
 			Format:  "table",
 			Obj:     environments,
-			Options: objectformats.GetGenericEnvironmentTableFormat(),
+			Options: objectformats.GetResourceTableFormat(),
 		},
 	}
 

--- a/pkg/cli/cmd/env/show/show.go
+++ b/pkg/cli/cmd/env/show/show.go
@@ -130,17 +130,12 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	environment, err := client.GetEnvDetails(ctx, r.EnvironmentName)
+	env, err := client.GetEnvDetails(ctx, r.EnvironmentName)
 	if clients.Is404Error(err) {
 		return clierrors.Message("The environment %q was not found or has been deleted.", r.EnvironmentName)
 	} else if err != nil {
 		return err
 	}
 
-	err = r.Output.WriteFormatted(r.Format, environment, objectformats.GetGenericEnvironmentTableFormat())
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return r.Output.WriteFormatted(r.Format, env, objectformats.GetResourceTableFormat())
 }

--- a/pkg/cli/cmd/env/show/show_test.go
+++ b/pkg/cli/cmd/env/show/show_test.go
@@ -131,7 +131,7 @@ func Test_Show(t *testing.T) {
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     environment,
-				Options: objectformats.GetGenericEnvironmentTableFormat(),
+				Options: objectformats.GetResourceTableFormat(),
 			},
 		}
 

--- a/pkg/cli/cmd/resource/list/list.go
+++ b/pkg/cli/cmd/resource/list/list.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/radius-project/radius/pkg/cli"
 	"github.com/radius-project/radius/pkg/cli/clients"
+	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
 	"github.com/radius-project/radius/pkg/cli/clierrors"
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
 	"github.com/radius-project/radius/pkg/cli/connections"
@@ -143,17 +144,13 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	if r.ApplicationName == "" {
-		resourceList, err := client.ListAllResourcesByType(ctx, r.ResourceType)
-		if err != nil {
-			return err
-		}
+	var resourceList []generated.GenericResource
 
-		err = r.Output.WriteFormatted(r.Format, resourceList, objectformats.GetResourceTableFormat())
+	if r.ApplicationName == "" {
+		resourceList, err = client.ListAllResourcesByType(ctx, r.ResourceType)
 		if err != nil {
 			return err
 		}
-		return nil
 	} else {
 		_, err = client.ShowApplication(ctx, r.ApplicationName)
 		if clients.Is404Error(err) {
@@ -162,15 +159,11 @@ func (r *Runner) Run(ctx context.Context) error {
 			return err
 		}
 
-		resourceList, err := client.ListAllResourcesOfTypeInApplication(ctx, r.ApplicationName, r.ResourceType)
+		resourceList, err = client.ListAllResourcesOfTypeInApplication(ctx, r.ApplicationName, r.ResourceType)
 		if err != nil {
 			return err
 		}
-
-		err = r.Output.WriteFormatted(r.Format, resourceList, objectformats.GetResourceTableFormat())
-		if err != nil {
-			return err
-		}
-		return nil
 	}
+
+	return r.Output.WriteFormatted(r.Format, resourceList, objectformats.GetGenericResourceTableFormat())
 }

--- a/pkg/cli/cmd/resource/list/list_test.go
+++ b/pkg/cli/cmd/resource/list/list_test.go
@@ -159,7 +159,7 @@ func Test_Run(t *testing.T) {
 				output.FormattedOutput{
 					Format:  "table",
 					Obj:     resources,
-					Options: objectformats.GetResourceTableFormat(),
+					Options: objectformats.GetGenericResourceTableFormat(),
 				},
 			}
 			require.Equal(t, expected, outputSink.Writes)
@@ -197,7 +197,7 @@ func Test_Run(t *testing.T) {
 				output.FormattedOutput{
 					Format:  "table",
 					Obj:     resources,
-					Options: objectformats.GetResourceTableFormat(),
+					Options: objectformats.GetGenericResourceTableFormat(),
 				},
 			}
 			require.Equal(t, expected, outputSink.Writes)

--- a/pkg/cli/cmd/resource/show/show.go
+++ b/pkg/cli/cmd/resource/show/show.go
@@ -138,10 +138,5 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	err = r.Output.WriteFormatted(r.Format, resourceDetails, objectformats.GetResourceTableFormat())
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return r.Output.WriteFormatted(r.Format, resourceDetails, objectformats.GetGenericResourceTableFormat())
 }

--- a/pkg/cli/cmd/resource/show/show_test.go
+++ b/pkg/cli/cmd/resource/show/show_test.go
@@ -122,7 +122,7 @@ func Test_Run(t *testing.T) {
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     resource,
-				Options: objectformats.GetResourceTableFormat(),
+				Options: objectformats.GetGenericResourceTableFormat(),
 			},
 		}
 		require.Equal(t, expected, outputSink.Writes)

--- a/pkg/cli/objectformats/objectformats.go
+++ b/pkg/cli/objectformats/objectformats.go
@@ -55,8 +55,7 @@ func GetApplicationGatewaysTableFormat() output.FormatterOptions {
 	}
 }
 
-// GetResourceTableFormat() returns a FormatterOptions struct containing two columns, one for the resource name and one for
-// the resource type.
+// GetResourceTableFormat returns the fields to output from a resource object.
 func GetResourceTableFormat() output.FormatterOptions {
 	return output.FormatterOptions{
 		Columns: []output.Column{
@@ -67,6 +66,32 @@ func GetResourceTableFormat() output.FormatterOptions {
 			{
 				Heading:  "TYPE",
 				JSONPath: "{ .Type }",
+			},
+			{
+				Heading:  "STATE",
+				JSONPath: "{ .Properties.ProvisioningState }",
+			},
+		},
+	}
+}
+
+// GetGenericResourceTableFormat returns the fields to output from a generic resource object.
+// The difference between this function and the GetResourceTableFormat function above is that
+// GenericResource properties is a map and the way to get the ProvisioningState is different.
+func GetGenericResourceTableFormat() output.FormatterOptions {
+	return output.FormatterOptions{
+		Columns: []output.Column{
+			{
+				Heading:  "RESOURCE",
+				JSONPath: "{ .Name }",
+			},
+			{
+				Heading:  "TYPE",
+				JSONPath: "{ .Type }",
+			},
+			{
+				Heading:  "STATE",
+				JSONPath: "{ .Properties.provisioningState }",
 			},
 		},
 	}

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -157,19 +157,26 @@ func verifyCLIBasics(ctx context.Context, t *testing.T, test shared.RPTest) {
 	cli := radcli.NewCLI(t, options.ConfigFilePath)
 	appName := test.Name
 	containerName := "containerA"
-	//spacing in output will change based on resource names
-	showSpacing := ""
 	if strings.EqualFold(appName, "kubernetes-cli-json") {
 		containerName = "containerA-json"
-		showSpacing = "     "
 	}
 
 	t.Run("Validate rad application show", func(t *testing.T) {
-		output, err := cli.ApplicationShow(ctx, appName)
+		actualOutput, err := cli.ApplicationShow(ctx, appName)
 		require.NoError(t, err)
-		expected := regexp.MustCompile(`RESOURCE      ` + showSpacing + `  TYPE\n` + appName + `  Applications.Core/applications\n`)
-		match := expected.MatchString(output)
-		require.Equal(t, true, match, "output: %s", output)
+
+		lines := strings.Split(actualOutput, "\n")
+		require.GreaterOrEqual(t, len(lines), 2, "Actual output should have 2 lines")
+
+		headers := strings.Fields(lines[0])
+		require.Equal(t, "RESOURCE", headers[0], "First header should be RESOURCE")
+		require.Equal(t, "TYPE", headers[1], "Second header should be TYPE")
+		require.Equal(t, "STATE", headers[2], "Third header should be STATE")
+
+		values := strings.Fields(lines[1])
+		require.Equal(t, appName, values[0], "First value should be %s", appName)
+		require.Equal(t, "Applications.Core/applications", values[1], "Second value should be Applications.Core/applications")
+		require.Equal(t, "Succeeded", values[2], "Third value should be Succeeded")
 	})
 
 	t.Run("Validate rad resource list", func(t *testing.T) {
@@ -187,14 +194,21 @@ func verifyCLIBasics(ctx context.Context, t *testing.T, test shared.RPTest) {
 	})
 
 	t.Run("Validate rad resource show", func(t *testing.T) {
-		output, err := cli.ResourceShow(ctx, "containers", containerName)
+		actualOutput, err := cli.ResourceShow(ctx, "containers", containerName)
 		require.NoError(t, err)
-		// We are more interested in the content and less about the formatting, which
-		// is already covered by unit tests. The spaces change depending on the input
-		// and it takes very long to get a feedback from CI.
-		expected := regexp.MustCompile(`RESOURCE  ` + showSpacing + `  TYPE\n` + containerName + `  Applications.Core/containers\n`)
-		match := expected.MatchString(output)
-		require.Equal(t, true, match, "output: %s", output)
+
+		lines := strings.Split(actualOutput, "\n")
+		require.GreaterOrEqual(t, len(lines), 2, "Actual output should have 2 lines")
+
+		headers := strings.Fields(lines[0])
+		require.Equal(t, "RESOURCE", headers[0], "First header should be RESOURCE")
+		require.Equal(t, "TYPE", headers[1], "Second header should be TYPE")
+		require.Equal(t, "STATE", headers[2], "Third header should be STATE")
+
+		values := strings.Fields(lines[1])
+		require.Equal(t, containerName, values[0], "First value should be %s", containerName)
+		require.Equal(t, "Applications.Core/containers", values[1], "Second value should be Applications.Core/applications")
+		require.Equal(t, "Succeeded", values[2], "Third value should be Succeeded")
 	})
 
 	t.Run("Validate rad resoure logs containers", func(t *testing.T) {


### PR DESCRIPTION
# Description
Adding provisioning state to the result of some commands:
1. `rad app list`
2. `rad app show`
3. `rad resource list`
4. `rad resource show`
5. `rad env list`
6. `rad env show`

![image](https://github.com/radius-project/radius/assets/5220939/7e90b849-aa1a-4bcf-8182-c6e61a9031d5)

![image](https://github.com/radius-project/radius/assets/5220939/83c1b7d7-2580-4543-a3ba-264d29aa844b)

Note: Had some free time and wanted to work on something else :)

## Type of change
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
Fixes: #6239 

## Auto-generated summary
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5143957</samp>

### Summary
🔄🆕🧪

<!--
1.  🔄 - This emoji indicates a change or update to existing code or functionality, such as renaming a variable, simplifying error handling, or refactoring a command.
2.  🆕 - This emoji indicates a new feature or addition to the codebase, such as supporting a new resource type, adding a new table format function, or creating a new type.
3.  🧪 - This emoji indicates a change or update to the test code or cases, such as using a different table format, updating the expected output, or adding a new test case.
-->
Refactored the `list` and `show` commands for applications and resources to use a generic table format and simplified error handling. Added a new function in `objectformats.go` to display generic resources with provisioning state. Renamed a variable in `list.go` for clarity. Updated the corresponding test cases to reflect the changes.

> _We are the masters of the generic resource_
> _We display them in a table with no remorse_
> _We simplify the error handling with our skill_
> _We use the `WriteFormatted` function to kill_

### Walkthrough
*  Rename variables and simplify error handling in app list and show commands ([link](https://github.com/radius-project/radius/pull/6839/files?diff=unified&w=0#diff-2eb5ec3b42c2edb0311cf8cba68f968c301094419b7142638908fc52ec79c3c1L121-R126), [link](https://github.com/radius-project/radius/pull/6839/files?diff=unified&w=0#diff-e81cb9ae5d8b783a0b674004a2df20c8faba1adf9585f4d028615c205e40e40cL134-R134), [link](https://github.com/radius-project/radius/pull/6839/files?diff=unified&w=0#diff-e81cb9ae5d8b783a0b674004a2df20c8faba1adf9585f4d028615c205e40e40cL141-R141))
*  Introduce `GenericResource` type and use it in resource list and show commands ([link](https://github.com/radius-project/radius/pull/6839/files?diff=unified&w=0#diff-b21dcd67dbc0d24e0f8bba90701dfcfb5736cf40427547c7a7ccb91478f262cfR24), [link](https://github.com/radius-project/radius/pull/6839/files?diff=unified&w=0#diff-b21dcd67dbc0d24e0f8bba90701dfcfb5736cf40427547c7a7ccb91478f262cfL146-R153), [link](https://github.com/radius-project/radius/pull/6839/files?diff=unified&w=0#diff-b21dcd67dbc0d24e0f8bba90701dfcfb5736cf40427547c7a7ccb91478f262cfL165-R168), [link](https://github.com/radius-project/radius/pull/6839/files?diff=unified&w=0#diff-138981c95bac1d0cc53334e04ceb673bedd5eab51e9ed2e597769579c79ea0cdL141-R141), [link](https://github.com/radius-project/radius/pull/6839/files?diff=unified&w=0#diff-f2e80353ac2e49da41bc04958b9568c662162f7dbb52ada2c328851436925482L71-R99))
*  Update `GetGenericResourceTableFormat` function to return three columns, including provisioning state ([link](https://github.com/radius-project/radius/pull/6839/files?diff=unified&w=0#diff-f2e80353ac2e49da41bc04958b9568c662162f7dbb52ada2c328851436925482L58-R59))
*  Update test cases to use `GetGenericResourceTableFormat` function ([link](https://github.com/radius-project/radius/pull/6839/files?diff=unified&w=0#diff-d57c4c1535dd3783fc94937211b66a786a621683678bcefdef775626c9e22c5eL162-R162), [link](https://github.com/radius-project/radius/pull/6839/files?diff=unified&w=0#diff-d57c4c1535dd3783fc94937211b66a786a621683678bcefdef775626c9e22c5eL200-R200), [link](https://github.com/radius-project/radius/pull/6839/files?diff=unified&w=0#diff-9155df368980f212b93e106c0fa8057864db95aa56e46bac04645d64e4c06c52L125-R125))


