### PR TITLE
ts-node call fix for node 23+

### DIFF
--- a/hack/bicep-types-radius/src/generator/package.json
+++ b/hack/bicep-types-radius/src/generator/package.json
@@ -4,7 +4,7 @@
   "description": "The Azure Bicep extension for classic generators in AutoRest.",
   "scripts": {
     "build": "tsc -p .",
-    "generate": "ts-node src/cmd/generate",
+    "generate": "ts-node src/cmd/generate.ts",
     "lint": "eslint src --ext ts",
     "lint:fix": "eslint src --ext ts --fix"
   },


### PR DESCRIPTION
# Description

In Node 23+, [this line of code](https://github.com/radius-project/radius/blob/main/hack/bicep-types-radius/src/generator/package.json#L7) is throwing an error because it is expecting generate.ts instead of just generate. This PR adds `.ts` to that line.

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (issue link required).
Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [ ] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [ ] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable