### PR TITLE
Fix dev container build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,6 @@
     "ghcr.io/devcontainers/features/go:1": {},
     "ghcr.io/guiyomh/features/gotestsum:0.1.1": {},
     "ghcr.io/devcontainers/features/node:1": {},
-    "ghcr.io/devcontainers-contrib/features/typescript:2": {},
     "ghcr.io/devcontainers/features/python:1": {},
     //Container and K8s
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
@@ -38,7 +37,8 @@
         "ms-kubernetes-tools.vscode-kubernetes-tools",
         "ms-azuretools.vscode-dapr",
         "ms-vscode.makefile-tools",
-        "timonwong.shellcheck"
+        "timonwong.shellcheck",
+        "typespec.typespec-vscode"
       ]
     }
   },

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Install TypeSpec first to ensure the language server is available when the VS Code extension loads.
+npm install -g @typespec/compiler
+
 # Adding workspace as safe directory to avoid permission issues
 git config --global --add safe.directory /workspaces/radius 
 


### PR DESCRIPTION
# Description

The dev container currently throws an error on container build due to dev container feature that no longer exists in its home GitHub repo. This feature is not needed, so it is removed in this PR in an update to `.devcontainer/devcontainer.json`.

This PR contains an additional change to add the [TypeSpec VS Code extension](https://marketplace.visualstudio.com/items?itemName=typespec.typespec-vscode) to the dev container. This change is not related to the build fix.

Development container configuration updates:

* Removed the `ghcr.io/devcontainers-contrib/features/typescript:2` feature from the container configuration, as it is no longer needed and causes an error on container build.
* Added the `typespec.typespec-vscode` extension to enable TypeSpec support in the development environment.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #N/A

## Details

The current dev container build returns an error, similar to the one below:

```shell
[2025-06-04T17:55:56.669Z] Resolving Feature dependencies for 'ghcr.io/devcontainers-contrib/features/typescript:2'...
[2025-06-04T17:55:56.669Z] * Processing feature: ghcr.io/devcontainers-contrib/features/typescript:2
[2025-06-04T17:55:56.937Z] Could not resolve Feature manifest for 'ghcr.io/devcontainers-contrib/features/typescript:2'.  If necessary, provide registry credentials with 'docker login <registry>'.
[2025-06-04T17:55:56.937Z] Github feature.
[2025-06-04T17:55:56.937Z] Could not resolve Feature 'ghcr.io/devcontainers-contrib/features/typescript:2'.  Ensure the Feature is published and accessible from your current environment.
[2025-06-04T17:55:56.935Z] Error: ERR: Feature 'ghcr.io/devcontainers-contrib/features/typescript:2' could not be processed.  You may not have permission to access this Feature, or may not be logged in.  If the issue persists, report this to the Feature author.
[2025-06-04T17:55:56.935Z]     at FX (/home//.vscode-remote-containers/dist/dev-containers-cli-0.413.0/dist/spec-node/devContainersSpecCLI.js:287:9690)
[2025-06-04T17:55:56.935Z]     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
[2025-06-04T17:55:56.936Z]     at async eC (/home//.vscode-remote-containers/dist/dev-containers-cli-0.413.0/dist/spec-node/devContainersSpecCLI.js:287:12258)
[2025-06-04T17:55:56.936Z]     at async vu (/home//.vscode-remote-containers/dist/dev-containers-cli-0.413.0/dist/spec-node/devContainersSpecCLI.js:287:12484)
[2025-06-04T17:55:56.936Z]     at async Tu (/home//.vscode-remote-containers/dist/dev-containers-cli-0.413.0/dist/spec-node/devContainersSpecCLI.js:392:1818)
[2025-06-04T17:55:56.936Z]     at async gC (/home//.vscode-remote-containers/dist/dev-containers-cli-0.413.0/dist/spec-node/devContainersSpecCLI.js:395:2228)
[2025-06-04T17:55:56.936Z]     at async Wu (/home//.vscode-remote-containers/dist/dev-containers-cli-0.413.0/dist/spec-node/devContainersSpecCLI.js:395:282)
[2025-06-04T17:55:56.936Z]     at async dw (/home//.vscode-remote-containers/dist/dev-containers-cli-0.413.0/dist/spec-node/devContainersSpecCLI.js:467:1923)
[2025-06-04T17:55:56.936Z]     at async Ix (/home//.vscode-remote-containers/dist/dev-containers-cli-0.413.0/dist/spec-node/devContainersSpecCLI.js:467:608)
[2025-06-04T17:55:56.936Z]     at async Y6 (/home//.vscode-remote-containers/dist/dev-containers-cli-0.413.0/dist/spec-node/devContainersSpecCLI.js:484:3842)
[2025-06-04T17:55:56.942Z] Stop (5593 ms): Run in Host: /home//.vscode-server/bin/258e40fedc6cb8edf399a463ce3a9d32e7e1f6f3/node /home//.vscode-remote-containers/dist/dev-containers-cli-0.413.0/dist/spec-node/devContainersSpecCLI.js up --container-session-data-folder /tmp/devcontainers-d25def13-28cf-4a0b-8053-63bf84e9de4f1749059749153 --workspace-folder /mnt/wsl/workspace/prs/radius --workspace-mount-consistency cached --gpu-availability detect --id-label devcontainer.local_folder=\\wsl.localhost\radius\mnt\wsl\workspace\prs\radius --id-label devcontainer.config_file=/mnt/wsl/workspace/prs/radius/.devcontainer/devcontainer.json --log-level debug --log-format json --config /mnt/wsl/workspace/prs/radius/.devcontainer/devcontainer.json --default-user-env-probe loginInteractiveShell --remove-existing-container --mount type=volume,source=vscode,target=/vscode,external=true --skip-post-create --update-remote-user-uid-default on --mount-workspace-git-root --terminal-columns 212 --terminal-rows 19 --include-configuration --include-merged-configuration
[2025-06-04T17:55:56.943Z] Exit code 1

```

## Contributor checklist
## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->