### PR TITLE
Disabling cache in the setup-go steps of CI/CD

### DIFF
--- a/.github/actions/setup-rad-cli/action.yaml
+++ b/.github/actions/setup-rad-cli/action.yaml
@@ -7,6 +7,7 @@ runs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVER }}
+        cache: false
     - name: Get Go Cache path
       shell: bash
       id: go-cache-paths

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -493,6 +493,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GOVER }}
+          cache: false
 
       - name: Get Go Cache path
         id: go-cache-paths

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -179,6 +179,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GOVER }}
+          cache: false
 
       - name: Get Go Cache path
         id: go-cache-paths


### PR DESCRIPTION
# Description

Because the cache already exists on the GitHub runners we use, disabling cache in the setup-go steps of our CI/CD pipelines is expected solve the issue of seeing bunch of logs that say "**cannot open: file exists**".

The official documentation of setup-go and the part that is relevant: https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs. This points out that setup-go does caching for us. If the cache is already there, we will get all the logs in our workflows.

There is no disadvantage of this approach, as far as I know, since the cache is already there. I actually ran into this [comment](https://github.com/actions/setup-go/issues/403#issuecomment-2299976549) that says that disabling cache in setup-go step improved the speed of the said step. We can always update our workflows if we see any other disadvantages.

Our runners: https://github.com/radius-project/radius/actions/runners.

References:
- https://github.com/actions/setup-go/issues/403
- https://github.com/actions/setup-go/issues/403#issuecomment-2299976549
- https://github.com/actions/setup-go/issues/314#issuecomment-1379132756

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (issue link required).
Fixes: #7790 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- [ ] An overview of proposed schema changes is included in a linked GitHub issue.
- [ ] A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
- [ ] If applicable, design document has been reviewed and approved by Radius maintainers/approvers.
- [ ] A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
- [ ] A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
- [ ] A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.