### PR TITLE
add type, name and id to properties accessible.

### DIFF
--- a/pkg/portableresources/backend/controller/createorupdateresource.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource.go
@@ -177,7 +177,7 @@ func (c *CreateOrUpdateResource[P, T]) executeRecipeIfNeeded(ctx context.Context
 	if err != nil {
 		return nil, fmt.Errorf("failed to get connected resource IDs: %w", err)
 	}
-	connectedResourcesProperties := make(map[string]recipes.ConnectedResource)
+	connectedResourcesMetadata := make(map[string]recipes.ConnectedResource)
 
 	// If there are connected resources, we need to fetch their properties and add them to the recipe context.
 	for connName, connectedResourceID := range connectionsAndSourceIDs {
@@ -193,7 +193,7 @@ func (c *CreateOrUpdateResource[P, T]) executeRecipeIfNeeded(ctx context.Context
 			return nil, fmt.Errorf("failed to get metadata from connected resource %s: %w", connectedResourceID, err)
 		}
 
-		connectedResourcesProperties[connName] = recipes.ConnectedResource{
+		connectedResourcesMetadata[connName] = recipes.ConnectedResource{
 			ID:         connectedResourceMetadata.ID,
 			Name:       connectedResourceMetadata.Name,
 			Type:       connectedResourceMetadata.Type,
@@ -208,7 +208,7 @@ func (c *CreateOrUpdateResource[P, T]) executeRecipeIfNeeded(ctx context.Context
 		ApplicationID:                resource.ResourceMetadata().ApplicationID(),
 		ResourceID:                   resource.GetBaseResource().ID,
 		Properties:                   resourceProperties,
-		ConnectedResourcesProperties: connectedResourcesProperties,
+		ConnectedResourcesProperties: connectedResourcesMetadata,
 	}
 
 	return c.engine.Execute(ctx, engine.ExecuteOptions{

--- a/pkg/portableresources/backend/controller/createorupdateresource.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource.go
@@ -188,7 +188,7 @@ func (c *CreateOrUpdateResource[P, T]) executeRecipeIfNeeded(ctx context.Context
 			return nil, fmt.Errorf("failed to get connected resource %s: %w", connectedResourceID, err)
 		}
 
-		connectedResourceMetadata, err := resourceutil.GetAllPropertiesFromResource(connectedResource.Data, connectedResourceID)
+		connectedResourceMetadata, err := resourceutil.GetAllPropertiesFromResource(connectedResource.Data)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get metadata from connected resource %s: %w", connectedResourceID, err)
 		}

--- a/pkg/portableresources/backend/controller/createorupdateresource.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource.go
@@ -177,7 +177,7 @@ func (c *CreateOrUpdateResource[P, T]) executeRecipeIfNeeded(ctx context.Context
 	if err != nil {
 		return nil, fmt.Errorf("failed to get connected resource IDs: %w", err)
 	}
-	connectedResourcesProperties := make(map[string]map[string]any)
+	connectedResourcesProperties := make(map[string]recipes.ConnectedResource)
 
 	// If there are connected resources, we need to fetch their properties and add them to the recipe context.
 	for connName, connectedResourceID := range connectionsAndSourceIDs {
@@ -188,12 +188,17 @@ func (c *CreateOrUpdateResource[P, T]) executeRecipeIfNeeded(ctx context.Context
 			return nil, fmt.Errorf("failed to get connected resource %s: %w", connectedResourceID, err)
 		}
 
-		connectedResourceProperties, err := resourceutil.GetPropertiesFromResource(connectedResource.Data)
+		connectedResourceMetadata, err := resourceutil.GetAllPropertiesFromResource(connectedResource.Data, connectedResourceID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get properties from connected resource %s: %w", connectedResourceID, err)
+			return nil, fmt.Errorf("failed to get metadata from connected resource %s: %w", connectedResourceID, err)
 		}
 
-		connectedResourcesProperties[connName] = connectedResourceProperties
+		connectedResourcesProperties[connName] = recipes.ConnectedResource{
+			ID:         connectedResourceMetadata.ID,
+			Name:       connectedResourceMetadata.Name,
+			Type:       connectedResourceMetadata.Type,
+			Properties: connectedResourceMetadata.Properties,
+		}
 	}
 
 	metadata := recipes.ResourceMetadata{

--- a/pkg/portableresources/backend/controller/createorupdateresource_test.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource_test.go
@@ -470,34 +470,3 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 		})
 	}
 }
-
-func TestGetAllPropertiesFromResource_Integration(t *testing.T) {
-	// Simple integration test for resourceutil.GetAllPropertiesFromResource
-	connectedResourceID := "/planes/radius/local/resourceGroups/radius-test-rg/providers/Applications.Datastores/sqlDatabases/test-db"
-	
-	// Create a test resource with properties
-	testResource := struct {
-		Properties map[string]any `json:"properties"`
-	}{
-		Properties: map[string]any{
-			"host":     "localhost",
-			"port":     5432,
-			"database": "testdb",
-		},
-	}
-
-	// Test the GetAllPropertiesFromResource function
-	metadata, err := resourceutil.GetAllPropertiesFromResource(testResource, connectedResourceID)
-	
-	// Assertions
-	require.NoError(t, err)
-	require.NotNil(t, metadata)
-	require.Equal(t, connectedResourceID, metadata.ID)
-	require.Equal(t, "test-db", metadata.Name)
-	require.Equal(t, "Applications.Datastores/sqlDatabases", metadata.Type)
-	require.Equal(t, map[string]any{
-		"host":     "localhost",
-		"port":     float64(5432), // JSON unmarshaling converts to float64
-		"database": "testdb",
-	}, metadata.Properties)
-}

--- a/pkg/portableresources/backend/controller/createorupdateresource_test.go
+++ b/pkg/portableresources/backend/controller/createorupdateresource_test.go
@@ -368,7 +368,7 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 					"p1": "v1",
 				},
 				Properties:                   properties,
-				ConnectedResourcesProperties: map[string]map[string]any{},
+				ConnectedResourcesProperties: map[string]recipes.ConnectedResource{},
 			}
 
 			prevState := []string{
@@ -469,4 +469,35 @@ func TestCreateOrUpdateResource_Run(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetAllPropertiesFromResource_Integration(t *testing.T) {
+	// Simple integration test for resourceutil.GetAllPropertiesFromResource
+	connectedResourceID := "/planes/radius/local/resourceGroups/radius-test-rg/providers/Applications.Datastores/sqlDatabases/test-db"
+	
+	// Create a test resource with properties
+	testResource := struct {
+		Properties map[string]any `json:"properties"`
+	}{
+		Properties: map[string]any{
+			"host":     "localhost",
+			"port":     5432,
+			"database": "testdb",
+		},
+	}
+
+	// Test the GetAllPropertiesFromResource function
+	metadata, err := resourceutil.GetAllPropertiesFromResource(testResource, connectedResourceID)
+	
+	// Assertions
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+	require.Equal(t, connectedResourceID, metadata.ID)
+	require.Equal(t, "test-db", metadata.Name)
+	require.Equal(t, "Applications.Datastores/sqlDatabases", metadata.Type)
+	require.Equal(t, map[string]any{
+		"host":     "localhost",
+		"port":     float64(5432), // JSON unmarshaling converts to float64
+		"database": "testdb",
+	}, metadata.Properties)
 }

--- a/pkg/recipes/engine/engine_test.go
+++ b/pkg/recipes/engine/engine_test.go
@@ -61,9 +61,14 @@ func Test_Engine_Execute_Success(t *testing.T) {
 		Parameters: map[string]any{
 			"resourceName": "resource1",
 		},
-		ConnectedResourcesProperties: map[string]map[string]any{
+		ConnectedResourcesProperties: map[string]recipes.ConnectedResource{
 			"database": {
-				"name": "db",
+				ID:   "/planes/radius/local/resourceGroups/radius-test-rg/providers/Applications.Datastores/sqlDatabases/database",
+				Name: "database",
+				Type: "Applications.Datastores/sqlDatabases",
+				Properties: map[string]any{
+					"name": "db",
+				},
 			},
 		},
 	}

--- a/pkg/recipes/recipecontext/context_test.go
+++ b/pkg/recipes/recipecontext/context_test.go
@@ -304,3 +304,82 @@ func TestNewContext_failures(t *testing.T) {
 		})
 	}
 }
+
+func TestNewContext_WithConnectedResources(t *testing.T) {
+	testMetadata := &recipes.ResourceMetadata{
+		ResourceID:    "/planes/radius/local/resourceGroups/testGroup/providers/applications.datastores/mongodatabases/mongo0",
+		ApplicationID: "/planes/radius/local/resourceGroups/testGroup/providers/applications.core/applications/testApplication",
+		EnvironmentID: "/planes/radius/local/resourceGroups/testGroup/providers/applications.core/environments/testEnvironment",
+		Name:          "recipe0",
+		Properties: map[string]any{
+			"property1": "value1",
+		},
+		ConnectedResourcesProperties: map[string]recipes.ConnectedResource{
+			"database": {
+				ID:   "/planes/radius/local/resourceGroups/testGroup/providers/applications.datastores/sqldatabases/testdb",
+				Name: "testdb",
+				Type: "Applications.Datastores/sqlDatabases",
+				Properties: map[string]any{
+					"host":     "localhost",
+					"port":     5432,
+					"database": "testdb",
+				},
+			},
+			"cache": {
+				ID:   "/planes/radius/local/resourceGroups/testGroup/providers/applications.datastores/redis/testcache",
+				Name: "testcache",
+				Type: "Applications.Datastores/redis",
+				Properties: map[string]any{
+					"host": "cache-host",
+					"port": 6379,
+				},
+			},
+		},
+	}
+
+	testConfig := &recipes.Configuration{
+		Providers: coredm.Providers{
+			Azure: coredm.ProvidersAzure{
+				Scope: "/planes/radius/local/resourceGroups/testGroup",
+			},
+			AWS: coredm.ProvidersAWS{
+				Scope: "/planes/aws/aws/accounts/1234567890/regions/us-west-2",
+			},
+		},
+	}
+
+	result, err := New(testMetadata, testConfig)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify basic resource properties
+	require.Equal(t, "mongo0", result.Resource.Name)
+	require.Equal(t, testMetadata.ResourceID, result.Resource.ID)
+	require.Equal(t, "applications.datastores/mongodatabases", result.Resource.Type)
+
+	// Verify connected resources metadata is available (connections are set by recipe engines)
+	require.NotNil(t, testMetadata.ConnectedResourcesProperties)
+	require.Len(t, testMetadata.ConnectedResourcesProperties, 2)
+
+	// Verify the metadata contains the expected connected resources
+	dbConn, exists := testMetadata.ConnectedResourcesProperties["database"]
+	require.True(t, exists)
+	require.Equal(t, "/planes/radius/local/resourceGroups/testGroup/providers/applications.datastores/sqldatabases/testdb", dbConn.ID)
+	require.Equal(t, "testdb", dbConn.Name)
+	require.Equal(t, "Applications.Datastores/sqlDatabases", dbConn.Type)
+	require.Equal(t, map[string]any{
+		"host":     "localhost",
+		"port":     5432,
+		"database": "testdb",
+	}, dbConn.Properties)
+
+	cacheConn, exists := testMetadata.ConnectedResourcesProperties["cache"]
+	require.True(t, exists)
+	require.Equal(t, "/planes/radius/local/resourceGroups/testGroup/providers/applications.datastores/redis/testcache", cacheConn.ID)
+	require.Equal(t, "testcache", cacheConn.Name)
+	require.Equal(t, "Applications.Datastores/redis", cacheConn.Type)
+	require.Equal(t, map[string]any{
+		"host": "cache-host",
+		"port": 6379,
+	}, cacheConn.Properties)
+}

--- a/pkg/recipes/recipecontext/types.go
+++ b/pkg/recipes/recipecontext/types.go
@@ -55,10 +55,13 @@ type Resource struct {
 	Properties map[string]any `json:"properties,omitempty"`
 
 	// Connections represent a map of connections to other resources.
-	// The key is the connection name, and the value is a map of connected resource properties.
-	// We enrich the recipe context with this, allowing the recipe to access properties of connected resources using the following format:
-	// context.resource.connections.[connection-name].[connected-resource-property]
-	Connections map[string]map[string]any `json:"connections,omitempty"`
+	// The key is the connection name, and the value contains the connected resource's metadata and properties.
+	// We enrich the recipe context with this, allowing the recipe to access connected resource info using:
+	// context.resource.connections.[connection-name].properties.[property-name]
+	// context.resource.connections.[connection-name].id
+	// context.resource.connections.[connection-name].name
+	// context.resource.connections.[connection-name].type
+	Connections map[string]recipes.ConnectedResource `json:"connections,omitempty"`
 }
 
 // ResourceInfo represents name and id of the resource

--- a/pkg/recipes/terraform/execute_test.go
+++ b/pkg/recipes/terraform/execute_test.go
@@ -43,9 +43,14 @@ func TestGenerateConfig(t *testing.T) {
 					TemplatePath: "test/module/source",
 				},
 				ResourceRecipe: &recipes.ResourceMetadata{
-					ConnectedResourcesProperties: map[string]map[string]any{
+					ConnectedResourcesProperties: map[string]recipes.ConnectedResource{
 						"conn1": {
-							"dbName": "db",
+							ID:   "/planes/radius/local/resourceGroups/radius-test-rg/providers/Applications.Datastores/redis/redis",
+							Name: "redis",
+							Type: "Applications.Datastores/redis",
+							Properties: map[string]any{
+								"dbName": "db",
+							},
 						},
 					},
 				},

--- a/pkg/recipes/types.go
+++ b/pkg/recipes/types.go
@@ -24,6 +24,18 @@ import (
 	rpv1 "github.com/radius-project/radius/pkg/rp/v1"
 )
 
+// ConnectedResource represents a connected resource's metadata and properties
+type ConnectedResource struct {
+	// ID represents the fully qualified resource id
+	ID string `json:"id"`
+	// Name represents the resource name
+	Name string `json:"name"`
+	// Type represents the resource type
+	Type string `json:"type"`
+	// Properties represents the resource properties
+	Properties map[string]any `json:"properties,omitempty"`
+}
+
 // Configuration represents runtime and cloud provider configuration, which is used by the driver while deploying recipes.
 type Configuration struct {
 	// Kubernetes Runtime configuration for the environment.
@@ -85,11 +97,10 @@ type ResourceMetadata struct {
 	ResourceID string
 	// Properties represents the properties of the resource that the recipe is deploying
 	Properties map[string]any
-	// ConnectedResourcesProperties represents the properties of the connected resources that the recipe is deploying.
-	// the key is connection name and the value is a map of properties for the connected resource.
-	// properties are inturn a map of key/value pairs, where the key is the property name and the value is the property value.
-	// these properties are passed into the recipe context.
-	ConnectedResourcesProperties map[string]map[string]any
+	// ConnectedResourcesProperties represents the connected resources that the recipe is deploying.
+	// The key is connection name and the value contains the connected resource's metadata and properties.
+	// These are passed into the recipe context.
+	ConnectedResourcesProperties map[string]ConnectedResource
 	// Parameters represents key/value pairs to pass into the recipe template. Overrides any parameters set by the environment.
 	Parameters map[string]any
 }

--- a/pkg/resourceutil/utils.go
+++ b/pkg/resourceutil/utils.go
@@ -31,23 +31,31 @@ const (
 // BasicProperties is a list of common properties that are expected to be present in all resources
 var BasicProperties = []string{"application", "environment", "status", "connections"}
 
+// marshalAndUnmarshalResource serializes a resource to JSON and then deserializes it into the target structure
+func marshalAndUnmarshalResource[P any, T any](resource P, target *T) error {
+	bytes, err := json.Marshal(resource)
+	if err != nil {
+		return fmt.Errorf("%s: %w", errMarshalResource, err)
+	}
+
+	if err := json.Unmarshal(bytes, target); err != nil {
+		return fmt.Errorf("%s: %w", errUnmarshalResourceProperties, err)
+	}
+
+	return nil
+}
+
 // GetPropertiesFromResource extracts the "properties" field from the resource
 // by serializing it to JSON and deserializing just the "properties" field.
 func GetPropertiesFromResource[P any](resource P) (map[string]any, error) {
-	// Serialize the resource to JSON
-	bytes, err := json.Marshal(resource)
-	if err != nil {
-		return nil, fmt.Errorf("%s: %w", errMarshalResource, err)
-	}
-
 	// Define a minimal struct to capture just the "properties" field
 	var partialResource struct {
 		Properties map[string]any `json:"properties"`
 	}
 
-	// Deserialize the JSON into the partialResource struct
-	if err := json.Unmarshal(bytes, &partialResource); err != nil {
-		return nil, fmt.Errorf("%s: %w", errUnmarshalResourceProperties, err)
+	// Use the common marshal/unmarshal helper
+	if err := marshalAndUnmarshalResource(resource, &partialResource); err != nil {
+		return nil, err
 	}
 
 	// Return an empty map if properties is nil
@@ -102,24 +110,30 @@ type ResourceMetadata struct {
 }
 
 // GetAllPropertiesFromResource extracts the resource metadata including ID, Name, Type and properties
-// by parsing the resource ID and extracting properties.
-func GetAllPropertiesFromResource[P any](resource P, resourceID string) (*ResourceMetadata, error) {
-	// Parse resource ID to get name and type
-	parsedResourceID, err := resources.Parse(resourceID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse resource ID %s: %w", resourceID, err)
+// by unmarshalling the resource and extracting the required fields.
+func GetAllPropertiesFromResource[P any](resource P) (*ResourceMetadata, error) {
+	// Define a struct to capture ID, Name, Type, and properties fields
+	var partialResource struct {
+		ID         string         `json:"id"`
+		Name       string         `json:"name"`
+		Type       string         `json:"type"`
+		Properties map[string]any `json:"properties"`
 	}
 
-	// Get properties using existing method
-	properties, err := GetPropertiesFromResource(resource)
-	if err != nil {
+	// Use the common marshal/unmarshal helper
+	if err := marshalAndUnmarshalResource(resource, &partialResource); err != nil {
 		return nil, err
 	}
 
+	// Return empty properties map if properties is nil
+	if partialResource.Properties == nil {
+		partialResource.Properties = map[string]any{}
+	}
+
 	return &ResourceMetadata{
-		ID:         resourceID,
-		Name:       parsedResourceID.Name(),
-		Type:       parsedResourceID.Type(),
-		Properties: properties,
+		ID:         partialResource.ID,
+		Name:       partialResource.Name,
+		Type:       partialResource.Type,
+		Properties: partialResource.Properties,
 	}, nil
 }

--- a/pkg/resourceutil/utils.go
+++ b/pkg/resourceutil/utils.go
@@ -92,3 +92,34 @@ func GetConnectionNameandSourceIDs[P any](resource P) (map[string]string, error)
 
 	return connectionNamesAndSourceIDs, nil
 }
+
+// ResourceMetadata represents resource metadata including ID, Name, Type and Properties
+type ResourceMetadata struct {
+	ID         string         `json:"id"`
+	Name       string         `json:"name"`
+	Type       string         `json:"type"`
+	Properties map[string]any `json:"properties,omitempty"`
+}
+
+// GetAllPropertiesFromResource extracts the resource metadata including ID, Name, Type and properties
+// by parsing the resource ID and extracting properties.
+func GetAllPropertiesFromResource[P any](resource P, resourceID string) (*ResourceMetadata, error) {
+	// Parse resource ID to get name and type
+	parsedResourceID, err := resources.Parse(resourceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse resource ID %s: %w", resourceID, err)
+	}
+
+	// Get properties using existing method
+	properties, err := GetPropertiesFromResource(resource)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ResourceMetadata{
+		ID:         resourceID,
+		Name:       parsedResourceID.Name(),
+		Type:       parsedResourceID.Type(),
+		Properties: properties,
+	}, nil
+}

--- a/pkg/resourceutil/utils_test.go
+++ b/pkg/resourceutil/utils_test.go
@@ -33,6 +33,9 @@ const (
 
 type PropertiesTestResource struct {
 	v1.BaseResource
+	ID         string         `json:"id"`
+	Name       string         `json:"name"`
+	Type       string         `json:"type"`
 	Properties map[string]any `json:"properties"`
 }
 
@@ -311,18 +314,127 @@ func TestGetConnectionNameandSourceIDs_InvalidJSONMarshaling(t *testing.T) {
 	require.Contains(t, err.Error(), errMarshalResource)
 }
 
+func TestMarshalAndUnmarshalResource(t *testing.T) {
+	t.Run("Valid marshal and unmarshal to same struct type", func(t *testing.T) {
+		source := &PropertiesTestResource{
+			ID:   TestResourceID,
+			Name: "test-resource",
+			Type: "MyResources.Test/testResources",
+			Properties: map[string]any{
+				"host": "localhost",
+				"port": 5432,
+			},
+		}
+
+		result, err := GetAllPropertiesFromResource(source)
+		require.NoError(t, err)
+		require.Equal(t, TestResourceID, result.ID)
+		require.Equal(t, "test-resource", result.Name)
+		require.Equal(t, "MyResources.Test/testResources", result.Type)
+		require.Equal(t, "localhost", result.Properties["host"])
+		require.Equal(t, float64(5432), result.Properties["port"]) // JSON numbers are float64
+	})
+
+	t.Run("Unmarshal properties through GetPropertiesFromResource", func(t *testing.T) {
+		source := &PropertiesTestResource{
+			ID:   TestResourceID,
+			Name: "test-resource",
+			Type: "MyResources.Test/testResources",
+			Properties: map[string]any{
+				"key":     "value",
+				"number":  123,
+				"boolean": true,
+				"nested": map[string]any{
+					"inner": "value",
+				},
+			},
+		}
+
+		properties, err := GetPropertiesFromResource(source)
+		require.NoError(t, err)
+		require.Equal(t, "value", properties["key"])
+		require.Equal(t, float64(123), properties["number"]) // JSON numbers are float64
+		require.Equal(t, true, properties["boolean"])
+		require.IsType(t, map[string]any{}, properties["nested"])
+		nested := properties["nested"].(map[string]any)
+		require.Equal(t, "value", nested["inner"])
+	})
+
+	t.Run("Marshal error through GetPropertiesFromResource", func(t *testing.T) {
+		source := &InvalidResourceForAll{
+			Properties: map[string]any{"key": "value"},
+			BadField:   func() {}, // Functions cannot be marshaled
+		}
+
+		_, err := GetPropertiesFromResource(source)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errMarshalResource)
+	})
+
+	t.Run("Unmarshal error through GetAllPropertiesFromResource", func(t *testing.T) {
+		source := &InvalidResourceForAll{
+			Properties: map[string]any{"key": "value"},
+			BadField:   func() {}, // Functions cannot be marshaled
+		}
+
+		_, err := GetAllPropertiesFromResource(source)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errMarshalResource)
+	})
+
+	t.Run("Test data type preservation", func(t *testing.T) {
+		source := &PropertiesTestResource{
+			ID:   TestResourceID,
+			Name: "test-resource",
+			Type: "MyResources.Test/testResources",
+			Properties: map[string]any{
+				"string":  "value",
+				"int":     42,
+				"float":   3.14,
+				"bool":    true,
+				"null":    nil,
+				"array":   []string{"item1", "item2"},
+				"object": map[string]any{
+					"nested": "value",
+				},
+			},
+		}
+
+		result, err := GetAllPropertiesFromResource(source)
+		require.NoError(t, err)
+
+		// Check that data types are preserved correctly through JSON marshal/unmarshal
+		require.Equal(t, "value", result.Properties["string"])
+		require.Equal(t, float64(42), result.Properties["int"]) // JSON converts all numbers to float64
+		require.Equal(t, 3.14, result.Properties["float"])
+		require.Equal(t, true, result.Properties["bool"])
+		require.Nil(t, result.Properties["null"])
+		
+		// Arrays become []any after JSON processing
+		array := result.Properties["array"].([]any)
+		require.Equal(t, "item1", array[0])
+		require.Equal(t, "item2", array[1])
+		
+		// Objects remain as map[string]any
+		object := result.Properties["object"].(map[string]any)
+		require.Equal(t, "value", object["nested"])
+	})
+}
+
 func TestGetAllPropertiesFromResource(t *testing.T) {
 	tests := []struct {
-		name         string
-		resource     any
-		resourceID   string
-		expected     *ResourceMetadata
-		expectError  bool
-		errorMsg     string
+		name        string
+		resource    any
+		expected    *ResourceMetadata
+		expectError bool
+		errorMsg    string
 	}{
 		{
 			name: "Valid resource with properties",
 			resource: &PropertiesTestResource{
+				ID:   TestResourceID,
+				Name: "tr",
+				Type: "MyResources.Test/testResources",
 				Properties: map[string]any{
 					"Application": TestApplicationID,
 					"Environment": TestEnvironmentID,
@@ -330,7 +442,6 @@ func TestGetAllPropertiesFromResource(t *testing.T) {
 					"port":        float64(5432),
 				},
 			},
-			resourceID: TestResourceID,
 			expected: &ResourceMetadata{
 				ID:   TestResourceID,
 				Name: "tr",
@@ -347,9 +458,11 @@ func TestGetAllPropertiesFromResource(t *testing.T) {
 		{
 			name: "Resource with empty properties",
 			resource: &PropertiesTestResource{
+				ID:         TestResourceID,
+				Name:       "tr",
+				Type:       "MyResources.Test/testResources",
 				Properties: nil,
 			},
-			resourceID: TestResourceID,
 			expected: &ResourceMetadata{
 				ID:         TestResourceID,
 				Name:       "tr",
@@ -359,20 +472,28 @@ func TestGetAllPropertiesFromResource(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "Invalid resource ID",
+			name: "Resource with missing fields",
 			resource: &PropertiesTestResource{
 				Properties: map[string]any{
 					"host": "localhost",
 				},
 			},
-			resourceID:  "invalid-resource-id",
-			expected:    nil,
-			expectError: true,
-			errorMsg:    "failed to parse resource ID",
+			expected: &ResourceMetadata{
+				ID:         "",
+				Name:       "",
+				Type:       "",
+				Properties: map[string]any{
+					"host": "localhost",
+				},
+			},
+			expectError: false,
 		},
 		{
 			name: "Resource with complex nested properties",
 			resource: &PropertiesTestResource{
+				ID:   TestResourceID,
+				Name: "tr",
+				Type: "MyResources.Test/testResources",
 				Properties: map[string]any{
 					"Application": TestApplicationID,
 					"Environment": TestEnvironmentID,
@@ -383,7 +504,6 @@ func TestGetAllPropertiesFromResource(t *testing.T) {
 					"enabled": true,
 				},
 			},
-			resourceID: TestResourceID,
 			expected: &ResourceMetadata{
 				ID:   TestResourceID,
 				Name: "tr",
@@ -401,14 +521,13 @@ func TestGetAllPropertiesFromResource(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "Resource with GetPropertiesFromResource error",
+			name: "Resource with unmarshalable data",
 			resource: &InvalidResourceForAll{
 				Properties: map[string]any{
 					"host": "localhost",
 				},
 				BadField: func() {}, // This will cause JSON marshaling to fail
 			},
-			resourceID:  TestResourceID,
 			expected:    nil,
 			expectError: true,
 			errorMsg:    errMarshalResource,
@@ -417,7 +536,7 @@ func TestGetAllPropertiesFromResource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := GetAllPropertiesFromResource(tt.resource, tt.resourceID)
+			result, err := GetAllPropertiesFromResource(tt.resource)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -426,10 +545,7 @@ func TestGetAllPropertiesFromResource(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, result)
-				require.Equal(t, tt.expected.ID, result.ID)
-				require.Equal(t, tt.expected.Name, result.Name)
-				require.Equal(t, tt.expected.Type, result.Type)
-				require.Equal(t, tt.expected.Properties, result.Properties)
+				require.Equal(t, tt.expected, result)
 			}
 		})
 	}

--- a/test/testrecipes/test-bicep-recipes/dynamicrp_recipe.bicep
+++ b/test/testrecipes/test-bicep-recipes/dynamicrp_recipe.bicep
@@ -41,7 +41,7 @@ resource usertypealpha 'apps/Deployment@v1' = {
             env: [
               {
                 name: 'CONN_INJECTED'
-                value: contains(context.resource, 'connections') && contains(context.resource.connections, 'externalresource') ? context.resource.connections.externalresource.configMap : ''
+                value: contains(context.resource, 'connections') && contains(context.resource.connections, 'externalresource') ? context.resource.connections.externalresource.properties.configMap : ''
               }
             ]
           }

--- a/test/testrecipes/test-terraform-recipes/parent-udt/main.tf
+++ b/test/testrecipes/test-terraform-recipes/parent-udt/main.tf
@@ -58,7 +58,7 @@ resource "kubernetes_deployment" "usertypealpha" {
           
           env {
             name  = "CONN_INJECTED"
-            value = try(var.context.resource.connections.externalresource.configMap, "")
+            value = try(var.context.resource.connections.externalresource.properties.configMap, "")
           }
         }
       }


### PR DESCRIPTION
# Description

Populate Name, ID and Type of the child resource in addition to existing Properties, in the data accessible to a parent resource's recipe.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #10890

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->