### PR TITLE
Change SSL_CERT_DIRS to SSL_CERT_DIR

### DIFF
--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -6,9 +6,9 @@ global:
     secretName: "root-ca-cert"
     volumeName: "root-ca-vol"
     mountPath: "/tmp/sslcerts"
-    # SSL_CERT_DIRS is used to override the default root CA location.
+    # SSL_CERT_DIR is used to override the default root CA location.
     # Dotnet runtime and Go use this environment variable to load the root CA.
-    sslCertDirEnvVar: "SSL_CERT_DIRS"
+    sslCertDirEnvVar: "SSL_CERT_DIR"
 
   prometheus:
     enabled: true


### PR DESCRIPTION
# Description

This is the bug to populate wrong environment variable name for SSL_CERT_DIR. To unblock this bug, user can set variable name for ssl cert location like below. 

```bash
rad install kubernetes --reinstall --set global.rootCA.sslCertDirEnvVar=SSL_CERT_DIR --set-file global.rootCA.cert=<CERT FILE>
```

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #6955 

## Auto-generated summary

<!--
GitHub Copilot for docs will auto-generate a summary of the PR
-->

copilot:all
