### PR TITLE
Avoid docker debian image ratelimitting issue in long running test

### DIFF
--- a/test/functional/shared/cli/cli_test.go
+++ b/test/functional/shared/cli/cli_test.go
@@ -294,6 +294,8 @@ func Test_Run_Logger(t *testing.T) {
 		filepath.Join(cwd, template),
 		"--application",
 		applicationName,
+		"--parameters",
+		functional.GetMagpieImage(),
 	}
 
 	// 'rad run' streams logs until canceled by the user. This is why we can't 'just' run the command in

--- a/test/functional/shared/cli/testdata/corerp-kubernetes-cli-run.bicep
+++ b/test/functional/shared/cli/testdata/corerp-kubernetes-cli-run.bicep
@@ -2,13 +2,16 @@ import radius as radius
 
 param application string
 
+@description('Specifies the image to be deployed.')
+param magpieimage string
+
 resource container 'Applications.Core/containers@2023-10-01-preview' = {
   name: 'k8s-cli-run-logger'
   location: 'global'
   properties: {
     application: application
     container: {
-      image: 'debian'
+      image: magpieimage
       command: ['/bin/sh']
 
       // The test looks for this specific output, keep in sync with the CLI run test!


### PR DESCRIPTION
# Description

`Test_Run_Logger` uses `debian` image for testing. This can encounter the rate limit problem during long-running test. This change uses magpie image to prevent this failure.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
