### PR TITLE
Updating error messages to be checked in bicep recipe functional tests for the new DE

### DIFF
--- a/test/functional-portable/corerp/noncloud/resources/recipe_bicep_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/recipe_bicep_test.go
@@ -306,7 +306,7 @@ func Test_BicepRecipe_ParameterNotDefined(t *testing.T) {
 				Details: []step.DeploymentErrorDetail{
 					{
 						Code:            "InvalidTemplate",
-						MessageContains: "Deployment template validation failed: 'The template parameters 'a, b' in the parameters file are not valid; they are not present in the original template and can therefore not be provided at deployment time. The only supported parameters for this template are ''. Please see https://aka.ms/arm-pass-parameter-values for usage details.'.",
+						MessageContains: "Deployment template validation failed:",
 					},
 				},
 			},
@@ -397,7 +397,7 @@ func Test_BicepRecipe_LanguageFailure(t *testing.T) {
 					// Instead of hardcoding values, we'll validate that the rest of the message is correct.
 					{
 						Code:            "DeploymentFailed",
-						MessageContains: "At least one resource deployment operation failed. Please see the details for the specific operation that failed.",
+						MessageContains: "At least one resource deployment operation failed.",
 						Details: []step.DeploymentErrorDetail{
 							{
 								Code:            "InvalidTemplate",
@@ -407,7 +407,7 @@ func Test_BicepRecipe_LanguageFailure(t *testing.T) {
 					},
 					{
 						Code:            "DeploymentFailed",
-						MessageContains: "At least one resource deployment operation failed. Please see the details for the specific operation that failed.",
+						MessageContains: "At least one resource deployment operation failed.",
 						Details: []step.DeploymentErrorDetail{
 							{
 								Code:            "InvalidTemplate",
@@ -460,7 +460,7 @@ func Test_BicepRecipe_ResourceCreationFailure(t *testing.T) {
 				Details: []step.DeploymentErrorDetail{
 					{
 						Code:            "DeploymentFailed",
-						MessageContains: "At least one resource deployment operation failed. Please see the details for the specific operation that failed.",
+						MessageContains: "At least one resource deployment operation failed.",
 						Details: []step.DeploymentErrorDetail{
 							{
 								Code:            "ResourceDeploymentFailure",


### PR DESCRIPTION
# Description

These 3 tests are failing because the error messages that are being looked for in the logs are updated in the new dependencies of DE.

I updated these messages to cover both cases: current DE and the new DE.

I will update the error messages after we merge in the DE work.

An example of new error messages: https://msazure.visualstudio.com/One/_search?action=contents&text=%22The%20following%20parameters%20were%20supplied%22&type=code&lp=code-Project&filters=ProjectFilters%7BOne%7DRepositoryFilters%7BAzureUX-Deployments%7D&pageSize=25&result=DefaultCollection/One/AzureUX-Deployments/GBmaster//src/Core/ErrorResponses/ErrorResponseMessages.Designer.cs.

## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable