### PR TITLE
Skipping Recipe Context e2e test

### DIFF
--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -86,7 +86,7 @@ env:
   AWS_ACCOUNT_ID: "${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}"
 
   # The valid radius build time window in seconds to rebuild radius. 24 hours = 24 * 60 * 60 = 86400
-  VALID_RADIUS_BUILD_WINDOW: 1800
+  VALID_RADIUS_BUILD_WINDOW: 86400
 
   # The functional test GitHub app id
   FUNCTIONAL_TEST_APP_ID: 425843

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -86,7 +86,7 @@ env:
   AWS_ACCOUNT_ID: "${{ secrets.FUNCTEST_AWS_ACCOUNT_ID }}"
 
   # The valid radius build time window in seconds to rebuild radius. 24 hours = 24 * 60 * 60 = 86400
-  VALID_RADIUS_BUILD_WINDOW: 86400
+  VALID_RADIUS_BUILD_WINDOW: 1800
 
   # The functional test GitHub app id
   FUNCTIONAL_TEST_APP_ID: 425843

--- a/test/functional-portable/corerp/noncloud/resources/recipe_bicep_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/recipe_bicep_test.go
@@ -112,6 +112,7 @@ func Test_BicepRecipe_ParametersAndOutputs(t *testing.T) {
 
 // This test validates that the recipe context parameter is populated as expected.
 func Test_BicepRecipe_ContextParameter(t *testing.T) {
+	t.Skip("https://github.com/radius-project/radius/issues/10002")
 	template := "testdata/corerp-resources-recipe-bicep.bicep"
 	name := "corerp-resources-recipe-bicep-contextparameter"
 


### PR DESCRIPTION
# Description

- Skipping the test until we fix https://github.com/radius-project/radius/issues/10002. 



## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->