### PR TITLE
Enable CLI container port expose test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 
 require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.5 // indirect
 	github.com/stretchr/objx v0.5.1 // indirect
 	github.com/tidwall/gjson v1.14.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -576,11 +576,14 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-retryablehttp v0.7.5 h1:bJj+Pj19UZMIweq/iie+1u5YCdGrnxCT9yvm0e+Nd5M=
+github.com/hashicorp/go-retryablehttp v0.7.5/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -260,7 +260,7 @@ func callHealthEndpointOnLocalPort(t *testing.T, retries int, port int) {
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = retries
 	retryClient.RetryWaitMin = 5 * time.Second
-	retryClient.RetryWaitMax = 60 * time.Second
+	retryClient.RetryWaitMax = 20 * time.Second
 	retryClient.Backoff = retryablehttp.LinearJitterBackoff
 	retryClient.RequestLogHook = func(_ retryablehttp.Logger, req *http.Request, retry int) {
 		t.Logf("retry calling healthz endpoint %s, retry: %d", healthzURL, retry)

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -259,12 +259,12 @@ func callHealthEndpointOnLocalPort(t *testing.T, retries int, port int) {
 
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = retries
-	retryClient.RequestLogHook = func(_ retryablehttp.Logger, req *http.Request, retry int) {
-		t.Logf("retry calling healthz endpoint %s, retry: %d", healthzURL, retry)
-	}
 	retryClient.RetryWaitMin = 5 * time.Second
 	retryClient.RetryWaitMax = 60 * time.Second
 	retryClient.Backoff = retryablehttp.LinearJitterBackoff
+	retryClient.RequestLogHook = func(_ retryablehttp.Logger, req *http.Request, retry int) {
+		t.Logf("retry calling healthz endpoint %s, retry: %d", healthzURL, retry)
+	}
 
 	resp, err := retryClient.Get(healthzURL)
 	require.NoError(t, err, "failed to get connect to resource after %d retries", retries)

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -233,7 +233,6 @@ func verifyCLIBasics(ctx context.Context, t *testing.T, test shared.RPTest) {
 
 		// We open a local port-forward and then make a request to it.
 		child, cancel := context.WithCancel(ctx)
-		t.Cleanup(cancel)
 
 		errCh := make(chan error)
 		go func() {
@@ -242,6 +241,7 @@ func verifyCLIBasics(ctx context.Context, t *testing.T, test shared.RPTest) {
 		}()
 
 		callHealthEndpointOnLocalPort(t, retries, port)
+		cancel()
 		require.NoError(t, <-errCh, "failed to expose endpoint from container")
 	})
 }

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -237,8 +237,8 @@ func verifyCLIBasics(ctx context.Context, t *testing.T, test shared.RPTest) {
 		done := make(chan error)
 		go func() {
 			output, err := cli.ResourceExpose(child, appName, containerName, port, 3000)
-			done <- err
 			t.Logf("ResourceExpose - output: %s", output)
+			done <- err
 		}()
 
 		callHealthEndpointOnLocalPort(t, retries, port)
@@ -264,7 +264,7 @@ func callHealthEndpointOnLocalPort(t *testing.T, retries int, port int) {
 				require.NoError(t, err, "failed to get connect to resource after %d retries", retries)
 			}
 			t.Logf("got error %s", err.Error())
-			time.Sleep(1 * time.Second)
+			time.Sleep(5 * time.Second)
 			continue
 		}
 		if response.Body != nil {

--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -236,8 +236,9 @@ func verifyCLIBasics(ctx context.Context, t *testing.T, test shared.RPTest) {
 
 		done := make(chan error)
 		go func() {
-			_, err = cli.ResourceExpose(child, appName, containerName, port, 3000)
+			output, err := cli.ResourceExpose(child, appName, containerName, port, 3000)
 			done <- err
+			t.Logf("ResourceExpose - output: %s", output)
 		}()
 
 		callHealthEndpointOnLocalPort(t, retries, port)


### PR DESCRIPTION
# Description

This is to enable CLI container port expose test with the better retry.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #3232 
