### PR TITLE
Update GetResourceTypeDetails to use new UCP client

### DIFF
--- a/pkg/cli/cmd/resource/list/list.go
+++ b/pkg/cli/cmd/resource/list/list.go
@@ -154,7 +154,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		r.UCPClientFactory = clientFactory
 	}
 
-	_, err := common.GetResourceTypeDetailsWithUCPClient(ctx, r.ResourceProviderNamespace, r.ResourceTypeSuffix, r.UCPClientFactory)
+	_, err := common.GetResourceTypeDetails(ctx, r.ResourceProviderNamespace, r.ResourceTypeSuffix, r.UCPClientFactory)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/resource/list/list_test.go
+++ b/pkg/cli/cmd/resource/list/list_test.go
@@ -25,12 +25,11 @@ import (
 	"github.com/radius-project/radius/pkg/cli/clierrors"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
+	"github.com/radius-project/radius/pkg/cli/manifest"
 	"github.com/radius-project/radius/pkg/cli/objectformats"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
-	"github.com/radius-project/radius/pkg/to"
-	ucp "github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
 	"github.com/radius-project/radius/test/radcli"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -109,40 +108,26 @@ func Test_Run(t *testing.T) {
 			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
 
 			appManagementClient.EXPECT().
-				GetResourceProviderSummary(context.Background(), "local", "Applications.Core").
-				Return(ucp.ResourceProviderSummary{
-					Name: to.Ptr("Applications.Core"),
-					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-						"containers": {
-							APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
-								"2023-01-01": {},
-							},
-							DefaultAPIVersion: to.Ptr("2023-01-01"),
-						},
-					},
-					Locations: map[string]map[string]any{
-						"east": {},
-					},
-				}, nil).Times(1)
-
-			appManagementClient.EXPECT().
 				GetApplication(gomock.Any(), "test-app").
 				Return(v20231001preview.ApplicationResource{}, radcli.Create404Error()).Times(1)
 
 			outputSink := &output.MockOutput{}
 
+			clientFactory, err := manifest.NewTestClientFactory(manifest.WithResourceProviderServerNoError)
+			require.NoError(t, err)
 			runner := &Runner{
 				ConnectionFactory:         &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+				UCPClientFactory:          clientFactory,
 				Output:                    outputSink,
 				Workspace:                 &workspaces.Workspace{Name: radcli.TestWorkspaceName},
 				ApplicationName:           "test-app",
-				ResourceType:              "Applications.Core/containers",
+				ResourceType:              "MyCompany.Resources/testResources",
 				Format:                    "table",
-				ResourceTypeSuffix:        "containers",
-				ResourceProviderNameSpace: "Applications.Core",
+				ResourceTypeSuffix:        "testResources",
+				ResourceProviderNamespace: "MyCompany.Resources",
 			}
 
-			err := runner.Run(context.Background())
+			err = runner.Run(context.Background())
 			require.Error(t, err)
 			require.IsType(t, err, clierrors.Message("The application %q could not be found in workspace %q. Make sure you specify the correct application with '-a/--application'.", "test-app", radcli.TestWorkspaceName))
 		})
@@ -151,48 +136,35 @@ func Test_Run(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			resources := []generated.GenericResource{
-				radcli.CreateResource("containers", "A"),
-				radcli.CreateResource("containers", "B"),
+				radcli.CreateResource("testResources", "A"),
+				radcli.CreateResource("testResources", "B"),
 			}
 
 			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
 			appManagementClient.EXPECT().
-				GetResourceProviderSummary(context.Background(), "local", "Applications.Core").
-				Return(ucp.ResourceProviderSummary{
-					Name: to.Ptr("Applications.Core"),
-					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-						"containers": {
-							APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
-								"2023-01-01": {},
-							},
-							DefaultAPIVersion: to.Ptr("2023-01-01"),
-						},
-					},
-					Locations: map[string]map[string]any{
-						"east": {},
-					},
-				}, nil).Times(1)
-			appManagementClient.EXPECT().
 				GetApplication(gomock.Any(), "test-app").
 				Return(v20231001preview.ApplicationResource{}, nil).Times(1)
 			appManagementClient.EXPECT().
-				ListResourcesOfTypeInApplication(gomock.Any(), "test-app", "Applications.Core/containers").
+				ListResourcesOfTypeInApplication(gomock.Any(), "test-app", "MyCompany.Resources/testResources").
 				Return(resources, nil).Times(1)
 
 			outputSink := &output.MockOutput{}
 
+			clientFactory, err := manifest.NewTestClientFactory(manifest.WithResourceProviderServerNoError)
+			require.NoError(t, err)
 			runner := &Runner{
 				ConnectionFactory:         &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+				UCPClientFactory:          clientFactory,
 				Output:                    outputSink,
 				Workspace:                 &workspaces.Workspace{},
 				ApplicationName:           "test-app",
-				ResourceType:              "Applications.Core/containers",
+				ResourceType:              "MyCompany.Resources/testResources",
 				Format:                    "table",
-				ResourceTypeSuffix:        "containers",
-				ResourceProviderNameSpace: "Applications.Core",
+				ResourceTypeSuffix:        "testResources",
+				ResourceProviderNamespace: "MyCompany.Resources",
 			}
 
-			err := runner.Run(context.Background())
+			err = runner.Run(context.Background())
 			require.NoError(t, err)
 
 			expected := []any{
@@ -205,51 +177,47 @@ func Test_Run(t *testing.T) {
 			require.Equal(t, expected, outputSink.Writes)
 		})
 	})
+
 	t.Run("List resources by type without application", func(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			resources := []generated.GenericResource{
-				radcli.CreateResource("Applications.Core/containers", "A"),
-				radcli.CreateResource("Applications.Core/containers", "B"),
+				radcli.CreateResource("MyCompany.Resources/testResources", "A"),
+				radcli.CreateResource("MyCompany.Resources/testResources", "B"),
 			}
 
 			appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
-			appManagementClient.EXPECT().
-				GetResourceProviderSummary(context.Background(), "local", "Applications.Core").
-				Return(ucp.ResourceProviderSummary{
-					Name: to.Ptr("Applications.Core"),
-					ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
-						"containers": {
-							APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
-								"2023-01-01": {},
-							},
-							DefaultAPIVersion: to.Ptr("2023-01-01"),
-						},
-					},
-					Locations: map[string]map[string]any{
-						"east": {},
-					},
-				}, nil).Times(1)
 
 			appManagementClient.EXPECT().
-				ListResourcesOfType(gomock.Any(), "Applications.Core/containers").
+				ListResourcesOfType(gomock.Any(), "MyCompany.Resources/testResources").
 				Return(resources, nil).Times(1)
 
 			outputSink := &output.MockOutput{}
 
+			workspace := &workspaces.Workspace{
+				Connection: map[string]any{
+					"kind":    "kubernetes",
+					"context": "kind-kind",
+				},
+				Name:  "kind-kind",
+				Scope: "/planes/radius/local/resourceGroups/test-group",
+			}
+			clientFactory, err := manifest.NewTestClientFactory(manifest.WithResourceProviderServerNoError)
+			require.NoError(t, err)
 			runner := &Runner{
 				ConnectionFactory:         &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
+				UCPClientFactory:          clientFactory,
 				Output:                    outputSink,
-				Workspace:                 &workspaces.Workspace{},
+				Workspace:                 workspace,
 				ApplicationName:           "",
-				ResourceType:              "Applications.Core/containers",
+				ResourceType:              "MyCompany.Resources/testResources",
 				Format:                    "table",
-				ResourceTypeSuffix:        "containers",
-				ResourceProviderNameSpace: "Applications.Core",
+				ResourceTypeSuffix:        "testResources",
+				ResourceProviderNamespace: "MyCompany.Resources",
 			}
 
-			err := runner.Run(context.Background())
+			err = runner.Run(context.Background())
 			require.NoError(t, err)
 
 			expected := []any{

--- a/pkg/cli/cmd/resourcetype/common/resourcetype.go
+++ b/pkg/cli/cmd/resourcetype/common/resourcetype.go
@@ -131,27 +131,8 @@ func GetResourceTypeShowSchemaTableFormat() output.FormatterOptions {
 	}
 }
 
-// GetResourceTypeDetails fetches the details of a resource type from the resource provider.
-func GetResourceTypeDetails(ctx context.Context, resourceProviderName string, resourceTypeName string, client clients.ApplicationsManagementClient) (ResourceType, error) {
-	resourceProvider, err := client.GetResourceProviderSummary(ctx, "local", resourceProviderName)
-	if clients.Is404Error(err) {
-		return ResourceType{}, clierrors.Message("The resource provider %q was not found or has been deleted.", resourceProviderName)
-	} else if err != nil {
-		return ResourceType{}, err
-	}
-
-	resourceTypes := ResourceTypesForProvider(&resourceProvider)
-	idx := slices.IndexFunc(resourceTypes, func(rt ResourceType) bool {
-		return rt.Name == resourceProviderName+"/"+resourceTypeName
-	})
-
-	if idx < 0 {
-		return ResourceType{}, clierrors.Message("Resource type %q not found in resource provider %q.", resourceTypeName, *resourceProvider.Name)
-	}
-
-	return resourceTypes[idx], nil
-}
-
+// GetResourceTypeDetailsWithUCPClient retrieves the details of a resource provider's resource type using the UCP client.
+// It returns the resource type details or an error if the resource type is not found.
 func GetResourceTypeDetailsWithUCPClient(ctx context.Context, resourceProviderName string, resourceTypeName string, clientFactory *v20231001preview.ClientFactory) (ResourceType, error) {
 	response, err := clientFactory.NewResourceProvidersClient().GetProviderSummary(ctx, "local", resourceProviderName, nil)
 	if clients.Is404Error(err) {

--- a/pkg/cli/cmd/resourcetype/common/resourcetype.go
+++ b/pkg/cli/cmd/resourcetype/common/resourcetype.go
@@ -131,9 +131,9 @@ func GetResourceTypeShowSchemaTableFormat() output.FormatterOptions {
 	}
 }
 
-// GetResourceTypeDetailsWithUCPClient retrieves the details of a resource provider's resource type using the UCP client.
+// GetResourceTypeDetails retrieves the details of a resource provider's resource type using the UCP client.
 // It returns the resource type details or an error if the resource type is not found.
-func GetResourceTypeDetailsWithUCPClient(ctx context.Context, resourceProviderName string, resourceTypeName string, clientFactory *v20231001preview.ClientFactory) (ResourceType, error) {
+func GetResourceTypeDetails(ctx context.Context, resourceProviderName string, resourceTypeName string, clientFactory *v20231001preview.ClientFactory) (ResourceType, error) {
 	response, err := clientFactory.NewResourceProvidersClient().GetProviderSummary(ctx, "local", resourceProviderName, nil)
 	if clients.Is404Error(err) {
 		return ResourceType{}, clierrors.Message("The resource provider %q was not found or has been deleted.", resourceProviderName)

--- a/pkg/cli/cmd/resourcetype/common/resourcetype_test.go
+++ b/pkg/cli/cmd/resourcetype/common/resourcetype_test.go
@@ -18,77 +18,12 @@ package common
 
 import (
 	"context"
-	"errors"
 	"testing"
 
-	"github.com/radius-project/radius/pkg/cli/clients"
 	"github.com/radius-project/radius/pkg/cli/manifest"
-	"github.com/radius-project/radius/pkg/to"
-	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
-	"github.com/radius-project/radius/test/radcli"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
-
-func Test_GetResourceTypeDetails(t *testing.T) {
-	t.Run("Get Resource Details Success", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		resourceProvider := v20231001preview.ResourceProviderSummary{
-			Name: to.Ptr("Applications.Test"),
-			ResourceTypes: map[string]*v20231001preview.ResourceProviderSummaryResourceType{
-				"exampleResources": {
-					APIVersions: map[string]*v20231001preview.ResourceTypeSummaryResultAPIVersion{
-						"2023-10-01-preview": {},
-					},
-				},
-			},
-		}
-
-		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
-		appManagementClient.EXPECT().
-			GetResourceProviderSummary(gomock.Any(), "local", "Applications.Test").
-			Return(resourceProvider, nil).
-			Times(1)
-
-		res, err := GetResourceTypeDetails(context.Background(), "Applications.Test", "exampleResources", appManagementClient)
-		require.NoError(t, err)
-		require.Equal(t, "Applications.Test/exampleResources", res.Name)
-
-	})
-
-	t.Run("Get Resource Details Failure - Resource Provider Not found", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
-		appManagementClient.EXPECT().
-			GetResourceProviderSummary(gomock.Any(), "local", "Applications.Test").
-			Return(v20231001preview.ResourceProviderSummary{}, radcli.Create404Error()).
-			Times(1)
-
-		_, err := GetResourceTypeDetails(context.Background(), "Applications.Test", "exampleResources", appManagementClient)
-
-		require.Error(t, err)
-		require.Equal(t, "The resource provider \"Applications.Test\" was not found or has been deleted.", err.Error())
-	})
-
-	t.Run("Get Resource Details Failures Other Than Not Found", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
-		appManagementClient.EXPECT().
-			GetResourceProviderSummary(gomock.Any(), "local", "Applications.Test").
-			Return(v20231001preview.ResourceProviderSummary{}, errors.New("some error occurred")).
-			Times(1)
-
-		_, err := GetResourceTypeDetails(context.Background(), "Applications.Test", "exampleResources", appManagementClient)
-
-		require.Error(t, err)
-	})
-}
 
 func Test_GetResourceTypeDetailsWithUCPClient(t *testing.T) {
 	t.Run("Get Resource Details Success", func(t *testing.T) {

--- a/pkg/cli/cmd/resourcetype/common/resourcetype_test.go
+++ b/pkg/cli/cmd/resourcetype/common/resourcetype_test.go
@@ -25,7 +25,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func Test_GetResourceTypeDetailsWithUCPClient(t *testing.T) {
+func Test_GetResourceTypeDetails(t *testing.T) {
 	t.Run("Get Resource Details Success", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -33,7 +33,7 @@ func Test_GetResourceTypeDetailsWithUCPClient(t *testing.T) {
 		clientFactory, err := manifest.NewTestClientFactory(manifest.WithResourceProviderServerNoError)
 		require.NoError(t, err)
 
-		res, err := GetResourceTypeDetailsWithUCPClient(context.Background(), "MyCompany.Resources", "testResources", clientFactory)
+		res, err := GetResourceTypeDetails(context.Background(), "MyCompany.Resources", "testResources", clientFactory)
 		require.NoError(t, err)
 		require.Equal(t, "MyCompany.Resources/testResources", res.Name)
 
@@ -46,7 +46,7 @@ func Test_GetResourceTypeDetailsWithUCPClient(t *testing.T) {
 		clientFactory, err := manifest.NewTestClientFactory(manifest.WithResourceProviderServerNotFoundError)
 		require.NoError(t, err)
 
-		_, err = GetResourceTypeDetailsWithUCPClient(context.Background(), "MyCompany.Resources", "testResources", clientFactory)
+		_, err = GetResourceTypeDetails(context.Background(), "MyCompany.Resources", "testResources", clientFactory)
 		require.Error(t, err)
 		require.Equal(t, "The resource provider \"MyCompany.Resources\" was not found or has been deleted.", err.Error())
 	})
@@ -58,7 +58,7 @@ func Test_GetResourceTypeDetailsWithUCPClient(t *testing.T) {
 		clientFactory, err := manifest.NewTestClientFactory(manifest.WithResourceProviderServerInternalError)
 		require.NoError(t, err)
 
-		_, err = GetResourceTypeDetailsWithUCPClient(context.Background(), "MyCompany.Resources", "testResources", clientFactory)
+		_, err = GetResourceTypeDetails(context.Background(), "MyCompany.Resources", "testResources", clientFactory)
 		require.Error(t, err)
 	})
 }

--- a/pkg/cli/cmd/resourcetype/create/create.go
+++ b/pkg/cli/cmd/resourcetype/create/create.go
@@ -161,7 +161,7 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	r.Output.LogInfo("")
 
-	resourceTypeDetails, err := common.GetResourceTypeDetailsWithUCPClient(ctx, r.ResourceProvider.Namespace, r.ResourceTypeName, r.UCPClientFactory)
+	resourceTypeDetails, err := common.GetResourceTypeDetails(ctx, r.ResourceProvider.Namespace, r.ResourceTypeName, r.UCPClientFactory)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/resourcetype/create/create_test.go
+++ b/pkg/cli/cmd/resourcetype/create/create_test.go
@@ -101,8 +101,32 @@ func Test_Run(t *testing.T) {
 				Obj: common.ResourceTypeListOutputFormat{
 					ResourceType: common.ResourceType{
 						Name:                      "MyCompany.Resources/testResources",
+						Description:               "Resource type description",
 						ResourceProviderNamespace: "MyCompany.Resources",
-						APIVersions:               map[string]*common.APIVersionProperties{"2023-10-01-preview": {}},
+						APIVersions: map[string]*common.APIVersionProperties{
+							"2023-10-01-preview": {
+								Schema: map[string]any{
+									"properties": map[string]any{
+										"application": map[string]any{
+											"type":        "string",
+											"description": "The name of the application.",
+										},
+										"environment": map[string]any{
+											"type":        "string",
+											"description": "The name of the environment.",
+										},
+										"database": map[string]any{
+											"type":        "string",
+											"description": "The name of the database.",
+											"readOnly":    true,
+										},
+									},
+									"required": []any{
+										"environment",
+									},
+								},
+							},
+						},
 					},
 					APIVersionList: []string{"2023-10-01-preview"},
 				},

--- a/pkg/cli/cmd/resourcetype/create/create_test.go
+++ b/pkg/cli/cmd/resourcetype/create/create_test.go
@@ -22,15 +22,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/radius-project/radius/pkg/cli/clients"
 	"github.com/radius-project/radius/pkg/cli/cmd/resourcetype/common"
-	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
 	"github.com/radius-project/radius/pkg/cli/manifest"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
-	"github.com/radius-project/radius/pkg/to"
-	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
 	"github.com/radius-project/radius/test/radcli"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -69,25 +65,8 @@ func Test_Validate(t *testing.T) {
 
 func Test_Run(t *testing.T) {
 	t.Run("Success: resource type created", func(t *testing.T) {
-		resourceProvider := v20231001preview.ResourceProviderSummary{
-			Name: to.Ptr("MyCompany.Resources"),
-			ResourceTypes: map[string]*v20231001preview.ResourceProviderSummaryResourceType{
-				"testResources": &v20231001preview.ResourceProviderSummaryResourceType{
-					APIVersions: map[string]*v20231001preview.ResourceTypeSummaryResultAPIVersion{
-						"2023-10-01-preview": {},
-					},
-					Capabilities: []*string{},
-				},
-			},
-		}
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-
-		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
-		appManagementClient.EXPECT().
-			GetResourceProviderSummary(gomock.Any(), "local", "MyCompany.Resources").
-			Return(resourceProvider, nil).
-			Times(1)
 
 		resourceProviderData, err := manifest.ReadFile("testdata/valid.yaml")
 		require.NoError(t, err)
@@ -97,7 +76,6 @@ func Test_Run(t *testing.T) {
 
 		outputSink := &output.MockOutput{}
 		runner := &Runner{
-			ConnectionFactory:                &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
 			UCPClientFactory:                 clientFactory,
 			Output:                           outputSink,
 			Workspace:                        &workspaces.Workspace{},
@@ -152,7 +130,6 @@ func Test_Run(t *testing.T) {
 	t.Run("Resource provider does not exist", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
 
 		resourceProviderData, err := manifest.ReadFile("testdata/valid.yaml")
 		require.NoError(t, err)
@@ -168,7 +145,6 @@ func Test_Run(t *testing.T) {
 		}
 
 		runner := &Runner{
-			ConnectionFactory:                &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
 			UCPClientFactory:                 clientFactory,
 			Output:                           &output.MockOutput{},
 			Workspace:                        &workspaces.Workspace{},
@@ -186,7 +162,6 @@ func Test_Run(t *testing.T) {
 	t.Run("Get Resource provider Internal Error", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		appManagementClient := clients.NewMockApplicationsManagementClient(ctrl)
 
 		resourceProviderData, err := manifest.ReadFile("testdata/valid.yaml")
 		require.NoError(t, err)
@@ -202,7 +177,6 @@ func Test_Run(t *testing.T) {
 		}
 
 		runner := &Runner{
-			ConnectionFactory:                &connections.MockFactory{ApplicationsManagementClient: appManagementClient},
 			UCPClientFactory:                 clientFactory,
 			Output:                           &output.MockOutput{},
 			Workspace:                        &workspaces.Workspace{},

--- a/pkg/cli/cmd/resourcetype/create/testdata/valid.yaml
+++ b/pkg/cli/cmd/resourcetype/create/testdata/valid.yaml
@@ -1,7 +1,21 @@
 namespace: MyCompany.Resources
 types:
   testResources:
-    apiVersions:
-      '2023-10-01-preview':
-        schema: {}
     capabilities: ["SupportsRecipes"]
+    description: Resource type description
+    apiVersions:
+      2023-10-01-preview:
+        schema:
+          properties:
+            application:
+              type: string
+              description: The name of the application.
+            environment:
+              type: string
+              description: The name of the environment.
+            database:
+              type: string
+              description: The name of the database.
+              readOnly: true
+          required:
+            - environment

--- a/pkg/cli/cmd/resourcetype/show/show.go
+++ b/pkg/cli/cmd/resourcetype/show/show.go
@@ -20,12 +20,13 @@ import (
 	"context"
 
 	"github.com/radius-project/radius/pkg/cli"
+	"github.com/radius-project/radius/pkg/cli/cmd"
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
 	"github.com/radius-project/radius/pkg/cli/cmd/resourcetype/common"
-	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
+	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
 	"github.com/spf13/cobra"
 )
 
@@ -54,11 +55,11 @@ rad resource-type show 'Applications.Core/containers'`,
 
 // Runner is the Runner implementation for the `rad resource-type show` command.
 type Runner struct {
-	ConnectionFactory connections.Factory
-	ConfigHolder      *framework.ConfigHolder
-	Output            output.Interface
-	Format            string
-	Workspace         *workspaces.Workspace
+	ConfigHolder     *framework.ConfigHolder
+	Output           output.Interface
+	Format           string
+	UCPClientFactory *v20231001preview.ClientFactory
+	Workspace        *workspaces.Workspace
 
 	ResourceTypeName          string
 	ResourceProviderNamespace string
@@ -68,9 +69,8 @@ type Runner struct {
 // NewRunner creates an instance of the runner for the `rad resource-type show` command.
 func NewRunner(factory framework.Factory) *Runner {
 	return &Runner{
-		ConnectionFactory: factory.GetConnectionFactory(),
-		ConfigHolder:      factory.GetConfigHolder(),
-		Output:            factory.GetOutput(),
+		ConfigHolder: factory.GetConfigHolder(),
+		Output:       factory.GetOutput(),
 	}
 }
 
@@ -99,12 +99,17 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 
 // Run runs the `rad resource-type show` command.
 func (r *Runner) Run(ctx context.Context) error {
-	client, err := r.ConnectionFactory.CreateApplicationsManagementClient(ctx, *r.Workspace)
-	if err != nil {
-		return err
+	// Initialize the client factory if it hasn't been set externally.
+	// This allows for flexibility where a test UCPClientFactory can be set externally during testing.
+	if r.UCPClientFactory == nil {
+		clientFactory, err := cmd.InitializeClientFactory(ctx, r.Workspace)
+		if err != nil {
+			return err
+		}
+		r.UCPClientFactory = clientFactory
 	}
 
-	resourceTypeDetails, err := common.GetResourceTypeDetails(ctx, r.ResourceProviderNamespace, r.ResourceTypeSuffix, client)
+	resourceTypeDetails, err := common.GetResourceTypeDetailsWithUCPClient(ctx, r.ResourceProviderNamespace, r.ResourceTypeSuffix, r.UCPClientFactory)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/resourcetype/show/show.go
+++ b/pkg/cli/cmd/resourcetype/show/show.go
@@ -109,7 +109,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		r.UCPClientFactory = clientFactory
 	}
 
-	resourceTypeDetails, err := common.GetResourceTypeDetailsWithUCPClient(ctx, r.ResourceProviderNamespace, r.ResourceTypeSuffix, r.UCPClientFactory)
+	resourceTypeDetails, err := common.GetResourceTypeDetails(ctx, r.ResourceProviderNamespace, r.ResourceTypeSuffix, r.UCPClientFactory)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/cmd/utils.go
+++ b/pkg/cli/cmd/utils.go
@@ -20,12 +20,16 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/radius-project/radius/pkg/azure/tokencredentials"
 	"github.com/radius-project/radius/pkg/cli/aws"
 	"github.com/radius-project/radius/pkg/cli/azure"
 	"github.com/radius-project/radius/pkg/cli/clients"
 	"github.com/radius-project/radius/pkg/cli/clierrors"
+	"github.com/radius-project/radius/pkg/cli/workspaces"
 	corerp "github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
+	"github.com/radius-project/radius/pkg/sdk"
 	"github.com/radius-project/radius/pkg/to"
+	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
 )
 
 // CreateEnvProviders forms the provider scope from the given
@@ -93,4 +97,22 @@ func CheckIfRecipeExists(ctx context.Context, client clients.ApplicationsManagem
 	}
 
 	return envResource, recipeProperties, nil
+}
+
+// InitializeClientFactory initializes a new v20231001preview.ClientFactory using the provided workspace context.
+// It connects to the workspace and creates a new client factory with anonymous credentials.
+// If the connection fails, it returns an error.
+func InitializeClientFactory(ctx context.Context, workspace *workspaces.Workspace) (*v20231001preview.ClientFactory, error) {
+	connection, err := workspace.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	clientOptions := sdk.NewClientOptions(connection)
+	clientFactory, err := v20231001preview.NewClientFactory(&tokencredentials.AnonymousCredential{}, clientOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientFactory, nil
 }

--- a/pkg/cli/manifest/testclientfactory.go
+++ b/pkg/cli/manifest/testclientfactory.go
@@ -97,8 +97,30 @@ func WithResourceProviderServerNoError() ucpfake.ResourceProvidersServer {
 					Name: to.Ptr(resourceProviderName),
 					ResourceTypes: map[string]*v20231001preview.ResourceProviderSummaryResourceType{
 						"testResources": {
+							Description: to.Ptr("Resource type description"),
 							APIVersions: map[string]*v20231001preview.ResourceTypeSummaryResultAPIVersion{
-								"2023-10-01-preview": {},
+								"2023-10-01-preview": {
+									Schema: map[string]any{
+										"properties": map[string]any{
+											"application": map[string]any{
+												"type":        "string",
+												"description": "The name of the application.",
+											},
+											"environment": map[string]any{
+												"type":        "string",
+												"description": "The name of the environment.",
+											},
+											"database": map[string]any{
+												"type":        "string",
+												"description": "The name of the database.",
+												"readOnly":    true,
+											},
+										},
+										"required": []any{
+											"environment",
+										},
+									},
+								},
 							},
 						},
 					},

--- a/pkg/cli/manifest/testclientfactory.go
+++ b/pkg/cli/manifest/testclientfactory.go
@@ -86,6 +86,27 @@ func WithResourceProviderServerNoError() ucpfake.ResourceProvidersServer {
 			resp.SetResponse(http.StatusOK, response, nil)
 			return
 		},
+		GetProviderSummary: func(
+			ctx context.Context,
+			planeName string,
+			resourceProviderName string,
+			options *v20231001preview.ResourceProvidersClientGetProviderSummaryOptions,
+		) (resp azfake.Responder[v20231001preview.ResourceProvidersClientGetProviderSummaryResponse], errResp azfake.ErrorResponder) {
+			response := v20231001preview.ResourceProvidersClientGetProviderSummaryResponse{
+				ResourceProviderSummary: v20231001preview.ResourceProviderSummary{
+					Name: to.Ptr(resourceProviderName),
+					ResourceTypes: map[string]*v20231001preview.ResourceProviderSummaryResourceType{
+						"testResources": {
+							APIVersions: map[string]*v20231001preview.ResourceTypeSummaryResultAPIVersion{
+								"2023-10-01-preview": {},
+							},
+						},
+					},
+				},
+			}
+			resp.SetResponse(http.StatusOK, response, nil)
+			return
+		},
 	}
 	return resourceProvidersServer
 }
@@ -225,6 +246,15 @@ func WithResourceProviderServerNotFoundError() ucpfake.ResourceProvidersServer {
 			resp.SetResponse(http.StatusNotFound, response, nil)
 			return
 		},
+		GetProviderSummary: func(
+			ctx context.Context,
+			planeName string,
+			resourceProviderName string,
+			options *v20231001preview.ResourceProvidersClientGetProviderSummaryOptions,
+		) (resp azfake.Responder[v20231001preview.ResourceProvidersClientGetProviderSummaryResponse], errResp azfake.ErrorResponder) {
+			resp.SetResponse(http.StatusNotFound, v20231001preview.ResourceProvidersClientGetProviderSummaryResponse{}, nil)
+			return
+		},
 	}
 	return resourceProvidersNotFoundServer
 }
@@ -259,6 +289,15 @@ func WithResourceProviderServerInternalError() ucpfake.ResourceProvidersServer {
 				},
 			}
 			resp.SetResponse(http.StatusInternalServerError, response, nil)
+			return
+		},
+		GetProviderSummary: func(
+			ctx context.Context,
+			planeName string,
+			resourceProviderName string,
+			options *v20231001preview.ResourceProvidersClientGetProviderSummaryOptions,
+		) (resp azfake.Responder[v20231001preview.ResourceProvidersClientGetProviderSummaryResponse], errResp azfake.ErrorResponder) {
+			resp.SetResponse(http.StatusInternalServerError, v20231001preview.ResourceProvidersClientGetProviderSummaryResponse{}, nil)
 			return
 		},
 	}


### PR DESCRIPTION
# Description

* The resource-type create command currently uses two different clients for API calls. Updating it to migrate away from the legacy client.

* Also updated other commands (resource-type show, resource list) to use the new UCP client through new GetResourceTypeDetails implementation.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request adds or changes features of Radius and has an approved issue (issue link required).
<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: https://github.com/radius-project/radius/issues/8251

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->