### PR TITLE
Restores the skip list from cache (if it exists)

### DIFF
--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -518,24 +518,12 @@ jobs:
         if: env.SKIP_BUILD != 'true'
         run: |
           kubectl get resources.ucp.dev -n radius-system --no-headers -o custom-columns=":metadata.name" > skip-delete-resources-list.txt
-          echo "Created skip-delete-resources-list.txt with the following resources:"
-          cat skip-delete-resources-list.txt
       - name: Save list of resources not to be deleted
         if: env.SKIP_BUILD != 'true'
         uses: actions/cache/save@v4
         with:
           path: skip-delete-resources-list.txt
           key: skip-delete-resources-list-file
-      - name: Display skip-delete-resources-list contents
-        if: always()
-        run: |
-          if [ -f skip-delete-resources-list.txt ]; then
-            echo "Contents of skip-delete-resources-list.txt:"
-            cat skip-delete-resources-list.txt
-            echo "Total resources in skip list: $(wc -l < skip-delete-resources-list.txt)"
-          else
-            echo "skip-delete-resources-list.txt does not exist"
-          fi
       - name: Configure Radius test workspace
         run: |
           set -x

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -438,12 +438,13 @@ jobs:
         if: always()
         timeout-minutes: 60
         run: |
-          if [ "${{ env.SKIP_BUILD }}" != "true" ] ; then
-            echo "Running cleanup without skip delete resource list. This will delete all resources."
-            ./.github/scripts/cleanup-long-running-cluster.sh
-          else
-            echo "Running cleanup with skip-delete-resources-list.txt. Built-In resources will not be deleted."
+          # Always use skip list if it exists, regardless of SKIP_BUILD
+          if [ -f skip-delete-resources-list.txt ] && [ -s skip-delete-resources-list.txt ]; then
+            echo "Running cleanup with skip-delete-resources-list.txt. Built-in resources will not be deleted."
             ./.github/scripts/cleanup-long-running-cluster.sh skip-delete-resources-list.txt
+          else
+            echo "No skip-delete-resources-list.txt found or file is empty. Running cleanup without skip list."
+            ./.github/scripts/cleanup-long-running-cluster.sh
           fi
       - name: Download Bicep
         run: |
@@ -517,12 +518,24 @@ jobs:
         if: env.SKIP_BUILD != 'true'
         run: |
           kubectl get resources.ucp.dev -n radius-system --no-headers -o custom-columns=":metadata.name" > skip-delete-resources-list.txt
+          echo "Created skip-delete-resources-list.txt with the following resources:"
+          cat skip-delete-resources-list.txt
       - name: Save list of resources not to be deleted
         if: env.SKIP_BUILD != 'true'
         uses: actions/cache/save@v4
         with:
           path: skip-delete-resources-list.txt
           key: skip-delete-resources-list-file
+      - name: Display skip-delete-resources-list contents
+        if: always()
+        run: |
+          if [ -f skip-delete-resources-list.txt ]; then
+            echo "Contents of skip-delete-resources-list.txt:"
+            cat skip-delete-resources-list.txt
+            echo "Total resources in skip list: $(wc -l < skip-delete-resources-list.txt)"
+          else
+            echo "skip-delete-resources-list.txt does not exist"
+          fi
       - name: Configure Radius test workspace
         run: |
           set -x


### PR DESCRIPTION
# Description

If new types are added, the LRT creates them successfully when skip_build is false. It also makes a skip list when skip_build is false. But it does not use the skip list when skip_build is false, so the new types added never make it to the skip list, causing LRT to pass only when skip_build is false. 

This PR runs cleanup using that skip list (protecting built-in types) irrespective of skip_build, as long as a file is available.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #10809 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->