### PR TITLE
Adding a test for annotations and labels to the existing k8s extensibility functional test

### DIFF
--- a/test/functional-portable/corerp/noncloud/mechanics/k8s_extensibility_test.go
+++ b/test/functional-portable/corerp/noncloud/mechanics/k8s_extensibility_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mechanics_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,7 +26,9 @@ import (
 	"github.com/radius-project/radius/test/rp"
 	"github.com/radius-project/radius/test/step"
 	"github.com/radius-project/radius/test/validation"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -33,13 +36,36 @@ func Test_Kubernetes_Extensibility(t *testing.T) {
 	template := "testdata/k8s-extensibility/connection-string.bicep"
 	name := "corerp-mechanics-k8s-extensibility"
 
+	expectedSecretLabels := map[string]string{
+		"format": "k8s-extension",
+	}
+
+	expectedSecretAnnotations := map[string]string{
+		"testAnnotation": "testAnnotation",
+	}
+
 	test := rp.NewRPTest(t, name, []rp.TestStep{
 		{
 			Executor:           step.NewDeployExecutor(template),
 			RPResources:        &validation.RPResourceSet{},
 			K8sOutputResources: loadResources("testdata/k8s-extensibility", ".output.yaml"),
-			// No output resources are expected
+			// No output resources are expected.
 			SkipKubernetesOutputResourceValidation: true,
+			// Added this step to verify the labels on the secret.
+			PostStepVerify: func(ctx context.Context, t *testing.T, test rp.RPTest) {
+				secretNamespace := "corerp-mechanics-k8s-extensibility"
+				secretName := "redis-conn"
+				secret, err := test.Options.K8sClient.CoreV1().Secrets(secretNamespace).Get(ctx, secretName, metav1.GetOptions{})
+				require.NoError(t, err)
+
+				labels := secret.GetLabels()
+				require.Len(t, labels, 1)
+				require.Equal(t, expectedSecretLabels, labels)
+
+				annotations := secret.GetAnnotations()
+				require.Len(t, annotations, 1)
+				require.Equal(t, expectedSecretAnnotations, annotations)
+			},
 		},
 	}, loadResources("testdata/k8s-extensibility", ".input.yaml")...)
 

--- a/test/functional-portable/corerp/noncloud/mechanics/testdata/k8s-extensibility/connection-string.bicep
+++ b/test/functional-portable/corerp/noncloud/mechanics/testdata/k8s-extensibility/connection-string.bicep
@@ -24,6 +24,9 @@ resource secret 'core/Secret@v1' = {
     labels: {
       format: 'k8s-extension'
     }
+    annotations: {
+      testAnnotation: 'testAnnotation'
+    }
   }
 
   stringData: {


### PR DESCRIPTION
# Description
Adding a test for annotations and labels to the existing k8s extensibility functional test.

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).