### PR TITLE
Release verification fix

### DIFF
--- a/.github/scripts/release-verification.sh
+++ b/.github/scripts/release-verification.sh
@@ -94,7 +94,6 @@ verify_pod_image() {
 # Note: The pre-upgrade image runs as a Kubernetes Job, so the verification process differs from standard deployments.
 # This verification checks the container image used in the pre-upgrade job.
 verify_pre_upgrade_image() {
-
     local expected_image="$1"
     
     # expect error - ignore and continue. We only want to trigger the pre-upgrade container to run as a job so that we 


### PR DESCRIPTION
# Description

This pull request fixes a bug in the release verification workflow that appeared when an init container was added. The presence of the init container broke the verification logic that was looking up the container image name using the `kubectl describe` command.

Changes include:
- Changed the `kubectl describe` command to use a json-based parsing of the container image name.
- Refactored duplicate code into functions.
- Added ability to test the script from a Mac.

The script does the following:
- Download the specified version of the `rad` CLI
- Create a local Kind cluster
- Install Radius
- Verify that the container images use the expected images and tags
- Cleanup: remove `rad` and delete the Kind cluster

## Testing

You can safely run this script on your local machine. The script performs verification of container images deployed to a local Kubernetes cluster and does not modify anything in GitHub or Kubernetes.

To test the change on a local machine:

1. Deploy a Radius release to a local Kubernetes cluster, e.g. 0.49.0.
1. Check out the PR branch.
1. `cd .github/scripts`
1. To test a regular release: `./release-verification.sh 0.49.0`
1. To test an RC release: `./release-verification.sh 0.50.0-rc5`

> If you are using a Mac, append `darwin arm64` to the arguments passed to the script.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #10222

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->