### PR TITLE
remove connections as alias

### DIFF
--- a/pkg/cli/cmd/app/graph/graph.go
+++ b/pkg/cli/cmd/app/graph/graph.go
@@ -24,11 +24,10 @@ import (
 func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	runner := NewRunner(factory)
 	cmd := &cobra.Command{
-		Use:     "graph",
-		Aliases: []string{"connections"},
-		Short:   "Shows the application graph for an application.",
-		Long:    `Shows the application graph for an application.`,
-		Args:    cobra.MaximumNArgs(1),
+		Use:   "graph",
+		Short: "Shows the application graph for an application.",
+		Long:  `Shows the application graph for an application.`,
+		Args:  cobra.MaximumNArgs(1),
 		Example: `
 # Show graph for current application
 rad app graph

--- a/pkg/cli/cmd/app/graph/graph_test.go
+++ b/pkg/cli/cmd/app/graph/graph_test.go
@@ -112,7 +112,7 @@ func Test_Validate(t *testing.T) {
 
 func Test_Run(t *testing.T) {
 	// This example is a very simple example of the application graph as an integration test.
-	// The unit tests for this package cover the more complex cases..
+	// The unit tests for this package cover the more complex cases.
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/cli/cmd/app/graph/graph_test.go
+++ b/pkg/cli/cmd/app/graph/graph_test.go
@@ -112,7 +112,8 @@ func Test_Validate(t *testing.T) {
 
 func Test_Run(t *testing.T) {
 	// This example is a very simple example of the application graph as an integration test.
-	// The unit tests for this package cover the more complex cases.
+	// The unit tests for this package cover the more complex cases..
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 

--- a/pkg/cli/cmd/app/graph/graph_test.go
+++ b/pkg/cli/cmd/app/graph/graph_test.go
@@ -126,7 +126,7 @@ func Test_Run(t *testing.T) {
 				ProvisioningState: to.Ptr(provisioningStateSuccess),
 				OutputResources: []*corerpv20231001preview.ApplicationGraphOutputResource{
 					{
-						ID:   to.Ptr("/planes/radius/local/resourcegroups/test-group/providers/kubernetes/Deployments/demo "),
+						ID:   to.Ptr("/planes/radius/local/resourcegroups/test-group/providers/kubernetes/Deployments/demo"),
 						Type: to.Ptr("kubernetes: apps/Deployment"),
 						Name: to.Ptr("demo"),
 					},

--- a/pkg/cli/cmd/app/graph/graph_test.go
+++ b/pkg/cli/cmd/app/graph/graph_test.go
@@ -126,7 +126,7 @@ func Test_Run(t *testing.T) {
 				ProvisioningState: to.Ptr(provisioningStateSuccess),
 				OutputResources: []*corerpv20231001preview.ApplicationGraphOutputResource{
 					{
-						ID:   to.Ptr("/planes/radius/local/resourcegroups/test-group/providers/kubernetes/Deployments/demo"),
+						ID:   to.Ptr("/planes/radius/local/resourcegroups/test-group/providers/kubernetes/Deployments/demo "),
 						Type: to.Ptr("kubernetes: apps/Deployment"),
 						Name: to.Ptr("demo"),
 					},

--- a/pkg/cli/cmd/app/graph/graph_test.go
+++ b/pkg/cli/cmd/app/graph/graph_test.go
@@ -113,7 +113,6 @@ func Test_Validate(t *testing.T) {
 func Test_Run(t *testing.T) {
 	// This example is a very simple example of the application graph as an integration test.
 	// The unit tests for this package cover the more complex cases.
-
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 


### PR DESCRIPTION
# Description

Removing "connections" as alias for "graph" command. 


## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #7262

