### PR TITLE
Update workflow conditions to enable workflow_dispatch with new build

### DIFF
--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -156,9 +156,9 @@ jobs:
       - name: Generate ID for release
         id: gen-id
         run: |
-          if [ -z "${{ steps.skip-build.outputs.SKIP_BUILD }}" ]; then
+          if [[ "${{ steps.skip-build.outputs.SKIP_BUILD }}" != "true" ]]; then
             BASE_STR="RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
-            if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
+            if [ "$GITHUB_EVENT_NAME" == "schedule" ] || [ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]; then
               # Add run number to randomize unique id for scheduled runs.
               BASE_STR="${GITHUB_RUN_NUMBER}|${BASE_STR}"
             fi


### PR DESCRIPTION
# Description
This pull request updates the conditions for generating an ID.

* Updated the condition to check if the `SKIP_BUILD` output is not "true" instead of current check if it is empty (since we now include a manual input in workflow_dispatch mode which can be set to 'false').
* Added an additional condition to include `workflow_dispatch` events for appending the run number to the unique ID.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue #8449 
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #8449

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [ ] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [ ] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable