### PR TITLE
Add permissions to allow dynamic-rp to manage resources in apps apiGroup

### DIFF
--- a/deploy/Chart/templates/dynamic-rp/rbac.yaml
+++ b/deploy/Chart/templates/dynamic-rp/rbac.yaml
@@ -41,6 +41,22 @@ rules:
   - patch
   - update
   - watch
+
+# Integration with DE
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  - replicasets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/Chart/templates/dynamic-rp/rbac.yaml
+++ b/deploy/Chart/templates/dynamic-rp/rbac.yaml
@@ -6,57 +6,57 @@ metadata:
     app.kubernetes.io/name: dynamic-rp
     app.kubernetes.io/part-of: radius
 rules:
-  # Adding coordination.k8s.io api group as Terraform need to access leases resource for backend initialization for state locking: https://developer.hashicorp.com/terraform/language/settings/backends/kubernetes.
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
+# Adding coordination.k8s.io api group as Terraform need to access leases resource for backend initialization for state locking: https://developer.hashicorp.com/terraform/language/settings/backends/kubernetes.
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
 
-  # Integration with UCP's API.
-  - apiGroups:
-      - api.ucp.dev
-    resources:
-      - "*"
-    verbs:
-      - "*"
+# Integration with UCP's API.
+- apiGroups:
+  - api.ucp.dev
+  resources:
+  - '*'
+  verbs:
+  - '*'
 
-  # Integration with data store and queues.
-  - apiGroups:
-      - ucp.dev
-    resources:
-      - resources
-      - queuemessages
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
+# Integration with data store and queues.
+- apiGroups:
+  - ucp.dev
+  resources:
+  - resources
+  - queuemessages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 
-  # Integration with DE
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-      - statefulsets
-      - replicasets
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
+# Integration with DE's API.
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  - replicasets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -67,6 +67,6 @@ roleRef:
   kind: ClusterRole
   name: dynamic-rp
 subjects:
-  - kind: ServiceAccount
-    name: dynamic-rp
-    namespace: { { .Release.Namespace } }
+- kind: ServiceAccount
+  name: dynamic-rp
+  namespace: {{ .Release.Namespace }}

--- a/deploy/Chart/templates/dynamic-rp/rbac.yaml
+++ b/deploy/Chart/templates/dynamic-rp/rbac.yaml
@@ -6,57 +6,57 @@ metadata:
     app.kubernetes.io/name: dynamic-rp
     app.kubernetes.io/part-of: radius
 rules:
-# Adding coordination.k8s.io api group as Terraform need to access leases resource for backend initialization for state locking: https://developer.hashicorp.com/terraform/language/settings/backends/kubernetes.
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
+  # Adding coordination.k8s.io api group as Terraform need to access leases resource for backend initialization for state locking: https://developer.hashicorp.com/terraform/language/settings/backends/kubernetes.
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
 
-# Integration with UCP's API.
-- apiGroups:
-  - api.ucp.dev
-  resources:
-  - '*'
-  verbs:
-  - '*'
+  # Integration with UCP's API.
+  - apiGroups:
+      - api.ucp.dev
+    resources:
+      - "*"
+    verbs:
+      - "*"
 
-# Integration with data store and queues.
-- apiGroups:
-  - ucp.dev
-  resources:
-  - resources
-  - queuemessages
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  # Integration with data store and queues.
+  - apiGroups:
+      - ucp.dev
+    resources:
+      - resources
+      - queuemessages
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
 
-# Integration with DE
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - statefulsets
-  - replicasets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  # Integration with DE
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+      - replicasets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -67,6 +67,6 @@ roleRef:
   kind: ClusterRole
   name: dynamic-rp
 subjects:
-- kind: ServiceAccount
-  name: dynamic-rp
-  namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: dynamic-rp
+    namespace: { { .Release.Namespace } }


### PR DESCRIPTION
# Description

This fix is neccessary to allow deletion of UDT resources in cluster by dynamic-rp.
Matching the verbs with app core rp's permission set.

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [ X] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [ X] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [ X] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [X ] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [ X] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [ X] Not applicable