### PR TITLE
Fix failing non-cloud functional tests by using built-in caching on the setup-go action

### DIFF
--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -126,7 +126,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest-m]
+        os: [ubuntu-latest]
         name:
           [
             cli-noncloud,

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -179,25 +179,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GOVER }}
-          cache: false
-
-      - name: Get Go Cache path
-        id: go-cache-paths
-        run: |
-          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
-          sudo rm -rf $(go env GOCACHE)
-
-          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
-          sudo rm -rf $(go env GOMODCACHE)
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ${{ steps.go-cache-paths.outputs.go-build }}
-            ${{ steps.go-cache-paths.outputs.go-mod }}
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
# Description

This PR is to remediate frequent failures of the [scheduled functional test (noncloud)](https://github.com/radius-project/radius/blob/main/.github/workflows/functional-test-noncloud.yaml) workflow. We are having issues with the caching logic. A test failure example is [here](https://github.com/radius-project/radius/actions/runs/12912790930/job/36008466625#step:8:31). 

This PR updates the workflow to remove the caching steps from the workflow and replace it with a new feature of the `actions/setup-go@v5` action, in which caching of Go dependencies is enabled by setting the `cache` parameter to `true`. See [the docs](https://github.com/actions/setup-go/blob/main/docs/adrs/0000-caching-dependencies.md) for details.

I also tested using the `ubuntu-latest` test runner, under the assumption that the non-cloud tests will have fewer artifact outputs and not need the larger disk on `ubuntu-latest-m`.

Changes:

* [`.github/workflows/functional-test-noncloud.yaml`](diffhunk://#diff-b7af1cc5c43a85f1f7d316c6e244726bb14b0b34b59512f60deea7abd498b90cL182-R182): Enabled caching for Go dependencies by setting the `cache` parameter to `true` in the `setup-go` action, and removed the manual cache path setup and cleanup steps to streamline the workflow.
* [`.github/workflows/functional-test-noncloud.yaml`](diffhunk://#diff-b7af1cc5c43a85f1f7d316c6e244726bb14b0b34b59512f60deea7abd498b90cL129-R129): Updated the operating system from `ubuntu-latest-m` to `ubuntu-latest`. Testing for this workflow in a fork did not encounter disk space limits we have seen on other workflows where we tested `ubuntu-latest`.
 
## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #8274 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- [ ] An overview of proposed schema changes is included in a linked GitHub issue.
- [ ] A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
- [ ] If applicable, design document has been reviewed and approved by Radius maintainers/approvers.
- [ ] A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
- [ ] A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
- [ ] A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.