### PR TITLE
rad group switch output

### DIFF
--- a/pkg/cli/cmd/group/groupswitch/switch.go
+++ b/pkg/cli/cmd/group/groupswitch/switch.go
@@ -131,7 +131,6 @@ func (r *Runner) Run(ctx context.Context) error {
 
 		return nil
 	})
-
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/group/groupswitch/switch.go
+++ b/pkg/cli/cmd/group/groupswitch/switch.go
@@ -25,6 +25,7 @@ import (
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
+	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/spf13/cobra"
 )
@@ -62,6 +63,7 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 type Runner struct {
 	ConfigHolder         *framework.ConfigHolder
 	ConnectionFactory    connections.Factory
+	Output               output.Interface
 	Workspace            *workspaces.Workspace
 	UCPResourceGroupName string
 }
@@ -71,6 +73,7 @@ func NewRunner(factory framework.Factory) *Runner {
 	return &Runner{
 		ConnectionFactory: factory.GetConnectionFactory(),
 		ConfigHolder:      factory.GetConfigHolder(),
+		Output:            factory.GetOutput(),
 	}
 }
 
@@ -128,6 +131,12 @@ func (r *Runner) Run(ctx context.Context) error {
 
 		return nil
 	})
-	return err
+
+	if err != nil {
+		return err
+	}
+
+	r.Output.LogInfo("Switched to resource group %q", r.UCPResourceGroupName)
+	return nil
 
 }

--- a/pkg/cli/cmd/group/groupswitch/switch_test.go
+++ b/pkg/cli/cmd/group/groupswitch/switch_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/radius-project/radius/pkg/cli/clierrors"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
+	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
 	"github.com/radius-project/radius/test/radcli"
@@ -148,6 +149,7 @@ func Test_Run(t *testing.T) {
 				Scope: "/planes/radius/local/resourceGroups/b",
 			}
 
+			outputSink := &output.MockOutput{}
 			runner := &Runner{
 				ConfigHolder: &framework.ConfigHolder{
 					Config:         config,
@@ -156,6 +158,7 @@ func Test_Run(t *testing.T) {
 				ConnectionFactory:    &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
 				Workspace:            workspace,
 				UCPResourceGroupName: "a",
+				Output:               outputSink,
 			}
 
 			err = runner.Run(context.Background())

--- a/pkg/cli/cmd/group/groupswitch/switch_test.go
+++ b/pkg/cli/cmd/group/groupswitch/switch_test.go
@@ -167,6 +167,16 @@ func Test_Run(t *testing.T) {
 			actualConfig, err := cli.ReadWorkspaceSection(config)
 			require.NoError(t, err)
 			require.Equal(t, expectedConfig, actualConfig)
+
+			expected := []any{
+				output.LogOutput{
+					Format: "Switched to resource group %q",
+					Params: []any{"a"},
+				},
+			}
+
+			require.Equal(t, expected, outputSink.Writes)
+
 		})
 
 		t.Run("Switch (not existent)", func(t *testing.T) {


### PR DESCRIPTION
# Description
rad cli group switch output to display success message when switching output to a group

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #7395
