### PR TITLE
fix: ensure deterministic sort order for environment recipes

### DIFF
--- a/pkg/cli/cmd/env/show/preview/show.go
+++ b/pkg/cli/cmd/env/show/preview/show.go
@@ -176,6 +176,12 @@ func (r *Runner) Run(ctx context.Context) error {
 		if a.RecipePack > b.RecipePack {
 			return 1
 		}
+		if a.ResourceType < b.ResourceType {
+			return -1
+		}
+		if a.ResourceType > b.ResourceType {
+			return 1
+		}
 		return 0
 	})
 

--- a/pkg/cli/cmd/env/show/preview/show.go
+++ b/pkg/cli/cmd/env/show/preview/show.go
@@ -17,6 +17,7 @@ limitations under the License.
 package preview
 
 import (
+	"cmp"
 	"context"
 	"slices"
 
@@ -169,20 +170,12 @@ func (r *Runner) Run(ctx context.Context) error {
 		}
 	}
 
+	// Sort for deterministic output
 	slices.SortFunc(envRecipes, func(a, b EnvRecipes) int {
-		if a.RecipePack < b.RecipePack {
-			return -1
+		if v := cmp.Compare(a.RecipePack, b.RecipePack); v != 0 {
+			return v
 		}
-		if a.RecipePack > b.RecipePack {
-			return 1
-		}
-		if a.ResourceType < b.ResourceType {
-			return -1
-		}
-		if a.ResourceType > b.ResourceType {
-			return 1
-		}
-		return 0
+		return cmp.Compare(a.ResourceType, b.ResourceType)
 	})
 
 	err = r.Output.WriteFormatted(r.Format, resp.EnvironmentResource, objectformats.GetResourceTableFormat())

--- a/pkg/cli/cmd/env/show/preview/show_test.go
+++ b/pkg/cli/cmd/env/show/preview/show_test.go
@@ -18,8 +18,10 @@ package preview
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
+	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
 	"github.com/stretchr/testify/require"
 
 	"github.com/radius-project/radius/pkg/cli/framework"
@@ -166,4 +168,107 @@ func Test_Run(t *testing.T) {
 			require.Equal(t, tc.expectedOutput, outputSink.Writes)
 		})
 	}
+}
+
+func Test_Run_RecipeSortOrder(t *testing.T) {
+	workspace := &workspaces.Workspace{
+		Name:  "test-workspace",
+		Scope: "/planes/radius/local/resourceGroups/test-group",
+	}
+
+	// Create environment server with multiple recipe packs
+	envServer := func() fake.EnvironmentsServer {
+		return fake.EnvironmentsServer{
+			Get: func(
+				ctx context.Context,
+				environmentName string,
+				options *corerpv20250801.EnvironmentsClientGetOptions,
+			) (resp azfake.Responder[corerpv20250801.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
+				result := corerpv20250801.EnvironmentsClientGetResponse{
+					EnvironmentResource: corerpv20250801.EnvironmentResource{
+						Name: to.Ptr(environmentName),
+						Properties: &corerpv20250801.EnvironmentProperties{
+							RecipePacks: []*string{
+								to.Ptr("/planes/radius/local/resourceGroups/test-group/providers/Radius.Core/recipePacks/pack-b"),
+								to.Ptr("/planes/radius/local/resourceGroups/test-group/providers/Radius.Core/recipePacks/pack-a"),
+							},
+						},
+					},
+				}
+				resp.SetResponse(http.StatusOK, result, nil)
+				return
+			},
+		}
+	}
+
+	// Create recipe pack server with recipes in non-alphabetical order
+	recipePackServer := func() fake.RecipePacksServer {
+		return fake.RecipePacksServer{
+			Get: func(ctx context.Context, recipePackName string, options *corerpv20250801.RecipePacksClientGetOptions) (resp azfake.Responder[corerpv20250801.RecipePacksClientGetResponse], errResp azfake.ErrorResponder) {
+				var recipes map[string]*corerpv20250801.RecipeDefinition
+				if recipePackName == "pack-a" {
+					recipes = map[string]*corerpv20250801.RecipeDefinition{
+						"Applications.Datastores/sqlDatabases": {
+							RecipeLocation: to.Ptr("ghcr.io/radius-project/recipes/sql"),
+							RecipeKind:     to.Ptr(corerpv20250801.RecipeKindTerraform),
+						},
+						"Applications.Datastores/redisCaches": {
+							RecipeLocation: to.Ptr("ghcr.io/radius-project/recipes/redis"),
+							RecipeKind:     to.Ptr(corerpv20250801.RecipeKindTerraform),
+						},
+					}
+				} else {
+					recipes = map[string]*corerpv20250801.RecipeDefinition{
+						"Applications.Messaging/rabbitMQQueues": {
+							RecipeLocation: to.Ptr("ghcr.io/radius-project/recipes/rabbitmq"),
+							RecipeKind:     to.Ptr(corerpv20250801.RecipeKindBicep),
+						},
+						"Applications.Dapr/stateStores": {
+							RecipeLocation: to.Ptr("ghcr.io/radius-project/recipes/dapr-state"),
+							RecipeKind:     to.Ptr(corerpv20250801.RecipeKindBicep),
+						},
+					}
+				}
+				result := corerpv20250801.RecipePacksClientGetResponse{
+					RecipePackResource: corerpv20250801.RecipePackResource{
+						Name: to.Ptr(recipePackName),
+						Properties: &corerpv20250801.RecipePackProperties{
+							Recipes: recipes,
+						},
+					},
+				}
+				resp.SetResponse(http.StatusOK, result, nil)
+				return
+			},
+		}
+	}
+
+	factory, err := test_client_factory.NewRadiusCoreTestClientFactory(workspace.Scope, envServer, recipePackServer)
+	require.NoError(t, err)
+
+	outputSink := &output.MockOutput{}
+	runner := &Runner{
+		RadiusCoreClientFactory: factory,
+		Workspace:               workspace,
+		EnvironmentName:         "test-env",
+		Format:                  "table",
+		Output:                  outputSink,
+	}
+
+	err = runner.Run(context.Background())
+	require.NoError(t, err)
+
+	// Verify the recipes are sorted by RecipePack first, then by ResourceType
+	expectedRecipes := []EnvRecipes{
+		{RecipePack: "pack-a", ResourceType: "Applications.Datastores/redisCaches", RecipeKind: "terraform", RecipeLocation: "ghcr.io/radius-project/recipes/redis"},
+		{RecipePack: "pack-a", ResourceType: "Applications.Datastores/sqlDatabases", RecipeKind: "terraform", RecipeLocation: "ghcr.io/radius-project/recipes/sql"},
+		{RecipePack: "pack-b", ResourceType: "Applications.Dapr/stateStores", RecipeKind: "bicep", RecipeLocation: "ghcr.io/radius-project/recipes/dapr-state"},
+		{RecipePack: "pack-b", ResourceType: "Applications.Messaging/rabbitMQQueues", RecipeKind: "bicep", RecipeLocation: "ghcr.io/radius-project/recipes/rabbitmq"},
+	}
+
+	// The third output should be the recipes table
+	require.Len(t, outputSink.Writes, 3)
+	formattedOutput, ok := outputSink.Writes[2].(output.FormattedOutput)
+	require.True(t, ok, "expected FormattedOutput")
+	require.Equal(t, expectedRecipes, formattedOutput.Obj)
 }


### PR DESCRIPTION
# Description

This pull request makes a small change to the sorting logic in the `Run` method of `pkg/cli/cmd/env/show/preview/show.go`. The change adds a secondary sort by `ResourceType` after sorting by `RecipePack`, ensuring resources are ordered more predictably when their `RecipePack` values are equal.

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (issue link required).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->