### PR TITLE
fix(workflows): enhance PR handling in functional test workflow

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -23,6 +23,7 @@ permissions:
   contents: read # Required for listing the commits
   packages: write # Required for uploading the package
   checks: write # Required for creating a check run
+  pull-requests: read # Required for fetching PR details
 
 on:
   # Enable manual trigger
@@ -179,16 +180,43 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             const payload = context.payload.workflow_run;
-            let fs = require('fs');
+            const fs = require('fs');
+            const prNumber = '${{ steps.get-pr-number.outputs.pr_number }}';
+
             let baseSha = "";
-            if (payload.pull_requests && payload.pull_requests.length > 0) {
-                baseSha = payload.pull_requests[0].base.sha;
+            let checkoutRepo = payload.head_repository.full_name;
+            let checkoutRef = payload.head_sha;
+
+            // For fork PRs, payload.pull_requests is empty due to GitHub security restrictions.
+            // We need to fetch the PR details using the API to get the base SHA for change detection.
+            if (prNumber) {
+              try {
+                const { data: pr } = await github.rest.pulls.get({
+                  ...context.repo,
+                  pull_number: parseInt(prNumber, 10)
+                });
+                baseSha = pr.base.sha;
+                // Use PR head info which works for both fork and non-fork PRs
+                checkoutRepo = pr.head.repo.full_name;
+                checkoutRef = pr.head.sha;
+                console.log(`Fetched PR #${prNumber}: base_sha=${baseSha}, head_repo=${checkoutRepo}, head_sha=${checkoutRef}`);
+              } catch (error) {
+                console.log(`Warning: Could not fetch PR #${prNumber}: ${error.message}`);
+                // Fall back to workflow_run payload data
+                if (payload.pull_requests && payload.pull_requests.length > 0) {
+                  baseSha = payload.pull_requests[0].base.sha;
+                }
+              }
+            } else if (payload.pull_requests && payload.pull_requests.length > 0) {
+              // Fallback for cases where PR number artifact is not available
+              baseSha = payload.pull_requests[0].base.sha;
             }
+
             // Set environment variables
             fs.appendFileSync(process.env.GITHUB_ENV,
-              `CHECKOUT_REPO=${payload.head_repository.full_name}\n`+
-              `CHECKOUT_REF=${payload.head_sha}\n` +
-              `PR_NUMBER=${{ steps.get-pr-number.outputs.pr_number }}\n` +
+              `CHECKOUT_REPO=${checkoutRepo}\n` +
+              `CHECKOUT_REF=${checkoutRef}\n` +
+              `PR_NUMBER=${prNumber}\n` +
               `BASE_SHA=${baseSha}\n`);
 
       - name: Set DE image and tag (repository_dispatch from de-functional-test)


### PR DESCRIPTION
# Description

This pull request improves the workflow for functional tests on cloud environments by enhancing how pull request (PR) details are fetched and processed, especially for forked PRs. The changes ensure that the workflow can reliably detect the base and head commit SHAs for both forked and non-forked PRs, which is important for accurate change detection and environment setup.

**Workflow permissions:**
* Added `pull-requests: read` permission to the workflow to allow fetching PR details using the GitHub API.

**PR details fetching and environment setup:**
* Updated the script in the workflow to use the GitHub API to fetch PR details (base SHA, head repo, and head SHA) when the PR number is available, ensuring correct values for forked PRs where `payload.pull_requests` is empty.
* Improved fallback logic to use `payload.pull_requests` if the PR number is not available or if the API call fails, maintaining robustness for different PR scenarios.
* Refactored variable declarations from `let` to `const` for consistency and clarity.
* Updated environment variable assignments to use the fetched or fallback PR details, ensuring the workflow steps use accurate information.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->