### PR TITLE
Disable Contour installation (Bitnami repo changes)

### DIFF
--- a/pkg/cli/cmd/install/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/install/kubernetes/kubernetes.go
@@ -101,10 +101,18 @@ rad install kubernetes --reinstall
 	cmd.Flags().StringArrayVar(&runner.Set, "set", []string{}, "Set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
 	cmd.Flags().StringArrayVar(&runner.SetFile, "set-file", []string{}, "Set values from files on the command line (can specify multiple or separate files with commas: key1=filename1,key2=filename2)")
 
-	cmd.Flags().BoolVar(&runner.ContourDisabled, "skip-contour-install", false, "Install Contour ingress controller (enabled by default)")
+	// Contour flags - hidden but retained for backward compatibility
+	cmd.Flags().BoolVar(&runner.ContourDisabled, "skip-contour-install", false, "Skip Contour ingress controller installation")
+	_ = cmd.Flags().MarkHidden("skip-contour-install")
+
 	cmd.Flags().StringVar(&runner.ContourChart, "contour-chart", "", "Specify a local file path to a helm chart to install Contour from")
-	cmd.Flags().StringArrayVar(&runner.ContourSet, "contour-set", []string{}, "Set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
-	cmd.Flags().StringArrayVar(&runner.ContourSetFile, "contour-set-file", []string{}, "Set values from files on the command line (can specify multiple or separate files with commas: key1=filename1,key2=filename2)")
+	_ = cmd.Flags().MarkHidden("contour-chart")
+
+	cmd.Flags().StringArrayVar(&runner.ContourSet, "contour-set", []string{}, "Set values on the command line")
+	_ = cmd.Flags().MarkHidden("contour-set")
+
+	cmd.Flags().StringArrayVar(&runner.ContourSetFile, "contour-set-file", []string{}, "Set values from files on the command line")
+	_ = cmd.Flags().MarkHidden("contour-set-file")
 
 	return cmd, runner
 }

--- a/pkg/cli/helm/cluster.go
+++ b/pkg/cli/helm/cluster.go
@@ -67,6 +67,7 @@ func NewDefaultClusterOptions() ClusterOptions {
 		},
 		Contour: ContourChartOptions{
 			ChartOptions: ChartOptions{
+				Disabled:     true,
 				ChartVersion: ContourChartDefaultVersion,
 				Namespace:    RadiusSystemNamespace,
 				ReleaseName:  contourReleaseName,
@@ -229,37 +230,28 @@ func (i *Impl) InstallRadius(ctx context.Context, clusterOptions ClusterOptions,
 		return fmt.Errorf("failed to apply Radius Helm chart, err: %w", err)
 	}
 
-	if clusterOptions.Contour.Disabled {
-		output.LogInfo("Contour is disabled, skipping installation")
-		return nil
+	// Contour installation is temporarily disabled due to Bitnami repository changes
+	// See: https://community.broadcom.com/tanzu/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon
+	if !clusterOptions.Contour.Disabled {
+		output.LogInfo(ContourDisabledReason)
+		output.LogInfo("For more information, see: https://community.broadcom.com/tanzu/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon")
 	}
-
-	// Install Contour
-	output.LogInfo("Installing Contour...")
-	contourHelmChart, contourHelmConf, err := prepareContourChart(helmAction, clusterOptions.Contour, kubeContext)
-	if err != nil {
-		return fmt.Errorf("failed to prepare Contour Helm chart, err: %w", err)
-	}
-
-	err = helmAction.ApplyHelmChart(kubeContext, contourHelmChart, contourHelmConf, clusterOptions.Contour.ChartOptions)
-	if err != nil {
-		return fmt.Errorf("failed to apply Contour Helm chart, err: %w", err)
-	}
+	output.LogInfo("Skipping Contour installation")
 
 	return nil
 }
 
-// UninstallRadius uninstalls Radius and its dependencies (Contour) from the cluster using the provided options.
+// UninstallRadius uninstalls Radius from the cluster using the provided options.
+// Note: Contour uninstallation is skipped due to Bitnami repository changes.
 func (i *Impl) UninstallRadius(ctx context.Context, clusterOptions ClusterOptions, kubeContext string) error {
 	// Uninstall Radius
 	if err := i.uninstallHelmRelease("Radius", radiusReleaseName, clusterOptions.Radius.Namespace, kubeContext); err != nil {
 		return err
 	}
 
-	// Uninstall Contour
-	if err := i.uninstallHelmRelease("Contour", contourReleaseName, clusterOptions.Radius.Namespace, kubeContext); err != nil {
-		return err
-	}
+	// Skip Contour uninstall due to Bitnami repository changes
+	// If Contour cleanup is needed, it should be done manually
+	output.LogInfo("Skipping Contour uninstall (" + ContourDisabledReason + ")")
 
 	return nil
 }
@@ -317,12 +309,10 @@ func (i *Impl) CheckRadiusInstall(kubeContext string) (InstallState, error) {
 		}
 	}
 
-	// Check if Contour is installed
-	contourInstalled, contourVersion, err := helmAction.QueryRelease(kubeContext, clusterOptions.Contour.ReleaseName, clusterOptions.Contour.Namespace)
-	if err != nil {
-		return InstallState{}, fmt.Errorf("failed to check Contour installation (release: %s, namespace: %s, context: %s): %w",
-			clusterOptions.Contour.ReleaseName, clusterOptions.Contour.Namespace, kubeContext, err)
-	}
+	// Contour installation is disabled due to Bitnami repository changes
+	// Skip checking Contour status to avoid potential repository access issues
+	contourInstalled := false
+	contourVersion := ""
 
 	state := InstallState{
 		RadiusInstalled:  radiusInstalled,
@@ -350,16 +340,8 @@ func (i *Impl) UpgradeRadius(ctx context.Context, clusterOptions ClusterOptions,
 	}
 	output.LogInfo("Radius upgrade complete")
 
-	output.LogInfo("Upgrading Contour...")
-	contourHelmChart, contourHelmConf, err := prepareContourChart(helmAction, clusterOptions.Contour, kubeContext)
-	if err != nil {
-		return fmt.Errorf("failed to prepare Contour Helm chart, err: %w", err)
-	}
-	_, err = i.Helm.RunHelmUpgrade(contourHelmConf, contourHelmChart, clusterOptions.Contour.ReleaseName, clusterOptions.Contour.Namespace, false)
-	if err != nil {
-		return fmt.Errorf("failed to upgrade Contour, err: %w", err)
-	}
-	output.LogInfo("Contour upgrade complete")
+	// Contour upgrade is temporarily disabled due to Bitnami repository changes
+	output.LogInfo("Skipping Contour upgrade (" + ContourDisabledReason + ")")
 
 	return nil
 }

--- a/pkg/cli/helm/cluster_test.go
+++ b/pkg/cli/helm/cluster_test.go
@@ -55,35 +55,20 @@ func Test_Helm_InstallRadius(t *testing.T) {
 			require.NoError(t, err)
 			return "Pulled", nil
 		}).Times(1)
-	mockHelmClient.EXPECT().
-		RunHelmPull(gomock.Any(), options.Contour.ReleaseName).
-		DoAndReturn(func(pullopts []helm.PullOpt, chartRef string) (string, error) {
-			pull := helm.NewPullWithOpts(pullopts...)
-			// Simulate downloading the chart to the temp dir
-			err := os.WriteFile(filepath.Join(pull.DestDir, "Chart.yaml"), []byte("name: contour\nversion: 0.1.0"), 0644)
-			require.NoError(t, err)
-			return "Pulled", nil
-		}).Times(1)
 
 	radiusRelease := &release.Release{
 		Name:  options.Radius.ReleaseName,
 		Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "0.1.0"}},
 	}
-	contourRelease := &release.Release{
-		Name:  options.Contour.ReleaseName,
-		Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "0.1.0"}},
-	}
 
 	// Mock Helm Get
 	mockHelmClient.EXPECT().RunHelmGet(gomock.AssignableToTypeOf(&helm.Configuration{}), "radius").Return(nil, driver.ErrReleaseNotFound).Times(1)
-	mockHelmClient.EXPECT().RunHelmGet(gomock.AssignableToTypeOf(&helm.Configuration{}), "contour").Return(nil, driver.ErrReleaseNotFound).Times(1)
 
 	// Mock Helm Install
 	mockHelmClient.EXPECT().RunHelmInstall(gomock.AssignableToTypeOf(&helm.Configuration{}), gomock.AssignableToTypeOf(&chart.Chart{}), "radius", "radius-system", true).Return(radiusRelease, nil).Times(1)
-	mockHelmClient.EXPECT().RunHelmInstall(gomock.AssignableToTypeOf(&helm.Configuration{}), gomock.AssignableToTypeOf(&chart.Chart{}), "contour", "radius-system", false).Return(contourRelease, nil).Times(1)
 
 	// Mock Helm Chart Load
-	mockHelmClient.EXPECT().LoadChart(gomock.Any()).Return(&chart.Chart{}, nil).Times(2)
+	mockHelmClient.EXPECT().LoadChart(gomock.Any()).Return(&chart.Chart{}, nil).Times(1)
 
 	err := impl.InstallRadius(ctx, options, kubeContext)
 	require.NoError(t, err)
@@ -101,19 +86,10 @@ func Test_Helm_UninstallRadius(t *testing.T) {
 	kubeContext := "test-context"
 	options := NewDefaultClusterOptions()
 
-	// Expect uninstall calls for Radius / Contour.
-	for _, c := range []struct {
-		releaseName string
-		ns          string
-	}{
-		{options.Radius.ReleaseName, options.Radius.Namespace},
-		{options.Contour.ReleaseName, options.Contour.Namespace},
-	} {
-		mockHelmClient.EXPECT().
-			RunHelmUninstall(gomock.AssignableToTypeOf(&helm.Configuration{}), c.releaseName, c.ns, true).
-			Return(&release.UninstallReleaseResponse{}, nil).
-			Times(1)
-	}
+	mockHelmClient.EXPECT().
+		RunHelmUninstall(gomock.AssignableToTypeOf(&helm.Configuration{}), options.Radius.ReleaseName, options.Radius.Namespace, true).
+		Return(&release.UninstallReleaseResponse{}, nil).
+		Times(1)
 
 	err := impl.UninstallRadius(ctx, options, kubeContext)
 	require.NoError(t, err)
@@ -131,23 +107,11 @@ func Test_Helm_UninstallRadius_ReleaseNotFound(t *testing.T) {
 	kubeContext := "test-context"
 	options := NewDefaultClusterOptions()
 
-	// Radius missing, other releases present.
+	// Radius missing, Contour uninstall is skipped
 	mockHelmClient.EXPECT().
 		RunHelmUninstall(gomock.AssignableToTypeOf(&helm.Configuration{}), options.Radius.ReleaseName, options.Radius.Namespace, true).
 		Return(&release.UninstallReleaseResponse{}, driver.ErrReleaseNotFound).
 		Times(1)
-
-	for _, c := range []struct {
-		releaseName string
-		ns          string
-	}{
-		{options.Contour.ReleaseName, options.Contour.Namespace},
-	} {
-		mockHelmClient.EXPECT().
-			RunHelmUninstall(gomock.AssignableToTypeOf(&helm.Configuration{}), c.releaseName, c.ns, true).
-			Return(&release.UninstallReleaseResponse{}, nil).
-			Times(1)
-	}
 
 	err := impl.UninstallRadius(ctx, options, kubeContext)
 	require.NoError(t, err) // ErrReleaseNotFound should be swallowed
@@ -184,9 +148,6 @@ func Test_Helm_CheckRadiusInstall(t *testing.T) {
 	mockHelmClient.EXPECT().
 		RunHelmHistory(gomock.AssignableToTypeOf(&helm.Configuration{}), options.Radius.ReleaseName).
 		Return([]*release.Release{radiusRelease}, nil).Times(1)
-	mockHelmClient.EXPECT().
-		RunHelmGet(gomock.AssignableToTypeOf(&helm.Configuration{}), options.Contour.ReleaseName).
-		Return(nil, driver.ErrReleaseNotFound).Times(1)
 
 	state, err := impl.CheckRadiusInstall(kubeContext)
 	require.NoError(t, err)
@@ -241,31 +202,17 @@ func Test_Helm_UpgradeRadius(t *testing.T) {
 			require.NoError(t, err)
 			return "Pulled", nil
 		}).Times(1)
-	mockHelmClient.EXPECT().
-		RunHelmPull(gomock.Any(), options.Contour.ReleaseName).
-		DoAndReturn(func(pullopts []helm.PullOpt, chartRef string) (string, error) {
-			pull := helm.NewPullWithOpts(pullopts...)
-			// Simulate downloading the chart to the temp dir
-			err := os.WriteFile(filepath.Join(pull.DestDir, "Chart.yaml"), []byte("name: contour\nversion: 0.1.0"), 0644)
-			require.NoError(t, err)
-			return "Pulled", nil
-		}).Times(1)
 
 	radiusRelease := &release.Release{
 		Name:  options.Radius.ReleaseName,
 		Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "0.1.0"}},
 	}
-	contourRelease := &release.Release{
-		Name:  options.Contour.ReleaseName,
-		Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "0.1.0"}},
-	}
 
 	// Mock Helm Upgrade
 	mockHelmClient.EXPECT().RunHelmUpgrade(gomock.AssignableToTypeOf(&helm.Configuration{}), gomock.AssignableToTypeOf(&chart.Chart{}), "radius", "radius-system", true).Return(radiusRelease, nil).Times(1)
-	mockHelmClient.EXPECT().RunHelmUpgrade(gomock.AssignableToTypeOf(&helm.Configuration{}), gomock.AssignableToTypeOf(&chart.Chart{}), "contour", "radius-system", false).Return(contourRelease, nil).Times(1)
 
 	// Mock Helm Chart Load
-	mockHelmClient.EXPECT().LoadChart(gomock.Any()).Return(&chart.Chart{}, nil).Times(2)
+	mockHelmClient.EXPECT().LoadChart(gomock.Any()).Return(&chart.Chart{}, nil).Times(1)
 
 	err := impl.UpgradeRadius(ctx, options, kubeContext)
 	require.NoError(t, err)
@@ -603,9 +550,6 @@ func Test_Helm_CheckRadiusInstall_UsesAppVersion(t *testing.T) {
 	mockHelmClient.EXPECT().
 		RunHelmHistory(gomock.AssignableToTypeOf(&helm.Configuration{}), options.Radius.ReleaseName).
 		Return([]*release.Release{radiusRelease}, nil).Times(1)
-	mockHelmClient.EXPECT().
-		RunHelmGet(gomock.AssignableToTypeOf(&helm.Configuration{}), options.Contour.ReleaseName).
-		Return(nil, driver.ErrReleaseNotFound).Times(1)
 
 	state, err := impl.CheckRadiusInstall(kubeContext)
 	require.NoError(t, err)

--- a/pkg/cli/helm/contour.go
+++ b/pkg/cli/helm/contour.go
@@ -14,6 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package helm contains Contour installation functionality.
+// NOTE: Contour installation is currently disabled in cluster.go due to Bitnami repository changes.
+// ref: https://community.broadcom.com/tanzu/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon
+// This code remains for future reactivation when the issue is resolved.
+
 package helm
 
 import (
@@ -28,6 +33,9 @@ const (
 	contourHelmRepo            = "https://charts.bitnami.com/bitnami"
 	contourReleaseName         = "contour"
 	ContourChartDefaultVersion = "11.1.1"
+
+	// ContourDisabledReason is the user-facing message explaining why Contour is disabled
+	ContourDisabledReason = "Contour installation temporarily disabled due to Bitnami repository changes."
 )
 
 type ContourChartOptions struct {
@@ -39,6 +47,8 @@ type ContourChartOptions struct {
 }
 
 // prepareContourChart prepares the Helm chart for Contour.
+//
+//lint:ignore U1000 Function temporarily unused due to Contour installation being disabled
 func prepareContourChart(helmAction HelmAction, options ContourChartOptions, kubeContext string) (*chart.Chart, *action.Configuration, error) {
 	var helmChart *chart.Chart
 

--- a/pkg/upgrade/preflight/installation_check.go
+++ b/pkg/upgrade/preflight/installation_check.go
@@ -64,13 +64,8 @@ func (r *RadiusInstallationCheck) Run(ctx context.Context) (bool, string, error)
 
 	message := fmt.Sprintf("Radius is installed (version: %s)", state.RadiusVersion)
 
-	// Also check if Contour is installed
-	if state.ContourInstalled {
-		message += fmt.Sprintf(", Contour is installed (version: %s)", state.ContourVersion)
-	} else {
-		// This is a warning, not an error, as upgrade might install Contour
-		message += ", Contour is not installed (will be installed during upgrade)"
-	}
+	// Note: Contour status checking is disabled due to Bitnami repository changes
+	message += " (" + helm.ContourDisabledReason + ")"
 
 	return true, message, nil
 }

--- a/pkg/upgrade/preflight/installation_check_test.go
+++ b/pkg/upgrade/preflight/installation_check_test.go
@@ -37,25 +37,14 @@ func TestRadiusInstallationCheck_Run(t *testing.T) {
 		expectError   bool
 	}{
 		{
-			name: "radius and contour installed",
+			name: "radius installed",
 			installState: helm.InstallState{
 				RadiusInstalled:  true,
 				RadiusVersion:    "v0.43.0",
-				ContourInstalled: true,
-				ContourVersion:   "v1.25.0",
+				ContourInstalled: false, // Set to false now due to hard disable
 			},
 			expectSuccess: true,
-			expectMessage: "Radius is installed (version: v0.43.0), Contour is installed (version: v1.25.0)",
-		},
-		{
-			name: "radius installed but contour missing",
-			installState: helm.InstallState{
-				RadiusInstalled:  true,
-				RadiusVersion:    "v0.43.0",
-				ContourInstalled: false,
-			},
-			expectSuccess: true,
-			expectMessage: "Radius is installed (version: v0.43.0), Contour is not installed (will be installed during upgrade)",
+			expectMessage: "Radius is installed (version: v0.43.0) (Contour installation temporarily disabled due to Bitnami repository changes.)",
 		},
 		{
 			name: "radius not installed",

--- a/test/functional-portable/corerp/noncloud/resources/gateway_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/gateway_test.go
@@ -47,6 +47,7 @@ type GatewayTestConfig struct {
 }
 
 func Test_GatewayDNS(t *testing.T) {
+	t.Skip("Skipping test temporarily due to Bitnami repo issues affecting Contour installation - issue #10484")
 	template := "testdata/corerp-resources-gateway-dns.bicep"
 	name := "corerp-resources-gateway-dns"
 	appNamespace := "default-corerp-resources-gateway-dns"
@@ -126,6 +127,7 @@ func Test_GatewayDNS(t *testing.T) {
 }
 
 func Test_Gateway_SSLPassthrough(t *testing.T) {
+	t.Skip("Skipping test temporarily due to Bitnami repo issues affecting Contour installation - issue #10484")
 	template := "testdata/corerp-resources-gateway-sslpassthrough.bicep"
 	name := "corerp-resources-gateway-sslpassthrough"
 	appNamespace := "default-corerp-resources-gateway-sslpassthrough"
@@ -192,6 +194,7 @@ func Test_Gateway_SSLPassthrough(t *testing.T) {
 }
 
 func Test_Gateway_Timeout(t *testing.T) {
+	t.Skip("Skipping test temporarily due to Bitnami repo issues affecting Contour installation - issue #10484")
 	template := "testdata/corerp-resources-gateway-timeout.bicep"
 	appName := "gateway-timeout-app"
 	appNamespace := "default-gateway-timeout-app"
@@ -309,6 +312,7 @@ func Test_Gateway_Timeout_Invalid_Duration(t *testing.T) {
 }
 
 func Test_Gateway_TLSTermination(t *testing.T) {
+	t.Skip("Skipping test temporarily due to Bitnami repo issues affecting Contour installation - issue #10484")
 	template := "testdata/corerp-resources-gateway-tlstermination.bicep"
 	name := "corerp-resources-gateway-tlstermination"
 	appNamespace := "default-corerp-resources-gateway-tlstermination"
@@ -381,6 +385,7 @@ func Test_Gateway_TLSTermination(t *testing.T) {
 }
 
 func Test_Gateway_Failure(t *testing.T) {
+	t.Skip("Skipping test temporarily due to Bitnami repo issues affecting Contour installation - issue #10484")
 	template := "testdata/corerp-resources-gateway-failure.bicep"
 	name := "corerp-resources-gateway-failure"
 	secret := "secret"

--- a/test/functional-portable/corerp/noncloud/resources/kubemetadata_gateway_test.go
+++ b/test/functional-portable/corerp/noncloud/resources/kubemetadata_gateway_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func Test_Gateway_KubernetesMetadata(t *testing.T) {
+	t.Skip("Skipping test temporarily due to Bitnami repo issues affecting Contour installation - issue #10484")
 	template := "testdata/corerp-resources-gateway-kubernetesmetadata.bicep"
 	name := "corerp-resources-gateway-kme"
 	appNamespace := "default-corerp-resources-gateway-kme"


### PR DESCRIPTION
# Description

Bitnami is deprecating public images that they are hosting. 
ref: https://community.broadcom.com/tanzu/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon

This affects Contour (dependency for Radius Gateways). It will not be available for install as of 29 Sept 2025.
This pull request disables automatic installation, upgrade, uninstallation, and status checks of the Contour ingress controller in the Radius CLI  while we figure out alternatives. The code and tests related to Contour have been updated to skip these operations and display user-facing messages explaining the temporary disablement. The Contour-related code is retained for future reactivation when repository issues are resolved.


## Type of change
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->