### PR TITLE
Fix broken lint.yaml due to helm-unittest plugin installation failure

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Run Helm unit tests
         run: |
-          helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.0.2 || true
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.0.3 || true
           cd ${{ env.HELM_CHARTS_DIR }} && helm unittest .
 
       - name: Run TypeSpec format check

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Run Helm unit tests
         run: |
-          helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.0.3 || true
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.0.2 || true
           cd ${{ env.HELM_CHARTS_DIR }} && helm unittest .
 
       - name: Run TypeSpec format check

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Run Helm unit tests
         run: |
-          helm plugin install https://github.com/helm-unittest/helm-unittest.git || true
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.0.2 || true
           cd ${{ env.HELM_CHARTS_DIR }} && helm unittest .
 
       - name: Run TypeSpec format check

--- a/build/test.mk
+++ b/build/test.mk
@@ -164,7 +164,7 @@ test-validate-bicep: ## Validates that all .bicep files compile cleanly
 .PHONY: test-helm
 test-helm: ## Runs Helm chart unit tests
 	@echo "$(ARROW) Installing helm-unittest plugin if not already installed..."
-	@helm plugin list | grep -q unittest || helm plugin install https://github.com/helm-unittest/helm-unittest.git
+	@helm plugin list | grep -q unittest || helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.0.2
 	@echo "$(ARROW) Running Helm unit tests..."
 	cd deploy/Chart && helm unittest .
 

--- a/deploy/Chart/tests/README.md
+++ b/deploy/Chart/tests/README.md
@@ -7,7 +7,7 @@ This directory contains unit tests for the Radius Helm chart templates.
 Install the helm-unittest plugin:
 
 ```bash
-helm plugin install https://github.com/helm-unittest/helm-unittest.git
+helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 1.0.2
 ```
 
 ## Running Tests


### PR DESCRIPTION
## Description

This PR fixes a breaking issue with the helm-unittest plugin installation that is affecting all `lint.yaml` workflow runs.

### The Problem

On December 15, 2025, the helm-unittest plugin began failing to install when using the default (latest) version. The issue is documented in [helm-unittest/helm-unittest#790](https://github.com/helm-unittest/helm-unittest/issues/790).

When attempting to install the plugin without a pinned version, the following error occurs:
```
helm plugin install https://github.com/helm-unittest/helm-unittest.git
Support linux-amd64
No version found
sed: can't read plugin.yaml: No such file or directory
Failed to install helm-unittest
```

The root cause appears to be that the `v1.0.3` tag was re-pushed around 2:30pm PST on 12/15, which introduced a bug in the installation script. Additionally, the new version uses `platformHooks` in `plugin.yaml` which is not supported by Helm 3.x, causing errors like:
```
error unmarshaling JSON: while decoding JSON: json: unknown field "platformHooks"
```

Examples in Radius test runs are [here](https://github.com/radius-project/radius/actions/runs/20252505523/job/58147518558?pr=10931#step:7:59) and [here](https://github.com/radius-project/radius/actions/runs/20252505563/job/58147834635?pr=10931).

### The Fix

As suggested in the issue discussion, the workaround is to pin the plugin installation to version `v1.0.2`, which is the last known working version.

## Changes

This PR updates the helm-unittest plugin installation to use `--version 1.0.2` in:

- [`.github/workflows/lint.yaml`](.github/workflows/lint.yaml) - CI workflow
- [`build/test.mk`](build/test.mk) - Local Make target for running Helm tests
- [`deploy/Chart/tests/README.md`](deploy/Chart/tests/README.md) - Documentation

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Verification

Once this PR is merged, the lint workflow should pass without helm-unittest installation errors.