### PR TITLE
Fix version issue in release verification workflow

### DIFF
--- a/.github/scripts/release-verification.sh
+++ b/.github/scripts/release-verification.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # ------------------------------------------------------------
 # Copyright 2023 The Radius Authors.
 #
@@ -52,8 +54,8 @@ echo "Downloading ${DOWNLOAD_URL}"
 curl -sSL "${DOWNLOAD_URL}" -o rad
 chmod +x ./rad
 
-RELEASE_FROM_RAD_VERSION=$(./rad version -o json | jq -r '.release')
-VERSION_FROM_RAD_VERSION=$(./rad version -o json | jq -r '.version')
+RELEASE_FROM_RAD_VERSION=$(./rad version --cli -o json | jq -r '.release')
+VERSION_FROM_RAD_VERSION=$(./rad version --cli -o json | jq -r '.version')
 
 if [[ "${RELEASE_FROM_RAD_VERSION}" != "${EXPECTED_CLI_VERSION}" ]]; then
     echo "Error: Release: ${RELEASE_FROM_RAD_VERSION} from rad version does not match the desired release: ${EXPECTED_CLI_VERSION}."


### PR DESCRIPTION
# Description

* Fix version issue in release verification workflow

example test:

```
❯ sh /Users/willsmith/dev/radius-old/radius/.github/scripts/release-verification.sh 0.48.0
+ RELEASE_VERSION_NUMBER=0.48.0
+ [[ -z 0.48.0 ]]
+ OS=darwin
+ ARCH=arm64
+ GITHUB_ORG=radius-project
+ GITHUB_REPO=radius
+ RADIUS_CLI_ARTIFACT=rad_darwin_arm64
+ DOWNLOAD_BASE=https://github.com/radius-project/radius/releases/download
+ DOWNLOAD_URL=https://github.com/radius-project/radius/releases/download/v0.48.0/rad_darwin_arm64
+ EXPECTED_CLI_VERSION=0.48.0
+ EXPECTED_TAG_VERSION=0.48.0
+ [[ 0.48.0 != *\r\c* ]]
++ echo 0.48.0
++ cut -d . -f 1,2
+ EXPECTED_TAG_VERSION=0.48
+ echo 'RELEASE_VERSION_NUMBER: 0.48.0'
RELEASE_VERSION_NUMBER: 0.48.0
+ echo 'EXPECTED_CLI_VERSION: 0.48.0'
EXPECTED_CLI_VERSION: 0.48.0
+ echo 'EXPECTED_TAG_VERSION: 0.48'
EXPECTED_TAG_VERSION: 0.48
+ echo 'Downloading https://github.com/radius-project/radius/releases/download/v0.48.0/rad_darwin_arm64'
Downloading https://github.com/radius-project/radius/releases/download/v0.48.0/rad_darwin_arm64
+ curl -sSL https://github.com/radius-project/radius/releases/download/v0.48.0/rad_darwin_arm64 -o rad
+ chmod +x ./rad
++ ./rad version --cli -o json
++ jq -r .release
+ RELEASE_FROM_RAD_VERSION=0.48.0
++ ./rad version --cli -o json
++ jq -r .version
+ VERSION_FROM_RAD_VERSION=v0.48.0
+ [[ 0.48.0 != \0\.\4\8\.\0 ]]
+ [[ v0.48.0 != \v\0\.\4\8\.\0 ]]
+ kind create cluster
Creating cluster "kind" ...
 ✓ Ensuring node image (kindest/node:v1.32.2) 🖼
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
Set kubectl context to "kind-kind"
You can now use your cluster with:

kubectl cluster-info --context kind-kind

Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
+ ./rad install kubernetes
Installing Radius version v0.48.0 to namespace: radius-system...
+ EXPECTED_APPCORE_RP_IMAGE=ghcr.io/radius-project/applications-rp:0.48
+ EXPECTED_DYNAMIC_RP_IMAGE=ghcr.io/radius-project/dynamic-rp:0.48
+ EXPECTED_UCP_IMAGE=ghcr.io/radius-project/ucpd:0.48
+ EXPECTED_DE_IMAGE=ghcr.io/radius-project/deployment-engine:0.48
++ kubectl describe pods -n radius-system -l control-plane=applications-rp
++ awk '/^.*Image:/ {print $2}'
+ APPCORE_RP_IMAGE=ghcr.io/radius-project/applications-rp:0.48
++ kubectl describe pods -n radius-system -l control-plane=dynamic-rp
++ awk '/^.*Image:/ {print $2}'
+ DYNAMIC_RP_IMAGE=ghcr.io/radius-project/dynamic-rp:0.48
++ kubectl describe pods -n radius-system -l control-plane=ucp
++ awk '/^.*Image:/ {print $2}'
+ UCP_IMAGE=ghcr.io/radius-project/ucpd:0.48
++ kubectl describe pods -n radius-system -l control-plane=bicep-de
++ awk '/^.*Image:/ {print $2}'
+ DE_IMAGE=ghcr.io/radius-project/deployment-engine:0.48
+ [[ ghcr.io/radius-project/applications-rp:0.48 != \g\h\c\r\.\i\o\/\r\a\d\i\u\s\-\p\r\o\j\e\c\t\/\a\p\p\l\i\c\a\t\i\o\n\s\-\r\p\:\0\.\4\8 ]]
+ [[ ghcr.io/radius-project/dynamic-rp:0.48 != \g\h\c\r\.\i\o\/\r\a\d\i\u\s\-\p\r\o\j\e\c\t\/\d\y\n\a\m\i\c\-\r\p\:\0\.\4\8 ]]
+ [[ ghcr.io/radius-project/ucpd:0.48 != \g\h\c\r\.\i\o\/\r\a\d\i\u\s\-\p\r\o\j\e\c\t\/\u\c\p\d\:\0\.\4\8 ]]
+ [[ ghcr.io/radius-project/deployment-engine:0.48 != \g\h\c\r\.\i\o\/\r\a\d\i\u\s\-\p\r\o\j\e\c\t\/\d\e\p\l\o\y\m\e\n\t\-\e\n\g\i\n\e\:\0\.\4\8 ]]
+ echo 'Release verification successful.'
Release verification successful.
```

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: https://github.com/radius-project/radius/issues/9639

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->