### PR TITLE
Fix rad version --output json to return valid JSON

### DIFF
--- a/pkg/cli/cmd/version/version.go
+++ b/pkg/cli/cmd/version/version.go
@@ -143,8 +143,8 @@ func (r *Runner) writeVersionInfo(format string) error {
 	// Get control plane info (handles errors internally)
 	cpInfo := r.getControlPlaneVersionInfo()
 
-	// For JSON and YAML formats, output a single combined object
-	if format == "json" || format == "yaml" {
+	// For JSON format, output a single combined object
+	if format == "json" {
 		combinedInfo := CombinedVersionInfo{
 			CLI:          cliVersion,
 			ControlPlane: cpInfo,

--- a/pkg/cli/cmd/version/version_test.go
+++ b/pkg/cli/cmd/version/version_test.go
@@ -68,13 +68,6 @@ func TestValidate(t *testing.T) {
 			expectedFormat:  "json",
 			expectedCLIOnly: true,
 		},
-		{
-			name:            "YAML output",
-			outputFlag:      "yaml",
-			cliFlag:         "false",
-			expectedFormat:  "yaml",
-			expectedCLIOnly: false,
-		},
 	}
 
 	for _, tc := range testCases {
@@ -179,7 +172,7 @@ func TestWriteVersionInfo(t *testing.T) {
 		expectedStatus  string
 		expectedVersion string
 		showHeaders     bool
-		isCombined      bool
+		isJSON          bool
 	}{
 		{
 			name:   "Radius installed - table format",
@@ -192,7 +185,7 @@ func TestWriteVersionInfo(t *testing.T) {
 			expectedStatus:  "Installed",
 			expectedVersion: "v0.45.0",
 			showHeaders:     true,
-			isCombined:      false,
+			isJSON:          false,
 		},
 		{
 			name:   "Radius not installed - table format",
@@ -204,7 +197,7 @@ func TestWriteVersionInfo(t *testing.T) {
 			expectedStatus:  "Not installed",
 			expectedVersion: "Not installed",
 			showHeaders:     true,
-			isCombined:      false,
+			isJSON:          false,
 		},
 		{
 			name:            "Connection error - table format",
@@ -214,7 +207,7 @@ func TestWriteVersionInfo(t *testing.T) {
 			expectedStatus:  "Not connected",
 			expectedVersion: "Not installed",
 			showHeaders:     true,
-			isCombined:      false,
+			isJSON:          false,
 		},
 		{
 			name:   "Radius installed - JSON format",
@@ -227,7 +220,7 @@ func TestWriteVersionInfo(t *testing.T) {
 			expectedStatus:  "Installed",
 			expectedVersion: "v0.45.0",
 			showHeaders:     false,
-			isCombined:      true,
+			isJSON:          true,
 		},
 	}
 
@@ -247,7 +240,7 @@ func TestWriteVersionInfo(t *testing.T) {
 
 			mockHelmInterface.EXPECT().CheckRadiusInstall("").Return(tc.installState, tc.helmError)
 
-			if tc.isCombined {
+			if tc.isJSON {
 				// For JSON, expect a single WriteFormatted call with combined data
 				mockOutput.EXPECT().WriteFormatted(tc.format, gomock.Any(), gomock.Any()).Do(
 					func(format string, data any, options output.FormatterOptions) error {
@@ -296,35 +289,35 @@ func TestRun(t *testing.T) {
 		cliOnly       bool
 		format        string
 		expectCLIOnly bool
-		isCombined    bool
+		isJSON        bool
 	}{
 		{
 			name:          "CLI and Control Plane versions - table format",
 			cliOnly:       false,
 			format:        "table",
 			expectCLIOnly: false,
-			isCombined:    false,
+			isJSON:        false,
 		},
 		{
 			name:          "CLI version only - table format",
 			cliOnly:       true,
 			format:        "table",
 			expectCLIOnly: true,
-			isCombined:    false,
+			isJSON:        false,
 		},
 		{
 			name:          "CLI and Control Plane versions - JSON format",
 			cliOnly:       false,
 			format:        "json",
 			expectCLIOnly: false,
-			isCombined:    true,
+			isJSON:        true,
 		},
 		{
 			name:          "CLI version only - JSON format",
 			cliOnly:       true,
 			format:        "json",
 			expectCLIOnly: true,
-			isCombined:    false,
+			isJSON:        false,
 		},
 	}
 
@@ -346,7 +339,7 @@ func TestRun(t *testing.T) {
 			if tc.expectCLIOnly {
 				// When --cli flag is used, always output CLI version only
 				mockOutput.EXPECT().WriteFormatted(tc.format, gomock.Any(), gomock.Any()).Return(nil)
-			} else if tc.isCombined {
+			} else if tc.isJSON {
 				// For JSON/YAML without --cli, output combined version
 				mockHelmInterface.EXPECT().CheckRadiusInstall("").Return(helm.InstallState{
 					RadiusInstalled: true,

--- a/pkg/cli/cmd/version/version_test.go
+++ b/pkg/cli/cmd/version/version_test.go
@@ -229,19 +229,6 @@ func TestWriteVersionInfo(t *testing.T) {
 			showHeaders:     false,
 			isCombined:      true,
 		},
-		{
-			name:   "Radius installed - YAML format",
-			format: "yaml",
-			installState: helm.InstallState{
-				RadiusInstalled: true,
-				RadiusVersion:   "v0.45.0",
-			},
-			helmError:       nil,
-			expectedStatus:  "Installed",
-			expectedVersion: "v0.45.0",
-			showHeaders:     false,
-			isCombined:      true,
-		},
 	}
 
 	for _, tc := range testCases {
@@ -261,11 +248,11 @@ func TestWriteVersionInfo(t *testing.T) {
 			mockHelmInterface.EXPECT().CheckRadiusInstall("").Return(tc.installState, tc.helmError)
 
 			if tc.isCombined {
-				// For JSON/YAML, expect a single WriteFormatted call with combined data
+				// For JSON, expect a single WriteFormatted call with combined data
 				mockOutput.EXPECT().WriteFormatted(tc.format, gomock.Any(), gomock.Any()).Do(
 					func(format string, data any, options output.FormatterOptions) error {
 						combined, ok := data.(CombinedVersionInfo)
-						require.True(t, ok, "Expected CombinedVersionInfo for JSON/YAML format")
+						require.True(t, ok, "Expected CombinedVersionInfo for JSON format")
 						require.Equal(t, tc.expectedStatus, combined.ControlPlane.Status)
 						require.Equal(t, tc.expectedVersion, combined.ControlPlane.Version)
 						require.Equal(t, version.Release(), combined.CLI.Release)


### PR DESCRIPTION
# Description

This change modifies the `rad version` command to output a single combined JSON object when using `--output json`, instead of outputting two separate JSON objects for CLI and control plane version information.

**Changes:**
- Added `CombinedVersionInfo` struct that wraps both CLI and control plane version info
- Modified `writeVersionInfo()` to detect JSON format and output the combined object
- Removed YAML from combined output logic (only JSON supported for combined output)
- Updated tests to validate the combined JSON output behavior

Running `rad version --output json` now looks like this:

```
$ rad version --output json
{
  "cli": {
    "release": "edge",
    "version": "v0.54.0-rc1-47-g0be839e",
    "bicep": "0.39.26",
    "commit": "0be839e3e22de5d58bc0e0cf5a8cbc8b6e39d9ac"
  },
  "controlPlane": {
    "version": "Not installed",
    "status": "Not connected"
  }
}
```

Running `rad version --cli --output json` is unchanged.
```
$ rad version --cli -o json
{
  "release": "edge",
  "version": "v0.54.0-rc1-47-g0be839e",
  "bicep": "0.39.26",
  "commit": "0be839e3e22de5d58bc0e0cf5a8cbc8b6e39d9ac"
}
```

## Type of change

- This pull request adds or changes features of Radius and has an approved issue (issue link required).
 - Fixes #9815

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->

## Testing

This script can be run on a client machine to test the updated `rad version` command:

```bash
#!/bin/bash

# ============================================================================
# Test Script: rad version -o json
# ============================================================================
#
# PURPOSE:
#   This script validates the JSON output of 'rad version -o json'.
#
# WHAT THIS PR FIXES:
#   Before: 'rad version -o json' output TWO separate JSON objects (invalid)
#   After:  'rad version -o json' outputs ONE combined JSON object (valid)
#
# EXPECTED JSON STRUCTURE (after fix):
#   {
#     "cli": {
#       "release": "...",
#       "version": "...",
#       "bicep": "...",
#       "commit": "..."
#     },
#     "controlPlane": {
#       "version": "...",
#       "status": "..."
#     }
#   }
#
# PREREQUISITES:
#   - jq must be installed
#   - rad CLI must be installed in your PATH
#
#   To build and install the rad CLI locally, run:
#     make install
#
# USAGE:
#   ./test-rad-version-json.sh
#
# ============================================================================

set -euo pipefail

# ============================================================================
# Setup
# ============================================================================

echo "========================================"
echo "rad version -o json Test Script"
echo "========================================"
echo ""

# Check dependencies
if ! command -v jq &> /dev/null; then
    echo "ERROR: jq is required. Install with: apt-get install jq"
    exit 1
fi

if ! command -v rad &> /dev/null; then
    echo "ERROR: rad CLI not found in PATH"
    echo ""
    echo "To build and install the rad CLI locally, run:"
    echo "  make install"
    exit 1
fi

echo "rad location: $(command -v rad)"
echo ""

# ============================================================================
# Capture the JSON output once (used by all tests)
# ============================================================================

echo "========================================"
echo "Step 1: Run 'rad version -o json'"
echo "========================================"
echo ""
echo "Command:"
echo "  \$ rad version -o json"
echo ""

JSON_OUTPUT=$(rad version -o json 2>&1)

echo "Raw Output:"
echo "----------------------------------------"
echo "${JSON_OUTPUT}"
echo "----------------------------------------"
echo ""

# ============================================================================
# Test 1: Is the output a SINGLE valid JSON object?
# ============================================================================

echo "========================================"
echo "Test 1: Is the output a SINGLE valid JSON object?"
echo "========================================"
echo ""
echo "Explanation:"
echo "  The old bug produced TWO separate JSON objects."
echo "  We count how many top-level JSON values jq parses."
echo ""
echo "Command:"
echo "  \$ rad version -o json | jq -s 'length'"
echo ""

JSON_COUNT=$(echo "${JSON_OUTPUT}" | jq -s 'length' 2>/dev/null || echo "0")
echo "Number of JSON objects: ${JSON_COUNT}"
echo ""

if [[ "${JSON_COUNT}" == "1" ]]; then
    echo "Result: PASS - Output is a single JSON object"
    TEST1="PASS"
else
    echo "Result: FAIL - Expected 1 JSON object, got ${JSON_COUNT}"
    echo ""
    echo "This indicates the old bug is still present:"
    echo "  The output contains multiple separate JSON objects"
    echo "  instead of one combined object."
    TEST1="FAIL"
fi
echo ""

# ============================================================================
# Test 2: Does '.cli' exist as a top-level key?
# ============================================================================

echo "========================================"
echo "Test 2: Does '.cli' exist as a top-level key?"
echo "========================================"
echo ""
echo "Command:"
echo "  \$ rad version -o json | jq 'has(\"cli\")'"
echo ""

HAS_CLI=$(echo "${JSON_OUTPUT}" | jq -s '.[0] | has("cli")' 2>/dev/null || echo "false")
echo "Result of has(\"cli\"): ${HAS_CLI}"
echo ""

if [[ "${HAS_CLI}" == "true" ]]; then
    echo "Result: PASS - '.cli' key exists"
    TEST2="PASS"
    
    echo ""
    echo "Value of .cli:"
    echo "${JSON_OUTPUT}" | jq -s '.[0].cli'
else
    echo "Result: FAIL - '.cli' key does not exist"
    echo ""
    echo "Expected structure:"
    echo '  { "cli": { ... }, "controlPlane": { ... } }'
    TEST2="FAIL"
fi
echo ""

# ============================================================================
# Test 3: Does '.controlPlane' exist as a top-level key?
# ============================================================================

echo "========================================"
echo "Test 3: Does '.controlPlane' exist as a top-level key?"
echo "========================================"
echo ""
echo "Command:"
echo "  \$ rad version -o json | jq 'has(\"controlPlane\")'"
echo ""

HAS_CP=$(echo "${JSON_OUTPUT}" | jq -s '.[0] | has("controlPlane")' 2>/dev/null || echo "false")
echo "Result of has(\"controlPlane\"): ${HAS_CP}"
echo ""

if [[ "${HAS_CP}" == "true" ]]; then
    echo "Result: PASS - '.controlPlane' key exists"
    TEST3="PASS"
    
    echo ""
    echo "Value of .controlPlane:"
    echo "${JSON_OUTPUT}" | jq -s '.[0].controlPlane'
else
    echo "Result: FAIL - '.controlPlane' key does not exist"
    echo ""
    echo "Expected structure:"
    echo '  { "cli": { ... }, "controlPlane": { ... } }'
    TEST3="FAIL"
fi
echo ""

# ============================================================================
# Test 4: Extract and display CLI version fields
# ============================================================================

echo "========================================"
echo "Test 4: CLI version fields"
echo "========================================"
echo ""
echo "Expected fields: release, version, bicep, commit"
echo ""

# Use jq -s to handle multi-object case gracefully
CLI_RELEASE=$(echo "${JSON_OUTPUT}" | jq -rs '.[0].cli.release // "MISSING"')
CLI_VERSION=$(echo "${JSON_OUTPUT}" | jq -rs '.[0].cli.version // "MISSING"')
CLI_BICEP=$(echo "${JSON_OUTPUT}" | jq -rs '.[0].cli.bicep // "MISSING"')
CLI_COMMIT=$(echo "${JSON_OUTPUT}" | jq -rs '.[0].cli.commit // "MISSING"')

echo "  .cli.release → ${CLI_RELEASE}"
echo "  .cli.version → ${CLI_VERSION}"
echo "  .cli.bicep   → ${CLI_BICEP}"
echo "  .cli.commit  → ${CLI_COMMIT}"
echo ""

# Check if any fields are missing
if [[ "${CLI_RELEASE}" != "MISSING" && "${CLI_VERSION}" != "MISSING" && \
      "${CLI_BICEP}" != "MISSING" && "${CLI_COMMIT}" != "MISSING" ]]; then
    echo "Result: PASS - All CLI fields present"
    TEST4="PASS"
else
    echo "Result: FAIL - Some CLI fields are missing"
    echo ""
    echo "Missing fields indicate the JSON structure is incorrect."
    TEST4="FAIL"
fi
echo ""

# ============================================================================
# Test 5: Extract and display controlPlane fields
# ============================================================================

echo "========================================"
echo "Test 5: controlPlane fields"
echo "========================================"
echo ""
echo "Expected fields: status, version"
echo ""

CP_STATUS=$(echo "${JSON_OUTPUT}" | jq -rs '.[0].controlPlane.status // "MISSING"')
CP_VERSION=$(echo "${JSON_OUTPUT}" | jq -rs '.[0].controlPlane.version // "MISSING"')

echo "  .controlPlane.status  → ${CP_STATUS}"
echo "  .controlPlane.version → ${CP_VERSION}"
echo ""

# Check if fields exist (values may vary based on install state)
if [[ "${CP_STATUS}" != "MISSING" && "${CP_VERSION}" != "MISSING" ]]; then
    echo "Result: PASS - All controlPlane fields present"
    TEST5="PASS"
else
    echo "Result: FAIL - Some controlPlane fields are missing"
    echo ""
    echo "Missing fields indicate the JSON structure is incorrect."
    TEST5="FAIL"
fi
echo ""

# ============================================================================
# Summary
# ============================================================================

echo "========================================"
echo "Test Summary"
echo "========================================"
echo ""
echo "  Test 1 (Single JSON object): ${TEST1}"
echo "  Test 2 (.cli exists):        ${TEST2}"
echo "  Test 3 (.controlPlane):      ${TEST3}"
echo "  Test 4 (CLI fields):         ${TEST4}"
echo "  Test 5 (controlPlane):       ${TEST5}"
echo ""

# Count failures
FAILURES=0
[[ "${TEST1}" == "FAIL" ]] && ((FAILURES++)) || true
[[ "${TEST2}" == "FAIL" ]] && ((FAILURES++)) || true
[[ "${TEST3}" == "FAIL" ]] && ((FAILURES++)) || true
[[ "${TEST4}" == "FAIL" ]] && ((FAILURES++)) || true
[[ "${TEST5}" == "FAIL" ]] && ((FAILURES++)) || true

if [[ ${FAILURES} -eq 0 ]]; then
    echo "All tests passed!"
    echo ""
    echo "The JSON output is valid and contains the expected structure:"
    echo '  { "cli": {...}, "controlPlane": {...} }'
    exit 0
else
    echo "${FAILURES} test(s) failed."
    echo ""
    echo "If Test 1 failed with '2 JSON objects', the old bug is present."
    echo "The fix should produce a single combined JSON object."
    exit 1
fi
```