### PR TITLE
Remove rad app switch reference from the error message

### DIFF
--- a/pkg/cli/clivalidation.go
+++ b/pkg/cli/clivalidation.go
@@ -166,8 +166,8 @@ func RequireApplicationArgs(cmd *cobra.Command, args []string, workspace workspa
 	}
 
 	if applicationName == "" {
-		return "", fmt.Errorf("no application name provided and no default application set, " +
-			"either pass in an application name or set a default application by using `rad application switch`")
+		return "", fmt.Errorf("no application name provided, " +
+			"pass in an application name with '-a/--application'")
 	}
 
 	return applicationName, nil


### PR DESCRIPTION
# Description

Updated the error message to remove the reference of rad application switch command.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #7078
