### PR TITLE
Fixing the cache is not started, can not read objects error in flux unit test

### DIFF
--- a/pkg/controller/reconciler/flux_controller_test.go
+++ b/pkg/controller/reconciler/flux_controller_test.go
@@ -15,6 +15,7 @@ package reconciler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -144,8 +145,6 @@ func setupFluxControllerTest(t *testing.T, opts setupFluxControllerTestOptions, 
 		Controller: crconfig.Controller{
 			SkipNameValidation: to.Ptr(true),
 		},
-
-		// Suppress metrics in tests to avoid conflicts.
 		Metrics: server.Options{
 			BindAddress: "0",
 		},
@@ -162,10 +161,41 @@ func setupFluxControllerTest(t *testing.T, opts setupFluxControllerTestOptions, 
 	err = (fluxController).SetupWithManager(mgr)
 	require.NoError(t, err)
 
+	mgrCtx, mgrCancel := context.WithCancel(ctx)
+	t.Cleanup(mgrCancel)
+
+	managerErr := make(chan error, 1)
 	go func() {
-		err := mgr.Start(ctx)
-		require.NoError(t, err)
+		t.Log("Starting manager...")
+		if err := mgr.Start(mgrCtx); err != nil {
+			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+				managerErr <- fmt.Errorf("manager failed to start: %w", err)
+			}
+		}
+		t.Log("Manager stopped.")
 	}()
+
+	t.Log("Waiting for cache to be ready")
+	waitCtx, waitCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer waitCancel()
+
+	err = wait.PollUntilContextTimeout(waitCtx, 100*time.Millisecond, 30*time.Second, true,
+		func(pollCtx context.Context) (bool, error) {
+			select {
+			case err := <-managerErr:
+				return false, fmt.Errorf("manager failed to start: %w", err)
+			default:
+				// No immediate error, check cache
+			}
+
+			if mgr.GetCache().WaitForCacheSync(pollCtx) {
+				return true, nil
+			}
+			return false, nil
+		})
+
+	require.NoError(t, err, "timeout or error waiting for cache to be ready")
+	t.Log("Cache is ready")
 
 	var archiveFetcherCalls []any
 	var bicepCalls []any


### PR DESCRIPTION
# Description

Fixing the cache is not started, can not read objects error in flux unit test.

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [ ] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [ ] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable