### PR TITLE
Skip report-test-results for dependabot pull_request events

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -995,7 +995,12 @@ jobs:
             --yes --verbose
 
   report-test-results:
-    if: always() && github.repository == 'radius-project/radius'
+    # Skip for dependabot pull_request events (secrets not available) - uses pull_request_target instead
+    # Skip for fork PRs (secrets not available)
+    if: |
+      always() &&
+      github.repository == 'radius-project/radius' &&
+      !(github.event_name == 'pull_request' && github.actor == 'dependabot[bot]')
     name: Report test results
     needs: [setup, build, tests]
     runs-on: ubuntu-24.04


### PR DESCRIPTION
# Description

This PR fixes an issue where the `report-test-results` job fails for dependabot PRs triggered via `pull_request` event. Secrets are not available in `pull_request` events from dependabot, so the GitHub App token creation fails.

## Problem

Dependabot PRs trigger BOTH:
- `pull_request` event - runs in PR context (no secrets)
- `pull_request_target` event - runs in base repo context (has secrets)

The `report-test-results` job was running for both events and failing on `pull_request` because secrets aren't available.

## Solution

Added condition to skip `report-test-results` job for dependabot PRs via `pull_request` event. The job will still run via `pull_request_target` where secrets are available.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->
