### PR TITLE
Update the registry in CLI functional test

### DIFF
--- a/.github/actions/create-local-registry/action.yaml
+++ b/.github/actions/create-local-registry/action.yaml
@@ -96,6 +96,11 @@ runs:
         sudo cp $TEMP_CERT_DIR/certs/${{ inputs.registry-server }}/client.crt /usr/local/share/ca-certificates/${{ inputs.registry-name }}.crt
         sudo update-ca-certificates
 
+    - name: Add registry name to /etc/hosts
+      shell: bash
+      run: |
+        echo "127.0.0.1 ${{ inputs.registry-name }}" | sudo tee -a /etc/hosts
+
     - name: Create secure Docker registry
       if: ${{ inputs.secure == 'true' }}
       shell: bash

--- a/test/functional-portable/cli/noncloud/cli_test.go
+++ b/test/functional-portable/cli/noncloud/cli_test.go
@@ -69,8 +69,8 @@ func verifyRecipeCLI(ctx context.Context, t *testing.T, test rp.RPTest) {
 	resourceType := "Applications.Datastores/redisCaches"
 	file := "../../../testrecipes/test-bicep-recipes/corerp-redis-recipe.bicep"
 
-	// The target is a local registry, so we can use localhost.
-	target := fmt.Sprintf("br:localhost:5000/dev/test-bicep-recipes/redis-recipe:%s", generateUniqueTag())
+	target := fmt.Sprintf("br:%s/dev/test-bicep-recipes/redis-recipe:%s",
+		strings.TrimPrefix(registry, "registry="), generateUniqueTag())
 
 	recipeName := "recipeName"
 	recipeTemplate := fmt.Sprintf("%s/recipes/local-dev/rediscaches:%s", registry, version)


### PR DESCRIPTION
# Description
It uses localhost:5000 by default which only applies for the non-cloud functional tests. It breaks the long-running tests.

## Type of change