### PR TITLE
Fix rad app delete does not clean up all resources when the application deployment originally failed

### DIFF
--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -294,7 +294,10 @@ func (dp *deploymentProcessor) Deploy(ctx context.Context, id resources.ID, rend
 				ID:      outputResource.ID,
 			}
 			deployedOutputResources = append(deployedOutputResources, outputResource)
-			dp.Delete(ctx, id, deployedOutputResources)
+			deleteErr := dp.Delete(ctx, id, deployedOutputResources)
+			if deleteErr != nil {
+				logger.Info("Failed to cleanup deployed output resources for resource %q. Error: %s", id.String(), deleteErr.Error())
+			}
 
 			return rpv1.DeploymentOutput{}, err
 		}

--- a/pkg/corerp/backend/deployment/deploymentprocessor.go
+++ b/pkg/corerp/backend/deployment/deploymentprocessor.go
@@ -287,6 +287,15 @@ func (dp *deploymentProcessor) Deploy(ctx context.Context, id resources.ID, rend
 
 		err := dp.deployOutputResource(ctx, id, rendererOutput, computedValues, &handlers.PutOptions{Resource: &outputResource, DependencyProperties: deployedOutputResourceProperties})
 		if err != nil {
+			// add the last deployed resource  which was deployed with error to deployed list
+			// cleanup all deployed output resources in reverse order since app deployment has failed
+			outputResource := rpv1.OutputResource{
+				LocalID: outputResource.LocalID,
+				ID:      outputResource.ID,
+			}
+			deployedOutputResources = append(deployedOutputResources, outputResource)
+			dp.Delete(ctx, id, deployedOutputResources)
+
 			return rpv1.DeploymentOutput{}, err
 		}
 


### PR DESCRIPTION
# Description

We do not track the outputResources in the event of deplyment failure, but might have created some, potentially with errors. 
If the deployment of outResource errors, we should cleanup these so that app can be deleted gracefully using rad app delete command. 

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).


Fixes: #7052
