### PR TITLE
Update Namespace.ValidateNamespace to add workspace to arguments

### DIFF
--- a/pkg/cli/cmd/env/create/create.go
+++ b/pkg/cli/cmd/env/create/create.go
@@ -141,7 +141,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = r.NamespaceInterface.ValidateNamespace(cmd.Context(), r.Namespace)
+	err = r.NamespaceInterface.ValidateNamespace(cmd.Context(), r.Namespace, *r.Workspace)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/env/create/create_test.go
+++ b/pkg/cli/cmd/env/create/create_test.go
@@ -271,13 +271,13 @@ func createMocksWithInvalidResourceGroup(namespaceClient *namespace.MockInterfac
 
 func createValidateNamespaceSuccess(namespaceClient *namespace.MockInterface) {
 	namespaceClient.EXPECT().
-		ValidateNamespace(gomock.Any(), "testingenv").
+		ValidateNamespace(gomock.Any(), "testingenv", gomock.Any()).
 		Return(nil).Times(1)
 }
 
 func createValidateNamespaceError(namespaceClient *namespace.MockInterface) {
 	namespaceClient.EXPECT().
-		ValidateNamespace(gomock.Any(), gomock.Any()).
+		ValidateNamespace(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(fmt.Errorf("failed to create namespace")).Times(1)
 }
 

--- a/pkg/cli/cmd/env/namespace/mock_namespace.go
+++ b/pkg/cli/cmd/env/namespace/mock_namespace.go
@@ -9,6 +9,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	
+	"github.com/radius-project/radius/pkg/cli/workspaces"
 )
 
 // MockInterface is a mock of Interface interface.
@@ -35,7 +37,7 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // ValidateNamespace mocks base method.
-func (m *MockInterface) ValidateNamespace(arg0 context.Context, arg1 string) error {
+func (m *MockInterface) ValidateNamespace(arg0 context.Context, arg1 string, workspace workspaces.Workspace) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateNamespace", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/pkg/cli/cmd/env/namespace/mock_namespace.go
+++ b/pkg/cli/cmd/env/namespace/mock_namespace.go
@@ -9,8 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	
-	"github.com/radius-project/radius/pkg/cli/workspaces"
+	workspaces "github.com/radius-project/radius/pkg/cli/workspaces"
 )
 
 // MockInterface is a mock of Interface interface.
@@ -37,15 +36,15 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // ValidateNamespace mocks base method.
-func (m *MockInterface) ValidateNamespace(arg0 context.Context, arg1 string, workspace workspaces.Workspace) error {
+func (m *MockInterface) ValidateNamespace(arg0 context.Context, arg1 string, arg2 workspaces.Workspace) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateNamespace", arg0, arg1)
+	ret := m.ctrl.Call(m, "ValidateNamespace", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ValidateNamespace indicates an expected call of ValidateNamespace.
-func (mr *MockInterfaceMockRecorder) ValidateNamespace(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) ValidateNamespace(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateNamespace", reflect.TypeOf((*MockInterface)(nil).ValidateNamespace), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateNamespace", reflect.TypeOf((*MockInterface)(nil).ValidateNamespace), arg0, arg1, arg2)
 }

--- a/pkg/cli/cmd/env/namespace/namespace.go
+++ b/pkg/cli/cmd/env/namespace/namespace.go
@@ -19,12 +19,14 @@ package namespace
 import (
 	"context"
 
+	"github.com/radius-project/radius/pkg/cli/clierrors"
 	"github.com/radius-project/radius/pkg/cli/kubernetes"
+	"github.com/radius-project/radius/pkg/cli/workspaces"
 )
 
 //go:generate mockgen -destination=./mock_namespace.go -package=namespace -self_package github.com/radius-project/radius/pkg/cli/cmd/env/namespace github.com/radius-project/radius/pkg/cli/cmd/env/namespace Interface
 type Interface interface {
-	ValidateNamespace(ctx context.Context, namespace string) error
+	ValidateNamespace(ctx context.Context, namespace string, workspace workspaces.Workspace) error
 }
 
 type Impl struct {
@@ -35,8 +37,13 @@ type Impl struct {
 
 // ValidateNamespace creates a Kubernetes client and checks if the given namespace exists. If it does not exist, creates it.
 // If unsuccessful, returns an error.
-func (i *Impl) ValidateNamespace(ctx context.Context, namespace string) error {
-	client, _, err := kubernetes.NewClientset("")
+func (i *Impl) ValidateNamespace(ctx context.Context, namespace string, workspace workspaces.Workspace) error {
+	// get the current kubernetes context from the workspace
+	kubernetesContext, hasContext := workspace.KubernetesContext()
+	if !hasContext {
+		return clierrors.Message("no kubernetes context found in the current workspace")
+	}
+	client, _, err := kubernetes.NewClientset(kubernetesContext)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Josh <josh@liveoak.ws>

# Description

in order for the non current context to be used by ValidateNamespaces so that it can create namespaces in the workspaces kubernetes context we need to pass in the workspace and then use workspace.KuberneteContext() to look up the correct context.

## Type of change

This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #5698
