### PR TITLE
Removing npx install check from publish bicep extesion command

### DIFF
--- a/pkg/cli/cmd/bicep/publishextension/publish.go
+++ b/pkg/cli/cmd/bicep/publishextension/publish.go
@@ -106,17 +106,10 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 
 // Run runs the `rad bicep publish-extension` command.
 func (r *Runner) Run(ctx context.Context) error {
-	// This command ties together two separate shell commands:
-	// 1. We use NPX to run https://github.com/radius-project/bicep-tools/tree/main/packages/manifest-to-bicep-extension
-	//       - This generates a Bicep extension "index"
-	// 2. We use `bicep publish-extension` to publish the extension "index" to the "target"
-	//
-	// 3. We can clean up the "index" directory after publishing.
-
-	_, err := exec.LookPath("npx")
-	if errors.Is(err, exec.ErrNotFound) {
-		return clierrors.Message("The command 'npx' was not found on the PATH. Please install Node.js 16+ to use this command.")
-	}
+	// This command performs three steps:
+    // 1. Run the generator (bicep-tools/generator) to build the Bicep extension "index"
+    // 2. We use `bicep publish-extension` to publish the extension "index" to the "target"
+    // 3. We can clean up the "index" directory after publishing.
 
 	temp, err := os.MkdirTemp("", "bicep-extension-*")
 	if err != nil {

--- a/pkg/cli/cmd/bicep/publishextension/publish.go
+++ b/pkg/cli/cmd/bicep/publishextension/publish.go
@@ -18,7 +18,6 @@ package publishextension
 
 import (
 	"context"
-	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -107,9 +106,9 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 // Run runs the `rad bicep publish-extension` command.
 func (r *Runner) Run(ctx context.Context) error {
 	// This command performs three steps:
-    // 1. Run the generator (bicep-tools/generator) to build the Bicep extension "index"
-    // 2. We use `bicep publish-extension` to publish the extension "index" to the "target"
-    // 3. We can clean up the "index" directory after publishing.
+	// 1. Run the generator (bicep-tools/generator) to build the Bicep extension "index"
+	// 2. We use `bicep publish-extension` to publish the extension "index" to the "target"
+	// 3. We can clean up the "index" directory after publishing.
 
 	temp, err := os.MkdirTemp("", "bicep-extension-*")
 	if err != nil {


### PR DESCRIPTION
# Description

Updating the publish bicep-extension command to remove the npx installation check.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->