### PR TITLE
Workflow schedule update for functional tests and long running tests

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -31,10 +31,8 @@ on:
         required: true
         default: "main"
   schedule:
-    # Run every 4 hours on weekdays.
-    - cron: "30 0,4,8,12,16,20 * * 1-5"
-    # Run every 12 hours on weekends.
-    - cron: "30 0,12 * * 0,6"
+    # Run three times a day at 6 AM PDT (1 PM UTC), 12 PM PDT (7 PM UTC), and 6 PM PDT (1 AM UTC next day)
+    - cron: "0 1,13,19 * * *"
   # Dispatch on external events
   repository_dispatch:
     types: [de-functional-test]

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -31,10 +31,8 @@ on:
         required: true
         default: "main"
   schedule:
-    # Run every 4 hours on weekdays.
-    - cron: "30 0,4,8,12,16,20 * * 1-5"
-    # Run every 12 hours on weekends.
-    - cron: "30 0,12 * * 0,6"
+    # Run three times a day at 6 AM PDT (1 PM UTC), 12 PM PDT (7 PM UTC), and 6 PM PDT (1 AM UTC next day)
+    - cron: "0 1,13,19 * * *"
   # Dispatch on external events
   repository_dispatch:
     types: [de-functional-test]

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -56,8 +56,8 @@ on:
           - 'true'
           - 'false'
   schedule:
-    # Run every 4 hours
-    - cron: "0 */4 * * *"
+    # Run once per day at 3:00 AM PDT (10:00 AM UTC)
+    - cron: "0 10 * * *"
 
 env:
 


### PR DESCRIPTION
# Description

This pull request updates the scheduled times for several GitHub Actions workflows to reduce the number of times per day the workflows run. Functional tests will run three times per day, and long-running tests will run once per day.

**Workflow schedule updates:**

* Functional test workflows (`.github/workflows/functional-test-cloud.yaml`, `.github/workflows/functional-test-noncloud.yaml`): Changed from running every 4 hours on weekdays and every 12 hours on weekends to running three times daily at 1 AM, 1 PM, and 7 PM UTC. [[1]](diffhunk://#diff-a5e3050f5c1a812d9565ba0c87fb5028ad0a004c2d966e71d67208b4b33042c4L34-R35) [[2]](diffhunk://#diff-b7af1cc5c43a85f1f7d316c6e244726bb14b0b34b59512f60deea7abd498b90cL34-R35)

* Long-running Azure workflow (`.github/workflows/long-running-azure.yaml`): Changed from running every 4 hours to running once per day at 10:00 AM UTC.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: N/A

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->