### PR TITLE
ci(codeql): handle cancellations and naming update

### DIFF
--- a/.github/scripts/codeql-matrix.mjs
+++ b/.github/scripts/codeql-matrix.mjs
@@ -12,7 +12,7 @@ const FULL_MATRIX = [
     "build-mode": "none",
     "working-directory": "typespec",
   },
-  { language: "custom-go", "build-mode": "none", "working-directory": "." },
+  { language: "custom-gosec", "build-mode": "none", "working-directory": "." },
 ];
 
 /**
@@ -23,7 +23,7 @@ const LANGUAGE_TO_KEYS = {
   actions: ["actions"],
   go: ["go"],
   javascript: ["javascript"],
-  "custom-go": ["go"], // GoSec analysis runs when Go files change
+  "custom-gosec": ["go"], // GoSec analysis runs when Go files change
 };
 
 const FULL_MATRIX_TRIGGER = "/codeql full";

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -128,14 +128,14 @@ jobs:
         working-directory: ${{ matrix.working-directory }}
 
       - name: Perform GoSec Analysis
-        if: matrix.language == 'custom-go'
+        if: matrix.language == 'custom-gosec'
         uses: securego/gosec@25804378cd3eb8715e79649ea5266b811713b6ee
         with:
           args: -no-fail -fmt sarif -out gosec-results.sarif ./...
         continue-on-error: true
 
       - name: Upload GoSec result
-        if: ${{ always() && matrix.language == 'custom-go' }}
+        if: ${{ always() && matrix.language == 'custom-gosec' }}
         uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
         with:
           sarif_file: gosec-results.sarif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -164,8 +164,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: ✅ OK
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
         run: exit 0
       - name: 🛑 Failure
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1


### PR DESCRIPTION
# Description

This pull request updates the GoSec analysis integration in the CodeQL workflow to use a more consistent naming convention and improves the final job status handling. The main changes ensure that the workflow references `custom-gosec` instead of `custom-go`, and that cancelled jobs are treated as failures in the workflow summary.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->