### PR TITLE
Show correct environment and application for delete commands

### DIFF
--- a/pkg/cli/cmd/env/create/create.go
+++ b/pkg/cli/cmd/env/create/create.go
@@ -52,7 +52,7 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 		Long: `Create a new Radius Environment
 Radius Environments are prepared "landing zones" for Radius Applications.
 Applications deployed to an environment will inherit the container runtime, configuration, and other settings from the environment.`,
-		Args:    cobra.MinimumNArgs(1),
+		Args:    cobra.ExactArgs(1),
 		Example: `rad env create myenv`,
 		RunE:    framework.RunCommand(runner),
 	}

--- a/pkg/cli/cmd/env/create/create_test.go
+++ b/pkg/cli/cmd/env/create/create_test.go
@@ -146,6 +146,15 @@ func Test_Validate(t *testing.T) {
 				Config:         configWithWorkspace,
 			},
 		},
+		{
+			Name:          "Create command with extra positional arg",
+			Input:         []string{"a", "b"},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+		},
 	}
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
 }


### PR DESCRIPTION
# Description

The existing prompt logic for application and resource deletion was relying the workspace configuration for the prompt data. This means a prompt like "would you like to delete application X from environment Z?" might print the wrong environment name!!! This is pretty bad because you might end up doing something you didn't want to and cause data loss.

The fix to do additional retrievals of the resource and potentially the application so that can give the correct prompt.

Also fixed a minor validation bug in `rad env create` where we could accept and ignore extra positional args.


## Type of change


- This pull request fixes a bug in Radius and has an approved issue (issue link required).


Fixes: #7542
