### PR TITLE
[Add] Adding ignore-not-found to the deletion of certificate in long haul test workflow

### DIFF
--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -390,7 +390,7 @@ jobs:
 
           # Temporary workaround to fix the x509 certificate error in the controller.
           # https://github.com/radius-project/radius/issues/6989
-          kubectl delete secrets controller-cert -n radius-system
+          kubectl delete secrets controller-cert -n radius-system --ignore-not-found
 
           echo "*** Configuring Azure provider ***"
           rad env update ${{ env.RADIUS_TEST_ENVIRONMENT_NAME }} --azure-subscription-id ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }} \


### PR DESCRIPTION
# Description
- Adding `--ignore-not-found` to the certificate deletion in long-haul test workflow because we have had a few instances of secret not being found causing workflow to fail.

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
Fixes: #issue_number
