### PR TITLE
Use workload identity in workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -306,12 +306,14 @@ jobs:
           mkdir -p ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
           helm package ${{ env.HELM_CHARTS_DIR }} --version ${{ env.CHART_VERSION }} --app-version ${{ env.REL_VERSION }} --destination ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
       # TODO: Delete this step once we use GHCR as the helm chart repo.
-      - name: Login to Azure
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
-          tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
+      - name: Setup Azure CLI
+        run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      - name: az CLI login
+        run: |
+          az login --service-principal \
+            --username ${{ secrets.AZURE_SP_TESTS_APPID }} \
+            --password ${{ secrets.AZURE_SP_TESTS_PASSWORD }} \
+            --tenant ${{ secrets.AZURE_SP_TESTS_TENANTID }}
       # TODO: Delete this step once we use GHCR as the helm chart repo.
       - name: Push helm chart to ACR
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -306,6 +306,7 @@ jobs:
           mkdir -p ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
           helm package ${{ env.HELM_CHARTS_DIR }} --version ${{ env.CHART_VERSION }} --app-version ${{ env.REL_VERSION }} --destination ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
       # TODO: Delete this step once we use GHCR as the helm chart repo.
+      # Cannot use Workload Identity because azure federated identity doesn't accept wildcard tag version.
       - name: Setup Azure CLI
         run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
       - name: az CLI login

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -306,14 +306,12 @@ jobs:
           mkdir -p ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
           helm package ${{ env.HELM_CHARTS_DIR }} --version ${{ env.CHART_VERSION }} --app-version ${{ env.REL_VERSION }} --destination ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
       # TODO: Delete this step once we use GHCR as the helm chart repo.
-      - name: Setup Azure CLI
-        run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-      - name: az CLI login
-        run: |
-          az login --service-principal \
-            --username ${{ secrets.AZURE_SP_TESTS_APPID }} \
-            --password ${{ secrets.AZURE_SP_TESTS_PASSWORD }} \
-            --tenant ${{ secrets.AZURE_SP_TESTS_TENANTID }}
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
+          tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
       # TODO: Delete this step once we use GHCR as the helm chart repo.
       - name: Push helm chart to ACR
         run: |

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -388,6 +388,7 @@ jobs:
         with:
           client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
           tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
+          subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
       - uses: marocchino/sticky-pull-request-comment@v2
         continue-on-error: true
         with:

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -388,7 +388,7 @@ jobs:
         with:
           client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
           tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
-          subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
       - uses: marocchino/sticky-pull-request-comment@v2
         continue-on-error: true
         with:
@@ -404,7 +404,7 @@ jobs:
           az group create \
             --location ${{ env.AZURE_LOCATION }} \
             --name $RESOURCE_GROUP \
-            --subscription ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }} \
+            --subscription ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }} \
             --tags creationTime=$current_time
           while [ $(az group exists --name $RESOURCE_GROUP) = false ]; do sleep 2; done
         env:
@@ -511,7 +511,7 @@ jobs:
           rad env switch kind-radius
 
           echo "*** Configuring Azure provider ***"
-          rad env update kind-radius --azure-subscription-id ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }} \
+          rad env update kind-radius --azure-subscription-id ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }} \
             --azure-resource-group ${{ env.AZURE_TEST_RESOURCE_GROUP }}
           rad credential register azure --client-id ${{ secrets.AZURE_SP_TESTS_APPID }} \
             --client-secret ${{ secrets.INTEGRATION_TEST_SP_PASSWORD }} \

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -19,6 +19,7 @@ name: Functional tests
 permissions:
   id-token: write # Required for requesting the JWT
   contents: read  # Required for actions/checkout
+  packages: write # Required for uploading the package
 
 on:
   schedule:

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -386,7 +386,7 @@ jobs:
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.INTEGRATION_TEST_SP_APP_ID }}
-          tenant-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+          tenant-id: ${{ secrets.INTEGRATION_TEST_TENANT_ID }}
           subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
       - uses: marocchino/sticky-pull-request-comment@v2
         continue-on-error: true

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -15,6 +15,11 @@
 # ------------------------------------------------------------
 
 name: Functional tests
+
+permissions:
+  id-token: write # Required for requesting the JWT
+  contents: read  # Required for actions/checkout
+
 on:
   schedule:
     # Run every 4 hours on weekdays.
@@ -380,7 +385,9 @@ jobs:
       - name: Login to Azure
         uses: azure/login@v1
         with:
-          creds: '{"clientId":"${{ secrets.INTEGRATION_TEST_SP_APP_ID }}","clientSecret":"${{ secrets.INTEGRATION_TEST_SP_PASSWORD }}","subscriptionId":"${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.INTEGRATION_TEST_TENANT_ID }}"}'
+          client-id: ${{ secrets.INTEGRATION_TEST_SP_APP_ID }}
+          tenant-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+          subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
       - uses: marocchino/sticky-pull-request-comment@v2
         continue-on-error: true
         with:

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -384,11 +384,10 @@ jobs:
           name: ${{ env.RAD_CLI_ARTIFACT_NAME }}
           path: bin
       - name: Login to Azure
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
-          client-id: ${{ secrets.INTEGRATION_TEST_SP_APP_ID }}
-          tenant-id: ${{ secrets.INTEGRATION_TEST_TENANT_ID }}
-          subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+          client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
+          tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
       - uses: marocchino/sticky-pull-request-comment@v2
         continue-on-error: true
         with:
@@ -464,7 +463,7 @@ jobs:
       - name: Install azure workload identity webhook chart
         run: |
           helm repo add azure-workload-identity https://azure.github.io/azure-workload-identity/charts
-          helm install workload-identity-webhook azure-workload-identity/workload-identity-webhook --namespace radius-default --create-namespace --version ${{ env.AZURE_WORKLOAD_IDENTITY_WEBHOOK_VER }} --set azureTenantID=${{ secrets.INTEGRATION_TEST_TENANT_ID }}
+          helm install workload-identity-webhook azure-workload-identity/workload-identity-webhook --namespace radius-default --create-namespace --version ${{ env.AZURE_WORKLOAD_IDENTITY_WEBHOOK_VER }} --set azureTenantID=${{ secrets.AZURE_SP_TESTS_TENANTID }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -513,9 +512,9 @@ jobs:
           echo "*** Configuring Azure provider ***"
           rad env update kind-radius --azure-subscription-id ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }} \
             --azure-resource-group ${{ env.AZURE_TEST_RESOURCE_GROUP }}
-          rad credential register azure --client-id ${{ secrets.INTEGRATION_TEST_SP_APP_ID }} \
+          rad credential register azure --client-id ${{ secrets.AZURE_SP_TESTS_APPID }} \
             --client-secret ${{ secrets.INTEGRATION_TEST_SP_PASSWORD }} \
-            --tenant-id ${{ secrets.INTEGRATION_TEST_TENANT_ID }}
+            --tenant-id ${{ secrets.AZURE_SP_TESTS_TENANTID }}
 
           echo "*** Configuring AWS provider ***"
           rad env update kind-radius --aws-region ${{ env.AWS_REGION }} --aws-account-id ${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -37,6 +37,11 @@
 # Grafana dashboard URL: https://radiuse2e00-dashboard-audycmffgberbghy.wus3.grafana.azure.com/
 
 name: Long-running test on Azure
+
+permissions:
+  id-token: write # Required for requesting the JWT
+  contents: read  # Required for actions/checkout
+
 on:
   schedule:
     # Run every 2 hours
@@ -203,7 +208,9 @@ jobs:
         if: steps.skip-build.outputs.SKIP_BUILD != 'true'
         uses: azure/login@v1
         with:
-          creds: '{"clientId":"${{ secrets.INTEGRATION_TEST_SP_APP_ID }}","clientSecret":"${{ secrets.INTEGRATION_TEST_SP_PASSWORD }}","subscriptionId":"${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.INTEGRATION_TEST_TENANT_ID }}"}'
+          client-id: ${{ secrets.INTEGRATION_TEST_SP_APP_ID }}
+          tenant-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+          subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -332,7 +339,9 @@ jobs:
       - name: Login to Azure
         uses: azure/login@v1
         with:
-          creds: '{"clientId":"${{ secrets.INTEGRATION_TEST_SP_APP_ID }}","clientSecret":"${{ secrets.INTEGRATION_TEST_SP_PASSWORD }}","subscriptionId":"${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.INTEGRATION_TEST_TENANT_ID }}"}'
+          client-id: ${{ secrets.INTEGRATION_TEST_SP_APP_ID }}
+          tenant-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+          subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -211,7 +211,7 @@ jobs:
         with:
           client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
           tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
-          subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -342,7 +342,7 @@ jobs:
         with:
           client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
           tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
-          subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -355,7 +355,7 @@ jobs:
           az group create \
             --location ${{ env.AZURE_LOCATION }} \
             --name $RESOURCE_GROUP \
-            --subscription ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }} \
+            --subscription ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }} \
             --tags creationTime=$current_time
           while [ $(az group exists --name $RESOURCE_GROUP) = false ]; do sleep 2; done
         env:
@@ -363,7 +363,7 @@ jobs:
       - name: Get kubeconf credential for AKS cluster
         run: |
           az aks get-credentials \
-            --subscription ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }} \
+            --subscription ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }} \
             --resource-group ${{ env.AKS_RESOURCE_GROUP }} \
             --name ${{ env.AKS_CLUSTER_NAME }} --admin
         env:
@@ -408,7 +408,7 @@ jobs:
           rad env switch ${{ env.RADIUS_TEST_ENVIRONMENT_NAME }}
 
           echo "*** Configuring Azure provider ***"
-          rad env update ${{ env.RADIUS_TEST_ENVIRONMENT_NAME }} --azure-subscription-id ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }} \
+          rad env update ${{ env.RADIUS_TEST_ENVIRONMENT_NAME }} --azure-subscription-id ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }} \
             --azure-resource-group ${{ env.AZURE_TEST_RESOURCE_GROUP }}
           rad credential register azure --client-id ${{ secrets.AZURE_SP_TESTS_APPID }} \
             --client-secret ${{ secrets.INTEGRATION_TEST_SP_PASSWORD }} \
@@ -489,7 +489,7 @@ jobs:
         run: |
           # if deletion fails, purge workflow will purge the resource group and its resources later.
           az group delete \
-            --subscription ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }} \
+            --subscription ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }} \
             --name ${{ env.AZURE_TEST_RESOURCE_GROUP }} \
             --yes --verbose
       - name: Clean up cluster

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -207,11 +207,10 @@ jobs:
         run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
       - name: Login to Azure
         if: steps.skip-build.outputs.SKIP_BUILD != 'true'
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
-          client-id: ${{ secrets.INTEGRATION_TEST_SP_APP_ID }}
-          tenant-id: ${{ secrets.INTEGRATION_TEST_TENANT_ID }}
-          subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+          client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
+          tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -338,11 +337,10 @@ jobs:
           mv ./dist/cache/rad ./bin/
           chmod +x ./bin/rad
       - name: Login to Azure
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
-          client-id: ${{ secrets.INTEGRATION_TEST_SP_APP_ID }}
-          tenant-id: ${{ secrets.INTEGRATION_TEST_TENANT_ID }}
-          subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+          client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
+          tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -410,9 +408,9 @@ jobs:
           echo "*** Configuring Azure provider ***"
           rad env update ${{ env.RADIUS_TEST_ENVIRONMENT_NAME }} --azure-subscription-id ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }} \
             --azure-resource-group ${{ env.AZURE_TEST_RESOURCE_GROUP }}
-          rad credential register azure --client-id ${{ secrets.INTEGRATION_TEST_SP_APP_ID }} \
+          rad credential register azure --client-id ${{ secrets.AZURE_SP_TESTS_APPID }} \
             --client-secret ${{ secrets.INTEGRATION_TEST_SP_PASSWORD }} \
-            --tenant-id ${{ secrets.INTEGRATION_TEST_TENANT_ID }}
+            --tenant-id ${{ secrets.AZURE_SP_TESTS_TENANTID }}
 
           echo "*** Configuring AWS provider ***"
           rad env update ${{ env.RADIUS_TEST_ENVIRONMENT_NAME }} --aws-region ${{ env.AWS_REGION }} --aws-account-id ${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -209,7 +209,7 @@ jobs:
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.INTEGRATION_TEST_SP_APP_ID }}
-          tenant-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+          tenant-id: ${{ secrets.INTEGRATION_TEST_TENANT_ID }}
           subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -340,7 +340,7 @@ jobs:
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.INTEGRATION_TEST_SP_APP_ID }}
-          tenant-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+          tenant-id: ${{ secrets.INTEGRATION_TEST_TENANT_ID }}
           subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -211,6 +211,7 @@ jobs:
         with:
           client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
           tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
+          subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -341,6 +342,7 @@ jobs:
         with:
           client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
           tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
+          subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -41,6 +41,7 @@ name: Long-running test on Azure
 permissions:
   id-token: write # Required for requesting the JWT
   contents: read  # Required for actions/checkout
+  packages: write # Required for uploading the package
 
 on:
   schedule:

--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.INTEGRATION_TEST_SP_APP_ID }}
-          tenant-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+          tenant-id: ${{ secrets.INTEGRATION_TEST_TENANT_ID }}
           subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
       - name: Find old test resource groups
         run: |

--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -55,6 +55,7 @@ jobs:
         with:
           client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
           tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
+          subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
       - name: Find old test resource groups
         run: |
           echo "## Test resource group list" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
           tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
-          subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
       - name: Find old test resource groups
         run: |
           echo "## Test resource group list" >> $GITHUB_STEP_SUMMARY
@@ -63,7 +63,7 @@ jobs:
           # Create the file to store the resource group list
           touch ${{ env.AZURE_RG_DELETE_LIST_FILE}}
 
-          az account set -s ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+          az account set -s ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
           resource_groups=$(az group list --query "[].{Name:name, creationTime:tags.creationTime}" -o tsv)
 
           current_time=$(date +%s)

--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -51,11 +51,10 @@ jobs:
       - name: Setup Azure CLI
         run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
       - name: Login to Azure
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
-          client-id: ${{ secrets.INTEGRATION_TEST_SP_APP_ID }}
-          tenant-id: ${{ secrets.INTEGRATION_TEST_TENANT_ID }}
-          subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+          client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
+          tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
       - name: Find old test resource groups
         run: |
           echo "## Test resource group list" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -15,7 +15,15 @@
 # ------------------------------------------------------------
 
 name: Purge test resources
+
+permissions:
+  id-token: write # Required for requesting the JWT
+  contents: read  # Required for actions/checkout
+
 on:
+  push:
+    branches:
+      - main
   schedule:
     # Run twice a day
     - cron: "30 0,12 * * *"
@@ -48,7 +56,9 @@ jobs:
       - name: Login to Azure
         uses: azure/login@v1
         with:
-          creds: '{"clientId":"${{ secrets.INTEGRATION_TEST_SP_APP_ID }}","clientSecret":"${{ secrets.INTEGRATION_TEST_SP_PASSWORD }}","subscriptionId":"${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.INTEGRATION_TEST_TENANT_ID }}"}'
+          client-id: ${{ secrets.INTEGRATION_TEST_SP_APP_ID }}
+          tenant-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
+          subscription-id: ${{ secrets.INTEGRATION_TEST_SUBSCRIPTION_ID }}
       - name: Find old test resource groups
         run: |
           echo "## Test resource group list" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/purge-test-resources.yaml
+++ b/.github/workflows/purge-test-resources.yaml
@@ -21,9 +21,6 @@ permissions:
   contents: read  # Required for actions/checkout
 
 on:
-  push:
-    branches:
-      - main
   schedule:
     # Run twice a day
     - cron: "30 0,12 * * *"


### PR DESCRIPTION
# Description

This is to use workload identity instead of secret auth for service principal.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #issue_number
