### PR TITLE
Update wait time on postgres db in functional test

### DIFF
--- a/test/testrecipes/test-terraform-recipes/postgres/main.tf
+++ b/test/testrecipes/test-terraform-recipes/postgres/main.tf
@@ -34,7 +34,7 @@ resource "kubernetes_deployment" "postgres" {
 
       spec {
         container {
-          image = "postgres:latest"
+          image = "ghcr.io/radius-project/mirror/postgres:latest"
           name  = "postgres"
 
           env {
@@ -69,13 +69,13 @@ resource "kubernetes_service" "postgres" {
   }
 }
 
-resource "time_sleep" "wait_20_seconds" {
+resource "time_sleep" "wait_50_seconds" {
   depends_on = [kubernetes_service.postgres]
-  create_duration = "20s"
+  create_duration = "50s"
 }
 
 resource postgresql_database "pg_db_test" {
   provider = postgresql.pgdb-test
-  depends_on = [time_sleep.wait_20_seconds]
+  depends_on = [time_sleep.wait_50_seconds]
   name = "pg_db_test"
 }


### PR DESCRIPTION
# Description

This update is to address timeout issue resulting in failures in long running test cluster.
eg: https://github.com/radius-project/radius/actions/runs/9607219705/job/26498020237

Updating wait time on postgres db in functional test from 20 sec to 50 sec.
Update includes accessing postgres:latest image from ghcr repo. 

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).


Fixes:https://github.com/radius-project/radius/issues/7705
