### PR TITLE
Create Release v0.28.0

### DIFF
--- a/docs/release-notes/v0.28.0.md
+++ b/docs/release-notes/v0.28.0.md
@@ -26,14 +26,10 @@ Radius installations now support custom certificates to allow Radius to operate 
 
 Contributing to the Radius project and want to know that your code is fully tested? Our new testing experience makes it easy to easily fork, PR, and make your first commit! Radius now leverages GitHub environments and integrated status checks to make sure that community contributions are good to go. All you need to do is submit your PR and our testing infrastructure will take care of the rest.
 
-
-## Breaking changes
-
 ## New contributors
 
 * @mouuii made their first contribution in https://github.com/radius-project/radius/pull/6788
 * @lechnerc77 made their first contribution in https://github.com/radius-project/radius/pull/6905
-
 
 ## Upgrading to Radius v0.28.0
 
@@ -100,7 +96,7 @@ During our preview stage, an upgrade to Radius v0.28.0 requires a full reinstall
 * Workflow for tests approvals using environments and workflow_run by @vinayada1 in https://github.com/radius-project/radius/pull/6796
 * Use github checks API to report test status by @vinayada1 in https://github.com/radius-project/radius/pull/6807
 * Adding names to the etag unit tests by @ytimocin in https://github.com/radius-project/radius/pull/6886
-* add workflow run trigger to build and run functional tests by @vinayada1 in https://github.com/radius-project/radius/pull/6891
+* Add workflow run trigger to build and run functional tests by @vinayada1 in https://github.com/radius-project/radius/pull/6891
 * Add actions/checkout by @vinayada1 in https://github.com/radius-project/radius/pull/6892
 * Add resource group to some object formats by @rynowak in https://github.com/radius-project/radius/pull/6894
 * Logs and some test changes to help debug test failure in Test_CLI_Delete by @vinayada1 in https://github.com/radius-project/radius/pull/6881

--- a/docs/release-notes/v0.28.0.md
+++ b/docs/release-notes/v0.28.0.md
@@ -10,7 +10,22 @@ If you're new to Radius, check out our website, [radapp.io](https://radapp.io), 
 
 ## Highlights
 
-<!-- TALK TO THE PM TEAM ABOUT WHAT HIGHLIGHTS TO ADD HERE -->
+### New dev container for contributing to the rad CLI
+
+Our new dev container makes it super easy to get up and running with a local dev container or GitHub Codespace in seconds. It's preloaded with everything you need to begin developing the rad CLI and other Radius services. Try it out for free [here](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=340522752&skip_quickstart=true&machine=basicLinux32gb&devcontainer_path=.devcontainer%2Fcontributor%2Fdevcontainer.json&geo=UsWest).
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=340522752&skip_quickstart=true&machine=basicLinux32gb&devcontainer_path=.devcontainer%2Fcontributor%2Fdevcontainer.json&geo=UsWest)
+
+Thanks to Radius community member @lechnerc77 for the contribution!
+
+### Run Radius behind a custom firewall
+
+Radius installations now support custom certificates to allow Radius to operate behind corporate/custom firewall solutions for enterprise installations. Visit the [Kubernetes installation docs](https://docs.radapp.io/guides/operations/kubernetes/install/#use-your-own-root-certificate-authority-certificate) for more information.
+
+### New test experience when contributing to Radius
+
+Contributing to the Radius project and want to know that your code is fully tested? Our new testing experience makes it easy to easily fork, PR, and make your first commit! Radius now leverages GitHub environments and integrated status checks to make sure that community contributions are good to go. All you need to do is submit your PR and our testing infrastructure will take care of the rest.
+
 
 ## Breaking changes
 

--- a/docs/release-notes/v0.28.0.md
+++ b/docs/release-notes/v0.28.0.md
@@ -1,0 +1,96 @@
+## Announcing Radius v0.28.0
+
+Today we're happy to announce the release of Radius v0.28.0 Check out the [highlights](#highlights) below, along with the [full changelog](#full-changelog) for more details.
+
+We would like to extend our thanks to all the [new](#new-contributors) and existing contributors who helped make this release possible!
+
+## Intro to Radius
+
+If you're new to Radius, check out our website, [radapp.io](https://radapp.io), for more information. Also visit our [getting started guide](https://docs.radapp.io/getting-started/) to learn how to install Radius and create your first app.
+
+## Highlights
+
+<!-- TALK TO THE PM TEAM ABOUT WHAT HIGHLIGHTS TO ADD HERE -->
+
+## Breaking changes
+
+## New contributors
+
+* @mouuii made their first contribution in https://github.com/radius-project/radius/pull/6788
+* @lechnerc77 made their first contribution in https://github.com/radius-project/radius/pull/6905
+
+
+## Upgrading to Radius v0.28.0
+
+During our preview stage, an upgrade to Radius v0.28.0 requires a full reinstallation of the Radius control-plane, rad CLI, and all Radius apps. Stay tuned for an in-place upgrade path in the future.
+
+1. Delete any environments you have created:
+   ```bash
+   rad env delete <env-name>
+   ```
+1. Uninstall the previous version of the Radius control-plane:
+   ```bash
+   rad uninstall kubernetes
+   ```
+1. Visit the [Radius installation guide](https://docs.radapp.io/getting-started/install/) to install the latest CLI, or download a binary below
+1. Install the latest version of the Radius control-plane:
+   ```bash
+   rad install kubernetes
+   ```
+
+## Full changelog
+
+* Revert "Switch ACR Helm chart to GHCR for rad init (#6510)" by @willdavsmith in https://github.com/radius-project/radius/pull/6668
+* Update Helm Chart Download Error Message by @kachawla in https://github.com/radius-project/radius/pull/6671
+* Use GHCR for Radius Helm repository by @willdavsmith in https://github.com/radius-project/radius/pull/6672
+* Change arch of release verification script to amd64 by @willdavsmith in https://github.com/radius-project/radius/pull/6665
+* Release 0.27: Create RC2 release by @kachawla in https://github.com/radius-project/radius/pull/6677
+* Fix redirection in bash script by @youngbupark in https://github.com/radius-project/radius/pull/6676
+* Release 0.27: Create RC3 release by @kachawla in https://github.com/radius-project/radius/pull/6678
+* Release 0.27: Create RC4 release by @kachawla in https://github.com/radius-project/radius/pull/6679
+* Release v0.27.0 by @kachawla in https://github.com/radius-project/radius/pull/6681
+* Update tests to remove httpRoutes since services can now be deployed as part of container rendering. by @nithyatsu in https://github.com/radius-project/radius/pull/6241
+* Revert "Use GHCR for Radius Helm repository" by @sk593 in https://github.com/radius-project/radius/pull/6698
+* Update patch release by @sk593 in https://github.com/radius-project/radius/pull/6699
+* Add auto-generation of markdown for resource references by @AaronCrawfis in https://github.com/radius-project/radius/pull/6331
+* Fix docs generation by @AaronCrawfis in https://github.com/radius-project/radius/pull/6716
+* Cleanup portable resource API routes by @sk593 in https://github.com/radius-project/radius/pull/6687
+* Update team membership requirement for `/ok-to-test` execution by @kachawla in https://github.com/radius-project/radius/pull/6732
+* Updating the rad download url from old CDN to github releases. by @vishwahiremat in https://github.com/radius-project/radius/pull/6728
+* Fix Docs Workflow when run from fork by @rynowak in https://github.com/radius-project/radius/pull/6786
+* Updating Functional Test to Validate Deletion in Absence of Terraform State File by @kachawla in https://github.com/radius-project/radius/pull/6741
+* Support the intermediate root CA in chart by @youngbupark in https://github.com/radius-project/radius/pull/6731
+* fix:typos by @mouuii in https://github.com/radius-project/radius/pull/6788
+* fix:typos by @mouuii in https://github.com/radius-project/radius/pull/6797
+* Adding changes to support k3d-managed/local registries by @vishwahiremat in https://github.com/radius-project/radius/pull/6641
+* Deleting proxy operations test by @kachawla in https://github.com/radius-project/radius/pull/6803
+* Delete Mongo recipe parameters test by @kachawla in https://github.com/radius-project/radius/pull/6806
+* Specify Dapr dashboard version on installation by @rynowak in https://github.com/radius-project/radius/pull/6814
+* Correct dapr dashboard version by @rynowak in https://github.com/radius-project/radius/pull/6818
+* Update the READMEs for the test/infra/azure by @ytimocin in https://github.com/radius-project/radius/pull/6792
+* Remove portable resource from description for shared types by @kachawla in https://github.com/radius-project/radius/pull/6813
+* Enable skipped bubble tea tests by updating the related libraries by @ytimocin in https://github.com/radius-project/radius/pull/6823
+* Remove `rad app switch` by @rynowak in https://github.com/radius-project/radius/pull/6837
+* Adding link to the CNCF sandbox submission  by @Reshrahim in https://github.com/radius-project/radius/pull/6816
+* Upgrading libraries in magpiego by @ytimocin in https://github.com/radius-project/radius/pull/6842
+* Update Dapr version from 1.12.2 to 1.12.0 by @ytimocin in https://github.com/radius-project/radius/pull/6846
+* Adding provisioning state to the result of some commands by @ytimocin in https://github.com/radius-project/radius/pull/6839
+* Updating table format docs for the object formatter by @ytimocin in https://github.com/radius-project/radius/pull/6859
+* Fix nil pointer dereference in deployment reconciler by @ytimocin in https://github.com/radius-project/radius/pull/6853
+* Recipe/Deployment- validation admission webhook by @lakshmimsft in https://github.com/radius-project/radius/pull/6571
+* Update workflow config to prevent specific jobs from executing in forked repositories by @ytimocin in https://github.com/radius-project/radius/pull/6873
+* Add functional tests instructions to setup local dev environment work with ghcr by @nithyatsu in https://github.com/radius-project/radius/pull/6717
+* Update logger.Info in Terraform driver by @ytimocin in https://github.com/radius-project/radius/pull/6879
+* Disabling scheduled functional test runs on forks by @ytimocin in https://github.com/radius-project/radius/pull/6885
+* Workflow for tests approvals using environments and workflow_run by @vinayada1 in https://github.com/radius-project/radius/pull/6796
+* Use github checks API to report test status by @vinayada1 in https://github.com/radius-project/radius/pull/6807
+* Adding names to the etag unit tests by @ytimocin in https://github.com/radius-project/radius/pull/6886
+* add workflow run trigger to build and run functional tests by @vinayada1 in https://github.com/radius-project/radius/pull/6891
+* Add actions/checkout by @vinayada1 in https://github.com/radius-project/radius/pull/6892
+* Add resource group to some object formats by @rynowak in https://github.com/radius-project/radius/pull/6894
+* Logs and some test changes to help debug test failure in Test_CLI_Delete by @vinayada1 in https://github.com/radius-project/radius/pull/6881
+* Check pods are created before waiting for them to be ready during publish recipes by @vinayada1 in https://github.com/radius-project/radius/pull/6914
+* Fixing the panic for annotations.Configuration by @ytimocin in https://github.com/radius-project/radius/pull/6864
+* chore: setup devcontainer for CLI contributions by @lechnerc77 in https://github.com/radius-project/radius/pull/6905
+* Create RC Release v0.28.0-rc1 by @lakshmimsft in https://github.com/radius-project/radius/pull/6920
+

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,6 +1,6 @@
 supported:
   - channel: '0.28'
-    version: 'v0.28.0-rc1'
+    version: 'v0.28.0'
 deprecated:
   - channel: '0.27'
     version: 'v0.27.1'


### PR DESCRIPTION
# Description

Create Release v0.28.0

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a1ef43b</samp>

### Summary
:green_circle::yellow_circle::red_circle:

<!--
1.  :green_circle: for the new supported channel 0.28, indicating that it is the recommended and most stable version to use.
2.  :yellow_circle: for the deprecated channel 0.27, indicating that it is still functional but not recommended and may have some issues or limitations.
3.  :red_circle: for the deprecated channel 0.26, indicating that it is outdated and should be avoided or upgraded as soon as possible.
-->
Added support for new channel `0.28` and deprecated channel `0.27` in `versions.yaml`. This file defines the available and outdated versions of radius for clients.

> _`radius` evolves_
> _New channel joins, old ones fade_
> _Autumn of versions_

### Walkthrough
* Add new channel 0.28 to the supported list and move channel 0.27 to the deprecated list in `versions.yaml` ([link](https://github.com/radius-project/radius/pull/6929/files?diff=unified&w=0#diff-1c4cd801df522f4a92edbfb0fea95364ed074a391ea47c284ddc078f512f7b6aL2-R6))


