### PR TITLE
Updated the release process to add release branch and tags to bicep-tools repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -222,6 +222,10 @@ jobs:
         if: success() && steps.release-branch-exists.outputs.result == 'false'
         run: |
           ./radius/.github/scripts/release-create-tag-and-branch.sh bicep-types-aws ${{ steps.get-version.outputs.release-version }} ${{ steps.get-version.outputs.release-branch-name }}
+      - name: Release radius-project/bicep-types version ${{ steps.get-version.outputs.release-version }}
+        if: success() && steps.release-branch-exists.outputs.result == 'false'
+        run: |
+          ./radius/.github/scripts/release-create-tag-and-branch.sh bicep-types ${{ steps.get-version.outputs.release-version }} ${{ steps.get-version.outputs.release-branch-name }}
       - name: Log in to Azure
         uses: azure/login@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -206,6 +206,10 @@ jobs:
           echo "* Desired release tag: ${{ steps.get-version.outputs.release-version }}" >> $GITHUB_STEP_SUMMARY
           echo "* Desired release branch: ${{ steps.get-version.outputs.release-branch-name }}" >> $GITHUB_STEP_SUMMARY
           echo "* Release date: $(date)" >> $GITHUB_STEP_SUMMARY
+      - name: Release radius-project/bicep-tools version ${{ steps.get-version.outputs.release-version }}
+        if: success() && steps.release-branch-exists.outputs.result == 'false'
+        run: |
+          ./radius/.github/scripts/release-create-tag-and-branch.sh bicep-tools ${{ steps.get-version.outputs.release-version }} ${{ steps.get-version.outputs.release-branch-name }}
       - name: Release radius-project/radius version ${{ steps.get-version.outputs.release-version }}
         if: success() && steps.release-branch-exists.outputs.result == 'false'
         run: |
@@ -222,10 +226,6 @@ jobs:
         if: success() && steps.release-branch-exists.outputs.result == 'false'
         run: |
           ./radius/.github/scripts/release-create-tag-and-branch.sh bicep-types-aws ${{ steps.get-version.outputs.release-version }} ${{ steps.get-version.outputs.release-branch-name }}
-      - name: Release radius-project/bicep-types version ${{ steps.get-version.outputs.release-version }}
-        if: success() && steps.release-branch-exists.outputs.result == 'false'
-        run: |
-          ./radius/.github/scripts/release-create-tag-and-branch.sh bicep-types ${{ steps.get-version.outputs.release-version }} ${{ steps.get-version.outputs.release-branch-name }}
       - name: Log in to Azure
         uses: azure/login@v2
         with:

--- a/pkg/cli/cmd/bicep/publishextension/publish.go
+++ b/pkg/cli/cmd/bicep/publishextension/publish.go
@@ -29,7 +29,7 @@ import (
 	"github.com/radius-project/radius/pkg/cli/framework"
 	"github.com/radius-project/radius/pkg/cli/manifest"
 	"github.com/radius-project/radius/pkg/cli/output"
-
+	"github.com/radius-project/radius/pkg/version"
 	"github.com/spf13/cobra"
 )
 
@@ -141,8 +141,13 @@ func (r *Runner) Run(ctx context.Context) error {
 
 func generateBicepExtensionIndex(ctx context.Context, inputFilePath string, outputDirectoryPath string) error {
 	// npx @radius-project/manifest-to-bicep-extension@alpha generate <resource provider> <temp>
+	bicepExtension := "@radius-project/manifest-to-bicep-extension@edge"
+	if version.Release() != "edge" {
+		bicepExtension = "@radius-project/manifest-to-bicep-extension@" + version.Release()
+	}
+
 	args := []string{
-		"@radius-project/manifest-to-bicep-extension@alpha",
+		bicepExtension,
 		"generate",
 		inputFilePath,
 		outputDirectoryPath,

--- a/pkg/cli/cmd/bicep/publishextension/publish.go
+++ b/pkg/cli/cmd/bicep/publishextension/publish.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/radius-project/radius/pkg/cli/bicep"
 	"github.com/radius-project/radius/pkg/cli/clierrors"
@@ -31,6 +32,7 @@ import (
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/version"
 	"github.com/spf13/cobra"
+	"golang.org/x/mod/semver"
 )
 
 // NewCommand creates a new instance of the `rad bicep publish-extension` command.
@@ -142,7 +144,7 @@ func (r *Runner) Run(ctx context.Context) error {
 func generateBicepExtensionIndex(ctx context.Context, inputFilePath string, outputDirectoryPath string) error {
 	// npx @radius-project/manifest-to-bicep-extension@alpha generate <resource provider> <temp>
 	bicepExtension := "@radius-project/manifest-to-bicep-extension@edge"
-	if version.Release() != "edge" {
+	if isValidSemver(version.Release()) {
 		bicepExtension = "@radius-project/manifest-to-bicep-extension@" + version.Release()
 	}
 
@@ -191,4 +193,12 @@ func publishExtension(ctx context.Context, inputDirectoryPath string, target str
 	}
 
 	return nil
+}
+
+func isValidSemver(version string) bool {
+	// The semver package expects versions to start with 'v'
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+	return semver.IsValid(version)
 }


### PR DESCRIPTION
# Description

- updated the release.yaml to add bicep-tools repo
- adding the check to use the right version of npm package for edge and release version.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: https://github.com/radius-project/bicep-tools/issues/19

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->