### PR TITLE
Removing resourceVersion and UID from radapp.io_recipes.yaml

### DIFF
--- a/deploy/Chart/crds/radius/radapp.io_recipes.yaml
+++ b/deploy/Chart/crds/radius/radapp.io_recipes.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.1
-  creationTimestamp: null
   name: recipes.radapp.io
 spec:
   group: radapp.io
@@ -134,13 +133,6 @@ spec:
                     type: string
                   namespace:
                     description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic

--- a/pkg/controller/reconciler/deployment_reconciler.go
+++ b/pkg/controller/reconciler/deployment_reconciler.go
@@ -671,7 +671,11 @@ func (r *DeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1.Deployment{}).
-		Watches(&radappiov1alpha3.Recipe{}, handler.EnqueueRequestsFromMapFunc(r.findDeploymentsForRecipe), builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
+		Watches(
+			&radappiov1alpha3.Recipe{},
+			handler.EnqueueRequestsFromMapFunc(r.findDeploymentsForRecipe),
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+		).
 		Owns(&corev1.Secret{}).
 		Complete(r)
 }


### PR DESCRIPTION
# Description
Removing **resourceVersion** and **UID** from **radapp.io_recipes.yaml**.

Link to the potential solution: https://stackoverflow.com/a/76757810.

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (issue link required).
Fixes: #6840 

## Auto-generated summary
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e8eecc1</samp>

### Summary
📝🗑️🧹

<!--
1.  📝 - This emoji represents the formatting change, as it is often used to indicate writing or editing something.
2.  🗑️ - This emoji represents the removal of unnecessary fields, as it is often used to indicate deleting or discarding something.
3.  🧹 - This emoji represents the simplification and cleanup of the CRD definitions, as it is often used to indicate tidying or sweeping something.
-->
This pull request simplifies the CRD definitions for `Recipe` and `ObjectReference` in `deploy/Chart/crds/radius/radapp.io_recipes.yaml` and improves the code formatting in `pkg/controller/reconciler/deployment_reconciler.go`. These changes aim to make the code more concise, consistent, and readable.

> _Sing, O Muse, of the skillful coder who refined_
> _The controller of the `Recipe`, the source of many dishes_
> _He formatted the `Watches` call with care and mind_
> _To make it clear and pleasing to the eyes of all who wish_

### Walkthrough
*  Remove unnecessary fields from CRD and ObjectReference definitions ([link](https://github.com/radius-project/radius/pull/6848/files?diff=unified&w=0#diff-4a45f7894d7cc49e41ed3ace50b10c4a0e26da6489ec2dd4e8ab9a06978ea0f3L7), [link](https://github.com/radius-project/radius/pull/6848/files?diff=unified&w=0#diff-4a45f7894d7cc49e41ed3ace50b10c4a0e26da6489ec2dd4e8ab9a06978ea0f3L138-L144))
* Format the `Watches` method call in the `SetupWithManager` function ([link](https://github.com/radius-project/radius/pull/6848/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L674-R678))


