### PR TITLE
Add submodule get on workflows to fix build failures

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -173,6 +173,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v5
+        with:
+          submodules: recursive
       - name: Parse release version and set environment variables
         run: python ./.github/scripts/get_release_version.py
       - name: Set up Go
@@ -267,6 +269,8 @@ jobs:
     steps: 
       - name: Check out code
         uses: actions/checkout@v5
+        with:
+          submodules: recursive
       - name: Parse release version and set environment variables
         run: python ./.github/scripts/get_release_version.py
       - name: Set up Go

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -208,7 +208,8 @@ jobs:
               );
             }
 
-      - uses: actions/checkout@v5
+      - name: Check out code
+        uses: actions/checkout@v5
         with:
           repository: ${{ env.CHECKOUT_REPO }}
           ref: ${{ env.CHECKOUT_REF }}

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -118,7 +118,8 @@ jobs:
               );
             }
 
-      - uses: actions/checkout@v5
+      - name: Check out code
+        uses: actions/checkout@v5
         with:
           repository: ${{ env.CHECKOUT_REPO }}
           ref: ${{ env.CHECKOUT_REF }}
@@ -197,6 +198,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@v5
+        with:
+          submodules: recursive
 
       - name: Checkout samples repo
         uses: actions/checkout@v5

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -203,6 +203,7 @@ jobs:
         with:
           repository: ${{ env.CHECKOUT_REPO }}
           ref: ${{ env.CHECKOUT_REF }}
+          submodules: recursive
       - name: Set up Go
         if: steps.skip-build.outputs.SKIP_BUILD != 'true'
         uses: actions/setup-go@v6
@@ -364,6 +365,7 @@ jobs:
         with:
           repository: ${{ env.CHECKOUT_REPO }}
           ref: ${{ env.CHECKOUT_REF }}
+          submodules: recursive
       - name: Checkout samples repo
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -31,6 +31,7 @@ jobs:
         with:
           repository: radius-project/radius
           path: radius
+          submodules: recursive
       - name: Parse release version and set environment variables
         run: python radius/.github/scripts/get_release_version.py
       - name: Generate docs release branch name


### PR DESCRIPTION
# Description

This pull request updates  GitHub Actions workflow files to ensure that submodules are checked out recursively during the build and test processes. 

**Submodule checkout improvements:**

* Added `submodules: recursive` to all relevant `actions/checkout@v5` steps in `.github/workflows/build.yaml`, `.github/workflows/functional-test-noncloud.yaml`, `.github/workflows/long-running-azure.yaml`, and `.github/workflows/publish-docs.yaml` to ensure submodules are always included during code checkout. [[1]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R176-R177) [[2]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R272-R273) [[3]](diffhunk://#diff-b7af1cc5c43a85f1f7d316c6e244726bb14b0b34b59512f60deea7abd498b90cR201-R202) [[4]](diffhunk://#diff-85cd86e7ae6da973e4808fe57f4fea7892ab78a499ba5aec72c0b3751a2cc226R206) [[5]](diffhunk://#diff-85cd86e7ae6da973e4808fe57f4fea7892ab78a499ba5aec72c0b3751a2cc226R368) [[6]](diffhunk://#diff-69250281a3f8b6ed9c93d9d9d8d92aa49e2105c37fe83fd22168ec5ab85250bdR34)

**Step naming consistency:**

* Updated unnamed `actions/checkout@v5` steps to use the name `Check out code` in `.github/workflows/functional-test-cloud.yaml` and `.github/workflows/functional-test-noncloud.yaml` for better clarity and consistency. [[1]](diffhunk://#diff-a5e3050f5c1a812d9565ba0c87fb5028ad0a004c2d966e71d67208b4b33042c4L211-R212) [[2]](diffhunk://#diff-b7af1cc5c43a85f1f7d316c6e244726bb14b0b34b59512f60deea7abd498b90cL121-R122)

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: 
- #10719
- #10720

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->