### PR TITLE
Add recipeparameters to environment

### DIFF
--- a/hack/bicep-types-radius/generated/index.json
+++ b/hack/bicep-types-radius/generated/index.json
@@ -49,10 +49,10 @@
       "$ref": "radius/radius.core/2025-08-01-preview/types.json#/44"
     },
     "Radius.Core/environments@2025-08-01-preview": {
-      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/64"
+      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/67"
     },
     "Radius.Core/recipePacks@2025-08-01-preview": {
-      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/87"
+      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/89"
     }
   },
   "resourceFunctions": {},

--- a/hack/bicep-types-radius/generated/radius/radius.core/2025-08-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/radius/radius.core/2025-08-01-preview/types.json
@@ -588,7 +588,7 @@
       },
       "tags": {
         "type": {
-          "$ref": "#/63"
+          "$ref": "#/66"
         },
         "flags": 0,
         "description": "Resource tags."
@@ -627,9 +627,16 @@
         "flags": 0,
         "description": "List of Recipe Pack resource IDs linked to this environment."
       },
+      "recipeParameters": {
+        "type": {
+          "$ref": "#/61"
+        },
+        "flags": 0,
+        "description": "Recipe specific parameters that apply to all resources of a given type in this environment."
+      },
       "providers": {
         "type": {
-          "$ref": "#/59"
+          "$ref": "#/62"
         },
         "flags": 0
       },
@@ -710,25 +717,44 @@
     }
   },
   {
+    "$type": "AnyType"
+  },
+  {
+    "$type": "ObjectType",
+    "name": "RecipeParameterValue",
+    "properties": {},
+    "additionalProperties": {
+      "$ref": "#/59"
+    }
+  },
+  {
+    "$type": "ObjectType",
+    "name": "EnvironmentPropertiesRecipeParameters",
+    "properties": {},
+    "additionalProperties": {
+      "$ref": "#/60"
+    }
+  },
+  {
     "$type": "ObjectType",
     "name": "Providers",
     "properties": {
       "azure": {
         "type": {
-          "$ref": "#/60"
+          "$ref": "#/63"
         },
         "flags": 0,
         "description": "The Azure cloud provider definition."
       },
       "kubernetes": {
         "type": {
-          "$ref": "#/61"
+          "$ref": "#/64"
         },
         "flags": 0
       },
       "aws": {
         "type": {
-          "$ref": "#/62"
+          "$ref": "#/65"
         },
         "flags": 0,
         "description": "The AWS cloud provider definition."
@@ -834,28 +860,28 @@
       },
       "type": {
         "type": {
-          "$ref": "#/65"
+          "$ref": "#/68"
         },
         "flags": 10,
         "description": "The resource type"
       },
       "apiVersion": {
         "type": {
-          "$ref": "#/66"
+          "$ref": "#/69"
         },
         "flags": 10,
         "description": "The resource api version"
       },
       "properties": {
         "type": {
-          "$ref": "#/68"
+          "$ref": "#/71"
         },
         "flags": 1,
         "description": "Recipe Pack properties"
       },
       "tags": {
         "type": {
-          "$ref": "#/86"
+          "$ref": "#/88"
         },
         "flags": 0,
         "description": "Resource tags."
@@ -882,21 +908,21 @@
     "properties": {
       "provisioningState": {
         "type": {
-          "$ref": "#/77"
+          "$ref": "#/80"
         },
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
       },
       "referencedBy": {
         "type": {
-          "$ref": "#/78"
+          "$ref": "#/81"
         },
         "flags": 2,
         "description": "List of environment IDs that reference this recipe pack"
       },
       "recipes": {
         "type": {
-          "$ref": "#/85"
+          "$ref": "#/87"
         },
         "flags": 1,
         "description": "Map of resource types to their recipe configurations"
@@ -939,15 +965,6 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/69"
-      },
-      {
-        "$ref": "#/70"
-      },
-      {
-        "$ref": "#/71"
-      },
-      {
         "$ref": "#/72"
       },
       {
@@ -961,6 +978,15 @@
       },
       {
         "$ref": "#/76"
+      },
+      {
+        "$ref": "#/77"
+      },
+      {
+        "$ref": "#/78"
+      },
+      {
+        "$ref": "#/79"
       }
     ]
   },
@@ -976,7 +1002,7 @@
     "properties": {
       "recipeKind": {
         "type": {
-          "$ref": "#/82"
+          "$ref": "#/85"
         },
         "flags": 1,
         "description": "The type of recipe"
@@ -997,7 +1023,7 @@
       },
       "parameters": {
         "type": {
-          "$ref": "#/84"
+          "$ref": "#/86"
         },
         "flags": 0,
         "description": "Parameters to pass to the recipe"
@@ -1016,22 +1042,19 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/80"
+        "$ref": "#/83"
       },
       {
-        "$ref": "#/81"
+        "$ref": "#/84"
       }
     ]
-  },
-  {
-    "$type": "AnyType"
   },
   {
     "$type": "ObjectType",
     "name": "RecipeDefinitionParameters",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/83"
+      "$ref": "#/59"
     }
   },
   {
@@ -1039,7 +1062,7 @@
     "name": "RecipePackPropertiesRecipes",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/79"
+      "$ref": "#/82"
     }
   },
   {
@@ -1054,7 +1077,7 @@
     "$type": "ResourceType",
     "name": "Radius.Core/recipePacks@2025-08-01-preview",
     "body": {
-      "$ref": "#/67"
+      "$ref": "#/70"
     },
     "readableScopes": 0,
     "writableScopes": 0,

--- a/pkg/corerp/api/v20250801preview/environment_conversion.go
+++ b/pkg/corerp/api/v20250801preview/environment_conversion.go
@@ -49,6 +49,11 @@ func (src *EnvironmentResource) ConvertTo() (v1.DataModelInterface, error) {
 		converted.Properties.RecipePacks = to.StringArray(src.Properties.RecipePacks)
 	}
 
+	// Convert RecipeParameters
+	if src.Properties.RecipeParameters != nil {
+		converted.Properties.RecipeParameters = src.Properties.RecipeParameters
+	}
+
 	// Convert Providers
 	if src.Properties.Providers != nil {
 		converted.Properties.Providers = toProvidersDataModel(src.Properties.Providers)
@@ -82,6 +87,11 @@ func (dst *EnvironmentResource) ConvertFrom(src v1.DataModelInterface) error {
 	// Convert RecipePacks
 	if len(env.Properties.RecipePacks) > 0 {
 		dst.Properties.RecipePacks = to.ArrayofStringPtrs(env.Properties.RecipePacks)
+	}
+
+	// Convert RecipeParameters
+	if len(env.Properties.RecipeParameters) > 0 {
+		dst.Properties.RecipeParameters = env.Properties.RecipeParameters
 	}
 
 	// Convert Providers

--- a/pkg/corerp/api/v20250801preview/environment_conversion_test.go
+++ b/pkg/corerp/api/v20250801preview/environment_conversion_test.go
@@ -39,6 +39,11 @@ func TestEnvironmentConvertVersionedToDataModel(t *testing.T) {
 			RecipePacks: []*string{
 				to.Ptr("/planes/radius/local/providers/Radius.Core/recipePacks/azure-aci-pack"),
 			},
+			RecipeParameters: map[string]map[string]any{
+				"Radius.Compute/containers": {
+					"allowPlatformOptions": false,
+				},
+			},
 			Providers: &Providers{
 				Azure: &ProvidersAzure{
 					SubscriptionID:    to.Ptr("00000000-0000-0000-0000-000000000000"),
@@ -70,6 +75,11 @@ func TestEnvironmentConvertVersionedToDataModel(t *testing.T) {
 	require.NotNil(t, env.Properties.Providers.Azure)
 	require.Equal(t, "00000000-0000-0000-0000-000000000000", env.Properties.Providers.Azure.SubscriptionId)
 	require.Equal(t, "my-resource-group", env.Properties.Providers.Azure.ResourceGroupName)
+	require.NotNil(t, env.Properties.RecipeParameters)
+	require.Len(t, env.Properties.RecipeParameters, 1)
+	containerParams, ok := env.Properties.RecipeParameters["Radius.Compute/containers"]
+	require.True(t, ok)
+	require.Equal(t, false, containerParams["allowPlatformOptions"])
 }
 
 func TestEnvironmentConvertDataModelToVersioned(t *testing.T) {
@@ -92,6 +102,11 @@ func TestEnvironmentConvertDataModelToVersioned(t *testing.T) {
 		},
 		Properties: datamodel.EnvironmentProperties_v20250801preview{
 			RecipePacks: []string{"/planes/radius/local/providers/Radius.Core/recipePacks/test-pack"},
+			RecipeParameters: map[string]map[string]any{
+				"Radius.Compute/containers": {
+					"allowPlatformOptions": true,
+				},
+			},
 			Providers: &datamodel.Providers_v20250801preview{
 				Kubernetes: &datamodel.ProvidersKubernetes_v20250801preview{
 					Namespace: "default",
@@ -113,4 +128,9 @@ func TestEnvironmentConvertDataModelToVersioned(t *testing.T) {
 	require.NotNil(t, versionedResource.Properties.Providers)
 	require.NotNil(t, versionedResource.Properties.Providers.Kubernetes)
 	require.Equal(t, to.Ptr("default"), versionedResource.Properties.Providers.Kubernetes.Namespace)
+	require.NotNil(t, versionedResource.Properties.RecipeParameters)
+	require.Len(t, versionedResource.Properties.RecipeParameters, 1)
+	containerParams, ok := versionedResource.Properties.RecipeParameters["Radius.Compute/containers"]
+	require.True(t, ok)
+	require.Equal(t, true, containerParams["allowPlatformOptions"])
 }

--- a/pkg/corerp/api/v20250801preview/zz_generated_models.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_models.go
@@ -184,6 +184,9 @@ type EnvironmentProperties struct {
 	// List of Recipe Pack resource IDs linked to this environment.
 	RecipePacks []*string
 
+	// Recipe specific parameters that apply to all resources of a given type in this environment.
+	RecipeParameters map[string]map[string]any
+
 	// Simulated environment.
 	Simulated *bool
 

--- a/pkg/corerp/api/v20250801preview/zz_generated_models_serde.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_models_serde.go
@@ -434,6 +434,7 @@ func (e EnvironmentProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "providers", e.Providers)
 	populate(objectMap, "provisioningState", e.ProvisioningState)
 	populate(objectMap, "recipePacks", e.RecipePacks)
+	populate(objectMap, "recipeParameters", e.RecipeParameters)
 	populate(objectMap, "simulated", e.Simulated)
 	return json.Marshal(objectMap)
 }
@@ -455,6 +456,9 @@ func (e *EnvironmentProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "recipePacks":
 			err = unpopulate(val, "RecipePacks", &e.RecipePacks)
+			delete(rawMsg, key)
+		case "recipeParameters":
+			err = unpopulate(val, "RecipeParameters", &e.RecipeParameters)
 			delete(rawMsg, key)
 		case "simulated":
 			err = unpopulate(val, "Simulated", &e.Simulated)

--- a/pkg/corerp/datamodel/environment_v20250801preview.go
+++ b/pkg/corerp/datamodel/environment_v20250801preview.go
@@ -41,6 +41,10 @@ type EnvironmentProperties_v20250801preview struct {
 	// RecipePacks is the list of recipe pack resource IDs linked to this environment.
 	RecipePacks []string `json:"recipePacks,omitempty"`
 
+	// RecipeParameters contains recipe-specific parameters that apply to all resources of a given type.
+	// The key is the resource type (e.g., "Radius.Compute/containers") and the value is a map of parameter names to values.
+	RecipeParameters map[string]map[string]any `json:"recipeParameters,omitempty"`
+
 	// Providers contains cloud provider configuration for the environment.
 	Providers *Providers_v20250801preview `json:"providers,omitempty"`
 

--- a/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/examples/Environments_CreateOrUpdate_Azure.json
+++ b/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/examples/Environments_CreateOrUpdate_Azure.json
@@ -11,6 +11,14 @@
         "recipePacks": [
           "/planes/radius/local/providers/Radius.Core/recipePacks/azure-aci-pack"
         ],
+        "recipeParameters": {
+          "Radius.Compute/containers": {
+            "allowPlatformOptions": false
+          },
+          "Radius.Data/sqlDatabases": {
+            "sku": "Basic"
+          }
+        },
         "providers": {
           "azure": {
             "subscriptionId": "00000000-0000-0000-0000-000000000000",
@@ -37,6 +45,14 @@
           "recipePacks": [
             "/planes/radius/local/providers/Radius.Core/recipePacks/azure-aci-pack"
           ],
+          "recipeParameters": {
+            "Radius.Compute/containers": {
+              "allowPlatformOptions": false
+            },
+            "Radius.Data/sqlDatabases": {
+              "sku": "Basic"
+            }
+          },
           "providers": {
             "azure": {
               "subscriptionId": "00000000-0000-0000-0000-000000000000",

--- a/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/examples/Environments_CreateOrUpdate_Hybrid.json
+++ b/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/examples/Environments_CreateOrUpdate_Hybrid.json
@@ -11,6 +11,14 @@
         "recipePacks": [
           "/planes/radius/local/providers/Radius.Core/recipePacks/azure-aci-pack"
         ],
+        "recipeParameters": {
+          "Radius.Compute/containers": {
+            "allowPlatformOptions": false
+          },
+          "Radius.Data/sqlDatabases": {
+            "sku": "Basic"
+          }
+        },
         "providers": {
           "azure": {
             "subscriptionId": "00000000-0000-0000-0000-000000000000",
@@ -40,6 +48,14 @@
           "recipePacks": [
             "/planes/radius/local/providers/Radius.Core/recipePacks/azure-aci-pack"
           ],
+          "recipeParameters": {
+            "Radius.Compute/containers": {
+              "allowPlatformOptions": false
+            },
+            "Radius.Data/sqlDatabases": {
+              "sku": "Basic"
+            }
+          },
           "providers": {
             "azure": {
               "subscriptionId": "00000000-0000-0000-0000-000000000000",

--- a/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/examples/Environments_CreateOrUpdate_Kubernetes.json
+++ b/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/examples/Environments_CreateOrUpdate_Kubernetes.json
@@ -11,6 +11,14 @@
         "recipePacks": [
           "/planes/radius/local/providers/Radius.Core/recipePacks/kubernetes-pack"
         ],
+        "recipeParameters": {
+          "Radius.Compute/containers": {
+            "allowPlatformOptions": false
+          },
+          "Radius.Data/sqlDatabases": {
+            "sku": "Basic"
+          }
+        },
         "providers": {
           "kubernetes": {
             "namespace": "default"
@@ -30,6 +38,14 @@
           "recipePacks": [
             "/planes/radius/local/providers/Radius.Core/recipePacks/kubernetes-pack"
           ],
+          "recipeParameters": {
+            "Radius.Compute/containers": {
+              "allowPlatformOptions": false
+            },
+            "Radius.Data/sqlDatabases": {
+              "sku": "Basic"
+            }
+          },
           "providers": {
             "kubernetes": {
               "namespace": "default"

--- a/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/openapi.json
+++ b/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/openapi.json
@@ -1106,6 +1106,13 @@
             "type": "string"
           }
         },
+        "recipeParameters": {
+          "type": "object",
+          "description": "Recipe specific parameters that apply to all resources of a given type in this environment.",
+          "additionalProperties": {
+            "$ref": "#/definitions/RecipeParameterValue"
+          }
+        },
         "providers": {
           "$ref": "#/definitions/Providers",
           "description": "Cloud provider configuration for the environment."
@@ -1532,6 +1539,11 @@
           "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
         }
       ]
+    },
+    "RecipeParameterValue": {
+      "type": "object",
+      "description": "Recipe parameter configuration for a specific resource type.",
+      "additionalProperties": {}
     },
     "RecipeStatus": {
       "type": "object",

--- a/typespec/Radius.Core/environments.tsp
+++ b/typespec/Radius.Core/environments.tsp
@@ -54,11 +54,19 @@ model EnvironmentProperties {
   @doc("List of Recipe Pack resource IDs linked to this environment.")
   recipePacks?: string[];
 
+  @doc("Recipe specific parameters that apply to all resources of a given type in this environment.")
+  recipeParameters?: Record<RecipeParameterValue>;
+
   @doc("Cloud provider configuration for the environment.")
   providers?: Providers;
 
   @doc("Simulated environment.")
   simulated?: boolean;
+}
+
+@doc("Recipe parameter configuration for a specific resource type.")
+model RecipeParameterValue {
+  ...Record<unknown>;
 }
 
 @doc("The Azure cloud provider definition.")

--- a/typespec/Radius.Core/examples/2025-08-01-preview/Environments_CreateOrUpdate_Azure.json
+++ b/typespec/Radius.Core/examples/2025-08-01-preview/Environments_CreateOrUpdate_Azure.json
@@ -11,6 +11,14 @@
         "recipePacks": [
           "/planes/radius/local/providers/Radius.Core/recipePacks/azure-aci-pack"
         ],
+        "recipeParameters": {
+          "Radius.Compute/containers": {
+            "allowPlatformOptions": false
+          },
+          "Radius.Data/sqlDatabases": {
+            "sku": "Basic"
+          }
+        },
         "providers": {
           "azure": {
             "subscriptionId": "00000000-0000-0000-0000-000000000000",
@@ -37,6 +45,14 @@
           "recipePacks": [
             "/planes/radius/local/providers/Radius.Core/recipePacks/azure-aci-pack"
           ],
+          "recipeParameters": {
+            "Radius.Compute/containers": {
+              "allowPlatformOptions": false
+            },
+            "Radius.Data/sqlDatabases": {
+              "sku": "Basic"
+            }
+          },
           "providers": {
             "azure": {
               "subscriptionId": "00000000-0000-0000-0000-000000000000",

--- a/typespec/Radius.Core/examples/2025-08-01-preview/Environments_CreateOrUpdate_Hybrid.json
+++ b/typespec/Radius.Core/examples/2025-08-01-preview/Environments_CreateOrUpdate_Hybrid.json
@@ -11,6 +11,14 @@
         "recipePacks": [
           "/planes/radius/local/providers/Radius.Core/recipePacks/azure-aci-pack"
         ],
+        "recipeParameters": {
+          "Radius.Compute/containers": {
+            "allowPlatformOptions": false
+          },
+          "Radius.Data/sqlDatabases": {
+            "sku": "Basic"
+          }
+        },
         "providers": {
           "azure": {
             "subscriptionId": "00000000-0000-0000-0000-000000000000",
@@ -40,6 +48,14 @@
           "recipePacks": [
             "/planes/radius/local/providers/Radius.Core/recipePacks/azure-aci-pack"
           ],
+          "recipeParameters": {
+            "Radius.Compute/containers": {
+              "allowPlatformOptions": false
+            },
+            "Radius.Data/sqlDatabases": {
+              "sku": "Basic"
+            }
+          },
           "providers": {
             "azure": {
               "subscriptionId": "00000000-0000-0000-0000-000000000000",

--- a/typespec/Radius.Core/examples/2025-08-01-preview/Environments_CreateOrUpdate_Kubernetes.json
+++ b/typespec/Radius.Core/examples/2025-08-01-preview/Environments_CreateOrUpdate_Kubernetes.json
@@ -11,6 +11,14 @@
         "recipePacks": [
           "/planes/radius/local/providers/Radius.Core/recipePacks/kubernetes-pack"
         ],
+        "recipeParameters": {
+          "Radius.Compute/containers": {
+            "allowPlatformOptions": false
+          },
+          "Radius.Data/sqlDatabases": {
+            "sku": "Basic"
+          }
+        },
         "providers": {
           "kubernetes": {
             "namespace": "default"
@@ -30,6 +38,14 @@
           "recipePacks": [
             "/planes/radius/local/providers/Radius.Core/recipePacks/kubernetes-pack"
           ],
+          "recipeParameters": {
+            "Radius.Compute/containers": {
+              "allowPlatformOptions": false
+            },
+            "Radius.Data/sqlDatabases": {
+              "sku": "Basic"
+            }
+          },
           "providers": {
             "kubernetes": {
               "namespace": "default"


### PR DESCRIPTION
# Description

datamodel support for  recipeParameters property in Radius.Core/environments
```
resource stdEnv 'Radius.Core/environments@2023-10-01-preview' = {
    name: 'std-env'
    properties: {
        recipePacks: [azure-aci-pack.id]
        recipeParameters: {
            Radius.Compute/containers: {
                allowPlatformOptions: false
            }
            Radius.Data/sqlDatabases: {
                sku: "Basic"
            }
        }
    }
    providers: {
        ...
    }
}
```

## Type of change


- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [x] Yes <!-- TaskRadio schema -->
    - [ ] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [x] Yes <!-- TaskRadio design-pr -->
    - [ ] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [x] Yes <!-- TaskRadio design-review -->
    - [ ] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->