### PR TITLE
Integrating preflight checks with rad upgrade kubernetes command

### DIFF
--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -70,6 +70,8 @@ import (
 	"github.com/radius-project/radius/pkg/cli/cmd/run"
 	"github.com/radius-project/radius/pkg/cli/cmd/uninstall"
 	uninstall_kubernetes "github.com/radius-project/radius/pkg/cli/cmd/uninstall/kubernetes"
+	"github.com/radius-project/radius/pkg/cli/cmd/upgrade"
+	upgrade_kubernetes "github.com/radius-project/radius/pkg/cli/cmd/upgrade/kubernetes"
 	version "github.com/radius-project/radius/pkg/cli/cmd/version"
 	workspace_create "github.com/radius-project/radius/pkg/cli/cmd/workspace/create"
 	workspace_delete "github.com/radius-project/radius/pkg/cli/cmd/workspace/delete"
@@ -374,6 +376,12 @@ func initSubCommands() {
 
 	uninstallKubernetesCmd, _ := uninstall_kubernetes.NewCommand(framework)
 	uninstallCmd.AddCommand(uninstallKubernetesCmd)
+
+	upgradeCmd := upgrade.NewCommand()
+	RootCmd.AddCommand(upgradeCmd)
+
+	upgradeKubernetesCmd, _ := upgrade_kubernetes.NewCommand(framework)
+	upgradeCmd.AddCommand(upgradeKubernetesCmd)
 
 	versionCmd, _ := version.NewCommand(framework)
 	RootCmd.AddCommand(versionCmd)

--- a/pkg/cli/cmd/upgrade/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/upgrade/kubernetes/kubernetes.go
@@ -1,0 +1,248 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
+	"github.com/radius-project/radius/pkg/cli/framework"
+	"github.com/radius-project/radius/pkg/cli/helm"
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/radius-project/radius/pkg/upgrade/preflight"
+	"github.com/radius-project/radius/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+// NewCommand creates an instance of the `rad upgrade kubernetes` command and runner.
+func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
+	runner := NewRunner(factory)
+
+	cmd := &cobra.Command{
+		Use:   "kubernetes",
+		Short: "Upgrades Radius on a Kubernetes cluster",
+		Long: `Upgrade Radius in a Kubernetes cluster using the Radius Helm chart.
+By default 'rad upgrade kubernetes' will upgrade Radius to the version matching the rad CLI version.
+
+This command upgrades the Radius control plane in the cluster associated with the active workspace.
+To upgrade Radius in a different cluster, switch to the appropriate workspace first using 'rad workspace switch'.
+
+The upgrade process includes preflight checks to ensure the cluster is ready for upgrade.
+Preflight checks include:
+- Kubernetes connectivity and permissions
+- Helm connectivity and Radius installation status
+- Version compatibility validation
+- Cluster resource availability
+- Custom configuration parameter validation
+
+Radius is installed in the 'radius-system' namespace. For more information visit https://docs.radapp.io/concepts/technical/architecture/
+
+Overrides can be set by specifying Helm chart values with the '--set' flag. For more information visit https://docs.radapp.io/guides/operations/kubernetes/install/.
+`,
+		Example: `# Upgrade Radius in the cluster of the active workspace
+rad upgrade kubernetes
+
+# Check which workspace is active
+rad workspace show
+
+# Switch to a different workspace before upgrading
+rad workspace switch myworkspace
+rad upgrade kubernetes
+
+# Upgrade Radius with custom configuration
+rad upgrade kubernetes --set key=value
+
+# Upgrade to a specific version
+rad upgrade kubernetes --version v0.47.0
+
+# Upgrade to the latest available version
+rad upgrade kubernetes --version latest
+
+# Upgrade Radius with values from a file
+rad upgrade kubernetes --set-file global.rootCA.cert=/path/to/rootCA.crt
+
+# Skip preflight checks (not recommended)
+rad upgrade kubernetes --skip-preflight
+
+# Run only preflight checks without upgrading
+rad upgrade kubernetes --preflight-only
+
+# Upgrade Radius using a Helm chart from specified file path
+rad upgrade kubernetes --chart /root/radius/deploy/Chart
+`,
+		Args: cobra.ExactArgs(0),
+		RunE: framework.RunCommand(runner),
+	}
+
+	commonflags.AddKubeContextFlagVar(cmd, &runner.KubeContext)
+	cmd.Flags().StringVar(&runner.Chart, "chart", "", "Specify a file path to a helm chart to upgrade Radius from")
+	cmd.Flags().StringVar(&runner.Version, "version", "", "Specify the version to upgrade to (default: CLI version, use 'latest' for latest available)")
+	cmd.Flags().StringArrayVar(&runner.Set, "set", []string{}, "Set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
+	cmd.Flags().StringArrayVar(&runner.SetFile, "set-file", []string{}, "Set values from files on the command line (can specify multiple or separate files with commas: key1=filename1,key2=filename2)")
+	cmd.Flags().BoolVar(&runner.SkipPreflight, "skip-preflight", false, "Skip preflight checks before upgrade (not recommended)")
+	cmd.Flags().BoolVar(&runner.PreflightOnly, "preflight-only", false, "Run only preflight checks without performing the upgrade")
+
+	return cmd, runner
+}
+
+// Runner is the Runner implementation for the `rad upgrade kubernetes` command.
+type Runner struct {
+	Helm   helm.Interface
+	Output output.Interface
+
+	KubeContext   string
+	Chart         string
+	Version       string
+	Set           []string
+	SetFile       []string
+	SkipPreflight bool
+	PreflightOnly bool
+}
+
+// NewRunner creates an instance of the runner for the `rad upgrade kubernetes` command.
+func NewRunner(factory framework.Factory) *Runner {
+	return &Runner{
+		Helm:   factory.GetHelmInterface(),
+		Output: factory.GetOutput(),
+	}
+}
+
+// Validate runs validation for the `rad upgrade kubernetes` command.
+func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
+	if r.SkipPreflight && r.PreflightOnly {
+		return fmt.Errorf("cannot specify both --skip-preflight and --preflight-only")
+	}
+	return nil
+}
+
+// Run runs the `rad upgrade kubernetes` command.
+func (r *Runner) Run(ctx context.Context) error {
+	// Get current installation state
+	state, err := r.Helm.CheckRadiusInstall(r.KubeContext)
+	if err != nil {
+		return fmt.Errorf("failed to check current Radius installation: %w", err)
+	}
+
+	if !state.RadiusInstalled {
+		return fmt.Errorf("Radius is not currently installed. Use 'rad install kubernetes' to install Radius first")
+	}
+
+	currentVersion := state.RadiusVersion
+
+	// Resolve target version
+	targetVersion, err := r.resolveTargetVersion()
+	if err != nil {
+		return fmt.Errorf("failed to resolve target version: %w", err)
+	}
+
+	r.Output.LogInfo("Current Radius version: %s", currentVersion)
+	r.Output.LogInfo("Target Radius version: %s", targetVersion)
+
+	// Run preflight checks unless skipped
+	if !r.SkipPreflight {
+		r.Output.LogInfo("Running preflight checks...")
+
+		err = r.runPreflightChecks(ctx, currentVersion, targetVersion)
+		if err != nil {
+			return fmt.Errorf("preflight checks failed: %w", err)
+		}
+
+		r.Output.LogInfo("✓ All preflight checks passed")
+	}
+
+	// If preflight-only mode, exit here
+	if r.PreflightOnly {
+		r.Output.LogInfo("Preflight checks completed successfully. Upgrade was not performed due to --preflight-only flag.")
+		return nil
+	}
+
+	// Perform the upgrade
+	r.Output.LogInfo("Upgrading Radius from version %s to %s...", currentVersion, targetVersion)
+
+	cliOptions := helm.CLIClusterOptions{
+		Radius: helm.ChartOptions{
+			ChartPath:    r.Chart,
+			ChartVersion: targetVersion,
+			SetArgs:      r.Set,
+			SetFileArgs:  r.SetFile,
+		},
+	}
+
+	clusterOptions := helm.PopulateDefaultClusterOptions(cliOptions)
+
+	err = r.Helm.UpgradeRadius(ctx, clusterOptions, r.KubeContext)
+	if err != nil {
+		return fmt.Errorf("failed to upgrade Radius: %w", err)
+	}
+
+	r.Output.LogInfo("✓ Radius upgrade completed successfully!")
+	return nil
+}
+
+// runPreflightChecks executes all preflight checks before upgrade.
+func (r *Runner) runPreflightChecks(ctx context.Context, currentVersion, targetVersion string) error {
+	// Create preflight check registry
+	registry := preflight.NewRegistry(r.Output)
+
+	// Add checks to registry in order of importance
+	// 1. Basic connectivity checks first
+	registry.AddCheck(preflight.NewKubernetesConnectivityCheck(r.KubeContext))
+	registry.AddCheck(preflight.NewHelmConnectivityCheck(r.Helm, r.KubeContext))
+
+	// 2. Installation and version validation
+	registry.AddCheck(preflight.NewRadiusInstallationCheck(r.Helm, r.KubeContext))
+	registry.AddCheck(preflight.NewVersionCompatibilityCheck(currentVersion, targetVersion))
+
+	// 3. Configuration validation (warnings only)
+	registry.AddCheck(preflight.NewCustomConfigValidationCheck(r.Set, r.SetFile))
+
+	// 4. Resource availability check (warnings only)
+	registry.AddCheck(preflight.NewKubernetesResourceCheck(r.KubeContext))
+
+	// Run all checks - registry handles execution and logging
+	_, err := registry.RunChecks(ctx)
+	return err
+}
+
+// resolveTargetVersion resolves the target version for upgrade based on user input.
+func (r *Runner) resolveTargetVersion() (string, error) {
+	// If no version specified, use CLI version
+	if r.Version == "" {
+		return version.Version(), nil
+	}
+
+	// If user specified "latest", resolve to actual latest version
+	if strings.ToLower(r.Version) == "latest" {
+		latestVersion, err := r.fetchLatestRadiusVersion()
+		if err != nil {
+			return "", fmt.Errorf("failed to fetch latest Radius version: %w", err)
+		}
+		r.Output.LogInfo("Resolved 'latest' to version: %s", latestVersion)
+		return latestVersion, nil
+	}
+
+	// Otherwise, use the specified version
+	return r.Version, nil
+}
+
+// fetchLatestRadiusVersion fetches the latest Radius version from Helm repository.
+func (r *Runner) fetchLatestRadiusVersion() (string, error) {
+	// Use the Helm interface to get the latest chart version
+	return r.Helm.GetLatestRadiusVersion(context.Background())
+}

--- a/pkg/cli/cmd/upgrade/kubernetes/kubernetes_test.go
+++ b/pkg/cli/cmd/upgrade/kubernetes/kubernetes_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/radius-project/radius/pkg/cli/framework"
+	"github.com/radius-project/radius/pkg/cli/helm"
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/radius-project/radius/pkg/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestNewCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockFactory := framework.NewMockFactory(ctrl)
+	mockHelm := helm.NewMockInterface(ctrl)
+	mockOutput := output.NewMockInterface(ctrl)
+
+	mockFactory.EXPECT().GetHelmInterface().Return(mockHelm)
+	mockFactory.EXPECT().GetOutput().Return(mockOutput)
+
+	cmd, runner := NewCommand(mockFactory)
+
+	require.NotNil(t, cmd)
+	require.NotNil(t, runner)
+	assert.Equal(t, "kubernetes", cmd.Use)
+	assert.Equal(t, "Upgrades Radius on a Kubernetes cluster", cmd.Short)
+}
+
+func TestRunner_Validate(t *testing.T) {
+	tests := []struct {
+		name          string
+		skipPreflight bool
+		preflightOnly bool
+		expectedError string
+	}{
+		{
+			name:          "valid flags",
+			skipPreflight: false,
+			preflightOnly: false,
+			expectedError: "",
+		},
+		{
+			name:          "skip preflight only",
+			skipPreflight: true,
+			preflightOnly: false,
+			expectedError: "",
+		},
+		{
+			name:          "preflight only",
+			skipPreflight: false,
+			preflightOnly: true,
+			expectedError: "",
+		},
+		{
+			name:          "conflicting flags",
+			skipPreflight: true,
+			preflightOnly: true,
+			expectedError: "cannot specify both --skip-preflight and --preflight-only",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &Runner{
+				SkipPreflight: tt.skipPreflight,
+				PreflightOnly: tt.preflightOnly,
+			}
+
+			err := runner.Validate(nil, nil)
+
+			if tt.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestRunner_Run(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMock     func(*helm.MockInterface, *output.MockInterface)
+		skipPreflight bool
+		preflightOnly bool
+		expectError   bool
+		errorMessage  string
+	}{
+		{
+			name: "successful upgrade with skipped preflight",
+			setupMock: func(mockHelm *helm.MockInterface, mockOutput *output.MockInterface) {
+				// Mock CheckRadiusInstall to return installed state
+				installState := helm.InstallState{
+					RadiusInstalled: true,
+					RadiusVersion:   "v0.46.0",
+				}
+				mockHelm.EXPECT().CheckRadiusInstall("").Return(installState, nil)
+
+				// Mock upgrade
+				mockHelm.EXPECT().UpgradeRadius(gomock.Any(), gomock.Any(), "").Return(nil)
+
+				// Mock output logging
+				mockOutput.EXPECT().LogInfo(gomock.Any(), gomock.Any()).AnyTimes()
+				mockOutput.EXPECT().LogInfo(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			},
+			skipPreflight: true, // Skip preflight to avoid version validation issues in tests
+			preflightOnly: false,
+			expectError:   false,
+		},
+		{
+			name: "radius not installed",
+			setupMock: func(mockHelm *helm.MockInterface, mockOutput *output.MockInterface) {
+				installState := helm.InstallState{
+					RadiusInstalled: false,
+				}
+				mockHelm.EXPECT().CheckRadiusInstall("").Return(installState, nil)
+			},
+			skipPreflight: false,
+			preflightOnly: false,
+			expectError:   true,
+			errorMessage:  "Radius is not currently installed",
+		},
+		{
+			name: "skip preflight and preflight only - should not run",
+			setupMock: func(mockHelm *helm.MockInterface, mockOutput *output.MockInterface) {
+				// This test case is handled by the Validate function, so no mocks needed
+			},
+			skipPreflight: true,
+			preflightOnly: true,
+			expectError:   true,
+			errorMessage:  "cannot specify both --skip-preflight and --preflight-only",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockHelm := helm.NewMockInterface(ctrl)
+			mockOutput := output.NewMockInterface(ctrl)
+
+			tt.setupMock(mockHelm, mockOutput)
+
+			runner := &Runner{
+				Helm:          mockHelm,
+				Output:        mockOutput,
+				SkipPreflight: tt.skipPreflight,
+				PreflightOnly: tt.preflightOnly,
+			}
+
+			// First run validation
+			validateErr := runner.Validate(nil, nil)
+			if validateErr != nil {
+				// If validation fails, that's our expected error
+				if tt.expectError {
+					assert.Error(t, validateErr)
+					if tt.errorMessage != "" {
+						assert.Contains(t, validateErr.Error(), tt.errorMessage)
+					}
+					return
+				} else {
+					t.Fatalf("Unexpected validation error: %v", validateErr)
+				}
+			}
+
+			// If validation passes, run the actual command
+			err := runner.Run(context.Background())
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorMessage != "" {
+					assert.Contains(t, err.Error(), tt.errorMessage)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRunner_ResolveTargetVersion(t *testing.T) {
+	tests := []struct {
+		name           string
+		versionFlag    string
+		expectedResult string
+		expectError    bool
+	}{
+		{
+			name:           "no version specified - uses CLI version",
+			versionFlag:    "",
+			expectedResult: version.Version(),
+			expectError:    false,
+		},
+		{
+			name:           "explicit version specified",
+			versionFlag:    "v0.47.0",
+			expectedResult: "v0.47.0",
+			expectError:    false,
+		},
+		{
+			name:           "latest version - should work with Helm implementation",
+			versionFlag:    "latest",
+			expectedResult: "v0.47.0", // Will be mocked to return this
+			expectError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockHelm := helm.NewMockInterface(ctrl)
+			mockOutput := output.NewMockInterface(ctrl)
+
+			if tt.versionFlag == "latest" {
+				// Mock the Helm method for getting latest version
+				mockHelm.EXPECT().GetLatestRadiusVersion(gomock.Any()).Return("v0.47.0", nil)
+				// Mock the log message for latest resolution attempt
+				mockOutput.EXPECT().LogInfo(gomock.Any(), gomock.Any()).AnyTimes()
+			}
+
+			runner := &Runner{
+				Helm:    mockHelm,
+				Output:  mockOutput,
+				Version: tt.versionFlag,
+			}
+
+			result, err := runner.resolveTargetVersion()
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedResult, result)
+			}
+		})
+	}
+}

--- a/pkg/cli/cmd/upgrade/kubernetes/kubernetes_test.go
+++ b/pkg/cli/cmd/upgrade/kubernetes/kubernetes_test.go
@@ -189,7 +189,7 @@ func TestRunner_Run(t *testing.T) {
 				mockHelm.EXPECT().CheckRadiusInstall("").Return(installState, nil)
 			},
 			expectError:  true,
-			errorMessage: "Radius is not currently installed",
+			errorMessage: "the Radius control plane is not currently installed",
 		},
 		{
 			name: "upgrade failure",
@@ -250,24 +250,22 @@ func TestRunner_ResolveTargetVersion(t *testing.T) {
 		versionFlag    string
 		expectedResult string
 		expectError    bool
+		skipCheck      bool
 	}{
 		{
 			name:           "no version specified - uses CLI release version",
 			versionFlag:    "",
 			expectedResult: version.Release(),
-			expectError:    false,
 		},
 		{
 			name:           "explicit version specified",
 			versionFlag:    "0.47.0",
 			expectedResult: "0.47.0",
-			expectError:    false,
 		},
 		{
 			name:           "latest version - should work with Helm implementation",
 			versionFlag:    "latest",
 			expectedResult: "0.47.0",
-			expectError:    false,
 		},
 	}
 
@@ -285,6 +283,14 @@ func TestRunner_ResolveTargetVersion(t *testing.T) {
 				mockOutput.EXPECT().LogInfo(gomock.Any(), gomock.Any()).AnyTimes()
 			}
 
+			// For edge builds with no version specified, expect latest version resolution
+			if tt.versionFlag == "" && version.Release() == "edge" {
+				mockOutput.EXPECT().LogInfo("Edge build detected. Upgrading to latest stable version...")
+				mockOutput.EXPECT().LogInfo("Resolved to version: %s", "0.47.0")
+				mockHelm.EXPECT().GetLatestRadiusVersion(gomock.Any()).Return("0.47.0", nil)
+				tt.expectedResult = "0.47.0"
+			}
+
 			runner := &Runner{
 				Helm:    mockHelm,
 				Output:  mockOutput,
@@ -297,10 +303,78 @@ func TestRunner_ResolveTargetVersion(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.expectedResult, result)
+				if !tt.skipCheck {
+					assert.Equal(t, tt.expectedResult, result)
+				}
 			}
 		})
 	}
 }
 
+func TestRunner_ResolveTargetVersion_EdgeBuild(t *testing.T) {
+	t.Parallel()
+	// This test specifically validates the behavior when no version is specified
+	// and the CLI is an edge build
 
+	t.Run("edge build resolves to latest", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockHelm := helm.NewMockInterface(ctrl)
+		mockOutput := output.NewMockInterface(ctrl)
+
+		runner := &Runner{
+			Helm:    mockHelm,
+			Output:  mockOutput,
+			Version: "", // No version specified
+		}
+
+		// When the CLI version is "edge" and no version is specified, it should resolve to latest
+		if version.Release() == "edge" {
+			// Expect log messages about edge build detection
+			mockOutput.EXPECT().LogInfo("Edge build detected. Upgrading to latest stable version...")
+			mockOutput.EXPECT().LogInfo("Resolved to version: %s", "0.47.0")
+
+			// Expect call to get latest version
+			mockHelm.EXPECT().GetLatestRadiusVersion(gomock.Any()).Return("0.47.0", nil)
+
+			result, err := runner.resolveTargetVersion()
+			assert.NoError(t, err)
+			assert.Equal(t, "0.47.0", result)
+		} else {
+			// For non-edge builds, it should return the CLI version
+			result, err := runner.resolveTargetVersion()
+			assert.NoError(t, err)
+			assert.Equal(t, version.Release(), result)
+		}
+	})
+
+	t.Run("edge build fails to get latest", func(t *testing.T) {
+		if version.Release() != "edge" {
+			t.Skip("This test only runs for edge builds")
+		}
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockHelm := helm.NewMockInterface(ctrl)
+		mockOutput := output.NewMockInterface(ctrl)
+
+		runner := &Runner{
+			Helm:    mockHelm,
+			Output:  mockOutput,
+			Version: "", // No version specified
+		}
+
+		// Expect log message about edge build detection
+		mockOutput.EXPECT().LogInfo("Edge build detected. Upgrading to latest stable version...")
+
+		// Expect call to get latest version to fail
+		mockHelm.EXPECT().GetLatestRadiusVersion(gomock.Any()).Return("", fmt.Errorf("network error"))
+
+		result, err := runner.resolveTargetVersion()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to fetch latest Radius version")
+		assert.Empty(t, result)
+	})
+}

--- a/pkg/cli/cmd/upgrade/upgrade.go
+++ b/pkg/cli/cmd/upgrade/upgrade.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import "github.com/spf13/cobra"
+
+// NewCommand returns a new cobra command for `rad upgrade`.
+func NewCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrades Radius for a given platform",
+		Long:  `Upgrades Radius for a given platform`,
+	}
+}

--- a/pkg/cli/helm/cluster.go
+++ b/pkg/cli/helm/cluster.go
@@ -20,7 +20,6 @@ import (
 	context "context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"helm.sh/helm/v3/pkg/storage/driver"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -336,9 +335,7 @@ func (i *Impl) GetLatestRadiusVersion(ctx context.Context) (string, error) {
 	// to fetch the latest chart and extract its version
 	chart, err := helmAction.HelmChartFromContainerRegistry("", helmConf, chartRepo, chartName)
 	if err != nil {
-		// If we can't fetch the latest version, fall back to CLI version
-		output.LogInfo("Warning: Could not fetch latest chart version from repository, using CLI version as fallback")
-		return version.Version(), nil
+		return "", fmt.Errorf("failed to fetch latest version from repository: %w", err)
 	}
 
 	// Extract version from chart metadata
@@ -346,12 +343,5 @@ func (i *Impl) GetLatestRadiusVersion(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("chart metadata does not contain version information")
 	}
 
-	latestVersion := chart.Metadata.Version
-
-	// Ensure version has 'v' prefix for consistency with Radius versioning
-	if !strings.HasPrefix(latestVersion, "v") {
-		latestVersion = "v" + latestVersion
-	}
-
-	return latestVersion, nil
+	return chart.Metadata.Version, nil
 }

--- a/pkg/cli/helm/cluster.go
+++ b/pkg/cli/helm/cluster.go
@@ -20,6 +20,7 @@ import (
 	context "context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"helm.sh/helm/v3/pkg/storage/driver"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -170,6 +171,9 @@ type Interface interface {
 
 	// CheckRadiusInstall checks whether Radius is installed on the cluster, based on the specified Kubernetes context.
 	CheckRadiusInstall(kubeContext string) (InstallState, error)
+
+	// GetLatestRadiusVersion gets the latest available version of the Radius chart from the Helm repository.
+	GetLatestRadiusVersion(ctx context.Context) (string, error)
 }
 
 type Impl struct {
@@ -308,4 +312,46 @@ func (i *Impl) UpgradeRadius(ctx context.Context, clusterOptions ClusterOptions,
 	output.LogInfo("Contour upgrade complete")
 
 	return nil
+}
+
+// GetLatestRadiusVersion gets the latest available version of the Radius chart from the Helm repository.
+func (i *Impl) GetLatestRadiusVersion(ctx context.Context) (string, error) {
+	helmAction := NewHelmAction(i.Helm)
+
+	// Use the same repository configuration as we use for installation
+	clusterOptions := NewDefaultClusterOptions()
+	chartRepo := clusterOptions.Radius.ChartRepo
+	chartName := radiusReleaseName
+
+	// Create a minimal helm configuration for chart operations
+	flags := genericclioptions.ConfigFlags{
+		Namespace: &clusterOptions.Radius.Namespace,
+	}
+	helmConf, err := initHelmConfig(&flags)
+	if err != nil {
+		return "", fmt.Errorf("failed to initialize helm config: %w", err)
+	}
+
+	// Use the existing HelmChartFromContainerRegistry method with empty version
+	// to fetch the latest chart and extract its version
+	chart, err := helmAction.HelmChartFromContainerRegistry("", helmConf, chartRepo, chartName)
+	if err != nil {
+		// If we can't fetch the latest version, fall back to CLI version
+		output.LogInfo("Warning: Could not fetch latest chart version from repository, using CLI version as fallback")
+		return version.Version(), nil
+	}
+
+	// Extract version from chart metadata
+	if chart.Metadata == nil || chart.Metadata.Version == "" {
+		return "", fmt.Errorf("chart metadata does not contain version information")
+	}
+
+	latestVersion := chart.Metadata.Version
+
+	// Ensure version has 'v' prefix for consistency with Radius versioning
+	if !strings.HasPrefix(latestVersion, "v") {
+		latestVersion = "v" + latestVersion
+	}
+
+	return latestVersion, nil
 }

--- a/pkg/cli/helm/cluster_test.go
+++ b/pkg/cli/helm/cluster_test.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/radius-project/radius/pkg/version"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	helm "helm.sh/helm/v3/pkg/action"
@@ -31,15 +30,6 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
 )
-
-func Test_DefaultsToHelmChartVersionValue(t *testing.T) {
-	t.Parallel()
-
-	clusterOptions := PopulateDefaultClusterOptions(CLIClusterOptions{})
-
-	// Not checking other values due to potential failures on release builds
-	require.Equal(t, version.ChartVersion(), clusterOptions.Radius.ChartVersion)
-}
 
 func Test_Helm_InstallRadius(t *testing.T) {
 	t.Parallel()

--- a/pkg/cli/helm/mock_cluster.go
+++ b/pkg/cli/helm/mock_cluster.go
@@ -78,6 +78,45 @@ func (c *MockInterfaceCheckRadiusInstallCall) DoAndReturn(f func(string) (Instal
 	return c
 }
 
+// GetLatestRadiusVersion mocks base method.
+func (m *MockInterface) GetLatestRadiusVersion(arg0 context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLatestRadiusVersion", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLatestRadiusVersion indicates an expected call of GetLatestRadiusVersion.
+func (mr *MockInterfaceMockRecorder) GetLatestRadiusVersion(arg0 any) *MockInterfaceGetLatestRadiusVersionCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestRadiusVersion", reflect.TypeOf((*MockInterface)(nil).GetLatestRadiusVersion), arg0)
+	return &MockInterfaceGetLatestRadiusVersionCall{Call: call}
+}
+
+// MockInterfaceGetLatestRadiusVersionCall wrap *gomock.Call
+type MockInterfaceGetLatestRadiusVersionCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockInterfaceGetLatestRadiusVersionCall) Return(arg0 string, arg1 error) *MockInterfaceGetLatestRadiusVersionCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockInterfaceGetLatestRadiusVersionCall) Do(f func(context.Context) (string, error)) *MockInterfaceGetLatestRadiusVersionCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockInterfaceGetLatestRadiusVersionCall) DoAndReturn(f func(context.Context) (string, error)) *MockInterfaceGetLatestRadiusVersionCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // InstallRadius mocks base method.
 func (m *MockInterface) InstallRadius(arg0 context.Context, arg1 ClusterOptions, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/upgrade/preflight/version_check.go
+++ b/pkg/upgrade/preflight/version_check.go
@@ -68,6 +68,11 @@ func (v *VersionCompatibilityCheck) Run(ctx context.Context) (bool, string, erro
 		return false, "Target version 'latest' must be resolved to a specific version before validation", nil
 	}
 
+	// Use the message from validation if provided
+	if message != "" {
+		return true, message, nil
+	}
+
 	return true, fmt.Sprintf("Upgrade from %s to %s is valid", v.currentVersion, v.targetVersion), nil
 }
 
@@ -77,6 +82,11 @@ func (v *VersionCompatibilityCheck) isValidUpgradeVersion(currentVersion, target
 	// "latest" should be resolved to an actual version before calling this check
 	if targetVersion == "latest" {
 		return false, "Target version 'latest' must be resolved to a specific version before validation", nil
+	}
+
+	// Allow "edge" for local development builds
+	if targetVersion == "edge" {
+		return true, "Upgrade to edge version (development build)", nil
 	}
 
 	// Ensure both versions have 'v' prefix for semver parsing

--- a/pkg/upgrade/preflight/version_check.go
+++ b/pkg/upgrade/preflight/version_check.go
@@ -84,11 +84,6 @@ func (v *VersionCompatibilityCheck) isValidUpgradeVersion(currentVersion, target
 		return false, "Target version 'latest' must be resolved to a specific version before validation", nil
 	}
 
-	// Allow "edge" for local development builds
-	if targetVersion == "edge" {
-		return true, "Upgrade to edge version (development build)", nil
-	}
-
 	// Ensure both versions have 'v' prefix for semver parsing
 	if len(currentVersion) > 0 && currentVersion[0] != 'v' {
 		currentVersion = "v" + currentVersion

--- a/pkg/upgrade/preflight/version_check_test.go
+++ b/pkg/upgrade/preflight/version_check_test.go
@@ -67,13 +67,6 @@ func TestVersionCompatibilityCheck_Run(t *testing.T) {
 			expectSuccess:  false,
 			expectMessage:  "Only incremental version upgrades are supported. Expected next version: 0.41.0",
 		},
-		{
-			name:           "edge version for development",
-			currentVersion: "v0.43.0",
-			targetVersion:  "edge",
-			expectSuccess:  true,
-			expectMessage:  "Upgrade to edge version (development build)",
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/upgrade/preflight/version_check_test.go
+++ b/pkg/upgrade/preflight/version_check_test.go
@@ -67,6 +67,13 @@ func TestVersionCompatibilityCheck_Run(t *testing.T) {
 			expectSuccess:  false,
 			expectMessage:  "Only incremental version upgrades are supported. Expected next version: 0.41.0",
 		},
+		{
+			name:           "edge version for development",
+			currentVersion: "v0.43.0",
+			targetVersion:  "edge",
+			expectSuccess:  true,
+			expectMessage:  "Upgrade to edge version (development build)",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Description

This pull request introduces a new `rad upgrade kubernetes` command to the CLI, enabling users to upgrade Radius installations, including a specific subcommand for Kubernetes.

**Testing**

* kind create cluster upgrade-test
* Install stable version (0.47 if possible not the latest one): https://docs.radapp.io/installation/
  * `wget -q "https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh" -O - | /bin/bash -s 0.47.0`
* Run `make build` on the root of the project (branch needs to be checked out)
* We will have two binaries:
  * 0.47 (stable)
  * local (we will run it from the dist folder)
* Run `rad install kubernetes` to install 0.47 and confirm that the version is installed with `rad version`
* Run `rad upgrade kubernetes` to see that the functionality doesn’t exist in 0.47
* Now you can start testing upgrade command with the other binary: `dist/darwin_arm64/release/rad`

## Type of change
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
Fixes: #8095 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [x] Yes <!-- TaskRadio schema -->
    - [ ] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [x] Yes <!-- TaskRadio design-pr -->
    - [ ] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->