### PR TITLE
Add resource group client APIs for listing and filtering resources

### DIFF
--- a/pkg/cli/clients/clients.go
+++ b/pkg/cli/clients/clients.go
@@ -225,6 +225,18 @@ type ApplicationsManagementClient interface {
 	// DeleteResourceGroup deletes a resource group by its name.
 	DeleteResourceGroup(ctx context.Context, planeName string, resourceGroupName string) (bool, error)
 
+	// ListResourcesInResourceGroup lists all resources in a specific resource group.
+	ListResourcesInResourceGroup(ctx context.Context, planeName string, resourceGroupName string) ([]generated.GenericResource, error)
+
+	// ListResourcesInResourceGroupFiltered lists resources in a resource group, optionally filtered by environment and/or application.
+	ListResourcesInResourceGroupFiltered(ctx context.Context, planeName string, resourceGroupName string, environmentID string, applicationID string) ([]generated.GenericResource, error)
+
+	// ListResourcesOfTypeInResourceGroup lists resources of a specific type in a resource group.
+	ListResourcesOfTypeInResourceGroup(ctx context.Context, planeName string, resourceGroupName string, resourceType string) ([]generated.GenericResource, error)
+
+	// ListResourcesOfTypeInResourceGroupFiltered lists resources of a specific type in a resource group, optionally filtered by environment and/or application.
+	ListResourcesOfTypeInResourceGroupFiltered(ctx context.Context, planeName string, resourceGroupName string, resourceType string, environmentID string, applicationID string) ([]generated.GenericResource, error)
+
 	// ListResourceProviders lists all resource providers in the configured scope.
 	ListResourceProviders(ctx context.Context, planeName string) ([]ucp_v20231001preview.ResourceProviderResource, error)
 

--- a/pkg/cli/clients/management.go
+++ b/pkg/cli/clients/management.go
@@ -55,7 +55,6 @@ var _ ApplicationsManagementClient = (*UCPApplicationsManagementClient)(nil)
 
 // ListResourcesOfType lists all resources of a given type in the configured scope.
 func (amc *UCPApplicationsManagementClient) ListResourcesOfType(ctx context.Context, resourceType string) ([]generated.GenericResource, error) {
-
 	apiVersions, err := amc.getApiVersionsForResourceType(ctx, resourceType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get API versions for resource type %q: %w", resourceType, err)
@@ -132,6 +131,7 @@ func (amc *UCPApplicationsManagementClient) GetResource(ctx context.Context, res
 	if err != nil {
 		return generated.GenericResource{}, err
 	}
+
 	scope, name, err := amc.extractScopeAndName(resourceNameOrID)
 	if err != nil {
 		return generated.GenericResource{}, err
@@ -372,7 +372,7 @@ func (amc *UCPApplicationsManagementClient) DeleteApplication(ctx context.Contex
 	for _, resource := range resources {
 		resource := resource
 		g.Go(func() error {
-			_, err := amc.DeleteResource(groupCtx, *resource.Type, *resource.Name)
+			_, err := amc.DeleteResource(groupCtx, *resource.Type, *resource.ID)
 			if err != nil {
 				return err
 			}
@@ -624,6 +624,31 @@ func (amc *UCPApplicationsManagementClient) CreateOrUpdateResourceGroup(ctx cont
 
 // DeleteResourceGroup deletes a resource group by its name.
 func (amc *UCPApplicationsManagementClient) DeleteResourceGroup(ctx context.Context, planeName string, resourceGroupName string) (bool, error) {
+	// First, try to get all resources in the group
+	resources, err := amc.ListResourcesInResourceGroup(ctx, planeName, resourceGroupName)
+	if err == nil && len(resources) > 0 {
+		// Delete all resources in parallel
+		g, groupCtx := errgroup.WithContext(ctx)
+		for _, resource := range resources {
+			resource := resource
+			g.Go(func() error {
+				// Delete each resource using its full ID to ensure correct scope
+				_, err := amc.DeleteResource(groupCtx, *resource.Type, *resource.ID)
+				if err != nil && !clientv2.Is404Error(err) {
+					return err
+				}
+
+				return nil
+			})
+		}
+
+		// Wait for all resources to be deleted
+		if err := g.Wait(); err != nil {
+			return false, fmt.Errorf("failed to delete resources in group: %w", err)
+		}
+	}
+
+	// Now delete the empty resource group
 	client, err := amc.createResourceGroupClient()
 	if err != nil {
 		return false, err
@@ -638,6 +663,131 @@ func (amc *UCPApplicationsManagementClient) DeleteResourceGroup(ctx context.Cont
 	}
 
 	return response.StatusCode != 204, nil
+}
+
+// ListResourcesInResourceGroup lists all resources in a specific resource group.
+func (amc *UCPApplicationsManagementClient) ListResourcesInResourceGroup(ctx context.Context, planeName string, resourceGroupName string) ([]generated.GenericResource, error) {
+	// Build the resource group scope
+	groupScope := fmt.Sprintf("/planes/radius/%s/resourceGroups/%s", planeName, resourceGroupName)
+
+	results := []generated.GenericResource{}
+	resourceTypesList, err := amc.ListAllResourceTypesNames(ctx, planeName)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, resourceType := range resourceTypesList {
+		// Create a client scoped to this resource group
+		apiVersions, err := amc.getApiVersionsForResourceType(ctx, resourceType)
+		if err != nil {
+			continue // Skip this resource type if we can't get API versions
+		}
+
+		client, err := amc.getGenericClient(groupScope, resourceType, apiVersions)
+		if err != nil {
+			continue
+		}
+
+		pager := client.NewListByRootScopePager(&generated.GenericResourcesClientListByRootScopeOptions{})
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				break
+			}
+
+			for _, resource := range page.GenericResourcesList.Value {
+				results = append(results, *resource)
+			}
+		}
+	}
+
+	return results, nil
+}
+
+// ListResourcesInResourceGroupFiltered lists resources in a resource group, optionally filtered by environment and/or application.
+func (amc *UCPApplicationsManagementClient) ListResourcesInResourceGroupFiltered(ctx context.Context, planeName string, resourceGroupName string, environmentID string, applicationID string) ([]generated.GenericResource, error) {
+	// First get all resources in the group
+	resources, err := amc.ListResourcesInResourceGroup(ctx, planeName, resourceGroupName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply filters if provided
+	results := []generated.GenericResource{}
+	for _, resource := range resources {
+		// Check environment filter
+		if environmentID != "" && !isResourceInEnvironment(resource, environmentID) {
+			continue
+		}
+
+		// Check application filter
+		if applicationID != "" && !isResourceInApplication(resource, applicationID) {
+			continue
+		}
+
+		results = append(results, resource)
+	}
+
+	return results, nil
+}
+
+// ListResourcesOfTypeInResourceGroup lists resources of a specific type in a resource group.
+func (amc *UCPApplicationsManagementClient) ListResourcesOfTypeInResourceGroup(ctx context.Context, planeName string, resourceGroupName string, resourceType string) ([]generated.GenericResource, error) {
+	// Build the resource group scope
+	groupScope := fmt.Sprintf("/planes/radius/%s/resourceGroups/%s", planeName, resourceGroupName)
+
+	// Get API versions for the resource type
+	apiVersions, err := amc.getApiVersionsForResourceType(ctx, resourceType)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := amc.getGenericClient(groupScope, resourceType, apiVersions)
+	if err != nil {
+		return nil, err
+	}
+
+	results := []generated.GenericResource{}
+	pager := client.NewListByRootScopePager(&generated.GenericResourcesClientListByRootScopeOptions{})
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, resource := range page.GenericResourcesList.Value {
+			results = append(results, *resource)
+		}
+	}
+
+	return results, nil
+}
+
+// ListResourcesOfTypeInResourceGroupFiltered lists resources of a specific type in a resource group, optionally filtered by environment and/or application.
+func (amc *UCPApplicationsManagementClient) ListResourcesOfTypeInResourceGroupFiltered(ctx context.Context, planeName string, resourceGroupName string, resourceType string, environmentID string, applicationID string) ([]generated.GenericResource, error) {
+	// First get all resources of the type in the group
+	resources, err := amc.ListResourcesOfTypeInResourceGroup(ctx, planeName, resourceGroupName, resourceType)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply filters if provided
+	results := []generated.GenericResource{}
+	for _, resource := range resources {
+		// Check environment filter
+		if environmentID != "" && !isResourceInEnvironment(resource, environmentID) {
+			continue
+		}
+
+		// Check application filter
+		if applicationID != "" && !isResourceInApplication(resource, applicationID) {
+			continue
+		}
+
+		results = append(results, resource)
+	}
+
+	return results, nil
 }
 
 // ListResourceProviders lists all resource providers in the configured plane.
@@ -761,13 +911,10 @@ func (amc *UCPApplicationsManagementClient) GetResourceProviderSummary(ctx conte
 
 // ListAllResourceTypesNames lists the names of all resource types in all resource providers in the configured plane.
 func (amc *UCPApplicationsManagementClient) ListAllResourceTypesNames(ctx context.Context, planeName string) ([]string, error) {
-	// excludedResourceTypesList is a list of resource types that should be excluded from the list of application resources
-	// to be displayed to the user.
+	// excludedResourceTypesList contains resource types that should be excluded
 	// Lowercase is used to avoid case sensitivity issues.
 	excludedResourceTypesList := []string{
-		"microsoft.resources/deployments",
-		"applications.core/applications",
-		"applications.core/environments",
+		"microsoft.resources/deployments", // Internal deployment metadata, not a user resource
 	}
 
 	resourceProviderSummaries, err := amc.ListResourceProviderSummaries(ctx, planeName)

--- a/pkg/cli/clients/mock_applicationsclient.go
+++ b/pkg/cli/clients/mock_applicationsclient.go
@@ -1286,6 +1286,84 @@ func (c *MockApplicationsManagementClientListResourcesInEnvironmentCall) DoAndRe
 	return c
 }
 
+// ListResourcesInResourceGroup mocks base method.
+func (m *MockApplicationsManagementClient) ListResourcesInResourceGroup(arg0 context.Context, arg1, arg2 string) ([]generated.GenericResource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListResourcesInResourceGroup", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]generated.GenericResource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListResourcesInResourceGroup indicates an expected call of ListResourcesInResourceGroup.
+func (mr *MockApplicationsManagementClientMockRecorder) ListResourcesInResourceGroup(arg0, arg1, arg2 any) *MockApplicationsManagementClientListResourcesInResourceGroupCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourcesInResourceGroup", reflect.TypeOf((*MockApplicationsManagementClient)(nil).ListResourcesInResourceGroup), arg0, arg1, arg2)
+	return &MockApplicationsManagementClientListResourcesInResourceGroupCall{Call: call}
+}
+
+// MockApplicationsManagementClientListResourcesInResourceGroupCall wrap *gomock.Call
+type MockApplicationsManagementClientListResourcesInResourceGroupCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationsManagementClientListResourcesInResourceGroupCall) Return(arg0 []generated.GenericResource, arg1 error) *MockApplicationsManagementClientListResourcesInResourceGroupCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationsManagementClientListResourcesInResourceGroupCall) Do(f func(context.Context, string, string) ([]generated.GenericResource, error)) *MockApplicationsManagementClientListResourcesInResourceGroupCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationsManagementClientListResourcesInResourceGroupCall) DoAndReturn(f func(context.Context, string, string) ([]generated.GenericResource, error)) *MockApplicationsManagementClientListResourcesInResourceGroupCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ListResourcesInResourceGroupFiltered mocks base method.
+func (m *MockApplicationsManagementClient) ListResourcesInResourceGroupFiltered(arg0 context.Context, arg1, arg2, arg3, arg4 string) ([]generated.GenericResource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListResourcesInResourceGroupFiltered", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].([]generated.GenericResource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListResourcesInResourceGroupFiltered indicates an expected call of ListResourcesInResourceGroupFiltered.
+func (mr *MockApplicationsManagementClientMockRecorder) ListResourcesInResourceGroupFiltered(arg0, arg1, arg2, arg3, arg4 any) *MockApplicationsManagementClientListResourcesInResourceGroupFilteredCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourcesInResourceGroupFiltered", reflect.TypeOf((*MockApplicationsManagementClient)(nil).ListResourcesInResourceGroupFiltered), arg0, arg1, arg2, arg3, arg4)
+	return &MockApplicationsManagementClientListResourcesInResourceGroupFilteredCall{Call: call}
+}
+
+// MockApplicationsManagementClientListResourcesInResourceGroupFilteredCall wrap *gomock.Call
+type MockApplicationsManagementClientListResourcesInResourceGroupFilteredCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationsManagementClientListResourcesInResourceGroupFilteredCall) Return(arg0 []generated.GenericResource, arg1 error) *MockApplicationsManagementClientListResourcesInResourceGroupFilteredCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationsManagementClientListResourcesInResourceGroupFilteredCall) Do(f func(context.Context, string, string, string, string) ([]generated.GenericResource, error)) *MockApplicationsManagementClientListResourcesInResourceGroupFilteredCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationsManagementClientListResourcesInResourceGroupFilteredCall) DoAndReturn(f func(context.Context, string, string, string, string) ([]generated.GenericResource, error)) *MockApplicationsManagementClientListResourcesInResourceGroupFilteredCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ListResourcesOfType mocks base method.
 func (m *MockApplicationsManagementClient) ListResourcesOfType(arg0 context.Context, arg1 string) ([]generated.GenericResource, error) {
 	m.ctrl.T.Helper()
@@ -1399,6 +1477,84 @@ func (c *MockApplicationsManagementClientListResourcesOfTypeInEnvironmentCall) D
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockApplicationsManagementClientListResourcesOfTypeInEnvironmentCall) DoAndReturn(f func(context.Context, string, string) ([]generated.GenericResource, error)) *MockApplicationsManagementClientListResourcesOfTypeInEnvironmentCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ListResourcesOfTypeInResourceGroup mocks base method.
+func (m *MockApplicationsManagementClient) ListResourcesOfTypeInResourceGroup(arg0 context.Context, arg1, arg2, arg3 string) ([]generated.GenericResource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListResourcesOfTypeInResourceGroup", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]generated.GenericResource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListResourcesOfTypeInResourceGroup indicates an expected call of ListResourcesOfTypeInResourceGroup.
+func (mr *MockApplicationsManagementClientMockRecorder) ListResourcesOfTypeInResourceGroup(arg0, arg1, arg2, arg3 any) *MockApplicationsManagementClientListResourcesOfTypeInResourceGroupCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourcesOfTypeInResourceGroup", reflect.TypeOf((*MockApplicationsManagementClient)(nil).ListResourcesOfTypeInResourceGroup), arg0, arg1, arg2, arg3)
+	return &MockApplicationsManagementClientListResourcesOfTypeInResourceGroupCall{Call: call}
+}
+
+// MockApplicationsManagementClientListResourcesOfTypeInResourceGroupCall wrap *gomock.Call
+type MockApplicationsManagementClientListResourcesOfTypeInResourceGroupCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationsManagementClientListResourcesOfTypeInResourceGroupCall) Return(arg0 []generated.GenericResource, arg1 error) *MockApplicationsManagementClientListResourcesOfTypeInResourceGroupCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationsManagementClientListResourcesOfTypeInResourceGroupCall) Do(f func(context.Context, string, string, string) ([]generated.GenericResource, error)) *MockApplicationsManagementClientListResourcesOfTypeInResourceGroupCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationsManagementClientListResourcesOfTypeInResourceGroupCall) DoAndReturn(f func(context.Context, string, string, string) ([]generated.GenericResource, error)) *MockApplicationsManagementClientListResourcesOfTypeInResourceGroupCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ListResourcesOfTypeInResourceGroupFiltered mocks base method.
+func (m *MockApplicationsManagementClient) ListResourcesOfTypeInResourceGroupFiltered(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string) ([]generated.GenericResource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListResourcesOfTypeInResourceGroupFiltered", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret0, _ := ret[0].([]generated.GenericResource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListResourcesOfTypeInResourceGroupFiltered indicates an expected call of ListResourcesOfTypeInResourceGroupFiltered.
+func (mr *MockApplicationsManagementClientMockRecorder) ListResourcesOfTypeInResourceGroupFiltered(arg0, arg1, arg2, arg3, arg4, arg5 any) *MockApplicationsManagementClientListResourcesOfTypeInResourceGroupFilteredCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourcesOfTypeInResourceGroupFiltered", reflect.TypeOf((*MockApplicationsManagementClient)(nil).ListResourcesOfTypeInResourceGroupFiltered), arg0, arg1, arg2, arg3, arg4, arg5)
+	return &MockApplicationsManagementClientListResourcesOfTypeInResourceGroupFilteredCall{Call: call}
+}
+
+// MockApplicationsManagementClientListResourcesOfTypeInResourceGroupFilteredCall wrap *gomock.Call
+type MockApplicationsManagementClientListResourcesOfTypeInResourceGroupFilteredCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationsManagementClientListResourcesOfTypeInResourceGroupFilteredCall) Return(arg0 []generated.GenericResource, arg1 error) *MockApplicationsManagementClientListResourcesOfTypeInResourceGroupFilteredCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationsManagementClientListResourcesOfTypeInResourceGroupFilteredCall) Do(f func(context.Context, string, string, string, string, string) ([]generated.GenericResource, error)) *MockApplicationsManagementClientListResourcesOfTypeInResourceGroupFilteredCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationsManagementClientListResourcesOfTypeInResourceGroupFilteredCall) DoAndReturn(f func(context.Context, string, string, string, string, string) ([]generated.GenericResource, error)) *MockApplicationsManagementClientListResourcesOfTypeInResourceGroupFilteredCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
# Description

Adds new client APIs for resource group operations to support enhanced resource listing and filtering capabilities. These APIs enable listing resources within resource groups with optional filtering by environment and application.

**New APIs Added:**
- ListResourcesInResourceGroup - Lists all resources in a resource group
- ListResourcesInResourceGroupFiltered - Lists resources with optional environment/application filtering
- ListResourcesOfTypeInResourceGroup - Lists resources of a specific type in a resource group
- ListResourcesOfTypeInResourceGroupFiltered - Lists resources of a specific type with filtering

**Modified APIs:**
- DeleteResourceGroup - Enhanced to cascade delete all resources in the group before deleting the group itself, preventing orphaned resources

**Implementation Details**
- All new functions support pagination for large result sets
- Graceful handling of API version lookup failures (continues with partial results)
- Parallel resource deletion using errgroup for better performance
- Comprehensive unit tests with exact mock call verification (no AnyTimes())

**Testing**
- Added extensive unit tests covering:
  - Success scenarios with multiple resources
  - Empty resource groups
  - Filtering by environment and/or application
  - Error handling (API version failures, deletion errors)
  - Cascade deletion with parallel processing
- All tests use exact call counts for proper verification

## Type of change
- This pull request adds or changes features of Radius and has an approved issue (issue link required).

Related to: #9362

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->