### PR TITLE
Fixing the wrong message in workspace switch command

### DIFF
--- a/pkg/cli/cmd/workspace/switch/switch.go
+++ b/pkg/cli/cmd/workspace/switch/switch.go
@@ -112,7 +112,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	if strings.EqualFold(section.Default, r.WorkspaceName) {
-		r.Output.LogInfo("Default environment is already set to %v", r.WorkspaceName)
+		r.Output.LogInfo("Default workspace is already set to %v", r.WorkspaceName)
 		return nil
 	}
 

--- a/pkg/cli/cmd/workspace/switch/switch_test.go
+++ b/pkg/cli/cmd/workspace/switch/switch_test.go
@@ -109,7 +109,7 @@ func Test_Run(t *testing.T) {
 
 		expected := []any{
 			output.LogOutput{
-				Format: "Default environment is already set to %v",
+				Format: "Default workspace is already set to %v",
 				Params: []any{"current-workspace"},
 			},
 		}


### PR DESCRIPTION
# Description
Fixing the wrong message in the workspace switch command.

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
Fixes: #7394 
