### PR TITLE
Tf errors bak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,10 +69,3 @@ hack/bicep-types-radius/generated/**/*.md
 
 # Bicep extensions
 *.tgz
-
-# Debug files
-debug_files/*
-
-# Demo app
-demo/*
-demo

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -36,7 +36,7 @@ global:
   # This avoids downloading terraform on each recipe execution
   terraform:
     # Enable terraform binary pre-downloading during pod startup
-    enabled: true
+    enabled: false
     # URL for downloading Terraform binary
     # Leave empty to automatically fetch the latest version from HashiCorp
     # Or provide a complete direct download URL for custom sources

--- a/pkg/recipes/terraform/execute.go
+++ b/pkg/recipes/terraform/execute.go
@@ -447,7 +447,7 @@ func destroyWithRetry(ctx context.Context, tf *tfexec.Terraform) error {
 			lockID := extractLockID(err.Error())
 
 			if attempt < maxRetries-1 {
-				waitTime := time.Duration(1<<attempt) * time.Second // Exponential backoff: 1s, 2s, 4s, 8s, 16s
+				waitTime := time.Duration(60) * time.Second
 				logger.Info(fmt.Sprintf("Terraform destroy failed due to state lock (attempt %d/%d), retrying in %v", attempt+1, maxRetries, waitTime))
 				time.Sleep(waitTime)
 				continue

--- a/test/validation/shared.go
+++ b/test/validation/shared.go
@@ -79,7 +79,7 @@ func DeleteRPResource(ctx context.Context, t *testing.T, cli *radcli.CLI, client
 
 		// Retry deletion upto 5 minutes for 409 Conflict errors
 		// Environments may be stuck in "Updating" state after failed deployments
-		maxRetries := 3
+		maxRetries := 5
 		var err error
 		var respFromCtx *http.Response
 


### PR DESCRIPTION
# Description

_Please explain the changes you've made._

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [ ] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [ ] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [ ] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [ ] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [ ] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [ ] Not applicable <!-- TaskRadio recipes-pr -->