### PR TITLE
Adding Resource Properties to Recipe Context

### DIFF
--- a/pkg/portableresources/backend/controller/createorupdateresource_test.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource_test.go
@@ -333,6 +333,33 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 				data["type"] = 3 // This won't convert to our data model.
 			}
 
+			testResource := &TestResource{
+				Properties: TestResourceProperties{
+					BasicResourceProperties: rpv1.BasicResourceProperties{
+						Application: TestApplicationID,
+						Environment: TestEnvironmentID,
+						Status: rpv1.ResourceStatus{
+							OutputResources: []rpv1.OutputResource{
+								{
+									ID: resources.MustParse(oldOutputResourceResourceID),
+								},
+							},
+						},
+					},
+					IsProcessed: false,
+					Recipe: portableresources.ResourceRecipe{
+						Name: "test-recipe",
+						Parameters: map[string]any{
+							"p1": "v1",
+						},
+					},
+				},
+			}
+
+			controller := &CreateOrUpdateResource[*TestResource, TestResource]{}
+			properties, err := controller.getPropertiesFromResource(testResource)
+			require.NoError(t, err)
+
 			recipeMetadata := recipes.ResourceMetadata{
 				Name:          "test-recipe",
 				EnvironmentID: TestEnvironmentID,
@@ -341,7 +368,9 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 				Parameters: map[string]any{
 					"p1": "v1",
 				},
+				Properties: properties,
 			}
+
 			prevState := []string{
 				oldOutputResourceResourceID,
 			}
@@ -440,4 +469,113 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 			}
 		})
 	}
+}
+
+// PropertiesTestResource is a test resource for testing of resource properties.
+type PropertiesTestResource struct {
+	v1.BaseResource
+	Properties map[string]any `json:"properties"`
+}
+
+func (p *PropertiesTestResource) ResourceMetadata() rpv1.BasicResourcePropertiesAdapter {
+	return nil
+}
+
+func (p *PropertiesTestResource) ApplyDeploymentOutput(deploymentOutput rpv1.DeploymentOutput) error {
+	return nil
+}
+
+func (p *PropertiesTestResource) OutputResources() []rpv1.OutputResource {
+	return nil
+}
+
+func TestGetPropertiesFromResource2(t *testing.T) {
+	tests := []struct {
+		name        string
+		resource    *PropertiesTestResource
+		expected    map[string]any
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "Valid properties 2",
+			resource: &PropertiesTestResource{
+				Properties: map[string]any{
+					"Application": TestApplicationID,
+					"Environment": TestEnvironmentID,
+				},
+			},
+			expected: map[string]any{
+				"Application": TestApplicationID,
+				"Environment": TestEnvironmentID,
+			},
+			expectError: false,
+		},
+		{
+			name: "Empty properties",
+			resource: &PropertiesTestResource{
+				Properties: nil,
+			},
+			expected:    map[string]any{},
+			expectError: false,
+		},
+		{
+			name: "Invalid JSON",
+			resource: &PropertiesTestResource{
+				Properties: map[string]any{
+					"key": func() {}, // Functions cannot be marshaled to JSON
+				},
+			},
+			expected:    nil,
+			expectError: true,
+			errorMsg:    errMarshalResource,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := &CreateOrUpdateResource[*PropertiesTestResource, PropertiesTestResource]{}
+			properties, err := controller.getPropertiesFromResource(tt.resource)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Nil(t, properties)
+				require.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, properties)
+				require.Equal(t, tt.expected, properties)
+			}
+		})
+	}
+}
+
+// InvalidTestResource is a test resource with invalid properties type.
+type InvalidTestResource struct {
+	v1.BaseResource
+	Name string `json:"properties"`
+}
+
+func (p *InvalidTestResource) ResourceMetadata() rpv1.BasicResourcePropertiesAdapter {
+	return nil
+}
+
+func (p *InvalidTestResource) ApplyDeploymentOutput(deploymentOutput rpv1.DeploymentOutput) error {
+	return nil
+}
+
+func (p *InvalidTestResource) OutputResources() []rpv1.OutputResource {
+	return nil
+}
+
+func TestGetPropertiesFromResource_MissingProperties(t *testing.T) {
+	testResource := &InvalidTestResource{
+		Name: "test-resource",
+	}
+
+	controller := &CreateOrUpdateResource[*InvalidTestResource, InvalidTestResource]{}
+	properties, err := controller.getPropertiesFromResource(testResource)
+	require.Error(t, err)
+	require.Nil(t, properties)
+	require.Contains(t, err.Error(), errUnmarshalResourceProperties)
 }

--- a/pkg/portableresources/backend/controller/deleteresource.go
+++ b/pkg/portableresources/backend/controller/deleteresource.go
@@ -75,16 +75,20 @@ func (c *DeleteResource[P, T]) Run(ctx context.Context, request *ctrl.Request) (
 	}
 
 	recipeDataModel, supportsRecipes := any(data).(datamodel.RecipeDataModel)
-
 	// If we have a setup error (error before recipe and output resources are executed, we skip engine/driver deletion.
 	// If we have an execution error, we call engine/driver deletion.
 	if supportsRecipes && recipeDataModel.GetRecipe() != nil && recipeDataModel.GetRecipe().DeploymentStatus != util.RecipeSetupError {
+		resourceProperties, err := GetPropertiesFromResource(data)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 		recipeData := recipes.ResourceMetadata{
 			Name:          recipeDataModel.GetRecipe().Name,
 			EnvironmentID: data.ResourceMetadata().EnvironmentID(),
 			ApplicationID: data.ResourceMetadata().ApplicationID(),
 			Parameters:    recipeDataModel.GetRecipe().Parameters,
 			ResourceID:    id.String(),
+			Properties:    resourceProperties,
 		}
 
 		err = c.engine.Delete(ctx, engine.DeleteOptions{

--- a/pkg/portableresources/backend/controller/deleteresource_test.go
+++ b/pkg/portableresources/backend/controller/deleteresource_test.go
@@ -107,12 +107,25 @@ func TestDeleteResourceRun_20231001Preview(t *testing.T) {
 				},
 			}
 
+			testResource := &TestResource{
+				Properties: TestResourceProperties{
+					BasicResourceProperties: rpv1.BasicResourceProperties{
+						Application: TestApplicationID,
+						Environment: TestEnvironmentID,
+						Status:      status,
+					},
+				},
+			}
+			properties, err := GetPropertiesFromResource(testResource)
+			require.NoError(t, err)
+
 			recipeData := recipes.ResourceMetadata{
 				Name:          "",
 				EnvironmentID: TestEnvironmentID,
 				ApplicationID: TestApplicationID,
 				Parameters:    nil,
 				ResourceID:    resourceID,
+				Properties:    properties,
 			}
 
 			msc.EXPECT().

--- a/pkg/portableresources/backend/controller/utils.go
+++ b/pkg/portableresources/backend/controller/utils.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	errMarshalResource             = "failed to marshal resource"
+	errUnmarshalResourceProperties = "failed to unmarshal resource for properties"
+)
+
+// GetPropertiesFromResource extracts the "properties" field from the resource
+// by serializing it to JSON and deserializing just the "properties" field.
+func GetPropertiesFromResource[P any](resource P) (map[string]any, error) {
+	// Serialize the resource to JSON
+	bytes, err := json.Marshal(resource)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errMarshalResource, err)
+	}
+
+	// Define a minimal struct to capture just the "properties" field
+	var partialResource struct {
+		Properties map[string]any `json:"properties"`
+	}
+
+	// Deserialize the JSON into the partialResource struct
+	if err := json.Unmarshal(bytes, &partialResource); err != nil {
+		return nil, fmt.Errorf("%s: %w", errUnmarshalResourceProperties, err)
+	}
+
+	// Return an empty map if properties is nil
+	if partialResource.Properties == nil {
+		return map[string]any{}, nil
+	}
+
+	return partialResource.Properties, nil
+}

--- a/pkg/portableresources/backend/controller/utils_test.go
+++ b/pkg/portableresources/backend/controller/utils_test.go
@@ -1,0 +1,115 @@
+package controller
+
+import (
+	"testing"
+
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
+	"github.com/stretchr/testify/require"
+)
+
+type PropertiesTestResource struct {
+	v1.BaseResource
+	Properties map[string]any `json:"properties"`
+}
+
+func (p *PropertiesTestResource) ResourceMetadata() rpv1.BasicResourcePropertiesAdapter {
+	return nil
+}
+
+func (p *PropertiesTestResource) ApplyDeploymentOutput(deploymentOutput rpv1.DeploymentOutput) error {
+	return nil
+}
+
+func (p *PropertiesTestResource) OutputResources() []rpv1.OutputResource {
+	return nil
+}
+
+func TestGetPropertiesFromResource(t *testing.T) {
+	tests := []struct {
+		name        string
+		resource    *PropertiesTestResource
+		expected    map[string]any
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "Valid properties",
+			resource: &PropertiesTestResource{
+				Properties: map[string]any{
+					"Application": TestApplicationID,
+					"Environment": TestEnvironmentID,
+				},
+			},
+			expected: map[string]any{
+				"Application": TestApplicationID,
+				"Environment": TestEnvironmentID,
+			},
+			expectError: false,
+		},
+		{
+			name: "Empty properties",
+			resource: &PropertiesTestResource{
+				Properties: nil,
+			},
+			expected:    map[string]any{},
+			expectError: false,
+		},
+		{
+			name: "Invalid JSON",
+			resource: &PropertiesTestResource{
+				Properties: map[string]any{
+					"key": func() {}, // Functions cannot be marshaled to JSON
+				},
+			},
+			expected:    nil,
+			expectError: true,
+			errorMsg:    errMarshalResource,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			properties, err := GetPropertiesFromResource(tt.resource)
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Nil(t, properties)
+				require.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, properties)
+				require.Equal(t, tt.expected, properties)
+			}
+		})
+	}
+}
+
+// InvalidTestResource is a test resource with invalid properties type.
+type InvalidTestResource struct {
+	v1.BaseResource
+	Name string `json:"properties"`
+}
+
+func (p *InvalidTestResource) ResourceMetadata() rpv1.BasicResourcePropertiesAdapter {
+	return nil
+}
+
+func (p *InvalidTestResource) ApplyDeploymentOutput(deploymentOutput rpv1.DeploymentOutput) error {
+	return nil
+}
+
+func (p *InvalidTestResource) OutputResources() []rpv1.OutputResource {
+	return nil
+}
+
+func TestGetPropertiesFromResource_MissingProperties(t *testing.T) {
+	testResource := &InvalidTestResource{
+		Name: "test-resource",
+	}
+
+	properties, err := GetPropertiesFromResource(testResource)
+	require.Error(t, err)
+	require.Nil(t, properties)
+	require.Contains(t, err.Error(), errUnmarshalResourceProperties)
+}

--- a/pkg/recipes/recipecontext/context.go
+++ b/pkg/recipes/recipecontext/context.go
@@ -48,7 +48,8 @@ func New(metadata *recipes.ResourceMetadata, config *recipes.Configuration) (*Co
 				Name: parsedResource.Name(),
 				ID:   metadata.ResourceID,
 			},
-			Type: parsedResource.Type(),
+			Type:       parsedResource.Type(),
+			Properties: metadata.Properties,
 		},
 		Environment: ResourceInfo{
 			Name: parsedEnv.Name(),

--- a/pkg/recipes/recipecontext/context_test.go
+++ b/pkg/recipes/recipecontext/context_test.go
@@ -30,6 +30,11 @@ func TestNewContext(t *testing.T) {
 		ResourceID:    "/planes/radius/local/resourceGroups/testGroup/providers/applications.datastores/mongodatabases/mongo0",
 		EnvironmentID: "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/environments/env0",
 		ApplicationID: "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+		Properties: map[string]any{
+			"throughput":               100,
+			"isZoneRedundant":          false,
+			"databaseAccountOfferType": "Standard",
+		},
 	}
 
 	ctxTests := []struct {
@@ -60,18 +65,19 @@ func TestNewContext(t *testing.T) {
 			out: &Context{
 				Resource: Resource{
 					ResourceInfo: ResourceInfo{
-						ID:   "/planes/radius/local/resourceGroups/testGroup/providers/applications.datastores/mongodatabases/mongo0",
 						Name: "mongo0",
+						ID:   testMetadata.ResourceID,
 					},
-					Type: "applications.datastores/mongodatabases",
+					Type:       "applications.datastores/mongodatabases",
+					Properties: testMetadata.Properties,
 				},
 				Application: ResourceInfo{
 					Name: "testApplication",
-					ID:   "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+					ID:   testMetadata.ApplicationID,
 				},
 				Environment: ResourceInfo{
 					Name: "env0",
-					ID:   "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+					ID:   testMetadata.EnvironmentID,
 				},
 				Runtime: recipes.RuntimeConfiguration{
 					Kubernetes: &recipes.KubernetesRuntime{
@@ -110,18 +116,19 @@ func TestNewContext(t *testing.T) {
 			out: &Context{
 				Resource: Resource{
 					ResourceInfo: ResourceInfo{
-						ID:   "/planes/radius/local/resourceGroups/testGroup/providers/applications.datastores/mongodatabases/mongo0",
 						Name: "mongo0",
+						ID:   testMetadata.ResourceID,
 					},
-					Type: "applications.datastores/mongodatabases",
+					Type:       "applications.datastores/mongodatabases",
+					Properties: testMetadata.Properties,
 				},
 				Application: ResourceInfo{
 					Name: "testApplication",
-					ID:   "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+					ID:   testMetadata.ApplicationID,
 				},
 				Environment: ResourceInfo{
 					Name: "env0",
-					ID:   "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+					ID:   testMetadata.EnvironmentID,
 				},
 				Runtime: recipes.RuntimeConfiguration{
 					Kubernetes: &recipes.KubernetesRuntime{
@@ -150,18 +157,19 @@ func TestNewContext(t *testing.T) {
 			out: &Context{
 				Resource: Resource{
 					ResourceInfo: ResourceInfo{
-						ID:   "/planes/radius/local/resourceGroups/testGroup/providers/applications.datastores/mongodatabases/mongo0",
 						Name: "mongo0",
+						ID:   testMetadata.ResourceID,
 					},
-					Type: "applications.datastores/mongodatabases",
+					Type:       "applications.datastores/mongodatabases",
+					Properties: testMetadata.Properties,
 				},
 				Application: ResourceInfo{
 					Name: "testApplication",
-					ID:   "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/applications/testApplication",
+					ID:   testMetadata.ApplicationID,
 				},
 				Environment: ResourceInfo{
 					Name: "env0",
-					ID:   "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/environments/env0",
+					ID:   testMetadata.EnvironmentID,
 				},
 				Runtime: recipes.RuntimeConfiguration{
 					Kubernetes: &recipes.KubernetesRuntime{

--- a/pkg/recipes/recipecontext/types.go
+++ b/pkg/recipes/recipecontext/types.go
@@ -50,6 +50,9 @@ type Resource struct {
 	ResourceInfo
 	// Type represents the resource type, this will be a namespace/type combo. Ex. Applications.Core/Environment
 	Type string `json:"type"`
+
+	// Properties represents the properties of the resource.
+	Properties map[string]any `json:"properties,omitempty"`
 }
 
 // ResourceInfo represents name and id of the resource

--- a/pkg/recipes/types.go
+++ b/pkg/recipes/types.go
@@ -67,7 +67,7 @@ type EnvironmentDefinition struct {
 	PlainHTTP bool
 }
 
-// ResourceMetadata represents recipe details provided while creating a portable resource.
+// ResourceMetadata represents recipe details provided while deploying a portable or a user-defined resource.
 type ResourceMetadata struct {
 	// Name represents the name of the recipe within the environment
 	Name string
@@ -77,6 +77,8 @@ type ResourceMetadata struct {
 	EnvironmentID string
 	// ResourceID represents fully qualified resource ID for the resource the recipe is deploying
 	ResourceID string
+	// Properties represents the properties of the resource that the recipe is deploying
+	Properties map[string]any
 	// Parameters represents key/value pairs to pass into the recipe template. Overrides any parameters set by the environment.
 	Parameters map[string]any
 }

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/postgres-env-scoped-resource.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/postgres-env-scoped-resource.bicep
@@ -5,6 +5,9 @@ param registry string
 
 param version string
 
+@description('PostgreSQL password')
+param password string = 'P@ssword1234$$'
+
 resource udtenv 'Applications.Core/environments@2023-10-01-preview' = {
   name: 'dynamicrp-postgres-env'
   location: 'global'
@@ -30,5 +33,6 @@ resource udtpg 'Test.Resources/postgres@2023-10-01-preview' = {
   location: 'global'
   properties: {
     environment: udtenv.id
+    password: password
   }
 }

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/postgres-env-scoped-resource.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/postgres-env-scoped-resource.bicep
@@ -6,7 +6,8 @@ param registry string
 param version string
 
 @description('PostgreSQL password')
-param password string = 'P@ssword1234$$'
+@secure()
+param password string = newGuid()
 
 resource udtenv 'Applications.Core/environments@2023-10-01-preview' = {
   name: 'dynamicrp-postgres-env'

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha.yaml
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha.yaml
@@ -27,6 +27,9 @@ types:
             application:
               type: string
               description: The resource ID of the application.
+            password:
+              type: string
+              description: The password for the database.
             status:
               type: object
               properties:

--- a/test/testrecipes/test-bicep-recipes/dynamicrp_postgress_recipe.bicep
+++ b/test/testrecipes/test-bicep-recipes/dynamicrp_postgress_recipe.bicep
@@ -26,7 +26,7 @@ param user string = 'postgres'
 @description('PostgreSQL password')
 @secure()
 #disable-next-line secure-parameter-default
-param password string = 'P@ssword1234$$'
+param password string = context.resource.properties.password
 
 @description('Tag to pull for the postgres container image.')
 param tag string = '16-alpine'


### PR DESCRIPTION
# Description

We want the ability to access resource properties in the recipe through recipe context. Changes include

* Adding resource properties to recipe context data model.
* Populating resource properties in recipe context initialization.
* Passing resource properties into resource metadata for recipe execution during UDT creation and deletion.
* Updated end to end test.

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable - captured as a part of overall UDT docs.
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable