### PR TITLE
remove description from recipe pack resource

### DIFF
--- a/hack/bicep-types-radius/generated/radius/radius.core/2025-08-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/radius/radius.core/2025-08-01-preview/types.json
@@ -887,13 +887,6 @@
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
       },
-      "description": {
-        "type": {
-          "$ref": "#/0"
-        },
-        "flags": 0,
-        "description": "Description of what this recipe pack provides"
-      },
       "referencedBy": {
         "type": {
           "$ref": "#/78"

--- a/pkg/corerp/api/v20250801preview/recipepack_conversion.go
+++ b/pkg/corerp/api/v20250801preview/recipepack_conversion.go
@@ -48,11 +48,6 @@ func (src *RecipePackResource) ConvertTo() (v1.DataModelInterface, error) {
 		converted.Properties.Recipes = toRecipesDataModel(src.Properties.Recipes)
 	}
 
-	// Convert Description
-	if src.Properties.Description != nil {
-		converted.Properties.Description = to.String(src.Properties.Description)
-	}
-
 	// Convert ReferencedBy
 	if src.Properties.ReferencedBy != nil {
 		converted.Properties.ReferencedBy = to.StringArray(src.Properties.ReferencedBy)
@@ -81,11 +76,6 @@ func (dst *RecipePackResource) ConvertFrom(src v1.DataModelInterface) error {
 	// Convert Recipes
 	if recipePack.Properties.Recipes != nil {
 		dst.Properties.Recipes = fromRecipesDataModel(recipePack.Properties.Recipes)
-	}
-
-	// Convert Description
-	if recipePack.Properties.Description != "" {
-		dst.Properties.Description = to.Ptr(recipePack.Properties.Description)
 	}
 
 	// Convert ReferencedBy

--- a/pkg/corerp/api/v20250801preview/testdata/recipepackresource.json
+++ b/pkg/corerp/api/v20250801preview/testdata/recipepackresource.json
@@ -9,7 +9,6 @@
   },
   "properties": {
     "provisioningState": "Succeeded",
-    "description": "A comprehensive recipe pack for containerized applications",
     "referencedBy": [
       "/planes/radius/local/resourceGroups/app-rg/providers/Radius.Core/environments/prod-env",
       "/planes/radius/local/resourceGroups/app-rg/providers/Radius.Core/environments/staging-env"

--- a/pkg/corerp/api/v20250801preview/testdata/recipepackresourcedatamodel.json
+++ b/pkg/corerp/api/v20250801preview/testdata/recipepackresourcedatamodel.json
@@ -21,7 +21,6 @@
     "asyncProvisioningState": "Succeeded"
   },
   "properties": {
-    "description": "A comprehensive recipe pack for containerized applications",
     "referencedBy": [
       "/planes/radius/local/resourceGroups/app-rg/providers/Radius.Core/environments/prod-env",
       "/planes/radius/local/resourceGroups/app-rg/providers/Radius.Core/environments/staging-env"

--- a/pkg/corerp/api/v20250801preview/zz_generated_models.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_models.go
@@ -434,9 +434,6 @@ type RecipePackProperties struct {
 	// REQUIRED; Map of resource types to their recipe configurations
 	Recipes map[string]*RecipeDefinition
 
-	// Description of what this recipe pack provides
-	Description *string
-
 	// READ-ONLY; The status of the asynchronous operation
 	ProvisioningState *ProvisioningState
 

--- a/pkg/corerp/api/v20250801preview/zz_generated_models_serde.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_models_serde.go
@@ -1085,7 +1085,6 @@ func (r *RecipeDefinition) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type RecipePackProperties.
 func (r RecipePackProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "description", r.Description)
 	populate(objectMap, "provisioningState", r.ProvisioningState)
 	populate(objectMap, "recipes", r.Recipes)
 	populate(objectMap, "referencedBy", r.ReferencedBy)
@@ -1101,9 +1100,6 @@ func (r *RecipePackProperties) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "description":
-			err = unpopulate(val, "Description", &r.Description)
-			delete(rawMsg, key)
 		case "provisioningState":
 			err = unpopulate(val, "ProvisioningState", &r.ProvisioningState)
 			delete(rawMsg, key)

--- a/pkg/corerp/datamodel/converter/recipepack_converter_test.go
+++ b/pkg/corerp/datamodel/converter/recipepack_converter_test.go
@@ -56,7 +56,6 @@ func TestRecipePackDataModelToVersioned(t *testing.T) {
 					},
 				},
 				Properties: datamodel.RecipePackProperties{
-					Description: "Test recipe pack",
 					Recipes: map[string]*datamodel.RecipeDefinition{
 						"Applications.Core/containers": {
 							RecipeKind:     "bicep",
@@ -128,10 +127,6 @@ func TestRecipePackDataModelToVersioned(t *testing.T) {
 					require.Equal(t, tc.dataModel.Type, to.String(versionedResource.Type))
 					require.Equal(t, tc.dataModel.Location, to.String(versionedResource.Location))
 
-					if tc.dataModel.Properties.Description != "" {
-						require.Equal(t, tc.dataModel.Properties.Description, to.String(versionedResource.Properties.Description))
-					}
-
 					if len(tc.dataModel.Properties.ReferencedBy) > 0 {
 						require.Equal(t, len(tc.dataModel.Properties.ReferencedBy), len(versionedResource.Properties.ReferencedBy))
 					}
@@ -165,7 +160,6 @@ func TestRecipePackDataModelFromVersioned(t *testing.T) {
 						"env": "test"
 					},
 					"properties": {
-						"description": "Test recipe pack",
 						"recipes": {
 							"Applications.Core/containers": {
 								"recipeKind": "bicep",
@@ -207,7 +201,6 @@ func TestRecipePackDataModelFromVersioned(t *testing.T) {
 					},
 				},
 				Properties: datamodel.RecipePackProperties{
-					Description: "Test recipe pack",
 					Recipes: map[string]*datamodel.RecipeDefinition{
 						"Applications.Core/containers": {
 							RecipeKind:     "bicep",
@@ -383,7 +376,6 @@ func TestRecipePackDataModelFromVersioned(t *testing.T) {
 				} else {
 					require.Equal(t, tc.expected.Tags, result.Tags)
 				}
-				require.Equal(t, tc.expected.Properties.Description, result.Properties.Description)
 				require.Equal(t, tc.expected.Properties.ReferencedBy, result.Properties.ReferencedBy)
 
 				// Validate recipes
@@ -432,7 +424,6 @@ func TestRecipePackRoundTripConversion(t *testing.T) {
 			},
 		},
 		Properties: datamodel.RecipePackProperties{
-			Description: "Round-trip test recipe pack",
 			Recipes: map[string]*datamodel.RecipeDefinition{
 				"Applications.Core/containers": {
 					RecipeKind:     "bicep",
@@ -470,7 +461,6 @@ func TestRecipePackRoundTripConversion(t *testing.T) {
 	require.Equal(t, originalDataModel.Type, resultDataModel.Type)
 	require.Equal(t, originalDataModel.Location, resultDataModel.Location)
 	require.Equal(t, originalDataModel.Tags, resultDataModel.Tags)
-	require.Equal(t, originalDataModel.Properties.Description, resultDataModel.Properties.Description)
 	require.Equal(t, originalDataModel.Properties.ReferencedBy, resultDataModel.Properties.ReferencedBy)
 
 	// Validate recipes

--- a/pkg/corerp/frontend/controller/recipepacks/createorupdaterecipepack_test.go
+++ b/pkg/corerp/frontend/controller/recipepacks/createorupdaterecipepack_test.go
@@ -95,7 +95,6 @@ func TestCreateOrUpdateRecipePackRun_CreateNew(t *testing.T) {
 
 	actualOutput := &v20250801preview.RecipePackResource{}
 	_ = json.Unmarshal(w.Body.Bytes(), actualOutput)
-	require.Equal(t, expectedOutput.Properties.Description, actualOutput.Properties.Description)
 	require.Equal(t, expectedOutput.Properties.Recipes, actualOutput.Properties.Recipes)
 	require.Equal(t, v20250801preview.ProvisioningStateSucceeded, *actualOutput.Properties.ProvisioningState)
 }
@@ -145,7 +144,6 @@ func TestCreateOrUpdateRecipePackRun_UpdateExisting(t *testing.T) {
 
 	actualOutput := &v20250801preview.RecipePackResource{}
 	_ = json.Unmarshal(w.Body.Bytes(), actualOutput)
-	require.Equal(t, expectedOutput.Properties.Description, actualOutput.Properties.Description)
 	require.Equal(t, expectedOutput.Properties.Recipes, actualOutput.Properties.Recipes)
 	require.Equal(t, v20250801preview.ProvisioningStateSucceeded, *actualOutput.Properties.ProvisioningState)
 }
@@ -154,12 +152,10 @@ func getTestModels() (*v20250801preview.RecipePackResource, *datamodel.RecipePac
 	resourceID := "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/default/providers/Radius.Core/recipePacks/testrecipepack"
 	resourceName := "testrecipepack"
 	location := "global"
-	description := "Test recipe pack with sample recipes"
 
 	recipePackInput := &v20250801preview.RecipePackResource{
 		Location: &location,
 		Properties: &v20250801preview.RecipePackProperties{
-			Description: &description,
 			Recipes: map[string]*v20250801preview.RecipeDefinition{
 				"Applications.Core/extenders": {
 					RecipeKind:     to.Ptr(v20250801preview.RecipeKindBicep),
@@ -190,7 +186,6 @@ func getTestModels() (*v20250801preview.RecipePackResource, *datamodel.RecipePac
 			},
 		},
 		Properties: datamodel.RecipePackProperties{
-			Description: description,
 			Recipes: map[string]*datamodel.RecipeDefinition{
 				"Applications.Core/extenders": {
 					RecipeKind:     "bicep",
@@ -217,7 +212,6 @@ func getTestModels() (*v20250801preview.RecipePackResource, *datamodel.RecipePac
 		Type:     to.Ptr(datamodel.RecipePackResourceType),
 		Location: &location,
 		Properties: &v20250801preview.RecipePackProperties{
-			Description:       &description,
 			ProvisioningState: to.Ptr(v20250801preview.ProvisioningStateSucceeded),
 			Recipes: map[string]*v20250801preview.RecipeDefinition{
 				"Applications.Core/extenders": {

--- a/pkg/corerp/frontend/controller/recipepacks/testdata/recipepack_datamodel.json
+++ b/pkg/corerp/frontend/controller/recipepacks/testdata/recipepack_datamodel.json
@@ -12,7 +12,6 @@
     "lastModifiedByType": "User"
   },
   "properties": {
-    "description": "Test recipe pack with sample recipes",
     "recipes": {
       "Applications.Core/extenders": {
         "recipeKind": "bicep",

--- a/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/examples/RecipePacks_CreateOrUpdate.json
+++ b/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/examples/RecipePacks_CreateOrUpdate.json
@@ -8,7 +8,6 @@
     "RecipePackResource": {
       "location": "West US",
       "properties": {
-        "description": "Azure container recipes for common container patterns",
         "recipes": {
           "Applications.Core/containers": {
             "recipeKind": "bicep",
@@ -39,7 +38,6 @@
         "location": "West US",
         "properties": {
           "provisioningState": "Succeeded",
-          "description": "Azure container recipes for common container patterns",
           "referencedBy": [
             "/planes/radius/local/resourceGroups/testGroup/providers/Radius.Core/environments/my-env"
           ],

--- a/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/examples/RecipePacks_Get.json
+++ b/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/examples/RecipePacks_Get.json
@@ -15,7 +15,6 @@
         "location": "West US",
         "properties": {
           "provisioningState": "Succeeded",
-          "description": "Azure container recipes for common container patterns",
           "referencedBy": [
             "/planes/radius/local/resourceGroups/testGroup/providers/Radius.Core/environments/my-env"
           ],

--- a/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/examples/RecipePacks_ListByScope.json
+++ b/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/examples/RecipePacks_ListByScope.json
@@ -16,7 +16,6 @@
             "location": "West US",
             "properties": {
               "provisioningState": "Succeeded",
-              "description": "Azure container recipes for common container patterns",
               "referencedBy": [
                 "/planes/radius/local/resourceGroups/testGroup/providers/Radius.Core/environments/my-env"
               ],
@@ -35,7 +34,6 @@
             "location": "East US",
             "properties": {
               "provisioningState": "Succeeded",
-              "description": "Kubernetes native recipes",
               "referencedBy": [],
               "recipes": {
                 "Applications.Core/containers": {

--- a/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/openapi.json
+++ b/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/openapi.json
@@ -1460,10 +1460,6 @@
           "description": "The status of the asynchronous operation",
           "readOnly": true
         },
-        "description": {
-          "type": "string",
-          "description": "Description of what this recipe pack provides"
-        },
         "referencedBy": {
           "type": "array",
           "description": "List of environment IDs that reference this recipe pack",

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/recipepacks-test-no-provider.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/recipepacks-test-no-provider.bicep
@@ -12,7 +12,6 @@ resource recipepack 'Radius.Core/recipePacks@2025-08-01-preview' = {
   name: 'test-recipe-pack-no-provider'
   location: 'global'
   properties: {
-    description: 'Test recipe pack with userTypeAlpha recipe'
     recipes: {
       'Test.Resources/userTypeAlpha': {
         recipeKind: 'bicep'

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/recipepacks-test.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/recipepacks-test.bicep
@@ -16,7 +16,6 @@ resource recipepack 'Radius.Core/recipePacks@2025-08-01-preview' = {
   name: 'test-recipe-pack'
   location: 'global'
   properties: {
-    description: 'Test recipe pack with userTypeAlpha recipe'
     recipes: {
       'Test.Resources/userTypeAlpha': {
         recipeKind: 'bicep'

--- a/typespec/Radius.Core/examples/2025-08-01-preview/RecipePacks_CreateOrUpdate.json
+++ b/typespec/Radius.Core/examples/2025-08-01-preview/RecipePacks_CreateOrUpdate.json
@@ -8,7 +8,6 @@
     "RecipePackResource": {
       "location": "West US",
       "properties": {
-        "description": "Azure container recipes for common container patterns",
         "recipes": {
           "Applications.Core/containers": {
             "recipeKind": "bicep",
@@ -39,7 +38,6 @@
         "location": "West US",
         "properties": {
           "provisioningState": "Succeeded",
-          "description": "Azure container recipes for common container patterns",
           "referencedBy": [
             "/planes/radius/local/resourceGroups/testGroup/providers/Radius.Core/environments/my-env"
           ],

--- a/typespec/Radius.Core/examples/2025-08-01-preview/RecipePacks_Get.json
+++ b/typespec/Radius.Core/examples/2025-08-01-preview/RecipePacks_Get.json
@@ -15,7 +15,6 @@
         "location": "West US",
         "properties": {
           "provisioningState": "Succeeded",
-          "description": "Azure container recipes for common container patterns",
           "referencedBy": [
             "/planes/radius/local/resourceGroups/testGroup/providers/Radius.Core/environments/my-env"
           ],

--- a/typespec/Radius.Core/examples/2025-08-01-preview/RecipePacks_List.json
+++ b/typespec/Radius.Core/examples/2025-08-01-preview/RecipePacks_List.json
@@ -15,7 +15,6 @@
             "location": "West US",
             "properties": {
               "provisioningState": "Succeeded",
-              "description": "Azure container recipes for common container patterns",
               "referencedBy": [
                 "/planes/radius/local/resourceGroups/group1/providers/Radius.Core/environments/my-env"
               ],
@@ -34,7 +33,6 @@
             "location": "East US",
             "properties": {
               "provisioningState": "Succeeded",
-              "description": "Kubernetes native recipes",
               "referencedBy": [],
               "recipes": {
                 "Applications.Core/containers": {

--- a/typespec/Radius.Core/examples/2025-08-01-preview/RecipePacks_ListByScope.json
+++ b/typespec/Radius.Core/examples/2025-08-01-preview/RecipePacks_ListByScope.json
@@ -16,7 +16,6 @@
             "location": "West US",
             "properties": {
               "provisioningState": "Succeeded",
-              "description": "Azure container recipes for common container patterns",
               "referencedBy": [
                 "/planes/radius/local/resourceGroups/testGroup/providers/Radius.Core/environments/my-env"
               ],
@@ -35,7 +34,6 @@
             "location": "East US",
             "properties": {
               "provisioningState": "Succeeded",
-              "description": "Kubernetes native recipes",
               "referencedBy": [],
               "recipes": {
                 "Applications.Core/containers": {

--- a/typespec/Radius.Core/recipePacks.tsp
+++ b/typespec/Radius.Core/recipePacks.tsp
@@ -47,9 +47,6 @@ model RecipePackProperties {
   @visibility(Lifecycle.Read)
   provisioningState?: ProvisioningState;
 
-  @doc("Description of what this recipe pack provides")
-  description?: string;
-
   @doc("List of environment IDs that reference this recipe pack")
   @visibility(Lifecycle.Read)
   referencedBy?: string[];


### PR DESCRIPTION
# Description

Removing "description" from recipe pack schema. 
We will add a description in future, if neccessary, to all radius.core resources ( based on discussion with @willtsai @zachcasper )

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #10831

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [x] Yes <!-- TaskRadio schema -->
    - [ ] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [x] Yes <!-- TaskRadio design-pr -->
    - [ ] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [x] Yes <!-- TaskRadio design-review -->
    - [ ] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->