### PR TITLE
add env recipe parameters reconciliation

### DIFF
--- a/pkg/recipes/configloader/environment.go
+++ b/pkg/recipes/configloader/environment.go
@@ -271,7 +271,7 @@ func getRecipeDefinitionFromEnvironmentV20250801(ctx context.Context, environmen
 	envDatamodel := env.(*datamodel.Environment_v20250801preview)
 
 	if envDatamodel.Properties.RecipePacks != nil {
-		recipeDefinition, err := fetchRecipePacks(ctx, envDatamodel.Properties.RecipePacks, armOptions, resource.Type())
+		recipeDefinition, err := fetchRecipeDefinition(ctx, envDatamodel.Properties.RecipePacks, armOptions, resource.Type())
 		if err != nil {
 			return nil, err
 		}
@@ -294,8 +294,10 @@ func getRecipeDefinitionFromEnvironmentV20250801(ctx context.Context, environmen
 	return nil, fmt.Errorf("could not find any recipe pack for %q in environment %q", resource.Type(), recipe.EnvironmentID)
 }
 
-// fetchRecipePacks fetches recipe pack resources from the given recipe pack IDs and returns the first recipe pack that has a recipe for the specified resource type.
-func fetchRecipePacks(ctx context.Context, recipePackIDs []string, armOptions *arm.ClientOptions, resourceType string) (*recipes.RecipeDefinition, error) {
+// fetchRecipeDefinition fetches recipe pack resources from the given recipe pack IDs and returns
+// the recipe definition from the first recipe pack that has a recipe defined for the specified resource type.
+// There cannot be more than one recipe pack with a recipe definition for the same resource type as part of an environment.
+func fetchRecipeDefinition(ctx context.Context, recipePackIDs []string, armOptions *arm.ClientOptions, resourceType string) (*recipes.RecipeDefinition, error) {
 	if recipePackIDs == nil {
 		return nil, fmt.Errorf("no recipe packs configured")
 	}

--- a/pkg/recipes/configloader/environment.go
+++ b/pkg/recipes/configloader/environment.go
@@ -271,22 +271,22 @@ func getRecipeDefinitionFromEnvironmentV20250801(ctx context.Context, environmen
 	envDatamodel := env.(*datamodel.Environment_v20250801preview)
 
 	if envDatamodel.Properties.RecipePacks != nil {
-		recipePackDefinition, err := fetchRecipePacks(ctx, envDatamodel.Properties.RecipePacks, armOptions, resource.Type())
+		recipeDefinition, err := fetchRecipePacks(ctx, envDatamodel.Properties.RecipePacks, armOptions, resource.Type())
 		if err != nil {
 			return nil, err
 		}
 
 		// Reconcile parameters from recipe pack and environment-level recipe parameters
-		parameters := reconcileRecipeParameters(recipePackDefinition.Parameters, envDatamodel.Properties.RecipeParameters, resource.Type())
+		parameters := reconcileRecipeParameters(recipeDefinition.Parameters, envDatamodel.Properties.RecipeParameters, resource.Type())
 
 		// TODO: For now, we can set "Name" to default as recipe packs don't have named recipes.
 		// We will remove this field from EnvironmentDefinition once we deprecate Applications.Core.
 		definition := &recipes.EnvironmentDefinition{
 			Name:         "default",
-			Driver:       recipePackDefinition.RecipeKind,
+			Driver:       recipeDefinition.RecipeKind,
 			ResourceType: resource.Type(),
 			Parameters:   parameters,
-			TemplatePath: recipePackDefinition.RecipeLocation,
+			TemplatePath: recipeDefinition.RecipeLocation,
 		}
 		return definition, nil
 	}
@@ -295,7 +295,7 @@ func getRecipeDefinitionFromEnvironmentV20250801(ctx context.Context, environmen
 }
 
 // fetchRecipePacks fetches recipe pack resources from the given recipe pack IDs and returns the first recipe pack that has a recipe for the specified resource type.
-func fetchRecipePacks(ctx context.Context, recipePackIDs []string, armOptions *arm.ClientOptions, resourceType string) (*recipes.RecipePackDefinition, error) {
+func fetchRecipePacks(ctx context.Context, recipePackIDs []string, armOptions *arm.ClientOptions, resourceType string) (*recipes.RecipeDefinition, error) {
 	if recipePackIDs == nil {
 		return nil, fmt.Errorf("no recipe packs configured")
 	}
@@ -313,7 +313,7 @@ func fetchRecipePacks(ctx context.Context, recipePackIDs []string, armOptions *a
 		// Convert recipes map
 		for recipePackResourceType, definition := range recipePackResource.Properties.Recipes {
 			if strings.EqualFold(recipePackResourceType, resourceType) {
-				return &recipes.RecipePackDefinition{
+				return &recipes.RecipeDefinition{
 					RecipeKind:     string(*definition.RecipeKind),
 					RecipeLocation: string(*definition.RecipeLocation),
 					Parameters:     definition.Parameters,

--- a/pkg/recipes/types.go
+++ b/pkg/recipes/types.go
@@ -136,11 +136,11 @@ type RecipePackResource struct {
 	// Description represents the description of the recipe pack
 	Description string
 	// Recipes represents the recipes available in this recipe pack
-	Recipes map[string]RecipePackDefinition
+	Recipes map[string]RecipeDefinition
 }
 
-// RecipePackDefinition represents a recipe definition for a specific resource type in a recipe pack.
-type RecipePackDefinition struct {
+// RecipeDefinition represents a recipe definition for a specific resource type in a recipe pack.
+type RecipeDefinition struct {
 	// RecipeKind represents the type of recipe (e.g., terraform, bicep)
 	RecipeKind string
 	// RecipeLocation represents URL or path to the recipe source

--- a/test/functional-portable/dynamicrp/noncloud/resources/recipepacks_test.go
+++ b/test/functional-portable/dynamicrp/noncloud/resources/recipepacks_test.go
@@ -131,9 +131,21 @@ func Test_RecipePacks_Deployment(t *testing.T) {
 				require.NotEmpty(t, deployments.Items, "No deployments found in namespace %s", appNamespace)
 
 				t.Logf("Found %d deployments in namespace %s", len(deployments.Items), appNamespace)
+
+				foundPort := false
 				for _, deploy := range deployments.Items {
 					t.Logf("Deployment: %s", deploy.Name)
+					for _, container := range deploy.Spec.Template.Spec.Containers {
+						for _, port := range container.Ports {
+							t.Logf("  Container %s has port %d", container.Name, port.ContainerPort)
+							if port.ContainerPort == 9090 {
+								foundPort = true
+								t.Logf("  ✓ Found container listening on port 9090")
+							}
+						}
+					}
 				}
+				require.True(t, foundPort, "Expected to find a container listening on port 9090")
 
 				// Clean up the namespace after verification
 				err = test.Options.K8sClient.CoreV1().Namespaces().Delete(ctx, appNamespace, metav1.DeleteOptions{})

--- a/test/functional-portable/dynamicrp/noncloud/resources/recipepacks_test.go
+++ b/test/functional-portable/dynamicrp/noncloud/resources/recipepacks_test.go
@@ -132,6 +132,7 @@ func Test_RecipePacks_Deployment(t *testing.T) {
 
 				t.Logf("Found %d deployments in namespace %s", len(deployments.Items), appNamespace)
 
+				// Recipe parameters reconciliation check: Verify that the deployed containers have the expected port from recipe parameters
 				foundPort := false
 				for _, deploy := range deployments.Items {
 					t.Logf("Deployment: %s", deploy.Name)

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/recipepacks-test.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/recipepacks-test.bicep
@@ -44,6 +44,11 @@ resource env 'Radius.Core/environments@2025-08-01-preview' = {
         namespace: 'recipepacks-ns'
      }
     }
+    recipeParameters: {
+      'Test.Resources/userTypeAlpha': {
+        port: 9090
+      }
+    }
   }
 }
 


### PR DESCRIPTION
# Description

Environments can have recipe parameters too. 
Recipe engine should consolidate parameters found in recipe packs and environment for a recipe, with environment values taking precedence. 

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).



Partially Fixes: #9832

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->