### PR TITLE
Update cloud functional test workflow - fix for (reading 'id')

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -42,6 +42,10 @@ on:
     workflows: ["Approve Functional Tests"]
     types:
       - completed
+  push:
+  # Avoid running the workflow when there is a push to the main branch.
+    branches-ignore:
+      - main    
 
 env:
   # Go version

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -42,10 +42,8 @@ on:
     workflows: ["Approve Functional Tests"]
     types:
       - completed
-  push:
-  # Avoid running the workflow when there is a push to the main branch.
     branches-ignore:
-      - main    
+      - main
 
 env:
   # Go version

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -43,10 +43,6 @@ on:
       - main
       - features/*
       - release/*
-  push:
-  # Avoid running the workflow when there is a push to the main branch.
-    branches-ignore:
-      - main    
 
 env:
   # Go version

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -43,6 +43,10 @@ on:
       - main
       - features/*
       - release/*
+  push:
+  # Avoid running the workflow when there is a push to the main branch.
+    branches-ignore:
+      - main    
 
 env:
   # Go version


### PR DESCRIPTION
# Description

As reported in #[7782](https://github.com/radius-project/radius/issues/7782), #[7668](https://github.com/radius-project/radius/issues/7668), attempting to stop functional test runs upon 'workflow_run' against main.
Manual workflow-dispatch for cloud tests works without errors on main branch and scheduled runs do not produce this error. Will run test runs to determine correct fix.

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #7782, #7668
