### PR TITLE
Do not try to load recipes for a simulated environment

### DIFF
--- a/pkg/recipes/configloader/environment_test.go
+++ b/pkg/recipes/configloader/environment_test.go
@@ -185,6 +185,30 @@ func TestGetConfiguration(t *testing.T) {
 			},
 		},
 		{
+			// Add test here for the simulated flag
+			name: "simulated env",
+			envResource: &model.EnvironmentResource{
+				Properties: &model.EnvironmentProperties{
+					Compute: &model.KubernetesCompute{
+						Kind:       to.Ptr(kind),
+						Namespace:  to.Ptr(envNamespace),
+						ResourceID: to.Ptr(envResourceId),
+					},
+					Simulated: to.Ptr(true),
+				},
+			},
+			appResource: nil,
+			expectedConfig: &recipes.Configuration{
+				Runtime: recipes.RuntimeConfiguration{
+					Kubernetes: &recipes.KubernetesRuntime{
+						Namespace:            "default",
+						EnvironmentNamespace: envNamespace,
+					},
+				},
+				Simulated: true,
+			},
+		},
+		{
 			name: "invalid app resource",
 			envResource: &model.EnvironmentResource{
 				Properties: &model.EnvironmentProperties{

--- a/pkg/recipes/driver/bicep.go
+++ b/pkg/recipes/driver/bicep.go
@@ -126,11 +126,6 @@ func (d *bicepDriver) Execute(ctx context.Context, opts ExecuteOptions) (*recipe
 		logger.Info("using Azure provider", "deploymentID", deploymentID, "scope", providerConfig.Az.Value.Scope)
 	}
 
-	if opts.Configuration.Simulated {
-		logger.Info("simulated environment enabled, skipping deployment")
-		return nil, nil
-	}
-
 	poller, err := d.DeploymentClient.CreateOrUpdate(
 		ctx,
 		clients.Deployment{

--- a/pkg/recipes/driver/bicep_test.go
+++ b/pkg/recipes/driver/bicep_test.go
@@ -378,40 +378,6 @@ func Test_Bicep_PrepareRecipeResponse_EmptyResult(t *testing.T) {
 	require.Equal(t, expectedResponse, actualResponse)
 }
 
-func Test_Bicep_Execute_SimulatedEnvironment(t *testing.T) {
-	ts := registrytest.NewFakeRegistryServer(t)
-	t.Cleanup(ts.CloseServer)
-
-	opts := ExecuteOptions{
-		BaseOptions: BaseOptions{
-			Configuration: recipes.Configuration{
-				Runtime: recipes.RuntimeConfiguration{
-					Kubernetes: &recipes.KubernetesRuntime{
-						Namespace: "test-namespace",
-					},
-				},
-				Simulated: true,
-			},
-			Recipe: recipes.ResourceMetadata{
-				EnvironmentID: "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Core/environments/test-env",
-				Name:          "test-recipe",
-				ResourceID:    "/subscriptions/test-sub/resourceGroups/test-group/providers/Applications.Datastores/mongoDatabases/test-db",
-			},
-			Definition: recipes.EnvironmentDefinition{
-				Name:         "test-recipe",
-				Driver:       recipes.TemplateKindBicep,
-				TemplatePath: ts.TestImageURL,
-				ResourceType: "Applications.Datastores/mongoDatabases",
-			},
-		},
-	}
-	ctx := testcontext.New(t)
-	d := &bicepDriver{RegistryClient: ts.TestServer.Client()}
-	recipesOutput, err := d.Execute(ctx, opts)
-	require.NoError(t, err)
-	require.Nil(t, recipesOutput)
-}
-
 func setupDeleteInputs(t *testing.T) (bicepDriver, *processors.MockResourceClient) {
 	ctrl := gomock.NewController(t)
 	client := processors.NewMockResourceClient(ctrl)

--- a/pkg/recipes/driver/terraform.go
+++ b/pkg/recipes/driver/terraform.go
@@ -87,11 +87,6 @@ func (d *terraformDriver) Execute(ctx context.Context, opts ExecuteOptions) (*re
 		}
 	}()
 
-	if opts.Configuration.Simulated {
-		logger.Info("simulated environment is set to true, skipping deployment")
-		return nil, nil
-	}
-
 	// Add credential information to .gitconfig if module source is of type git.
 	if strings.HasPrefix(opts.Definition.TemplatePath, "git::") && !reflect.DeepEqual(opts.BaseOptions.Secrets, v20231001preview.SecretStoresClientListSecretsResponse{}) {
 		err := addSecretsToGitConfig(opts.BaseOptions.Secrets, &opts.Recipe, opts.Definition.TemplatePath)

--- a/pkg/recipes/driver/terraform_test.go
+++ b/pkg/recipes/driver/terraform_test.go
@@ -307,28 +307,6 @@ func Test_Terraform_Execute_MissingARMRequestContext_Panics(t *testing.T) {
 	})
 }
 
-func Test_Terraform_Execute_SimulatedEnvironment(t *testing.T) {
-	ctx := testcontext.New(t)
-	armCtx := &v1.ARMRequestContext{
-		OperationID: uuid.New(),
-	}
-	ctx = v1.WithARMRequestContext(ctx, armCtx)
-
-	_, driver := setup(t)
-	envConfig, recipeMetadata, envRecipe := buildTestInputs()
-	envConfig.Simulated = true
-
-	recipeOutput, err := driver.Execute(ctx, ExecuteOptions{
-		BaseOptions: BaseOptions{
-			Configuration: envConfig,
-			Recipe:        recipeMetadata,
-			Definition:    envRecipe,
-		},
-	})
-	require.NoError(t, err)
-	require.Nil(t, recipeOutput)
-}
-
 func TestTerraformDriver_GetRecipeMetadata_Success(t *testing.T) {
 	ctx := testcontext.New(t)
 	armCtx := &v1.ARMRequestContext{

--- a/pkg/recipes/engine/engine.go
+++ b/pkg/recipes/engine/engine.go
@@ -28,6 +28,7 @@ import (
 	recipedriver "github.com/radius-project/radius/pkg/recipes/driver"
 	"github.com/radius-project/radius/pkg/recipes/util"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
+	"github.com/radius-project/radius/pkg/ucp/ucplog"
 )
 
 // NewEngine creates a new Engine to deploy recipe.
@@ -73,14 +74,22 @@ func (e *engine) Execute(ctx context.Context, opts ExecuteOptions) (*recipes.Rec
 // executeCore function is the core logic of the Execute function.
 // Any changes to the core logic of the Execute function should be made here.
 func (e *engine) executeCore(ctx context.Context, recipe recipes.ResourceMetadata, prevState []string) (*recipes.RecipeOutput, *recipes.EnvironmentDefinition, error) {
-	definition, driver, err := e.getDriver(ctx, recipe)
-	if err != nil {
-		return nil, nil, err
-	}
+	logger := ucplog.FromContextOrDiscard(ctx)
 
 	configuration, err := e.options.ConfigurationLoader.LoadConfiguration(ctx, recipe)
 	if err != nil {
-		return nil, definition, recipes.NewRecipeError(recipes.RecipeConfigurationFailure, err.Error(), util.RecipeSetupError, recipes.GetErrorDetails(err))
+		return nil, nil, recipes.NewRecipeError(recipes.RecipeConfigurationFailure, err.Error(), util.RecipeSetupError, recipes.GetErrorDetails(err))
+	}
+
+	// No need to try executing the recipe if it's a simulated environment.
+	if configuration.Simulated {
+		logger.Info("simulated environment enabled, skipping deployment")
+		return nil, nil, nil
+	}
+
+	definition, driver, err := e.getDriver(ctx, recipe)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Retrieves the secret store id from the recipes configuration for the terraform module source of type git.
@@ -138,14 +147,18 @@ func (e *engine) Delete(ctx context.Context, opts DeleteOptions) error {
 // deleteCore function is the core logic of the Delete function.
 // Any changes to the core logic of the Delete function should be made here.
 func (e *engine) deleteCore(ctx context.Context, recipe recipes.ResourceMetadata, outputResources []rpv1.OutputResource) (*recipes.EnvironmentDefinition, error) {
-	definition, driver, err := e.getDriver(ctx, recipe)
+	configuration, err := e.options.ConfigurationLoader.LoadConfiguration(ctx, recipe)
 	if err != nil {
 		return nil, err
 	}
 
-	configuration, err := e.options.ConfigurationLoader.LoadConfiguration(ctx, recipe)
+	if configuration.Simulated {
+		return nil, nil
+	}
+
+	definition, driver, err := e.getDriver(ctx, recipe)
 	if err != nil {
-		return definition, err
+		return nil, err
 	}
 
 	err = driver.Delete(ctx, recipedriver.DeleteOptions{

--- a/pkg/recipes/engine/engine.go
+++ b/pkg/recipes/engine/engine.go
@@ -147,12 +147,14 @@ func (e *engine) Delete(ctx context.Context, opts DeleteOptions) error {
 // deleteCore function is the core logic of the Delete function.
 // Any changes to the core logic of the Delete function should be made here.
 func (e *engine) deleteCore(ctx context.Context, recipe recipes.ResourceMetadata, outputResources []rpv1.OutputResource) (*recipes.EnvironmentDefinition, error) {
+	logger := ucplog.FromContextOrDiscard(ctx)
 	configuration, err := e.options.ConfigurationLoader.LoadConfiguration(ctx, recipe)
 	if err != nil {
 		return nil, err
 	}
 
 	if configuration.Simulated {
+		logger.Info("simulated environment enabled, skipping deleting resources")
 		return nil, nil
 	}
 


### PR DESCRIPTION
# Description

Currently, for a simulated env, if a recipe if not found in the env, the deployment fails. This is unnecessary for simulated environments as there are no output resources rendered i.e. the result with or without loading the recipe is the same. Therefore, skip the loading of recipes in the case of simulated environments

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #7156 
