### PR TITLE
Remove reference to `status` in UDT postgres test

### DIFF
--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/postgres-existing-and-cntr.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/postgres-existing-and-cntr.bicep
@@ -38,13 +38,13 @@ resource udtcntr 'Applications.Core/containers@2023-10-01-preview' = {
             value: string(udtpgexisting.properties.port)
           }
           CONNECTION_POSTGRES_USERNAME: {
-            value: udtpgexisting.properties.status.computedValues.username
+            value: udtpgexisting.properties.username
           }
           CONNECTION_POSTGRES_DATABASE: {
             value: udtpgexisting.properties.database
           }
           CONNECTION_POSTGRES_PASSWORD: {
-            value: udtpgexisting.properties.status.computedValues.password
+            value: udtpgexisting.properties.password
           }
         }
     }

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/testresourcetypes.yaml
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/testresourcetypes.yaml
@@ -86,15 +86,9 @@ types:
             password:
               type: string
               description: The password for the database.
-            status:
-              type: object
-              properties:
-                computedValues:
-                  type: object
-                  properties:
-                    username:
-                      type: string
-                      description: The username for the database.
+            username:
+              type: string
+              description: The username for the database.
   externalResource:
     capabilities: ["ManualResourceProvisioning"]
     apiVersions:


### PR DESCRIPTION
# Description

Update  UDT postgres test to remove reference to status.

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->