### PR TITLE
Add an in-memory data store

### DIFF
--- a/pkg/ucp/dataprovider/factory.go
+++ b/pkg/ucp/dataprovider/factory.go
@@ -27,6 +27,7 @@ import (
 	ucpv1alpha1 "github.com/radius-project/radius/pkg/ucp/store/apiserverstore/api/ucp.dev/v1alpha1"
 	"github.com/radius-project/radius/pkg/ucp/store/cosmosdb"
 	"github.com/radius-project/radius/pkg/ucp/store/etcdstore"
+	"github.com/radius-project/radius/pkg/ucp/store/inmemory"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,6 +39,7 @@ var storageClientFactory = map[StorageProviderType]storageFactoryFunc{
 	TypeAPIServer: initAPIServerClient,
 	TypeCosmosDB:  initCosmosDBClient,
 	TypeETCD:      InitETCDClient,
+	TypeInMemory:  initInMemoryClient,
 }
 
 func initAPIServerClient(ctx context.Context, opt StorageProviderOptions, _ string) (store.StorageClient, error) {
@@ -116,4 +118,9 @@ func InitETCDClient(ctx context.Context, opt StorageProviderOptions, _ string) (
 
 	etcdClient := etcdstore.NewETCDClient(client)
 	return etcdClient, nil
+}
+
+// initInMemoryClient creates a new in-memory store client.
+func initInMemoryClient(ctx context.Context, opt StorageProviderOptions, _ string) (store.StorageClient, error) {
+	return inmemory.NewClient(), nil
 }

--- a/pkg/ucp/dataprovider/options.go
+++ b/pkg/ucp/dataprovider/options.go
@@ -34,6 +34,9 @@ type StorageProviderOptions struct {
 
 	// ETCD configures options for the etcd store. Will be ignored if another store is configured.
 	ETCD ETCDOptions `yaml:"etcd,omitempty"`
+
+	// InMemory configures options for the in-memory store. Will be ignored if another store is configured.
+	InMemory InMemoryOptions `yaml:"inmemory,omitempty"`
 }
 
 // APIServerOptions represents options for the configuring the Kubernetes APIServer store.
@@ -65,3 +68,6 @@ type ETCDOptions struct {
 	// We need a way to share state between the etcd service and the things that want to consume it. This is that.
 	Client *hosting.AsyncValue[etcdclient.Client] `yaml:"-"`
 }
+
+// InMemoryOptions represents options for the in-memory store.
+type InMemoryOptions struct{}

--- a/pkg/ucp/dataprovider/types.go
+++ b/pkg/ucp/dataprovider/types.go
@@ -34,6 +34,9 @@ const (
 
 	// TypeETCD represents the etcd provider.
 	TypeETCD StorageProviderType = "etcd"
+
+	// TypeInMemory represents the in-memory provider.
+	TypeInMemory StorageProviderType = "inmemory"
 )
 
 //go:generate mockgen -typed -destination=./mock_datastorage_provider.go -package=dataprovider -self_package github.com/radius-project/radius/pkg/ucp/dataprovider github.com/radius-project/radius/pkg/ucp/dataprovider DataStorageProvider

--- a/pkg/ucp/store/inmemory/client.go
+++ b/pkg/ucp/store/inmemory/client.go
@@ -1,0 +1,289 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inmemory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/radius-project/radius/pkg/ucp/resources"
+	"github.com/radius-project/radius/pkg/ucp/store"
+	"github.com/radius-project/radius/pkg/ucp/store/storeutil"
+	"github.com/radius-project/radius/pkg/ucp/util/etag"
+	"golang.org/x/exp/maps"
+)
+
+var _ store.StorageClient = (*Client)(nil)
+
+// Client is an in-memory implementation of store.StorageClient.
+type Client struct {
+	// mutex is used to synchronize access to the resources map.
+	mutex sync.Mutex
+
+	// resources is a map of resource IDs to their corresponding entries.
+	//
+	// The Get/Save/Delete methods will use the resource ID directly since they only access
+	// a single entry at a time.
+	//
+	// The Query method will iterate over all entries in the map to find the matching ones.
+	resources map[string]entry
+}
+
+// entry stores the commonly-used fields (extracted from the resource ID) for comparison in queries.
+// This is provided for ease of debugging.
+//
+// We use the existing normalization logic to simplify comparisons:
+//
+// - Convert to lowercase
+// - Add leading/trailing slashes.
+//
+// Here's an example:
+//
+//	resource ID: "/planes/radius/local/resourceGroups/my-rg/providers/Applications.Test/testType1/my-resource/testType2/my-child-resource"
+//
+// The entry would be:
+//
+//	rootScope: "/planes/radius/local/resourcegroups/my-rg/"
+//	resourceType: "/applications.test/testtype1/testtype2/"
+//	routingScope: "/applications.test/testtype1/my-resource/testtype2/my-child-resource/"
+//
+// All fields are compared case-insensitively.
+type entry struct {
+	// obj stores the object data.
+	obj store.Object
+
+	// rootScope is the root scope of the resource ID.
+	rootScope string
+
+	// resourceType is the resource type of the resource ID.
+	resourceType string
+
+	// routingScope is the routing scope of the resource ID.
+	routingScope string
+}
+
+// NewClient creates a new in-memory store client.
+func NewClient() *Client {
+	return &Client{
+		mutex:     sync.Mutex{},
+		resources: map[string]entry{},
+	}
+}
+
+// Get implements store.StorageClient.
+func (c *Client) Get(ctx context.Context, id string, options ...store.GetOptions) (*store.Object, error) {
+	if ctx == nil {
+		return nil, &store.ErrInvalid{Message: "invalid argument. 'ctx' is required"}
+	}
+	parsed, err := resources.Parse(id)
+	if err != nil {
+		return nil, &store.ErrInvalid{Message: "invalid argument. 'id' must be a valid resource id"}
+	}
+	if parsed.IsEmpty() {
+		return nil, &store.ErrInvalid{Message: "invalid argument. 'id' must not be empty"}
+	}
+	if parsed.IsResourceCollection() || parsed.IsScopeCollection() {
+		return nil, &store.ErrInvalid{Message: "invalid argument. 'id' must refer to a named resource, not a collection"}
+	}
+
+	normalized, err := storeutil.NormalizeResourceID(parsed)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	entry, ok := c.resources[strings.ToLower(normalized.String())]
+	if !ok {
+		return nil, &store.ErrNotFound{ID: id}
+	}
+
+	// Make a defensive copy so users can't modify the data in the store.
+	copy, err := entry.obj.DeepCopy()
+	if err != nil {
+		return nil, err
+	}
+
+	return copy, nil
+}
+
+// Delete implements store.StorageClient.
+func (c *Client) Delete(ctx context.Context, id string, options ...store.DeleteOptions) error {
+	if ctx == nil {
+		return &store.ErrInvalid{Message: "invalid argument. 'ctx' is required"}
+	}
+	parsed, err := resources.Parse(id)
+	if err != nil {
+		return &store.ErrInvalid{Message: "invalid argument. 'id' must be a valid resource id"}
+	}
+	if parsed.IsEmpty() {
+		return &store.ErrInvalid{Message: "invalid argument. 'id' must not be empty"}
+	}
+	if parsed.IsResourceCollection() || parsed.IsScopeCollection() {
+		return &store.ErrInvalid{Message: "invalid argument. 'id' must refer to a named resource, not a collection"}
+	}
+
+	normalized, err := storeutil.NormalizeResourceID(parsed)
+	if err != nil {
+		return err
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	config := store.NewDeleteConfig(options...)
+
+	entry, ok := c.resources[strings.ToLower(normalized.String())]
+	if !ok && config.ETag != "" {
+		return &store.ErrConcurrency{}
+	} else if !ok {
+		return &store.ErrNotFound{ID: id}
+	} else if config.ETag != "" && config.ETag != entry.obj.ETag {
+		return &store.ErrConcurrency{}
+	}
+
+	delete(c.resources, strings.ToLower(normalized.String()))
+
+	return nil
+}
+
+// Query implements store.StorageClient.
+func (c *Client) Query(ctx context.Context, query store.Query, options ...store.QueryOptions) (*store.ObjectQueryResult, error) {
+	if ctx == nil {
+		return nil, &store.ErrInvalid{Message: "invalid argument. 'ctx' is required"}
+	}
+
+	err := query.Validate()
+	if err != nil {
+		return nil, &store.ErrInvalid{Message: fmt.Sprintf("invalid argument. Query is invalid: %s", err.Error())}
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	result := &store.ObjectQueryResult{}
+	for _, entry := range c.resources {
+		// Check root scope.
+		if query.ScopeRecursive && !strings.HasPrefix(entry.rootScope, storeutil.NormalizePart(query.RootScope)) {
+			continue
+		} else if !query.ScopeRecursive && entry.rootScope != storeutil.NormalizePart(query.RootScope) {
+			continue
+		}
+
+		// Check resource type.
+		resourceType, err := storeutil.NormalizeResourceType(query.ResourceType)
+		if err != nil {
+			return nil, err
+		}
+		if entry.resourceType != storeutil.NormalizePart(resourceType) {
+			continue
+		}
+
+		// Check routing scope prefix (optional).
+		if query.RoutingScopePrefix != "" && !strings.HasPrefix(entry.routingScope, storeutil.NormalizePart(query.RoutingScopePrefix)) {
+			continue
+		}
+
+		// Check filters (optional).
+		match, err := entry.obj.MatchesFilters(query.Filters)
+		if err != nil {
+			return nil, err
+		}
+		if !match {
+			continue
+		}
+
+		// Make a defensive copy so users can't modify the data in the store.
+		copy, err := entry.obj.DeepCopy()
+		if err != nil {
+			return nil, err
+		}
+
+		result.Items = append(result.Items, *copy)
+	}
+
+	return result, nil
+}
+
+// Save implements store.StorageClient.
+func (c *Client) Save(ctx context.Context, obj *store.Object, options ...store.SaveOptions) error {
+	if ctx == nil {
+		return &store.ErrInvalid{Message: "invalid argument. 'ctx' is required"}
+	}
+	if obj == nil {
+		return &store.ErrInvalid{Message: "invalid argument. 'obj' is required"}
+	}
+
+	parsed, err := resources.Parse(obj.ID)
+	if err != nil {
+		return &store.ErrInvalid{Message: "invalid argument. 'obj.ID' must be a valid resource id"}
+	}
+
+	normalized, err := storeutil.NormalizeResourceID(parsed)
+	if err != nil {
+		return err
+	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	config := store.NewSaveConfig(options...)
+
+	entry, ok := c.resources[strings.ToLower(normalized.String())]
+	if !ok && config.ETag != "" {
+		return &store.ErrConcurrency{}
+	} else if ok && config.ETag != "" && config.ETag != entry.obj.ETag {
+		return &store.ErrConcurrency{}
+	} else if !ok {
+		// New entry, initialize it.
+		entry.rootScope = storeutil.NormalizePart(normalized.RootScope())
+		entry.resourceType = storeutil.NormalizePart(normalized.Type())
+		entry.routingScope = storeutil.NormalizePart(normalized.RoutingScope())
+	}
+
+	raw, err := json.Marshal(obj.Data)
+	if err != nil {
+		return err
+	}
+
+	// Updated the ETag before copying. Callers are allowed to read the ETag after calling save.
+	obj.ETag = etag.New(raw)
+
+	// Make a defensive copy so users can't modify the data in the store.
+	copy, err := obj.DeepCopy()
+	if err != nil {
+		return err
+	}
+
+	entry.obj = *copy
+
+	c.resources[strings.ToLower(normalized.String())] = entry
+
+	return nil
+}
+
+// Clear can be used to clear all stored data.
+func (c *Client) Clear() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	maps.Clear(c.resources)
+}

--- a/pkg/ucp/store/inmemory/client_test.go
+++ b/pkg/ucp/store/inmemory/client_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inmemory
+
+import (
+	"testing"
+
+	shared "github.com/radius-project/radius/test/ucp/storetest"
+)
+
+func Test_InMemoryClient(t *testing.T) {
+	client := NewClient()
+
+	clear := func(t *testing.T) {
+		client.Clear()
+	}
+
+	// The actual test logic lives in a shared package, we're just doing the setup here.
+	shared.RunTest(t, client, clear)
+}

--- a/pkg/ucp/store/inmemory/doc.go
+++ b/pkg/ucp/store/inmemory/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// inmemory contains an implementation of the Radius data store interface that stores data in memory.
+// This is suitable for testing and development purposes. The in-memory store has no persistence
+// and will be **SLOW** for large data sets.
+package inmemory

--- a/pkg/ucp/store/object.go
+++ b/pkg/ucp/store/object.go
@@ -18,6 +18,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 )
 
 type ETag = string
@@ -32,6 +33,28 @@ type Object struct {
 
 	// Data is the payload of the object. It will be marshaled to and from JSON for storage.
 	Data any
+}
+
+// DeepCopy creates a deep copy of the Object instance.
+func (o *Object) DeepCopy() (*Object, error) {
+	var data any
+	if o.Data != nil {
+		b, err := json.Marshal(o.Data)
+		if err != nil {
+			return nil, err
+		}
+
+		err = json.Unmarshal(b, &data)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &Object{
+		// Metadata is copied by value.
+		Metadata: o.Metadata,
+		Data:     data,
+	}, nil
 }
 
 // ObjectQueryResult represents the result of Query().

--- a/pkg/ucp/store/storeutil/id.go
+++ b/pkg/ucp/store/storeutil/id.go
@@ -17,6 +17,7 @@ limitations under the License.
 package storeutil
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/radius-project/radius/pkg/ucp/resources"
@@ -96,4 +97,96 @@ func NormalizePart(part string) string {
 	}
 
 	return strings.ToLower(part)
+}
+
+// NormalizeResourceID normalizes the resource ID to be consistent between scopes and resources.
+//
+// For a resource id that identifies a resource, it is already in normalized form.
+//
+// - eg: "/planes/radius/local/resourceGroups/my-rg/providers/Applications.Core/applications/my-app" is already
+// normalized.
+// - eg: "/planes/radius/local/resourceGroups/my-rg" needs normalization.
+func NormalizeResourceID(parsed resources.ID) (resources.ID, error) {
+	// This function normalizes the resource ID to be consistent between scopes and resources.
+	//
+	// For a resource id that identifies a resource, it is already in normalized form.
+	//
+	// eg: "/planes/radius/local/resourceGroups/my-rg/providers/Applications.Core/applications/my-app"
+	if parsed.IsResource() {
+		return parsed, nil
+	}
+
+	// For a resource id that identifies a scope, we truncate the last segement and make it look like a resource by
+	// adding a type.
+	//
+	// eg: "/planes/radius/local/resourceGroups/my-rg" -> "/planes/radius/local/providers/System.Resources/resourceGroups/my-rg"
+	//
+	// This means that the scope could be looked up using two different forms.
+	//
+	// - "/planes/radius/local/resourceGroups/my-rg"
+	// - "/planes/radius/local/providers/System.Resources/resourceGroups/my-rg"
+	//
+	// This important because right now the controller code uses the former, but the latter is more useful for storage.
+	// Over time we want to eliminate the former and only use the latter by pushing this change into the controllers.
+	//
+	// There's a fixed set of scopes in Radius/UCP right now but we'd like to avoid maintaining a hardcoded list
+	// of scope types.
+	//
+	// Cases we have to handle:
+	// - /planes/azure/<name>
+	// - /planes/aws/<name>
+	// - /planes/radius/<name>
+	// - /planes/radius/<name>/resourceGroups/<name>
+	scopes := parsed.ScopeSegments()
+	if len(scopes) == 0 {
+		return resources.ID{}, fmt.Errorf("invalid resource id: %s", parsed.String())
+	}
+
+	switch strings.ToLower(scopes[0].Type) {
+	case "azure":
+		if len(scopes) == 1 {
+			return resources.MustParse(fmt.Sprintf("/planes/providers/System.Azure/planes/%s", scopes[0].Name)), nil
+		}
+
+	case "aws":
+		if len(scopes) == 1 {
+			return resources.MustParse(fmt.Sprintf("/planes/providers/System.AWS/planes/%s", scopes[0].Name)), nil
+		}
+
+	case "radius":
+		if len(scopes) == 1 {
+			return resources.MustParse(fmt.Sprintf("/planes/providers/System.Radius/planes/%s", scopes[0].Name)), nil
+		} else if len(scopes) == 2 && strings.EqualFold(scopes[1].Type, "resourceGroups") {
+			return resources.MustParse(fmt.Sprintf("/planes/radius/%s/providers/System.Resources/resourceGroups/%s", scopes[0].Name, scopes[1].Name)), nil
+		}
+	}
+
+	return resources.ID{}, fmt.Errorf("invalid resource id: %s", parsed.String())
+}
+
+// NormalizeResourceType normalizes the resource type to be consistent between scopes and resources.
+// See comments on NormalizeResourceID for full context.
+//
+// For a resource type that identifies a resource, it is already in normalized form.
+//
+// - eg: "Applications.Core/applications" is already normalized.
+// - eg: "resourceGroups" needs normalization.
+func NormalizeResourceType(resourceType string) (string, error) {
+	if strings.Contains(resourceType, "/") {
+		// Already normalized.
+		return resourceType, nil
+	}
+
+	switch strings.ToLower(resourceType) {
+	case "aws":
+		return "System.Aws/planes", nil
+	case "azure":
+		return "System.Azure/planes", nil
+	case "radius":
+		return "System.Radius/planes", nil
+	case "resourcegroups":
+		return "System.Resources/resourceGroups", nil
+	}
+
+	return "", fmt.Errorf("invalid resource type: %s", resourceType)
 }

--- a/test/ucp/storetest/shared.go
+++ b/test/ucp/storetest/shared.go
@@ -521,7 +521,9 @@ func RunTest(t *testing.T, client store.StorageClient, clear func(t *testing.T))
 		})
 
 		t.Run("query_scopes_with_filter_non_matching", func(t *testing.T) {
-			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, IsScopeQuery: true, ResourceType: "subscriptions"})
+			objs, err := client.Query(ctx, store.Query{RootScope: RadiusScope, IsScopeQuery: true, ResourceType: "resourcegroups", Filters: []store.QueryFilter{
+				{Field: "value", Value: "asdf"},
+			}})
 			require.NoError(t, err)
 			expected := []store.Object{}
 			CompareObjectLists(t, expected, objs.Items)


### PR DESCRIPTION
# Description

Implements an in-memory data store

This change implements an in-memory version of our data store interface. This is provided for testing and development purposes.

The in-memory store uses our data store compliance tests so it will behave consistently with other implementations. This will be simpler to use than mocks, which we use frequently in tests. This will be faster to use than the ETC.d implementation which we frequently use in integration tests.

**Note: this pull request depends on https://github.com/radius-project/radius/pull/7949 and will be rebased once that change is merged.**

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

