### PR TITLE
Add entries to help register new applications type

### DIFF
--- a/deploy/manifest/built-in-providers/dev/radius-core.yaml
+++ b/deploy/manifest/built-in-providers/dev/radius-core.yaml
@@ -6,6 +6,10 @@ types:
     apiVersions:
       "2025-08-01-preview":
         schema: {}
+  applications:
+    apiVersions:
+      "2025-08-01-preview":
+        schema: {}      
   recipePacks:
     apiVersions:
       "2025-08-01-preview":

--- a/deploy/manifest/built-in-providers/dev/radius-core.yaml
+++ b/deploy/manifest/built-in-providers/dev/radius-core.yaml
@@ -9,7 +9,7 @@ types:
   applications:
     apiVersions:
       "2025-08-01-preview":
-        schema: {}      
+        schema: {}
   recipePacks:
     apiVersions:
       "2025-08-01-preview":

--- a/deploy/manifest/built-in-providers/self-hosted/radius-core.yaml
+++ b/deploy/manifest/built-in-providers/self-hosted/radius-core.yaml
@@ -6,6 +6,10 @@ types:
     apiVersions:
       "2025-08-01-preview":
         schema: {}
+  applications:
+    apiVersions:
+      "2025-08-01-preview":
+        schema: {}      
   recipePacks:
     apiVersions:
       "2025-08-01-preview":

--- a/deploy/manifest/built-in-providers/self-hosted/radius-core.yaml
+++ b/deploy/manifest/built-in-providers/self-hosted/radius-core.yaml
@@ -9,7 +9,7 @@ types:
   applications:
     apiVersions:
       "2025-08-01-preview":
-        schema: {}      
+        schema: {}
   recipePacks:
     apiVersions:
       "2025-08-01-preview":

--- a/pkg/cli/clients/management.go
+++ b/pkg/cli/clients/management.go
@@ -943,6 +943,7 @@ func (amc *UCPApplicationsManagementClient) ListAllResourceTypesNames(ctx contex
 	excludedResourceTypesList := []string{
 		"microsoft.resources/deployments", // Internal deployment metadata, not a user resource
 		"radius.core/environments",
+		"radius.core/applications",
 	}
 
 	resourceProviderSummaries, err := amc.ListResourceProviderSummaries(ctx, planeName)

--- a/pkg/corerp/setup/setup.go
+++ b/pkg/corerp/setup/setup.go
@@ -254,16 +254,6 @@ func SetupNamespace(recipeControllerConfig *controllerconfig.RecipeControllerCon
 func SetupRadiusCoreNamespace(recipeControllerConfig *controllerconfig.RecipeControllerConfig) *builder.Namespace {
 	ns := builder.NewNamespace("Radius.Core")
 
-	_ = ns.AddResource("environments", &builder.ResourceOption[*datamodel.Environment_v20250801preview, datamodel.Environment_v20250801preview]{
-		RequestConverter:  converter.Environment20250801DataModelFromVersioned,
-		ResponseConverter: converter.Environment20250801DataModelToVersioned,
-	})
-
-	_ = ns.AddResource("applications", &builder.ResourceOption[*datamodel.Application_v20250801preview, datamodel.Application_v20250801preview]{
-		RequestConverter:  converter.Application20250801DataModelFromVersioned,
-		ResponseConverter: converter.Application20250801DataModelToVersioned,
-	})
-
 	_ = ns.AddResource("recipePacks", &builder.ResourceOption[*datamodel.RecipePack, datamodel.RecipePack]{
 		RequestConverter:  converter.RecipePackDataModelFromVersioned,
 		ResponseConverter: converter.RecipePackDataModelToVersioned,

--- a/pkg/corerp/setup/setup.go
+++ b/pkg/corerp/setup/setup.go
@@ -254,6 +254,16 @@ func SetupNamespace(recipeControllerConfig *controllerconfig.RecipeControllerCon
 func SetupRadiusCoreNamespace(recipeControllerConfig *controllerconfig.RecipeControllerConfig) *builder.Namespace {
 	ns := builder.NewNamespace("Radius.Core")
 
+	_ = ns.AddResource("environments", &builder.ResourceOption[*datamodel.Environment_v20250801preview, datamodel.Environment_v20250801preview]{
+		RequestConverter:  converter.Environment20250801DataModelFromVersioned,
+		ResponseConverter: converter.Environment20250801DataModelToVersioned,
+	})
+
+	_ = ns.AddResource("applications", &builder.ResourceOption[*datamodel.Application_v20250801preview, datamodel.Application_v20250801preview]{
+		RequestConverter:  converter.Application20250801DataModelFromVersioned,
+		ResponseConverter: converter.Application20250801DataModelToVersioned,
+	})
+
 	_ = ns.AddResource("recipePacks", &builder.ResourceOption[*datamodel.RecipePack, datamodel.RecipePack]{
 		RequestConverter:  converter.RecipePackDataModelFromVersioned,
 		ResponseConverter: converter.RecipePackDataModelToVersioned,


### PR DESCRIPTION
# Description
This pull request adds support for an `applications` resource to the Radius Core provider, in both the deployment manifests. 

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->