### PR TITLE
Update RequireResource to handle duplicate short names and proper fully qualified names (also make life a little better for windows file system contributors)

### DIFF
--- a/pkg/cli/clivalidation.go
+++ b/pkg/cli/clivalidation.go
@@ -249,7 +249,7 @@ func RequireResource(cmd *cobra.Command, args []string) (resourceType string, re
 // are present. If either is missing, an error is returned.
 func RequireResourceTypeAndName(args []string) (string, string, error) {
 	if len(args) < 2 {
-		return "", "", errors.New("No resource type or name provided")
+		return "", "", errors.New("no resource type or name provided")
 	}
 	resourceType, err := RequireResourceType(args)
 	if err != nil {

--- a/pkg/cli/clivalidation.go
+++ b/pkg/cli/clivalidation.go
@@ -270,12 +270,20 @@ func RequireResourceType(args []string) (string, error) {
 	}
 	resourceTypeName := args[0]
 	supportedTypes := []string{}
+	foundTypes := []string{}
 	for _, resourceType := range clients.ResourceTypesList {
 		supportedType := strings.Split(resourceType, "/")[1]
 		supportedTypes = append(supportedTypes, supportedType)
-		if strings.EqualFold(supportedType, resourceTypeName) {
-			return resourceType, nil
+		//check to see if the resource type is the correct short or long name.
+		if strings.EqualFold(supportedType, resourceTypeName) || strings.EqualFold(resourceType, resourceTypeName) {
+			foundTypes = append(foundTypes, resourceType)
 		}
+	}
+	if len(foundTypes) == 1 {
+		return foundTypes[0], nil
+	} else if len(foundTypes) > 1 {
+		return "", fmt.Errorf("multiple resource types match '%s'. Please specify the full resource type and try again:\n\n%s\n",
+			resourceTypeName, strings.Join(foundTypes, "\n"))
 	}
 	return "", fmt.Errorf("'%s' is not a valid resource type. Available Types are: \n\n%s\n",
 		resourceTypeName, strings.Join(supportedTypes, "\n"))

--- a/pkg/cli/clivalidation_test.go
+++ b/pkg/cli/clivalidation_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2024 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/radius-project/radius/pkg/cli/clients"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_RequireResourceType(t *testing.T) {
+
+	supportedTypes := []string{}
+
+	for _, resourceType := range clients.ResourceTypesList {
+		supportedType := strings.Split(resourceType, "/")[1]
+		supportedTypes = append(supportedTypes, supportedType)
+	}
+
+	resourceTypesErrorString := strings.Join(supportedTypes, "\n")
+
+	tests := []struct {
+		name    string
+		args    []string
+		want    string
+		wantErr error
+	}{
+		{
+			name:    "No arguments",
+			args:    []string{},
+			want:    "",
+			wantErr: errors.New("no resource type provided"),
+		},
+		{
+			name:    "Supported resource type",
+			args:    []string{"mongoDatabases"},
+			want:    "Applications.Datastores/mongoDatabases",
+			wantErr: nil,
+		},
+		{
+			name:    "Multiple resource types",
+			args:    []string{"secretStores"},
+			want:    "",
+			wantErr: fmt.Errorf("multiple resource types match 'secretStores'. Please specify the full resource type and try again:\n\nApplications.Dapr/secretStores\nApplications.Core/secretStores\n"),
+		},
+		{
+			name:    "Unsupported resource type",
+			args:    []string{"unsupported"},
+			want:    "",
+			wantErr: fmt.Errorf("'unsupported' is not a valid resource type. Available Types are: \n\n" + resourceTypesErrorString + "\n"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RequireResourceType(tt.args)
+			if len(tt.want) > 0 {
+				require.Equal(t, tt.want, got)
+			} else {
+				require.Equal(t, tt.wantErr, err)
+			}
+		})
+	}
+}

--- a/pkg/cli/cmd/resource/delete/delete_test.go
+++ b/pkg/cli/cmd/resource/delete/delete_test.go
@@ -84,6 +84,15 @@ func Test_Validate(t *testing.T) {
 				Config:         configWithWorkspace,
 			},
 		},
+		{
+			Name:          "List Command with ambiguous args",
+			Input:         []string{"secretStores"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+		},
 	}
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
 }

--- a/pkg/cli/cmd/resource/list/list_test.go
+++ b/pkg/cli/cmd/resource/list/list_test.go
@@ -95,6 +95,15 @@ func Test_Validate(t *testing.T) {
 				Config:         configWithWorkspace,
 			},
 		},
+		{
+			Name:          "List Command with ambiguous args",
+			Input:         []string{"secretStores"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+		},
 	}
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
 }

--- a/pkg/cli/cmd/resource/show/show_test.go
+++ b/pkg/cli/cmd/resource/show/show_test.go
@@ -89,6 +89,15 @@ func Test_Validate(t *testing.T) {
 				Config:         configWithWorkspace,
 			},
 		},
+		{
+			Name:          "List Command with ambiguous args",
+			Input:         []string{"secretStores"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+		},
 	}
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
 }

--- a/pkg/corerp/renderers/container/testdata/.gitattributes
+++ b/pkg/corerp/renderers/container/testdata/.gitattributes
@@ -1,0 +1,4 @@
+#test files should use lf line endings
+*.tf text eol=lf
+*.json text eol=lf
+*.yaml text eol=lf

--- a/pkg/recipes/terraform/config/testdata/.gitattributes
+++ b/pkg/recipes/terraform/config/testdata/.gitattributes
@@ -1,0 +1,4 @@
+#test files should use lf line endings
+*.tf text eol=lf
+*.json text eol=lf
+*.yaml text eol=lf

--- a/pkg/recipes/terraform/testdata/.terraform/modules/.gitattributes
+++ b/pkg/recipes/terraform/testdata/.terraform/modules/.gitattributes
@@ -1,0 +1,4 @@
+#test files should use lf line endings
+*.tf text eol=lf
+*.json text eol=lf
+*.yaml text eol=lf


### PR DESCRIPTION
# Description

Updated clivalidation.RequireResourceType so that it can take either fully qualified names or short names.. and if a short name is used and there are duplicate short names display the list of matching short names.

I also added a .gitattributes to the following folders so that their test files would maintain lf line ends instead of crlf line ends when cloned or pulled into a windows filesystem.

* pkg/corperp/renderers/containers/testdata
* pkg/recipes/terraform/config/testdata
* pkg/recipes/terraform/testdata/.terraform/modules


## Type of change

This pull request fixes a bug in Radius and has an approved issue 

Fixes: #7070

This pull request fixes a bug in Radius but its not an approved issue

Fixes:  #7121
