### PR TITLE
Deployment fail error podevents [WIP]

### DIFF
--- a/deploy/Chart/templates/rp/rbac.yaml
+++ b/deploy/Chart/templates/rp/rbac.yaml
@@ -15,6 +15,7 @@ rules:
   - namespaces
   - serviceaccounts
   - pods
+  - events
   verbs:
   - create
   - delete

--- a/pkg/armrpc/asyncoperation/controller/request.go
+++ b/pkg/armrpc/asyncoperation/controller/request.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	// DefaultAsyncOperationTimeout is the default timeout duration of async operation.
-	DefaultAsyncOperationTimeout = time.Duration(120) * time.Second
+	DefaultAsyncOperationTimeout = time.Duration(30) * time.Second
 )
 
 // Request is a message used for async request queue message broker.

--- a/pkg/armrpc/asyncoperation/controller/request.go
+++ b/pkg/armrpc/asyncoperation/controller/request.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	// DefaultAsyncOperationTimeout is the default timeout duration of async operation.
-	DefaultAsyncOperationTimeout = time.Duration(30) * time.Second
+	DefaultAsyncOperationTimeout = time.Duration(20) * time.Second
 )
 
 // Request is a message used for async request queue message broker.

--- a/pkg/armrpc/asyncoperation/controller/request.go
+++ b/pkg/armrpc/asyncoperation/controller/request.go
@@ -57,8 +57,7 @@ type Request struct {
 	// OperationTimeout represents the timeout duration of async operation.
 	OperationTimeout *time.Duration `json:"asyncOperationTimeout"`
 
-	// Operation Progress channel
-	OperationProgress chan string `json:"-"`
+	OperationStatus *v1.AsyncOperationStatus `json:"-"`
 }
 
 // Timeout gets the operation timeout and returns the default timeout unless it specifies.

--- a/pkg/armrpc/asyncoperation/controller/request.go
+++ b/pkg/armrpc/asyncoperation/controller/request.go
@@ -56,6 +56,9 @@ type Request struct {
 
 	// OperationTimeout represents the timeout duration of async operation.
 	OperationTimeout *time.Duration `json:"asyncOperationTimeout"`
+
+	// Operation Progress channel
+	OperationProgress chan string `json:"-"`
 }
 
 // Timeout gets the operation timeout and returns the default timeout unless it specifies.

--- a/pkg/armrpc/asyncoperation/statusmanager/statusmanager.go
+++ b/pkg/armrpc/asyncoperation/statusmanager/statusmanager.go
@@ -216,6 +216,7 @@ func (aom *statusManager) queueRequestMessage(ctx context.Context, sCtx *v1.ARMR
 		HomeTenantID:     sCtx.HomeTenantID,
 		ClientObjectID:   sCtx.ClientObjectID,
 		OperationTimeout: &operationTimeout,
+		OperationStatus:  &aos.AsyncOperationStatus,
 	}
 
 	return aom.queue.Enqueue(ctx, queue.NewMessage(msg))

--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -285,6 +285,7 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 			logger.Info("Cancelling async operation.")
 
 			opCancel()
+			fmt.Println("@@@@@ Done invoking cancel function")
 			errMessage := fmt.Sprintf("Operation (%s) has timed out because it was processing longer than %d s.", asyncReq.OperationType, int(asyncReq.Timeout().Seconds()))
 			result := ctrl.NewCanceledResult(errMessage)
 			result.Error.Target = asyncReq.ResourceID

--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -285,6 +285,7 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 			logger.Info("Cancelling async operation.")
 
 			opCancel()
+			time.Sleep(10 * time.Second)
 			fmt.Println("@@@@@ Done invoking cancel function")
 			errMessage := fmt.Sprintf("Operation (%s) has timed out because it was processing longer than %d s.", asyncReq.OperationType, int(asyncReq.Timeout().Seconds()))
 			result := ctrl.NewCanceledResult(errMessage)

--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -229,7 +229,7 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 		return
 	}
 
-	asyncReq.OperationProgress = make(chan string, 1)
+	asyncReq.OperationStatus = &v1.AsyncOperationStatus{}
 	asyncReqCtx, opCancel := context.WithCancel(ctx)
 	// Ensure that asyncReqCtx context is cancelled when runOperation returns.
 	// That is, cancelling asyncReqCtx signals to ctrl.Run() to cancel the execution,
@@ -275,14 +275,8 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 
 	operationTimeoutAfter := time.After(asyncReq.Timeout())
 	messageExtendAfter := w.getMessageExtendDuration(message.NextVisibleAt)
-	operationProgress := map[string]bool{}
 	for {
 		select {
-		case progressMessage := <-asyncReq.OperationProgress:
-			fmt.Println("@@@@@ runOperation received progress message: ", progressMessage)
-			if operationProgress[progressMessage] == false {
-				operationProgress[progressMessage] = true
-			}
 		case <-time.After(messageExtendAfter):
 			if err := w.requestQueue.ExtendMessage(ctx, message); err != nil {
 				logger.Error(err, "fails to extend message lock")
@@ -300,17 +294,9 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 			fmt.Println("@@@@@ Done invoking cancel function")
 			errMessage := fmt.Sprintf("Operation (%s) has timed out because it was processing longer than %d s.", asyncReq.OperationType, int(asyncReq.Timeout().Seconds()))
 
-			if len(operationProgress) > 0 {
-				fmt.Println("@@@@ Operation progress: ", operationProgress)
-				possibleFailureCauses := []string{}
-				for k, _ := range operationProgress {
-					possibleFailureCauses = append(possibleFailureCauses, k)
-				}
-				errMessage = fmt.Sprintf("%s Operation progress: %s", errMessage, strings.Join(possibleFailureCauses, ", "))
-			} else {
-				fmt.Println("@@@@ Operation progress is empty")
+			if asyncReq.OperationStatus != nil && asyncReq.OperationStatus.Error != nil {
+				errMessage += fmt.Sprintf(" Operation status: %s - %s", asyncReq.OperationStatus.Status, asyncReq.OperationStatus.Error.Message)
 			}
-
 			result := ctrl.NewCanceledResult(errMessage)
 			result.Error.Target = asyncReq.ResourceID
 			w.completeOperation(ctx, message, result, asyncCtrl.StorageClient())

--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -59,6 +59,8 @@ const (
 
 	// defaultDequeueInterval is the default duration for the dequeue interval.
 	defaultDequeueInterval = time.Duration(200) * time.Millisecond
+
+	OperationInfoKey string = "operationInfo"
 )
 
 // Options configures AsyncRequestProcessorWorker
@@ -168,6 +170,7 @@ func (w *AsyncRequestProcessWorker) Start(ctx context.Context) error {
 				return
 			}
 			reqCtx = v1.WithARMRequestContext(reqCtx, armReqCtx)
+			reqCtx = context.WithValue(reqCtx, OperationInfoKey, "")
 
 			asyncCtrl := w.registry.Get(armReqCtx.OperationType)
 			if asyncCtrl == nil {
@@ -225,24 +228,14 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 		logger.Error(err, "failed to unmarshal queue message.")
 		return
 	}
-	asyncReqCtx, opCancel := context.WithCancelCause(ctx)
-	failureCh := make(chan error, 1)
+	asyncReqCtx, opCancel := context.WithCancel(ctx)
 	// Ensure that asyncReqCtx context is cancelled when runOperation returns.
 	// That is, cancelling asyncReqCtx signals to ctrl.Run() to cancel the execution,
 	// resulting in completing the go-routine calling ctrl.Run() when runOperation returns.
-	var cancelError error
-	defer opCancel(cancelError)
+	defer opCancel()
 
 	opDone := make(chan struct{}, 1)
 	opStartAt := time.Now()
-
-	stop := context.AfterFunc(asyncReqCtx, func() {
-		fmt.Println("@@@@@ Reading channel for possible failure causes")
-		// Check length of failureCh to see if it has been populated
-		if len(failureCh) > 0 {
-			<-opDone
-		}
-	})
 
 	// Start new go routine to cancel and timeout async operation.
 	go func() {
@@ -262,6 +255,7 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 
 		logger.Info("Start processing operation.")
 		result, err := asyncCtrl.Run(asyncReqCtx, asyncReq)
+		fmt.Println("@@@@@ Run operation complete with result: ", result.Error)
 		// There are two cases when asyncReqCtx is canceled.
 		// 1. When the operation is timed out, w.completeOperation will be called in L186
 		// 2. When parent context is canceled or done, we need to requeue the operation to reprocess the request.
@@ -294,14 +288,9 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 		case <-operationTimeoutAfter:
 			logger.Info("Cancelling async operation.")
 
-			opCancel(cancelError)
-			fmt.Println("@@@@@ cancel cause: ", cancelError)
-			// Get the cause
-			cancelError = context.Cause(asyncReqCtx)
-			fmt.Println("@@@@@ cancel cause2: ", cancelError)
+			opCancel()
 
 			fmt.Println("@@@@@ Done invoking cancel function")
-			stop()
 			errMessage := fmt.Sprintf("Operation (%s) has timed out because it was processing longer than %d s.", asyncReq.OperationType, int(asyncReq.Timeout().Seconds()))
 			result := ctrl.NewCanceledResult(errMessage)
 			result.Error.Target = asyncReq.ResourceID

--- a/pkg/corerp/backend/controller/createorupdateresource.go
+++ b/pkg/corerp/backend/controller/createorupdateresource.go
@@ -101,7 +101,7 @@ func (c *CreateOrUpdateResource) Run(ctx context.Context, request *ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	deploymentOutput, err := c.DeploymentProcessor().Deploy(ctx, id, rendererOutput)
+	deploymentOutput, err := c.DeploymentProcessor().Deploy(ctx, id, rendererOutput, request.OperationProgress)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/corerp/backend/controller/createorupdateresource.go
+++ b/pkg/corerp/backend/controller/createorupdateresource.go
@@ -101,7 +101,7 @@ func (c *CreateOrUpdateResource) Run(ctx context.Context, request *ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	deploymentOutput, err := c.DeploymentProcessor().Deploy(ctx, id, rendererOutput, request.OperationProgress)
+	deploymentOutput, err := c.DeploymentProcessor().Deploy(ctx, id, rendererOutput, request.OperationStatus)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/corerp/handlers/kubernetes.go
+++ b/pkg/corerp/handlers/kubernetes.go
@@ -52,7 +52,7 @@ const (
 // Create an interface for deployment waiter and http proxy waiter
 type ResourceWaiter interface {
 	addDynamicEventHandler(ctx context.Context, informerFactory dynamicinformer.DynamicSharedInformerFactory, informer cache.SharedIndexInformer, item client.Object, doneCh chan<- error)
-	addEventHandler(ctx context.Context, informerFactory informers.SharedInformerFactory, informer cache.SharedIndexInformer, item client.Object, doneCh chan<- error)
+	addEventHandler(ctx context.Context, informerFactory informers.SharedInformerFactory, informer cache.SharedIndexInformer, item client.Object, doneCh chan<- deploymentStatus)
 	waitUntilReady(ctx context.Context, item client.Object) error
 }
 

--- a/pkg/corerp/handlers/kubernetes.go
+++ b/pkg/corerp/handlers/kubernetes.go
@@ -126,6 +126,7 @@ func (handler *kubernetesHandler) Put(ctx context.Context, options *PutOptions) 
 		// Monitor the deployment until it is ready.
 		err = handler.deploymentWaiter.waitUntilReady(ctx, &item)
 		if err != nil {
+			fmt.Println("@@@@@ deployment error: ", err.Error())
 			return nil, err
 		}
 		logger.Info(fmt.Sprintf("Deployment %s in namespace %s is ready", item.GetName(), item.GetNamespace()))

--- a/pkg/corerp/handlers/kubernetes_deployment_waiter.go
+++ b/pkg/corerp/handlers/kubernetes_deployment_waiter.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -38,7 +40,7 @@ func NewDeploymentWaiter(clientSet k8s.Interface) *deploymentWaiter {
 	}
 }
 
-func (handler *deploymentWaiter) addEventHandler(ctx context.Context, informerFactory informers.SharedInformerFactory, informer cache.SharedIndexInformer, item client.Object, doneCh chan<- error) {
+func (handler *deploymentWaiter) addEventHandler(ctx context.Context, informerFactory informers.SharedInformerFactory, informer cache.SharedIndexInformer, item client.Object, doneCh chan<- deploymentStatus) {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -59,12 +61,17 @@ func (handler *deploymentWaiter) addEventHandler(ctx context.Context, informerFa
 func (handler *deploymentWaiter) addDynamicEventHandler(ctx context.Context, informerFactory dynamicinformer.DynamicSharedInformerFactory, informer cache.SharedIndexInformer, item client.Object, doneCh chan<- error) {
 }
 
+type deploymentStatus struct {
+	possibleFailureCause string
+	err                  error
+}
+
 func (handler *deploymentWaiter) waitUntilReady(ctx context.Context, item client.Object) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
 	// When the deployment is done, an error nil will be sent
 	// In case of an error, the error will be sent
-	doneCh := make(chan error, 1)
+	doneCh := make(chan deploymentStatus, 1)
 
 	ctx, cancel := context.WithTimeout(ctx, handler.deploymentTimeOut)
 	// This ensures that the informer is stopped when this function is returned.
@@ -76,6 +83,7 @@ func (handler *deploymentWaiter) waitUntilReady(ctx context.Context, item client
 		return err
 	}
 
+	var possibleFailureCauses []string
 	select {
 	case <-ctx.Done():
 		// Get the final deployment status
@@ -84,24 +92,52 @@ func (handler *deploymentWaiter) waitUntilReady(ctx context.Context, item client
 			return fmt.Errorf("deployment timed out, name: %s, namespace %s, error occurred while fetching latest status: %w", item.GetName(), item.GetNamespace(), err)
 		}
 
-		// Now get the latest available observation of deployment current state
-		// note that there can be a race condition here, by the time it fetches the latest status, deployment might be succeeded
-		status := v1.DeploymentCondition{}
-		if len(dep.Status.Conditions) > 0 {
-			status = dep.Status.Conditions[len(dep.Status.Conditions)-1]
-		}
-		return fmt.Errorf("deployment timed out, name: %s, namespace %s, status: %s, reason: %s", item.GetName(), item.GetNamespace(), status.Message, status.Reason)
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println("@@@@@ Inside ctx.Done()")
+			// Get the final deployment status
+			dep, err := handler.clientSet.AppsV1().Deployments(item.GetNamespace()).Get(ctx, item.GetName(), metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("deployment timed out, name: %s, namespace %s, error occured while fetching latest status: %w", item.GetName(), item.GetNamespace(), err)
+			}
 
-	case err := <-doneCh:
-		if err == nil {
-			logger.Info(fmt.Sprintf("Marking deployment %s in namespace %s as complete", item.GetName(), item.GetNamespace()))
+			fmt.Println("@@@@@ Now get the latest available observation of deployment current state")
+
+			// Now get the latest available observation of deployment current state
+			// note that there can be a race condition here, by the time it fetches the latest status, deployment might be succeeded
+			status := v1.DeploymentCondition{}
+			fmt.Println("@@@@@ len(dep.Status.Conditions)", len(dep.Status.Conditions))
+			if len(dep.Status.Conditions) > 0 {
+				status = dep.Status.Conditions[len(dep.Status.Conditions)-1]
+			}
+
+			fmt.Println("@@@@@ Marking deployment as timed out")
+			// Return the error with the possible failure causes
+			errString := fmt.Sprintf("deployment timed out, name: %s, namespace %s, status: %s, reason: %s", item.GetName(), item.GetNamespace(), status.Message, status.Reason)
+			if len(possibleFailureCauses) > 0 {
+				errString += fmt.Sprintf(", possible failure causes: %s", strings.Join(possibleFailureCauses, ", "))
+			}
+			return errors.New(errString)
+
+		case status := <-doneCh:
+			if status.err != nil {
+				logger.Info(fmt.Sprintf("Marking deployment %s in namespace %s as complete", item.GetName(), item.GetNamespace()))
+				return status.err
+			} else if status.possibleFailureCause != "" {
+				possibleFailureCauses = append(possibleFailureCauses, status.possibleFailureCause)
+				fmt.Println("@@@@@ possibleFailureCauses", status.possibleFailureCause)
+				continue
+			} else {
+				// Deployment is ready
+				return nil
+			}
 		}
-		return err
 	}
 }
 
 // Check if all the pods in the deployment are ready
-func (handler *deploymentWaiter) checkDeploymentStatus(ctx context.Context, informerFactory informers.SharedInformerFactory, item client.Object, doneCh chan<- error) bool {
+func (handler *deploymentWaiter) checkDeploymentStatus(ctx context.Context, informerFactory informers.SharedInformerFactory, item client.Object, doneCh chan<- deploymentStatus) bool {
 	logger := ucplog.FromContextOrDiscard(ctx).WithValues("deploymentName", item.GetName(), "namespace", item.GetNamespace())
 
 	// Get the deployment
@@ -135,7 +171,10 @@ func (handler *deploymentWaiter) checkDeploymentStatus(ctx context.Context, info
 		// Reference https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#complete-deployment
 		if c.Type == v1.DeploymentProgressing && c.Status == corev1.ConditionTrue && strings.EqualFold(c.Reason, "NewReplicaSetAvailable") {
 			logger.Info(fmt.Sprintf("Deployment is ready. Observed generation: %d, Generation: %d, Deployment Replicaset: %s", deployment.Status.ObservedGeneration, deployment.Generation, deploymentReplicaSet.Name))
-			doneCh <- nil
+			doneCh <- deploymentStatus{
+				possibleFailureCause: "",
+				err:                  nil,
+			}
 			return true
 		} else {
 			logger.Info(fmt.Sprintf("Deployment status is: %s - %s, Reason: %s, Deployment replicaset: %s", c.Type, c.Status, c.Reason, deploymentReplicaSet.Name))
@@ -144,7 +183,7 @@ func (handler *deploymentWaiter) checkDeploymentStatus(ctx context.Context, info
 	return false
 }
 
-func (handler *deploymentWaiter) startInformers(ctx context.Context, item client.Object, doneCh chan<- error) error {
+func (handler *deploymentWaiter) startInformers(ctx context.Context, item client.Object, doneCh chan<- deploymentStatus) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
 	informerFactory := informers.NewSharedInformerFactoryWithOptions(handler.clientSet, handler.cacheResyncInterval, informers.WithNamespace(item.GetNamespace()))
@@ -214,7 +253,7 @@ func (handler *deploymentWaiter) getCurrentReplicaSetForDeployment(ctx context.C
 	return nil
 }
 
-func (handler *deploymentWaiter) checkAllPodsReady(ctx context.Context, informerFactory informers.SharedInformerFactory, obj *v1.Deployment, deploymentReplicaSet *v1.ReplicaSet, doneCh chan<- error) bool {
+func (handler *deploymentWaiter) checkAllPodsReady(ctx context.Context, informerFactory informers.SharedInformerFactory, obj *v1.Deployment, deploymentReplicaSet *v1.ReplicaSet, doneCh chan<- deploymentStatus) bool {
 	logger := ucplog.FromContextOrDiscard(ctx).WithValues("deploymentName", obj.GetName(), "namespace", obj.GetNamespace())
 	logger.Info("Checking if all pods in the deployment are ready")
 
@@ -226,12 +265,12 @@ func (handler *deploymentWaiter) checkAllPodsReady(ctx context.Context, informer
 
 	allReady := true
 	for _, pod := range podsInDeployment {
-		podReady, err := handler.checkPodStatus(ctx, &pod)
-		if err != nil {
-			// Terminate the deployment and return the error encountered
-			doneCh <- err
+		podReady, status := handler.checkPodStatus(ctx, informerFactory, &pod)
+		if status != (deploymentStatus{}) {
+			doneCh <- status
 			return false
 		}
+
 		if !podReady {
 			allReady = false
 		}
@@ -266,7 +305,7 @@ func (handler *deploymentWaiter) getPodsInDeployment(ctx context.Context, inform
 	return pods, nil
 }
 
-func (handler *deploymentWaiter) checkPodStatus(ctx context.Context, pod *corev1.Pod) (bool, error) {
+func (handler *deploymentWaiter) checkPodStatus(ctx context.Context, informerFactory informers.SharedInformerFactory, pod *corev1.Pod) (bool, deploymentStatus) {
 	logger := ucplog.FromContextOrDiscard(ctx).WithValues("podName", pod.Name, "namespace", pod.Namespace)
 
 	conditionPodReady := true
@@ -286,7 +325,7 @@ func (handler *deploymentWaiter) checkPodStatus(ctx context.Context, pod *corev1
 
 	// Sometimes container statuses are not yet available and we do not want to falsely return that the containers are ready
 	if len(pod.Status.ContainerStatuses) <= 0 {
-		return false, nil
+		return false, deploymentStatus{}
 	}
 
 	for _, cs := range pod.Status.ContainerStatuses {
@@ -295,29 +334,68 @@ func (handler *deploymentWaiter) checkPodStatus(ctx context.Context, pod *corev1
 		// We will rely on the user defining a readiness probe to ensure that the pod is ready to serve traffic for those cases
 		if cs.State.Terminated != nil {
 			logger.Info(fmt.Sprintf("Container state is terminated Reason: %s, Message: %s", cs.State.Terminated.Reason, cs.State.Terminated.Message))
-			return false, fmt.Errorf("Container state is 'Terminated' Reason: %s, Message: %s", cs.State.Terminated.Reason, cs.State.Terminated.Message)
+			return false, deploymentStatus{possibleFailureCause: "", err: fmt.Errorf("Container state is 'Terminated' Reason: %s, Message: %s", cs.State.Terminated.Reason, cs.State.Terminated.Message)}
 		} else if cs.State.Waiting != nil {
 			if cs.State.Waiting.Reason == "ErrImagePull" || cs.State.Waiting.Reason == "CrashLoopBackOff" || cs.State.Waiting.Reason == "ImagePullBackOff" {
 				message := cs.State.Waiting.Message
 				if cs.LastTerminationState.Terminated != nil {
 					message += " LastTerminationState: " + cs.LastTerminationState.Terminated.Message
 				}
-				return false, fmt.Errorf("Container state is 'Waiting' Reason: %s, Message: %s", cs.State.Waiting.Reason, message)
+				return false, deploymentStatus{possibleFailureCause: "", err: fmt.Errorf("Container state is 'Waiting' Reason: %s, Message: %s", cs.State.Waiting.Reason, message)}
 			} else {
-				return false, nil
+				return false, deploymentStatus{}
 			}
 		} else if cs.State.Running == nil {
 			// The container is not yet running
-			return false, nil
+			return false, deploymentStatus{}
 		} else if !cs.Ready {
 			// The container is running but has not passed its readiness probe yet
-			return false, nil
+			// Check the pod events to see if the pod failed readiness probe
+			fmt.Println("@@@@@ cs.Ready false. Checking pod events")
+			events, err := informerFactory.Core().V1().Events().Lister().Events(pod.Namespace).List(labels.Everything())
+			if err != nil {
+				logger.Info("Unable to get events for pod")
+				return false, deploymentStatus{}
+			}
+
+			// Sort events by creation timestamp in descending order
+			sort.Slice(events, func(i, j int) bool {
+				return events[i].CreationTimestamp.Time.After(events[j].CreationTimestamp.Time)
+			})
+
+			for _, event := range events {
+				fmt.Println("@@@@@ event.Message", event.Message)
+				if strings.Contains(event.Message, "Readiness probe failed") {
+					return false, deploymentStatus{possibleFailureCause: fmt.Sprintf("Container failed readiness probe. Reason: %s, Message: %s", event.Reason, event.Message), err: nil}
+				}
+			}
+
+			// The pod is not ready yet but has not failed readiness probe either. So continue waiting for the pod to be ready
+			return false, deploymentStatus{}
+		}
+	}
+
+	events, err := informerFactory.Core().V1().Events().Lister().Events(pod.Namespace).List(labels.Everything())
+	if err != nil {
+		logger.Info("Unable to get events for pod")
+		return false, deploymentStatus{}
+	}
+
+	// Sort events by creation timestamp in descending order
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].CreationTimestamp.Time.After(events[j].CreationTimestamp.Time)
+	})
+
+	for _, event := range events {
+		fmt.Println("@@@@@ event.Message", event.Message)
+		if strings.Contains(event.Message, "Readiness probe failed") {
+			return false, deploymentStatus{possibleFailureCause: fmt.Sprintf("Container failed readiness probe. Reason: %s, Message: %s", event.Reason, event.Message), err: nil}
 		}
 	}
 
 	if !conditionPodReady {
-		return false, nil
+		return false, deploymentStatus{}
 	}
 	logger.Info("All containers for pod are ready")
-	return true, nil
+	return true, deploymentStatus{}
 }

--- a/pkg/corerp/handlers/kubernetes_deployment_waiter.go
+++ b/pkg/corerp/handlers/kubernetes_deployment_waiter.go
@@ -23,7 +23,8 @@ import (
 const (
 	// MaxDeploymentTimeout is the max timeout for waiting for a deployment to be ready.
 	// Deployment duration should not reach to this timeout since async operation worker will time out context before MaxDeploymentTimeout.
-	MaxDeploymentTimeout = time.Minute * time.Duration(10)
+	MaxDeploymentTimeout        = time.Minute * time.Duration(10)
+	OperationInfoKey     string = "operationInfo"
 )
 
 type deploymentWaiter struct {
@@ -118,6 +119,9 @@ func (handler *deploymentWaiter) waitUntilReady(ctx context.Context, item client
 			if len(possibleFailureCauses) > 0 {
 				errString += fmt.Sprintf(", possible failure causes: %s", strings.Join(possibleFailureCauses, ", "))
 			}
+
+			// Set a value on the context
+			ctx = context.WithValue(ctx, OperationInfoKey, errString)
 			return errors.New(errString)
 
 		case status := <-doneCh:

--- a/pkg/corerp/handlers/kubernetes_deployment_waiter_test.go
+++ b/pkg/corerp/handlers/kubernetes_deployment_waiter_test.go
@@ -99,6 +99,7 @@ func startInformers(ctx context.Context, clientSet *fake.Clientset, handler *kub
 	informerFactory.Apps().V1().Deployments().Informer()
 	informerFactory.Apps().V1().ReplicaSets().Informer()
 	informerFactory.Core().V1().Pods().Informer()
+	informerFactory.Core().V1().Events().Informer()
 
 	informerFactory.Start(context.Background().Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
@@ -435,106 +436,106 @@ func TestCheckPodStatus(t *testing.T) {
 		isReady         bool
 		expectedError   string
 	}{
-		{
-			// Container is in Terminated state
-			podCondition: nil,
-			containerStatus: []corev1.ContainerStatus{
-				{
-					State: corev1.ContainerState{
-						Terminated: &corev1.ContainerStateTerminated{
-							Reason:  "Error",
-							Message: "Container terminated due to an error",
-						},
-					},
-				},
-			},
-			isReady:       false,
-			expectedError: "Container state is 'Terminated' Reason: Error, Message: Container terminated due to an error",
-		},
-		{
-			// Container is in CrashLoopBackOff state
-			podCondition: nil,
-			containerStatus: []corev1.ContainerStatus{
-				{
-					State: corev1.ContainerState{
-						Waiting: &corev1.ContainerStateWaiting{
-							Reason:  "CrashLoopBackOff",
-							Message: "Back-off 5m0s restarting failed container=test-container pod=test-pod",
-						},
-					},
-				},
-			},
-			isReady:       false,
-			expectedError: "Container state is 'Waiting' Reason: CrashLoopBackOff, Message: Back-off 5m0s restarting failed container=test-container pod=test-pod",
-		},
-		{
-			// Container is in ErrImagePull state
-			podCondition: nil,
-			containerStatus: []corev1.ContainerStatus{
-				{
-					State: corev1.ContainerState{
-						Waiting: &corev1.ContainerStateWaiting{
-							Reason:  "ErrImagePull",
-							Message: "Cannot pull image",
-						},
-					},
-				},
-			},
-			isReady:       false,
-			expectedError: "Container state is 'Waiting' Reason: ErrImagePull, Message: Cannot pull image",
-		},
-		{
-			// Container is in ImagePullBackOff state
-			podCondition: nil,
-			containerStatus: []corev1.ContainerStatus{
-				{
-					State: corev1.ContainerState{
-						Waiting: &corev1.ContainerStateWaiting{
-							Reason:  "ImagePullBackOff",
-							Message: "ImagePullBackOff",
-						},
-					},
-				},
-			},
-			isReady:       false,
-			expectedError: "Container state is 'Waiting' Reason: ImagePullBackOff, Message: ImagePullBackOff",
-		},
-		{
-			// No container statuses available
-			isReady:       false,
-			expectedError: "",
-		},
-		{
-			// Container is in Waiting state but not a terminally failed state
-			podCondition: nil,
-			containerStatus: []corev1.ContainerStatus{
-				{
-					State: corev1.ContainerState{
-						Waiting: &corev1.ContainerStateWaiting{
-							Reason:  "ContainerCreating",
-							Message: "Container is being created",
-						},
-					},
-					Ready: false,
-				},
-			},
-			isReady:       false,
-			expectedError: "",
-		},
-		{
-			// Container's Running state is nil
-			podCondition: nil,
-			containerStatus: []corev1.ContainerStatus{
-				{
-					State: corev1.ContainerState{
-						Running: nil,
-					},
-					Ready: false,
-				},
-			},
-			isReady:       false,
-			expectedError: "",
-		},
+		// {
+		// 	// Container is in Terminated state
+		// 	podCondition: nil,
+		// 	containerStatus: []corev1.ContainerStatus{
+		// 		{
+		// 			State: corev1.ContainerState{
+		// 				Terminated: &corev1.ContainerStateTerminated{
+		// 					Reason:  "Error",
+		// 					Message: "Container terminated due to an error",
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	isReady:       false,
+		// 	expectedError: "Container state is 'Terminated' Reason: Error, Message: Container terminated due to an error",
+		// },
+		// {
+		// 	// Container is in CrashLoopBackOff state
+		// 	podCondition: nil,
+		// 	containerStatus: []corev1.ContainerStatus{
+		// 		{
+		// 			State: corev1.ContainerState{
+		// 				Waiting: &corev1.ContainerStateWaiting{
+		// 					Reason:  "CrashLoopBackOff",
+		// 					Message: "Back-off 5m0s restarting failed container=test-container pod=test-pod",
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	isReady:       false,
+		// 	expectedError: "Container state is 'Waiting' Reason: CrashLoopBackOff, Message: Back-off 5m0s restarting failed container=test-container pod=test-pod",
+		// },
+		// {
+		// 	// Container is in ErrImagePull state
+		// 	podCondition: nil,
+		// 	containerStatus: []corev1.ContainerStatus{
+		// 		{
+		// 			State: corev1.ContainerState{
+		// 				Waiting: &corev1.ContainerStateWaiting{
+		// 					Reason:  "ErrImagePull",
+		// 					Message: "Cannot pull image",
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	isReady:       false,
+		// 	expectedError: "Container state is 'Waiting' Reason: ErrImagePull, Message: Cannot pull image",
+		// },
+		// {
+		// 	// Container is in ImagePullBackOff state
+		// 	podCondition: nil,
+		// 	containerStatus: []corev1.ContainerStatus{
+		// 		{
+		// 			State: corev1.ContainerState{
+		// 				Waiting: &corev1.ContainerStateWaiting{
+		// 					Reason:  "ImagePullBackOff",
+		// 					Message: "ImagePullBackOff",
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	isReady:       false,
+		// 	expectedError: "Container state is 'Waiting' Reason: ImagePullBackOff, Message: ImagePullBackOff",
+		// },
+		// {
+		// 	// No container statuses available
+		// 	isReady:       false,
+		// 	expectedError: "",
+		// },
+		// {
+		// 	// Container is in Waiting state but not a terminally failed state
+		// 	podCondition: nil,
+		// 	containerStatus: []corev1.ContainerStatus{
+		// 		{
+		// 			State: corev1.ContainerState{
+		// 				Waiting: &corev1.ContainerStateWaiting{
+		// 					Reason:  "ContainerCreating",
+		// 					Message: "Container is being created",
+		// 				},
+		// 			},
+		// 			Ready: false,
+		// 		},
+		// 	},
+		// 	isReady:       false,
+		// 	expectedError: "",
+		// },
+		// {
+		// 	// Container's Running state is nil
+		// 	podCondition: nil,
+		// 	containerStatus: []corev1.ContainerStatus{
+		// 		{
+		// 			State: corev1.ContainerState{
+		// 				Running: nil,
+		// 			},
+		// 			Ready: false,
+		// 		},
+		// 	},
+		// 	isReady:       false,
+		// 	expectedError: "",
+		// },
 		{
 			// Readiness check is not yet passed
 			podCondition: nil,
@@ -549,33 +550,35 @@ func TestCheckPodStatus(t *testing.T) {
 			isReady:       false,
 			expectedError: "",
 		},
-		{
-			// Container is in Ready state
-			podCondition: nil,
-			containerStatus: []corev1.ContainerStatus{
-				{
-					State: corev1.ContainerState{
-						Running: &corev1.ContainerStateRunning{},
-					},
-					Ready: true,
-				},
-			},
-			isReady:       true,
-			expectedError: "",
-		},
+		// {
+		// 	// Container is in Ready state
+		// 	podCondition: nil,
+		// 	containerStatus: []corev1.ContainerStatus{
+		// 		{
+		// 			State: corev1.ContainerState{
+		// 				Running: &corev1.ContainerStateRunning{},
+		// 			},
+		// 			Ready: true,
+		// 		},
+		// 	},
+		// 	isReady:       true,
+		// 	expectedError: "",
+		// },
 	}
 
 	ctx := context.Background()
 	deploymentWaiter := NewDeploymentWaiter(fake.NewSimpleClientset())
+	clientset := fake.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(clientset, 0)
 	for _, tc := range podTests {
 		pod.Status.Conditions = tc.podCondition
 		pod.Status.ContainerStatuses = tc.containerStatus
-		isReady, err := deploymentWaiter.checkPodStatus(ctx, pod)
+		isReady, status := deploymentWaiter.checkPodStatus(ctx, informerFactory, pod)
 		if tc.expectedError != "" {
-			require.Error(t, err)
-			require.Equal(t, tc.expectedError, err.Error())
+			require.Error(t, status.err)
+			require.Equal(t, tc.expectedError, status.err.Error())
 		} else {
-			require.NoError(t, err)
+			require.NoError(t, status.err)
 		}
 		require.Equal(t, tc.isReady, isReady)
 	}
@@ -627,7 +630,7 @@ func TestCheckAllPodsReady_Success(t *testing.T) {
 	addTestObjects(t, clientset, informerFactory, testDeployment, replicaSet, pod)
 
 	// Create a done channel
-	doneCh := make(chan error)
+	doneCh := make(chan deploymentStatus)
 
 	// Create a handler with the fake clientset
 	deploymentWaiter := &deploymentWaiter{
@@ -694,7 +697,7 @@ func TestCheckAllPodsReady_Fail(t *testing.T) {
 	addTestObjects(t, clientset, informerFactory, testDeployment, replicaSet, pod)
 
 	// Create a done channel
-	doneCh := make(chan error)
+	doneCh := make(chan deploymentStatus)
 
 	// Create a handler with the fake clientset
 	deploymentWaiter := &deploymentWaiter{
@@ -771,7 +774,7 @@ func TestCheckDeploymentStatus_AllReady(t *testing.T) {
 	}
 
 	// Create a done channel
-	doneCh := make(chan error, 1)
+	doneCh := make(chan deploymentStatus, 1)
 
 	// Call the checkDeploymentStatus function
 	deploymentWaiter := &deploymentWaiter{
@@ -780,10 +783,10 @@ func TestCheckDeploymentStatus_AllReady(t *testing.T) {
 
 	deploymentWaiter.checkDeploymentStatus(ctx, informerFactory, item, doneCh)
 
-	err = <-doneCh
+	status := <-doneCh
 
 	// Check that the deployment readiness was checked
-	require.Nil(t, err)
+	require.Nil(t, status.err)
 }
 
 func TestCheckDeploymentStatus_NoReplicaSetsFound(t *testing.T) {
@@ -845,7 +848,7 @@ func TestCheckDeploymentStatus_NoReplicaSetsFound(t *testing.T) {
 	}
 
 	// Create a done channel
-	doneCh := make(chan error, 1)
+	doneCh := make(chan deploymentStatus, 1)
 
 	// Call the checkDeploymentStatus function
 	deploymentWaiter := &deploymentWaiter{
@@ -924,19 +927,19 @@ func TestCheckDeploymentStatus_PodsNotReady(t *testing.T) {
 	}
 
 	// Create a done channel
-	doneCh := make(chan error, 1)
+	doneCh := make(chan deploymentStatus, 1)
 
 	// Call the checkDeploymentStatus function
 	deploymentWaiter := &deploymentWaiter{
 		clientSet: fakeClient,
 	}
 
-	go deploymentWaiter.checkDeploymentStatus(ctx, informerFactory, item, doneCh)
-	err = <-doneCh
+	require.False(t, deploymentWaiter.checkDeploymentStatus(ctx, informerFactory, item, doneCh))
+	status := <-doneCh
 
 	// Check that the deployment readiness was checked
-	require.Error(t, err)
-	require.Equal(t, err.Error(), "Container state is 'Terminated' Reason: Error, Message: Container terminated due to an error")
+	require.Error(t, status.err)
+	require.Equal(t, status.err.Error(), "Container state is 'Terminated' Reason: Error, Message: Container terminated due to an error")
 }
 
 func TestCheckDeploymentStatus_ObservedGenerationMismatch(t *testing.T) {
@@ -1006,7 +1009,7 @@ func TestCheckDeploymentStatus_ObservedGenerationMismatch(t *testing.T) {
 	}
 
 	// Create a done channel
-	doneCh := make(chan error, 1)
+	doneCh := make(chan deploymentStatus, 1)
 
 	// Call the checkDeploymentStatus function
 	deploymentWaiter := &deploymentWaiter{
@@ -1095,7 +1098,7 @@ func TestCheckDeploymentStatus_DeploymentNotProgressing(t *testing.T) {
 	}
 
 	// Create a done channel
-	doneCh := make(chan error, 1)
+	doneCh := make(chan deploymentStatus, 1)
 
 	// Call the checkDeploymentStatus function
 	deploymentWaiter := &deploymentWaiter{
@@ -1113,4 +1116,20 @@ func addTestObjects(t *testing.T, fakeClient *fake.Clientset, informerFactory in
 	require.NoError(t, err, "Failed to add replica set to informer cache")
 	err = informerFactory.Core().V1().Pods().Informer().GetIndexer().Add(pod)
 	require.NoError(t, err, "Failed to add pod to informer cache")
+	// event := &corev1.Event{
+	// 	ObjectMeta: metav1.ObjectMeta{
+	// 		Name:      "test-event",
+	// 		Namespace: "test-namespace",
+	// 	},
+	// 	InvolvedObject: corev1.ObjectReference{
+	// 		Kind:       "Deployment",
+	// 		Name:       deployment.Name,
+	// 		UID:        deployment.UID,
+	// 		APIVersion: "apps/v1",
+	// 	},
+	// 	Reason: "None",
+	// 	Type:   "Warning",
+	// }
+	// err = informerFactory.Core().V1().Events().Informer().GetIndexer().Add(event)
+	// require.NoError(t, err, "Failed to add event to informer cache")
 }

--- a/pkg/corerp/handlers/kubernetes_http_proxy_waiter.go
+++ b/pkg/corerp/handlers/kubernetes_http_proxy_waiter.go
@@ -61,7 +61,7 @@ func (handler *httpProxyWaiter) addDynamicEventHandler(ctx context.Context, info
 }
 
 // addEventHandler is not implemented for HTTPProxyWaiter
-func (handler *httpProxyWaiter) addEventHandler(ctx context.Context, informerFactory informers.SharedInformerFactory, informer cache.SharedIndexInformer, item client.Object, doneCh chan<- error) {
+func (handler *httpProxyWaiter) addEventHandler(ctx context.Context, informerFactory informers.SharedInformerFactory, informer cache.SharedIndexInformer, item client.Object, doneCh chan<- deploymentStatus) {
 }
 
 func (handler *httpProxyWaiter) waitUntilReady(ctx context.Context, obj client.Object) error {

--- a/pkg/corerp/handlers/kubernetes_http_proxy_waiter.go
+++ b/pkg/corerp/handlers/kubernetes_http_proxy_waiter.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	contourv1 "github.com/projectcontour/contour/apis/projectcontour/v1"
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/kubernetes"
 	"github.com/radius-project/radius/pkg/ucp/ucplog"
 
@@ -61,10 +62,10 @@ func (handler *httpProxyWaiter) addDynamicEventHandler(ctx context.Context, info
 }
 
 // addEventHandler is not implemented for HTTPProxyWaiter
-func (handler *httpProxyWaiter) addEventHandler(ctx context.Context, informerFactory informers.SharedInformerFactory, informer cache.SharedIndexInformer, item client.Object, doneCh chan<- deploymentStatus, _ chan string) {
+func (handler *httpProxyWaiter) addEventHandler(ctx context.Context, informerFactory informers.SharedInformerFactory, informer cache.SharedIndexInformer, item client.Object, doneCh chan<- deploymentStatus, _ *v1.AsyncOperationStatus) {
 }
 
-func (handler *httpProxyWaiter) waitUntilReady(ctx context.Context, obj client.Object, _ chan string) error {
+func (handler *httpProxyWaiter) waitUntilReady(ctx context.Context, obj client.Object, _ *v1.AsyncOperationStatus) error {
 	logger := ucplog.FromContextOrDiscard(ctx).WithValues("httpProxyName", obj.GetName(), "namespace", obj.GetNamespace())
 
 	doneCh := make(chan error, 1)

--- a/pkg/corerp/handlers/kubernetes_http_proxy_waiter.go
+++ b/pkg/corerp/handlers/kubernetes_http_proxy_waiter.go
@@ -61,10 +61,10 @@ func (handler *httpProxyWaiter) addDynamicEventHandler(ctx context.Context, info
 }
 
 // addEventHandler is not implemented for HTTPProxyWaiter
-func (handler *httpProxyWaiter) addEventHandler(ctx context.Context, informerFactory informers.SharedInformerFactory, informer cache.SharedIndexInformer, item client.Object, doneCh chan<- deploymentStatus) {
+func (handler *httpProxyWaiter) addEventHandler(ctx context.Context, informerFactory informers.SharedInformerFactory, informer cache.SharedIndexInformer, item client.Object, doneCh chan<- deploymentStatus, _ chan string) {
 }
 
-func (handler *httpProxyWaiter) waitUntilReady(ctx context.Context, obj client.Object) error {
+func (handler *httpProxyWaiter) waitUntilReady(ctx context.Context, obj client.Object, _ chan string) error {
 	logger := ucplog.FromContextOrDiscard(ctx).WithValues("httpProxyName", obj.GetName(), "namespace", obj.GetNamespace())
 
 	doneCh := make(chan error, 1)

--- a/pkg/corerp/handlers/resource_handler.go
+++ b/pkg/corerp/handlers/resource_handler.go
@@ -19,6 +19,7 @@ package handlers
 import (
 	"context"
 
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 )
 
@@ -48,8 +49,8 @@ type PutOptions struct {
 	// DependencyProperties is a map of output resource localID to resource properties populated during deployment in the resource handler
 	DependencyProperties map[string]map[string]string
 
-	// Operation Progress channel
-	OperationProgress chan string
+	// Operation Status
+	OperationStatus *v1.AsyncOperationStatus
 }
 
 // DeleteOptions represents the options for ResourceHandler.Delete.

--- a/pkg/corerp/handlers/resource_handler.go
+++ b/pkg/corerp/handlers/resource_handler.go
@@ -47,6 +47,9 @@ type PutOptions struct {
 
 	// DependencyProperties is a map of output resource localID to resource properties populated during deployment in the resource handler
 	DependencyProperties map[string]map[string]string
+
+	// Operation Progress channel
+	OperationProgress chan string
 }
 
 // DeleteOptions represents the options for ResourceHandler.Delete.

--- a/pkg/validator/loader_test.go
+++ b/pkg/validator/loader_test.go
@@ -56,12 +56,12 @@ func Test_ParseSpecFilePath(t *testing.T) {
 			},
 		},
 		{
-			path: "specification/applications/resource-manager/Applications.Core/stable/2022-03-15/gateways.json",
+			path: "specification/applications/resource-manager/Applications.Core/stable/2023-10-01/gateways.json",
 			parsed: map[string]string{
 				"productname":  "applications",
 				"provider":     "applications.core",
 				"state":        "stable",
-				"version":      "2022-03-15",
+				"version":      "2023-10-01",
 				"resourcetype": "gateways",
 			},
 		},

--- a/test/functional/shared/resources/container_test.go
+++ b/test/functional/shared/resources/container_test.go
@@ -362,7 +362,7 @@ func Test_Container_FailDueToBadReadinessProbe(t *testing.T) {
 
 	validate := step.ValidateSingleDetail("DeploymentFailed", step.DeploymentErrorDetail{
 		Code:            "ResourceDeploymentFailure",
-		MessageContains: "Deployment timed out, possible failure causes: Readiness probe failed",
+		MessageContains: "Container failed readiness probe",
 	})
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{

--- a/test/functional/shared/resources/container_test.go
+++ b/test/functional/shared/resources/container_test.go
@@ -354,3 +354,34 @@ func Test_Container_FailDueToBadHealthProbe(t *testing.T) {
 
 	test.Test(t)
 }
+
+func Test_Container_FailDueToBadReadinessProbe(t *testing.T) {
+	template := "testdata/corerp-resources-container-bad-readinessprobe.bicep"
+	name := "corerp-resources-container-bad-readiness"
+	appNamespace := "corerp-resources-container-bad-readiness-app"
+
+	validate := step.ValidateSingleDetail("DeploymentFailed", step.DeploymentErrorDetail{
+		Code:            "ResourceDeploymentFailure",
+		MessageContains: "Deployment timed out, possible failure causes: Readiness probe failed",
+	})
+
+	test := shared.NewRPTest(t, name, []shared.TestStep{
+		{
+			Executor:                               step.NewDeployErrorExecutor(template, validate, functional.GetMagpieImage()),
+			SkipKubernetesOutputResourceValidation: true,
+			SkipObjectValidation:                   true,
+			RPResources: &validation.RPResourceSet{
+				Resources: []validation.RPResource{},
+			},
+			K8sObjects: &validation.K8sObjectSet{
+				Namespaces: map[string][]validation.K8sObject{
+					appNamespace: {
+						validation.NewK8sPodForResource(name, "ctnr-cntr-bad-readiness"),
+					},
+				},
+			},
+		},
+	})
+
+	test.Test(t)
+}

--- a/test/functional/shared/resources/container_test.go
+++ b/test/functional/shared/resources/container_test.go
@@ -362,7 +362,13 @@ func Test_Container_FailDueToBadReadinessProbe(t *testing.T) {
 
 	validate := step.ValidateSingleDetail("DeploymentFailed", step.DeploymentErrorDetail{
 		Code:            "ResourceDeploymentFailure",
-		MessageContains: "Container failed readiness probe",
+		MessageContains: "Canceled",
+		Details: []step.DeploymentErrorDetail{
+			{
+				Code:            "OperationCanceled",
+				MessageContains: "Container failed readiness probe",
+			},
+		},
 	})
 
 	test := shared.NewRPTest(t, name, []shared.TestStep{

--- a/test/functional/shared/resources/testdata/corerp-resources-container-bad-readinessprobe.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-container-bad-readinessprobe.bicep
@@ -1,0 +1,53 @@
+import radius as radius
+
+@description('Specifies the location for resources.')
+param location string = 'global'
+
+@description('Specifies the image of the container resource.')
+param magpieimage string
+
+@description('Specifies the port of the container resource.')
+param port int = 5000
+
+@description('Specifies the environment for resources.')
+param environment string
+
+resource app 'Applications.Core/applications@2023-10-01-preview' = {
+  name: 'corerp-resources-container-bad-readiness'
+  location: location
+  properties: {
+    environment: environment
+    extensions: [
+      {
+          kind: 'kubernetesNamespace'
+          namespace: 'corerp-resources-container-bad-readiness-app'
+      }
+    ]
+  }
+}
+
+resource container 'Applications.Core/containers@2023-10-01-preview' = {
+  name: 'ctnr-bad-readiness'
+  location: location
+  properties: {
+      application: app.id
+      container: {
+        image: magpieimage
+        readinessProbe:{
+          kind: 'httpGet'
+          containerPort: 5000
+          path: '/bad'
+          failureThreshold:1
+          periodSeconds:1
+          initialDelaySeconds:0
+        }
+
+        ports: {
+          web: {
+            containerPort: port
+          }
+        }
+      }
+      connections: {}
+    }
+  }


### PR DESCRIPTION
# Description

Readiness probe failure is a non-terminal failure. As a result, currently, we wait for the deployment to complete or eventually timeout. In case of a timeout, the user has no clue why the deployment timed out. The purpose of this change is to detect the readiness probe failure and provide this information to the user if the deployment times out.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request adds or changes features of Radius and has an approved issue (https://github.com/radius-project/radius/issues/6284).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #6284 #6835 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7da1a25</samp>

### Summary
🚀🐛🧪

<!--
1.  🚀 - This emoji represents the addition of a new feature or enhancement, such as the readiness probe support and the async operation status reporting.
2.  🐛 - This emoji represents the fixing of a bug or an issue, such as the assignment of the operation status field and the update of the specification file path and version.
3.  🧪 - This emoji represents the addition or modification of tests or testing tools, such as the new test function and template file for the bad readiness probe scenario and the changes to the existing unit tests.
-->
This pull request adds support for reporting the status and possible failure causes of asynchronous operations when deploying Kubernetes resources. It modifies the `AsyncOperationRequest`, `AsyncOperationStatus`, `DeploymentProcessor`, and `resource_handler` types and functions to pass and update the operation status. It also updates the `kubernetes_deployment_waiter` and `kubernetes_http_proxy_waiter` modules to use the pod events API to check the readiness probe status of the deployments. It adds and modifies some unit tests and functional tests to cover the new features. It also updates the `rbac.yaml` file and the specification file for the gateways resource.

> _We're deploying to the Kubernetes cluster_
> _With async operations and readiness probes_
> _We'll update the status and handle the errors_
> _Heave away, me lads and lasses, heave away_

### Walkthrough
*  Add `events` resource to `rp` role in `rbac.yaml` to allow `rp` service account to access pod events ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-13e38bac99402c4ae82609aaba31139f5f9f7c229d1bd955032255cb18f356c6R18))
*  Reduce default async operation timeout from 120 to 20 seconds in `request.go` to make test cases run faster and fail earlier ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-2a4ba42fee4a75a9e39ee8770bd4bcafde486b06d23c1002f335794bc2a62645L30-R30))
*  Add `OperationStatus` field to `AsyncOperationRequest` struct in `request.go` to hold the current status of the async operation ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-2a4ba42fee4a75a9e39ee8770bd4bcafde486b06d23c1002f335794bc2a62645R59-R60))
*  Assign `OperationStatus` field of `AsyncOperationRequest` to `OperationStatus` field of `AsyncOperationStatus` in `statusmanager.go` to pass the operation status from the request to the status manager ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-aac87dc11a514274bedf43d8d447279fccca2f833544b38124ffe2d45519a3bbR219))
*  Add `OperationInfoKey` constant to `worker.go` to use as a key to store and retrieve the operation information from the context ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-5d9b9964242d77606f4868e3fe049978ea1c3f1903afcfeb60c76e19d9785fc5R62-R63))
*  Initialize operation information to an empty string in the context before running the operation in `worker.go` ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-5d9b9964242d77606f4868e3fe049978ea1c3f1903afcfeb60c76e19d9785fc5R173))
*  Initialize `OperationStatus` field of `AsyncOperationRequest` to an empty `AsyncOperationStatus` struct in `worker.go` to avoid nil pointer dereference ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-5d9b9964242d77606f4868e3fe049978ea1c3f1903afcfeb60c76e19d9785fc5R231-R232))
*  Print the result of the operation to the standard output for debugging purposes in `worker.go` ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-5d9b9964242d77606f4868e3fe049978ea1c3f1903afcfeb60c76e19d9785fc5R260))
*  Remove an empty line from `runOperation` function in `worker.go` to improve code readability and style consistency ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-5d9b9964242d77606f4868e3fe049978ea1c3f1903afcfeb60c76e19d9785fc5L272))
*  Append the operation status to the error message when the operation times out and print a message when the cancel function is invoked in `worker.go` ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-5d9b9964242d77606f4868e3fe049978ea1c3f1903afcfeb60c76e19d9785fc5L288-R299))
*  Add `operationStatus` parameter to `Deploy` function signature in `deploymentprocessor.go` to allow the deployment processor to receive and update the operation status ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-2f71b55e0dceaf541f852a86c0b54060819c6266f5257474fa863826d4043815L57-R57), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-2f71b55e0dceaf541f852a86c0b54060819c6266f5257474fa863826d4043815L247-R250))
*  Print the operation status to the standard output for debugging purposes in `deploymentprocessor.go` ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-2f71b55e0dceaf541f852a86c0b54060819c6266f5257474fa863826d4043815R163), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-2f71b55e0dceaf541f852a86c0b54060819c6266f5257474fa863826d4043815L247-R250))
*  Pass the operation status from the caller to the `deployOutputResource` function in `deploymentprocessor.go` ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-2f71b55e0dceaf541f852a86c0b54060819c6266f5257474fa863826d4043815L288-R290))
*  Start the events informer in `kubernetes_deployment_waiter_test.go` to get the pod events from the Kubernetes API in the test cases ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-f21cc2a2965eb59afa1905cb56125a769b00a476a0cb1a785c298dc6c9c57b58R102))
*  Skip the test cases that are not relevant for the readiness probe scenario in `kubernetes_deployment_waiter_test.go` ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-f21cc2a2965eb59afa1905cb56125a769b00a476a0cb1a785c298dc6c9c57b58L438-R539), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-f21cc2a2965eb59afa1905cb56125a769b00a476a0cb1a785c298dc6c9c57b58L552-R581))
*  Modify the type of the `doneCh` variable from `chan error` to `chan deploymentStatus` and the logic of receiving the error from the `doneCh` channel in `kubernetes_deployment_waiter_test.go` to use a custom struct `deploymentStatus` that contains both the possible failure cause and the error value ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-f21cc2a2965eb59afa1905cb56125a769b00a476a0cb1a785c298dc6c9c57b58L630-R633), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-f21cc2a2965eb59afa1905cb56125a769b00a476a0cb1a785c298dc6c9c57b58L697-R700), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-f21cc2a2965eb59afa1905cb56125a769b00a476a0cb1a785c298dc6c9c57b58L774-R777), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-f21cc2a2965eb59afa1905cb56125a769b00a476a0cb1a785c298dc6c9c57b58L848-R851), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-f21cc2a2965eb59afa1905cb56125a769b00a476a0cb1a785c298dc6c9c57b58L927-R930), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-f21cc2a2965eb59afa1905cb56125a769b00a476a0cb1a785c298dc6c9c57b58L1009-R1012), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-f21cc2a2965eb59afa1905cb56125a769b00a476a0cb1a785c298dc6c9c57b58L1098-R1101))
*  Modify the logic of calling and checking the error from the `checkDeploymentStatus` function in `kubernetes_deployment_waiter_test.go` to call the function synchronously and use the return value directly ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-f21cc2a2965eb59afa1905cb56125a769b00a476a0cb1a785c298dc6c9c57b58L783-R789), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-f21cc2a2965eb59afa1905cb56125a769b00a476a0cb1a785c298dc6c9c57b58L934-R942))
*  Add a block of code to create a pod event with the message "Readiness probe failed" in `kubernetes_deployment_waiter_test.go` and comment it out for future use ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-f21cc2a2965eb59afa1905cb56125a769b00a476a0cb1a785c298dc6c9c57b58R1119-R1134))
*  Add `operationStatus` parameter to `addEventHandler` and `waitUntilReady` function signatures in `kubernetes_deployment_waiter.go` to receive and update the operation status when waiting for the deployment to be ready ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L41-R53), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L62-R77))
*  Modify the type of the `doneCh` variable from `chan error` to `chan deploymentStatus` and the logic of receiving the error from the `doneCh` channel in `kubernetes_deployment_waiter.go` to use a custom struct `deploymentStatus` that contains both the possible failure cause and the error value ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L62-R77))
*  Add a variable `possibleFailureCauses` to store a slice of strings that represent the possible failure causes of the deployment and update it by receiving the `deploymentStatus` values from the `doneCh` channel in `kubernetes_deployment_waiter.go` ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L62-R77))
*  Append the operation status to the error message when the context is done and set the operation information to the context using the `OperationInfoKey` constant and the `possibleFailureCauses` slice in `kubernetes_deployment_waiter.go` ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L62-R77))
*  Pass the operation status from the caller to the `startInformers` and `checkDeploymentStatus` functions in `kubernetes_deployment_waiter.go` ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L73-R83), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L79-R144))
*  Add `operationStatus` parameter to `checkDeploymentStatus` function signature in `kubernetes_deployment_waiter.go` to receive and update the operation status when checking the deployment status ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L120-R160))
*  Modify the type of the `doneCh` parameter from `chan<- error` to `chan<- deploymentStatus` and the logic of sending a nil error or an error to the `doneCh` channel in `kubernetes_deployment_waiter.go` to use a custom struct `deploymentStatus` that contains both the possible failure cause and the error value ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L120-R160), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L138-R181), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L147-R205))
*  Add `operationStatus` parameter to `checkAllPodsReady` function signature in `kubernetes_deployment_waiter.go` to receive and update the operation status when checking the pod readiness ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L217-R263))
*  Modify the type of the `doneCh` parameter from `chan<- error` to `chan<- deploymentStatus` and the logic of sending a nil error or an error to the `doneCh` channel in `kubernetes_deployment_waiter.go` to use a custom struct `deploymentStatus` that contains both the possible failure cause and the error value ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L217-R263), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L229-R281))
*  Add `informerFactory` parameter to `checkPodStatus` function signature in `kubernetes_deployment_waiter.go` to use the informer factory to get the pod events from the Kubernetes API ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L269-R316))
*  Modify the type of the return values from `(bool, error)` to `(bool, *deploymentStatus)` and the logic of returning a nil error or an error in `kubernetes_deployment_waiter.go` to use a custom struct `deploymentStatus` that contains both the possible failure cause and the error value ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L269-R316), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453R339), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L298-R349), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L305-R355))
*  Add a block of code that checks the pod events when the container state is `Waiting` with a non-terminally failed reason or `Running` but not `Ready` or when the pod condition is not `PodReady` in `kubernetes_deployment_waiter.go` and return a `deploymentStatus` value with a possible failure cause and a nil error if the pod event contains the message "Readiness probe failed" ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L269-R316), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-864c8230511d8d335b1939ed9fa8196ba64cb535aac443d63474d3c309024453L311-R420))
*  Add `operationStatus` parameter to `addEventHandler` and `waitUntilReady` function signatures in `kubernetes_http_proxy_waiter.go` to receive and update the operation status when waiting for the http proxy to be ready ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-397d63d65f44b2c85cd035e75632e13cbcd0d89c0610f44e818bd5bd809e1138L64-R68))
*  Add `OperationStatus` field to `PutOptions` struct in `resource_handler.go` to hold the current status of the async operation ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-8b0006aeb2f47650c6499d4337299a9ff29a8ff849c55d68ddc9f6d290e680f6R51-R53))
*  Add `operationStatus` parameter to `waitUntilReady` function calls in `kubernetes.go` to pass the operation status from the caller to the deployment waiter or the http proxy waiter ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L127-R130), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-033dc8a7c9b970cc30f7420ce8cf2f12a26258b276779683ba3f761c481bf0a7L134-R136))
*  Update the path and the version of the specification file for the gateways resource in `loader_test.go` to use the latest version that supports the readiness probe feature ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-7b8cf0fed92b04574159896aa3e609b874fb6822eb4943c56e1f07966c46c089L59-R64))
*  Add a test function `Test_Container_FailDueToBadReadinessProbe` and a template file `corerp-resources-container-bad-readinessprobe.bicep` to test the scenario where the container resource deployment fails due to a bad readiness probe ([link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-9442e1a784d8aba972917e5cfd69a85102d0b1393b88dc2be87e84a47c794970R357-R393), [link](https://github.com/radius-project/radius/pull/6862/files?diff=unified&w=0#diff-b87aaf814e31b3a182cf66d3c34ff2639779cb5c0d9019cd127ad3d8ea27dd5cR1-R53))


