### PR TITLE
Add retry logic for registermanifests, introduce skip-build override for LRT

### DIFF
--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -46,6 +46,12 @@ permissions:
 on:
   # Enable manual trigger to deploy the latest changes from main.
   workflow_dispatch:
+    inputs:
+      skip-build:
+        description: 'Skip build (true/false)'
+        required: false
+        default: 'true'
+        type: string
   schedule:
     # Run every 2 hours
     - cron: "0 */2 * * *"
@@ -115,20 +121,29 @@ jobs:
           path: ./dist/cache
           key: radius-test-latest-
       - name: Skip build if build is still valid
-        if: github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'pull_request'
         id: skip-build
         run: |
           # check if the last build time to see if we need to build again
+          SKIP_BUILD="false"
           if [ -f ./dist/cache/.lastbuildtime ]; then
             lastbuild=$(cat ./dist/cache/.lastbuildtime)
             current_time=$(date +%s)
             if [ $((current_time-lastbuild)) -lt ${{ env.VALID_RADIUS_BUILD_WINDOW }} ]; then
-              echo "Skipping build as the last build is still valid."
-              echo "SKIP_BUILD=true" >> $GITHUB_OUTPUT
+              echo "Last build is still within valid window"   
+              SKIP_BUILD="true"
             fi
           fi
+          
+          # Check override in workflow_dispatch mode
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.skip-build }}" = "false" ]; then
+            echo "Manual run with skip-build=false, forcing build"
+            SKIP_BUILD="false"
+          fi
+
+          echo "SKIP_BUILD=${SKIP_BUILD}" >> $GITHUB_OUTPUT
       - name: Set up checkout target (scheduled)
-        if: steps.skip-build.outputs.SKIP_BUILD != 'true' && github.event_name == 'schedule'
+        if: steps.skip-build.outputs.SKIP_BUILD != 'true' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |
           echo "CHECKOUT_REPO=${{ github.repository }}" >> $GITHUB_ENV
           echo "CHECKOUT_REF=refs/heads/main" >> $GITHUB_ENV
@@ -436,8 +451,8 @@ jobs:
             exit 1
           fi
 
-          # Poll logs for up to  iterations, 30 seconds each (upto 3 minutes total)
-          for i in {1..6}; do
+          # Poll logs for up to 20 iterations, 30 seconds each (up to 10 minutes total)
+          for i in {1..20}; do
             kubectl logs "$POD_NAME" -n radius-system | tee registermanifest_logs.txt > /dev/null
 
             # Exit on error
@@ -459,7 +474,7 @@ jobs:
 
           # Final check to ensure success message was found
           if ! grep -q "Successfully registered manifests" registermanifest_logs.txt; then
-            echo "Manifests not registered after 3 minutes."
+            echo "Manifests not registered after 10 minutes."
             exit 1
           fi
       - name: Create a list of resources not to be deleted


### PR DESCRIPTION
# Description

The pull request addresses findings in the failures related to Long Running Test:
We see manifests not being registered successfully due to errors "409 Conflict : The target resource is in Accepted state"
This was determined due to the fact that every PUT request for a resourceprovider/resource type/location/api within a file will internally make an entry towards a resourceprovidersummary entry which is kept updated with the latest updates for the resourceprovider and is optimized for GET calls which receive summarized data for the resource provider.

The system actually corrects itself eventually and the pods are up with the manifests registered and ucp is running but the workflow logic will fail as is designed, the in-built types are not saved in the skip-delete-resources-list.txt and will be deleted in the next subsequent runs and they fail. 
This error is intermittent (latest fresh build run this evening did not have this error, https://github.com/radius-project/radius/actions/runs/13316073926/job/37190564570) but when it does error, it can lead to 12 subsequent failures. 

The PR  includes addition of retry logic with exponential backoff for handling 409 conflict errors.
Introduction of a 'skip-build' override mechism for workflow_dispatch to be able to run Long Running Tests against latest build on demand.

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #8449 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [ ] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [ ] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable