### PR TITLE
Go module dependency for bicep-types-go instead of submodule

### DIFF
--- a/docs/contributing/contributing-code/contributing-code-building/README.md
+++ b/docs/contributing/contributing-code/contributing-code-building/README.md
@@ -4,7 +4,9 @@ Radius uses a Makefile to build the repository and automate most common reposito
 
 You can run `make` (no additional arguments) to see the list of targets and their descriptions.
 
-> NOTE: Some parts of the build process depend on the submodule `bicep-types`, so after cloning the repository, you should run `git submodule update --init --recursive` to ensure that the `bicep-types` submodule is checked out. By default, `git clone` will not clone submodules. If you have not cloned the submodule, or if the submodule is out of date, the `make build` command will fail and prompt you to update the submodule.
+> NOTE: Some parts of the build process depend on the submodule `bicep-types`. After cloning the repository, you should run `git submodule update --init --recursive` to ensure that the `bicep-types` submodule is checked out. By default, `git clone` will not clone submodules. If you have not cloned the submodule, or if the submodule is out of date, some targets in `make build` may fail and prompt you to update the submodule.
+>
+> **Go module dependencies**: Go code uses the `bicep-types-go` package as a standard Go module dependency fetched via `go mod download`. The submodule is only required for TypeScript/pnpm tooling.
 
 ## Building the repository
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1
-	github.com/Azure/bicep-types/src/bicep-types-go v0.0.0-20260115172958-c1a289be58be
+	github.com/Azure/bicep-types/src/bicep-types-go v0.0.0-20260118201541-556bf5edad58
 	github.com/Azure/secrets-store-csi-driver-provider-azure v1.7.2
 	github.com/Masterminds/semver v1.5.0
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,6 @@ go 1.25.5
 // xref: https://github.com/opencontainers/go-digest/pull/66
 replace github.com/opencontainers/go-digest => github.com/opencontainers/go-digest v1.0.1-0.20220411205349-bde1400a84be
 
-// replace github.com/radius-project/radius/bicep-types/src/bicep-types-go => ./bicep-types/src/bicep-types-go
-replace github.com/Azure/bicep-types/src/bicep-types-go => ./bicep-types/src/bicep-types-go
-
 replace github.com/stretchr/testify => github.com/stretchr/testify v1.10.0
 
 require (
@@ -22,7 +19,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1
-	github.com/Azure/bicep-types/src/bicep-types-go v0.0.0-00010101000000-000000000000
+	github.com/Azure/bicep-types/src/bicep-types-go v0.0.0-20260115172958-c1a289be58be
 	github.com/Azure/secrets-store-csi-driver-provider-azure v1.7.2
 	github.com/Masterminds/semver v1.5.0
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3/go.mod h1:9sfaaa+UF5VVus+Tr/bd1qm1oRoltnewm3HpiT9l8VU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 h1:/Zt+cDPnpC3OVDm/JKLOs7M2DKmLRIIp3XIx9pHHiig=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1/go.mod h1:Ng3urmn6dYe8gnbCMoHHVl5APYz2txho3koEkV2o2HA=
+github.com/Azure/bicep-types/src/bicep-types-go v0.0.0-20260115172958-c1a289be58be h1:yRx8H2QNmQ8qNcngJIfgzRjbma72V3/TS7I7BSmHuWA=
+github.com/Azure/bicep-types/src/bicep-types-go v0.0.0-20260115172958-c1a289be58be/go.mod h1:Bk9rIa7p8ROWO4hK+qs5RacRf6tbU8/divPJ7PMUsyI=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Azure/secrets-store-csi-driver-provider-azure v1.7.2 h1:GVtAKa3sOzkHQGgOXiKQSbNf7aKo6eIHq96nmnjrugA=

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1/go.mod h1:Ng3urmn6dYe8gnbCMoHHVl5APYz2txho3koEkV2o2HA=
 github.com/Azure/bicep-types/src/bicep-types-go v0.0.0-20260115172958-c1a289be58be h1:yRx8H2QNmQ8qNcngJIfgzRjbma72V3/TS7I7BSmHuWA=
 github.com/Azure/bicep-types/src/bicep-types-go v0.0.0-20260115172958-c1a289be58be/go.mod h1:Bk9rIa7p8ROWO4hK+qs5RacRf6tbU8/divPJ7PMUsyI=
+github.com/Azure/bicep-types/src/bicep-types-go v0.0.0-20260118201541-556bf5edad58 h1:VQiFcfOBo02AKxCc2CIGGUe4mG9WnwQWK7GdUZ0E5rU=
+github.com/Azure/bicep-types/src/bicep-types-go v0.0.0-20260118201541-556bf5edad58/go.mod h1:Bk9rIa7p8ROWO4hK+qs5RacRf6tbU8/divPJ7PMUsyI=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Azure/secrets-store-csi-driver-provider-azure v1.7.2 h1:GVtAKa3sOzkHQGgOXiKQSbNf7aKo6eIHq96nmnjrugA=


### PR DESCRIPTION
# Description

This PR updates Go code to use the `bicep-types-go` package as a standard Go module dependency fetched via `go get github.com/Azure/bicep-types/src/bicep-types-go@<commit hash>`, rather than relying on the git submodule. The submodule remains for TypeScript/pnpm tooling, but Go tooling now references the package directly from the `Azure/bicep-types` repository.

This PR is step 1 of 2 in a two-step update to remove the git submodule. The plan is here: https://github.com/radius-project/design-notes/pull/138

**Changes:**
- Removed the `replace` directive in `go.mod` that pointed to the local submodule
- Added direct dependency on `github.com/Azure/bicep-types/src/bicep-types-go` 
- Updated contributor documentation to clarify when the submodule is required

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Related issue #10913

- Design document: https://github.com/radius-project/design-notes/pull/138

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [x] Yes <!-- TaskRadio design-pr -->
    - [ ] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->
