### PR TITLE
Add Deployment Webhook

### DIFF
--- a/deploy/Chart/templates/controller/webhook.yaml
+++ b/deploy/Chart/templates/controller/webhook.yaml
@@ -69,6 +69,7 @@ webhooks:
     - v1
     operations:
     - CREATE
+    - UPDATE
     resources:
     - deployments
   sideEffects: None

--- a/deploy/Chart/templates/controller/webhook.yaml
+++ b/deploy/Chart/templates/controller/webhook.yaml
@@ -45,3 +45,30 @@ webhooks:
     resources:
     - recipes
   sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: deployment-webhook.apps.io
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: {{ include "secrets.lookup" (dict "secret" "controller-cert" "namespace" .Release.Namespace "key" "ca.crt" "defaultValue" $ca.Cert) }}
+    service:
+      name: controller
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-apps-v1-deployment
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: deployment-webhook.apps.io
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - deployments
+  sideEffects: None

--- a/deploy/Chart/templates/controller/webhook.yaml
+++ b/deploy/Chart/templates/controller/webhook.yaml
@@ -69,7 +69,6 @@ webhooks:
     - v1
     operations:
     - CREATE
-    - UPDATE
     resources:
     - deployments
   sideEffects: None

--- a/pkg/controller/reconciler/deployment_reconciler.go
+++ b/pkg/controller/reconciler/deployment_reconciler.go
@@ -351,6 +351,12 @@ func (r *DeploymentReconciler) reconcileUpdate(ctx context.Context, deployment *
 		return ctrl.Result{}, fmt.Errorf("failed to update deployment: %w", err)
 	}
 
+	// Deployment is unpaused
+	if deployment.Spec.Paused {
+		deployment.Spec.Paused = false
+		logger.Info("Deployment is unpaused.")
+	}
+
 	err = r.saveState(ctx, deployment, annotations)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/pkg/controller/reconciler/deployment_webhook.go
+++ b/pkg/controller/reconciler/deployment_webhook.go
@@ -49,7 +49,6 @@ func (a *DeploymentWebhook) Default(ctx context.Context, obj runtime.Object) err
 	}
 
 	if annotationValue, exists := deployment.ObjectMeta.Annotations[AnnotationRadiusEnabled]; exists && annotationValue == "true" {
-
 		logger.Info("Pausing Deployment", "deploymentName", deployment.Name)
 		deployment.Spec.Paused = true
 	}

--- a/pkg/controller/reconciler/deployment_webhook.go
+++ b/pkg/controller/reconciler/deployment_webhook.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/radius-project/radius/pkg/ucp/ucplog"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// SetupWebhookWithManager sets up a webhook for the built in Deployment resource with the given manager.
+// It configures the webhook to watch for changes in the appsv1.Deployment resource type and applies the provided defaulter.
+// Returns an error if there was a problem setting up the webhook.
+func (d *DeploymentWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&appsv1.Deployment{}).
+		WithDefaulter(d).
+		Complete()
+}
+
+// DeploymentWebhook implements the mutating webhook function for the type Deployment.
+type DeploymentWebhook struct{}
+
+// Default mutates the built in Deployment object.
+func (a *DeploymentWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	logger := ucplog.FromContextOrDiscard(ctx)
+
+	deployment, ok := obj.(*appsv1.Deployment)
+	if !ok {
+		return fmt.Errorf("expected a built in Deployment but got a %T", obj)
+	}
+
+	if annotationValue, exists := deployment.ObjectMeta.Annotations[AnnotationRadiusEnabled]; exists && annotationValue == "true" {
+
+		logger.Info("Pausing Deployment", "deploymentName", deployment.Name)
+		deployment.Spec.Paused = true
+	}
+
+	return nil
+}

--- a/pkg/controller/reconciler/deployment_webhook_test.go
+++ b/pkg/controller/reconciler/deployment_webhook_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/radius-project/radius/test/testcontext"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// Test_DeploymentPaused tests for expected deployment being paused and  with valid and invalid types.
+func Test_DeploymentPaused(t *testing.T) {
+	ctx := testcontext.New(t)
+	radius, client := setupWebhookTest(t)
+
+	// Environment is created.
+	createEnvironment(radius, "default")
+
+	t.Run("test deployment is paused ", func(t *testing.T) {
+		name := types.NamespacedName{Namespace: "deployment-paused", Name: "test-deployment-paused"}
+		err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+		require.NoError(t, err)
+
+		deployment := makeDeployment(name)
+		deployment.Annotations[AnnotationRadiusEnabled] = "true"
+		err = client.Create(ctx, deployment)
+		require.NoError(t, err)
+
+		// Webhook is expected to trigger during this call and pause the deployment.
+		// Wait for the webhook to process the deployment
+		time.Sleep(time.Second * 2)
+
+		// Get the deployment
+		actualDeployment := &appsv1.Deployment{}
+		err = client.Get(ctx, name, actualDeployment)
+		require.NoError(t, err)
+
+		// Check if the deployment is paused
+		require.True(t, actualDeployment.Spec.Paused)
+
+		err = client.Delete(ctx, deployment)
+		require.NoError(t, err)
+
+		// Now deleting of the deployment object can complete.
+		waitForDeploymentDeleted(t, client, name)
+	})
+
+	t.Run("test deployment is not paused ", func(t *testing.T) {
+		name := types.NamespacedName{Namespace: "deployment-not-paused", Name: "test-deployment-not-paused"}
+		err := client.Create(ctx, &corev1.Namespace{ObjectMeta: ctrl.ObjectMeta{Name: name.Namespace}})
+		require.NoError(t, err)
+
+		deployment := makeDeployment(name)
+		err = client.Create(ctx, deployment)
+		require.NoError(t, err)
+
+		// Webhook is expected to trigger during this call and skip the deployment.
+		// Wait for the webhook to process the deployment
+		time.Sleep(time.Second * 2)
+
+		// Get the deployment
+		actualDeployment := &appsv1.Deployment{}
+		err = client.Get(ctx, name, actualDeployment)
+		require.NoError(t, err)
+
+		// Check if the deployment is paused
+		require.False(t, actualDeployment.Spec.Paused)
+
+		err = client.Delete(ctx, deployment)
+		require.NoError(t, err)
+
+		// Now deleting of the deployment object can complete.
+		waitForDeploymentDeleted(t, client, name)
+	})
+
+	// NOTE: We are updating the FailurePolicy of the webhook to Ignore after running webhook tests.
+	// This is to ensure that the webhook does not interfere with other tests in the reconciler package.
+	// This approach may be updated in the future.
+	failurePolicy := admissionv1.Ignore
+	updateWebhookFailurePolicy(t, webhookConfigName, &failurePolicy)
+}
+
+// Test_DeploymentWebhook_Mutate is a unit test function that tests the Mutate method of the DeploymentWebhook struct.
+// It verifies the behavior of the Mutate method by running multiple test cases with different input values.
+// Each test case represents a scenario where a deployment is created with different annotations, and the expected result is checked.
+// Test_DeploymentWebhook_Mutate tests webhook functions for DeploymentWebhook
+// for a recipe with valid and invalid resource types.
+func Test_DeploymentWebhook_Mutate(t *testing.T) {
+	tests := []struct {
+		name                   string
+		deploymentName         string
+		radappAnnotation       string
+		expectPausedDeployment bool
+	}{
+		{
+			name:                   "create deployment radapp enabled",
+			deploymentName:         "create-deployment-radapp-enabled",
+			radappAnnotation:       "true",
+			expectPausedDeployment: true,
+		},
+		{
+			name:                   "create deployment radapp disabled",
+			deploymentName:         "create-deployment-radapp-disabled",
+			radappAnnotation:       "false",
+			expectPausedDeployment: false,
+		},
+		{
+			name:                   "create deployment no annotation",
+			deploymentName:         "create-deployment-no-annotation",
+			radappAnnotation:       "missing",
+			expectPausedDeployment: false,
+		},
+	}
+	for _, tr := range tests {
+		t.Run(tr.name, func(t *testing.T) {
+			ctx := testcontext.New(t)
+			var err error
+			namespace := types.NamespacedName{Namespace: defaultNamespace, Name: tr.deploymentName}
+			deployment := makeDeployment(namespace)
+			if tr.radappAnnotation != "missing" {
+				deployment.Annotations[AnnotationRadiusEnabled] = tr.radappAnnotation
+			}
+
+			deploymentWebhook := &DeploymentWebhook{}
+			err = deploymentWebhook.Default(ctx, deployment)
+			require.NoError(t, err)
+
+			// Check if the deployment is paused
+			require.Equal(t, tr.expectPausedDeployment, deployment.Spec.Paused)
+		})
+	}
+}

--- a/pkg/controller/reconciler/main_test.go
+++ b/pkg/controller/reconciler/main_test.go
@@ -103,6 +103,7 @@ func initializeWebhookInEnvironment(env *envtest.Environment) {
 	equivalentTypeV1 := admissionv1.Equivalent
 	noSideEffectsV1 := admissionv1.SideEffectClassNone
 	recipeWebhookPathV1 := "/validate-radapp-io-v1alpha3-recipe"
+	deploymentWebhookPathV1 := "/mutate-apps-v1-deployment"
 
 	env.WebhookInstallOptions = envtest.WebhookInstallOptions{
 		ValidatingWebhooks: []*admissionv1.ValidatingWebhookConfiguration{
@@ -136,6 +137,44 @@ func initializeWebhookInEnvironment(env *envtest.Environment) {
 								Name:      "controller",
 								Namespace: "default",
 								Path:      &recipeWebhookPathV1,
+							},
+						},
+						AdmissionReviewVersions: []string{"v1"},
+					},
+				},
+			},
+		},
+		MutatingWebhooks: []*admissionv1.MutatingWebhookConfiguration{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "deployment-webhook-config",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "MutatingWebhookConfiguration",
+					APIVersion: "admissionregistration.k8s.io/v1",
+				},
+				Webhooks: []admissionv1.MutatingWebhook{
+					{
+						Name: "deployment-webhook.apps.io",
+						Rules: []admissionv1.RuleWithOperations{
+							{
+								Operations: []admissionv1.OperationType{"CREATE"},
+								Rule: admissionv1.Rule{
+									APIGroups:   []string{"apps"},
+									APIVersions: []string{"v1"},
+									Resources:   []string{"deployments"},
+									Scope:       &defaultScopeV1,
+								},
+							},
+						},
+						FailurePolicy: &failedTypeV1,
+						MatchPolicy:   &equivalentTypeV1,
+						SideEffects:   &noSideEffectsV1,
+						ClientConfig: admissionv1.WebhookClientConfig{
+							Service: &admissionv1.ServiceReference{
+								Name:      "controller",
+								Namespace: "default",
+								Path:      &deploymentWebhookPathV1,
 							},
 						},
 						AdmissionReviewVersions: []string{"v1"},

--- a/pkg/controller/reconciler/main_test.go
+++ b/pkg/controller/reconciler/main_test.go
@@ -158,7 +158,7 @@ func initializeWebhookInEnvironment(env *envtest.Environment) {
 						Name: "deployment-webhook.apps.io",
 						Rules: []admissionv1.RuleWithOperations{
 							{
-								Operations: []admissionv1.OperationType{"CREATE", "UPDATE"},
+								Operations: []admissionv1.OperationType{"CREATE"},
 								Rule: admissionv1.Rule{
 									APIGroups:   []string{"apps"},
 									APIVersions: []string{"v1"},

--- a/pkg/controller/reconciler/main_test.go
+++ b/pkg/controller/reconciler/main_test.go
@@ -158,7 +158,7 @@ func initializeWebhookInEnvironment(env *envtest.Environment) {
 						Name: "deployment-webhook.apps.io",
 						Rules: []admissionv1.RuleWithOperations{
 							{
-								Operations: []admissionv1.OperationType{"CREATE"},
+								Operations: []admissionv1.OperationType{"CREATE", "UPDATE"},
 								Rule: admissionv1.Rule{
 									APIGroups:   []string{"apps"},
 									APIVersions: []string{"v1"},

--- a/pkg/controller/reconciler/recipe_webhook.go
+++ b/pkg/controller/reconciler/recipe_webhook.go
@@ -54,7 +54,7 @@ func (r *RecipeWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) 
 		return nil, fmt.Errorf("expected a Recipe but got a %T", obj)
 	}
 
-	logger.Info("Validating Create Recipe %s", recipe.Name)
+	logger.Info("Validating Create Recipe.", "recipeName", recipe.Name)
 	return r.validateRecipeType(ctx, recipe)
 }
 
@@ -67,7 +67,7 @@ func (r *RecipeWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runti
 		return nil, fmt.Errorf("expected a Recipe but got a %T", newObj)
 	}
 
-	logger.Info("Validating Update Recipe %s", recipe.Name)
+	logger.Info("Validating Update Recipe.", "recipeName", recipe.Name)
 	return r.validateRecipeType(ctx, recipe)
 }
 
@@ -92,7 +92,7 @@ func (r *RecipeWebhook) validateRecipeType(ctx context.Context, recipe *radappio
 	flPath := field.NewPath("spec").Child("type")
 	validResourceTypes := strings.Join(portableresources.GetValidPortableResourceTypes(), ", ")
 
-	logger.Info("Validating Recipe Type %s in Recipe %s", recipe.Spec.Type, recipe.Name)
+	logger.Info("Validating Recipe Type in Recipe", "recipeType", recipe.Spec.Type, "recipeName", recipe.Name)
 	if !portableresources.IsValidPortableResourceType(recipe.Spec.Type) {
 		errList = append(errList, field.Invalid(flPath, recipe.Spec.Type, fmt.Sprintf("allowed values are: %s", validResourceTypes)))
 

--- a/pkg/controller/reconciler/recipe_webhook_test.go
+++ b/pkg/controller/reconciler/recipe_webhook_test.go
@@ -284,6 +284,9 @@ func setupWebhookTest(t *testing.T) (*mockRadiusClient, client.Client) {
 	err = (&RecipeWebhook{}).SetupWebhookWithManager(mgr)
 	require.NoError(t, err)
 
+	err = (&DeploymentWebhook{}).SetupWebhookWithManager(mgr)
+	require.NoError(t, err)
+
 	go func() {
 		err := mgr.Start(ctx)
 		require.NoError(t, err)

--- a/pkg/controller/service.go
+++ b/pkg/controller/service.go
@@ -113,6 +113,11 @@ func (s *Service) Run(ctx context.Context) error {
 		if err = (&reconciler.RecipeWebhook{}).SetupWebhookWithManager(mgr); err != nil {
 			return fmt.Errorf("failed to create recipe-webhook: %w", err)
 		}
+
+		logger.Info("Registering mutating webhook.")
+		if err = (&reconciler.DeploymentWebhook{}).SetupWebhookWithManager(mgr); err != nil {
+			return fmt.Errorf("failed to create deployment-webhook: %w", err)
+		}
 	}
 
 	logger.Info("Registering health checks.")


### PR DESCRIPTION
# Description

Adding Deployment webhook to pause new radius enabled deployments.
Deployment is unpaused after necessary env variables are created.

## Type of change

- This pull request adds or changes features of Radius and has an approved issue ( #6431 ).


Fixes: Part of #6431
