### PR TITLE
rad rollback kubernetes command implementation

### DIFF
--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -67,6 +67,8 @@ import (
 	resourcetype_delete "github.com/radius-project/radius/pkg/cli/cmd/resourcetype/delete"
 	resourcetype_list "github.com/radius-project/radius/pkg/cli/cmd/resourcetype/list"
 	resourcetype_show "github.com/radius-project/radius/pkg/cli/cmd/resourcetype/show"
+	"github.com/radius-project/radius/pkg/cli/cmd/rollback"
+	rollback_kubernetes "github.com/radius-project/radius/pkg/cli/cmd/rollback/kubernetes"
 	"github.com/radius-project/radius/pkg/cli/cmd/run"
 	"github.com/radius-project/radius/pkg/cli/cmd/uninstall"
 	uninstall_kubernetes "github.com/radius-project/radius/pkg/cli/cmd/uninstall/kubernetes"
@@ -382,6 +384,12 @@ func initSubCommands() {
 
 	upgradeKubernetesCmd, _ := upgrade_kubernetes.NewCommand(framework)
 	upgradeCmd.AddCommand(upgradeKubernetesCmd)
+
+	rollbackCmd := rollback.NewCommand()
+	RootCmd.AddCommand(rollbackCmd)
+
+	rollbackKubernetesCmd, _ := rollback_kubernetes.NewCommand(framework)
+	rollbackCmd.AddCommand(rollbackKubernetesCmd)
 
 	versionCmd, _ := version.NewCommand(framework)
 	RootCmd.AddCommand(versionCmd)

--- a/pkg/cli/cmd/rollback/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/rollback/kubernetes/kubernetes.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
+	"github.com/radius-project/radius/pkg/cli/framework"
+	"github.com/radius-project/radius/pkg/cli/helm"
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/spf13/cobra"
+)
+
+// NewCommand creates an instance of the `rad rollback kubernetes` command and runner.
+func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
+	runner := NewRunner(factory)
+
+	cmd := &cobra.Command{
+		Use:   "kubernetes",
+		Short: "Rolls back Radius on a Kubernetes cluster",
+		Long: `Roll back Radius in a Kubernetes cluster to a previous revision.
+
+This command rolls back the Radius control plane in the cluster associated with the active workspace.
+By default, it rolls back to the previous successful deployment with an older version (n-1 revision).
+You can also specify a specific revision number to rollback to.
+
+The rollback operation will:
+- Check that Radius is currently installed
+- Verify that the target revision exists and is valid
+- Roll back to the specified revision or previous version
+- Wait for the rollback to complete
+
+This command operates on the cluster associated with the active workspace.
+To rollback Radius in a different cluster, switch to the appropriate workspace first using 'rad workspace switch'.
+
+Radius is installed in the 'radius-system' namespace. For more information visit https://docs.radapp.io/concepts/technical/architecture/
+`,
+		Example: `# Rollback Radius to the previous version in the cluster of the active workspace
+rad rollback kubernetes
+
+# Rollback Radius to a specific revision number
+rad rollback kubernetes --revision 3
+
+# Check which workspace is active  
+rad workspace show
+
+# Switch to a different workspace before rolling back
+rad workspace switch myworkspace
+rad rollback kubernetes --revision 2
+`,
+		Args: cobra.ExactArgs(0),
+		RunE: framework.RunCommand(runner),
+	}
+
+	commonflags.AddKubeContextFlagVar(cmd, &runner.KubeContext)
+	cmd.Flags().IntVar(&runner.Revision, "revision", 0, "Specify the revision number to rollback to (defaults to previous version)")
+
+	return cmd, runner
+}
+
+// Runner is the Runner implementation for the `rad rollback kubernetes` command.
+type Runner struct {
+	Helm   helm.Interface
+	Output output.Interface
+
+	KubeContext string
+	Revision    int
+}
+
+// NewRunner creates an instance of the runner for the `rad rollback kubernetes` command.
+func NewRunner(factory framework.Factory) *Runner {
+	return &Runner{
+		Helm:   factory.GetHelmInterface(),
+		Output: factory.GetOutput(),
+	}
+}
+
+// Validate runs validation for the `rad rollback kubernetes` command.
+func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+// Run runs the `rad rollback kubernetes` command.
+func (r *Runner) Run(ctx context.Context) error {
+	// Check current installation state
+	state, err := r.Helm.CheckRadiusInstall(r.KubeContext)
+	if err != nil {
+		return fmt.Errorf("failed to check current Radius installation: %w", err)
+	}
+
+	if !state.RadiusInstalled {
+		return fmt.Errorf("Radius is not currently installed. Use 'rad install kubernetes' to install Radius first")
+	}
+
+	r.Output.LogInfo("Current Radius version: %s", state.RadiusVersion)
+
+	if r.Revision != 0 {
+		// Specific revision rollback
+		r.Output.LogInfo("Rolling back to specified revision %d...", r.Revision)
+		err = r.Helm.RollbackRadiusToRevision(ctx, r.KubeContext, r.Revision)
+		if err != nil {
+			return fmt.Errorf("failed to rollback Radius to revision %d: %w", r.Revision, err)
+		}
+	} else {
+		// Automatic rollback to previous version
+		r.Output.LogInfo("Checking for previous revisions...")
+		err = r.Helm.RollbackRadius(ctx, r.KubeContext)
+		if err != nil {
+			return fmt.Errorf("failed to rollback Radius: %w", err)
+		}
+	}
+
+	r.Output.LogInfo("✓ Radius rollback completed successfully!")
+	return nil
+}

--- a/pkg/cli/cmd/rollback/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/rollback/kubernetes/kubernetes.go
@@ -38,7 +38,10 @@ func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
 
 This command rolls back the Radius control plane in the cluster associated with the active workspace.
 By default, it rolls back to the previous successful deployment with an older version (n-1 revision).
-You can also specify a specific revision number to rollback to.
+You can also specify a specific revision number to rollback to, or use --list-revisions to see all available revisions.
+
+Note: Specifying --revision 0 or omitting the --revision flag will roll back to the previous version.
+This aligns with Helm's behavior where revision 0 is a special value meaning "previous revision".
 
 The rollback operation will:
 - Check that Radius is currently installed
@@ -54,8 +57,14 @@ Radius is installed in the 'radius-system' namespace. For more information visit
 		Example: `# Rollback Radius to the previous version in the cluster of the active workspace
 rad rollback kubernetes
 
+# Rollback to the previous version explicitly using revision 0
+rad rollback kubernetes --revision 0
+
 # Rollback Radius to a specific revision number
 rad rollback kubernetes --revision 3
+
+# List available revisions without performing rollback
+rad rollback kubernetes --list-revisions
 
 # Check which workspace is active  
 rad workspace show
@@ -69,7 +78,8 @@ rad rollback kubernetes --revision 2
 	}
 
 	commonflags.AddKubeContextFlagVar(cmd, &runner.KubeContext)
-	cmd.Flags().IntVar(&runner.Revision, "revision", 0, "Specify the revision number to rollback to (defaults to previous version)")
+	cmd.Flags().IntVar(&runner.Revision, "revision", 0, "Specify the revision number to rollback to (0 or omitted = previous version)")
+	cmd.Flags().BoolVar(&runner.ListRevisions, "list-revisions", false, "List available revisions without performing rollback")
 
 	return cmd, runner
 }
@@ -79,8 +89,9 @@ type Runner struct {
 	Helm   helm.Interface
 	Output output.Interface
 
-	KubeContext string
-	Revision    int
+	KubeContext   string
+	Revision      int
+	ListRevisions bool
 }
 
 // NewRunner creates an instance of the runner for the `rad rollback kubernetes` command.
@@ -110,6 +121,18 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	r.Output.LogInfo("Current Radius version: %s", state.RadiusVersion)
 
+	// If --list-revisions is specified, show the revisions and exit
+	if r.ListRevisions {
+		revisions, err := r.Helm.GetRadiusRevisions(ctx, r.KubeContext)
+		if err != nil {
+			return fmt.Errorf("failed to get revision history: %w", err)
+		}
+
+		return r.displayRevisions(revisions)
+	}
+
+	// Note: revision 0 has special meaning - it indicates rollback to the previous version.
+	// This aligns with Helm's behavior where 'helm rollback <release> 0' rolls back to n-1.
 	if r.Revision != 0 {
 		// Specific revision rollback
 		r.Output.LogInfo("Rolling back to specified revision %d...", r.Revision)
@@ -118,7 +141,7 @@ func (r *Runner) Run(ctx context.Context) error {
 			return fmt.Errorf("failed to rollback Radius to revision %d: %w", r.Revision, err)
 		}
 	} else {
-		// Automatic rollback to previous version
+		// Automatic rollback to previous version (revision 0 or --revision flag omitted)
 		r.Output.LogInfo("Checking for previous revisions...")
 		err = r.Helm.RollbackRadius(ctx, r.KubeContext)
 		if err != nil {
@@ -127,5 +150,39 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	r.Output.LogInfo("✓ Radius rollback completed successfully!")
+	return nil
+}
+
+// displayRevisions displays the available revisions in a formatted table.
+func (r *Runner) displayRevisions(revisions []helm.RevisionInfo) error {
+	columns := []output.Column{
+		{
+			Heading:  "REVISION",
+			JSONPath: "{ .Revision }",
+		},
+		{
+			Heading:  "CHART VERSION",
+			JSONPath: "{ .ChartVersion }",
+		},
+		{
+			Heading:  "STATUS",
+			JSONPath: "{ .Status }",
+		},
+		{
+			Heading:  "UPDATED",
+			JSONPath: "{ .UpdatedAt }",
+		},
+		{
+			Heading:  "DESCRIPTION",
+			JSONPath: "{ .Description }",
+		},
+	}
+
+	err := r.Output.WriteFormatted("table", revisions, output.FormatterOptions{
+		Columns: columns,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to display revisions: %w", err)
+	}
 	return nil
 }

--- a/pkg/cli/cmd/rollback/kubernetes/kubernetes_test.go
+++ b/pkg/cli/cmd/rollback/kubernetes/kubernetes_test.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/radius-project/radius/pkg/cli/framework"
+	"github.com/radius-project/radius/pkg/cli/helm"
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestNewCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockFactory := framework.NewMockFactory(ctrl)
+	mockHelm := helm.NewMockInterface(ctrl)
+	mockOutput := output.NewMockInterface(ctrl)
+
+	mockFactory.EXPECT().GetHelmInterface().Return(mockHelm)
+	mockFactory.EXPECT().GetOutput().Return(mockOutput)
+
+	cmd, runner := NewCommand(mockFactory)
+
+	require.NotNil(t, cmd)
+	require.NotNil(t, runner)
+	assert.Equal(t, "kubernetes", cmd.Use)
+	assert.Equal(t, "Rolls back Radius on a Kubernetes cluster", cmd.Short)
+}
+
+func TestRunner_Validate(t *testing.T) {
+	runner := &Runner{}
+	err := runner.Validate(nil, nil)
+	require.NoError(t, err)
+}
+
+func TestRunner_Run_SpecificRevision_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	helmMock := helm.NewMockInterface(ctrl)
+	outputMock := output.NewMockInterface(ctrl)
+
+	runner := &Runner{
+		Helm:        helmMock,
+		Output:      outputMock,
+		KubeContext: "test-context",
+		Revision:    3,
+	}
+
+	// Mock CheckRadiusInstall to return that Radius is installed
+	helmMock.EXPECT().
+		CheckRadiusInstall("test-context").
+		Return(helm.InstallState{RadiusInstalled: true, RadiusVersion: "v0.46.0"}, nil).
+		Times(1)
+
+	// Mock output calls
+	outputMock.EXPECT().LogInfo("Current Radius version: %s", "v0.46.0").Times(1)
+	outputMock.EXPECT().LogInfo("Rolling back to specified revision %d...", 3).Times(1)
+	outputMock.EXPECT().LogInfo("✓ Radius rollback completed successfully!").Times(1)
+
+	// Mock RollbackRadiusToRevision to succeed
+	helmMock.EXPECT().
+		RollbackRadiusToRevision(gomock.Any(), "test-context", 3).
+		Return(nil).
+		Times(1)
+
+	err := runner.Run(context.Background())
+	require.NoError(t, err)
+}
+
+func TestRunner_Run_SpecificRevision_Fails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	helmMock := helm.NewMockInterface(ctrl)
+	outputMock := output.NewMockInterface(ctrl)
+
+	runner := &Runner{
+		Helm:        helmMock,
+		Output:      outputMock,
+		KubeContext: "test-context",
+		Revision:    999,
+	}
+
+	// Mock CheckRadiusInstall to return that Radius is installed
+	helmMock.EXPECT().
+		CheckRadiusInstall("test-context").
+		Return(helm.InstallState{RadiusInstalled: true, RadiusVersion: "v0.46.0"}, nil).
+		Times(1)
+
+	// Mock output calls
+	outputMock.EXPECT().LogInfo("Current Radius version: %s", "v0.46.0").Times(1)
+	outputMock.EXPECT().LogInfo("Rolling back to specified revision %d...", 999).Times(1)
+
+	// Mock RollbackRadiusToRevision to fail
+	helmMock.EXPECT().
+		RollbackRadiusToRevision(gomock.Any(), "test-context", 999).
+		Return(errors.New("revision not found")).
+		Times(1)
+
+	err := runner.Run(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to rollback Radius to revision 999")
+}
+
+func TestRunner_Run_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	helmMock := helm.NewMockInterface(ctrl)
+	outputMock := output.NewMockInterface(ctrl)
+
+	runner := &Runner{
+		Helm:        helmMock,
+		Output:      outputMock,
+		KubeContext: "test-context",
+	}
+
+	// Mock CheckRadiusInstall to return that Radius is installed
+	helmMock.EXPECT().
+		CheckRadiusInstall("test-context").
+		Return(helm.InstallState{RadiusInstalled: true, RadiusVersion: "v0.46.0"}, nil).
+		Times(1)
+
+	// Mock output calls
+	outputMock.EXPECT().LogInfo("Current Radius version: %s", "v0.46.0").Times(1)
+	outputMock.EXPECT().LogInfo("Checking for previous revisions...").Times(1)
+	outputMock.EXPECT().LogInfo("✓ Radius rollback completed successfully!").Times(1)
+
+	// Mock RollbackRadius to succeed
+	helmMock.EXPECT().
+		RollbackRadius(gomock.Any(), "test-context").
+		Return(nil).
+		Times(1)
+
+	err := runner.Run(context.Background())
+	require.NoError(t, err)
+}
+
+func TestRunner_Run_RadiusNotInstalled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	helmMock := helm.NewMockInterface(ctrl)
+	outputMock := output.NewMockInterface(ctrl)
+
+	runner := &Runner{
+		Helm:        helmMock,
+		Output:      outputMock,
+		KubeContext: "test-context",
+	}
+
+	// Mock CheckRadiusInstall to return that Radius is not installed
+	helmMock.EXPECT().
+		CheckRadiusInstall("test-context").
+		Return(helm.InstallState{RadiusInstalled: false}, nil).
+		Times(1)
+
+	err := runner.Run(context.Background())
+	require.Error(t, err)
+	require.Equal(t, "Radius is not currently installed. Use 'rad install kubernetes' to install Radius first", err.Error())
+}
+
+func TestRunner_Run_CheckInstallFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	helmMock := helm.NewMockInterface(ctrl)
+	outputMock := output.NewMockInterface(ctrl)
+
+	runner := &Runner{
+		Helm:        helmMock,
+		Output:      outputMock,
+		KubeContext: "test-context",
+	}
+
+	// Mock CheckRadiusInstall to fail
+	helmMock.EXPECT().
+		CheckRadiusInstall("test-context").
+		Return(helm.InstallState{}, errors.New("helm error")).
+		Times(1)
+
+	err := runner.Run(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to check current Radius installation")
+}
+
+func TestRunner_Run_RollbackFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	helmMock := helm.NewMockInterface(ctrl)
+	outputMock := output.NewMockInterface(ctrl)
+
+	runner := &Runner{
+		Helm:        helmMock,
+		Output:      outputMock,
+		KubeContext: "test-context",
+	}
+
+	// Mock CheckRadiusInstall to return that Radius is installed
+	helmMock.EXPECT().
+		CheckRadiusInstall("test-context").
+		Return(helm.InstallState{RadiusInstalled: true, RadiusVersion: "v0.46.0"}, nil).
+		Times(1)
+
+	// Mock output calls
+	outputMock.EXPECT().LogInfo("Current Radius version: %s", "v0.46.0").Times(1)
+	outputMock.EXPECT().LogInfo("Checking for previous revisions...").Times(1)
+
+	// Mock RollbackRadius to fail
+	helmMock.EXPECT().
+		RollbackRadius(gomock.Any(), "test-context").
+		Return(errors.New("rollback failed")).
+		Times(1)
+
+	err := runner.Run(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to rollback Radius")
+}
+
+func TestNewRunner(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockFactory := framework.NewMockFactory(ctrl)
+	helmMock := helm.NewMockInterface(ctrl)
+	outputMock := output.NewMockInterface(ctrl)
+
+	mockFactory.EXPECT().GetHelmInterface().Return(helmMock).Times(1)
+	mockFactory.EXPECT().GetOutput().Return(outputMock).Times(1)
+
+	runner := NewRunner(mockFactory)
+
+	require.Same(t, helmMock, runner.Helm)
+	require.Same(t, outputMock, runner.Output)
+}

--- a/pkg/cli/cmd/rollback/rollback.go
+++ b/pkg/cli/cmd/rollback/rollback.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rollback
+
+import "github.com/spf13/cobra"
+
+// NewCommand returns a new cobra command for `rad rollback`.
+func NewCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "rollback",
+		Short: "Rolls back Radius for a given platform",
+		Long:  `Rolls back Radius for a given platform`,
+	}
+}

--- a/pkg/cli/helm/cluster.go
+++ b/pkg/cli/helm/cluster.go
@@ -173,6 +173,12 @@ type Interface interface {
 
 	// GetLatestRadiusVersion gets the latest available version of the Radius chart from the Helm repository.
 	GetLatestRadiusVersion(ctx context.Context) (string, error)
+
+	// RollbackRadius rolls back the Radius installation to the previous revision.
+	RollbackRadius(ctx context.Context, kubeContext string) error
+
+	// RollbackRadiusToRevision rolls back the Radius installation to a specific revision.
+	RollbackRadiusToRevision(ctx context.Context, kubeContext string, revision int) error
 }
 
 type Impl struct {
@@ -344,4 +350,168 @@ func (i *Impl) GetLatestRadiusVersion(ctx context.Context) (string, error) {
 	}
 
 	return chart.Metadata.Version, nil
+}
+
+// RollbackRadius rolls back the Radius installation to the previous revision.
+func (i *Impl) RollbackRadius(ctx context.Context, kubeContext string) error {
+	clusterOptions := NewDefaultClusterOptions()
+
+	// Initialize helm configuration
+	flags := genericclioptions.ConfigFlags{
+		Namespace: &clusterOptions.Radius.Namespace,
+		Context:   &kubeContext,
+	}
+	helmConf, err := initHelmConfig(&flags)
+	if err != nil {
+		return fmt.Errorf("failed to initialize helm config: %w", err)
+	}
+
+	// Get release history to find the previous version
+	history, err := i.Helm.RunHelmHistory(helmConf, radiusReleaseName)
+	if err != nil {
+		return fmt.Errorf("failed to get release history: %w", err)
+	}
+
+	if len(history) < 2 {
+		return fmt.Errorf("no previous revision available for rollback. Current revision count: %d", len(history))
+	}
+
+	// Find the previous successful deployment with a different chart version
+	// History is returned in chronological order (oldest first)
+	var targetRevision int
+	var currentRevision int
+	var currentChartVersion string
+
+	// Find the current deployed revision
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].Info.Status == "deployed" {
+			currentRevision = history[i].Version
+			if history[i].Chart != nil && history[i].Chart.Metadata != nil {
+				currentChartVersion = history[i].Chart.Metadata.Version
+			}
+			break
+		}
+	}
+
+	// Look for the most recent revision with an OLDER chart version
+	// We need to find a revision that's chronologically older than the current one
+	var currentRevisionIndex int = -1
+
+	// First, find the index of the current revision in the history
+	for i, release := range history {
+		if release.Version == currentRevision {
+			currentRevisionIndex = i
+			break
+		}
+	}
+
+	if currentRevisionIndex == -1 {
+		return fmt.Errorf("could not find current revision in history")
+	}
+
+	// Parse current version for comparison
+	currentSemver, err := semver.NewVersion(currentChartVersion)
+	if err != nil {
+		return fmt.Errorf("invalid current chart version format: %s", currentChartVersion)
+	}
+
+	// Look backwards from the current revision for an older chart version
+	for i := currentRevisionIndex - 1; i >= 0; i-- {
+		if history[i].Info.Status == "deployed" || history[i].Info.Status == "superseded" {
+			if history[i].Chart != nil && history[i].Chart.Metadata != nil {
+				candidateVersion := history[i].Chart.Metadata.Version
+				if candidateVersion != currentChartVersion {
+					// Parse candidate version and compare
+					candidateSemver, err := semver.NewVersion(candidateVersion)
+					if err != nil {
+						// Skip versions that can't be parsed
+						continue
+					}
+
+					// Only rollback to a semantically older version
+					if candidateSemver.LessThan(currentSemver) {
+						targetRevision = history[i].Version
+						break
+					}
+				}
+			}
+		}
+	}
+
+	if targetRevision == 0 {
+		return fmt.Errorf("no older version found for rollback. Current version %s is the oldest available", currentChartVersion)
+	}
+
+	// Find the target version name for the output message
+	var targetChartVersion string
+	for _, release := range history {
+		if release.Version == targetRevision && release.Chart != nil && release.Chart.Metadata != nil {
+			targetChartVersion = release.Chart.Metadata.Version
+			break
+		}
+	}
+
+	output.LogInfo("Rolling back Radius from version %s to version %s...", currentChartVersion, targetChartVersion)
+
+	// Perform the rollback
+	err = i.Helm.RunHelmRollback(helmConf, radiusReleaseName, targetRevision, true)
+	if err != nil {
+		return fmt.Errorf("failed to rollback Radius: %w", err)
+	}
+
+	output.LogInfo("Radius rollback completed successfully!")
+	return nil
+}
+
+// RollbackRadiusToRevision rolls back the Radius installation to a specific revision.
+func (i *Impl) RollbackRadiusToRevision(ctx context.Context, kubeContext string, revision int) error {
+	clusterOptions := NewDefaultClusterOptions()
+
+	// Initialize helm configuration
+	flags := genericclioptions.ConfigFlags{
+		Namespace: &clusterOptions.Radius.Namespace,
+		Context:   &kubeContext,
+	}
+	helmConf, err := initHelmConfig(&flags)
+	if err != nil {
+		return fmt.Errorf("failed to initialize helm config: %w", err)
+	}
+
+	// Get release history to validate the target revision exists
+	history, err := i.Helm.RunHelmHistory(helmConf, radiusReleaseName)
+	if err != nil {
+		return fmt.Errorf("failed to get release history: %w", err)
+	}
+
+	// Validate that the target revision exists
+	var targetFound bool
+	var targetChartVersion string
+	for _, release := range history {
+		if release.Version == revision {
+			targetFound = true
+			if release.Chart != nil && release.Chart.Metadata != nil {
+				targetChartVersion = release.Chart.Metadata.Version
+			}
+			break
+		}
+	}
+
+	if !targetFound {
+		return fmt.Errorf("revision %d not found in release history", revision)
+	}
+
+	if targetChartVersion != "" {
+		output.LogInfo("Rolling back Radius to revision %d (version %s)...", revision, targetChartVersion)
+	} else {
+		output.LogInfo("Rolling back Radius to revision %d...", revision)
+	}
+
+	// Perform the rollback
+	err = i.Helm.RunHelmRollback(helmConf, radiusReleaseName, revision, true)
+	if err != nil {
+		return fmt.Errorf("failed to rollback Radius to revision %d: %w", revision, err)
+	}
+
+	output.LogInfo("Radius rollback completed successfully!")
+	return nil
 }

--- a/pkg/cli/helm/cluster_test.go
+++ b/pkg/cli/helm/cluster_test.go
@@ -282,3 +282,189 @@ func Test_PopulateDefaultClusterOptions(t *testing.T) {
 	require.Equal(t, []string{"cert=./ca.crt"}, opts.Radius.SetFileArgs)
 	require.Equal(t, "1.2.3", opts.Radius.ChartVersion)
 }
+
+func Test_Helm_RollbackRadius_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHelmClient := NewMockHelmClient(ctrl)
+	impl := &Impl{Helm: mockHelmClient}
+	ctx := context.Background()
+	kubeContext := "test-context"
+
+	// Mock history with multiple versions
+	history := []*release.Release{
+		{Version: 1, Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "0.45.0"}}, Info: &release.Info{Status: "superseded"}},
+		{Version: 2, Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "0.46.0"}}, Info: &release.Info{Status: "deployed"}},
+	}
+
+	mockHelmClient.EXPECT().
+		RunHelmHistory(gomock.AssignableToTypeOf(&helm.Configuration{}), "radius").
+		Return(history, nil).
+		Times(1)
+
+	mockHelmClient.EXPECT().
+		RunHelmRollback(gomock.AssignableToTypeOf(&helm.Configuration{}), "radius", 1, true).
+		Return(nil).
+		Times(1)
+
+	err := impl.RollbackRadius(ctx, kubeContext)
+	require.NoError(t, err)
+}
+
+func Test_Helm_RollbackRadius_NoOlderVersion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHelmClient := NewMockHelmClient(ctrl)
+	impl := &Impl{Helm: mockHelmClient}
+	ctx := context.Background()
+	kubeContext := "test-context"
+
+	// Mock history with only one version
+	history := []*release.Release{
+		{Version: 1, Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "0.45.0"}}, Info: &release.Info{Status: "deployed"}},
+	}
+
+	mockHelmClient.EXPECT().
+		RunHelmHistory(gomock.AssignableToTypeOf(&helm.Configuration{}), "radius").
+		Return(history, nil).
+		Times(1)
+
+	err := impl.RollbackRadius(ctx, kubeContext)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no previous revision available for rollback")
+}
+
+func Test_Helm_RollbackRadius_SameVersionSkipped(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHelmClient := NewMockHelmClient(ctrl)
+	impl := &Impl{Helm: mockHelmClient}
+	ctx := context.Background()
+	kubeContext := "test-context"
+
+	// Mock history with same versions (no semantic rollback available)
+	history := []*release.Release{
+		{Version: 1, Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "0.46.0"}}, Info: &release.Info{Status: "superseded"}},
+		{Version: 2, Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "0.46.0"}}, Info: &release.Info{Status: "deployed"}},
+	}
+
+	mockHelmClient.EXPECT().
+		RunHelmHistory(gomock.AssignableToTypeOf(&helm.Configuration{}), "radius").
+		Return(history, nil).
+		Times(1)
+
+	err := impl.RollbackRadius(ctx, kubeContext)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no older version found for rollback. Current version 0.46.0 is the oldest available")
+}
+
+func Test_Helm_RollbackRadius_HistoryError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHelmClient := NewMockHelmClient(ctrl)
+	impl := &Impl{Helm: mockHelmClient}
+	ctx := context.Background()
+	kubeContext := "test-context"
+
+	mockHelmClient.EXPECT().
+		RunHelmHistory(gomock.AssignableToTypeOf(&helm.Configuration{}), "radius").
+		Return(nil, fmt.Errorf("history error")).
+		Times(1)
+
+	err := impl.RollbackRadius(ctx, kubeContext)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to get release history")
+}
+
+func Test_Helm_RollbackRadiusToRevision_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHelmClient := NewMockHelmClient(ctrl)
+	impl := &Impl{Helm: mockHelmClient}
+	ctx := context.Background()
+	kubeContext := "test-context"
+	targetRevision := 3
+
+	// Mock history containing the target revision
+	history := []*release.Release{
+		{Version: 1, Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "0.45.0"}}, Info: &release.Info{Status: "superseded"}},
+		{Version: 2, Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "0.46.0"}}, Info: &release.Info{Status: "superseded"}},
+		{Version: 3, Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "0.45.0"}}, Info: &release.Info{Status: "superseded"}},
+		{Version: 4, Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "0.46.0"}}, Info: &release.Info{Status: "deployed"}},
+	}
+
+	mockHelmClient.EXPECT().
+		RunHelmHistory(gomock.AssignableToTypeOf(&helm.Configuration{}), "radius").
+		Return(history, nil).
+		Times(1)
+
+	mockHelmClient.EXPECT().
+		RunHelmRollback(gomock.AssignableToTypeOf(&helm.Configuration{}), "radius", targetRevision, true).
+		Return(nil).
+		Times(1)
+
+	err := impl.RollbackRadiusToRevision(ctx, kubeContext, targetRevision)
+	require.NoError(t, err)
+}
+
+func Test_Helm_RollbackRadiusToRevision_RevisionNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHelmClient := NewMockHelmClient(ctrl)
+	impl := &Impl{Helm: mockHelmClient}
+	ctx := context.Background()
+	kubeContext := "test-context"
+	targetRevision := 999
+
+	// Mock history without the target revision
+	history := []*release.Release{
+		{Version: 1, Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "0.45.0"}}, Info: &release.Info{Status: "superseded"}},
+		{Version: 2, Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "0.46.0"}}, Info: &release.Info{Status: "deployed"}},
+	}
+
+	mockHelmClient.EXPECT().
+		RunHelmHistory(gomock.AssignableToTypeOf(&helm.Configuration{}), "radius").
+		Return(history, nil).
+		Times(1)
+
+	err := impl.RollbackRadiusToRevision(ctx, kubeContext, targetRevision)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "revision 999 not found in release history")
+}
+
+func Test_Helm_RollbackRadiusToRevision_RollbackError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockHelmClient := NewMockHelmClient(ctrl)
+	impl := &Impl{Helm: mockHelmClient}
+	ctx := context.Background()
+	kubeContext := "test-context"
+	targetRevision := 1
+
+	// Mock history containing the target revision
+	history := []*release.Release{
+		{Version: 1, Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "0.45.0"}}, Info: &release.Info{Status: "superseded"}},
+		{Version: 2, Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "0.46.0"}}, Info: &release.Info{Status: "deployed"}},
+	}
+
+	mockHelmClient.EXPECT().
+		RunHelmHistory(gomock.AssignableToTypeOf(&helm.Configuration{}), "radius").
+		Return(history, nil).
+		Times(1)
+
+	mockHelmClient.EXPECT().
+		RunHelmRollback(gomock.AssignableToTypeOf(&helm.Configuration{}), "radius", targetRevision, true).
+		Return(fmt.Errorf("rollback failed")).
+		Times(1)
+
+	err := impl.RollbackRadiusToRevision(ctx, kubeContext, targetRevision)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to rollback Radius to revision 1")
+}

--- a/pkg/cli/helm/helmclient.go
+++ b/pkg/cli/helm/helmclient.go
@@ -29,6 +29,7 @@ const (
 	installTimeout   = time.Duration(5) * time.Minute
 	uninstallTimeout = time.Duration(5) * time.Minute
 	upgradeTimeout   = time.Duration(5) * time.Minute
+	rollbackTimeout  = time.Duration(5) * time.Minute
 )
 
 //go:generate mockgen -typed -destination=./mock_helmclient.go -package=helm -self_package github.com/radius-project/radius/pkg/cli/helm github.com/radius-project/radius/pkg/cli/helm HelmClient
@@ -46,6 +47,12 @@ type HelmClient interface {
 
 	// RunHelmList lists the Helm releases.
 	RunHelmList(helmConf *helm.Configuration, releaseName string) ([]*release.Release, error)
+
+	// RunHelmHistory lists the release revisions for a given release.
+	RunHelmHistory(helmConf *helm.Configuration, releaseName string) ([]*release.Release, error)
+
+	// RunHelmRollback rolls back a release to a previous revision.
+	RunHelmRollback(helmConf *helm.Configuration, releaseName string, revision int, wait bool) error
 
 	// RunHelmPull pulls the Helm chart.
 	RunHelmPull(pullopts []helm.PullOpt, chartRef string) (string, error)
@@ -108,6 +115,22 @@ func (client *HelmClientImpl) RunHelmPull(pullopts []helm.PullOpt, chartRef stri
 	)
 
 	return pullClient.Run(chartRef)
+}
+
+func (client *HelmClientImpl) RunHelmHistory(helmConf *helm.Configuration, releaseName string) ([]*release.Release, error) {
+	historyClient := helm.NewHistory(helmConf)
+	historyClient.Max = 256 // Helm default
+
+	return historyClient.Run(releaseName)
+}
+
+func (client *HelmClientImpl) RunHelmRollback(helmConf *helm.Configuration, releaseName string, revision int, wait bool) error {
+	rollbackClient := helm.NewRollback(helmConf)
+	rollbackClient.Timeout = rollbackTimeout
+	rollbackClient.Wait = wait
+	rollbackClient.Version = revision
+
+	return rollbackClient.Run(releaseName)
 }
 
 func (client *HelmClientImpl) LoadChart(chartPath string) (*chart.Chart, error) {

--- a/pkg/cli/helm/helmclient_test.go
+++ b/pkg/cli/helm/helmclient_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	helm "helm.sh/helm/v3/pkg/action"
+)
+
+func TestHelmClientImpl_RunHelmHistory(t *testing.T) {
+	client := &HelmClientImpl{}
+
+	// Since RunHelmHistory uses real Helm internals that require a configured cluster,
+	// we test the method exists and has the correct signature.
+	// The actual functionality is tested through integration tests in cluster_test.go
+	require.NotNil(t, client.RunHelmHistory)
+
+	// Test with nil configuration - should handle gracefully or panic predictably
+	defer func() {
+		if r := recover(); r != nil {
+			// Expected behavior when configuration is nil
+			t.Log("Expected panic when configuration is nil")
+		}
+	}()
+
+	// This will panic or error, which is expected behavior
+	client.RunHelmHistory(nil, "test-release")
+}
+
+func TestHelmClientImpl_RunHelmRollback(t *testing.T) {
+	client := &HelmClientImpl{}
+
+	// Since RunHelmRollback uses real Helm internals that require a configured cluster,
+	// we test the method exists and has the correct signature.
+	// The actual functionality is tested through integration tests in cluster_test.go
+	require.NotNil(t, client.RunHelmRollback)
+
+	// Test with nil configuration - should handle gracefully or panic predictably
+	defer func() {
+		if r := recover(); r != nil {
+			// Expected behavior when configuration is nil
+			t.Log("Expected panic when configuration is nil")
+		}
+	}()
+
+	// This will panic or error, which is expected behavior
+	client.RunHelmRollback(nil, "test-release", 1, true)
+}
+
+func TestHelmClient_Constants(t *testing.T) {
+	// Test that our new timeout constant is defined
+	require.Equal(t, time.Duration(5)*time.Minute, rollbackTimeout)
+	require.Equal(t, time.Duration(5)*time.Minute, installTimeout)
+	require.Equal(t, time.Duration(5)*time.Minute, uninstallTimeout)
+	require.Equal(t, time.Duration(5)*time.Minute, upgradeTimeout)
+}
+
+func TestHelmClient_Interface(t *testing.T) {
+	// Test that HelmClientImpl implements the HelmClient interface
+	var _ HelmClient = &HelmClientImpl{}
+
+	// Test that all new methods are included in the interface
+	client := NewHelmClient()
+	require.NotNil(t, client)
+
+	// Verify the interface includes the new methods by checking they exist
+	// We can't call them without a proper Helm configuration
+	require.NotNil(t, client.(*HelmClientImpl).RunHelmHistory)
+	require.NotNil(t, client.(*HelmClientImpl).RunHelmRollback)
+}
+
+// Mock test to verify the method signatures are correct
+func TestHelmClient_MockCompatibility(t *testing.T) {
+	// This test ensures our new methods can be mocked properly
+	client := &HelmClientImpl{}
+
+	// Test RunHelmHistory method signature
+	var historyFunc = client.RunHelmHistory
+	require.NotNil(t, historyFunc)
+
+	// Test RunHelmRollback method signature
+	var rollbackFunc func(*helm.Configuration, string, int, bool) error = client.RunHelmRollback
+	require.NotNil(t, rollbackFunc)
+}

--- a/pkg/cli/helm/helmclient_test.go
+++ b/pkg/cli/helm/helmclient_test.go
@@ -41,7 +41,10 @@ func TestHelmClientImpl_RunHelmHistory(t *testing.T) {
 	}()
 
 	// This will panic or error, which is expected behavior
-	client.RunHelmHistory(nil, "test-release")
+	_, err := client.RunHelmHistory(nil, "test-release")
+	if err == nil {
+		t.Error("Expected error when configuration is nil, but got nil")
+	}
 }
 
 func TestHelmClientImpl_RunHelmRollback(t *testing.T) {
@@ -61,7 +64,10 @@ func TestHelmClientImpl_RunHelmRollback(t *testing.T) {
 	}()
 
 	// This will panic or error, which is expected behavior
-	client.RunHelmRollback(nil, "test-release", 1, true)
+	err := client.RunHelmRollback(nil, "test-release", 1, true)
+	if err == nil {
+		t.Error("Expected error when configuration is nil, but got nil")
+	}
 }
 
 func TestHelmClient_Constants(t *testing.T) {

--- a/pkg/cli/helm/mock_cluster.go
+++ b/pkg/cli/helm/mock_cluster.go
@@ -155,6 +155,82 @@ func (c *MockInterfaceInstallRadiusCall) DoAndReturn(f func(context.Context, Clu
 	return c
 }
 
+// RollbackRadius mocks base method.
+func (m *MockInterface) RollbackRadius(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RollbackRadius", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RollbackRadius indicates an expected call of RollbackRadius.
+func (mr *MockInterfaceMockRecorder) RollbackRadius(arg0, arg1 any) *MockInterfaceRollbackRadiusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RollbackRadius", reflect.TypeOf((*MockInterface)(nil).RollbackRadius), arg0, arg1)
+	return &MockInterfaceRollbackRadiusCall{Call: call}
+}
+
+// MockInterfaceRollbackRadiusCall wrap *gomock.Call
+type MockInterfaceRollbackRadiusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockInterfaceRollbackRadiusCall) Return(arg0 error) *MockInterfaceRollbackRadiusCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockInterfaceRollbackRadiusCall) Do(f func(context.Context, string) error) *MockInterfaceRollbackRadiusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockInterfaceRollbackRadiusCall) DoAndReturn(f func(context.Context, string) error) *MockInterfaceRollbackRadiusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// RollbackRadiusToRevision mocks base method.
+func (m *MockInterface) RollbackRadiusToRevision(arg0 context.Context, arg1 string, arg2 int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RollbackRadiusToRevision", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RollbackRadiusToRevision indicates an expected call of RollbackRadiusToRevision.
+func (mr *MockInterfaceMockRecorder) RollbackRadiusToRevision(arg0, arg1, arg2 any) *MockInterfaceRollbackRadiusToRevisionCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RollbackRadiusToRevision", reflect.TypeOf((*MockInterface)(nil).RollbackRadiusToRevision), arg0, arg1, arg2)
+	return &MockInterfaceRollbackRadiusToRevisionCall{Call: call}
+}
+
+// MockInterfaceRollbackRadiusToRevisionCall wrap *gomock.Call
+type MockInterfaceRollbackRadiusToRevisionCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockInterfaceRollbackRadiusToRevisionCall) Return(arg0 error) *MockInterfaceRollbackRadiusToRevisionCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockInterfaceRollbackRadiusToRevisionCall) Do(f func(context.Context, string, int) error) *MockInterfaceRollbackRadiusToRevisionCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockInterfaceRollbackRadiusToRevisionCall) DoAndReturn(f func(context.Context, string, int) error) *MockInterfaceRollbackRadiusToRevisionCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // UninstallRadius mocks base method.
 func (m *MockInterface) UninstallRadius(arg0 context.Context, arg1 ClusterOptions, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/cli/helm/mock_cluster.go
+++ b/pkg/cli/helm/mock_cluster.go
@@ -117,6 +117,45 @@ func (c *MockInterfaceGetLatestRadiusVersionCall) DoAndReturn(f func(context.Con
 	return c
 }
 
+// GetRadiusRevisions mocks base method.
+func (m *MockInterface) GetRadiusRevisions(arg0 context.Context, arg1 string) ([]RevisionInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRadiusRevisions", arg0, arg1)
+	ret0, _ := ret[0].([]RevisionInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRadiusRevisions indicates an expected call of GetRadiusRevisions.
+func (mr *MockInterfaceMockRecorder) GetRadiusRevisions(arg0, arg1 any) *MockInterfaceGetRadiusRevisionsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRadiusRevisions", reflect.TypeOf((*MockInterface)(nil).GetRadiusRevisions), arg0, arg1)
+	return &MockInterfaceGetRadiusRevisionsCall{Call: call}
+}
+
+// MockInterfaceGetRadiusRevisionsCall wrap *gomock.Call
+type MockInterfaceGetRadiusRevisionsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockInterfaceGetRadiusRevisionsCall) Return(arg0 []RevisionInfo, arg1 error) *MockInterfaceGetRadiusRevisionsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockInterfaceGetRadiusRevisionsCall) Do(f func(context.Context, string) ([]RevisionInfo, error)) *MockInterfaceGetRadiusRevisionsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockInterfaceGetRadiusRevisionsCall) DoAndReturn(f func(context.Context, string) ([]RevisionInfo, error)) *MockInterfaceGetRadiusRevisionsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // InstallRadius mocks base method.
 func (m *MockInterface) InstallRadius(arg0 context.Context, arg1 ClusterOptions, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/cli/helm/mock_helmclient.go
+++ b/pkg/cli/helm/mock_helmclient.go
@@ -80,6 +80,45 @@ func (c *MockHelmClientLoadChartCall) DoAndReturn(f func(string) (*chart.Chart, 
 	return c
 }
 
+// RunHelmHistory mocks base method.
+func (m *MockHelmClient) RunHelmHistory(arg0 *action.Configuration, arg1 string) ([]*release.Release, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunHelmHistory", arg0, arg1)
+	ret0, _ := ret[0].([]*release.Release)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunHelmHistory indicates an expected call of RunHelmHistory.
+func (mr *MockHelmClientMockRecorder) RunHelmHistory(arg0, arg1 any) *MockHelmClientRunHelmHistoryCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunHelmHistory", reflect.TypeOf((*MockHelmClient)(nil).RunHelmHistory), arg0, arg1)
+	return &MockHelmClientRunHelmHistoryCall{Call: call}
+}
+
+// MockHelmClientRunHelmHistoryCall wrap *gomock.Call
+type MockHelmClientRunHelmHistoryCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockHelmClientRunHelmHistoryCall) Return(arg0 []*release.Release, arg1 error) *MockHelmClientRunHelmHistoryCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockHelmClientRunHelmHistoryCall) Do(f func(*action.Configuration, string) ([]*release.Release, error)) *MockHelmClientRunHelmHistoryCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockHelmClientRunHelmHistoryCall) DoAndReturn(f func(*action.Configuration, string) ([]*release.Release, error)) *MockHelmClientRunHelmHistoryCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // RunHelmInstall mocks base method.
 func (m *MockHelmClient) RunHelmInstall(arg0 *action.Configuration, arg1 *chart.Chart, arg2, arg3 string, arg4 bool) (*release.Release, error) {
 	m.ctrl.T.Helper()
@@ -193,6 +232,44 @@ func (c *MockHelmClientRunHelmPullCall) Do(f func([]action.PullOpt, string) (str
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockHelmClientRunHelmPullCall) DoAndReturn(f func([]action.PullOpt, string) (string, error)) *MockHelmClientRunHelmPullCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// RunHelmRollback mocks base method.
+func (m *MockHelmClient) RunHelmRollback(arg0 *action.Configuration, arg1 string, arg2 int, arg3 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunHelmRollback", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunHelmRollback indicates an expected call of RunHelmRollback.
+func (mr *MockHelmClientMockRecorder) RunHelmRollback(arg0, arg1, arg2, arg3 any) *MockHelmClientRunHelmRollbackCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunHelmRollback", reflect.TypeOf((*MockHelmClient)(nil).RunHelmRollback), arg0, arg1, arg2, arg3)
+	return &MockHelmClientRunHelmRollbackCall{Call: call}
+}
+
+// MockHelmClientRunHelmRollbackCall wrap *gomock.Call
+type MockHelmClientRunHelmRollbackCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockHelmClientRunHelmRollbackCall) Return(arg0 error) *MockHelmClientRunHelmRollbackCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockHelmClientRunHelmRollbackCall) Do(f func(*action.Configuration, string, int, bool) error) *MockHelmClientRunHelmRollbackCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockHelmClientRunHelmRollbackCall) DoAndReturn(f func(*action.Configuration, string, int, bool) error) *MockHelmClientRunHelmRollbackCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
# Description

## How to test `rad upgrade kubernetes` and `rad rollback kubernetes`

1. **Binary 1**: Download and install and older version of Radius (0.47 or 0.48).
2. **Binary 2**: Run `make build` on this branch locally and the binary in the dist folder is going to be your 2nd binary for testing.

**Testing Scenarios**

1. Run `rad install` with the first binary and then run `rad version` to see what is installed in the cluster.
2. Try different upgrade scenarios with the second binary. Please pay attention to the help section of the command `rad upgrade kubernetes -h`.
3. Then start playing with the `rad rollback kubernetes` command. Again, please pay attention to the help section of the rollback command.
4. You can combine different scenarios of upgrade and rollback together.
5. Please try different commands like this:
  * `rad rollback kubernetes --revision`
  * `rad rollback kubernetes --list-revisions`
  * `rad upgrade kubernetes`
  * `rad upgrade kubernetes --version X.Y.Z`

## AI-Generated Description of the PR

This pull request introduces a new `rad rollback kubernetes` command to the CLI, enabling users to roll back the Radius control plane on a Kubernetes cluster to a previous revision. The implementation includes command wiring, core logic, test coverage, and required Helm interface extensions.

**Key changes:**

### New Rollback Command Functionality

* Added a new top-level `rad rollback` command and a subcommand `rad rollback kubernetes` that allows users to roll back the Radius installation on a Kubernetes cluster to a previous or specified revision, or list available revisions. (`cmd/rad/cmd/root.go`, `pkg/cli/cmd/rollback/rollback.go`, `pkg/cli/cmd/rollback/kubernetes/kubernetes.go`) [[1]](diffhunk://#diff-d36b7b4d04f01a6cf60c50dd9c01da8fb8c190231ea4c59cbbfbe070178b510bR70-R71) [[2]](diffhunk://#diff-d36b7b4d04f01a6cf60c50dd9c01da8fb8c190231ea4c59cbbfbe070178b510bR388-R393) [[3]](diffhunk://#diff-a7781ef0913086e7f57ee6bf5b3e5e5b8533436212d6182c6b29180cc48d8a67R1-R28) [[4]](diffhunk://#diff-ec6714c4ad06b1011fbc1b4ffc7cf291958b37b88de7ffaa89fd408e0b67dd88R1-R188)

### Helm Interface Enhancements

* Extended the `helm.Interface` with new methods: `RollbackRadius`, `RollbackRadiusToRevision`, and `GetRadiusRevisions`, and added a `RevisionInfo` struct for revision metadata. (`pkg/cli/helm/cluster.go`) [[1]](diffhunk://#diff-a94c29c96fb0778e35d7983669dedfa10de7111040707a3839dace9836b20d0bR158-R175) [[2]](diffhunk://#diff-a94c29c96fb0778e35d7983669dedfa10de7111040707a3839dace9836b20d0bR194-R202)

### Test Coverage

* Added comprehensive unit tests for the new rollback command, covering various scenarios including successful rollbacks, error handling, and revision listing. (`pkg/cli/cmd/rollback/kubernetes/kubernetes_test.go`)

## Type of change
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [x] Yes <!-- TaskRadio schema -->
    - [ ] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [x] Yes <!-- TaskRadio design-pr -->
    - [ ] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->