### PR TITLE
Update tests to pull test images from ghcr instead of docker

### DIFF
--- a/test/functional-portable/corerp/noncloud/resources/testdata/containers/corerp-resources-friendly-container-version-1.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/containers/corerp-resources-friendly-container-version-1.bicep
@@ -41,7 +41,7 @@ resource redisContainer 'Applications.Core/containers@2023-10-01-preview' = {
   properties: {
     application: app.id
     container: {
-      image: 'redis:6.2'
+      image: 'ghcr.io/radius-project/dev/redis:6.2'
       ports: {
         redis: {
           containerPort: 6379

--- a/test/functional-portable/corerp/noncloud/resources/testdata/containers/corerp-resources-friendly-container-version-1.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/containers/corerp-resources-friendly-container-version-1.bicep
@@ -41,7 +41,7 @@ resource redisContainer 'Applications.Core/containers@2023-10-01-preview' = {
   properties: {
     application: app.id
     container: {
-      image: 'ghcr.io/radius-project/dev/redis:6.2'
+      image: 'ghcr.io/radius-project/mirror/redis:6.2'
       ports: {
         redis: {
           containerPort: 6379

--- a/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-container-cmd-args.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-container-cmd-args.bicep
@@ -26,7 +26,7 @@ resource container 'Applications.Core/containers@2023-10-01-preview' = {
   properties: {
     application: app.id
     container: {
-      image: 'debian'
+      image: 'ghcr.io/radius-project/mirror/debian:latest'
       command: ['/bin/sh']
       args: ['-c', 'while true; do echo hello; sleep 10;done']
     }

--- a/test/functional-portable/datastoresrp/noncloud/resources/testdata/datastoresrp-resources-redis-manual.bicep
+++ b/test/functional-portable/datastoresrp/noncloud/resources/testdata/datastoresrp-resources-redis-manual.bicep
@@ -41,7 +41,7 @@ resource redisContainer 'Applications.Core/containers@2023-10-01-preview' = {
   properties: {
     application: app.id
     container: {
-      image: 'redis:6.2'
+      image: 'ghcr.io/radius-project/dev/redis:6.2'
       ports: {
         redis: {
           containerPort: 6379

--- a/test/functional-portable/datastoresrp/noncloud/resources/testdata/datastoresrp-resources-redis-manual.bicep
+++ b/test/functional-portable/datastoresrp/noncloud/resources/testdata/datastoresrp-resources-redis-manual.bicep
@@ -41,7 +41,7 @@ resource redisContainer 'Applications.Core/containers@2023-10-01-preview' = {
   properties: {
     application: app.id
     container: {
-      image: 'ghcr.io/radius-project/dev/redis:6.2'
+      image: 'ghcr.io/radius-project/mirror/redis:6.2'
       ports: {
         redis: {
           containerPort: 6379

--- a/test/functional-portable/datastoresrp/noncloud/resources/testdata/datastoresrp-rs-mongodb-manual.bicep
+++ b/test/functional-portable/datastoresrp/noncloud/resources/testdata/datastoresrp-rs-mongodb-manual.bicep
@@ -43,7 +43,7 @@ resource mongoContainer 'Applications.Core/containers@2023-10-01-preview' = {
   properties: {
     application: app.id
     container: {
-      image: 'mongo:4.2'
+      image: 'ghcr.io/radius-project/mirror/mongo:4.2'
       env: {
         DBCONNECTION: mongo.connectionString()
         MONGO_INITDB_ROOT_USERNAME: username

--- a/test/functional-portable/messagingrp/noncloud/resources/testdata/msgrp-resources-rabbitmq.bicep
+++ b/test/functional-portable/messagingrp/noncloud/resources/testdata/msgrp-resources-rabbitmq.bicep
@@ -13,7 +13,7 @@ param magpiePort int = 3000
 param environment string = 'test'
 
 @description('Specifies the image for the RabbitMQ container resource.')
-param rabbitmqImage string = 'rabbitmq:3.10'
+param rabbitmqImage string = 'ghcr.io/radius-project/mirror/rabbitmq:3.10'
 
 @description('Specifies the port for the container resource.')
 param rabbitmqPort int = 5672

--- a/test/testrecipes/modules/redis-selfhost.bicep
+++ b/test/testrecipes/modules/redis-selfhost.bicep
@@ -33,7 +33,7 @@ resource redis 'apps/Deployment@v1' = {
           {
             // This container is the running redis instance.
             name: 'redis'
-            image: 'redis'
+            image: 'ghcr.io/radius-project/mirror/redis:6.2'
             ports: [
               {
                 containerPort: 6379
@@ -43,7 +43,7 @@ resource redis 'apps/Deployment@v1' = {
           {
             // This container will connect to redis and stream logs to stdout for aid in development.
             name: 'redis-monitor'
-            image: 'redis'
+            image: 'ghcr.io/radius-project/mirror/redis:6.2'
             args: [
               'redis-cli'
               '-h'

--- a/test/testrecipes/test-bicep-recipes/mongodb-recipe-kubernetes.bicep
+++ b/test/testrecipes/test-bicep-recipes/mongodb-recipe-kubernetes.bicep
@@ -34,7 +34,7 @@ resource mongo 'apps/Deployment@v1' = {
         containers: [
           {
             name: 'mongo'
-            image: 'mongo:4.2'
+            image: 'ghcr.io/radius-project/mirror/mongo:4.2'
             ports: [
               {
                 containerPort: 27017

--- a/test/testrecipes/test-bicep-recipes/rabbitmq-recipe.bicep
+++ b/test/testrecipes/test-bicep-recipes/rabbitmq-recipe.bicep
@@ -34,7 +34,7 @@ resource rabbitmq 'apps/Deployment@v1' = {
         containers: [
           {
             name: 'rabbitmq'
-            image: 'rabbitmq:3.10'
+            image: 'ghcr.io/radius-project/mirror/rabbitmq:3.10'
             ports: [
               {
                 containerPort: 5672

--- a/test/testrecipes/test-bicep-recipes/redis-recipe-value-backed.bicep
+++ b/test/testrecipes/test-bicep-recipes/redis-recipe-value-backed.bicep
@@ -27,7 +27,7 @@ resource redis 'apps/Deployment@v1' = {
         containers: [
           {
             name: 'redis'
-            image: 'redis'
+            image: 'ghcr.io/radius-project/mirror/redis:6.2'
             ports: [
               {
                 containerPort: 6379


### PR DESCRIPTION
# Description

We encountered intermittent errors in scheduled functional tests when downloading redis image from docker either due to network issues/rate limiting. eg. https://github.com/radius-project/radius/issues/7512
List of errors: https://github.com/radius-project/radius/issues?q=is%3Aissue+is%3Aopen+docker.io%2Flibrary%2Fredis

This PR will pull redis image from ghcr.io instead of docker and then we will continue to monitor if the update eliminates this error.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius.

Fixes: #7512 , #7509 , #7504 , #7521 
