### PR TITLE
Update release docs with bicep-types-aws workflow run

### DIFF
--- a/docs/contributing/contributing-releases/README.md
+++ b/docs/contributing/contributing-releases/README.md
@@ -88,6 +88,8 @@ git push origin vx.y.z-rc1
 
 1. There should be a GitHub workflow run in progress [here](https://github.com/radius-project/radius/actions/workflows/build.yaml) that was triggered by the `vx.y.z-rc1` tag. Monitor this workflow to ensure that it completes successfully. If it does, then the release candidate has been created.
 
+1. In the `bicep-types-aws` repository, there should be a run of the `Update extensibility provider types` job that was triggered by the `vx.y.z-rc1` tag that needs to be approved and started. Approve the run of this job and monitor it to ensure that it completes successfully. 
+
 1. Verify that an RC release was created on Github Releases for the current version ([Example](https://github.com/radius-project/radius/releases)).
 
 1. In the `radius-project/radius` repo, run the [Release verification](https://github.com/radius-project/radius/actions/workflows/release-verification.yaml) workflow. Run the workflow from the release branch (format: `release/x.y`) and use the Radius RC release version number being released.
@@ -146,6 +148,8 @@ git push origin vx.y.z
 1. After maintainer approval, merge the pull request into the release branch.
 
 1. There should be a GitHub workflow run in progress [here](https://github.com/radius-project/radius/actions/workflows/build.yaml) that was triggered by the `vx.y.z` tag. Monitor this workflow to ensure that it completes successfully.
+
+1. In the `bicep-types-aws` repository, there should be a run of the `Update extensibility provider types` job that was triggered by the `vx.y.z` tag that needs to be approved and started. Approve the run of this job and monitor it to ensure that it completes successfully. 
 
 1. You may need to wait around ~20 minutes for the release assets to be published.
 


### PR DESCRIPTION
# Description

This is a minor change to the release docs to ensure publish runs in the `bicep-types-aws` [repo](https://github.com/radius-project/bicep-types-aws) complete during the release. 

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->