### PR TITLE
support deployment of an application to a scope "scope1" using environment in a different scope "scope2"

### DIFF
--- a/pkg/cli/cmd/deploy/deploy.go
+++ b/pkg/cli/cmd/deploy/deploy.go
@@ -194,7 +194,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		// If the environment doesn't exist, but the user specified it's name as
+		// If the environment doesn't exist, but the user specified its name or resource id as
 		// a command-line option, return an error
 		if cli.DidSpecifyEnvironmentName(cmd, args) {
 			return clierrors.Message("The environment %q does not exist in scope %q. Run `rad env create` first. You could also provide the environment ID if the environment exists in a different group.", r.EnvironmentNameOrID, r.Workspace.Scope)

--- a/pkg/cli/cmd/deploy/deploy.go
+++ b/pkg/cli/cmd/deploy/deploy.go
@@ -87,6 +87,10 @@ rad deploy myapp.bicep --environment production
 # deploy using a specific environment and resource group
 rad deploy myapp.bicep --environment production --group mygroup
 
+# deploy using an environment ID and a resource group. The application will be deployed in mygroup scope, using the specified environment.
+# use this option if the environment is in a different group.
+rad deploy myapp.bicep --environment /planes/radius/local/resourcegroups/prod/providers/Applications.Core/environments/prod --group mygroup
+
 # specify a string parameter
 rad deploy myapp.bicep --parameters version=latest
 
@@ -123,12 +127,12 @@ type Runner struct {
 	Deploy            deploy.Interface
 	Output            output.Interface
 
-	ApplicationName string
-	EnvironmentName string
-	FilePath        string
-	Parameters      map[string]map[string]any
-	Workspace       *workspaces.Workspace
-	Providers       *clients.Providers
+	ApplicationName     string
+	EnvironmentNameOrID string
+	FilePath            string
+	Parameters          map[string]map[string]any
+	Workspace           *workspaces.Workspace
+	Providers           *clients.Providers
 }
 
 // NewRunner creates a new instance of the `rad deploy` runner.
@@ -166,7 +170,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	// does not exist.
 	workspace.Scope = scope
 
-	r.EnvironmentName, err = cli.RequireEnvironmentName(cmd, args, *workspace)
+	r.EnvironmentNameOrID, err = cli.RequireEnvironmentNameOrID(cmd, args, *workspace)
 	if err != nil {
 		return err
 	}
@@ -183,17 +187,17 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	env, err := client.GetEnvironment(cmd.Context(), r.EnvironmentName)
+	env, err := client.GetEnvironment(cmd.Context(), r.EnvironmentNameOrID)
 	if err != nil {
 		// If the error is not a 404, return it
 		if !clients.Is404Error(err) {
 			return err
 		}
 
-		// If the environment doesn't exist, but the user specified it as
+		// If the environment doesn't exist, but the user specified it's name as
 		// a command-line option, return an error
 		if cli.DidSpecifyEnvironmentName(cmd, args) {
-			return clierrors.Message("The environment %q does not exist in scope %q. Run `rad env create` first.", r.EnvironmentName, r.Workspace.Scope)
+			return clierrors.Message("The environment %q does not exist in scope %q. Run `rad env create` first. You could also provide the environment ID if the environment exists in a different group.", r.EnvironmentNameOrID, r.Workspace.Scope)
 		}
 
 		// If we got here, it means that the error was a 404 and the user did not specify the environment name.
@@ -202,8 +206,10 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 
 	r.Providers = &clients.Providers{}
 	r.Providers.Radius = &clients.RadiusProvider{}
-	r.Providers.Radius.EnvironmentID = r.Workspace.Scope + "/providers/applications.core/environments/" + r.EnvironmentName
-	r.Workspace.Environment = r.Providers.Radius.EnvironmentID
+	if env.ID != nil {
+		r.Providers.Radius.EnvironmentID = *env.ID
+		r.Workspace.Environment = r.Providers.Radius.EnvironmentID
+	}
 
 	if r.ApplicationName != "" {
 		r.Providers.Radius.ApplicationID = r.Workspace.Scope + "/providers/applications.core/applications/" + r.ApplicationName
@@ -272,7 +278,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 
 		// Validate that the environment exists already
-		_, err = client.GetEnvironment(ctx, r.EnvironmentName)
+		_, err = client.GetEnvironment(ctx, r.EnvironmentNameOrID)
 		if err != nil {
 			// If the error is not a 404, return it
 			if !clients.Is404Error(err) {
@@ -298,11 +304,11 @@ func (r *Runner) Run(ctx context.Context) error {
 	if r.ApplicationName == "" {
 		progressText = fmt.Sprintf(
 			"Deploying template '%v' into environment '%v' from workspace '%v'...\n\n"+
-				"Deployment In Progress...", r.FilePath, r.EnvironmentName, r.Workspace.Name)
+				"Deployment In Progress...", r.FilePath, r.EnvironmentNameOrID, r.Workspace.Name)
 	} else {
 		progressText = fmt.Sprintf(
 			"Deploying template '%v' for application '%v' and environment '%v' from workspace '%v'...\n\n"+
-				"Deployment In Progress... ", r.FilePath, r.ApplicationName, r.EnvironmentName, r.Workspace.Name)
+				"Deployment In Progress... ", r.FilePath, r.ApplicationName, r.EnvironmentNameOrID, r.Workspace.Name)
 	}
 
 	_, err = r.Deploy.DeployWithProgress(ctx, deploy.Options{

--- a/pkg/cli/cmd/deploy/deploy_test.go
+++ b/pkg/cli/cmd/deploy/deploy_test.go
@@ -116,6 +116,30 @@ func Test_Validate(t *testing.T) {
 			},
 		},
 		{
+			Name:          "rad deploy - valid with env ID",
+			Input:         []string{"app.bicep", "-e", "/planes/radius/local/resourceGroups/test-resource-group/providers/applications.core/environments/prod"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				mocks.ApplicationManagementClient.EXPECT().
+					GetEnvironment(gomock.Any(), "/planes/radius/local/resourceGroups/test-resource-group/providers/applications.core/environments/prod").
+					Return(v20231001preview.EnvironmentResource{
+						ID: to.Ptr("/planes/radius/local/resourceGroups/test-resource-group/providers/applications.core/environments/prod"),
+					}, nil).
+					Times(1)
+			},
+			ValidateCallback: func(t *testing.T, obj framework.Runner) {
+				runner := obj.(*Runner)
+				scope := "/planes/radius/local/resourceGroups/test-resource-group"
+				environmentID := scope + "/providers/applications.core/environments/prod"
+				require.Equal(t, scope, runner.Workspace.Scope)
+				require.Equal(t, environmentID, runner.Workspace.Environment)
+			},
+		},
+		{
 			Name:          "rad deploy - valid with app and env",
 			Input:         []string{"app.bicep", "-e", "prod", "-a", "my-app"},
 			ExpectedValid: true,

--- a/pkg/cli/cmd/deploy/deploy_test.go
+++ b/pkg/cli/cmd/deploy/deploy_test.go
@@ -43,6 +43,7 @@ func Test_CommandValidation(t *testing.T) {
 func Test_Validate(t *testing.T) {
 	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
 	testcases := []radcli.ValidateInput{
+
 		{
 			Name:          "rad deploy - valid",
 			Input:         []string{"app.bicep"},
@@ -53,7 +54,7 @@ func Test_Validate(t *testing.T) {
 			},
 			ConfigureMocks: func(mocks radcli.ValidateMocks) {
 				mocks.ApplicationManagementClient.EXPECT().
-					GetEnvironment(gomock.Any(), radcli.TestEnvironmentName).
+					GetEnvironment(gomock.Any(), "/planes/radius/local/resourceGroups/test-resource-group/providers/Applications.Core/environments/test-environment").
 					Return(v20231001preview.EnvironmentResource{}, nil).
 					Times(1)
 			},
@@ -68,7 +69,7 @@ func Test_Validate(t *testing.T) {
 			},
 			ConfigureMocks: func(mocks radcli.ValidateMocks) {
 				mocks.ApplicationManagementClient.EXPECT().
-					GetEnvironment(gomock.Any(), radcli.TestEnvironmentName).
+					GetEnvironment(gomock.Any(), radcli.TestEnvironmentID).
 					Return(v20231001preview.EnvironmentResource{}, nil).
 					Times(1)
 
@@ -125,7 +126,9 @@ func Test_Validate(t *testing.T) {
 			ConfigureMocks: func(mocks radcli.ValidateMocks) {
 				mocks.ApplicationManagementClient.EXPECT().
 					GetEnvironment(gomock.Any(), "prod").
-					Return(v20231001preview.EnvironmentResource{}, nil).
+					Return(v20231001preview.EnvironmentResource{
+						ID: to.Ptr("/planes/radius/local/resourceGroups/test-resource-group/providers/applications.core/environments/prod"),
+					}, nil).
 					Times(1)
 			},
 			ValidateCallback: func(t *testing.T, obj framework.Runner) {
@@ -243,7 +246,7 @@ func Test_Run(t *testing.T) {
 		filePath := "app.bicep"
 		progressText := fmt.Sprintf(
 			"Deploying template '%v' into environment '%v' from workspace '%v'...\n\n"+
-				"Deployment In Progress...", filePath, radcli.TestEnvironmentName, workspace.Name)
+				"Deployment In Progress...", filePath, radcli.TestEnvironmentID, workspace.Name)
 
 		options := deploy.Options{
 			Workspace:      *workspace,
@@ -266,14 +269,14 @@ func Test_Run(t *testing.T) {
 
 		outputSink := &output.MockOutput{}
 		runner := &Runner{
-			Bicep:           bicep,
-			Deploy:          deployMock,
-			Output:          outputSink,
-			FilePath:        filePath,
-			EnvironmentName: radcli.TestEnvironmentName,
-			Parameters:      map[string]map[string]any{},
-			Workspace:       workspace,
-			Providers:       provider,
+			Bicep:               bicep,
+			Deploy:              deployMock,
+			Output:              outputSink,
+			FilePath:            filePath,
+			EnvironmentNameOrID: radcli.TestEnvironmentID,
+			Parameters:          map[string]map[string]any{},
+			Workspace:           workspace,
+			Providers:           provider,
 		}
 
 		err := runner.Run(context.Background())
@@ -317,7 +320,7 @@ func Test_Run(t *testing.T) {
 		filePath := "app.bicep"
 		progressText := fmt.Sprintf(
 			"Deploying template '%v' into environment '%v' from workspace '%v'...\n\n"+
-				"Deployment In Progress...", filePath, radcli.TestEnvironmentName, workspace.Name)
+				"Deployment In Progress...", filePath, radcli.TestEnvironmentID, workspace.Name)
 
 		options := deploy.Options{
 			Workspace:      *workspace,
@@ -340,14 +343,14 @@ func Test_Run(t *testing.T) {
 
 		outputSink := &output.MockOutput{}
 		runner := &Runner{
-			Bicep:           bicep,
-			Deploy:          deployMock,
-			Output:          outputSink,
-			Providers:       &ProviderConfig,
-			FilePath:        filePath,
-			EnvironmentName: radcli.TestEnvironmentName,
-			Parameters:      map[string]map[string]any{},
-			Workspace:       workspace,
+			Bicep:               bicep,
+			Deploy:              deployMock,
+			Output:              outputSink,
+			Providers:           &ProviderConfig,
+			FilePath:            filePath,
+			EnvironmentNameOrID: radcli.TestEnvironmentID,
+			Parameters:          map[string]map[string]any{},
+			Workspace:           workspace,
 		}
 
 		err := runner.Run(context.Background())
@@ -410,16 +413,16 @@ func Test_Run(t *testing.T) {
 		}
 
 		runner := &Runner{
-			Bicep:             bicep,
-			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagmentMock},
-			Deploy:            deployMock,
-			Output:            outputSink,
-			Providers:         &providers,
-			FilePath:          "app.bicep",
-			ApplicationName:   "test-application",
-			EnvironmentName:   radcli.TestEnvironmentName,
-			Parameters:        map[string]map[string]any{},
-			Workspace:         workspace,
+			Bicep:               bicep,
+			ConnectionFactory:   &connections.MockFactory{ApplicationsManagementClient: appManagmentMock},
+			Deploy:              deployMock,
+			Output:              outputSink,
+			Providers:           &providers,
+			FilePath:            "app.bicep",
+			ApplicationName:     "test-application",
+			EnvironmentNameOrID: radcli.TestEnvironmentName,
+			Parameters:          map[string]map[string]any{},
+			Workspace:           workspace,
 		}
 
 		err := runner.Run(context.Background())
@@ -477,16 +480,16 @@ func Test_Run(t *testing.T) {
 		}
 
 		runner := &Runner{
-			Bicep:             bicep,
-			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagmentMock},
-			Deploy:            deployMock,
-			Output:            outputSink,
-			Providers:         &providers,
-			FilePath:          "app.bicep",
-			ApplicationName:   "appdoesntexist",
-			EnvironmentName:   "envdoesntexist",
-			Parameters:        map[string]map[string]any{},
-			Workspace:         workspace,
+			Bicep:               bicep,
+			ConnectionFactory:   &connections.MockFactory{ApplicationsManagementClient: appManagmentMock},
+			Deploy:              deployMock,
+			Output:              outputSink,
+			Providers:           &providers,
+			FilePath:            "app.bicep",
+			ApplicationName:     "appdoesntexist",
+			EnvironmentNameOrID: "envdoesntexist",
+			Parameters:          map[string]map[string]any{},
+			Workspace:           workspace,
 		}
 
 		err := runner.Run(context.Background())
@@ -500,6 +503,7 @@ func Test_Run(t *testing.T) {
 	})
 
 	t.Run("Deployment with missing parameters", func(t *testing.T) {
+		//t.Skip()
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -532,14 +536,14 @@ func Test_Run(t *testing.T) {
 		}
 
 		runner := &Runner{
-			Bicep:             bicep,
-			ConnectionFactory: &connections.MockFactory{},
-			Output:            outputSink,
-			Providers:         &providers,
-			EnvironmentName:   radcli.TestEnvironmentName,
-			FilePath:          "app.bicep",
-			Parameters:        map[string]map[string]any{},
-			Workspace:         workspace,
+			Bicep:               bicep,
+			ConnectionFactory:   &connections.MockFactory{},
+			Output:              outputSink,
+			Providers:           &providers,
+			EnvironmentNameOrID: radcli.TestEnvironmentName,
+			FilePath:            "app.bicep",
+			Parameters:          map[string]map[string]any{},
+			Workspace:           workspace,
 		}
 
 		err := runner.Run(context.Background())

--- a/pkg/cli/cmd/run/run_test.go
+++ b/pkg/cli/cmd/run/run_test.go
@@ -73,6 +73,7 @@ func Test_Validate(t *testing.T) {
 					Times(1)
 			},
 		},
+
 		{
 			Name:          "rad run - app set by directory config",
 			Input:         []string{"app.bicep", "-e", "prod"},
@@ -103,7 +104,7 @@ func Test_Validate(t *testing.T) {
 			},
 			ConfigureMocks: func(mocks radcli.ValidateMocks) {
 				mocks.ApplicationManagementClient.EXPECT().
-					GetEnvironment(gomock.Any(), radcli.TestEnvironmentName).
+					GetEnvironment(gomock.Any(), "/planes/radius/local/resourceGroups/test-resource-group/providers/Applications.Core/environments/test-environment").
 					Return(v20231001preview.EnvironmentResource{}, nil).
 					Times(1)
 			},
@@ -265,12 +266,12 @@ func Test_Run(t *testing.T) {
 				ApplicationsManagementClient: clientMock,
 			},
 
-			FilePath:        "app.bicep",
-			ApplicationName: "test-application",
-			EnvironmentName: radcli.TestEnvironmentName,
-			Parameters:      map[string]map[string]any{},
-			Workspace:       workspace,
-			Providers:       providers,
+			FilePath:            "app.bicep",
+			ApplicationName:     "test-application",
+			EnvironmentNameOrID: radcli.TestEnvironmentName,
+			Parameters:          map[string]map[string]any{},
+			Workspace:           workspace,
+			Providers:           providers,
 		},
 		Logstream:        logstreamMock,
 		Portforward:      portforwardMock,
@@ -440,12 +441,12 @@ func Test_Run_NoDashboard(t *testing.T) {
 				ApplicationsManagementClient: clientMock,
 			},
 
-			FilePath:        "app.bicep",
-			ApplicationName: "test-application",
-			EnvironmentName: radcli.TestEnvironmentName,
-			Parameters:      map[string]map[string]any{},
-			Workspace:       workspace,
-			Providers:       providers,
+			FilePath:            "app.bicep",
+			ApplicationName:     "test-application",
+			EnvironmentNameOrID: radcli.TestEnvironmentName,
+			Parameters:          map[string]map[string]any{},
+			Workspace:           workspace,
+			Providers:           providers,
 		},
 		Logstream:        logstreamMock,
 		Portforward:      portforwardMock,

--- a/test/radcli/shared.go
+++ b/test/radcli/shared.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"go.uber.org/mock/gomock"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/cli/aws"
 	"github.com/radius-project/radius/pkg/cli/azure"
@@ -44,6 +43,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 type ValidateInput struct {
@@ -202,6 +202,7 @@ func validateRequiredFlags(c *cobra.Command) error {
 const (
 	TestWorkspaceName   = "test-workspace"
 	TestEnvironmentName = "test-environment"
+	TestEnvironmentID   = "/planes/radius/local/resourceGroups/test-resource-group/providers/Applications.Core/environments/test-environment"
 )
 
 // LoadConfig reads a YAML configuration from a string and returns a Viper object.


### PR DESCRIPTION
# Description

Today, rad deploy can use only the environments that are in same scope as where the application is being deployed to (either default scope or one specified by -g). 
It should be able to use environments in different groups to deploy application. 

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
Fixes: #7520
