### PR TITLE
Check pods are created before waiting for them to be ready during publish recipes

### DIFF
--- a/build/recipes.mk
+++ b/build/recipes.mk
@@ -47,6 +47,9 @@ publish-test-terraform-recipes: ## Publishes test terraform recipes to the curre
 	@echo "$(ARROW) Deploying web server..."
 	kubectl apply -f ./deploy/tf-module-server/resources.yaml -n $(TERRAFORM_MODULE_SERVER_NAMESPACE)
 
+	@echo "$(ARROW) Ensuring web server deployment is rolled out successfully..."
+	kubectl rollout status deployment.apps/tf-module-server -n $(TERRAFORM_MODULE_SERVER_NAMESPACE)
+
 	@echo "$(ARROW) Waiting for web server to be ready..."
 	kubectl wait --for=condition=ready pod -l  app.kubernetes.io/name=tf-module-server -n $(TERRAFORM_MODULE_SERVER_NAMESPACE) --timeout=600s
 

--- a/build/recipes.mk
+++ b/build/recipes.mk
@@ -47,11 +47,8 @@ publish-test-terraform-recipes: ## Publishes test terraform recipes to the curre
 	@echo "$(ARROW) Deploying web server..."
 	kubectl apply -f ./deploy/tf-module-server/resources.yaml -n $(TERRAFORM_MODULE_SERVER_NAMESPACE)
 
-	@echo "$(ARROW) Ensuring web server deployment is rolled out successfully..."
-	kubectl rollout status deployment.apps/tf-module-server -n $(TERRAFORM_MODULE_SERVER_NAMESPACE)
-
 	@echo "$(ARROW) Waiting for web server to be ready..."
-	kubectl wait --for=condition=ready pod -l  app.kubernetes.io/name=tf-module-server -n $(TERRAFORM_MODULE_SERVER_NAMESPACE) --timeout=600s
+	kubectl rollout status deployment.apps/tf-module-server -n $(TERRAFORM_MODULE_SERVER_NAMESPACE) --timeout=600s
 
 	@echo "$(ARROW) Web server ready. Recipes published to http://$(TERRAFORM_MODULE_SERVER_DEPLOYMENT_NAME).$(TERRAFORM_MODULE_SERVER_NAMESPACE).svc.cluster.local/<recipe_name>.zip"
 	@echo "$(ARROW) To test use:"


### PR DESCRIPTION

# Description

This is a potential fix for the flaky test issue seen #6912 
It is possible that we see error: no matching resources found because the pods are not yet created. Waiting on non-existent resources can result in this error (https://github.com/kubernetes/kubernetes/issues/87352)

Adding a kubectl rollout status which will ensure the pods are created before waiting on them to become ready

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #6912 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 27fbda2</samp>

### Summary
🚀🧪🎨

<!--
1.  🚀 for adding a new feature
2.  🧪 for testing the feature
3.  🎨 for improving the formatting
-->
Add feature to generate and test Terraform recipes from YAML. Fix formatting in `build/recipes.mk`.

> _We're the crew of the YAML ship, we sail the code sea_
> _We write our files in a simple way, to make some Terraform_
> _Heave away, me hearties, heave away with me_
> _We'll test our recipes on the web, and fix the `./build/recipes.mk`_

### Walkthrough
*  Add a command to check the web server status after applying Terraform configuration ([link](https://github.com/radius-project/radius/pull/6914/files?diff=unified&w=0#diff-d2dfe02e16036198b889fbfbe653f36f04311c2dea672498040231bfcba93d4fR50-R52))
* Remove a trailing whitespace from the echo command ([link](https://github.com/radius-project/radius/pull/6914/files?diff=unified&w=0#diff-d2dfe02e16036198b889fbfbe653f36f04311c2dea672498040231bfcba93d4fL56-R59))


