### PR TITLE
Add dapr-sts* namespaces to be deleted to the clean-up workflow

### DIFF
--- a/.github/scripts/cleanup-long-running-cluster.sh
+++ b/.github/scripts/cleanup-long-running-cluster.sh
@@ -45,7 +45,7 @@ fi
 # Delete all test namespaces.
 echo "delete all test namespaces"
 namespaces=$(kubectl get namespace |
-    grep -E '^kubernetes-interop-tutorial.*|^corerp.*|^test.*|^default-.*|^radiusfunctionaltestbucket.*|^radius-test.*|^kubernetes-cli.*|^dpsb-.*|^dsrp-.*|^azstorage-workload.*|^dapr-serviceinvocation|^daprrp-rs-.*|^mynamespace.*|^demo.*|^tutorial-demo.*|^ms.+' |
+    grep -E '^kubernetes-interop-tutorial.*|^corerp.*|^test.*|^default-.*|^radiusfunctionaltestbucket.*|^radius-test.*|^kubernetes-cli.*|^dpsb-.*|^dsrp-.*|^azstorage-workload.*|^dapr-serviceinvocation|^daprrp-rs-.*|^dapr-sts-.*|^mynamespace.*|^demo.*|^tutorial-demo.*|^ms.+' |
     awk '{print $1}')
 for ns in $namespaces; do
     if [ -z "$ns" ]; then


### PR DESCRIPTION
# Description

This new namespace was added a few weeks ago and wasn't added to the cleanup-cluster.sh. I saw this when checking the long-running cluster. Adding this namespace.

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).