### PR TITLE
fix: remove duplicate securityContext

### DIFF
--- a/deploy/Chart/templates/rp/deployment.yaml
+++ b/deploy/Chart/templates/rp/deployment.yaml
@@ -73,8 +73,6 @@ spec:
           mountPath: {{ .Values.global.rootCA.mountPath }}
           readOnly: true
         {{- end }}
-        securityContext:
-          allowPrivilegeEscalation: false
         {{- if .Values.rp.resources }}
         resources:{{ toYaml .Values.rp.resources | nindent 10 }}
         {{- end }}


### PR DESCRIPTION
# Description

When installing the 0.29.0 helm chart, I received an error message:

```
Helm install failed for release radius-system/radius with chart radius@0.29.0: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
        line 61: mapping key "securityContext" already defined at line 54
```

This PR removed the duplicate key :)

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Issue: #6997