### PR TITLE
Fix namespace in devcontainer feature publishing

### DIFF
--- a/.github/workflows/devcontainer-feature-release.yaml
+++ b/.github/workflows/devcontainer-feature-release.yaml
@@ -32,7 +32,7 @@ jobs:
           disable-repo-tagging: "true"
           # We don't want to include the repo name, being consistent without
           # examples at https://containers.dev/collections
-          features-namespace: "devcontainer-features"
+          features-namespace: "radius-project/devcontainer-features"
           
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

This change corrects the "feature namespace" from `devcontainer-features` -> `radius-project/devcontainer-features`. Our goal is to be consistent with https://containers.dev/collections

The previous attempt failed due to missing the org name. See failing workflow here: https://github.com/radius-project/radius/actions/runs/7278838782/job/19833934876



_Please explain the changes you've made._

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->


- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

copilot:all
