### PR TITLE
Deploy by recipe digest

### DIFF
--- a/pkg/cli/cmd/bicep/publish/publish.go
+++ b/pkg/cli/cmd/bicep/publish/publish.go
@@ -180,7 +180,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	r.Output.LogInfo("Successfully published Bicep file %q to %q", r.File, r.Target)
-	r.Output.LogInfo("Copy the digest '%s' into your recipe pack to pin the artifact immutably.", digest)
+	r.Output.LogInfo("To pin the artifact immutable use the following recipe url: %s", computeImmutableRecipeUrl(r.Target, digest.String()))
 
 	return nil
 }
@@ -363,4 +363,11 @@ func generateManifestContent(config ocispec.Descriptor, layers ...ocispec.Descri
 		Versioned: specs.Versioned{SchemaVersion: 2},
 	}
 	return json.Marshal(content)
+}
+
+// computeImmutableRecipeUrl builds an OCI URL using the registry/repo portion of the
+// target (no leading "br:" and without the tag) and replaces the tag with the digest.
+func computeImmutableRecipeUrl(target, hash string) string {
+	host := strings.Split(target, ":")[0]
+	return fmt.Sprintf("%s@%s", host, hash)
 }

--- a/pkg/cli/cmd/bicep/publish/publish.go
+++ b/pkg/cli/cmd/bicep/publish/publish.go
@@ -180,7 +180,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	r.Output.LogInfo("Successfully published Bicep file %q to %q", r.File, r.Target)
-	r.Output.LogInfo("To pin the artifact immutable use the following recipe url: %s", computeImmutableRecipeUrl(r.Target, digest.String()))
+	r.Output.LogInfo("To immutably pin the artifact, use the following Recipe url: %s", computeImmutableRecipeUrl(r.Target, digest.String()))
 
 	return nil
 }

--- a/test/functional-portable/dynamicrp/noncloud/resources/testdata/recipepacks-test.bicep
+++ b/test/functional-portable/dynamicrp/noncloud/resources/testdata/recipepacks-test.bicep
@@ -26,7 +26,8 @@ resource recipepack 'Radius.Core/recipePacks@2025-08-01-preview' = {
       }
       'Test.Resources/postgres': {
         recipeKind: 'bicep'
-        recipeLocation: '${registry}/test/testrecipes/test-bicep-recipes/dynamicrp_postgress_recipe:${version}'
+        // update the sha sum after making changes to the recipe
+        recipeLocation: '${registry}/test/testrecipes/test-bicep-recipes/dynamicrp_postgress_recipe@sha256:40d079856c2b7cf4df146c0726b31b8bea6a82ef1eb7fa9bc9e00498367f2a4d'
       }
     }
   }


### PR DESCRIPTION
# Description

- Updated rad recipe bicep publish command
<img width="1429" height="138" alt="image" src="https://github.com/user-attachments/assets/d6f6e66c-d94e-4ba7-9f2c-7b29181b9bff" />
- added a e2e test to deploy using digest

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->