### PR TITLE
Update nginx image in LR test workflow

### DIFF
--- a/deploy/tf-module-server/resources.yaml
+++ b/deploy/tf-module-server/resources.yaml
@@ -15,7 +15,7 @@ spec:
         app.kubernetes.io/name: tf-module-server
     spec:
       containers:
-      - image: nginx:1.25
+      - image: nginx:1.27
         name: nginx
         # nginx will serve files found in this directory.
         volumeMounts:


### PR DESCRIPTION
# Description

Fixing issues with an old version of nginx during the LRT workflows during the publish TF test recipes step. `1.27` is the latest version released of nginx 

```
kubectl apply -f ./deploy/tf-module-server/resources.yaml -n radius-test-tf-module-server
Warning: [azurepolicy-k8sazurev2customcontainerallow-db27d7bfaf0671f6e28a] Container image nginx:1.25 for container nginx has not been allowed.
```

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #4277
