### PR TITLE
Add temporary login for expired auth

### DIFF
--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -485,6 +485,12 @@ jobs:
         if: failure()
         run: |
           echo ":x: functional test failed." >> $GITHUB_STEP_SUMMARY
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
+          tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
       - name: Delete azure resource group - ${{ env.AZURE_TEST_RESOURCE_GROUP }}
         if: always()
         run: |


### PR DESCRIPTION
# Description

Long-running tests have started to fail due to the az login authentication expiring. Based on the error message (see linked issue), the authentication is only valid for 5 minutes. This seems to be a known issue [based on discussion here](https://github.com/Azure/azure-cli/issues/28708#issuecomment-2049400226) but there's no fix so adding this temporary workaround until there's a way to extend the time the auth is valid. 


## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius #7490 

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
