### PR TITLE
Add purge job for bicep artifacts

### DIFF
--- a/.github/workflows/purge-azure-test-resources.yaml
+++ b/.github/workflows/purge-azure-test-resources.yaml
@@ -91,9 +91,36 @@ jobs:
               az group delete --resource-group $line --yes --verbose --no-wait
           done
 
+  purge_bicep_types:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.BICEPTYPES_CLIENT_ID }}
+          tenant-id: ${{ secrets.BICEPTYPES_TENANT_ID }}
+          subscription-id: ${{ secrets.BICEPTYPES_SUBSCRIPTION_ID }}
+
+      # Delete Bicep types that are older than 90 days from the test registry 
+      - name: Delete test bicep type manifests
+        run: |
+          REPO_NAME="test/radius"
+          REGISTRY_NAME="biceptypes"
+          DATE="$(date -d '90 days ago' +%Y-%m-%d)"
+
+          az acr manifest list-metadata \ 
+            -r $REGISTRY_NAME \
+            -n $REPO_NAME \
+            --query "[?lastUpdateTime<='$DATE'].digest" \
+            -o tsv | while read DIGEST; do 
+              az acr manifest delete \
+                -n $REPO_NAME@$DIGEST \
+                -r $REGISTRY_NAME --yes
+          done
+
   create_issue_on_failure:
     name: Create issue for failing purge Azure test resources run
-    needs: [purge_azure_resources]
+    needs: [purge_azure_resources, purge_bicep_types]
     runs-on: ubuntu-latest
     if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
     steps:


### PR DESCRIPTION
# Description

This adds a purge job for test bicep artifacts. It will delete any manifests that are older than 90 days. This only applies to the test schemas uploaded as part of PRs, not any major release versions of Radius or AWS bicep types. 

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- [ ] An overview of proposed schema changes is included in a linked GitHub issue.
- [ ] A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
- [ ] If applicable, design document has been reviewed and approved by Radius maintainers/approvers.
- [ ] A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
- [ ] A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
- [ ] A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.