### PR TITLE
Adding rad recipe-pack delete command

### DIFF
--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -55,6 +55,7 @@ import (
 	recipe_register "github.com/radius-project/radius/pkg/cli/cmd/recipe/register"
 	recipe_show "github.com/radius-project/radius/pkg/cli/cmd/recipe/show"
 	recipe_unregister "github.com/radius-project/radius/pkg/cli/cmd/recipe/unregister"
+	recipe_pack_delete "github.com/radius-project/radius/pkg/cli/cmd/recipepack/delete"
 	recipe_pack_list "github.com/radius-project/radius/pkg/cli/cmd/recipepack/list"
 	recipe_pack_show "github.com/radius-project/radius/pkg/cli/cmd/recipepack/show"
 	resource_create "github.com/radius-project/radius/pkg/cli/cmd/resource/create"
@@ -308,6 +309,9 @@ func initSubCommands() {
 
 	listRecipePackCmd, _ := recipe_pack_list.NewCommand(framework)
 	recipePackCmd.AddCommand(listRecipePackCmd)
+
+	deleteRecipePackCmd, _ := recipe_pack_delete.NewCommand(framework)
+	recipePackCmd.AddCommand(deleteRecipePackCmd)
 
 	showRecipePackCmd, _ := recipe_pack_show.NewCommand(framework)
 	recipePackCmd.AddCommand(showRecipePackCmd)

--- a/pkg/cli/clients/clients.go
+++ b/pkg/cli/clients/clients.go
@@ -211,6 +211,9 @@ type ApplicationsManagementClient interface {
 	// GetRecipePack retrieves a recipe pack by its name (in the configured scope) or resource ID.
 	GetRecipePack(ctx context.Context, recipePackNameOrID string) (radiuscore.RecipePackResource, error)
 
+	// DeleteRecipePack deletes a recipe pack by its name (in the configured scope) or resource ID.
+	DeleteRecipePack(ctx context.Context, recipePackNameOrID string) (bool, error)
+
 	// GetEnvironment retrieves an environment by its name (in the configured scope) or resource ID.
 	GetEnvironment(ctx context.Context, environmentNameOrID string) (corerp.EnvironmentResource, error)
 

--- a/pkg/cli/clients/management.go
+++ b/pkg/cli/clients/management.go
@@ -560,6 +560,36 @@ func (amc *UCPApplicationsManagementClient) GetRecipePack(ctx context.Context, r
 	return resp.RecipePackResource, nil
 }
 
+// DeleteRecipePack deletes a recipe pack by its name (in the configured scope) or resource ID.
+func (amc *UCPApplicationsManagementClient) DeleteRecipePack(ctx context.Context, recipePackNameOrID string) (bool, error) {
+	scope, name, err := amc.extractScopeAndName(recipePackNameOrID)
+	if err != nil {
+		return false, err
+	}
+
+	client, err := amc.createRecipePackClient(scope)
+	if err != nil {
+		return false, err
+	}
+
+	var response *http.Response
+	ctx = amc.captureResponse(ctx, &response)
+
+	_, err = client.Delete(ctx, name, nil)
+	if err != nil {
+		if Is404Error(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if response != nil && response.StatusCode == http.StatusNoContent {
+		return false, nil
+	}
+
+	return true, nil
+}
+
 // GetRecipeMetadata shows recipe details including list of all parameters for a given recipe registered to an environment.
 func (amc *UCPApplicationsManagementClient) GetRecipeMetadata(ctx context.Context, environmentNameOrID string, recipeMetadata corerpv20231001.RecipeGetMetadata) (corerpv20231001.RecipeGetMetadataResponse, error) {
 	scope, name, err := amc.extractScopeAndName(environmentNameOrID)

--- a/pkg/cli/clients/management.go
+++ b/pkg/cli/clients/management.go
@@ -577,10 +577,6 @@ func (amc *UCPApplicationsManagementClient) DeleteRecipePack(ctx context.Context
 
 	_, err = client.Delete(ctx, name, nil)
 	if err != nil {
-		if Is404Error(err) {
-			return false, nil
-		}
-
 		return false, err
 	}
 

--- a/pkg/cli/clients/management.go
+++ b/pkg/cli/clients/management.go
@@ -580,14 +580,11 @@ func (amc *UCPApplicationsManagementClient) DeleteRecipePack(ctx context.Context
 		if Is404Error(err) {
 			return false, nil
 		}
+
 		return false, err
 	}
 
-	if response != nil && response.StatusCode == http.StatusNoContent {
-		return false, nil
-	}
-
-	return true, nil
+	return response.StatusCode != 204, nil
 }
 
 // GetRecipeMetadata shows recipe details including list of all parameters for a given recipe registered to an environment.

--- a/pkg/cli/clients/mock_applicationsclient.go
+++ b/pkg/cli/clients/mock_applicationsclient.go
@@ -468,6 +468,45 @@ func (c *MockApplicationsManagementClientDeleteEnvironmentCall) DoAndReturn(f fu
 	return c
 }
 
+// DeleteRecipePack mocks base method.
+func (m *MockApplicationsManagementClient) DeleteRecipePack(arg0 context.Context, arg1 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRecipePack", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteRecipePack indicates an expected call of DeleteRecipePack.
+func (mr *MockApplicationsManagementClientMockRecorder) DeleteRecipePack(arg0, arg1 any) *MockApplicationsManagementClientDeleteRecipePackCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRecipePack", reflect.TypeOf((*MockApplicationsManagementClient)(nil).DeleteRecipePack), arg0, arg1)
+	return &MockApplicationsManagementClientDeleteRecipePackCall{Call: call}
+}
+
+// MockApplicationsManagementClientDeleteRecipePackCall wrap *gomock.Call
+type MockApplicationsManagementClientDeleteRecipePackCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationsManagementClientDeleteRecipePackCall) Return(arg0 bool, arg1 error) *MockApplicationsManagementClientDeleteRecipePackCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationsManagementClientDeleteRecipePackCall) Do(f func(context.Context, string) (bool, error)) *MockApplicationsManagementClientDeleteRecipePackCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationsManagementClientDeleteRecipePackCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockApplicationsManagementClientDeleteRecipePackCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // DeleteResource mocks base method.
 func (m *MockApplicationsManagementClient) DeleteResource(arg0 context.Context, arg1, arg2 string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/pkg/cli/cmd/recipepack/delete/delete.go
+++ b/pkg/cli/cmd/recipepack/delete/delete.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/radius-project/radius/pkg/cli"
+	"github.com/radius-project/radius/pkg/cli/clients"
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
@@ -141,6 +142,10 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	deleted, err := client.DeleteRecipePack(ctx, r.RecipePackName)
 	if err != nil {
+		if clients.Is404Error(err) {
+			r.Output.LogInfo(msgRecipePackNotFound, r.RecipePackName)
+			return nil
+		}
 		return fmt.Errorf("failed to delete resource group %s: %w", r.RecipePackName, err)
 	}
 

--- a/pkg/cli/cmd/recipepack/delete/delete.go
+++ b/pkg/cli/cmd/recipepack/delete/delete.go
@@ -1,5 +1,3 @@
-package delete
-
 /*
 Copyright 2023 The Radius Authors.
 
@@ -15,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+package delete
 
 import (
 	"context"

--- a/pkg/cli/cmd/recipepack/delete/delete.go
+++ b/pkg/cli/cmd/recipepack/delete/delete.go
@@ -20,15 +20,15 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/radius-project/radius/pkg/cli"
-	"github.com/radius-project/radius/pkg/cli/clients"
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/prompt"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
-	"github.com/spf13/cobra"
 )
 
 const (
@@ -130,6 +130,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+
 		if !confirmed {
 			r.Output.LogInfo(msgRecipePackNotDeleted, r.RecipePackName)
 			return nil
@@ -140,11 +141,7 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	deleted, err := client.DeleteRecipePack(ctx, r.RecipePackName)
 	if err != nil {
-		if clients.Is404Error(err) {
-			r.Output.LogInfo(msgRecipePackNotFound, r.RecipePackName)
-			return nil
-		}
-		return err
+		return fmt.Errorf("failed to delete resource group %s: %w", r.RecipePackName, err)
 	}
 
 	if deleted {

--- a/pkg/cli/cmd/recipepack/delete/delete.go
+++ b/pkg/cli/cmd/recipepack/delete/delete.go
@@ -1,0 +1,157 @@
+package delete
+
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/radius-project/radius/pkg/cli"
+	"github.com/radius-project/radius/pkg/cli/clients"
+	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
+	"github.com/radius-project/radius/pkg/cli/connections"
+	"github.com/radius-project/radius/pkg/cli/framework"
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/radius-project/radius/pkg/cli/prompt"
+	"github.com/radius-project/radius/pkg/cli/workspaces"
+	"github.com/spf13/cobra"
+)
+
+const (
+	deleteConfirmationMsg   = "Are you sure you want to delete recipe pack '%s'?"
+	msgDeletingRecipePack   = "Deleting recipe pack %s...\n"
+	msgRecipePackDeleted    = "Recipe pack %s deleted."
+	msgRecipePackNotFound   = "Recipe pack %s does not exist or has already been deleted."
+	msgRecipePackNotDeleted = "Recipe pack %q NOT deleted"
+)
+
+// NewCommand creates a new Cobra command for deleting a recipe pack.
+func NewCommand(factory framework.Factory) (*cobra.Command, framework.Runner) {
+	runner := NewRunner(factory)
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete recipe pack",
+		Long:  "Delete a recipe pack from the current workspace scope.",
+		Args:  cobra.ExactArgs(1),
+		Example: `
+# Delete specified recipe pack
+rad recipe-pack delete my-recipe-pack
+
+# Delete recipe pack in a specified resource group
+rad recipe-pack delete my-recipe-pack --group my-group
+
+# Delete recipe pack and bypass confirmation prompt
+rad recipe-pack delete my-recipe-pack --yes
+`,
+		RunE: framework.RunCommand(runner),
+	}
+
+	commonflags.AddWorkspaceFlag(cmd)
+	commonflags.AddResourceGroupFlag(cmd)
+	commonflags.AddConfirmationFlag(cmd)
+
+	return cmd, runner
+}
+
+// Runner executes the recipe pack delete command.
+type Runner struct {
+	ConfigHolder      *framework.ConfigHolder
+	ConnectionFactory connections.Factory
+	Workspace         *workspaces.Workspace
+	Output            output.Interface
+	InputPrompter     prompt.Interface
+
+	RecipePackName string
+	Confirm        bool
+}
+
+// NewRunner creates a new instance of the recipe pack delete runner.
+func NewRunner(factory framework.Factory) *Runner {
+	return &Runner{
+		ConfigHolder:      factory.GetConfigHolder(),
+		ConnectionFactory: factory.GetConnectionFactory(),
+		Output:            factory.GetOutput(),
+		InputPrompter:     factory.GetPrompter(),
+	}
+}
+
+// Validate ensures command arguments and flags are correct before execution.
+func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
+	workspace, err := cli.RequireWorkspace(cmd, r.ConfigHolder.Config, r.ConfigHolder.DirectoryConfig)
+	if err != nil {
+		return err
+	}
+	r.Workspace = workspace
+
+	scope, err := cli.RequireScope(cmd, *r.Workspace)
+	if err != nil {
+		return err
+	}
+	r.Workspace.Scope = scope
+
+	recipePackName, err := cli.RequireRecipePackNameArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+	r.RecipePackName = recipePackName
+
+	r.Confirm, err = cmd.Flags().GetBool("yes")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Run performs the delete operation for the recipe pack.
+func (r *Runner) Run(ctx context.Context) error {
+	client, err := r.ConnectionFactory.CreateApplicationsManagementClient(ctx, *r.Workspace)
+	if err != nil {
+		return err
+	}
+
+	if !r.Confirm {
+		confirmed, err := prompt.YesOrNoPrompt(fmt.Sprintf(deleteConfirmationMsg, r.RecipePackName), prompt.ConfirmNo, r.InputPrompter)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			r.Output.LogInfo(msgRecipePackNotDeleted, r.RecipePackName)
+			return nil
+		}
+	}
+
+	r.Output.LogInfo(msgDeletingRecipePack, r.RecipePackName)
+
+	deleted, err := client.DeleteRecipePack(ctx, r.RecipePackName)
+	if err != nil {
+		if clients.Is404Error(err) {
+			r.Output.LogInfo(msgRecipePackNotFound, r.RecipePackName)
+			return nil
+		}
+		return err
+	}
+
+	if deleted {
+		r.Output.LogInfo(msgRecipePackDeleted, r.RecipePackName)
+	} else {
+		r.Output.LogInfo(msgRecipePackNotFound, r.RecipePackName)
+	}
+
+	return nil
+}

--- a/pkg/cli/cmd/recipepack/delete/delete_test.go
+++ b/pkg/cli/cmd/recipepack/delete/delete_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package delete
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	"github.com/radius-project/radius/pkg/cli/clients"
+	"github.com/radius-project/radius/pkg/cli/connections"
+	"github.com/radius-project/radius/pkg/cli/framework"
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/radius-project/radius/pkg/cli/prompt"
+	"github.com/radius-project/radius/pkg/cli/workspaces"
+	"github.com/radius-project/radius/test/radcli"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_CommandValidation(t *testing.T) {
+	radcli.SharedCommandValidation(t, NewCommand)
+}
+
+func Test_Validate(t *testing.T) {
+	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
+
+	testcases := []radcli.ValidateInput{
+		{
+			Name:          "Missing recipe pack name",
+			Input:         []string{},
+			ExpectedValid: false,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+		},
+		{
+			Name:          "Valid with workspace flag",
+			Input:         []string{"my-pack", "-w", radcli.TestWorkspaceName},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+		},
+		{
+			Name:          "Valid with group fallback",
+			Input:         []string{"--group", "test-group", "my-pack"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         radcli.LoadEmptyConfig(t),
+			},
+		},
+	}
+
+	radcli.SharedValidateValidation(t, NewCommand, testcases)
+}
+
+func Test_Run_DeleteConfirmed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	appMgmtClient := clients.NewMockApplicationsManagementClient(ctrl)
+	appMgmtClient.EXPECT().DeleteRecipePack(gomock.Any(), "sample-pack").Return(true, nil)
+
+	outputSink := &output.MockOutput{}
+	runner := &Runner{
+		ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appMgmtClient},
+		Workspace:         &workspaces.Workspace{Name: "test", Scope: "/planes/radius/local/resourceGroups/test-group"},
+		Output:            outputSink,
+		InputPrompter:     prompt.NewMockInterface(ctrl),
+		RecipePackName:    "sample-pack",
+		Confirm:           true,
+	}
+
+	err := runner.Run(context.Background())
+	require.NoError(t, err)
+
+	expected := []any{
+		output.LogOutput{Format: msgDeletingRecipePack, Params: []any{"sample-pack"}},
+		output.LogOutput{Format: msgRecipePackDeleted, Params: []any{"sample-pack"}},
+	}
+	require.Equal(t, expected, outputSink.Writes)
+}
+
+func Test_Run_DeleteWithPromptConfirmed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	promptMock := prompt.NewMockInterface(ctrl)
+	promptMock.EXPECT().GetListInput([]string{prompt.ConfirmNo, prompt.ConfirmYes}, fmt.Sprintf(deleteConfirmationMsg, "sample-pack")).Return(prompt.ConfirmYes, nil)
+
+	appMgmtClient := clients.NewMockApplicationsManagementClient(ctrl)
+	appMgmtClient.EXPECT().DeleteRecipePack(gomock.Any(), "sample-pack").Return(true, nil)
+
+	outputSink := &output.MockOutput{}
+	runner := &Runner{
+		ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appMgmtClient},
+		Workspace:         &workspaces.Workspace{Name: "test", Scope: "/planes/radius/local/resourceGroups/test-group"},
+		Output:            outputSink,
+		InputPrompter:     promptMock,
+		RecipePackName:    "sample-pack",
+		Confirm:           false,
+	}
+
+	err := runner.Run(context.Background())
+	require.NoError(t, err)
+
+	expected := []any{
+		output.LogOutput{Format: msgDeletingRecipePack, Params: []any{"sample-pack"}},
+		output.LogOutput{Format: msgRecipePackDeleted, Params: []any{"sample-pack"}},
+	}
+	require.Equal(t, expected, outputSink.Writes)
+}
+
+func Test_Run_DeleteWithPromptDeclined(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	promptMock := prompt.NewMockInterface(ctrl)
+	promptMock.EXPECT().GetListInput([]string{prompt.ConfirmNo, prompt.ConfirmYes}, fmt.Sprintf(deleteConfirmationMsg, "sample-pack")).Return(prompt.ConfirmNo, nil)
+
+	outputSink := &output.MockOutput{}
+	runner := &Runner{
+		ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: clients.NewMockApplicationsManagementClient(ctrl)},
+		Workspace:         &workspaces.Workspace{Name: "test", Scope: "/planes/radius/local/resourceGroups/test-group"},
+		Output:            outputSink,
+		InputPrompter:     promptMock,
+		RecipePackName:    "sample-pack",
+		Confirm:           false,
+	}
+
+	err := runner.Run(context.Background())
+	require.NoError(t, err)
+
+	expected := []any{
+		output.LogOutput{Format: msgRecipePackNotDeleted, Params: []any{"sample-pack"}},
+	}
+	require.Equal(t, expected, outputSink.Writes)
+}
+
+func Test_Run_DeleteNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	appMgmtClient := clients.NewMockApplicationsManagementClient(ctrl)
+	appMgmtClient.EXPECT().DeleteRecipePack(gomock.Any(), "sample-pack").Return(false, nil)
+
+	outputSink := &output.MockOutput{}
+	runner := &Runner{
+		ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appMgmtClient},
+		Workspace:         &workspaces.Workspace{Name: "test", Scope: "/planes/radius/local"},
+		Output:            outputSink,
+		InputPrompter:     prompt.NewMockInterface(ctrl),
+		RecipePackName:    "sample-pack",
+		Confirm:           true,
+	}
+
+	err := runner.Run(context.Background())
+	require.NoError(t, err)
+
+	expected := []any{
+		output.LogOutput{Format: msgDeletingRecipePack, Params: []any{"sample-pack"}},
+		output.LogOutput{Format: msgRecipePackNotFound, Params: []any{"sample-pack"}},
+	}
+	require.Equal(t, expected, outputSink.Writes)
+}
+
+func Test_Run_DeleteError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	deleteErr := fmt.Errorf("boom")
+
+	appMgmtClient := clients.NewMockApplicationsManagementClient(ctrl)
+	appMgmtClient.EXPECT().DeleteRecipePack(gomock.Any(), "sample-pack").Return(false, deleteErr)
+
+	outputSink := &output.MockOutput{}
+	runner := &Runner{
+		ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appMgmtClient},
+		Workspace:         &workspaces.Workspace{Name: "test", Scope: "/planes/radius/local"},
+		Output:            outputSink,
+		InputPrompter:     prompt.NewMockInterface(ctrl),
+		RecipePackName:    "sample-pack",
+		Confirm:           true,
+	}
+
+	err := runner.Run(context.Background())
+	require.Error(t, err)
+	require.Equal(t, deleteErr, err)
+
+	expected := []any{
+		output.LogOutput{Format: msgDeletingRecipePack, Params: []any{"sample-pack"}},
+	}
+	require.Equal(t, expected, outputSink.Writes)
+}
+
+func Test_Run_DeleteError404(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	notFoundErr := &azcore.ResponseError{StatusCode: 404, ErrorCode: v1.CodeNotFound}
+
+	appMgmtClient := clients.NewMockApplicationsManagementClient(ctrl)
+	appMgmtClient.EXPECT().DeleteRecipePack(gomock.Any(), "sample-pack").Return(false, notFoundErr)
+
+	outputSink := &output.MockOutput{}
+	runner := &Runner{
+		ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appMgmtClient},
+		Workspace:         &workspaces.Workspace{Name: "test", Scope: "/planes/radius/local"},
+		Output:            outputSink,
+		InputPrompter:     prompt.NewMockInterface(ctrl),
+		RecipePackName:    "sample-pack",
+		Confirm:           true,
+	}
+
+	err := runner.Run(context.Background())
+	require.NoError(t, err)
+
+	expected := []any{
+		output.LogOutput{Format: msgDeletingRecipePack, Params: []any{"sample-pack"}},
+		output.LogOutput{Format: msgRecipePackNotFound, Params: []any{"sample-pack"}},
+	}
+	require.Equal(t, expected, outputSink.Writes)
+}

--- a/pkg/cli/cmd/recipepack/delete/delete_test.go
+++ b/pkg/cli/cmd/recipepack/delete/delete_test.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/cli/clients"
@@ -30,8 +33,6 @@ import (
 	"github.com/radius-project/radius/pkg/cli/prompt"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/test/radcli"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
 )
 
 func Test_CommandValidation(t *testing.T) {

--- a/pkg/cli/cmd/recipepack/delete/delete_test.go
+++ b/pkg/cli/cmd/recipepack/delete/delete_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/cli/clients"
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
@@ -148,7 +150,7 @@ func Test_Run(t *testing.T) {
 			confirm:        true,
 			expectDelete:   true,
 			deleteReturn:   false,
-			deleteErr:      nil,
+			deleteErr:      &azcore.ResponseError{StatusCode: 404, ErrorCode: v1.CodeNotFound},
 			workspaceScope: "/planes/radius/local",
 			expectedLogs: []output.LogOutput{
 				{Format: msgDeletingRecipePack, Params: []any{"sample-pack"}},

--- a/test/functional-portable/cli/noncloud/cli_test.go
+++ b/test/functional-portable/cli/noncloud/cli_test.go
@@ -846,10 +846,17 @@ func Test_RecipePack(t *testing.T) {
 	})
 
 	t.Run("delete recipe pack", func(t *testing.T) {
-		err := cli.RecipePackDelete(ctx, packName, radcli.DeleteOptions{Confirm: true})
+		err := cli.Deploy(ctx, templatePath, "", "")
 		require.NoError(t, err)
 
 		output, err := cli.RecipePackList(ctx, "")
+		require.NoError(t, err)
+
+		require.Contains(t, output, packName)
+		err = cli.RecipePackDelete(ctx, packName, radcli.DeleteOptions{Confirm: true})
+		require.NoError(t, err)
+
+		output, err = cli.RecipePackList(ctx, "")
 		require.NoError(t, err)
 		require.NotContains(t, output, packName)
 	})

--- a/test/functional-portable/cli/noncloud/cli_test.go
+++ b/test/functional-portable/cli/noncloud/cli_test.go
@@ -844,4 +844,13 @@ func Test_RecipePack(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, output, packName)
 	})
+
+	t.Run("delete recipe pack", func(t *testing.T) {
+		err := cli.RecipePackDelete(ctx, packName, radcli.DeleteOptions{Confirm: true})
+		require.NoError(t, err)
+
+		output, err := cli.RecipePackList(ctx, "")
+		require.NoError(t, err)
+		require.NotContains(t, output, packName)
+	})
 }

--- a/test/radcli/cli.go
+++ b/test/radcli/cli.go
@@ -493,6 +493,37 @@ func (cli *CLI) RecipePackShow(ctx context.Context, recipepackName, groupName st
 	return cli.RunCommand(ctx, args)
 }
 
+// RecipePackDelete runs the "recipe-pack delete" command for the specified recipe pack name.
+// The options parameter is optional and allows specifying group, workspace, and confirmation bypass.
+func (cli *CLI) RecipePackDelete(ctx context.Context, recipepackName string, opts ...DeleteOptions) error {
+	args := []string{
+		"recipe-pack",
+		"delete",
+		recipepackName,
+	}
+
+	if len(opts) > 0 {
+		opt := opts[0]
+		if opt.Confirm {
+			args = append(args, "--yes")
+		}
+		if opt.Group != "" {
+			args = append(args, "--group", opt.Group)
+		}
+		if opt.Workspace != "" {
+			args = append(args, "--workspace", opt.Workspace)
+		}
+		if opt.Output != "" {
+			args = append(args, "--output", opt.Output)
+		}
+	} else {
+		args = append(args, "--yes")
+	}
+
+	_, err := cli.RunCommand(ctx, args)
+	return err
+}
+
 // RecipeRegister runs a command to register a recipe with the given environment, template kind, template path and
 // resource type, and returns the output string or an error.
 func (cli *CLI) RecipeRegister(ctx context.Context, envName, recipeName, templateKind, templatePath, resourceType string, plainHTTP bool) (string, error) {


### PR DESCRIPTION
# Description

- Added rad recipe-pack delete command
- Added unit and functional tests for rad recipe-pack delete command
<img width="1196" height="72" alt="image" src="https://github.com/user-attachments/assets/86b7a364-a1c4-4c43-9aba-e800ca0bdef9" />

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

https://github.com/radius-project/radius/issues/9832

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->