### PR TITLE
Adding the step to delete the created Azure resource group to the functional test workflow

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -657,6 +657,14 @@ jobs:
           append: true
           message: |
             :x: ${{ matrix.name }} functional test cancelled. Please check [the logs](${{ env.ACTION_LINK }}) for more details
+      - name: Delete azure resource group - ${{ env.AZURE_TEST_RESOURCE_GROUP }}
+        if: always()
+        run: |
+          # if deletion fails, purge workflow will purge the resource group and its resources later.
+          az group delete \
+            --subscription ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }} \
+            --name ${{ env.AZURE_TEST_RESOURCE_GROUP }} \
+            --yes --verbose
   report-test-results:
     name: Report test results
     needs: [build, tests]


### PR DESCRIPTION
# Description

Adding the step to delete the created Azure resource group to the functional test workflow.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #7677 
