### PR TITLE
Fix race conditions in Gateway timeout functional tests

### DIFF
--- a/test/functional-portable/corerp/noncloud/resources/gateway_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/gateway_test.go
@@ -193,38 +193,40 @@ func Test_Gateway_SSLPassthrough(t *testing.T) {
 
 func Test_Gateway_Timeout(t *testing.T) {
 	template := "testdata/corerp-resources-gateway-timeout.bicep"
-	name := "corerp-resources-gateway-timeout"
-	appNamespace := "default-corerp-resources-gateway-timeout"
+	appName := "gateway-timeout-app"
+	appNamespace := "default-gateway-timeout-app"
+	gatewayName := "gateway-timeout"
+	ctnrName := "gateway-timeout-ctnr"
 
-	test := rp.NewRPTest(t, name, []rp.TestStep{
+	test := rp.NewRPTest(t, gatewayName, []rp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, testutil.GetMagpieImage()),
+			Executor: step.NewDeployExecutor(template, testutil.GetMagpieImage(), "appName="+appName, "name="+gatewayName, "ctnrName="+ctnrName),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
-						Name: name,
+						Name: appName,
 						Type: validation.ApplicationsResource,
 					},
 					{
-						Name: "timeout-gtwy-gtwy",
+						Name: gatewayName,
 						Type: validation.GatewaysResource,
-						App:  name,
+						App:  appName,
 					},
 				},
 			},
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(name, "timeout-gtwy-front-ctnr"),
-						validation.NewK8sHTTPProxyForResource(name, "timeout-gtwy-gtwy"),
-						validation.NewK8sHTTPProxyForResource(name, "timeout-gtwy-front-ctnr"),
-						validation.NewK8sServiceForResource(name, "timeout-gtwy-front-ctnr"),
+						validation.NewK8sPodForResource(appName, ctnrName),
+						validation.NewK8sHTTPProxyForResource(appName, gatewayName),
+						validation.NewK8sHTTPProxyForResource(appName, ctnrName),
+						validation.NewK8sServiceForResource(appName, ctnrName),
 					},
 				},
 			},
 			PostStepVerify: func(ctx context.Context, t *testing.T, ct rp.RPTest) {
 				// Get hostname from root HTTPProxy in application namespace
-				metadata, err := testutil.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, name)
+				metadata, err := testutil.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, gatewayName)
 				require.NoError(t, err)
 				t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
 
@@ -253,7 +255,9 @@ func Test_Gateway_Timeout(t *testing.T) {
 
 func Test_Gateway_Timeout_Backend_Exceeds_Request(t *testing.T) {
 	template := "testdata/corerp-resources-gateway-timeout-ber.bicep"
-	name := "corerp-resources-gateway-timeout-ber"
+	appName := "gateway-timeout-ber-app"
+	ctnrName := "gateway-timeout-ber-ctnr"
+	gatewayName := "gateway-timeout-ber"
 
 	validateFn := step.ValidateAnyDetails("DeploymentFailed", []step.DeploymentErrorDetail{
 		{
@@ -266,9 +270,9 @@ func Test_Gateway_Timeout_Backend_Exceeds_Request(t *testing.T) {
 			},
 		},
 	})
-	test := rp.NewRPTest(t, name, []rp.TestStep{
+	test := rp.NewRPTest(t, gatewayName, []rp.TestStep{
 		{
-			Executor:                               step.NewDeployErrorExecutor(template, validateFn, testutil.GetMagpieImage()),
+			Executor:                               step.NewDeployErrorExecutor(template, validateFn, testutil.GetMagpieImage(), "appName="+appName, "name="+gatewayName, "ctnrName="+ctnrName),
 			SkipObjectValidation:                   true,
 			SkipKubernetesOutputResourceValidation: true,
 		},
@@ -278,7 +282,9 @@ func Test_Gateway_Timeout_Backend_Exceeds_Request(t *testing.T) {
 
 func Test_Gateway_Timeout_Invalid_Duration(t *testing.T) {
 	template := "testdata/corerp-resources-gateway-timeout-invalid.bicep"
-	name := "corerp-resources-gateway-timeout-invalid"
+	appName := "gateway-timeout-invalid-app"
+	ctnrName := "gateway-timeout-invalid-ctnr"
+	gatewayName := "gateway-timeout-invalid"
 
 	validateFn := step.ValidateAnyDetails("DeploymentFailed", []step.DeploymentErrorDetail{
 		{
@@ -292,9 +298,9 @@ func Test_Gateway_Timeout_Invalid_Duration(t *testing.T) {
 		},
 	})
 
-	test := rp.NewRPTest(t, name, []rp.TestStep{
+	test := rp.NewRPTest(t, gatewayName, []rp.TestStep{
 		{
-			Executor:                               step.NewDeployErrorExecutor(template, validateFn, testutil.GetMagpieImage()),
+			Executor:                               step.NewDeployErrorExecutor(template, validateFn, testutil.GetMagpieImage(), "appName="+appName, "name="+gatewayName, "ctnrName="+ctnrName),
 			SkipObjectValidation:                   true,
 			SkipKubernetesOutputResourceValidation: true,
 		},

--- a/test/functional-portable/corerp/noncloud/resources/gateway_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/gateway_test.go
@@ -196,11 +196,11 @@ func Test_Gateway_Timeout(t *testing.T) {
 	appName := "gateway-timeout-app"
 	appNamespace := "default-gateway-timeout-app"
 	gatewayName := "gateway-timeout"
-	ctnrName := "gateway-timeout-ctnr"
+	containerName := "gateway-timeout-ctnr"
 
-	test := rp.NewRPTest(t, gatewayName, []rp.TestStep{
+	test := rp.NewRPTest(t, appName, []rp.TestStep{
 		{
-			Executor: step.NewDeployExecutor(template, testutil.GetMagpieImage(), "appName="+appName, "name="+gatewayName, "ctnrName="+ctnrName),
+			Executor: step.NewDeployExecutor(template, testutil.GetMagpieImage(), "appName="+appName, "gatewayName="+gatewayName, "containerName="+containerName),
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
 					{
@@ -217,16 +217,16 @@ func Test_Gateway_Timeout(t *testing.T) {
 			K8sObjects: &validation.K8sObjectSet{
 				Namespaces: map[string][]validation.K8sObject{
 					appNamespace: {
-						validation.NewK8sPodForResource(appName, ctnrName),
+						validation.NewK8sPodForResource(appName, containerName),
 						validation.NewK8sHTTPProxyForResource(appName, gatewayName),
-						validation.NewK8sHTTPProxyForResource(appName, ctnrName),
-						validation.NewK8sServiceForResource(appName, ctnrName),
+						validation.NewK8sHTTPProxyForResource(appName, containerName),
+						validation.NewK8sServiceForResource(appName, containerName),
 					},
 				},
 			},
 			PostStepVerify: func(ctx context.Context, t *testing.T, ct rp.RPTest) {
 				// Get hostname from root HTTPProxy in application namespace
-				metadata, err := testutil.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, gatewayName)
+				metadata, err := testutil.GetHTTPProxyMetadata(ctx, ct.Options.Client, appNamespace, appName)
 				require.NoError(t, err)
 				t.Logf("found root proxy with hostname: {%s} and status: {%s}", metadata.Hostname, metadata.Status)
 
@@ -256,7 +256,7 @@ func Test_Gateway_Timeout(t *testing.T) {
 func Test_Gateway_Timeout_Backend_Exceeds_Request(t *testing.T) {
 	template := "testdata/corerp-resources-gateway-timeout-ber.bicep"
 	appName := "gateway-timeout-ber-app"
-	ctnrName := "gateway-timeout-ber-ctnr"
+	containerName := "gateway-timeout-ber-ctnr"
 	gatewayName := "gateway-timeout-ber"
 
 	validateFn := step.ValidateAnyDetails("DeploymentFailed", []step.DeploymentErrorDetail{
@@ -270,9 +270,9 @@ func Test_Gateway_Timeout_Backend_Exceeds_Request(t *testing.T) {
 			},
 		},
 	})
-	test := rp.NewRPTest(t, gatewayName, []rp.TestStep{
+	test := rp.NewRPTest(t, appName, []rp.TestStep{
 		{
-			Executor:                               step.NewDeployErrorExecutor(template, validateFn, testutil.GetMagpieImage(), "appName="+appName, "name="+gatewayName, "ctnrName="+ctnrName),
+			Executor:                               step.NewDeployErrorExecutor(template, validateFn, testutil.GetMagpieImage(), "appName="+appName, "gatewayName="+gatewayName, "containerName="+containerName),
 			SkipObjectValidation:                   true,
 			SkipKubernetesOutputResourceValidation: true,
 		},
@@ -283,7 +283,7 @@ func Test_Gateway_Timeout_Backend_Exceeds_Request(t *testing.T) {
 func Test_Gateway_Timeout_Invalid_Duration(t *testing.T) {
 	template := "testdata/corerp-resources-gateway-timeout-invalid.bicep"
 	appName := "gateway-timeout-invalid-app"
-	ctnrName := "gateway-timeout-invalid-ctnr"
+	containerName := "gateway-timeout-invalid-ctnr"
 	gatewayName := "gateway-timeout-invalid"
 
 	validateFn := step.ValidateAnyDetails("DeploymentFailed", []step.DeploymentErrorDetail{
@@ -298,9 +298,9 @@ func Test_Gateway_Timeout_Invalid_Duration(t *testing.T) {
 		},
 	})
 
-	test := rp.NewRPTest(t, gatewayName, []rp.TestStep{
+	test := rp.NewRPTest(t, appName, []rp.TestStep{
 		{
-			Executor:                               step.NewDeployErrorExecutor(template, validateFn, testutil.GetMagpieImage(), "appName="+appName, "name="+gatewayName, "ctnrName="+ctnrName),
+			Executor:                               step.NewDeployErrorExecutor(template, validateFn, testutil.GetMagpieImage(), "appName="+appName, "gatewayName="+gatewayName, "containerName="+containerName),
 			SkipObjectValidation:                   true,
 			SkipKubernetesOutputResourceValidation: true,
 		},

--- a/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-gateway-timeout-ber.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-gateway-timeout-ber.bicep
@@ -7,10 +7,10 @@ param environment string
 param appName string
 
 @description('Name of the Gateway resource.')
-param name string
+param gatewayName string
 
 @description('Name of the Container resource.')
-param ctnrName string
+param containerName string
 
 @description('Specifies the port for the container resource.')
 param port int = 3000
@@ -26,13 +26,13 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
 }
 
 resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
-  name: name
+  name: gatewayName
   properties: {
     application: app.id
     routes: [
       {
         path: '/'
-        destination: 'http://timeout-gtwy-front-ctnr:81'
+        destination: 'http://${containerName}:81'
         timeoutPolicy: {
           request: '30s'
           backendRequest: '40s'
@@ -43,7 +43,7 @@ resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
 }
 
 resource frontendContainer 'Applications.Core/containers@2023-10-01-preview' = {
-  name: ctnrName
+  name: containerName
   properties: {
     application: app.id
     container: {

--- a/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-gateway-timeout-ber.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-gateway-timeout-ber.bicep
@@ -3,6 +3,15 @@ extension radius
 @description('Specifies the environment for resources.')
 param environment string
 
+@description('Name of the Radius Application.')
+param appName string
+
+@description('Name of the Gateway resource.')
+param name string
+
+@description('Name of the Container resource.')
+param ctnrName string
+
 @description('Specifies the port for the container resource.')
 param port int = 3000
 
@@ -10,14 +19,14 @@ param port int = 3000
 param magpieimage string
 
 resource app 'Applications.Core/applications@2023-10-01-preview' = {
-  name: 'corerp-resources-gateway-timeout'
+  name: appName
   properties: {
     environment: environment
   }
 }
 
 resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
-  name: 'timeout-gtwy-gtwy'
+  name: name
   properties: {
     application: app.id
     routes: [
@@ -34,7 +43,7 @@ resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
 }
 
 resource frontendContainer 'Applications.Core/containers@2023-10-01-preview' = {
-  name: 'timeout-gtwy-front-ctnr'
+  name: ctnrName
   properties: {
     application: app.id
     container: {

--- a/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-gateway-timeout-invalid.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-gateway-timeout-invalid.bicep
@@ -3,6 +3,15 @@ extension radius
 @description('Specifies the environment for resources.')
 param environment string
 
+@description('Name of the Radius Application.')
+param appName string
+
+@description('Name of the Gateway resource.')
+param name string
+
+@description('Name of the Container resource.')
+param ctnrName string
+
 @description('Specifies the port for the container resource.')
 param port int = 3000
 
@@ -10,14 +19,14 @@ param port int = 3000
 param magpieimage string
 
 resource app 'Applications.Core/applications@2023-10-01-preview' = {
-  name: 'corerp-resources-gateway-timeout'
+  name: appName
   properties: {
     environment: environment
   }
 }
 
 resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
-  name: 'timeout-gtwy-gtwy'
+  name: name
   properties: {
     application: app.id
     routes: [
@@ -33,7 +42,7 @@ resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
 }
 
 resource frontendContainer 'Applications.Core/containers@2023-10-01-preview' = {
-  name: 'timeout-gtwy-front-ctnr'
+  name: ctnrName
   properties: {
     application: app.id
     container: {

--- a/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-gateway-timeout-invalid.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-gateway-timeout-invalid.bicep
@@ -7,10 +7,10 @@ param environment string
 param appName string
 
 @description('Name of the Gateway resource.')
-param name string
+param gatewayName string
 
 @description('Name of the Container resource.')
-param ctnrName string
+param containerName string
 
 @description('Specifies the port for the container resource.')
 param port int = 3000
@@ -26,13 +26,13 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
 }
 
 resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
-  name: name
+  name: gatewayName
   properties: {
     application: app.id
     routes: [
       {
         path: '/'
-        destination: 'http://timeout-gtwy-front-ctnr:81'
+        destination: 'http://${containerName}:81'
         timeoutPolicy: {
           request: '30potatoes'
         }
@@ -42,7 +42,7 @@ resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
 }
 
 resource frontendContainer 'Applications.Core/containers@2023-10-01-preview' = {
-  name: ctnrName
+  name: containerName
   properties: {
     application: app.id
     container: {

--- a/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-gateway-timeout.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-gateway-timeout.bicep
@@ -3,6 +3,15 @@ extension radius
 @description('Specifies the environment for resources.')
 param environment string
 
+@description('Name of the Radius Application.')
+param appName string
+
+@description('Name of the Gateway resource.')
+param name string
+
+@description('Name of the Container resource.')
+param ctnrName string
+
 @description('Specifies the port for the container resource.')
 param port int = 3000
 
@@ -10,14 +19,14 @@ param port int = 3000
 param magpieimage string
 
 resource app 'Applications.Core/applications@2023-10-01-preview' = {
-  name: 'corerp-resources-gateway-timeout'
+  name: appName
   properties: {
     environment: environment
   }
 }
 
 resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
-  name: 'timeout-gtwy-gtwy'
+  name: name
   properties: {
     application: app.id
     routes: [
@@ -33,7 +42,7 @@ resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
 }
 
 resource frontendContainer 'Applications.Core/containers@2023-10-01-preview' = {
-  name: 'timeout-gtwy-front-ctnr'
+  name: ctnrName
   properties: {
     application: app.id
     container: {

--- a/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-gateway-timeout.bicep
+++ b/test/functional-portable/corerp/noncloud/resources/testdata/corerp-resources-gateway-timeout.bicep
@@ -7,10 +7,10 @@ param environment string
 param appName string
 
 @description('Name of the Gateway resource.')
-param name string
+param gatewayName string
 
 @description('Name of the Container resource.')
-param ctnrName string
+param containerName string
 
 @description('Specifies the port for the container resource.')
 param port int = 3000
@@ -26,13 +26,13 @@ resource app 'Applications.Core/applications@2023-10-01-preview' = {
 }
 
 resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
-  name: name
+  name: gatewayName
   properties: {
     application: app.id
     routes: [
       {
         path: '/'
-        destination: 'http://timeout-gtwy-front-ctnr:81'
+        destination: 'http://${containerName}:81'
         timeoutPolicy: {
           request: '30s'
         }
@@ -42,7 +42,7 @@ resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
 }
 
 resource frontendContainer 'Applications.Core/containers@2023-10-01-preview' = {
-  name: ctnrName
+  name: containerName
   properties: {
     application: app.id
     container: {


### PR DESCRIPTION
# Description

The Gateway timeout functional tests were all using the same resource name, which caused race conditions when the tests were executed in parallel. Updated the tests to use unique names so they don't interfere with each other.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes:
https://github.com/radius-project/radius/issues/9404
https://github.com/radius-project/radius/issues/9415
https://github.com/radius-project/radius/issues/9416

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable