### PR TITLE
Allow codecov to create comment

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,7 @@ on:
 permissions:
   id-token: write      # Required for requesting the JWT
   contents: write      # Required for creating releases
+  issues: write        # Required for creating comments
   checks: write        # Required for updating check runs
   pull-requests: write # Required for updating pull requests
   packages: write      # Required for uploading the package


### PR DESCRIPTION
# Description

When I removed `issues` permission, codecov can still update the previous comment. but looks like it is always required for creating new comment. 

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
