### PR TITLE
Update devcontainer publishing path

### DIFF
--- a/.github/workflows/devcontainer-feature-release.yaml
+++ b/.github/workflows/devcontainer-feature-release.yaml
@@ -28,6 +28,11 @@ jobs:
           generate-docs: "false"
           # disable validation due to used preview feature
           disable-schema-validation: "true"
+          # We handle tagging ourselves
+          disable-repo-tagging: "true"
+          # We don't want to include the repo name, being consistent without
+          # examples at https://containers.dev/collections
+          features-namespace: "devcontainer-features"
           
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/deploy/devcontainer-feature/src/radcli/README.md
+++ b/deploy/devcontainer-feature/src/radcli/README.md
@@ -8,7 +8,7 @@ This will install the latest stable release of the `rad` CLI.
 
 ```json
 "features": {
-    "ghcr.io/devcontainers/radius/radiuscli:latest": {
+    "ghcr.io/radius-project/devcontainer-features/radcli:latest": {
         "version": "latest"
     }
 }
@@ -20,7 +20,7 @@ This will install the edge (unstable) release of the `rad` CLI.
 
 ```json
 "features": {
-    "ghcr.io/devcontainers/radius/radiuscli:latest": {
+    "ghcr.io/radius-project/devcontainer-features/radcli:latest": {
         "version": "edge"
     }
 }
@@ -32,7 +32,7 @@ This will install version 0.28.0 of the `rad` CLI.
 
 ```json
 "features": {
-    "ghcr.io/devcontainers/radius/radiuscli:latest": {
+    "ghcr.io/radius-project/devcontainer-features/radcli:latest": {
         "version": "0.28.0"
     }
 }


### PR DESCRIPTION
# Description

This updates the devcontainer publishing path to (hopefully):

```
ghcr.io/radius-project/devcontainer-features/radcli:latest
```

This matches the container that everyone seems to be following at: https://containers.dev/collections

In particular I don't want the repo name to be part of the path, because we will probably change repos in the future.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).


Part of: #6923

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

copilot:all
