### PR TITLE
Add workflow condition in cloud functional tests

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -97,7 +97,10 @@ jobs:
   build:
     name: Build Radius for test
     runs-on: ubuntu-latest
-    if: github.event_name == 'repository_dispatch' || (github.event_name == 'schedule' && github.repository == 'radius-project/radius') || github.event_name == 'workflow_run' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'repository_dispatch' ||
+        (github.event_name == 'schedule' && github.repository == 'radius-project/radius') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        github.event_name == 'workflow_dispatch'
     env:
       DE_IMAGE: "ghcr.io/radius-project/deployment-engine"
       DE_TAG: "latest"
@@ -443,7 +446,10 @@ jobs:
   tests:
     name: Run ${{ matrix.name }} functional tests
     needs: [build]
-    if: github.event_name == 'repository_dispatch' || (github.event_name == 'schedule' && github.repository == 'radius-project/radius') || github.event_name == 'workflow_run' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'repository_dispatch' ||
+        (github.event_name == 'schedule' && github.repository == 'radius-project/radius') ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+        github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
# Description

Ref: https://github.com/radius-project/radius/pull/7892
Based on logs seen for errors in the past week,
eg. https://github.com/radius-project/radius/actions/runs/10753879482/job/29823820614

Adding condition to workflow to run when github.event.workflow_run.conclusion == 'success' when event is workflow_run.
Keeping additional debug logs in place for the next few days to monitor any subsequent failures. 
Another PR to remove logs will be sent closer to end of this week if no failures are detected.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (#7782).

Fixes: #7782 
