### PR TITLE
Set recreate on automatic pr comment

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -247,14 +247,16 @@ jobs:
         continue-on-error: true
         with:
           GITHUB_TOKEN: ${{ steps.get_installation_token.outputs.token }}
-          header: teststatus-${{ github.run_id }}
+          header: teststatus
           number: ${{ env.PR_NUMBER }}
-          hide: true
-          hide_classify: "OUTDATED"
+          recreate: true
           message: |
             ## Radius functional test overview
 
             :mag: **[Go to test action run](${{ env.ACTION_LINK }})**
+
+            <details>
+            <summary> Click here to see the test run details</summary>
 
             | Name | Value |
             |------|-------|
@@ -262,10 +264,7 @@ jobs:
             |**Commit ref** | ${{ steps.gen-id.outputs.CHECKOUT_REF }} |
             |**Unique ID** | ${{ steps.gen-id.outputs.UNIQUE_ID }} |
             |**Image tag** | ${{ steps.gen-id.outputs.REL_VERSION }} |
-
-            <details>
-            <summary> Click here to see the list of tools in the current test run</summary>
-
+            
             * gotestsum ${{ env.GOTESTSUM_VER }}
             * KinD: ${{ env.KIND_VER }}
             * Dapr: ${{ env.DAPR_VER }}


### PR DESCRIPTION
# Description

This pull request modifies the automatic PR messages created from the functional test workflows to remove the previous message in a PR when a new functional test workflow is triggered. It also moves the summary table into the `<summary>` block, which reduces the vertical space used by the comment block.

The result of this change is that PRs will no longer have multiple test summary comments. Each update to the PR will remove the previous summary comment block when the new comment block is created.

The new comment box will look like this below, moving the table into the collapsible summary element:

> ## Radius functional test overview
> 
> :mag: **[Go to test action run](https://github.com/radius-project/radius/actions/runs/18245026031)**
> 
> <details>
> <summary> Click here to see the list of tools in the current test run</summary>
> 
> | Name | Value |
> |------|-------|
> |**Repository** | brooke-hamilton/radius |
> |**Commit ref** | baa333228b92b318e0f6e84c985550f6d0e456de |
> |**Unique ID** | funca43fe5f55a |
> |**Image tag** | pr-funca43fe5f55a |
> 
> * gotestsum 1.12.0
> * KinD: v0.29.0
> * Dapr: 
> * Azure KeyVault CSI driver: 1.4.2
> * Azure Workload identity webhook: 1.3.0
> * Bicep recipe location `ghcr.io/radius-project/dev/test/testrecipes/test-bicep-recipes/<name>:pr-funca43fe5f55a`
> * Terraform recipe location `http://tf-module-server.radius-test-tf-module-server.svc.cluster.local/<name>.zip` (in cluster)
> * applications-rp test image location: `ghcr.io/radius-project/dev/applications-rp:pr-funca43fe5f55a`
> * dynamic-rp test image location: `ghcr.io/radius-project/dev/dynamic-rp:pr-funca43fe5f55a`
> * controller test image location: `ghcr.io/radius-project/dev/controller:pr-funca43fe5f55a`
> * ucp test image location: `ghcr.io/radius-project/dev/ucpd:pr-funca43fe5f55a`
> * deployment-engine test image location: `ghcr.io/radius-project/deployment-engine:latest`
> 
> </details>
> 
> ## Test Status
> :hourglass: Building Radius and pushing container images for functional tests...
> :white_check_mark: Container images build succeeded
> :hourglass: Publishing Bicep Recipes for functional tests...
> :white_check_mark: Recipe publishing succeeded
> :hourglass: Starting ucp-cloud functional tests...
> :hourglass: Starting corerp-cloud functional tests...
> :white_check_mark: ucp-cloud functional tests succeeded
> :white_check_mark: corerp-cloud functional tests succeeded
> <!-- Sticky Pull Request Commentteststatus-18245026031 -->

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: N/A

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->