### PR TITLE
rad credential show - support for IRSA

### DIFF
--- a/pkg/cli/cmd/credential/show/objectformats.go
+++ b/pkg/cli/cmd/credential/show/objectformats.go
@@ -86,6 +86,10 @@ func credentialFormatAWSAccessKey() output.FormatterOptions {
 				JSONPath: "{ .Enabled }",
 			},
 			{
+				Heading:  "KIND",
+				JSONPath: "{ .AWSCredentials.Kind }",
+			},
+			{
 				Heading:  "ACCESSKEYID",
 				JSONPath: "{ .AWSCredentials.AccessKey.AccessKeyID }",
 			},
@@ -103,6 +107,10 @@ func credentialFormatAWSIRSA() output.FormatterOptions {
 			{
 				Heading:  "REGISTERED",
 				JSONPath: "{ .Enabled }",
+			},
+			{
+				Heading:  "KIND",
+				JSONPath: "{ .AWSCredentials.Kind }",
 			},
 			{
 				Heading:  "ROLEARN",

--- a/pkg/cli/cmd/credential/show/objectformats.go
+++ b/pkg/cli/cmd/credential/show/objectformats.go
@@ -74,7 +74,7 @@ func credentialFormatAzureWorkloadIdentity() output.FormatterOptions {
 	}
 }
 
-func credentialFormatAWS() output.FormatterOptions {
+func credentialFormatAWSAccessKey() output.FormatterOptions {
 	return output.FormatterOptions{
 		Columns: []output.Column{
 			{
@@ -87,7 +87,26 @@ func credentialFormatAWS() output.FormatterOptions {
 			},
 			{
 				Heading:  "ACCESSKEYID",
-				JSONPath: "{ .AWSCredentials.AccessKeyID }",
+				JSONPath: "{ .AWSCredentials.AccessKey.AccessKeyID }",
+			},
+		},
+	}
+}
+
+func credentialFormatAWSIRSA() output.FormatterOptions {
+	return output.FormatterOptions{
+		Columns: []output.Column{
+			{
+				Heading:  "NAME",
+				JSONPath: "{ .Name }",
+			},
+			{
+				Heading:  "REGISTERED",
+				JSONPath: "{ .Enabled }",
+			},
+			{
+				Heading:  "ROLEARN",
+				JSONPath: "{ .AWSCredentials.IRSA.RoleARN }",
 			},
 		},
 	}

--- a/pkg/cli/cmd/credential/show/objectformats_test.go
+++ b/pkg/cli/cmd/credential/show/objectformats_test.go
@@ -76,7 +76,7 @@ func Test_credentialFormat_Azure_WorkloadIdentity(t *testing.T) {
 	require.Equal(t, expected, buffer.String())
 }
 
-func Test_credentialFormat_AWS_AcessKey(t *testing.T) {
+func Test_credentialFormatAWSAccessKey(t *testing.T) {
 	obj := credential.ProviderCredentialConfiguration{
 		CloudProviderStatus: credential.CloudProviderStatus{
 			Name:    "test",
@@ -97,11 +97,11 @@ func Test_credentialFormat_AWS_AcessKey(t *testing.T) {
 	err := output.Write(output.FormatTable, obj, buffer, credentialFormatOutput)
 	require.NoError(t, err)
 
-	expected := "NAME      REGISTERED  ACCESSKEYID\ntest      true        test-access-key-id\n"
+	expected := "NAME      REGISTERED  KIND       ACCESSKEYID\ntest      true        AccessKey  test-access-key-id\n"
 	require.Equal(t, expected, buffer.String())
 }
 
-func Test_credentialFormat_AWS_IRSA(t *testing.T) {
+func Test_credentialFormatAWSIRSA(t *testing.T) {
 	obj := credential.ProviderCredentialConfiguration{
 		CloudProviderStatus: credential.CloudProviderStatus{
 			Name:    "test",
@@ -122,6 +122,6 @@ func Test_credentialFormat_AWS_IRSA(t *testing.T) {
 	err := output.Write(output.FormatTable, obj, buffer, credentialFormatOutput)
 	require.NoError(t, err)
 
-	expected := "NAME      REGISTERED  ROLEARN\ntest      true        test-role-arn\n"
+	expected := "NAME      REGISTERED  KIND      ROLEARN\ntest      true        IRSA      test-role-arn\n"
 	require.Equal(t, expected, buffer.String())
 }

--- a/pkg/cli/cmd/credential/show/objectformats_test.go
+++ b/pkg/cli/cmd/credential/show/objectformats_test.go
@@ -76,23 +76,52 @@ func Test_credentialFormat_Azure_WorkloadIdentity(t *testing.T) {
 	require.Equal(t, expected, buffer.String())
 }
 
-func Test_credentialFormat_AWS(t *testing.T) {
+func Test_credentialFormat_AWS_AcessKey(t *testing.T) {
 	obj := credential.ProviderCredentialConfiguration{
 		CloudProviderStatus: credential.CloudProviderStatus{
 			Name:    "test",
 			Enabled: true,
 		},
 		AWSCredentials: &credential.AWSCredentialProperties{
-			AccessKeyID: to.Ptr("test-access-key-id"),
+			Kind: to.Ptr("AccessKey"),
+			AccessKey: &credential.AWSAccessKeyCredentialProperties{
+				Kind:        to.Ptr("AccessKey"),
+				AccessKeyID: to.Ptr("test-access-key-id"),
+			},
 		},
 	}
 
 	buffer := &bytes.Buffer{}
-	credentialFormatOutput := credentialFormatAWS()
+	credentialFormatOutput := credentialFormatAWSAccessKey()
 
 	err := output.Write(output.FormatTable, obj, buffer, credentialFormatOutput)
 	require.NoError(t, err)
 
 	expected := "NAME      REGISTERED  ACCESSKEYID\ntest      true        test-access-key-id\n"
+	require.Equal(t, expected, buffer.String())
+}
+
+func Test_credentialFormat_AWS_IRSA(t *testing.T) {
+	obj := credential.ProviderCredentialConfiguration{
+		CloudProviderStatus: credential.CloudProviderStatus{
+			Name:    "test",
+			Enabled: true,
+		},
+		AWSCredentials: &credential.AWSCredentialProperties{
+			Kind: to.Ptr("IRSA"),
+			IRSA: &credential.AWSIRSACredentialProperties{
+				Kind:    to.Ptr("IRSA"),
+				RoleARN: to.Ptr("test-role-arn"),
+			},
+		},
+	}
+
+	buffer := &bytes.Buffer{}
+	credentialFormatOutput := credentialFormatAWSIRSA()
+
+	err := output.Write(output.FormatTable, obj, buffer, credentialFormatOutput)
+	require.NoError(t, err)
+
+	expected := "NAME      REGISTERED  ROLEARN\ntest      true        test-role-arn\n"
 	require.Equal(t, expected, buffer.String())
 }

--- a/pkg/cli/cmd/credential/show/show.go
+++ b/pkg/cli/cmd/credential/show/show.go
@@ -140,7 +140,14 @@ func (r *Runner) Run(ctx context.Context) error {
 			return fmt.Errorf("unknown Azure credential kind, expected ServicePrincipal or WorkloadIdentity (got %s)", *providers.AzureCredentials.Kind)
 		}
 	case "aws":
-		output = credentialFormatAWS()
+		switch *providers.AWSCredentials.Kind {
+		case datamodel.AWSAccessKeyCredentialKind:
+			output = credentialFormatAWSAccessKey()
+		case datamodel.AWSIRSACredentialKind:
+			output = credentialFormatAWSIRSA()
+		default:
+			return fmt.Errorf("unknown AWS credential kind, expected AccessKey or IRSA (got %s)", *providers.AWSCredentials.Kind)
+		}
 	default:
 		return fmt.Errorf("unknown credential type: %s", r.Kind)
 	}

--- a/pkg/cli/cmd/credential/show/show_test.go
+++ b/pkg/cli/cmd/credential/show/show_test.go
@@ -184,6 +184,9 @@ func Test_Run(t *testing.T) {
 					Name:    "aws",
 					Enabled: true,
 				},
+				AWSCredentials: &cli_credential.AWSCredentialProperties{
+					Kind: to.Ptr("AccessKey"),
+				},
 			}
 
 			client := cli_credential.NewMockCredentialManagementClient(ctrl)
@@ -205,7 +208,7 @@ func Test_Run(t *testing.T) {
 			err := runner.Run(context.Background())
 			require.NoError(t, err)
 
-			credentialFormatOutput := credentialFormatAWS()
+			credentialFormatOutput := credentialFormatAWSAccessKey()
 
 			expected := []any{
 				output.LogOutput{


### PR DESCRIPTION
# Description

rad credential show should work with the new datamodel that supports 2 aws credential types - accesskey and irsa

## Type of change

- This pull request adds or changes features of Radius and has an approved issue (issue link required).
Partially Fixes: #7618
