### PR TITLE
Fix bug: Terraform Recipe Deletion with Provider Config

### DIFF
--- a/pkg/recipes/driver/terraform.go
+++ b/pkg/recipes/driver/terraform.go
@@ -122,7 +122,8 @@ func (d *terraformDriver) Execute(ctx context.Context, opts ExecuteOptions) (*re
 	return recipeOutputs, nil
 }
 
-// Delete returns an error if called as it is not yet implemented.
+// Delete creates a unique directory for each execution of terraform and deletes the resources deployed by the Terraform module
+// using the Terraform CLI through terraform-exec. It returns an error if the deletion fails.
 func (d *terraformDriver) Delete(ctx context.Context, opts DeleteOptions) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
@@ -153,6 +154,7 @@ func (d *terraformDriver) Delete(ctx context.Context, opts DeleteOptions) error 
 		EnvConfig:      &opts.Configuration,
 		ResourceRecipe: &opts.Recipe,
 		EnvRecipe:      &opts.Definition,
+		Secrets:        opts.Secrets,
 	})
 
 	unsetError := unsetGitConfigForDirIfApplicable(secretStoreID, opts.Secrets, requestDirPath, opts.Definition.TemplatePath)

--- a/test/functional-portable/corerp/noncloud/resources/recipe_terraform_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/recipe_terraform_test.go
@@ -196,7 +196,6 @@ func Test_TerraformRecipe_KubernetesPostgres(t *testing.T) {
 				},
 			},
 			SkipObjectValidation: true,
-			SkipResourceDeletion: true,
 			PostStepVerify: func(ctx context.Context, t *testing.T, test rp.RPTest) {
 				secret, err := test.Options.K8sClient.CoreV1().Secrets(secretNamespace).
 					Get(ctx, secretPrefix+secretSuffix, metav1.GetOptions{})


### PR DESCRIPTION
# Description

Terraform recipe deletion fails currently if a recipe uses references a secretstore from Radius environmen for Terraform provider config. Looks like this bug has always existed since this functionality was added but was never caught as the corresponding functional test was skipping deletion of resources.

Remove skipping of resource deletion from functional test, there is no reason why we shouldn't be deleting resources for this test.

```
"error": {
        	            	    "code": "RecipeDeletionFailed",
        	            	    "message": "missing secret store id: /planes/radius/local/resourcegroups/kind-radius/providers/Applications.Core/secretStores/pgs-secretstore"
        	            	  }
```

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable