### PR TITLE
get "rad core environment" needs env name not id

### DIFF
--- a/pkg/cli/cmd/deploy/deploy.go
+++ b/pkg/cli/cmd/deploy/deploy.go
@@ -475,7 +475,7 @@ func (r *Runner) getApplicationsCoreEnvironment(ctx context.Context, id string) 
 }
 
 // getRadiusCoreEnvironment retrieves environment using Radius Core client and returns as Applications.Core format
-func (r *Runner) getRadiusCoreEnvironment(ctx context.Context, id string) (*v20250801preview.EnvironmentResource, error) {
+func (r *Runner) getRadiusCoreEnvironment(ctx context.Context, name string) (*v20250801preview.EnvironmentResource, error) {
 	if r.RadiusCoreClientFactory == nil {
 		clientFactory, err := cmd.InitializeRadiusCoreClientFactory(ctx, r.Workspace, r.Workspace.Scope)
 		if err != nil {
@@ -485,7 +485,7 @@ func (r *Runner) getRadiusCoreEnvironment(ctx context.Context, id string) (*v202
 	}
 
 	environmentClient := r.RadiusCoreClientFactory.NewEnvironmentsClient()
-	env, err := environmentClient.Get(ctx, id, nil)
+	env, err := environmentClient.Get(ctx, name, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -553,14 +553,14 @@ func (r *Runner) FetchEnvironment(ctx context.Context, envNameOrID string) (*Env
 		}
 	}
 	if fetchRadiusCoreEnv {
-		var radCoreEnvID string
-		if !isID {
-			radCoreEnvID = r.constructRadiusCoreEnvironmentID(envNameOrID)
+		var radCoreEnvName string
+		if isID {
+			radCoreEnvName = envID.Name()
 		} else {
-			radCoreEnvID = envNameOrID
+			radCoreEnvName = envNameOrID
 		}
 
-		radiusCoreEnv, err := r.getRadiusCoreEnvironment(ctx, radCoreEnvID)
+		radiusCoreEnv, err := r.getRadiusCoreEnvironment(ctx, radCoreEnvName)
 		if err != nil {
 			if !clients.Is404Error(err) {
 				return nil, err


### PR DESCRIPTION
# Description

rad deploy now handles both applications core env and radius core env. For radius core env, there is a bug since  the code calls the generated client to fetch the env using its id, while the generated clients expect a name. This caused incorrect 404 response. 


## Type of change


- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).


## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->