### PR TITLE
Improve error message for missing secret key in populateSecretData function

### DIFF
--- a/pkg/recipes/configloader/secrets.go
+++ b/pkg/recipes/configloader/secrets.go
@@ -110,7 +110,11 @@ func populateSecretData(secretStoreID string, secretKeysFilter []string, secrets
 	for _, secretKey := range secretKeysFilter {
 		secretDataValue, ok := secrets.Data[secretKey]
 		if !ok {
-			return recipes.SecretData{}, fmt.Errorf("a secret key was not found in secret store '%s'", secretStoreID)
+			return recipes.SecretData{}, fmt.Errorf(
+				"'%s' secret key was not found in secret store '%s'",
+				secretKey,
+				secretStoreID,
+			)
 		}
 		secretData.Data[secretKey] = *secretDataValue.Value
 	}

--- a/pkg/recipes/configloader/secrets_test.go
+++ b/pkg/recipes/configloader/secrets_test.go
@@ -102,7 +102,7 @@ func Test_populateSecretData(t *testing.T) {
 			secretStoreID:   "testSecretStore",
 			expectedSecrets: recipes.SecretData{},
 			expectError:     true,
-			expectedErrMsg:  "a secret key was not found in secret store 'testSecretStore'",
+			expectedErrMsg:  "'missingKey' secret key was not found in secret store 'testSecretStore'",
 		},
 		{
 			name:       "fail - missing secret type",


### PR DESCRIPTION

# Description

This is a very simple change that aims to improve troubleshooting experience for scenarios where documentation is misleading - e.g. documentation says the `username` is optional but the codebase says the opposite. 

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #9929

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [x] Yes <!-- TaskRadio docs-pr -->
    - [ ] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->