### PR TITLE
New GH Action to pull deployment engine image to GHCR

### DIFF
--- a/.github/actions/copy-deployment-engine-image/action.yml
+++ b/.github/actions/copy-deployment-engine-image/action.yml
@@ -1,0 +1,60 @@
+name: Copy Deployment Engine image
+description: Copy a deployment engine image from Azure Container Registry to GitHub Container Registry.
+inputs:
+  tag:
+    description: Tag to apply to the destination image and pull from the source image.
+    required: true
+  acr-name:
+    description: Name of the Azure Container Registry that hosts the deployment engine image.
+    required: false
+    default: radiusdeploymentengine
+  source-repository:
+    description: Repository name for the image inside the ACR.
+    required: false
+    default: deployment-engine
+  destination-registry:
+    description: Hostname for the destination registry (defaults to GHCR).
+    required: false
+    default: ghcr.io
+  destination-repository:
+    description: Repository path in the destination registry.
+    required: false
+    default: radius-project/deployment-engine
+  ghcr-username:
+    description: Username to authenticate against the destination registry.
+    required: false
+    default: rad-ci-bot
+  ghcr-password:
+    description: Password or PAT to authenticate against the destination registry.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Azure Container Registry
+      shell: bash
+      run: |
+        az acr login --name "${{ inputs.acr-name }}"
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.destination-registry }}
+        username: ${{ inputs.ghcr-username }}
+        password: ${{ inputs.ghcr-password }}
+
+    - name: Copy Deployment Engine image from ACR to GHCR
+      shell: bash
+      env:
+        TAG: ${{ inputs.tag }}
+        ACR_NAME: ${{ inputs.acr-name }}
+        SRC_REPO: ${{ inputs.source-repository }}
+        DEST_REGISTRY: ${{ inputs.destination-registry }}
+        DEST_REPO: ${{ inputs.destination-repository }}
+      run: |
+        docker buildx imagetools create \
+          --tag "${DEST_REGISTRY}/${DEST_REPO}:${TAG}" \
+          "${ACR_NAME}.azurecr.io/${SRC_REPO}:${TAG}"

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -205,7 +205,14 @@ jobs:
                 `CHECKOUT_REF=refs/heads/main`
               );
             }
-
+      
+      - name: Copy Deployment Engine image to GHCR
+        if: github.event_name == 'repository_dispatch'
+        uses: ./.github/actions/copy-deployment-engine-image
+        with:
+          tag: ${{ env.DE_TAG }}
+          ghcr-password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+      
       - name: Check out code
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -118,6 +118,13 @@ jobs:
               );
             }
 
+      - name: Copy Deployment Engine image to GHCR
+        if: github.event_name == 'repository_dispatch'
+        uses: ./.github/actions/copy-deployment-engine-image
+        with:
+          tag: ${{ env.DE_TAG }}
+          ghcr-password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+      
       - name: Generate ID for release
         id: gen-id
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -239,24 +239,9 @@ jobs:
           client-id: ${{ secrets.DE_CONTAINER_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.DE_CONTAINER_AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.DE_CONTAINER_AZURE_SUBSCRIPTION_ID }}
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Log in to ACR
+      - name: Copy Deployment Engine image to GHCR
         if: success() && steps.release-branch-exists.outputs.result == 'false'
-        shell: bash
-        run: |
-          az acr login --name radiusdeploymentengine
-      - name: Login to GitHub Container Registry
-        if: success() && steps.release-branch-exists.outputs.result == 'false'
-        uses: docker/login-action@v3
+        uses: ./.github/actions/copy-deployment-engine-image
         with:
-          registry: ghcr.io
-          username: rad-ci-bot
-          password: ${{ secrets.GH_RAD_CI_BOT_PAT }}
-      - name: Copy Deployment Engine images from ACR to GHCR
-        if: success() && steps.release-branch-exists.outputs.result == 'false'
-        run: |
-          TAG=${{ steps.get-version.outputs.release-channel }}
-          docker buildx imagetools create \
-            --tag ghcr.io/radius-project/deployment-engine:${TAG} \
-            radiusdeploymentengine.azurecr.io/deployment-engine:${TAG}
+          tag: ${{ steps.get-version.outputs.release-channel }}
+          ghcr-password: ${{ secrets.GH_RAD_CI_BOT_PAT }}


### PR DESCRIPTION
# Description

This pull request introduces a new reusable GitHub Action for copying the Deployment Engine container image from Azure Container Registry (ACR) to GitHub Container Registry (GHCR), and refactors existing workflows to use this action. 

The reason for creating this action is to have the functional test workflows pull the right deployment engine container image from the ACR instance that is used by the deployment engine repo. When a new PR is created for DE, the build workflow publishes images to ACR because permissions do not allow publishing to the Radius GCHR. Therefore, when the Radius functional tests are triggered, we want to pull the right container image from ACR and push it to GHCR.

**Reusable Action Implementation:**

* Added `.github/actions/copy-deployment-engine-image/action.yml` to encapsulate the logic for copying the Deployment Engine image between registries, including authentication and image transfer steps.

**Workflow Refactoring:**

* Updated `.github/workflows/release.yaml` to replace inline image copy steps with a call to the new reusable action, simplifying the workflow and ensuring consistent behavior.
* Updated `.github/workflows/functional-test-cloud.yaml` and `.github/workflows/functional-test-noncloud.yaml` to use the new reusable action for copying the Deployment Engine image when triggered by a `repository_dispatch` event. [[1]](diffhunk://#diff-a5e3050f5c1a812d9565ba0c87fb5028ad0a004c2d966e71d67208b4b33042c4R209-R215) [[2]](diffhunk://#diff-b7af1cc5c43a85f1f7d316c6e244726bb14b0b34b59512f60deea7abd498b90cR121-R127)

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: N/A

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->