### PR TITLE
Adding the PreflightCheck interface and adding the version check preflight check

### DIFF
--- a/pkg/upgrade/README.md
+++ b/pkg/upgrade/README.md
@@ -1,0 +1,61 @@
+# Radius Upgrade Package
+
+This package contains utilities and components for upgrading Radius installations across different platforms and contexts.
+
+## Structure
+
+- `preflight/` - Pre-upgrade validation checks that can be used by any component
+
+## Preflight Checks
+
+The preflight checks are designed to be reusable across different upgrade contexts:
+
+- **CLI Commands** - `rad upgrade kubernetes` command
+- **Controllers** - Kubernetes controllers managing Radius upgrades
+- **APIs** - REST APIs that trigger upgrade operations
+- **Automated Systems** - CI/CD or GitOps systems managing Radius
+
+### Available Checks
+
+Currently implemented:
+
+1. **VersionCompatibilityCheck** - Validates version upgrade paths and prevents downgrades
+
+### Usage Example
+
+```go
+import (
+    "context"
+    "github.com/radius-project/radius/pkg/upgrade/preflight"
+    "github.com/radius-project/radius/pkg/cli/output"
+)
+
+func validateUpgrade(ctx context.Context, output output.Interface, currentVersion, targetVersion string) error {
+    // Create preflight check registry
+    registry := preflight.NewRegistry(output)
+
+    // Add checks to registry
+    registry.AddCheck(preflight.NewVersionCompatibilityCheck(currentVersion, targetVersion))
+
+    // Run all checks - registry handles execution and logging
+    results, err := registry.RunChecks(ctx)
+    if err != nil {
+        return fmt.Errorf("preflight checks failed: %w", err)
+    }
+
+    // All checks passed
+    return nil
+}
+```
+
+### Extensibility
+
+The preflight check system is designed to be extensible. New checks can be added by implementing the `PreflightCheck` interface:
+
+```go
+type PreflightCheck interface {
+    Run(ctx context.Context) (bool, string, error)
+    Name() string
+    Severity() CheckSeverity
+}
+```

--- a/pkg/upgrade/preflight/registry.go
+++ b/pkg/upgrade/preflight/registry.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/radius-project/radius/pkg/cli/output"
+)
+
+// Registry manages and executes a collection of preflight checks.
+type Registry struct {
+	checks []PreflightCheck
+	output output.Interface
+}
+
+// NewRegistry creates a new preflight check registry.
+func NewRegistry(output output.Interface) *Registry {
+	return &Registry{
+		checks: []PreflightCheck{},
+		output: output,
+	}
+}
+
+// AddCheck adds a preflight check to the registry.
+func (r *Registry) AddCheck(check PreflightCheck) {
+	r.checks = append(r.checks, check)
+}
+
+// RunChecks executes all registered preflight checks and returns the results.
+// If any Error severity check fails, the function returns an error immediately.
+func (r *Registry) RunChecks(ctx context.Context) ([]CheckResult, error) {
+	if len(r.checks) == 0 {
+		return []CheckResult{}, nil
+	}
+
+	r.output.LogInfo("Running pre-flight checks...")
+
+	results := make([]CheckResult, 0, len(r.checks))
+
+	for _, check := range r.checks {
+		r.output.LogInfo("  Running %s...", check.Name())
+
+		success, message, err := check.Run(ctx)
+		result := CheckResult{
+			Check:    check,
+			Success:  success,
+			Message:  message,
+			Error:    err,
+			Severity: check.Severity(),
+		}
+
+		results = append(results, result)
+
+		r.logCheckResult(result)
+
+		// If this is an error severity check and it failed, stop immediately
+		if result.Severity == SeverityError && (!success || err != nil) {
+			return results, fmt.Errorf("pre-flight check '%s' failed: %s", check.Name(), r.getFailureReason(result))
+		}
+	}
+
+	r.output.LogInfo("Pre-flight checks completed successfully")
+	return results, nil
+}
+
+// logCheckResult logs the result of a preflight check with appropriate formatting.
+func (r *Registry) logCheckResult(result CheckResult) {
+	status := "✓"
+	if !result.Success || result.Error != nil {
+		status = "✗"
+	}
+
+	message := result.Message
+	if result.Error != nil {
+		if message == "" {
+			message = result.Error.Error()
+		} else {
+			message = fmt.Sprintf("%s (%s)", message, result.Error.Error())
+		}
+	}
+
+	// Use LogInfo for all messages with severity prefix
+	switch result.Severity {
+	case SeverityError:
+		if result.Success && result.Error == nil {
+			r.output.LogInfo("    %s %s", status, message)
+		} else {
+			r.output.LogInfo("    %s [ERROR] %s", status, message)
+		}
+	case SeverityWarning:
+		if result.Success && result.Error == nil {
+			r.output.LogInfo("    %s %s", status, message)
+		} else {
+			r.output.LogInfo("    %s [WARNING] %s", status, message)
+		}
+	case SeverityInfo:
+		r.output.LogInfo("    %s %s", status, message)
+	}
+}
+
+// getFailureReason returns a descriptive reason for why a check failed.
+func (r *Registry) getFailureReason(result CheckResult) string {
+	if result.Error != nil {
+		return result.Error.Error()
+	}
+	if result.Message != "" {
+		return result.Message
+	}
+	return "check failed"
+}

--- a/pkg/upgrade/preflight/registry_test.go
+++ b/pkg/upgrade/preflight/registry_test.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preflight
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MockPreflightCheck implements PreflightCheck for testing
+type MockPreflightCheck struct {
+	name     string
+	severity CheckSeverity
+	success  bool
+	message  string
+	err      error
+}
+
+func (m *MockPreflightCheck) Name() string            { return m.name }
+func (m *MockPreflightCheck) Severity() CheckSeverity { return m.severity }
+func (m *MockPreflightCheck) Run(ctx context.Context) (bool, string, error) {
+	return m.success, m.message, m.err
+}
+
+func TestRegistry_NewRegistry(t *testing.T) {
+	mockOutput := &output.MockOutput{}
+	registry := NewRegistry(mockOutput)
+
+	assert.NotNil(t, registry)
+	assert.Equal(t, mockOutput, registry.output)
+	assert.Empty(t, registry.checks)
+}
+
+func TestRegistry_AddCheck(t *testing.T) {
+	mockOutput := &output.MockOutput{}
+	registry := NewRegistry(mockOutput)
+
+	check1 := &MockPreflightCheck{name: "test1"}
+	check2 := &MockPreflightCheck{name: "test2"}
+
+	registry.AddCheck(check1)
+	registry.AddCheck(check2)
+
+	assert.Len(t, registry.checks, 2)
+	assert.Equal(t, check1, registry.checks[0])
+	assert.Equal(t, check2, registry.checks[1])
+}
+
+func TestRegistry_RunChecks_EmptyRegistry(t *testing.T) {
+	mockOutput := &output.MockOutput{}
+	registry := NewRegistry(mockOutput)
+
+	results, err := registry.RunChecks(context.Background())
+
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestRegistry_RunChecks_AllSuccess(t *testing.T) {
+	mockOutput := &output.MockOutput{}
+	registry := NewRegistry(mockOutput)
+
+	check1 := &MockPreflightCheck{
+		name:     "Check 1",
+		severity: SeverityError,
+		success:  true,
+		message:  "Check 1 passed",
+	}
+	check2 := &MockPreflightCheck{
+		name:     "Check 2",
+		severity: SeverityWarning,
+		success:  true,
+		message:  "Check 2 passed",
+	}
+
+	registry.AddCheck(check1)
+	registry.AddCheck(check2)
+
+	results, err := registry.RunChecks(context.Background())
+
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+
+	// Verify first result
+	assert.Equal(t, check1, results[0].Check)
+	assert.True(t, results[0].Success)
+	assert.Equal(t, "Check 1 passed", results[0].Message)
+	assert.NoError(t, results[0].Error)
+	assert.Equal(t, SeverityError, results[0].Severity)
+
+	// Verify second result
+	assert.Equal(t, check2, results[1].Check)
+	assert.True(t, results[1].Success)
+	assert.Equal(t, "Check 2 passed", results[1].Message)
+	assert.NoError(t, results[1].Error)
+	assert.Equal(t, SeverityWarning, results[1].Severity)
+}
+
+func TestRegistry_RunChecks_ErrorSeverityFails(t *testing.T) {
+	mockOutput := &output.MockOutput{}
+	registry := NewRegistry(mockOutput)
+
+	check1 := &MockPreflightCheck{
+		name:     "Passing Check",
+		severity: SeverityInfo,
+		success:  true,
+		message:  "This check passed",
+	}
+	check2 := &MockPreflightCheck{
+		name:     "Failing Check",
+		severity: SeverityError,
+		success:  false,
+		message:  "This check failed",
+	}
+	check3 := &MockPreflightCheck{
+		name:     "Should Not Run",
+		severity: SeverityWarning,
+		success:  true,
+		message:  "This should not be reached",
+	}
+
+	registry.AddCheck(check1)
+	registry.AddCheck(check2)
+	registry.AddCheck(check3)
+
+	results, err := registry.RunChecks(context.Background())
+
+	// Should fail immediately on error severity check
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pre-flight check 'Failing Check' failed")
+	assert.Len(t, results, 2) // Only first two checks should have run
+
+	// Verify results
+	assert.True(t, results[0].Success)
+	assert.False(t, results[1].Success)
+}
+
+func TestRegistry_RunChecks_WarningSeverityDoesNotFail(t *testing.T) {
+	mockOutput := &output.MockOutput{}
+	registry := NewRegistry(mockOutput)
+
+	check1 := &MockPreflightCheck{
+		name:     "Warning Check",
+		severity: SeverityWarning,
+		success:  false,
+		message:  "This is a warning",
+	}
+	check2 := &MockPreflightCheck{
+		name:     "Info Check",
+		severity: SeverityInfo,
+		success:  true,
+		message:  "This is info",
+	}
+
+	registry.AddCheck(check1)
+	registry.AddCheck(check2)
+
+	results, err := registry.RunChecks(context.Background())
+
+	// Should succeed even with failed warning check
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+
+	assert.False(t, results[0].Success)
+	assert.Equal(t, SeverityWarning, results[0].Severity)
+	assert.True(t, results[1].Success)
+	assert.Equal(t, SeverityInfo, results[1].Severity)
+}
+
+func TestRegistry_RunChecks_CheckReturnsError(t *testing.T) {
+	mockOutput := &output.MockOutput{}
+	registry := NewRegistry(mockOutput)
+
+	check1 := &MockPreflightCheck{
+		name:     "Error Check",
+		severity: SeverityError,
+		success:  false,
+		message:  "Check failed",
+		err:      errors.New("internal error"),
+	}
+
+	registry.AddCheck(check1)
+
+	results, err := registry.RunChecks(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pre-flight check 'Error Check' failed")
+	assert.Len(t, results, 1)
+
+	assert.False(t, results[0].Success)
+	assert.Equal(t, "Check failed", results[0].Message)
+	assert.EqualError(t, results[0].Error, "internal error")
+}
+
+func TestRegistry_GetFailureReason(t *testing.T) {
+	mockOutput := &output.MockOutput{}
+	registry := NewRegistry(mockOutput)
+
+	tests := []struct {
+		name     string
+		result   CheckResult
+		expected string
+	}{
+		{
+			name: "error takes precedence",
+			result: CheckResult{
+				Error:   errors.New("error occurred"),
+				Message: "some message",
+			},
+			expected: "error occurred",
+		},
+		{
+			name: "message when no error",
+			result: CheckResult{
+				Message: "check failed message",
+			},
+			expected: "check failed message",
+		},
+		{
+			name:     "default when no error or message",
+			result:   CheckResult{},
+			expected: "check failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason := registry.getFailureReason(tt.result)
+			assert.Equal(t, tt.expected, reason)
+		})
+	}
+}

--- a/pkg/upgrade/preflight/types.go
+++ b/pkg/upgrade/preflight/types.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preflight
+
+import "context"
+
+// PreflightCheck defines the interface for all preflight checks
+// that must be performed before an upgrade operation.
+type PreflightCheck interface {
+	// Run executes the preflight check and returns success status,
+	// a descriptive message, and any error encountered.
+	Run(ctx context.Context) (bool, string, error)
+
+	// Name returns the human-readable name of this check.
+	Name() string
+
+	// Severity returns the severity level of this check.
+	Severity() CheckSeverity
+}
+
+// CheckSeverity represents the severity level of a preflight check.
+type CheckSeverity string
+
+const (
+	// SeverityError indicates a check failure that must prevent the upgrade.
+	SeverityError CheckSeverity = "Error"
+
+	// SeverityWarning indicates a check failure that should be noted but may not prevent the upgrade.
+	SeverityWarning CheckSeverity = "Warning"
+
+	// SeverityInfo indicates an informational check that provides useful context.
+	SeverityInfo CheckSeverity = "Info"
+)
+
+// CheckResult represents the result of running a preflight check.
+type CheckResult struct {
+	Check    PreflightCheck
+	Success  bool
+	Message  string
+	Error    error
+	Severity CheckSeverity
+}

--- a/pkg/upgrade/preflight/version_check.go
+++ b/pkg/upgrade/preflight/version_check.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// VersionCompatibilityCheck validates that the target version is a valid upgrade
+// from the current version. It prevents downgrades and enforces incremental upgrade policies.
+type VersionCompatibilityCheck struct {
+	currentVersion string
+	targetVersion  string
+}
+
+// NewVersionCompatibilityCheck creates a new version compatibility check.
+// Both currentVersion and targetVersion must be specific semantic versions (e.g., "v0.43.0").
+// If targetVersion is "latest", it must be resolved to a specific version before creating this check.
+func NewVersionCompatibilityCheck(currentVersion, targetVersion string) *VersionCompatibilityCheck {
+	return &VersionCompatibilityCheck{
+		currentVersion: currentVersion,
+		targetVersion:  targetVersion,
+	}
+}
+
+// Name returns the name of this check.
+func (v *VersionCompatibilityCheck) Name() string {
+	return "Version Compatibility"
+}
+
+// Severity returns the severity level of this check.
+func (v *VersionCompatibilityCheck) Severity() CheckSeverity {
+	return SeverityError
+}
+
+// Run executes the version compatibility check.
+func (v *VersionCompatibilityCheck) Run(ctx context.Context) (bool, string, error) {
+	valid, message, err := v.isValidUpgradeVersion(v.currentVersion, v.targetVersion)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to validate version compatibility: %w", err)
+	}
+
+	if !valid {
+		return false, message, nil
+	}
+
+	if v.targetVersion == "latest" {
+		return false, "Target version 'latest' must be resolved to a specific version before validation", nil
+	}
+
+	return true, fmt.Sprintf("Upgrade from %s to %s is valid", v.currentVersion, v.targetVersion), nil
+}
+
+// isValidUpgradeVersion checks if the target version is a valid upgrade from the current version.
+// This logic is extracted from the original kubernetes upgrade command.
+func (v *VersionCompatibilityCheck) isValidUpgradeVersion(currentVersion, targetVersion string) (bool, string, error) {
+	// "latest" should be resolved to an actual version before calling this check
+	if targetVersion == "latest" {
+		return false, "Target version 'latest' must be resolved to a specific version before validation", nil
+	}
+
+	// Ensure both versions have 'v' prefix for semver parsing
+	if len(currentVersion) > 0 && currentVersion[0] != 'v' {
+		currentVersion = "v" + currentVersion
+	}
+	if len(targetVersion) > 0 && targetVersion[0] != 'v' {
+		targetVersion = "v" + targetVersion
+	}
+
+	// Parse versions using semver library
+	current, err := semver.NewVersion(currentVersion)
+	if err != nil {
+		return false, "", fmt.Errorf("invalid current version format: %w", err)
+	}
+
+	target, err := semver.NewVersion(targetVersion)
+	if err != nil {
+		return false, "", fmt.Errorf("invalid target version format: %w", err)
+	}
+
+	// Check if versions are the same
+	if current.Equal(target) {
+		return false, "Target version is the same as current version", nil
+	}
+
+	// Check if downgrade attempt
+	if target.LessThan(current) {
+		return false, "Downgrading is not supported", nil
+	}
+
+	// Get the next expected version (increment minor version)
+	expectedNextMinor := semver.New(current.Major(), current.Minor()+1, 0, "", "")
+
+	// Special case: major version increment (e.g., 0.x -> 1.0)
+	if target.Major() > current.Major() {
+		if target.Major() == current.Major()+1 && target.Minor() == 0 && target.Patch() == 0 {
+			return true, "", nil
+		}
+		return false, fmt.Sprintf("Skipping multiple major versions not supported. Expected next major version: %d.0.0", current.Major()+1), nil
+	}
+
+	// Allow increment of minor version by exactly 1
+	if target.Major() == current.Major() && target.Minor() == current.Minor()+1 {
+		return true, "", nil
+	}
+
+	return false, fmt.Sprintf("Only incremental version upgrades are supported. Expected next version: %s", expectedNextMinor), nil
+}
+
+// ValidateVersionJump checks if a version jump is safe for upgrade.
+// This is a utility function that can be used when resolving "latest" versions.
+// It returns true if the jump is safe (incremental), false if it requires special handling.
+func ValidateVersionJump(currentVersion, targetVersion string) (bool, string, error) {
+	check := NewVersionCompatibilityCheck(currentVersion, targetVersion)
+	return check.isValidUpgradeVersion(currentVersion, targetVersion)
+}

--- a/pkg/upgrade/preflight/version_check_test.go
+++ b/pkg/upgrade/preflight/version_check_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preflight
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionCompatibilityCheck_Run(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentVersion string
+		targetVersion  string
+		expectSuccess  bool
+		expectMessage  string
+	}{
+		{
+			name:           "valid upgrade to next minor version",
+			currentVersion: "v0.43.0",
+			targetVersion:  "v0.44.0",
+			expectSuccess:  true,
+			expectMessage:  "Upgrade from v0.43.0 to v0.44.0 is valid",
+		},
+		{
+			name:           "latest version must be resolved",
+			currentVersion: "v0.43.0",
+			targetVersion:  "latest",
+			expectSuccess:  false,
+			expectMessage:  "Target version 'latest' must be resolved to a specific version before validation",
+		},
+		{
+			name:           "invalid downgrade",
+			currentVersion: "v0.44.0",
+			targetVersion:  "v0.43.0",
+			expectSuccess:  false,
+			expectMessage:  "Downgrading is not supported",
+		},
+		{
+			name:           "same version",
+			currentVersion: "v0.43.0",
+			targetVersion:  "v0.43.0",
+			expectSuccess:  false,
+			expectMessage:  "Target version is the same as current version",
+		},
+		{
+			name:           "skip multiple versions",
+			currentVersion: "v0.40.0",
+			targetVersion:  "v0.44.0",
+			expectSuccess:  false,
+			expectMessage:  "Only incremental version upgrades are supported. Expected next version: 0.41.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			check := NewVersionCompatibilityCheck(tt.currentVersion, tt.targetVersion)
+
+			success, message, err := check.Run(context.Background())
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectSuccess, success)
+			assert.Contains(t, message, tt.expectMessage)
+		})
+	}
+}
+
+func TestVersionCompatibilityCheck_Properties(t *testing.T) {
+	check := NewVersionCompatibilityCheck("v0.43.0", "v0.44.0")
+
+	assert.Equal(t, "Version Compatibility", check.Name())
+	assert.Equal(t, SeverityError, check.Severity())
+}
+
+func TestValidateVersionJump(t *testing.T) {
+	tests := []struct {
+		name           string
+		currentVersion string
+		targetVersion  string
+		expectValid    bool
+		expectMessage  string
+	}{
+		{
+			name:           "safe incremental upgrade",
+			currentVersion: "v0.43.0",
+			targetVersion:  "v0.44.0",
+			expectValid:    true,
+		},
+		{
+			name:           "unsafe version skip",
+			currentVersion: "v0.42.0",
+			targetVersion:  "v0.46.0",
+			expectValid:    false,
+			expectMessage:  "Only incremental version upgrades are supported",
+		},
+		{
+			name:           "downgrade attempt",
+			currentVersion: "v0.44.0",
+			targetVersion:  "v0.43.0",
+			expectValid:    false,
+			expectMessage:  "Downgrading is not supported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid, message, err := ValidateVersionJump(tt.currentVersion, tt.targetVersion)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectValid, valid)
+			if tt.expectMessage != "" {
+				assert.Contains(t, message, tt.expectMessage)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

This pull request introduces a preflight check system for validating upgrade operations in the Radius project. The changes include the implementation of a `Registry` to manage checks, a `VersionCompatibilityCheck` to validate version upgrade paths, and associated tests to ensure reliability. Additionally, the documentation has been updated to explain the new system.

### Preflight Check System Implementation:

* **`pkg/upgrade/preflight/registry.go`**: Introduced a `Registry` to manage and execute preflight checks, including methods for adding checks (`AddCheck`) and running them (`RunChecks`). The system logs results and halts on critical errors.
* **`pkg/upgrade/preflight/types.go`**: Defined the `PreflightCheck` interface and supporting types like `CheckSeverity` and `CheckResult` to standardize checks and their results.

### Version Compatibility Check:

* **`pkg/upgrade/preflight/version_check.go`**: Added `VersionCompatibilityCheck` to enforce upgrade rules, such as preventing downgrades and skipping multiple versions. Includes a utility function `ValidateVersionJump` for external use.

### Testing:

* **`pkg/upgrade/preflight/registry_test.go`**: Added unit tests for the `Registry` class, covering scenarios like empty registries, successful checks, and error handling for critical failures.
* **`pkg/upgrade/preflight/version_check_test.go`**: Added tests for `VersionCompatibilityCheck` to validate upgrade paths and ensure proper handling of edge cases like downgrades and unresolved versions.

### Documentation:

* **`pkg/upgrade/README.md`**: Updated to include details about the preflight check system, its extensibility, and usage examples for developers.

## Type of change
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [ ] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [ ] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable