### PR TITLE
Update kubebuilder to the latest working version

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -49,7 +49,7 @@ test: test-get-envtools ## Runs unit tests, excluding kubernetes controller test
 .PHONY: test-get-envtools
 test-get-envtools:
 	@echo "$(ARROW) Installing Kubebuilder test tools..."
-	$(call go-install-tool,$(ENV_SETUP),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	$(call go-install-tool,$(ENV_SETUP),sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240521074430-fbb7d370bebc)
 	@echo "$(ARROW) Instructions:"
 	@echo "$(ARROW) Set environment variable KUBEBUILDER_ASSETS for tests."
 	@echo "$(ARROW) KUBEBUILDER_ASSETS=\"$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)\""


### PR DESCRIPTION
# Description

We have a dependency on the controller-runtime package that is failing during our build tests. Reverting the package to the last known working version instead of latest. 

Package: https://github.com/kubernetes-sigs/controller-runtime
Error: 
```
/bin/sh: 1: /home/runner/go/bin/setup-envtest: not found
=> Installing Kubebuilder test tools...
go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20240522175850-2e9781e9fc60
go: downloading github.com/spf13/afero v1.6.0
go: downloading go.uber.org/zap v1.26.0
go: downloading sigs.k8s.io/yaml v1.3.0
go: downloading golang.org/x/text v0.14.0
go: downloading go.uber.org/multierr v1.10.0
=> Instructions:
=> Set environment variable KUBEBUILDER_ASSETS for tests.
=> KUBEBUILDER_ASSETS=""
unable to find a version that was supported for platform linux/amd64
KUBEBUILDER_ASSETS="" CGO_ENABLED=1 gotestsum --junitfile ./dist/unit_test/results.xml -- -v ./pkg/... -race -coverprofile ./dist/unit_test/ut_coverage.out
```

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
