### PR TITLE
Fix for wrong error message with kubernetes namespace value validation

### DIFF
--- a/pkg/components/secret/inmemory/client.go
+++ b/pkg/components/secret/inmemory/client.go
@@ -44,7 +44,7 @@ func (c *Client) Save(ctx context.Context, name string, value []byte) error {
 		return &secret.ErrInvalid{Message: "invalid argument. 'value' is required"}
 	}
 
-	if !kubernetes.IsValidObjectName(name) {
+	if valid, _ := kubernetes.IsValidObjectName(name); !valid {
 		return &secret.ErrInvalid{Message: "invalid name: " + name}
 	}
 
@@ -66,7 +66,7 @@ func (c *Client) Delete(ctx context.Context, name string) error {
 		return &secret.ErrInvalid{Message: "invalid argument. 'name' is required"}
 	}
 
-	if !kubernetes.IsValidObjectName(name) {
+	if valid, _ := kubernetes.IsValidObjectName(name); !valid {
 		return &secret.ErrInvalid{Message: "invalid name: " + name}
 	}
 
@@ -93,7 +93,7 @@ func (c *Client) Get(ctx context.Context, name string) ([]byte, error) {
 		return nil, &secret.ErrInvalid{Message: "invalid argument. 'name' is required"}
 	}
 
-	if !kubernetes.IsValidObjectName(name) {
+	if valid, _ := kubernetes.IsValidObjectName(name); !valid {
 		return nil, &secret.ErrInvalid{Message: "invalid name: " + name}
 	}
 

--- a/pkg/components/secret/kubernetes/client.go
+++ b/pkg/components/secret/kubernetes/client.go
@@ -50,7 +50,7 @@ func (c *Client) Save(ctx context.Context, name string, value []byte) error {
 		return &secret.ErrInvalid{Message: "invalid argument. 'value' is required"}
 	}
 
-	if !kubernetes.IsValidObjectName(name) {
+	if valid, _ := kubernetes.IsValidObjectName(name); !valid {
 		return &secret.ErrInvalid{Message: "invalid name: " + name}
 	}
 
@@ -88,7 +88,7 @@ func (c *Client) Delete(ctx context.Context, name string) error {
 		return &secret.ErrInvalid{Message: "invalid argument. 'name' is required"}
 	}
 
-	if !kubernetes.IsValidObjectName(name) {
+	if valid, _ := kubernetes.IsValidObjectName(name); !valid {
 		return &secret.ErrInvalid{Message: "invalid name: " + name}
 	}
 
@@ -115,7 +115,7 @@ func (c *Client) Get(ctx context.Context, name string) ([]byte, error) {
 		return nil, &secret.ErrInvalid{Message: "invalid argument. 'name' is required"}
 	}
 
-	if !kubernetes.IsValidObjectName(name) {
+	if valid, _ := kubernetes.IsValidObjectName(name); !valid {
 		return nil, &secret.ErrInvalid{Message: "invalid name: " + name}
 	}
 

--- a/pkg/corerp/api/v20231001preview/environment_conversion.go
+++ b/pkg/corerp/api/v20231001preview/environment_conversion.go
@@ -281,7 +281,7 @@ func toEnvironmentComputeDataModel(h EnvironmentComputeClassification) (*rpv1.En
 			return nil, err
 		}
 
-		if !kubernetes.IsValidObjectName(to.String(v.Namespace)) {
+		if valid, _ := kubernetes.IsValidObjectName(to.String(v.Namespace)); !valid {
 			return nil, &v1.ErrModelConversion{PropertyName: "$.properties.compute.namespace", ValidValue: "63 characters or less"}
 		}
 

--- a/pkg/corerp/frontend/controller/applications/updatefilter.go
+++ b/pkg/corerp/frontend/controller/applications/updatefilter.go
@@ -123,7 +123,7 @@ func CreateAppScopedNamespace(ctx context.Context, newResource, oldResource *dat
 	}
 
 	if valid, msg := kubernetes.IsValidObjectName(kubeNamespace); !valid {
-		return rest.NewBadRequestResponse(fmt.Sprintf("'%s' is the invalid namespace: %s. Please specify a valid namespace using 'kubernetesNamespace' extension in '$.properties.extensions[*]'.", kubeNamespace, msg)), nil
+		return rest.NewBadRequestResponse(fmt.Sprintf("'%s' is an invalid namespace name: %s. Please specify a valid namespace using 'kubernetesNamespace' extension in '$.properties.extensions[*]'.", kubeNamespace, msg)), nil
 	}
 
 	if oldResource != nil {

--- a/pkg/corerp/frontend/controller/applications/updatefilter.go
+++ b/pkg/corerp/frontend/controller/applications/updatefilter.go
@@ -82,9 +82,9 @@ func CreateAppScopedNamespace(ctx context.Context, newResource, oldResource *dat
 		}
 
 		namespace := fmt.Sprintf("%s-%s", envNamespace, serviceCtx.ResourceID.Name())
-		if !kubernetes.IsValidObjectName(namespace) {
-			return rest.NewBadRequestResponse(fmt.Sprintf("Application namespace '%s' could not be created: the combination of application and environment names is too long.",
-				namespace)), nil
+		if valid, msg := kubernetes.IsValidObjectName(namespace); !valid {
+			return rest.NewBadRequestResponse(fmt.Sprintf("Application namespace '%s' could not be created: %s",
+				namespace, msg)), nil
 		}
 
 		kubeNamespace = kubernetes.NormalizeResourceName(namespace)
@@ -122,8 +122,8 @@ func CreateAppScopedNamespace(ctx context.Context, newResource, oldResource *dat
 		}
 	}
 
-	if !kubernetes.IsValidObjectName(kubeNamespace) {
-		return rest.NewBadRequestResponse(fmt.Sprintf("'%s' is the invalid namespace. This must be at most 63 alphanumeric characters or '-'. Please specify a valid namespace using 'kubernetesNamespace' extension in '$.properties.extensions[*]'.", kubeNamespace)), nil
+	if valid, msg := kubernetes.IsValidObjectName(kubeNamespace); !valid {
+		return rest.NewBadRequestResponse(fmt.Sprintf("'%s' is the invalid namespace: %s. Please specify a valid namespace using 'kubernetesNamespace' extension in '$.properties.extensions[*]'.", kubeNamespace, msg)), nil
 	}
 
 	if oldResource != nil {

--- a/pkg/corerp/frontend/controller/applications/updatefilter_test.go
+++ b/pkg/corerp/frontend/controller/applications/updatefilter_test.go
@@ -205,7 +205,7 @@ func TestCreateAppScopedNamespace_invalid_property(t *testing.T) {
 		require.NoError(t, err)
 		res := resp.(*rest.BadRequestResponse)
 
-		require.Equal(t, "Application namespace 'this-is-a-very-long-environment-name-that-is-invalid-this-is-a-very-long-application-name-that-is-invalid' could not be created: the combination of application and environment names is too long.", res.Body.Error.Message)
+		require.Contains(t, res.Body.Error.Message, "Application namespace 'this-is-a-very-long-environment-name-that-is-invalid-this-is-a-very-long-application-name-that-is-invalid' could not be created")
 	})
 
 	t.Run("invalid namespace", func(t *testing.T) {
@@ -252,7 +252,7 @@ func TestCreateAppScopedNamespace_invalid_property(t *testing.T) {
 		resp, err := CreateAppScopedNamespace(ctx, newResource, nil, &opts)
 		require.NoError(t, err)
 		res := resp.(*rest.BadRequestResponse)
-		require.Equal(t, res.Body.Error.Message, "'invalid-nameinvalid-nameinvalid-nameinvalid-nameinvalid-nameinvalid-name' is the invalid namespace. This must be at most 63 alphanumeric characters or '-'. Please specify a valid namespace using 'kubernetesNamespace' extension in '$.properties.extensions[*]'.")
+		require.Contains(t, res.Body.Error.Message, "'invalid-nameinvalid-nameinvalid-nameinvalid-nameinvalid-nameinvalid-name' is the invalid namespace")
 	})
 
 	t.Run("conflicted namespace in environment resource", func(t *testing.T) {

--- a/pkg/corerp/frontend/controller/applications/updatefilter_test.go
+++ b/pkg/corerp/frontend/controller/applications/updatefilter_test.go
@@ -252,7 +252,7 @@ func TestCreateAppScopedNamespace_invalid_property(t *testing.T) {
 		resp, err := CreateAppScopedNamespace(ctx, newResource, nil, &opts)
 		require.NoError(t, err)
 		res := resp.(*rest.BadRequestResponse)
-		require.Contains(t, res.Body.Error.Message, "'invalid-nameinvalid-nameinvalid-nameinvalid-nameinvalid-nameinvalid-name' is the invalid namespace")
+		require.Contains(t, res.Body.Error.Message, "'invalid-nameinvalid-nameinvalid-nameinvalid-nameinvalid-nameinvalid-name' is an invalid namespace name")
 	})
 
 	t.Run("conflicted namespace in environment resource", func(t *testing.T) {

--- a/pkg/corerp/frontend/controller/secretstores/kubernetes.go
+++ b/pkg/corerp/frontend/controller/secretstores/kubernetes.go
@@ -183,14 +183,18 @@ func fromResourceID(id string) (ns string, name string, err error) {
 		return
 	}
 
-	if name != "" && !kubernetes.IsValidObjectName(name) {
-		err = fmt.Errorf("'%s' is the invalid resource name. This must be at most 63 alphanumeric characters or '-'", name)
-		return
+	if name != "" {
+		if valid, msg := kubernetes.IsValidObjectName(name); !valid {
+			err = fmt.Errorf("'%s' is the invalid resource name. %s", name, msg)
+			return
+		}
 	}
 
-	if ns != "" && !kubernetes.IsValidObjectName(ns) {
-		err = fmt.Errorf("'%s' is the invalid namespace. This must be at most 63 alphanumeric characters or '-'", ns)
-		return
+	if ns != "" {
+		if valid, msg := kubernetes.IsValidObjectName(ns); !valid {
+			err = fmt.Errorf("'%s' is the invalid namespace. %s", ns, msg)
+			return
+		}
 	}
 
 	return

--- a/pkg/corerp/frontend/controller/secretstores/kubernetes_test.go
+++ b/pkg/corerp/frontend/controller/secretstores/kubernetes_test.go
@@ -147,11 +147,11 @@ func TestFromResourceID(t *testing.T) {
 		},
 		{
 			resourceID: "namespace/namE_2",
-			err:        errors.New("'namE_2' is the invalid resource name. This must be at most 63 alphanumeric characters or '-'"),
+			err:        errors.New("'namE_2' is the invalid resource name."),
 		},
 		{
 			resourceID: "namespa_ce/name",
-			err:        errors.New("'namespa_ce' is the invalid namespace. This must be at most 63 alphanumeric characters or '-'"),
+			err:        errors.New("'namespa_ce' is the invalid namespace."),
 		},
 	}
 

--- a/pkg/kubernetes/labels.go
+++ b/pkg/kubernetes/labels.go
@@ -119,7 +119,7 @@ func NormalizeResourceName(name string) string {
 		return normalized
 	}
 
-	if !IsValidObjectName(normalized) {
+	if valid, _ := IsValidObjectName(normalized); !valid {
 		// This should not happen.
 		panic(normalized + " is an invalid name.")
 	}

--- a/pkg/kubernetes/object.go
+++ b/pkg/kubernetes/object.go
@@ -145,7 +145,8 @@ func GetShortenedTargetPortName(name string) string {
 	return "a" + fmt.Sprint(h.Sum32())
 }
 
-// IsValidObjectName checks if the given string is a valid Kubernetes object name.
+// IsValidObjectName checks if the given string is a valid Kubernetes object name and returns a boolean value along with a concatenated string of error messages.
+// E.g error message: The Namespace "test-Invalid" is invalid: metadata.name: Invalid value: "test-Invalid": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name', or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?').
 func IsValidObjectName(name string) (bool, string) {
 	if len(validation.IsDNS1123Label(name)) == 0 {
 		return true, ""

--- a/pkg/kubernetes/object.go
+++ b/pkg/kubernetes/object.go
@@ -146,8 +146,12 @@ func GetShortenedTargetPortName(name string) string {
 }
 
 // IsValidObjectName checks if the given string is a valid Kubernetes object name.
-func IsValidObjectName(name string) bool {
-	return len(validation.IsDNS1123Label(name)) == 0
+func IsValidObjectName(name string) (bool, string) {
+	if len(validation.IsDNS1123Label(name)) == 0 {
+		return true, ""
+	}
+
+	return false, strings.Join(validation.IsDNS1123Label(name), ", ")
 }
 
 // IsValidDaprObjectName checks if the given string is a valid Dapr object name and returns a boolean value.

--- a/pkg/kubernetes/object_test.go
+++ b/pkg/kubernetes/object_test.go
@@ -47,7 +47,8 @@ func TestIsValidObjectName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			require.Equal(t, tt.valid, IsValidObjectName(tt.in))
+			valid, _ := IsValidObjectName(tt.in)
+			require.Equal(t, tt.valid, valid)
 		})
 	}
 }


### PR DESCRIPTION
# Description

Adding changes to throw the error returned by kubernetes for name validation for namespace.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: https://dev.azure.com/azure-octo/Incubations/_workitems/edit/17889

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->