### PR TITLE
Added helm chart updates for rootca support

### DIFF
--- a/deploy/Chart/templates/controller/deployment.yaml
+++ b/deploy/Chart/templates/controller/deployment.yaml
@@ -40,6 +40,22 @@ spec:
           mountPath: /usr/local/bin
         - name: bicepconfig
           mountPath: /bicepconfig
+      {{- if .Values.global.appendRootCA.cert }}
+      - name: append-root-ca
+        image: "{{ .Values.rp.image }}:{{ .Values.rp.tag | default $appversion }}"
+        command:
+        - sh
+        - -c
+        - |
+          mkdir -p /etc/radius-ssl/certs
+          cp /etc/ssl/certs/* /etc/radius-ssl/certs/
+          cat >> /etc/radius-ssl/certs/ca-certificates.crt <<'CERTEOF'
+        {{ .Values.global.appendRootCA.cert | nindent 10 }}
+          CERTEOF
+        volumeMounts:
+        - name: ssl-certs
+          mountPath: /etc/radius-ssl/certs
+      {{- end }}
       containers:
       - name: controller
         image: "{{ include "radius.image" (dict "image" .Values.controller.image "tag" (.Values.controller.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"
@@ -92,6 +108,11 @@ spec:
           mountPath: {{ .Values.global.rootCA.mountPath }}
           readOnly: true
         {{- end }}
+        {{- if .Values.global.appendRootCA.cert }}
+        - name: ssl-certs
+          mountPath: /etc/ssl/certs
+          readOnly: true
+        {{- end }}
       volumes:
         - name: bicep
           emptyDir: {}
@@ -107,4 +128,8 @@ spec:
         - name: {{ .Values.global.rootCA.volumeName }}
           secret:
             secretName: {{ .Values.global.rootCA.secretName }}
+        {{- end }}
+        {{- if .Values.global.appendRootCA.cert }}
+        - name: ssl-certs
+          emptyDir: {}
         {{- end }}

--- a/deploy/Chart/templates/de/deployment.yaml
+++ b/deploy/Chart/templates/de/deployment.yaml
@@ -30,6 +30,23 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: bicep-de
+      {{- if .Values.global.appendRootCA.cert }}
+      initContainers:
+      - name: append-root-ca
+        image: "{{ .Values.rp.image }}:{{ .Values.rp.tag | default $appversion }}"
+        command:
+        - sh
+        - -c
+        - |
+          mkdir -p /etc/radius-ssl/certs
+          cp /etc/ssl/certs/* /etc/radius-ssl/certs/
+          cat >> /etc/radius-ssl/certs/ca-certificates.crt <<'CERTEOF'
+        {{ .Values.global.appendRootCA.cert | nindent 10 }}
+          CERTEOF
+        volumeMounts:
+        - name: ssl-certs
+          mountPath: /etc/radius-ssl/certs
+      {{- end }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 6 }}
@@ -43,6 +60,10 @@ spec:
           secret:
             secretName: {{ .Values.global.rootCA.secretName }}
         {{- end }}
+        {{- if .Values.global.appendRootCA.cert }}
+        - name: ssl-certs
+          emptyDir: {}
+        {{- end }}
       containers:
       - name: de
         image: {{ include "radius.image" (dict "image" .Values.de.image "tag" (.Values.de.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}
@@ -55,6 +76,11 @@ spec:
         {{- if .Values.global.rootCA.cert }}
         - name: {{ .Values.global.rootCA.volumeName }}
           mountPath: {{ .Values.global.rootCA.mountPath }}
+          readOnly: true
+        {{- end }}
+        {{- if .Values.global.appendRootCA.cert }}
+        - name: ssl-certs
+          mountPath: /etc/ssl/certs
           readOnly: true
         {{- end }}
         env:

--- a/deploy/Chart/templates/dynamic-rp/deployment.yaml
+++ b/deploy/Chart/templates/dynamic-rp/deployment.yaml
@@ -38,6 +38,22 @@ spec:
       # Init container to pre-download Terraform binary to a shared volume
       # This avoids downloading Terraform at runtime and improves recipe execution performance
       initContainers:
+      {{- if .Values.global.appendRootCA.cert }}
+      - name: append-root-ca
+        image: "{{ .Values.rp.image }}:{{ .Values.rp.tag | default $appversion }}"
+        command:
+        - sh
+        - -c
+        - |
+          mkdir -p /etc/radius-ssl/certs
+          cp /etc/ssl/certs/* /etc/radius-ssl/certs/
+          cat >> /etc/radius-ssl/certs/ca-certificates.crt <<'CERTEOF'
+        {{ .Values.global.appendRootCA.cert | nindent 10 }}
+          CERTEOF
+        volumeMounts:
+        - name: ssl-certs
+          mountPath: /etc/radius-ssl/certs
+      {{- end }}
       - name: terraform-init
         image: "alpine:latest"
         command:
@@ -164,6 +180,11 @@ spec:
           mountPath: {{ .Values.global.rootCA.mountPath }}
           readOnly: true
         {{- end }}
+        {{- if .Values.global.appendRootCA.cert }}
+        - name: ssl-certs
+          mountPath: /etc/ssl/certs
+          readOnly: true
+        {{- end }}
         {{- if .Values.dynamicrp.resources }}
         resources:{{ toYaml .Values.rp.resources | nindent 10 }}
         {{- end }}
@@ -186,4 +207,8 @@ spec:
         - name: {{ .Values.global.rootCA.volumeName }}
           secret:
             secretName: {{ .Values.global.rootCA.secretName }}
+        {{- end }}
+        {{- if .Values.global.appendRootCA.cert }}
+        - name: ssl-certs
+          emptyDir: {}
         {{- end }}

--- a/deploy/Chart/templates/rp/deployment.yaml
+++ b/deploy/Chart/templates/rp/deployment.yaml
@@ -38,6 +38,22 @@ spec:
       # Init container to pre-download Terraform binary to a shared volume
       # This avoids downloading Terraform at runtime and improves recipe execution performance
       initContainers:
+      {{- if .Values.global.appendRootCA.cert }}
+      - name: append-root-ca
+        image: "{{ .Values.rp.image }}:{{ .Values.rp.tag | default $appversion }}"
+        command:
+        - sh
+        - -c
+        - |
+          mkdir -p /etc/radius-ssl/certs
+          cp /etc/ssl/certs/* /etc/radius-ssl/certs/
+          cat >> /etc/radius-ssl/certs/ca-certificates.crt <<'CERTEOF'
+        {{ .Values.global.appendRootCA.cert | nindent 10 }}
+          CERTEOF
+        volumeMounts:
+        - name: ssl-certs
+          mountPath: /etc/radius-ssl/certs
+      {{- end }}
       - name: terraform-init
         image: "alpine:latest"
         command:
@@ -171,6 +187,11 @@ spec:
           mountPath: {{ .Values.global.rootCA.mountPath }}
           readOnly: true
         {{- end }}
+        {{- if .Values.global.appendRootCA.cert }}
+        - name: ssl-certs
+          mountPath: /etc/ssl/certs
+          readOnly: true
+        {{- end }}
         {{- if .Values.rp.resources }}
         resources:{{ toYaml .Values.rp.resources | nindent 10 }}
         {{- end }}
@@ -193,4 +214,8 @@ spec:
         - name: {{ .Values.global.rootCA.volumeName }}
           secret:
             secretName: {{ .Values.global.rootCA.secretName }}
+        {{- end }}
+        {{- if .Values.global.appendRootCA.cert }}
+        - name: ssl-certs
+          emptyDir: {}
         {{- end }}

--- a/deploy/Chart/templates/ucp/deployment.yaml
+++ b/deploy/Chart/templates/ucp/deployment.yaml
@@ -30,6 +30,23 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: ucp
+      {{- if .Values.global.appendRootCA.cert }}
+      initContainers:
+      - name: append-root-ca
+        image: "{{ .Values.rp.image }}:{{ .Values.rp.tag | default $appversion }}"
+        command:
+        - sh
+        - -c
+        - |
+          mkdir -p /etc/radius-ssl/certs
+          cp /etc/ssl/certs/* /etc/radius-ssl/certs/
+          cat >> /etc/radius-ssl/certs/ca-certificates.crt <<'CERTEOF'
+        {{ .Values.global.appendRootCA.cert | nindent 10 }}
+          CERTEOF
+        volumeMounts:
+        - name: ssl-certs
+          mountPath: /etc/radius-ssl/certs
+      {{- end }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 6 }}
@@ -77,6 +94,11 @@ spec:
           mountPath: {{ .Values.global.rootCA.mountPath }}
           readOnly: true
         {{- end }}
+        {{- if .Values.global.appendRootCA.cert }}
+        - name: ssl-certs
+          mountPath: /etc/ssl/certs
+          readOnly: true
+        {{- end }}
       volumes:
         - name: config-volume
           configMap:
@@ -99,4 +121,8 @@ spec:
         - name: {{ .Values.global.rootCA.volumeName }}
           secret:
             secretName: {{ .Values.global.rootCA.secretName }}
+        {{- end }}
+        {{- if .Values.global.appendRootCA.cert }}
+        - name: ssl-certs
+          emptyDir: {}
         {{- end }}

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -26,6 +26,14 @@ global:
     # SSL_CERT_DIR is used to override the default root CA location.
     # Dotnet runtime and Go use this environment variable to load the root CA.
     sslCertDirEnvVar: "SSL_CERT_DIR"
+  
+  appendRootCA:
+    # Auto-enabled when global.rootCA.cert is provided via --set-file
+    # Init image to normalize and prepare certs directory
+    initImage: "alpine:latest"
+    # Working and target mount paths
+    workDir: "/work/certs"
+    targetMountPath: "/etc/ssl/certs"
 
   prometheus:
     enabled: true


### PR DESCRIPTION
# Description

- added optional init container that appends the provided CA bundle into the container trust store when .Values.global.appendRootCA.cert is set
- wire ssl-certs emptyDir volume to main container when CA injection is enabled


## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->