### PR TITLE
Fixing #8043 - adding long form commands and aliasing abbreviations

### DIFF
--- a/cmd/rad/cmd/env.go
+++ b/cmd/rad/cmd/env.go
@@ -28,8 +28,9 @@ func init() {
 
 func NewEnvironmentCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "env",
-		Short: "Manage Radius Environments",
+		Use:     "environment",
+		Aliases: []string{"env"},
+		Short:   "Manage Radius Environments",
 		Long: `Manage Radius Environments
 Radius Environments are prepared “landing zones” for Radius Applications. Applications deployed to an environment will inherit the container runtime, configuration, and other settings from the environment.`,
 	}

--- a/pkg/cli/cmd/radinit/init.go
+++ b/pkg/cli/cmd/radinit/init.go
@@ -54,8 +54,9 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 	runner := NewRunner(factory)
 
 	cmd := &cobra.Command{
-		Use:   "init",
-		Short: "Initialize Radius",
+		Use:     "initialize",
+		Aliases: []string{"init"},
+		Short:   "Initialize Radius",
 		Long: `
 Interactively install the Radius control-plane and setup an environment.
 


### PR DESCRIPTION
# Description

Updated cmd line functions to use `environment` in place of `env` and `initialize` in place of `init`. Both abbreviations are now aliased so this is a non breaking change.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #8043 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- [ ] An overview of proposed schema changes is included in a linked GitHub issue.
- [ ] A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
- [ ] If applicable, design document has been reviewed and approved by Radius maintainers/approvers.
- [ ] A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
- [ ] A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
- [ ] A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.