### PR TITLE
Fix nil pointer dereference in deployment reconciler

### DIFF
--- a/pkg/controller/reconciler/annotations.go
+++ b/pkg/controller/reconciler/annotations.go
@@ -82,9 +82,9 @@ type deploymentStatus struct {
 // readAnnotations reads the annotations from a Deployment.
 //
 // This includes the configuration specified by the user, the hash of the configuration, and the status.
-func readAnnotations(deployment *appsv1.Deployment) (*deploymentAnnotations, error) {
+func readAnnotations(deployment *appsv1.Deployment) (deploymentAnnotations, error) {
 	if deployment.Annotations == nil {
-		return nil, nil
+		return deploymentAnnotations{}, nil
 	}
 
 	result := deploymentAnnotations{
@@ -96,7 +96,7 @@ func readAnnotations(deployment *appsv1.Deployment) (*deploymentAnnotations, err
 	if status != "" {
 		err := json.Unmarshal([]byte(status), &s)
 		if err != nil {
-			return &result, fmt.Errorf("failed to unmarshal status annotation: %w", err)
+			return result, fmt.Errorf("failed to unmarshal status annotation: %w", err)
 		}
 	}
 
@@ -106,7 +106,7 @@ func readAnnotations(deployment *appsv1.Deployment) (*deploymentAnnotations, err
 	// This is important so that can clean up previously created connections when Radius is disabled.
 	enabled := deployment.Annotations[AnnotationRadiusEnabled]
 	if !strings.EqualFold(enabled, "true") {
-		return &result, nil
+		return result, nil
 	}
 
 	result.Configuration = &deploymentConfiguration{
@@ -121,7 +121,7 @@ func readAnnotations(deployment *appsv1.Deployment) (*deploymentAnnotations, err
 		}
 	}
 
-	return &result, nil
+	return result, nil
 }
 
 // ApplyToDeployment applies the configuration and status to a Deployment.

--- a/pkg/controller/reconciler/deployment_reconciler.go
+++ b/pkg/controller/reconciler/deployment_reconciler.go
@@ -107,7 +107,7 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// and repair it on the next reconcile.
 	}
 
-	if annotations.Status.Operation != nil {
+	if annotations.Status != nil && annotations.Status.Operation != nil {
 		// NOTE: if reconcileOperation completes successfully, then it will return a "zero" result,
 		// this means the operation has completed and we should continue processing.
 		result, err := r.reconcileOperation(ctx, &deployment, annotations)
@@ -181,7 +181,6 @@ func (r *DeploymentReconciler) reconcileOperation(ctx context.Context, deploymen
 		annotations.Status.Operation = nil
 		annotations.Status.Container = annotations.Status.Scope + "/providers/Applications.Core/containers/" + deployment.Name
 		return ctrl.Result{}, nil
-
 	} else if annotations.Status.Operation.OperationKind == radappiov1alpha3.OperationKindDelete {
 		poller, err := r.Radius.Containers(annotations.Status.Scope).ContinueDeleteOperation(ctx, annotations.Status.Operation.ResumeToken)
 		if err != nil {

--- a/pkg/controller/reconciler/deployment_reconciler_test.go
+++ b/pkg/controller/reconciler/deployment_reconciler_test.go
@@ -482,7 +482,7 @@ func waitForStateWaiting(t *testing.T, client client.Client, name types.Namespac
 	ctx := testcontext.New(t)
 
 	logger := t
-	var annotations *deploymentAnnotations
+	var annotations deploymentAnnotations
 	require.EventuallyWithTf(t, func(t *assert.CollectT) {
 		logger.Logf("Fetching Deployment: %+v", name)
 		current := &appsv1.Deployment{}
@@ -499,14 +499,14 @@ func waitForStateWaiting(t *testing.T, client client.Client, name types.Namespac
 		}
 	}, deploymentTestWaitDuration, deploymentTestWaitInterval, "waiting for state to be Waiting")
 
-	return annotations
+	return &annotations
 }
 
 func waitForStateUpdating(t *testing.T, client client.Client, name types.NamespacedName) *deploymentAnnotations {
 	ctx := testcontext.New(t)
 
 	logger := t
-	var annotations *deploymentAnnotations
+	var annotations deploymentAnnotations
 	require.EventuallyWithTf(t, func(t *assert.CollectT) {
 		logger.Logf("Fetching Deployment: %+v", name)
 		current := &appsv1.Deployment{}
@@ -523,14 +523,14 @@ func waitForStateUpdating(t *testing.T, client client.Client, name types.Namespa
 		}
 	}, deploymentTestWaitDuration, deploymentTestWaitInterval, "waiting for state to be Updating")
 
-	return annotations
+	return &annotations
 }
 
 func waitForStateReady(t *testing.T, client client.Client, name types.NamespacedName) *deploymentAnnotations {
 	ctx := testcontext.New(t)
 
 	logger := t
-	var annotations *deploymentAnnotations
+	var annotations deploymentAnnotations
 	require.EventuallyWithTf(t, func(t *assert.CollectT) {
 		logger.Logf("Fetching Deployment: %+v", name)
 		current := &appsv1.Deployment{}
@@ -547,14 +547,14 @@ func waitForStateReady(t *testing.T, client client.Client, name types.Namespaced
 		}
 	}, deploymentTestWaitDuration, deploymentTestWaitInterval, "waiting for state to be Ready")
 
-	return annotations
+	return &annotations
 }
 
 func waitForStateDeleting(t *testing.T, client client.Client, name types.NamespacedName) *deploymentAnnotations {
 	ctx := testcontext.New(t)
 
 	logger := t
-	var annotations *deploymentAnnotations
+	var annotations deploymentAnnotations
 	require.EventuallyWithTf(t, func(t *assert.CollectT) {
 		logger.Logf("Fetching Deployment: %+v", name)
 		current := &appsv1.Deployment{}
@@ -571,7 +571,7 @@ func waitForStateDeleting(t *testing.T, client client.Client, name types.Namespa
 		}
 	}, deploymentTestWaitDuration, deploymentTestWaitInterval, "waiting for state to be Deleting")
 
-	return annotations
+	return &annotations
 }
 
 func waitForRadiusContainerDeleted(t *testing.T, client client.Client, name types.NamespacedName) *deploymentAnnotations {


### PR DESCRIPTION
# Description
Fix nil pointer dereference in deployment reconciler.

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (issue link required).
Fixes: #6841 

## Auto-generated summary
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e480029</samp>

### Summary
🐛🚑💅

<!--
1.  🐛 for fixing a bug
2.  🚑 for improving error handling
3.  💅 for improving code formatting
-->
Fix nil pointer bug and improve formatting in `reconciler` package. The pull request updates the `deployment_reconciler` logic to avoid a potential crash and applies consistent code style to the `reconciler` files.

> _`deployment_reconciler`_
> _Fixes a nil pointer bug_
> _Code is more tidy_

### Walkthrough
*  Prevent nil pointer dereference when accessing status annotation ([link](https://github.com/radius-project/radius/pull/6853/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L110-R110))
*  Remove unnecessary blank line from `reconciler` package ([link](https://github.com/radius-project/radius/pull/6853/files?diff=unified&w=0#diff-87a7dfa06c174a6b41b671b2cfffb84c81e481881baec866a026e7dd00db8195L184))


