### PR TITLE
Pin alpine image to 3.23 in terraform init containers

### DIFF
--- a/deploy/Chart/templates/dynamic-rp/deployment.yaml
+++ b/deploy/Chart/templates/dynamic-rp/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           mountPath: /etc/radius-ssl/certs
       {{- end }}
       - name: terraform-init
-        image: "alpine:latest"
+        image: "alpine:3.23"
         command:
         - /bin/sh
         - -c

--- a/deploy/Chart/templates/rp/deployment.yaml
+++ b/deploy/Chart/templates/rp/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           mountPath: /etc/radius-ssl/certs
       {{- end }}
       - name: terraform-init
-        image: "alpine:latest"
+        image: "alpine:3.23"
         command:
         - /bin/sh
         - -c

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -30,7 +30,7 @@ global:
   appendRootCA:
     # Auto-enabled when global.rootCA.cert is provided via --set-file
     # Init image to normalize and prepare certs directory
-    initImage: "alpine:latest"
+    initImage: "alpine:3.23"
     # Working and target mount paths
     workDir: "/work/certs"
     targetMountPath: "/etc/ssl/certs"


### PR DESCRIPTION
# Description

Pin alpine image to 3.23 in terraform init containers

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->