### PR TITLE
Add capabilities to resource type API

### DIFF
--- a/deploy/manifest/built-in-providers/applications_core.yaml
+++ b/deploy/manifest/built-in-providers/applications_core.yaml
@@ -4,34 +4,34 @@ types:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: []
+    capabilities: []
   applications:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: []
+    capabilities: []
   environments:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: []
+    capabilities: []
   gateways:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: []
+    capabilities: []
   secretStores:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: []
+    capabilities: []
   extenders:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]
   volumes:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: []
+    capabilities: []

--- a/deploy/manifest/built-in-providers/applications_dapr.yaml
+++ b/deploy/manifest/built-in-providers/applications_dapr.yaml
@@ -4,19 +4,19 @@ types:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]
   pubSubBrokers:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]
   secretStores:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]
   stateStores:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]

--- a/deploy/manifest/built-in-providers/applications_datastores.yaml
+++ b/deploy/manifest/built-in-providers/applications_datastores.yaml
@@ -4,14 +4,14 @@ types:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]
   sqlDatabases:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]
   redisCaches:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]

--- a/deploy/manifest/built-in-providers/applications_messaging.yaml
+++ b/deploy/manifest/built-in-providers/applications_messaging.yaml
@@ -4,4 +4,4 @@ types:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]

--- a/deploy/manifest/built-in-providers/microsoft_resources.yaml
+++ b/deploy/manifest/built-in-providers/microsoft_resources.yaml
@@ -4,5 +4,5 @@ types:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: []
+    capabilities: []
   

--- a/pkg/cli/cmd/resourceprovider/create/testdata/missing-required-field.yaml
+++ b/pkg/cli/cmd/resourceprovider/create/testdata/missing-required-field.yaml
@@ -3,4 +3,4 @@ types:
     apiVersions:
       '2025-01-01-preview':
         schema: {}
-        capabilities: ["Recipes"]
+        capabilities: ["SupportsRecipes"]

--- a/pkg/cli/cmd/resourceprovider/create/testdata/valid.yaml
+++ b/pkg/cli/cmd/resourceprovider/create/testdata/valid.yaml
@@ -4,4 +4,4 @@ types:
     apiVersions:
       '2025-01-01-preview':
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]

--- a/pkg/cli/manifest/manifest.go
+++ b/pkg/cli/manifest/manifest.go
@@ -27,6 +27,9 @@ type ResourceProvider struct {
 
 // ResourceType represents a resource type in a resource provider manifest.
 type ResourceType struct {
+	// Capabilities is a list of capabilities for the resource type.
+	Capabilities []string `yaml:"capabilities" validate:"dive,capability"`
+
 	// DefaultAPIVersion is the default API version for the resource type.
 	DefaultAPIVersion *string `yaml:"defaultApiVersion,omitempty" validate:"omitempty,apiVersion"`
 
@@ -40,7 +43,4 @@ type ResourceTypeAPIVersion struct {
 	// TODO: this allows anything right now, and will be ignored. We'll improve this in
 	// a future pull-request.
 	Schema any `yaml:"schema" validate:"required"`
-
-	// Capabilities is a list of capabilities for the resource type.
-	Capabilities []string `yaml:"capabilities" validate:"dive,capability"`
 }

--- a/pkg/cli/manifest/manifest_test.go
+++ b/pkg/cli/manifest/manifest_test.go
@@ -29,10 +29,10 @@ func TestReadFileYAML(t *testing.T) {
 			"testResources": {
 				APIVersions: map[string]*ResourceTypeAPIVersion{
 					"2025-01-01-preview": {
-						Schema:       map[string]any{},
-						Capabilities: []string{"Recipes"},
+						Schema: map[string]any{},
 					},
 				},
+				Capabilities: []string{"SupportsRecipes"},
 			},
 		},
 	}
@@ -70,10 +70,10 @@ func TestReadFileJSON(t *testing.T) {
 			"testResources": {
 				APIVersions: map[string]*ResourceTypeAPIVersion{
 					"2025-01-01-preview": {
-						Schema:       map[string]any{},
-						Capabilities: []string{"Recipes"},
+						Schema: map[string]any{},
 					},
 				},
+				Capabilities: []string{"SupportsRecipes"},
 			},
 		},
 	}

--- a/pkg/cli/manifest/registermanifest.go
+++ b/pkg/cli/manifest/registermanifest.go
@@ -66,6 +66,7 @@ func RegisterFile(ctx context.Context, clientFactory *v20231001preview.ClientFac
 		logIfEnabled(logger, "Creating resource type %s/%s", resourceProvider.Name, resourceTypeName)
 		resourceTypePoller, err := clientFactory.NewResourceTypesClient().BeginCreateOrUpdate(ctx, planeName, resourceProvider.Name, resourceTypeName, v20231001preview.ResourceTypeResource{
 			Properties: &v20231001preview.ResourceTypeProperties{
+				Capabilities:      to.SliceOfPtrs(resourceType.Capabilities...),
 				DefaultAPIVersion: resourceType.DefaultAPIVersion,
 			},
 		}, nil)

--- a/pkg/cli/manifest/testdata/duplicate-key.yaml
+++ b/pkg/cli/manifest/testdata/duplicate-key.yaml
@@ -4,10 +4,10 @@ types:
     apiVersions:
       '2025-01-01-preview':
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]
 types:
   testResources:
     apiVersions:
       '2025-01-01-preview':
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]

--- a/pkg/cli/manifest/testdata/invalid-yaml.yaml
+++ b/pkg/cli/manifest/testdata/invalid-yaml.yaml
@@ -5,4 +5,4 @@ types:
     apiVersions:
       '2025-01-01-preview':
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]

--- a/pkg/cli/manifest/testdata/missing-required-field.yaml
+++ b/pkg/cli/manifest/testdata/missing-required-field.yaml
@@ -3,4 +3,4 @@ types:
     apiVersions:
       '2025-01-01-preview':
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]

--- a/pkg/cli/manifest/testdata/registerdirectory/resourceprovider-valid1.yaml
+++ b/pkg/cli/manifest/testdata/registerdirectory/resourceprovider-valid1.yaml
@@ -4,9 +4,9 @@ types:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: []
+    capabilities: []
   testResource2:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: []
+    capabilities: []

--- a/pkg/cli/manifest/testdata/registerdirectory/resourceprovider-valid2.yaml
+++ b/pkg/cli/manifest/testdata/registerdirectory/resourceprovider-valid2.yaml
@@ -4,9 +4,9 @@ types:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]
   testResource4:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]

--- a/pkg/cli/manifest/testdata/valid.json
+++ b/pkg/cli/manifest/testdata/valid.json
@@ -4,10 +4,10 @@
     "testResources": {
       "apiVersions": {
         "2025-01-01-preview": {
-          "schema": {},
-          "capabilities": ["Recipes"]
+          "schema": {}
         }
-      }
+      },
+      "capabilities": ["SupportsRecipes"]
     }
   }
 }

--- a/pkg/cli/manifest/testdata/valid.yaml
+++ b/pkg/cli/manifest/testdata/valid.yaml
@@ -4,4 +4,4 @@ types:
     apiVersions:
       '2025-01-01-preview':
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]

--- a/pkg/ucp/api/v20231001preview/resourceprovidersummary_conversion.go
+++ b/pkg/ucp/api/v20231001preview/resourceprovidersummary_conversion.go
@@ -48,6 +48,7 @@ func (dst *ResourceProviderSummary) ConvertFrom(src v1.DataModelInterface) error
 	dst.ResourceTypes = map[string]*ResourceProviderSummaryResourceType{}
 	for resourceTypeName, resourceType := range dm.Properties.ResourceTypes {
 		dst.ResourceTypes[resourceTypeName] = &ResourceProviderSummaryResourceType{
+			Capabilities:      to.SliceOfPtrs(resourceType.Capabilities...),
 			DefaultAPIVersion: resourceType.DefaultAPIVersion,
 			APIVersions:       map[string]map[string]any{},
 		}

--- a/pkg/ucp/api/v20231001preview/resourceprovidersummary_conversion_test.go
+++ b/pkg/ucp/api/v20231001preview/resourceprovidersummary_conversion_test.go
@@ -44,6 +44,7 @@ func Test_ResourceProviderSummary_DataModelToVersioned(t *testing.T) {
 				},
 				ResourceTypes: map[string]*ResourceProviderSummaryResourceType{
 					"testResources": {
+						Capabilities:      []*string{to.Ptr("SupportsRecipes")},
 						DefaultAPIVersion: to.Ptr("2025-01-01"),
 						APIVersions: map[string]map[string]any{
 							"2025-01-01": {},

--- a/pkg/ucp/api/v20231001preview/testdata/resourceprovidersummary_datamodel.json
+++ b/pkg/ucp/api/v20231001preview/testdata/resourceprovidersummary_datamodel.json
@@ -6,6 +6,7 @@
     },
     "resourceTypes": {
       "testResources": {
+        "capabilities": ["SupportsRecipes"],
         "defaultApiVersion": "2025-01-01",
         "apiVersions": {
           "2025-01-01": {}

--- a/pkg/ucp/api/v20231001preview/testdata/resourcetype_datamodel.json
+++ b/pkg/ucp/api/v20231001preview/testdata/resourcetype_datamodel.json
@@ -4,6 +4,7 @@
   "type": "System.Resources/resourceProviders/resourceTypes",
   "provisioningState": "Succeeded",
   "properties": {
+    "capabilities": ["SupportsRecipes"],
     "defaultApiVersion": "2025-01-01"
   }
 }

--- a/pkg/ucp/api/v20231001preview/testdata/resourcetype_resource.json
+++ b/pkg/ucp/api/v20231001preview/testdata/resourcetype_resource.json
@@ -2,6 +2,7 @@
   "id": "/planes/radius/local/providers/System.Resources/resourceProviders/Applications.Test/resourceTypes/testResources",
   "name": "testResources",
   "properties": {
+    "capabilities": ["SupportsRecipes"],
     "defaultApiVersion": "2025-01-01"
   }
 }

--- a/pkg/ucp/api/v20231001preview/zz_generated_models.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_models.go
@@ -726,12 +726,18 @@ type ResourceProviderSummaryResourceType struct {
 // REQUIRED; API versions supported by the resource type.
 	APIVersions map[string]map[string]any
 
+// The resource type capabilities.
+	Capabilities []*string
+
 // The default api version for the resource type.
 	DefaultAPIVersion *string
 }
 
 // ResourceTypeProperties - The properties of a resource type.
 type ResourceTypeProperties struct {
+// The resource type capabilities.
+	Capabilities []*string
+
 // The default api version for the resource type.
 	DefaultAPIVersion *string
 

--- a/pkg/ucp/api/v20231001preview/zz_generated_models_serde.go
+++ b/pkg/ucp/api/v20231001preview/zz_generated_models_serde.go
@@ -1921,6 +1921,7 @@ func (r *ResourceProviderSummary) UnmarshalJSON(data []byte) error {
 func (r ResourceProviderSummaryResourceType) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "apiVersions", r.APIVersions)
+	populate(objectMap, "capabilities", r.Capabilities)
 	populate(objectMap, "defaultApiVersion", r.DefaultAPIVersion)
 	return json.Marshal(objectMap)
 }
@@ -1937,6 +1938,9 @@ func (r *ResourceProviderSummaryResourceType) UnmarshalJSON(data []byte) error {
 		case "apiVersions":
 				err = unpopulate(val, "APIVersions", &r.APIVersions)
 			delete(rawMsg, key)
+		case "capabilities":
+				err = unpopulate(val, "Capabilities", &r.Capabilities)
+			delete(rawMsg, key)
 		case "defaultApiVersion":
 				err = unpopulate(val, "DefaultAPIVersion", &r.DefaultAPIVersion)
 			delete(rawMsg, key)
@@ -1951,6 +1955,7 @@ func (r *ResourceProviderSummaryResourceType) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ResourceTypeProperties.
 func (r ResourceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
+	populate(objectMap, "capabilities", r.Capabilities)
 	populate(objectMap, "defaultApiVersion", r.DefaultAPIVersion)
 	populate(objectMap, "provisioningState", r.ProvisioningState)
 	return json.Marshal(objectMap)
@@ -1965,6 +1970,9 @@ func (r *ResourceTypeProperties) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
+		case "capabilities":
+				err = unpopulate(val, "Capabilities", &r.Capabilities)
+			delete(rawMsg, key)
 		case "defaultApiVersion":
 				err = unpopulate(val, "DefaultAPIVersion", &r.DefaultAPIVersion)
 			delete(rawMsg, key)

--- a/pkg/ucp/backend/controller/resourceproviders/resourcetype_put.go
+++ b/pkg/ucp/backend/controller/resourceproviders/resourcetype_put.go
@@ -78,6 +78,7 @@ func (c *ResourceTypePutController) updateSummary(id resources.ID, resourceType 
 			resourceTypeEntry = datamodel.ResourceProviderSummaryPropertiesResourceType{}
 		}
 
+		resourceTypeEntry.Capabilities = resourceType.Properties.Capabilities
 		resourceTypeEntry.DefaultAPIVersion = resourceType.Properties.DefaultAPIVersion
 		summary.Properties.ResourceTypes[resourceTypeName] = resourceTypeEntry
 		return nil

--- a/pkg/ucp/datamodel/capabilities.go
+++ b/pkg/ucp/datamodel/capabilities.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datamodel
+
+const (
+	// CapabilitySupportsRecipes is a capability that indicates the resource type supports recipes.
+	CapabilitySupportsRecipes = "SupportsRecipes"
+)

--- a/pkg/ucp/datamodel/resourceprovidersummary.go
+++ b/pkg/ucp/datamodel/resourceprovidersummary.go
@@ -72,6 +72,9 @@ type ResourceProviderSummaryPropertiesResourceType struct {
 	// DefaultAPIVersion is the default API version for the resource type.
 	DefaultAPIVersion *string `json:"defaultApiVersion,omitempty"`
 
+	// Capabilities is the list of capabilities supported by the resource type.
+	Capabilities []string `json:"capabilities,omitempty"`
+
 	// APIVersions is the list of API versions available for the resource type.
 	APIVersions map[string]ResourceProviderSummaryPropertiesAPIVersion `json:"apiVersions,omitempty"`
 }

--- a/pkg/ucp/datamodel/resourcetype.go
+++ b/pkg/ucp/datamodel/resourcetype.go
@@ -41,6 +41,9 @@ func (r *ResourceType) ResourceTypeName() string {
 
 // ResourceTypeProperties stores the properties of a resource type.
 type ResourceTypeProperties struct {
+	// Capabilities is the list of capabilities supported by the resource type.
+	Capabilities []string `json:"capabilities,omitempty"`
+
 	// DefaultAPIVersion is the default API version for this resource type.
 	DefaultAPIVersion *string `json:"defaultApiVersion"`
 }

--- a/pkg/ucp/integrationtests/resourceproviders/summary_test.go
+++ b/pkg/ucp/integrationtests/resourceproviders/summary_test.go
@@ -64,6 +64,7 @@ func Test_ResourceProviderSummary_Lifecycle(t *testing.T) {
 	createResourceType(server)
 	expected.ResourceTypes[resourceTypeName] = &v20231001preview.ResourceProviderSummaryResourceType{
 		APIVersions:       map[string]map[string]any{},
+		Capabilities:      []*string{to.Ptr("SupportsRecipes")},
 		DefaultAPIVersion: to.Ptr("2025-01-01"),
 	}
 

--- a/pkg/ucp/integrationtests/resourceproviders/testdata/manifests/resourceprovider-valid1.yaml
+++ b/pkg/ucp/integrationtests/resourceproviders/testdata/manifests/resourceprovider-valid1.yaml
@@ -4,4 +4,4 @@ types:
     apiVersions:
       "2023-10-01-preview":
         schema: {}
-        capabilities: []
+    capabilities: []

--- a/pkg/ucp/integrationtests/resourceproviders/testdata/resourcetype_manifest_list_responsebody.json
+++ b/pkg/ucp/integrationtests/resourceproviders/testdata/resourcetype_manifest_list_responsebody.json
@@ -4,7 +4,8 @@
       "id": "/planes/radius/local/providers/System.Resources/resourceproviders/TestProvider.TestCompany/resourcetypes/testResourcesAbc",
       "name": "testResourcesAbc",
       "properties": {
-        "provisioningState": "Succeeded"
+        "provisioningState": "Succeeded",
+        "capabilities": []
       },
       "type": "System.Resources/resourceproviders/resourcetypes"
     }

--- a/pkg/ucp/integrationtests/resourceproviders/testdata/resourcetype_manifest_responsebody.json
+++ b/pkg/ucp/integrationtests/resourceproviders/testdata/resourcetype_manifest_responsebody.json
@@ -2,7 +2,8 @@
   "id": "/planes/radius/local/providers/System.Resources/resourceproviders/TestProvider.TestCompany/resourcetypes/testResourcesAbc",
   "name": "testResourcesAbc",
   "properties": {
-    "provisioningState": "Succeeded"
+    "provisioningState": "Succeeded",
+    "capabilities": []
   },
   "type": "System.Resources/resourceproviders/resourcetypes"
 }

--- a/pkg/ucp/integrationtests/resourceproviders/testdata/resourcetype_v20231001preview_list_responsebody.json
+++ b/pkg/ucp/integrationtests/resourceproviders/testdata/resourcetype_v20231001preview_list_responsebody.json
@@ -4,6 +4,7 @@
       "id": "/planes/radius/local/providers/System.Resources/resourceproviders/Applications.Test/resourcetypes/testResources",
       "name": "testResources",
       "properties": {
+        "capabilities": ["SupportsRecipes"],
         "defaultApiVersion": "2025-01-01",
         "provisioningState": "Succeeded"
       },

--- a/pkg/ucp/integrationtests/resourceproviders/testdata/resourcetype_v20231001preview_requestbody.json
+++ b/pkg/ucp/integrationtests/resourceproviders/testdata/resourcetype_v20231001preview_requestbody.json
@@ -1,5 +1,6 @@
 {
   "properties": {
+    "capabilities": ["SupportsRecipes"],
     "defaultApiVersion": "2025-01-01"
   }
 }

--- a/pkg/ucp/integrationtests/resourceproviders/testdata/resourcetype_v20231001preview_responsebody.json
+++ b/pkg/ucp/integrationtests/resourceproviders/testdata/resourcetype_v20231001preview_responsebody.json
@@ -2,6 +2,7 @@
   "id": "/planes/radius/local/providers/System.Resources/resourceproviders/Applications.Test/resourcetypes/testResources",
   "name": "testResources",
   "properties": {
+    "capabilities": ["SupportsRecipes"],
     "defaultApiVersion": "2025-01-01",
     "provisioningState": "Succeeded"
   },

--- a/swagger/specification/ucp/resource-manager/UCP/preview/2023-10-01-preview/openapi.json
+++ b/swagger/specification/ucp/resource-manager/UCP/preview/2023-10-01-preview/openapi.json
@@ -3381,6 +3381,12 @@
       ],
       "x-ms-discriminator-value": "WorkloadIdentity"
     },
+    "Capability": {
+      "type": "string",
+      "description": "A capability defines the behaviors and features that a resource type supports.",
+      "maxLength": 63,
+      "pattern": "^[A-Za-z][A-Za-z0-9]*$"
+    },
     "CredentialStorageKind": {
       "type": "string",
       "description": "Credential store kinds supported.",
@@ -3969,6 +3975,13 @@
             "$ref": "#/definitions/ResourceTypeSummaryResultApiVersion"
           }
         },
+        "capabilities": {
+          "type": "array",
+          "description": "The resource type capabilities.",
+          "items": {
+            "$ref": "#/definitions/Capability"
+          }
+        },
         "defaultApiVersion": {
           "type": "string",
           "description": "The default api version for the resource type."
@@ -3992,6 +4005,13 @@
           "$ref": "#/definitions/ProvisioningState",
           "description": "The status of the asynchronous operation.",
           "readOnly": true
+        },
+        "capabilities": {
+          "type": "array",
+          "description": "The resource type capabilities.",
+          "items": {
+            "$ref": "#/definitions/Capability"
+          }
         },
         "defaultApiVersion": {
           "$ref": "#/definitions/ApiVersionNameString",

--- a/test/functional-portable/ucp/noncloud/resourceprovider_test.go
+++ b/test/functional-portable/ucp/noncloud/resourceprovider_test.go
@@ -51,6 +51,7 @@ func Test_ResourceProviderRegistration(t *testing.T) {
 				"apiVersions": map[string]any{
 					expectedApiVersion: map[string]any{},
 				},
+				"capabilities": []any{"SupportsRecipes"},
 			},
 		},
 	}

--- a/test/functional-portable/ucp/noncloud/testdata/resourceprovider.yaml
+++ b/test/functional-portable/ucp/noncloud/testdata/resourceprovider.yaml
@@ -4,4 +4,4 @@ types:
     apiVersions:
       "2025-01-01-preview":
         schema: {}
-        capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]

--- a/typespec/UCP/resourceproviders.tsp
+++ b/typespec/UCP/resourceproviders.tsp
@@ -86,11 +86,19 @@ model ResourceTypeResource
   name: ResourceTypeNameString;
 }
 
+@doc("A capability defines the behaviors and features that a resource type supports.")
+@maxLength(63)
+@pattern("^[A-Za-z][A-Za-z0-9]*$")
+scalar Capability extends string;
+
 @doc("The properties of a resource type.")
 model ResourceTypeProperties {
   @doc("The status of the asynchronous operation.")
   @visibility("read")
   provisioningState?: ProvisioningState;
+
+  @doc("The resource type capabilities.")
+  capabilities?: Capability[];
 
   @doc("The default api version for the resource type.")
   defaultApiVersion?: ApiVersionNameString;
@@ -166,6 +174,9 @@ model ResourceProviderSummaryLocation {}
 model ResourceProviderSummaryResourceType {
   @doc("API versions supported by the resource type.")
   apiVersions: Record<ResourceTypeSummaryResultApiVersion>;
+
+  @doc("The resource type capabilities.")
+  capabilities?: Capability[];
 
   @doc("The default api version for the resource type.")
   defaultApiVersion?: string;


### PR DESCRIPTION
# Description

This change adds the 'capabilities' concept to the resource type API.

- Capabilities enable resource types to indicate the schema and behaviors they support.
- Capabilities enable clients like the `rad` CLI to understand the behaviors of resource types dynamically.

For example, we're adding the `SupportsRecipes` capability.

- All resource types that support recipes should declare this capability. This is how a UDT will opt-in to recipe functionality during provisioning.
- The `rad` CLI functionality for `rad recipe register` can introspect the resource type to validate recipe support, rather than hardcoding which types have the support and which don't.

----

Description of the changes:

- The manifests previously supported capabilities as part of the API version, we're moving this to the resource type for a simplification.
- The manifest entry for capabilities wasn't sent to the server. Now it is.
- Updated API, converters, and UCP functionality.


## Type of change

- This pull request adds or changes features of Radius and has an approved issue (issue link required).


Part of: #6688

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- [ ] An overview of proposed schema changes is included in a linked GitHub issue.
- [ ] A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
- [ ] If applicable, design document has been reviewed and approved by Radius maintainers/approvers.
- [ ] A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
- [ ] A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
- [ ] A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.