### PR TITLE
Fix operator precedence in approval-gate environment expression

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -100,10 +100,12 @@ jobs:
     timeout-minutes: 5
     # Only applies to pull_request_target events
     if: github.event_name == 'pull_request_target'
-    # Use environment with required reviewers for external contributors
+    # Use environment with required reviewers for external contributors.
+    # Trusted users (dependabot, org members) get empty environment (no approval needed).
+    # External contributors get 'external-contributor-approval' environment (requires approval).
     environment: ${{
-      github.actor == 'dependabot[bot]' ||
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+      (github.actor == 'dependabot[bot]' ||
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))
       && '' || 'external-contributor-approval' }}
     permissions: {}
     steps:


### PR DESCRIPTION
# Description

Fixes a bug introduced in PR #11169 where org members (like PR #11139 from @brooke-hamilton) were incorrectly being blocked by the approval gate.

The `&&` operator has higher precedence than `||` in GitHub expressions. Without parentheses, the expression was incorrectly evaluating to `'external-contributor-approval'` for ALL PRs, blocking org members.

Added parentheses to group the trusted user check so it correctly returns empty string (no approval needed) for dependabot and org members.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
