### PR TITLE
fix: remove schema validation from feature release flow

### DIFF
--- a/.github/workflows/devcontainer-feature-release.yaml
+++ b/.github/workflows/devcontainer-feature-release.yaml
@@ -26,6 +26,8 @@ jobs:
           publish-features: "true"
           base-path-to-features: "./deploy/devcontainer-feature/src"
           generate-docs: "false"
+          # disable validation due to used preview feature
+          disable-schema-validation: "true"
           
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

The GitHub Action workflow currently fails (see https://github.com/radius-project/radius/actions/runs/7183715348) due to the usage of preview features in the devcontainer feature schema (for details see PR #6930)
This PR contains a fix to allow the release of the devcontainer feature even when suing preview features in the schema. 

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: n/a

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 184d5c9</samp>

### Summary
🛠️🚀🐳

<!--
1.  🛠️ - This emoji represents a tool or fixing something, and can be used to indicate that the schema validation was disabled to avoid errors and enable the workflow to run properly.
2.  🚀 - This emoji represents launching or deploying something, and can be used to indicate that the workflow uses a preview feature (the `pull_request_target` event) that allows it to run on pull requests from forks and merge them to the main branch when ready.
3.  🐳 - This emoji represents a whale or Docker, and can be used to indicate that the workflow builds and tests the devcontainer feature branch, which is related to using Docker containers for development environments.
-->
Disable schema validation for devcontainer feature release workflow. This fixes a compatibility issue with a preview GitHub Actions feature and allows the workflow to run on pull requests from forks.

> _`pull_request_target`_
> _Preview feature, no schema_
> _Workflow runs in fall_

### Walkthrough
*  Disable schema validation for GitHub Actions workflow to use preview feature `pull_request_target` ([link](https://github.com/radius-project/radius/pull/6945/files?diff=unified&w=0#diff-786e5036d5206693ef00172e6655e7b814833b8a1117ffed490dd9178f7e2d77R29-R30))


