### PR TITLE
Update codeowners: Remove oncall team from github workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,9 +10,6 @@ test/magpiego/go.mod @radius-project/on-call @radius-project/maintainers-radius 
 test/magpiego/go.sum @radius-project/on-call @radius-project/maintainers-radius @radius-project/approvers-radius
 # Files in the `typespec` directory
 typespec/package*.json @radius-project/on-call @radius-project/maintainers-radius @radius-project/approvers-radius
-# GitHub workflow files
-.github/*.yml  @radius-project/on-call @radius-project/maintainers-radius @radius-project/approvers-radius
-.github/*.yaml @radius-project/on-call @radius-project/maintainers-radius @radius-project/approvers-radius
 # Devcontainer files
 .devcontainer/devcontainer.json @radius-project/on-call @radius-project/maintainers-radius @radius-project/approvers-radius
 # Radius bicep types generator files


### PR DESCRIPTION
# Description

I recently added on-call group as owner for a few dependency related files to allow on-call to handle depedenabot/snyk PRs: https://github.com/radius-project/radius/pull/8884. However, looking at the list again, I realized that github workflows have a lot of core functionality and are generally not limited to version updates, so removing on-call team from the codeowners list for github workflows.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable