### PR TITLE
Adding a re-authentication step to LRT

### DIFF
--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -48,19 +48,18 @@ on:
   workflow_dispatch:
     inputs:
       skip-build:
-        description: 'Skip build (true/false). Setting to false will cause the tests to run with the latest changes from the main branch.'
+        description: "Skip build (true/false). Setting to false will cause the tests to run with the latest changes from the main branch."
         required: false
-        default: 'true'
+        default: "true"
         type: choice
         options:
-          - 'true'
-          - 'false'
+          - "true"
+          - "false"
   schedule:
     # Run every 4 hours
     - cron: "0 */4 * * *"
 
 env:
-
   GOPROXY: https://proxy.golang.org
 
   # gotestsum version - see: https://github.com/gotestyourself/gotestsum
@@ -71,7 +70,7 @@ env:
   # Container registry for storing Bicep recipe artifacts
   BICEP_RECIPE_REGISTRY: ghcr.io/radius-project/dev
   # ACR url for uploading test UDT Bicep types
-  TEST_BICEP_TYPES_REGISTRY: 'testuserdefinedbiceptypes.azurecr.io'
+  TEST_BICEP_TYPES_REGISTRY: "testuserdefinedbiceptypes.azurecr.io"
   # The radius functional test timeout
   FUNCTIONALTEST_TIMEOUT: 60m
   # The Azure Location to store test resources
@@ -147,7 +146,7 @@ jobs:
               SKIP_BUILD="true"
             fi
           fi
-          
+
           # Check override in workflow_dispatch mode
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.skip-build }}" = "false" ]; then
             echo "Manual run with skip-build=false, forcing build"
@@ -431,7 +430,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: skip-delete-resources-list.txt
-          key: skip-delete-resources-list-file    
+          key: skip-delete-resources-list-file
       - name: Clean up cluster
         if: always()
         timeout-minutes: 60
@@ -567,13 +566,13 @@ jobs:
         run: |
           # Start port forwarding in the background
           kubectl port-forward -n gitea svc/gitea-http 30080:3000 &
-          
+
           # Wait for port forwarding to be established
           sleep 5
-          
+
           # Test the connection to ensure port forwarding is working
           curl -s http://localhost:30080 > /dev/null || (echo "Port forwarding failed" && exit 1)
-          
+
           echo "Port forwarding established successfully"
       - name: Publish Terraform test recipes
         run: |
@@ -582,13 +581,20 @@ jobs:
         run: |
           echo "FUNCTEST_OIDC_ISSUER=$(az aks show -n ${{ env.AKS_CLUSTER_NAME }} -g ${{ env.AKS_RESOURCE_GROUP }} --query "oidcIssuerProfile.issuerUrl" -otsv)" >> $GITHUB_ENV
       - name: Restore Bicep artifacts before running functional tests
-      # The exact files chosen to run the command can be changed, but we need 1 that uses the Radius extension, 1 that uses the AWS extension and 1 that uses UDT testresources
-      # so we can restore all Bicep artifacts before the tests start.
+        # The exact files chosen to run the command can be changed, but we need 1 that uses the Radius extension, 1 that uses the AWS extension and 1 that uses UDT testresources
+        # so we can restore all Bicep artifacts before the tests start.
         run: |
           # Restore Radius Bicep types
           bicep restore ./test/functional-portable/corerp/cloud/resources/testdata/corerp-azure-connection-database-service.bicep --force
-          # Restore AWS Bicep types 
+          # Restore AWS Bicep types
           bicep restore ./test/functional-portable/corerp/cloud/resources/testdata/aws-s3-bucket.bicep --force
+      # Refresh Azure login to avoid token expiration during long-running tests
+      - name: Re-authenticate with Azure before tests
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
+          tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
       - name: Run functional tests
         run: |
           # Ensure rad cli is in path before running tests.


### PR DESCRIPTION
# Description

### Problem
The long-running Azure workflow started failing on August 25, 2024 with OIDC token expiration errors (AADSTS700024). Tests that deploy Bicep templates with custom extensions (extension testresources) need to pull from a private Azure Container Registry (testuserdefinedbiceptypes.azurecr.io), but the OIDC tokens expire after 10 minutes while tests run for up to 60 minutes.

### Still Being Investigated
The workflow had been working for 4 months despite this token expiration issue. We believe Azure CLI credentials were persisting on the long-running runner between workflow runs, masking the problem until the runner was likely restarted/recreated around August 25.

### Solution
Added a re-authentication step with Azure immediately before test execution to ensure fresh OIDC tokens are available when tests need to pull Bicep extensions from the private ACR.

### Investigation Steps Taken
- Analyzed error logs showing token expiration after 5-minute validity window
- Compared authentication methods between workflows (OIDC vs password-based)
- Traced timeline of configuration changes (skip-build logic added 20 months ago, ACR usage added 4 months ago)
- Confirmed ACR doesn't allow anonymous pulls (anonymousPullEnabled=false)
- Identified that OIDC tokens expire after 10 minutes per Azure/GitHub documentation
- Determined the issue was masked by credential persistence until runner restart (Not sure)

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (issue link required).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->