### PR TITLE
Remove bug label from workflow test failures

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -938,6 +938,6 @@ jobs:
             github.rest.issues.create({
               ...context.repo,
               title: `Scheduled functional test failed - Run ID: ${context.runId}`,
-              labels: ['bug', 'test-failure'],
+              labels: ['test-failure'],
               body: `## Bug information \n\nThis issue is automatically generated if the scheduled functional test fails. The Radius functional test operates on a schedule of every 4 hours during weekdays and every 12 hours over the weekend. It's important to understand that the test may fail due to workflow infrastructure issues, like network problems, rather than the flakiness of the test itself. For the further investigation, please visit [here](${process.env.ACTION_LINK}).`
             })

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -486,6 +486,6 @@ jobs:
             github.rest.issues.create({
               ...context.repo,
               title: `Scheduled functional test (noncloud) failed - Run ID: ${context.runId}`,
-              labels: ['bug', 'test-failure'],
+              labels: ['test-failure'],
               body: `## Bug information \n\nThis issue is automatically generated if the scheduled functional test fails. The Radius functional test operates on a schedule of every 4 hours during weekdays and every 12 hours over the weekend. It's important to understand that the test may fail due to workflow infrastructure issues, like network problems, rather than the flakiness of the test itself. For the further investigation, please visit [here](${process.env.ACTION_LINK}).`
             })

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -625,6 +625,6 @@ jobs:
             github.rest.issues.create({
               ...context.repo,
               title: `Scheduled long running test failed - Run ID: ${context.runId}`,
-              labels: ['bug', 'test-failure'],
+              labels: ['test-failure'],
               body: `## Bug information \n\nThis issue is automatically generated if the scheduled long running test fails. The Radius long running test operates on a schedule of every 2 hours everyday. It's important to understand that the test may fail due to workflow infrastructure issues, like network problems, rather than the flakiness of the test itself. For the further investigation, please visit [here](${process.env.ACTION_LINK}).`
             })

--- a/.github/workflows/purge-aws-test-resources.yaml
+++ b/.github/workflows/purge-aws-test-resources.yaml
@@ -53,6 +53,6 @@ jobs:
             github.rest.issues.create({
               ...context.repo,
               title: `Purge aws test resources failed - Run ID: ${context.runId}`,
-              labels: ['bug', 'test-failure'],
+              labels: ['test-failure'],
               body: `## Bug information \n\nThis bug is generated automatically if the purge aws test resources workflow fails. For the further investigation, please visit [here](${process.env.ACTION_LINK}).`
             })

--- a/.github/workflows/purge-azure-test-resources.yaml
+++ b/.github/workflows/purge-azure-test-resources.yaml
@@ -131,6 +131,6 @@ jobs:
             github.rest.issues.create({
               ...context.repo,
               title: `Purge Azure test resources failed - Run ID: ${context.runId}`,
-              labels: ['bug', 'test-failure'],
+              labels: ['test-failure'],
               body: `## Bug information \n\nThis bug is generated automatically if the purge Azure test resources workflow fails. For the further investigation, please visit [here](${process.env.ACTION_LINK}).`
             })

--- a/.github/workflows/purge-old-images.yaml
+++ b/.github/workflows/purge-old-images.yaml
@@ -43,6 +43,6 @@ jobs:
             github.rest.issues.create({
               ...context.repo,
               title: `Purge old images failed - Run ID: ${context.runId}`,
-              labels: ['bug', 'test-failure'],
+              labels: ['test-failure'],
               body: `## Bug information \n\nThis bug is generated automatically if the purge old images workflow fails. For further investigation, please visit [here](${process.env.ACTION_LINK}).`
             })


### PR DESCRIPTION
# Description

This pull request includes changes to the GitHub Actions workflows to update the labels used when creating issues for failed jobs. The changes involve removing the 'bug' label from the issues created by various workflows.

⚠️ There is no way to test these workflows from a fork. However, I did run the workflow step below in a private repo to create issues.

```yaml
      - name: Create GitHub issue
        uses: actions/github-script@v7
        with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          script: |
            github.rest.issues.create({
              ...context.repo,
              title: `Scheduled functional test failed - Run ID: ${context.runId}`,
              labels: ['test-failure'],
              body: `test failure.`
            })
```

Label updates in issue creation:

* [`.github/workflows/functional-test-cloud.yaml`](diffhunk://#diff-a5e3050f5c1a812d9565ba0c87fb5028ad0a004c2d966e71d67208b4b33042c4L941-R941): Removed the 'bug' label from issues created when the scheduled functional test fails.
* [`.github/workflows/functional-test-noncloud.yaml`](diffhunk://#diff-b7af1cc5c43a85f1f7d316c6e244726bb14b0b34b59512f60deea7abd498b90cL489-R489): Removed the 'bug' label from issues created when the scheduled functional test (noncloud) fails.
* [`.github/workflows/long-running-azure.yaml`](diffhunk://#diff-85cd86e7ae6da973e4808fe57f4fea7892ab78a499ba5aec72c0b3751a2cc226L628-R628): Removed the 'bug' label from issues created when the scheduled long running test fails.
* [`.github/workflows/purge-aws-test-resources.yaml`](diffhunk://#diff-cdbef2239fc7a1aa34d773cb6dae3395193da5015c322ef49bb02025b701a0bcL56-R56): Removed the 'bug' label from issues created when the purge AWS test resources workflow fails.
* [`.github/workflows/purge-azure-test-resources.yaml`](diffhunk://#diff-c8c49c87d86116281359243707cc8e16f5a2527d8b5b0537d4c1b72bb1039820L134-R134): Removed the 'bug' label from issues created when the purge Azure test resources workflow fails.
* [`.github/workflows/purge-old-images.yaml`](diffhunk://#diff-8ee52cc366de9b56e7fb33d5ec555e9ca098e2eb22f764c6d02c0aa440f8135bL46-R46): Removed the 'bug' label from issues created when the purge old images workflow fails.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: N/A

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable