### PR TITLE
Randomize the id with GITHUB_RUN_NUMBER for scheduled test 

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -164,7 +164,7 @@ jobs:
       - name: Generate ID for release
         id: gen-id
         run: |
-          BASE_STR="RAD|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
+          BASE_STR="RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
           if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
             # Add run number to randomize unique id for scheduled runs.
             BASE_STR="${GITHUB_RUN_NUMBER}|${BASE_STR}"

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -164,15 +164,12 @@ jobs:
       - name: Generate ID for release
         id: gen-id
         run: |
-          if [ "$GITHUB_EVENT_NAME" == "schedule"]; then
-            BASE_STR="RADSCHEDULE|${GITHUB_RUN_NUMBER}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}"
+          if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
+            UNIQUE_ID="rads${GITHUB_RUN_NUMBER}"
           else
-            BASE_STR="RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
+            BASE_STR="RAD|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
+            UNIQUE_ID=$(echo $BASE_STR | sha1sum | head -c 10)
           fi
-          echo "RADSCHEDULE|${GITHUB_RUN_NUMBER}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}"
-          echo "RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
-          echo $BASE_STR
-          UNIQUE_ID=$(echo $BASE_STR | sha1sum | head -c 10)
           echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_ENV
           
           # Set output variables to be used in the other jobs

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -164,12 +164,12 @@ jobs:
       - name: Generate ID for release
         id: gen-id
         run: |
+          BASE_STR="RAD|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
           if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
-            UNIQUE_ID="rads${GITHUB_RUN_NUMBER}"
-          else
-            BASE_STR="RAD|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
-            UNIQUE_ID=$(echo $BASE_STR | sha1sum | head -c 10)
+            # Add run number to randomize unique id for scheduled runs.
+            BASE_STR="${GITHUB_RUN_NUMBER}|${BASE_STR}"
           fi
+          UNIQUE_ID=func$(echo $BASE_STR | sha1sum | head -c 10)
           echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_ENV
           
           # Set output variables to be used in the other jobs

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -164,8 +164,14 @@ jobs:
       - name: Generate ID for release
         id: gen-id
         run: |
-          BASE_STR="RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
-          UNIQUE_ID=$(echo $BASE_STR | sha1sum | head -c 10)
+          if GITHUB_EVENT_NAME == 'schedule'; then
+            BASE_STR="RADSCHEDULE|${GITHUB_RUN_NUMBER}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}"
+          else
+            BASE_STR="RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
+          fi
+          echo "RADSCHEDULE|${GITHUB_RUN_NUMBER}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}"
+          echo "RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
+          echo $BASE_STR
           echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_ENV
           
           # Set output variables to be used in the other jobs

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -164,7 +164,7 @@ jobs:
       - name: Generate ID for release
         id: gen-id
         run: |
-          if GITHUB_EVENT_NAME == 'schedule'; then
+          if [ "$GITHUB_EVENT_NAME" == "schedule"]; then
             BASE_STR="RADSCHEDULE|${GITHUB_RUN_NUMBER}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}"
           else
             BASE_STR="RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
@@ -172,6 +172,7 @@ jobs:
           echo "RADSCHEDULE|${GITHUB_RUN_NUMBER}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}"
           echo "RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
           echo $BASE_STR
+          UNIQUE_ID=$(echo $BASE_STR | sha1sum | head -c 10)
           echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_ENV
           
           # Set output variables to be used in the other jobs

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -144,7 +144,14 @@ jobs:
         id: gen-id
         run: |
           if [ -z "${{ steps.skip-build.outputs.SKIP_BUILD }}" ]; then
-            BASE_STR="RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
+            if [ "$GITHUB_EVENT_NAME" == "schedule"]; then
+              BASE_STR="RADSCHEDULE|${GITHUB_RUN_NUMBER}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}"
+            else
+              BASE_STR="RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
+            fi
+            echo "RADSCHEDULE|${GITHUB_RUN_NUMBER}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}"
+            echo "RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
+            echo $BASE_STR
             UNIQUE_ID=$(echo $BASE_STR | sha1sum | head -c 10)
             echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_ENV
             

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -151,6 +151,7 @@ jobs:
               UNIQUE_ID=$(echo $BASE_STR | sha1sum | head -c 10)
             fi
             echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_ENV
+            echo "rads${GITHUB_RUN_NUMBER}"
             
             # Set output variables to be used in the other jobs
             echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_OUTPUT

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -144,7 +144,7 @@ jobs:
         id: gen-id
         run: |
           if [ -z "${{ steps.skip-build.outputs.SKIP_BUILD }}" ]; then
-            BASE_STR="RAD|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
+            BASE_STR="RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
             if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
               # Add run number to randomize unique id for scheduled runs.
               BASE_STR="${GITHUB_RUN_NUMBER}|${BASE_STR}"

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -144,15 +144,12 @@ jobs:
         id: gen-id
         run: |
           if [ -z "${{ steps.skip-build.outputs.SKIP_BUILD }}" ]; then
-            if [ "$GITHUB_EVENT_NAME" == "schedule"]; then
-              BASE_STR="RADSCHEDULE|${GITHUB_RUN_NUMBER}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}"
+            if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
+              UNIQUE_ID="rads${GITHUB_RUN_NUMBER}"
             else
-              BASE_STR="RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
+              BASE_STR="RAD|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
+              UNIQUE_ID=$(echo $BASE_STR | sha1sum | head -c 10)
             fi
-            echo "RADSCHEDULE|${GITHUB_RUN_NUMBER}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}"
-            echo "RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
-            echo $BASE_STR
-            UNIQUE_ID=$(echo $BASE_STR | sha1sum | head -c 10)
             echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_ENV
             
             # Set output variables to be used in the other jobs

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -144,14 +144,13 @@ jobs:
         id: gen-id
         run: |
           if [ -z "${{ steps.skip-build.outputs.SKIP_BUILD }}" ]; then
+            BASE_STR="RAD|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
             if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
-              UNIQUE_ID="rads${GITHUB_RUN_NUMBER}"
-            else
-              BASE_STR="RAD|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
-              UNIQUE_ID=$(echo $BASE_STR | sha1sum | head -c 10)
+              # Add run number to randomize unique id for scheduled runs.
+              BASE_STR="${GITHUB_RUN_NUMBER}|${BASE_STR}"
             fi
+            UNIQUE_ID=longr$(echo $BASE_STR | sha1sum | head -c 10)
             echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_ENV
-            echo "rads${GITHUB_RUN_NUMBER}"
             
             # Set output variables to be used in the other jobs
             echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_OUTPUT

--- a/.github/workflows/retry-functional-test.yaml
+++ b/.github/workflows/retry-functional-test.yaml
@@ -112,7 +112,11 @@ jobs:
         id: gen-id
         run: |
           BASE_STR="RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
-          UNIQUE_ID=$(echo $BASE_STR | sha1sum | head -c 10)
+          if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
+            # Add run number to randomize unique id for scheduled runs.
+            BASE_STR="${GITHUB_RUN_NUMBER}|${BASE_STR}"
+          fi
+          UNIQUE_ID=retry$(echo $BASE_STR | sha1sum | head -c 10)
           echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_ENV
           
           # Set output variables to be used in the other jobs


### PR DESCRIPTION
# Description

We generate unique id by concatenating GitHub Actions' system variables, hashing the string, and taking 10 characters. This way will reduce the chance to create multiple resource for the same PR. In scheduled test, the most of variables are same, so there is a little chance to face the conflicts. particularly, when resource group is being in progress triggered by the previous action runs like below failures. This change 1) adds GITHUB_RUN_NUMBER, which is updated for each action run, to the raw id before hashing and 2) adds the prefix to each hashed string to avoid the conflicts between different workflows.

https://github.com/radius-project/radius/issues/7383
https://github.com/radius-project/radius/issues/7382
https://github.com/radius-project/radius/issues/7380

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #7388 
