### PR TITLE
Add reorganized cli tests to the matrix

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -307,7 +307,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        name: [ucp,kubernetes,shared,msgrp,daprrp,samples]
+        name: [ucp,kubernetes,shared,msgrp,daprrp,samples,cli]
         include:
           # datastorerp functional tests need the larger VM.
           - os: ubuntu-latest-m


### PR DESCRIPTION
# Description

cli tests were moved out of the shared folder. The functional test workflow was missing the cli tests in the matrix and it does not use "make test-functional-all" unlike the long running tests. As a result, these tests were skipped. This PR adds the cli tests to the matrix.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (#7279 ).


<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #7279 
