### PR TITLE
Improve validation and simplify database tests

### DIFF
--- a/pkg/ucp/api/v20231001preview/awsplane_conversion_test.go
+++ b/pkg/ucp/api/v20231001preview/awsplane_conversion_test.go
@@ -41,7 +41,7 @@ func Test_AWSPlane_ConvertVersionedToDataModel(t *testing.T) {
 					TrackedResource: v1.TrackedResource{
 						ID:       "/planes/aws/aws",
 						Name:     "aws",
-						Type:     "System.AWS/planes",
+						Type:     datamodel.AWSPlaneResourceType,
 						Location: "global",
 						Tags: map[string]string{
 							"env": "dev",
@@ -87,7 +87,7 @@ func Test_AWSPlane_ConvertDataModelToVersioned(t *testing.T) {
 			expected: &AwsPlaneResource{
 				ID:       to.Ptr("/planes/aws/aws"),
 				Name:     to.Ptr("aws"),
-				Type:     to.Ptr("System.AWS/planes"),
+				Type:     to.Ptr(datamodel.AWSPlaneResourceType),
 				Location: to.Ptr("global"),
 				Tags: map[string]*string{
 					"env": to.Ptr("dev"),

--- a/pkg/ucp/api/v20231001preview/azureplane_conversion_test.go
+++ b/pkg/ucp/api/v20231001preview/azureplane_conversion_test.go
@@ -41,7 +41,7 @@ func Test_AzurePlane_ConvertVersionedToDataModel(t *testing.T) {
 					TrackedResource: v1.TrackedResource{
 						ID:       "/planes/azure/azurecloud",
 						Name:     "azurecloud",
-						Type:     "System.Azure/planes",
+						Type:     datamodel.AzurePlaneResourceType,
 						Location: "global",
 						Tags: map[string]string{
 							"env": "dev",
@@ -89,7 +89,7 @@ func Test_AzurePlane_ConvertDataModelToVersioned(t *testing.T) {
 			expected: &AzurePlaneResource{
 				ID:       to.Ptr("/planes/azure/azurecloud"),
 				Name:     to.Ptr("azurecloud"),
-				Type:     to.Ptr("System.Azure/planes"),
+				Type:     to.Ptr(datamodel.AzurePlaneResourceType),
 				Location: to.Ptr("global"),
 				Tags: map[string]*string{
 					"env": to.Ptr("dev"),

--- a/pkg/ucp/api/v20231001preview/genericplane_conversion_test.go
+++ b/pkg/ucp/api/v20231001preview/genericplane_conversion_test.go
@@ -42,7 +42,7 @@ func Test_GenericPlane_ConvertDataModelToVersioned(t *testing.T) {
 			expected: &GenericPlaneResource{
 				ID:       to.Ptr("/planes/aws/aws"),
 				Name:     to.Ptr("aws"),
-				Type:     to.Ptr("System.AWS/planes"),
+				Type:     to.Ptr(datamodel.AWSPlaneResourceType),
 				Location: to.Ptr("global"),
 				Tags: map[string]*string{
 					"env": to.Ptr("dev"),

--- a/pkg/ucp/api/v20231001preview/radiusplane_conversion_test.go
+++ b/pkg/ucp/api/v20231001preview/radiusplane_conversion_test.go
@@ -41,7 +41,7 @@ func Test_RadiusPlane_ConvertVersionedToDataModel(t *testing.T) {
 					TrackedResource: v1.TrackedResource{
 						ID:       "/planes/radius/local",
 						Name:     "local",
-						Type:     "System.Radius/planes",
+						Type:     datamodel.RadiusPlaneResourceType,
 						Location: "global",
 						Tags: map[string]string{
 							"env": "dev",
@@ -91,7 +91,7 @@ func Test_RadiusPlane_ConvertDataModelToVersioned(t *testing.T) {
 			expected: &RadiusPlaneResource{
 				ID:       to.Ptr("/planes/radius/local"),
 				Name:     to.Ptr("local"),
-				Type:     to.Ptr("System.Radius/planes"),
+				Type:     to.Ptr(datamodel.RadiusPlaneResourceType),
 				Location: to.Ptr("global"),
 				Tags: map[string]*string{
 					"env": to.Ptr("dev"),

--- a/pkg/ucp/datamodel/awsplane.go
+++ b/pkg/ucp/datamodel/awsplane.go
@@ -20,6 +20,11 @@ import (
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 )
 
+const (
+	// AWSPlaneResourceType is the type of the AWS plane.
+	AWSPlaneResourceType = "System.AWS/planes"
+)
+
 // AwsPlaneProperties is the properties of an AWS plane.
 type AWSPlaneProperties struct {
 }

--- a/pkg/ucp/datamodel/azureplane.go
+++ b/pkg/ucp/datamodel/azureplane.go
@@ -20,6 +20,11 @@ import (
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 )
 
+const (
+	// AzurePlaneResourceType is the type of the Azure plane.
+	AzurePlaneResourceType = "System.Azure/planes"
+)
+
 // AzurePlaneProperties is the properties of an Azure plane.
 type AzurePlaneProperties struct {
 	URL string

--- a/pkg/ucp/datamodel/radiusplane.go
+++ b/pkg/ucp/datamodel/radiusplane.go
@@ -22,6 +22,11 @@ import (
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 )
 
+const (
+	// RadiusPlaneResourceType is the type of the Radius plane.
+	RadiusPlaneResourceType = "System.Radius/planes"
+)
+
 // RadiusPlaneProperties is the properties of a Radius plane.
 type RadiusPlaneProperties struct {
 

--- a/pkg/ucp/frontend/aws/routes.go
+++ b/pkg/ucp/frontend/aws/routes.go
@@ -93,7 +93,6 @@ func (m *Module) Initialize(ctx context.Context) (http.Handler, error) {
 	}
 
 	// URLs for lifecycle of planes
-	planeResourceType := "System.AWS/planes"
 	planeCollectionRouter := server.NewSubrouter(baseRouter, planeCollectionPath, apiValidator)
 	planeResourceRouter := server.NewSubrouter(baseRouter, planeResourcePath, apiValidator)
 
@@ -102,7 +101,7 @@ func (m *Module) Initialize(ctx context.Context) (http.Handler, error) {
 			// This is a scope query so we can't use the default operation.
 			ParentRouter:  planeCollectionRouter,
 			Method:        v1.OperationList,
-			OperationType: &v1.OperationType{Type: planeResourceType, Method: v1.OperationList},
+			OperationType: &v1.OperationType{Type: datamodel.AWSPlaneResourceType, Method: v1.OperationList},
 			ControllerFactory: func(opts controller.Options) (controller.Controller, error) {
 				return &planes_ctrl.ListPlanesByType[*datamodel.AWSPlane, datamodel.AWSPlane]{
 					Operation: controller.NewOperation(opts, planeResourceOptions),
@@ -112,7 +111,7 @@ func (m *Module) Initialize(ctx context.Context) (http.Handler, error) {
 		{
 			ParentRouter:  planeResourceRouter,
 			Method:        v1.OperationGet,
-			OperationType: &v1.OperationType{Type: planeResourceType, Method: v1.OperationGet},
+			OperationType: &v1.OperationType{Type: datamodel.AWSPlaneResourceType, Method: v1.OperationGet},
 			ControllerFactory: func(opts controller.Options) (controller.Controller, error) {
 				return defaultoperation.NewGetResource(opts, planeResourceOptions)
 			},
@@ -120,7 +119,7 @@ func (m *Module) Initialize(ctx context.Context) (http.Handler, error) {
 		{
 			ParentRouter:  planeResourceRouter,
 			Method:        v1.OperationPut,
-			OperationType: &v1.OperationType{Type: planeResourceType, Method: v1.OperationPut},
+			OperationType: &v1.OperationType{Type: datamodel.AWSPlaneResourceType, Method: v1.OperationPut},
 			ControllerFactory: func(opts controller.Options) (controller.Controller, error) {
 				return defaultoperation.NewDefaultSyncPut(opts, planeResourceOptions)
 			},
@@ -128,7 +127,7 @@ func (m *Module) Initialize(ctx context.Context) (http.Handler, error) {
 		{
 			ParentRouter:  planeResourceRouter,
 			Method:        v1.OperationDelete,
-			OperationType: &v1.OperationType{Type: planeResourceType, Method: v1.OperationDelete},
+			OperationType: &v1.OperationType{Type: datamodel.AWSPlaneResourceType, Method: v1.OperationDelete},
 			ControllerFactory: func(opts controller.Options) (controller.Controller, error) {
 				return defaultoperation.NewDefaultSyncDelete(opts, planeResourceOptions)
 			},

--- a/pkg/ucp/frontend/aws/routes_test.go
+++ b/pkg/ucp/frontend/aws/routes_test.go
@@ -27,6 +27,7 @@ import (
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/armrpc/rpctest"
 	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
+	"github.com/radius-project/radius/pkg/ucp/datamodel"
 	"github.com/radius-project/radius/pkg/ucp/dataprovider"
 	"github.com/radius-project/radius/pkg/ucp/frontend/modules"
 	"github.com/radius-project/radius/pkg/ucp/hostoptions"
@@ -39,19 +40,19 @@ const pathBase = "/some-path-base"
 func Test_Routes(t *testing.T) {
 	tests := []rpctest.HandlerTestSpec{
 		{
-			OperationType: v1.OperationType{Type: "System.AWS/planes", Method: v1.OperationList},
+			OperationType: v1.OperationType{Type: datamodel.AWSPlaneResourceType, Method: v1.OperationList},
 			Method:        http.MethodGet,
 			Path:          "/planes/aws",
 		}, {
-			OperationType: v1.OperationType{Type: "System.AWS/planes", Method: v1.OperationGet},
+			OperationType: v1.OperationType{Type: datamodel.AWSPlaneResourceType, Method: v1.OperationGet},
 			Method:        http.MethodGet,
 			Path:          "/planes/aws/someName",
 		}, {
-			OperationType: v1.OperationType{Type: "System.AWS/planes", Method: v1.OperationPut},
+			OperationType: v1.OperationType{Type: datamodel.AWSPlaneResourceType, Method: v1.OperationPut},
 			Method:        http.MethodPut,
 			Path:          "/planes/aws/someName",
 		}, {
-			OperationType: v1.OperationType{Type: "System.AWS/planes", Method: v1.OperationDelete},
+			OperationType: v1.OperationType{Type: datamodel.AWSPlaneResourceType, Method: v1.OperationDelete},
 			Method:        http.MethodDelete,
 			Path:          "/planes/aws/someName",
 		}, {

--- a/pkg/ucp/frontend/azure/routes.go
+++ b/pkg/ucp/frontend/azure/routes.go
@@ -62,7 +62,6 @@ func (m *Module) Initialize(ctx context.Context) (http.Handler, error) {
 	}
 
 	// URLs for lifecycle of planes
-	planeResourceType := "System.Azure/planes"
 	planeCollectionRouter := server.NewSubrouter(baseRouter, planeCollectionPath, apiValidator)
 	planeResourceRouter := server.NewSubrouter(baseRouter, planeResourcePath, apiValidator)
 
@@ -74,7 +73,7 @@ func (m *Module) Initialize(ctx context.Context) (http.Handler, error) {
 			// This is a scope query so we can't use the default operation.
 			ParentRouter:  planeCollectionRouter,
 			Method:        v1.OperationList,
-			OperationType: &v1.OperationType{Type: planeResourceType, Method: v1.OperationList},
+			OperationType: &v1.OperationType{Type: datamodel.AzurePlaneResourceType, Method: v1.OperationList},
 			ControllerFactory: func(opts controller.Options) (controller.Controller, error) {
 				return &planes_ctrl.ListPlanesByType[*datamodel.AzurePlane, datamodel.AzurePlane]{
 					Operation: controller.NewOperation(opts, planeResourceOptions),
@@ -84,7 +83,7 @@ func (m *Module) Initialize(ctx context.Context) (http.Handler, error) {
 		{
 			ParentRouter:  planeResourceRouter,
 			Method:        v1.OperationGet,
-			OperationType: &v1.OperationType{Type: planeResourceType, Method: v1.OperationGet},
+			OperationType: &v1.OperationType{Type: datamodel.AzurePlaneResourceType, Method: v1.OperationGet},
 			ControllerFactory: func(opts controller.Options) (controller.Controller, error) {
 				return defaultoperation.NewGetResource(opts, planeResourceOptions)
 			},
@@ -92,7 +91,7 @@ func (m *Module) Initialize(ctx context.Context) (http.Handler, error) {
 		{
 			ParentRouter:  planeResourceRouter,
 			Method:        v1.OperationPut,
-			OperationType: &v1.OperationType{Type: planeResourceType, Method: v1.OperationPut},
+			OperationType: &v1.OperationType{Type: datamodel.AzurePlaneResourceType, Method: v1.OperationPut},
 			ControllerFactory: func(opts controller.Options) (controller.Controller, error) {
 				return defaultoperation.NewDefaultSyncPut(opts, planeResourceOptions)
 			},
@@ -100,7 +99,7 @@ func (m *Module) Initialize(ctx context.Context) (http.Handler, error) {
 		{
 			ParentRouter:  planeResourceRouter,
 			Method:        v1.OperationDelete,
-			OperationType: &v1.OperationType{Type: planeResourceType, Method: v1.OperationDelete},
+			OperationType: &v1.OperationType{Type: datamodel.AzurePlaneResourceType, Method: v1.OperationDelete},
 			ControllerFactory: func(opts controller.Options) (controller.Controller, error) {
 				return defaultoperation.NewDefaultSyncDelete(opts, planeResourceOptions)
 			},

--- a/pkg/ucp/frontend/azure/routes_test.go
+++ b/pkg/ucp/frontend/azure/routes_test.go
@@ -27,6 +27,7 @@ import (
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/armrpc/rpctest"
 	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
+	"github.com/radius-project/radius/pkg/ucp/datamodel"
 	"github.com/radius-project/radius/pkg/ucp/dataprovider"
 	"github.com/radius-project/radius/pkg/ucp/frontend/modules"
 	"github.com/radius-project/radius/pkg/ucp/hostoptions"
@@ -39,19 +40,19 @@ const pathBase = "/some-path-base"
 func Test_Routes(t *testing.T) {
 	tests := []rpctest.HandlerTestSpec{
 		{
-			OperationType: v1.OperationType{Type: "System.Azure/planes", Method: v1.OperationList},
+			OperationType: v1.OperationType{Type: datamodel.AzurePlaneResourceType, Method: v1.OperationList},
 			Method:        http.MethodGet,
 			Path:          "/planes/azure",
 		}, {
-			OperationType: v1.OperationType{Type: "System.Azure/planes", Method: v1.OperationGet},
+			OperationType: v1.OperationType{Type: datamodel.AzurePlaneResourceType, Method: v1.OperationGet},
 			Method:        http.MethodGet,
 			Path:          "/planes/azure/someName",
 		}, {
-			OperationType: v1.OperationType{Type: "System.Azure/planes", Method: v1.OperationPut},
+			OperationType: v1.OperationType{Type: datamodel.AzurePlaneResourceType, Method: v1.OperationPut},
 			Method:        http.MethodPut,
 			Path:          "/planes/azure/someName",
 		}, {
-			OperationType: v1.OperationType{Type: "System.Azure/planes", Method: v1.OperationDelete},
+			OperationType: v1.OperationType{Type: datamodel.AzurePlaneResourceType, Method: v1.OperationDelete},
 			Method:        http.MethodDelete,
 			Path:          "/planes/azure/someName",
 		}, {

--- a/pkg/ucp/frontend/controller/planes/listplanes_test.go
+++ b/pkg/ucp/frontend/controller/planes/listplanes_test.go
@@ -41,14 +41,9 @@ func Test_ListPlanes(t *testing.T) {
 
 	url := "/planes?api-version=2023-10-01-preview"
 
-	query := store.Query{
-		RootScope:    "/planes",
-		IsScopeQuery: true,
-	}
-
-	testPlaneId := "/planes/radius"
-	testPlaneName := "radius"
-	testPlaneType := "planes"
+	testPlaneId := "/planes/aws"
+	testPlaneName := "aws"
+	testPlaneType := datamodel.AWSPlaneResourceType
 
 	planeData := datamodel.AWSPlane{
 		BaseResource: v1.BaseResource{
@@ -62,7 +57,11 @@ func Test_ListPlanes(t *testing.T) {
 		Properties: datamodel.AWSPlaneProperties{},
 	}
 
-	mockStorageClient.EXPECT().Query(gomock.Any(), query).Return(&store.ObjectQueryResult{
+	mockStorageClient.EXPECT().Query(gomock.Any(), store.Query{
+		RootScope:    "/planes",
+		ResourceType: "aws",
+		IsScopeQuery: true,
+	}).Return(&store.ObjectQueryResult{
 		Items: []store.Object{
 			{
 				Metadata: store.Metadata{},
@@ -70,6 +69,18 @@ func Test_ListPlanes(t *testing.T) {
 			},
 		},
 	}, nil)
+
+	mockStorageClient.EXPECT().Query(gomock.Any(), store.Query{
+		RootScope:    "/planes",
+		ResourceType: "azure",
+		IsScopeQuery: true,
+	}).Return(&store.ObjectQueryResult{}, nil)
+
+	mockStorageClient.EXPECT().Query(gomock.Any(), store.Query{
+		RootScope:    "/planes",
+		ResourceType: "radius",
+		IsScopeQuery: true,
+	}).Return(&store.ObjectQueryResult{}, nil)
 
 	request, err := http.NewRequest(http.MethodGet, url, nil)
 	require.NoError(t, err)

--- a/pkg/ucp/frontend/controller/planes/listplanesbytype_test.go
+++ b/pkg/ucp/frontend/controller/planes/listplanesbytype_test.go
@@ -55,7 +55,7 @@ func Test_ListPlanesByType(t *testing.T) {
 
 	testPlaneId := "/planes/radius/local"
 	testPlaneName := "local"
-	testPlaneType := "System.Radius/planes"
+	testPlaneType := datamodel.RadiusPlaneResourceType
 
 	planeData := datamodel.RadiusPlane{
 		BaseResource: v1.BaseResource{

--- a/pkg/ucp/frontend/radius/routes.go
+++ b/pkg/ucp/frontend/radius/routes.go
@@ -57,7 +57,6 @@ func (m *Module) Initialize(ctx context.Context) (http.Handler, error) {
 	}
 
 	// URLs for lifecycle of planes
-	planeResourceType := "System.Radius/planes"
 	planeCollectionRouter := server.NewSubrouter(baseRouter, planeCollectionPath, apiValidator)
 	planeResourceRouter := server.NewSubrouter(baseRouter, planeResourcePath, apiValidator)
 
@@ -75,7 +74,7 @@ func (m *Module) Initialize(ctx context.Context) (http.Handler, error) {
 			// This is a scope query so we can't use the default operation.
 			ParentRouter:  planeCollectionRouter,
 			Method:        v1.OperationList,
-			OperationType: &v1.OperationType{Type: planeResourceType, Method: v1.OperationList},
+			OperationType: &v1.OperationType{Type: datamodel.RadiusPlaneResourceType, Method: v1.OperationList},
 			ControllerFactory: func(opts controller.Options) (controller.Controller, error) {
 				return &planes_ctrl.ListPlanesByType[*datamodel.RadiusPlane, datamodel.RadiusPlane]{
 					Operation: controller.NewOperation(opts, planeResourceOptions),
@@ -85,7 +84,7 @@ func (m *Module) Initialize(ctx context.Context) (http.Handler, error) {
 		{
 			ParentRouter:  planeResourceRouter,
 			Method:        v1.OperationGet,
-			OperationType: &v1.OperationType{Type: planeResourceType, Method: v1.OperationGet},
+			OperationType: &v1.OperationType{Type: datamodel.RadiusPlaneResourceType, Method: v1.OperationGet},
 			ControllerFactory: func(opts controller.Options) (controller.Controller, error) {
 				return defaultoperation.NewGetResource(opts, planeResourceOptions)
 			},
@@ -93,7 +92,7 @@ func (m *Module) Initialize(ctx context.Context) (http.Handler, error) {
 		{
 			ParentRouter:  planeResourceRouter,
 			Method:        v1.OperationPut,
-			OperationType: &v1.OperationType{Type: planeResourceType, Method: v1.OperationPut},
+			OperationType: &v1.OperationType{Type: datamodel.RadiusPlaneResourceType, Method: v1.OperationPut},
 			ControllerFactory: func(opts controller.Options) (controller.Controller, error) {
 				return defaultoperation.NewDefaultSyncPut(opts, planeResourceOptions)
 			},
@@ -101,7 +100,7 @@ func (m *Module) Initialize(ctx context.Context) (http.Handler, error) {
 		{
 			ParentRouter:  planeResourceRouter,
 			Method:        v1.OperationDelete,
-			OperationType: &v1.OperationType{Type: planeResourceType, Method: v1.OperationDelete},
+			OperationType: &v1.OperationType{Type: datamodel.RadiusPlaneResourceType, Method: v1.OperationDelete},
 			ControllerFactory: func(opts controller.Options) (controller.Controller, error) {
 				return defaultoperation.NewDefaultSyncDelete(opts, planeResourceOptions)
 			},

--- a/pkg/ucp/frontend/radius/routes_test.go
+++ b/pkg/ucp/frontend/radius/routes_test.go
@@ -25,6 +25,7 @@ import (
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/armrpc/rpctest"
 	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
+	"github.com/radius-project/radius/pkg/ucp/datamodel"
 	"github.com/radius-project/radius/pkg/ucp/dataprovider"
 	"github.com/radius-project/radius/pkg/ucp/frontend/modules"
 	"github.com/radius-project/radius/pkg/ucp/hostoptions"
@@ -38,22 +39,22 @@ const pathBase = "/some-path-base"
 func Test_Routes(t *testing.T) {
 	tests := []rpctest.HandlerTestSpec{
 		{
-			OperationType: v1.OperationType{Type: "System.Radius/planes", Method: v1.OperationList},
+			OperationType: v1.OperationType{Type: datamodel.RadiusPlaneResourceType, Method: v1.OperationList},
 			Method:        http.MethodGet,
 			Path:          "/planes/radius",
 		},
 		{
-			OperationType: v1.OperationType{Type: "System.Radius/planes", Method: v1.OperationGet},
+			OperationType: v1.OperationType{Type: datamodel.RadiusPlaneResourceType, Method: v1.OperationGet},
 			Method:        http.MethodGet,
 			Path:          "/planes/radius/someName",
 		},
 		{
-			OperationType: v1.OperationType{Type: "System.Radius/planes", Method: v1.OperationPut},
+			OperationType: v1.OperationType{Type: datamodel.RadiusPlaneResourceType, Method: v1.OperationPut},
 			Method:        http.MethodPut,
 			Path:          "/planes/radius/someName",
 		},
 		{
-			OperationType: v1.OperationType{Type: "System.Radius/planes", Method: v1.OperationDelete},
+			OperationType: v1.OperationType{Type: datamodel.RadiusPlaneResourceType, Method: v1.OperationDelete},
 			Method:        http.MethodDelete,
 			Path:          "/planes/radius/someName",
 		},

--- a/pkg/ucp/store/client_test.go
+++ b/pkg/ucp/store/client_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuery_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   Query
+		wantErr bool
+	}{
+		{
+			name:    "ResourceType is empty",
+			query:   Query{ResourceType: "", RootScope: "/planes"},
+			wantErr: true,
+		},
+		{
+			name:    "RootScope is empty",
+			query:   Query{ResourceType: "Applications.Core/applications", RootScope: ""},
+			wantErr: true,
+		},
+		{
+			name: "ScopeQuery with RoutingScopePrefix",
+			query: Query{
+				ResourceType:       "Applications.Core/applications",
+				RootScope:          "/planes",
+				IsScopeQuery:       true,
+				RoutingScopePrefix: "/asdf",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Filter is invalid",
+			query: Query{
+				ResourceType: "Applications.Core/applications",
+				RootScope:    "/planes",
+				Filters:      []QueryFilter{{Field: "invalid field!", Value: "some value"}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Valid",
+			query: Query{
+				ResourceType: "Applications.Core/applications",
+				RootScope:    "/planes",
+				Filters:      []QueryFilter{{Field: "location", Value: "some value"}},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.query.Validate()
+			if tt.wantErr {
+				require.Error(t, err, "expected an error but got none")
+			} else {
+				require.NoError(t, err, "expected no error but got one")
+			}
+		})
+	}
+}
+
+func TestQueryFilter_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		filter  QueryFilter
+		wantErr bool
+	}{
+		{
+			name:    "Field is empty",
+			filter:  QueryFilter{Field: "", Value: "some value"},
+			wantErr: true,
+		},
+		{
+			name:    "Field is invalid (contains special characters)",
+			filter:  QueryFilter{Field: "invalid[field]", Value: "some value"},
+			wantErr: true,
+		},
+		{
+			name:    "Field is valid (property)",
+			filter:  QueryFilter{Field: "properties.application", Value: "some value"},
+			wantErr: false,
+		},
+		{
+			name:    "Field is valid (path)",
+			filter:  QueryFilter{Field: "properties.application.some.other.thing", Value: "some value"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.filter.Validate()
+			if tt.wantErr {
+				require.Error(t, err, "expected an error but got none")
+			} else {
+				require.NoError(t, err, "expected no error but got one")
+			}
+		})
+	}
+}

--- a/pkg/ucp/store/cosmosdb/cosmosdbstorageclient.go
+++ b/pkg/ucp/store/cosmosdb/cosmosdbstorageclient.go
@@ -237,11 +237,9 @@ func (c *CosmosDBStorageClient) Query(ctx context.Context, query store.Query, op
 	if ctx == nil {
 		return nil, &store.ErrInvalid{Message: "invalid argument. 'ctx' is required"}
 	}
-	if query.RootScope == "" {
-		return nil, &store.ErrInvalid{Message: "invalid argument. 'query.RootScope' is required"}
-	}
-	if query.IsScopeQuery && query.RoutingScopePrefix != "" {
-		return nil, &store.ErrInvalid{Message: "invalid argument. 'query.RoutingScopePrefix' is not supported for scope queries"}
+	err := query.Validate()
+	if err != nil {
+		return nil, &store.ErrInvalid{Message: fmt.Sprintf("invalid argument. Query is invalid: %s", err.Error())}
 	}
 
 	cfg := store.NewQueryConfig(opts...)

--- a/pkg/ucp/store/etcdstore/etcdclient.go
+++ b/pkg/ucp/store/etcdstore/etcdclient.go
@@ -49,6 +49,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/radius-project/radius/pkg/ucp/resources"
@@ -78,11 +79,10 @@ func (c *ETCDClient) Query(ctx context.Context, query store.Query, options ...st
 	if ctx == nil {
 		return nil, &store.ErrInvalid{Message: "invalid argument. 'ctx' is required"}
 	}
-	if query.RootScope == "" {
-		return nil, &store.ErrInvalid{Message: "invalid argument. 'query.RootScope' is required"}
-	}
-	if query.IsScopeQuery && query.RoutingScopePrefix != "" {
-		return nil, &store.ErrInvalid{Message: "invalid argument. 'query.RoutingScopePrefix' is not supported for scope queries"}
+	
+	err := query.Validate()
+	if err != nil {
+		return nil, &store.ErrInvalid{Message: fmt.Sprintf("invalid argument. Query is invalid: %s", err.Error())}
 	}
 
 	key := keyFromQuery(query)

--- a/pkg/ucp/store/object.go
+++ b/pkg/ucp/store/object.go
@@ -23,10 +23,8 @@ import (
 type ETag = string
 
 type Metadata struct {
-	ID          string
-	ETag        ETag
-	APIVersion  string
-	ContentType string
+	ID   string
+	ETag ETag
 }
 
 type Object struct {

--- a/test/ucp/storetest/shared.go
+++ b/test/ucp/storetest/shared.go
@@ -37,13 +37,15 @@ const (
 	ResourcePath2       = "System.Resources/resourceType2/resource2"
 	ResourcePath3       = "System.Resources/resourceType2/Resource3"
 	NestedResourcePath1 = "System.Resources/resourceType1/resource1/nestedType/nested1"
+	NestedResourcePath2 = "System.Resources/resourceType1/resource1/nestedType/nested2"
+	NestedResourcePath3 = "System.Resources/resourceType1/resource2/nestedType/nested3"
+	NestedResourcePath4 = "System.Resources/resourceType1/resource2/nestedType/nested4"
 
 	RadiusScope         = "/planes/radius/local/"
 	PlaneScope          = "/planes"
 	ResourceGroup1Scope = "/planes/radius/local/resourceGroups/group1"
 	ResourceGroup2Scope = "/planes/radius/local/resourceGroups/group2"
 	ARMResourceScope    = "/subscriptions/abc/resourceGroups/group3"
-	APIVersion          = "test-api-version"
 )
 
 var ResourceGroup1ID = parseOrPanic(ResourceGroup1Scope)
@@ -52,6 +54,9 @@ var Resource1ID = parseOrPanic(ResourceGroup1Scope + "/providers/" + ResourcePat
 var Resource2ID = parseOrPanic(ResourceGroup2Scope + "/providers/" + ResourcePath2)
 var Resource3ID = parseOrPanic(ResourceGroup2Scope + "/providers/" + ResourcePath3)
 var NestedResource1ID = parseOrPanic(ResourceGroup1Scope + "/providers/" + NestedResourcePath1)
+var NestedResource2ID = parseOrPanic(ResourceGroup1Scope + "/providers/" + NestedResourcePath2)
+var NestedResource3ID = parseOrPanic(ResourceGroup1Scope + "/providers/" + NestedResourcePath3)
+var NestedResource4ID = parseOrPanic(ResourceGroup1Scope + "/providers/" + NestedResourcePath4)
 var ARMResourceID = parseOrPanic(ARMResourceScope + "/providers/" + ResourcePath1)
 var RadiusPlaneID = parseOrPanic(RadiusScope)
 
@@ -81,11 +86,34 @@ var Data2 = map[string]any{
 		"resource": "2",
 	},
 }
-
-var NestedData1 = map[string]any{
+var Data3 = map[string]any{
 	"value": "3",
 	"properties": map[string]any{
 		"resource": "3",
+	},
+}
+var NestedData1 = map[string]any{
+	"value": "n1",
+	"properties": map[string]any{
+		"resource": "n1",
+	},
+}
+var NestedData2 = map[string]any{
+	"value": "n2",
+	"properties": map[string]any{
+		"resource": "n2",
+	},
+}
+var NestedData3 = map[string]any{
+	"value": "n3",
+	"properties": map[string]any{
+		"resource": "n3",
+	},
+}
+var NestedData4 = map[string]any{
+	"value": "n4",
+	"properties": map[string]any{
+		"resource": "n4",
 	},
 }
 
@@ -118,9 +146,7 @@ func parseOrPanic(id string) resources.ID {
 func createObject(id resources.ID, data any) store.Object {
 	return store.Object{
 		Metadata: store.Metadata{
-			ID:          id.String(),
-			APIVersion:  APIVersion,
-			ContentType: "application/json",
+			ID: id.String(),
 		},
 		Data: data,
 	}
@@ -354,17 +380,7 @@ func RunTest(t *testing.T, client store.StorageClient, clear func(t *testing.T))
 	t.Run("list_can_be_empty", func(t *testing.T) {
 		clear(t)
 
-		objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope})
-		require.NoError(t, err)
-		require.Empty(t, objs)
-	})
-
-	t.Run("query_planes", func(t *testing.T) {
-		clear(t)
-
-		objs, err := client.Query(ctx, store.Query{RootScope: PlaneScope,
-			IsScopeQuery: true,
-		})
+		objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ResourceType: "asdf"})
 		require.NoError(t, err)
 		require.Empty(t, objs)
 	})
@@ -388,6 +404,18 @@ func RunTest(t *testing.T, client store.StorageClient, clear func(t *testing.T))
 		err = client.Save(ctx, &nested1)
 		require.NoError(t, err)
 
+		nested2 := createObject(NestedResource2ID, NestedData2)
+		err = client.Save(ctx, &nested2)
+		require.NoError(t, err)
+
+		nested3 := createObject(NestedResource3ID, NestedData3)
+		err = client.Save(ctx, &nested3)
+		require.NoError(t, err)
+
+		nested4 := createObject(NestedResource4ID, NestedData4)
+		err = client.Save(ctx, &nested4)
+		require.NoError(t, err)
+
 		obj2 := createObject(Resource2ID, Data2)
 		err = client.Save(ctx, &obj2)
 		require.NoError(t, err)
@@ -397,61 +425,38 @@ func RunTest(t *testing.T, client store.StorageClient, clear func(t *testing.T))
 		require.NoError(t, err)
 
 		t.Run("query_resources_at_resource_group_scope", func(t *testing.T) {
-			objs, err := client.Query(ctx, store.Query{RootScope: ResourceGroup1Scope})
+			objs, err := client.Query(ctx, store.Query{RootScope: ResourceGroup1Scope, ResourceType: NestedResourceType1})
 			require.NoError(t, err)
 			expected := []store.Object{
-				obj1,
 				nested1,
+				nested2,
+				nested3,
+				nested4,
 			}
 			CompareObjectLists(t, expected, objs.Items)
 		})
 
 		t.Run("query_resources_at_resource_group_scope_with_field_filter", func(t *testing.T) {
-			filters := []store.QueryFilter{{Field: "value", Value: "1"}}
-			objs, err := client.Query(ctx, store.Query{RootScope: ResourceGroup1Scope, Filters: filters})
+			filters := []store.QueryFilter{{Field: "value", Value: "n1"}}
+			objs, err := client.Query(ctx, store.Query{RootScope: ResourceGroup1Scope, ResourceType: NestedResourceType1, Filters: filters})
 			require.NoError(t, err)
 			expected := []store.Object{
-				obj1,
+				nested1,
 			}
 			CompareObjectLists(t, expected, objs.Items)
 		})
 
 		t.Run("query_resources_at_resource_group_scope_with_prefix", func(t *testing.T) {
-			objs, err := client.Query(ctx, store.Query{RootScope: ResourceGroup1Scope, RoutingScopePrefix: ResourcePath1})
-			require.NoError(t, err)
-			expected := []store.Object{
-				obj1,
-				nested1,
-			}
-			CompareObjectLists(t, expected, objs.Items)
-		})
-
-		t.Run("query_resources_at_resource_group_scope_with_type_filter", func(t *testing.T) {
-			objs, err := client.Query(ctx, store.Query{RootScope: ResourceGroup1Scope, ResourceType: NestedResourceType1})
+			objs, err := client.Query(ctx, store.Query{RootScope: ResourceGroup1Scope, ResourceType: NestedResourceType1, RoutingScopePrefix: ResourcePath1})
 			require.NoError(t, err)
 			expected := []store.Object{
 				nested1,
-			}
-			CompareObjectLists(t, expected, objs.Items)
-		})
-
-		t.Run("query_resources_at_resource_group_scope_with_prefix_and_type_filter", func(t *testing.T) {
-			objs, err := client.Query(ctx, store.Query{RootScope: ResourceGroup1Scope, RoutingScopePrefix: ResourcePath1, ResourceType: NestedResourceType1})
-			require.NoError(t, err)
-			expected := []store.Object{
-				nested1,
+				nested2,
 			}
 			CompareObjectLists(t, expected, objs.Items)
 		})
 
 		t.Run("query_scopes_at_resource_group_scope", func(t *testing.T) {
-			objs, err := client.Query(ctx, store.Query{RootScope: ResourceGroup1Scope, IsScopeQuery: true})
-			require.NoError(t, err)
-			expected := []store.Object{}
-			CompareObjectLists(t, expected, objs.Items)
-		})
-
-		t.Run("query_scopes_at_resource_group_scope_with_type_filter", func(t *testing.T) {
 			objs, err := client.Query(ctx, store.Query{RootScope: ResourceGroup1Scope, IsScopeQuery: true, ResourceType: "resourceGroups"})
 			require.NoError(t, err)
 			expected := []store.Object{}
@@ -459,25 +464,26 @@ func RunTest(t *testing.T, client store.StorageClient, clear func(t *testing.T))
 		})
 
 		t.Run("query_resources_at_plane_scope", func(t *testing.T) {
-			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope})
+			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ResourceType: ResourceType1})
 			require.NoError(t, err)
 			require.Empty(t, objs)
 		})
 
 		t.Run("query_resources_at_plane_scope_recursive", func(t *testing.T) {
-			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ScopeRecursive: true})
+			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ScopeRecursive: true, ResourceType: NestedResourceType1})
 			require.NoError(t, err)
 			expected := []store.Object{
-				obj1,
-				obj2,
 				nested1,
+				nested2,
+				nested3,
+				nested4,
 			}
 			CompareObjectLists(t, expected, objs.Items)
 		})
 
 		t.Run("query_resources_at_plane_scope_recursive_with_field_filter", func(t *testing.T) {
 			filters := []store.QueryFilter{{Field: "value", Value: "1"}}
-			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ScopeRecursive: true, Filters: filters})
+			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ScopeRecursive: true, ResourceType: ResourceType1, Filters: filters})
 			require.NoError(t, err)
 			expected := []store.Object{
 				obj1,
@@ -486,43 +492,16 @@ func RunTest(t *testing.T, client store.StorageClient, clear func(t *testing.T))
 		})
 
 		t.Run("query_resources_at_plane_scope_recursive_with_prefix", func(t *testing.T) {
-			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ScopeRecursive: true, RoutingScopePrefix: ResourcePath1})
-			require.NoError(t, err)
-			expected := []store.Object{
-				obj1,
-				nested1,
-			}
-			CompareObjectLists(t, expected, objs.Items)
-		})
-
-		t.Run("query_resources_at_plane_scope_recursive_and_type_filter", func(t *testing.T) {
-			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ScopeRecursive: true, ResourceType: NestedResourceType1})
+			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ScopeRecursive: true, ResourceType: NestedResourceType1, RoutingScopePrefix: ResourcePath1})
 			require.NoError(t, err)
 			expected := []store.Object{
 				nested1,
-			}
-			CompareObjectLists(t, expected, objs.Items)
-		})
-
-		t.Run("query_resources_at_plane_scope_recursive_with_prefix_and_type_filter", func(t *testing.T) {
-			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ScopeRecursive: true, RoutingScopePrefix: ResourcePath1, ResourceType: NestedResourceType1})
-			require.NoError(t, err)
-			expected := []store.Object{
-				nested1,
+				nested2,
 			}
 			CompareObjectLists(t, expected, objs.Items)
 		})
 
 		t.Run("query_scopes_at_plane_scope", func(t *testing.T) {
-			objs, err := client.Query(ctx, store.Query{RootScope: PlaneScope, IsScopeQuery: true})
-			require.NoError(t, err)
-			expected := []store.Object{
-				plane1,
-			}
-			CompareObjectLists(t, expected, objs.Items)
-		})
-
-		t.Run("query_scopes_at_plane_scope_with_type_filter", func(t *testing.T) {
 			objs, err := client.Query(ctx, store.Query{RootScope: PlaneScope, IsScopeQuery: true, ResourceType: "radius"})
 			require.NoError(t, err)
 			expected := []store.Object{
@@ -532,7 +511,7 @@ func RunTest(t *testing.T, client store.StorageClient, clear func(t *testing.T))
 		})
 
 		t.Run("query_scopes_at_plane_scope_recursive", func(t *testing.T) {
-			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ScopeRecursive: true, IsScopeQuery: true})
+			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ScopeRecursive: true, IsScopeQuery: true, ResourceType: "resourcegroups"})
 			require.NoError(t, err)
 			expected := []store.Object{
 				group1,
@@ -541,17 +520,7 @@ func RunTest(t *testing.T, client store.StorageClient, clear func(t *testing.T))
 			CompareObjectLists(t, expected, objs.Items)
 		})
 
-		t.Run("query_scopes_at_with_type_filter", func(t *testing.T) {
-			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, IsScopeQuery: true, ResourceType: "resourcegroups"})
-			require.NoError(t, err)
-			expected := []store.Object{
-				group1,
-				group2,
-			}
-			CompareObjectLists(t, expected, objs.Items)
-		})
-
-		t.Run("query_scopes_at_with_type_filter_non_matching", func(t *testing.T) {
+		t.Run("query_scopes_with_filter_non_matching", func(t *testing.T) {
 			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, IsScopeQuery: true, ResourceType: "subscriptions"})
 			require.NoError(t, err)
 			expected := []store.Object{}
@@ -559,7 +528,7 @@ func RunTest(t *testing.T, client store.StorageClient, clear func(t *testing.T))
 		})
 
 		t.Run("query_scopes_at_plane_scope_recursive", func(t *testing.T) {
-			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ScopeRecursive: true, IsScopeQuery: true})
+			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ScopeRecursive: true, IsScopeQuery: true, ResourceType: "resourcegroups"})
 			require.NoError(t, err)
 			expected := []store.Object{
 				group1,
@@ -570,20 +539,10 @@ func RunTest(t *testing.T, client store.StorageClient, clear func(t *testing.T))
 
 		t.Run("query_scopes_at_plane_scope_recursive_with_field_filter", func(t *testing.T) {
 			filters := []store.QueryFilter{{Field: "value", Value: "1"}}
-			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ScopeRecursive: true, IsScopeQuery: true, Filters: filters})
+			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ScopeRecursive: true, IsScopeQuery: true, Filters: filters, ResourceType: "resourcegroups"})
 			require.NoError(t, err)
 			expected := []store.Object{
 				group1,
-			}
-			CompareObjectLists(t, expected, objs.Items)
-		})
-
-		t.Run("query_scopes_at_plane_scope_recursive_with_type_filter", func(t *testing.T) {
-			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, ScopeRecursive: true, IsScopeQuery: true, ResourceType: "resourceGroups"})
-			require.NoError(t, err)
-			expected := []store.Object{
-				group1,
-				group2,
 			}
 			CompareObjectLists(t, expected, objs.Items)
 		})


### PR DESCRIPTION
# Description

This is an improvement to the Radius datastore package that improves the validation and enforces some useful invariants for the design.

Our datastore package is design to support multiple implementations across different technologies (ranging from KV-stores to document-stores to RDBMSes). We have a few of these implementations today but they are inconsistent in how they work.

This change:

- Improves and consolidates validation for the Query() function.
- Adds a new invariant that ResourceType must be provided for a Query().
- Removes tests for cases that are no longer possible.

The new invariant (resource type must be provided for a query) was enforced for the CosmosDB store, but not for the ETC.d or API Server stores. As a result the CosmosDB store was more limited. I'm working on some cleanup in the area and so I wanted to simplify the interface towards the bare-minimum number of requirements. The result is that we can delete tests and functionality, and it will be easier to add new store implementations in the future.

In general our access patterns support the new invariant. One place in code that had to be touched was the `/planes` endpoint in UCP. This would not have worked correctly using the existing CosmosDB store.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

