### PR TITLE
Add support for new 'x-radius-sensitive' annotation

### DIFF
--- a/bicep-tools/pkg/manifest/manifest.go
+++ b/bicep-tools/pkg/manifest/manifest.go
@@ -38,6 +38,7 @@ type Schema struct {
 	ReadOnly             *bool             `yaml:"readOnly,omitempty" json:"readOnly,omitempty"`
 	Items                *Schema           `yaml:"items,omitempty" json:"items,omitempty"`
 	Enum                 []string          `yaml:"enum,omitempty" json:"enum,omitempty"`
+	IsSensitive          *bool             `yaml:"x-radius-sensitive,omitempty" json:"x-radius-sensitive,omitempty"`
 }
 
 // ParseManifest parses a YAML manifest string into a ResourceProvider struct
@@ -118,6 +119,13 @@ func (s *Schema) Validate(context string) error {
 
 	if !validTypes[s.Type] {
 		return fmt.Errorf("invalid schema type '%s' in %s", s.Type, context)
+	}
+
+	// Validate x-radius-sensitive is only used on valid types
+	if s.IsSensitive != nil && *s.IsSensitive {
+		if s.Type != "string" && s.Type != "object" {
+			return fmt.Errorf("x-radius-sensitive annotation is only supported on string and object types, got '%s' in %s", s.Type, context)
+		}
 	}
 
 	// Validate nested properties if this is an object type


### PR DESCRIPTION
# Description
This pull request adds support for a new `x-radius-sensitive` annotation in schema definitions, allowing string and object types to be marked as sensitive for downstream processing.
Updates for manifest schema validation to follow in separate PR.

ref: Design Doc: [2025-11-11-secrets-redactdata](https://github.com/radius-project/design-notes/blob/main/resources/2025-11-11-secrets-redactdata.md)

- This pull request adds or changes features of Radius and has an approved issue (issue link #10421).

Fixes: #10421 


## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [x] Yes <!-- TaskRadio design-pr -->
    - [] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [x] Yes <!-- TaskRadio design-review -->
    - [] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->