### PR TITLE
Update Dynamic RP RBAC rules

### DIFF
--- a/deploy/Chart/templates/dynamic-rp/rbac.yaml
+++ b/deploy/Chart/templates/dynamic-rp/rbac.yaml
@@ -6,6 +6,23 @@ metadata:
     app.kubernetes.io/name: dynamic-rp
     app.kubernetes.io/part-of: radius
 rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - services
+  - namespaces
+  - serviceaccounts
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 # Adding coordination.k8s.io api group as Terraform need to access leases resource for backend initialization for state locking: https://developer.hashicorp.com/terraform/language/settings/backends/kubernetes.
 - apiGroups:
   - coordination.k8s.io


### PR DESCRIPTION
# Description

Needed for Terraform recipe execution. Currently it's failing with the following error:

terraform init failure: exit status 1\n\nError: Failed to get existing workspaces: secrets is forbidden: User \"system:serviceaccount:radius-system:dynamic-rp\" cannot list resource \"secrets\" in API group \"\" in the namespace \"radius-system\"\n\n"

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: https://github.com/radius-project/radius/issues/9182

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable