### PR TITLE
rad deploy should be able work with both rad core and app core environments

### DIFF
--- a/pkg/cli/cmd/deploy/deploy.go
+++ b/pkg/cli/cmd/deploy/deploy.go
@@ -225,7 +225,6 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		// If no environment found and user didn't specify environment name using -e, that's ok
 		if envResult == nil {
 			return clierrors.Message("The environment %q does not exist in scope %q. Run `rad env create` first. You could also provide the environment ID if the environment exists in a different group.", r.EnvironmentNameOrID, r.Workspace.Scope)
 		}

--- a/pkg/cli/cmd/deploy/deploy.go
+++ b/pkg/cli/cmd/deploy/deploy.go
@@ -221,7 +221,7 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	}
 
 	if r.EnvironmentNameOrID != "" {
-		envResult, err := r.FetchEnvironment(cmd.Context(), r.EnvironmentNameOrID, cmd, args)
+		envResult, err := r.FetchEnvironment(cmd.Context(), r.EnvironmentNameOrID)
 		if err != nil {
 			return err
 		}
@@ -516,7 +516,7 @@ type EnvironmentCheckResult struct {
 
 // FetchEnvironment fetches Applications.Core and Radius.Core environments for a given name/id and returns the result
 // If no environment is found, returns (nil, nil)
-func (r *Runner) FetchEnvironment(ctx context.Context, envNameOrID string, command *cobra.Command, args []string) (*EnvironmentCheckResult, error) {
+func (r *Runner) FetchEnvironment(ctx context.Context, envNameOrID string) (*EnvironmentCheckResult, error) {
 	result := &EnvironmentCheckResult{}
 	// If the environment is specified as a full resource ID, we can skip the check and based on the provider get the environment
 	fetchAppCoreEnv := true

--- a/pkg/cli/cmd/deploy/deploy.go
+++ b/pkg/cli/cmd/deploy/deploy.go
@@ -156,6 +156,7 @@ func NewRunner(factory framework.Factory) *Runner {
 		ConfigHolder:      factory.GetConfigHolder(),
 		Deploy:            factory.GetDeploy(),
 		Output:            factory.GetOutput(),
+		Providers:         &clients.Providers{},
 	}
 }
 
@@ -511,6 +512,7 @@ type EnvironmentCheckResult struct {
 }
 
 // FetchEnvironment fetches Applications.Core and Radius.Core environments for a given name/id and returns the result
+// If no environment is found, returns (nil, nil)
 func (r *Runner) FetchEnvironment(ctx context.Context, envNameOrID string, command *cobra.Command, args []string) (*EnvironmentCheckResult, error) {
 	result := &EnvironmentCheckResult{}
 	// If the environment is specified as a full resource ID, we can skip the check and based on the provider get the environment

--- a/pkg/cli/cmd/deploy/deploy.go
+++ b/pkg/cli/cmd/deploy/deploy.go
@@ -486,7 +486,10 @@ func (r *Runner) getRadiusCoreEnvironment(ctx context.Context, id string) (*v202
 
 	environmentClient := r.RadiusCoreClientFactory.NewEnvironmentsClient()
 	env, err := environmentClient.Get(ctx, id, nil)
-	return &env.EnvironmentResource, err
+	if err != nil {
+		return nil, err
+	}
+	return &env.EnvironmentResource, nil
 }
 
 // constructEnvironmentID constructs an environment ID from a name and provider type

--- a/pkg/cli/cmd/deploy/deploy.go
+++ b/pkg/cli/cmd/deploy/deploy.go
@@ -667,6 +667,12 @@ func (r *Runner) configureProviders() error {
 			r.setupCloudProviders(e.Properties)
 		}
 		if r.ApplicationName != "" {
+			if r.Providers == nil {
+				r.Providers = &clients.Providers{}
+			}
+			if r.Providers.Radius == nil {
+				r.Providers.Radius = &clients.RadiusProvider{}
+			}
 			r.Providers.Radius.ApplicationID = r.Workspace.Scope + "/providers/" + appCoreProviderName + "/applications/" + r.ApplicationName
 		}
 	case *v20250801preview.EnvironmentResource:
@@ -675,6 +681,12 @@ func (r *Runner) configureProviders() error {
 			r.setupCloudProviders(e.Properties)
 		}
 		if r.ApplicationName != "" {
+			if r.Providers == nil {
+				r.Providers = &clients.Providers{}
+			}
+			if r.Providers.Radius == nil {
+				r.Providers.Radius = &clients.RadiusProvider{}
+			}
 			r.Providers.Radius.ApplicationID = r.Workspace.Scope + "/providers/" + radiusCoreProviderName + "/applications/" + r.ApplicationName
 		}
 	}

--- a/pkg/cli/cmd/deploy/deploy.go
+++ b/pkg/cli/cmd/deploy/deploy.go
@@ -282,7 +282,7 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	if r.ApplicationName != "" {
 		// Environment validation has already happened, so only create application if we have an environment
-		if r.Workspace.Environment != "" {
+		if r.Providers.Radius.EnvironmentID != "" {
 			if _, err := isApplicationsCoreProvider(r.Providers.Radius.EnvironmentID); err == nil {
 				client, err := r.ConnectionFactory.CreateApplicationsManagementClient(ctx, *r.Workspace)
 				if err != nil {

--- a/pkg/cli/cmd/deploy/deploy.go
+++ b/pkg/cli/cmd/deploy/deploy.go
@@ -646,6 +646,13 @@ func (r *Runner) setupCloudProviders(properties any) {
 // configureProviders configures environment and cloud providers based on the environment and provider type
 func (r *Runner) configureProviders() error {
 	var env any
+	if r.Providers == nil {
+		r.Providers = &clients.Providers{}
+	}
+	if r.Providers.Radius == nil {
+		r.Providers.Radius = &clients.RadiusProvider{}
+	}
+
 	if r.EnvResult != nil {
 		if r.EnvResult.UseApplicationsCore {
 			if r.EnvResult.ApplicationsCoreEnv != nil {
@@ -663,31 +670,32 @@ func (r *Runner) configureProviders() error {
 	switch e := env.(type) {
 	case *v20231001preview.EnvironmentResource:
 		if e != nil && e.ID != nil {
+			r.Providers.Radius.EnvironmentID = *e.ID
 			r.setupEnvironmentID(e.ID)
 			r.setupCloudProviders(e.Properties)
 		}
 		if r.ApplicationName != "" {
-			if r.Providers == nil {
-				r.Providers = &clients.Providers{}
+			// Extract provider namespace from environment ID to preserve casing
+			providerNamespace := appCoreProviderName
+			if parsedID, err := resources.Parse(r.Providers.Radius.EnvironmentID); err == nil {
+				providerNamespace = parsedID.ProviderNamespace()
 			}
-			if r.Providers.Radius == nil {
-				r.Providers.Radius = &clients.RadiusProvider{}
-			}
-			r.Providers.Radius.ApplicationID = r.Workspace.Scope + "/providers/" + appCoreProviderName + "/applications/" + r.ApplicationName
+			r.Providers.Radius.ApplicationID = r.Workspace.Scope + "/providers/" + providerNamespace + "/applications/" + r.ApplicationName
+
 		}
 	case *v20250801preview.EnvironmentResource:
 		if e != nil && e.ID != nil {
+			r.Providers.Radius.EnvironmentID = *e.ID
 			r.setupEnvironmentID(e.ID)
 			r.setupCloudProviders(e.Properties)
 		}
 		if r.ApplicationName != "" {
-			if r.Providers == nil {
-				r.Providers = &clients.Providers{}
+			// Extract provider namespace from environment ID to preserve casing
+			providerNamespace := radiusCoreProviderName
+			if parsedID, err := resources.Parse(r.Providers.Radius.EnvironmentID); err == nil {
+				providerNamespace = parsedID.ProviderNamespace()
 			}
-			if r.Providers.Radius == nil {
-				r.Providers.Radius = &clients.RadiusProvider{}
-			}
-			r.Providers.Radius.ApplicationID = r.Workspace.Scope + "/providers/" + radiusCoreProviderName + "/applications/" + r.ApplicationName
+			r.Providers.Radius.ApplicationID = r.Workspace.Scope + "/providers/" + providerNamespace + "/applications/" + r.ApplicationName
 		}
 	}
 

--- a/pkg/cli/cmd/deploy/deploy_test.go
+++ b/pkg/cli/cmd/deploy/deploy_test.go
@@ -791,6 +791,10 @@ func Test_Run(t *testing.T) {
 		bicep := bicep.NewMockInterface(ctrl)
 
 		appManagmentMock := clients.NewMockApplicationsManagementClient(ctrl)
+		appManagmentMock.EXPECT().
+			CreateApplicationIfNotFound(gomock.Any(), "appdoesntexist", gomock.Any()).
+			Return(nil).
+			Times(1)
 
 		deployMock := deploy.NewMockInterface(ctrl)
 		deployMock.EXPECT().

--- a/pkg/cli/cmd/deploy/deploy_test.go
+++ b/pkg/cli/cmd/deploy/deploy_test.go
@@ -91,58 +91,215 @@ func Test_Validate(t *testing.T) {
 					Times(1)
 
 			},
-		}, 
-				{
-					Name:          "rad deploy - app set by directory config",
-					Input:         []string{"app.bicep", "-e", "/planes/radius/local/resourceGroups/test-resource-group/providers/Applications.Core/environments/prod"},
-					ExpectedValid: true,
-					ConfigHolder: framework.ConfigHolder{
-						ConfigFilePath: "",
-						Config:         configWithWorkspace,
-						DirectoryConfig: &config.DirectoryConfig{
-							Workspace: config.DirectoryWorkspaceConfig{
-								Application: "my-app",
+		},
+		{
+			Name:          "rad deploy - app set by directory config",
+			Input:         []string{"app.bicep", "-e", "/planes/radius/local/resourceGroups/test-resource-group/providers/Applications.Core/environments/prod"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+				DirectoryConfig: &config.DirectoryConfig{
+					Workspace: config.DirectoryWorkspaceConfig{
+						Application: "my-app",
+					},
+				},
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				mocks.Bicep.EXPECT().
+					PrepareTemplate("app.bicep").
+					Return(map[string]any{}, nil).
+					Times(1)
+				// Since environment name "prod" will trigger dual-check logic,
+				// it will first try the full Applications.Core path
+				mocks.ApplicationManagementClient.EXPECT().
+					GetEnvironment(gomock.Any(), "/planes/radius/local/resourceGroups/test-resource-group/providers/Applications.Core/environments/prod").
+					Return(v20231001preview.EnvironmentResource{
+						ID: to.Ptr("/planes/radius/local/resourceGroups/test-resource-group/providers/Applications.Core/environments/prod"),
+					}, nil).
+					Times(1)
+			},
+		},
+		{
+			Name:          "rad deploy - fallback workspace",
+			Input:         []string{"app.bicep", "--group", "my-group", "--environment", "/planes/radius/local/resourceGroups/my-group/providers/Applications.Core/environments/prod"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         radcli.LoadEmptyConfig(t),
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				mocks.Bicep.EXPECT().
+					PrepareTemplate("app.bicep").
+					Return(map[string]any{}, nil).
+					Times(1)
+				// Since environment id indicates a applications core environment, only that will be fetched
+				mocks.ApplicationManagementClient.EXPECT().
+					GetEnvironment(gomock.Any(), "/planes/radius/local/resourceGroups/my-group/providers/Applications.Core/environments/prod").
+					Return(v20231001preview.EnvironmentResource{
+						ID: to.Ptr("/planes/radius/local/resourceGroups/my-group/providers/Applications.Core/environments/prod"),
+					}, nil).
+					Times(1)
+			},
+		},
+		{
+			Name:          "rad deploy - valid with app and env",
+			Input:         []string{"app.bicep", "-e", "/planes/radius/local/resourceGroups/test-resource-group/providers/applications.core/environments/prod", "-a", "my-app"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				mocks.Bicep.EXPECT().
+					PrepareTemplate("app.bicep").
+					Return(map[string]any{}, nil).
+					Times(1)
+				mocks.ApplicationManagementClient.EXPECT().
+					GetEnvironment(gomock.Any(), "/planes/radius/local/resourceGroups/test-resource-group/providers/applications.core/environments/prod").
+					Return(v20231001preview.EnvironmentResource{
+						ID: to.Ptr("/planes/radius/local/resourceGroups/test-resource-group/providers/applications.core/environments/prod"),
+					}, nil).
+					Times(1)
+			},
+			ValidateCallback: func(t *testing.T, obj framework.Runner) {
+				runner := obj.(*Runner)
+				scope := "/planes/radius/local/resourceGroups/test-resource-group"
+				environmentID := scope + "/providers/applications.core/environments/prod"
+				applicationID := scope + "/providers/applications.core/applications/my-app"
+				require.Equal(t, scope, runner.Workspace.Scope)
+				require.Equal(t, environmentID, runner.Workspace.Environment)
+				require.Equal(t, clients.RadiusProvider{ApplicationID: applicationID, EnvironmentID: environmentID}, *runner.Providers.Radius)
+			},
+		}, /*
+			{
+				Name:          "rad deploy - fallback workspace requires resource group",
+				Input:         []string{"app.bicep", "--environment", "prod"},
+				ExpectedValid: false,
+				ConfigHolder: framework.ConfigHolder{
+					ConfigFilePath: "",
+					Config:         radcli.LoadEmptyConfig(t),
+				},
+			},
+			{
+				Name:          "rad deploy - too many args",
+				Input:         []string{"app.bicep", "anotherfile.json"},
+				ExpectedValid: false,
+				ConfigHolder: framework.ConfigHolder{
+					ConfigFilePath: "",
+					Config:         radcli.LoadEmptyConfig(t),
+				},
+			},
+			{
+				Name:          "rad deploy - no env in config, no env flag, no env in template invalid",
+				Input:         []string{"app.bicep", "--group", "test-group"},
+				ExpectedValid: false,
+				ConfigHolder: framework.ConfigHolder{
+					ConfigFilePath: "",
+					Config:         radcli.LoadEmptyConfig(t),
+				},
+				ConfigureMocks: func(mocks radcli.ValidateMocks) {
+					mocks.Bicep.EXPECT().
+						PrepareTemplate("app.bicep").
+						Return(map[string]any{}, nil).
+						Times(1)
+				},
+			},
+			{
+				Name:          "rad deploy - no env in config, env flag provided, no env in template valid",
+				Input:         []string{"app.bicep", "-e", "prod", "--group", "test-group"},
+				ExpectedValid: true,
+				ConfigHolder: framework.ConfigHolder{
+					ConfigFilePath: "",
+					Config:         radcli.LoadEmptyConfig(t),
+				},
+				ConfigureMocks: func(mocks radcli.ValidateMocks) {
+					mocks.Bicep.EXPECT().
+						PrepareTemplate("app.bicep").
+						Return(map[string]any{}, nil).
+						Times(1)
+					mocks.ApplicationManagementClient.EXPECT().
+						GetEnvironment(gomock.Any(), "prod").
+						Return(v20231001preview.EnvironmentResource{}, nil).
+						Times(1)
+				},
+			},
+			{
+				Name:          "rad deploy - no env in config, no env flag, env in template valid",
+				Input:         []string{"app.bicep", "--group", "test-group"},
+				ExpectedValid: true,
+				ConfigHolder: framework.ConfigHolder{
+					ConfigFilePath: "",
+					Config:         radcli.LoadEmptyConfig(t),
+				},
+				ConfigureMocks: func(mocks radcli.ValidateMocks) {
+					templateWithEnv := map[string]any{
+						"resources": map[string]any{
+							"env": map[string]any{
+								"type": "Radius.Core/environments@2023-10-01-preview",
 							},
 						},
-					},
-					ConfigureMocks: func(mocks radcli.ValidateMocks) {
-						mocks.Bicep.EXPECT().
-							PrepareTemplate("app.bicep").
-							Return(map[string]any{}, nil).
-							Times(1)
-						// Since environment name "prod" will trigger dual-check logic,
-						// it will first try the full Applications.Core path
-						mocks.ApplicationManagementClient.EXPECT().
-							GetEnvironment(gomock.Any(), "/planes/radius/local/resourceGroups/test-resource-group/providers/Applications.Core/environments/prod").
-							Return(v20231001preview.EnvironmentResource{
-								ID: to.Ptr("/planes/radius/local/resourceGroups/test-resource-group/providers/Applications.Core/environments/prod"),
-							}, nil).
-							Times(1)
-					},
+					}
+					mocks.Bicep.EXPECT().
+						PrepareTemplate("app.bicep").
+						Return(templateWithEnv, nil).
+						Times(1)
 				},
-				{
-					Name:          "rad deploy - fallback workspace",
-					Input:         []string{"app.bicep", "--group", "my-group", "--environment", "/planes/radius/local/resourceGroups/my-group/providers/Applications.Core/environments/prod"},
-					ExpectedValid: true,
-					ConfigHolder: framework.ConfigHolder{
-						ConfigFilePath: "",
-						Config:         radcli.LoadEmptyConfig(t),
-					},
-					ConfigureMocks: func(mocks radcli.ValidateMocks) {
-						mocks.Bicep.EXPECT().
-							PrepareTemplate("app.bicep").
-							Return(map[string]any{}, nil).
-							Times(1)
-						// Since environment name "prod" will trigger dual-check logic,
-						// it will first try the full Applications.Core path with my-group scope
-						mocks.ApplicationManagementClient.EXPECT().
-							GetEnvironment(gomock.Any(), "/planes/radius/local/resourceGroups/my-group/providers/Applications.Core/environments/prod").
-							Return(v20231001preview.EnvironmentResource{
-								ID: to.Ptr("/planes/radius/local/resourceGroups/my-group/providers/Applications.Core/environments/prod"),
-							}, nil).
-							Times(1)
-					},
+			},
+			{
+				Name:          "rad deploy - no env in config, env flag provided, env in template valid",
+				Input:         []string{"app.bicep", "-e", "prod", "--group", "test-group"},
+				ExpectedValid: true,
+				ConfigHolder: framework.ConfigHolder{
+					ConfigFilePath: "",
+					Config:         radcli.LoadEmptyConfig(t),
 				},
+				ConfigureMocks: func(mocks radcli.ValidateMocks) {
+					templateWithEnv := map[string]any{
+						"resources": map[string]any{
+							"env": map[string]any{
+								"type": "Radius.Core/environments@2023-10-01-preview",
+							},
+						},
+					}
+					mocks.Bicep.EXPECT().
+						PrepareTemplate("app.bicep").
+						Return(templateWithEnv, nil).
+						Times(1)
+					// When env flag is explicitly provided, we honor it and validate even if template creates environment
+					mocks.ApplicationManagementClient.EXPECT().
+						GetEnvironment(gomock.Any(), "prod").
+						Return(v20231001preview.EnvironmentResource{}, nil).
+						Times(1)
+				},
+			},
+			{
+				Name:          "rad deploy - missing env and app succeeds with env in config",
+				Input:         []string{"app.bicep", "--group", "new-group"},
+				ExpectedValid: true,
+				ConfigHolder: framework.ConfigHolder{
+					ConfigFilePath: "",
+					Config:         configWithWorkspace,
+				},
+				ConfigureMocks: func(mocks radcli.ValidateMocks) {
+					templateWithEnv := map[string]any{
+						"resources": map[string]any{
+							"env": map[string]any{
+								"type": "Applications.Core/environments@2023-10-01-preview",
+							},
+						},
+					}
+					mocks.Bicep.EXPECT().
+						PrepareTemplate("app.bicep").
+						Return(templateWithEnv, nil).
+						Times(1)
+					// Since workspace has default environment (full ID), we validate it even though template creates one
+					mocks.ApplicationManagementClient.EXPECT().
+						GetEnvironment(gomock.Any(), "/planes/radius/local/resourceGroups/test-resource-group/providers/Applications.Core/environments/test-environment").
+						Return(v20231001preview.EnvironmentResource{}, nil).
+						Times(1)
+				},
+			},*/
 		{
 			Name:          "rad deploy fails - env required when not explicitly specified and template doesn't create env",
 			Input:         []string{"app.bicep", "--group", "new-group"},

--- a/pkg/cli/cmd/deploy/deploy_test.go
+++ b/pkg/cli/cmd/deploy/deploy_test.go
@@ -1192,7 +1192,7 @@ func Test_constructApplicationsCoreEnvironmentID(t *testing.T) {
 		},
 	}
 
-	result := runner.ConstructApplicationsCoreEnvironmentID("myenv")
+	result := runner.constructApplicationsCoreEnvironmentID("myenv")
 	expected := "/planes/radius/local/resourceGroups/test-rg/providers/Applications.Core/environments/myenv"
 	require.Equal(t, expected, result)
 }
@@ -1204,7 +1204,7 @@ func Test_constructRadiusCoreEnvironmentID(t *testing.T) {
 		},
 	}
 
-	result := runner.ConstructRadiusCoreEnvironmentID("myenv")
+	result := runner.constructRadiusCoreEnvironmentID("myenv")
 	expected := "/planes/radius/local/resourceGroups/test-rg/providers/Radius.Core/environments/myenv"
 	require.Equal(t, expected, result)
 }

--- a/pkg/cli/cmd/deploy/deploy_test.go
+++ b/pkg/cli/cmd/deploy/deploy_test.go
@@ -1423,8 +1423,7 @@ func Test_FetchEnvironment(t *testing.T) {
 				runner.RadiusCoreClientFactory = factory
 			}
 
-			cmd := &cobra.Command{}
-			result, err := runner.FetchEnvironment(context.Background(), tc.envNameOrID, cmd, []string{"template.bicep"})
+			result, err := runner.FetchEnvironment(context.Background(), tc.envNameOrID)
 
 			if tc.shouldError {
 				require.Error(t, err)

--- a/pkg/cli/cmd/run/run_test.go
+++ b/pkg/cli/cmd/run/run_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"testing"
 
+	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -33,8 +34,11 @@ import (
 	"github.com/radius-project/radius/pkg/cli/kubernetes/logstream"
 	"github.com/radius-project/radius/pkg/cli/kubernetes/portforward"
 	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/radius-project/radius/pkg/cli/test_client_factory"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
+	"github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
+	corerpfake "github.com/radius-project/radius/pkg/corerp/api/v20250801preview/fake"
 	"github.com/radius-project/radius/pkg/to"
 	"github.com/radius-project/radius/test/radcli"
 	"github.com/radius-project/radius/test/testcontext"
@@ -79,7 +83,7 @@ func Test_Validate(t *testing.T) {
 
 		{
 			Name:          "rad run - app set by directory config",
-			Input:         []string{"app.bicep", "-e", "prod"},
+			Input:         []string{"app.bicep", "-e", "/planes/radius/local/resourceGroups/test-resource-group/providers/Applications.Core/environments/prod"},
 			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
@@ -268,6 +272,133 @@ func Test_Validate(t *testing.T) {
 	}
 
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
+}
+
+func Test_ValidateWithFakeEnvServer(t *testing.T) {
+	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
+
+	// Test case: rad run with valid environment using fake env server
+	t.Run("rad run - valid with app and env using fake env server", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// Create a fake env server that returns valid environment
+		validEnvServer := corerpfake.EnvironmentsServer{
+			Get: test_client_factory.WithEnvironmentServerNoError().Get,
+		}
+
+		workspace := &workspaces.Workspace{
+			Name:  "test-workspace",
+			Scope: "/planes/radius/local/resourceGroups/test-resource-group",
+		}
+
+		// Create test client factory with fake env server
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(
+			workspace.Scope,
+			func() corerpfake.EnvironmentsServer {
+				return validEnvServer
+			},
+			nil,
+		)
+		require.NoError(t, err)
+
+		// Set up Applications.Core mock to return successful environment
+		mockAppClient := clients.NewMockApplicationsManagementClient(ctrl)
+		mockAppClient.EXPECT().
+			GetEnvironment(gomock.Any(), "/planes/radius/local/resourceGroups/test-resource-group/providers/Applications.Core/environments/prod").
+			Return(v20231001preview.EnvironmentResource{}, radcli.Create404Error()).Times(1)
+
+		f := &framework.Impl{
+			ConfigHolder: &framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+			Output: &output.MockOutput{},
+		}
+
+		cmd, runner := NewCommand(f)
+		r := runner.(*Runner)
+		r.Workspace = workspace
+		r.RadiusCoreClientFactory = factory
+		r.ConnectionFactory = &connections.MockFactory{ApplicationsManagementClient: mockAppClient}
+
+		// Parse the flags manually to set the environment and app flags
+		cmd.SetArgs([]string{"app.bicep", "-e", "prod", "-a", "my-app"})
+		cmd.SetContext(context.Background())
+		err = cmd.ParseFlags([]string{"-e", "prod", "-a", "my-app"})
+		require.NoError(t, err)
+
+		// This should successfully validate
+		err = r.Validate(cmd, []string{"app.bicep"})
+		require.NoError(t, err, "Run should succeed with valid environment and app")
+	})
+
+	// Test case: rad run with environment that returns 404 from both providers should fail
+	t.Run("rad run - env specified with -e returns 404 from both providers should fail", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// Create a fake env server that returns 404
+		nonExistentEnvServer := corerpfake.EnvironmentsServer{
+			Get: func(
+				_ context.Context,
+				_ string,
+				_ *v20250801preview.EnvironmentsClientGetOptions,
+			) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
+				errResp.SetError(fmt.Errorf("Environment not found"))
+				errResp.SetResponseError(404, "Not Found")
+				return
+			},
+		}
+
+		workspace := &workspaces.Workspace{
+			Name:  "test-workspace",
+			Scope: "/planes/radius/local/resourceGroups/test-resource-group",
+		}
+
+		// Create test client factory with fake env server
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(
+			workspace.Scope,
+			func() corerpfake.EnvironmentsServer {
+				return nonExistentEnvServer
+			},
+			nil,
+		)
+		require.NoError(t, err)
+
+		// Set up Applications.Core mock to also return 404
+		mockAppClient := clients.NewMockApplicationsManagementClient(ctrl)
+		mockAppClient.EXPECT().
+			GetEnvironment(gomock.Any(), "/planes/radius/local/resourceGroups/test-resource-group/providers/Applications.Core/environments/nonexistent").
+			Return(v20231001preview.EnvironmentResource{}, radcli.Create404Error()).
+			Times(1)
+
+		f := &framework.Impl{
+			ConfigHolder: &framework.ConfigHolder{
+				ConfigFilePath: "",
+				Config:         configWithWorkspace,
+			},
+			Output: &output.MockOutput{},
+		}
+
+		cmd, runner := NewCommand(f)
+		r := runner.(*Runner)
+		r.Workspace = workspace
+		r.RadiusCoreClientFactory = factory
+		r.ConnectionFactory = &connections.MockFactory{ApplicationsManagementClient: mockAppClient}
+
+		// Parse the flags manually to set the environment flag with a non-existent environment
+		cmd.SetArgs([]string{"app.bicep", "-e", "nonexistent", "-a", "my-app"})
+		cmd.SetContext(context.Background())
+		err = cmd.ParseFlags([]string{"-e", "nonexistent", "-a", "my-app"})
+		require.NoError(t, err)
+
+		// This should fail because both providers return 404 and user specified environment name
+		err = r.Validate(cmd, []string{"app.bicep"})
+		require.Error(t, err, "Run should fail when both Radius.Core and Applications.Core return 404 for specified environment")
+		require.Contains(t, err.Error(), "The environment \"nonexistent\" does not exist in scope", "Error should indicate environment doesn't exist")
+		require.Contains(t, err.Error(), "Run `rad env create` first", "Error should suggest creating environment")
+	})
 }
 
 func Test_Run(t *testing.T) {

--- a/pkg/cli/cmd/run/run_test.go
+++ b/pkg/cli/cmd/run/run_test.go
@@ -71,7 +71,7 @@ func Test_Validate(t *testing.T) {
 					Return(map[string]any{}, nil).
 					Times(1)
 				mocks.ApplicationManagementClient.EXPECT().
-					GetEnvironment(gomock.Any(), "prod").
+					GetEnvironment(gomock.Any(), "/planes/radius/local/resourceGroups/test-resource-group/providers/Applications.Core/environments/prod").
 					Return(v20231001preview.EnvironmentResource{}, nil).
 					Times(1)
 			},
@@ -96,7 +96,7 @@ func Test_Validate(t *testing.T) {
 					Return(map[string]any{}, nil).
 					Times(1)
 				mocks.ApplicationManagementClient.EXPECT().
-					GetEnvironment(gomock.Any(), "prod").
+					GetEnvironment(gomock.Any(), "/planes/radius/local/resourceGroups/test-resource-group/providers/Applications.Core/environments/prod").
 					Return(v20231001preview.EnvironmentResource{}, nil).
 					Times(1)
 			},
@@ -363,10 +363,6 @@ func Test_Run(t *testing.T) {
 
 	clientMock := clients.NewMockApplicationsManagementClient(ctrl)
 	clientMock.EXPECT().
-		GetEnvironment(gomock.Any(), "test-environment").
-		Return(v20231001preview.EnvironmentResource{}, nil).
-		Times(1)
-	clientMock.EXPECT().
 		CreateApplicationIfNotFound(gomock.Any(), "test-application", gomock.Any()).
 		Return(nil).
 		Times(1)
@@ -380,7 +376,8 @@ func Test_Run(t *testing.T) {
 			"kind":    "kubernetes",
 			"context": "kind-kind",
 		},
-		Name: "kind-kind",
+		Name:        "kind-kind",
+		Environment: fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/applications.core/environments/%s", radcli.TestEnvironmentName, radcli.TestEnvironmentName),
 	}
 	outputSink := &output.MockOutput{}
 	providers := &clients.Providers{
@@ -532,10 +529,6 @@ func Test_Run_NoDashboard(t *testing.T) {
 
 	clientMock := clients.NewMockApplicationsManagementClient(ctrl)
 	clientMock.EXPECT().
-		GetEnvironment(gomock.Any(), "test-environment").
-		Return(v20231001preview.EnvironmentResource{}, nil).
-		Times(1)
-	clientMock.EXPECT().
 		CreateApplicationIfNotFound(gomock.Any(), "test-application", gomock.Any()).
 		Return(nil).
 		Times(1)
@@ -549,7 +542,8 @@ func Test_Run_NoDashboard(t *testing.T) {
 			"kind":    "kubernetes",
 			"context": "kind-kind",
 		},
-		Name: "kind-kind",
+		Name:        "kind-kind",
+		Environment: fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/applications.core/environments/%s", radcli.TestEnvironmentName, radcli.TestEnvironmentName),
 	}
 	outputSink := &output.MockOutput{}
 	providers := &clients.Providers{

--- a/pkg/cli/cmd/run/run_test.go
+++ b/pkg/cli/cmd/run/run_test.go
@@ -302,7 +302,7 @@ func Test_ValidateWithFakeEnvServer(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		// Set up Applications.Core mock to return successful environment
+		// Set up Applications.Core mock to return 404
 		mockAppClient := clients.NewMockApplicationsManagementClient(ctrl)
 		mockAppClient.EXPECT().
 			GetEnvironment(gomock.Any(), "/planes/radius/local/resourceGroups/test-resource-group/providers/Applications.Core/environments/prod").


### PR DESCRIPTION

# Description

- Dual-provider environment lookup - check both Applications.Core and Radius.Core providers when resolving environment names, automatically selecting the correct provider setting logic based on which one contains the environment

- Conflict detection: Returns clear error message when an environment with the same name exists in both Applications.Core and Radius.Core, prompting users to specify the full resource ID to disambiguate

- Refactored provider configuration: Unified configureProviders() method handles both v20231001preview (Applications.Core) and v20250801preview (Radius.Core) API versions, 

- Application ID provider inferred correctly based on the environment in use.

Below cases should now work:

rad deploy /Users/nithya/rp/app.bicep -e /planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/radcoreenv

rad deploy /Users/nithya/rp/app.bicep -e /planes/radius/local/resourceGroups/default/providers/Radius.Core/environments/radcoreenv

rad deploy /Users/nithya/rp/app.bicep -e radcoreenv (returns conflict error)

vi ~/rp/app.bicep  # set workspace env to an application core env
rad deploy /Users/nithya/rp/app.bicep 

vi ~/.rad/config.yaml  # set workspace env to a radius core env
rad deploy /Users/nithya/rp/app.bicep 


## Type of change



Fixes: #10895 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->