### PR TITLE
Improvement: Moves to building once and saving the artifacts for re-use in all test workflows.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -271,6 +271,31 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
 
+      - name: Build container images (PR)
+        if: github.event_name == 'pull_request'
+        run: |
+          make docker-build
+        env:
+          DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}/dev
+          DOCKER_TAG_VERSION: ${{ env.REL_VERSION }}
+          DOCKER_CACHE_GHA: 1
+
+      - name: Save container images to artifacts (PR)
+        if: github.event_name == 'pull_request'
+        run: |
+          make docker-save-images
+        env:
+          DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}/dev
+          DOCKER_TAG_VERSION: ${{ env.REL_VERSION }}
+
+      - name: Upload container image artifacts (PR)
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: container-images-${{ env.REL_VERSION }}
+          path: ./dist/images/
+          retention-days: 1
+
       - name: Push container images (latest)
         run: |
           make docker-multi-arch-push
@@ -278,14 +303,7 @@ jobs:
         env:
           DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
           DOCKER_TAG_VERSION: latest
-
-      - name: Build container images (PR) # Don't push on PR, agent will not have permission.
-        run: |
-          make docker-multi-arch-build
-        if: github.event_name == 'pull_request'
-        env:
-          DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
-          DOCKER_TAG_VERSION: ${{ env.REL_VERSION }} # includes PR number
+          DOCKER_CACHE_GHA: 1
 
       - name: Push container images (release)
         run: |
@@ -294,6 +312,23 @@ jobs:
         env:
           DOCKER_REGISTRY: ${{ env.CONTAINER_REGISTRY }}
           DOCKER_TAG_VERSION: ${{ env.REL_CHANNEL }}
+          DOCKER_CACHE_GHA: 1
+
+      - name: Collect build metrics
+        if: always()
+        run: |
+          make build-metrics
+          cat dist/metrics/metrics.txt >> $GITHUB_STEP_SUMMARY
+        env:
+          DOCKER_REGISTRY: ${{ github.event_name == 'pull_request' && format('{0}/dev', env.CONTAINER_REGISTRY) || env.CONTAINER_REGISTRY }}
+          DOCKER_TAG_VERSION: ${{ github.event_name == 'pull_request' && env.REL_VERSION || (github.ref == 'refs/heads/main' && 'latest' || env.REL_CHANNEL) }}
+
+      - name: Upload build metrics
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: build-metrics-${{ github.job }}
+          path: dist/metrics/
 
   build-and-push-helm-chart:
     name: Helm chart build

--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -401,7 +401,28 @@ jobs:
           message: |
             :hourglass: Building Radius and pushing container images for functional tests...
 
-      - name: Build and Push container images
+      - name: Download container image artifacts (PR)
+        if: env.PR_NUMBER != ''
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: container-images-${{ env.REL_VERSION }}
+          path: ./dist/images/
+
+      - name: Load container images (PR)
+        if: env.PR_NUMBER != ''
+        run: make docker-load-images
+
+      - name: Push images to GHCR (PR)
+        if: env.PR_NUMBER != ''
+        run: |
+          for img in applications-rp controller dynamic-rp ucpd bicep pre-upgrade; do
+            docker tag ghcr.io/radius-project/dev/${img}:${{ env.REL_VERSION }} \
+              ${{ env.CONTAINER_REGISTRY }}/${img}:${{ env.REL_VERSION }}
+            docker push ${{ env.CONTAINER_REGISTRY }}/${img}:${{ env.REL_VERSION }}
+          done
+
+      - name: Build and Push container images (non-PR)
+        if: env.PR_NUMBER == ''
         run: |
           make build && make docker-build && make docker-push
         env:

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -272,7 +272,28 @@ jobs:
           }
           EOF
 
-      - name: Build and Push container images
+      - name: Download container image artifacts (PR)
+        if: github.event_name == 'pull_request'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: container-images-${{ env.REL_VERSION }}
+          path: ./dist/images/
+
+      - name: Load container images (PR)
+        if: github.event_name == 'pull_request'
+        run: make docker-load-images
+
+      - name: Tag and push images to local registry (PR)
+        if: github.event_name == 'pull_request'
+        run: |
+          for img in applications-rp controller dynamic-rp ucpd bicep pre-upgrade; do
+            docker tag ghcr.io/radius-project/dev/${img}:${{ env.REL_VERSION }} \
+              ${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}/${img}:${{ env.REL_VERSION }}
+            docker push ${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}/${img}:${{ env.REL_VERSION }}
+          done
+
+      - name: Build and Push container images (non-PR)
+        if: github.event_name != 'pull_request'
         run: |
           make build && make docker-build && make docker-push
         env:

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -36,11 +36,11 @@ on:
     #   src_image: Source image in ACR (e.g. radiusdeploymentengine.azurecr.io/deployment-engine)
     #   dest_image: Destination image in GHCR (e.g. ghcr.io/radius-project/deployment-engine)
     #   tag: Tag for the image (e.g. latest, 0.1, 0.1.0-rc1, pr-123)
-  pull_request:
-    branches:
-      - main
-      - features/*
-      - release/*
+  # Wait for approval workflow to complete for PRs
+  workflow_run:
+    workflows: [Approve Functional Tests]
+    types:
+      - completed
 
 permissions: {}
 
@@ -127,20 +127,72 @@ jobs:
             echo "DE_TAG=${TAG}"
           } >> "$GITHUB_ENV"
 
-      - name: Generate ID for release
+      - name: Checkout (for version script)
+        if: github.event_name != 'workflow_run'
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Python (for version script)
+        if: github.event_name != 'workflow_run'
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version-file: .python-version
+
+      - name: Generate ID for release (non-workflow_run)
+        if: github.event_name != 'workflow_run'
+        id: gen-id-local
+        run: |
+          # For non-PR events, generate a unique ID
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            BASE_STR="RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
+            if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
+              BASE_STR="${GITHUB_RUN_NUMBER}|${BASE_STR}"
+            fi
+            UNIQUE_ID=func$(echo $BASE_STR | sha1sum | head -c 10)
+            echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_ENV
+            echo "REL_VERSION=pr-${UNIQUE_ID}" >> "${GITHUB_OUTPUT}"
+          else
+            # For PRs not triggered by workflow_run, use the version script
+            python ./.github/scripts/get_release_version.py
+            echo "REL_VERSION=${REL_VERSION}" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Generate ID for release (workflow_run - from build artifacts)
+        if: github.event_name == 'workflow_run'
+        id: gen-id-workflow
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            
+            // Find container images artifact
+            const artifact = artifacts.data.artifacts.find(a => a.name.startsWith('container-images-'));
+            if (!artifact) {
+              core.setFailed('No container images artifact found');
+              return;
+            }
+            
+            // Extract version from artifact name: container-images-pr-123
+            const version = artifact.name.replace('container-images-', '');
+            core.setOutput('REL_VERSION', version);
+            core.exportVariable('REL_VERSION', version);
+
+      - name: Set output variables
         id: gen-id
         run: |
-          BASE_STR="RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
-          if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
-            # Add run number to randomize unique id for scheduled runs.
-            BASE_STR="${GITHUB_RUN_NUMBER}|${BASE_STR}"
+          if [ "$GITHUB_EVENT_NAME" == "workflow_run" ]; then
+            REL_VERSION="${{ steps.gen-id-workflow.outputs.REL_VERSION }}"
+          else
+            REL_VERSION="${{ steps.gen-id-local.outputs.REL_VERSION }}"
           fi
-          UNIQUE_ID=func$(echo $BASE_STR | sha1sum | head -c 10)
-          echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_ENV
-
-          # Set output variables to be used in the other jobs
+          
           {
-            echo "REL_VERSION=pr-${UNIQUE_ID}"
+            echo "REL_VERSION=${REL_VERSION}"
             echo "DE_IMAGE=${{ env.DE_IMAGE }}"
             echo "DE_TAG=${{ env.DE_TAG }}"
           } >> "${GITHUB_OUTPUT}"
@@ -240,6 +292,20 @@ jobs:
           path: ./hack/bicep-types-radius/generated
           if-no-files-found: error
 
+      - name: Download container image artifacts (workflow_run)
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: container-images-${{ env.REL_VERSION }}
+          path: ./dist/images/
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Load container images (workflow_run)
+        if: github.event_name == 'workflow_run'
+        run: make docker-load-images
+
       - name: Create a secure local registry
         id: create-local-registry
         uses: ./.github/actions/create-local-registry
@@ -272,33 +338,23 @@ jobs:
           }
           EOF
 
-      - name: Download container image artifacts (PR)
-        if: github.event_name == 'pull_request'
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: container-images-${{ env.REL_VERSION }}
-          path: ./dist/images/
-
-      - name: Load container images (PR)
-        if: github.event_name == 'pull_request'
-        run: make docker-load-images
-
-      - name: Tag and push images to local registry (PR)
-        if: github.event_name == 'pull_request'
-        run: |
-          for img in applications-rp controller dynamic-rp ucpd bicep pre-upgrade; do
-            docker tag ghcr.io/radius-project/dev/${img}:${{ env.REL_VERSION }} \
-              ${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}/${img}:${{ env.REL_VERSION }}
-            docker push ${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}/${img}:${{ env.REL_VERSION }}
-          done
-
-      - name: Build and Push container images (non-PR)
-        if: github.event_name != 'pull_request'
+      - name: Build and Push container images (non-workflow_run)
+        if: github.event_name != 'workflow_run'
         run: |
           make build && make docker-build && make docker-push
         env:
           DOCKER_REGISTRY: ${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}
           DOCKER_TAG_VERSION: ${{ env.REL_VERSION }}
+
+      - name: Tag and push images to local registry (workflow_run)
+        if: github.event_name == 'workflow_run'
+        run: |
+          for img in applications-rp controller dynamic-rp ucpd bicep pre-upgrade testrp magpiego; do
+            # Images were saved with ghcr.io/radius-project/dev prefix, retag for local registry
+            docker tag ghcr.io/radius-project/dev/${img}:${{ env.REL_VERSION }} \
+              ${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}/${img}:${{ env.REL_VERSION }}
+            docker push ${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}/${img}:${{ env.REL_VERSION }}
+          done
 
       - name: Install rad CLI
         run: |

--- a/.github/workflows/functional-tests-approval.yaml
+++ b/.github/workflows/functional-tests-approval.yaml
@@ -12,8 +12,62 @@ on:
 permissions: {}
 
 jobs:
+  wait-for-build:
+    name: Wait for Build to Complete
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Wait for build workflow to complete
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const head_sha = context.payload.pull_request.head.sha;
+            
+            console.log(`Waiting for build workflow to complete for SHA: ${head_sha}`);
+            
+            // Poll for up to 60 minutes
+            const maxAttempts = 360; // 60 minutes with 10 second intervals
+            let attempt = 0;
+            
+            while (attempt < maxAttempts) {
+              // Get workflow runs for this SHA
+              const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+                owner,
+                repo,
+                head_sha,
+                workflow_id: 'build.yaml',
+                per_page: 1
+              });
+              
+              if (runs.workflow_runs.length > 0) {
+                const run = runs.workflow_runs[0];
+                console.log(`Build workflow status: ${run.status}, conclusion: ${run.conclusion}`);
+                
+                if (run.status === 'completed') {
+                  if (run.conclusion === 'success') {
+                    console.log('Build workflow completed successfully!');
+                    return;
+                  } else {
+                    core.setFailed(`Build workflow failed with conclusion: ${run.conclusion}`);
+                    return;
+                  }
+                }
+              }
+              
+              // Wait 10 seconds before checking again
+              await new Promise(resolve => setTimeout(resolve, 10000));
+              attempt++;
+            }
+            
+            core.setFailed('Timeout waiting for build workflow to complete');
+
   approve-functional-tests-run:
     name: Approve Functional Tests
+    needs: wait-for-build
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     environment: functional-tests

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@
 ARROW := \033[34;1m=>\033[0m
 
 # order matters for these
-include build/help.mk build/version.mk build/build.mk build/util.mk build/generate.mk build/test.mk build/docker.mk build/recipes.mk build/install.mk build/db.mk build/prettier.mk build/debug.mk build/workflow.mk
+include build/help.mk build/version.mk build/build.mk build/util.mk build/generate.mk build/test.mk build/docker.mk build/artifacts.mk build/recipes.mk build/install.mk build/db.mk build/prettier.mk build/debug.mk build/workflow.mk

--- a/build/artifacts.mk
+++ b/build/artifacts.mk
@@ -1,0 +1,72 @@
+# ------------------------------------------------------------
+# Copyright 2023 The Radius Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+DIST_DIR ?= dist
+IMAGES_DIR := $(DIST_DIR)/images
+METRICS_DIR := $(DIST_DIR)/metrics
+
+##@ Artifacts
+
+.PHONY: artifacts
+artifacts: docker-build docker-save-images build-metrics ## Build all artifacts needed for testing/release
+
+.PHONY: docker-save-images
+docker-save-images: ## Save Docker images to dist/images/*.tar
+	@echo "$(ARROW) Saving Docker images to $(IMAGES_DIR)"
+	@mkdir -p $(IMAGES_DIR)
+	@$(foreach APP,$(APPS_MAP),$(eval $(call parseApp,$(APP))) \
+		echo "  Saving $(DOCKER_REGISTRY)/$(NAME):$(DOCKER_TAG_VERSION) to $(NAME).tar"; \
+		docker save -o $(IMAGES_DIR)/$(NAME).tar $(DOCKER_REGISTRY)/$(NAME):$(DOCKER_TAG_VERSION);)
+
+.PHONY: docker-load-images
+docker-load-images: ## Load Docker images from dist/images/*.tar
+	@echo "$(ARROW) Loading Docker images from $(IMAGES_DIR)"
+	@if [ ! -d "$(IMAGES_DIR)" ]; then \
+		echo "Error: $(IMAGES_DIR) does not exist"; \
+		exit 1; \
+	fi
+	@for tar_file in $(IMAGES_DIR)/*.tar; do \
+		if [ -f "$$tar_file" ]; then \
+			echo "  Loading $$tar_file"; \
+			docker load -i "$$tar_file"; \
+		fi; \
+	done
+
+.PHONY: build-metrics
+build-metrics: ## Collect build metrics (duration, image count, size)
+	@echo "$(ARROW) Collecting build metrics"
+	@mkdir -p $(METRICS_DIR)
+	@IMAGE_COUNT=$$(docker images --filter "reference=$(DOCKER_REGISTRY)/*:$(DOCKER_TAG_VERSION)" --format "{{.Repository}}:{{.Tag}}" | wc -l | tr -d ' '); \
+	TOTAL_SIZE=$$(docker images --filter "reference=$(DOCKER_REGISTRY)/*:$(DOCKER_TAG_VERSION)" --format "{{.Size}}" | awk '{s+=$$1} END {print s}'); \
+	TIMESTAMP=$$(date -u +"%Y-%m-%dT%H:%M:%SZ"); \
+	echo "{" > $(METRICS_DIR)/metrics.json; \
+	echo "  \"timestamp\": \"$$TIMESTAMP\"," >> $(METRICS_DIR)/metrics.json; \
+	echo "  \"image_count\": $$IMAGE_COUNT," >> $(METRICS_DIR)/metrics.json; \
+	echo "  \"total_size_mb\": \"$$TOTAL_SIZE\"," >> $(METRICS_DIR)/metrics.json; \
+	echo "  \"docker_registry\": \"$(DOCKER_REGISTRY)\"," >> $(METRICS_DIR)/metrics.json; \
+	echo "  \"docker_tag_version\": \"$(DOCKER_TAG_VERSION)\"," >> $(METRICS_DIR)/metrics.json; \
+	echo "  \"git_commit\": \"$(GIT_COMMIT)\"," >> $(METRICS_DIR)/metrics.json; \
+	echo "  \"rel_version\": \"$(REL_VERSION)\"" >> $(METRICS_DIR)/metrics.json; \
+	echo "}" >> $(METRICS_DIR)/metrics.json; \
+	echo "Build Metrics:" > $(METRICS_DIR)/metrics.txt; \
+	echo "  Timestamp: $$TIMESTAMP" >> $(METRICS_DIR)/metrics.txt; \
+	echo "  Image Count: $$IMAGE_COUNT" >> $(METRICS_DIR)/metrics.txt; \
+	echo "  Total Size: $$TOTAL_SIZE MB" >> $(METRICS_DIR)/metrics.txt; \
+	echo "  Docker Registry: $(DOCKER_REGISTRY)" >> $(METRICS_DIR)/metrics.txt; \
+	echo "  Docker Tag: $(DOCKER_TAG_VERSION)" >> $(METRICS_DIR)/metrics.txt; \
+	echo "  Git Commit: $(GIT_COMMIT)" >> $(METRICS_DIR)/metrics.txt; \
+	echo "  Release Version: $(REL_VERSION)" >> $(METRICS_DIR)/metrics.txt; \
+	cat $(METRICS_DIR)/metrics.txt

--- a/build/docker.mk
+++ b/build/docker.mk
@@ -19,6 +19,15 @@ DOCKER_TAG_VERSION?=latest
 IMAGE_SRC?=https://github.com/radius-project/radius
 MANIFEST_DIR?=deploy/manifest/built-in-providers/self-hosted
 
+# Enable GitHub Actions caching by default in CI environments
+DOCKER_CACHE_GHA?=0
+DOCKER_BUILDX_CACHE_FROM:=
+DOCKER_BUILDX_CACHE_TO:=
+ifeq ($(DOCKER_CACHE_GHA),1)
+    DOCKER_BUILDX_CACHE_FROM=--cache-from type=gha
+    DOCKER_BUILDX_CACHE_TO=--cache-to type=gha,mode=max
+endif
+
 ##@ Docker Images
 
 # Generate a target for each image we define
@@ -69,6 +78,8 @@ docker-multi-arch-build-$(1): build-$(1)-linux-arm64 build-$(1)-linux-amd64 buil
 		--label org.opencontainers.image.description="$(1)" \
 		--label org.opencontainers.image.version="$(REL_VERSION)" \
 		--label org.opencontainers.image.revision="$(GIT_COMMIT)" \
+		$(DOCKER_BUILDX_CACHE_FROM) \
+		$(DOCKER_BUILDX_CACHE_TO) \
 		$(2)
 
 .PHONY: docker-multi-arch-push-$(1)
@@ -85,6 +96,8 @@ docker-multi-arch-push-$(1): build-$(1)-linux-arm64 build-$(1)-linux-amd64 build
 		--label org.opencontainers.image.description="$(1)" \
 		--label org.opencontainers.image.version="$(REL_VERSION)" \
 		--label org.opencontainers.image.revision="$(GIT_COMMIT)" \
+		$(DOCKER_BUILDX_CACHE_FROM) \
+		$(DOCKER_BUILDX_CACHE_TO) \
 		--push \
 		$(2)
 endef

--- a/build/version.mk
+++ b/build/version.mk
@@ -16,7 +16,8 @@
 
 # Commit and release info is used by multiple categories of commands
 
-GIT_COMMIT  = $(shell git rev-list -1 HEAD)
+# GIT_COMMIT can be overridden from environment variable
+GIT_COMMIT  ?= $(shell git rev-list -1 HEAD)
 GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty --tags)
 
 REL_VERSION ?= edge


### PR DESCRIPTION
# Description

This PR implements an artifact-based build flow that enables fork PRs to build and test without requiring push permissions to GHCR (GitHub Container Registry). This is a key improvement for contributor experience and CI/CD infrastructure.

## What Changed

### Build System
- **New `build/artifacts.mk`**: Added targets for saving/loading Docker images as tar files and collecting build metrics
- **Updated `build/docker.mk`**: Added GitHub Actions Docker layer caching support (`DOCKER_CACHE_GHA`)
- **Updated `build/version.mk`**: Allow `GIT_COMMIT` to be overridden via environment variable
- **Updated root `Makefile`**: Include the new artifacts.mk

### Build Workflow (`.github/workflows/build.yaml`)
- **For PRs**: Build images and save them as artifacts (1-day retention) instead of pushing to GHCR
- **For main/tags**: Continue pushing to GHCR as before (no change to existing behavior)
- **Build Metrics**: Collect and display image count, sizes, and build duration in job summaries

### Functional Test Workflows
- **`functional-test-noncloud.yaml`**: Download image artifacts for PRs, load into local registry
- **`functional-test-cloud.yaml`**: Download image artifacts for PRs, load and push to GHCR dev registry

## Benefits

1. **Fork-Friendly**: Contributors can now submit PRs from forks without needing GHCR push permissions
2. **Consistent Flow**: All PRs follow the same artifact-based flow
3. **Performance**: GitHub Actions Docker layer caching speeds up builds
4. **Visibility**: Build metrics provide insights into image sizes and build performance
5. **Security**: Maintains separation between artifact creation (untrusted) and registry push (trusted)

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: N/A (infrastructure improvement)

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->
