### PR TITLE
Update logger.Info in Terraform driver

### DIFF
--- a/pkg/recipes/driver/terraform.go
+++ b/pkg/recipes/driver/terraform.go
@@ -307,7 +307,7 @@ func (d *terraformDriver) getDeployedOutputResources(ctx context.Context, module
 					_, err := resources.ParseResource(id)
 					if err != nil {
 						// The Azure resources Ids that doesnt not follow relative ID format are mostly Non ARM resources and not added to the recipe output.
-						logger.Info("Resource ID %s does not represent ARM resource and is not added to recipe output", id)
+						logger.Info("Resource ID does not represent ARM resource and is not added to recipe output", "ResourceID", id)
 					} else {
 						recipeResources = append(recipeResources, id)
 					}


### PR DESCRIPTION
# Description
Update logger.Info in Terraform driver

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (issue link required).
Fixes: #6868 

## Auto-generated summary
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6faa112</samp>

### Summary
:recycle::mag::key:

<!--
1.  :recycle: - This emoji can be used to indicate a refactoring or code improvement that does not change the functionality or behavior of the code, but makes it more readable, maintainable, or consistent. The :recycle: emoji can also be used to show that something is being reused or recycled, such as a dependency or a resource.
2.  :mag: - This emoji can be used to indicate a change that improves the observability, debugging, or testing of the code, such as adding or enhancing logging, metrics, tracing, or assertions. The :mag: emoji can also be used to show that something is being searched, inspected, or verified, such as a query, a filter, or a validation.
3.  :key: - This emoji can be used to indicate a change that involves adding, modifying, or removing a key, a value, or a pair of them, such as in a map, a dictionary, a configuration, or a structured log. The :key: emoji can also be used to show that something is being encrypted, decrypted, authenticated, or authorized, such as a password, a token, or a certificate.
-->
Refactor logging in `terraform.go` to use structured key-value pairs instead of formatted strings. This improves observability and consistency of the radius project.

> _`logger.Info` changed_
> _Structured logging for clarity_
> _Refactoring in spring_

### Walkthrough
*  Refactor the logger.Info calls to use structured key-value pairs instead of formatted strings ([link](https://github.com/radius-project/radius/pull/6879/files?diff=unified&w=0#diff-1b98bc9b02b96687752860c11c68d87d99ad99f24ecdfc5497fda6823abc0612L310-R310),                            


