### PR TITLE
Update version for dependency to use tilde instead of carat

### DIFF
--- a/typespec/package-lock.json
+++ b/typespec/package-lock.json
@@ -97,9 +97,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-providerhub": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-providerhub/-/typespec-providerhub-0.47.0.tgz",
-      "integrity": "sha512-528VwSeoF0W6p5DS+wTQePeqJI/5H4KoP3tZe1rB5PI4ykLyV3IDrAsASMov3ULPXjkjC0AZp41S+M4q4PZe+Q==",
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-providerhub/-/typespec-providerhub-0.46.0.tgz",
+      "integrity": "sha512-N+lp8wHDJJTbt0vVijELfjEcukz19YvS6nMhR5Um13nIWveCcYBXaCGwkVJMfFL8Dm6yZS0B9q+FLkQ043xpzg==",
       "engines": {
         "node": ">=18.0.0"
       }

--- a/typespec/package-lock.json
+++ b/typespec/package-lock.json
@@ -12,7 +12,7 @@
         "@azure-tools/typespec-autorest": "~0.46.0",
         "@azure-tools/typespec-azure-core": "~0.46.0",
         "@azure-tools/typespec-azure-resource-manager": "~0.46.0",
-        "@azure-tools/typespec-providerhub": "^0.47.0",
+        "@azure-tools/typespec-providerhub": "~0.46.0",
         "@typespec/compiler": "~0.60.0",
         "@typespec/http": "~0.60.0",
         "@typespec/openapi": "~0.60.0",

--- a/typespec/package.json
+++ b/typespec/package.json
@@ -7,7 +7,7 @@
     "@azure-tools/typespec-autorest": "~0.46.0",
     "@azure-tools/typespec-azure-core": "~0.46.0",
     "@azure-tools/typespec-azure-resource-manager": "~0.46.0",
-    "@azure-tools/typespec-providerhub": "^0.47.0",
+    "@azure-tools/typespec-providerhub": "~0.46.0",
     "@typespec/http": "~0.60.0",
     "@typespec/openapi": "~0.60.0",
     "@typespec/rest": "~0.60.0",


### PR DESCRIPTION
# Description

Update version for dependency @azure-tools/typespec-providerhub to use tilde instead of carat

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- [ ] An overview of proposed schema changes is included in a linked GitHub issue.
- [ ] A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
- [ ] If applicable, design document has been reviewed and approved by Radius maintainers/approvers.
- [ ] A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
- [ ] A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
- [ ] A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.