### PR TITLE
Disable Gitea install and Flux tests

### DIFF
--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -482,7 +482,7 @@ jobs:
           BICEP_RECIPE_TAG_VERSION: ${{ env.BICEP_RECIPE_TAG_VERSION }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOTESTSUM_OPTS: "--junitfile ./dist/functional_test/results.xml"
-          GITEA_ACCESS_TOKEN: ${{ steps.install-gitea.outputs.gitea-access-token }}
+          # GITEA_ACCESS_TOKEN: ${{ steps.install-gitea.outputs.gitea-access-token }}
           RADIUS_TEST_FAST_CLEANUP: true
 
       - name: Process Functional Test Results

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -374,30 +374,32 @@ jobs:
         if: matrix.name == 'kubernetes-noncloud'
         uses: ./.github/actions/install-flux
 
-      - name: Install Gitea
-        if: matrix.name == 'kubernetes-noncloud'
-        id: install-gitea
-        uses: ./.github/actions/install-gitea
-        env:
-          GITEA_PASSWORD: ${{ secrets.GITEA_PASSWORD }}
-        with:
-          gitea-username: ${{ env.GITEA_USERNAME }}
-          gitea-email: ${{ env.GITEA_EMAIL }}
-          gitea-access-token-name: ${{ env.GITEA_ACCESS_TOKEN_NAME }}
+      # https://github.com/radius-project/radius/issues/10441
+      # - name: Install Gitea
+      #   if: matrix.name == 'kubernetes-noncloud'
+      #   id: install-gitea
+      #   uses: ./.github/actions/install-gitea
+      #   env:
+      #     GITEA_PASSWORD: ${{ secrets.GITEA_PASSWORD }}
+      #   with:
+      #     gitea-username: ${{ env.GITEA_USERNAME }}
+      #     gitea-email: ${{ env.GITEA_EMAIL }}
+      #     gitea-access-token-name: ${{ env.GITEA_ACCESS_TOKEN_NAME }}
  
-      - name: Port-forward to Gitea
-        if: matrix.name == 'kubernetes-noncloud'
-        run: |
-          # Start port forwarding in the background
-          kubectl port-forward -n gitea svc/gitea-http 30080:3000 &
+      # https://github.com/radius-project/radius/issues/10441
+      # - name: Port-forward to Gitea
+      #   if: matrix.name == 'kubernetes-noncloud'
+      #   run: |
+      #     # Start port forwarding in the background
+      #     kubectl port-forward -n gitea svc/gitea-http 30080:3000 &
           
-          # Wait for port forwarding to be established
-          sleep 5
+      #     # Wait for port forwarding to be established
+      #     sleep 5
           
-          # Test the connection to ensure port forwarding is working
-          curl -s http://localhost:30080 > /dev/null || (echo "Port forwarding failed" && exit 1)
+      #     # Test the connection to ensure port forwarding is working
+      #     curl -s http://localhost:30080 > /dev/null || (echo "Port forwarding failed" && exit 1)
           
-          echo "Port forwarding established successfully"
+      #     echo "Port forwarding established successfully"
 
       - name: Install Dapr CLI and control plane
         if: matrix.name == 'daprrp-noncloud'

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -554,27 +554,27 @@ jobs:
           echo ":x: Failed to install Radius for functional test." >> $GITHUB_STEP_SUMMARY
       - name: Install Flux CLI and Source Controller
         uses: ./.github/actions/install-flux
-      - name: Install Gitea
-        id: install-gitea
-        uses: ./.github/actions/install-gitea
-        env:
-          GITEA_PASSWORD: ${{ secrets.GITEA_PASSWORD }}
-        with:
-          gitea-username: ${{ env.GITEA_USERNAME }}
-          gitea-email: ${{ env.GITEA_EMAIL }}
-          gitea-access-token-name: ${{ env.GITEA_ACCESS_TOKEN_NAME }}
-      - name: Port-forward to Gitea
-        run: |
-          # Start port forwarding in the background
-          kubectl port-forward -n gitea svc/gitea-http 30080:3000 &
+      # - name: Install Gitea
+      #   id: install-gitea
+      #   uses: ./.github/actions/install-gitea
+      #   env:
+      #     GITEA_PASSWORD: ${{ secrets.GITEA_PASSWORD }}
+      #   with:
+      #     gitea-username: ${{ env.GITEA_USERNAME }}
+      #     gitea-email: ${{ env.GITEA_EMAIL }}
+      #     gitea-access-token-name: ${{ env.GITEA_ACCESS_TOKEN_NAME }}
+      # - name: Port-forward to Gitea
+      #   run: |
+      #     # Start port forwarding in the background
+      #     kubectl port-forward -n gitea svc/gitea-http 30080:3000 &
           
-          # Wait for port forwarding to be established
-          sleep 5
+      #     # Wait for port forwarding to be established
+      #     sleep 5
           
-          # Test the connection to ensure port forwarding is working
-          curl -s http://localhost:30080 > /dev/null || (echo "Port forwarding failed" && exit 1)
+      #     # Test the connection to ensure port forwarding is working
+      #     curl -s http://localhost:30080 > /dev/null || (echo "Port forwarding failed" && exit 1)
           
-          echo "Port forwarding established successfully"
+      #     echo "Port forwarding established successfully"
       - name: Publish Terraform test recipes
         run: |
           make publish-test-terraform-recipes
@@ -621,7 +621,7 @@ jobs:
           BICEP_RECIPE_REGISTRY: ${{ env.BICEP_RECIPE_REGISTRY }}
           BICEP_RECIPE_TAG_VERSION: ${{ env.BICEP_RECIPE_TAG_VERSION }}
           GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
-          GITEA_ACCESS_TOKEN: ${{ steps.install-gitea.outputs.gitea-access-token }}
+          # GITEA_ACCESS_TOKEN: ${{ steps.install-gitea.outputs.gitea-access-token }}
       - name: Collect Pod details
         if: always()
         run: |

--- a/test/functional-portable/kubernetes/noncloud/flux_test.go
+++ b/test/functional-portable/kubernetes/noncloud/flux_test.go
@@ -59,6 +59,7 @@ const (
 )
 
 func Test_Flux_Basic(t *testing.T) {
+	t.Skip("https://github.com/radius-project/radius/issues/10441")
 	testName := "flux-basic"
 	steps := []GitOpsTestStep{
 		{
@@ -85,6 +86,7 @@ func Test_Flux_Basic(t *testing.T) {
 }
 
 func Test_Flux_Complex(t *testing.T) {
+	t.Skip("https://github.com/radius-project/radius/issues/10441")
 	testName := "flux-complex"
 	steps := []GitOpsTestStep{
 		{


### PR DESCRIPTION
# Description

* Disable Gitea install (fails due to Bitnami image deprecation)
* Disable Flux functional tests (fail due to Gitea not being installed)

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: https://github.com/radius-project/radius/issues/10441

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [x] Yes <!-- TaskRadio schema -->
    - [ ] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [x] Yes <!-- TaskRadio design-pr -->
    - [ ] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [x] Yes <!-- TaskRadio design-review -->
    - [ ] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [x] Yes <!-- TaskRadio samples-pr -->
    - [ ] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [x] Yes <!-- TaskRadio docs-pr -->
    - [ ] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [x] Yes <!-- TaskRadio recipes-pr -->
    - [ ] Not applicable <!-- TaskRadio recipes-pr -->