### PR TITLE
Update Terraform Postgres Recipe Test Resource Name

### DIFF
--- a/test/functional-portable/corerp/noncloud/resources/recipe_terraform_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/recipe_terraform_test.go
@@ -143,7 +143,7 @@ func Test_TerraformRecipe_KubernetesPostgres(t *testing.T) {
 	template := "testdata/corerp-resources-terraform-postgres.bicep"
 	appName := "corerp-resources-terraform-pg-app"
 	envName := "corerp-resources-terraform-pg-env"
-	extenderName := "pgs-resources-terraform-pgsapp"
+	extenderName := "corerp-resources-terraform-pg"
 	secretName := "pgs-secretstore"
 	secretResourceName := appName + "/" + secretName
 	userName := "postgres"

--- a/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-terraform-postgres.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-terraform-postgres.bicep
@@ -74,7 +74,7 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
 }
 
 resource pgsapp 'Applications.Core/extenders@2023-10-01-preview' = {
-  name: 'pgs-resources-terraform-pgsapp'
+  name: 'corerp-resources-terraform-pg'
   properties: {
     application: app.id
     environment: env.id


### PR DESCRIPTION
# Description

Update resource name to reset generated TF state name in long running tests.

## Type of change

Attempts to fix: https://github.com/radius-project/radius/issues/8786

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable