### PR TITLE
Add check for cleanup process - Long Running Test

### DIFF
--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -379,10 +379,23 @@ jobs:
             --name ${{ env.AKS_CLUSTER_NAME }} --admin
         env:
           RESOURCE_GROUP: ${{ env.AZURE_TEST_RESOURCE_GROUP }}
+      - name: Restore skip-delete-resources-list
+        if: always()
+        uses: actions/cache/restore@v4
+        with:
+          path: skip-delete-resources-list.txt
+          key: skip-delete-resources-list-file    
       - name: Clean up cluster
         if: always()
         timeout-minutes: 60
-        run: ./.github/scripts/cleanup-long-running-cluster.sh
+        run: |
+          if [ "${{ env.SKIP_BUILD }}" != "true" ] ; then
+            echo "Running cleanup without skip delete resource list. This will delete all resources."
+            ./.github/scripts/cleanup-long-running-cluster.sh
+          else
+            echo "Running cleanup with skip-delete-resources-list.txt. Built-In resources will not be deleted."
+            ./.github/scripts/cleanup-long-running-cluster.sh skip-delete-resources-list.txt
+          fi
       - name: Download Bicep
         run: |
           chmod +x ./bin/rad


### PR DESCRIPTION
# Description

The PR adds a check to the cleanup process for long-running cluster, so we skip the deletion of builtin resources when a new build is not generated. 

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #8357

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [ ] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [ ] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable