### PR TITLE
Skipping one of the text prompt tests

### DIFF
--- a/pkg/cli/prompt/text/text_test.go
+++ b/pkg/cli/prompt/text/text_test.go
@@ -78,12 +78,12 @@ func validateNewTextModel(t *testing.T, model *Model, options *TextModelOptions)
 }
 
 func Test_E2E(t *testing.T) {
-	
+
 	const expectedPrompt = "\r" + testPrompt + "\n" +
-			"\n" +
-			"> " + testPlaceholder + "\n" +
-			"\n" +
-			"(ctrl+c to quit)"
+		"\n" +
+		"> " + testPlaceholder + "\n" +
+		"\n" +
+		"(ctrl+c to quit)"
 
 	setup := func(t *testing.T) *teatest.TestModel {
 		options := TextModelOptions{
@@ -117,11 +117,12 @@ func Test_E2E(t *testing.T) {
 		tm := setup(t)
 
 		output := waitForInitialRender(t, tm.Output())
-		
+
 		require.Equal(t, expectedPrompt, output)
 	})
 
 	t.Run("confirm default", func(t *testing.T) {
+		t.Skip("This test is intermittently failing in linux_amd64: https://github.com/radius-project/radius/issues/7670")
 		tm := setup(t)
 
 		tm.Send(tea.KeyMsg{Type: tea.KeyEnter})


### PR DESCRIPTION
# Description
Skipping one of the text prompt tests because of flakiness: https://github.com/radius-project/radius/actions/runs/11277938942/job/31365273830?pr=7939.

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
Addresses: #7670 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- [ ] An overview of proposed schema changes is included in a linked GitHub issue.
- [ ] A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
- [ ] If applicable, design document has been reviewed and approved by Radius maintainers/approvers.
- [ ] A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
- [ ] A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
- [ ] A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.