### PR TITLE
handle aws arns without region

### DIFF
--- a/pkg/ucp/resources/aws/aws.go
+++ b/pkg/ucp/resources/aws/aws.go
@@ -52,17 +52,16 @@ func ToUCPResourceID(arn string) (string, error) {
 	if len(arnSegments) < 6 {
 		return "", fmt.Errorf("\"%s\" is not a valid ARN", arn)
 	}
-
 	service := arnSegments[2]
 	region := arnSegments[3]
-	account := arnSegments[4]
-	resourcePath := strings.Join(arnSegments[5:], "/")
-	ucpID := ""
 	// Handle global services that don't have regions (like IAM policies, users, groups, route53, cloudfront etc.)
 	if region == "" {
 		region = "global"
 	}
-	ucpID = fmt.Sprintf("/planes/aws/%s/accounts/%s/regions/%s/providers/AWS.%s/%s", arnSegments[1], account, region, service, resourcePath)
+	account := arnSegments[4]
+	resourcePath := strings.Join(arnSegments[5:], "/")
+
+	ucpID := fmt.Sprintf("/planes/aws/%s/accounts/%s/regions/%s/providers/AWS.%s/%s", arnSegments[1], account, region, service, resourcePath)
 
 	return ucpID, nil
 }

--- a/pkg/ucp/resources/aws/aws.go
+++ b/pkg/ucp/resources/aws/aws.go
@@ -52,6 +52,17 @@ func ToUCPResourceID(arn string) (string, error) {
 	if len(arnSegments) < 6 {
 		return "", fmt.Errorf("\"%s\" is not a valid ARN", arn)
 	}
-	ucpId := fmt.Sprintf("/planes/aws/%s/accounts/%s/regions/%s/providers/AWS.%s/%s", arnSegments[1], arnSegments[4], arnSegments[3], arnSegments[2], strings.Join(arnSegments[5:], "/"))
-	return ucpId, nil
+
+	service := arnSegments[2]
+	region := arnSegments[3]
+	account := arnSegments[4]
+	resourcePath := strings.Join(arnSegments[5:], "/")
+	ucpID := ""
+	// Handle global services that don't have regions (like IAM policies, users, groups, route53, cloudfront etc.)
+	if region == "" {
+		region = "global"
+	}
+	ucpID = fmt.Sprintf("/planes/aws/%s/accounts/%s/regions/%s/providers/AWS.%s/%s", arnSegments[1], account, region, service, resourcePath)
+
+	return ucpID, nil
 }

--- a/pkg/ucp/resources/aws/aws_test.go
+++ b/pkg/ucp/resources/aws/aws_test.go
@@ -60,6 +60,14 @@ func Test_ToUCPResourceID(t *testing.T) {
 		require.Equal(t, expectedID, ucpID)
 	})
 
+	t.Run("arn format 4", func(t *testing.T) {
+		arn := "arn:aws:iam::179022619019:policy/BedrockUserPolicy-5b0a628b"
+		expectedID := "/planes/aws/aws/accounts/179022619019/regions/global/providers/AWS.iam/policy/BedrockUserPolicy-5b0a628b"
+		ucpID, err := ToUCPResourceID(arn)
+		require.NoError(t, err)
+		require.Equal(t, expectedID, ucpID)
+	})
+
 	t.Run("invalid arn", func(t *testing.T) {
 		arn := "arn:aws:ec2:us-east-2:179022619019"
 		_, err := ToUCPResourceID(arn)


### PR DESCRIPTION
# Description

Many AWS resources are global and not tied to a region. 
This includes AWS policies, roles, users, and many other IAM entities. 
There are also other resources such as route 53 and cloudfront.

Since with UDTs we are open to managing any AWS resource through a recipe, we want to remove the region requirement for valid ARNs.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->