### PR TITLE
Enable Bicep recipe unit-test with fake registry server

### DIFF
--- a/pkg/recipes/driver/bicep.go
+++ b/pkg/recipes/driver/bicep.go
@@ -26,7 +26,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/go-logr/logr"
-	"github.com/radius-project/radius/pkg/to"
 	"golang.org/x/sync/errgroup"
 	"oras.land/oras-go/v2/registry/remote"
 
@@ -39,7 +38,8 @@ import (
 	recipes_util "github.com/radius-project/radius/pkg/recipes/util"
 	"github.com/radius-project/radius/pkg/rp/util"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
-	clients "github.com/radius-project/radius/pkg/sdk/clients"
+	"github.com/radius-project/radius/pkg/sdk/clients"
+	"github.com/radius-project/radius/pkg/to"
 	"github.com/radius-project/radius/pkg/ucp/resources"
 	resources_radius "github.com/radius-project/radius/pkg/ucp/resources/radius"
 	"github.com/radius-project/radius/pkg/ucp/ucplog"

--- a/pkg/rp/util/registry.go
+++ b/pkg/rp/util/registry.go
@@ -89,15 +89,6 @@ func getDigestFromManifest(ctx context.Context, repo *remote.Repository, tag str
 	if err != nil {
 		return "", err
 	}
-	layers, ok := manifest["layers"]
-	if !ok {
-		return "", fmt.Errorf("failed to decode the layers from manifest")
-	}
-
-	arr := layers.([]any)
-	if len(arr) == 0 {
-		return "", fmt.Errorf("no layers found in manifest")
-	}
 
 	// get the layers digest to fetch the blob
 	layer, ok := manifest["layers"].([]any)[0].(map[string]any)

--- a/pkg/rp/util/registrytest/fakeregistryserver.go
+++ b/pkg/rp/util/registrytest/fakeregistryserver.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registrytest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type fakeServerInfo struct {
+	TestServer   *httptest.Server
+	URL          *url.URL
+	CloseServer  func()
+	TestImageURL string
+	ImageName    string
+}
+
+// NewFakeRegistryServer creates a fake registry server that serves a single blob and index.
+func NewFakeRegistryServer(t *testing.T) fakeServerInfo {
+	blob := []byte(`{
+	"parameters": {
+		"documentdbName": {"type": "string"},
+		"location": {"defaultValue": "[resourceGroup().location]", "type": "string"}
+	}
+}`)
+
+	blobDesc := ocispec.Descriptor{
+		MediaType: "recipe",
+		Digest:    digest.FromBytes(blob),
+		Size:      int64(len(blob)),
+	}
+
+	index := []byte(`{
+	"layers": [
+		{
+			"digest": "` + blobDesc.Digest.String() + `"
+		}
+	]
+}`)
+
+	indexDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageIndex,
+		Digest:    digest.FromBytes(index),
+		Size:      int64(len(index)),
+	}
+
+	prefixURL := "/v2/test"
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			if strings.HasPrefix(r.URL.Path, prefixURL+"/manifests/") {
+				w.Header().Set("Content-Type", indexDesc.MediaType)
+				w.Header().Set("Docker-Content-Digest", indexDesc.Digest.String())
+				w.Header().Set("Content-Length", strconv.Itoa(int(indexDesc.Size)))
+				w.WriteHeader(http.StatusOK)
+			} else if strings.HasPrefix(r.URL.Path, prefixURL+"/blobs/") {
+				w.Header().Set("Content-Type", blobDesc.MediaType)
+				w.Header().Set("Docker-Content-Digest", blobDesc.Digest.String())
+				w.Header().Set("Content-Length", strconv.Itoa(int(blobDesc.Size)))
+				w.WriteHeader(http.StatusOK)
+			} else {
+				w.WriteHeader(http.StatusNotFound)
+			}
+
+			return
+		} else if r.Method == http.MethodGet {
+			switch r.URL.Path {
+			case prefixURL + "/blobs/" + blobDesc.Digest.String():
+				w.Header().Set("Content-Type", "application/octet-stream")
+				w.Header().Set("Docker-Content-Digest", blobDesc.Digest.String())
+				if _, err := w.Write(blob); err != nil {
+					t.Errorf("failed to write %q: %v", r.URL, err)
+				}
+
+			case prefixURL + "/manifests/" + indexDesc.Digest.String():
+				if accept := r.Header.Get("Accept"); !strings.Contains(accept, indexDesc.MediaType) {
+					t.Errorf("manifest not convertable: %s", accept)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				w.Header().Set("Content-Type", indexDesc.MediaType)
+				w.Header().Set("Docker-Content-Digest", indexDesc.Digest.String())
+				if _, err := w.Write(index); err != nil {
+					t.Errorf("failed to write %q: %v", r.URL, err)
+				}
+
+			default:
+				t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+				w.WriteHeader(http.StatusNotFound)
+			}
+		} else {
+			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+	}))
+
+	url, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("failed to parse url: %v", err)
+	}
+
+	return fakeServerInfo{
+		TestServer:   ts,
+		URL:          url,
+		CloseServer:  ts.Close,
+		TestImageURL: ts.URL + "/test:latest",
+		ImageName:    "test:latest",
+	}
+}


### PR DESCRIPTION
# Description

This is to enable bicep recipe unit test with the fake registry server.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #6490 
