### PR TITLE
Add UserAssigned Managed Identity

### DIFF
--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -309,21 +309,9 @@ jobs:
           chmod +x ./bin/rad
           export PATH=$GITHUB_WORKSPACE/bin:$PATH
           which rad || { echo "cannot find rad"; exit 1; }
-          rad bicep publish-extension -f ./test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha.yaml --target br:${{ env.BICEP_TYPES_REGISTRY }}/testresources:latest --force
-      - name: Publish Bicep Test Recipes
-        if: steps.skip-build.outputs.SKIP_BUILD != 'true'
-        run: |
-          export PATH=$GITHUB_WORKSPACE/bin:$PATH
-          which rad || { echo "cannot find rad"; exit 1; }
           rad bicep download
           rad version
           rad bicep publish-extension -f ./test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha.yaml --target br:${{ env.BICEP_TYPES_REGISTRY }}/testresources:latest --force
-      - name: Login to Azure
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
-          tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
       - name: Publish Bicep Test Recipes
         if: steps.skip-build.outputs.SKIP_BUILD != 'true'
         run: |

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -302,6 +302,12 @@ jobs:
         with:
           path: ./dist/cache
           key: radius-test-latest-${{ github.sha }}-${{ github.run_number }}
+      - name: 'Login via Azure CLI'
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.BICEPTYPES_CLIENT_ID }}
+          tenant-id: ${{ secrets.BICEPTYPES_TENANT_ID }}
+          subscription-id: ${{ secrets.BICEPTYPES_SUBSCRIPTION_ID }}    
       - name: Publish UDT types
         run: |
           mkdir ./bin
@@ -312,6 +318,12 @@ jobs:
           rad bicep download
           rad version
           rad bicep publish-extension -f ./test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha.yaml --target br:${{ env.BICEP_TYPES_REGISTRY }}/testresources:latest --force
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
+          tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
       - name: Publish Bicep Test Recipes
         if: steps.skip-build.outputs.SKIP_BUILD != 'true'
         run: |
@@ -584,8 +596,6 @@ jobs:
           bicep restore ./test/functional-portable/corerp/cloud/resources/testdata/corerp-azure-connection-database-service.bicep --force
           # Restore AWS Bicep types 
           bicep restore ./test/functional-portable/corerp/cloud/resources/testdata/aws-s3-bucket.bicep --force
-          # Restore UDT Test Bicep types
-          bicep restore ./test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha-recipe.bicep
       - name: Run functional tests
         run: |
           # Ensure rad cli is in path before running tests.

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -302,18 +302,17 @@ jobs:
         with:
           path: ./dist/cache
           key: radius-test-latest-${{ github.sha }}-${{ github.run_number }}
-      - name: 'Login via Azure CLI'
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.BICEPTYPES_CLIENT_ID }}
-          tenant-id: ${{ secrets.BICEPTYPES_TENANT_ID }}
-          subscription-id: ${{ secrets.BICEPTYPES_SUBSCRIPTION_ID }}    
       - name: Publish UDT types
-        if: steps.skip-build.outputs.SKIP_BUILD != 'true'
         run: |
           mkdir ./bin
           cp ./dist/linux_amd64/release/rad ./bin/rad
           chmod +x ./bin/rad
+          export PATH=$GITHUB_WORKSPACE/bin:$PATH
+          which rad || { echo "cannot find rad"; exit 1; }
+          rad bicep publish-extension -f ./test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha.yaml --target br:${{ env.BICEP_TYPES_REGISTRY }}/testresources:latest" --force
+      - name: Publish Bicep Test Recipes
+        if: steps.skip-build.outputs.SKIP_BUILD != 'true'
+        run: |
           export PATH=$GITHUB_WORKSPACE/bin:$PATH
           which rad || { echo "cannot find rad"; exit 1; }
           rad bicep download
@@ -597,6 +596,8 @@ jobs:
           bicep restore ./test/functional-portable/corerp/cloud/resources/testdata/corerp-azure-connection-database-service.bicep --force
           # Restore AWS Bicep types 
           bicep restore ./test/functional-portable/corerp/cloud/resources/testdata/aws-s3-bucket.bicep --force
+          # Restore UDT Test Bicep types
+          bicep restore ./test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha-recipe.bicep
       - name: Run functional tests
         run: |
           # Ensure rad cli is in path before running tests.

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -309,7 +309,7 @@ jobs:
           chmod +x ./bin/rad
           export PATH=$GITHUB_WORKSPACE/bin:$PATH
           which rad || { echo "cannot find rad"; exit 1; }
-          rad bicep publish-extension -f ./test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha.yaml --target br:${{ env.BICEP_TYPES_REGISTRY }}/testresources:latest" --force
+          rad bicep publish-extension -f ./test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha.yaml --target br:${{ env.BICEP_TYPES_REGISTRY }}/testresources:latest --force
       - name: Publish Bicep Test Recipes
         if: steps.skip-build.outputs.SKIP_BUILD != 'true'
         run: |

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -309,6 +309,7 @@ jobs:
           tenant-id: ${{ secrets.BICEPTYPES_TENANT_ID }}
           subscription-id: ${{ secrets.BICEPTYPES_SUBSCRIPTION_ID }}    
       - name: Publish UDT types
+        if: steps.skip-build.outputs.SKIP_BUILD != 'true'
         run: |
           mkdir ./bin
           cp ./dist/linux_amd64/release/rad ./bin/rad

--- a/pkg/corerp/api/v20231001preview/environment_conversion.go
+++ b/pkg/corerp/api/v20231001preview/environment_conversion.go
@@ -313,7 +313,7 @@ func toEnvironmentComputeDataModel(h EnvironmentComputeClassification) (*rpv1.En
 		if v.Identity != nil {
 			identity = &rpv1.IdentitySettings{
 				Kind:            toIdentityKindDataModel(v.Identity.Kind),
-				ManagedIdentity: to.String(v.Identity.ManagedIdentity),
+				ManagedIdentity: to.StringArray(v.Identity.ManagedIdentity),
 			}
 		}
 
@@ -360,7 +360,7 @@ func fromEnvironmentComputeDataModel(envCompute *rpv1.EnvironmentCompute) Enviro
 		if envCompute.Identity != nil {
 			identity = &IdentitySettings{
 				Kind:            fromIdentityKind(envCompute.Identity.Kind),
-				ManagedIdentity: toStringPtr(envCompute.Identity.ManagedIdentity),
+				ManagedIdentity: to.ArrayofStringPtrs(envCompute.Identity.ManagedIdentity),
 			}
 		}
 		compute := &AzureContainerInstanceCompute{

--- a/pkg/corerp/api/v20231001preview/environment_conversion_test.go
+++ b/pkg/corerp/api/v20231001preview/environment_conversion_test.go
@@ -354,7 +354,7 @@ func TestConvertVersionedToDataModel(t *testing.T) {
 						},
 						Identity: &rpv1.IdentitySettings{
 							Kind:            rpv1.ManagedIdentity,
-							ManagedIdentity: "test-mi",
+							ManagedIdentity: []string{"test-mi"},
 						},
 					},
 					Providers: datamodel.Providers{
@@ -582,10 +582,14 @@ func TestConvertDataModelWithACIToVersioned(t *testing.T) {
 	require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup", string(*versioned.Properties.Providers.Azure.Scope))
 	require.Equal(t, &IdentitySettings{
 		Kind:            to.Ptr(IdentitySettingKindManagedIdentity),
-		ManagedIdentity: to.Ptr("test-mi"),
+		ManagedIdentity: []*string{to.Ptr("test-mi-0"), to.Ptr("test-mi-1")},
 	}, versioned.Properties.Compute.GetEnvironmentCompute().Identity)
 	require.Equal(t, "managedIdentity", string(*versioned.Properties.Compute.GetEnvironmentCompute().Identity.Kind))
-	require.Equal(t, "test-mi", string(*versioned.Properties.Compute.GetEnvironmentCompute().Identity.ManagedIdentity))
+	// validate managed identity urls match the template input
+	for i, mi := range versioned.Properties.Compute.GetEnvironmentCompute().Identity.ManagedIdentity {
+		require.Equal(t, "test-mi-"+fmt.Sprintf("%d", i), string(*mi))
+	}
+
 	require.Equal(t, map[string][]*ProviderConfigProperties{}, versioned.Properties.RecipeConfig.Terraform.Providers)
 	require.Equal(t, map[string]*string{}, versioned.Properties.RecipeConfig.Env)
 }

--- a/pkg/corerp/api/v20231001preview/environment_conversion_test.go
+++ b/pkg/corerp/api/v20231001preview/environment_conversion_test.go
@@ -572,26 +572,25 @@ func TestConvertDataModelWithACIToVersioned(t *testing.T) {
 	// act
 	versioned := &EnvironmentResource{}
 	err = versioned.ConvertFrom(r)
+	var envCompute = versioned.Properties.Compute.GetEnvironmentCompute()
 
 	// assert
 	require.NoError(t, err)
 	require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Applications.Core/environments/env0", string(*versioned.ID))
 	require.Equal(t, "env0", string(*versioned.Name))
 	require.Equal(t, "Applications.Core/environments", string(*versioned.Type))
-	require.Equal(t, "aci", string(*versioned.Properties.Compute.GetEnvironmentCompute().Kind))
+	require.Equal(t, "aci", string(*envCompute.Kind))
 	require.Equal(t, "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup", string(*versioned.Properties.Providers.Azure.Scope))
 	require.Equal(t, &IdentitySettings{
 		Kind:            to.Ptr(IdentitySettingKindManagedIdentity),
 		ManagedIdentity: []*string{to.Ptr("test-mi-0"), to.Ptr("test-mi-1")},
-	}, versioned.Properties.Compute.GetEnvironmentCompute().Identity)
-	require.Equal(t, "managedIdentity", string(*versioned.Properties.Compute.GetEnvironmentCompute().Identity.Kind))
+	}, envCompute.Identity)
+	require.Equal(t, "managedIdentity", string(*envCompute.Identity.Kind))
 	// validate managed identity urls match the template input
-	for i, mi := range versioned.Properties.Compute.GetEnvironmentCompute().Identity.ManagedIdentity {
-		require.Equal(t, "test-mi-"+fmt.Sprintf("%d", i), string(*mi))
+	for i, mi := range envCompute.Identity.ManagedIdentity {
+		var expectedUserAssignedManagedIdentityName = "test-mi-" + fmt.Sprintf("%d", i)
+		require.Equal(t, expectedUserAssignedManagedIdentityName, string(*mi))
 	}
-
-	require.Equal(t, map[string][]*ProviderConfigProperties{}, versioned.Properties.RecipeConfig.Terraform.Providers)
-	require.Equal(t, map[string]*string{}, versioned.Properties.RecipeConfig.Env)
 }
 
 func TestConvertFromValidation(t *testing.T) {

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresource-with-acicompute.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresource-with-acicompute.json
@@ -8,7 +8,7 @@
       "resourceGroup": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup",
       "identity": {
         "kind": "managedIdentity",
-        "managedIdentity": "test-mi"
+        "managedIdentity": ["test-mi"]
       }
     },
     "providers": {

--- a/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodel-with-aci.json
+++ b/pkg/corerp/api/v20231001preview/testdata/environmentresourcedatamodel-with-aci.json
@@ -21,7 +21,7 @@
 		},
 		"identity": {
 		  "kind": "managedIdentity",
-		  "managedIdentity": "test-mi"
+		  "managedIdentity": ["test-mi-0", "test-mi-1"]
 		}
 	  },
 	  "providers": {

--- a/pkg/corerp/model/application_model.go
+++ b/pkg/corerp/model/application_model.go
@@ -221,6 +221,20 @@ func NewApplicationModel(arm *armauth.ArmConfig, k8sClient client.Client, k8sCli
 			},
 			ResourceHandler: handlers.NewAzureAppGWHandler(arm),
 		},
+		{
+			ResourceType: resourcemodel.ResourceType{
+				Type:     "Microsoft.Network/loadBalancers",
+				Provider: resourcemodel.ProviderAzure,
+			},
+			ResourceHandler: handlers.NewAzureContainerLoadBalancerHandler(arm),
+		},
+		{
+			ResourceType: resourcemodel.ResourceType{
+				Type:     "Microsoft.Network/vitualNetworks/subnets",
+				Provider: resourcemodel.ProviderAzure,
+			},
+			ResourceHandler: handlers.NewAzureVirtualNetworkSubnetHandler(arm),
+		},
 	}
 	err := checkForDuplicateRegistrations(radiusResourceModel, outputResourceModel)
 	if err != nil {

--- a/pkg/corerp/renderers/aci/renderer.go
+++ b/pkg/corerp/renderers/aci/renderer.go
@@ -361,11 +361,8 @@ func (r Renderer) Render(ctx context.Context, dm v1.DataModelInterface, options 
 		Name:     to.Ptr(resource.Name),
 		Location: to.Ptr(aciLocation),
 		Identity: &ngroupsclient.NGroupIdentity{
-			// TODO: update with user assigned identity
-			Type: to.Ptr(ngroupsclient.ResourceIdentityTypeUserAssigned),
-			UserAssignedIdentities: map[string]*ngroupsclient.UserAssignedIdentities{
-				"/subscriptions/<>/resourceGroups/<>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<>": {},
-			},
+			Type:                   to.Ptr(ngroupsclient.ResourceIdentityTypeUserAssigned),
+			UserAssignedIdentities: ConvertToUserAssignedIdentity(options.Environment.Compute.Identity.ManagedIdentity),
 		},
 		Properties: &ngroupsclient.NGroupProperties{
 			UpdateProfile: &ngroupsclient.UpdateProfile{
@@ -476,4 +473,14 @@ func getSortedKeys(env map[string]EnvVar) []string {
 
 	sort.Strings(keys)
 	return keys
+}
+
+func ConvertToUserAssignedIdentity(urls []string) map[string]*ngroupsclient.UserAssignedIdentities {
+	identities := make(map[string]*ngroupsclient.UserAssignedIdentities)
+
+	for _, url := range urls {
+		identities[url] = &ngroupsclient.UserAssignedIdentities{}
+	}
+
+	return identities
 }

--- a/pkg/rp/v1/identity.go
+++ b/pkg/rp/v1/identity.go
@@ -39,7 +39,7 @@ type IdentitySettings struct {
 	// Resource represents the resource id of managed identity.
 	Resource string `json:"resource,omitempty"`
 	// ManagedIdentity represents the name of the managed identity.
-	ManagedIdentity string `json:"managedIdentity,omitempty"`
+	ManagedIdentity []string `json:"managedIdentity,omitempty"`
 }
 
 // Validate checks if the IdentitySettings struct is nil and if the Kind is AzureIdentityWorkload, checks if the OIDCIssuer

--- a/pkg/rp/v1/identity.go
+++ b/pkg/rp/v1/identity.go
@@ -27,7 +27,7 @@ const (
 	// AzureIdentityWorkload represents Azure Workload identity.
 	AzureIdentityWorkload IdentitySettingKind = "azure.com.workload"
 	// ManagedIdentity represents Azure User Assigned Managed Identity.
-	ManagedIdentity IdentitySettingKind = "managedidentity"
+	ManagedIdentity IdentitySettingKind = "managedIdentity"
 )
 
 // IdentitySettings represents the identity info to access azure resource, such as Key vault.

--- a/pkg/to/ptr.go
+++ b/pkg/to/ptr.go
@@ -40,3 +40,11 @@ func StringMapPtr(ms map[string]string) *map[string]*string {
 	}
 	return &msp
 }
+
+func ArrayofStringPtrs(s []string) []*string {
+	var ptrs []*string
+	for _, val := range s {
+		ptrs = append(ptrs, &val)
+	}
+	return ptrs
+}

--- a/pkg/to/value.go
+++ b/pkg/to/value.go
@@ -34,8 +34,6 @@ func StringArray(s []*string) []string {
 	for _, ptr := range s {
 		if ptr != nil {
 			values = append(values, *ptr)
-		} else {
-			values = append(values, "") // or handle nil however you'd like
 		}
 	}
 	return values

--- a/pkg/to/value.go
+++ b/pkg/to/value.go
@@ -28,6 +28,19 @@ func String(s *string) string {
 	return ""
 }
 
+// Map array of string pointers to an array of strings. If a value in the the array is nil then append empty string.
+func StringArray(s []*string) []string {
+	var values []string
+	for _, ptr := range s {
+		if ptr != nil {
+			values = append(values, *ptr)
+		} else {
+			values = append(values, "") // or handle nil however you'd like
+		}
+	}
+	return values
+}
+
 // StringSlice returns a string slice value for the passed string slice pointer. It returns a nil
 // slice if the pointer is nil.
 func StringSlice(s *[]string) []string {


### PR DESCRIPTION
Add support for ACI-Ngroups managed identity. 
Changes:
Update managed identity data model 
Update environment_conversion to map from API to DM and vice-versa
Update renderer to read and convert array of identity urls to a map of user-assigned managed identity
Update conversion tests to validate identity urls mapping from template to radius API model
