### PR TITLE
Updating table format docs for the object formatter

### DIFF
--- a/pkg/cli/objectformats/objectformats.go
+++ b/pkg/cli/objectformats/objectformats.go
@@ -56,6 +56,7 @@ func GetApplicationGatewaysTableFormat() output.FormatterOptions {
 }
 
 // GetResourceTableFormat returns the fields to output from a resource object.
+// This function should be used with the generated CoreRP and other portable resource types.
 func GetResourceTableFormat() output.FormatterOptions {
 	return output.FormatterOptions{
 		Columns: []output.Column{
@@ -76,6 +77,7 @@ func GetResourceTableFormat() output.FormatterOptions {
 }
 
 // GetGenericResourceTableFormat returns the fields to output from a generic resource object.
+// This function should be used with the Go type GenericResource.
 // The difference between this function and the GetResourceTableFormat function above is that
 // GenericResource properties is a map and the way to get the ProvisioningState is different.
 func GetGenericResourceTableFormat() output.FormatterOptions {


### PR DESCRIPTION
# Description
Updating table format docs for the object formatter

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
Fixes: #issue_number

## Auto-generated summary
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7b5d1e8</samp>

### Summary
💬📝🧑‍💻

<!--
1.  💬 - This emoji can be used to indicate that comments were added or updated in the code, as a way of documenting or clarifying the logic or purpose of the functions.
2.  📝 - This emoji can be used to signify that some writing or editing was done in the code, such as adding comments, descriptions, or annotations. It can also imply that some documentation was created or updated outside of the code, such as in a README or a wiki page.
3.  🧑‍💻 - This emoji can be used to represent that some coding or programming work was done, such as implementing or refactoring functions, fixing bugs, or adding features. It can also convey that the developer was actively working on the code or the project.
-->
Improved code documentation for `objectformats` package. Added comments to clarify how Go structs are converted to YAML, JSON, and HCL formats for portable resources.

> _We are the converters of the structs_
> _We shape the resources with our skills_
> _We serve the objectformats of doom_
> _We make the Radius project rule_

### Walkthrough
*  Document the functions for converting Go structs to portable and generic resource formats ([link](https://github.com/radius-project/radius/pull/6859/files?diff=unified&w=0#diff-f2e80353ac2e49da41bc04958b9568c662162f7dbb52ada2c328851436925482R59), [link](https://github.com/radius-project/radius/pull/6859/files?diff=unified&w=0#diff-f2e80353ac2e49da41bc04958b9568c662162f7dbb52ada2c328851436925482R80))


