### PR TITLE
Add error handling for failed `oras pull` during installation.

### DIFF
--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -126,7 +126,8 @@ if ($Version -eq "edge") {
     # Check if the oras pull command was successful
     if ($LASTEXITCODE -ne 0) {
         Write-Output "Failed to download edge rad CLI."
-        Write-Output "Please visit https://edge.docs.radapp.io/installation for edge build installation instructions."
+        Write-Output "If this was an authentication issue, please run 'docker logout ghcr.io' to clear any expired credentials."
+        Write-Output "Visit https://edge.docs.radapp.io/installation for edge build installation instructions."
         Exit 1
     }
 }

--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -122,6 +122,13 @@ if ($Version -eq "edge") {
     $downloadURL = "ghcr.io/${GitHubOrg}/rad/${OS}-${Arch}:latest"
     Write-Output "Downloading edge CLI from ${downloadURL}..."
     oras pull $downloadURL -o $RadiusRoot
+
+    # Check if the oras pull command was successful
+    if ($LASTEXITCODE -ne 0) {
+        Write-Output "Failed to download edge rad CLI."
+        Write-Output "Please visit https://edge.docs.radapp.io/installation for edge build installation instructions."
+        Exit 1
+    }
 }
 else {
     # Get the list of releases from GitHub

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -128,6 +128,14 @@ downloadFile() {
         DOWNLOAD_URL="ghcr.io/radius-project/rad/${OS}-${ARCH}:latest"
         echo "Downloading edge CLI from ${DOWNLOAD_URL}..."
         oras pull $DOWNLOAD_URL -o $RADIUS_TMP_ROOT
+
+        # Check if the oras pull command was successfull
+        if [ $? -ne 0 ]; then
+            echo "Failed to download edge CLI."
+            echo "Please visit https://edge.docs.radapp.io/installation for edge CLI installation instructions."
+            exit 1
+        fi
+
         mv $RADIUS_TMP_ROOT/rad $ARTIFACT_TMP_FILE
     else
         DOWNLOAD_BASE="https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -132,7 +132,8 @@ downloadFile() {
         # Check if the oras pull command was successfull
         if [ $? -ne 0 ]; then
             echo "Failed to download edge CLI."
-            echo "Please visit https://edge.docs.radapp.io/installation for edge CLI installation instructions."
+            echo "If this was an authentication issue, please run 'docker logout ghcr.io' to clear any expired credentials."
+            echo "Visit https://edge.docs.radapp.io/installation for edge CLI installation instructions."
             exit 1
         fi
 


### PR DESCRIPTION
# Description

This PR adds a check to make sure the `oras pull` command compelted successfully. This is needed because it will fail if you have an expired token for GHCR.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #7301
