### PR TITLE
Add validation for reserved words. (UDT)

### DIFF
--- a/pkg/cli/manifest/validation_test.go
+++ b/pkg/cli/manifest/validation_test.go
@@ -316,6 +316,9 @@ func TestValidateManifestSchemas(t *testing.T) {
 									"count": map[string]any{
 										"type": "integer",
 									},
+									"environment": map[string]any{
+										"type": "string",
+									},
 								},
 							},
 						},
@@ -419,7 +422,8 @@ func TestValidateManifestSchemas(t *testing.T) {
 							Schema: map[string]any{
 								"type": "object",
 								"properties": map[string]any{
-									"name": map[string]any{"type": "string"},
+									"name":        map[string]any{"type": "string"},
+									"environment": map[string]any{"type": "string"},
 								},
 							},
 						},
@@ -429,6 +433,7 @@ func TestValidateManifestSchemas(t *testing.T) {
 								"properties": map[string]any{
 									"name":        map[string]any{"type": "string"},
 									"description": map[string]any{"type": "string"},
+									"environment": map[string]any{"type": "string"},
 								},
 							},
 						},
@@ -440,8 +445,9 @@ func TestValidateManifestSchemas(t *testing.T) {
 							Schema: map[string]any{
 								"type": "object",
 								"properties": map[string]any{
-									"id":     map[string]any{"type": "string"},
-									"active": map[string]any{"type": "boolean"},
+									"id":          map[string]any{"type": "string"},
+									"active":      map[string]any{"type": "boolean"},
+									"environment": map[string]any{"type": "string"},
 								},
 							},
 						},

--- a/pkg/schema/errors.go
+++ b/pkg/schema/errors.go
@@ -91,9 +91,9 @@ func (ve *ValidationErrors) Error() string {
 		return ve.Errors[0].Error()
 	default:
 		var b strings.Builder
-		fmt.Fprintf(&b, "validation failed with %d errors:\n", len(ve.Errors))
-		for i, err := range ve.Errors {
-			fmt.Fprintf(&b, "  %d. %s\n", i+1, err.Error())
+		fmt.Fprintf(&b, "validation failed with following errors:\n")
+		for _, err := range ve.Errors {
+			fmt.Fprintf(&b, "  • %s\n", err.Error())
 		}
 		return strings.TrimSuffix(b.String(), "\n")
 	}

--- a/pkg/schema/errors_test.go
+++ b/pkg/schema/errors_test.go
@@ -120,7 +120,7 @@ func TestValidationErrors_Error(t *testing.T) {
 					NewConstraintError("field2", "second error"),
 				},
 			},
-			expected: "validation failed with 2 errors:\n  1. SchemaError error at \"field1\": first error\n  2. ConstraintError error at \"field2\": second error",
+			expected: "validation failed with following errors:\n  • SchemaError error at \"field1\": first error\n  • ConstraintError error at \"field2\": second error",
 		},
 	}
 

--- a/pkg/schema/validator.go
+++ b/pkg/schema/validator.go
@@ -24,6 +24,15 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
+// Constants for reserved property names
+const (
+	reservedPropApplication = "application"
+	reservedPropEnvironment = "environment"
+	reservedPropStatus      = "status"
+	reservedPropRecipe      = "recipe"
+	reservedPropConnections = "connections"
+)
+
 // Validator validates OpenAPI 3.0 schemas with Radius-specific constraints
 type Validator struct{}
 
@@ -469,13 +478,13 @@ func (v *Validator) checkReservedProperties(schema *openapi3.Schema) error {
 
 	for propName, propRef := range schema.Properties {
 		// Check for restricted property names
-		if propName == "status" || propName == "recipe" {
+		if propName == reservedPropStatus || propName == reservedPropRecipe {
 			err := NewConstraintError(propName, fmt.Sprintf("property '%s' is reserved and cannot be used", propName))
 			errors.Add(err)
 		}
 
 		// Check specific property type constraints
-		if propName == "application" || propName == "environment" {
+		if propName == reservedPropApplication || propName == reservedPropEnvironment {
 			if propRef.Value != nil {
 				if propRef.Value.Type == nil || !propRef.Value.Type.Is("string") {
 					err := NewConstraintError(propName, fmt.Sprintf("property '%s' must be a string", propName))
@@ -484,11 +493,11 @@ func (v *Validator) checkReservedProperties(schema *openapi3.Schema) error {
 			}
 		}
 
-		if propName == "connections" {
+		if propName == reservedPropConnections {
 			if propRef.Value != nil {
 				// Check if it's an object type
 				if propRef.Value.Type != nil && !propRef.Value.Type.Is("object") {
-					err := NewConstraintError(propName, "property 'connections' must be a map object")
+					err := NewConstraintError(propName, fmt.Sprintf("property '%s' must be a map object", reservedPropConnections))
 					errors.Add(err)
 				}
 
@@ -498,7 +507,7 @@ func (v *Validator) checkReservedProperties(schema *openapi3.Schema) error {
 						propRef.Value.AdditionalProperties.Schema != nil
 
 					if !hasAdditionalProps {
-						err := NewConstraintError(propName, "property 'connections' must be a map object (use additionalProperties)")
+						err := NewConstraintError(propName, fmt.Sprintf("property '%s' must be a map object (use additionalProperties)", reservedPropConnections))
 						errors.Add(err)
 					}
 				}
@@ -508,8 +517,8 @@ func (v *Validator) checkReservedProperties(schema *openapi3.Schema) error {
 
 	// Check that environment property is always included
 	if schema.Properties != nil {
-		if _, hasEnv := schema.Properties["environment"]; !hasEnv {
-			err := NewConstraintError("environment", "property 'environment' must be included in schema")
+		if _, hasEnv := schema.Properties[reservedPropEnvironment]; !hasEnv {
+			err := NewConstraintError(reservedPropEnvironment, fmt.Sprintf("property '%s' must be included in schema", reservedPropEnvironment))
 			errors.Add(err)
 		}
 	}

--- a/pkg/schema/validator_test.go
+++ b/pkg/schema/validator_test.go
@@ -3,7 +3,7 @@ Copyright 2023 The Radius Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+You may obtain a copy of the License ats
 
     http://www.apache.org/licenses/LICENSE-2.0
 
@@ -59,6 +59,11 @@ func TestValidator_ValidateSchema(t *testing.T) {
 				"age": &openapi3.SchemaRef{
 					Value: &openapi3.Schema{
 						Type: &openapi3.Types{"integer"},
+					},
+				},
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
 					},
 				},
 			},
@@ -344,6 +349,11 @@ func TestValidator_validateRadiusConstraints_NestedProperties(t *testing.T) {
 						},
 					},
 				},
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
 			},
 		}
 		err := validator.validateRadiusConstraints(schema)
@@ -364,6 +374,11 @@ func TestValidator_validateRadiusConstraints_NestedProperties(t *testing.T) {
 								},
 							},
 						},
+					},
+				},
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
 					},
 				},
 			},
@@ -969,6 +984,11 @@ func TestValidator_ObjectPropertyConstraintsIntegration(t *testing.T) {
 				"name": {
 					Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
 				},
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
 			},
 		}
 		err := validator.validateRadiusConstraints(schema)
@@ -1255,5 +1275,461 @@ func TestValidator_ValidateSchema_EdgeCases(t *testing.T) {
 
 		err := validator.ValidateSchema(ctx, schema)
 		require.NoError(t, err)
+	})
+}
+
+func TestValidator_checkReservedProperties(t *testing.T) {
+	validator := NewValidator()
+
+	t.Run("nil properties", func(t *testing.T) {
+		schema := &openapi3.Schema{}
+		err := validator.checkReservedProperties(schema)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid properties", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"validProp": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+			},
+		}
+		err := validator.checkReservedProperties(schema)
+		require.NoError(t, err)
+	})
+
+	t.Run("status property is not allowed", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"status": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+			},
+		}
+		err := validator.checkReservedProperties(schema)
+		require.Error(t, err)
+		validationErrors, ok := err.(*ValidationErrors)
+		require.True(t, ok)
+		require.Len(t, validationErrors.Errors, 1)
+		require.Equal(t, "status", validationErrors.Errors[0].Field)
+		require.Contains(t, validationErrors.Errors[0].Message, "property 'status' is reserved and cannot be used")
+	})
+
+	t.Run("recipe property is not allowed", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"recipe": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+			},
+		}
+		err := validator.checkReservedProperties(schema)
+		require.Error(t, err)
+		validationErrors, ok := err.(*ValidationErrors)
+		require.True(t, ok)
+		require.Len(t, validationErrors.Errors, 2) // recipe + environment
+		// Check that recipe error is present
+		errorFields := make(map[string]bool)
+		for _, ve := range validationErrors.Errors {
+			errorFields[ve.Field] = true
+		}
+		require.Contains(t, errorFields, "recipe")
+		require.Contains(t, errorFields, "environment")
+		require.Contains(t, validationErrors.Errors[0].Message, "property 'recipe' is reserved and cannot be used")
+	})
+
+	t.Run("application property must be string", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"application": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"integer"},
+					},
+				},
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+			},
+		}
+		err := validator.checkReservedProperties(schema)
+		require.Error(t, err)
+		validationErrors, ok := err.(*ValidationErrors)
+		require.True(t, ok)
+		require.Len(t, validationErrors.Errors, 1)
+		require.Equal(t, "application", validationErrors.Errors[0].Field)
+		require.Contains(t, validationErrors.Errors[0].Message, "property 'application' must be a string")
+	})
+
+	t.Run("valid application property as string", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"application": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+			},
+		}
+		err := validator.checkReservedProperties(schema)
+		require.NoError(t, err)
+	})
+
+	t.Run("environment property must be string", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"number"},
+					},
+				},
+			},
+		}
+		err := validator.checkReservedProperties(schema)
+		require.Error(t, err)
+		validationErrors, ok := err.(*ValidationErrors)
+		require.True(t, ok)
+		require.Len(t, validationErrors.Errors, 1)
+		require.Equal(t, "environment", validationErrors.Errors[0].Field)
+		require.Contains(t, validationErrors.Errors[0].Message, "property 'environment' must be a string")
+	})
+
+	t.Run("valid environment property as string", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+			},
+		}
+		err := validator.checkReservedProperties(schema)
+		require.NoError(t, err)
+	})
+
+	t.Run("connections property must be object", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"connections": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+			},
+		}
+		err := validator.checkReservedProperties(schema)
+		require.Error(t, err)
+		validationErrors, ok := err.(*ValidationErrors)
+		require.True(t, ok)
+		require.Len(t, validationErrors.Errors, 1)
+		require.Equal(t, "connections", validationErrors.Errors[0].Field)
+		require.Contains(t, validationErrors.Errors[0].Message, "property 'connections' must be a map object")
+	})
+
+	t.Run("valid connections property as map with additionalProperties", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"connections": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"object"},
+						AdditionalProperties: openapi3.AdditionalProperties{
+							Has: &[]bool{true}[0], // Helper to get *bool from true
+						},
+					},
+				},
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+			},
+		}
+		err := validator.checkReservedProperties(schema)
+		require.NoError(t, err)
+	})
+
+	t.Run("connections property without additionalProperties should fail", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"connections": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"object"},
+						// No additionalProperties - should fail
+					},
+				},
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+			},
+		}
+		err := validator.checkReservedProperties(schema)
+		require.Error(t, err)
+		validationErrors, ok := err.(*ValidationErrors)
+		require.True(t, ok)
+		require.Len(t, validationErrors.Errors, 1)
+		require.Equal(t, "connections", validationErrors.Errors[0].Field)
+		require.Contains(t, validationErrors.Errors[0].Message, "must be a map object (use additionalProperties)")
+	})
+
+	t.Run("connections property with fixed properties should fail", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"connections": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"object"},
+						Properties: openapi3.Schemas{
+							"fixedProp": &openapi3.SchemaRef{
+								Value: &openapi3.Schema{
+									Type: &openapi3.Types{"string"},
+								},
+							},
+						},
+					},
+				},
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+			},
+		}
+		err := validator.checkReservedProperties(schema)
+		require.Error(t, err)
+		validationErrors, ok := err.(*ValidationErrors)
+		require.True(t, ok)
+		require.Len(t, validationErrors.Errors, 1)
+		require.Equal(t, "connections", validationErrors.Errors[0].Field)
+		require.Contains(t, validationErrors.Errors[0].Message, "must be a map object (use additionalProperties)")
+	})
+
+	t.Run("environment property always required", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"application": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+			},
+			// environment missing from properties - should always fail, regardless of Required array
+		}
+		err := validator.checkReservedProperties(schema)
+		require.Error(t, err)
+		validationErrors, ok := err.(*ValidationErrors)
+		require.True(t, ok)
+		require.Len(t, validationErrors.Errors, 1)
+		require.Equal(t, "environment", validationErrors.Errors[0].Field)
+		require.Contains(t, validationErrors.Errors[0].Message, "property 'environment' must be included in schema")
+	})
+
+	t.Run("environment property missing from any schema should fail", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"someOtherProp": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+			},
+			// No Required array, no environment property - should still fail
+		}
+		err := validator.checkReservedProperties(schema)
+		require.Error(t, err)
+		validationErrors, ok := err.(*ValidationErrors)
+		require.True(t, ok)
+		require.Len(t, validationErrors.Errors, 1)
+		require.Equal(t, "environment", validationErrors.Errors[0].Field)
+		require.Contains(t, validationErrors.Errors[0].Message, "property 'environment' must be included in schema")
+	})
+
+	t.Run("environment property present", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+			},
+			Required: []string{"environment"},
+		}
+		err := validator.checkReservedProperties(schema)
+		require.NoError(t, err)
+	})
+
+	t.Run("property with nil value", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"application": &openapi3.SchemaRef{
+					Value: nil,
+				},
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+			},
+		}
+		err := validator.checkReservedProperties(schema)
+		require.NoError(t, err)
+	})
+
+	t.Run("property with nil type", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"application": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: nil,
+					},
+				},
+			},
+		}
+		err := validator.checkReservedProperties(schema)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "property 'application' must be a string")
+	})
+
+	t.Run("multiple violations", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"status": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+				"application": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"integer"},
+					},
+				},
+			},
+		}
+		err := validator.checkReservedProperties(schema)
+		require.Error(t, err)
+		// Should now collect all violations
+		validationErrors, ok := err.(*ValidationErrors)
+		require.True(t, ok)
+		require.Len(t, validationErrors.Errors, 3) // status, application, environment
+
+		// Check that all errors are present
+		errorFields := make(map[string]bool)
+		for _, ve := range validationErrors.Errors {
+			errorFields[ve.Field] = true
+		}
+		require.Contains(t, errorFields, "status")
+		require.Contains(t, errorFields, "application")
+		require.Contains(t, errorFields, "environment")
+	})
+}
+
+func TestValidator_ValidateSchema_MultipleErrors(t *testing.T) {
+	validator := NewValidator()
+	ctx := context.Background()
+
+	t.Run("always collects all errors", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"status": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+				"application": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"integer"},
+					},
+				},
+				"connections": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"boolean"},
+					},
+				},
+			},
+		}
+
+		err := validator.ValidateSchema(ctx, schema)
+		require.Error(t, err)
+
+		validationErrors, ok := err.(*ValidationErrors)
+		require.True(t, ok)
+		require.GreaterOrEqual(t, len(validationErrors.Errors), 4) // At least status, application, connections, environment
+
+		t.Logf("Collected errors:\n%s", err.Error())
+	})
+
+	t.Run("single error still returns ValidationErrors", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"status": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+				"environment": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+					},
+				},
+			},
+		}
+
+		err := validator.ValidateSchema(ctx, schema)
+		require.Error(t, err)
+
+		// Should still be a ValidationErrors collection, not a single ValidationError
+		validationErrors, ok := err.(*ValidationErrors)
+		require.True(t, ok)
+		require.Len(t, validationErrors.Errors, 1)
+		require.Equal(t, "status", validationErrors.Errors[0].Field)
 	})
 }

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/testresourcetypes.yaml
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/testresourcetypes.yaml
@@ -74,9 +74,6 @@ types:
             password:
               type: string
               description: The password for the database.
-            username:
-              type: string
-              description: The username for the database.
   externalResource:
     capabilities: ["ManualResourceProvisioning"]
     apiVersions:

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/testresourcetypes.yaml
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/testresourcetypes.yaml
@@ -20,15 +20,9 @@ types:
                   source:
                     type: string
                     description: The resourceID of the source of the connection.
-            status:
-              type: object
-              properties:
-                computedValues:
-                  type: object
-                  properties:
-                    port:
-                      type: string
-                      description: The port the container listens on.
+            port:
+              type: string
+              description: The port number exposed by the application.
           required:
             - application
             - environment
@@ -50,15 +44,6 @@ types:
                   source:
                     type: string
                     description: The resourceID of the source of the connection.
-            status:
-              type: object
-              properties:
-                computedValues:
-                  type: object
-                  properties:
-                    port:
-                      type: string
-                      description: The port the container listens on.
           required:
             - application
             - environment
@@ -83,6 +68,9 @@ types:
             port:
               type: string
               description: The port number of the database.
+            username:
+              type: string
+              description: The username for the database.
             password:
               type: string
               description: The password for the database.

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha-recipe.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha-recipe.bicep
@@ -52,7 +52,7 @@ resource usertypealphacntr 'Applications.Core/containers@2023-10-01-preview' = {
         args: ['-c', 'while true; do echo hello; sleep 10;done']
         env: {
           USERTYPEALPHA_PORT: {
-            value: string(usertypealpha.properties.status.computedValues.port)
+            value: string(usertypealpha.properties.port)
           }
         }
       }


### PR DESCRIPTION
This pull request introduces updates to schema validation and error handling, and updates to associated tests
1. Add validation for reserved words:
`application` property must be a string
`environment` property must be a string
`environment` property must be included in schema
`connections` must be a map object
`status` cannot be used as a property
`recipe` cannot be used as a property
2. Updated to return all errors for all schemas in a document when registering types.
3. Added restriction to not allow: additionalProperties: true

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (#6688 ).

Fixes: Part of #6688 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->