### PR TITLE
Adding names to the etag unit tests

### DIFF
--- a/pkg/armrpc/frontend/controller/util_test.go
+++ b/pkg/armrpc/frontend/controller/util_test.go
@@ -70,20 +70,51 @@ var tag string = uuid.New().String()
 func TestValidateEtag_IfMatch(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
+		name         string
 		ifMatchEtag  string
 		etagProvided string
 		shouldFail   bool
 	}{
-		{"", "existingEtag", false},
-		{"", "", false},
-		{tag, tag, false},
-		{tag, uuid.New().String(), true},
-		{"*", "", true},
-		{"*", tag, false},
+		{
+			"etag-provided-if-match-empty",
+			"",
+			"existingEtag",
+			false,
+		},
+		{
+			"etag-and-if-match-not-provided",
+			"",
+			"",
+			false,
+		},
+		{
+			"etag-if-match-provided-match",
+			tag,
+			tag,
+			false,
+		},
+		{
+			"etag-if-match-provided-no-match",
+			tag,
+			uuid.New().String(),
+			true,
+		},
+		{
+			"etag-not-provided-if-match-wildcard",
+			"*",
+			"",
+			true,
+		},
+		{
+			"etag-provided-if-match-wildcard",
+			"*",
+			tag,
+			false,
+		},
 	}
 
 	for _, tt := range cases {
-		t.Run(tt.ifMatchEtag, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			armRequestContext := v1.ARMRequestContextFromContext(
 				v1.WithARMRequestContext(
 					context.Background(), &v1.ARMRequestContext{
@@ -104,18 +135,39 @@ func TestValidateEtag_IfMatch(t *testing.T) {
 func TestValidateEtag_IfNoneMatch(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
+		name            string
 		ifNoneMatchEtag string
 		etagProvided    string
 		shouldFail      bool
 	}{
-		{"", "", false},
-		{"", tag, false},
-		{"*", "", false},
-		{"*", tag, true},
+		{
+			"etag-and-if-none-match-empty",
+			"",
+			"",
+			false,
+		},
+		{
+			"etag-provided-if-none-match-empty",
+			"",
+			tag,
+			false,
+		},
+		{
+			"etag-empty-if-none-match-wildcard",
+			"*",
+			"",
+			false,
+		},
+		{
+			"etag-provided-if-none-match-wildcard",
+			"*",
+			tag,
+			true,
+		},
 	}
 
 	for _, tt := range cases {
-		t.Run(tt.ifNoneMatchEtag, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			armRequestContext := v1.ARMRequestContextFromContext(
 				v1.WithARMRequestContext(
 					context.Background(), &v1.ARMRequestContext{


### PR DESCRIPTION
# Description
Adding names to the etag unit tests.

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #6887 

## Auto-generated summary
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at de6e319</samp>

### Summary
🧪🎨📝

<!--
1.  🧪 This emoji represents testing, experimentation, or science, and can be used to indicate that the change is related to improving or adding tests.
2.  🎨 This emoji represents art, creativity, or design, and can be used to indicate that the change is related to improving the appearance, style, or format of the code.
3.  📝 This emoji represents writing, documentation, or notes, and can be used to indicate that the change is related to adding or updating comments, names, or descriptions of the code.
-->
Refactor test cases for `TestValidateEtag_IfMatch` in `util_test.go` to use names and readable format. This improves the test code quality and style for the armrpc package.

> _`armrpc` tests grow_
> _Refactored with names and style_
> _Autumn of cleanup_

### Walkthrough
*  Refactor test cases for `TestValidateEtag_IfMatch` function to include name field and use consistent format ([link](https://github.com/radius-project/radius/pull/6886/files?diff=unified&w=0#diff-8f964ad7752e403193ac37a0a9f39543c5003c0a7c04f4d4521b5e40808aecf9L73-R117))


