### PR TITLE
Add more Logging for cloud functional test workflow

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -114,6 +114,9 @@ jobs:
       - name: Log Event Information
         run: |
           echo "Event Name: ${{ github.event_name }}"
+
+          # Additional logging is temporary for debugging purposes
+          # https://github.com/radius-project/radius/issues/7782
           if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
             echo "Triggered by workflow_run."
             echo "Head Ref: ${{ github.head_ref }}"

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -111,6 +111,20 @@ jobs:
       DE_IMAGE: ${{ steps.gen-id.outputs.DE_IMAGE }}
       DE_TAG: ${{ steps.gen-id.outputs.DE_TAG }}
     steps:
+      - name: Log Event Information
+        run: |
+          echo "Event Name: ${{ github.event_name }}"
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            echo "Triggered by workflow_run."
+            echo "Head Ref: ${{ github.head_ref }}"
+            echo "Ref: ${{ github.ref }}"
+            echo "Head Branch Name: ${{ github.event.workflow_run.head_branch }}"
+            echo "SHA Value: ${{ github.event.workflow_run.head_sha }}"
+            echo "Github Repository: ${{ github.repository }}"
+            echo "Event Repository ID: ${{ github.event.workflow_run.repository.id }}"
+            echo "Event Repository Name: ${{ github.event.workflow_run.repository.name }}"
+            echo "Event Repository Full Name: ${{ github.event.workflow_run.repository.full_name }}"
+          fi
       - name: Get GitHub app token
         uses: tibdex/github-app-token@v2
         id: get_installation_token


### PR DESCRIPTION
# Description

There have been some unexpected runs for the cloud-functional-tests which fail. A recent instance was on 9/1/2024, with multiple runs, some of which were against commits that were already merged into main 2 days ago. 
eg. https://github.com/radius-project/radius/actions/runs/10648348010

This PR adds additional logging to capture the values of multiple fields, allowing us to determine the correct filter conditions for triggering the workflow when event = workflow_run.

Note: This specific event may also have been related to a GitHub outage that happened the same week but nonetheless, similar failed runs have been recorded earlier.

## Type of change
- This pull request fixes a bug in Radius and has an approved issue #7782 

Fixes: Gets more data for #7782
