### PR TITLE
add workflow run trigger to build and run functional tests

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -75,7 +75,7 @@ jobs:
   build:
     name: Build Radius for test
     runs-on: ubuntu-latest
-    if: github.event_name == 'repository_dispatch' || (github.event_name == 'schedule' && github.repository == 'radius-project/radius')
+    if: github.event_name == 'repository_dispatch' || (github.event_name == 'schedule' && github.repository == 'radius-project/radius') || github.event_name == 'workflow_run'
     env:
       DE_IMAGE: 'ghcr.io/radius-project/deployment-engine'
       DE_TAG: 'latest'
@@ -300,7 +300,7 @@ jobs:
   tests:
     name: Run ${{ matrix.name }} functional tests
     needs: build
-    if: github.event_name == 'repository_dispatch' || (github.event_name == 'schedule' && github.repository == 'radius-project/radius')
+    if: github.event_name == 'repository_dispatch' || (github.event_name == 'schedule' && github.repository == 'radius-project/radius') || github.event_name == 'workflow_run'
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
# Description

Functional tests job is being triggered by approvals but skipped. Need to add the workflow_run trigger to build and tests

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->


- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #6548 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ce52f0d</samp>

### Summary
🏗️🧪🚀

<!--
1.  🏗️ - This emoji represents the `build` job, which builds the Radius image from the source code and pushes it to a registry.
2.  🧪 - This emoji represents the `test` job, which runs functional tests against the Radius image using a test framework and reports the results.
3.  🚀 - This emoji represents the `workflow_run` event, which triggers the `functional-test` workflow after another workflow (such as `lint` or `unit-test`) completes successfully. This ensures that the functional tests only run on verified code.
-->
Updated the `functional-test` workflow to run on `workflow_run` events. This allows the Radius image to be built and tested automatically on every code change.

> _`workflow_run` triggers the doom_
> _Build and test the Radius of gloom_
> _No escape from the continuous fate_
> _Push or pull, you must integrate_

### Walkthrough
*  Enable the `build` and `test` jobs to run when triggered by another workflow ([link](https://github.com/radius-project/radius/pull/6891/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL78-R78), [link](https://github.com/radius-project/radius/pull/6891/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL303-R303)) in `.github/workflows/functional-test.yaml`


