### PR TITLE
Add Functional Test for Bicep Recipe Context Parameter

### DIFF
--- a/test/functional/datastoresrp/resources/mongodb_test.go
+++ b/test/functional/datastoresrp/resources/mongodb_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resource_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/radius-project/radius/test/functional"
@@ -109,61 +108,6 @@ func Test_MongoDB_Recipe(t *testing.T) {
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
 						validation.NewK8sPodForResource(name, "mongodb-app-ctnr").ValidateLabels(false),
-					},
-				},
-			},
-		},
-	})
-
-	test.Test(t)
-}
-
-// Test_MongoDB_Recipe_ContextParameter validates creation of a mongoDB from
-// a default recipe using the context parameter generated and set by DatastoresRP,
-// and container using the mongoDatabases portable resource to connect to the underlying mongoDB resource.
-func Test_MongoDB_Recipe_ContextParameter(t *testing.T) {
-	t.Skip("Skipping test as creating/deleting cosmosdb resource is unreliable - https://github.com/radius-project/radius/issues/5929")
-
-	template := "testdata/datastoresrp-resources-mongodb-recipe-context.bicep"
-	name := "dsrp-resources-mongodb-recipe-context"
-	appNamespace := "dsrp-resources-mongodb-recipe-context-app"
-	rg := os.Getenv("INTEGRATION_TEST_RESOURCE_GROUP_NAME")
-	// Error the test if INTEGRATION_TEST_RESOURCE_GROUP_NAME is not set
-	// for running locally set the INTEGRATION_TEST_RESOURCE_GROUP_NAME with the test resourceGroup
-	if rg == "" {
-		t.Error("This test needs the env variable INTEGRATION_TEST_RESOURCE_GROUP_NAME to be set")
-	}
-
-	test := shared.NewRPTest(t, name, []shared.TestStep{
-		{
-			Executor: step.NewDeployExecutor(template, functional.GetMagpieImage(), functional.GetBicepRecipeRegistry(), functional.GetBicepRecipeVersion()),
-			RPResources: &validation.RPResourceSet{
-				Resources: []validation.RPResource{
-					{
-						Name: "dsrp-resources-env-recipes-context-env",
-						Type: validation.EnvironmentsResource,
-					},
-					{
-						Name: name,
-						Type: validation.ApplicationsResource,
-						App:  name,
-					},
-					{
-						Name: "mdb-ctx-ctnr",
-						Type: validation.ContainersResource,
-						App:  name,
-					},
-					{
-						Name: "mdb-ctx",
-						Type: validation.MongoDatabasesResource,
-						App:  name,
-					},
-				},
-			},
-			K8sObjects: &validation.K8sObjectSet{
-				Namespaces: map[string][]validation.K8sObject{
-					appNamespace: {
-						validation.NewK8sPodForResource(name, "mdb-ctx-ctnr").ValidateLabels(false),
 					},
 				},
 			},

--- a/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/context-parameter.bicep
+++ b/test/functional/shared/resources/testdata/recipes/test-bicep-recipes/context-parameter.bicep
@@ -1,0 +1,12 @@
+// A simple Bicep recipe that tests context parameter is applied. It doesn't provision any resources.
+param context object
+
+output result object = {
+  values: {
+    environment: context.environment.Name
+    application: context.application.Name
+    resource: context.resource.Name
+    namespace: context.runtime.kubernetes.namespace
+    envNamespace: context.runtime.kubernetes.environmentNamespace
+  }
+}


### PR DESCRIPTION
# Description

Removing the dependency on Azure CosmosDB for context parameter functional test and replacing the existing skipped test by introducing a test that doesn't deploy any resources, as our primary goal is to verify the successful population of the context parameter.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes:
https://github.com/radius-project/radius/issues/5418
https://github.com/radius-project/radius/issues/6293
