### PR TITLE
Waiting for the cache to sync in flux test

### DIFF
--- a/pkg/controller/reconciler/flux_controller_test.go
+++ b/pkg/controller/reconciler/flux_controller_test.go
@@ -149,7 +149,6 @@ func setupFluxControllerTest(t *testing.T, opts setupFluxControllerTestOptions, 
 		Metrics: server.Options{
 			BindAddress: "0",
 		},
-		// Disable leader election for tests to prevent timeout
 		LeaderElection: false,
 	})
 	require.NoError(t, err)
@@ -163,34 +162,10 @@ func setupFluxControllerTest(t *testing.T, opts setupFluxControllerTestOptions, 
 	err = (fluxController).SetupWithManager(mgr)
 	require.NoError(t, err)
 
-	mgrCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	managerErr := make(chan error, 1)
 	go func() {
-		if err := mgr.Start(mgrCtx); err != nil {
-			managerErr <- err
-		}
+		err := mgr.Start(ctx)
+		require.NoError(t, err)
 	}()
-
-	t.Log("Waiting for cache to be ready")
-	waitCtx, waitCancel := context.WithTimeout(ctx, 30*time.Second)
-	defer waitCancel()
-
-	err = wait.PollUntilContextTimeout(waitCtx, 100*time.Millisecond, 30*time.Second, true,
-		func(ctx context.Context) (bool, error) {
-			select {
-			case err := <-managerErr:
-				return false, fmt.Errorf("manager failed to start: %w", err)
-			default:
-				// No error, continue checking cache
-			}
-
-			return mgr.GetCache().WaitForCacheSync(ctx), nil
-		})
-
-	require.NoError(t, err, "timeout waiting for cache to be ready")
-	t.Log("Cache is ready")
 
 	var archiveFetcherCalls []any
 	var bicepCalls []any


### PR DESCRIPTION
# Description

Fixes a race condition in **flux_controller_test.go** where tests could attempt to use the Kubernetes client before the controller manager's cache was fully synchronized. The fix ensures synchronization by waiting for the manager's election signal before proceeding to wait for the cache sync.

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #9235 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable