### PR TITLE
updating doc to use DE from existing installation

### DIFF
--- a/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
+++ b/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
@@ -98,9 +98,8 @@ kubectl create namespace radius-testing
 
 ## Setup Step 4: Setup Deployment Engine 
 
-
-> 💡 The Bicep deployment engine uses .NET. However you don't need to know C# or .NET to develop locally with Radius.
 > 💡 This way of setting up deployment-engine is useful if you are an external contributor and do not have access to `radius-project/deployment-engine` repo.
+
 > 💡 If you have access to the deployment-engine repository and would like to debug it, you can omit this step and proceed to step 5.
 
 ### Setup Docker
@@ -152,11 +151,15 @@ Wait until all five debuggers have attached and their startup sequences have com
 - Controller
 ## Setup Step 5 (optional): Setup deployment Engine for debugging
 
-If you have access to `radius-project/deployment-engine` repo, you can follow the steps below to set up Deployment Engine for debugging.
+
+> 💡 The Bicep deployment engine uses .NET. However you don't need to know C# or .NET to develop locally with Radius.
+
+If you have access to `radius-project/deployment-engine` repo, you can follow the steps below to set up Deployment Engine for debugging instead of running it in a docker container.
 1. Clone the `radius-project/radius` and `radius-project/deployment-engine` repos next to each other.
 2. Run `git submodule update --init` in the `deployment-engine` repo.
 3. Install .NET 8.0 SDK - <https://dotnet.microsoft.com/en-us/download/dotnet/8.0>.
 4. Install C# VS Code extension - <https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp>.
+5. Uncomment // "Launch Deployment Engine" in launch.json if it's commented out.
 
 
 

--- a/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
+++ b/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
@@ -23,14 +23,8 @@ If you need to manually test APIs you can reach them at the following endpoints 
 ## Prerequisites
 
 1. Create a Kubernetes cluster, or set your current context to a cluster you want to use. The debug configuration will use your current cluster for storing data. 
-2. If you have access to `radius-project/deployment-engine` repo, 
-   1. Clone the `radius-project/radius` and `radius-project/deployment-engine` repos next to each other.
-   2. Run `git submodule update --init` in the `deployment-engine` repo.
-   3. Install .NET 8.0 SDK - <https://dotnet.microsoft.com/en-us/download/dotnet/8.0>.
-   4. Install C# VS Code extension - <https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp>.
-3. (Optional) Configure any cloud provider credentials you want to use for developing Radius.
+2. (Optional) Configure any cloud provider credentials you want to use for developing Radius.
   
-> 💡 The Bicep deployment engine uses .NET. However you don't need to know C# or .NET to develop locally with Radius.
 > 💡 Radius will use your locally configured Azure or AWS credentials. If you are able to use the `az` or `aws` CLI then you don't need to do any additional setup.
 
 ## Setup Step 1: Run `rad init`
@@ -104,8 +98,10 @@ kubectl create namespace radius-testing
 
 ## Setup Step 4: Setup Deployment Engine 
 
+
+> 💡 The Bicep deployment engine uses .NET. However you don't need to know C# or .NET to develop locally with Radius.
 > 💡 This way of setting up deployment-engine is useful if you are an external contributor and do not have access to `radius-project/deployment-engine` repo.
-> 💡 If you have access to the deployment-engine repository, you can directly proceed to step 5.
+> 💡 If you have access to the deployment-engine repository and would like to debug it, you can omit this step and proceed to step 5.
 
 ### Setup Docker
 
@@ -154,9 +150,17 @@ Wait until all five debuggers have attached and their startup sequences have com
 - Applications RP
 - Dynamic RP
 - Controller
+## Setup Step 5 (optional): Setup deployment Engine for debugging
+
+If you have access to `radius-project/deployment-engine` repo, you can follow the steps below to set up Deployment Engine for debugging.
+1. Clone the `radius-project/radius` and `radius-project/deployment-engine` repos next to each other.
+2. Run `git submodule update --init` in the `deployment-engine` repo.
+3. Install .NET 8.0 SDK - <https://dotnet.microsoft.com/en-us/download/dotnet/8.0>.
+4. Install C# VS Code extension - <https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp>.
 
 
-## Setup Step 5: Create Resource Group and Environment
+
+## Setup Step 6: Create Resource Group and Environment
 
 At this point you can start the control-plane locally but you don't have a resource group or environment. You can launch Radius and then use the CLI to create these.
 

--- a/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
+++ b/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
@@ -107,8 +107,9 @@ kubectl create namespace radius-testing
 > 💡 This way of setting up deployment-engine is useful if you are an external contributor and do not have access to `radius-project/deployment-engine` repo.
 > 💡 If you have access to the deployment-engine repository, you can directly proceed to step 5.
 
-You can run deployment-engine as a docker container. If Docker is not already installed, 
+### Setup Docker
 
+If Docker is not already installed, 
 * Download and install it from the [Docker Desktop download page](https://www.docker.com/products/docker-desktop). 
 Choose the installer that matches your operating system.
 * Open a terminal and run the following command to verify that Docker is installed and running:
@@ -117,13 +118,17 @@ docker --version
 ```
 You should see the Docker version information.
 
-Now, run the below command.
+### Run Deployment Engine as a Docker container
+
+Run the below command.
 
 ```sh
 docker run -e RADIUSBACKENDURL=http://host.docker.internal:9000/apis/api.ucp.dev/v1alpha3 -p 5017:8080 ghcr.io/radius-project/deployment-engine:latest
 ```
 
 `host.docker.internal` is a special DNS name provided by Docker that allows containers to access services running on the host machine 
+
+### Update launch.json 
 
 Open launch.json and comment out `Launch Deployment Engine` in `Launch Control Plane (all)`. The debug setup will use the Deployment Engine running as docker container. 
   ```json

--- a/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
+++ b/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
@@ -142,13 +142,6 @@ Open launch.json and comment out `Launch Deployment Engine` in `Launch Control P
   ],
   ```
 
-Wait until all five debuggers have attached and their startup sequences have completed. You should see the following entries in the Debug Tab --> Call Stack window:
-
-- Deployment Engine
-- UCP
-- Applications RP
-- Dynamic RP
-- Controller
 ## Setup Step 5 (optional): Setup deployment Engine for debugging
 
 
@@ -165,14 +158,21 @@ If you have access to `radius-project/deployment-engine` repo, you can follow th
 
 ## Setup Step 6: Create Resource Group and Environment
 
-At this point you can start the control-plane locally but you don't have a resource group or environment. You can launch Radius and then use the CLI to create these.
+At this point Radius is working but you don't have a resource group or environment. You can launch Radius and then use the CLI to create these.
 
 In VS Code:
 
 - Open the Debug tab in VS Code
-- Select `Launch Control Plane (all)` from the drop-down 
+- Select `Launch Control Plane (all)` from the drop-down
 - Press Debug
-- Wait for all the services to start.
+
+Wait until all five debuggers have attached and their startup sequences have completed. You should see the following entries in the Debug Tab --> Call Stack window:
+
+- Deployment Engine
+- UCP
+- Applications RP
+- Dynamic RP
+- Controller
 
 Then at the command line run:
 

--- a/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
+++ b/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
@@ -27,11 +27,12 @@ If you need to manually test APIs you can reach them at the following endpoints 
 ## Prerequisites
 
 1. Create a Kubernetes cluster, or set your current context to a cluster you want to use. The debug configuration will use your current cluster for storing data.
-2. Clone the `radius-project/radius` and `radius-project/deployment-engine` repo next to each other.
-3. Run `git submodule update --init` in the `deployment-engine` repo.
-4. Install .NET 8.0 SDK - <https://dotnet.microsoft.com/en-us/download/dotnet/8.0>.
-5. Install C# VS Code extension - <https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp>.
-6. (Optional) Configure any cloud provider credentials you want to use for developing Radius.
+2. If you have access to `radius-project/deployment-engine` repo, 
+   1. Clone the `radius-project/radius` and `radius-project/deployment-engine` repo next to each other.
+   2. Run `git submodule update --init` in the `deployment-engine` repo.
+   3. Install .NET 8.0 SDK - <https://dotnet.microsoft.com/en-us/download/dotnet/8.0>.
+   4. Install C# VS Code extension - <https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp>.
+3. (Optional) Configure any cloud provider credentials you want to use for developing Radius.
   
 > 💡 The Bicep deployment engine uses .NET. However you don't need to know C# or .NET to develop locally with Radius.
 > 💡 Radius will use your locally configured Azure or AWS credentials. If you are able to use the `az` or `aws` CLI then you don't need to do any additional setup.
@@ -105,14 +106,38 @@ Run this command to create the namespace that will be used to store data.
 kubectl create namespace radius-testing
 ```
 
-## Setup Step 4: Create Resource Group and Environment
+## Setup Step 4: Run Deployment Engine as docker container
+
+Note: This step is required only if you are an external contributor and do not have access to `radius-project/deployment-engine` repo
+`docker run -e RADIUSBACKENDURI=http://host.docker.internal:9000 -p 5017:8080 ghcr.io/radius-project/deployment-engine:latest.`
+
+`host.docker.internal` is a special DNS name provided by Docker that allows containers to access services running on the host machine
+
+## Setup Step 5: Create Resource Group and Environment
 
 At this point Radius is working but you don't have a resource group or environment. You can launch Radius and then use the CLI to create these.
 
 In VS Code:
 
 - Open the Debug tab in VS Code
-- Select `Launch Control Plane (all)` from the drop-down
+- If you have access to `radius-project/deployment-engine` repo
+  - Select `Launch Control Plane (all)` from the drop-down 
+- If you are an external contributor, open launch.json and comment out `Launch Deployment Engine` in `Launch Control Plane (all)`. The debug setup will use the Deployment Engine running as docker container. 
+  ```
+  "compounds": [
+    {
+      "name": "Launch Control Plane (all)",
+      "configurations": [
+        "Launch UCP",
+        "Launch Applications RP",
+        "Launch Dynamic RP",
+        "Launch Controller",
+        // "Launch Deployment Engine"
+      ],
+      "stopAll": true
+    }
+  ],
+  ```
 - Press Debug
 
 Wait until all five debuggers have attached and their startup sequences have completed. You should see the following entries in the Debug Tab --> Call Stack window:

--- a/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
+++ b/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
@@ -26,7 +26,7 @@ If you need to manually test APIs you can reach them at the following endpoints 
 
 ## Prerequisites
 
-1. Create a Kubernetes cluster, or set your current context to a cluster you want to use. The debug configuration will use your current cluster for storing data.
+1. Create a Kubernetes cluster, or set your current context to a cluster you want to use. The debug configuration will use your current cluster for storing data. 
 2. If you have access to `radius-project/deployment-engine` repo, 
    1. Clone the `radius-project/radius` and `radius-project/deployment-engine` repo next to each other.
    2. Run `git submodule update --init` in the `deployment-engine` repo.

--- a/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
+++ b/docs/contributing/contributing-code/contributing-code-control-plane/running-controlplane-locally.md
@@ -1,9 +1,5 @@
 # Running Radius control plane provider locally
 
-> 🚧🚧🚧 Under Construction 🚧🚧🚧
->
-> This guide refers to an internal repo that can only be accessed by the Radius team. This will be updated as we migrate to public resources (running deployment engine in a container).
-
 Radius consists of a few processes that get deployed inside a Kubernetes cluster.
 
  This includes:
@@ -28,7 +24,7 @@ If you need to manually test APIs you can reach them at the following endpoints 
 
 1. Create a Kubernetes cluster, or set your current context to a cluster you want to use. The debug configuration will use your current cluster for storing data. 
 2. If you have access to `radius-project/deployment-engine` repo, 
-   1. Clone the `radius-project/radius` and `radius-project/deployment-engine` repo next to each other.
+   1. Clone the `radius-project/radius` and `radius-project/deployment-engine` repos next to each other.
    2. Run `git submodule update --init` in the `deployment-engine` repo.
    3. Install .NET 8.0 SDK - <https://dotnet.microsoft.com/en-us/download/dotnet/8.0>.
    4. Install C# VS Code extension - <https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp>.
@@ -106,24 +102,31 @@ Run this command to create the namespace that will be used to store data.
 kubectl create namespace radius-testing
 ```
 
-## Setup Step 4: Run Deployment Engine as docker container
+## Setup Step 4: Setup Deployment Engine 
 
-Note: This step is required only if you are an external contributor and do not have access to `radius-project/deployment-engine` repo
-`docker run -e RADIUSBACKENDURI=http://host.docker.internal:9000 -p 5017:8080 ghcr.io/radius-project/deployment-engine:latest.`
+> 💡 This way of setting up deployment-engine is useful if you are an external contributor and do not have access to `radius-project/deployment-engine` repo.
+> 💡 If you have access to the deployment-engine repository, you can directly proceed to step 5.
 
-`host.docker.internal` is a special DNS name provided by Docker that allows containers to access services running on the host machine
+You can run deployment-engine as a docker container. If Docker is not already installed, 
 
-## Setup Step 5: Create Resource Group and Environment
+* Download and install it from the [Docker Desktop download page](https://www.docker.com/products/docker-desktop). 
+Choose the installer that matches your operating system.
+* Open a terminal and run the following command to verify that Docker is installed and running:
+```sh
+docker --version
+```
+You should see the Docker version information.
 
-At this point Radius is working but you don't have a resource group or environment. You can launch Radius and then use the CLI to create these.
+Now, run the below command.
 
-In VS Code:
+```sh
+docker run -e RADIUSBACKENDURL=http://host.docker.internal:9000/apis/api.ucp.dev/v1alpha3 -p 5017:8080 ghcr.io/radius-project/deployment-engine:latest
+```
 
-- Open the Debug tab in VS Code
-- If you have access to `radius-project/deployment-engine` repo
-  - Select `Launch Control Plane (all)` from the drop-down 
-- If you are an external contributor, open launch.json and comment out `Launch Deployment Engine` in `Launch Control Plane (all)`. The debug setup will use the Deployment Engine running as docker container. 
-  ```
+`host.docker.internal` is a special DNS name provided by Docker that allows containers to access services running on the host machine 
+
+Open launch.json and comment out `Launch Deployment Engine` in `Launch Control Plane (all)`. The debug setup will use the Deployment Engine running as docker container. 
+  ```json
   "compounds": [
     {
       "name": "Launch Control Plane (all)",
@@ -138,7 +141,6 @@ In VS Code:
     }
   ],
   ```
-- Press Debug
 
 Wait until all five debuggers have attached and their startup sequences have completed. You should see the following entries in the Debug Tab --> Call Stack window:
 
@@ -147,6 +149,18 @@ Wait until all five debuggers have attached and their startup sequences have com
 - Applications RP
 - Dynamic RP
 - Controller
+
+
+## Setup Step 5: Create Resource Group and Environment
+
+At this point you can start the control-plane locally but you don't have a resource group or environment. You can launch Radius and then use the CLI to create these.
+
+In VS Code:
+
+- Open the Debug tab in VS Code
+- Select `Launch Control Plane (all)` from the drop-down 
+- Press Debug
+- Wait for all the services to start.
 
 Then at the command line run:
 
@@ -157,22 +171,13 @@ rad env create default
 
 At this point you're done with setup! Feel free to stop the debugger.
 
-## Debugging
-
-Now you can launch the Radius locally through the VSCode menu.
-
-- Open the Debug tab in VS Code
-- Select `Launch Control Plane (all)` from the drop-down
-- Press Debug
-- You're up and running!
-
 ## Troubleshooting
 
 ### I got an error saying I need to clone the deployment engine
 
 > The radius-project/deployment-engine is not cloned as a sibling to the Radius repo. Please clone the radius-project/deployment-engine repo next to the Radius repo and try again.
 
-You should be to successfully the following commands from the Radius repository root:
+You should be able to successfully the following commands from the Radius repository root:
 
 ```sh
 ls ../deployment-engine/src


### PR DESCRIPTION
# Description

deployment-engine is currently a private repo. Updating contributor docs to use DE from existing installation.


## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
