### PR TITLE
Add inmemory secret store

### DIFF
--- a/pkg/ucp/secret/inmemory/client.go
+++ b/pkg/ucp/secret/inmemory/client.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inmemory
+
+import (
+	"context"
+	"sync"
+
+	"github.com/radius-project/radius/pkg/kubernetes"
+	"github.com/radius-project/radius/pkg/ucp/secret"
+)
+
+var _ secret.Client = (*Client)(nil)
+
+// Client implements an in-memory secret client.
+//
+// The in-memory client is suitable for testing and development.
+type Client struct {
+	lock sync.Mutex
+	data map[string][]byte
+}
+
+// Save saves the secret data.
+func (c *Client) Save(ctx context.Context, name string, value []byte) error {
+	if name == "" {
+		return &secret.ErrInvalid{Message: "invalid argument. 'name' is required"}
+	}
+
+	if value == nil {
+		return &secret.ErrInvalid{Message: "invalid argument. 'value' is required"}
+	}
+
+	if !kubernetes.IsValidObjectName(name) {
+		return &secret.ErrInvalid{Message: "invalid name: " + name}
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.data == nil {
+		c.data = map[string][]byte{}
+	}
+
+	c.data[name] = value
+
+	return nil
+}
+
+// Delete deletes the secret data if it is present in the store, otherwise returns an ErrNotFound.
+func (c *Client) Delete(ctx context.Context, name string) error {
+	if name == "" {
+		return &secret.ErrInvalid{Message: "invalid argument. 'name' is required"}
+	}
+
+	if !kubernetes.IsValidObjectName(name) {
+		return &secret.ErrInvalid{Message: "invalid name: " + name}
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.data == nil {
+		c.data = map[string][]byte{}
+	}
+
+	_, ok := c.data[name]
+	if !ok {
+		return &secret.ErrNotFound{}
+	}
+
+	delete(c.data, name)
+
+	return nil
+}
+
+// Get returns the secret data if it is found, otherwise returns an ErrNotFound.
+func (c *Client) Get(ctx context.Context, name string) ([]byte, error) {
+	if name == "" {
+		return nil, &secret.ErrInvalid{Message: "invalid argument. 'name' is required"}
+	}
+
+	if !kubernetes.IsValidObjectName(name) {
+		return nil, &secret.ErrInvalid{Message: "invalid name: " + name}
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	data, ok := c.data[name]
+	if !ok {
+		return nil, &secret.ErrNotFound{}
+	}
+
+	return data, nil
+}

--- a/pkg/ucp/secret/provider/factory.go
+++ b/pkg/ucp/secret/provider/factory.go
@@ -24,6 +24,7 @@ import (
 	"github.com/radius-project/radius/pkg/ucp/dataprovider"
 	"github.com/radius-project/radius/pkg/ucp/secret"
 	"github.com/radius-project/radius/pkg/ucp/secret/etcd"
+	"github.com/radius-project/radius/pkg/ucp/secret/inmemory"
 	kubernetes_client "github.com/radius-project/radius/pkg/ucp/secret/kubernetes"
 	"github.com/radius-project/radius/pkg/ucp/store/etcdstore"
 	"k8s.io/kubectl/pkg/scheme"
@@ -35,6 +36,7 @@ type secretFactoryFunc func(context.Context, SecretProviderOptions) (secret.Clie
 var secretClientFactory = map[SecretProviderType]secretFactoryFunc{
 	TypeETCDSecret:       initETCDSecretClient,
 	TypeKubernetesSecret: initKubernetesSecretClient,
+	TypeInMemorySecret:   initInMemorySecretClient,
 }
 
 func initETCDSecretClient(ctx context.Context, opts SecretProviderOptions) (secret.Client, error) {
@@ -69,4 +71,8 @@ func initKubernetesSecretClient(ctx context.Context, opt SecretProviderOptions) 
 		return nil, err
 	}
 	return &kubernetes_client.Client{K8sClient: client}, nil
+}
+
+func initInMemorySecretClient(ctx context.Context, opt SecretProviderOptions) (secret.Client, error) {
+	return &inmemory.Client{}, nil
 }

--- a/pkg/ucp/secret/provider/options.go
+++ b/pkg/ucp/secret/provider/options.go
@@ -25,4 +25,7 @@ type SecretProviderOptions struct {
 
 	// ETCD configures options for the etcd secret store.
 	ETCD dataprovider.ETCDOptions `yaml:"etcd,omitempty"`
+
+	// InMemory configures options for the in-memory secret store.
+	InMemory struct{} `yaml:"inmemory,omitempty"`
 }

--- a/pkg/ucp/secret/provider/types.go
+++ b/pkg/ucp/secret/provider/types.go
@@ -25,4 +25,7 @@ const (
 
 	// TypeKubernetesSecret represents the Kubernetes secret provider.
 	TypeKubernetesSecret SecretProviderType = "kubernetes"
+
+	// TypeInMemorySecret represents the in-memory secret provider.
+	TypeInMemorySecret SecretProviderType = "inmemory"
 )


### PR DESCRIPTION
# Description

This change adds an inmemory version of our secret store abstraction.

I created this to help with integration-testing the new dynamic-rp component, and it felt right to send it as a separate PR to make like easier for reviewers.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).


## Contributor checklist

Please verify that the PR meets the following requirements, where applicable:

- [ ] An overview of proposed schema changes is included in a linked GitHub issue.
- [ ] A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
- [ ] If applicable, design document has been reviewed and approved by Radius maintainers/approvers.
- [ ] A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
- [ ] A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
- [ ] A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.