### PR TITLE
Update error message value for LRT

### DIFF
--- a/test/functional-portable/corerp/noncloud/resources/recipe_bicep_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/recipe_bicep_test.go
@@ -398,7 +398,17 @@ func Test_BicepRecipe_LanguageFailure(t *testing.T) {
 						Details: []step.DeploymentErrorDetail{
 							{
 								Code:            "InvalidTemplate",
-								MessageContains: "Unable to process template language expressions for resource 'Applications.Core/extenders/corerp-resources-recipe-bicep-langugagefailure-failure' at line '1' and column '456'. 'Unable to evaluate the template language function 'substring'. The index parameter cannot be larger than the length of the string. The index parameter: '10', the length of the string parameter: '4'. Please see https://aka.ms/arm-function-substring for usage details.'",
+								MessageContains: "Unable to process template language expressions for resource 'Applications.Core/extenders/corerp-resources-recipe-bicep-langugagefailure-failure' at line '1' and column",
+							},
+						},
+					},
+					{
+						Code:            "DeploymentFailed",
+						MessageContains: "At least one resource deployment operation failed. Please see the details for the specific operation that failed.",
+						Details: []step.DeploymentErrorDetail{
+							{
+								Code:            "InvalidTemplate",
+								MessageContains: "'Unable to evaluate the template language function 'substring'. The index parameter cannot be larger than the length of the string. The index parameter: '10', the length of the string parameter: '4'. Please see https://aka.ms/arm-function-substring for usage details.'",
 							},
 						},
 					},

--- a/test/functional-portable/corerp/noncloud/resources/recipe_bicep_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/recipe_bicep_test.go
@@ -392,6 +392,9 @@ func Test_BicepRecipe_LanguageFailure(t *testing.T) {
 				Code:            recipes.RecipeDeploymentFailed,
 				MessageContains: "failed to deploy recipe",
 				Details: []step.DeploymentErrorDetail{
+					// The column index flagged for the error is different depending on what version of the extension is used.
+					// These values might be different between functional test and long running test runs.
+					// Instead of hardcoding values, we'll validate that the rest of the message is correct.
 					{
 						Code:            "DeploymentFailed",
 						MessageContains: "At least one resource deployment operation failed. Please see the details for the specific operation that failed.",


### PR DESCRIPTION
# Description

This updates the error message checked in the bicep language failure check. There's a character mismatch in the two templates that get deployed in the func tests vs the LRT. The error message is coded towards the func tests so the character mismatch causes the LRT to fail 

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #7809
