### PR TITLE
Add schema validation for new annotation

### DIFF
--- a/pkg/schema/validator.go
+++ b/pkg/schema/validator.go
@@ -35,6 +35,11 @@ const (
 	reservedPropConnections = "connections"
 )
 
+// Constants for annotation names
+const (
+	annotationRadiusSensitive = "x-radius-sensitive"
+)
+
 // joinPath concatenates two path segments with a dot separator for property path tracking.
 func joinPath(parent, child string) string {
 	if parent == "" {
@@ -344,6 +349,38 @@ func (v *Validator) validateRadiusConstraintsWithPath(schema *openapi3.Schema, p
 		}
 	}
 
+	// Validate array items if present
+	if schema.Items != nil {
+		if schema.Items.Ref != "" {
+			// The $ref validation is already handled by checkRefUsage above
+		} else if schema.Items.Value != nil {
+			if err := v.validateRadiusConstraintsWithPath(schema.Items.Value, joinPath(path, "items")); err != nil {
+				// Add context to error
+				if valErrs, ok := err.(*ValidationErrors); ok {
+					for _, ve := range valErrs.Errors {
+						// Clone the error to avoid modifying the original
+						contextualErr := &ValidationError{
+							Type:    ve.Type,
+							Field:   joinPath(joinPath(path, "items"), ve.Field),
+							Message: ve.Message,
+						}
+						errors.Add(contextualErr)
+					}
+				} else if valErr, ok := err.(*ValidationError); ok {
+					// Clone the error to avoid modifying the original
+					contextualErr := &ValidationError{
+						Type:    valErr.Type,
+						Field:   joinPath(joinPath(path, "items"), valErr.Field),
+						Message: valErr.Message,
+					}
+					errors.Add(contextualErr)
+				} else {
+					errors.Add(NewSchemaError(joinPath(path, "items"), err.Error()))
+				}
+			}
+		}
+	}
+
 	if errors.HasErrors() {
 		return &errors
 	}
@@ -423,7 +460,7 @@ func (v *Validator) checkSensitiveAnnotation(schema *openapi3.Schema, path strin
 		return nil
 	}
 
-	sensitive, exists := schema.Extensions["x-radius-sensitive"]
+	sensitive, exists := schema.Extensions[annotationRadiusSensitive]
 	if !exists {
 		return nil
 	}
@@ -431,22 +468,24 @@ func (v *Validator) checkSensitiveAnnotation(schema *openapi3.Schema, path strin
 	// Validate that the value is a boolean
 	boolVal, ok := sensitive.(bool)
 	if !ok {
-		return NewConstraintError(path, "x-radius-sensitive must be a boolean value")
+		return NewConstraintError(path, fmt.Sprintf("%s must be a boolean value", annotationRadiusSensitive))
 	}
 
 	// Only validate type constraints when x-radius-sensitive is true
 	if boolVal {
 		// Require explicit type when x-radius-sensitive is used
 		if schema.Type == nil || len(*schema.Type) == 0 {
-			return NewConstraintError(path, "x-radius-sensitive annotation requires an explicit type (string or object)")
+			return NewConstraintError(path, fmt.Sprintf("%s annotation requires an explicit type (string or object)", annotationRadiusSensitive))
 		}
 
-		// Validate it's only on string or object types
+		// Validate it's only on string or object types.
+		// This restriction comes from Bicep's type system, which only supports
+		// sensitive string and object types.
 		typeStr := (*schema.Type)[0]
 		isString := schema.Type.Is("string")
 		isObject := schema.Type.Is("object")
 		if !isString && !isObject {
-			return NewConstraintError(path, fmt.Sprintf("x-radius-sensitive annotation is only supported on string and object types, got '%s'", typeStr))
+			return NewConstraintError(path, fmt.Sprintf("%s annotation is only supported on string and object types, got '%s'", annotationRadiusSensitive, typeStr))
 		}
 	}
 

--- a/pkg/schema/validator_test.go
+++ b/pkg/schema/validator_test.go
@@ -2309,6 +2309,18 @@ func TestValidator_checkSensitiveAnnotation(t *testing.T) {
 			hasErr: true,
 			errMsg: "x-radius-sensitive must be a boolean value",
 		},
+		{
+			name: "x-radius-sensitive on string enum - valid",
+			schema: &openapi3.Schema{
+				Type: &openapi3.Types{"string"},
+				Enum: []any{"value1", "value2", "value3"},
+				Extensions: map[string]any{
+					"x-radius-sensitive": true,
+				},
+			},
+			path:   "status",
+			hasErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2513,5 +2525,27 @@ func TestValidator_ValidateSchema_WithSensitiveAnnotation(t *testing.T) {
 		err := validator.ValidateSchema(ctx, schema)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "x-radius-sensitive must be a boolean value")
+	})
+
+	t.Run("valid string enum with x-radius-sensitive", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"environment": {
+					Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+				},
+				"secretType": {
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+						Enum: []any{"apiKey", "password", "certificate"},
+						Extensions: map[string]any{
+							"x-radius-sensitive": true,
+						},
+					},
+				},
+			},
+		}
+		err := validator.ValidateSchema(ctx, schema)
+		require.NoError(t, err)
 	})
 }

--- a/pkg/schema/validator_test.go
+++ b/pkg/schema/validator_test.go
@@ -18,6 +18,7 @@ package schema
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -2178,7 +2179,7 @@ func TestValidator_checkSensitiveAnnotation(t *testing.T) {
 			schema: &openapi3.Schema{
 				Type: &openapi3.Types{"string"},
 				Extensions: map[string]any{
-					"x-radius-sensitive": true,
+					annotationRadiusSensitive: true,
 				},
 			},
 			path:   "password",
@@ -2189,7 +2190,7 @@ func TestValidator_checkSensitiveAnnotation(t *testing.T) {
 			schema: &openapi3.Schema{
 				Type: &openapi3.Types{"object"},
 				Extensions: map[string]any{
-					"x-radius-sensitive": true,
+					annotationRadiusSensitive: true,
 				},
 			},
 			path:   "credentials",
@@ -2200,55 +2201,55 @@ func TestValidator_checkSensitiveAnnotation(t *testing.T) {
 			schema: &openapi3.Schema{
 				Type: &openapi3.Types{"integer"},
 				Extensions: map[string]any{
-					"x-radius-sensitive": true,
+					annotationRadiusSensitive: true,
 				},
 			},
 			path:   "count",
 			hasErr: true,
-			errMsg: "x-radius-sensitive annotation is only supported on string and object types, got 'integer'",
+			errMsg: fmt.Sprintf("%s annotation is only supported on string and object types, got 'integer'", annotationRadiusSensitive),
 		},
 		{
 			name: "x-radius-sensitive on boolean type - invalid",
 			schema: &openapi3.Schema{
 				Type: &openapi3.Types{"boolean"},
 				Extensions: map[string]any{
-					"x-radius-sensitive": true,
+					annotationRadiusSensitive: true,
 				},
 			},
 			path:   "flag",
 			hasErr: true,
-			errMsg: "x-radius-sensitive annotation is only supported on string and object types, got 'boolean'",
+			errMsg: fmt.Sprintf("%s annotation is only supported on string and object types, got 'boolean'", annotationRadiusSensitive),
 		},
 		{
 			name: "x-radius-sensitive on array type - invalid",
 			schema: &openapi3.Schema{
 				Type: &openapi3.Types{"array"},
 				Extensions: map[string]any{
-					"x-radius-sensitive": true,
+					annotationRadiusSensitive: true,
 				},
 			},
 			path:   "items",
 			hasErr: true,
-			errMsg: "x-radius-sensitive annotation is only supported on string and object types, got 'array'",
+			errMsg: fmt.Sprintf("%s annotation is only supported on string and object types, got 'array'", annotationRadiusSensitive),
 		},
 		{
 			name: "x-radius-sensitive on number type - invalid",
 			schema: &openapi3.Schema{
 				Type: &openapi3.Types{"number"},
 				Extensions: map[string]any{
-					"x-radius-sensitive": true,
+					annotationRadiusSensitive: true,
 				},
 			},
 			path:   "value",
 			hasErr: true,
-			errMsg: "x-radius-sensitive annotation is only supported on string and object types, got 'number'",
+			errMsg: fmt.Sprintf("%s annotation is only supported on string and object types, got 'number'", annotationRadiusSensitive),
 		},
 		{
 			name: "x-radius-sensitive set to false - valid",
 			schema: &openapi3.Schema{
 				Type: &openapi3.Types{"integer"},
 				Extensions: map[string]any{
-					"x-radius-sensitive": false,
+					annotationRadiusSensitive: false,
 				},
 			},
 			path:   "count",
@@ -2266,48 +2267,48 @@ func TestValidator_checkSensitiveAnnotation(t *testing.T) {
 			name: "x-radius-sensitive with no type - invalid",
 			schema: &openapi3.Schema{
 				Extensions: map[string]any{
-					"x-radius-sensitive": true,
+					annotationRadiusSensitive: true,
 				},
 			},
 			path:   "field",
 			hasErr: true,
-			errMsg: "x-radius-sensitive annotation requires an explicit type (string or object)",
+			errMsg: fmt.Sprintf("%s annotation requires an explicit type (string or object)", annotationRadiusSensitive),
 		},
 		{
 			name: "x-radius-sensitive with string value - invalid",
 			schema: &openapi3.Schema{
 				Type: &openapi3.Types{"string"},
 				Extensions: map[string]any{
-					"x-radius-sensitive": "true",
+					annotationRadiusSensitive: "true",
 				},
 			},
 			path:   "password",
 			hasErr: true,
-			errMsg: "x-radius-sensitive must be a boolean value",
+			errMsg: fmt.Sprintf("%s must be a boolean value", annotationRadiusSensitive),
 		},
 		{
 			name: "x-radius-sensitive with integer value - invalid",
 			schema: &openapi3.Schema{
 				Type: &openapi3.Types{"string"},
 				Extensions: map[string]any{
-					"x-radius-sensitive": 1,
+					annotationRadiusSensitive: 1,
 				},
 			},
 			path:   "apiKey",
 			hasErr: true,
-			errMsg: "x-radius-sensitive must be a boolean value",
+			errMsg: fmt.Sprintf("%s must be a boolean value", annotationRadiusSensitive),
 		},
 		{
 			name: "x-radius-sensitive with null value - invalid",
 			schema: &openapi3.Schema{
 				Type: &openapi3.Types{"string"},
 				Extensions: map[string]any{
-					"x-radius-sensitive": nil,
+					annotationRadiusSensitive: nil,
 				},
 			},
 			path:   "token",
 			hasErr: true,
-			errMsg: "x-radius-sensitive must be a boolean value",
+			errMsg: fmt.Sprintf("%s must be a boolean value", annotationRadiusSensitive),
 		},
 		{
 			name: "x-radius-sensitive on string enum - valid",
@@ -2315,7 +2316,7 @@ func TestValidator_checkSensitiveAnnotation(t *testing.T) {
 				Type: &openapi3.Types{"string"},
 				Enum: []any{"value1", "value2", "value3"},
 				Extensions: map[string]any{
-					"x-radius-sensitive": true,
+					annotationRadiusSensitive: true,
 				},
 			},
 			path:   "status",
@@ -2354,7 +2355,7 @@ func TestValidator_ValidateSchema_WithSensitiveAnnotation(t *testing.T) {
 					Value: &openapi3.Schema{
 						Type: &openapi3.Types{"string"},
 						Extensions: map[string]any{
-							"x-radius-sensitive": true,
+							annotationRadiusSensitive: true,
 						},
 					},
 				},
@@ -2375,7 +2376,7 @@ func TestValidator_ValidateSchema_WithSensitiveAnnotation(t *testing.T) {
 					Value: &openapi3.Schema{
 						Type: &openapi3.Types{"object"},
 						Extensions: map[string]any{
-							"x-radius-sensitive": true,
+							annotationRadiusSensitive: true,
 						},
 						AdditionalProperties: openapi3.AdditionalProperties{
 							Schema: &openapi3.SchemaRef{
@@ -2401,7 +2402,7 @@ func TestValidator_ValidateSchema_WithSensitiveAnnotation(t *testing.T) {
 					Value: &openapi3.Schema{
 						Type: &openapi3.Types{"integer"},
 						Extensions: map[string]any{
-							"x-radius-sensitive": true,
+							annotationRadiusSensitive: true,
 						},
 					},
 				},
@@ -2409,7 +2410,7 @@ func TestValidator_ValidateSchema_WithSensitiveAnnotation(t *testing.T) {
 		}
 		err := validator.ValidateSchema(ctx, schema)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "x-radius-sensitive annotation is only supported on string and object types, got 'integer'")
+		require.Contains(t, err.Error(), fmt.Sprintf("%s annotation is only supported on string and object types, got 'integer'", annotationRadiusSensitive))
 	})
 
 	t.Run("invalid nested property with x-radius-sensitive on boolean", func(t *testing.T) {
@@ -2427,7 +2428,7 @@ func TestValidator_ValidateSchema_WithSensitiveAnnotation(t *testing.T) {
 								Value: &openapi3.Schema{
 									Type: &openapi3.Types{"boolean"},
 									Extensions: map[string]any{
-										"x-radius-sensitive": true,
+										annotationRadiusSensitive: true,
 									},
 								},
 							},
@@ -2438,7 +2439,7 @@ func TestValidator_ValidateSchema_WithSensitiveAnnotation(t *testing.T) {
 		}
 		err := validator.ValidateSchema(ctx, schema)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "x-radius-sensitive annotation is only supported on string and object types, got 'boolean'")
+		require.Contains(t, err.Error(), fmt.Sprintf("%s annotation is only supported on string and object types, got 'boolean'", annotationRadiusSensitive))
 	})
 
 	t.Run("invalid array with x-radius-sensitive", func(t *testing.T) {
@@ -2452,7 +2453,7 @@ func TestValidator_ValidateSchema_WithSensitiveAnnotation(t *testing.T) {
 					Value: &openapi3.Schema{
 						Type: &openapi3.Types{"array"},
 						Extensions: map[string]any{
-							"x-radius-sensitive": true,
+							annotationRadiusSensitive: true,
 						},
 						Items: &openapi3.SchemaRef{
 							Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
@@ -2463,7 +2464,7 @@ func TestValidator_ValidateSchema_WithSensitiveAnnotation(t *testing.T) {
 		}
 		err := validator.ValidateSchema(ctx, schema)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "x-radius-sensitive annotation is only supported on string and object types, got 'array'")
+		require.Contains(t, err.Error(), fmt.Sprintf("%s annotation is only supported on string and object types, got 'array'", annotationRadiusSensitive))
 	})
 
 	t.Run("valid multiple sensitive strings in nested structure", func(t *testing.T) {
@@ -2484,7 +2485,7 @@ func TestValidator_ValidateSchema_WithSensitiveAnnotation(t *testing.T) {
 								Value: &openapi3.Schema{
 									Type: &openapi3.Types{"string"},
 									Extensions: map[string]any{
-										"x-radius-sensitive": true,
+										annotationRadiusSensitive: true,
 									},
 								},
 							},
@@ -2492,7 +2493,7 @@ func TestValidator_ValidateSchema_WithSensitiveAnnotation(t *testing.T) {
 								Value: &openapi3.Schema{
 									Type: &openapi3.Types{"string"},
 									Extensions: map[string]any{
-										"x-radius-sensitive": true,
+										annotationRadiusSensitive: true,
 									},
 								},
 							},
@@ -2516,7 +2517,7 @@ func TestValidator_ValidateSchema_WithSensitiveAnnotation(t *testing.T) {
 					Value: &openapi3.Schema{
 						Type: &openapi3.Types{"string"},
 						Extensions: map[string]any{
-							"x-radius-sensitive": "true",
+							annotationRadiusSensitive: "true",
 						},
 					},
 				},
@@ -2524,7 +2525,7 @@ func TestValidator_ValidateSchema_WithSensitiveAnnotation(t *testing.T) {
 		}
 		err := validator.ValidateSchema(ctx, schema)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "x-radius-sensitive must be a boolean value")
+		require.Contains(t, err.Error(), fmt.Sprintf("%s must be a boolean value", annotationRadiusSensitive))
 	})
 
 	t.Run("valid string enum with x-radius-sensitive", func(t *testing.T) {
@@ -2539,7 +2540,7 @@ func TestValidator_ValidateSchema_WithSensitiveAnnotation(t *testing.T) {
 						Type: &openapi3.Types{"string"},
 						Enum: []any{"apiKey", "password", "certificate"},
 						Extensions: map[string]any{
-							"x-radius-sensitive": true,
+							annotationRadiusSensitive: true,
 						},
 					},
 				},
@@ -2547,5 +2548,94 @@ func TestValidator_ValidateSchema_WithSensitiveAnnotation(t *testing.T) {
 		}
 		err := validator.ValidateSchema(ctx, schema)
 		require.NoError(t, err)
+	})
+
+	t.Run("valid array with sensitive string items", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"environment": {
+					Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+				},
+				"apiKeys": {
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"array"},
+						Items: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{
+								Type: &openapi3.Types{"string"},
+								Extensions: map[string]any{
+									annotationRadiusSensitive: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		err := validator.ValidateSchema(ctx, schema)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid array with sensitive object items", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"environment": {
+					Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+				},
+				"secrets": {
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"array"},
+						Items: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{
+								Type: &openapi3.Types{"object"},
+								Properties: openapi3.Schemas{
+									"name": {
+										Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+									},
+									"token": {
+										Value: &openapi3.Schema{
+											Type: &openapi3.Types{"string"},
+											Extensions: map[string]any{
+												annotationRadiusSensitive: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		err := validator.ValidateSchema(ctx, schema)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid array with sensitive integer items", func(t *testing.T) {
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"environment": {
+					Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+				},
+				"codes": {
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"array"},
+						Items: &openapi3.SchemaRef{
+							Value: &openapi3.Schema{
+								Type: &openapi3.Types{"integer"},
+								Extensions: map[string]any{
+									annotationRadiusSensitive: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		err := validator.ValidateSchema(ctx, schema)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), fmt.Sprintf("%s annotation is only supported on string and object types, got 'integer'", annotationRadiusSensitive))
 	})
 }


### PR DESCRIPTION
This pull request adds support for validating the `x-radius-sensitive` annotation in OpenAPI schemas, ensuring it is used correctly and only on permitted types. It introduces a new validation method, integrates it into the schema validation flow, and provides comprehensive unit tests to cover various scenarios.

ref: Design Doc: [2025-11-11-secrets-redactdata](https://github.com/radius-project/design-notes/blob/main/resources/2025-11-11-secrets-redactdata.md)

## Type of change

- This pull request adds or changes features of Radius and has an approved issue (issue link https://github.com/radius-project/radius/issues/10421).

Fixes: #10421 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [x] Yes <!-- TaskRadio design-pr -->
    - [ ] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [x] Yes <!-- TaskRadio design-review -->
    - [ ] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->