### PR TITLE
feat: add global.imagePullSecrets parameter for private registry authentication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,213 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+
+### Building the Project
+```bash
+# Build all packages, binaries, and bicep templates
+make build
+
+# Build specific components
+make build-packages    # Build all Go packages
+make build-binaries    # Build all Go binaries
+make build-rad        # Build the rad CLI
+make build-controller # Build the Radius controller
+
+# Build for specific platforms
+make build-rad-darwin-arm64   # Build rad CLI for macOS ARM64
+make build-rad-linux-amd64    # Build rad CLI for Linux AMD64
+
+# Clean build artifacts
+make clean
+```
+
+### Code Generation
+```bash
+# Generate all code (clients, CRDs, OpenAPI specs)
+make generate
+
+# Generate specific components
+make generate-openapi-spec  # Generate OpenAPI specs from TypeSpec
+make generate-controller    # Generate CRDs for Radius controller
+make generate-ucp-crd       # Generate CRDs for UCP APIServer
+```
+
+## Testing
+
+### Unit Tests
+```bash
+# Run unit tests
+make test
+
+# Run CLI integration tests
+make test-validate-cli
+```
+
+### Functional Tests
+```bash
+# Run all functional tests (requires Kubernetes cluster)
+make test-functional-all
+
+# Run specific functional test suites
+make test-functional-corerp    # Core RP tests
+make test-functional-cli       # CLI tests
+make test-functional-ucp       # UCP tests
+make test-functional-daprrp    # Dapr RP tests
+
+# Run tests that don't require cloud resources
+make test-functional-all-noncloud
+```
+
+### Single Test Execution
+```bash
+# Run a single test file
+go test -v ./pkg/cli/cmd/rollback/...
+
+# Run a specific test
+go test -v ./pkg/cli/cmd/rollback/... -run TestRollbackKubernetes
+
+# Run tests with coverage
+go test -v -cover ./pkg/cli/cmd/rollback/...
+
+# Run tests with race detection
+go test -v -race ./pkg/cli/cmd/rollback/...
+```
+
+## Linting and Formatting
+```bash
+# Format Go code
+go fmt ./...
+
+# Install golangci-lint if needed
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+
+# Run golangci-lint (ensure it's installed first)
+golangci-lint run
+
+# Run specific linters
+golangci-lint run --disable-all --enable=gofmt,govet,errcheck,staticcheck
+
+# Auto-fix linting issues where possible
+golangci-lint run --fix
+```
+
+## High-Level Architecture
+
+### Repository Structure
+The Radius project is a cloud-native application platform with the following key components:
+
+1. **Universal Control Plane (UCP)** (`pkg/ucp/`)
+   - Front-door proxy for all Radius operations
+   - Handles integration with cloud resources (Azure, AWS)
+   - Manages resource providers and planes
+   - Located in `pkg/ucp/` with server entry point in `cmd/ucpd/`
+
+2. **Resource Providers**
+   - **Core RP** (`pkg/corerp/`): Manages applications, containers, environments
+   - **Dapr RP** (`pkg/daprrp/`): Dapr integration (state stores, pub/sub, etc.)
+   - **Datastores RP** (`pkg/datastoresrp/`): Database resources and recipes
+   - **Messaging RP** (`pkg/messagingrp/`): Messaging resources (RabbitMQ, etc.)
+   - **Dynamic RP** (`pkg/dynamicrp/`): Dynamic resource handling
+
+3. **Radius CLI** (`pkg/cli/`, `cmd/rad/`)
+   - Command-line interface for Radius operations
+   - Commands organized in `pkg/cli/cmd/` with subcommands for each feature
+   - Main entry point in `cmd/rad/main.go`
+
+4. **Controller** (`pkg/controller/`, `cmd/controller/`)
+   - Kubernetes controller for managing Radius resources
+   - Handles reconciliation of deployments, recipes, and resources
+   - Uses Kubernetes CRDs defined in `pkg/controller/api/`
+
+5. **Recipe System** (`pkg/recipes/`)
+   - Infrastructure-as-Code recipe engine
+   - Supports Terraform and Bicep recipes
+   - Recipe drivers for different IaC technologies
+
+### Key Architectural Patterns
+
+1. **ARM-RPC Pattern**: All resource providers follow Azure Resource Manager RPC patterns
+   - Frontend handlers in `*/frontend/`
+   - Backend processors in `*/backend/`
+   - Data models in `*/datamodel/`
+   - OpenAPI definitions generated from TypeSpec
+
+2. **Resource ID System**: Uses ARM-style resource IDs
+   - Parsed and handled via `pkg/ucp/resources/`
+   - Scoped resources follow `/planes/.../providers/.../` pattern
+
+3. **Async Operations**: Long-running operations use async patterns
+   - Operations tracked in database
+   - Status polling via operation endpoints
+
+4. **Multi-Cloud Support**: Abstracted cloud operations
+   - AWS support via `pkg/aws/`
+   - Azure support via `pkg/azure/`
+   - Cloud-agnostic interfaces in resource providers
+
+## Development Tips
+
+### Common Development Tasks
+
+```bash
+# Install Radius CLI locally after building
+make build-rad
+sudo cp ./dist/darwin_arm64/release/rad /usr/local/bin/rad
+
+# Quick iteration on CLI changes
+make build-rad && ./dist/darwin_arm64/release/rad [command]
+
+# Debug a specific resource provider
+go run ./cmd/applications-rp/main.go
+
+# Check generated code is up to date
+make generate && git diff
+
+# Run local Kubernetes cluster for testing
+kind create cluster --name radius-test
+make test-functional-cli
+```
+
+### Working with Helm Charts
+
+The project includes Helm charts for deployment located in `deploy/Chart/`:
+- Main chart configuration in `deploy/Chart/values.yaml`
+- CRD definitions in `deploy/Chart/crds/`
+- Templates for all Radius components in `deploy/Chart/templates/`
+
+```bash
+# Package Helm chart
+helm package deploy/Chart/
+
+# Install Radius using Helm
+helm install radius ./deploy/Chart/ --namespace radius-system --create-namespace
+
+# Upgrade existing installation
+helm upgrade radius ./deploy/Chart/ --namespace radius-system
+```
+
+### API Development
+
+When modifying APIs:
+1. Update TypeSpec definitions in `typespec/`
+2. Run `make generate-openapi-spec` to regenerate OpenAPI specs
+3. Run `make generate` to update Go clients and models
+4. Update corresponding frontend/backend handlers in the resource provider
+
+### Database Operations
+
+The project uses MongoDB or In-Memory database for state storage:
+- Database interfaces in `pkg/ucp/store/`
+- MongoDB implementation in `pkg/components/database/mongo/`
+- In-memory implementation for testing in `pkg/components/database/inmemory/`
+
+## Important Notes
+
+- The project uses Go 1.24.5 with modules
+- All code generation requires TypeSpec and Autorest tools installed
+- Kubernetes integration tests require a running cluster (use `kind` for local testing)
+- The project follows CNCF standards and is a CNCF sandbox project
+- Main documentation site: https://docs.radapp.io/
+- Contributing guidelines: See CONTRIBUTING.md for detailed contribution process

--- a/deploy/Chart/README.md
+++ b/deploy/Chart/README.md
@@ -108,7 +108,7 @@ helm upgrade --wait --install radius deploy/Chart -n radius-system \
 
 For private registries that require authentication:
 
-1. Create the docker-registry secret in the namespace:
+1. Create the docker-registry secret in the `radius-system` namespace:
 
 ```bash
 kubectl create secret docker-registry regcred \

--- a/deploy/Chart/README.md
+++ b/deploy/Chart/README.md
@@ -104,12 +104,51 @@ helm upgrade --wait --install radius deploy/Chart -n radius-system \
   --set-file global.rootCA.cert=/path/to/ca-certificate.pem
 ```
 
+#### Using with Private Registries and Authentication
+
+For private registries that require authentication:
+
+1. Create the docker-registry secret in the namespace:
+
+```bash
+kubectl create secret docker-registry regcred \
+  --docker-server=myregistry.azurecr.io \
+  --docker-username=<username> \
+  --docker-password=<password> \
+  --docker-email=<email> \
+  -n radius-system
+```
+
+2. Reference the secret in your Helm values:
+
+```console
+helm upgrade --wait --install radius deploy/Chart -n radius-system \
+  --set global.imageRegistry=myregistry.azurecr.io \
+  --set-string 'global.imagePullSecrets[0].name=regcred'
+
+# Or using values file:
+# values.yaml:
+# global:
+#   imageRegistry: myregistry.azurecr.io
+#   imagePullSecrets:
+#     - name: regcred
+```
+
+3. With rad CLI:
+
+```console
+rad install kubernetes \
+  --set global.imageRegistry=myregistry.azurecr.io \
+  --set-string 'global.imagePullSecrets[0].name=regcred'
+```
+
 #### Air-gapped Environment Setup
 
 For completely air-gapped environments, you'll need to:
 
 1. Mirror all Radius images to your private registry
 2. Configure Radius to use your private registry
+3. Create and reference image pull secrets if authentication is required
 
 Example of mirroring images (requires access to both registries):
 

--- a/deploy/Chart/templates/controller/deployment.yaml
+++ b/deploy/Chart/templates/controller/deployment.yaml
@@ -27,6 +27,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: controller
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 6 }}
+      {{- end }}
       initContainers:
       - name: bicep
         image: "{{ include "radius.image" (dict "image" .Values.bicep.image "tag" (.Values.bicep.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"

--- a/deploy/Chart/templates/dashboard/deployment.yaml
+++ b/deploy/Chart/templates/dashboard/deployment.yaml
@@ -22,6 +22,10 @@ spec:
         app.kubernetes.io/part-of: radius
     spec:
       serviceAccountName: dashboard
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 6 }}
+      {{- end }}
       containers:
       - name: dashboard
         image: "{{ include "radius.image" (dict "image" .Values.dashboard.image "tag" (.Values.dashboard.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"

--- a/deploy/Chart/templates/database/statefulset.yaml
+++ b/deploy/Chart/templates/database/statefulset.yaml
@@ -22,6 +22,10 @@ spec:
         app.kubernetes.io/part-of: radius
     spec:
       serviceAccountName: database
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 6 }}
+      {{- end }}
       containers:
       - name: database
         securityContext:

--- a/deploy/Chart/templates/de/deployment.yaml
+++ b/deploy/Chart/templates/de/deployment.yaml
@@ -30,6 +30,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: bicep-de
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 6 }}
+      {{- end }}
       volumes:
         - name: appsettings-vol
           configMap:

--- a/deploy/Chart/templates/dynamic-rp/deployment.yaml
+++ b/deploy/Chart/templates/dynamic-rp/deployment.yaml
@@ -30,6 +30,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: dynamic-rp
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 6 }}
+      {{- end }}
       {{- if eq .Values.global.terraform.enabled true }}
       # Init container to pre-download Terraform binary to a shared volume
       # This avoids downloading Terraform at runtime and improves recipe execution performance

--- a/deploy/Chart/templates/rp/deployment.yaml
+++ b/deploy/Chart/templates/rp/deployment.yaml
@@ -30,6 +30,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: applications-rp
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 6 }}
+      {{- end }}
       {{- if eq .Values.global.terraform.enabled true }}
       # Init container to pre-download Terraform binary to a shared volume
       # This avoids downloading Terraform at runtime and improves recipe execution performance

--- a/deploy/Chart/templates/ucp/deployment.yaml
+++ b/deploy/Chart/templates/ucp/deployment.yaml
@@ -30,6 +30,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: ucp
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 6 }}
+      {{- end }}
       containers:
       - name: ucp
         image: "{{ include "radius.image" (dict "image" .Values.ucp.image "tag" (.Values.ucp.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"

--- a/deploy/Chart/tests/README.md
+++ b/deploy/Chart/tests/README.md
@@ -39,15 +39,28 @@ The tests validate:
 - Custom registry is properly prepended when `global.imageRegistry` is set
 - `global.imageTag` is used when component tag is not specified
 - Tag priority is respected: component tag > global.imageTag > appVersion
+- `global.imagePullSecrets` are correctly applied to pod specs when specified
+- Multiple image pull secrets are properly handled
 - All deployments and statefulsets use the helper correctly
 
 ## Adding New Tests
 
-When adding new templates that reference container images, ensure they use the `radius.image` helper:
+When adding new templates that reference container images, ensure they:
 
-```yaml
-image: "{{ include "radius.image" (dict "image" .Values.component.image "tag" (.Values.component.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"
-```
+1. Use the `radius.image` helper for image construction:
+
+   ```yaml
+   image: "{{ include "radius.image" (dict "image" .Values.component.image "tag" (.Values.component.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"
+   ```
+
+2. Include imagePullSecrets support in the pod spec:
+
+   ```yaml
+   {{- if .Values.global.imagePullSecrets }}
+   imagePullSecrets:
+     {{- toYaml .Values.global.imagePullSecrets | nindent 2 }}
+   {{- end }}
+   ```
 
 The tag priority system ensures:
 
@@ -55,4 +68,8 @@ The tag priority system ensures:
 2. Falls back to `global.imageTag` if component tag is not set
 3. Finally falls back to chart's appVersion if neither is set
 
-Then add corresponding tests to validate the image construction.
+Then add corresponding tests to validate:
+
+- Image construction with various registry and tag combinations
+- imagePullSecrets are correctly applied when specified
+- imagePullSecrets are omitted when not specified

--- a/deploy/Chart/tests/helpers_test.yaml
+++ b/deploy/Chart/tests/helpers_test.yaml
@@ -213,6 +213,30 @@ tests:
           value: azure-cred
         template: rp/deployment.yaml
 
+  # Edge case tests for imagePullSecrets
+  - it: should handle empty imagePullSecrets array
+    set:
+      global.imagePullSecrets: []
+      controller.image: controller
+      controller.tag: latest
+    asserts:
+      - isNull:
+          path: spec.template.spec.imagePullSecrets
+        template: controller/deployment.yaml
+
+  # Keep one malformed test as documentation of behavior without schema validation
+  - it: should handle imagePullSecrets with missing name field
+    set:
+      global.imagePullSecrets:
+        - {}
+      rp.image: applications-rp
+      rp.tag: latest
+    asserts:
+      # Document that objects without name field are passed through (schema validation would catch this)
+      - isNull:
+          path: spec.template.spec.imagePullSecrets[0].name
+        template: rp/deployment.yaml
+
   - it: should work with default tag from appVersion
     set:
       controller.image: controller

--- a/deploy/Chart/tests/helpers_test.yaml
+++ b/deploy/Chart/tests/helpers_test.yaml
@@ -105,6 +105,114 @@ tests:
           value: 123456789.dkr.ecr.us-west-2.amazonaws.com/custom-ucpd:1.0.0
         template: ucp/deployment.yaml
 
+  # Tests for global.imagePullSecrets functionality
+  - it: should add imagePullSecrets when specified
+    set:
+      global.imagePullSecrets:
+        - name: myregistrykey
+      controller.image: controller
+      controller.tag: latest
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: myregistrykey
+        template: controller/deployment.yaml
+
+  - it: should handle multiple imagePullSecrets
+    set:
+      global.imagePullSecrets:
+        - name: regcred1
+        - name: regcred2
+      ucp.image: ucpd
+      ucp.tag: latest
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: regcred1
+        template: ucp/deployment.yaml
+      - equal:
+          path: spec.template.spec.imagePullSecrets[1].name
+          value: regcred2
+        template: ucp/deployment.yaml
+
+  - it: should not add imagePullSecrets when not specified
+    set:
+      controller.image: controller
+      controller.tag: latest
+    asserts:
+      - isNull:
+          path: spec.template.spec.imagePullSecrets
+        template: controller/deployment.yaml
+
+  - it: should work with imagePullSecrets and custom registry
+    set:
+      global.imageRegistry: myregistry.azurecr.io
+      global.imagePullSecrets:
+        - name: azurecred
+      dashboard.image: dashboard
+      dashboard.tag: 0.48
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: myregistry.azurecr.io/dashboard:0.48
+        template: dashboard/deployment.yaml
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: azurecred
+        template: dashboard/deployment.yaml
+
+  - it: should apply imagePullSecrets to database statefulset
+    set:
+      database.enabled: true
+      global.imagePullSecrets:
+        - name: dbregistrykey
+      database.image: mirror/postgres
+      database.tag: 14-alpine
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: dbregistrykey
+        template: database/statefulset.yaml
+
+  - it: should handle multiple imagePullSecrets with custom registry and tag
+    set:
+      global.imageRegistry: private.registry.io
+      global.imageTag: 0.48
+      global.imagePullSecrets:
+        - name: azure-cred
+        - name: aws-cred
+        - name: gcr-cred
+      controller.image: controller
+      rp.image: applications-rp
+    asserts:
+      # Check image is correctly formed
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: private.registry.io/controller:0.48
+        template: controller/deployment.yaml
+      # Check all three secrets are present
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: azure-cred
+        template: controller/deployment.yaml
+      - equal:
+          path: spec.template.spec.imagePullSecrets[1].name
+          value: aws-cred
+        template: controller/deployment.yaml
+      - equal:
+          path: spec.template.spec.imagePullSecrets[2].name
+          value: gcr-cred
+        template: controller/deployment.yaml
+      # Verify it applies to other deployments too
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: private.registry.io/applications-rp:0.48
+        template: rp/deployment.yaml
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: azure-cred
+        template: rp/deployment.yaml
+
   - it: should work with default tag from appVersion
     set:
       controller.image: controller

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -9,6 +9,13 @@ global:
   # Example: global.imageTag=0.48
   imageTag: ""
   
+  # Configure global.imagePullSecrets for pulling images from private registries.
+  # Secrets must be manually created in the namespace.
+  # Example:
+  # imagePullSecrets:
+  #   - name: myregistrykey
+  imagePullSecrets: []
+  
   # Configure global.rootCA.cert to use the intermediate CA cert in Radius containers.
   # Otherwise, Radius containers use the default root CA provided by base OS image.
   rootCA:

--- a/docs/contributing/contributing-code/contributing-code-control-plane/generating-and-installing-custom-build.md
+++ b/docs/contributing/contributing-code/contributing-code-control-plane/generating-and-installing-custom-build.md
@@ -1,38 +1,55 @@
 # Generating a custom build
 
-If you are working on changes to the Radius services, you can test the functionality end to end 
+If you are working on changes to the Radius services, you can test the functionality end to end
 by creating a Radius installation with your code changes. For this, you need to:
-	
+
 - Choose a Kubernetes cluster to use for development.
-- Build the Radius containers and push them to a container registry. 
+- Build the Radius containers and push them to a container registry.
 - Install Radius from these images.
 
 ## Instructions
 
 Prerequisite: [Supported Kubernetes cluster](https://docs.radapp.io/guides/operations/kubernetes/overview)
 
-Note that installing a custom build could corrupt existing data or installation. For these reasons, it might be useful to install the custom build on a clean test cluster.  
+Note that installing a custom build could corrupt existing data or installation. For these reasons, it might be useful to install the custom build on a clean test cluster.
 
+1. Set environment variables for your docker registry and docker tag version.
 
-1. Set environment variables for your docker registry and docker tag version. 
-    ```
-    export DOCKER_REGISTRY=ghcr.io/your-registry
-    export DOCKER_IMAGE_TAG=latest
-    ```
+   ```console
+   export DOCKER_REGISTRY=ghcr.io/your-registry
+   export DOCKER_IMAGE_TAG=latest
+   ```
 
 2. Log into your container registry and make sure you have permission to push images.
 
-3. [Build Radius containers]( ../../contributing-code/contributing-code-building/README.md#building-containers) and push them to your registry. 
-    ```
-    make docker-build docker-push
-    ```
+3. [Build Radius containers](../../contributing-code/contributing-code-building/README.md#building-containers) and push them to your registry.
+
+   ```console
+   make docker-build docker-push
+   ```
 
 4. Use the image from your container registry to install the Radius control plane.
-    ```
-    rad install kubernetes --chart deploy/Chart/ --set rp.image=ghcr.io/your-registry/applications-rp,rp.tag=latest,ucp.image=ghcr.io/your-registry/ucpd,ucp.tag=latest
-    ```
+
+   ```console
+   rad install kubernetes --chart deploy/Chart/ --set global.imageRegistry=ghcr.io/your-registry --set global.imageTag=latest
+   ```
+
+   For private registries that require authentication, first create a Kubernetes secret:
+
+   ```console
+   kubectl create secret docker-registry regcred \
+     --docker-server=ghcr.io/your-registry \
+     --docker-username=<username> \
+     --docker-password=<password> \
+     -n radius-system
+
+   rad install kubernetes --chart deploy/Chart/ \
+     --set global.imageRegistry=ghcr.io/your-registry \
+     --set global.imageTag=latest \
+     --set-string 'global.imagePullSecrets[0].name=regcred'
+   ```
 
 5. Use `rad init` command to set up the Radius workspace, environment, credentials, and provider as needed.
-The setup is ready for use!
+   The setup is ready for use!
 
 If you run into issues using working with a custom build, please refer to [Troubleshooting Installation](./troubleshooting-installation.md)

--- a/docs/contributing/contributing-code/contributing-code-tests/testing-local.md
+++ b/docs/contributing/contributing-code/contributing-code-tests/testing-local.md
@@ -1,72 +1,104 @@
-## Accelerating verification on a k8s cluster
+# Accelerating verification on a k8s cluster
 
-This is to help local development setup for quickly iterating on changes in the app core RP. 
+This is to help local development setup for quickly iterating on changes in the app core RP.
 
 Note, this only applies when we want to update the app core image, if we need to update the deployment/environment, a rerun of `rad init` may need to happen.
 
 1. Create a new Azure Container Registry. [link to Azure Docs](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-get-started-portal?tabs=azure-cli)
 
 1. Set the environment variable DOCKER_REGISTRY set to the container registry
-    ```
-    export DOCKER_REGISTRY=ghcr.io/your-registry
-    ```
+
+   ```console
+   export DOCKER_REGISTRY=ghcr.io/your-registry
+   ```
+
 1. Ensure you login to your container registry AND enable anonymous pull. The login command will need to be called every 3 hours as needed as it does log the user out frequently.
-    ```
-    az acr login -n <registry>
-    az acr update --name <registry> --anonymous-pull-enabled
-    ```
+
+   ```console
+   az acr login -n <registry>
+   az acr update --name <registry> --anonymous-pull-enabled
+   ```
+
 1. Build and push an initial version of all images in the Radius repo. This should push images for the applications-rp, the ucpd, etc that are required to run radius.
-    ```
-    make docker-build && make docker-push
-    ```
+
+   ```console
+   make docker-build && make docker-push
+   ```
+
 1. Deploy an environment with command on kubernetes
-    ```
-    go run ./cmd/rad/main.go install kubernetes --chart deploy/Chart --set rp.image=ghcr.io/your-registry/applications-rp,rp.tag=latest,ucp.image=ghcr.io/your-registry/ucpd,ucp.tag=latest
-    go run ./cmd/rad/main.go workspace create kubernetes
-    go run ./cmd/rad/main.go group create radius-rg
-    go run ./cmd/rad/main.go switch radius-rg
-    go run ./cmd/rad/main.go env create radius-rg --namespace default
-    go run ./cmd/rad/main.go env switch radius-rg
-    ```
+
+   ```console
+   go run ./cmd/rad/main.go install kubernetes --chart deploy/Chart --set global.imageRegistry=ghcr.io/your-registry --set global.imageTag=latest
+   go run ./cmd/rad/main.go workspace create kubernetes
+   go run ./cmd/rad/main.go group create radius-rg
+   go run ./cmd/rad/main.go switch radius-rg
+   go run ./cmd/rad/main.go env create radius-rg --namespace default
+   go run ./cmd/rad/main.go env switch radius-rg
+   ```
+
+   Note: If your registry requires authentication, create a Kubernetes secret and use imagePullSecrets:
+
+   ```console
+   kubectl create secret docker-registry regcred \
+     --docker-server=ghcr.io/your-registry \
+     --docker-username=<username> \
+     --docker-password=<password> \
+     -n radius-system
+
+   go run ./cmd/rad/main.go install kubernetes --chart deploy/Chart \
+     --set global.imageRegistry=ghcr.io/your-registry \
+     --set global.imageTag=latest \
+     --set-string 'global.imagePullSecrets[0].name=regcred'
+   ```
+
 1. Run a deployment. Executing `go run \cmd\rad\main.go deploy <bicep>` will deploy your file to the cluster.
 
 ## To deploy azure resources
+
 The above steps will not configure the ability for Radius to talk with azure resource. In order to do that, run everything above till Step 4 above and then:
 
 1. Create Service Principal
-    ```
-    az ad sp create-for-rbac --role Owner --scope /subscriptions/<subscriptionId>/resourceGroups/<resourcegroupname>
-    ```
-    the output of the above command looks like the following
-    ```
-    {
-     "appId": <appId>,
-     "displayName": <displayNameValue>,
-     "password": <pwd>,
-     "tenant": <tenantId>
-    }
-    ```
+
+   ```console
+   az ad sp create-for-rbac --role Owner --scope /subscriptions/<subscriptionId>/resourceGroups/<resourcegroupname>
+   ```
+
+   the output of the above command looks like the following
+
+   ```json
+   {
+    "appId": <appId>,
+    "displayName": <displayNameValue>,
+    "password": <pwd>,
+    "tenant": <tenantId>
+   }
+   ```
+
 1. Use these values in the following command:
-    ```
-    go run ./cmd/rad/main.go install kubernetes --chart deploy/Chart --set rp.image=ghcr.io/your-registry/applications-rp,rp.tag=latest,ucp.image=ghcr.io/your-registry/ucpd,ucp.tag=latest
-    go run ./cmd/rad/main.go workspace create kubernetes
-    go run ./cmd/rad/main.go group create radius-rg
-    go run ./cmd/rad/main.go switch radius-rg
-    go run ./cmd/rad/main.go env create radius-rg --namespace default
-    go run ./cmd/rad/main.go env switch radius-rg
-    go run ./cmd/rad/main.go env update radius-rg --azure-subscription-id <subscriptionId> --azure-resource-group <resourcegroupName>
-    go run ./cmd/rad/main.go credential register azure sp --client-id <appId> --client-secret <pwd> --tenant-id <tenantId>
-    ```
+
+   ```console
+   go run ./cmd/rad/main.go install kubernetes --chart deploy/Chart --set global.imageRegistry=ghcr.io/your-registry --set global.imageTag=latest
+   go run ./cmd/rad/main.go workspace create kubernetes
+   go run ./cmd/rad/main.go group create radius-rg
+   go run ./cmd/rad/main.go switch radius-rg
+   go run ./cmd/rad/main.go env create radius-rg --namespace default
+   go run ./cmd/rad/main.go env switch radius-rg
+   go run ./cmd/rad/main.go env update radius-rg --azure-subscription-id <subscriptionId> --azure-resource-group <resourcegroupName>
+   go run ./cmd/rad/main.go credential register azure sp --client-id <appId> --client-secret <pwd> --tenant-id <tenantId>
+   ```
+
 1. Run a deployment. Executing `go run \cmd\rad\main.go deploy <bicep>` will deploy your file to the cluster.
 
 ## To redeploy the applications resource provider
-  
+
 After validating the behavior with logs, commands, etc., you can quickly iterate on the applications resource provider with the following command
-```
+
+```console
 make docker-build-applications-rp && make docker-push-applications-rp && kubectl delete pod -l control-plane=applications-rp
 ```
 
 This will:
+
 - Build and push the applications-rp image
 - Delete the running pod for the applications-rp. On restart, because we have specified the [latest tag](https://kubernetes.io/docs/concepts/containers/images/#updating-images) Kubernetes will repull the image each time
 - The pod will restart with the latest image pushed prior.
@@ -75,7 +107,7 @@ This will:
 
 Reploying an environment is a bit clunky right now. Use the following commands and deploy Radius again.
 
-```
+```console
 go run ./cmd/rad/main.go env delete <envname>
 go run ./cmd/rad/main.go uninstall kubernetes
 go run ./cmd/rad/main.go workspace delete

--- a/go.mod
+++ b/go.mod
@@ -319,7 +319,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.40.0 // indirect
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0
-	golang.org/x/mod v0.26.0 // indirect
+	golang.org/x/mod v0.26.0
 	golang.org/x/net v0.42.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect

--- a/pkg/cli/cmd/install/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/install/kubernetes/kubernetes.go
@@ -68,6 +68,14 @@ rad install kubernetes --set global.imageTag=0.48
 # Images will be pulled as: myregistry.azurecr.io/controller:0.48, etc.
 rad install kubernetes --set global.imageRegistry=myregistry.azurecr.io,global.imageTag=0.48
 
+# Install Radius with private registry and image pull secrets
+# Note: Secret must be created in radius-system namespace first
+rad install kubernetes --set global.imageRegistry=myregistry.azurecr.io --set-string 'global.imagePullSecrets[0].name=regcred'
+
+# Install Radius with multiple image pull secrets for different registries
+rad install kubernetes --set-string 'global.imagePullSecrets[0].name=azure-cred' \
+                       --set-string 'global.imagePullSecrets[1].name=aws-cred'
+
 # Install Radius with the intermediate root CA certificate in the current Kubernetes context
 rad install kubernetes --set-file global.rootCA.cert=/path/to/rootCA.crt
 

--- a/pkg/cli/cmd/radinit/init.go
+++ b/pkg/cli/cmd/radinit/init.go
@@ -84,6 +84,14 @@ rad init --set global.imageTag=0.48
 ## Images will be pulled as: myregistry.azurecr.io/controller:0.48, etc.
 rad init --set global.imageRegistry=myregistry.azurecr.io,global.imageTag=0.48
 
+## Initialize with private registry and image pull secrets
+## Note: Secret must be created in radius-system namespace first
+rad init --set global.imageRegistry=myregistry.azurecr.io --set-string 'global.imagePullSecrets[0].name=regcred'
+
+## Initialize with multiple image pull secrets for different registries
+rad init --set-string 'global.imagePullSecrets[0].name=azure-cred' \
+         --set-string 'global.imagePullSecrets[1].name=aws-cred'
+
 ## Initialize with custom values from a file
 rad init --set-file global.rootCA.cert=/path/to/rootCA.crt
 `,

--- a/pkg/cli/cmd/upgrade/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/upgrade/kubernetes/kubernetes.go
@@ -75,6 +75,14 @@ rad upgrade kubernetes --set global.imageTag=0.48
 # Images will be pulled as: myregistry.azurecr.io/controller:0.48, etc.
 rad upgrade kubernetes --set global.imageRegistry=myregistry.azurecr.io,global.imageTag=0.48
 
+# Upgrade Radius with private registry and image pull secrets
+# Note: Secret must be created in radius-system namespace first
+rad upgrade kubernetes --set global.imageRegistry=myregistry.azurecr.io --set-string 'global.imagePullSecrets[0].name=regcred'
+
+# Upgrade Radius with multiple image pull secrets for different registries
+rad upgrade kubernetes --set-string 'global.imagePullSecrets[0].name=azure-cred' \
+                       --set-string 'global.imagePullSecrets[1].name=aws-cred'
+
 # Upgrade to a specific version
 rad upgrade kubernetes --version 0.47.0
 


### PR DESCRIPTION
- Add global.imagePullSecrets to values.yaml and all deployment/statefulset templates
- Update CLI examples in rad init, install, and upgrade commands
- Add comprehensive Helm unit tests for multiple pull secrets
- Update Chart README with configuration examples

# Description

This pull request adds comprehensive support for configuring image pull secrets across all Radius Helm chart deployments, enabling seamless use of private container registries that require authentication. It includes updates to documentation, Helm templates, default values, CLI usage examples, and Helm chart tests to ensure correct handling and validation of `imagePullSecrets`.

**Enhancements for private registry support:**

* Added `global.imagePullSecrets` configuration to `values.yaml`, allowing users to specify one or more Kubernetes secrets for pulling images from private registries.
* Updated deployment and statefulset templates (`controller`, `dashboard`, `database`, `de`, `dynamic-rp`, `rp`, `ucp`) to inject `imagePullSecrets` when specified, ensuring all components can authenticate to private registries. [[1]](diffhunk://#diff-6e17741710603ff5eab2c2df3885c905ebc5c657cf16232734059f645f97397fR30-R33) [[2]](diffhunk://#diff-fa8b3636d5cfdf8b941b89a5af4b2f3725e7ddc086f406111a08afbe14ce4267R25-R28) [[3]](diffhunk://#diff-9366e0a3212639c13de30e1ab3896ba45398986535acd618702b94c38ecab701R25-R28) [[4]](diffhunk://#diff-aa649ac3a27b3a57cd4da52d741118f2870fd721886d603f5091a90fc825e025R33-R36) [[5]](diffhunk://#diff-bb1c415d2aa24ec5f2f090395448250831b3b467289e1fa6c603fd1661453de1R33-R36) [[6]](diffhunk://#diff-92bd08c7c2302e12d2ceb2f7bf0a5bdd0016bb8e2eb2639588e994366e9ee841R33-R36) [[7]](diffhunk://#diff-0fe5610e45572cab258709e7346308d2bdc2f9c16a46d493f049de4707ea465dR33-R36)

**Documentation and usage improvements:**

* Expanded documentation in `README.md` with step-by-step instructions for using private registries and configuring image pull secrets, including both Helm and `rad` CLI workflows.
* Added CLI usage examples for `rad install`, `rad upgrade`, and `rad init` commands to demonstrate how to set `imagePullSecrets` for single or multiple registries. [[1]](diffhunk://#diff-969a1495c18d847fc09b31b1e6854e7be42d541513807361aaa5e9497a62e86fR71-R78) [[2]](diffhunk://#diff-5a9f77a14a8179c704434f4c6c41708529bb7bf86eddc14759fedb66def1dc4fR78-R85) [[3]](diffhunk://#diff-043b8a9fb42a3b3d2876c07a59c8975147156ed05f3e2c30c934e8a0e65d2ecfR87-R94)

**Testing and validation:**

* Introduced new Helm chart tests to validate correct rendering and propagation of `imagePullSecrets` across all relevant deployments, including support for multiple secrets and various configuration scenarios.

**Miscellaneous:**

* Minor update to `go.mod` to remove the `// indirect` comment from the `golang.org/x/mod` dependency, with no functional impact.

## Type of change

- This pull request adds or changes features of Radius and has an approved issue (issue link required).

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->