### PR TITLE
ci(workflows): add skip tests functionality

### DIFF
--- a/.github/workflows/__changes.yml
+++ b/.github/workflows/__changes.yml
@@ -17,6 +17,16 @@ on:
           test/**/*.md
           test/*.md
           *.md
+      ref:
+        description: The branch, tag or SHA to checkout
+        required: false
+        default: ""
+        type: string
+      repository:
+        description: Repository name with owner
+        required: false
+        default: ${{ github.repository }}
+        type: string
     outputs:
       only_changed:
         description: Returns 'true' when only files in the configured patterns have changed.
@@ -39,6 +49,8 @@ jobs:
         with:
           fetch-depth: 2
           persist-credentials: false
+          ref: ${{ inputs.ref }}
+          repository: ${{ inputs.repository }}
 
       - name: Filter
         id: filter

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -88,8 +88,8 @@ env:
   # Kubernetes client QPS and Burst settings for high-concurrency CI environments
   RADIUS_QPS_AND_BURST: "800"
 jobs:
-  build:
-    name: Build Radius for test
+  setup:
+    name: Setup
     runs-on: ubuntu-latest
     if: github.event_name == 'repository_dispatch' ||
       (github.event_name == 'schedule' && github.repository == 'radius-project/radius') ||
@@ -109,6 +109,7 @@ jobs:
       RAD_CLI_ARTIFACT_NAME: ${{ steps.gen-id.outputs.RAD_CLI_ARTIFACT_NAME }}
       DE_IMAGE: ${{ steps.gen-id.outputs.DE_IMAGE }}
       DE_TAG: ${{ steps.gen-id.outputs.DE_TAG }}
+      AZURE_TEST_RESOURCE_GROUP: ${{ steps.gen-id.outputs.AZURE_TEST_RESOURCE_GROUP }}
     steps:
       - name: Log Event Information
         run: |
@@ -208,6 +209,72 @@ jobs:
               );
             }
 
+      - name: Generate ID for release
+        id: gen-id
+        run: |
+          BASE_STR="RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
+          if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
+            # Add run number to randomize unique id for scheduled runs.
+            BASE_STR="${GITHUB_RUN_NUMBER}|${BASE_STR}"
+          fi
+          UNIQUE_ID=func$(echo $BASE_STR | sha1sum | head -c 10)
+          echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_ENV
+
+          # Set output variables to be used in the other jobs
+          echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_OUTPUT
+          echo "UNIQUE_ID=${UNIQUE_ID}" >> $GITHUB_OUTPUT
+          echo "CHECKOUT_REPO=${{ env.CHECKOUT_REPO }}" >> $GITHUB_OUTPUT
+          echo "CHECKOUT_REF=${{ env.CHECKOUT_REF }}" >> $GITHUB_OUTPUT
+          echo "AZURE_TEST_RESOURCE_GROUP=radtest-${UNIQUE_ID}" >> $GITHUB_OUTPUT
+          echo "RAD_CLI_ARTIFACT_NAME=rad_cli_linux_amd64" >> $GITHUB_OUTPUT
+          echo "PR_NUMBER=${{ env.PR_NUMBER }}" >> $GITHUB_OUTPUT
+          echo "DE_IMAGE=${{ env.DE_IMAGE }}" >> $GITHUB_OUTPUT
+          echo "DE_TAG=${{ env.DE_TAG }}" >> $GITHUB_OUTPUT
+
+  changes:
+    name: Changes
+    needs: setup
+    uses: ./.github/workflows/__changes.yml
+    with:
+      ref: ${{ needs.setup.outputs.CHECKOUT_REF }}
+      repository: ${{ needs.setup.outputs.CHECKOUT_REPO }}
+    permissions:
+      contents: read
+      pull-requests: read
+
+  build:
+    name: Build Radius for test
+    needs: [setup, changes]
+    if: needs.changes.outputs.only_changed != 'true'
+    runs-on: ubuntu-latest
+    env:
+      REL_VERSION: ${{ needs.setup.outputs.REL_VERSION }}
+      UNIQUE_ID: ${{ needs.setup.outputs.UNIQUE_ID }}
+      PR_NUMBER: ${{ needs.setup.outputs.PR_NUMBER }}
+      CHECKOUT_REPO: ${{ needs.setup.outputs.CHECKOUT_REPO }}
+      CHECKOUT_REF: ${{ needs.setup.outputs.CHECKOUT_REF }}
+      RAD_CLI_ARTIFACT_NAME: ${{ needs.setup.outputs.RAD_CLI_ARTIFACT_NAME }}
+      DE_IMAGE: ${{ needs.setup.outputs.DE_IMAGE }}
+      DE_TAG: ${{ needs.setup.outputs.DE_TAG }}
+      DAPR_VER: "1.14.4"
+      ACTION_LINK: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+    outputs:
+      REL_VERSION: ${{ needs.setup.outputs.REL_VERSION }}
+      UNIQUE_ID: ${{ needs.setup.outputs.UNIQUE_ID }}
+      PR_NUMBER: ${{ needs.setup.outputs.PR_NUMBER }}
+      CHECKOUT_REPO: ${{ needs.setup.outputs.CHECKOUT_REPO }}
+      CHECKOUT_REF: ${{ needs.setup.outputs.CHECKOUT_REF }}
+      RAD_CLI_ARTIFACT_NAME: ${{ needs.setup.outputs.RAD_CLI_ARTIFACT_NAME }}
+      DE_IMAGE: ${{ needs.setup.outputs.DE_IMAGE }}
+      DE_TAG: ${{ needs.setup.outputs.DE_TAG }}
+    steps:
+      - name: Get GitHub app token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        id: get_installation_token
+        with:
+          app_id: ${{ env.FUNCTIONAL_TEST_APP_ID }}
+          private_key: ${{ secrets.FUNCTIONAL_TEST_APP_PRIVATE_KEY }}
+
       - name: Check out code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
@@ -240,28 +307,6 @@ jobs:
           cache-dependency-path: go.sum
           cache: true
 
-      - name: Generate ID for release
-        id: gen-id
-        run: |
-          BASE_STR="RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
-          if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
-            # Add run number to randomize unique id for scheduled runs.
-            BASE_STR="${GITHUB_RUN_NUMBER}|${BASE_STR}"
-          fi
-          UNIQUE_ID=func$(echo $BASE_STR | sha1sum | head -c 10)
-          echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_ENV
-
-          # Set output variables to be used in the other jobs
-          echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_OUTPUT
-          echo "UNIQUE_ID=${UNIQUE_ID}" >> $GITHUB_OUTPUT
-          echo "CHECKOUT_REPO=${{ env.CHECKOUT_REPO }}" >> $GITHUB_OUTPUT
-          echo "CHECKOUT_REF=${{ env.CHECKOUT_REF }}" >> $GITHUB_OUTPUT
-          echo "AZURE_TEST_RESOURCE_GROUP=radtest-${UNIQUE_ID}" >> $GITHUB_OUTPUT
-          echo "RAD_CLI_ARTIFACT_NAME=rad_cli_linux_amd64" >> $GITHUB_OUTPUT
-          echo "PR_NUMBER=${{ env.PR_NUMBER }}" >> $GITHUB_OUTPUT
-          echo "DE_IMAGE=${{ env.DE_IMAGE }}" >> $GITHUB_OUTPUT
-          echo "DE_TAG=${{ env.DE_TAG }}" >> $GITHUB_OUTPUT
-
       - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         if: env.PR_NUMBER != ''
         continue-on-error: true
@@ -280,10 +325,10 @@ jobs:
 
             | Name | Value |
             |------|-------|
-            |**Repository** | ${{ steps.gen-id.outputs.CHECKOUT_REPO }} |
-            |**Commit ref** | ${{ steps.gen-id.outputs.CHECKOUT_REF }} |
-            |**Unique ID** | ${{ steps.gen-id.outputs.UNIQUE_ID }} |
-            |**Image tag** | ${{ steps.gen-id.outputs.REL_VERSION }} |
+            |**Repository** | ${{ env.CHECKOUT_REPO }} |
+            |**Commit ref** | ${{ env.CHECKOUT_REF }} |
+            |**Unique ID** | ${{ env.UNIQUE_ID }} |
+            |**Image tag** | ${{ env.REL_VERSION }} |
 
             * gotestsum ${{ env.GOTESTSUM_VER }}
             * KinD: ${{ env.KIND_VER }}
@@ -330,7 +375,7 @@ jobs:
       - name: Upload CLI binary
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: ${{ steps.gen-id.outputs.RAD_CLI_ARTIFACT_NAME }}
+          name: ${{ env.RAD_CLI_ARTIFACT_NAME }}
           path: |
             ./dist/linux_amd64/release/rad
 
@@ -455,6 +500,30 @@ jobs:
           append: true
           message: |
             :x: Test recipe publishing failed
+
+  skip-tests:
+    name: Skip Functional Tests
+    needs: [setup, changes]
+    if: needs.changes.outputs.only_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get GitHub app token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        id: get_installation_token
+        with:
+          app_id: ${{ env.FUNCTIONAL_TEST_APP_ID }}
+          private_key: ${{ secrets.FUNCTIONAL_TEST_APP_PRIVATE_KEY }}
+
+      - uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
+        with:
+          token: ${{ steps.get_installation_token.outputs.token }}
+          name: Functional Test Run
+          status: completed
+          conclusion: success
+          repo: ${{ github.repository }}
+          sha: ${{ needs.setup.outputs.CHECKOUT_REF }}
+          output: |
+            {"summary":"Skipped functional tests"}
 
   tests:
     name: Run ${{ matrix.name }} functional tests

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -109,7 +109,6 @@ jobs:
       RAD_CLI_ARTIFACT_NAME: ${{ steps.gen-id.outputs.RAD_CLI_ARTIFACT_NAME }}
       DE_IMAGE: ${{ steps.gen-id.outputs.DE_IMAGE }}
       DE_TAG: ${{ steps.gen-id.outputs.DE_TAG }}
-      AZURE_TEST_RESOURCE_GROUP: ${{ steps.gen-id.outputs.AZURE_TEST_RESOURCE_GROUP }}
     steps:
       - name: Log Event Information
         run: |
@@ -225,7 +224,6 @@ jobs:
           echo "UNIQUE_ID=${UNIQUE_ID}" >> $GITHUB_OUTPUT
           echo "CHECKOUT_REPO=${{ env.CHECKOUT_REPO }}" >> $GITHUB_OUTPUT
           echo "CHECKOUT_REF=${{ env.CHECKOUT_REF }}" >> $GITHUB_OUTPUT
-          echo "AZURE_TEST_RESOURCE_GROUP=radtest-${UNIQUE_ID}" >> $GITHUB_OUTPUT
           echo "RAD_CLI_ARTIFACT_NAME=rad_cli_linux_amd64" >> $GITHUB_OUTPUT
           echo "PR_NUMBER=${{ env.PR_NUMBER }}" >> $GITHUB_OUTPUT
           echo "DE_IMAGE=${{ env.DE_IMAGE }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -258,15 +258,6 @@ jobs:
       DE_TAG: ${{ needs.setup.outputs.DE_TAG }}
       DAPR_VER: "1.14.4"
       ACTION_LINK: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-    outputs:
-      REL_VERSION: ${{ needs.setup.outputs.REL_VERSION }}
-      UNIQUE_ID: ${{ needs.setup.outputs.UNIQUE_ID }}
-      PR_NUMBER: ${{ needs.setup.outputs.PR_NUMBER }}
-      CHECKOUT_REPO: ${{ needs.setup.outputs.CHECKOUT_REPO }}
-      CHECKOUT_REF: ${{ needs.setup.outputs.CHECKOUT_REF }}
-      RAD_CLI_ARTIFACT_NAME: ${{ needs.setup.outputs.RAD_CLI_ARTIFACT_NAME }}
-      DE_IMAGE: ${{ needs.setup.outputs.DE_IMAGE }}
-      DE_TAG: ${{ needs.setup.outputs.DE_TAG }}
     steps:
       - name: Get GitHub app token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
@@ -527,7 +518,7 @@ jobs:
 
   tests:
     name: Run ${{ matrix.name }} functional tests
-    needs: [build]
+    needs: [setup, build]
     if: github.event_name == 'repository_dispatch' ||
       (github.event_name == 'schedule' && github.repository == 'radius-project/radius') ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
@@ -539,16 +530,16 @@ jobs:
         name: [corerp-cloud, ucp-cloud]
     runs-on: ${{ matrix.os }}
     env:
-      UNIQUE_ID: ${{ needs.build.outputs.UNIQUE_ID }}
-      REL_VERSION: ${{ needs.build.outputs.REL_VERSION }}
-      CHECKOUT_REPO: ${{ needs.build.outputs.CHECKOUT_REPO }}
-      CHECKOUT_REF: ${{ needs.build.outputs.CHECKOUT_REF }}
-      PR_NUMBER: ${{ needs.build.outputs.PR_NUMBER }}
-      AZURE_TEST_RESOURCE_GROUP: radtest-${{ needs.build.outputs.UNIQUE_ID }}-${{ matrix.name }}
-      RAD_CLI_ARTIFACT_NAME: ${{ needs.build.outputs.RAD_CLI_ARTIFACT_NAME }}
-      BICEP_RECIPE_TAG_VERSION: ${{ needs.build.outputs.REL_VERSION }}
-      DE_IMAGE: ${{ needs.build.outputs.DE_IMAGE }}
-      DE_TAG: ${{ needs.build.outputs.DE_TAG }}
+      UNIQUE_ID: ${{ needs.setup.outputs.UNIQUE_ID }}
+      REL_VERSION: ${{ needs.setup.outputs.REL_VERSION }}
+      CHECKOUT_REPO: ${{ needs.setup.outputs.CHECKOUT_REPO }}
+      CHECKOUT_REF: ${{ needs.setup.outputs.CHECKOUT_REF }}
+      PR_NUMBER: ${{ needs.setup.outputs.PR_NUMBER }}
+      AZURE_TEST_RESOURCE_GROUP: radtest-${{ needs.setup.outputs.UNIQUE_ID }}-${{ matrix.name }}
+      RAD_CLI_ARTIFACT_NAME: ${{ needs.setup.outputs.RAD_CLI_ARTIFACT_NAME }}
+      BICEP_RECIPE_TAG_VERSION: ${{ needs.setup.outputs.REL_VERSION }}
+      DE_IMAGE: ${{ needs.setup.outputs.DE_IMAGE }}
+      DE_TAG: ${{ needs.setup.outputs.DE_TAG }}
     steps:
       - name: Get GitHub app token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
@@ -972,11 +963,11 @@ jobs:
 
   report-test-results:
     name: Report test results
-    needs: [build, tests]
+    needs: [setup, build, tests]
     runs-on: ubuntu-latest
     if: always()
     env:
-      CHECKOUT_REF: ${{ needs.build.outputs.CHECKOUT_REF }}
+      CHECKOUT_REF: ${{ needs.setup.outputs.CHECKOUT_REF }}
     steps:
       - name: Get GitHub app token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0

--- a/.github/workflows/functional-tests-approval.yaml
+++ b/.github/workflows/functional-tests-approval.yaml
@@ -1,6 +1,7 @@
 # yaml-language-server: $schema=https://www.schemastore.org/github-workflow.json
 ---
-name: "Approve Functional Tests"
+name: Approve Functional Tests
+
 on:
   pull_request:
     branches:
@@ -9,18 +10,9 @@ on:
       - release/*
 
 jobs:
-  changes:
-    name: Changes
-    uses: ./.github/workflows/__changes.yml
-    permissions:
-      contents: read
-      pull-requests: read
-
   approve-functional-tests-run:
-    name: "Approve Functional Tests"
+    name: Approve Functional Tests
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.only_changed != 'true'
     environment: functional-tests
     steps:
       - name: Checkout Radius repository


### PR DESCRIPTION
# Description

This pull request refactors the GitHub Actions workflow for functional tests to improve modularity and efficiency. The main changes include splitting the workflow into distinct jobs for setup, change detection, building, and conditional test execution. It introduces a mechanism to skip functional tests if only documentation files have changed, and improves how environment variables and outputs are managed across jobs.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #10799

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->