### PR TITLE
Adding a fix for group delete command

### DIFF
--- a/pkg/cli/clients/clients.go
+++ b/pkg/cli/clients/clients.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
+	"github.com/radius-project/radius/pkg/cli/output"
 	corerp "github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
 	ucp_v20231001preview "github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
 	ucpresources "github.com/radius-project/radius/pkg/ucp/resources"
@@ -191,6 +192,9 @@ type ApplicationsManagementClient interface {
 	// ListEnvironmentsAll lists all environments across resource groups.
 	ListEnvironmentsAll(ctx context.Context) ([]corerp.EnvironmentResource, error)
 
+	// ListEnvironmentsInResourceGroup lists all environments in a resource group.
+	ListEnvironmentsInResourceGroup(ctx context.Context, resourceGroupName string) ([]corerp.EnvironmentResource, error)
+
 	// GetEnvironment retrieves an environment by its name (in the configured scope) or resource ID.
 	GetEnvironment(ctx context.Context, environmentNameOrID string) (corerp.EnvironmentResource, error)
 
@@ -213,7 +217,7 @@ type ApplicationsManagementClient interface {
 	CreateOrUpdateResourceGroup(ctx context.Context, planeName string, resourceGroupName string, resource *ucp_v20231001preview.ResourceGroupResource) error
 
 	// DeleteResourceGroup deletes a resource group by its name.
-	DeleteResourceGroup(ctx context.Context, planeName string, resourceGroupName string) (bool, error)
+	DeleteResourceGroup(ctx context.Context, planeName string, resourceGroupName string, outputInterface output.Interface) (bool, error)
 
 	// ListResourceProviders lists all resource providers in the configured scope.
 	ListResourceProviders(ctx context.Context, planeName string) ([]ucp_v20231001preview.ResourceProviderResource, error)

--- a/pkg/cli/clients/mock_applicationsclient.go
+++ b/pkg/cli/clients/mock_applicationsclient.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	generated "github.com/radius-project/radius/pkg/cli/clients_new/generated"
+	output "github.com/radius-project/radius/pkg/cli/output"
 	v20231001preview "github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
 	v20231001preview0 "github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
 	gomock "go.uber.org/mock/gomock"
@@ -507,18 +508,18 @@ func (c *MockApplicationsManagementClientDeleteResourceCall) DoAndReturn(f func(
 }
 
 // DeleteResourceGroup mocks base method.
-func (m *MockApplicationsManagementClient) DeleteResourceGroup(arg0 context.Context, arg1, arg2 string) (bool, error) {
+func (m *MockApplicationsManagementClient) DeleteResourceGroup(arg0 context.Context, arg1, arg2 string, arg3 output.Interface) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteResourceGroup", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "DeleteResourceGroup", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DeleteResourceGroup indicates an expected call of DeleteResourceGroup.
-func (mr *MockApplicationsManagementClientMockRecorder) DeleteResourceGroup(arg0, arg1, arg2 any) *MockApplicationsManagementClientDeleteResourceGroupCall {
+func (mr *MockApplicationsManagementClientMockRecorder) DeleteResourceGroup(arg0, arg1, arg2, arg3 any) *MockApplicationsManagementClientDeleteResourceGroupCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResourceGroup", reflect.TypeOf((*MockApplicationsManagementClient)(nil).DeleteResourceGroup), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResourceGroup", reflect.TypeOf((*MockApplicationsManagementClient)(nil).DeleteResourceGroup), arg0, arg1, arg2, arg3)
 	return &MockApplicationsManagementClientDeleteResourceGroupCall{Call: call}
 }
 
@@ -534,13 +535,13 @@ func (c *MockApplicationsManagementClientDeleteResourceGroupCall) Return(arg0 bo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationsManagementClientDeleteResourceGroupCall) Do(f func(context.Context, string, string) (bool, error)) *MockApplicationsManagementClientDeleteResourceGroupCall {
+func (c *MockApplicationsManagementClientDeleteResourceGroupCall) Do(f func(context.Context, string, string, output.Interface) (bool, error)) *MockApplicationsManagementClientDeleteResourceGroupCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationsManagementClientDeleteResourceGroupCall) DoAndReturn(f func(context.Context, string, string) (bool, error)) *MockApplicationsManagementClientDeleteResourceGroupCall {
+func (c *MockApplicationsManagementClientDeleteResourceGroupCall) DoAndReturn(f func(context.Context, string, string, output.Interface) (bool, error)) *MockApplicationsManagementClientDeleteResourceGroupCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1087,6 +1088,45 @@ func (c *MockApplicationsManagementClientListEnvironmentsAllCall) Do(f func(cont
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockApplicationsManagementClientListEnvironmentsAllCall) DoAndReturn(f func(context.Context) ([]v20231001preview.EnvironmentResource, error)) *MockApplicationsManagementClientListEnvironmentsAllCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ListEnvironmentsInResourceGroup mocks base method.
+func (m *MockApplicationsManagementClient) ListEnvironmentsInResourceGroup(arg0 context.Context, arg1 string) ([]v20231001preview.EnvironmentResource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListEnvironmentsInResourceGroup", arg0, arg1)
+	ret0, _ := ret[0].([]v20231001preview.EnvironmentResource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListEnvironmentsInResourceGroup indicates an expected call of ListEnvironmentsInResourceGroup.
+func (mr *MockApplicationsManagementClientMockRecorder) ListEnvironmentsInResourceGroup(arg0, arg1 any) *MockApplicationsManagementClientListEnvironmentsInResourceGroupCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEnvironmentsInResourceGroup", reflect.TypeOf((*MockApplicationsManagementClient)(nil).ListEnvironmentsInResourceGroup), arg0, arg1)
+	return &MockApplicationsManagementClientListEnvironmentsInResourceGroupCall{Call: call}
+}
+
+// MockApplicationsManagementClientListEnvironmentsInResourceGroupCall wrap *gomock.Call
+type MockApplicationsManagementClientListEnvironmentsInResourceGroupCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationsManagementClientListEnvironmentsInResourceGroupCall) Return(arg0 []v20231001preview.EnvironmentResource, arg1 error) *MockApplicationsManagementClientListEnvironmentsInResourceGroupCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationsManagementClientListEnvironmentsInResourceGroupCall) Do(f func(context.Context, string) ([]v20231001preview.EnvironmentResource, error)) *MockApplicationsManagementClientListEnvironmentsInResourceGroupCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationsManagementClientListEnvironmentsInResourceGroupCall) DoAndReturn(f func(context.Context, string) ([]v20231001preview.EnvironmentResource, error)) *MockApplicationsManagementClientListEnvironmentsInResourceGroupCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
# Description

Adding a fix for `rad group delete ` commad
- delete group command deletes all the resources in the group
- added unit tests

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->