### PR TITLE
Add kubebuilder instruction to exclude format specifier

### DIFF
--- a/deploy/Chart/crds/radius/radapp.io_deploymentresources.yaml
+++ b/deploy/Chart/crds/radius/radapp.io_deploymentresources.yaml
@@ -63,7 +63,6 @@ spec:
               observedGeneration:
                 description: ObservedGeneration is the most recent generation observed
                   for this DeploymentResource.
-                format: int64
                 type: integer
               operation:
                 description: Operation tracks the status of an in-progress provisioning

--- a/deploy/Chart/crds/radius/radapp.io_deploymenttemplates.yaml
+++ b/deploy/Chart/crds/radius/radapp.io_deploymenttemplates.yaml
@@ -73,7 +73,6 @@ spec:
               observedGeneration:
                 description: ObservedGeneration is the most recent generation observed
                   for this DeploymentTemplate.
-                format: int64
                 type: integer
               operation:
                 description: Operation tracks the status of an in-progress provisioning

--- a/deploy/Chart/crds/radius/radapp.io_recipes.yaml
+++ b/deploy/Chart/crds/radius/radapp.io_recipes.yaml
@@ -88,7 +88,6 @@ spec:
                 description: |-
                   ObservedGeneration is the most recent generation observed for this Recipe. It corresponds to the
                   Recipe's generation, which is updated on mutation by the API Server.
-                format: int64
                 type: integer
               operation:
                 description: Operation tracks the status of an in-progress provisioning

--- a/pkg/controller/api/radapp.io/v1alpha3/deploymentresource_types.go
+++ b/pkg/controller/api/radapp.io/v1alpha3/deploymentresource_types.go
@@ -32,6 +32,7 @@ type DeploymentResourceStatus struct {
 	Id string `json:"id,omitempty"`
 
 	// ObservedGeneration is the most recent generation observed for this DeploymentResource.
+	// +kubebuilder:validation:Format=""
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,1,opt,name=observedGeneration"`
 
 	// Operation tracks the status of an in-progress provisioning operation.

--- a/pkg/controller/api/radapp.io/v1alpha3/deploymenttemplate_types.go
+++ b/pkg/controller/api/radapp.io/v1alpha3/deploymenttemplate_types.go
@@ -38,6 +38,7 @@ type DeploymentTemplateSpec struct {
 // DeploymentTemplateStatus defines the observed state of a DeploymentTemplate resource.
 type DeploymentTemplateStatus struct {
 	// ObservedGeneration is the most recent generation observed for this DeploymentTemplate.
+	// +kubebuilder:validation:Format=""
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,1,opt,name=observedGeneration"`
 
 	// StatusHash is a hash of the DeploymentTemplate's state (template, parameters, and provider config).

--- a/pkg/controller/api/radapp.io/v1alpha3/recipe_types.go
+++ b/pkg/controller/api/radapp.io/v1alpha3/recipe_types.go
@@ -67,6 +67,7 @@ type RecipeStatus struct {
 	// ObservedGeneration is the most recent generation observed for this Recipe. It corresponds to the
 	// Recipe's generation, which is updated on mutation by the API Server.
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Format=""
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,1,opt,name=observedGeneration"`
 
 	// Application is the resource ID of the application.


### PR DESCRIPTION
# Description

potential fix for 
```
Installing Radius version v0.53.0-rc3 to namespace: radius-system...
I1107 02:17:39.056895    3753 warnings.go:110] "Warning: unrecognized format \"int64\""
I1107 02:17:39.064520    3753 warnings.go:110] "Warning: unrecognized format \"int64\""
I1107 02:17:39.074029    3753 warnings.go:110] "Warning: unrecognized format \"int64\""
Error: failed to apply Radius Helm chart, err: failed to run Helm install, err: context deadline exceeded
```
ref: https://github.com/radius-project/radius/actions/runs/19156054247/job/54756722016

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).


Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->