### PR TITLE
Reverting the delete resource changes in e2e test cleanup.

### DIFF
--- a/test/validation/shared.go
+++ b/test/validation/shared.go
@@ -98,35 +98,8 @@ func DeleteRPResource(ctx context.Context, t *testing.T, cli *radcli.CLI, client
 	} else if resource.Type == ApplicationsResource {
 		t.Logf("deleting application: %s", resource.Name)
 		return cli.ApplicationDelete(ctx, resource.Name)
-	} else {
-		// Handle other resource types (like ExtendersResource, ContainersResource, etc.)
-		t.Logf("deleting resource: %s of type: %s", resource.Name, resource.Type)
-		
-		// Retry deletion with exponential backoff for 409 Conflict errors
-		// Resources may be stuck in "Updating" state after failed deployments
-		maxRetries := 5
-		var err error
-		for attempt := 0; attempt < maxRetries; attempt++ {
-			_, err = client.DeleteResource(ctx, resource.Type, resource.Name)
-			if err == nil {
-				break
-			}
-			
-			// Check if it's a 409 Conflict error (resource is updating)
-			if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "Conflict") {
-				if attempt < maxRetries-1 {
-					waitTime := time.Duration(1<<attempt) * time.Second // Exponential backoff: 1s, 2s, 4s, 8s, 16s
-					t.Logf("resource %s is updating (409 Conflict), retrying in %v (attempt %d/%d)", resource.Name, waitTime, attempt+1, maxRetries)
-					time.Sleep(waitTime)
-					continue
-				} else {
-					t.Logf("resource %s still updating after %d attempts, giving up", resource.Name, maxRetries)
-				}
-			}
-			break
-		}
-		return err
 	}
+	return nil
 }
 
 // DeleteRPResourceSilent deletes an environment or application resource without logging to the test.
@@ -146,7 +119,7 @@ func DeleteRPResourceSilent(ctx context.Context, cli *radcli.CLI, client clients
 		return cli.ApplicationDelete(ctx, resource.Name)
 	} else {
 		// Handle other resource types (like ExtendersResource, ContainersResource, etc.)
-		
+
 		// Retry deletion with exponential backoff for 409 Conflict errors
 		// Resources may be stuck in "Updating" state after failed deployments
 		maxRetries := 5
@@ -156,7 +129,7 @@ func DeleteRPResourceSilent(ctx context.Context, cli *radcli.CLI, client clients
 			if err == nil {
 				break
 			}
-			
+
 			// Check if it's a 409 Conflict error (resource is updating)
 			if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "Conflict") {
 				if attempt < maxRetries-1 {


### PR DESCRIPTION
# Description

Reverting the changes for deleting the resource from PR https://github.com/radius-project/radius/pull/9958

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->