### PR TITLE
[WIP] Updating functional test workflow to use runners from the cluster

### DIFF
--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -86,8 +86,8 @@ env:
 jobs:
   build:
     name: Build Radius for test
-    runs-on: ubuntu-latest
-    if: github.repository == 'radius-project/radius'
+    runs-on: arc-runner-set
+    # if: github.repository == 'radius-project/radius'
     outputs:
       SKIP_BUILD: ${{ steps.skip-build.outputs.SKIP_BUILD }}
       REL_VERSION: ${{ steps.gen-id.outputs.REL_VERSION }}
@@ -275,8 +275,8 @@ jobs:
   tests:
     name: Run functional tests
     needs: build
-    runs-on: ubuntu-latest
-    if: github.repository == 'radius-project/radius'
+    runs-on: arc-runner-set
+    # if: github.repository == 'radius-project/radius'
     env:
       SKIP_BUILD: ${{ needs.build.outputs.SKIP_BUILD }}
       UNIQUE_ID: ${{ needs.build.outputs.UNIQUE_ID }}


### PR DESCRIPTION
# Description
Updating functional test workflow to use runners from the cluster

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
Fixes: #issue_number

## Auto-generated summary
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a910fea</samp>

### Summary
🏃🚀🧪

<!--
1.  🏃 - This emoji represents the runners that are used to execute the workflow jobs, and the change to use a custom pool of self-hosted runners.
2.  🚀 - This emoji represents the improvement in reliability and performance of the workflow by using a consistent and optimized environment for building and testing Radius.
3.  🧪 - This emoji represents the functional testing aspect of the workflow, which is the main purpose of the `functional-test.yaml` file.
-->
The pull request switches the `functional-test.yaml` workflow to use a custom runner pool `arc-runner-set` for better reliability and performance.

> _We are the arc-runners, we defy the doom_
> _We build and test the Radius, we make it zoom_
> _We don't need no matrix, we have our own pool_
> _We are the arc-runners, we break the rules_

### Walkthrough
* Use `arc-runner-set` runner for all jobs in `.github/workflows/functional-test.yaml` to run on self-hosted pool with required dependencies and configurations ([link](https://github.com/radius-project/radius/pull/6907/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL77-R77), [link](https://github.com/radius-project/radius/pull/6907/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL315-R315), [link](https://github.com/radius-project/radius/pull/6907/files?diff=unified&w=0#diff-c79f364a9293abaaa8595776b74674e24bec6287834e63ab8aa7aec6a42f0dbcL624-R624))


