### PR TITLE
Update location property flags in type generator

### DIFF
--- a/hack/bicep-types-radius/generated/applications/applications.core/2023-10-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/applications/applications.core/2023-10-01-preview/types.json
@@ -60,7 +60,7 @@
         "type": {
           "$ref": "#/0"
         },
-        "flags": 1,
+        "flags": 0,
         "description": "The geo-location where the resource lives"
       },
       "systemData": {
@@ -724,7 +724,7 @@
         "type": {
           "$ref": "#/0"
         },
-        "flags": 1,
+        "flags": 0,
         "description": "The geo-location where the resource lives"
       },
       "systemData": {
@@ -1581,7 +1581,7 @@
         "type": {
           "$ref": "#/0"
         },
-        "flags": 1,
+        "flags": 0,
         "description": "The geo-location where the resource lives"
       },
       "systemData": {
@@ -2091,7 +2091,7 @@
         "type": {
           "$ref": "#/0"
         },
-        "flags": 1,
+        "flags": 0,
         "description": "The geo-location where the resource lives"
       },
       "systemData": {
@@ -2344,7 +2344,7 @@
         "type": {
           "$ref": "#/0"
         },
-        "flags": 1,
+        "flags": 0,
         "description": "The geo-location where the resource lives"
       },
       "systemData": {
@@ -2661,7 +2661,7 @@
         "type": {
           "$ref": "#/0"
         },
-        "flags": 1,
+        "flags": 0,
         "description": "The geo-location where the resource lives"
       },
       "systemData": {
@@ -3012,7 +3012,7 @@
         "type": {
           "$ref": "#/0"
         },
-        "flags": 1,
+        "flags": 0,
         "description": "The geo-location where the resource lives"
       },
       "systemData": {

--- a/hack/bicep-types-radius/generated/applications/applications.dapr/2023-10-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/applications/applications.dapr/2023-10-01-preview/types.json
@@ -60,7 +60,7 @@
         "type": {
           "$ref": "#/0"
         },
-        "flags": 1,
+        "flags": 0,
         "description": "The geo-location where the resource lives"
       },
       "systemData": {
@@ -646,7 +646,7 @@
         "type": {
           "$ref": "#/0"
         },
-        "flags": 1,
+        "flags": 0,
         "description": "The geo-location where the resource lives"
       },
       "systemData": {
@@ -883,7 +883,7 @@
         "type": {
           "$ref": "#/0"
         },
-        "flags": 1,
+        "flags": 0,
         "description": "The geo-location where the resource lives"
       },
       "systemData": {

--- a/hack/bicep-types-radius/generated/applications/applications.datastores/2023-10-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/applications/applications.datastores/2023-10-01-preview/types.json
@@ -60,7 +60,7 @@
         "type": {
           "$ref": "#/0"
         },
-        "flags": 1,
+        "flags": 0,
         "description": "The geo-location where the resource lives"
       },
       "systemData": {
@@ -710,7 +710,7 @@
         "type": {
           "$ref": "#/0"
         },
-        "flags": 1,
+        "flags": 0,
         "description": "The geo-location where the resource lives"
       },
       "systemData": {
@@ -1035,7 +1035,7 @@
         "type": {
           "$ref": "#/0"
         },
-        "flags": 1,
+        "flags": 0,
         "description": "The geo-location where the resource lives"
       },
       "systemData": {

--- a/hack/bicep-types-radius/generated/applications/applications.messaging/2023-10-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/applications/applications.messaging/2023-10-01-preview/types.json
@@ -60,7 +60,7 @@
         "type": {
           "$ref": "#/0"
         },
-        "flags": 1,
+        "flags": 0,
         "description": "The geo-location where the resource lives"
       },
       "systemData": {

--- a/hack/bicep-types-radius/src/autorest.bicep/src/type-generator.ts
+++ b/hack/bicep-types-radius/src/autorest.bicep/src/type-generator.ts
@@ -358,11 +358,13 @@ export function generateTypes(host: AutorestExtensionHost, definition: ProviderD
     return ObjectTypePropertyFlags.None;
   }
 
-  function parsePropertyFlags(putProperty: Property | undefined, getProperty: Property | undefined, propertyName: string) {
+  function parsePropertyFlags(putProperty: Property | undefined, getProperty: Property | undefined, propertyName?: string) {
     let flags = ObjectTypePropertyFlags.None;
 
-    if (putProperty && putProperty.required && propertyName !== 'location') {
-      flags |= ObjectTypePropertyFlags.Required;
+    if (putProperty && putProperty.required) {
+      if (!propertyName || propertyName !== 'location') {
+        flags |= ObjectTypePropertyFlags.Required;
+      }
     }
 
     if (putProperty && getProperty) {
@@ -465,7 +467,7 @@ export function generateTypes(host: AutorestExtensionHost, definition: ProviderD
       const propertyDefinition = parseType(putProperty?.schema, getProperty?.schema);
       if (propertyDefinition) {
         const description = (putProperty?.schema ?? getProperty?.schema)?.language.default?.description;
-        const flags = parsePropertyFlags(putProperty, getProperty, propertyName);
+        const flags = parsePropertyFlags(putProperty, getProperty);
         definitionProperties[propertyName] = createObjectProperty(propertyDefinition, flags, description);
       }
     }

--- a/hack/bicep-types-radius/src/autorest.bicep/src/type-generator.ts
+++ b/hack/bicep-types-radius/src/autorest.bicep/src/type-generator.ts
@@ -68,7 +68,7 @@ export function generateTypes(host: AutorestExtensionHost, definition: ProviderD
       const propertyDefinition = parseType(putProperty?.schema, getProperty?.schema);
       if (propertyDefinition) {
         const description = (putProperty?.schema ?? getProperty?.schema)?.language.default?.description;
-        const flags = parsePropertyFlags(putProperty, getProperty);
+        const flags = parsePropertyFlags(putProperty, getProperty, propertyName);
         resourceProperties[propertyName] = createObjectProperty(propertyDefinition, flags, description);
       }
     }
@@ -358,10 +358,10 @@ export function generateTypes(host: AutorestExtensionHost, definition: ProviderD
     return ObjectTypePropertyFlags.None;
   }
 
-  function parsePropertyFlags(putProperty: Property | undefined, getProperty: Property | undefined) {
+  function parsePropertyFlags(putProperty: Property | undefined, getProperty: Property | undefined, propertyName: string) {
     let flags = ObjectTypePropertyFlags.None;
 
-    if (putProperty && putProperty.required) {
+    if (putProperty && putProperty.required && propertyName !== 'location') {
       flags |= ObjectTypePropertyFlags.Required;
     }
 
@@ -465,7 +465,7 @@ export function generateTypes(host: AutorestExtensionHost, definition: ProviderD
       const propertyDefinition = parseType(putProperty?.schema, getProperty?.schema);
       if (propertyDefinition) {
         const description = (putProperty?.schema ?? getProperty?.schema)?.language.default?.description;
-        const flags = parsePropertyFlags(putProperty, getProperty);
+        const flags = parsePropertyFlags(putProperty, getProperty, propertyName);
         definitionProperties[propertyName] = createObjectProperty(propertyDefinition, flags, description);
       }
     }

--- a/hack/bicep-types-radius/src/autorest.bicep/src/type-generator.ts
+++ b/hack/bicep-types-radius/src/autorest.bicep/src/type-generator.ts
@@ -362,6 +362,10 @@ export function generateTypes(host: AutorestExtensionHost, definition: ProviderD
     let flags = ObjectTypePropertyFlags.None;
 
     if (putProperty && putProperty.required) {
+      // 'location' is not a required property on resources but can be a required property on other nested types
+      // We need to update the property flag to not be required if we're processing a top-level 'location' property
+      // If propertyName is provided, then we are processing a top-level property and need to check if the property name is 'location'
+      // If propertyName is not provided, then we are not processing a top-level property and can proceed with no changes 
       if (!propertyName || propertyName !== 'location') {
         flags |= ObjectTypePropertyFlags.Required;
       }

--- a/hack/bicep-types-radius/src/autorest.bicep/test/integration/generated/basic/test.rp1/2021-10-31/docs/testtype1.md
+++ b/hack/bicep-types-radius/src/autorest.bicep/test/integration/generated/basic/test.rp1/2021-10-31/docs/testtype1.md
@@ -6,7 +6,7 @@
 |----------|------|-------------|
 | **apiVersion** | '2021-10-31' | The resource api version <br />_(ReadOnly, DeployTimeConstant)_ |
 | **id** | string | The resource id <br />_(ReadOnly, DeployTimeConstant)_ |
-| **location** | string | The geo-location where the resource lives <br />_(Required)_ |
+| **location** | string | The geo-location where the resource lives |
 | **name** | string | The resource name <br />_(Required, DeployTimeConstant, Identifier)_ |
 | **properties** | [TestType1Properties](#testtype1properties) |  |
 | **systemData** | [SystemData](#systemdata) | Metadata pertaining to creation and last modification of the resource. <br />_(ReadOnly)_ |

--- a/hack/bicep-types-radius/src/autorest.bicep/test/integration/generated/basic/test.rp1/2021-10-31/types.json
+++ b/hack/bicep-types-radius/src/autorest.bicep/test/integration/generated/basic/test.rp1/2021-10-31/types.json
@@ -59,7 +59,7 @@
         "type": {
           "$ref": "#/0"
         },
-        "flags": 1,
+        "flags": 0,
         "description": "The geo-location where the resource lives"
       },
       "systemData": {

--- a/hack/bicep-types-radius/src/autorest.bicep/test/integration/generated/basic/test.rp1/2021-10-31/types.md
+++ b/hack/bicep-types-radius/src/autorest.bicep/test/integration/generated/basic/test.rp1/2021-10-31/types.md
@@ -5,7 +5,7 @@
 ### Properties
 * **apiVersion**: '2021-10-31' (ReadOnly, DeployTimeConstant): The resource api version
 * **id**: string (ReadOnly, DeployTimeConstant): The resource id
-* **location**: string (Required): The geo-location where the resource lives
+* **location**: string: The geo-location where the resource lives
 * **name**: string (Required, DeployTimeConstant, Identifier): The resource name
 * **properties**: [TestType1Properties](#testtype1properties)
 * **systemData**: [SystemData](#systemdata) (ReadOnly): Metadata pertaining to creation and last modification of the resource.


### PR DESCRIPTION
# Description

location is not a required field in our Bicep templates since the DE will inject it if it's missing. it is a required field in our API specs so the generator has been treating it as required. this PR doesn't add the required flag if the field is location 

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number
