### PR TITLE
Update Terraform Postgres Recipe Test

### DIFF
--- a/test/functional-portable/corerp/noncloud/resources/recipe_terraform_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/recipe_terraform_test.go
@@ -139,11 +139,14 @@ func Test_TerraformRecipe_KubernetesRedis(t *testing.T) {
 //
 // - Create an extender resource using a Terraform recipe that deploys Postgres on Kubernetes.
 // - The recipe deployment creates a Kubernetes deployment and a Kubernetes service and a postgres db.
+//
+// The purpose of this test is to validate that the Terraform provider config referencing secret store
+// resource is passed correctly during recipe deployment.
 func Test_TerraformRecipe_KubernetesPostgres(t *testing.T) {
 	template := "testdata/corerp-resources-terraform-postgres.bicep"
 	appName := "corerp-resources-terraform-pg-app"
 	envName := "corerp-resources-terraform-pg-env"
-	extenderName := "pgs-resources-terraform-pgsapp"
+	extenderName := "corerp-resources-terraform-pg"
 	secretName := "pgs-secretstore"
 	secretResourceName := appName + "/" + secretName
 	userName := "postgres"
@@ -196,31 +199,6 @@ func Test_TerraformRecipe_KubernetesPostgres(t *testing.T) {
 				},
 			},
 			SkipObjectValidation: true,
-			PostStepVerify: func(ctx context.Context, t *testing.T, test rp.RPTest) {
-				secret, err := test.Options.K8sClient.CoreV1().Secrets(secretNamespace).
-					Get(ctx, secretPrefix+secretSuffix, metav1.GetOptions{})
-				require.NoError(t, err)
-				require.Equal(t, secretNamespace, secret.Namespace)
-				require.Equal(t, secretPrefix+secretSuffix, secret.Name)
-
-				pg, err := test.Options.ManagementClient.GetResource(ctx, "Applications.Core/extenders", extenderName)
-				require.NoError(t, err)
-				require.NotNil(t, pg)
-				status := pg.Properties["status"].(map[string]any)
-				recipe := status["recipe"].(map[string]interface{})
-				require.Equal(t, "terraform", recipe["templateKind"].(string))
-				expectedTemplatePath := strings.Replace(testutil.GetTerraformRecipeModuleServerURL()+"/postgres.zip", "moduleServer=", "", 1)
-				require.Equal(t, expectedTemplatePath, recipe["templatePath"].(string))
-
-				// At present, it is not possible to verify the template version in functional tests
-				// This is verified by UTs though
-
-				// Manually delete Kubernetes the secret that stores the Terraform state file now. The next step in the test will be the deletion
-				// of the portable resource that uses this secret for Terraform recipe. This is to verify that the test and portable resource
-				// deletion will not fail even though the secret is already deleted.
-				err = test.Options.K8sClient.CoreV1().Secrets(secretNamespace).Delete(ctx, secretPrefix+secretSuffix, metav1.DeleteOptions{})
-				require.NoError(t, err)
-			},
 		},
 	})
 

--- a/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-terraform-postgres.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-terraform-postgres.bicep
@@ -74,7 +74,7 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
 }
 
 resource pgsapp 'Applications.Core/extenders@2023-10-01-preview' = {
-  name: 'pgs-resources-terraform-pgsapp'
+  name: 'corerp-resources-terraform-pg'
   properties: {
     application: app.id
     environment: env.id


### PR DESCRIPTION
# Description

* <s>Update resource name to reset generated TF state name in long running tests.</s> - Updated in https://github.com/radius-project/radius/pull/8835

* <s>Remove skipping of resource deletion, there is no reason why we shouldn't be deleting resources for this test.</s> - Updated in https://github.com/radius-project/radius/pull/8821 instead along with server side bug fix.

* Remove manual verification and deletion of Kubernetes secret that stores the TF state file. This is only needed in one Terraform test to ensure that the delete can go through if the state is deleted outside of Radius, which is already covered in another test.

## Type of change

Attempts to fix: https://github.com/radius-project/radius/issues/8786

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable