### PR TITLE
Include 2023-10-01-preview in Microsoft.Resources/deployments manifest

### DIFF
--- a/deploy/manifest/built-in-providers/dev/microsoft_resources.yaml
+++ b/deploy/manifest/built-in-providers/dev/microsoft_resources.yaml
@@ -8,5 +8,7 @@ types:
       "2020-10-01":
         schema: {}
       "2022-09-01":
-        schema: {}  
+        schema: {} 
+      "2023-10-01-preview":
+        schema: {}   
     capabilities: []

--- a/deploy/manifest/built-in-providers/self-hosted/microsoft_resources.yaml
+++ b/deploy/manifest/built-in-providers/self-hosted/microsoft_resources.yaml
@@ -8,5 +8,7 @@ types:
       "2020-10-01":
         schema: {}
       "2022-09-01":
-        schema: {} 
+        schema: {}
+      "2023-10-01-preview":
+        schema: {}   
     capabilities: []


### PR DESCRIPTION
# Description

I've been seeing some issues when trying to create resources on the `Microsoft.Deployments/resources` endpoint with `api-version=2023-10-01-preview`. I'm wondering if this is intentional behavior (I should change my use-case) or something we missed?

```
{
          "error": {
            "code": "BadRequest",
            "message": "api version \"2023-10-01-preview\" is not supported for resource type \"Microsoft.Resources/deployments\" by location \"global\"",
            "target": "/planes/radius/local/resourcegroups/default/providers/Microsoft.Resources/deployments/dt-env"
          }
        }
```

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [ ] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable