### PR TITLE
update terraform kubernetes provider to fix getResourceIdentitySchemas Not Implemented issue

### DIFF
--- a/test/testrecipes/test-terraform-recipes/k8ssecret-context/main.tf
+++ b/test/testrecipes/test-terraform-recipes/k8ssecret-context/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.0"
+      version = ">= 2.37.1"
     }
   }
 }

--- a/test/testrecipes/test-terraform-recipes/kubernetes-redis/modules/main.tf
+++ b/test/testrecipes/test-terraform-recipes/kubernetes-redis/modules/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.0"
+      version = ">= 2.37.1"
     }
   }
 }

--- a/test/testrecipes/test-terraform-recipes/postgres/main.tf
+++ b/test/testrecipes/test-terraform-recipes/postgres/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.0"
+      version = ">= 2.37.1"
     }
     postgresql = {
       source  = "cyrilgdn/postgresql"


### PR DESCRIPTION
# Description

updating the kubernetes provider version to fix the GetResourceIdentitySchemas Not Implemented issue based on 
https://github.com/hashicorp/terraform-provider-kubernetes/issues/2732 discussion.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #9673

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [ ] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [ ] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable