### PR TITLE
Adding Radius (and Contour) installation preflight check

### DIFF
--- a/pkg/upgrade/README.md
+++ b/pkg/upgrade/README.md
@@ -20,6 +20,7 @@ The preflight checks are designed to be reusable across different upgrade contex
 Currently implemented:
 
 1. **VersionCompatibilityCheck** - Validates version upgrade paths and prevents downgrades
+2. **RadiusInstallationCheck** - Verifies Radius is currently installed and healthy
 
 ### Usage Example
 
@@ -28,13 +29,16 @@ import (
     "context"
     "github.com/radius-project/radius/pkg/upgrade/preflight"
     "github.com/radius-project/radius/pkg/cli/output"
+    "github.com/radius-project/radius/pkg/cli/helm"
 )
 
-func validateUpgrade(ctx context.Context, output output.Interface, currentVersion, targetVersion string) error {
+func validateUpgrade(ctx context.Context, output output.Interface, helmInterface helm.Interface, 
+    currentVersion, targetVersion, kubeContext string) error {
     // Create preflight check registry
     registry := preflight.NewRegistry(output)
 
-    // Add checks to registry
+    // Add checks to registry in order of importance
+    registry.AddCheck(preflight.NewRadiusInstallationCheck(helmInterface, kubeContext))
     registry.AddCheck(preflight.NewVersionCompatibilityCheck(currentVersion, targetVersion))
 
     // Run all checks - registry handles execution and logging

--- a/pkg/upgrade/preflight/installation_check.go
+++ b/pkg/upgrade/preflight/installation_check.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/radius-project/radius/pkg/cli/helm"
+)
+
+// RadiusInstallationCheck validates that Radius is currently installed
+// in the cluster and in a healthy state for upgrading.
+type RadiusInstallationCheck struct {
+	helmInterface helm.Interface
+	kubeContext   string
+}
+
+// NewRadiusInstallationCheck creates a new Radius installation check.
+func NewRadiusInstallationCheck(helmInterface helm.Interface, kubeContext string) *RadiusInstallationCheck {
+	return &RadiusInstallationCheck{
+		helmInterface: helmInterface,
+		kubeContext:   kubeContext,
+	}
+}
+
+// Name returns the name of this check.
+func (r *RadiusInstallationCheck) Name() string {
+	return "Radius Installation"
+}
+
+// Severity returns the severity level of this check.
+func (r *RadiusInstallationCheck) Severity() CheckSeverity {
+	return SeverityError
+}
+
+// Run executes the Radius installation check.
+func (r *RadiusInstallationCheck) Run(ctx context.Context) (bool, string, error) {
+	state, err := r.helmInterface.CheckRadiusInstall(r.kubeContext)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to check Radius installation: %w", err)
+	}
+
+	if !state.RadiusInstalled {
+		return false, "Radius is not installed. Use 'rad install kubernetes' to install Radius first", nil
+	}
+
+	message := fmt.Sprintf("Radius is installed (version: %s)", state.RadiusVersion)
+
+	// Also check if Contour is installed
+	if state.ContourInstalled {
+		message += fmt.Sprintf(", Contour is installed (version: %s)", state.ContourVersion)
+	} else {
+		// This is a warning, not an error, as upgrade might install Contour
+		message += ", Contour is not installed (will be installed during upgrade)"
+	}
+
+	return true, message, nil
+}

--- a/pkg/upgrade/preflight/installation_check_test.go
+++ b/pkg/upgrade/preflight/installation_check_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preflight
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/radius-project/radius/pkg/cli/helm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRadiusInstallationCheck_Run(t *testing.T) {
+	tests := []struct {
+		name          string
+		installState  helm.InstallState
+		helmError     error
+		expectSuccess bool
+		expectMessage string
+		expectError   bool
+	}{
+		{
+			name: "radius and contour installed",
+			installState: helm.InstallState{
+				RadiusInstalled:  true,
+				RadiusVersion:    "v0.43.0",
+				ContourInstalled: true,
+				ContourVersion:   "v1.25.0",
+			},
+			expectSuccess: true,
+			expectMessage: "Radius is installed (version: v0.43.0), Contour is installed (version: v1.25.0)",
+		},
+		{
+			name: "radius installed but contour missing",
+			installState: helm.InstallState{
+				RadiusInstalled:  true,
+				RadiusVersion:    "v0.43.0",
+				ContourInstalled: false,
+			},
+			expectSuccess: true,
+			expectMessage: "Radius is installed (version: v0.43.0), Contour is not installed (will be installed during upgrade)",
+		},
+		{
+			name: "radius not installed",
+			installState: helm.InstallState{
+				RadiusInstalled: false,
+			},
+			expectSuccess: false,
+			expectMessage: "Radius is not installed. Use 'rad install kubernetes' to install Radius first",
+		},
+		{
+			name:        "helm error",
+			helmError:   errors.New("failed to connect to cluster"),
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockHelm := helm.NewMockInterface(ctrl)
+
+			mockHelm.EXPECT().
+				CheckRadiusInstall("test-context").
+				Return(tt.installState, tt.helmError)
+
+			check := NewRadiusInstallationCheck(mockHelm, "test-context")
+
+			success, message, err := check.Run(context.Background())
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to check Radius installation")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectSuccess, success)
+				assert.Contains(t, message, tt.expectMessage)
+			}
+		})
+	}
+}
+
+func TestRadiusInstallationCheck_Properties(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHelm := helm.NewMockInterface(ctrl)
+	check := NewRadiusInstallationCheck(mockHelm, "test-context")
+
+	assert.Equal(t, "Radius Installation", check.Name())
+	assert.Equal(t, SeverityError, check.Severity())
+}


### PR DESCRIPTION
# Description

This pull request introduces a new preflight check for validating the installation and health of Radius during the upgrade process. The most significant changes include the addition of the `RadiusInstallationCheck` class, updates to the upgrade validation logic to incorporate this check, and corresponding unit tests to ensure its correctness.

### New Feature: Radius Installation Check

* **New check implementation**: Added `RadiusInstallationCheck` to validate whether Radius is installed and healthy, including checks for Contour installation. This check ensures that upgrades are only performed on valid installations. (`pkg/upgrade/preflight/installation_check.go`)
* **Unit tests**: Created comprehensive tests for `RadiusInstallationCheck` to verify its behavior under various scenarios, such as when Radius is installed, missing, or when there are errors connecting to the cluster. (`pkg/upgrade/preflight/installation_check_test.go`)

### Updates to Upgrade Logic

* **Integration of new check**: Updated the `validateUpgrade` function to include the `RadiusInstallationCheck` in the preflight check registry, ensuring it is executed during the upgrade validation process. (`pkg/upgrade/README.md`)

### Documentation Updates

* **Preflight checks list**: Updated the documentation to include `RadiusInstallationCheck` in the list of preflight checks, providing users with a clear understanding of its purpose. (`pkg/upgrade/README.md`)

## Type of change
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->