### PR TITLE
feat: adding global.imageRegistry and global.imageTag parameters

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -239,6 +239,10 @@ jobs:
       - name: Run Helm linter
         run: |
           helm lint ${{ env.HELM_CHARTS_DIR }}
+      - name: Run Helm unit tests
+        run: |
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git || true
+          cd ${{ env.HELM_CHARTS_DIR }} && helm unittest .
       - name: Package Helm chart
         run: |
           mkdir -p ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -239,10 +239,6 @@ jobs:
       - name: Run Helm linter
         run: |
           helm lint ${{ env.HELM_CHARTS_DIR }}
-      - name: Run Helm unit tests
-        run: |
-          helm plugin install https://github.com/helm-unittest/helm-unittest.git || true
-          cd ${{ env.HELM_CHARTS_DIR }} && helm unittest .
       - name: Package Helm chart
         run: |
           mkdir -p ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -69,6 +69,10 @@ jobs:
       - name: Run Helm linter
         run: |
           helm lint ${{ env.HELM_CHARTS_DIR }}
+      - name: Run Helm unit tests
+        run: |
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git || true
+          cd ${{ env.HELM_CHARTS_DIR }} && helm unittest .
       - name: Run TypeSpec format check
         run: |
           pushd typespec

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ debug_files/*
 # Demo app
 demo/*
 demo
+
+# Helm debug output
+.debug/

--- a/build/test.mk
+++ b/build/test.mk
@@ -43,7 +43,7 @@ GOTEST_TOOL ?= gotestsum $(GOTESTSUM_OPTS) --
 endif
 
 .PHONY: test
-test: test-get-envtools ## Runs unit tests, excluding kubernetes controller tests
+test: test-get-envtools test-helm ## Runs unit tests, excluding kubernetes controller tests
 	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" CGO_ENABLED=1 $(GOTEST_TOOL) -v ./pkg/... $(GOTEST_OPTS)
 
 .PHONY: test-get-envtools
@@ -141,6 +141,13 @@ test-functional-samples-noncloud: ## Runs Samples functional tests that do not r
 .PHONY: test-validate-bicep
 test-validate-bicep: ## Validates that all .bicep files compile cleanly
 	BICEP_PATH="${HOME}/.rad/bin/rad-bicep" ./build/validate-bicep.sh
+
+.PHONY: test-helm
+test-helm: ## Runs Helm chart unit tests
+	@echo "$(ARROW) Installing helm-unittest plugin if not already installed..."
+	@helm plugin list | grep -q unittest || helm plugin install https://github.com/helm-unittest/helm-unittest.git
+	@echo "$(ARROW) Running Helm unit tests..."
+	cd deploy/Chart && helm unittest .
 
 .PHONY: oav-installed
 oav-installed:

--- a/deploy/Chart/README.md
+++ b/deploy/Chart/README.md
@@ -1,13 +1,13 @@
-## Introduction
+# Introduction
 
 The Radius helm chart deploys the Radius services on a Kubernetes cluster using Helm.
 
-### Prerequisites
+## Prerequisites
 
 - Kubernetes cluster with RBAC enabled
 - Helm 3
 
-### Installing the Chart
+## Installing the Chart
 
 To install the chart with the release name `radius`:
 
@@ -15,9 +15,103 @@ To install the chart with the release name `radius`:
 helm upgrade --wait --install radius deploy/Chart -n radius-system
 ```
 
-### Configuration Options
+## Configuration Options
 
-#### Terraform Binary Pre-downloading
+### Custom Container Registry
+
+By default, Radius pulls container images from GitHub Container Registry (ghcr.io). For air-gapped environments or when using private registries, you can configure a custom container registry using the `global.imageRegistry` parameter.
+
+#### Using a Custom Registry
+
+```console
+# Using Azure Container Registry
+helm upgrade --wait --install radius deploy/Chart -n radius-system \
+  --set global.imageRegistry=myregistry.azurecr.io
+
+# Using AWS Elastic Container Registry
+helm upgrade --wait --install radius deploy/Chart -n radius-system \
+  --set global.imageRegistry=123456789.dkr.ecr.us-west-2.amazonaws.com
+
+# Using a private registry with custom port
+helm upgrade --wait --install radius deploy/Chart -n radius-system \
+  --set global.imageRegistry=private.registry.com:5000
+```
+
+#### With rad CLI commands
+
+The custom registry configuration is also supported in rad CLI commands:
+
+```console
+# During initial installation
+rad install kubernetes \
+  --set global.imageRegistry=myregistry.azurecr.io
+
+# During upgrade
+rad upgrade kubernetes \
+  --set global.imageRegistry=myregistry.azurecr.io
+
+# During initialization
+rad init \
+  --set global.imageRegistry=myregistry.azurecr.io
+```
+
+#### Using with Private Registries and Certificates
+
+For private registries that require custom CA certificates:
+
+```console
+# Install with custom CA certificate
+rad install kubernetes \
+  --set global.imageRegistry=private.registry.com \
+  --set-file global.rootCA.cert=/path/to/ca-certificate.pem
+
+# Or using Helm directly
+helm upgrade --wait --install radius deploy/Chart -n radius-system \
+  --set global.imageRegistry=private.registry.com \
+  --set-file global.rootCA.cert=/path/to/ca-certificate.pem
+```
+
+#### Air-gapped Environment Setup
+
+For completely air-gapped environments, you'll need to:
+
+1. Mirror all Radius images to your private registry
+2. Configure Radius to use your private registry
+
+Example of mirroring images (requires access to both registries):
+
+```bash
+# List of Radius images
+IMAGES=(
+  "radius-project/controller"
+  "radius-project/ucpd"
+  "radius-project/applications-rp"
+  "radius-project/dynamic-rp"
+  "radius-project/deployment-engine"
+  "radius-project/dashboard"
+  "radius-project/bicep"
+)
+
+SOURCE_REGISTRY="ghcr.io"
+TARGET_REGISTRY="myregistry.azurecr.io"
+VERSION="latest"  # or specific version like "v0.36.0"
+
+# Mirror each image
+for IMAGE in "${IMAGES[@]}"; do
+  docker pull ${SOURCE_REGISTRY}/${IMAGE}:${VERSION}
+  docker tag ${SOURCE_REGISTRY}/${IMAGE}:${VERSION} ${TARGET_REGISTRY}/${IMAGE}:${VERSION}
+  docker push ${TARGET_REGISTRY}/${IMAGE}:${VERSION}
+done
+```
+
+Then install Radius using your private registry:
+
+```console
+rad install kubernetes \
+  --set global.imageRegistry=myregistry.azurecr.io
+```
+
+### Terraform Binary Pre-downloading
 
 By default, Radius downloads Terraform binaries at runtime when Terraform recipes are executed. You can optionally configure Radius to pre-download Terraform binaries during pod startup to improve performance.
 
@@ -36,16 +130,15 @@ helm upgrade --wait --install radius deploy/Chart -n radius-system \
   --set global.terraform.downloadUrl="https://my-artifactory.com/terraform_1.5.7_linux_amd64.zip"
 ```
 
-
-### Verify the installation
+## Verify the installation
 
 Verify that the controller is running in the radius-system namespace:
 
-```
+```bash
 kubectl get pods -n radius-system
 ```
 
-### Uninstalling the Chart
+## Uninstalling the Chart
 
 To uninstall/delete the `radius` deployment:
 

--- a/deploy/Chart/README.md
+++ b/deploy/Chart/README.md
@@ -116,16 +116,16 @@ Example of mirroring images (requires access to both registries):
 ```bash
 # List of Radius images
 IMAGES=(
-  "radius-project/controller"
-  "radius-project/ucpd"
-  "radius-project/applications-rp"
-  "radius-project/dynamic-rp"
-  "radius-project/deployment-engine"
-  "radius-project/dashboard"
-  "radius-project/bicep"
+  "controller"
+  "ucpd"
+  "applications-rp"
+  "dynamic-rp"
+  "deployment-engine"
+  "dashboard"
+  "bicep"
 )
 
-SOURCE_REGISTRY="ghcr.io"
+SOURCE_REGISTRY="ghcr.io/radius-project"
 TARGET_REGISTRY="myregistry.azurecr.io"
 VERSION="latest"  # or specific version like "v0.36.0"
 
@@ -143,6 +143,8 @@ Then install Radius using your private registry:
 rad install kubernetes \
   --set global.imageRegistry=myregistry.azurecr.io
 ```
+
+**Note:** When using a custom registry, images are pulled directly from `<registry>/<image-name>:<tag>` format. For example, with `myregistry.azurecr.io`, the controller image will be pulled from `myregistry.azurecr.io/controller:latest`.
 
 ### Terraform Binary Pre-downloading
 

--- a/deploy/Chart/README.md
+++ b/deploy/Chart/README.md
@@ -46,17 +46,17 @@ helm upgrade --wait --install radius deploy/Chart -n radius-system \
 ```console
 # Use a specific version for all components
 helm upgrade --wait --install radius deploy/Chart -n radius-system \
-  --set global.imageTag=v0.48.0
+  --set global.imageTag=0.48
 
 # Combine custom registry with custom tag
 helm upgrade --wait --install radius deploy/Chart -n radius-system \
   --set global.imageRegistry=myregistry.azurecr.io \
-  --set global.imageTag=v0.48.0
+  --set global.imageTag=0.48
 
 # Override specific component while using global tag for others
 helm upgrade --wait --install radius deploy/Chart -n radius-system \
-  --set global.imageTag=v0.48.0 \
-  --set controller.tag=v0.48.1
+  --set global.imageTag=0.48 \
+  --set controller.tag=0.49
 ```
 
 #### With rad CLI commands
@@ -70,22 +70,22 @@ rad install kubernetes \
 
 # During initial installation with custom tag
 rad install kubernetes \
-  --set global.imageTag=v0.48.0
+  --set global.imageTag=0.48
 
 # Combine custom registry and tag
 rad install kubernetes \
   --set global.imageRegistry=myregistry.azurecr.io \
-  --set global.imageTag=v0.48.0
+  --set global.imageTag=0.48
 
 # During upgrade
 rad upgrade kubernetes \
   --set global.imageRegistry=myregistry.azurecr.io \
-  --set global.imageTag=v0.48.0
+  --set global.imageTag=0.48
 
 # During initialization
 rad init \
   --set global.imageRegistry=myregistry.azurecr.io \
-  --set global.imageTag=v0.48.0
+  --set global.imageTag=0.48
 ```
 
 #### Using with Private Registries and Certificates

--- a/deploy/Chart/README.md
+++ b/deploy/Chart/README.md
@@ -127,7 +127,7 @@ IMAGES=(
 
 SOURCE_REGISTRY="ghcr.io/radius-project"
 TARGET_REGISTRY="myregistry.azurecr.io"
-VERSION="latest"  # or specific version like "v0.36.0"
+VERSION="latest"  # or specific version like "0.48"
 
 # Mirror each image
 for IMAGE in "${IMAGES[@]}"; do

--- a/deploy/Chart/README.md
+++ b/deploy/Chart/README.md
@@ -21,6 +21,10 @@ helm upgrade --wait --install radius deploy/Chart -n radius-system
 
 By default, Radius pulls container images from GitHub Container Registry (ghcr.io). For air-gapped environments or when using private registries, you can configure a custom container registry using the `global.imageRegistry` parameter.
 
+### Custom Image Tag
+
+You can specify a custom tag for all Radius images using the `global.imageTag` parameter. This is useful when you want to deploy a specific version across all components or use custom-built images.
+
 #### Using a Custom Registry
 
 ```console
@@ -37,22 +41,51 @@ helm upgrade --wait --install radius deploy/Chart -n radius-system \
   --set global.imageRegistry=private.registry.com:5000
 ```
 
-#### With rad CLI commands
-
-The custom registry configuration is also supported in rad CLI commands:
+#### Using a Custom Image Tag
 
 ```console
-# During initial installation
+# Use a specific version for all components
+helm upgrade --wait --install radius deploy/Chart -n radius-system \
+  --set global.imageTag=v0.48.0
+
+# Combine custom registry with custom tag
+helm upgrade --wait --install radius deploy/Chart -n radius-system \
+  --set global.imageRegistry=myregistry.azurecr.io \
+  --set global.imageTag=v0.48.0
+
+# Override specific component while using global tag for others
+helm upgrade --wait --install radius deploy/Chart -n radius-system \
+  --set global.imageTag=v0.48.0 \
+  --set controller.tag=v0.48.1
+```
+
+#### With rad CLI commands
+
+The custom registry and tag configuration is also supported in rad CLI commands:
+
+```console
+# During initial installation with custom registry
 rad install kubernetes \
   --set global.imageRegistry=myregistry.azurecr.io
 
+# During initial installation with custom tag
+rad install kubernetes \
+  --set global.imageTag=v0.48.0
+
+# Combine custom registry and tag
+rad install kubernetes \
+  --set global.imageRegistry=myregistry.azurecr.io \
+  --set global.imageTag=v0.48.0
+
 # During upgrade
 rad upgrade kubernetes \
-  --set global.imageRegistry=myregistry.azurecr.io
+  --set global.imageRegistry=myregistry.azurecr.io \
+  --set global.imageTag=v0.48.0
 
 # During initialization
 rad init \
-  --set global.imageRegistry=myregistry.azurecr.io
+  --set global.imageRegistry=myregistry.azurecr.io \
+  --set global.imageTag=v0.48.0
 ```
 
 #### Using with Private Registries and Certificates

--- a/deploy/Chart/templates/_helpers.tpl
+++ b/deploy/Chart/templates/_helpers.tpl
@@ -43,20 +43,25 @@ References:
 {{- end -}}
 
 {{/*
-Create a fully qualified image name with optional registry override.
+Create a fully qualified image name with optional registry and tag overrides.
 
 Usage:
-{{ include "radius.image" (dict "image" .Values.component.image "tag" (.Values.component.tag | default $appversion) "global" .Values.global) }}
+{{ include "radius.image" (dict "image" .Values.component.image "tag" (.Values.component.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}
 
 Params:
   - image - String - Required - Image name (e.g., "radius-project/controller" or "myregistry.io/custom-image")
-  - tag - String - Required - Image tag
-  - global - Object - Required - Global values containing imageRegistry
+  - tag - String - Required - Image tag (can be component-specific, global, or default)
+  - global - Object - Required - Global values containing imageRegistry and imageTag
 
-Priority:
+Priority for registry:
 1. If image appears to be a full registry path (contains domain or port before first /), use it as-is with tag handling
 2. If global.imageRegistry is set, prepend it to the image name
 3. Otherwise, use ghcr.io as the default registry
+
+Priority for tag (handled by caller):
+1. Component-specific tag (e.g., controller.tag)
+2. global.imageTag
+3. Chart AppVersion (default)
 */}}
 {{- define "radius.image" -}}
 {{- $isFullPath := false -}}

--- a/deploy/Chart/templates/_helpers.tpl
+++ b/deploy/Chart/templates/_helpers.tpl
@@ -49,14 +49,14 @@ Usage:
 {{ include "radius.image" (dict "image" .Values.component.image "tag" (.Values.component.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}
 
 Params:
-  - image - String - Required - Image name (e.g., "radius-project/controller" or "myregistry.io/custom-image")
+  - image - String - Required - Image name (e.g., "controller" or "myregistry.io/custom-image")
   - tag - String - Required - Image tag (can be component-specific, global, or default)
   - global - Object - Required - Global values containing imageRegistry and imageTag
 
 Priority for registry:
 1. If image appears to be a full registry path (contains domain or port before first /), use it as-is with tag handling
-2. If global.imageRegistry is set, prepend it to the image name
-3. Otherwise, use ghcr.io as the default registry
+2. If global.imageRegistry is set, use it as the registry
+3. Otherwise, use ghcr.io/radius-project as the default registry
 
 Priority for tag (handled by caller):
 1. Component-specific tag (e.g., controller.tag)
@@ -94,7 +94,7 @@ Priority for tag (handled by caller):
   {{- /* Not a full path, use global registry */ -}}
   {{- .global.imageRegistry }}/{{ .image }}:{{ .tag }}
 {{- else -}}
-  {{- /* Not a full path, no global registry, use default */ -}}
-  ghcr.io/{{ .image }}:{{ .tag }}
+  {{- /* Not a full path, no global registry, use default ghcr.io/radius-project */ -}}
+  ghcr.io/radius-project/{{ .image }}:{{ .tag }}
 {{- end -}}
 {{- end -}}

--- a/deploy/Chart/templates/controller/deployment.yaml
+++ b/deploy/Chart/templates/controller/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: controller
       initContainers:
       - name: bicep
-        image: "{{ .Values.bicep.image }}:{{ .Values.bicep.tag | default $appversion }}"
+        image: "{{ include "radius.image" (dict "image" .Values.bicep.image "tag" (.Values.bicep.tag | default $appversion) "global" .Values.global) }}"
         command: ['sh', '-c', 'mv /bicepconfig.json /bicepconfig/bicepconfig.json && mv /bicep /usr/local/bin/bicep']
         volumeMounts:
         - name: bicep
@@ -38,7 +38,7 @@ spec:
           mountPath: /bicepconfig
       containers:
       - name: controller
-        image: "{{ .Values.controller.image }}:{{ .Values.controller.tag | default $appversion }}"
+        image: "{{ include "radius.image" (dict "image" .Values.controller.image "tag" (.Values.controller.tag | default $appversion) "global" .Values.global) }}"
         imagePullPolicy: 'Always'
         args: 
         - '--config-file'

--- a/deploy/Chart/templates/controller/deployment.yaml
+++ b/deploy/Chart/templates/controller/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: controller
       initContainers:
       - name: bicep
-        image: "{{ include "radius.image" (dict "image" .Values.bicep.image "tag" (.Values.bicep.tag | default $appversion) "global" .Values.global) }}"
+        image: "{{ include "radius.image" (dict "image" .Values.bicep.image "tag" (.Values.bicep.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"
         command: ['sh', '-c', 'mv /bicepconfig.json /bicepconfig/bicepconfig.json && mv /bicep /usr/local/bin/bicep']
         volumeMounts:
         - name: bicep
@@ -38,7 +38,7 @@ spec:
           mountPath: /bicepconfig
       containers:
       - name: controller
-        image: "{{ include "radius.image" (dict "image" .Values.controller.image "tag" (.Values.controller.tag | default $appversion) "global" .Values.global) }}"
+        image: "{{ include "radius.image" (dict "image" .Values.controller.image "tag" (.Values.controller.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"
         imagePullPolicy: 'Always'
         args: 
         - '--config-file'

--- a/deploy/Chart/templates/dashboard/deployment.yaml
+++ b/deploy/Chart/templates/dashboard/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: dashboard
       containers:
       - name: dashboard
-        image: "{{ .Values.dashboard.image }}:{{ .Values.dashboard.tag | default $appversion }}"
+        image: "{{ include "radius.image" (dict "image" .Values.dashboard.image "tag" (.Values.dashboard.tag | default $appversion) "global" .Values.global) }}"
         imagePullPolicy: Always
         ports:
         - name: http

--- a/deploy/Chart/templates/dashboard/deployment.yaml
+++ b/deploy/Chart/templates/dashboard/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: dashboard
       containers:
       - name: dashboard
-        image: "{{ include "radius.image" (dict "image" .Values.dashboard.image "tag" (.Values.dashboard.tag | default $appversion) "global" .Values.global) }}"
+        image: "{{ include "radius.image" (dict "image" .Values.dashboard.image "tag" (.Values.dashboard.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"
         imagePullPolicy: Always
         ports:
         - name: http

--- a/deploy/Chart/templates/database/statefulset.yaml
+++ b/deploy/Chart/templates/database/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
       - name: database
         securityContext:
           allowPrivilegeEscalation: false
-        image: "{{ .Values.database.image }}:{{ .Values.database.tag }}"
+        image: "{{ include "radius.image" (dict "image" .Values.database.image "tag" .Values.database.tag "global" .Values.global) }}"
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/deploy/Chart/templates/database/statefulset.yaml
+++ b/deploy/Chart/templates/database/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
       - name: database
         securityContext:
           allowPrivilegeEscalation: false
-        image: "{{ include "radius.image" (dict "image" .Values.database.image "tag" .Values.database.tag "global" .Values.global) }}"
+        image: "{{ include "radius.image" (dict "image" .Values.database.image "tag" (.Values.database.tag | default .Values.global.imageTag | default "latest") "global" .Values.global) }}"
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/deploy/Chart/templates/de/deployment.yaml
+++ b/deploy/Chart/templates/de/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         {{- end }}
       containers:
       - name: de
-        image: {{ .Values.de.image }}:{{ .Values.de.tag | default $appversion }}
+        image: {{ include "radius.image" (dict "image" .Values.de.image "tag" (.Values.de.tag | default $appversion) "global" .Values.global) }}
         args:
         - --kubernetes=true
         volumeMounts:

--- a/deploy/Chart/templates/de/deployment.yaml
+++ b/deploy/Chart/templates/de/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         {{- end }}
       containers:
       - name: de
-        image: {{ include "radius.image" (dict "image" .Values.de.image "tag" (.Values.de.tag | default $appversion) "global" .Values.global) }}
+        image: {{ include "radius.image" (dict "image" .Values.de.image "tag" (.Values.de.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}
         args:
         - --kubernetes=true
         volumeMounts:

--- a/deploy/Chart/templates/dynamic-rp/deployment.yaml
+++ b/deploy/Chart/templates/dynamic-rp/deployment.yaml
@@ -119,7 +119,7 @@ spec:
       {{- end }}
       containers:
       - name: dynamic-rp
-        image: "{{ include "radius.image" (dict "image" .Values.dynamicrp.image "tag" (.Values.dynamicrp.tag | default $appversion) "global" .Values.global) }}"
+        image: "{{ include "radius.image" (dict "image" .Values.dynamicrp.image "tag" (.Values.dynamicrp.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"
         args:
         - --config-file=/etc/config/radius-self-host.yaml
         env:

--- a/deploy/Chart/templates/dynamic-rp/deployment.yaml
+++ b/deploy/Chart/templates/dynamic-rp/deployment.yaml
@@ -119,7 +119,7 @@ spec:
       {{- end }}
       containers:
       - name: dynamic-rp
-        image: "{{ .Values.dynamicrp.image }}:{{ .Values.dynamicrp.tag | default $appversion }}"
+        image: "{{ include "radius.image" (dict "image" .Values.dynamicrp.image "tag" (.Values.dynamicrp.tag | default $appversion) "global" .Values.global) }}"
         args:
         - --config-file=/etc/config/radius-self-host.yaml
         env:

--- a/deploy/Chart/templates/rp/deployment.yaml
+++ b/deploy/Chart/templates/rp/deployment.yaml
@@ -119,7 +119,7 @@ spec:
       {{- end }}
       containers:
       - name: applications-rp
-        image: "{{ .Values.rp.image }}:{{ .Values.rp.tag | default $appversion }}"
+        image: "{{ include "radius.image" (dict "image" .Values.rp.image "tag" (.Values.rp.tag | default $appversion) "global" .Values.global) }}"
         args:
         - --config-file=/etc/config/radius-self-host.yaml
         env:

--- a/deploy/Chart/templates/rp/deployment.yaml
+++ b/deploy/Chart/templates/rp/deployment.yaml
@@ -119,7 +119,7 @@ spec:
       {{- end }}
       containers:
       - name: applications-rp
-        image: "{{ include "radius.image" (dict "image" .Values.rp.image "tag" (.Values.rp.tag | default $appversion) "global" .Values.global) }}"
+        image: "{{ include "radius.image" (dict "image" .Values.rp.image "tag" (.Values.rp.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"
         args:
         - --config-file=/etc/config/radius-self-host.yaml
         env:

--- a/deploy/Chart/templates/ucp/deployment.yaml
+++ b/deploy/Chart/templates/ucp/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: ucp
       containers:
       - name: ucp
-        image: "{{ include "radius.image" (dict "image" .Values.ucp.image "tag" (.Values.ucp.tag | default $appversion) "global" .Values.global) }}"
+        image: "{{ include "radius.image" (dict "image" .Values.ucp.image "tag" (.Values.ucp.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"
         args:
         - --config-file=/etc/config/ucp-config.yaml
         env:

--- a/deploy/Chart/templates/ucp/deployment.yaml
+++ b/deploy/Chart/templates/ucp/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: ucp
       containers:
       - name: ucp
-        image: "{{ .Values.ucp.image }}:{{ .Values.ucp.tag | default $appversion }}"
+        image: "{{ include "radius.image" (dict "image" .Values.ucp.image "tag" (.Values.ucp.tag | default $appversion) "global" .Values.global) }}"
         args:
         - --config-file=/etc/config/ucp-config.yaml
         env:

--- a/deploy/Chart/tests/README.md
+++ b/deploy/Chart/tests/README.md
@@ -1,0 +1,50 @@
+# Helm Chart Tests
+
+This directory contains unit tests for the Radius Helm chart templates.
+
+## Prerequisites
+
+Install the helm-unittest plugin:
+
+```bash
+helm plugin install https://github.com/helm-unittest/helm-unittest.git
+```
+
+## Running Tests
+
+From the Chart directory:
+
+```bash
+helm unittest .
+```
+
+To run with verbose output:
+
+```bash
+helm unittest . -v
+```
+
+To run a specific test file:
+
+```bash
+helm unittest . -f tests/helpers_test.yaml
+```
+
+## Test Structure
+
+The tests validate:
+
+- The `radius.image` helper template correctly constructs image URLs
+- Default registry (ghcr.io) is used when `global.imageRegistry` is not set
+- Custom registry is properly prepended when `global.imageRegistry` is set
+- All deployments and statefulsets use the helper correctly
+
+## Adding New Tests
+
+When adding new templates that reference container images, ensure they use the `radius.image` helper:
+
+```yaml
+image: "{{ include "radius.image" (dict "image" .Values.component.image "tag" (.Values.component.tag | default $appversion) "global" .Values.global) }}"
+```
+
+Then add corresponding tests to validate the image construction.

--- a/deploy/Chart/tests/README.md
+++ b/deploy/Chart/tests/README.md
@@ -35,8 +35,10 @@ helm unittest . -f tests/helpers_test.yaml
 The tests validate:
 
 - The `radius.image` helper template correctly constructs image URLs
-- Default registry (ghcr.io) is used when `global.imageRegistry` is not set
+- Default registry (ghcr.io/radius-project) is used when `global.imageRegistry` is not set
 - Custom registry is properly prepended when `global.imageRegistry` is set
+- `global.imageTag` is used when component tag is not specified
+- Tag priority is respected: component tag > global.imageTag > appVersion
 - All deployments and statefulsets use the helper correctly
 
 ## Adding New Tests
@@ -44,7 +46,13 @@ The tests validate:
 When adding new templates that reference container images, ensure they use the `radius.image` helper:
 
 ```yaml
-image: "{{ include "radius.image" (dict "image" .Values.component.image "tag" (.Values.component.tag | default $appversion) "global" .Values.global) }}"
+image: "{{ include "radius.image" (dict "image" .Values.component.image "tag" (.Values.component.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"
 ```
+
+The tag priority system ensures:
+
+1. Component-specific tag is used if specified
+2. Falls back to `global.imageTag` if component tag is not set
+3. Finally falls back to chart's appVersion if neither is set
 
 Then add corresponding tests to validate the image construction.

--- a/deploy/Chart/tests/helpers_test.yaml
+++ b/deploy/Chart/tests/helpers_test.yaml
@@ -12,55 +12,55 @@ tests:
   - it: should use default ghcr.io registry when global.imageRegistry is not set
     set:
       controller.image: controller
-      controller.tag: v1.0.0
+      controller.tag: 1.0.0
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/radius-project/controller:v1.0.0
+          value: ghcr.io/radius-project/controller:1.0.0
         template: controller/deployment.yaml
 
   - it: should use custom registry when global.imageRegistry is set
     set:
       global.imageRegistry: myregistry.azurecr.io
       controller.image: controller
-      controller.tag: v1.0.0
+      controller.tag: 1.0.0
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.azurecr.io/controller:v1.0.0
+          value: myregistry.azurecr.io/controller:1.0.0
         template: controller/deployment.yaml
 
   - it: should handle empty global.imageRegistry
     set:
       global.imageRegistry: ""
       controller.image: controller
-      controller.tag: v1.0.0
+      controller.tag: 1.0.0
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/radius-project/controller:v1.0.0
+          value: ghcr.io/radius-project/controller:1.0.0
         template: controller/deployment.yaml
 
   - it: should use full image path as-is when it contains registry and tag
     set:
       global.imageRegistry: otherregistry.io
-      controller.image: myregistry.io/custom-controller:v2.0.0
+      controller.image: myregistry.io/custom-controller:2.0.0
       controller.tag: ignored-tag
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.io/custom-controller:v2.0.0
+          value: myregistry.io/custom-controller:2.0.0
         template: controller/deployment.yaml
 
   - it: should append tag to full image path when tag is missing
     set:
       global.imageRegistry: otherregistry.io
       controller.image: myregistry.io/custom-controller
-      controller.tag: v1.0.0
+      controller.tag: 1.0.0
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.io/custom-controller:v1.0.0
+          value: myregistry.io/custom-controller:1.0.0
         template: controller/deployment.yaml
 
   - it: should handle localhost with port in full image path
@@ -98,11 +98,11 @@ tests:
   - it: should handle ECR-style registry in full path
     set:
       ucp.image: 123456789.dkr.ecr.us-west-2.amazonaws.com/custom-ucpd
-      ucp.tag: v1.0.0
+      ucp.tag: 1.0.0
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: 123456789.dkr.ecr.us-west-2.amazonaws.com/custom-ucpd:v1.0.0
+          value: 123456789.dkr.ecr.us-west-2.amazonaws.com/custom-ucpd:1.0.0
         template: ucp/deployment.yaml
 
   - it: should work with default tag from appVersion
@@ -194,26 +194,26 @@ tests:
     set:
       global.imageRegistry: default-registry.io
       controller.image: controller
-      controller.tag: v1.0.0
-      rp.image: custom-registry.io/custom-rp:v2.0.0
+      controller.tag: 1.0.0
+      rp.image: custom-registry.io/custom-rp:2.0.0
       rp.tag: ignored
       ucp.image: ucpd
-      ucp.tag: v1.0.0
+      ucp.tag: 1.0.0
     asserts:
       # Controller should use global registry
       - equal:
           path: spec.template.spec.containers[0].image
-          value: default-registry.io/controller:v1.0.0
+          value: default-registry.io/controller:1.0.0
         template: controller/deployment.yaml
       # RP should use its full path
       - equal:
           path: spec.template.spec.containers[0].image
-          value: custom-registry.io/custom-rp:v2.0.0
+          value: custom-registry.io/custom-rp:2.0.0
         template: rp/deployment.yaml
       # UCP should use global registry
       - equal:
           path: spec.template.spec.containers[0].image
-          value: default-registry.io/ucpd:v1.0.0
+          value: default-registry.io/ucpd:1.0.0
         template: ucp/deployment.yaml
 
   # Tests for global.imageTag functionality

--- a/deploy/Chart/tests/helpers_test.yaml
+++ b/deploy/Chart/tests/helpers_test.yaml
@@ -11,7 +11,7 @@ templates:
 tests:
   - it: should use default ghcr.io registry when global.imageRegistry is not set
     set:
-      controller.image: radius-project/controller
+      controller.image: controller
       controller.tag: v1.0.0
     asserts:
       - equal:
@@ -22,18 +22,18 @@ tests:
   - it: should use custom registry when global.imageRegistry is set
     set:
       global.imageRegistry: myregistry.azurecr.io
-      controller.image: radius-project/controller
+      controller.image: controller
       controller.tag: v1.0.0
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.azurecr.io/radius-project/controller:v1.0.0
+          value: myregistry.azurecr.io/controller:v1.0.0
         template: controller/deployment.yaml
 
   - it: should handle empty global.imageRegistry
     set:
       global.imageRegistry: ""
-      controller.image: radius-project/controller
+      controller.image: controller
       controller.tag: v1.0.0
     asserts:
       - equal:
@@ -107,7 +107,7 @@ tests:
 
   - it: should work with default tag from appVersion
     set:
-      controller.image: radius-project/controller
+      controller.image: controller
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
@@ -117,93 +117,93 @@ tests:
   - it: should work with custom registry and default tag
     set:
       global.imageRegistry: custom.registry.io
-      controller.image: radius-project/controller
+      controller.image: controller
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: ^custom\.registry\.io/radius-project/controller:.*$
+          pattern: ^custom\.registry\.io/controller:.*$
         template: controller/deployment.yaml
 
   - it: should apply to all deployments with custom registry
     set:
       global.imageRegistry: private.registry.com
-      controller.image: radius-project/controller
+      controller.image: controller
       controller.tag: latest
-      ucp.image: radius-project/ucpd
+      ucp.image: ucpd
       ucp.tag: latest
-      rp.image: radius-project/applications-rp
+      rp.image: applications-rp
       rp.tag: latest
-      dynamicrp.image: radius-project/dynamic-rp
+      dynamicrp.image: dynamic-rp
       dynamicrp.tag: latest
-      de.image: radius-project/deployment-engine
+      de.image: deployment-engine
       de.tag: latest
-      dashboard.image: radius-project/dashboard
+      dashboard.image: dashboard
       dashboard.tag: latest
-      bicep.image: radius-project/bicep
+      bicep.image: bicep
       bicep.tag: latest
     asserts:
       # Test controller image
       - equal:
           path: spec.template.spec.containers[0].image
-          value: private.registry.com/radius-project/controller:latest
+          value: private.registry.com/controller:latest
         template: controller/deployment.yaml
       # Test bicep init container
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: private.registry.com/radius-project/bicep:latest
+          value: private.registry.com/bicep:latest
         template: controller/deployment.yaml
       # Test UCP image
       - equal:
           path: spec.template.spec.containers[0].image
-          value: private.registry.com/radius-project/ucpd:latest
+          value: private.registry.com/ucpd:latest
         template: ucp/deployment.yaml
       # Test applications-rp image
       - equal:
           path: spec.template.spec.containers[0].image
-          value: private.registry.com/radius-project/applications-rp:latest
+          value: private.registry.com/applications-rp:latest
         template: rp/deployment.yaml
       # Test dynamic-rp image
       - equal:
           path: spec.template.spec.containers[0].image
-          value: private.registry.com/radius-project/dynamic-rp:latest
+          value: private.registry.com/dynamic-rp:latest
         template: dynamic-rp/deployment.yaml
       # Test deployment-engine image
       - equal:
           path: spec.template.spec.containers[0].image
-          value: private.registry.com/radius-project/deployment-engine:latest
+          value: private.registry.com/deployment-engine:latest
         template: de/deployment.yaml
       # Test dashboard image
       - equal:
           path: spec.template.spec.containers[0].image
-          value: private.registry.com/radius-project/dashboard:latest
+          value: private.registry.com/dashboard:latest
         template: dashboard/deployment.yaml
 
   - it: should handle database statefulset with custom registry
     set:
       global.imageRegistry: internal.registry.io
       database.enabled: true
-      database.image: radius-project/mirror/postgres
+      database.image: mirror/postgres
       database.tag: 14-alpine
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: internal.registry.io/radius-project/mirror/postgres:14-alpine
+          value: internal.registry.io/mirror/postgres:14-alpine
         template: database/statefulset.yaml
 
   - it: should handle mixed scenario - some with full paths, some without
     set:
       global.imageRegistry: default-registry.io
-      controller.image: radius-project/controller
+      controller.image: controller
       controller.tag: v1.0.0
       rp.image: custom-registry.io/custom-rp:v2.0.0
       rp.tag: ignored
-      ucp.image: radius-project/ucpd
+      ucp.image: ucpd
       ucp.tag: v1.0.0
     asserts:
       # Controller should use global registry
       - equal:
           path: spec.template.spec.containers[0].image
-          value: default-registry.io/radius-project/controller:v1.0.0
+          value: default-registry.io/controller:v1.0.0
         template: controller/deployment.yaml
       # RP should use its full path
       - equal:
@@ -213,16 +213,16 @@ tests:
       # UCP should use global registry
       - equal:
           path: spec.template.spec.containers[0].image
-          value: default-registry.io/radius-project/ucpd:v1.0.0
+          value: default-registry.io/ucpd:v1.0.0
         template: ucp/deployment.yaml
 
   # Tests for global.imageTag functionality
   - it: should use global.imageTag when component tag is not specified
     set:
       global.imageTag: v0.48.0
-      controller.image: radius-project/controller
-      ucp.image: radius-project/ucpd
-      rp.image: radius-project/applications-rp
+      controller.image: controller
+      ucp.image: ucpd
+      rp.image: applications-rp
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
@@ -240,9 +240,9 @@ tests:
   - it: should prioritize component tag over global.imageTag
     set:
       global.imageTag: v0.48.0
-      controller.image: radius-project/controller
+      controller.image: controller
       controller.tag: v0.49.0
-      ucp.image: radius-project/ucpd
+      ucp.image: ucpd
     asserts:
       # Controller should use its specific tag
       - equal:
@@ -259,37 +259,37 @@ tests:
     set:
       global.imageRegistry: myregistry.azurecr.io
       global.imageTag: v0.48.0
-      controller.image: radius-project/controller
-      ucp.image: radius-project/ucpd
-      rp.image: radius-project/applications-rp
-      dynamicrp.image: radius-project/dynamic-rp
-      de.image: radius-project/deployment-engine
+      controller.image: controller
+      ucp.image: ucpd
+      rp.image: applications-rp
+      dynamicrp.image: dynamic-rp
+      de.image: deployment-engine
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.azurecr.io/radius-project/controller:v0.48.0
+          value: myregistry.azurecr.io/controller:v0.48.0
         template: controller/deployment.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.azurecr.io/radius-project/ucpd:v0.48.0
+          value: myregistry.azurecr.io/ucpd:v0.48.0
         template: ucp/deployment.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.azurecr.io/radius-project/applications-rp:v0.48.0
+          value: myregistry.azurecr.io/applications-rp:v0.48.0
         template: rp/deployment.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.azurecr.io/radius-project/dynamic-rp:v0.48.0
+          value: myregistry.azurecr.io/dynamic-rp:v0.48.0
         template: dynamic-rp/deployment.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.azurecr.io/radius-project/deployment-engine:v0.48.0
+          value: myregistry.azurecr.io/deployment-engine:v0.48.0
         template: de/deployment.yaml
 
   - it: should handle empty global.imageTag and fall back to appVersion
     set:
       global.imageTag: ""
-      controller.image: radius-project/controller
+      controller.image: controller
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
@@ -299,8 +299,8 @@ tests:
   - it: should apply global.imageTag to bicep init container
     set:
       global.imageTag: v0.48.0
-      bicep.image: radius-project/bicep
-      controller.image: radius-project/controller
+      bicep.image: bicep
+      controller.image: controller
     asserts:
       # Check bicep init container
       - equal:
@@ -317,17 +317,17 @@ tests:
     set:
       global.imageRegistry: myregistry.io
       global.imageTag: v0.48.0
-      controller.image: radius-project/controller
+      controller.image: controller
       controller.tag: v0.49.0-rc1
-      ucp.image: radius-project/ucpd
+      ucp.image: ucpd
     asserts:
       # Controller with override should use its specific tag
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.io/radius-project/controller:v0.49.0-rc1
+          value: myregistry.io/controller:v0.49.0-rc1
         template: controller/deployment.yaml
       # UCP should use global tag
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.io/radius-project/ucpd:v0.48.0
+          value: myregistry.io/ucpd:v0.48.0
         template: ucp/deployment.yaml

--- a/deploy/Chart/tests/helpers_test.yaml
+++ b/deploy/Chart/tests/helpers_test.yaml
@@ -215,3 +215,119 @@ tests:
           path: spec.template.spec.containers[0].image
           value: default-registry.io/radius-project/ucpd:v1.0.0
         template: ucp/deployment.yaml
+
+  # Tests for global.imageTag functionality
+  - it: should use global.imageTag when component tag is not specified
+    set:
+      global.imageTag: v0.48.0
+      controller.image: radius-project/controller
+      ucp.image: radius-project/ucpd
+      rp.image: radius-project/applications-rp
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/radius-project/controller:v0.48.0
+        template: controller/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/radius-project/ucpd:v0.48.0
+        template: ucp/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/radius-project/applications-rp:v0.48.0
+        template: rp/deployment.yaml
+
+  - it: should prioritize component tag over global.imageTag
+    set:
+      global.imageTag: v0.48.0
+      controller.image: radius-project/controller
+      controller.tag: v0.49.0
+      ucp.image: radius-project/ucpd
+    asserts:
+      # Controller should use its specific tag
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/radius-project/controller:v0.49.0
+        template: controller/deployment.yaml
+      # UCP should use global.imageTag
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/radius-project/ucpd:v0.48.0
+        template: ucp/deployment.yaml
+
+  - it: should combine global.imageRegistry with global.imageTag
+    set:
+      global.imageRegistry: myregistry.azurecr.io
+      global.imageTag: v0.48.0
+      controller.image: radius-project/controller
+      ucp.image: radius-project/ucpd
+      rp.image: radius-project/applications-rp
+      dynamicrp.image: radius-project/dynamic-rp
+      de.image: radius-project/deployment-engine
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: myregistry.azurecr.io/radius-project/controller:v0.48.0
+        template: controller/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: myregistry.azurecr.io/radius-project/ucpd:v0.48.0
+        template: ucp/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: myregistry.azurecr.io/radius-project/applications-rp:v0.48.0
+        template: rp/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: myregistry.azurecr.io/radius-project/dynamic-rp:v0.48.0
+        template: dynamic-rp/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: myregistry.azurecr.io/radius-project/deployment-engine:v0.48.0
+        template: de/deployment.yaml
+
+  - it: should handle empty global.imageTag and fall back to appVersion
+    set:
+      global.imageTag: ""
+      controller.image: radius-project/controller
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^ghcr\.io/radius-project/controller:.*$
+        template: controller/deployment.yaml
+
+  - it: should apply global.imageTag to bicep init container
+    set:
+      global.imageTag: v0.48.0
+      bicep.image: radius-project/bicep
+      controller.image: radius-project/controller
+    asserts:
+      # Check bicep init container
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: ghcr.io/radius-project/bicep:v0.48.0
+        template: controller/deployment.yaml
+      # Check main controller container
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/radius-project/controller:v0.48.0
+        template: controller/deployment.yaml
+
+  - it: should handle component tag override with global registry and tag
+    set:
+      global.imageRegistry: myregistry.io
+      global.imageTag: v0.48.0
+      controller.image: radius-project/controller
+      controller.tag: v0.49.0-rc1
+      ucp.image: radius-project/ucpd
+    asserts:
+      # Controller with override should use its specific tag
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: myregistry.io/radius-project/controller:v0.49.0-rc1
+        template: controller/deployment.yaml
+      # UCP should use global tag
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: myregistry.io/radius-project/ucpd:v0.48.0
+        template: ucp/deployment.yaml

--- a/deploy/Chart/tests/helpers_test.yaml
+++ b/deploy/Chart/tests/helpers_test.yaml
@@ -1,0 +1,217 @@
+suite: test helpers
+templates:
+  - _helpers.tpl
+  - controller/deployment.yaml
+  - ucp/deployment.yaml
+  - rp/deployment.yaml
+  - dynamic-rp/deployment.yaml
+  - de/deployment.yaml
+  - dashboard/deployment.yaml
+  - database/statefulset.yaml
+tests:
+  - it: should use default ghcr.io registry when global.imageRegistry is not set
+    set:
+      controller.image: radius-project/controller
+      controller.tag: v1.0.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/radius-project/controller:v1.0.0
+        template: controller/deployment.yaml
+
+  - it: should use custom registry when global.imageRegistry is set
+    set:
+      global.imageRegistry: myregistry.azurecr.io
+      controller.image: radius-project/controller
+      controller.tag: v1.0.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: myregistry.azurecr.io/radius-project/controller:v1.0.0
+        template: controller/deployment.yaml
+
+  - it: should handle empty global.imageRegistry
+    set:
+      global.imageRegistry: ""
+      controller.image: radius-project/controller
+      controller.tag: v1.0.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/radius-project/controller:v1.0.0
+        template: controller/deployment.yaml
+
+  - it: should use full image path as-is when it contains registry and tag
+    set:
+      global.imageRegistry: otherregistry.io
+      controller.image: myregistry.io/custom-controller:v2.0.0
+      controller.tag: ignored-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: myregistry.io/custom-controller:v2.0.0
+        template: controller/deployment.yaml
+
+  - it: should append tag to full image path when tag is missing
+    set:
+      global.imageRegistry: otherregistry.io
+      controller.image: myregistry.io/custom-controller
+      controller.tag: v1.0.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: myregistry.io/custom-controller:v1.0.0
+        template: controller/deployment.yaml
+
+  - it: should handle localhost with port in full image path
+    set:
+      global.imageRegistry: ""
+      rp.image: localhost:5000/custom-rp
+      rp.tag: latest
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: localhost:5000/custom-rp:latest
+        template: rp/deployment.yaml
+
+  - it: should handle functional test scenario with radius-registry
+    set:
+      global.imageRegistry: ""
+      rp.image: radius-registry:5000/applications-rp
+      rp.tag: pr-funceeffa6fd43
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: radius-registry:5000/applications-rp:pr-funceeffa6fd43
+        template: rp/deployment.yaml
+
+  - it: should handle full image path with existing tag and ignore provided tag
+    set:
+      de.image: custom-registry.io/deployment-engine:custom-tag
+      de.tag: ignored-tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: custom-registry.io/deployment-engine:custom-tag
+        template: de/deployment.yaml
+
+  - it: should handle ECR-style registry in full path
+    set:
+      ucp.image: 123456789.dkr.ecr.us-west-2.amazonaws.com/custom-ucpd
+      ucp.tag: v1.0.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: 123456789.dkr.ecr.us-west-2.amazonaws.com/custom-ucpd:v1.0.0
+        template: ucp/deployment.yaml
+
+  - it: should work with default tag from appVersion
+    set:
+      controller.image: radius-project/controller
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^ghcr\.io/radius-project/controller:.*$
+        template: controller/deployment.yaml
+
+  - it: should work with custom registry and default tag
+    set:
+      global.imageRegistry: custom.registry.io
+      controller.image: radius-project/controller
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^custom\.registry\.io/radius-project/controller:.*$
+        template: controller/deployment.yaml
+
+  - it: should apply to all deployments with custom registry
+    set:
+      global.imageRegistry: private.registry.com
+      controller.image: radius-project/controller
+      controller.tag: latest
+      ucp.image: radius-project/ucpd
+      ucp.tag: latest
+      rp.image: radius-project/applications-rp
+      rp.tag: latest
+      dynamicrp.image: radius-project/dynamic-rp
+      dynamicrp.tag: latest
+      de.image: radius-project/deployment-engine
+      de.tag: latest
+      dashboard.image: radius-project/dashboard
+      dashboard.tag: latest
+      bicep.image: radius-project/bicep
+      bicep.tag: latest
+    asserts:
+      # Test controller image
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: private.registry.com/radius-project/controller:latest
+        template: controller/deployment.yaml
+      # Test bicep init container
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: private.registry.com/radius-project/bicep:latest
+        template: controller/deployment.yaml
+      # Test UCP image
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: private.registry.com/radius-project/ucpd:latest
+        template: ucp/deployment.yaml
+      # Test applications-rp image
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: private.registry.com/radius-project/applications-rp:latest
+        template: rp/deployment.yaml
+      # Test dynamic-rp image
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: private.registry.com/radius-project/dynamic-rp:latest
+        template: dynamic-rp/deployment.yaml
+      # Test deployment-engine image
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: private.registry.com/radius-project/deployment-engine:latest
+        template: de/deployment.yaml
+      # Test dashboard image
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: private.registry.com/radius-project/dashboard:latest
+        template: dashboard/deployment.yaml
+
+  - it: should handle database statefulset with custom registry
+    set:
+      global.imageRegistry: internal.registry.io
+      database.enabled: true
+      database.image: radius-project/mirror/postgres
+      database.tag: 14-alpine
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: internal.registry.io/radius-project/mirror/postgres:14-alpine
+        template: database/statefulset.yaml
+
+  - it: should handle mixed scenario - some with full paths, some without
+    set:
+      global.imageRegistry: default-registry.io
+      controller.image: radius-project/controller
+      controller.tag: v1.0.0
+      rp.image: custom-registry.io/custom-rp:v2.0.0
+      rp.tag: ignored
+      ucp.image: radius-project/ucpd
+      ucp.tag: v1.0.0
+    asserts:
+      # Controller should use global registry
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: default-registry.io/radius-project/controller:v1.0.0
+        template: controller/deployment.yaml
+      # RP should use its full path
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: custom-registry.io/custom-rp:v2.0.0
+        template: rp/deployment.yaml
+      # UCP should use global registry
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: default-registry.io/radius-project/ucpd:v1.0.0
+        template: ucp/deployment.yaml

--- a/deploy/Chart/tests/helpers_test.yaml
+++ b/deploy/Chart/tests/helpers_test.yaml
@@ -219,46 +219,46 @@ tests:
   # Tests for global.imageTag functionality
   - it: should use global.imageTag when component tag is not specified
     set:
-      global.imageTag: v0.48.0
+      global.imageTag: 0.48
       controller.image: controller
       ucp.image: ucpd
       rp.image: applications-rp
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/radius-project/controller:v0.48.0
+          value: ghcr.io/radius-project/controller:0.48
         template: controller/deployment.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/radius-project/ucpd:v0.48.0
+          value: ghcr.io/radius-project/ucpd:0.48
         template: ucp/deployment.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/radius-project/applications-rp:v0.48.0
+          value: ghcr.io/radius-project/applications-rp:0.48
         template: rp/deployment.yaml
 
   - it: should prioritize component tag over global.imageTag
     set:
-      global.imageTag: v0.48.0
+      global.imageTag: 0.48
       controller.image: controller
-      controller.tag: v0.49.0
+      controller.tag: 0.49
       ucp.image: ucpd
     asserts:
       # Controller should use its specific tag
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/radius-project/controller:v0.49.0
+          value: ghcr.io/radius-project/controller:0.49
         template: controller/deployment.yaml
       # UCP should use global.imageTag
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/radius-project/ucpd:v0.48.0
+          value: ghcr.io/radius-project/ucpd:0.48
         template: ucp/deployment.yaml
 
   - it: should combine global.imageRegistry with global.imageTag
     set:
       global.imageRegistry: myregistry.azurecr.io
-      global.imageTag: v0.48.0
+      global.imageTag: 0.48
       controller.image: controller
       ucp.image: ucpd
       rp.image: applications-rp
@@ -267,23 +267,23 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.azurecr.io/controller:v0.48.0
+          value: myregistry.azurecr.io/controller:0.48
         template: controller/deployment.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.azurecr.io/ucpd:v0.48.0
+          value: myregistry.azurecr.io/ucpd:0.48
         template: ucp/deployment.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.azurecr.io/applications-rp:v0.48.0
+          value: myregistry.azurecr.io/applications-rp:0.48
         template: rp/deployment.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.azurecr.io/dynamic-rp:v0.48.0
+          value: myregistry.azurecr.io/dynamic-rp:0.48
         template: dynamic-rp/deployment.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.azurecr.io/deployment-engine:v0.48.0
+          value: myregistry.azurecr.io/deployment-engine:0.48
         template: de/deployment.yaml
 
   - it: should handle empty global.imageTag and fall back to appVersion
@@ -298,36 +298,36 @@ tests:
 
   - it: should apply global.imageTag to bicep init container
     set:
-      global.imageTag: v0.48.0
+      global.imageTag: 0.48
       bicep.image: bicep
       controller.image: controller
     asserts:
       # Check bicep init container
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: ghcr.io/radius-project/bicep:v0.48.0
+          value: ghcr.io/radius-project/bicep:0.48
         template: controller/deployment.yaml
       # Check main controller container
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/radius-project/controller:v0.48.0
+          value: ghcr.io/radius-project/controller:0.48
         template: controller/deployment.yaml
 
   - it: should handle component tag override with global registry and tag
     set:
       global.imageRegistry: myregistry.io
-      global.imageTag: v0.48.0
+      global.imageTag: 0.48
       controller.image: controller
-      controller.tag: v0.49.0-rc1
+      controller.tag: 0.49-rc1
       ucp.image: ucpd
     asserts:
       # Controller with override should use its specific tag
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.io/controller:v0.49.0-rc1
+          value: myregistry.io/controller:0.49-rc1
         template: controller/deployment.yaml
       # UCP should use global tag
       - equal:
           path: spec.template.spec.containers[0].image
-          value: myregistry.io/ucpd:v0.48.0
+          value: myregistry.io/ucpd:0.48
         template: ucp/deployment.yaml

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -4,6 +4,11 @@ global:
   # Example: global.imageRegistry=myregistry.azurecr.io
   imageRegistry: ""
   
+  # Configure global.imageTag to use a specific tag for all Radius images.
+  # When empty (default), images will use the tag derived from Chart AppVersion.
+  # Example: global.imageTag=v0.48.0
+  imageTag: ""
+  
   # Configure global.rootCA.cert to use the intermediate CA cert in Radius containers.
   # Otherwise, Radius containers use the default root CA provided by base OS image.
   rootCA:

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -53,7 +53,7 @@ global:
     downloadUrl: ""
 
 controller:
-  image: radius-project/controller
+  image: controller
   # Default tag uses Chart AppVersion.
   # tag: latest
   resources:
@@ -63,7 +63,7 @@ controller:
       memory: "300Mi"
 
 de:
-  image: radius-project/deployment-engine
+  image: deployment-engine
   # Default tag uses Chart AppVersion.
   # tag: latest
   resources:
@@ -74,7 +74,7 @@ de:
       memory: "300Mi"
 
 ucp:
-  image: radius-project/ucpd
+  image: ucpd
   # Default tag uses Chart AppVersion.
   # tag: latest
   resources:
@@ -85,7 +85,7 @@ ucp:
       memory: "300Mi"
 
 dynamicrp:
-  image: radius-project/dynamic-rp
+  image: dynamic-rp
   # Default tag uses Chart AppVersion.
   # tag: latest
   resources:
@@ -103,7 +103,7 @@ dynamicrp:
     path: "/terraform"
 
 rp:
-  image: radius-project/applications-rp
+  image: applications-rp
   # Default tag uses Chart AppVersion.
   # tag: latest
   publicEndpointOverride: ""
@@ -124,7 +124,7 @@ rp:
 dashboard:
   enabled: true
   containerPort: 7007
-  image: radius-project/dashboard
+  image: dashboard
   # Default tag uses Chart AppVersion.
   # tag: latest
   resources:
@@ -136,7 +136,7 @@ dashboard:
 database:
   enabled: false # Enable the Postgres database install
   postgres_user: "radius"
-  image: radius-project/mirror/postgres
+  image: mirror/postgres
   tag: latest
   storageClassName: "" # set to the storage class name if required, the empty string will pickup the default storage class.
   # Minimum resource requirements, may need to revisit and scale.
@@ -150,6 +150,6 @@ database:
       memory: "1024Mi"
 
 bicep:
-  image: radius-project/bicep
+  image: bicep
   # Default tag uses Chart AppVersion.
   # tag: latest

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -1,6 +1,6 @@
 global:
   # Configure global.imageRegistry to use a custom container registry for all Radius images.
-  # When empty (default), images will use their default registries (ghcr.io).
+  # When empty (default), images will use ghcr.io/radius-project as the registry.
   # Example: global.imageRegistry=myregistry.azurecr.io
   imageRegistry: ""
   

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -1,4 +1,9 @@
 global:
+  # Configure global.imageRegistry to use a custom container registry for all Radius images.
+  # When empty (default), images will use their default registries (ghcr.io).
+  # Example: global.imageRegistry=myregistry.azurecr.io
+  imageRegistry: ""
+  
   # Configure global.rootCA.cert to use the intermediate CA cert in Radius containers.
   # Otherwise, Radius containers use the default root CA provided by base OS image.
   rootCA:
@@ -43,7 +48,7 @@ global:
     downloadUrl: ""
 
 controller:
-  image: ghcr.io/radius-project/controller
+  image: radius-project/controller
   # Default tag uses Chart AppVersion.
   # tag: latest
   resources:
@@ -53,7 +58,7 @@ controller:
       memory: "300Mi"
 
 de:
-  image: ghcr.io/radius-project/deployment-engine
+  image: radius-project/deployment-engine
   # Default tag uses Chart AppVersion.
   # tag: latest
   resources:
@@ -64,7 +69,7 @@ de:
       memory: "300Mi"
 
 ucp:
-  image: ghcr.io/radius-project/ucpd
+  image: radius-project/ucpd
   # Default tag uses Chart AppVersion.
   # tag: latest
   resources:
@@ -75,7 +80,7 @@ ucp:
       memory: "300Mi"
 
 dynamicrp:
-  image: ghcr.io/radius-project/dynamic-rp
+  image: radius-project/dynamic-rp
   # Default tag uses Chart AppVersion.
   # tag: latest
   resources:
@@ -93,7 +98,7 @@ dynamicrp:
     path: "/terraform"
 
 rp:
-  image: ghcr.io/radius-project/applications-rp
+  image: radius-project/applications-rp
   # Default tag uses Chart AppVersion.
   # tag: latest
   publicEndpointOverride: ""
@@ -114,7 +119,7 @@ rp:
 dashboard:
   enabled: true
   containerPort: 7007
-  image: ghcr.io/radius-project/dashboard
+  image: radius-project/dashboard
   # Default tag uses Chart AppVersion.
   # tag: latest
   resources:
@@ -126,7 +131,7 @@ dashboard:
 database:
   enabled: false # Enable the Postgres database install
   postgres_user: "radius"
-  image: ghcr.io/radius-project/mirror/postgres
+  image: radius-project/mirror/postgres
   tag: latest
   storageClassName: "" # set to the storage class name if required, the empty string will pickup the default storage class.
   # Minimum resource requirements, may need to revisit and scale.
@@ -140,6 +145,6 @@ database:
       memory: "1024Mi"
 
 bicep:
-  image: ghcr.io/radius-project/bicep
+  image: radius-project/bicep
   # Default tag uses Chart AppVersion.
   # tag: latest

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -6,7 +6,7 @@ global:
   
   # Configure global.imageTag to use a specific tag for all Radius images.
   # When empty (default), images will use the tag derived from Chart AppVersion.
-  # Example: global.imageTag=v0.48.0
+  # Example: global.imageTag=0.48
   imageTag: ""
   
   # Configure global.rootCA.cert to use the intermediate CA cert in Radius containers.

--- a/pkg/cli/cmd/install/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/install/kubernetes/kubernetes.go
@@ -57,6 +57,9 @@ rad install kubernetes --skip-contour-install
 # Install Radius with overrides in the current Kubernetes context
 rad install kubernetes --set key=value
 
+# Install Radius with a custom container registry
+rad install kubernetes --set global.imageRegistry=myregistry.azurecr.io
+
 # Install Radius with the intermediate root CA certificate in the current Kubernetes context
 rad install kubernetes --set-file global.rootCA.cert=/path/to/rootCA.crt
 

--- a/pkg/cli/cmd/install/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/install/kubernetes/kubernetes.go
@@ -62,11 +62,11 @@ rad install kubernetes --set key=value
 rad install kubernetes --set global.imageRegistry=myregistry.azurecr.io
 
 # Install Radius with a specific version tag for all components
-rad install kubernetes --set global.imageTag=v0.48.0
+rad install kubernetes --set global.imageTag=0.48
 
 # Install Radius with custom registry and tag
-# Images will be pulled as: myregistry.azurecr.io/controller:v0.48.0, etc.
-rad install kubernetes --set global.imageRegistry=myregistry.azurecr.io,global.imageTag=v0.48.0
+# Images will be pulled as: myregistry.azurecr.io/controller:0.48, etc.
+rad install kubernetes --set global.imageRegistry=myregistry.azurecr.io,global.imageTag=0.48
 
 # Install Radius with the intermediate root CA certificate in the current Kubernetes context
 rad install kubernetes --set-file global.rootCA.cert=/path/to/rootCA.crt

--- a/pkg/cli/cmd/install/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/install/kubernetes/kubernetes.go
@@ -60,6 +60,12 @@ rad install kubernetes --set key=value
 # Install Radius with a custom container registry
 rad install kubernetes --set global.imageRegistry=myregistry.azurecr.io
 
+# Install Radius with a specific version tag for all components
+rad install kubernetes --set global.imageTag=v0.48.0
+
+# Install Radius with custom registry and tag
+rad install kubernetes --set global.imageRegistry=myregistry.azurecr.io,global.imageTag=v0.48.0
+
 # Install Radius with the intermediate root CA certificate in the current Kubernetes context
 rad install kubernetes --set-file global.rootCA.cert=/path/to/rootCA.crt
 

--- a/pkg/cli/cmd/install/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/install/kubernetes/kubernetes.go
@@ -58,12 +58,14 @@ rad install kubernetes --skip-contour-install
 rad install kubernetes --set key=value
 
 # Install Radius with a custom container registry
+# Images will be pulled as: myregistry.azurecr.io/controller, myregistry.azurecr.io/ucpd, etc.
 rad install kubernetes --set global.imageRegistry=myregistry.azurecr.io
 
 # Install Radius with a specific version tag for all components
 rad install kubernetes --set global.imageTag=v0.48.0
 
 # Install Radius with custom registry and tag
+# Images will be pulled as: myregistry.azurecr.io/controller:v0.48.0, etc.
 rad install kubernetes --set global.imageRegistry=myregistry.azurecr.io,global.imageTag=v0.48.0
 
 # Install Radius with the intermediate root CA certificate in the current Kubernetes context

--- a/pkg/cli/cmd/install/kubernetes/kubernetes_test.go
+++ b/pkg/cli/cmd/install/kubernetes/kubernetes_test.go
@@ -230,7 +230,7 @@ func Test_Run(t *testing.T) {
 			Output: outputMock,
 
 			KubeContext: "test-context",
-			Set:         []string{"global.imageTag=v0.48.0"},
+			Set:         []string{"global.imageTag=0.48"},
 		}
 
 		helmMock.EXPECT().CheckRadiusInstall("test-context").
@@ -239,7 +239,7 @@ func Test_Run(t *testing.T) {
 
 		expectedOptions := helm.PopulateDefaultClusterOptions(helm.CLIClusterOptions{
 			Radius: helm.ChartOptions{
-				SetArgs: []string{"global.imageTag=v0.48.0"},
+				SetArgs: []string{"global.imageTag=0.48"},
 			},
 		})
 		helmMock.EXPECT().InstallRadius(ctx, expectedOptions, "test-context").
@@ -269,7 +269,7 @@ func Test_Run(t *testing.T) {
 			Output: outputMock,
 
 			KubeContext: "test-context",
-			Set:         []string{"global.imageRegistry=myregistry.azurecr.io", "global.imageTag=v0.48.0"},
+			Set:         []string{"global.imageRegistry=myregistry.azurecr.io", "global.imageTag=0.48"},
 		}
 
 		helmMock.EXPECT().CheckRadiusInstall("test-context").
@@ -278,7 +278,7 @@ func Test_Run(t *testing.T) {
 
 		expectedOptions := helm.PopulateDefaultClusterOptions(helm.CLIClusterOptions{
 			Radius: helm.ChartOptions{
-				SetArgs: []string{"global.imageRegistry=myregistry.azurecr.io", "global.imageTag=v0.48.0"},
+				SetArgs: []string{"global.imageRegistry=myregistry.azurecr.io", "global.imageTag=0.48"},
 			},
 		})
 		helmMock.EXPECT().InstallRadius(ctx, expectedOptions, "test-context").

--- a/pkg/cli/cmd/radinit/environment.go
+++ b/pkg/cli/cmd/radinit/environment.go
@@ -68,6 +68,8 @@ func (r *Runner) CreateEnvironment(ctx context.Context) error {
 
 	var recipes map[string]map[string]corerp.RecipePropertiesClassification
 	if r.Options.Recipes.DevRecipes {
+		// Note: To use custom registry for recipes, users need to manually configure
+		// their environment after initialization or use custom recipe definitions
 		recipes, err = r.DevRecipeClient.GetDevRecipes(ctx)
 		if err != nil {
 			return err

--- a/pkg/cli/cmd/radinit/init.go
+++ b/pkg/cli/cmd/radinit/init.go
@@ -72,6 +72,12 @@ rad init
 
 ## Prompt the user for all available options to create a new environment
 rad init --full
+
+## Initialize with a custom container registry
+rad init --set global.imageRegistry=myregistry.azurecr.io
+
+## Initialize with custom values from a file
+rad init --set-file global.rootCA.cert=/path/to/rootCA.crt
 `,
 		Args: cobra.ExactArgs(0),
 		RunE: framework.RunCommand(runner),
@@ -80,6 +86,8 @@ rad init --full
 	// Define your flags here
 	commonflags.AddOutputFlag(cmd)
 	cmd.Flags().Bool("full", false, "Prompt user for all available configuration options")
+	cmd.Flags().StringArrayVar(&runner.Set, "set", []string{}, "Set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
+	cmd.Flags().StringArrayVar(&runner.SetFile, "set-file", []string{}, "Set values from files on the command line (can specify multiple or separate files with commas: key1=filename1,key2=filename2)")
 	return cmd, runner
 }
 
@@ -120,6 +128,12 @@ type Runner struct {
 
 	// Full determines whether or not we ask the user for all options.
 	Full bool
+
+	// Set is the list of additional Helm values to set.
+	Set []string
+
+	// SetFile is the list of additional Helm values from files.
+	SetFile []string
 
 	// Options provides the options to used for Radius initialization. This will be populated by Validate.
 	Options *initOptions
@@ -215,7 +229,8 @@ func (r *Runner) Run(ctx context.Context) error {
 	if r.Options.Cluster.Install {
 		cliOptions := helm.CLIClusterOptions{
 			Radius: helm.ChartOptions{
-				SetArgs: r.Options.SetValues,
+				SetArgs:     append(r.Options.SetValues, r.Set...),
+				SetFileArgs: r.SetFile,
 			},
 		}
 

--- a/pkg/cli/cmd/radinit/init.go
+++ b/pkg/cli/cmd/radinit/init.go
@@ -78,11 +78,11 @@ rad init --full
 rad init --set global.imageRegistry=myregistry.azurecr.io
 
 ## Initialize with a specific version tag
-rad init --set global.imageTag=v0.48.0
+rad init --set global.imageTag=0.48
 
 ## Initialize with custom registry and tag
-## Images will be pulled as: myregistry.azurecr.io/controller:v0.48.0, etc.
-rad init --set global.imageRegistry=myregistry.azurecr.io,global.imageTag=v0.48.0
+## Images will be pulled as: myregistry.azurecr.io/controller:0.48, etc.
+rad init --set global.imageRegistry=myregistry.azurecr.io,global.imageTag=0.48
 
 ## Initialize with custom values from a file
 rad init --set-file global.rootCA.cert=/path/to/rootCA.crt

--- a/pkg/cli/cmd/radinit/init.go
+++ b/pkg/cli/cmd/radinit/init.go
@@ -76,6 +76,12 @@ rad init --full
 ## Initialize with a custom container registry
 rad init --set global.imageRegistry=myregistry.azurecr.io
 
+## Initialize with a specific version tag
+rad init --set global.imageTag=v0.48.0
+
+## Initialize with custom registry and tag
+rad init --set global.imageRegistry=myregistry.azurecr.io,global.imageTag=v0.48.0
+
 ## Initialize with custom values from a file
 rad init --set-file global.rootCA.cert=/path/to/rootCA.crt
 `,

--- a/pkg/cli/cmd/radinit/init.go
+++ b/pkg/cli/cmd/radinit/init.go
@@ -74,12 +74,14 @@ rad init
 rad init --full
 
 ## Initialize with a custom container registry
+## Images will be pulled as: myregistry.azurecr.io/controller, myregistry.azurecr.io/ucpd, etc.
 rad init --set global.imageRegistry=myregistry.azurecr.io
 
 ## Initialize with a specific version tag
 rad init --set global.imageTag=v0.48.0
 
 ## Initialize with custom registry and tag
+## Images will be pulled as: myregistry.azurecr.io/controller:v0.48.0, etc.
 rad init --set global.imageRegistry=myregistry.azurecr.io,global.imageTag=v0.48.0
 
 ## Initialize with custom values from a file

--- a/pkg/cli/cmd/upgrade/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/upgrade/kubernetes/kubernetes.go
@@ -65,12 +65,14 @@ rad upgrade kubernetes
 rad upgrade kubernetes --set key=value
 
 # Upgrade Radius with a custom container registry
+# Images will be pulled as: myregistry.azurecr.io/controller, myregistry.azurecr.io/ucpd, etc.
 rad upgrade kubernetes --set global.imageRegistry=myregistry.azurecr.io
 
 # Upgrade Radius to a specific version tag for all components
 rad upgrade kubernetes --set global.imageTag=v0.48.0
 
 # Upgrade Radius with custom registry and tag
+# Images will be pulled as: myregistry.azurecr.io/controller:v0.48.0, etc.
 rad upgrade kubernetes --set global.imageRegistry=myregistry.azurecr.io,global.imageTag=v0.48.0
 
 # Upgrade to a specific version

--- a/pkg/cli/cmd/upgrade/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/upgrade/kubernetes/kubernetes.go
@@ -69,11 +69,11 @@ rad upgrade kubernetes --set key=value
 rad upgrade kubernetes --set global.imageRegistry=myregistry.azurecr.io
 
 # Upgrade Radius to a specific version tag for all components
-rad upgrade kubernetes --set global.imageTag=v0.48.0
+rad upgrade kubernetes --set global.imageTag=0.48
 
 # Upgrade Radius with custom registry and tag
-# Images will be pulled as: myregistry.azurecr.io/controller:v0.48.0, etc.
-rad upgrade kubernetes --set global.imageRegistry=myregistry.azurecr.io,global.imageTag=v0.48.0
+# Images will be pulled as: myregistry.azurecr.io/controller:0.48, etc.
+rad upgrade kubernetes --set global.imageRegistry=myregistry.azurecr.io,global.imageTag=0.48
 
 # Upgrade to a specific version
 rad upgrade kubernetes --version 0.47.0

--- a/pkg/cli/cmd/upgrade/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/upgrade/kubernetes/kubernetes.go
@@ -64,6 +64,9 @@ rad upgrade kubernetes
 # Upgrade Radius with custom configuration
 rad upgrade kubernetes --set key=value
 
+# Upgrade Radius with a custom container registry
+rad upgrade kubernetes --set global.imageRegistry=myregistry.azurecr.io
+
 # Upgrade to a specific version
 rad upgrade kubernetes --version 0.47.0
 

--- a/pkg/cli/cmd/upgrade/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/upgrade/kubernetes/kubernetes.go
@@ -67,6 +67,12 @@ rad upgrade kubernetes --set key=value
 # Upgrade Radius with a custom container registry
 rad upgrade kubernetes --set global.imageRegistry=myregistry.azurecr.io
 
+# Upgrade Radius to a specific version tag for all components
+rad upgrade kubernetes --set global.imageTag=v0.48.0
+
+# Upgrade Radius with custom registry and tag
+rad upgrade kubernetes --set global.imageRegistry=myregistry.azurecr.io,global.imageTag=v0.48.0
+
 # Upgrade to a specific version
 rad upgrade kubernetes --version 0.47.0
 


### PR DESCRIPTION
# Description

## Human Description

- global.imageRegistry parameter
- global.imageTag parameter
- Helm unit tests for the parameters above 
- Adding Helm unit tests to CI/CD pipeline
- Update the following commands to accept the new paramaters:
  - `rad init`
  - `rad install kubernetes`
  - `rad upgrade kubernetes`
- Adding the following functionalities to `rad init`
  - `--set` so that some parameters could be set
  - `--set-file` to initialize with custom values from a file

## Testing

You need to create a binary from this branch. Then, you can run the following commands:

- `rad install kubernetes --set global.imageRegistry=ghcr.io/username --set global.imageTag=0.45`
- You can do different combinations of the new parameters and these commands: `rad init`, `rad install kubernetes`, and `rad upgrade kubernetes`.

**Note: You should pass in `--chart deploy/Chart` because the chart that is in ghcr doesn't have the new changes.**

## AI-Generated Description

This pull request introduces support for custom container registries and image tags across all Radius Helm chart deployments, making it easier to deploy in air-gapped or private registry environments. It also adds Helm chart unit tests to the CI workflows and Makefile, and provides documentation updates for these new features and testing processes.

**Helm Chart Image Registry and Tag Support:**

* Added a new `radius.image` Helm helper template to construct fully qualified image names, supporting custom registries and tags via `global.imageRegistry` and `global.imageTag` values. All deployments and statefulsets now use this helper for their image references. [[1]](diffhunk://#diff-0ba89421395856d6246fed28806565a0d3475d08fdd81093c97091a888ef6529R44-R100) [[2]](diffhunk://#diff-6e17741710603ff5eab2c2df3885c905ebc5c657cf16232734059f645f97397fL32-R32) [[3]](diffhunk://#diff-6e17741710603ff5eab2c2df3885c905ebc5c657cf16232734059f645f97397fL41-R41) [[4]](diffhunk://#diff-fa8b3636d5cfdf8b941b89a5af4b2f3725e7ddc086f406111a08afbe14ce4267L27-R27) [[5]](diffhunk://#diff-9366e0a3212639c13de30e1ab3896ba45398986535acd618702b94c38ecab701L29-R29) [[6]](diffhunk://#diff-aa649ac3a27b3a57cd4da52d741118f2870fd721886d603f5091a90fc825e025L44-R44) [[7]](diffhunk://#diff-bb1c415d2aa24ec5f2f090395448250831b3b467289e1fa6c603fd1661453de1L122-R122) [[8]](diffhunk://#diff-92bd08c7c2302e12d2ceb2f7bf0a5bdd0016bb8e2eb2639588e994366e9ee841L122-R122) [[9]](diffhunk://#diff-0fe5610e45572cab258709e7346308d2bdc2f9c16a46d493f049de4707ea465dL35-R35)
* Updated `deploy/Chart/README.md` with detailed instructions on configuring custom registries and tags, air-gapped deployments, and certificate handling. [[1]](diffhunk://#diff-3f9a3e2ff0e91c183113a295169a98b4ec58c328613c999c82cd43e1e822d6a3L1-R149) [[2]](diffhunk://#diff-3f9a3e2ff0e91c183113a295169a98b4ec58c328613c999c82cd43e1e822d6a3L39-R176)

**Testing and CI Improvements:**

* Added Helm chart unit tests using the `helm-unittest` plugin, with sample tests and documentation in `deploy/Chart/tests/README.md`.
* Integrated Helm unit tests into CI workflows (`.github/workflows/build.yaml` and `.github/workflows/lint.yaml`) and the Makefile (`build/test.mk`). [[1]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R242-R245) [[2]](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bR72-R75) [[3]](diffhunk://#diff-607e82dd7ce2736355a7703fb1a4a832dddb294c3683c4b51a5118218e379712L46-R46) [[4]](diffhunk://#diff-607e82dd7ce2736355a7703fb1a4a832dddb294c3683c4b51a5118218e379712R145-R151)

## Type of change

- This pull request adds or changes features of Radius and has an approved issue (issue link required).

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->