### PR TITLE
update gh to ado sync workflow to use service principals

### DIFF
--- a/.github/workflows/devops-boards.yaml
+++ b/.github/workflows/devops-boards.yaml
@@ -9,19 +9,41 @@ concurrency:
   group: issue-${{ github.event.issue.number }}
   cancel-in-progress: false
 
+# Extra permissions needed to login with Entra ID service principal via federated identity
+permissions:
+  id-token: write
+  issues: write
+
 jobs:
-  alert:
+  ado:
     runs-on: ubuntu-latest
+    environment:
+      name: issues
     steps:
-      - uses: danhellem/github-actions-issue-to-work-item@v2.3
+      # Auth using Azure Service Principals was added as a part of v2.3
+      # reference: https://github.com/danhellem/github-actions-issue-to-work-item/pull/143
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_SP_DEVOPS_SYNC_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_SP_DEVOPS_SYNC_TENANT_ID }}
+          allow-no-subscriptions: true
+      - name: Get Azure DevOps token
+        id: get_ado_token
+        run:
+          # The resource ID for Azure DevOps is always 499b84ac-1321-427f-aa17-267ca6975798
+          # https://learn.microsoft.com/azure/devops/integrate/get-started/authentication/service-principal-managed-identity
+          echo "ADO_TOKEN=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query "accessToken" --output tsv)" >> $GITHUB_ENV
+      - name: Sync issue to Azure DevOps
+        uses: danhellem/github-actions-issue-to-work-item@v2.3
         env:
-          ado_token: "${{ secrets.ADO_AOCTO_BOT_TOKEN }}"
-          github_token: "${{ secrets.GH_RAD_CI_BOT_PAT }}"
-          ado_organization: "azure-octo"
-          ado_project: "Incubations"
+          ado_token: ${{ env.ADO_TOKEN }}
+          github_token: '${{ secrets.GH_RAD_CI_BOT_PAT }}'
+          ado_organization: 'azure-octo'
+          ado_project: 'Incubations'
           ado_area_path: "Incubations\\Radius"
           ado_iteration_path: "Incubations\\Radius"
-          ado_wit: "GitHub Issue"
-          ado_new_state: "New"
-          ado_active_state: "Active"
-          ado_close_state: "Closed"
+          ado_new_state: 'New'
+          ado_active_state: 'Active'
+          ado_close_state: 'Closed'
+          ado_wit: 'GitHub Issue'


### PR DESCRIPTION
# Description

As explained in https://github.com/radius-project/radius/issues/7402, we must switch to using Service Principals for auth when running the GH-ADO sync workflow.

Auth using Azure Service Principals was added as a part of v2.3 of the `danhellem/github-actions-issue-to-work-item` GitHub Actions workflow we use. Reference: https://github.com/danhellem/github-actions-issue-to-work-item/pull/143

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #7402 
