### PR TITLE
Add global panic recovery for CLI commands

### DIFF
--- a/cmd/rad/cmd/root.go
+++ b/cmd/rad/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"strings"
 
 	"github.com/acarl005/stripansi"
@@ -153,6 +154,16 @@ func prettyPrintJSON(o any) (string, error) {
 	return string(b), nil
 }
 
+// handlePanic is the global panic recovery handler that formats and displays panic information
+func handlePanic() {
+	if r := recover(); r != nil {
+		fmt.Printf("Error: An unexpected internal error occurred: %v\n\n", r)
+		fmt.Println(string(debug.Stack()))
+		fmt.Println("\nPlease report this issue at https://github.com/radius-project/radius/issues")
+		fmt.Println("") // Output an extra blank line for readability
+	}
+}
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 // It also initializes the tracerprovider for cli.
@@ -170,6 +181,9 @@ func Execute() error {
 	defer func() {
 		_ = shutdown(ctx)
 	}()
+
+	// Panic recovery
+	defer handlePanic()
 
 	tr := otel.Tracer(tracerName)
 	spanName := getRootSpanName()

--- a/cmd/rad/cmd/root_test.go
+++ b/cmd/rad/cmd/root_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_HandlePanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatal("handlePanic should recover and not propagate panic")
+		}
+	}()
+
+	func() {
+		defer handlePanic()
+		panic("test panic")
+	}()
+}
+
+func Test_prettyPrintRPError(t *testing.T) {
+	err := fmt.Errorf("test error message")
+	result := prettyPrintRPError(err)
+	require.Contains(t, result, "test error")
+}
+
+func Test_prettyPrintJSON(t *testing.T) {
+	t.Run("formats JSON correctly", func(t *testing.T) {
+		obj := map[string]string{"key": "value"}
+		result, err := prettyPrintJSON(obj)
+		require.NoError(t, err)
+		require.Contains(t, result, "key")
+		require.Contains(t, result, "value")
+		require.Contains(t, result, "\n")
+	})
+
+	t.Run("handles invalid JSON", func(t *testing.T) {
+		invalidObj := make(chan int)
+		_, err := prettyPrintJSON(invalidObj)
+		require.Error(t, err)
+	})
+
+	t.Run("formats complex objects", func(t *testing.T) {
+		obj := map[string]any{
+			"nested": map[string]string{"inner": "value"},
+			"array":  []string{"a", "b", "c"},
+		}
+		result, err := prettyPrintJSON(obj)
+		require.NoError(t, err)
+		require.Contains(t, result, "nested")
+		require.Contains(t, result, "inner")
+		require.Contains(t, result, "array")
+	})
+}


### PR DESCRIPTION
# Description

Adding global panic recovery for CLI commands. This will provide a better user experience in scenarios like this https://github.com/radius-project/radius/pull/10833

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->