### PR TITLE
Fix nil pointer dereference by setting Kind field in Azure credentials

### DIFF
--- a/pkg/cli/cmd/credential/show/show_test.go
+++ b/pkg/cli/cmd/credential/show/show_test.go
@@ -151,6 +151,7 @@ func Test_Run(t *testing.T) {
 			}
 			require.Equal(t, expected, outputSink.Writes)
 		})
+        
 		t.Run("Azure WorkloadIdentity - Exists", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 

--- a/pkg/cli/cmd/credential/show/show_test.go
+++ b/pkg/cli/cmd/credential/show/show_test.go
@@ -199,6 +199,7 @@ func Test_Run(t *testing.T) {
 			}
 			require.Equal(t, expected, outputSink.Writes)
 		})
+		
 		t.Run("Not Found", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 

--- a/pkg/cli/cmd/credential/show/show_test.go
+++ b/pkg/cli/cmd/credential/show/show_test.go
@@ -151,6 +151,53 @@ func Test_Run(t *testing.T) {
 			}
 			require.Equal(t, expected, outputSink.Writes)
 		})
+		t.Run("Azure WorkloadIdentity - Exists", func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			provider := cli_credential.ProviderCredentialConfiguration{
+				CloudProviderStatus: cli_credential.CloudProviderStatus{
+					Name:    "azure",
+					Enabled: true,
+				},
+				AzureCredentials: &cli_credential.AzureCredentialProperties{
+					Kind: to.Ptr("WorkloadIdentity"),
+				},
+			}
+
+			client := cli_credential.NewMockCredentialManagementClient(ctrl)
+			client.EXPECT().
+				Get(gomock.Any(), "azure").
+				Return(provider, nil).
+				Times(1)
+
+			outputSink := &output.MockOutput{}
+
+			runner := &Runner{
+				ConnectionFactory: &connections.MockFactory{CredentialManagementClient: client},
+				Output:            outputSink,
+				Workspace:         &workspaces.Workspace{Connection: connection},
+				Kind:              "azure",
+				Format:            "table",
+			}
+
+			err := runner.Run(context.Background())
+			require.NoError(t, err)
+
+			credentialFormatOutput := credentialFormatAzureWorkloadIdentity()
+
+			expected := []any{
+				output.LogOutput{
+					Format: "Showing credential for cloud provider %q for Radius installation %q...",
+					Params: []any{"azure", "Kubernetes (context=my-context)"},
+				},
+				output.FormattedOutput{
+					Format:  "table",
+					Obj:     provider,
+					Options: credentialFormatOutput,
+				},
+			}
+			require.Equal(t, expected, outputSink.Writes)
+		})
 		t.Run("Not Found", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 

--- a/pkg/cli/credential/azure_credential_management.go
+++ b/pkg/cli/credential/azure_credential_management.go
@@ -138,6 +138,7 @@ func (cpm *AzureCredentialManagementClient) Get(ctx context.Context, credentialN
 				Enabled: true,
 			},
 			AzureCredentials: &AzureCredentialProperties{
+				Kind: (*string)(azureServicePrincipal.Kind),
 				ServicePrincipal: &AzureServicePrincipalCredentialProperties{
 					ClientID: azureServicePrincipal.ClientID,
 					Kind:     (*string)(azureServicePrincipal.Kind),
@@ -159,6 +160,7 @@ func (cpm *AzureCredentialManagementClient) Get(ctx context.Context, credentialN
 				Enabled: true,
 			},
 			AzureCredentials: &AzureCredentialProperties{
+				Kind: (*string)(azureWorkloadIdentity.Kind),
 				WorkloadIdentity: &AzureWorkloadIdentityCredentialProperties{
 					ClientID: azureWorkloadIdentity.ClientID,
 					Kind:     (*string)(azureWorkloadIdentity.Kind),


### PR DESCRIPTION
# Description

The `rad credential show azure` command panics with a nil pointer dereference when attempting to display Azure service principal credentials. The panic occurs because `AzureCredentialProperties.Kind` is dereferenced without being populated.

* Set the top-level Kind field in AzureCredentialProperties for both ServicePrincipal and WorkloadIdentity credential types.
* Added unit test coverage for WorkloadIdentity credential type.


## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: https://github.com/radius-project/radius/issues/9452

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->