### PR TITLE
Refactoring recipe folder

### DIFF
--- a/pkg/dynamicrp/options.go
+++ b/pkg/dynamicrp/options.go
@@ -33,6 +33,8 @@ import (
 	"github.com/radius-project/radius/pkg/recipes"
 	"github.com/radius-project/radius/pkg/recipes/configloader"
 	"github.com/radius-project/radius/pkg/recipes/driver"
+	"github.com/radius-project/radius/pkg/recipes/driver/bicep"
+	"github.com/radius-project/radius/pkg/recipes/driver/terraform"
 	"github.com/radius-project/radius/pkg/recipes/engine"
 	"github.com/radius-project/radius/pkg/sdk"
 	"github.com/radius-project/radius/pkg/sdk/clients"
@@ -192,21 +194,21 @@ func bicepDriver(options *Options) (driver.Driver, error) {
 		return nil, err
 	}
 
-	return driver.NewBicepDriver(
+	return bicep.NewBicepDriver(
 		sdk.NewClientOptions(options.UCP),
 		deploymentEngineClient,
 		resourceClient,
-		driver.BicepOptions{
+		bicep.BicepOptions{
 			DeleteRetryCount:        bicepDeleteRetryCount,
 			DeleteRetryDelaySeconds: bicepDeleteRetryDeleteSeconds,
 		}), nil
 }
 
 func terraformDriver(options *Options) (driver.Driver, error) {
-	return driver.NewTerraformDriver(
+	return terraform.NewTerraformDriver(
 		options.UCP,
 		options.SecretProvider,
-		driver.TerraformOptions{
+		terraform.TerraformOptions{
 			Path: options.Config.Terraform.Path,
 		}, *options.KubernetesProvider), nil
 }

--- a/pkg/recipes/controllerconfig/config.go
+++ b/pkg/recipes/controllerconfig/config.go
@@ -28,6 +28,8 @@ import (
 	"github.com/radius-project/radius/pkg/recipes"
 	"github.com/radius-project/radius/pkg/recipes/configloader"
 	"github.com/radius-project/radius/pkg/recipes/driver"
+	"github.com/radius-project/radius/pkg/recipes/driver/bicep"
+	"github.com/radius-project/radius/pkg/recipes/driver/terraform"
 	"github.com/radius-project/radius/pkg/recipes/engine"
 	"github.com/radius-project/radius/pkg/sdk"
 	"github.com/radius-project/radius/pkg/sdk/clients"
@@ -99,17 +101,17 @@ func New(options hostoptions.HostOptions) (*RecipeControllerConfig, error) {
 		ConfigurationLoader: cfg.ConfigLoader,
 		SecretsLoader:       configloader.NewSecretStoreLoader(clientOptions),
 		Drivers: map[string]driver.Driver{
-			recipes.TemplateKindBicep: driver.NewBicepDriver(
+			recipes.TemplateKindBicep: bicep.NewBicepDriver(
 				clientOptions,
 				cfg.DeploymentEngineClient,
 				processors.NewResourceClient(options.Arm, options.UCPConnection, cfg.Kubernetes),
-				driver.BicepOptions{
+				bicep.BicepOptions{
 					DeleteRetryCount:        bicepDeleteRetryCount,
 					DeleteRetryDelaySeconds: bicepDeleteRetryDeleteSeconds,
 				},
 			),
-			recipes.TemplateKindTerraform: driver.NewTerraformDriver(options.UCPConnection, secretprovider.NewSecretProvider(options.Config.SecretProvider),
-				driver.TerraformOptions{
+			recipes.TemplateKindTerraform: terraform.NewTerraformDriver(options.UCPConnection, secretprovider.NewSecretProvider(options.Config.SecretProvider),
+				terraform.TerraformOptions{
 					Path: options.Config.Terraform.Path,
 				}, *cfg.Kubernetes),
 		},

--- a/pkg/recipes/driver/terraform/gitconfig.go
+++ b/pkg/recipes/driver/terraform/gitconfig.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package driver
+package terraform
 
 import (
 	"errors"

--- a/pkg/recipes/driver/terraform/gitconfig_test.go
+++ b/pkg/recipes/driver/terraform/gitconfig_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package driver
+package terraform
 
 import (
 	"errors"

--- a/pkg/recipes/driver/terraform/terraform.go
+++ b/pkg/recipes/driver/terraform/terraform.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package driver
+package terraform
 
 import (
 	"context"
@@ -33,6 +33,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/radius-project/radius/pkg/recipes"
+	"github.com/radius-project/radius/pkg/recipes/driver"
 	"github.com/radius-project/radius/pkg/recipes/terraform"
 	recipes_util "github.com/radius-project/radius/pkg/recipes/util"
 	"github.com/radius-project/radius/pkg/sdk"
@@ -45,10 +46,10 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 )
 
-var _ Driver = (*terraformDriver)(nil)
+var _ driver.Driver = (*terraformDriver)(nil)
 
 // NewTerraformDriver creates a new instance of driver to execute a Terraform recipe.
-func NewTerraformDriver(ucpConn sdk.Connection, secretProvider *secretprovider.SecretProvider, options TerraformOptions, kubernetesClients kubernetesclientprovider.KubernetesClientProvider) Driver {
+func NewTerraformDriver(ucpConn sdk.Connection, secretProvider *secretprovider.SecretProvider, options TerraformOptions, kubernetesClients kubernetesclientprovider.KubernetesClientProvider) driver.Driver {
 	return &terraformDriver{
 		terraformExecutor: terraform.NewExecutor(ucpConn, secretProvider, kubernetesClients),
 		options:           options,
@@ -72,7 +73,7 @@ type terraformDriver struct {
 
 // Execute creates a unique directory for each execution of terraform and deploys the recipe using the
 // the Terraform CLI through terraform-exec. It returns a RecipeOutput or an error if the deployment fails.
-func (d *terraformDriver) Execute(ctx context.Context, opts ExecuteOptions) (*recipes.RecipeOutput, error) {
+func (d *terraformDriver) Execute(ctx context.Context, opts driver.ExecuteOptions) (*recipes.RecipeOutput, error) {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
 	requestDirPath, err := d.createExecutionDirectory(ctx, opts.Recipe, opts.Definition)
@@ -125,7 +126,7 @@ func (d *terraformDriver) Execute(ctx context.Context, opts ExecuteOptions) (*re
 
 // Delete creates a unique directory for each execution of terraform and deletes the resources deployed by the Terraform module
 // using the Terraform CLI through terraform-exec. It returns an error if the deletion fails.
-func (d *terraformDriver) Delete(ctx context.Context, opts DeleteOptions) error {
+func (d *terraformDriver) Delete(ctx context.Context, opts driver.DeleteOptions) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
 	requestDirPath, err := d.createExecutionDirectory(ctx, opts.Recipe, opts.Definition)
@@ -253,7 +254,7 @@ func (d *terraformDriver) createExecutionDirectory(ctx context.Context, recipe r
 }
 
 // GetRecipeMetadata returns the Terraform Recipe parameters by downloading the module and retrieving variable information
-func (d *terraformDriver) GetRecipeMetadata(ctx context.Context, opts BaseOptions) (map[string]any, error) {
+func (d *terraformDriver) GetRecipeMetadata(ctx context.Context, opts driver.BaseOptions) (map[string]any, error) {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
 	requestDirPath, err := d.createExecutionDirectory(ctx, opts.Recipe, opts.Definition)

--- a/pkg/recipes/driver/terraform/types.go
+++ b/pkg/recipes/driver/terraform/types.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package terraform
+
+import (
+	"strings"
+
+	"github.com/radius-project/radius/pkg/recipes"
+)
+
+const (
+	TerraformAzureProvider            = "registry.terraform.io/hashicorp/azurerm"
+	TerraformAWSProvider              = "registry.terraform.io/hashicorp/aws"
+	TerraformKubernetesProvider       = "registry.terraform.io/hashicorp/kubernetes"
+	PrivateRegistrySecretKey_Pat      = "pat"
+	PrivateRegistrySecretKey_Username = "username"
+)
+
+// GetPrivateGitRepoSecretStoreID returns secretstore resource ID associated with git private terraform repository source.
+func GetPrivateGitRepoSecretStoreID(envConfig recipes.Configuration, templatePath string) (string, error) {
+	if strings.HasPrefix(templatePath, "git::") {
+		url, err := GetGitURL(templatePath)
+		if err != nil {
+			return "", err
+		}
+
+		// get the secret store id associated with the git domain of the template path.
+		return envConfig.RecipeConfig.Terraform.Authentication.Git.PAT[strings.TrimPrefix(url.Hostname(), "www.")].Secret, nil
+	}
+	return "", nil
+}

--- a/pkg/recipes/driver/terraform/types.go
+++ b/pkg/recipes/driver/terraform/types.go
@@ -44,5 +44,6 @@ func GetPrivateGitRepoSecretStoreID(envConfig recipes.Configuration, templatePat
 			return patConfig.Secret, nil
 		}
 	}
+
 	return "", nil
 }

--- a/pkg/recipes/driver/terraform/types.go
+++ b/pkg/recipes/driver/terraform/types.go
@@ -38,8 +38,11 @@ func GetPrivateGitRepoSecretStoreID(envConfig recipes.Configuration, templatePat
 			return "", err
 		}
 
+		hostname := strings.TrimPrefix(url.Hostname(), "www.")
 		// get the secret store id associated with the git domain of the template path.
-		return envConfig.RecipeConfig.Terraform.Authentication.Git.PAT[strings.TrimPrefix(url.Hostname(), "www.")].Secret, nil
+		if patConfig, ok := envConfig.RecipeConfig.Terraform.Authentication.Git.PAT[hostname]; ok {
+			return patConfig.Secret, nil
+		}
 	}
 	return "", nil
 }

--- a/pkg/recipes/driver/terraform/types_test.go
+++ b/pkg/recipes/driver/terraform/types_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package driver
+package terraform
 
 import (
 	"testing"

--- a/pkg/recipes/driver/types.go
+++ b/pkg/recipes/driver/types.go
@@ -18,18 +18,9 @@ package driver
 
 import (
 	"context"
-	"strings"
 
 	"github.com/radius-project/radius/pkg/recipes"
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
-)
-
-const (
-	TerraformAzureProvider            = "registry.terraform.io/hashicorp/azurerm"
-	TerraformAWSProvider              = "registry.terraform.io/hashicorp/aws"
-	TerraformKubernetesProvider       = "registry.terraform.io/hashicorp/kubernetes"
-	PrivateRegistrySecretKey_Pat      = "pat"
-	PrivateRegistrySecretKey_Username = "username"
 )
 
 // Driver is an interface to implement recipe deployment and recipe resources deletion.
@@ -98,18 +89,4 @@ type DeleteOptions struct {
 
 	// OutputResources is the list of output resources for the recipe.
 	OutputResources []rpv1.OutputResource
-}
-
-// GetPrivateGitRepoSecretStoreID returns secretstore resource ID associated with git private terraform repository source.
-func GetPrivateGitRepoSecretStoreID(envConfig recipes.Configuration, templatePath string) (string, error) {
-	if strings.HasPrefix(templatePath, "git::") {
-		url, err := GetGitURL(templatePath)
-		if err != nil {
-			return "", err
-		}
-
-		// get the secret store id associated with the git domain of the template path.
-		return envConfig.RecipeConfig.Terraform.Authentication.Git.PAT[strings.TrimPrefix(url.Hostname(), "www.")].Secret, nil
-	}
-	return "", nil
 }


### PR DESCRIPTION
# Description

Today in the `pkg/recipes/driver/terraform` package we have files like gitcofig which is only realted to terraform driver . And we have added more terraform specific files as part of the air gapped changes. So as part of this PR I have added `bicep` and `terraform` package and moved the each driver specific files into respective packages.
 - Refactored the recipes folder to create `bicep` and `terraform` packages inside `recipes`.
## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius .

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->