### PR TITLE
Temporarily skipping test using resources in `dt-recipe-ns` namespace

### DIFF
--- a/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
+++ b/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
@@ -185,6 +185,7 @@ func Test_DeploymentTemplate_Module(t *testing.T) {
 }
 
 func Test_DeploymentTemplate_Recipe(t *testing.T) {
+	t.Skip("Skipping this test temporarily - https://github.com/radius-project/radius/issues/9742")
 	ctx := testcontext.New(t)
 	opts := rp.NewRPTestOptions(t)
 


### PR DESCRIPTION
# Description

Temporarily skipping test using resources in `dt-recipe-ns` namespace.

Ref: https://github.com/radius-project/radius/issues/9641
Issue to re-enable the test: https://github.com/radius-project/radius/issues/9742

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: Part of #9742

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [x] Yes
    - [ ] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable