### PR TITLE
Update config to use mcr target for image

### DIFF
--- a/deploy/tf-module-server/resources.yaml
+++ b/deploy/tf-module-server/resources.yaml
@@ -15,7 +15,7 @@ spec:
         app.kubernetes.io/name: tf-module-server
     spec:
       containers:
-      - image: nginx:1.25
+      - image: mcr.microsoft.com/azurelinux/base/nginx:1.25
         name: nginx
         # nginx will serve files found in this directory.
         volumeMounts:


### PR DESCRIPTION
# Description

Two failures recorded this week in scheduled functional tests due to docker rate limits. Updating config to use mirrored image in mcr instead. ref: docs/contributing/contributing-code/contributing-code-tests/tests-images-pushtoghcr.md

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

https://github.com/radius-project/radius/issues/9178 and 
https://github.com/radius-project/radius/issues/9153

Fixes: #9178, #9153

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [ ] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [ ] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable