### PR TITLE
Remove checkbox from issue templates that ask for support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -62,10 +62,3 @@ body:
         Tip: You can attach images or files by clicking this area to highlight it and then dragging files in.
     validations:
       required: false
-  - type: checkboxes
-    attributes:
-      label: Would you like to support us?
-      description: Would you like to support us in fixing this bug?
-      options:
-        - label: Yes, I would like to support you
-          required: false

--- a/.github/ISSUE_TEMPLATE/engineering.yaml
+++ b/.github/ISSUE_TEMPLATE/engineering.yaml
@@ -62,10 +62,3 @@ body:
         Tip: You can attach images or files by clicking this area to highlight it and then dragging files in.
     validations:
       required: false
-  - type: checkboxes
-    attributes:
-      label: Would you like to support us?
-      description: Would you like to support us in improving Radius engineering processes and/or pipelines?
-      options:
-        - label: Yes, I would like to support you
-          required: false

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -25,10 +25,3 @@ body:
         Tip: You can attach images or files by clicking this area to highlight it and then dragging files in.
     validations:
       required: false
-  - type: checkboxes
-    attributes:
-      label: Would you like to support us?
-      description: Would you like to support us in implementing the feature?
-      options:
-        - label: Yes, I would like to support you
-          required: false


### PR DESCRIPTION
# Description

This pull request makes a small update to our GitHub issue templates by removing the "Would you like to support us?" checkbox section from the bug, feature, and engineering issue forms. The checkbox is confusing and provides us with no value.

**Issue template simplification:**

* Removed the "Would you like to support us?" checkbox from `.github/ISSUE_TEMPLATE/bug.yaml`.
* Removed the "Would you like to support us?" checkbox from `.github/ISSUE_TEMPLATE/feature.yaml`.
* Removed the "Would you like to support us?" checkbox from `.github/ISSUE_TEMPLATE/engineering.yaml`.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: N/A

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->