### PR TITLE
add capabilities to resource-type update

### DIFF
--- a/pkg/cli/manifest/registermanifest_test.go
+++ b/pkg/cli/manifest/registermanifest_test.go
@@ -31,6 +31,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	supportsRecipeCapability = "SupportsRecipe"
+)
+
 func TestRegisterDirectory(t *testing.T) {
 	tests := []struct {
 		name                     string
@@ -236,7 +240,7 @@ func TestRegisterType(t *testing.T) {
 					require.Equal(t, to.Ptr(tt.expectedResourceProvider), rp.Name)
 
 					logOutput := logBuffer.String()
-					require.Contains(t, logOutput, fmt.Sprintf("Creating resource type %s/%s with capabilities %s", tt.expectedResourceProvider, tt.expectedResourceTypeName, "SupportsRecipe"))
+					require.Contains(t, logOutput, fmt.Sprintf("Creating resource type %s/%s with capabilities %s", tt.expectedResourceProvider, tt.expectedResourceTypeName, supportsRecipeCapability))
 					require.Contains(t, logOutput, fmt.Sprintf("Creating API Version %s/%s@%s", tt.expectedResourceProvider, tt.expectedResourceTypeName, tt.expectedAPIVersion))
 				}
 			}

--- a/pkg/cli/manifest/registermanifest_test.go
+++ b/pkg/cli/manifest/registermanifest_test.go
@@ -28,11 +28,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/radius-project/radius/pkg/to"
+	"github.com/radius-project/radius/pkg/ucp/datamodel"
 	"github.com/stretchr/testify/require"
-)
-
-const (
-	supportsRecipeCapability = "SupportsRecipe"
 )
 
 func TestRegisterDirectory(t *testing.T) {
@@ -240,7 +237,7 @@ func TestRegisterType(t *testing.T) {
 					require.Equal(t, to.Ptr(tt.expectedResourceProvider), rp.Name)
 
 					logOutput := logBuffer.String()
-					require.Contains(t, logOutput, fmt.Sprintf("Creating resource type %s/%s with capabilities %s", tt.expectedResourceProvider, tt.expectedResourceTypeName, supportsRecipeCapability))
+					require.Contains(t, logOutput, fmt.Sprintf("Creating resource type %s/%s with capabilities %s", tt.expectedResourceProvider, tt.expectedResourceTypeName, datamodel.CapabilitySupportsRecipes))
 					require.Contains(t, logOutput, fmt.Sprintf("Creating API Version %s/%s@%s", tt.expectedResourceProvider, tt.expectedResourceTypeName, tt.expectedAPIVersion))
 				}
 			}

--- a/pkg/cli/manifest/registermanifest_test.go
+++ b/pkg/cli/manifest/registermanifest_test.go
@@ -236,7 +236,7 @@ func TestRegisterType(t *testing.T) {
 					require.Equal(t, to.Ptr(tt.expectedResourceProvider), rp.Name)
 
 					logOutput := logBuffer.String()
-					require.Contains(t, logOutput, fmt.Sprintf("Creating resource type %s/%s", tt.expectedResourceProvider, tt.expectedResourceTypeName))
+					require.Contains(t, logOutput, fmt.Sprintf("Creating resource type %s/%s with capabilities %s", tt.expectedResourceProvider, tt.expectedResourceTypeName, "SupportsRecipe"))
 					require.Contains(t, logOutput, fmt.Sprintf("Creating API Version %s/%s@%s", tt.expectedResourceProvider, tt.expectedResourceTypeName, tt.expectedAPIVersion))
 				}
 			}


### PR DESCRIPTION
# Description

rad resource-type create missed capabilities field if running as an update. 
This caused recipes to not be invoked on updates.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).=

Fixes: #9089 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [X ] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [ X] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [X ] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [ X] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [X ] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [X ] Not applicable