### PR TITLE
Update functional tests and long-running tests to use ubuntu-latest runner

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -465,7 +465,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest-m]
+        os: [oracle-vm-4cpu-16gb-x86-64]
         name: [corerp-cloud, ucp-cloud]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -465,7 +465,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [oracle-vm-4cpu-16gb-x86-64]
+        os: [ubuntu-latest]
         name: [corerp-cloud, ucp-cloud]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -334,7 +334,7 @@ jobs:
   tests:
     name: Run functional tests
     needs: build
-    runs-on: ubuntu-latest-m
+    runs-on: oracle-vm-4cpu-16gb-x86-64
     if: github.repository == 'radius-project/radius'
     env:
       SKIP_BUILD: ${{ needs.build.outputs.SKIP_BUILD }}

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -334,7 +334,7 @@ jobs:
   tests:
     name: Run functional tests
     needs: build
-    runs-on: oracle-vm-4cpu-16gb-x86-64
+    runs-on: ubuntu-latest
     if: github.repository == 'radius-project/radius'
     env:
       SKIP_BUILD: ${{ needs.build.outputs.SKIP_BUILD }}


### PR DESCRIPTION
# Description

This pull request updates the operating system configuration for CI workflows in the `.github/workflows/functional-test-cloud.yaml` and `.github/workflows/long-running-azure.yaml` files. The main change is switching the runner from a custom Oracle VM to the standard `ubuntu-latest` environment, which should fix build breaks due to Azure conditional access policies.

This change is an overall downgrade for the VM sizes used in the build runners, so we need to monitor for failures to determine if we have to adjust the tests to fit within the smaller CPU/RAM configuration.

CI/CD workflow improvements:

* Updated the `os` matrix in `functional-test-cloud.yaml` to use `ubuntu-latest` instead of `oracle-vm-4cpu-16gb-x86-64`.
* Changed the runner in `long-running-azure.yaml` from `oracle-vm-4cpu-16gb-x86-64` to `ubuntu-latest`.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: N/A

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->