### PR TITLE
Add cli validation for missing Bicep parameters

### DIFF
--- a/pkg/cli/bicep/envinject.go
+++ b/pkg/cli/bicep/envinject.go
@@ -35,12 +35,13 @@ func InjectApplicationParam(deploymentTemplate map[string]any, parameters map[st
 }
 
 func injectParam(deploymentTemplate map[string]any, parameters map[string]map[string]any, parameter string, value string) error {
-	if deploymentTemplate["parameters"] == nil {
-		return nil
+	formalParams, err := ExtractParameters(deploymentTemplate)
+	if err != nil {
+		return err
 	}
 
-	innerParameters := deploymentTemplate["parameters"].(map[string]any)
-	if innerParameters[parameter] == nil {
+	if _, ok := formalParams[parameter]; !ok {
+		// If we got here, it means 'parameter' is not a formal parameter of the template.
 		return nil
 	}
 

--- a/pkg/cli/bicep/parameters.go
+++ b/pkg/cli/bicep/parameters.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bicep
+
+import "fmt"
+
+// ExtractParameters extracts the parameters from the deployment template.
+func ExtractParameters(template map[string]any) (map[string]any, error) {
+	if template["parameters"] == nil {
+		return map[string]any{}, nil
+	}
+
+	params, ok := template["parameters"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("invalid template: parameters must be a map of maps, got: %T", template["parameters"])
+	}
+
+	return params, nil
+}
+
+// DefaultValue returns the default value of a parameter and a boolean indicating if it was found.
+func DefaultValue(parameter any) (any, bool) {
+	if parameter == nil {
+		return nil, false
+	}
+
+	param, ok := parameter.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+
+	defaultValue, ok := param["defaultValue"]
+	return defaultValue, ok
+}

--- a/pkg/cli/bicep/parameters_test.go
+++ b/pkg/cli/bicep/parameters_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bicep
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ExtractParameters(t *testing.T) {
+	b, err := os.ReadFile("testdata/test-extractparameters.json")
+	require.NoError(t, err)
+
+	template := map[string]any{}
+	err = json.Unmarshal(b, &template)
+	require.NoError(t, err)
+
+	params, err := ExtractParameters(template)
+	require.NoError(t, err)
+
+	expected := map[string]any{
+		"application": map[string]any{
+			"metadata": map[string]any{
+				"description": "Specifies the application for resources.",
+			},
+			"type": "string",
+		},
+		"location": map[string]any{
+			"defaultValue": "westus2",
+			"metadata": map[string]any{
+				"description": "Specifies the location for resources.",
+			},
+			"type": "string",
+		},
+	}
+	require.Equal(t, expected, params)
+}
+
+func Test_DefaultValue_HasDefaultValue(t *testing.T) {
+	parameter := map[string]any{
+		"defaultValue": "westus2",
+		"metadata": map[string]any{
+			"description": "Specifies the location for resources.",
+		},
+		"type": "string",
+	}
+
+	value, ok := DefaultValue(parameter)
+	require.Equal(t, "westus2", value)
+	require.True(t, ok)
+}
+
+func Test_DefaultValue_NoDefaultValue(t *testing.T) {
+	parameter := map[string]any{
+		"metadata": map[string]any{
+			"description": "Specifies the location for resources.",
+		},
+		"type": "string",
+	}
+
+	value, ok := DefaultValue(parameter)
+	require.Nil(t, value)
+	require.False(t, ok)
+}

--- a/pkg/cli/bicep/testdata/test-extractparameters.json
+++ b/pkg/cli/bicep/testdata/test-extractparameters.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "languageVersion": "1.9-experimental",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+    },
+    "parameters": {
+        "location": {
+            "type": "string",
+            "defaultValue": "westus2",
+            "metadata": {
+                "description": "Specifies the location for resources."
+            }
+        },
+        "application": {
+            "type": "string",
+            "metadata": {
+                "description": "Specifies the application for resources."
+            }
+        }
+    },
+    "resources": {
+    }
+}

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/radius-project/radius/pkg/cli/bicep"
 	"github.com/radius-project/radius/pkg/cli/clients"
 	"github.com/radius-project/radius/pkg/cli/output"
 )
@@ -33,16 +32,6 @@ import (
 // deploying, and logs the deployment results and public endpoints. If an error occurs, an error is returned.
 func DeployWithProgress(ctx context.Context, options Options) (clients.DeploymentResult, error) {
 	deploymentClient, err := options.ConnectionFactory.CreateDeploymentClient(ctx, options.Workspace)
-	if err != nil {
-		return clients.DeploymentResult{}, err
-	}
-
-	err = bicep.InjectEnvironmentParam(options.Template, options.Parameters, options.Providers.Radius.EnvironmentID)
-	if err != nil {
-		return clients.DeploymentResult{}, err
-	}
-
-	err = bicep.InjectApplicationParam(options.Template, options.Parameters, options.Providers.Radius.ApplicationID)
 	if err != nil {
 		return clients.DeploymentResult{}, err
 	}


### PR DESCRIPTION
# Description

This change adds validation for parameters that required by a Bicep template but not supplied by the CLI. There are some nasty cases today that can occur when the application parameter is defined, but not supplied. Short circuiting this behavior on the CLI improves the user-experience.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #issue_number
