### PR TITLE
Add resource group to some object formats

### DIFF
--- a/pkg/cli/cmd/app/status/objectformats.go
+++ b/pkg/cli/cmd/app/status/objectformats.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import "github.com/radius-project/radius/pkg/cli/output"
+
+// statusFormat sets up the columns and headings for a table to display application names and resource counts.
+func statusFormat() output.FormatterOptions {
+	return output.FormatterOptions{
+		Columns: []output.Column{
+			{
+				Heading:  "APPLICATION",
+				JSONPath: "{ .Name }",
+			},
+			{
+				Heading:  "RESOURCES",
+				JSONPath: "{ .ResourceCount }",
+			},
+		},
+	}
+}
+
+// gatewayFormat returns a FormatterOptions object which contains a list of columns to be used for
+// formatting the output of a list of application gateways.
+func gatewayFormat() output.FormatterOptions {
+	return output.FormatterOptions{
+		Columns: []output.Column{
+			{
+				Heading:  "GATEWAY",
+				JSONPath: "{ .Name }",
+			},
+			{
+				Heading:  "ENDPOINT",
+				JSONPath: "{ .Endpoint }",
+			},
+		},
+	}
+}

--- a/pkg/cli/cmd/app/status/objectformats_test.go
+++ b/pkg/cli/cmd/app/status/objectformats_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/radius-project/radius/pkg/cli/clients"
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GetApplicationStatusTableFormat(t *testing.T) {
+	obj := clients.ApplicationStatus{
+		Name:          "test",
+		ResourceCount: 3,
+	}
+
+	buffer := &bytes.Buffer{}
+	err := output.Write(output.FormatTable, obj, buffer, statusFormat())
+	require.NoError(t, err)
+
+	expected := "APPLICATION  RESOURCES\ntest         3\n"
+	require.Equal(t, expected, buffer.String())
+}
+
+func Test_GetApplicationGatewaysTableFormat(t *testing.T) {
+	obj := clients.GatewayStatus{
+		Name:     "test",
+		Endpoint: "test-endpoint",
+	}
+
+	buffer := &bytes.Buffer{}
+	err := output.Write(output.FormatTable, obj, buffer, gatewayFormat())
+	require.NoError(t, err)
+
+	expected := "GATEWAY   ENDPOINT\ntest      test-endpoint\n"
+	require.Equal(t, expected, buffer.String())
+}

--- a/pkg/cli/cmd/app/status/status.go
+++ b/pkg/cli/cmd/app/status/status.go
@@ -25,7 +25,6 @@ import (
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/pkg/ucp/resources"
@@ -170,7 +169,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 	}
 
-	err = r.Output.WriteFormatted(r.Format, applicationStatus, objectformats.GetApplicationStatusTableFormat())
+	err = r.Output.WriteFormatted(r.Format, applicationStatus, statusFormat())
 	if err != nil {
 		return err
 	}
@@ -179,7 +178,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		// Print newline for readability
 		r.Output.LogInfo("")
 
-		err = r.Output.WriteFormatted(r.Format, applicationStatus.Gateways, objectformats.GetApplicationGatewaysTableFormat())
+		err = r.Output.WriteFormatted(r.Format, applicationStatus.Gateways, gatewayFormat())
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/cmd/app/status/status_test.go
+++ b/pkg/cli/cmd/app/status/status_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/radius-project/radius/pkg/cli/config"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
@@ -186,7 +185,7 @@ func Test_Run(t *testing.T) {
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     applicationStatus,
-				Options: objectformats.GetApplicationStatusTableFormat(),
+				Options: statusFormat(),
 			},
 			output.LogOutput{
 				Format: "",
@@ -194,7 +193,7 @@ func Test_Run(t *testing.T) {
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     applicationStatus.Gateways,
-				Options: objectformats.GetApplicationGatewaysTableFormat(),
+				Options: gatewayFormat(),
 			},
 		}
 

--- a/pkg/cli/cmd/credential/list/list.go
+++ b/pkg/cli/cmd/credential/list/list.go
@@ -24,7 +24,6 @@ import (
 	"github.com/radius-project/radius/pkg/cli/cmd/credential/common"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/spf13/cobra"
@@ -110,7 +109,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	err = r.Output.WriteFormatted(r.Format, providers, objectformats.CloudProviderTableFormat())
+	err = r.Output.WriteFormatted(r.Format, providers, credentialFormat())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/credential/list/list_test.go
+++ b/pkg/cli/cmd/credential/list/list_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/radius-project/radius/pkg/cli/connections"
 	cli_credential "github.com/radius-project/radius/pkg/cli/credential"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/test/radcli"
@@ -112,7 +111,7 @@ func Test_Run(t *testing.T) {
 				output.FormattedOutput{
 					Format:  "table",
 					Obj:     providers,
-					Options: objectformats.CloudProviderTableFormat(),
+					Options: credentialFormat(),
 				},
 			}
 			require.Equal(t, expected, outputSink.Writes)

--- a/pkg/cli/cmd/credential/list/objectformats.go
+++ b/pkg/cli/cmd/credential/list/objectformats.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package list
+
+import "github.com/radius-project/radius/pkg/cli/output"
+
+// credentialFormat configures the output format of a table to display the Name and Status of a cloud provider.
+func credentialFormat() output.FormatterOptions {
+	return output.FormatterOptions{
+		Columns: []output.Column{
+			{
+				Heading:  "PROVIDER",
+				JSONPath: "{ .Name }",
+			},
+			{
+				Heading:  "REGISTERED",
+				JSONPath: "{ .Enabled }",
+			},
+		},
+	}
+}

--- a/pkg/cli/cmd/credential/list/objectformats_test.go
+++ b/pkg/cli/cmd/credential/list/objectformats_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package list
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/radius-project/radius/pkg/cli/credential"
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_credentialFormat(t *testing.T) {
+	obj := credential.ProviderCredentialConfiguration{
+		CloudProviderStatus: credential.CloudProviderStatus{
+			Name:    "test",
+			Enabled: true,
+		},
+	}
+
+	buffer := &bytes.Buffer{}
+	err := output.Write(output.FormatTable, obj, buffer, credentialFormat())
+	require.NoError(t, err)
+
+	expected := "PROVIDER  REGISTERED\ntest      true\n"
+	require.Equal(t, expected, buffer.String())
+}

--- a/pkg/cli/cmd/credential/show/objectformats.go
+++ b/pkg/cli/cmd/credential/show/objectformats.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package show
+
+import (
+	"strings"
+
+	"github.com/radius-project/radius/pkg/cli/output"
+)
+
+// credentialFormat function returns a FormatterOptions struct based on the credentialType parameter, which can
+// be either "azure" or "aws".
+func credentialFormat(credentialType string) output.FormatterOptions {
+	if strings.EqualFold(credentialType, "azure") {
+		return output.FormatterOptions{
+			Columns: []output.Column{
+				{
+					Heading:  "NAME",
+					JSONPath: "{ .Name }",
+				},
+				{
+					Heading:  "REGISTERED",
+					JSONPath: "{ .Enabled }",
+				},
+				{
+					Heading:  "CLIENTID",
+					JSONPath: "{ .AzureCredentials.ClientID }",
+				},
+				{
+					Heading:  "TENANTID",
+					JSONPath: "{ .AzureCredentials.TenantID }",
+				},
+			},
+		}
+	} else if strings.EqualFold(credentialType, "aws") {
+		return output.FormatterOptions{
+			Columns: []output.Column{
+				{
+					Heading:  "NAME",
+					JSONPath: "{ .Name }",
+				},
+				{
+					Heading:  "REGISTERED",
+					JSONPath: "{ .Enabled }",
+				},
+				{
+					Heading:  "ACCESSKEYID",
+					JSONPath: "{ .AWSCredentials.AccessKeyID }",
+				},
+			},
+		}
+	}
+	return output.FormatterOptions{}
+}

--- a/pkg/cli/cmd/credential/show/objectformats_test.go
+++ b/pkg/cli/cmd/credential/show/objectformats_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package show
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/radius-project/radius/pkg/cli/credential"
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/radius-project/radius/pkg/to"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_credentialFormat_Azure(t *testing.T) {
+	obj := credential.ProviderCredentialConfiguration{
+		CloudProviderStatus: credential.CloudProviderStatus{
+			Name:    "test",
+			Enabled: true,
+		},
+		AzureCredentials: &credential.AzureCredentialProperties{
+			ClientID: to.Ptr("test-client-id"),
+			TenantID: to.Ptr("test-tenant-id"),
+		},
+	}
+
+	buffer := &bytes.Buffer{}
+	err := output.Write(output.FormatTable, obj, buffer, credentialFormat("azure"))
+	require.NoError(t, err)
+
+	expected := "NAME      REGISTERED  CLIENTID        TENANTID\ntest      true        test-client-id  test-tenant-id\n"
+	require.Equal(t, expected, buffer.String())
+}
+
+func Test_credentialFormat_AWS(t *testing.T) {
+	obj := credential.ProviderCredentialConfiguration{
+		CloudProviderStatus: credential.CloudProviderStatus{
+			Name:    "test",
+			Enabled: true,
+		},
+		AWSCredentials: &credential.AWSCredentialProperties{
+			AccessKeyID: to.Ptr("test-access-key-id"),
+		},
+	}
+
+	buffer := &bytes.Buffer{}
+	err := output.Write(output.FormatTable, obj, buffer, credentialFormat("aws"))
+	require.NoError(t, err)
+
+	expected := "NAME      REGISTERED  ACCESSKEYID\ntest      true        test-access-key-id\n"
+	require.Equal(t, expected, buffer.String())
+}

--- a/pkg/cli/cmd/credential/show/show.go
+++ b/pkg/cli/cmd/credential/show/show.go
@@ -25,7 +25,6 @@ import (
 	"github.com/radius-project/radius/pkg/cli/cmd/credential/common"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/spf13/cobra"
@@ -126,7 +125,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	if !providers.Enabled {
 		return clierrors.Message("The credentials for cloud provider %q could not be found.", r.Kind)
 	}
-	err = r.Output.WriteFormatted(r.Format, providers, objectformats.GetCloudProviderTableFormat(r.Kind))
+	err = r.Output.WriteFormatted(r.Format, providers, credentialFormat(r.Kind))
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/credential/show/show_test.go
+++ b/pkg/cli/cmd/credential/show/show_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/radius-project/radius/pkg/cli/connections"
 	cli_credential "github.com/radius-project/radius/pkg/cli/credential"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/test/radcli"
@@ -141,7 +140,7 @@ func Test_Run(t *testing.T) {
 				output.FormattedOutput{
 					Format:  "table",
 					Obj:     provider,
-					Options: objectformats.GetCloudProviderTableFormat(runner.Kind),
+					Options: credentialFormat(runner.Kind),
 				},
 			}
 			require.Equal(t, expected, outputSink.Writes)
@@ -208,7 +207,7 @@ func Test_Run(t *testing.T) {
 				output.FormattedOutput{
 					Format:  "table",
 					Obj:     provider,
-					Options: objectformats.GetCloudProviderTableFormat(runner.Kind),
+					Options: credentialFormat(runner.Kind),
 				},
 			}
 			require.Equal(t, expected, outputSink.Writes)

--- a/pkg/cli/cmd/env/update/objectformats.go
+++ b/pkg/cli/cmd/env/update/objectformats.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package update
+
+import "github.com/radius-project/radius/pkg/cli/output"
+
+type environmentForDisplay struct {
+	Name        string
+	ComputeKind string
+	Recipes     int
+	Providers   int
+}
+
+// environmentFormat returns a FormatterOptions object containing the column headings and JSONPaths for the
+// environment table.
+func environmentFormat() output.FormatterOptions {
+	return output.FormatterOptions{
+		Columns: []output.Column{
+			{
+				Heading:  "NAME",
+				JSONPath: "{ .Name }",
+			},
+			{
+				Heading:  "COMPUTE",
+				JSONPath: "{ .ComputeKind }",
+			},
+			{
+				Heading:  "RECIPES",
+				JSONPath: "{ .Recipes }",
+			},
+			{
+				Heading:  "PROVIDERS",
+				JSONPath: "{ .Providers }",
+			},
+		},
+	}
+}

--- a/pkg/cli/cmd/env/update/objectformats_test.go
+++ b/pkg/cli/cmd/env/update/objectformats_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package update
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_environmentFormat(t *testing.T) {
+	obj := environmentForDisplay{
+		Name:        "test_env_resource",
+		ComputeKind: "kubernetes",
+		Recipes:     3,
+		Providers:   2,
+	}
+
+	buffer := &bytes.Buffer{}
+	err := output.Write(output.FormatTable, obj, buffer, environmentFormat())
+	require.NoError(t, err)
+
+	expected := "NAME               COMPUTE     RECIPES   PROVIDERS\ntest_env_resource  kubernetes  3         2\n"
+	require.Equal(t, expected, buffer.String())
+}

--- a/pkg/cli/cmd/env/update/update.go
+++ b/pkg/cli/cmd/env/update/update.go
@@ -27,7 +27,6 @@ import (
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	corerp "github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
@@ -253,14 +252,14 @@ func (r *Runner) Run(ctx context.Context) error {
 	if env.Properties.Compute != nil {
 		computeKind = *env.Properties.Compute.GetEnvironmentCompute().Kind
 	}
-	obj := objectformats.OutputEnvObject{
-		EnvName:     *env.Name,
+	obj := environmentForDisplay{
+		Name:        *env.Name,
 		ComputeKind: computeKind,
 		Recipes:     recipeCount,
 		Providers:   providerCount,
 	}
 
-	err = r.Output.WriteFormatted("table", obj, objectformats.GetUpdateEnvironmentTableFormat())
+	err = r.Output.WriteFormatted("table", obj, environmentFormat())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/env/update/update_test.go
+++ b/pkg/cli/cmd/env/update/update_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/radius-project/radius/pkg/cli/clierrors"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	corerp "github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
@@ -336,8 +335,8 @@ func Test_Update(t *testing.T) {
 		require.NoError(t, err)
 
 		environment.Properties.Providers = testProviders
-		obj := objectformats.OutputEnvObject{
-			EnvName:     "test-env",
+		obj := environmentForDisplay{
+			Name:        "test-env",
 			Recipes:     0,
 			Providers:   2,
 			ComputeKind: "kubernetes",
@@ -350,7 +349,7 @@ func Test_Update(t *testing.T) {
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     obj,
-				Options: objectformats.GetUpdateEnvironmentTableFormat(),
+				Options: environmentFormat(),
 			},
 			output.LogOutput{
 				Format: "Successfully updated environment %q.",
@@ -513,8 +512,8 @@ func Test_Update(t *testing.T) {
 					return numberOfProviders
 				}
 
-				obj := objectformats.OutputEnvObject{
-					EnvName:   "test-env",
+				obj := environmentForDisplay{
+					Name:      "test-env",
 					Recipes:   0,
 					Providers: numberOfProviders(),
 				}
@@ -526,7 +525,7 @@ func Test_Update(t *testing.T) {
 					output.FormattedOutput{
 						Format:  "table",
 						Obj:     obj,
-						Options: objectformats.GetUpdateEnvironmentTableFormat(),
+						Options: environmentFormat(),
 					},
 					output.LogOutput{
 						Format: "Successfully updated environment %q.",

--- a/pkg/cli/cmd/group/common/objectformats.go
+++ b/pkg/cli/cmd/group/common/objectformats.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import "github.com/radius-project/radius/pkg/cli/output"
+
+// ResourceGroupFormat returns a FormatterOptions object containing a list of columns with their headings and JSONPaths.
+func ResourceGroupFormat() output.FormatterOptions {
+	return output.FormatterOptions{
+		Columns: []output.Column{
+			{
+				Heading:  "GROUP",
+				JSONPath: "{ .Name }",
+			},
+			{
+				Heading:  "ID",
+				JSONPath: "{ .ID }",
+			},
+		},
+	}
+}

--- a/pkg/cli/cmd/group/common/objectformats_test.go
+++ b/pkg/cli/cmd/group/common/objectformats_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/radius-project/radius/pkg/to"
+	ucpv20231001preview "github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ResourceGroupFormat(t *testing.T) {
+	obj := ucpv20231001preview.ResourceGroupResource{
+		Name: to.Ptr("test"),
+		ID:   to.Ptr("/planes/radius/local/resourceGroups/test-group"),
+	}
+
+	buffer := &bytes.Buffer{}
+	err := output.Write(output.FormatTable, obj, buffer, ResourceGroupFormat())
+	require.NoError(t, err)
+
+	expected := "GROUP     ID\ntest      /planes/radius/local/resourceGroups/test-group\n"
+	require.Equal(t, expected, buffer.String())
+}

--- a/pkg/cli/cmd/group/list/list.go
+++ b/pkg/cli/cmd/group/list/list.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/radius-project/radius/pkg/cli"
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
+	"github.com/radius-project/radius/pkg/cli/cmd/group/common"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/spf13/cobra"
@@ -119,5 +119,5 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	return r.Output.WriteFormatted(r.Format, resourceGroupDetails, objectformats.GetResourceGroupTableFormat())
+	return r.Output.WriteFormatted(r.Format, resourceGroupDetails, common.ResourceGroupFormat())
 }

--- a/pkg/cli/cmd/group/list/list_test.go
+++ b/pkg/cli/cmd/group/list/list_test.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/radius-project/radius/pkg/cli/clients"
+	"github.com/radius-project/radius/pkg/cli/cmd/group/common"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/pkg/to"
@@ -131,7 +131,7 @@ func Test_Run(t *testing.T) {
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     groups,
-				Options: objectformats.GetResourceGroupTableFormat(),
+				Options: common.ResourceGroupFormat(),
 			},
 		}
 

--- a/pkg/cli/cmd/group/show/show.go
+++ b/pkg/cli/cmd/group/show/show.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/radius-project/radius/pkg/cli"
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
+	"github.com/radius-project/radius/pkg/cli/cmd/group/common"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/spf13/cobra"
@@ -128,7 +128,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	err = r.Output.WriteFormatted(r.Format, resourceGroup, objectformats.GetResourceGroupTableFormat())
+	err = r.Output.WriteFormatted(r.Format, resourceGroup, common.ResourceGroupFormat())
 
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/group/show/show_test.go
+++ b/pkg/cli/cmd/group/show/show_test.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/radius-project/radius/pkg/cli/clients"
+	"github.com/radius-project/radius/pkg/cli/cmd/group/common"
 
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
@@ -118,7 +118,7 @@ func Test_Run(t *testing.T) {
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     resourceGroup,
-				Options: objectformats.GetResourceGroupTableFormat(),
+				Options: common.ResourceGroupFormat(),
 			},
 		}
 		require.Equal(t, expected, outputSink.Writes)

--- a/pkg/cli/cmd/recipe/common/objectformats.go
+++ b/pkg/cli/cmd/recipe/common/objectformats.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"github.com/radius-project/radius/pkg/cli/output"
+)
+
+// RecipeFormat returns a FormatterOptions struct containing a list of Columns with their respective
+// Headings and JSONPaths to be used for formatting the output of environment recipes.
+func RecipeFormat() output.FormatterOptions {
+	return output.FormatterOptions{
+		Columns: []output.Column{
+			{
+				Heading:  "RECIPE",
+				JSONPath: "{ .Name }",
+			},
+			{
+				Heading:  "TYPE",
+				JSONPath: "{ .ResourceType }",
+			},
+			{
+				Heading:  "TEMPLATE KIND",
+				JSONPath: "{ .TemplateKind }",
+			},
+			{
+				Heading:  "TEMPLATE VERSION",
+				JSONPath: "{ .TemplateVersion }",
+			},
+			{
+				Heading:  "TEMPLATE",
+				JSONPath: "{ .TemplatePath }",
+			},
+		},
+	}
+}
+
+// RecipeParametersFormat returns a FormatterOptions struct containing the column headings and JSONPaths for the
+// recipe parameters table.
+func RecipeParametersFormat() output.FormatterOptions {
+	return output.FormatterOptions{
+		Columns: []output.Column{
+			{
+				Heading:  "PARAMETER",
+				JSONPath: "{ .Name }",
+			},
+			{
+				Heading:  "TYPE",
+				JSONPath: "{ .Type }",
+			},
+			{
+				Heading:  "DEFAULT VALUE",
+				JSONPath: "{ .DefaultValue }",
+			},
+			{
+				Heading:  "MIN",
+				JSONPath: "{ .MinValue }",
+			},
+			{
+				Heading:  "MAX",
+				JSONPath: "{ .MaxValue }",
+			},
+		},
+	}
+}

--- a/pkg/cli/cmd/recipe/common/objectformats_test.go
+++ b/pkg/cli/cmd/recipe/common/objectformats_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"bytes"
+	"testing"
+
+	types "github.com/radius-project/radius/pkg/cli/cmd/recipe"
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_RecipeFormat(t *testing.T) {
+	obj := types.EnvironmentRecipe{
+		Name:            "test",
+		ResourceType:    "test-type",
+		TemplateKind:    "test-kind",
+		TemplatePath:    "test-path",
+		TemplateVersion: "test-version",
+	}
+
+	buffer := &bytes.Buffer{}
+	err := output.Write(output.FormatTable, obj, buffer, RecipeFormat())
+	require.NoError(t, err)
+
+	expected := "RECIPE    TYPE       TEMPLATE KIND  TEMPLATE VERSION  TEMPLATE\ntest      test-type  test-kind      test-version      test-path\n"
+	require.Equal(t, expected, buffer.String())
+}
+
+func Test_RecipeParametersFormat(t *testing.T) {
+	obj := types.RecipeParameter{
+		Name:         "test",
+		DefaultValue: 1,
+		Type:         "test-type",
+		MaxValue:     "3",
+		MinValue:     "4",
+	}
+
+	buffer := &bytes.Buffer{}
+	err := output.Write(output.FormatTable, obj, buffer, RecipeParametersFormat())
+	require.NoError(t, err)
+
+	expected := "PARAMETER  TYPE       DEFAULT VALUE  MIN       MAX\ntest       test-type  1              4         3\n"
+	require.Equal(t, expected, buffer.String())
+}

--- a/pkg/cli/cmd/recipe/list/list.go
+++ b/pkg/cli/cmd/recipe/list/list.go
@@ -23,9 +23,9 @@ import (
 	"github.com/radius-project/radius/pkg/cli"
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
 	types "github.com/radius-project/radius/pkg/cli/cmd/recipe"
+	"github.com/radius-project/radius/pkg/cli/cmd/recipe/common"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	corerp "github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
@@ -145,7 +145,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	sort.Slice(envRecipes, func(i, j int) bool {
 		return envRecipes[i].Name < envRecipes[j].Name
 	})
-	err = r.Output.WriteFormatted(r.Format, envRecipes, objectformats.GetEnvironmentRecipesTableFormat())
+	err = r.Output.WriteFormatted(r.Format, envRecipes, common.RecipeFormat())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/recipe/list/list_test.go
+++ b/pkg/cli/cmd/recipe/list/list_test.go
@@ -25,9 +25,9 @@ import (
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/cli/clients"
 	types "github.com/radius-project/radius/pkg/cli/cmd/recipe"
+	"github.com/radius-project/radius/pkg/cli/cmd/recipe/common"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
@@ -154,7 +154,7 @@ func Test_Run(t *testing.T) {
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     recipes,
-				Options: objectformats.GetEnvironmentRecipesTableFormat(),
+				Options: common.RecipeFormat(),
 			},
 		}
 		require.Equal(t, expected, outputSink.Writes)

--- a/pkg/cli/cmd/recipe/show/show.go
+++ b/pkg/cli/cmd/recipe/show/show.go
@@ -24,9 +24,9 @@ import (
 	"github.com/radius-project/radius/pkg/cli"
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
 	types "github.com/radius-project/radius/pkg/cli/cmd/recipe"
+	"github.com/radius-project/radius/pkg/cli/cmd/recipe/common"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
@@ -171,19 +171,19 @@ func (r *Runner) Run(ctx context.Context) error {
 		recipe.PlainHTTP = *recipeDetails.PlainHTTP
 	}
 
-	err = r.Output.WriteFormatted(r.Format, recipe, objectformats.GetEnvironmentRecipesTableFormat())
+	err = r.Output.WriteFormatted(r.Format, recipe, common.RecipeFormat())
 	if err != nil {
 		return err
 	}
 
 	r.Output.LogInfo("")
 
-	var recipeParams []RecipeParameter
+	var recipeParams []types.RecipeParameter
 
 	for parameter := range recipeDetails.Parameters {
 		values := recipeDetails.Parameters[parameter].(map[string]any)
 
-		paramItem := RecipeParameter{
+		paramItem := types.RecipeParameter{
 			Name:         parameter,
 			DefaultValue: "-",
 			MaxValue:     "-",
@@ -211,7 +211,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		return recipeParams[i].Name > recipeParams[j].Name
 	})
 
-	err = r.Output.WriteFormatted(r.Format, recipeParams, objectformats.GetRecipeParamsTableFormat())
+	err = r.Output.WriteFormatted(r.Format, recipeParams, common.RecipeParametersFormat())
 	if err != nil {
 		return err
 	}
@@ -221,12 +221,4 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-type RecipeParameter struct {
-	Name         string      `json:"name,omitempty"`
-	DefaultValue interface{} `json:"defaultValue,omitempty"`
-	Type         string      `json:"type,omitempty"`
-	MaxValue     string      `json:"maxValue,omitempty"`
-	MinValue     string      `json:"minValue,omitempty"`
 }

--- a/pkg/cli/cmd/recipe/show/show_test.go
+++ b/pkg/cli/cmd/recipe/show/show_test.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/radius-project/radius/pkg/cli/clients"
 	types "github.com/radius-project/radius/pkg/cli/cmd/recipe"
+	"github.com/radius-project/radius/pkg/cli/cmd/recipe/common"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
@@ -115,7 +115,7 @@ func Test_Run(t *testing.T) {
 			TemplateKind: recipes.TemplateKindBicep,
 			TemplatePath: "ghcr.io/testpublicrecipe/bicep/modules/mongodatabases:v1",
 		}
-		recipeParams := []RecipeParameter{
+		recipeParams := []types.RecipeParameter{
 			{
 				Name:         "throughput",
 				Type:         "float64",
@@ -155,7 +155,7 @@ func Test_Run(t *testing.T) {
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     recipe,
-				Options: objectformats.GetEnvironmentRecipesTableFormat(),
+				Options: common.RecipeFormat(),
 			},
 			output.LogOutput{
 				Format: "",
@@ -163,7 +163,7 @@ func Test_Run(t *testing.T) {
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     recipeParams,
-				Options: objectformats.GetRecipeParamsTableFormat(),
+				Options: common.RecipeParametersFormat(),
 			},
 		}
 		require.Equal(t, expected, outputSink.Writes)
@@ -192,7 +192,7 @@ func Test_Run(t *testing.T) {
 			TemplatePath: "localhost:8000/mongodatabases:v1",
 			PlainHTTP:    true,
 		}
-		recipeParams := []RecipeParameter{
+		recipeParams := []types.RecipeParameter{
 			{
 				Name:         "throughput",
 				Type:         "float64",
@@ -232,7 +232,7 @@ func Test_Run(t *testing.T) {
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     recipe,
-				Options: objectformats.GetEnvironmentRecipesTableFormat(),
+				Options: common.RecipeFormat(),
 			},
 			output.LogOutput{
 				Format: "",
@@ -240,7 +240,7 @@ func Test_Run(t *testing.T) {
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     recipeParams,
-				Options: objectformats.GetRecipeParamsTableFormat(),
+				Options: common.RecipeParametersFormat(),
 			},
 		}
 		require.Equal(t, expected, outputSink.Writes)
@@ -269,7 +269,7 @@ func Test_Run(t *testing.T) {
 			TemplatePath:    "Azure/cosmosdb/azurerm",
 			TemplateVersion: "1.1.0",
 		}
-		recipeParams := []RecipeParameter{
+		recipeParams := []types.RecipeParameter{
 			{
 				Name:         "throughput",
 				Type:         "float64",
@@ -309,7 +309,7 @@ func Test_Run(t *testing.T) {
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     recipe,
-				Options: objectformats.GetEnvironmentRecipesTableFormat(),
+				Options: common.RecipeFormat(),
 			},
 			output.LogOutput{
 				Format: "",
@@ -317,7 +317,7 @@ func Test_Run(t *testing.T) {
 			output.FormattedOutput{
 				Format:  "table",
 				Obj:     recipeParams,
-				Options: objectformats.GetRecipeParamsTableFormat(),
+				Options: common.RecipeParametersFormat(),
 			},
 		}
 		require.Equal(t, expected, outputSink.Writes)

--- a/pkg/cli/cmd/recipe/types.go
+++ b/pkg/cli/cmd/recipe/types.go
@@ -24,3 +24,11 @@ type EnvironmentRecipe struct {
 	TemplateVersion string `json:"templateVersion"`
 	PlainHTTP       bool   `json:"plainHTTP"`
 }
+
+type RecipeParameter struct {
+	Name         string      `json:"name,omitempty"`
+	DefaultValue interface{} `json:"defaultValue,omitempty"`
+	Type         string      `json:"type,omitempty"`
+	MaxValue     string      `json:"maxValue,omitempty"`
+	MinValue     string      `json:"minValue,omitempty"`
+}

--- a/pkg/cli/cmd/workspace/common/objectformats.go
+++ b/pkg/cli/cmd/workspace/common/objectformats.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"github.com/radius-project/radius/pkg/cli/objectformats"
+	"github.com/radius-project/radius/pkg/cli/output"
+)
+
+// WorkspaceFormat returns a FormatterOptions object which contains a list of columns to be used for displaying
+// workspace information such as name, kind, kubecontext and environment."
+func WorkspaceFormat() output.FormatterOptions {
+	return output.FormatterOptions{
+		Columns: []output.Column{
+			{
+				Heading:  "WORKSPACE",
+				JSONPath: "{ .Name }",
+			},
+			{
+				Heading:  "KIND",
+				JSONPath: "{ .Connection.kind }",
+			},
+			{
+				Heading:  "KUBECONTEXT",
+				JSONPath: "{ .Connection.context }",
+			},
+			{
+				Heading:     "ENVIRONMENT",
+				JSONPath:    "{ .Environment }",
+				Transformer: &objectformats.ResourceIDToResourceNameTransformer{},
+			},
+		},
+	}
+}

--- a/pkg/cli/cmd/workspace/common/objectformats_test.go
+++ b/pkg/cli/cmd/workspace/common/objectformats_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/radius-project/radius/pkg/cli/workspaces"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_WorkspaceFormat(t *testing.T) {
+	obj := workspaces.Workspace{
+		Name: "test",
+		Connection: map[string]any{
+			"kind":    workspaces.KindKubernetes,
+			"context": "test-context",
+		},
+		Environment: "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/environments/test",
+	}
+
+	buffer := &bytes.Buffer{}
+	err := output.Write(output.FormatTable, obj, buffer, WorkspaceFormat())
+	require.NoError(t, err)
+
+	expected := "WORKSPACE  KIND        KUBECONTEXT   ENVIRONMENT\ntest       kubernetes  test-context  test\n"
+	require.Equal(t, expected, buffer.String())
+}

--- a/pkg/cli/cmd/workspace/list/list.go
+++ b/pkg/cli/cmd/workspace/list/list.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/radius-project/radius/pkg/cli"
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
+	"github.com/radius-project/radius/pkg/cli/cmd/workspace/common"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/spf13/cobra"
@@ -105,7 +105,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		items = append(items, section.Items[name])
 	}
 
-	err = r.Output.WriteFormatted(r.Format, items, objectformats.GetWorkspaceTableFormat())
+	err = r.Output.WriteFormatted(r.Format, items, common.WorkspaceFormat())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/workspace/list/list_test.go
+++ b/pkg/cli/cmd/workspace/list/list_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli"
+	"github.com/radius-project/radius/pkg/cli/cmd/workspace/common"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/test/radcli"
@@ -108,7 +108,7 @@ func Test_Run(t *testing.T) {
 						Connection:  map[string]any{},
 					},
 				},
-				Options: objectformats.GetWorkspaceTableFormat(),
+				Options: common.WorkspaceFormat(),
 			},
 		}
 

--- a/pkg/cli/cmd/workspace/show/show.go
+++ b/pkg/cli/cmd/workspace/show/show.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/radius-project/radius/pkg/cli"
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
+	"github.com/radius-project/radius/pkg/cli/cmd/workspace/common"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/spf13/cobra"
@@ -99,7 +99,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 
 // Run runs the `rad workspace show` command.
 func (r *Runner) Run(ctx context.Context) error {
-	err := r.Output.WriteFormatted(r.Format, r.Workspace, objectformats.GetWorkspaceTableFormat())
+	err := r.Output.WriteFormatted(r.Format, r.Workspace, common.WorkspaceFormat())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/workspace/show/show_test.go
+++ b/pkg/cli/cmd/workspace/show/show_test.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/radius-project/radius/pkg/cli/cmd/workspace/common"
 	"github.com/radius-project/radius/pkg/cli/framework"
-	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/test/radcli"
@@ -107,7 +107,7 @@ func Test_Run(t *testing.T) {
 					Environment: "test-environment",
 					Connection:  map[string]any{},
 				},
-				Options: objectformats.GetWorkspaceTableFormat(),
+				Options: common.WorkspaceFormat(),
 			},
 		}
 
@@ -130,7 +130,7 @@ func Test_Run(t *testing.T) {
 			output.FormattedOutput{
 				Format:  "",
 				Obj:     runner.Workspace,
-				Options: objectformats.GetWorkspaceTableFormat(),
+				Options: common.WorkspaceFormat(),
 			},
 		}
 

--- a/pkg/cli/objectformats/objectformats.go
+++ b/pkg/cli/objectformats/objectformats.go
@@ -17,43 +17,8 @@ limitations under the License.
 package objectformats
 
 import (
-	"strings"
-
 	"github.com/radius-project/radius/pkg/cli/output"
 )
-
-// GetApplicationStatusTableFormat() sets up the columns and headings for a table to display application names and resource counts.
-func GetApplicationStatusTableFormat() output.FormatterOptions {
-	return output.FormatterOptions{
-		Columns: []output.Column{
-			{
-				Heading:  "APPLICATION",
-				JSONPath: "{ .Name }",
-			},
-			{
-				Heading:  "RESOURCES",
-				JSONPath: "{ .ResourceCount }",
-			},
-		},
-	}
-}
-
-// GetApplicationGatewaysTableFormat() returns a FormatterOptions object which contains a list of columns to be used for
-// formatting the output of a list of application gateways.
-func GetApplicationGatewaysTableFormat() output.FormatterOptions {
-	return output.FormatterOptions{
-		Columns: []output.Column{
-			{
-				Heading:  "GATEWAY",
-				JSONPath: "{ .Name }",
-			},
-			{
-				Heading:  "ENDPOINT",
-				JSONPath: "{ .Endpoint }",
-			},
-		},
-	}
-}
 
 // GetResourceTableFormat returns the fields to output from a resource object.
 // This function should be used with the generated CoreRP and other portable resource types.
@@ -67,6 +32,11 @@ func GetResourceTableFormat() output.FormatterOptions {
 			{
 				Heading:  "TYPE",
 				JSONPath: "{ .Type }",
+			},
+			{
+				Heading:     "GROUP",
+				JSONPath:    "{ .ID }",
+				Transformer: &ResourceIDToResourceGroupNameTransformer{},
 			},
 			{
 				Heading:  "STATE",
@@ -92,229 +62,13 @@ func GetGenericResourceTableFormat() output.FormatterOptions {
 				JSONPath: "{ .Type }",
 			},
 			{
+				Heading:     "GROUP",
+				JSONPath:    "{ .ID }",
+				Transformer: &ResourceIDToResourceGroupNameTransformer{},
+			},
+			{
 				Heading:  "STATE",
 				JSONPath: "{ .Properties.provisioningState }",
-			},
-		},
-	}
-}
-
-// GetResourceGroupTableFormat() returns a FormatterOptions object containing a list of columns with their headings and JSONPaths.
-func GetResourceGroupTableFormat() output.FormatterOptions {
-	return output.FormatterOptions{
-		Columns: []output.Column{
-			{
-				Heading:  "ID",
-				JSONPath: "{ .ID }",
-			},
-			{
-				Heading:  "NAME",
-				JSONPath: "{ .Name }",
-			},
-		},
-	}
-}
-
-// GetGenericEnvironmentTableFormat returns a FormatterOptions struct containing a slice of Columns, each of which
-// contains a Heading and JSONPath.
-func GetGenericEnvironmentTableFormat() output.FormatterOptions {
-	return output.FormatterOptions{
-		Columns: []output.Column{
-			{
-				Heading:  "NAME",
-				JSONPath: "{ .Name }",
-			},
-		},
-	}
-}
-
-// GetGenericEnvErrorTableFormat() returns a FormatterOptions struct containing a single column with the heading "errors:"
-// and a JSONPath to the Errors field.
-func GetGenericEnvErrorTableFormat() output.FormatterOptions {
-	return output.FormatterOptions{
-		Columns: []output.Column{
-			{
-				Heading:  "errors:",
-				JSONPath: "{ .Errors }",
-			},
-		},
-	}
-}
-
-// "GetWorkspaceTableFormat() returns a FormatterOptions object which contains a list of columns to be used for displaying
-// workspace information such as name, kind, kubecontext and environment."
-func GetWorkspaceTableFormat() output.FormatterOptions {
-	return output.FormatterOptions{
-		Columns: []output.Column{
-			{
-				Heading:  "WORKSPACE",
-				JSONPath: "{ .Name }",
-			},
-			{
-				Heading:  "KIND",
-				JSONPath: "{ .Connection.kind }",
-			},
-			{
-				Heading:  "KUBECONTEXT",
-				JSONPath: "{ .Connection.context }",
-			},
-			{
-				Heading:  "ENVIRONMENT",
-				JSONPath: "{ .Environment }",
-			},
-		},
-	}
-}
-
-// CloudProviderTableFormat() configures the output format of a table to display the Name and Status of a cloud provider.
-func CloudProviderTableFormat() output.FormatterOptions {
-	return output.FormatterOptions{
-		Columns: []output.Column{
-			{
-				Heading:  "NAME",
-				JSONPath: "{ .Name }",
-			},
-			{
-				Heading:  "REGISTERED",
-				JSONPath: "{ .Enabled }",
-			},
-		},
-	}
-}
-
-// GetCloudProviderTableFormat function returns a FormatterOptions struct based on the credentialType parameter, which can
-// be either "azure" or "aws".
-func GetCloudProviderTableFormat(credentialType string) output.FormatterOptions {
-	if strings.EqualFold(credentialType, "azure") {
-		return output.FormatterOptions{
-			Columns: []output.Column{
-				{
-					Heading:  "NAME",
-					JSONPath: "{ .Name }",
-				},
-				{
-					Heading:  "REGISTERED",
-					JSONPath: "{ .Enabled }",
-				},
-				{
-					Heading:  "CLIENTID",
-					JSONPath: "{ .AzureCredentials.ClientID }",
-				},
-				{
-					Heading:  "TENANTID",
-					JSONPath: "{ .AzureCredentials.TenantID }",
-				},
-			},
-		}
-	} else if strings.EqualFold(credentialType, "aws") {
-		return output.FormatterOptions{
-			Columns: []output.Column{
-				{
-					Heading:  "NAME",
-					JSONPath: "{ .Name }",
-				},
-				{
-					Heading:  "REGISTERED",
-					JSONPath: "{ .Enabled }",
-				},
-				{
-					Heading:  "ACCESSKEYID",
-					JSONPath: "{ .AWSCredentials.AccessKeyID }",
-				},
-			},
-		}
-	}
-	return output.FormatterOptions{}
-}
-
-// GetEnvironmentRecipesTableFormat() returns a FormatterOptions struct containing a list of Columns with their respective
-// Headings and JSONPaths to be used for formatting the output of environment recipes.
-func GetEnvironmentRecipesTableFormat() output.FormatterOptions {
-	return output.FormatterOptions{
-		Columns: []output.Column{
-			{
-				Heading:  "NAME",
-				JSONPath: "{ .Name }",
-			},
-			{
-				Heading:  "TYPE",
-				JSONPath: "{ .ResourceType }",
-			},
-			{
-				Heading:  "TEMPLATE KIND",
-				JSONPath: "{ .TemplateKind }",
-			},
-			{
-				Heading:  "TEMPLATE VERSION",
-				JSONPath: "{ .TemplateVersion }",
-			},
-			{
-				Heading:  "TEMPLATE",
-				JSONPath: "{ .TemplatePath }",
-			},
-		},
-	}
-}
-
-type OutputEnvObject struct {
-	EnvName     string
-	ComputeKind string
-	Recipes     int
-	Providers   int
-}
-
-// GetUpdateEnvironmentTableFormat returns the fields to output from env object after upation.
-//
-
-// GetUpdateEnvironmentTableFormat() returns a FormatterOptions object containing the column headings and JSONPaths for the
-// environment table.
-func GetUpdateEnvironmentTableFormat() output.FormatterOptions {
-	return output.FormatterOptions{
-		Columns: []output.Column{
-			{
-				Heading:  "NAME",
-				JSONPath: "{ .EnvName }",
-			},
-			{
-				Heading:  "COMPUTE",
-				JSONPath: "{ .ComputeKind }",
-			},
-			{
-				Heading:  "RECIPES",
-				JSONPath: "{ .Recipes }",
-			},
-			{
-				Heading:  "PROVIDERS",
-				JSONPath: "{ .Providers }",
-			},
-		},
-	}
-}
-
-// GetRecipeParamsTableFormat returns a FormatterOptions struct containing the column headings and JSONPaths for the
-// recipe parameters table.
-func GetRecipeParamsTableFormat() output.FormatterOptions {
-	return output.FormatterOptions{
-		Columns: []output.Column{
-			{
-				Heading:  "PARAMETER NAME",
-				JSONPath: "{ .Name }",
-			},
-			{
-				Heading:  "TYPE",
-				JSONPath: "{ .Type }",
-			},
-			{
-				Heading:  "DEFAULT VALUE",
-				JSONPath: "{ .DefaultValue }",
-			},
-			{
-				Heading:  "MIN",
-				JSONPath: "{ .MinValue }",
-			},
-			{
-				Heading:  "MAX",
-				JSONPath: "{ .MaxValue }",
 			},
 		},
 	}

--- a/pkg/cli/objectformats/objectformats_test.go
+++ b/pkg/cli/objectformats/objectformats_test.go
@@ -20,37 +20,45 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
 	"github.com/radius-project/radius/pkg/cli/output"
-	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
+	corerpv20231001preview "github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
 	"github.com/radius-project/radius/pkg/to"
 	"github.com/stretchr/testify/require"
 )
 
-func Test_GenericEnvTableFormat(t *testing.T) {
-	obj := v20231001preview.EnvironmentResource{
-		Name: to.Ptr("test_env_resource"),
+func Test_GetResourceTableFormat(t *testing.T) {
+	obj := corerpv20231001preview.EnvironmentResource{
+		Name: to.Ptr("test"),
+		Type: to.Ptr("test-type"),
+		ID:   to.Ptr("/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/environments/test"),
+		Properties: &corerpv20231001preview.EnvironmentProperties{
+			ProvisioningState: to.Ptr(corerpv20231001preview.ProvisioningStateUpdating),
+		},
 	}
 
 	buffer := &bytes.Buffer{}
-	err := output.Write(output.FormatTable, obj, buffer, GetGenericEnvironmentTableFormat())
+	err := output.Write(output.FormatTable, obj, buffer, GetResourceTableFormat())
 	require.NoError(t, err)
 
-	expected := "NAME\ntest_env_resource\n"
+	expected := "RESOURCE  TYPE       GROUP       STATE\ntest      test-type  test-group  Updating\n"
 	require.Equal(t, expected, buffer.String())
 }
 
-func Test_EnvTableFormat(t *testing.T) {
-	obj := OutputEnvObject{
-		EnvName:     "test_env_resource",
-		ComputeKind: "kubernetes",
-		Recipes:     3,
-		Providers:   2,
+func Test_GetGenericResourceTableFormat(t *testing.T) {
+	obj := generated.GenericResource{
+		Name: to.Ptr("test"),
+		Type: to.Ptr("test-type"),
+		ID:   to.Ptr("/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/environments/test"),
+		Properties: map[string]any{
+			"provisioningState": corerpv20231001preview.ProvisioningStateUpdating,
+		},
 	}
 
 	buffer := &bytes.Buffer{}
-	err := output.Write(output.FormatTable, obj, buffer, GetUpdateEnvironmentTableFormat())
+	err := output.Write(output.FormatTable, obj, buffer, GetGenericResourceTableFormat())
 	require.NoError(t, err)
 
-	expected := "NAME               COMPUTE     RECIPES   PROVIDERS\ntest_env_resource  kubernetes  3         2\n"
+	expected := "RESOURCE  TYPE       GROUP       STATE\ntest      test-type  test-group  Updating\n"
 	require.Equal(t, expected, buffer.String())
 }

--- a/pkg/cli/objectformats/transformers.go
+++ b/pkg/cli/objectformats/transformers.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objectformats
+
+import (
+	"github.com/radius-project/radius/pkg/ucp/resources"
+	"github.com/radius-project/radius/pkg/ucp/resources/radius"
+)
+
+// ResourceIDToResourceGroupNameTransformer is a transformer that takes a resource ID and returns the resource group name.
+type ResourceIDToResourceGroupNameTransformer struct {
+}
+
+// Transform takes a resource ID and returns the resource group name.
+func (t *ResourceIDToResourceGroupNameTransformer) Transform(input string) string {
+	if input == "" {
+		return ""
+	}
+
+	// NOTE: this is for display to human users in a table. It's not a great place
+	// for us to put a long explanation.
+	id, err := resources.ParseResource(input)
+	if err != nil {
+		return "<error>"
+	}
+
+	return id.FindScope(radius.ScopeResourceGroups)
+}
+
+// ResourceIDToResourceNameTransformer is a transformer that takes a resource ID and returns the resource name.
+type ResourceIDToResourceNameTransformer struct {
+}
+
+// Transform takes a resource ID and returns the resource name.
+func (t *ResourceIDToResourceNameTransformer) Transform(input string) string {
+	if input == "" {
+		return ""
+	}
+
+	// NOTE: this is for display to human users in a table. It's not a great place
+	// for us to put a long explanation.
+	id, err := resources.ParseResource(input)
+	if err != nil {
+		return "<error>"
+	}
+
+	return id.Name()
+}

--- a/pkg/cli/objectformats/transformers_test.go
+++ b/pkg/cli/objectformats/transformers_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objectformats
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ResourceIDToResourceNameTransformer(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "invalid input",
+			input:    "////",
+			expected: "<error>",
+		},
+		{
+			name:     "valid input",
+			input:    "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/environments/test",
+			expected: "test",
+		},
+	}
+
+	for _, testcase := range cases {
+		t.Run(testcase.name, func(t *testing.T) {
+			transformer := &ResourceIDToResourceNameTransformer{}
+			actual := transformer.Transform(testcase.input)
+			require.Equal(t, testcase.expected, actual)
+		})
+	}
+}
+
+func Test_ResourceIDToResourceGroupNameTransformer(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "invalid input",
+			input:    "////",
+			expected: "<error>",
+		},
+		{
+			name:     "valid input",
+			input:    "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/environments/test",
+			expected: "test-group",
+		},
+	}
+
+	for _, testcase := range cases {
+		t.Run(testcase.name, func(t *testing.T) {
+			transformer := &ResourceIDToResourceGroupNameTransformer{}
+			actual := transformer.Transform(testcase.input)
+			require.Equal(t, testcase.expected, actual)
+		})
+	}
+}

--- a/pkg/cli/output/formatter.go
+++ b/pkg/cli/output/formatter.go
@@ -31,7 +31,14 @@ type FormatterOptions struct {
 type Column struct {
 	Heading     string
 	JSONPath    string
-	Transformer func(string) string
+	Transformer ColumnTransformer
+}
+
+// ColumnTransformer is an interface for transforming a column value for display.
+//
+// NOTE: this is an interface so that we can easily compare data in tests.
+type ColumnTransformer interface {
+	Transform(input string) string
 }
 
 type Formatter interface {

--- a/pkg/cli/output/table.go
+++ b/pkg/cli/output/table.go
@@ -52,7 +52,7 @@ func (f *TableFormatter) Format(obj any, writer io.Writer, options FormatterOpti
 
 	headings := []string{}
 	parsers := []*jsonpath.JSONPath{}
-	transformers := []func(string) string{}
+	transformers := []ColumnTransformer{}
 	for _, c := range options.Columns {
 		headings = append(headings, c.Heading)
 
@@ -86,7 +86,7 @@ func (f *TableFormatter) Format(obj any, writer io.Writer, options FormatterOpti
 
 			text := buf.String()
 			if transformer != nil {
-				text = transformer(text)
+				text = transformer.Transform(text)
 			}
 
 			lines := strings.Split(text, "\n")

--- a/pkg/cli/output/table_test.go
+++ b/pkg/cli/output/table_test.go
@@ -51,9 +51,16 @@ var tableInputOptions = FormatterOptions{
 		{
 			Heading:     "Lowered",
 			JSONPath:    "Some-Value",
-			Transformer: strings.ToLower,
+			Transformer: &lowercaseTransformer{},
 		},
 	},
+}
+
+type lowercaseTransformer struct {
+}
+
+func (l *lowercaseTransformer) Transform(input string) string {
+	return strings.ToLower(input)
 }
 
 func Test_Table_NoColumns(t *testing.T) {

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
+	"github.com/radius-project/radius/pkg/ucp/resources"
 	"github.com/radius-project/radius/pkg/version"
 	"github.com/radius-project/radius/test/functional"
 	"github.com/radius-project/radius/test/functional/shared"
@@ -161,6 +162,9 @@ func verifyCLIBasics(ctx context.Context, t *testing.T, test shared.RPTest) {
 		containerName = "containerA-json"
 	}
 
+	scope, err := resources.ParseScope(options.Workspace.Scope)
+	require.NoError(t, err)
+
 	t.Run("Validate rad application show", func(t *testing.T) {
 		actualOutput, err := cli.ApplicationShow(ctx, appName)
 		require.NoError(t, err)
@@ -171,12 +175,14 @@ func verifyCLIBasics(ctx context.Context, t *testing.T, test shared.RPTest) {
 		headers := strings.Fields(lines[0])
 		require.Equal(t, "RESOURCE", headers[0], "First header should be RESOURCE")
 		require.Equal(t, "TYPE", headers[1], "Second header should be TYPE")
-		require.Equal(t, "STATE", headers[2], "Third header should be STATE")
+		require.Equal(t, "GROUP", headers[2], "Third header should be GROUP")
+		require.Equal(t, "STATE", headers[3], "Fourth header should be STATE")
 
 		values := strings.Fields(lines[1])
 		require.Equal(t, appName, values[0], "First value should be %s", appName)
 		require.Equal(t, "Applications.Core/applications", values[1], "Second value should be Applications.Core/applications")
-		require.Equal(t, "Succeeded", values[2], "Third value should be Succeeded")
+		require.Equal(t, scope.Name(), values[2], "Third value should be %s", scope.Name())
+		require.Equal(t, "Succeeded", values[3], "Fourth value should be Succeeded")
 	})
 
 	t.Run("Validate rad resource list", func(t *testing.T) {
@@ -203,12 +209,14 @@ func verifyCLIBasics(ctx context.Context, t *testing.T, test shared.RPTest) {
 		headers := strings.Fields(lines[0])
 		require.Equal(t, "RESOURCE", headers[0], "First header should be RESOURCE")
 		require.Equal(t, "TYPE", headers[1], "Second header should be TYPE")
-		require.Equal(t, "STATE", headers[2], "Third header should be STATE")
+		require.Equal(t, "GROUP", headers[2], "Third header should be GROUP")
+		require.Equal(t, "STATE", headers[3], "Fourth header should be STATE")
 
 		values := strings.Fields(lines[1])
 		require.Equal(t, containerName, values[0], "First value should be %s", containerName)
 		require.Equal(t, "Applications.Core/containers", values[1], "Second value should be Applications.Core/applications")
-		require.Equal(t, "Succeeded", values[2], "Third value should be Succeeded")
+		require.Equal(t, scope.Name(), values[2], "Third value should be %s", scope.Name())
+		require.Equal(t, "Succeeded", values[3], "Fourth value should be Succeeded")
 	})
 
 	t.Run("Validate rad resoure logs containers", func(t *testing.T) {

--- a/test/functional/shared/test.go
+++ b/test/functional/shared/test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/radius-project/radius/pkg/cli"
 	"github.com/radius-project/radius/pkg/cli/clients"
 	"github.com/radius-project/radius/pkg/cli/connections"
+	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/pkg/sdk"
 	"github.com/radius-project/radius/pkg/ucp/aws"
 	"github.com/radius-project/radius/test"
@@ -85,6 +86,7 @@ func NewRPTestOptions(t *testing.T) RPTestOptions {
 		ManagementClient: client,
 		AWSClient:        awsClient,
 		Connection:       connection,
+		Workspace:        workspace,
 	}
 }
 
@@ -96,4 +98,7 @@ type RPTestOptions struct {
 
 	// Connection gets access to the Radius connection which can be used to create API clients.
 	Connection sdk.Connection
+
+	// Workspace gets access to the Radius workspace which can be used to create API clients.
+	Workspace *workspaces.Workspace
 }


### PR DESCRIPTION
# Description

This change refactors our code a bit for object formats used in the tables displayed by the CLI. This also adds resource group to some of the more commonly used formats. I did some general consistency cleanup and added tests where they were missing.

This is part of an effort to make resource groups more usable as a concept.



## Type of change

- This pull request adds or changes features of Radius and has an approved issue (issue link required).


Part of: #6827

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 90ce712</samp>

### Summary
📝🧪♻️

<!--
1.  📝 - This emoji represents the addition of license header comments and package declarations, which are documentation and code organization changes.
2.  🧪 - This emoji represents the changes in the unit tests, which are testing and quality assurance changes.
3.  ♻️ - This emoji represents the refactoring and renaming of some types and functions, which are code improvement and maintenance changes.
-->
This pull request refactors and updates the CLI output formatting logic for various commands, such as status, list, show, and update. It introduces new functions and types in separate files under `pkg/cli/cmd` to handle the formatting for different objects, such as applications, gateways, credentials, environments, and groups. It also adds license header comments and test package declarations to the new files, and updates the unit tests and imports accordingly.

> _We're the masters of the CLI_
> _We format the output with our skill_
> _We refactor and update our code_
> _We make the license header bold_

### Walkthrough
*  Add license header comments and package declarations to new files `objectformats.go` and `objectformats_test.go` in various subpackages of `pkg/cli/cmd` ([link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-e06a44cea8361e2d18e8364dc3bd4314addb8d06363a34c55c1580c553b87b8aR1-R54), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-68a2f8c98489dcc7a323cf0d207e0e1bbd1c0e2ed92ff78ab349f63b23097a02R1-R42), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-52a83605230057a2497b7fe3c6a72535ed246483766377aa4b9a47dea8da455fR1-R66), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-5dc5d1caf78012566c3dd84a46d6822d122f6a355b8d4a77a05035f41a48a786R1-R51), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-2ac3287b3b738308dcfb5d03e0719b4ecf949bd4ce29ef81f42fba20b36919baR1-R41), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-0c16bfbe9fa55b51aa34d6f26bd4ed0b0eb2677e8a4c75c15f0e85209acd6bbbR1-R35), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-c4f775f7262efd1dcf8eee0ed5b70793cd0e428a17909488a415ff51569bc887R1-R41))
* Move and rename functions that format the output of various commands from `objectformats.go` to the respective files where they are used, and update the corresponding calls and tests ([link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-d3a3459434e925881f5cd87077b6f7db62ff30d190094cb46a71d632a71fe32dL189-R188), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-d3a3459434e925881f5cd87077b6f7db62ff30d190094cb46a71d632a71fe32dL197-R196), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-2b3a46be3fab0d68fc258c962cf6ce1621b93ca7667fb4239a2ba6e0d1ec3308L173-R172), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-2b3a46be3fab0d68fc258c962cf6ce1621b93ca7667fb4239a2ba6e0d1ec3308L182-R181), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-926e301add91949c5a44382390c0b2c18616911beb4796e72b57aac0cc2ff2dcL115-R114), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-22afbf3787c0875661e06987c8d9d419cc8e91384f199ec8f44cca77afcdd146L113-R112), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-d7e98275cadf1da7d21c9ac06cdda7907310f6152077c0db4096ab3264446460L144-R143), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-d7e98275cadf1da7d21c9ac06cdda7907310f6152077c0db4096ab3264446460L211-R210), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-d4a9101ceaa220d437b0ef29440cbba8d20178502d94aa88eb33524bbe48bdfbL129-R128), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-c8b9a3315a934ca0d8e0b750b2872603b1c504239f5d310251e87e5fb6a8e4a2L353-R352), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-c8b9a3315a934ca0d8e0b750b2872603b1c504239f5d310251e87e5fb6a8e4a2L529-R528), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-5666f913c4913108ef57c2f23dec3f4b6a4fc6bc653f2b0c51982b9619fb6e12L263-R262), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-b6f63f3ed2aaeada863bd788b630879282e34fce2ad6672636ea677a37748853L134-R134), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-260f1d886aae571f8487e5405785053daf07362bfef8b8bc6d9509900a3b3cc0L122-R122))
* Remove unused imports of the package `objectformats` from various files in `pkg/cli/cmd` ([link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-d3a3459434e925881f5cd87077b6f7db62ff30d190094cb46a71d632a71fe32dL30), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-2b3a46be3fab0d68fc258c962cf6ce1621b93ca7667fb4239a2ba6e0d1ec3308L28), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-926e301add91949c5a44382390c0b2c18616911beb4796e72b57aac0cc2ff2dcL27), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-22afbf3787c0875661e06987c8d9d419cc8e91384f199ec8f44cca77afcdd146L27), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-d7e98275cadf1da7d21c9ac06cdda7907310f6152077c0db4096ab3264446460L28), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-d4a9101ceaa220d437b0ef29440cbba8d20178502d94aa88eb33524bbe48bdfbL28), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-c8b9a3315a934ca0d8e0b750b2872603b1c504239f5d310251e87e5fb6a8e4a2L32), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-5666f913c4913108ef57c2f23dec3f4b6a4fc6bc653f2b0c51982b9619fb6e12L30), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-b6f63f3ed2aaeada863bd788b630879282e34fce2ad6672636ea677a37748853L25-R27), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-260f1d886aae571f8487e5405785053daf07362bfef8b8bc6d9509900a3b3cc0L24-R26))
* Add import of the package `common` to the files `pkg/cli/cmd/group/list/list.go` and `pkg/cli/cmd/group/list/list_test.go`, which use the function `common.ResourceGroupFormat()` ([link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-b6f63f3ed2aaeada863bd788b630879282e34fce2ad6672636ea677a37748853L25-R27), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-260f1d886aae571f8487e5405785053daf07362bfef8b8bc6d9509900a3b3cc0L24-R26))
* Replace the type `objectformats.OutputEnvObject` with `environmentForDisplay` in the files `pkg/cli/cmd/env/update/update.go` and `pkg/cli/cmd/env/update/update_test.go`, as the former type has been moved to the latter file and renamed ([link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-c8b9a3315a934ca0d8e0b750b2872603b1c504239f5d310251e87e5fb6a8e4a2L339-R339), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-c8b9a3315a934ca0d8e0b750b2872603b1c504239f5d310251e87e5fb6a8e4a2L516-R516), [link](https://github.com/radius-project/radius/pull/6894/files?diff=unified&w=0#diff-5666f913c4913108ef57c2f23dec3f4b6a4fc6bc653f2b0c51982b9619fb6e12L256-R256))


