### PR TITLE
modify udt2udt test to remove unneccessary dependency on configmap

### DIFF
--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/udt2udt-connection-tf.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/udt2udt-connection-tf.bicep
@@ -67,16 +67,6 @@ resource udttoudtchild 'Test.Resources/externalResource@2023-10-01-preview' = {
   properties: {
     environment: udttoudtenv.id
     application: udttoudtapp.id
-    configMap: string(udttoudttfcfgmap.data)
-  }
-}
-
-resource udttoudttfcfgmap 'core/ConfigMap@v1' = {
-  metadata: {
-    name: 'udttoudttfcfgmap'
-  }
-  data: {
-    'app1.sample.properties': 'property1=value1\nproperty2=value2'
-    'app2.sample.properties': 'property3=value3\nproperty4=value4'
+    configMap: '{"app1.sample.properties":"property1=value1\\nproperty2=value2","app2.sample.properties":"property3=value3\\nproperty4=value4"}'
   }
 }

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/udt2udt-connection.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/udt2udt-connection.bicep
@@ -70,16 +70,6 @@ resource udttoudtchild 'Test.Resources/externalResource@2023-10-01-preview' = {
   properties: {
     environment: udttoudtenv.id
     application: udttoudtapp.id
-    configMap: string(udttoudtcfgmap.data)
-  }
-}
-
-resource udttoudtcfgmap 'core/ConfigMap@v1' = {
-  metadata: {
-    name: 'udttoudtcfgmap'
-  }
-  data: {
-    'app1.sample.properties': 'property1=value1\nproperty2=value2'
-    'app2.sample.properties': 'property3=value3\nproperty4=value4'
+    configMap: '{"app1.sample.properties":"property1=value1\\nproperty2=value2","app2.sample.properties":"property3=value3\\nproperty4=value4"}'
   }
 }


### PR DESCRIPTION
# Description

current strategy does not take care of the order in which resources are created.
so if configmap was not created before the udt, then the test errors out. removing this dependency.

## Type of change


- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [X] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [X] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [X] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [X] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [X] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [X] Not applicable <!-- TaskRadio recipes-pr -->