### PR TITLE
Fix failed run count logic for alerting test failures

### DIFF
--- a/.github/actions/count-failed-runs/action.yaml
+++ b/.github/actions/count-failed-runs/action.yaml
@@ -1,16 +1,16 @@
-name: "Count failed runs"
-description: This is to count the number of consecutive failed runs.
+name: "Count completed failed runs"
+description: This actions counts the number of consecutive failed runs for a given workflow.
 inputs:
   workflow_id:
     description: 'Workflow ID to use for counting failed runs'
     required: true
-  per_page:
-    description: 'Maximum number of workflow runs to check'
-    default: '10'
-    required: false
   workflow_event:
     description: 'Maximum number of workflow runs to check'
     default: 'schedule'
+    required: false
+  per_page:
+    description: 'Number of workflow runs to check for failures'
+    default: '10'
     required: false
 outputs:
   total_runs:
@@ -44,12 +44,12 @@ runs:
             per_page: perpage
           });
 
-          console.log(response);
-
           // Scan `failure` conclusion runs to find the consecutive failures while
           // skipping the other conclusions, such as 'cancelled`.
           failureCount = 0;
           for (const run of response.data.workflow_runs) {
+            console.log(`Validating the workflow run - ID: ${run.id}, Conclusion: ${run.conclusion}.`);
+
             if (run.conclusion === 'failure') {
               failureCount++;
             } else if (run.conclusion === 'success') {
@@ -60,5 +60,6 @@ runs:
               console.log(`Skipping run ${run.id} with conclusion ${run.conclusion}.`)
             }
           }
+
           console.log(`Found ${failureCount} failed runs in a row.`);
           return failureCount;

--- a/.github/actions/count-failed-runs/action.yaml
+++ b/.github/actions/count-failed-runs/action.yaml
@@ -4,7 +4,7 @@ inputs:
   workflow_id:
     description: 'Workflow ID to use for counting failed runs'
     required: true
-  max_workflow_runs:
+  per_page:
     description: 'Maximum number of workflow runs to check'
     default: '10'
     required: false
@@ -22,20 +22,26 @@ runs:
     - name: Count recently failed tests
       id: count_failures
       uses: actions/github-script@v7
+      env:
+        WORKFLOWID: ${{ inputs.workflow_id }}
+        PERPAGE: ${{ inputs.per_page }}
+        WORKFLOWEVENT: ${{ inputs.workflow_event }}
       with:
         script: |
-          inputs = context.payload.inputs;
+          workflowid = process.env.WORKFLOWID;
+          perpage = parseInt(process.env.PERPAGE, 10);
+          workflowevent = process.env.WORKFLOWEVENT;
 
-          console.log(inputs)
+          console.log("workflow ID: " + workflowid + ", event: " + workflowevent + ", per_page " + perpage)
 
           // Fetch actions runs to scan the recent failure conclusion runs.
           response = await github.rest.actions.listWorkflowRuns({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            workflow_id: inputs.workflow_id,
-            event: inputs.workflow_event,
+            workflow_id: workflowid,
+            event: workflowevent,
             status: 'completed',
-            per_page: inputs.max_workflow_runs
+            per_page: perpage
           });
 
           console.log(response);

--- a/.github/actions/count-failed-runs/action.yaml
+++ b/.github/actions/count-failed-runs/action.yaml
@@ -24,14 +24,15 @@ runs:
       uses: actions/github-script@v7
       with:
         script: |
+          console.log(context.inputs)
           // Fetch actions runs to scan the recent failure conclusion runs.
           response = await github.rest.actions.listWorkflowRuns({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            workflow_id: core.getInput('workflow_id'),
-            event: core.getInput('workflow_event'),
+            workflow_id: context.inputs.workflow_id,
+            event: context.inputs.workflow_event,
             status: 'completed',
-            per_page: core.getInput('max_workflow_runs')
+            per_page: context.inputs.max_workflow_runs
           });
 
           console.log(response);

--- a/.github/actions/count-failed-runs/action.yaml
+++ b/.github/actions/count-failed-runs/action.yaml
@@ -24,15 +24,18 @@ runs:
       uses: actions/github-script@v7
       with:
         script: |
-          console.log(context.inputs)
+          inputs = context.payload.inputs;
+
+          console.log(inputs)
+
           // Fetch actions runs to scan the recent failure conclusion runs.
           response = await github.rest.actions.listWorkflowRuns({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            workflow_id: context.inputs.workflow_id,
-            event: context.inputs.workflow_event,
+            workflow_id: inputs.workflow_id,
+            event: inputs.workflow_event,
             status: 'completed',
-            per_page: context.inputs.max_workflow_runs
+            per_page: inputs.max_workflow_runs
           });
 
           console.log(response);

--- a/.github/actions/count-failed-runs/action.yaml
+++ b/.github/actions/count-failed-runs/action.yaml
@@ -1,0 +1,54 @@
+name: "Count failed runs"
+description: This is to count the number of consecutive failed runs.
+inputs:
+  workflow_id:
+    description: 'Workflow ID to use for counting failed runs'
+    required: true
+  max_workflow_runs:
+    description: 'Maximum number of workflow runs to check'
+    default: '10'
+    required: false
+  workflow_event:
+    description: 'Maximum number of workflow runs to check'
+    default: 'schedule'
+    required: false
+outputs:
+  total_runs:
+    value: ${{ steps.count_failures.outputs.result }}
+    description: The number of consecutive failed runs
+runs:
+  using: "composite"
+  steps:
+    - name: Count recently failed tests
+      id: count_failures
+      uses: actions/github-script@v7
+      with:
+        script: |
+          // Fetch actions runs to scan the recent failure conclusion runs.
+          response = await github.rest.actions.listWorkflowRuns({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: context.inputs.workflow_id,
+            event: context.inputs.workflow_event,
+            status: 'completed',
+            per_page: context.inputs.max_workflow_runs
+          });
+
+          console.log(response);
+
+          // Scan `failure` conclusion runs to find the consecutive failures while
+          // skipping the other conclusions, such as 'cancelled`.
+          failureCount = 0;
+          for (const run of response.data.workflow_runs) {
+            if (run.conclusion === 'failure') {
+              failureCount++;
+            } else if (run.conclusion === 'success') {
+              // If we find a successful run, we can stop scanning.
+              break;
+            } else {
+              // Skipping the other conclusions such as 'cancelled'.
+              console.log(`Skipping run ${run.id} with conclusion ${run.conclusion}.`)
+            }
+          }
+          console.log(`Found ${failureCount} failed runs in a row.`);
+          return failureCount;

--- a/.github/actions/count-failed-runs/action.yaml
+++ b/.github/actions/count-failed-runs/action.yaml
@@ -28,10 +28,10 @@ runs:
           response = await github.rest.actions.listWorkflowRuns({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            workflow_id: context.inputs.workflow_id,
-            event: context.inputs.workflow_event,
+            workflow_id: core.getInput('workflow_id'),
+            event: core.getInput('workflow_event'),
             status: 'completed',
-            per_page: context.inputs.max_workflow_runs
+            per_page: core.getInput('max_workflow_runs')
           });
 
           console.log(response);

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
             });
 
             const workflowRuns = response.data.workflow_runs;
-            return len(workflowRuns) > 0 && workflowRuns[0].conclusion === 'failure';
+            return workflowRuns && workflowRuns.length > 0 && workflowRuns[0].conclusion === 'failure';
       - name: Create failure issue for failing scheduled run
         if: steps.checkprevfail.outputs.result == 'true'
         run: echo "hello"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,6 +66,29 @@ env:
   IMAGE_SRC: https://github.com/radius-project/radius
 
 jobs:
+  report-failure:
+    name: Report test failure
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if this is the consecutive failure
+        id: checkprevfail
+        uses: actions/github-script@v7
+        with:
+          script: |
+            response = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'functional-test.yaml',
+              event: 'schedule',
+              status: 'completed',
+              per_page: 1
+            });
+
+            const workflowRuns = response.data.workflow_runs;
+            return len(workflowRuns) > 0 && workflowRuns[0].conclusion === 'failure';
+      - name: Create failure issue for failing scheduled run
+        if: steps.checkprevfail.outputs.result == 'true'
+        run: echo "hello"
   build-and-push-cli:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,6 +70,8 @@ jobs:
     name: Report test failure
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
       - name: Count failed runs
         id: count_failed_runs
         uses: ./.github/actions/count-failed-runs

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,6 +66,18 @@ env:
   IMAGE_SRC: https://github.com/radius-project/radius
 
 jobs:
+  report-failure:
+    name: Report test failure
+    runs-on: ubuntu-latest
+    steps:
+      - name: Count failed runs
+        id: count_failed_runs
+        uses: ./.github/actions/count-failed-runs
+        with:
+          workflow_id: 'functional-test.yaml'
+      - name: hello
+        if: steps.count_failed_runs.outputs.total_runs >= 2
+        run: echo "hello"
   build-and-push-cli:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,22 +66,6 @@ env:
   IMAGE_SRC: https://github.com/radius-project/radius
 
 jobs:
-  report-failure:
-    name: Report test failure
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-      - name: Count failed runs
-        id: count_failed_runs
-        uses: ./.github/actions/count-failed-runs
-        with:
-          workflow_id: 'functional-test.yaml'
-      - name: hello 1
-        run: echo ${{ steps.count_failed_runs.outputs.total_runs }}
-      - name: hello 2
-        if: steps.count_failed_runs.outputs.total_runs >= 1
-        run: echo "hello"
   build-and-push-cli:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,8 +77,10 @@ jobs:
         uses: ./.github/actions/count-failed-runs
         with:
           workflow_id: 'functional-test.yaml'
-      - name: hello
-        if: steps.count_failed_runs.outputs.total_runs >= 2
+      - name: hello 1
+        run: echo ${{ steps.count_failed_runs.outputs.total_runs }}
+      - name: hello 2
+        if: steps.count_failed_runs.outputs.total_runs >= 1
         run: echo "hello"
   build-and-push-cli:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,29 +66,6 @@ env:
   IMAGE_SRC: https://github.com/radius-project/radius
 
 jobs:
-  report-failure:
-    name: Report test failure
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check if this is the consecutive failure
-        id: checkprevfail
-        uses: actions/github-script@v7
-        with:
-          script: |
-            response = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'functional-test.yaml',
-              event: 'schedule',
-              status: 'completed',
-              per_page: 1
-            });
-
-            const workflowRuns = response.data.workflow_runs;
-            return workflowRuns && workflowRuns.length > 0 && workflowRuns[0].conclusion === 'failure';
-      - name: Create failure issue for failing scheduled run
-        if: steps.checkprevfail.outputs.result == 'true'
-        run: echo "hello"
   build-and-push-cli:
     name: Build ${{ matrix.target_os }}_${{ matrix.target_arch }} binaries
     runs-on: ubuntu-latest

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -83,7 +83,7 @@ env:
   # Private Git repository where terraform module for testing is stored.
   TF_RECIPE_PRIVATE_GIT_SOURCE: "git::https://github.com/radius-project/terraform-private-modules//kubernetes-redis"
   # The number of failed tests to report.
-  ISSUE_CREATE_THRESHOLD: 2
+  ISSUE_CREATE_THRESHOLD: 1
 
 jobs:
   build:
@@ -717,37 +717,15 @@ jobs:
     runs-on: ubuntu-latest
     if: failure() && github.event_name == 'schedule' && github.repository == 'radius-project/radius'
     steps:
-      - name: Count recently failed tests
-        id: count_failures
-        uses: actions/github-script@v7
+      - name: Count failed runs
+        id: count_failed_runs
+        uses: ./.github/actions/count-failed-runs
         with:
-          script: |
-            response = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'functional-test.yaml',
-              event: 'schedule',
-              status: 'completed',
-              per_page: 10
-            });
-            
-            failureCount = 1;
-            for (const run of response.data.workflow_runs) {
-              if (run.conclusion === 'failure') {
-                failureCount++;
-              } else if (run.conclusion === 'success') {
-                // If we find a successful run, we can stop scanning.
-                break;
-              } else {
-                console.log(`Skipping run ${run.id} with conclusion ${run.conclusion}.`)
-              }
-            }
-            console.log(`Found ${failureCount} failed runs in a row.`);
-            return failureCount;
+          workflow_id: 'functional-test.yaml'
       - name: Create failure issue for failing scheduled run
         uses: actions/github-script@v7
         # Only create an issue if there are (env.ISSUE_CREATE_THRESHOLD) failures of the recent tests.
-        if: steps.count_failures.outputs.result >= env.ISSUE_CREATE_THRESHOLD
+        if: steps.count_failed_runs.outputs.total_runs >= env.ISSUE_CREATE_THRESHOLD
         with:
           github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
           script: |
@@ -755,5 +733,5 @@ jobs:
               ...context.repo,
               title: `Scheduled functional test failed - Run ID: ${context.runId}`,
               labels: ['bug', 'test-failure'],
-              body: `## Bug information \n\nThis bug is generated automatically if the scheduled functional test fails at least ${process.env.ISSUE_CREATE_THRESHOLD} times in a row. The Radius functional test operates on a schedule of every 4 hours during weekdays and every 12 hours over the weekend. It's important to understand that the test may fail due to workflow infrastructure issues, like network problems, rather than the flakiness of the test itself. For the further investigation, please visit [here](${process.env.ACTION_LINK}).`
+              body: `## Bug information \n\nThis bug is generated automatically if the scheduled functional test fails more than ${process.env.ISSUE_CREATE_THRESHOLD} times in a row. The Radius functional test operates on a schedule of every 4 hours during weekdays and every 12 hours over the weekend. It's important to understand that the test may fail due to workflow infrastructure issues, like network problems, rather than the flakiness of the test itself. For the further investigation, please visit [here](${process.env.ACTION_LINK}).`
             })

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -734,10 +734,14 @@ jobs:
             for (const run of response.data.workflow_runs) {
               if (run.conclusion === 'failure') {
                 failureCount++;
-              } else {
+              } else if (run.conclusion === 'success') {
+                // If we find a successful run, we can stop scanning.
                 break;
+              } else {
+                console.log(`Skipping run ${run.id} with conclusion ${run.conclusion}.`)
               }
             }
+            console.log(`Found ${failureCount} failed runs in a row.`);
             return failureCount;
       - name: Create failure issue for failing scheduled run
         uses: actions/github-script@v7

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -716,7 +716,15 @@ jobs:
     needs: [build, tests]
     runs-on: ubuntu-latest
     if: failure() && github.event_name == 'schedule' && github.repository == 'radius-project/radius'
+    env:
+      CHECKOUT_REPO: ${{ needs.build.outputs.CHECKOUT_REPO }}
+      CHECKOUT_REF: ${{ needs.build.outputs.CHECKOUT_REF }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.CHECKOUT_REPO }}
+          ref: ${{ env.CHECKOUT_REF }}
       - name: Count failed runs
         id: count_failed_runs
         uses: ./.github/actions/count-failed-runs

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -82,8 +82,6 @@ env:
   FUNCTIONAL_TEST_APP_ID: 425843
   # Private Git repository where terraform module for testing is stored.
   TF_RECIPE_PRIVATE_GIT_SOURCE: "git::https://github.com/radius-project/terraform-private-modules//kubernetes-redis"
-  # The number of failed tests to report.
-  ISSUE_CREATE_THRESHOLD: 2
 
 jobs:
   build:
@@ -717,8 +715,8 @@ jobs:
     runs-on: ubuntu-latest
     if: failure() && github.event_name == 'schedule' && github.repository == 'radius-project/radius'
     steps:
-      - name: Count recently failed tests
-        id: count_failures
+      - name: Check if this is the consecutive failure
+        id: checkprevfail
         uses: actions/github-script@v7
         with:
           script: |
@@ -727,26 +725,16 @@ jobs:
               repo: context.repo.repo,
               workflow_id: 'functional-test.yaml',
               event: 'schedule',
-              per_page: 10
+              status: 'completed',
+              per_page: 1
             });
-            
-            failureCount = 1;
-            for (const run of response.data.workflow_runs) {
-              if (run.conclusion === 'failure') {
-                failureCount++;
-              } else if (run.conclusion === 'success') {
-                // If we find a successful run, we can stop scanning.
-                break;
-              } else {
-                console.log(`Skipping run ${run.id} with conclusion ${run.conclusion}.`)
-              }
-            }
-            console.log(`Found ${failureCount} failed runs in a row.`);
-            return failureCount;
+
+            const workflowRuns = response.data.workflow_runs;
+            return len(workflowRuns) > 0 && workflowRuns[0].conclusion === 'failure';
       - name: Create failure issue for failing scheduled run
         uses: actions/github-script@v7
         # Only create an issue if there are (env.ISSUE_CREATE_THRESHOLD) failures of the recent tests.
-        if: steps.count_failures.outputs.result >= env.ISSUE_CREATE_THRESHOLD
+        if: steps.checkprevfail.outputs.result == 'true'
         with:
           github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
           script: |

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -82,6 +82,8 @@ env:
   FUNCTIONAL_TEST_APP_ID: 425843
   # Private Git repository where terraform module for testing is stored.
   TF_RECIPE_PRIVATE_GIT_SOURCE: "git::https://github.com/radius-project/terraform-private-modules//kubernetes-redis"
+  # The number of failed tests to report.
+  ISSUE_CREATE_THRESHOLD: 2
 
 jobs:
   build:
@@ -715,8 +717,8 @@ jobs:
     runs-on: ubuntu-latest
     if: failure() && github.event_name == 'schedule' && github.repository == 'radius-project/radius'
     steps:
-      - name: Check if this is the consecutive failure
-        id: checkprevfail
+      - name: Count recently failed tests
+        id: count_failures
         uses: actions/github-script@v7
         with:
           script: |
@@ -726,15 +728,26 @@ jobs:
               workflow_id: 'functional-test.yaml',
               event: 'schedule',
               status: 'completed',
-              per_page: 1
+              per_page: 10
             });
-
-            const workflowRuns = response.data.workflow_runs;
-            return len(workflowRuns) > 0 && workflowRuns[0].conclusion === 'failure';
+            
+            failureCount = 1;
+            for (const run of response.data.workflow_runs) {
+              if (run.conclusion === 'failure') {
+                failureCount++;
+              } else if (run.conclusion === 'success') {
+                // If we find a successful run, we can stop scanning.
+                break;
+              } else {
+                console.log(`Skipping run ${run.id} with conclusion ${run.conclusion}.`)
+              }
+            }
+            console.log(`Found ${failureCount} failed runs in a row.`);
+            return failureCount;
       - name: Create failure issue for failing scheduled run
         uses: actions/github-script@v7
         # Only create an issue if there are (env.ISSUE_CREATE_THRESHOLD) failures of the recent tests.
-        if: steps.checkprevfail.outputs.result == 'true'
+        if: steps.count_failures.outputs.result >= env.ISSUE_CREATE_THRESHOLD
         with:
           github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
           script: |

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -93,7 +93,7 @@ env:
   ACTION_LINK: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   # The number of failed tests to report.
-  ISSUE_CREATE_THRESHOLD: 2
+  ISSUE_CREATE_THRESHOLD: 1
 
 jobs:
   build:
@@ -512,37 +512,15 @@ jobs:
     runs-on: ubuntu-latest
     if: failure() && github.repository == 'radius-project/radius' && github.event_name == 'schedule'
     steps:
-      - name: Count recently failed tests
-        id: count_failures
-        uses: actions/github-script@v7
+      - name: Count failed runs
+        id: count_failed_runs
+        uses: ./.github/actions/count-failed-runs
         with:
-          script: |
-            response = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'long-running-azure.yaml',
-              event: 'schedule',
-              status: 'completed',
-              per_page: 10
-            });
-            
-            failureCount = 1;
-            for (const run of response.data.workflow_runs) {
-              if (run.conclusion === 'failure') {
-                failureCount++;
-              } else if (run.conclusion === 'success') {
-                // If we find a successful run, we can stop scanning.
-                break;
-              } else {
-                console.log(`Skipping run ${run.id} with conclusion ${run.conclusion}.`)
-              }
-            }
-            console.log(`Found ${failureCount} failed runs in a row.`);
-            return failureCount;
-      - name: Create failure issue for failing long running test run
+          workflow_id: 'long-running-azure-test.yaml'
+      - name: Create failure issue for failing scheduled run
         uses: actions/github-script@v7
         # Only create an issue if there are (env.ISSUE_CREATE_THRESHOLD) failures of the recent tests.
-        if: steps.count_failures.outputs.result >= env.ISSUE_CREATE_THRESHOLD
+        if: steps.count_failed_runs.outputs.total_runs >= env.ISSUE_CREATE_THRESHOLD
         with:
           github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
           script: |
@@ -550,5 +528,5 @@ jobs:
               ...context.repo,
               title: `Scheduled long running test failed - Run ID: ${context.runId}`,
               labels: ['bug', 'test-failure'],
-              body: `## Bug information \n\nThis bug is generated automatically if the scheduled long running test fails at least ${process.env.ISSUE_CREATE_THRESHOLD} times in a row. The Radius long running test operates on a schedule of every 2 hours everyday. It's important to understand that the test may fail due to workflow infrastructure issues, like network problems, rather than the flakiness of the test itself. For the further investigation, please visit [here](${process.env.ACTION_LINK}).`
+              body: `## Bug information \n\nThis bug is generated automatically if the scheduled long running test fails more than ${process.env.ISSUE_CREATE_THRESHOLD} times in a row. The Radius long running test operates on a schedule of every 2 hours everyday. It's important to understand that the test may fail due to workflow infrastructure issues, like network problems, rather than the flakiness of the test itself. For the further investigation, please visit [here](${process.env.ACTION_LINK}).`
             })

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -522,36 +522,26 @@ jobs:
     runs-on: ubuntu-latest
     if: failure() && github.repository == 'radius-project/radius' && github.event_name == 'schedule'
     steps:
-      - name: Count recently failed tests
-        id: count_failures
+      - name: Check if this is the consecutive failure
+        id: checkprevfail
         uses: actions/github-script@v7
         with:
           script: |
             response = await github.rest.actions.listWorkflowRuns({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              workflow_id: 'long-running-azure.yaml',
+              workflow_id: 'functional-test.yaml',
               event: 'schedule',
-              per_page: 10
+              status: 'completed',
+              per_page: 1
             });
-            
-            failureCount = 1;
-            for (const run of response.data.workflow_runs) {
-              if (run.conclusion === 'failure') {
-                failureCount++;
-              } else if (run.conclusion === 'success') {
-                // If we find a successful run, we can stop scanning.
-                break;
-              } else {
-                console.log(`Skipping run ${run.id} with conclusion ${run.conclusion}.`)
-              }
-            }
-            console.log(`Found ${failureCount} failed runs in a row.`);
-            return failureCount;
+
+            const workflowRuns = response.data.workflow_runs;
+            return len(workflowRuns) > 0 && workflowRuns[0].conclusion === 'failure';
       - name: Create failure issue for failing long running test run
         uses: actions/github-script@v7
         # Only create an issue if there are (env.ISSUE_CREATE_THRESHOLD) failures of the recent tests.
-        if: steps.count_failures.outputs.result >= env.ISSUE_CREATE_THRESHOLD
+        if: steps.checkprevfail.outputs.result == 'true'
         with:
           github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
           script: |

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -78,6 +78,9 @@ env:
   # The valid radius build time window in seconds to rebuild radius. 24 hours = 24 * 60 * 60 = 86400
   VALID_RADIUS_BUILD_WINDOW: 86400
 
+  # The functional test GitHub app id
+  FUNCTIONAL_TEST_APP_ID: 425843
+
   # The AKS cluster name
   AKS_CLUSTER_NAME: "radlrtest00-aks"
   # The resource group for AKS_CLUSTER_NAME resource.
@@ -307,6 +310,12 @@ jobs:
       RAD_CLI_ARTIFACT_NAME: ${{ needs.build.outputs.RAD_CLI_ARTIFACT_NAME }}
       BICEP_RECIPE_TAG_VERSION: ${{ needs.build.outputs.REL_VERSION }}
     steps:
+      - name: Get GitHub app token
+        uses: tibdex/github-app-token@v2
+        id: get_installation_token
+        with: 
+          app_id: ${{ env.FUNCTIONAL_TEST_APP_ID }}
+          private_key: ${{ secrets.FUNCTIONAL_TEST_APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -465,6 +474,7 @@ jobs:
           DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
           BICEP_RECIPE_REGISTRY: ${{ env.BICEP_RECIPE_REGISTRY }}
           BICEP_RECIPE_TAG_VERSION: ${{ env.BICEP_RECIPE_TAG_VERSION }}
+          GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
       - name: Collect Pod details
         if: always()
         run: |

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -510,13 +510,21 @@ jobs:
     name: Report test failure
     needs: [build, tests]
     runs-on: ubuntu-latest
+    env:
+      CHECKOUT_REPO: ${{ needs.build.outputs.CHECKOUT_REPO }}
+      CHECKOUT_REF: ${{ needs.build.outputs.CHECKOUT_REF }}
     if: failure() && github.repository == 'radius-project/radius' && github.event_name == 'schedule'
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.CHECKOUT_REPO }}
+          ref: ${{ env.CHECKOUT_REF }}
       - name: Count failed runs
         id: count_failed_runs
         uses: ./.github/actions/count-failed-runs
         with:
-          workflow_id: 'long-running-azure-test.yaml'
+          workflow_id: 'long-running-azure.yaml'
       - name: Create failure issue for failing scheduled run
         uses: actions/github-script@v7
         # Only create an issue if there are (env.ISSUE_CREATE_THRESHOLD) failures of the recent tests.

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -78,9 +78,6 @@ env:
   # The valid radius build time window in seconds to rebuild radius. 24 hours = 24 * 60 * 60 = 86400
   VALID_RADIUS_BUILD_WINDOW: 86400
 
-  # The functional test GitHub app id
-  FUNCTIONAL_TEST_APP_ID: 425843
-
   # The AKS cluster name
   AKS_CLUSTER_NAME: "radlrtest00-aks"
   # The resource group for AKS_CLUSTER_NAME resource.
@@ -310,12 +307,6 @@ jobs:
       RAD_CLI_ARTIFACT_NAME: ${{ needs.build.outputs.RAD_CLI_ARTIFACT_NAME }}
       BICEP_RECIPE_TAG_VERSION: ${{ needs.build.outputs.REL_VERSION }}
     steps:
-      - name: Get GitHub app token
-        uses: tibdex/github-app-token@v2
-        id: get_installation_token
-        with: 
-          app_id: ${{ env.FUNCTIONAL_TEST_APP_ID }}
-          private_key: ${{ secrets.FUNCTIONAL_TEST_APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -474,7 +465,6 @@ jobs:
           DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
           BICEP_RECIPE_REGISTRY: ${{ env.BICEP_RECIPE_REGISTRY }}
           BICEP_RECIPE_TAG_VERSION: ${{ env.BICEP_RECIPE_TAG_VERSION }}
-          GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
       - name: Collect Pod details
         if: always()
         run: |
@@ -522,26 +512,37 @@ jobs:
     runs-on: ubuntu-latest
     if: failure() && github.repository == 'radius-project/radius' && github.event_name == 'schedule'
     steps:
-      - name: Check if this is the consecutive failure
-        id: checkprevfail
+      - name: Count recently failed tests
+        id: count_failures
         uses: actions/github-script@v7
         with:
           script: |
             response = await github.rest.actions.listWorkflowRuns({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              workflow_id: 'functional-test.yaml',
+              workflow_id: 'long-running-azure.yaml',
               event: 'schedule',
               status: 'completed',
-              per_page: 1
+              per_page: 10
             });
-
-            const workflowRuns = response.data.workflow_runs;
-            return len(workflowRuns) > 0 && workflowRuns[0].conclusion === 'failure';
+            
+            failureCount = 1;
+            for (const run of response.data.workflow_runs) {
+              if (run.conclusion === 'failure') {
+                failureCount++;
+              } else if (run.conclusion === 'success') {
+                // If we find a successful run, we can stop scanning.
+                break;
+              } else {
+                console.log(`Skipping run ${run.id} with conclusion ${run.conclusion}.`)
+              }
+            }
+            console.log(`Found ${failureCount} failed runs in a row.`);
+            return failureCount;
       - name: Create failure issue for failing long running test run
         uses: actions/github-script@v7
         # Only create an issue if there are (env.ISSUE_CREATE_THRESHOLD) failures of the recent tests.
-        if: steps.checkprevfail.outputs.result == 'true'
+        if: steps.count_failures.outputs.result >= env.ISSUE_CREATE_THRESHOLD
         with:
           github-token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
           script: |

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -539,10 +539,14 @@ jobs:
             for (const run of response.data.workflow_runs) {
               if (run.conclusion === 'failure') {
                 failureCount++;
-              } else {
+              } else if (run.conclusion === 'success') {
+                // If we find a successful run, we can stop scanning.
                 break;
+              } else {
+                console.log(`Skipping run ${run.id} with conclusion ${run.conclusion}.`)
               }
             }
+            console.log(`Found ${failureCount} failed runs in a row.`);
             return failureCount;
       - name: Create failure issue for failing long running test run
         uses: actions/github-script@v7


### PR DESCRIPTION
# Description

When it counts the consecutive failed runs, the old code treats `in_progress` as `success`. This will fix the issue to count the failed runs correctly by skipping non-success runs. I validated this logic in [this action run](https://github.com/radius-project/radius/actions/runs/8855367365/job/24320096122).

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
