### PR TITLE
Updating environment variables set at Terraform process to include env variables at current process

### DIFF
--- a/pkg/recipes/terraform/execute.go
+++ b/pkg/recipes/terraform/execute.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	install "github.com/hashicorp/hc-install"
@@ -90,7 +89,7 @@ func (e *executor) Deploy(ctx context.Context, options Options) (*tfjson.State, 
 	}
 
 	// Set environment variables for the Terraform process.
-	err = e.setEnvironmentVariables(ctx, options.EnvConfig)
+	err = e.setEnvironmentVariables(ctx, tf, options.EnvConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -201,15 +200,18 @@ func (e *executor) GetRecipeMetadata(ctx context.Context, options Options) (map[
 	}, nil
 }
 
-// setEnvironmentVariables sets environment variables by reading values from the environment configuration.
+// setEnvironmentVariables sets environment variables for the Terraform process by reading values from the environment configuration.
 // Terraform process will use environment variables as input for the recipe deployment.
-func (e executor) setEnvironmentVariables(ctx context.Context, envConfig *recipes.Configuration) error {
-	if envConfig != nil && envConfig.RecipeConfig.Env.AdditionalProperties != nil && len(envConfig.RecipeConfig.Env.AdditionalProperties) > 0 {
+func (e executor) setEnvironmentVariables(ctx context.Context, tf *tfexec.Terraform, envConfig *recipes.Configuration) error {
+	if envConfig != nil && envConfig.RecipeConfig.Env.AdditionalProperties != nil {
+		envVars := map[string]string{}
 
 		for key, value := range envConfig.RecipeConfig.Env.AdditionalProperties {
-			if err := os.Setenv(key, value); err != nil {
-				return fmt.Errorf("error setting environment variable %s: %w", key, err)
-			}
+			envVars[key] = value
+		}
+
+		if err := tf.SetEnv(envVars); err != nil {
+			return fmt.Errorf("failed to set environment variables: %w", err)
 		}
 	}
 

--- a/pkg/recipes/terraform/execute.go
+++ b/pkg/recipes/terraform/execute.go
@@ -20,11 +20,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	install "github.com/hashicorp/hc-install"
 	"github.com/hashicorp/terraform-exec/tfexec"
 	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
 	"github.com/radius-project/radius/pkg/metrics"
 	"github.com/radius-project/radius/pkg/recipes"
 	"github.com/radius-project/radius/pkg/recipes/recipecontext"
@@ -88,10 +91,12 @@ func (e *executor) Deploy(ctx context.Context, options Options) (*tfjson.State, 
 		return nil, err
 	}
 
-	// Set environment variables for the Terraform process.
-	err = e.setEnvironmentVariables(ctx, tf, options.EnvConfig)
-	if err != nil {
-		return nil, err
+	if options.EnvConfig != nil {
+		// Set environment variables for the Terraform process.
+		err = e.setEnvironmentVariables(ctx, tf, &options.EnvConfig.RecipeConfig)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Run TF Init and Apply in the working directory
@@ -200,13 +205,14 @@ func (e *executor) GetRecipeMetadata(ctx context.Context, options Options) (map[
 	}, nil
 }
 
-// setEnvironmentVariables sets environment variables for the Terraform process by reading values from the environment configuration.
+// setEnvironmentVariables sets environment variables for the Terraform process by reading values from the recipe configuration.
 // Terraform process will use environment variables as input for the recipe deployment.
-func (e executor) setEnvironmentVariables(ctx context.Context, tf *tfexec.Terraform, envConfig *recipes.Configuration) error {
-	if envConfig != nil && envConfig.RecipeConfig.Env.AdditionalProperties != nil {
-		envVars := map[string]string{}
+func (e executor) setEnvironmentVariables(ctx context.Context, tf *tfexec.Terraform, recipeConfig *datamodel.RecipeConfigProperties) error {
+	if recipeConfig != nil && recipeConfig.Env.AdditionalProperties != nil && len(recipeConfig.Env.AdditionalProperties) > 0 {
+		// populate envVars with the environment variables from current process
+		envVars := splitEnvVar(os.Environ())
 
-		for key, value := range envConfig.RecipeConfig.Env.AdditionalProperties {
+		for key, value := range recipeConfig.Env.AdditionalProperties {
 			envVars[key] = value
 		}
 
@@ -216,6 +222,19 @@ func (e executor) setEnvironmentVariables(ctx context.Context, tf *tfexec.Terraf
 	}
 
 	return nil
+}
+
+// splitEnvVar splits a slice of environment variables into a map of keys and values.
+func splitEnvVar(env []string) map[string]string {
+	envVars := make(map[string]string)
+	for _, item := range env {
+		splits := strings.SplitN(item, "=", 2) // Split on the first "="
+		if len(splits) == 2 {
+			envVars[splits[0]] = splits[1]
+		}
+	}
+
+	return envVars
 }
 
 // generateConfig generates Terraform configuration with required inputs for the module, providers and backend to be initialized and applied.

--- a/pkg/recipes/terraform/execute.go
+++ b/pkg/recipes/terraform/execute.go
@@ -225,16 +225,16 @@ func (e executor) setEnvironmentVariables(ctx context.Context, tf *tfexec.Terraf
 }
 
 // splitEnvVar splits a slice of environment variables into a map of keys and values.
-func splitEnvVar(env []string) map[string]string {
-	envVars := make(map[string]string)
-	for _, item := range env {
+func splitEnvVar(envVars []string) map[string]string {
+	parsedEnvVars := make(map[string]string)
+	for _, item := range envVars {
 		splits := strings.SplitN(item, "=", 2) // Split on the first "="
 		if len(splits) == 2 {
-			envVars[splits[0]] = splits[1]
+			parsedEnvVars[splits[0]] = splits[1]
 		}
 	}
 
-	return envVars
+	return parsedEnvVars
 }
 
 // generateConfig generates Terraform configuration with required inputs for the module, providers and backend to be initialized and applied.

--- a/pkg/recipes/terraform/execute_test.go
+++ b/pkg/recipes/terraform/execute_test.go
@@ -168,7 +168,10 @@ func TestSetEnvironmentVariables(t *testing.T) {
 
 			e := executor{}
 
-			err = e.setEnvironmentVariables(ctx, tf, tc.opts.EnvConfig)
+			if tc.opts.EnvConfig != nil {
+				err = e.setEnvironmentVariables(ctx, tf, &tc.opts.EnvConfig.RecipeConfig)
+			}
+
 			require.NoError(t, err)
 		})
 	}

--- a/test/functional/shared/resources/testdata/corerp-resources-terraform-redis.bicep
+++ b/test/functional/shared/resources/testdata/corerp-resources-terraform-redis.bicep
@@ -17,6 +17,12 @@ resource env 'Applications.Core/environments@2023-10-01-preview' = {
       resourceId: 'self'
       namespace: 'corerp-resources-terraform-redis-env'
     }
+    recipeConfig: {
+      env: {
+        MY_ENV_VAR_1: 'env-var-value-1'
+        MY_ENV_VAR_2: 'env-var-value-2'
+      }
+    }
     recipes: {
       'Applications.Core/extenders': {
         default: {


### PR DESCRIPTION
# Description
We encountered an issue with the current implementation of setting environment variables at the Terraform process. The environment variables set at current process are not copied over by default when calling tf.SetEnv().
We're updating code to include environment variables set at current process and then apply them to the Terraform process.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue #7269 .

Fixes: #7269 
