### PR TITLE
Resource type create - fixes

### DIFF
--- a/pkg/cli/clients/errors.go
+++ b/pkg/cli/clients/errors.go
@@ -43,6 +43,11 @@ func Is404Error(err error) bool {
 		return false
 	}
 
+	// NotFound Response from Fake Server - used for testing
+	if strings.Contains(err.Error(), FakeServerNotFoundResponse) {
+		return true
+	}
+
 	// The error might already be an ResponseError
 	responseError := &azcore.ResponseError{}
 	if errors.As(err, &responseError) && responseError.ErrorCode == v1.CodeNotFound || responseError.StatusCode == http.StatusNotFound {
@@ -59,11 +64,6 @@ func Is404Error(err error) bool {
 	}
 
 	if errorResponse.Error != nil && *errorResponse.Error.Code == v1.CodeNotFound {
-		return true
-	}
-
-	// NotFound Response from Fake Server - used for testing
-	if strings.Contains(err.Error(), FakeServerNotFoundResponse) {
 		return true
 	}
 

--- a/pkg/cli/clients/errors.go
+++ b/pkg/cli/clients/errors.go
@@ -20,10 +20,15 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
+)
+
+const (
+	FakeServerNotFoundResponse = "unexpected status code 404. acceptable values are http.StatusOK"
 )
 
 // Is404Error returns true if the error is a 404 payload from an autorest operation.
@@ -54,6 +59,11 @@ func Is404Error(err error) bool {
 	}
 
 	if errorResponse.Error != nil && *errorResponse.Error.Code == v1.CodeNotFound {
+		return true
+	}
+
+	// NotFound Response from Fake Server - used for testing
+	if strings.Contains(err.Error(), FakeServerNotFoundResponse) {
 		return true
 	}
 

--- a/pkg/cli/clients/errors.go
+++ b/pkg/cli/clients/errors.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	FakeServerNotFoundResponse = "unexpected status code 404. acceptable values are http.StatusOK"
+	fakeServerNotFoundResponse = "unexpected status code 404. acceptable values are http.StatusOK"
 )
 
 // Is404Error returns true if the error is a 404 payload from an autorest operation.
@@ -44,7 +44,7 @@ func Is404Error(err error) bool {
 	}
 
 	// NotFound Response from Fake Server - used for testing
-	if strings.Contains(err.Error(), FakeServerNotFoundResponse) {
+	if strings.Contains(err.Error(), fakeServerNotFoundResponse) {
 		return true
 	}
 

--- a/pkg/cli/clients/errors_test.go
+++ b/pkg/cli/clients/errors_test.go
@@ -62,4 +62,10 @@ func TestIs404Error(t *testing.T) {
 	if Is404Error(nil) {
 		t.Errorf("Expected Is404Error to return false for nil error, but it returned true")
 	}
+
+	// Test with a fake server not found response
+	err = errors.New(FakeServerNotFoundResponse)
+	if !Is404Error(err) {
+		t.Errorf("Expected Is404Error to return true for fake server not found response, but it returned false")
+	}
 }

--- a/pkg/cli/clients/errors_test.go
+++ b/pkg/cli/clients/errors_test.go
@@ -64,7 +64,7 @@ func TestIs404Error(t *testing.T) {
 	}
 
 	// Test with a fake server not found response
-	err = errors.New(FakeServerNotFoundResponse)
+	err = errors.New(fakeServerNotFoundResponse)
 	if !Is404Error(err) {
 		t.Errorf("Expected Is404Error to return true for fake server not found response, but it returned false")
 	}

--- a/pkg/cli/cmd/resourcetype/common/resourcetype.go
+++ b/pkg/cli/cmd/resourcetype/common/resourcetype.go
@@ -74,6 +74,7 @@ func GetResourceTypeTableFormat() output.FormatterOptions {
 	}
 }
 
+// GetResourceTypeDetails fetches the details of a resource type from the resource provider.
 func GetResourceTypeDetails(ctx context.Context, resourceProviderName string, resourceTypeName string, client clients.ApplicationsManagementClient) (ResourceType, error) {
 	resourceProvider, err := client.GetResourceProviderSummary(ctx, "local", resourceProviderName)
 	if clients.Is404Error(err) {

--- a/pkg/cli/cmd/resourcetype/common/resourcetype.go
+++ b/pkg/cli/cmd/resourcetype/common/resourcetype.go
@@ -88,7 +88,7 @@ func GetResourceTypeDetails(ctx context.Context, resourceProviderName string, re
 	})
 
 	if idx < 0 {
-		return ResourceType{}, clierrors.Message("Resource type %q not found in resource provider %q.", resourceTypeName, resourceProvider)
+		return ResourceType{}, clierrors.Message("Resource type %q not found in resource provider %q.", resourceTypeName, resourceProvider.Name)
 	}
 
 	return resourceTypes[idx], nil

--- a/pkg/cli/cmd/resourcetype/common/resourcetype.go
+++ b/pkg/cli/cmd/resourcetype/common/resourcetype.go
@@ -62,7 +62,7 @@ func GetResourceTypeTableFormat() output.FormatterOptions {
 				JSONPath: "{ .ResourceProviderNamespace }",
 			},
 			{
-				Heading:  "APIVERSION",
+				Heading:  "DEFAULT APIVERSION",
 				JSONPath: "{ .APIVersions }",
 			},
 		},

--- a/pkg/cli/cmd/resourcetype/common/resourcetype.go
+++ b/pkg/cli/cmd/resourcetype/common/resourcetype.go
@@ -88,7 +88,7 @@ func GetResourceTypeDetails(ctx context.Context, resourceProviderName string, re
 	})
 
 	if idx < 0 {
-		return ResourceType{}, clierrors.Message("Resource type %q not found in resource provider %q.", resourceTypeName, resourceProvider.Name)
+		return ResourceType{}, clierrors.Message("Resource type %q not found in resource provider %q.", resourceTypeName, *resourceProvider.Name)
 	}
 
 	return resourceTypes[idx], nil

--- a/pkg/cli/cmd/resourcetype/common/resourcetype_test.go
+++ b/pkg/cli/cmd/resourcetype/common/resourcetype_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/radius-project/radius/pkg/cli/clients"
+	"github.com/radius-project/radius/pkg/to"
+	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
+	"github.com/radius-project/radius/test/radcli"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_GetResourceTypeDetails(t *testing.T) {
+	t.Run("Get Resource Details Success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		resourceProvider := v20231001preview.ResourceProviderSummary{
+			Name: to.Ptr("Applications.Test"),
+			ResourceTypes: map[string]*v20231001preview.ResourceProviderSummaryResourceType{
+				"exampleResources": {
+					APIVersions: map[string]map[string]any{
+						"2023-10-01-preview": {},
+					},
+				},
+			},
+		}
+
+		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
+		appManagementClient.EXPECT().
+			GetResourceProviderSummary(gomock.Any(), "local", "Applications.Test").
+			Return(resourceProvider, nil).
+			Times(1)
+
+		res, err := GetResourceTypeDetails(context.Background(), "Applications.Test", "exampleResources", appManagementClient)
+		require.NoError(t, err)
+		require.Equal(t, "Applications.Test/exampleResources", res.Name)
+
+	})
+
+	t.Run("Get Resource Details Failure - Resource Provider Not found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
+		appManagementClient.EXPECT().
+			GetResourceProviderSummary(gomock.Any(), "local", "Applications.Test").
+			Return(v20231001preview.ResourceProviderSummary{}, radcli.Create404Error()).
+			Times(1)
+
+		_, err := GetResourceTypeDetails(context.Background(), "Applications.Test", "exampleResources", appManagementClient)
+
+		require.Error(t, err)
+		require.Equal(t, "The resource provider \"Applications.Test\" was not found or has been deleted.", err.Error())
+	})
+
+	t.Run("Get Resource Details Failures Other Than Not Found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
+		appManagementClient.EXPECT().
+			GetResourceProviderSummary(gomock.Any(), "local", "Applications.Test").
+			Return(v20231001preview.ResourceProviderSummary{}, errors.New("some error occurred")).
+			Times(1)
+
+		_, err := GetResourceTypeDetails(context.Background(), "Applications.Test", "exampleResources", appManagementClient)
+
+		require.Error(t, err)
+	})
+}

--- a/pkg/cli/cmd/resourcetype/create/create.go
+++ b/pkg/cli/cmd/resourcetype/create/create.go
@@ -18,7 +18,6 @@ package create
 
 import (
 	"context"
-	"slices"
 	"strings"
 
 	"github.com/radius-project/radius/pkg/cli"
@@ -175,24 +174,8 @@ func (r *Runner) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
-	resourceProvider, err := client.GetResourceProviderSummary(ctx, "local", r.ResourceProvider.Name)
-	if clients.Is404Error(err) {
-		return clierrors.Message("The resource provider %q was not found or has been deleted.", r.ResourceProvider.Name)
-	} else if err != nil {
-		return err
-	}
-
-	resourceTypes := common.ResourceTypesForProvider(&resourceProvider)
-	idx := slices.IndexFunc(resourceTypes, func(rt common.ResourceType) bool {
-		return rt.Name == r.ResourceProvider.Name+"/"+r.ResourceTypeName
-	})
-
-	if idx < 0 {
-		return clierrors.Message("Resource type %q not found in resource provider %q.", r.ResourceTypeName, r.ResourceProvider)
-	}
-
-	err = r.Output.WriteFormatted(r.Format, resourceTypes[idx], common.GetResourceTypeTableFormat())
+	resourceTypeDetails, err := common.GetResourceTypeDetails(ctx, r.ResourceProvider.Name, r.ResourceTypeName, client)
+	err = r.Output.WriteFormatted(r.Format, resourceTypeDetails, common.GetResourceTypeTableFormat())
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/resourcetype/create/create.go
+++ b/pkg/cli/cmd/resourcetype/create/create.go
@@ -18,7 +18,6 @@ package create
 
 import (
 	"context"
-	"strings"
 
 	"github.com/radius-project/radius/pkg/cli"
 	"github.com/radius-project/radius/pkg/cli/clients"
@@ -35,10 +34,6 @@ import (
 	"github.com/spf13/cobra"
 
 	aztoken "github.com/radius-project/radius/pkg/azure/tokencredentials"
-)
-
-const (
-	fakeServerResourceProviderNotFoundResponse = "unexpected status code 404. acceptable values are http.StatusOK"
 )
 
 // NewCommand creates an instance of the `rad resource-type create` command and runner.
@@ -147,8 +142,7 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	_, err := r.UCPClientFactory.NewResourceProvidersClient().Get(ctx, "local", r.ResourceProvider.Name, nil)
 	if err != nil {
-		// The second clause is required for testing purpose since fake server returns a different type of error.
-		if clients.Is404Error(err) || strings.Contains(err.Error(), fakeServerResourceProviderNotFoundResponse) {
+		if clients.Is404Error(err) {
 			r.Output.LogInfo("Resource provider %q not found.", r.ResourceProvider.Name)
 			if registerErr := manifest.RegisterFile(ctx, r.UCPClientFactory, "local", r.ResourceProviderManifestFilePath, r.Logger); err != nil {
 				return registerErr

--- a/pkg/cli/cmd/resourcetype/create/create.go
+++ b/pkg/cli/cmd/resourcetype/create/create.go
@@ -175,6 +175,9 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 	resourceTypeDetails, err := common.GetResourceTypeDetails(ctx, r.ResourceProvider.Name, r.ResourceTypeName, client)
+	if err != nil {
+		return err
+	}
 	err = r.Output.WriteFormatted(r.Format, resourceTypeDetails, common.GetResourceTypeTableFormat())
 	if err != nil {
 		return err

--- a/pkg/cli/cmd/resourcetype/create/create_test.go
+++ b/pkg/cli/cmd/resourcetype/create/create_test.go
@@ -22,12 +22,18 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/radius-project/radius/pkg/cli/clients"
+	"github.com/radius-project/radius/pkg/cli/cmd/resourcetype/common"
+	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
 	"github.com/radius-project/radius/pkg/cli/manifest"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
+	"github.com/radius-project/radius/pkg/to"
+	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
 	"github.com/radius-project/radius/test/radcli"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func Test_CommandValidation(t *testing.T) {
@@ -63,38 +69,76 @@ func Test_Validate(t *testing.T) {
 
 func Test_Run(t *testing.T) {
 	t.Run("Success: resource type created", func(t *testing.T) {
+		resourceProvider := v20231001preview.ResourceProviderSummary{
+			Name: to.Ptr("MyCompany.Resources"),
+			ResourceTypes: map[string]*v20231001preview.ResourceProviderSummaryResourceType{
+				"testResources": &v20231001preview.ResourceProviderSummaryResourceType{
+					APIVersions: map[string]map[string]any{
+						"2023-10-01-preview": {},
+					},
+					Capabilities: []*string{},
+				},
+			},
+		}
+
+		resourceType := common.ResourceType{
+			Name:                      "MyCompany.Resources/testResources",
+			ResourceProviderNamespace: "MyCompany.Resources",
+			APIVersions:               []string{"2023-10-01-preview"},
+		}
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
+		appManagementClient.EXPECT().
+			GetResourceProviderSummary(gomock.Any(), "local", "MyCompany.Resources").
+			Return(resourceProvider, nil).
+			Times(1)
+
 		resourceProviderData, err := manifest.ReadFile("testdata/valid.yaml")
 		require.NoError(t, err)
-
-		expectedResourceType := "testResources"
 
 		clientFactory, err := manifest.NewTestClientFactory(manifest.WithResourceProviderServerNoError)
 		require.NoError(t, err)
 
-		var logBuffer bytes.Buffer
-		logger := func(format string, args ...any) {
-			fmt.Fprintf(&logBuffer, format+"\n", args...)
-		}
-
+		//var logBuffer bytes.Buffer
+		//logger := func(format string, args ...any) {
+		//	fmt.Fprintf(&logBuffer, format+"\n", args...)
+		//}
+		outputSink := &output.MockOutput{}
 		runner := &Runner{
-			UCPClientFactory:                 clientFactory,
-			Output:                           &output.MockOutput{},
-			Workspace:                        &workspaces.Workspace{},
-			ResourceProvider:                 resourceProviderData,
-			Format:                           "table",
-			Logger:                           logger,
+			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+			UCPClientFactory:  clientFactory,
+			Output:            outputSink,
+			Workspace:         &workspaces.Workspace{},
+			ResourceProvider:  resourceProviderData,
+			Format:            "table",
+			//Logger:                           logger,
 			ResourceProviderManifestFilePath: "testdata/valid.yaml",
-			ResourceTypeName:                 expectedResourceType,
+			ResourceTypeName:                 "testResources",
 		}
 
 		err = runner.Run(context.Background())
 		require.NoError(t, err)
 
-		logOutput := logBuffer.String()
-		require.NotContains(t, logOutput, fmt.Sprintf("Creating resource provider %s", runner.ResourceProvider.Name))
-		require.Contains(t, logOutput, fmt.Sprintf("Resource type %s/%s created successfully", resourceProviderData.Name, expectedResourceType))
+		expected := []any{
+			output.FormattedOutput{
+				Format:  "table",
+				Obj:     resourceType,
+				Options: common.GetResourceTypeTableFormat(),
+			},
+		}
+		require.Contains(t, expected, outputSink.Writes)
+		//logOutput := logBuffer.String()
+		//require.NotContains(t, logOutput, fmt.Sprintf("Creating resource provider %s", runner.ResourceProvider.Name))
+		//require.Contains(t, logOutput, fmt.Sprintf("Resource type %s/testResources created successfully", runner.ResourceProvider.Name))
 	})
+
 	t.Run("Resource provider does not exist", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
+
 		resourceProviderData, err := manifest.ReadFile("testdata/valid.yaml")
 		require.NoError(t, err)
 
@@ -109,6 +153,7 @@ func Test_Run(t *testing.T) {
 		}
 
 		runner := &Runner{
+			ConnectionFactory:                &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
 			UCPClientFactory:                 clientFactory,
 			Output:                           &output.MockOutput{},
 			Workspace:                        &workspaces.Workspace{},
@@ -125,6 +170,10 @@ func Test_Run(t *testing.T) {
 
 	})
 	t.Run("Get Resource provider Internal Error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
+
 		resourceProviderData, err := manifest.ReadFile("testdata/valid.yaml")
 		require.NoError(t, err)
 
@@ -139,6 +188,7 @@ func Test_Run(t *testing.T) {
 		}
 
 		runner := &Runner{
+			ConnectionFactory:                &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
 			UCPClientFactory:                 clientFactory,
 			Output:                           &output.MockOutput{},
 			Workspace:                        &workspaces.Workspace{},

--- a/pkg/cli/cmd/resourcetype/create/create_test.go
+++ b/pkg/cli/cmd/resourcetype/create/create_test.go
@@ -46,7 +46,7 @@ func Test_Validate(t *testing.T) {
 	testcases := []radcli.ValidateInput{
 		{
 			Name:          "Valid",
-			Input:         []string{"coolResources", "--from-file", "testdata/valid.yaml"},
+			Input:         []string{"testResources", "--from-file", "testdata/valid.yaml"},
 			ExpectedValid: true,
 			ConfigHolder:  framework.ConfigHolder{Config: config},
 		},
@@ -136,7 +136,7 @@ func Test_Run(t *testing.T) {
 							JSONPath: "{ .ResourceProviderNamespace }",
 						},
 						{
-							Heading:  "DEFAULT APIVERSION",
+							Heading:  "APIVERSION",
 							JSONPath: "{ .APIVersions }",
 						},
 					},

--- a/pkg/cli/cmd/resourcetype/create/create_test.go
+++ b/pkg/cli/cmd/resourcetype/create/create_test.go
@@ -179,7 +179,6 @@ func Test_Run(t *testing.T) {
 		_ = runner.Run(context.Background())
 		logOutput := logBuffer.String()
 		require.Contains(t, logOutput, fmt.Sprintf("Creating resource provider %s", runner.ResourceProvider.Name))
-
 	})
 	t.Run("Get Resource provider Internal Error", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/pkg/cli/cmd/resourcetype/create/testdata/valid.yaml
+++ b/pkg/cli/cmd/resourcetype/create/testdata/valid.yaml
@@ -1,12 +1,7 @@
-name: CoolCompany.Resources
+name: MyCompany.Resources
 types:
   testResources:
     apiVersions:
-      '2023-10-01-preview':
+      '2025-01-01-preview':
         schema: {}
-    capabilities: ["Recipes"]
-  coolResources:
-    apiVersions:
-      '2023-10-01-preview':
-        schema: {}
-    capabilities: ["Recipes"]
+    capabilities: ["SupportsRecipes"]

--- a/pkg/cli/manifest/registermanifest.go
+++ b/pkg/cli/manifest/registermanifest.go
@@ -200,7 +200,6 @@ func RegisterType(ctx context.Context, clientFactory *v20231001preview.ClientFac
 		if err != nil {
 			return err
 		}
-
 	}
 
 	// get the existing location resource and update it with new resource type. We have to revisit this code once schema is finalized and validated.

--- a/pkg/cli/manifest/registermanifest.go
+++ b/pkg/cli/manifest/registermanifest.go
@@ -187,6 +187,22 @@ func RegisterType(ctx context.Context, clientFactory *v20231001preview.ClientFac
 		return err
 	}
 
+	for apiVersionName := range resourceType.APIVersions {
+		logIfEnabled(logger, "Creating API Version %s/%s@%s", resourceProvider.Name, typeName, apiVersionName)
+		apiVersionsPoller, err := clientFactory.NewAPIVersionsClient().BeginCreateOrUpdate(ctx, planeName, resourceProvider.Name, typeName, apiVersionName, v20231001preview.APIVersionResource{
+			Properties: &v20231001preview.APIVersionProperties{},
+		}, nil)
+		if err != nil {
+			return err
+		}
+
+		_, err = apiVersionsPoller.PollUntilDone(ctx, nil)
+		if err != nil {
+			return err
+		}
+
+	}
+
 	// get the existing location resource and update it with new resource type. We have to revisit this code once schema is finalized and validated.
 	locationResourceGetResponse, err := clientFactory.NewLocationsClient().Get(ctx, planeName, resourceProvider.Name, v1.LocationGlobal, nil)
 	if err != nil {

--- a/pkg/cli/manifest/registermanifest_test.go
+++ b/pkg/cli/manifest/registermanifest_test.go
@@ -144,7 +144,6 @@ func TestRegisterFile(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 
-				// Verify the expected resource provider exists
 				if tt.expectedResourceProvider != "" {
 					rp, err := clientFactory.NewResourceProvidersClient().Get(context.Background(), tt.planeName, tt.expectedResourceProvider, nil)
 					require.NoError(t, err, "Failed to retrieve the expected resource provider")


### PR DESCRIPTION
# Description

Fixes below issues in resource-type create
- APIversion for the created resource-type was blank. 
- Display of the resource-type created at the end of the command was incorrect
- Added UTs that would have caught these issues.
- sample manifest updated to have just one resource-type

## Type of change


- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional)

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- [ NA ] An overview of proposed schema changes is included in a linked GitHub issue.
- [ NA ] A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
- [ NA ] If applicable, design document has been reviewed and approved by Radius maintainers/approvers.
- [ NA ] A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
- [ NA ] A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
- [ NA ] A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.