### PR TITLE
Add GH action to close stale PRs

### DIFF
--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,0 +1,27 @@
+# This workflow warns and then closes PRs that have had no activity for 90 days.
+#
+# For more information, see:
+# https://github.com/actions/stale
+name: Close stale pull requests
+
+on:
+  schedule:
+  - cron: '0 18 * * *' # Run the workflow every day at 6PM UTC (10AM PST).
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'This pull request has been automatically marked as stale because it has been inactive for 90 days. Remove stale label or comment or this PR will be closed in 7 days.'
+        stale-pr-label: 'stale'
+        days-before-pr-stale: 90 # 3 months
+        days-before-pr-close: 7
+        days-before-issue-stale: -1
+        days-before-issue-close: -1

--- a/docs/contributing/contributing-pull-requests/README.md
+++ b/docs/contributing/contributing-pull-requests/README.md
@@ -103,3 +103,7 @@ If you are the code reviewer, it's your responsibility to follow up (politely) i
 We welcome **any contributor or community member** to engage with **any pull request** on our repository. Feel free to make suggestions for improvements and ask questions that are relevant. If you're asking questions for your learning, please make it clear that your questions are "non-blocking" for the pull request.
 
 See the [code reviewing documentation](../contributing-code/contributing-code-reviewing/README.md) for guidance on code reviewing.
+
+## Inactive Pull Requests
+
+Pull requests that have been inactive for 90 days will be marked with a stale label. They will automatically be closed after a subsequent 7 days of inactivity. This timeframe may be adjusted in the future based on project needs.


### PR DESCRIPTION
# Description

To declutter the PR queue and ensure that active contributions receive attention, enabling https://github.com/actions/stale github action to automatically close stale PRs after 90 days of inactivity, with a notification period of 7 days.

This will provide contributors with a reasonable window to address any outstanding feedback or issues before the PR is automatically closed. We can adjust this timeframe in the future based on the feedback and learnings. We can also consider PRs labeled with certain labels to be excluded from this workflow if we see the need for this in the future: https://github.com/actions/stale?tab=readme-ov-file#exempt-pr-labels.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: https://github.com/radius-project/radius/issues/7151
