### PR TITLE
Adding DELETE operation to the webhook rules in the config

### DIFF
--- a/deploy/Chart/templates/controller/validating-webhook-configuration.yaml
+++ b/deploy/Chart/templates/controller/validating-webhook-configuration.yaml
@@ -42,6 +42,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - recipes
   sideEffects: None


### PR DESCRIPTION
# Description
Added the DELETE op to the webhook rules in the webhook configuration. Here is where the **ValidateDelete** function is: https://github.com/radius-project/radius/blob/main/pkg/controller/reconciler/recipe_webhook.go#L75. We have the function but we don't have the DELETE operation added to the rules.

Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-rules.

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).