### PR TITLE
Fix Delete application confirmation message points to the workspace but says environment #7089

### DIFF
--- a/pkg/cli/cmd/app/delete/delete.go
+++ b/pkg/cli/cmd/app/delete/delete.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	deleteConfirmation = "Are you sure you want to delete application '%v' from environment '%v'?"
+	deleteConfirmation = "Are you sure you want to delete application '%v' from workspace '%v'?"
 	bicepWarning       = "'%v' is a Bicep filename or path and not the name of a Radius Application. Specify the name of a valid application and try again"
 )
 

--- a/pkg/cli/cmd/app/delete/delete.go
+++ b/pkg/cli/cmd/app/delete/delete.go
@@ -123,7 +123,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Lopkup the environment name for use in the confirmation prompt
+	// Lookup the environment name for use in the confirmation prompt
 	if workspace.Environment != "" {
 		id, err := resources.ParseResource(workspace.Environment)
 		if err != nil {

--- a/pkg/cli/cmd/app/delete/delete_test.go
+++ b/pkg/cli/cmd/app/delete/delete_test.go
@@ -132,8 +132,9 @@ func Test_Show(t *testing.T) {
 				"kind":    "kubernetes",
 				"context": "kind-kind",
 			},
-			Name:  "kind-kind",
-			Scope: "/planes/radius/local/resourceGroups/test-group",
+			Name:        "kind-kind",
+			Scope:       "/planes/radius/local/resourceGroups/test-group",
+			Environment: "/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default",
 		}
 		outputSink := &output.MockOutput{}
 		runner := &Runner{
@@ -166,13 +167,14 @@ func Test_Show(t *testing.T) {
 				"kind":    "kubernetes",
 				"context": "kind-kind",
 			},
-			Name:  "kind-kind",
-			Scope: "/planes/radius/local/resourceGroups/test-group",
+			Name:        "kind-kind",
+			Scope:       "/planes/radius/local/resourceGroups/test-group",
+			Environment: "/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default",
 		}
 
 		promptMock := prompt.NewMockInterface(ctrl)
 		promptMock.EXPECT().
-			GetListInput([]string{prompt.ConfirmNo, prompt.ConfirmYes}, fmt.Sprintf(deleteConfirmation, "test-app", workspace.Name)).
+			GetListInput([]string{prompt.ConfirmNo, prompt.ConfirmYes}, fmt.Sprintf(deleteConfirmation, "test-app", "default")).
 			Return(prompt.ConfirmYes, nil).
 			Times(1)
 
@@ -189,6 +191,7 @@ func Test_Show(t *testing.T) {
 			Workspace:         workspace,
 			Output:            outputSink,
 			ApplicationName:   "test-app",
+			EnvironmentName:   "default",
 		}
 
 		err := runner.Run(context.Background())
@@ -213,13 +216,14 @@ func Test_Show(t *testing.T) {
 				"kind":    "kubernetes",
 				"context": "kind-kind",
 			},
-			Name:  "kind-kind",
-			Scope: "/planes/radius/local/resourceGroups/test-group",
+			Name:        "kind-kind",
+			Scope:       "/planes/radius/local/resourceGroups/test-group",
+			Environment: "/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default",
 		}
 
 		promptMock := prompt.NewMockInterface(ctrl)
 		promptMock.EXPECT().
-			GetListInput([]string{prompt.ConfirmNo, prompt.ConfirmYes}, fmt.Sprintf(deleteConfirmation, "test-app", workspace.Name)).
+			GetListInput([]string{prompt.ConfirmNo, prompt.ConfirmYes}, fmt.Sprintf(deleteConfirmation, "test-app", "default")).
 			Return(prompt.ConfirmNo, nil).
 			Times(1)
 
@@ -229,6 +233,7 @@ func Test_Show(t *testing.T) {
 			Workspace:       workspace,
 			Output:          outputSink,
 			ApplicationName: "test-app",
+			EnvironmentName: "default",
 		}
 
 		err := runner.Run(context.Background())
@@ -255,8 +260,9 @@ func Test_Show(t *testing.T) {
 				"kind":    "kubernetes",
 				"context": "kind-kind",
 			},
-			Name:  "kind-kind",
-			Scope: "/planes/radius/local/resourceGroups/test-group",
+			Name:        "kind-kind",
+			Scope:       "/planes/radius/local/resourceGroups/test-group",
+			Environment: "/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default",
 		}
 		outputSink := &output.MockOutput{}
 		runner := &Runner{
@@ -264,6 +270,7 @@ func Test_Show(t *testing.T) {
 			Workspace:         workspace,
 			Output:            outputSink,
 			ApplicationName:   "test-app",
+			EnvironmentName:   "default",
 			Confirm:           true,
 		}
 
@@ -290,13 +297,14 @@ func Test_Show(t *testing.T) {
 				"kind":    "kubernetes",
 				"context": "kind-kind",
 			},
-			Name:  "kind-kind",
-			Scope: "/planes/radius/local/resourceGroups/test-group",
+			Name:        "kind-kind",
+			Scope:       "/planes/radius/local/resourceGroups/test-group",
+			Environment: "/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default",
 		}
 
 		promptMock := prompt.NewMockInterface(ctrl)
 		promptMock.EXPECT().
-			GetListInput([]string{prompt.ConfirmNo, prompt.ConfirmYes}, fmt.Sprintf(deleteConfirmation, "test-app", workspace.Name)).
+			GetListInput([]string{prompt.ConfirmNo, prompt.ConfirmYes}, fmt.Sprintf(deleteConfirmation, "test-app", "default")).
 			Return("", &prompt.ErrExitConsole{}).
 			Times(1)
 
@@ -306,6 +314,7 @@ func Test_Show(t *testing.T) {
 			Output:          outputSink,
 			Workspace:       workspace,
 			ApplicationName: "test-app",
+			EnvironmentName: "default",
 		}
 
 		err := runner.Run(context.Background())


### PR DESCRIPTION
Signed-off-by: Josh <josh@liveoak.ws>

# Description

Parse out the environment name from the Workspace.Environment property using the resources library.

## Type of change

This pull request fixes a bug in Radius and has an approved issue

Fixes: #7089
