### PR TITLE
fix for rad init cannot work from folders with uppercase 

### DIFF
--- a/pkg/cli/cmd/radinit/application.go
+++ b/pkg/cli/cmd/radinit/application.go
@@ -76,7 +76,7 @@ func (r *Runner) enterApplicationName(chooseDefault func() (string, error)) (str
 
 	name, err = r.Prompter.GetTextInput(enterApplicationNamePrompt, prompt.TextInputOptions{
 		Placeholder: enterApplicationNamePlaceholder,
-		Validate:    prompt.ValidateResourceName,
+		Validate:    prompt.ValidateApplicationName,
 	})
 	if err != nil {
 		return "", err

--- a/pkg/cli/cmd/radinit/application.go
+++ b/pkg/cli/cmd/radinit/application.go
@@ -68,7 +68,7 @@ func (r *Runner) enterApplicationName(chooseDefault func() (string, error)) (str
 		return "", err
 	}
 
-	err = prompt.ValidateResourceName(name)
+	err = prompt.ValidateApplicationName(name)
 	if err == nil {
 		// Default name is a valid application name.
 		return name, nil

--- a/pkg/cli/cmd/radinit/application_test.go
+++ b/pkg/cli/cmd/radinit/application_test.go
@@ -74,5 +74,16 @@ func Test_enterApplicationName(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "another-name", name)
 	})
+	t.Run("Usr is prompted for application name containing uppercase", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		prompter := prompt.NewMockInterface(ctrl)
+		runner := Runner{Prompter: prompter}
+
+		setApplicationNamePrompt(prompter, "another-name")
+
+		name, err := runner.enterApplicationName(func() (string, error) { return "Invalid-Name", nil })
+		require.NoError(t, err)
+		require.Equal(t, "another-name", name)
+	}
 
 }

--- a/pkg/cli/cmd/radinit/application_test.go
+++ b/pkg/cli/cmd/radinit/application_test.go
@@ -74,7 +74,7 @@ func Test_enterApplicationName(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "another-name", name)
 	})
-	t.Run("Usr is prompted for application name containing uppercase", func(t *testing.T) {
+	t.Run("user is prompted when application name contains uppercase", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		prompter := prompt.NewMockInterface(ctrl)
 		runner := Runner{Prompter: prompter}
@@ -82,6 +82,32 @@ func Test_enterApplicationName(t *testing.T) {
 		setApplicationNamePrompt(prompter, "another-name")
 
 		name, err := runner.enterApplicationName(func() (string, error) { return "Invalid-Name", nil })
+		require.NoError(t, err)
+		require.Equal(t, "another-name", name)
+	})
+
+	t.Run("user is prompted when application name does not end with alphanumeric", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		prompter := prompt.NewMockInterface(ctrl)
+		runner := Runner{Prompter: prompter}
+
+		setApplicationNamePrompt(prompter, "another-name")
+
+		name, err := runner.enterApplicationName(func() (string, error) { return "test-application-", nil })
+		require.NoError(t, err)
+		require.Equal(t, "another-name", name)
+	})
+
+	t.Run("user is prompted when application name is too long", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		prompter := prompt.NewMockInterface(ctrl)
+		runner := Runner{Prompter: prompter}
+
+		setApplicationNamePrompt(prompter, "another-name")
+
+		name, err := runner.enterApplicationName(func() (string, error) {
+			return "this-is-a-very-long-environment-name-that-is-invalid-this-is-a-very-long-application-name-that-is-invalid", nil
+		})
 		require.NoError(t, err)
 		require.Equal(t, "another-name", name)
 	})

--- a/pkg/cli/cmd/radinit/application_test.go
+++ b/pkg/cli/cmd/radinit/application_test.go
@@ -84,6 +84,6 @@ func Test_enterApplicationName(t *testing.T) {
 		name, err := runner.enterApplicationName(func() (string, error) { return "Invalid-Name", nil })
 		require.NoError(t, err)
 		require.Equal(t, "another-name", name)
-	}
+	})
 
 }

--- a/pkg/cli/prompt/validator.go
+++ b/pkg/cli/prompt/validator.go
@@ -79,7 +79,7 @@ func ValidateResourceName(input string) error {
 }
 
 // ValidateApplicationName checks if the given string is a valid Application name, and returns an error if it is not.
-// The rules for application name disallows upper case since we use the name to also create a kubernetes namespace for the application.
+// The rules for application name matches that of kubernetes namespace since we use the name to also create a namespace for the application.
 func ValidateApplicationName(input string) error {
 	err := ValidateKubernetesNamespace(input)
 	if err != nil {

--- a/pkg/cli/prompt/validator.go
+++ b/pkg/cli/prompt/validator.go
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	invalidNamespaceNameMessage   = "namespace must be 1-63 characters, made up of of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character"
+	invalidNamespaceNameMessage   = "namespace must be 1-63 characters, made up of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character"
 	invalidResourceNameMessage    = "name must be made up of alphanumeric characters and hyphens, and must begin with an alphabetic character and end with an alphanumeric character"
-	invalidApplicationNameMessage = "application name must be 1-63 characters, made up of of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character"
+	invalidApplicationNameMessage = "application name must be 1-63 characters, made up of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character"
 	invalidUUIDv4Message          = "must be a valid UUID v4 (GUID)"
 
 	// ErrExitConsoleMessage is the message that is displayed when the user exits the console. This is exported for use in tests.

--- a/pkg/cli/prompt/validator.go
+++ b/pkg/cli/prompt/validator.go
@@ -43,7 +43,7 @@ func ValidateKubernetesNamespace(input string) error {
 		return nil
 	}
 
-	return errors.New(invalidResourceNameMessage)
+	return errors.New(invalidNamespaceNameMessage)
 }
 
 // ValidateKubernetesNamespaceOrDefault validates the user input according to Kubernetes rules for a namespace name, but also allows empty input.

--- a/pkg/cli/prompt/validator.go
+++ b/pkg/cli/prompt/validator.go
@@ -78,6 +78,7 @@ func ValidateResourceName(input string) error {
 }
 
 // ValidateApplicationName checks if the given string is a valid Application name, and returns an error if it is not.
+// The rules for application name disallows upper case since we use the name to also create a kubernetes namespace for the application.
 func ValidateApplicationName(input string) error {
 	r := regexp.MustCompile("^[a-z]([a-z0-9-]*[a-z0-9])?$")
 	if r.MatchString(input) {

--- a/pkg/cli/prompt/validator.go
+++ b/pkg/cli/prompt/validator.go
@@ -22,9 +22,10 @@ import (
 )
 
 const (
-	invalidNamespaceNameMessage = "namespace must be 1-63 characters, made up of of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character"
-	invalidResourceNameMessage  = "name must be made up of alphanumeric characters and hyphens, and must begin with an alphabetic character and end with an alphanumeric character"
-	invalidUUIDv4Message        = "must be a valid UUID v4 (GUID)"
+	invalidNamespaceNameMessage   = "namespace must be 1-63 characters, made up of of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character"
+	invalidResourceNameMessage    = "name must be made up of alphanumeric characters and hyphens, and must begin with an alphabetic character and end with an alphanumeric character"
+	invalidApplicationNameMessage = "application name must be 1-63 characters, made up of of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character"
+	invalidUUIDv4Message          = "must be a valid UUID v4 (GUID)"
 
 	// ErrExitConsoleMessage is the message that is displayed when the user exits the console. This is exported for use in tests.
 	ErrExitConsoleMessage = "exiting command"
@@ -80,12 +81,11 @@ func ValidateResourceName(input string) error {
 // ValidateApplicationName checks if the given string is a valid Application name, and returns an error if it is not.
 // The rules for application name disallows upper case since we use the name to also create a kubernetes namespace for the application.
 func ValidateApplicationName(input string) error {
-	r := regexp.MustCompile("^[a-z]([a-z0-9-]*[a-z0-9])?$")
-	if r.MatchString(input) {
-		return nil
+	err := ValidateKubernetesNamespace(input)
+	if err != nil {
+		return errors.New(invalidApplicationNameMessage)
 	}
-
-	return errors.New(invalidResourceNameMessage)
+	return nil
 }
 
 // ValidateResourceName validates the user input according to ARM/UCP rules for a resource name, but also allows empty input.

--- a/pkg/cli/prompt/validator.go
+++ b/pkg/cli/prompt/validator.go
@@ -77,6 +77,16 @@ func ValidateResourceName(input string) error {
 	return errors.New(invalidResourceNameMessage)
 }
 
+// ValidateApplicationName checks if the given string is a valid Application name, and returns an error if it is not.
+func ValidateApplicationName(input string) error {
+	r := regexp.MustCompile("^[a-z]([a-z0-9-]*[a-z0-9])?$")
+	if r.MatchString(input) {
+		return nil
+	}
+
+	return errors.New(invalidResourceNameMessage)
+}
+
 // ValidateResourceName validates the user input according to ARM/UCP rules for a resource name, but also allows empty input.
 //
 // Largely matches https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules


### PR DESCRIPTION
# Description

When we run rad init, we create a namespace for application. The application name depends on folder name.  
When run from folder with name that is considered invalid for k8s label, we should prompt the user to enter a valid name instead.


## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #7528 
