### PR TITLE
Add functional test for resourceprovider registration (UDT)

### DIFF
--- a/pkg/ucp/api/v20231001preview/zz_generated_models.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_models.go
@@ -729,13 +729,13 @@ type ResourceProviderSummaryResourceType struct {
 	// REQUIRED; API versions supported by the resource type.
 	APIVersions map[string]map[string]any
 
-	// REQUIRED; The default api version for the resource type.
+	// The default api version for the resource type.
 	DefaultAPIVersion *string
 }
 
 // ResourceTypeProperties - The properties of a resource type.
 type ResourceTypeProperties struct {
-	// REQUIRED; The default api version for the resource type.
+	// The default api version for the resource type.
 	DefaultAPIVersion *string
 
 	// READ-ONLY; The status of the asynchronous operation.

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2023-10-01-preview/openapi.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2023-10-01-preview/openapi.json
@@ -3975,8 +3975,7 @@
         }
       },
       "required": [
-        "apiVersions",
-        "defaultApiVersion"
+        "apiVersions"
       ]
     },
     "ResourceTypeNameString": {
@@ -3998,10 +3997,7 @@
           "$ref": "#/definitions/ApiVersionNameString",
           "description": "The default api version for the resource type."
         }
-      },
-      "required": [
-        "defaultApiVersion"
-      ]
+      }
     },
     "ResourceTypeResource": {
       "type": "object",

--- a/test/functional-portable/ucp/noncloud/resourceprovider_test.go
+++ b/test/functional-portable/ucp/noncloud/resourceprovider_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ucp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/radius-project/radius/test/radcli"
+	"github.com/radius-project/radius/test/rp"
+	"github.com/radius-project/radius/test/testcontext"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ResourceProviderRegistration(t *testing.T) {
+	ctx, cancel := testcontext.NewWithCancel(t)
+	t.Cleanup(cancel)
+
+	options := rp.NewTestOptions(t)
+	cli := radcli.NewCLI(t, options.ConfigFilePath)
+
+	// Setup test data.
+	const (
+		manifestPath             = "testdata/resourceprovider.yaml"
+		resourceProviderName     = "MyCompany.Resources"
+		expectedResourceTypeName = "testResources"
+		expectedApiVersion       = "2025-01-01-preview"
+	)
+
+	expectedData := map[string]any{
+		"name": resourceProviderName,
+		"locations": map[string]any{
+			"global": map[string]any{},
+		},
+		"resourceTypes": map[string]any{
+			expectedResourceTypeName: map[string]any{
+				"apiVersions": map[string]any{
+					expectedApiVersion: map[string]any{},
+				},
+			},
+		},
+	}
+
+	// Create the resource provider using the manifest.
+	_, err := cli.RunCommand(ctx, []string{"resource-provider", "create", "--from-file", manifestPath})
+	require.NoError(t, err)
+
+	// List resource providers.
+	output, err := cli.RunCommand(ctx, []string{"resource-provider", "list"})
+	require.NoError(t, err)
+	require.Contains(t, output, resourceProviderName)
+
+	// Show details of the resource provider.
+	output, err = cli.RunCommand(ctx, []string{"resource-provider", "show", resourceProviderName, "--output", "json"})
+	require.NoError(t, err)
+
+	var data map[string]any
+	err = json.Unmarshal([]byte(output), &data)
+	require.NoError(t, err)
+	require.Equal(t, expectedData, data)
+}

--- a/test/functional-portable/ucp/noncloud/testdata/resourceprovider.yaml
+++ b/test/functional-portable/ucp/noncloud/testdata/resourceprovider.yaml
@@ -1,0 +1,7 @@
+name: MyCompany.Resources
+types:
+  testResources:
+    apiVersions:
+      "2025-01-01-preview":
+        schema: {}
+        capabilities: ["Recipes"]

--- a/typespec/UCP/resourceproviders.tsp
+++ b/typespec/UCP/resourceproviders.tsp
@@ -93,7 +93,7 @@ model ResourceTypeProperties {
   provisioningState?: ProvisioningState;
 
   @doc("The default api version for the resource type.")
-  defaultApiVersion: ApiVersionNameString;
+  defaultApiVersion?: ApiVersionNameString;
 }
 
 @doc("The resource type for defining an API version of a resource type supported by the containing resource provider.")
@@ -168,7 +168,7 @@ model ResourceProviderSummaryResourceType {
   apiVersions: Record<ResourceTypeSummaryResultApiVersion>;
 
   @doc("The default api version for the resource type.")
-  defaultApiVersion: string;
+  defaultApiVersion?: string;
 }
 
 @doc("The configuration of a resource type API version.")


### PR DESCRIPTION
# Description

-Update to Typespec for ResourceType, ResourceProviderSummary to update defaultApiVersion to be optional field. 
-Added test for resourceprovider registration which includes calls to create, list and show resource provider.

## Type of change
- This pull request adds or changes features of Radius and has an approved issue (#6688 ).

Fixes: Part of #6688

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- [ ] An overview of proposed schema changes is included in a linked GitHub issue.
- [ ] A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
- [ ] If applicable, design document has been reviewed and approved by Radius maintainers/approvers.
- [ ] A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
- [ ] A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
- [ ] A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.