### PR TITLE
Add support to set environment variables to Terraform environment

### DIFF
--- a/pkg/recipes/terraform/execute.go
+++ b/pkg/recipes/terraform/execute.go
@@ -88,8 +88,7 @@ func (e *executor) Deploy(ctx context.Context, options Options) (*tfjson.State, 
 		return nil, err
 	}
 
-	// Set environment variables for the Terraform process reading input from the environment configuration.
-	// This is required for the Terraform process to read the environment variables and use them as input for the recipe deployment.
+	// Set environment variables for the Terraform process.
 	err = e.setEnvironmentVariables(ctx, tf, options.EnvConfig)
 	if err != nil {
 		return nil, err
@@ -201,16 +200,14 @@ func (e *executor) GetRecipeMetadata(ctx context.Context, options Options) (map[
 	}, nil
 }
 
-// setEnvironmentVariables sets environment variables for the Terraform process reading input from the environment configuration.
+// setEnvironmentVariables sets environment variables for the Terraform process by reading values from the environment configuration.
+// Terraform process will use environment variables as input for the recipe deployment.
 func (e executor) setEnvironmentVariables(ctx context.Context, tf *tfexec.Terraform, envConfig *recipes.Configuration) error {
-	// Set environment variables for the Terraform process reading input from the environment configuration.
-	// This is required for the Terraform process to read the environment variables and use them as input for the recipe deployment.
 	if envConfig != nil && envConfig.RecipeConfig.Env.AdditionalProperties != nil {
 		envVars := map[string]string{}
 
 		for key, value := range envConfig.RecipeConfig.Env.AdditionalProperties {
-			strValue := fmt.Sprintf("%v", value)
-			envVars[key] = strValue
+			envVars[key] = value
 		}
 
 		if err := tf.SetEnv(envVars); err != nil {

--- a/pkg/recipes/terraform/execute_test.go
+++ b/pkg/recipes/terraform/execute_test.go
@@ -157,6 +157,7 @@ func TestSetEnvironmentVariables(t *testing.T) {
 			},
 		},
 	}
+
 	for _, tc := range testCase {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := testcontext.New(t)
@@ -165,10 +166,8 @@ func TestSetEnvironmentVariables(t *testing.T) {
 			tf, err := tfexec.NewTerraform(workingDir, filepath.Join(workingDir, "terraform"))
 			require.NoError(t, err)
 
-			// Create an executor
 			e := executor{}
 
-			// Call the function to set environment variables
 			err = e.setEnvironmentVariables(ctx, tf, tc.opts.EnvConfig)
 			require.NoError(t, err)
 		})


### PR DESCRIPTION
# Description
Added a function to set environment variables to the Terraform process. This function reads user provided configuration from the RecipeConfig/EnvVariables section of the Radius environment configuration and is invoked during the setup phase for Terraform deployment.

[link to PR for design doc](https://github.com/radius-project/design-notes/pull/39)

The design document describes a SecretReference type and ability to fetch data from secrets and set environment variables. This will be implemented in subsequent PRs.

## Type of change
- This pull request adds or changes features of Radius and has an approved issue #6539 

Fixes: Part of #6539