### PR TITLE
Fix for failing dev container dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,10 +20,6 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    groups:
-      all:
-        patterns:
-          - "*"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:


### PR DESCRIPTION
# Description

This pull request includes a small change to the `.github/dependabot.yml` file. The change removes the `groups` section under the `updates` configuration. 

Before making this change I was able to reproduce the error on a fork. After the change the issue was resolved and Dependabot ran successfully on the fork. See the related GitHub issue #8757 for details.

Before the change:

```text
updater | 2025/03/24 03:50:28 INFO <job_985181026> Running command: devcontainer outdated --workspace-folder . --config devcontainer.json --output-format json
updater | 2025/03/24 03:50:28 INFO <job_985181026> Started process PID: 1504 with command: {} devcontainer outdated --workspace-folder . --config devcontainer.json --output-format json {}
updater | 2025/03/24 03:50:28 INFO <job_985181026> Process PID: 1504 completed with status: pid 1504 exit 1
```

After the change:

```text
Running command: devcontainer outdated --workspace-folder . --config devcontainer.json --output-format json
updater | 2025/03/27 03:21:29 INFO <job_987645316> Started process PID: 82 with command: {} devcontainer outdated --workspace-folder . --config devcontainer.json --output-format json {}
```

This change conforms to the example on the dev container announcement of dependabot support [here](https://containers.dev/guide/dependabot).

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #8757

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable