### PR TITLE
Disabling scheduled functional test runs on forks

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -71,6 +71,7 @@ jobs:
   build:
     name: Build Radius for test
     runs-on: ubuntu-latest
+    if: github.event_name == 'repository_dispatch' || (github.event_name == 'schedule' && github.repository == 'radius-project/radius')
     env:
       DE_IMAGE: 'ghcr.io/radius-project/deployment-engine'
       DE_TAG: 'latest'
@@ -280,6 +281,7 @@ jobs:
   tests:
     name: Run ${{ matrix.name }} functional tests
     needs: build
+    if: github.event_name == 'repository_dispatch' || (github.event_name == 'schedule' && github.repository == 'radius-project/radius')
     strategy:
       fail-fast: true
       matrix:
@@ -564,7 +566,7 @@ jobs:
     name: Report test failure
     needs: [build, tests]
     runs-on: ubuntu-latest
-    if: failure() && github.event_name == 'schedule'
+    if: failure() && github.event_name == 'schedule' && github.repository == 'radius-project/radius'
     steps:
       - name: Create failure issue for failing scheduled run
         uses: actions/github-script@v6


### PR DESCRIPTION
# Description
Disabling scheduled functional test runs on forks

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Auto-generated summary
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f3b701d</samp>

### Summary
🛡️🚀🧪

<!--
1.  🛡️ - This emoji represents security or protection, and can be used to indicate the changes that restrict the execution of the jobs to specific triggers and contexts, such as only running them on the `main` branch or on pull requests from the same repository.
2.  🚀 - This emoji represents speed or performance, and can be used to indicate the changes that improve the efficiency of the workflow by avoiding unnecessary or redundant tests or actions, such as not running the functional tests twice on pull requests or forks.
3.  🧪 - This emoji represents testing or experimentation, and can be used to indicate the changes that affect the functional tests or the coverage reports, such as adding new steps or conditions to the jobs.
-->
Restrict functional test workflow to specific triggers and contexts. Prevent running tests or actions on pull requests or forks that do not need them or have permission for them.

> _No more wasted tests, no more false alarms_
> _We control the triggers, we set the contexts_
> _`functional-test` and `coverage` only when we need_
> _`create-failure-issue` only for the authorized_

### Walkthrough
*  Add conditions to run functional tests and coverage only on repository dispatch or scheduled events on main repository ([link](https://github.com/radius-project/radius/pull/6885/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcR74), [link](https://github.com/radius-project/radius/pull/6885/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcR284), [link](https://github.com/radius-project/radius/pull/6885/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL567-R569))


