### PR TITLE
Add CanNotDelete lock to LRT infrastructure

### DIFF
--- a/test/infra/azure/README.md
+++ b/test/infra/azure/README.md
@@ -64,14 +64,15 @@ This directory includes the Bicep templates to deploy the following resources on
 
 1. Deploy main.bicep:
 
-   By default, `grafanaEnabled` is false. We do not need to set any parameters unless you need Grafana dashboard. If you want to see Grafana dashboard later, you can redeploy main.bicep with `grafanaEnabled` and `grafanaAdminObjectId` later--bicep will install only Grafana dashboard with your existing cluster.
+   By default, `grafanaEnabled` is false and `enableDeletionLock` is true. We do not need to set any parameters unless you need Grafana dashboard or want to disable the deletion lock. If you want to see Grafana dashboard later, you can redeploy main.bicep with `grafanaEnabled` and `grafanaAdminObjectId` later--bicep will install only Grafana dashboard with your existing cluster.
 
    ```bash
-   az deployment group create --resource-group [Resource Group Name] --template-file main.bicep --parameters grafanaEnabled=[Grafana Dashboard Enabled] grafanaAdminObjectId='[Grafana Admin Object Id]'
+   az deployment group create --resource-group [Resource Group Name] --template-file main.bicep --parameters grafanaEnabled=[Grafana Dashboard Enabled] grafanaAdminObjectId='[Grafana Admin Object Id]' enableDeletionLock=[Enable Deletion Lock]
    ```
 
    - **[Grafana Dashboard Enabled]**: Set `true` if you want to see metrics and its dashboard with Azure managed Prometheus and Grafana dashboard. Otherwise, `false` is recommended to save the cost.
    - **[Grafana Admin Object Id]**: Set the object ID of the Grafana Admin user or group. To find the object id, search for the admin user or group name on [AAD Portal Overview search box](https://portal.azure.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/Overview) and get the object id or run `az ad signed-in-user show` to get your own user object id.
+   - **[Enable Deletion Lock]**: Set `false` if you want to disable the resource lock that prevents accidental deletion. By default, it is `true` to protect long running test resources from accidental deletion.
 
 ## Monitor Radius
 

--- a/test/infra/azure/main.bicep
+++ b/test/infra/azure/main.bicep
@@ -61,6 +61,9 @@ param grafanaDashboardName string = '${prefix}-dashboard'
 @description('Specifies whether to install the required tools for running Radius. Default is true.')
 param installKubernetesDependencies bool = true
 
+@description('Specifies whether to create a resource lock to prevent accidental deletion. Default is true.')
+param enableDeletionLock bool = true
+
 param defaultTags object = {
   radius: 'infra'
 }
@@ -200,6 +203,16 @@ module deploymentScript './modules/deployment-script.bicep' = if (installKuberne
   dependsOn: [
     aksCluster
   ]
+}
+
+// Create a resource lock to prevent accidental deletion of the resource group and all its resources.
+resource deletionLock 'Microsoft.Authorization/locks@2020-05-01' = if (enableDeletionLock) {
+  scope: resourceGroup()
+  name: 'DeleteLock'
+  properties: {
+    level: 'CanNotDelete'
+    notes: 'This lock prevents accidental deletion of long running test resources.'
+  }
 }
 
 output aksControlPlaneFQDN string = aksCluster.outputs.controlPlaneFQDN


### PR DESCRIPTION
# Description

Add deletion lock on resource group to prevent accidental deletion of LRT resources. Current resource group is already locked (was done manually) so we don't have to take any action right now. This update allows us to create the resource group with deletion lock enabled if we need to re-create it.

## Changes

- **Added `Microsoft.Authorization/locks` resource** in `test/infra/azure/main.bicep` with `CanNotDelete` level explicitly scoped to resource group
- **Added `enableDeletionLock` parameter** (default: `true`) to allow toggling the lock
- **Updated README** with deployment instructions for the new parameter
- The lock resource uses `scope: resourceGroup()` to explicitly declare the resource group scope.

## Usage

The lock is enabled by default. To deploy without it:

```bash
az deployment group create \
  --resource-group [RG_NAME] \
  --template-file main.bicep \
  --parameters enableDeletionLock=false
```

To remove an existing lock before deletion:

```bash
az lock delete --name DeleteLock --resource-group [RG_NAME]
```

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request adds or changes features of Radius and has an approved issue (issue link required).
<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #7719

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->