### PR TITLE
Log errors for failed requests

### DIFF
--- a/pkg/armrpc/asyncoperation/controller/result_test.go
+++ b/pkg/armrpc/asyncoperation/controller/result_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"errors"
+	"testing"
+
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	"github.com/radius-project/radius/test/testcontext"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFailedResult(t *testing.T) {
+	ctx := testcontext.New(t)
+	err := errors.New("test error")
+	errorDetails := v1.ErrorDetails{
+		Message: "test error message",
+	}
+
+	result := NewFailedResult(ctx, err, errorDetails)
+	require.Equal(t, errorDetails, *result.Error)
+	require.Equal(t, false, result.Requeue)
+	require.Equal(t, v1.ProvisioningStateFailed, *result.state)
+}
+
+func TestSetFailed(t *testing.T) {
+	err := v1.ErrorDetails{
+		Message: "test error message",
+	}
+
+	result := &Result{}
+	result.SetFailed(testcontext.New(t), errors.New("test error"), err, true)
+	require.Equal(t, err, *result.Error)
+	require.Equal(t, true, result.Requeue)
+}

--- a/pkg/armrpc/asyncoperation/worker/worker.go
+++ b/pkg/armrpc/asyncoperation/worker/worker.go
@@ -179,8 +179,7 @@ func (w *AsyncRequestProcessWorker) Start(ctx context.Context) error {
 
 			if msgreq.DequeueCount > w.options.MaxOperationRetryCount {
 				errMsg := fmt.Sprintf("exceeded max retry count to process async operation message: %d", msgreq.DequeueCount)
-				opLogger.Error(nil, errMsg)
-				failed := ctrl.NewFailedResult(v1.ErrorDetails{
+				failed := ctrl.NewFailedResult(ctx, nil, v1.ErrorDetails{
 					Code:    v1.CodeInternal,
 					Message: errMsg,
 				})
@@ -266,8 +265,7 @@ func (w *AsyncRequestProcessWorker) runOperation(ctx context.Context, message *q
 		if !errors.Is(asyncReqCtx.Err(), context.Canceled) {
 			if err != nil {
 				armErr := extractError(err)
-				result.SetFailed(armErr, false)
-				logger.Error(err, "Operation Failed")
+				result.SetFailed(ctx, err, armErr, false)
 			}
 
 			w.completeOperation(ctx, message, result, asyncCtrl.StorageClient())

--- a/pkg/corerp/backend/controller/createorupdateresource.go
+++ b/pkg/corerp/backend/controller/createorupdateresource.go
@@ -108,7 +108,7 @@ func (c *CreateOrUpdateResource) Run(ctx context.Context, request *ctrl.Request)
 
 	deploymentDataModel, ok := dataModel.(rpv1.DeploymentDataModel)
 	if !ok {
-		return ctrl.NewFailedResult(v1.ErrorDetails{Message: "deployment data model conversion error"}), err
+		return ctrl.NewFailedResult(ctx, nil, v1.ErrorDetails{Message: "deployment data model conversion error"}), nil
 	}
 
 	oldOutputResources := deploymentDataModel.OutputResources()
@@ -136,5 +136,5 @@ func (c *CreateOrUpdateResource) Run(ctx context.Context, request *ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	return ctrl.Result{}, err
+	return ctrl.Result{}, nil
 }

--- a/pkg/corerp/backend/controller/deleteresource.go
+++ b/pkg/corerp/backend/controller/deleteresource.go
@@ -43,7 +43,7 @@ func NewDeleteResource(opts ctrl.Options) (ctrl.Controller, error) {
 func (c *DeleteResource) Run(ctx context.Context, request *ctrl.Request) (ctrl.Result, error) {
 	obj, err := c.StorageClient().Get(ctx, request.ResourceID)
 	if err != nil {
-		return ctrl.NewFailedResult(v1.ErrorDetails{Message: err.Error()}), err
+		return ctrl.NewFailedResult(ctx, err, v1.ErrorDetails{Message: err.Error()}), err
 	}
 
 	// This code is general and we might be processing an async job for a resource or a scope, so using the general Parse function.
@@ -63,7 +63,7 @@ func (c *DeleteResource) Run(ctx context.Context, request *ctrl.Request) (ctrl.R
 
 	deploymentDataModel, ok := dataModel.(rpv1.DeploymentDataModel)
 	if !ok {
-		return ctrl.NewFailedResult(v1.ErrorDetails{Message: "deployment data model conversion error"}), nil
+		return ctrl.NewFailedResult(ctx, nil, v1.ErrorDetails{Message: "deployment data model conversion error"}), nil
 	}
 
 	err = c.DeploymentProcessor().Delete(ctx, id, deploymentDataModel.OutputResources())

--- a/pkg/portableresources/backend/controller/createorupdateresource.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	ctrl "github.com/radius-project/radius/pkg/armrpc/asyncoperation/controller"
 	"github.com/radius-project/radius/pkg/portableresources/datamodel"
@@ -97,7 +96,6 @@ func (c *CreateOrUpdateResource[P, T]) Run(ctx context.Context, req *ctrl.Reques
 	recipeOutput, err := c.executeRecipeIfNeeded(ctx, data, previousOutputResources, config.Simulated)
 	if err != nil {
 		if recipeError, ok := err.(*recipes.RecipeError); ok {
-			logger.Error(err, fmt.Sprintf("failed to execute recipe. Encountered error while processing %s ", recipeError.ErrorDetails.Target))
 			// Set the deployment status to the recipe error code.
 			recipeDataModel.Recipe().DeploymentStatus = util.RecipeDeploymentStatus(recipeError.DeploymentStatus)
 			update := &store.Object{
@@ -111,7 +109,7 @@ func (c *CreateOrUpdateResource[P, T]) Run(ctx context.Context, req *ctrl.Reques
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			return ctrl.NewFailedResult(recipeError.ErrorDetails), nil
+			return ctrl.NewFailedResult(ctx, err, recipeError.ErrorDetails), nil
 		}
 		return ctrl.Result{}, err
 	}

--- a/pkg/portableresources/backend/controller/deleteresource.go
+++ b/pkg/portableresources/backend/controller/deleteresource.go
@@ -60,7 +60,7 @@ func NewDeleteResource[P interface {
 func (c *DeleteResource[P, T]) Run(ctx context.Context, request *ctrl.Request) (ctrl.Result, error) {
 	obj, err := c.StorageClient().Get(ctx, request.ResourceID)
 	if err != nil {
-		return ctrl.NewFailedResult(v1.ErrorDetails{Message: err.Error()}), err
+		return ctrl.NewFailedResult(ctx, err, v1.ErrorDetails{Message: err.Error()}), err
 	}
 
 	// This code is general and we might be processing an async job for a resource or a scope, so using the general Parse function.
@@ -95,7 +95,7 @@ func (c *DeleteResource[P, T]) Run(ctx context.Context, request *ctrl.Request) (
 		})
 		if err != nil {
 			if recipeError, ok := err.(*recipes.RecipeError); ok {
-				return ctrl.NewFailedResult(recipeError.ErrorDetails), nil
+				return ctrl.NewFailedResult(ctx, err, recipeError.ErrorDetails), nil
 			}
 			return ctrl.Result{}, err
 		}

--- a/pkg/ucp/integrationtests/radius/proxy_test.go
+++ b/pkg/ucp/integrationtests/radius/proxy_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/radius-project/radius/pkg/ucp/frontend/api"
 	"github.com/radius-project/radius/pkg/ucp/integrationtests/testrp"
 	"github.com/radius-project/radius/pkg/ucp/integrationtests/testserver"
+	"github.com/radius-project/radius/test/testcontext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -282,7 +283,7 @@ func Test_RadiusPlane_ResourceAsync(t *testing.T) {
 
 	t.Run("Complete DELETE FAILURE", func(t *testing.T) {
 		t.Log("completing DELETE FAILURE operation")
-		deleteCh <- backend_ctrl.NewFailedResult(v1.ErrorDetails{
+		deleteCh <- backend_ctrl.NewFailedResult(testcontext.New(t), nil, v1.ErrorDetails{
 			Code:    v1.CodeInternal,
 			Message: "Oh no!",
 		})


### PR DESCRIPTION
# Description

We currently lack error logging upon failure for many operations which hinders our ability to debug failures. This gap exists because errors that aren't propagated back up (async operations) [aren't logged automatically](https://github.com/radius-project/radius/blob/main/docs/contributing/contributing-code/contributing-code-control-plane/logging.md?plain=1#L45). The current state of the code is inconsistent, with some operations logging errors while others do not.

To address this, the proposed change is to move error logging to the setFailed method. By doing so, we ensure that error logging is not reliant on every individual operation to log errors.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: https://github.com/radius-project/radius/issues/7297
