### PR TITLE
revert workflow changes.

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -36,9 +36,8 @@ on:
     #   src_image: Source image in ACR (e.g. radiusdeploymentengine.azurecr.io/deployment-engine)
     #   dest_image: Destination image in GHCR (e.g. ghcr.io/radius-project/deployment-engine)
     #   tag: Tag for the image (e.g. latest, 0.1, 0.1.0-rc1, pr-123)
-  # Wait for build or approval workflow to complete
   workflow_run:
-    workflows: [Build and Test, Approve Functional Tests]
+    workflows: [Approve Functional Tests]
     types:
       - completed
 
@@ -90,13 +89,9 @@ jobs:
     name: Setup
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    if: |
-      github.event_name == 'repository_dispatch' ||
+    if: github.event_name == 'repository_dispatch' ||
       (github.event_name == 'schedule' && github.repository == 'radius-project/radius') ||
-      (github.event_name == 'workflow_run' && 
-        github.event.workflow_run.conclusion == 'success' && 
-        (github.event.workflow_run.name == 'Approve Functional Tests' || 
-         github.event.workflow_run.event != 'pull_request')) ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
       github.event_name == 'workflow_dispatch'
     permissions:
       contents: read # Required for listing the commits
@@ -116,7 +111,6 @@ jobs:
       DE_IMAGE: ${{ steps.gen-id.outputs.DE_IMAGE }}
       DE_TAG: ${{ steps.gen-id.outputs.DE_TAG }}
       BASE_SHA: ${{ steps.gen-id.outputs.BASE_SHA }}
-      BUILD_RUN_ID: ${{ steps.find-build-run.outputs.BUILD_RUN_ID || '' }}
     steps:
       - name: Log Event Information
         run: |
@@ -283,39 +277,6 @@ jobs:
             echo "BASE_SHA=${{ env.BASE_SHA }}"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Find Build workflow run ID (workflow_run from Approve)
-        if: github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Approve Functional Tests'
-        id: find-build-run
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            const headSha = context.payload.workflow_run.head_sha;
-            console.log(`Looking for Build workflow run with head_sha: ${headSha}`);
-            
-            const { data: workflowRuns } = await github.rest.actions.listWorkflowRunsForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              event: 'pull_request',
-              head_sha: headSha,
-              per_page: 100
-            });
-            
-            const buildRun = workflowRuns.workflow_runs.find(run => 
-              run.name === 'Build and Test' && 
-              run.head_sha === headSha &&
-              run.status === 'completed' &&
-              run.conclusion === 'success'
-            );
-            
-            if (!buildRun) {
-              core.setFailed('No successful Build and Test workflow run found');
-              return;
-            }
-            
-            console.log(`Found Build workflow run: ${buildRun.id}`);
-            core.setOutput('BUILD_RUN_ID', buildRun.id.toString());
-            core.exportVariable('BUILD_RUN_ID', buildRun.id.toString());
-
   changes:
     name: Changes
     needs: setup
@@ -348,7 +309,6 @@ jobs:
       RAD_CLI_ARTIFACT_NAME: ${{ needs.setup.outputs.RAD_CLI_ARTIFACT_NAME }}
       DE_IMAGE: ${{ needs.setup.outputs.DE_IMAGE }}
       DE_TAG: ${{ needs.setup.outputs.DE_TAG }}
-      BUILD_RUN_ID: ${{ needs.setup.outputs.BUILD_RUN_ID }}
       DAPR_VER: 1.14.4
       ACTION_LINK: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
@@ -441,31 +401,7 @@ jobs:
           message: |
             :hourglass: Building Radius and pushing container images for functional tests...
 
-      - name: Download container image artifacts (PR)
-        if: github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Approve Functional Tests'
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: container-images-${{ env.REL_VERSION }}
-          path: ./dist/images/
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ env.BUILD_RUN_ID }}
-
-      - name: Load container images (PR)
-        if: github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Approve Functional Tests'
-        run: make docker-load-images
-
-      - name: Push images to GHCR (PR)
-        if: github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Approve Functional Tests'
-        run: |
-          for img in applications-rp controller dynamic-rp ucpd bicep pre-upgrade; do
-            docker tag ghcr.io/radius-project/dev/${img}:${{ env.REL_VERSION }} \
-              ${{ env.CONTAINER_REGISTRY }}/${img}:${{ env.REL_VERSION }}
-            docker push ${{ env.CONTAINER_REGISTRY }}/${img}:${{ env.REL_VERSION }}
-          done
-
-      - name: Build and Push container images (non-PR)
-        if: github.event_name != 'workflow_run' || github.event.workflow_run.name != 'Approve Functional Tests'
+      - name: Build and Push container images
         run: |
           make build && make docker-build && make docker-push
         env:

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -36,11 +36,11 @@ on:
     #   src_image: Source image in ACR (e.g. radiusdeploymentengine.azurecr.io/deployment-engine)
     #   dest_image: Destination image in GHCR (e.g. ghcr.io/radius-project/deployment-engine)
     #   tag: Tag for the image (e.g. latest, 0.1, 0.1.0-rc1, pr-123)
-  # Wait for build or approval workflow to complete
-  workflow_run:
-    workflows: [Build and Test, Approve Functional Tests]
-    types:
-      - completed
+  pull_request:
+    branches:
+      - main
+      - features/*
+      - release/*
 
 permissions: {}
 
@@ -101,11 +101,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     needs: [changes]
-    if: |
-      needs.changes.outputs.only_changed != 'true' &&
-      (github.event_name != 'workflow_run' ||
-       github.event.workflow_run.name == 'Approve Functional Tests' ||
-       github.event.workflow_run.event != 'pull_request')
+    if: needs.changes.outputs.only_changed != 'true'
     permissions:
       id-token: write # Required for requesting the JWT
       contents: read # Required for listing the commits
@@ -118,7 +114,6 @@ jobs:
       REL_VERSION: ${{ steps.gen-id.outputs.REL_VERSION }}
       DE_IMAGE: ${{ steps.gen-id.outputs.DE_IMAGE }}
       DE_TAG: ${{ steps.gen-id.outputs.DE_TAG }}
-      BUILD_RUN_ID: ${{ steps.gen-id.outputs.BUILD_RUN_ID }}
     steps:
       - name: Set DE image and tag (repository_dispatch from deployment-engine.run-functional-tests)
         if: github.event_name == 'repository_dispatch'
@@ -132,113 +127,22 @@ jobs:
             echo "DE_TAG=${TAG}"
           } >> "$GITHUB_ENV"
 
-      - name: Checkout (for version script)
-        if: github.event_name != 'workflow_run'
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          persist-credentials: false
-
-      - name: Setup Python (for version script)
-        if: github.event_name != 'workflow_run'
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
-        with:
-          python-version-file: .python-version
-
-      - name: Generate ID for release (non-workflow_run or Build and Test workflow_run)
-        if: github.event_name != 'workflow_run' || github.event.workflow_run.name == 'Build and Test'
-        id: gen-id-local
-        run: |
-          # For workflow_run events or non-PR events, generate a unique ID
-          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
-            BASE_STR="RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
-            if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
-              BASE_STR="${GITHUB_RUN_NUMBER}|${BASE_STR}"
-            fi
-            UNIQUE_ID=func$(echo $BASE_STR | sha1sum | head -c 10)
-            echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_ENV
-            echo "REL_VERSION=pr-${UNIQUE_ID}" >> "${GITHUB_OUTPUT}"
-          else
-            # For PRs not triggered by workflow_run, use the version script
-            python ./.github/scripts/get_release_version.py
-            echo "REL_VERSION=${REL_VERSION}" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Generate ID for release (workflow_run from Approve Functional Tests - from PR artifacts)
-        if: github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Approve Functional Tests'
-        id: gen-id-workflow
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            // When triggered by Approve workflow, we need to find the Build workflow run
-            // that has the artifacts (same commit SHA)
-            const headSha = context.payload.workflow_run.head_sha;
-            
-            console.log(`Looking for Build workflow run with head_sha: ${headSha}`);
-            
-            // List workflow runs for this commit
-            const { data: workflowRuns } = await github.rest.actions.listWorkflowRunsForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              event: 'pull_request',
-              head_sha: headSha,
-              per_page: 100
-            });
-            
-            // Find the Build and Test workflow run
-            const buildRun = workflowRuns.workflow_runs.find(run => 
-              run.name === 'Build and Test' && 
-              run.head_sha === headSha &&
-              run.status === 'completed' &&
-              run.conclusion === 'success'
-            );
-            
-            if (!buildRun) {
-              core.setFailed('No successful Build and Test workflow run found for this commit');
-              return;
-            }
-            
-            console.log(`Found Build workflow run: ${buildRun.id}`);
-            
-            // Get artifacts from the Build workflow run
-            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: buildRun.id,
-            });
-            
-            // Find container images artifact
-            const artifact = artifacts.data.artifacts.find(a => a.name.startsWith('container-images-'));
-            if (!artifact) {
-              core.setFailed('No container images artifact found in Build workflow');
-              return;
-            }
-            
-            console.log(`Found artifact: ${artifact.name}`);
-            
-            // Extract version from artifact name: container-images-pr-123
-            const version = artifact.name.replace('container-images-', '');
-            
-            // Export both version and build run ID (needed for artifact download)
-            core.setOutput('REL_VERSION', version);
-            core.setOutput('BUILD_RUN_ID', buildRun.id.toString());
-            core.exportVariable('REL_VERSION', version);
-            core.exportVariable('BUILD_RUN_ID', buildRun.id.toString());
-
-      - name: Set output variables
+      - name: Generate ID for release
         id: gen-id
         run: |
-          # REL_VERSION is set by either gen-id-local or gen-id-workflow via exportVariable
-          # If neither ran, REL_VERSION will be empty
-          if [ -z "$REL_VERSION" ]; then
-            echo "Error: REL_VERSION not set by any version generation step"
-            exit 1
+          BASE_STR="RADIUS|${GITHUB_SHA}|${GITHUB_SERVER_URL}|${GITHUB_REPOSITORY}|${GITHUB_RUN_ID}|${GITHUB_RUN_ATTEMPT}"
+          if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
+            # Add run number to randomize unique id for scheduled runs.
+            BASE_STR="${GITHUB_RUN_NUMBER}|${BASE_STR}"
           fi
-          
+          UNIQUE_ID=func$(echo $BASE_STR | sha1sum | head -c 10)
+          echo "REL_VERSION=pr-${UNIQUE_ID}" >> $GITHUB_ENV
+
+          # Set output variables to be used in the other jobs
           {
-            echo "REL_VERSION=${REL_VERSION}"
+            echo "REL_VERSION=pr-${UNIQUE_ID}"
             echo "DE_IMAGE=${{ env.DE_IMAGE }}"
             echo "DE_TAG=${{ env.DE_TAG }}"
-            echo "BUILD_RUN_ID=${BUILD_RUN_ID:-}"
           } >> "${GITHUB_OUTPUT}"
 
   tests:
@@ -272,7 +176,6 @@ jobs:
       BICEP_RECIPE_TAG_VERSION: ${{ needs.build.outputs.REL_VERSION }}
       DE_IMAGE: ${{ needs.build.outputs.DE_IMAGE }}
       DE_TAG: ${{ needs.build.outputs.DE_TAG }}
-      BUILD_RUN_ID: ${{ needs.build.outputs.BUILD_RUN_ID }}
     steps:
       - name: Set up checkout target (scheduled)
         if: github.event_name == 'schedule' || github.event_name == 'repository_dispatch'
@@ -337,20 +240,6 @@ jobs:
           path: ./hack/bicep-types-radius/generated
           if-no-files-found: error
 
-      - name: Download container image artifacts (workflow_run from PR approval)
-        if: github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Approve Functional Tests'
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          name: container-images-${{ env.REL_VERSION }}
-          path: ./dist/images/
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ env.BUILD_RUN_ID }}
-
-      - name: Load container images (workflow_run from PR approval)
-        if: github.event_name == 'workflow_run' && github.event.workflow_run.name == 'Approve Functional Tests'
-        run: make docker-load-images
-
       - name: Create a secure local registry
         id: create-local-registry
         uses: ./.github/actions/create-local-registry
@@ -383,23 +272,12 @@ jobs:
           }
           EOF
 
-      - name: Build and Push container images (non-workflow_run)
-        if: github.event_name != 'workflow_run'
+      - name: Build and Push container images
         run: |
           make build && make docker-build && make docker-push
         env:
           DOCKER_REGISTRY: ${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}
           DOCKER_TAG_VERSION: ${{ env.REL_VERSION }}
-
-      - name: Tag and push images to local registry (workflow_run)
-        if: github.event_name == 'workflow_run'
-        run: |
-          for img in applications-rp controller dynamic-rp ucpd bicep pre-upgrade testrp magpiego; do
-            # Images were saved with ghcr.io/radius-project/dev prefix, retag for local registry
-            docker tag ghcr.io/radius-project/dev/${img}:${{ env.REL_VERSION }} \
-              ${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}/${img}:${{ env.REL_VERSION }}
-            docker push ${{ env.LOCAL_REGISTRY_SERVER }}:${{ env.LOCAL_REGISTRY_PORT }}/${img}:${{ env.REL_VERSION }}
-          done
 
       - name: Install rad CLI
         run: |

--- a/.github/workflows/functional-tests-approval.yaml
+++ b/.github/workflows/functional-tests-approval.yaml
@@ -3,7 +3,6 @@
 name: Approve Functional Tests
 
 on:
-  # Trigger on PR to show as a PR check
   pull_request:
     branches:
       - main
@@ -13,86 +12,8 @@ on:
 permissions: {}
 
 jobs:
-  wait-for-build:
-    name: Wait for Build to Complete
-    runs-on: ubuntu-24.04
-    timeout-minutes: 60
-    permissions:
-      contents: read
-      actions: read
-    outputs:
-      build-completed: ${{ steps.check-build.outputs.result }}
-    steps:
-      - name: Wait for build workflow to complete
-        id: check-build
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            const maxAttempts = 180; // 30 minutes max (10 second intervals)
-            const delay = 10000; // 10 seconds
-            let buildRunFound = false;
-            
-            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-              console.log(`Checking build status (attempt ${attempt}/${maxAttempts})...`);
-              
-              // Get workflow runs for the same commit
-              const { data: workflowRuns } = await github.rest.actions.listWorkflowRunsForRepo({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                event: 'pull_request',
-                head_sha: context.payload.pull_request.head.sha,
-                per_page: 100
-              });
-              
-              // Find the "Build and Test" workflow run
-              const buildRun = workflowRuns.workflow_runs.find(run => 
-                run.name === 'Build and Test' && 
-                run.head_sha === context.payload.pull_request.head.sha
-              );
-              
-              if (buildRun) {
-                buildRunFound = true;
-                console.log(`Build workflow status: ${buildRun.status}, conclusion: ${buildRun.conclusion}`);
-                
-                if (buildRun.status === 'completed') {
-                  if (buildRun.conclusion === 'success') {
-                    console.log('Build completed successfully!');
-                    console.log('Setting output: build-completed=success');
-                    core.setOutput('result', 'success');
-                    return 'success';
-                  } else {
-                    console.log(`Build failed with conclusion: ${buildRun.conclusion}`);
-                    console.log('Setting output: build-completed=failed');
-                    core.setOutput('result', 'failed');
-                    core.setFailed(`Build workflow failed with conclusion: ${buildRun.conclusion}`);
-                    return 'failed';
-                  }
-                }
-              } else if (attempt === 1) {
-                console.log('Build workflow not found yet, waiting for it to start...');
-              } else if (!buildRunFound && attempt > 30) {
-                // After 5 minutes, if still no build workflow, something is wrong
-                console.log('Setting output: build-completed=not-found');
-                core.setOutput('result', 'not-found');
-                core.setFailed('Build workflow did not start within 5 minutes');
-                return 'not-found';
-              }
-              
-              // Wait before next attempt
-              if (attempt < maxAttempts) {
-                await new Promise(resolve => setTimeout(resolve, delay));
-              }
-            }
-            
-            console.log('Setting output: build-completed=timeout');
-            core.setOutput('result', 'timeout');
-            core.setFailed('Build workflow did not complete within timeout period');
-            return 'timeout';
-
   approve-functional-tests-run:
     name: Approve Functional Tests
-    needs: wait-for-build
-    if: needs.wait-for-build.outputs.build-completed == 'success'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     environment: functional-tests
@@ -104,12 +25,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Save PR number
+      - name: Get PR number
         run: |
           mkdir -p ./pr
-          echo "${{ github.event.pull_request.number }}" > ./pr/pr_number
+          echo "${PR_NUMBER}" > ./pr/pr_number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
 
-      - name: Upload PR number artifact
+      - name: Save PR number
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: pr_number


### PR DESCRIPTION
# Description

This PR reverts the "build once" artifact optimization feature introduced in PR #11021 and all subsequent fixes (commits `4a526e7ff` through `4c3cc4c12`).

## Why This Revert is Needed

The feature can only be tested on main and there are tons of edge cases around the approval workflow vs merges to main that were not easily resolved. The whole approach for the workflows is going to be revisited and we can address this at that time. 

## What This PR Reverts

Reverted workflow files:
- `.github/workflows/functional-test-noncloud.yaml` - Back to building from scratch
- `.github/workflows/functional-test-cloud.yaml` - Back to building from scratch  
- `.github/workflows/functional-tests-approval.yaml` - Removed (was incomplete)
- `.github/workflows/build.yaml` - Reverted gotestsum version change (was unrelated)
- `.github/workflows/unit-tests.yaml` - Reverted gotestsum version change (was unrelated)

## Impact

- Functional tests will build container images from scratch again (as they did before)
- Build times will return to previous levels (builds are fast, minimal impact)
- Approval workflow removed (can be re-introduced properly if needed)
- All tests should pass again on PRs and main branch

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->