### PR TITLE
feat(cli): enhance rad env delete with resource counting and safety prompts

### DIFF
--- a/pkg/cli/clients/management.go
+++ b/pkg/cli/clients/management.go
@@ -1007,6 +1007,7 @@ func (amc *UCPApplicationsManagementClient) ListResourcesInEnvironment(ctx conte
 		if err != nil {
 			return nil, err
 		}
+
 		results = append(results, resources...)
 	}
 

--- a/pkg/cli/clients/management_test.go
+++ b/pkg/cli/clients/management_test.go
@@ -972,6 +972,127 @@ func Test_Application(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, deleted)
 	})
+
+	t.Run("DeleteApplication_WithResourceGroupNotFound", func(t *testing.T) {
+		// Test case where ListResourcesInApplication returns 404 error (resource group doesn't exist)
+		// This should be ignored and deletion should continue
+		ctrl := gomock.NewController(t)
+		mock := NewMockapplicationResourceClient(ctrl)
+		mockResourceProviderClient := NewMockresourceProviderClient(ctrl)
+		genericResourceMock := NewMockgenericResourceClient(ctrl)
+		client := createClient(mock)
+		client.genericResourceClientFactory = func(scope string, resourceType string) (genericResourceClient, error) {
+			return genericResourceMock, nil
+		}
+		client.resourceProviderClientFactory = func() (resourceProviderClient, error) {
+			return mockResourceProviderClient, nil
+		}
+
+		// Mock ListAllResourceTypesNames to return one provider with resource types
+		mockResourceProviderClient.EXPECT().
+			NewListProviderSummariesPager("local", gomock.Any()).
+			Return(pager(resourceProviderSummaryPages))
+
+		// Mock GetProviderSummary to return valid responses for listing resource types
+		mockResourceProviderClient.EXPECT().
+			GetProviderSummary(gomock.Any(), "local", gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, plane string, providerName string, opts *ucp.ResourceProvidersClientGetProviderSummaryOptions) (ucp.ResourceProvidersClientGetProviderSummaryResponse, error) {
+				summary := findProviderSummary(providerName)
+				if summary != nil {
+					return ucp.ResourceProvidersClientGetProviderSummaryResponse{
+						ResourceProviderSummary: *summary,
+					}, nil
+				}
+
+				// Fallback for providers not in test data
+				return ucp.ResourceProvidersClientGetProviderSummaryResponse{
+					ResourceProviderSummary: ucp.ResourceProviderSummary{
+						Name: &providerName,
+						ResourceTypes: map[string]*ucp.ResourceProviderSummaryResourceType{
+							"resourceType1": {
+								APIVersions: map[string]*ucp.ResourceTypeSummaryResultAPIVersion{
+									version: {},
+								},
+							},
+						},
+					},
+				}, nil
+			}).AnyTimes()
+
+		// Mock genericResourceClient to return 404 when listing resources
+		// This simulates the resource group not existing
+		genericResourceMock.EXPECT().
+			NewListByRootScopePager(gomock.Any()).
+			DoAndReturn(func(opts *generated.GenericResourcesClientListByRootScopeOptions) *runtime.Pager[generated.GenericResourcesClientListByRootScopeResponse] {
+				// Create a handler that returns error immediately
+				handler := runtime.PagingHandler[generated.GenericResourcesClientListByRootScopeResponse]{
+					More: func(page generated.GenericResourcesClientListByRootScopeResponse) bool {
+						return false
+					},
+					Fetcher: func(ctx context.Context, page *generated.GenericResourcesClientListByRootScopeResponse) (generated.GenericResourcesClientListByRootScopeResponse, error) {
+						// Return 404 error immediately
+						return generated.GenericResourcesClientListByRootScopeResponse{}, &azcore.ResponseError{
+							StatusCode: http.StatusNotFound,
+							ErrorCode:  v1.CodeNotFound,
+						}
+					},
+				}
+				return runtime.NewPager(handler)
+			}).AnyTimes()
+
+		// Even though ListResourcesInApplication fails with 404, Delete should still be called
+		mock.EXPECT().
+			Delete(gomock.Any(), testResourceName, gomock.Any()).
+			DoAndReturn(func(ctx context.Context, s string, acdo *corerp.ApplicationsClientDeleteOptions) (corerp.ApplicationsClientDeleteResponse, error) {
+				setCapture(ctx, &http.Response{StatusCode: 200})
+				return corerp.ApplicationsClientDeleteResponse{}, nil
+			})
+
+		deleted, err := client.DeleteApplication(context.Background(), testResourceID)
+		require.NoError(t, err)
+		require.True(t, deleted)
+	})
+
+	t.Run("DeleteApplication_WithListResourcesError", func(t *testing.T) {
+		// Test case where ListResourcesInApplication returns a non-404 error
+		// This should cause DeleteApplication to fail and return the error
+		ctrl := gomock.NewController(t)
+		mock := NewMockapplicationResourceClient(ctrl)
+		mockResourceProviderClient := NewMockresourceProviderClient(ctrl)
+		client := createClient(mock)
+		client.resourceProviderClientFactory = func() (resourceProviderClient, error) {
+			return mockResourceProviderClient, nil
+		}
+
+		// Mock ListProviderSummaries to return an error
+		mockResourceProviderClient.EXPECT().
+			NewListProviderSummariesPager("local", gomock.Any()).
+			DoAndReturn(func(plane string, opts *ucp.ResourceProvidersClientListProviderSummariesOptions) *runtime.Pager[ucp.ResourceProvidersClientListProviderSummariesResponse] {
+				// Create a handler that returns error immediately
+				handler := runtime.PagingHandler[ucp.ResourceProvidersClientListProviderSummariesResponse]{
+					More: func(page ucp.ResourceProvidersClientListProviderSummariesResponse) bool {
+						return false
+					},
+					Fetcher: func(ctx context.Context, page *ucp.ResourceProvidersClientListProviderSummariesResponse) (ucp.ResourceProvidersClientListProviderSummariesResponse, error) {
+						// Return internal server error immediately
+						return ucp.ResourceProvidersClientListProviderSummariesResponse{}, &azcore.ResponseError{
+							StatusCode: http.StatusInternalServerError,
+							ErrorCode:  "InternalServerError",
+						}
+					},
+				}
+				return runtime.NewPager(handler)
+			})
+
+		// Delete should NOT be called when ListResourcesInApplication fails with non-404 error
+		// No expectation set for mock.Delete()
+
+		deleted, err := client.DeleteApplication(context.Background(), testResourceID)
+		require.Error(t, err)
+		require.False(t, deleted)
+		// Verify the error is propagated correctly
+		require.Contains(t, err.Error(), "failed to list resource provider summaries")
+	})
 }
 
 func Test_Environment(t *testing.T) {

--- a/test/functional-portable/cli/noncloud/env_delete_test.go
+++ b/test/functional-portable/cli/noncloud/env_delete_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/radius-project/radius/test/radcli"
+	"github.com/radius-project/radius/test/rp"
+	"github.com/radius-project/radius/test/testcontext"
+	"github.com/radius-project/radius/test/testutil"
+	"github.com/radius-project/radius/test/validation"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_EnvDelete(t *testing.T) {
+	ctx, cancel := testcontext.NewWithCancel(t)
+	t.Cleanup(cancel)
+
+	options := rp.NewRPTestOptions(t)
+	cli := radcli.NewCLI(t, options.ConfigFilePath)
+
+	// Generate a unique resource group name to avoid conflicts with parallel tests
+	uniqueGroupName := fmt.Sprintf("test-env-delete-%d", time.Now().Unix())
+	envName := "env-delete-test-env"
+	appName := "env-delete-test-app"
+	containerA := "env-delete-container-a"
+	containerB := "env-delete-container-b"
+
+	// Ensure cleanup even if test fails
+	t.Cleanup(func() {
+		// Try to delete the test group if it still exists
+		// Ignore errors as the group might have been successfully deleted
+		_ = cli.GroupDelete(context.Background(), uniqueGroupName, radcli.DeleteOptions{Confirm: true})
+	})
+
+	// Create the unique resource group
+	t.Logf("Creating resource group: %s", uniqueGroupName)
+	err := cli.GroupCreate(ctx, uniqueGroupName)
+	require.NoError(t, err, "Failed to create resource group")
+
+	// Get the template file path
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	templateFilePath := filepath.Join(cwd, "testdata/corerp-env-delete-test.bicep")
+
+	// Deploy resources to the specific resource group
+	t.Logf("Deploying resources to group: %s", uniqueGroupName)
+	err = cli.DeployWithGroup(ctx, templateFilePath, "", "", uniqueGroupName, testutil.GetMagpieImage())
+	require.NoError(t, err, "Failed to deploy resources to resource group")
+
+	// Validate that resources were created successfully
+	// Note: We need to wait a bit for Kubernetes resources to be created
+	validation.ValidateObjectsRunning(ctx, t, options.K8sClient, options.DynamicClient, validation.K8sObjectSet{
+		Namespaces: map[string][]validation.K8sObject{
+			"default-env-delete-test-env-env-delete-test-app": {
+				validation.NewK8sPodForResource(appName, containerA),
+				validation.NewK8sPodForResource(appName, containerB),
+			},
+		},
+	})
+
+	// Set options for group-scoped operations
+	showOpts := radcli.ShowOptions{Group: uniqueGroupName}
+	deleteOpts := radcli.DeleteOptions{Group: uniqueGroupName, Confirm: true}
+
+	// Verify environment exists
+	t.Logf("Verifying environment exists: %s", envName)
+	output, err := cli.EnvShow(ctx, envName, showOpts)
+	require.NoError(t, err, "Failed to show environment")
+	require.Contains(t, output, envName, "Environment should exist")
+
+	// Verify application exists
+	output, err = cli.ApplicationShow(ctx, appName, showOpts)
+	require.NoError(t, err, "Failed to show application")
+	require.Contains(t, output, appName, "Application should exist")
+
+	// Delete the environment with all its resources
+	t.Logf("Deleting environment: %s in group: %s", envName, uniqueGroupName)
+	err = cli.EnvDelete(ctx, envName, deleteOpts)
+	require.NoError(t, err, "Failed to delete environment with resources")
+
+	// Verify environment is deleted - checking in the specific group
+	t.Logf("Verifying environment deletion: %s", envName)
+	output, err = cli.EnvShow(ctx, envName, showOpts)
+	require.Error(t, err, "Environment should be deleted")
+	outputStr := strings.ToLower(output)
+	require.Contains(t, outputStr, "not found", "Expected 'not found' in output but got: %s", output)
+
+	// Verify all associated resources are deleted
+	output, err = cli.ApplicationShow(ctx, appName, showOpts)
+	require.Error(t, err, "Application should be deleted")
+	outputStr = strings.ToLower(output)
+	require.Contains(t, outputStr, "not found", "Expected 'not found' in output but got: %s", output)
+
+	output, err = cli.ResourceShow(ctx, "Applications.Core/containers", containerA, showOpts)
+	require.Error(t, err, "Container A should be deleted")
+	outputStr = strings.ToLower(output)
+	require.Contains(t, outputStr, "not found", "Expected 'not found' in output but got: %s", output)
+
+	output, err = cli.ResourceShow(ctx, "Applications.Core/containers", containerB, showOpts)
+	require.Error(t, err, "Container B should be deleted")
+	outputStr = strings.ToLower(output)
+	require.Contains(t, outputStr, "not found", "Expected 'not found' in output but got: %s", output)
+
+	t.Logf("Successfully verified deletion of environment %s and all its resources", envName)
+
+	// Test 2: Delete empty environment
+	t.Log("Testing deletion of empty environment")
+	emptyEnvName := fmt.Sprintf("test-empty-env-%d", time.Now().Unix())
+	emptyEnvNamespace := fmt.Sprintf("empty-env-ns-%d", time.Now().Unix())
+
+	// Create an empty environment in the unique group
+	t.Logf("Creating empty environment: %s in group: %s", emptyEnvName, uniqueGroupName)
+	createOpts := radcli.CreateOptions{
+		Namespace: emptyEnvNamespace,
+		Group:     uniqueGroupName,
+	}
+	err = cli.EnvCreate(ctx, emptyEnvName, createOpts)
+	require.NoError(t, err, "Failed to create empty environment")
+
+	// Verify empty environment exists
+	output, err = cli.EnvShow(ctx, emptyEnvName, showOpts)
+	require.NoError(t, err, "Failed to show empty environment")
+	require.Contains(t, output, emptyEnvName, "Empty environment should exist")
+
+	// Delete the empty environment
+	t.Logf("Deleting empty environment: %s", emptyEnvName)
+	err = cli.EnvDelete(ctx, emptyEnvName, deleteOpts)
+	require.NoError(t, err, "Failed to delete empty environment")
+
+	// Verify empty environment is deleted
+	output, err = cli.EnvShow(ctx, emptyEnvName, showOpts)
+	require.Error(t, err, "Empty environment should be deleted")
+	outputStr = strings.ToLower(output)
+	require.Contains(t, outputStr, "not found", "Expected 'not found' in output but got: %s", output)
+
+	t.Logf("Successfully tested deletion of empty environment %s", emptyEnvName)
+}

--- a/test/functional-portable/cli/noncloud/group_delete_test.go
+++ b/test/functional-portable/cli/noncloud/group_delete_test.go
@@ -51,7 +51,7 @@ func Test_GroupDelete(t *testing.T) {
 	t.Cleanup(func() {
 		// Try to delete the test group if it still exists
 		// Ignore errors as the group might have been successfully deleted
-		_ = cli.GroupDelete(context.Background(), uniqueGroupName, true)
+		_ = cli.GroupDelete(context.Background(), uniqueGroupName, radcli.DeleteOptions{Confirm: true})
 	})
 
 	// Create the unique resource group
@@ -82,7 +82,7 @@ func Test_GroupDelete(t *testing.T) {
 
 	// Delete the resource group with all its resources
 	t.Logf("Deleting resource group: %s", uniqueGroupName)
-	err = cli.GroupDelete(ctx, uniqueGroupName, true)
+	err = cli.GroupDelete(ctx, uniqueGroupName, radcli.DeleteOptions{Confirm: true})
 	require.NoError(t, err, "Failed to delete resource group with resources")
 
 	// Verify group is deleted

--- a/test/functional-portable/cli/noncloud/testdata/corerp-env-delete-test.bicep
+++ b/test/functional-portable/cli/noncloud/testdata/corerp-env-delete-test.bicep
@@ -1,0 +1,59 @@
+extension radius
+
+@description('Specifies the location for resources.')
+param location string = 'global'
+
+@description('Specifies the image to be deployed.')
+param magpieimage string
+
+resource env 'Applications.Core/environments@2023-10-01-preview' = {
+  name: 'env-delete-test-env'
+  location: location
+  properties: {
+    compute: {
+      kind: 'kubernetes'
+      resourceId: 'self'
+      namespace: 'default-env-delete-test-env'
+    }
+  }
+}
+
+resource app 'Applications.Core/applications@2023-10-01-preview' = {
+  name: 'env-delete-test-app'
+  location: location
+  properties: {
+    environment: env.id
+  }
+}
+
+resource containerA 'Applications.Core/containers@2023-10-01-preview' = {
+  name: 'env-delete-container-a'
+  location: location
+  properties: {
+    application: app.id
+    container: {
+      image: magpieimage
+      ports: {
+        web: {
+          containerPort: 3000
+        }
+      }
+    }
+  }
+}
+
+resource containerB 'Applications.Core/containers@2023-10-01-preview' = {
+  name: 'env-delete-container-b'
+  location: location
+  properties: {
+    application: app.id
+    container: {
+      image: magpieimage
+      ports: {
+        web: {
+          containerPort: 3000
+        }
+      }
+    }
+  }
+}

--- a/test/radcli/cli.go
+++ b/test/radcli/cli.go
@@ -151,6 +151,25 @@ type ShowOptions struct {
 	Application string // Application name (for resource show)
 }
 
+// DeleteOptions provides configuration for delete commands
+type DeleteOptions struct {
+	Group     string // Resource group name (--group)
+	Workspace string // Workspace name (--workspace)
+	Confirm   bool   // Skip confirmation prompt (--yes)
+	Output    string // Output format (--output)
+}
+
+// CreateOptions provides configuration for create commands
+type CreateOptions struct {
+	Group       string // Resource group name (--group)
+	Workspace   string // Workspace name (--workspace)
+	Environment string // Environment name (--environment)
+	Namespace   string // Kubernetes namespace (--namespace, for env create)
+	Context     string // Kubernetes context (--context, for workspace create)
+	Force       bool   // Overwrite if exists (--force, for workspace create)
+	Output      string // Output format (--output)
+}
+
 // ApplicationShow returns the output of running the "application show" command with flexible options.
 // The options parameter is optional and allows specifying group, workspace, and output format.
 func (cli *CLI) ApplicationShow(ctx context.Context, applicationName string, opts ...ShowOptions) (string, error) {
@@ -223,14 +242,65 @@ func (cli *CLI) ApplicationDelete(ctx context.Context, applicationName string) e
 	return err
 }
 
+// EnvCreate runs the command to create an environment with the given name.
+// The options parameter is optional and allows specifying namespace, group, workspace, and output format.
+func (cli *CLI) EnvCreate(ctx context.Context, environmentName string, opts ...CreateOptions) error {
+	args := []string{
+		"env",
+		"create",
+		environmentName,
+	}
+
+	// Apply options if provided
+	if len(opts) > 0 {
+		opt := opts[0]
+		if opt.Namespace != "" {
+			args = append(args, "--namespace", opt.Namespace)
+		}
+		if opt.Group != "" {
+			args = append(args, "--group", opt.Group)
+		}
+		if opt.Workspace != "" {
+			args = append(args, "--workspace", opt.Workspace)
+		}
+		if opt.Output != "" {
+			args = append(args, "--output", opt.Output)
+		}
+	}
+
+	_, err := cli.RunCommand(ctx, args)
+	return err
+}
+
 // EnvDelete runs the command to delete an environment with the given name and returns an error if the command fails.
-func (cli *CLI) EnvDelete(ctx context.Context, environmentName string) error {
+// The options parameter is optional and allows specifying group, workspace, and confirmation bypass.
+func (cli *CLI) EnvDelete(ctx context.Context, environmentName string, opts ...DeleteOptions) error {
 	args := []string{
 		"env",
 		"delete",
-		"--yes",
 		"-e", environmentName,
 	}
+
+	// Apply options if provided
+	if len(opts) > 0 {
+		opt := opts[0]
+		if opt.Confirm {
+			args = append(args, "--yes")
+		}
+		if opt.Group != "" {
+			args = append(args, "--group", opt.Group)
+		}
+		if opt.Workspace != "" {
+			args = append(args, "--workspace", opt.Workspace)
+		}
+		if opt.Output != "" {
+			args = append(args, "--output", opt.Output)
+		}
+	} else {
+		// Default to --yes for backward compatibility
+		args = append(args, "--yes")
+	}
+
 	_, err := cli.RunCommand(ctx, args)
 	return err
 }
@@ -288,28 +358,51 @@ func (cli *CLI) ResourceListInResourceGroup(ctx context.Context, groupName strin
 	return cli.RunCommand(ctx, args)
 }
 
-// GroupCreate creates a resource group with the given name and returns an error if the command fails.
-func (cli *CLI) GroupCreate(ctx context.Context, groupName string) error {
+// GroupCreate creates a resource group with the given name.
+// The options parameter is optional and allows specifying workspace and output format.
+func (cli *CLI) GroupCreate(ctx context.Context, groupName string, opts ...CreateOptions) error {
 	args := []string{
 		"group",
 		"create",
 		groupName,
 	}
+
+	// Apply options if provided
+	if len(opts) > 0 {
+		opt := opts[0]
+		if opt.Workspace != "" {
+			args = append(args, "--workspace", opt.Workspace)
+		}
+		if opt.Output != "" {
+			args = append(args, "--output", opt.Output)
+		}
+	}
+
 	_, err := cli.RunCommand(ctx, args)
 	return err
 }
 
 // GroupDelete deletes a resource group with the given name. If confirm is true, it will pass the --yes flag
 // to skip confirmation prompts. Returns an error if the command fails.
-func (cli *CLI) GroupDelete(ctx context.Context, groupName string, confirm bool) error {
+func (cli *CLI) GroupDelete(ctx context.Context, groupName string, opts ...DeleteOptions) error {
 	args := []string{
 		"group",
 		"delete",
 		groupName,
 	}
 
-	if confirm {
-		args = append(args, "--yes")
+	// Apply options if provided
+	if len(opts) > 0 {
+		opt := opts[0]
+		if opt.Confirm {
+			args = append(args, "--yes")
+		}
+		if opt.Workspace != "" {
+			args = append(args, "--workspace", opt.Workspace)
+		}
+		if opt.Output != "" {
+			args = append(args, "--output", opt.Output)
+		}
 	}
 
 	_, err := cli.RunCommand(ctx, args)


### PR DESCRIPTION
# Description

Enhance rad env delete with resource counting and safety prompts:

- Add resource counting before deletion
- Show different prompts for empty vs populated environments
- Display progress messages during deletion
- Remove redundant API call for listing applications
- Add functional tests for env delete command

## Type of change

- This pull request adds or changes features of Radius and has an approved issue (issue link required).

Fixes: #9809 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->