### PR TITLE
Windows install script fix

### DIFF
--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -89,7 +89,7 @@ if (Test-Path "C:\radius\rad.exe" -PathType Leaf) {
 if (Test-Path $RadiusCliFilePath -PathType Leaf) {
     Write-Output "Previous rad CLI detected: $RadiusCliFilePath"
     try {
-        $CurrentVersion = &$RadiusCliFilePath version -o json | ConvertFrom-JSON | Select-Object -ExpandProperty version
+        $CurrentVersion = &$RadiusCliFilePath version --cli --output json | ConvertFrom-JSON | Select-Object -ExpandProperty version
         Write-Output "Previous version: $CurrentVersion`r`n"
     }
     catch {
@@ -180,7 +180,7 @@ if (!(Test-Path $RadiusCliFilePath -PathType Leaf)) {
 }
 
 # Print the version string of the installed CLI
-Write-Output "rad CLI version: $(&$RadiusCliFilePath version -o json | ConvertFrom-JSON | Select-Object -ExpandProperty version)"
+Write-Output "rad CLI version: $(&$RadiusCliFilePath version --cli --output json | ConvertFrom-JSON | Select-Object -ExpandProperty version)"
 
 # Add RadiusRoot directory to User Path environment variable
 $UserPathEnvironmentVar = (Get-Item -Path HKCU:\Environment).GetValue(


### PR DESCRIPTION
# Description

This pull request updates the `deploy/install.ps1` script to improve compatibility with the `rad CLI` by modifying the command syntax used for version retrieval.

### Updates to `rad CLI` command syntax:

* Changed the `rad CLI` command to include the `--cli` flag and updated `-o json` to `--output json` for version retrieval in two locations within the script. This ensures compatibility with the latest `rad CLI` syntax. [[1]](diffhunk://#diff-506d53c740958f1f7b269e6b80b68300aeb53417fccb0297240700f1d84811bfL92-R92) [[2]](diffhunk://#diff-506d53c740958f1f7b269e6b80b68300aeb53417fccb0297240700f1d84811bfL183-R183)

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #9812 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->