### PR TITLE
Adding Kubernetes resources Preflight Check

### DIFF
--- a/pkg/upgrade/README.md
+++ b/pkg/upgrade/README.md
@@ -21,6 +21,8 @@ Currently implemented:
 
 1. **VersionCompatibilityCheck** - Validates version upgrade paths and prevents downgrades
 2. **RadiusInstallationCheck** - Verifies Radius is currently installed and healthy
+3. **KubernetesConnectivityCheck** - Tests cluster connectivity and permissions
+4. **KubernetesResourceCheck** - Checks cluster resource availability for upgrades
 
 ### Usage Example
 
@@ -32,14 +34,16 @@ import (
     "github.com/radius-project/radius/pkg/cli/helm"
 )
 
-func validateUpgrade(ctx context.Context, output output.Interface, helmInterface helm.Interface, 
+func validateUpgrade(ctx context.Context, output output.Interface, helmInterface helm.Interface,
     currentVersion, targetVersion, kubeContext string) error {
     // Create preflight check registry
     registry := preflight.NewRegistry(output)
 
     // Add checks to registry in order of importance
+    registry.AddCheck(preflight.NewKubernetesConnectivityCheck(kubeContext))
     registry.AddCheck(preflight.NewRadiusInstallationCheck(helmInterface, kubeContext))
     registry.AddCheck(preflight.NewVersionCompatibilityCheck(currentVersion, targetVersion))
+    registry.AddCheck(preflight.NewKubernetesResourceCheck(kubeContext))
 
     // Run all checks - registry handles execution and logging
     results, err := registry.RunChecks(ctx)

--- a/pkg/upgrade/preflight/kubernetes_check.go
+++ b/pkg/upgrade/preflight/kubernetes_check.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/radius-project/radius/pkg/kubeutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// RadiusSystemNamespace is the namespace where Radius components are installed
+	RadiusSystemNamespace = "radius-system"
+)
+
+// KubernetesConnectivityCheck validates cluster connectivity and basic permissions.
+type KubernetesConnectivityCheck struct {
+	kubeContext string
+	clientset   kubernetes.Interface
+}
+
+// NewKubernetesConnectivityCheck creates a new check that will create its own client.
+func NewKubernetesConnectivityCheck(kubeContext string) *KubernetesConnectivityCheck {
+	return &KubernetesConnectivityCheck{
+		kubeContext: kubeContext,
+	}
+}
+
+// NewKubernetesConnectivityCheckWithClientset creates a new check with an existing client.
+func NewKubernetesConnectivityCheckWithClientset(kubeContext string, clientset kubernetes.Interface) *KubernetesConnectivityCheck {
+	return &KubernetesConnectivityCheck{
+		kubeContext: kubeContext,
+		clientset:   clientset,
+	}
+}
+
+// Name returns the name of this check.
+func (k *KubernetesConnectivityCheck) Name() string {
+	return "Kubernetes Connectivity"
+}
+
+// Severity returns the severity level of this check.
+func (k *KubernetesConnectivityCheck) Severity() CheckSeverity {
+	return SeverityError
+}
+
+// Run executes the connectivity check.
+func (k *KubernetesConnectivityCheck) Run(ctx context.Context) (bool, string, error) {
+	clientset, err := k.getClientset()
+	if err != nil {
+		return false, "", err
+	}
+
+	// Check basic connectivity
+	serverVersion, err := clientset.Discovery().ServerVersion()
+	if err != nil {
+		return false, "Cannot connect to Kubernetes cluster", fmt.Errorf("failed to get server version: %w", err)
+	}
+
+	// Check namespace existence - required for upgrade
+	_, err = clientset.CoreV1().Namespaces().Get(ctx, RadiusSystemNamespace, metav1.GetOptions{})
+	if err != nil {
+		return false, fmt.Sprintf("Connected (version: %s) but %s namespace not found", serverVersion.GitVersion, RadiusSystemNamespace), nil
+	}
+
+	// Check deployment permissions
+	_, err = clientset.AppsV1().Deployments(RadiusSystemNamespace).List(ctx, metav1.ListOptions{Limit: 1})
+	if err != nil {
+		return false, fmt.Sprintf("Connected (version: %s) but insufficient permissions", serverVersion.GitVersion), nil
+	}
+
+	return true, fmt.Sprintf("Connected (version: %s) with sufficient permissions", serverVersion.GitVersion), nil
+}
+
+// getClientset returns the clientset, creating one if necessary.
+func (k *KubernetesConnectivityCheck) getClientset() (kubernetes.Interface, error) {
+	if k.clientset != nil {
+		return k.clientset, nil
+	}
+
+	config, err := kubeutil.NewClientConfig(&kubeutil.ConfigOptions{
+		ContextName: k.kubeContext,
+		QPS:         kubeutil.DefaultCLIQPS,
+		Burst:       kubeutil.DefaultCLIBurst,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kubernetes client config: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	return clientset, nil
+}

--- a/pkg/upgrade/preflight/kubernetes_check_test.go
+++ b/pkg/upgrade/preflight/kubernetes_check_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preflight
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func TestKubernetesConnectivityCheck_Properties(t *testing.T) {
+	check := NewKubernetesConnectivityCheck("test-context")
+	assert.Equal(t, "Kubernetes Connectivity", check.Name())
+	assert.Equal(t, SeverityError, check.Severity())
+}
+
+func TestKubernetesConnectivityCheck_WithClientset(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	check := NewKubernetesConnectivityCheckWithClientset("test-context", clientset)
+
+	assert.Equal(t, "test-context", check.kubeContext)
+	assert.NotNil(t, check.clientset)
+}
+
+func TestKubernetesConnectivityCheck_Run(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("successful connection with permissions", func(t *testing.T) {
+		// Setup: namespace exists, deployments can be listed
+		clientset := fake.NewSimpleClientset(
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: RadiusSystemNamespace},
+			},
+		)
+
+		check := NewKubernetesConnectivityCheckWithClientset("test", clientset)
+		pass, msg, err := check.Run(ctx)
+
+		require.NoError(t, err)
+		assert.True(t, pass)
+		assert.Contains(t, msg, "with sufficient permissions")
+	})
+
+	t.Run("namespace not found", func(t *testing.T) {
+		// Setup: empty cluster
+		clientset := fake.NewSimpleClientset()
+
+		check := NewKubernetesConnectivityCheckWithClientset("test", clientset)
+		pass, msg, err := check.Run(ctx)
+
+		require.NoError(t, err)
+		assert.False(t, pass) // This is a failure for upgrade preflight
+		assert.Contains(t, msg, "namespace not found")
+	})
+
+	t.Run("insufficient permissions", func(t *testing.T) {
+		// Setup: namespace exists but can't list deployments
+		clientset := fake.NewSimpleClientset(
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: RadiusSystemNamespace},
+			},
+		)
+
+		// Simulate permission error
+		clientset.PrependReactor("list", "deployments", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("forbidden")
+		})
+
+		check := NewKubernetesConnectivityCheckWithClientset("test", clientset)
+		pass, msg, err := check.Run(ctx)
+
+		require.NoError(t, err)
+		assert.False(t, pass)
+		assert.Contains(t, msg, "insufficient permissions")
+	})
+
+	t.Run("connection failure", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+
+		// Simulate connection error on discovery calls
+		clientset.PrependReactor("*", "*", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("connection refused")
+		})
+
+		check := NewKubernetesConnectivityCheckWithClientset("test", clientset)
+		pass, msg, err := check.Run(ctx)
+
+		require.Error(t, err)
+		assert.False(t, pass)
+		assert.Equal(t, "Cannot connect to Kubernetes cluster", msg)
+		assert.Contains(t, err.Error(), "connection refused")
+	})
+}
+
+func TestKubernetesConnectivityCheck_NoClientset(t *testing.T) {
+	// This tests the scenario where no clientset is provided
+	// In a test environment, this should fail to create a client
+	check := NewKubernetesConnectivityCheck("nonexistent-context")
+
+	pass, _, err := check.Run(context.Background())
+
+	require.Error(t, err)
+	assert.False(t, pass)
+	assert.Contains(t, err.Error(), "failed to create Kubernetes client")
+}

--- a/pkg/upgrade/preflight/resource_check.go
+++ b/pkg/upgrade/preflight/resource_check.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preflight
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/radius-project/radius/pkg/kubeutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// KubernetesResourceCheck validates cluster resource availability for upgrades.
+type KubernetesResourceCheck struct {
+	kubeContext string
+	clientset   kubernetes.Interface
+}
+
+// NewKubernetesResourceCheck creates a new check that will create its own client.
+func NewKubernetesResourceCheck(kubeContext string) *KubernetesResourceCheck {
+	return &KubernetesResourceCheck{
+		kubeContext: kubeContext,
+	}
+}
+
+// NewKubernetesResourceCheckWithClientset creates a new check with an existing client.
+func NewKubernetesResourceCheckWithClientset(kubeContext string, clientset kubernetes.Interface) *KubernetesResourceCheck {
+	return &KubernetesResourceCheck{
+		kubeContext: kubeContext,
+		clientset:   clientset,
+	}
+}
+
+// Name returns the name of this check.
+func (k *KubernetesResourceCheck) Name() string {
+	return "Kubernetes Resource Availability"
+}
+
+// Severity returns the severity level of this check.
+func (k *KubernetesResourceCheck) Severity() CheckSeverity {
+	return SeverityWarning // Warning level since this is an estimate
+}
+
+// Run executes the resource availability check.
+func (k *KubernetesResourceCheck) Run(ctx context.Context) (bool, string, error) {
+	clientset, err := k.getClientset()
+	if err != nil {
+		return false, "", err
+	}
+
+	// Get cluster resource availability
+	_, totalAllocatable, err := k.getClusterResources(ctx, clientset)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to get cluster resources: %w", err)
+	}
+
+	// Get current Radius resource usage
+	radiusUsage, err := k.getCurrentRadiusResourceUsage(ctx, clientset)
+	if err != nil {
+		// If we can't get current usage, we'll estimate based on defaults
+		radiusUsage = k.getEstimatedRadiusResourceUsage()
+	}
+
+	// Calculate if we have enough resources for a rolling upgrade
+	// During rolling upgrade, we temporarily need ~1.5x the current Radius resources
+	upgradeExtraNeeds := ResourceQuota{
+		CPU:    radiusUsage.CPU / 2, // Additional 50% during rolling upgrade
+		Memory: radiusUsage.Memory / 2,
+	}
+
+	// Check if allocatable resources can handle the additional load
+	cpuSufficient := totalAllocatable.CPU >= upgradeExtraNeeds.CPU
+	memorySufficient := totalAllocatable.Memory >= upgradeExtraNeeds.Memory
+
+	// Format resource values for display
+	radiusCPU := float64(radiusUsage.CPU) / 1000.0 // Convert milliCPU to CPU
+	radiusMemoryMB := radiusUsage.Memory / (1024 * 1024)
+	extraCPU := float64(upgradeExtraNeeds.CPU) / 1000.0
+	extraMemoryMB := upgradeExtraNeeds.Memory / (1024 * 1024)
+	allocatableCPU := float64(totalAllocatable.CPU) / 1000.0
+	allocatableMemoryMB := totalAllocatable.Memory / (1024 * 1024)
+
+	if !cpuSufficient || !memorySufficient {
+		return false, fmt.Sprintf(
+			"Insufficient resources for upgrade. Current Radius usage: %.2f CPU, %d MB memory. "+
+				"Upgrade needs additional: %.2f CPU, %d MB memory. "+
+				"Available: %.2f CPU, %d MB memory",
+			radiusCPU, radiusMemoryMB, extraCPU, extraMemoryMB, allocatableCPU, allocatableMemoryMB,
+		), nil
+	}
+
+	return true, fmt.Sprintf(
+		"Sufficient resources available for upgrade. Current Radius usage: %.2f CPU, %d MB memory. "+
+			"Additional resources needed: %.2f CPU, %d MB memory. "+
+			"Available: %.2f CPU, %d MB memory",
+		radiusCPU, radiusMemoryMB, extraCPU, extraMemoryMB, allocatableCPU, allocatableMemoryMB,
+	), nil
+}
+
+// getClientset returns the clientset, creating one if necessary.
+func (k *KubernetesResourceCheck) getClientset() (kubernetes.Interface, error) {
+	if k.clientset != nil {
+		return k.clientset, nil
+	}
+
+	config, err := kubeutil.NewClientConfig(&kubeutil.ConfigOptions{
+		ContextName: k.kubeContext,
+		QPS:         kubeutil.DefaultCLIQPS,
+		Burst:       kubeutil.DefaultCLIBurst,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kubernetes client config: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	return clientset, nil
+}
+
+// ResourceQuota represents CPU and memory resource quantities.
+type ResourceQuota struct {
+	CPU    int64 // milliCPU
+	Memory int64 // bytes
+}
+
+// getClusterResources calculates total cluster capacity and allocatable resources.
+func (k *KubernetesResourceCheck) getClusterResources(ctx context.Context, clientset kubernetes.Interface) (ResourceQuota, ResourceQuota, error) {
+	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return ResourceQuota{}, ResourceQuota{}, fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	var totalCapacity, totalAllocatable ResourceQuota
+
+	for _, node := range nodes.Items {
+		// Skip nodes that are not ready or schedulable
+		if !k.isNodeReady(node) || !k.isNodeSchedulable(node) {
+			continue
+		}
+
+		// Add node capacity
+		if cpu := node.Status.Capacity.Cpu(); cpu != nil {
+			totalCapacity.CPU += cpu.MilliValue()
+		}
+		if memory := node.Status.Capacity.Memory(); memory != nil {
+			totalCapacity.Memory += memory.Value()
+		}
+
+		// Add node allocatable
+		if cpu := node.Status.Allocatable.Cpu(); cpu != nil {
+			totalAllocatable.CPU += cpu.MilliValue()
+		}
+		if memory := node.Status.Allocatable.Memory(); memory != nil {
+			totalAllocatable.Memory += memory.Value()
+		}
+	}
+
+	return totalCapacity, totalAllocatable, nil
+}
+
+// getCurrentRadiusResourceUsage gets the current resource requests of Radius components.
+func (k *KubernetesResourceCheck) getCurrentRadiusResourceUsage(ctx context.Context, clientset kubernetes.Interface) (ResourceQuota, error) {
+	deployments, err := clientset.AppsV1().Deployments("radius-system").List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/part-of=radius",
+	})
+	if err != nil {
+		return ResourceQuota{}, fmt.Errorf("failed to list Radius deployments: %w", err)
+	}
+
+	var totalUsage ResourceQuota
+
+	for _, deployment := range deployments.Items {
+		for _, container := range deployment.Spec.Template.Spec.Containers {
+			if container.Resources.Requests != nil {
+				if cpu := container.Resources.Requests.Cpu(); cpu != nil {
+					totalUsage.CPU += cpu.MilliValue()
+				}
+				if memory := container.Resources.Requests.Memory(); memory != nil {
+					totalUsage.Memory += memory.Value()
+				}
+			}
+		}
+
+		// Multiply by replica count
+		if deployment.Spec.Replicas != nil {
+			totalUsage.CPU *= int64(*deployment.Spec.Replicas)
+			totalUsage.Memory *= int64(*deployment.Spec.Replicas)
+		}
+	}
+
+	return totalUsage, nil
+}
+
+// getEstimatedRadiusResourceUsage provides default estimates if we can't get actual usage.
+func (k *KubernetesResourceCheck) getEstimatedRadiusResourceUsage() ResourceQuota {
+	// Conservative estimates based on typical Radius deployment
+	return ResourceQuota{
+		CPU:    2000,                   // 2 CPU cores in milliCPU
+		Memory: 4 * 1024 * 1024 * 1024, // 4 GB in bytes
+	}
+}
+
+// isNodeReady checks if a node is in ready state.
+func (k *KubernetesResourceCheck) isNodeReady(node corev1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// isNodeSchedulable checks if a node is schedulable.
+func (k *KubernetesResourceCheck) isNodeSchedulable(node corev1.Node) bool {
+	return !node.Spec.Unschedulable
+}

--- a/pkg/upgrade/preflight/resource_check_test.go
+++ b/pkg/upgrade/preflight/resource_check_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preflight
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func TestKubernetesResourceCheck_Properties(t *testing.T) {
+	check := NewKubernetesResourceCheck("test-context")
+	assert.Equal(t, "Kubernetes Resource Availability", check.Name())
+	assert.Equal(t, SeverityWarning, check.Severity())
+}
+
+func TestKubernetesResourceCheck_WithClientset(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	check := NewKubernetesResourceCheckWithClientset("test-context", clientset)
+
+	assert.Equal(t, "test-context", check.kubeContext)
+	assert.NotNil(t, check.clientset)
+}
+
+func TestKubernetesResourceCheck_Run(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("sufficient resources", func(t *testing.T) {
+		clientset := createClientsetWithResources(
+			createNode("node1", "4000m", "8Gi"), // 4 CPU, 8GB
+			createRadiusDeployment("ucp", "500m", "1Gi", 1),
+		)
+
+		check := NewKubernetesResourceCheckWithClientset("test", clientset)
+		pass, msg, err := check.Run(ctx)
+
+		require.NoError(t, err)
+		assert.True(t, pass)
+		assert.Contains(t, msg, "Sufficient resources available")
+	})
+
+	t.Run("insufficient resources", func(t *testing.T) {
+		clientset := createClientsetWithResources(
+			createNode("node1", "100m", "50Mi"),              // Very limited: 0.1 CPU, 50MB
+			createRadiusDeployment("ucp", "1000m", "1Gi", 1), // Needs 1 CPU, 1GB, extra 0.5 CPU, 0.5GB for upgrade
+		)
+		// Extra needs: 500m CPU, 512MB memory
+		// Available: 100m CPU, 50MB memory - clearly insufficient
+
+		check := NewKubernetesResourceCheckWithClientset("test", clientset)
+		pass, msg, err := check.Run(ctx)
+
+		require.NoError(t, err)
+		assert.False(t, pass)
+		assert.Contains(t, msg, "Insufficient resources")
+	})
+
+	t.Run("no radius deployments found", func(t *testing.T) {
+		clientset := createClientsetWithResources(
+			createNode("node1", "4000m", "8Gi"),
+		)
+
+		check := NewKubernetesResourceCheckWithClientset("test", clientset)
+		pass, _, err := check.Run(ctx)
+
+		require.NoError(t, err)
+		// Should still pass using estimated usage
+		assert.True(t, pass)
+	})
+
+	t.Run("no nodes found - uses estimated usage", func(t *testing.T) {
+		// Create a scenario with no nodes but namespace exists (so estimated usage is used)
+		clientset := fake.NewSimpleClientset()
+		// Simulate error when getting radius deployments to force estimated usage
+		clientset.PrependReactor("list", "deployments", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("namespace not found")
+		})
+
+		check := NewKubernetesResourceCheckWithClientset("test", clientset)
+		pass, msg, err := check.Run(ctx)
+
+		require.NoError(t, err)
+		// With no nodes (allocatable=0) but estimated usage > 0, should fail
+		assert.False(t, pass)
+		assert.Contains(t, msg, "Insufficient resources")
+	})
+
+	t.Run("connection failure", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		clientset.PrependReactor("*", "*", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("connection refused")
+		})
+
+		check := NewKubernetesResourceCheckWithClientset("test", clientset)
+		pass, _, err := check.Run(ctx)
+
+		require.Error(t, err)
+		assert.False(t, pass)
+		assert.Contains(t, err.Error(), "connection refused")
+	})
+}
+
+func TestKubernetesResourceCheck_NodeHelpers(t *testing.T) {
+	check := NewKubernetesResourceCheck("test-context")
+
+	t.Run("isNodeReady", func(t *testing.T) {
+		readyNode := corev1.Node{
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+		assert.True(t, check.isNodeReady(readyNode))
+
+		notReadyNode := corev1.Node{
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+				},
+			},
+		}
+		assert.False(t, check.isNodeReady(notReadyNode))
+	})
+
+	t.Run("isNodeSchedulable", func(t *testing.T) {
+		schedulableNode := corev1.Node{
+			Spec: corev1.NodeSpec{Unschedulable: false},
+		}
+		assert.True(t, check.isNodeSchedulable(schedulableNode))
+
+		unschedulableNode := corev1.Node{
+			Spec: corev1.NodeSpec{Unschedulable: true},
+		}
+		assert.False(t, check.isNodeSchedulable(unschedulableNode))
+	})
+}
+
+func TestKubernetesResourceCheck_EstimatedUsage(t *testing.T) {
+	check := NewKubernetesResourceCheck("test-context")
+	usage := check.getEstimatedRadiusResourceUsage()
+
+	assert.Equal(t, int64(2000), usage.CPU)                // 2 CPU cores in milliCPU
+	assert.Equal(t, int64(4*1024*1024*1024), usage.Memory) // 4 GB in bytes
+}
+
+func TestKubernetesResourceCheck_NoClientset(t *testing.T) {
+	check := NewKubernetesResourceCheck("nonexistent-context")
+
+	pass, _, err := check.Run(context.Background())
+
+	require.Error(t, err)
+	assert.False(t, pass)
+	assert.Contains(t, err.Error(), "failed to create Kubernetes client")
+}
+
+// Helper functions for creating test objects
+
+func createNode(name, cpu, memory string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			},
+			Capacity: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(cpu),
+				corev1.ResourceMemory: resource.MustParse(memory),
+			},
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(cpu),
+				corev1.ResourceMemory: resource.MustParse(memory),
+			},
+		},
+		Spec: corev1.NodeSpec{Unschedulable: false},
+	}
+}
+
+func createRadiusDeployment(name, cpu, memory string, replicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "radius-system",
+			Labels:    map[string]string{"app.kubernetes.io/part-of": "radius"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse(cpu),
+									corev1.ResourceMemory: resource.MustParse(memory),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createClientsetWithResources(objects ...runtime.Object) *fake.Clientset {
+	return fake.NewSimpleClientset(objects...)
+}


### PR DESCRIPTION
# Description

This pull request introduces two new preflight checks for Kubernetes clusters to enhance the upgrade process: a connectivity check and a resource availability check. It also includes corresponding unit tests and updates documentation to reflect these changes.

### New Preflight Checks

* **Kubernetes Connectivity Check**: Validates cluster connectivity and ensures the user has sufficient permissions to perform upgrade operations. This includes verifying access to the `radius-system` namespace and the ability to list deployments. (`pkg/upgrade/preflight/kubernetes_check.go` and `pkg/upgrade/preflight/kubernetes_check_test.go`) [[1]](diffhunk://#diff-85156d609624f62ca02b8fbe27446a403ed6abe6a45cdee0da329153759d412fR1-R86) [[2]](diffhunk://#diff-80bea6c4bfb3feeb3ab5a637dd068d311f3f384cb9398ec8e48dd7381779fd70R1-R30)

* **Kubernetes Resource Availability Check**: Ensures that the cluster has sufficient CPU and memory resources to handle a rolling upgrade of Radius components. Estimates additional resource needs during the upgrade and checks against allocatable cluster resources. (`pkg/upgrade/preflight/resource_check.go` and `pkg/upgrade/preflight/resource_check_test.go`) [[1]](diffhunk://#diff-24e2fe78e643ba8434ddc23385bba1a418d4925394d4e5c73566b8cd2852594eR1-R215) [[2]](diffhunk://#diff-8492a9727bf43477f3678e880180097925f13eedf7bde2d32197b5abfe37a236R1-R132)

### Documentation Updates

* Updated `pkg/upgrade/README.md` to include the new checks (`KubernetesConnectivityCheck` and `KubernetesResourceCheck`) in the list of preflight checks and their usage example. [[1]](diffhunk://#diff-43abf285648424a257a3c4552d05a6cc6b95e65a56e7837b8508060a943c09deR24-R25) [[2]](diffhunk://#diff-43abf285648424a257a3c4552d05a6cc6b95e65a56e7837b8508060a943c09deR43-R46)

## Type of change
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->