### PR TITLE
Remove unused recipe context

### DIFF
--- a/pkg/portableresources/types.go
+++ b/pkg/portableresources/types.go
@@ -68,38 +68,5 @@ type ResourceReference struct {
 	ID string `json:"id"`
 }
 
-// RecipeContext Recipe template authors can leverage the RecipeContext parameter to access portable resource properties to
-// generate name and properties that are unique for the resource calling the recipe.
-type RecipeContext struct {
-	Resource    Resource     `json:"resource,omitempty"`
-	Application ResourceInfo `json:"application,omitempty"`
-	Environment ResourceInfo `json:"environment,omitempty"`
-	Runtime     Runtime      `json:"runtime,omitempty"`
-}
-
-// Resource contains the information needed to deploy a recipe.
-// In the case the resource is a portable resource, it represents the resource's id, name and type.
-type Resource struct {
-	ResourceInfo
-	Type string `json:"type"`
-}
-
-// ResourceInfo name and id of the resource
-type ResourceInfo struct {
-	Name string `json:"name"`
-	ID   string `json:"id"`
-}
-
-type Runtime struct {
-	Kubernetes Kubernetes `json:"kubernetes,omitempty"`
-}
-
 // ResourceProvisioning specifies how the resource should be managed
 type ResourceProvisioning string
-
-type Kubernetes struct {
-	// Namespace is set to the applicationNamespace when the portable resource is application-scoped, and set to the environmentNamespace when it is environment scoped
-	Namespace string `json:"namespace"`
-	// EnvironmentNamespace is set to environment namespace.
-	EnvironmentNamespace string `json:"environmentNamespace"`
-}


### PR DESCRIPTION
# Description

Looks like the recipe context was moved to https://github.com/radius-project/radius/blob/main/pkg/recipes/recipecontext/types.go#L31, but the old definition was never removed.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable