### PR TITLE
Add flag to 'rad bicep publish-extension' cmd

### DIFF
--- a/pkg/cli/cmd/bicep/publishextension/publish_test.go
+++ b/pkg/cli/cmd/bicep/publishextension/publish_test.go
@@ -33,6 +33,11 @@ func TestRunner_Validate(t *testing.T) {
 			ExpectedValid: true,
 		},
 		{
+			Name:          "Valid with force flag",
+			Input:         []string{"--from-file", "testdata/valid.yaml", "--target", "./output.tgz", "--force"},
+			ExpectedValid: true,
+		},
+		{
 			Name:          "Invalid: invalid manifest",
 			Input:         []string{"--from-file", "testdata/invalid.yaml", "--target", "./output.tgz"},
 			ExpectedValid: false,


### PR DESCRIPTION
# Description
This PR includes a 'force' flag to the `rad bicep publish-extension` command. This flag allows users to overwrite the target extension if it already exists.

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (issue link required). (#9043)

Fixes: #9043 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [ ] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [ ] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable