### PR TITLE
Improve rad group delete: add safety checks and refactor code

### DIFF
--- a/pkg/cli/clients/management.go
+++ b/pkg/cli/clients/management.go
@@ -373,7 +373,7 @@ func (amc *UCPApplicationsManagementClient) DeleteApplication(ctx context.Contex
 		resource := resource
 		g.Go(func() error {
 			_, err := amc.DeleteResource(groupCtx, *resource.Type, *resource.ID)
-			if err != nil {
+			if err != nil && !clientv2.Is404Error(err) {
 				return err
 			}
 			return nil

--- a/test/functional-portable/cli/noncloud/group_delete_test.go
+++ b/test/functional-portable/cli/noncloud/group_delete_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/radius-project/radius/test/radcli"
+	"github.com/radius-project/radius/test/rp"
+	"github.com/radius-project/radius/test/testcontext"
+	"github.com/radius-project/radius/test/testutil"
+	"github.com/radius-project/radius/test/validation"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GroupDelete(t *testing.T) {
+	ctx, cancel := testcontext.NewWithCancel(t)
+	t.Cleanup(cancel)
+
+	options := rp.NewRPTestOptions(t)
+	cli := radcli.NewCLI(t, options.ConfigFilePath)
+
+	// Generate a unique resource group name to avoid conflicts with parallel tests
+	uniqueGroupName := fmt.Sprintf("test-group-delete-%d", time.Now().Unix())
+	envName := "group-delete-test-env"
+	appName := "group-delete-test-app"
+	containerA := "group-delete-container-a"
+	containerB := "group-delete-container-b"
+
+	// Ensure cleanup even if test fails
+	t.Cleanup(func() {
+		// Try to delete the test group if it still exists
+		// Ignore errors as the group might have been successfully deleted
+		_ = cli.GroupDelete(context.Background(), uniqueGroupName, true)
+	})
+
+	// Create the unique resource group
+	t.Logf("Creating resource group: %s", uniqueGroupName)
+	err := cli.GroupCreate(ctx, uniqueGroupName)
+	require.NoError(t, err, "Failed to create resource group")
+
+	// Get the template file path
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	templateFilePath := filepath.Join(cwd, "testdata/corerp-group-delete-test.bicep")
+
+	// Deploy resources to the specific resource group
+	t.Logf("Deploying resources to group: %s", uniqueGroupName)
+	err = cli.DeployWithGroup(ctx, templateFilePath, "", "", uniqueGroupName, testutil.GetMagpieImage())
+	require.NoError(t, err, "Failed to deploy resources to resource group")
+
+	// Validate that resources were created successfully
+	// Note: We need to wait a bit for Kubernetes resources to be created
+	validation.ValidateObjectsRunning(ctx, t, options.K8sClient, options.DynamicClient, validation.K8sObjectSet{
+		Namespaces: map[string][]validation.K8sObject{
+			"default-group-delete-test-env-group-delete-test-app": {
+				validation.NewK8sPodForResource(appName, containerA),
+				validation.NewK8sPodForResource(appName, containerB),
+			},
+		},
+	})
+
+	// Delete the resource group with all its resources
+	t.Logf("Deleting resource group: %s", uniqueGroupName)
+	err = cli.GroupDelete(ctx, uniqueGroupName, true)
+	require.NoError(t, err, "Failed to delete resource group with resources")
+
+	// Verify group is deleted
+	t.Logf("Verifying resource group deletion: %s", uniqueGroupName)
+	output, err := cli.GroupShow(ctx, uniqueGroupName)
+	require.Error(t, err, "Group should be deleted")
+	outputStr := strings.ToLower(output)
+	require.Contains(t, outputStr, "not found", "Expected 'not found' in output but got: %s", output)
+
+	// Verify all resources are deleted - checking in the specific group
+	opts := radcli.ShowOptions{Group: uniqueGroupName}
+
+	output, err = cli.ApplicationShow(ctx, appName, opts)
+	require.Error(t, err, "Application should be deleted")
+	outputStr = strings.ToLower(output)
+	require.Contains(t, outputStr, "not found", "Expected 'not found' in output but got: %s", output)
+
+	output, err = cli.EnvShow(ctx, envName, opts)
+	require.Error(t, err, "Environment should be deleted")
+	outputStr = strings.ToLower(output)
+	require.Contains(t, outputStr, "not found", "Expected 'not found' in output but got: %s", output)
+
+	output, err = cli.ResourceShow(ctx, "Applications.Core/containers", containerA, opts)
+	require.Error(t, err, "Container A should be deleted")
+	outputStr = strings.ToLower(output)
+	require.Contains(t, outputStr, "not found", "Expected 'not found' in output but got: %s", output)
+
+	output, err = cli.ResourceShow(ctx, "Applications.Core/containers", containerB, opts)
+	require.Error(t, err, "Container B should be deleted")
+	outputStr = strings.ToLower(output)
+	require.Contains(t, outputStr, "not found", "Expected 'not found' in output but got: %s", output)
+
+	t.Logf("Successfully verified deletion of resource group %s and all its resources", uniqueGroupName)
+}

--- a/test/functional-portable/cli/noncloud/testdata/corerp-group-delete-test.bicep
+++ b/test/functional-portable/cli/noncloud/testdata/corerp-group-delete-test.bicep
@@ -1,0 +1,59 @@
+extension radius
+
+@description('Specifies the location for resources.')
+param location string = 'global'
+
+@description('Specifies the image to be deployed.')
+param magpieimage string
+
+resource env 'Applications.Core/environments@2023-10-01-preview' = {
+  name: 'group-delete-test-env'
+  location: location
+  properties: {
+    compute: {
+      kind: 'kubernetes'
+      resourceId: 'self'
+      namespace: 'default-group-delete-test-env'
+    }
+  }
+}
+
+resource app 'Applications.Core/applications@2023-10-01-preview' = {
+  name: 'group-delete-test-app'
+  location: location
+  properties: {
+    environment: env.id
+  }
+}
+
+resource containerA 'Applications.Core/containers@2023-10-01-preview' = {
+  name: 'group-delete-container-a'
+  location: location
+  properties: {
+    application: app.id
+    container: {
+      image: magpieimage
+      ports: {
+        web: {
+          containerPort: 3000
+        }
+      }
+    }
+  }
+}
+
+resource containerB 'Applications.Core/containers@2023-10-01-preview' = {
+  name: 'group-delete-container-b'
+  location: location
+  properties: {
+    application: app.id
+    container: {
+      image: magpieimage
+      ports: {
+        web: {
+          containerPort: 3000
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description

Improves `rad group delete` command safety and code quality by preventing deletion when resource listing fails and refactoring for better maintainability.

## Changes
- Add safety check: Stop deletion if unable to list resources (except 404 errors)
- Extract confirmation prompt logic into separate method
- Add constants for repeated strings
- Add error context wrapping for better debugging
- Fix redundant boolean logic
- Add comprehensive test coverage

## Testing
```bash
# Build the CLI
make build

# Test 1: Delete empty group
./dist/darwin_arm64/release/rad group create test-empty
./dist/darwin_arm64/release/rad group delete test-empty --yes
# Expected: "Resource group test-empty deleted."

# Test 2: Delete group with resources
./dist/darwin_arm64/release/rad group create test-with-resources
./dist/darwin_arm64/release/rad env create test-env --group test-with-resources
./dist/darwin_arm64/release/rad group delete test-with-resources --yes
# Expected: "Deleting 1 resource(s) in group test-with-resources..."

# Test 3: Delete without --yes flag (interactive prompt)
./dist/darwin_arm64/release/rad group create test-interactive
./dist/darwin_arm64/release/rad group delete test-interactive
# Expected: Prompt "The resource group test-interactive is empty. Are you sure..."
```

## Type of change
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
Fixes: #9362

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->