### PR TITLE
feat: Connect Terraform and Bicep Settings to the Environment resource

### DIFF
--- a/deploy/manifest/built-in-providers/dev/radius_core.yaml
+++ b/deploy/manifest/built-in-providers/dev/radius_core.yaml
@@ -14,3 +14,12 @@ types:
     apiVersions:
       "2025-08-01-preview":
         schema: {}
+  bicepSettings:
+    apiVersions:
+      "2025-08-01-preview":
+        schema: {}
+  terraformSettings:
+    apiVersions:
+      "2025-08-01-preview":
+        schema: {}
+  

--- a/deploy/manifest/built-in-providers/self-hosted/radius_core.yaml
+++ b/deploy/manifest/built-in-providers/self-hosted/radius_core.yaml
@@ -14,3 +14,11 @@ types:
     apiVersions:
       "2025-08-01-preview":
         schema: {}
+  bicepSettings:
+    apiVersions:
+      "2025-08-01-preview":
+        schema: {}
+  terraformSettings:
+    apiVersions:
+      "2025-08-01-preview":
+        schema: {}

--- a/hack/bicep-types-radius/generated/index.json
+++ b/hack/bicep-types-radius/generated/index.json
@@ -49,16 +49,16 @@
       "$ref": "radius/radius.core/2025-08-01-preview/types.json#/44"
     },
     "Radius.Core/bicepSettings@2025-08-01-preview": {
-      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/66"
+      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/67"
     },
     "Radius.Core/environments@2025-08-01-preview": {
-      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/89"
+      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/90"
     },
     "Radius.Core/recipePacks@2025-08-01-preview": {
-      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/111"
+      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/112"
     },
     "Radius.Core/terraformSettings@2025-08-01-preview": {
-      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/147"
+      "$ref": "radius/radius.core/2025-08-01-preview/types.json#/149"
     }
   },
   "resourceFunctions": {},

--- a/hack/bicep-types-radius/generated/radius/radius.core/2025-08-01-preview/types.json
+++ b/hack/bicep-types-radius/generated/radius/radius.core/2025-08-01-preview/types.json
@@ -588,7 +588,7 @@
       },
       "tags": {
         "type": {
-          "$ref": "#/65"
+          "$ref": "#/66"
         },
         "flags": 0,
         "description": "Resource tags."
@@ -626,6 +626,13 @@
         },
         "flags": 0,
         "description": "Authentication configuration for Bicep registries."
+      },
+      "referencedBy": {
+        "type": {
+          "$ref": "#/65"
+        },
+        "flags": 2,
+        "description": "List of environment resource IDs that reference this settings resource."
       }
     }
   },
@@ -826,6 +833,12 @@
     }
   },
   {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
+  },
+  {
     "$type": "ObjectType",
     "name": "TrackedResourceTags",
     "properties": {},
@@ -871,28 +884,28 @@
       },
       "type": {
         "type": {
-          "$ref": "#/67"
+          "$ref": "#/68"
         },
         "flags": 10,
         "description": "The resource type"
       },
       "apiVersion": {
         "type": {
-          "$ref": "#/68"
+          "$ref": "#/69"
         },
         "flags": 10,
         "description": "The resource api version"
       },
       "properties": {
         "type": {
-          "$ref": "#/70"
+          "$ref": "#/71"
         },
         "flags": 1,
         "description": "Environment properties"
       },
       "tags": {
         "type": {
-          "$ref": "#/88"
+          "$ref": "#/89"
         },
         "flags": 0,
         "description": "Resource tags."
@@ -919,7 +932,7 @@
     "properties": {
       "provisioningState": {
         "type": {
-          "$ref": "#/79"
+          "$ref": "#/80"
         },
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
@@ -940,21 +953,21 @@
       },
       "recipePacks": {
         "type": {
-          "$ref": "#/80"
+          "$ref": "#/81"
         },
         "flags": 0,
         "description": "List of Recipe Pack resource IDs linked to this environment."
       },
       "recipeParameters": {
         "type": {
-          "$ref": "#/83"
+          "$ref": "#/84"
         },
         "flags": 0,
         "description": "Recipe specific parameters that apply to all resources of a given type in this environment."
       },
       "providers": {
         "type": {
-          "$ref": "#/84"
+          "$ref": "#/85"
         },
         "flags": 0
       },
@@ -1003,9 +1016,6 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/71"
-      },
-      {
         "$ref": "#/72"
       },
       {
@@ -1025,6 +1035,9 @@
       },
       {
         "$ref": "#/78"
+      },
+      {
+        "$ref": "#/79"
       }
     ]
   },
@@ -1042,7 +1055,7 @@
     "name": "RecipeParameterValue",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/81"
+      "$ref": "#/82"
     }
   },
   {
@@ -1050,7 +1063,7 @@
     "name": "EnvironmentPropertiesRecipeParameters",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/82"
+      "$ref": "#/83"
     }
   },
   {
@@ -1059,20 +1072,20 @@
     "properties": {
       "azure": {
         "type": {
-          "$ref": "#/85"
+          "$ref": "#/86"
         },
         "flags": 0,
         "description": "The Azure cloud provider definition."
       },
       "kubernetes": {
         "type": {
-          "$ref": "#/86"
+          "$ref": "#/87"
         },
         "flags": 0
       },
       "aws": {
         "type": {
-          "$ref": "#/87"
+          "$ref": "#/88"
         },
         "flags": 0,
         "description": "The AWS cloud provider definition."
@@ -1151,7 +1164,7 @@
     "$type": "ResourceType",
     "name": "Radius.Core/environments@2025-08-01-preview",
     "body": {
-      "$ref": "#/69"
+      "$ref": "#/70"
     },
     "readableScopes": 0,
     "writableScopes": 0,
@@ -1185,28 +1198,28 @@
       },
       "type": {
         "type": {
-          "$ref": "#/90"
+          "$ref": "#/91"
         },
         "flags": 10,
         "description": "The resource type"
       },
       "apiVersion": {
         "type": {
-          "$ref": "#/91"
+          "$ref": "#/92"
         },
         "flags": 10,
         "description": "The resource api version"
       },
       "properties": {
         "type": {
-          "$ref": "#/93"
+          "$ref": "#/94"
         },
         "flags": 1,
         "description": "Recipe Pack properties"
       },
       "tags": {
         "type": {
-          "$ref": "#/110"
+          "$ref": "#/111"
         },
         "flags": 0,
         "description": "Resource tags."
@@ -1233,21 +1246,21 @@
     "properties": {
       "provisioningState": {
         "type": {
-          "$ref": "#/102"
+          "$ref": "#/103"
         },
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
       },
       "referencedBy": {
         "type": {
-          "$ref": "#/103"
+          "$ref": "#/104"
         },
         "flags": 2,
         "description": "List of environment IDs that reference this recipe pack"
       },
       "recipes": {
         "type": {
-          "$ref": "#/109"
+          "$ref": "#/110"
         },
         "flags": 1,
         "description": "Map of resource types to their recipe configurations"
@@ -1290,9 +1303,6 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/94"
-      },
-      {
         "$ref": "#/95"
       },
       {
@@ -1312,6 +1322,9 @@
       },
       {
         "$ref": "#/101"
+      },
+      {
+        "$ref": "#/102"
       }
     ]
   },
@@ -1327,7 +1340,7 @@
     "properties": {
       "recipeKind": {
         "type": {
-          "$ref": "#/107"
+          "$ref": "#/108"
         },
         "flags": 1,
         "description": "The type of recipe"
@@ -1348,7 +1361,7 @@
       },
       "parameters": {
         "type": {
-          "$ref": "#/108"
+          "$ref": "#/109"
         },
         "flags": 0,
         "description": "Parameters to pass to the recipe"
@@ -1367,10 +1380,10 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/105"
+        "$ref": "#/106"
       },
       {
-        "$ref": "#/106"
+        "$ref": "#/107"
       }
     ]
   },
@@ -1379,7 +1392,7 @@
     "name": "RecipeDefinitionParameters",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/81"
+      "$ref": "#/82"
     }
   },
   {
@@ -1387,7 +1400,7 @@
     "name": "RecipePackPropertiesRecipes",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/104"
+      "$ref": "#/105"
     }
   },
   {
@@ -1402,7 +1415,7 @@
     "$type": "ResourceType",
     "name": "Radius.Core/recipePacks@2025-08-01-preview",
     "body": {
-      "$ref": "#/92"
+      "$ref": "#/93"
     },
     "readableScopes": 0,
     "writableScopes": 0,
@@ -1436,28 +1449,28 @@
       },
       "type": {
         "type": {
-          "$ref": "#/112"
+          "$ref": "#/113"
         },
         "flags": 10,
         "description": "The resource type"
       },
       "apiVersion": {
         "type": {
-          "$ref": "#/113"
+          "$ref": "#/114"
         },
         "flags": 10,
         "description": "The resource api version"
       },
       "properties": {
         "type": {
-          "$ref": "#/115"
+          "$ref": "#/116"
         },
         "flags": 1,
         "description": "Terraform settings properties."
       },
       "tags": {
         "type": {
-          "$ref": "#/146"
+          "$ref": "#/148"
         },
         "flags": 0,
         "description": "Resource tags."
@@ -1484,38 +1497,45 @@
     "properties": {
       "provisioningState": {
         "type": {
-          "$ref": "#/124"
+          "$ref": "#/125"
         },
         "flags": 2,
         "description": "Provisioning state of the resource at the time the operation was called"
       },
       "terraformrc": {
         "type": {
-          "$ref": "#/125"
+          "$ref": "#/126"
         },
         "flags": 0,
         "description": "Terraform CLI configuration matching the terraformrc file."
       },
       "backend": {
         "type": {
-          "$ref": "#/135"
+          "$ref": "#/136"
         },
         "flags": 0,
         "description": "Terraform backend configuration matching the terraform block."
       },
       "env": {
         "type": {
-          "$ref": "#/137"
+          "$ref": "#/138"
         },
         "flags": 0,
         "description": "Environment variables injected into the Terraform process."
       },
       "logging": {
         "type": {
-          "$ref": "#/138"
+          "$ref": "#/139"
         },
         "flags": 0,
         "description": "Logging options for Terraform executions."
+      },
+      "referencedBy": {
+        "type": {
+          "$ref": "#/147"
+        },
+        "flags": 2,
+        "description": "List of environment resource IDs that reference this settings resource."
       }
     }
   },
@@ -1555,9 +1575,6 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/116"
-      },
-      {
         "$ref": "#/117"
       },
       {
@@ -1577,6 +1594,9 @@
       },
       {
         "$ref": "#/123"
+      },
+      {
+        "$ref": "#/124"
       }
     ]
   },
@@ -1586,14 +1606,14 @@
     "properties": {
       "providerInstallation": {
         "type": {
-          "$ref": "#/126"
+          "$ref": "#/127"
         },
         "flags": 0,
         "description": "Provider installation options for Terraform."
       },
       "credentials": {
         "type": {
-          "$ref": "#/134"
+          "$ref": "#/135"
         },
         "flags": 0,
         "description": "Credentials keyed by registry or module source hostname."
@@ -1606,14 +1626,14 @@
     "properties": {
       "networkMirror": {
         "type": {
-          "$ref": "#/127"
+          "$ref": "#/128"
         },
         "flags": 0,
         "description": "Network mirror configuration for Terraform providers."
       },
       "direct": {
         "type": {
-          "$ref": "#/130"
+          "$ref": "#/131"
         },
         "flags": 0,
         "description": "Direct installation configuration for Terraform providers."
@@ -1633,14 +1653,14 @@
       },
       "include": {
         "type": {
-          "$ref": "#/128"
+          "$ref": "#/129"
         },
         "flags": 0,
         "description": "Provider addresses included in this mirror."
       },
       "exclude": {
         "type": {
-          "$ref": "#/129"
+          "$ref": "#/130"
         },
         "flags": 0,
         "description": "Provider addresses excluded from this mirror."
@@ -1665,14 +1685,14 @@
     "properties": {
       "include": {
         "type": {
-          "$ref": "#/131"
+          "$ref": "#/132"
         },
         "flags": 0,
         "description": "Provider addresses included when falling back to direct installation."
       },
       "exclude": {
         "type": {
-          "$ref": "#/132"
+          "$ref": "#/133"
         },
         "flags": 0,
         "description": "Provider addresses excluded from direct installation."
@@ -1709,7 +1729,7 @@
     "name": "TerraformCliConfigurationCredentials",
     "properties": {},
     "additionalProperties": {
-      "$ref": "#/133"
+      "$ref": "#/134"
     }
   },
   {
@@ -1725,7 +1745,7 @@
       },
       "config": {
         "type": {
-          "$ref": "#/136"
+          "$ref": "#/137"
         },
         "flags": 0,
         "description": "Backend-specific configuration values."
@@ -1754,7 +1774,7 @@
     "properties": {
       "level": {
         "type": {
-          "$ref": "#/145"
+          "$ref": "#/146"
         },
         "flags": 0,
         "description": "Terraform log verbosity levels."
@@ -1796,9 +1816,6 @@
     "$type": "UnionType",
     "elements": [
       {
-        "$ref": "#/139"
-      },
-      {
         "$ref": "#/140"
       },
       {
@@ -1812,8 +1829,17 @@
       },
       {
         "$ref": "#/144"
+      },
+      {
+        "$ref": "#/145"
       }
     ]
+  },
+  {
+    "$type": "ArrayType",
+    "itemType": {
+      "$ref": "#/0"
+    }
   },
   {
     "$type": "ObjectType",
@@ -1827,7 +1853,7 @@
     "$type": "ResourceType",
     "name": "Radius.Core/terraformSettings@2025-08-01-preview",
     "body": {
-      "$ref": "#/114"
+      "$ref": "#/115"
     },
     "readableScopes": 0,
     "writableScopes": 0,

--- a/pkg/corerp/api/v20250801preview/bicepsettings_conversion.go
+++ b/pkg/corerp/api/v20250801preview/bicepsettings_conversion.go
@@ -47,6 +47,11 @@ func (src *BicepSettingsResource) ConvertTo() (v1.DataModelInterface, error) {
 		converted.Properties.Authentication = toBicepAuthenticationConfigurationDataModel(src.Properties.Authentication)
 	}
 
+	// Convert ReferencedBy
+	if src.Properties.ReferencedBy != nil {
+		converted.Properties.ReferencedBy = to.StringArray(src.Properties.ReferencedBy)
+	}
+
 	return converted, nil
 }
 
@@ -70,6 +75,11 @@ func (dst *BicepSettingsResource) ConvertFrom(src v1.DataModelInterface) error {
 	// Convert Authentication
 	if bs.Properties.Authentication != nil {
 		dst.Properties.Authentication = fromBicepAuthenticationConfigurationDataModel(bs.Properties.Authentication)
+	}
+
+	// Convert ReferencedBy
+	if len(bs.Properties.ReferencedBy) > 0 {
+		dst.Properties.ReferencedBy = to.ArrayofStringPtrs(bs.Properties.ReferencedBy)
 	}
 
 	return nil

--- a/pkg/corerp/api/v20250801preview/fake/zz_generated_bicepsettings_server.go
+++ b/pkg/corerp/api/v20250801preview/fake/zz_generated_bicepsettings_server.go
@@ -22,15 +22,15 @@ import (
 type BicepSettingsServer struct {
 	// CreateOrUpdate is the fake for method BicepSettingsClient.CreateOrUpdate
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusCreated
-	CreateOrUpdate func(ctx context.Context, bicepSettingsName string, resource v20250801preview.BicepSettingsResource, options *v20250801preview.BicepSettingsClientCreateOrUpdateOptions) (resp azfake.Responder[v20250801preview.BicepSettingsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder)
+	CreateOrUpdate func(ctx context.Context, bicepSettingName string, resource v20250801preview.BicepSettingsResource, options *v20250801preview.BicepSettingsClientCreateOrUpdateOptions) (resp azfake.Responder[v20250801preview.BicepSettingsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder)
 
 	// Delete is the fake for method BicepSettingsClient.Delete
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusNoContent
-	Delete func(ctx context.Context, bicepSettingsName string, options *v20250801preview.BicepSettingsClientDeleteOptions) (resp azfake.Responder[v20250801preview.BicepSettingsClientDeleteResponse], errResp azfake.ErrorResponder)
+	Delete func(ctx context.Context, bicepSettingName string, options *v20250801preview.BicepSettingsClientDeleteOptions) (resp azfake.Responder[v20250801preview.BicepSettingsClientDeleteResponse], errResp azfake.ErrorResponder)
 
 	// Get is the fake for method BicepSettingsClient.Get
 	// HTTP status codes to indicate success: http.StatusOK
-	Get func(ctx context.Context, bicepSettingsName string, options *v20250801preview.BicepSettingsClientGetOptions) (resp azfake.Responder[v20250801preview.BicepSettingsClientGetResponse], errResp azfake.ErrorResponder)
+	Get func(ctx context.Context, bicepSettingName string, options *v20250801preview.BicepSettingsClientGetOptions) (resp azfake.Responder[v20250801preview.BicepSettingsClientGetResponse], errResp azfake.ErrorResponder)
 
 	// NewListByScopePager is the fake for method BicepSettingsClient.NewListByScopePager
 	// HTTP status codes to indicate success: http.StatusOK
@@ -38,7 +38,7 @@ type BicepSettingsServer struct {
 
 	// Update is the fake for method BicepSettingsClient.Update
 	// HTTP status codes to indicate success: http.StatusOK
-	Update func(ctx context.Context, bicepSettingsName string, properties v20250801preview.BicepSettingsResourceUpdate, options *v20250801preview.BicepSettingsClientUpdateOptions) (resp azfake.Responder[v20250801preview.BicepSettingsClientUpdateResponse], errResp azfake.ErrorResponder)
+	Update func(ctx context.Context, bicepSettingName string, properties v20250801preview.BicepSettingsResourceUpdate, options *v20250801preview.BicepSettingsClientUpdateOptions) (resp azfake.Responder[v20250801preview.BicepSettingsClientUpdateResponse], errResp azfake.ErrorResponder)
 }
 
 // NewBicepSettingsServerTransport creates a new instance of BicepSettingsServerTransport with the provided implementation.
@@ -114,7 +114,7 @@ func (b *BicepSettingsServerTransport) dispatchCreateOrUpdate(req *http.Request)
 	if b.srv.CreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method CreateOrUpdate not implemented")}
 	}
-	const regexStr = `/(?P<rootScope>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Radius\.Core/bicepSettings/(?P<bicepSettingsName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
+	const regexStr = `/(?P<rootScope>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Radius\.Core/bicepSettings/(?P<bicepSettingName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 	regex := regexp.MustCompile(regexStr)
 	matches := regex.FindStringSubmatch(req.URL.EscapedPath())
 	if len(matches) < 3 {
@@ -124,11 +124,11 @@ func (b *BicepSettingsServerTransport) dispatchCreateOrUpdate(req *http.Request)
 	if err != nil {
 		return nil, err
 	}
-	bicepSettingsNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("bicepSettingsName")])
+	bicepSettingNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("bicepSettingName")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := b.srv.CreateOrUpdate(req.Context(), bicepSettingsNameParam, body, nil)
+	respr, errRespr := b.srv.CreateOrUpdate(req.Context(), bicepSettingNameParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -147,17 +147,17 @@ func (b *BicepSettingsServerTransport) dispatchDelete(req *http.Request) (*http.
 	if b.srv.Delete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Delete not implemented")}
 	}
-	const regexStr = `/(?P<rootScope>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Radius\.Core/bicepSettings/(?P<bicepSettingsName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
+	const regexStr = `/(?P<rootScope>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Radius\.Core/bicepSettings/(?P<bicepSettingName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 	regex := regexp.MustCompile(regexStr)
 	matches := regex.FindStringSubmatch(req.URL.EscapedPath())
 	if len(matches) < 3 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	bicepSettingsNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("bicepSettingsName")])
+	bicepSettingNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("bicepSettingName")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := b.srv.Delete(req.Context(), bicepSettingsNameParam, nil)
+	respr, errRespr := b.srv.Delete(req.Context(), bicepSettingNameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -176,17 +176,17 @@ func (b *BicepSettingsServerTransport) dispatchGet(req *http.Request) (*http.Res
 	if b.srv.Get == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Get not implemented")}
 	}
-	const regexStr = `/(?P<rootScope>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Radius\.Core/bicepSettings/(?P<bicepSettingsName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
+	const regexStr = `/(?P<rootScope>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Radius\.Core/bicepSettings/(?P<bicepSettingName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 	regex := regexp.MustCompile(regexStr)
 	matches := regex.FindStringSubmatch(req.URL.EscapedPath())
 	if len(matches) < 3 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	bicepSettingsNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("bicepSettingsName")])
+	bicepSettingNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("bicepSettingName")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := b.srv.Get(req.Context(), bicepSettingsNameParam, nil)
+	respr, errRespr := b.srv.Get(req.Context(), bicepSettingNameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -238,7 +238,7 @@ func (b *BicepSettingsServerTransport) dispatchUpdate(req *http.Request) (*http.
 	if b.srv.Update == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Update not implemented")}
 	}
-	const regexStr = `/(?P<rootScope>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Radius\.Core/bicepSettings/(?P<bicepSettingsName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
+	const regexStr = `/(?P<rootScope>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Radius\.Core/bicepSettings/(?P<bicepSettingName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 	regex := regexp.MustCompile(regexStr)
 	matches := regex.FindStringSubmatch(req.URL.EscapedPath())
 	if len(matches) < 3 {
@@ -248,11 +248,11 @@ func (b *BicepSettingsServerTransport) dispatchUpdate(req *http.Request) (*http.
 	if err != nil {
 		return nil, err
 	}
-	bicepSettingsNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("bicepSettingsName")])
+	bicepSettingNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("bicepSettingName")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := b.srv.Update(req.Context(), bicepSettingsNameParam, body, nil)
+	respr, errRespr := b.srv.Update(req.Context(), bicepSettingNameParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/pkg/corerp/api/v20250801preview/fake/zz_generated_terraformsettings_server.go
+++ b/pkg/corerp/api/v20250801preview/fake/zz_generated_terraformsettings_server.go
@@ -22,15 +22,15 @@ import (
 type TerraformSettingsServer struct {
 	// CreateOrUpdate is the fake for method TerraformSettingsClient.CreateOrUpdate
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusCreated
-	CreateOrUpdate func(ctx context.Context, terraformSettingsName string, resource v20250801preview.TerraformSettingsResource, options *v20250801preview.TerraformSettingsClientCreateOrUpdateOptions) (resp azfake.Responder[v20250801preview.TerraformSettingsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder)
+	CreateOrUpdate func(ctx context.Context, terraformSettingName string, resource v20250801preview.TerraformSettingsResource, options *v20250801preview.TerraformSettingsClientCreateOrUpdateOptions) (resp azfake.Responder[v20250801preview.TerraformSettingsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder)
 
 	// Delete is the fake for method TerraformSettingsClient.Delete
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusNoContent
-	Delete func(ctx context.Context, terraformSettingsName string, options *v20250801preview.TerraformSettingsClientDeleteOptions) (resp azfake.Responder[v20250801preview.TerraformSettingsClientDeleteResponse], errResp azfake.ErrorResponder)
+	Delete func(ctx context.Context, terraformSettingName string, options *v20250801preview.TerraformSettingsClientDeleteOptions) (resp azfake.Responder[v20250801preview.TerraformSettingsClientDeleteResponse], errResp azfake.ErrorResponder)
 
 	// Get is the fake for method TerraformSettingsClient.Get
 	// HTTP status codes to indicate success: http.StatusOK
-	Get func(ctx context.Context, terraformSettingsName string, options *v20250801preview.TerraformSettingsClientGetOptions) (resp azfake.Responder[v20250801preview.TerraformSettingsClientGetResponse], errResp azfake.ErrorResponder)
+	Get func(ctx context.Context, terraformSettingName string, options *v20250801preview.TerraformSettingsClientGetOptions) (resp azfake.Responder[v20250801preview.TerraformSettingsClientGetResponse], errResp azfake.ErrorResponder)
 
 	// NewListByScopePager is the fake for method TerraformSettingsClient.NewListByScopePager
 	// HTTP status codes to indicate success: http.StatusOK
@@ -38,7 +38,7 @@ type TerraformSettingsServer struct {
 
 	// Update is the fake for method TerraformSettingsClient.Update
 	// HTTP status codes to indicate success: http.StatusOK
-	Update func(ctx context.Context, terraformSettingsName string, properties v20250801preview.TerraformSettingsResourceUpdate, options *v20250801preview.TerraformSettingsClientUpdateOptions) (resp azfake.Responder[v20250801preview.TerraformSettingsClientUpdateResponse], errResp azfake.ErrorResponder)
+	Update func(ctx context.Context, terraformSettingName string, properties v20250801preview.TerraformSettingsResourceUpdate, options *v20250801preview.TerraformSettingsClientUpdateOptions) (resp azfake.Responder[v20250801preview.TerraformSettingsClientUpdateResponse], errResp azfake.ErrorResponder)
 }
 
 // NewTerraformSettingsServerTransport creates a new instance of TerraformSettingsServerTransport with the provided implementation.
@@ -114,7 +114,7 @@ func (t *TerraformSettingsServerTransport) dispatchCreateOrUpdate(req *http.Requ
 	if t.srv.CreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method CreateOrUpdate not implemented")}
 	}
-	const regexStr = `/(?P<rootScope>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Radius\.Core/terraformSettings/(?P<terraformSettingsName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
+	const regexStr = `/(?P<rootScope>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Radius\.Core/terraformSettings/(?P<terraformSettingName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 	regex := regexp.MustCompile(regexStr)
 	matches := regex.FindStringSubmatch(req.URL.EscapedPath())
 	if len(matches) < 3 {
@@ -124,11 +124,11 @@ func (t *TerraformSettingsServerTransport) dispatchCreateOrUpdate(req *http.Requ
 	if err != nil {
 		return nil, err
 	}
-	terraformSettingsNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("terraformSettingsName")])
+	terraformSettingNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("terraformSettingName")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := t.srv.CreateOrUpdate(req.Context(), terraformSettingsNameParam, body, nil)
+	respr, errRespr := t.srv.CreateOrUpdate(req.Context(), terraformSettingNameParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -147,17 +147,17 @@ func (t *TerraformSettingsServerTransport) dispatchDelete(req *http.Request) (*h
 	if t.srv.Delete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Delete not implemented")}
 	}
-	const regexStr = `/(?P<rootScope>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Radius\.Core/terraformSettings/(?P<terraformSettingsName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
+	const regexStr = `/(?P<rootScope>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Radius\.Core/terraformSettings/(?P<terraformSettingName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 	regex := regexp.MustCompile(regexStr)
 	matches := regex.FindStringSubmatch(req.URL.EscapedPath())
 	if len(matches) < 3 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	terraformSettingsNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("terraformSettingsName")])
+	terraformSettingNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("terraformSettingName")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := t.srv.Delete(req.Context(), terraformSettingsNameParam, nil)
+	respr, errRespr := t.srv.Delete(req.Context(), terraformSettingNameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -176,17 +176,17 @@ func (t *TerraformSettingsServerTransport) dispatchGet(req *http.Request) (*http
 	if t.srv.Get == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Get not implemented")}
 	}
-	const regexStr = `/(?P<rootScope>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Radius\.Core/terraformSettings/(?P<terraformSettingsName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
+	const regexStr = `/(?P<rootScope>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Radius\.Core/terraformSettings/(?P<terraformSettingName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 	regex := regexp.MustCompile(regexStr)
 	matches := regex.FindStringSubmatch(req.URL.EscapedPath())
 	if len(matches) < 3 {
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
-	terraformSettingsNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("terraformSettingsName")])
+	terraformSettingNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("terraformSettingName")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := t.srv.Get(req.Context(), terraformSettingsNameParam, nil)
+	respr, errRespr := t.srv.Get(req.Context(), terraformSettingNameParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -238,7 +238,7 @@ func (t *TerraformSettingsServerTransport) dispatchUpdate(req *http.Request) (*h
 	if t.srv.Update == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Update not implemented")}
 	}
-	const regexStr = `/(?P<rootScope>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Radius\.Core/terraformSettings/(?P<terraformSettingsName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
+	const regexStr = `/(?P<rootScope>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Radius\.Core/terraformSettings/(?P<terraformSettingName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 	regex := regexp.MustCompile(regexStr)
 	matches := regex.FindStringSubmatch(req.URL.EscapedPath())
 	if len(matches) < 3 {
@@ -248,11 +248,11 @@ func (t *TerraformSettingsServerTransport) dispatchUpdate(req *http.Request) (*h
 	if err != nil {
 		return nil, err
 	}
-	terraformSettingsNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("terraformSettingsName")])
+	terraformSettingNameParam, err := url.PathUnescape(matches[regex.SubexpIndex("terraformSettingName")])
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := t.srv.Update(req.Context(), terraformSettingsNameParam, body, nil)
+	respr, errRespr := t.srv.Update(req.Context(), terraformSettingNameParam, body, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/pkg/corerp/api/v20250801preview/terraformsettings_conversion.go
+++ b/pkg/corerp/api/v20250801preview/terraformsettings_conversion.go
@@ -62,6 +62,11 @@ func (src *TerraformSettingsResource) ConvertTo() (v1.DataModelInterface, error)
 		converted.Properties.Logging = toTerraformLoggingConfigurationDataModel(src.Properties.Logging)
 	}
 
+	// Convert ReferencedBy
+	if src.Properties.ReferencedBy != nil {
+		converted.Properties.ReferencedBy = to.StringArray(src.Properties.ReferencedBy)
+	}
+
 	return converted, nil
 }
 
@@ -100,6 +105,11 @@ func (dst *TerraformSettingsResource) ConvertFrom(src v1.DataModelInterface) err
 	// Convert Logging
 	if ts.Properties.Logging != nil {
 		dst.Properties.Logging = fromTerraformLoggingConfigurationDataModel(ts.Properties.Logging)
+	}
+
+	// Convert ReferencedBy
+	if len(ts.Properties.ReferencedBy) > 0 {
+		dst.Properties.ReferencedBy = to.ArrayofStringPtrs(ts.Properties.ReferencedBy)
 	}
 
 	return nil

--- a/pkg/corerp/api/v20250801preview/zz_generated_bicepsettings_client.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_bicepsettings_client.go
@@ -45,17 +45,17 @@ func NewBicepSettingsClient(rootScope string, credential azcore.TokenCredential,
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2025-08-01-preview
-//   - bicepSettingsName - Bicep settings resource name.
+//   - bicepSettingName - Bicep settings resource name.
 //   - resource - Resource create parameters.
 //   - options - BicepSettingsClientCreateOrUpdateOptions contains the optional parameters for the BicepSettingsClient.CreateOrUpdate
 //     method.
-func (client *BicepSettingsClient) CreateOrUpdate(ctx context.Context, bicepSettingsName string, resource BicepSettingsResource, options *BicepSettingsClientCreateOrUpdateOptions) (BicepSettingsClientCreateOrUpdateResponse, error) {
+func (client *BicepSettingsClient) CreateOrUpdate(ctx context.Context, bicepSettingName string, resource BicepSettingsResource, options *BicepSettingsClientCreateOrUpdateOptions) (BicepSettingsClientCreateOrUpdateResponse, error) {
 	var err error
 	const operationName = "BicepSettingsClient.CreateOrUpdate"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.createOrUpdateCreateRequest(ctx, bicepSettingsName, resource, options)
+	req, err := client.createOrUpdateCreateRequest(ctx, bicepSettingName, resource, options)
 	if err != nil {
 		return BicepSettingsClientCreateOrUpdateResponse{}, err
 	}
@@ -72,13 +72,13 @@ func (client *BicepSettingsClient) CreateOrUpdate(ctx context.Context, bicepSett
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *BicepSettingsClient) createOrUpdateCreateRequest(ctx context.Context, bicepSettingsName string, resource BicepSettingsResource, _ *BicepSettingsClientCreateOrUpdateOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Radius.Core/bicepSettings/{bicepSettingsName}"
+func (client *BicepSettingsClient) createOrUpdateCreateRequest(ctx context.Context, bicepSettingName string, resource BicepSettingsResource, _ *BicepSettingsClientCreateOrUpdateOptions) (*policy.Request, error) {
+	urlPath := "/{rootScope}/providers/Radius.Core/bicepSettings/{bicepSettingName}"
 	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
-	if bicepSettingsName == "" {
-		return nil, errors.New("parameter bicepSettingsName cannot be empty")
+	if bicepSettingName == "" {
+		return nil, errors.New("parameter bicepSettingName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{bicepSettingsName}", url.PathEscape(bicepSettingsName))
+	urlPath = strings.ReplaceAll(urlPath, "{bicepSettingName}", url.PathEscape(bicepSettingName))
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
@@ -106,15 +106,15 @@ func (client *BicepSettingsClient) createOrUpdateHandleResponse(resp *http.Respo
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2025-08-01-preview
-//   - bicepSettingsName - Bicep settings resource name.
+//   - bicepSettingName - Bicep settings resource name.
 //   - options - BicepSettingsClientDeleteOptions contains the optional parameters for the BicepSettingsClient.Delete method.
-func (client *BicepSettingsClient) Delete(ctx context.Context, bicepSettingsName string, options *BicepSettingsClientDeleteOptions) (BicepSettingsClientDeleteResponse, error) {
+func (client *BicepSettingsClient) Delete(ctx context.Context, bicepSettingName string, options *BicepSettingsClientDeleteOptions) (BicepSettingsClientDeleteResponse, error) {
 	var err error
 	const operationName = "BicepSettingsClient.Delete"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.deleteCreateRequest(ctx, bicepSettingsName, options)
+	req, err := client.deleteCreateRequest(ctx, bicepSettingName, options)
 	if err != nil {
 		return BicepSettingsClientDeleteResponse{}, err
 	}
@@ -130,13 +130,13 @@ func (client *BicepSettingsClient) Delete(ctx context.Context, bicepSettingsName
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *BicepSettingsClient) deleteCreateRequest(ctx context.Context, bicepSettingsName string, _ *BicepSettingsClientDeleteOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Radius.Core/bicepSettings/{bicepSettingsName}"
+func (client *BicepSettingsClient) deleteCreateRequest(ctx context.Context, bicepSettingName string, _ *BicepSettingsClientDeleteOptions) (*policy.Request, error) {
+	urlPath := "/{rootScope}/providers/Radius.Core/bicepSettings/{bicepSettingName}"
 	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
-	if bicepSettingsName == "" {
-		return nil, errors.New("parameter bicepSettingsName cannot be empty")
+	if bicepSettingName == "" {
+		return nil, errors.New("parameter bicepSettingName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{bicepSettingsName}", url.PathEscape(bicepSettingsName))
+	urlPath = strings.ReplaceAll(urlPath, "{bicepSettingName}", url.PathEscape(bicepSettingName))
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
@@ -152,15 +152,15 @@ func (client *BicepSettingsClient) deleteCreateRequest(ctx context.Context, bice
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2025-08-01-preview
-//   - bicepSettingsName - Bicep settings resource name.
+//   - bicepSettingName - Bicep settings resource name.
 //   - options - BicepSettingsClientGetOptions contains the optional parameters for the BicepSettingsClient.Get method.
-func (client *BicepSettingsClient) Get(ctx context.Context, bicepSettingsName string, options *BicepSettingsClientGetOptions) (BicepSettingsClientGetResponse, error) {
+func (client *BicepSettingsClient) Get(ctx context.Context, bicepSettingName string, options *BicepSettingsClientGetOptions) (BicepSettingsClientGetResponse, error) {
 	var err error
 	const operationName = "BicepSettingsClient.Get"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.getCreateRequest(ctx, bicepSettingsName, options)
+	req, err := client.getCreateRequest(ctx, bicepSettingName, options)
 	if err != nil {
 		return BicepSettingsClientGetResponse{}, err
 	}
@@ -177,13 +177,13 @@ func (client *BicepSettingsClient) Get(ctx context.Context, bicepSettingsName st
 }
 
 // getCreateRequest creates the Get request.
-func (client *BicepSettingsClient) getCreateRequest(ctx context.Context, bicepSettingsName string, _ *BicepSettingsClientGetOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Radius.Core/bicepSettings/{bicepSettingsName}"
+func (client *BicepSettingsClient) getCreateRequest(ctx context.Context, bicepSettingName string, _ *BicepSettingsClientGetOptions) (*policy.Request, error) {
+	urlPath := "/{rootScope}/providers/Radius.Core/bicepSettings/{bicepSettingName}"
 	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
-	if bicepSettingsName == "" {
-		return nil, errors.New("parameter bicepSettingsName cannot be empty")
+	if bicepSettingName == "" {
+		return nil, errors.New("parameter bicepSettingName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{bicepSettingsName}", url.PathEscape(bicepSettingsName))
+	urlPath = strings.ReplaceAll(urlPath, "{bicepSettingName}", url.PathEscape(bicepSettingName))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
@@ -260,16 +260,16 @@ func (client *BicepSettingsClient) listByScopeHandleResponse(resp *http.Response
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2025-08-01-preview
-//   - bicepSettingsName - Bicep settings resource name.
+//   - bicepSettingName - Bicep settings resource name.
 //   - properties - The resource properties to be updated.
 //   - options - BicepSettingsClientUpdateOptions contains the optional parameters for the BicepSettingsClient.Update method.
-func (client *BicepSettingsClient) Update(ctx context.Context, bicepSettingsName string, properties BicepSettingsResourceUpdate, options *BicepSettingsClientUpdateOptions) (BicepSettingsClientUpdateResponse, error) {
+func (client *BicepSettingsClient) Update(ctx context.Context, bicepSettingName string, properties BicepSettingsResourceUpdate, options *BicepSettingsClientUpdateOptions) (BicepSettingsClientUpdateResponse, error) {
 	var err error
 	const operationName = "BicepSettingsClient.Update"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.updateCreateRequest(ctx, bicepSettingsName, properties, options)
+	req, err := client.updateCreateRequest(ctx, bicepSettingName, properties, options)
 	if err != nil {
 		return BicepSettingsClientUpdateResponse{}, err
 	}
@@ -286,13 +286,13 @@ func (client *BicepSettingsClient) Update(ctx context.Context, bicepSettingsName
 }
 
 // updateCreateRequest creates the Update request.
-func (client *BicepSettingsClient) updateCreateRequest(ctx context.Context, bicepSettingsName string, properties BicepSettingsResourceUpdate, _ *BicepSettingsClientUpdateOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Radius.Core/bicepSettings/{bicepSettingsName}"
+func (client *BicepSettingsClient) updateCreateRequest(ctx context.Context, bicepSettingName string, properties BicepSettingsResourceUpdate, _ *BicepSettingsClientUpdateOptions) (*policy.Request, error) {
+	urlPath := "/{rootScope}/providers/Radius.Core/bicepSettings/{bicepSettingName}"
 	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
-	if bicepSettingsName == "" {
-		return nil, errors.New("parameter bicepSettingsName cannot be empty")
+	if bicepSettingName == "" {
+		return nil, errors.New("parameter bicepSettingName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{bicepSettingsName}", url.PathEscape(bicepSettingsName))
+	urlPath = strings.ReplaceAll(urlPath, "{bicepSettingName}", url.PathEscape(bicepSettingName))
 	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err

--- a/pkg/corerp/api/v20250801preview/zz_generated_models.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_models.go
@@ -216,6 +216,9 @@ type BicepSettingsProperties struct {
 
 	// READ-ONLY; Provisioning state of the asynchronous operation.
 	ProvisioningState *ProvisioningState
+
+	// READ-ONLY; List of environment resource IDs that reference this settings resource.
+	ReferencedBy []*string
 }
 
 // BicepSettingsResource - Bicep settings resource.
@@ -760,6 +763,9 @@ type TerraformSettingsProperties struct {
 
 	// READ-ONLY; Provisioning state of the asynchronous operation.
 	ProvisioningState *ProvisioningState
+
+	// READ-ONLY; List of environment resource IDs that reference this settings resource.
+	ReferencedBy []*string
 }
 
 // TerraformSettingsResource - Terraform settings resource.

--- a/pkg/corerp/api/v20250801preview/zz_generated_models_serde.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_models_serde.go
@@ -557,6 +557,7 @@ func (b BicepSettingsProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "authentication", b.Authentication)
 	populate(objectMap, "provisioningState", b.ProvisioningState)
+	populate(objectMap, "referencedBy", b.ReferencedBy)
 	return json.Marshal(objectMap)
 }
 
@@ -574,6 +575,9 @@ func (b *BicepSettingsProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "provisioningState":
 			err = unpopulate(val, "ProvisioningState", &b.ProvisioningState)
+			delete(rawMsg, key)
+		case "referencedBy":
+			err = unpopulate(val, "ReferencedBy", &b.ReferencedBy)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -1984,6 +1988,7 @@ func (t TerraformSettingsProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "env", t.Env)
 	populate(objectMap, "logging", t.Logging)
 	populate(objectMap, "provisioningState", t.ProvisioningState)
+	populate(objectMap, "referencedBy", t.ReferencedBy)
 	populate(objectMap, "terraformrc", t.Terraformrc)
 	return json.Marshal(objectMap)
 }
@@ -2008,6 +2013,9 @@ func (t *TerraformSettingsProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "provisioningState":
 			err = unpopulate(val, "ProvisioningState", &t.ProvisioningState)
+			delete(rawMsg, key)
+		case "referencedBy":
+			err = unpopulate(val, "ReferencedBy", &t.ReferencedBy)
 			delete(rawMsg, key)
 		case "terraformrc":
 			err = unpopulate(val, "Terraformrc", &t.Terraformrc)

--- a/pkg/corerp/api/v20250801preview/zz_generated_terraformsettings_client.go
+++ b/pkg/corerp/api/v20250801preview/zz_generated_terraformsettings_client.go
@@ -45,17 +45,17 @@ func NewTerraformSettingsClient(rootScope string, credential azcore.TokenCredent
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2025-08-01-preview
-//   - terraformSettingsName - Terraform settings resource name.
+//   - terraformSettingName - Terraform settings resource name.
 //   - resource - Resource create parameters.
 //   - options - TerraformSettingsClientCreateOrUpdateOptions contains the optional parameters for the TerraformSettingsClient.CreateOrUpdate
 //     method.
-func (client *TerraformSettingsClient) CreateOrUpdate(ctx context.Context, terraformSettingsName string, resource TerraformSettingsResource, options *TerraformSettingsClientCreateOrUpdateOptions) (TerraformSettingsClientCreateOrUpdateResponse, error) {
+func (client *TerraformSettingsClient) CreateOrUpdate(ctx context.Context, terraformSettingName string, resource TerraformSettingsResource, options *TerraformSettingsClientCreateOrUpdateOptions) (TerraformSettingsClientCreateOrUpdateResponse, error) {
 	var err error
 	const operationName = "TerraformSettingsClient.CreateOrUpdate"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.createOrUpdateCreateRequest(ctx, terraformSettingsName, resource, options)
+	req, err := client.createOrUpdateCreateRequest(ctx, terraformSettingName, resource, options)
 	if err != nil {
 		return TerraformSettingsClientCreateOrUpdateResponse{}, err
 	}
@@ -72,13 +72,13 @@ func (client *TerraformSettingsClient) CreateOrUpdate(ctx context.Context, terra
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *TerraformSettingsClient) createOrUpdateCreateRequest(ctx context.Context, terraformSettingsName string, resource TerraformSettingsResource, _ *TerraformSettingsClientCreateOrUpdateOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Radius.Core/terraformSettings/{terraformSettingsName}"
+func (client *TerraformSettingsClient) createOrUpdateCreateRequest(ctx context.Context, terraformSettingName string, resource TerraformSettingsResource, _ *TerraformSettingsClientCreateOrUpdateOptions) (*policy.Request, error) {
+	urlPath := "/{rootScope}/providers/Radius.Core/terraformSettings/{terraformSettingName}"
 	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
-	if terraformSettingsName == "" {
-		return nil, errors.New("parameter terraformSettingsName cannot be empty")
+	if terraformSettingName == "" {
+		return nil, errors.New("parameter terraformSettingName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{terraformSettingsName}", url.PathEscape(terraformSettingsName))
+	urlPath = strings.ReplaceAll(urlPath, "{terraformSettingName}", url.PathEscape(terraformSettingName))
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
@@ -106,16 +106,16 @@ func (client *TerraformSettingsClient) createOrUpdateHandleResponse(resp *http.R
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2025-08-01-preview
-//   - terraformSettingsName - Terraform settings resource name.
+//   - terraformSettingName - Terraform settings resource name.
 //   - options - TerraformSettingsClientDeleteOptions contains the optional parameters for the TerraformSettingsClient.Delete
 //     method.
-func (client *TerraformSettingsClient) Delete(ctx context.Context, terraformSettingsName string, options *TerraformSettingsClientDeleteOptions) (TerraformSettingsClientDeleteResponse, error) {
+func (client *TerraformSettingsClient) Delete(ctx context.Context, terraformSettingName string, options *TerraformSettingsClientDeleteOptions) (TerraformSettingsClientDeleteResponse, error) {
 	var err error
 	const operationName = "TerraformSettingsClient.Delete"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.deleteCreateRequest(ctx, terraformSettingsName, options)
+	req, err := client.deleteCreateRequest(ctx, terraformSettingName, options)
 	if err != nil {
 		return TerraformSettingsClientDeleteResponse{}, err
 	}
@@ -131,13 +131,13 @@ func (client *TerraformSettingsClient) Delete(ctx context.Context, terraformSett
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *TerraformSettingsClient) deleteCreateRequest(ctx context.Context, terraformSettingsName string, _ *TerraformSettingsClientDeleteOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Radius.Core/terraformSettings/{terraformSettingsName}"
+func (client *TerraformSettingsClient) deleteCreateRequest(ctx context.Context, terraformSettingName string, _ *TerraformSettingsClientDeleteOptions) (*policy.Request, error) {
+	urlPath := "/{rootScope}/providers/Radius.Core/terraformSettings/{terraformSettingName}"
 	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
-	if terraformSettingsName == "" {
-		return nil, errors.New("parameter terraformSettingsName cannot be empty")
+	if terraformSettingName == "" {
+		return nil, errors.New("parameter terraformSettingName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{terraformSettingsName}", url.PathEscape(terraformSettingsName))
+	urlPath = strings.ReplaceAll(urlPath, "{terraformSettingName}", url.PathEscape(terraformSettingName))
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
@@ -153,15 +153,15 @@ func (client *TerraformSettingsClient) deleteCreateRequest(ctx context.Context, 
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2025-08-01-preview
-//   - terraformSettingsName - Terraform settings resource name.
+//   - terraformSettingName - Terraform settings resource name.
 //   - options - TerraformSettingsClientGetOptions contains the optional parameters for the TerraformSettingsClient.Get method.
-func (client *TerraformSettingsClient) Get(ctx context.Context, terraformSettingsName string, options *TerraformSettingsClientGetOptions) (TerraformSettingsClientGetResponse, error) {
+func (client *TerraformSettingsClient) Get(ctx context.Context, terraformSettingName string, options *TerraformSettingsClientGetOptions) (TerraformSettingsClientGetResponse, error) {
 	var err error
 	const operationName = "TerraformSettingsClient.Get"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.getCreateRequest(ctx, terraformSettingsName, options)
+	req, err := client.getCreateRequest(ctx, terraformSettingName, options)
 	if err != nil {
 		return TerraformSettingsClientGetResponse{}, err
 	}
@@ -178,13 +178,13 @@ func (client *TerraformSettingsClient) Get(ctx context.Context, terraformSetting
 }
 
 // getCreateRequest creates the Get request.
-func (client *TerraformSettingsClient) getCreateRequest(ctx context.Context, terraformSettingsName string, _ *TerraformSettingsClientGetOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Radius.Core/terraformSettings/{terraformSettingsName}"
+func (client *TerraformSettingsClient) getCreateRequest(ctx context.Context, terraformSettingName string, _ *TerraformSettingsClientGetOptions) (*policy.Request, error) {
+	urlPath := "/{rootScope}/providers/Radius.Core/terraformSettings/{terraformSettingName}"
 	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
-	if terraformSettingsName == "" {
-		return nil, errors.New("parameter terraformSettingsName cannot be empty")
+	if terraformSettingName == "" {
+		return nil, errors.New("parameter terraformSettingName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{terraformSettingsName}", url.PathEscape(terraformSettingsName))
+	urlPath = strings.ReplaceAll(urlPath, "{terraformSettingName}", url.PathEscape(terraformSettingName))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
@@ -261,17 +261,17 @@ func (client *TerraformSettingsClient) listByScopeHandleResponse(resp *http.Resp
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2025-08-01-preview
-//   - terraformSettingsName - Terraform settings resource name.
+//   - terraformSettingName - Terraform settings resource name.
 //   - properties - The resource properties to be updated.
 //   - options - TerraformSettingsClientUpdateOptions contains the optional parameters for the TerraformSettingsClient.Update
 //     method.
-func (client *TerraformSettingsClient) Update(ctx context.Context, terraformSettingsName string, properties TerraformSettingsResourceUpdate, options *TerraformSettingsClientUpdateOptions) (TerraformSettingsClientUpdateResponse, error) {
+func (client *TerraformSettingsClient) Update(ctx context.Context, terraformSettingName string, properties TerraformSettingsResourceUpdate, options *TerraformSettingsClientUpdateOptions) (TerraformSettingsClientUpdateResponse, error) {
 	var err error
 	const operationName = "TerraformSettingsClient.Update"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.updateCreateRequest(ctx, terraformSettingsName, properties, options)
+	req, err := client.updateCreateRequest(ctx, terraformSettingName, properties, options)
 	if err != nil {
 		return TerraformSettingsClientUpdateResponse{}, err
 	}
@@ -288,13 +288,13 @@ func (client *TerraformSettingsClient) Update(ctx context.Context, terraformSett
 }
 
 // updateCreateRequest creates the Update request.
-func (client *TerraformSettingsClient) updateCreateRequest(ctx context.Context, terraformSettingsName string, properties TerraformSettingsResourceUpdate, _ *TerraformSettingsClientUpdateOptions) (*policy.Request, error) {
-	urlPath := "/{rootScope}/providers/Radius.Core/terraformSettings/{terraformSettingsName}"
+func (client *TerraformSettingsClient) updateCreateRequest(ctx context.Context, terraformSettingName string, properties TerraformSettingsResourceUpdate, _ *TerraformSettingsClientUpdateOptions) (*policy.Request, error) {
+	urlPath := "/{rootScope}/providers/Radius.Core/terraformSettings/{terraformSettingName}"
 	urlPath = strings.ReplaceAll(urlPath, "{rootScope}", client.rootScope)
-	if terraformSettingsName == "" {
-		return nil, errors.New("parameter terraformSettingsName cannot be empty")
+	if terraformSettingName == "" {
+		return nil, errors.New("parameter terraformSettingName cannot be empty")
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{terraformSettingsName}", url.PathEscape(terraformSettingsName))
+	urlPath = strings.ReplaceAll(urlPath, "{terraformSettingName}", url.PathEscape(terraformSettingName))
 	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err

--- a/pkg/corerp/datamodel/bicepsettings_v20250801preview.go
+++ b/pkg/corerp/datamodel/bicepsettings_v20250801preview.go
@@ -37,6 +37,9 @@ func (b *BicepSettings_v20250801preview) ResourceTypeName() string {
 type BicepSettingsProperties_v20250801preview struct {
 	// Authentication contains registry authentication entries keyed by hostname.
 	Authentication *BicepAuthenticationConfiguration `json:"authentication,omitempty"`
+
+	// ReferencedBy is a list of environment IDs that reference this settings resource.
+	ReferencedBy []string `json:"referencedBy,omitempty"`
 }
 
 // BicepAuthenticationConfiguration captures registry authentication entries.

--- a/pkg/corerp/datamodel/terraformsettings_v20250801preview.go
+++ b/pkg/corerp/datamodel/terraformsettings_v20250801preview.go
@@ -46,6 +46,9 @@ type TerraformSettingsProperties_v20250801preview struct {
 
 	// Logging controls Terraform logging behaviour (TF_LOG/TF_LOG_PATH).
 	Logging *TerraformLoggingConfiguration `json:"logging,omitempty"`
+
+	// ReferencedBy is a list of environment IDs that reference this settings resource.
+	ReferencedBy []string `json:"referencedBy,omitempty"`
 }
 
 // TerraformCliConfiguration mirrors the terraformrc provider installation + credentials sections.

--- a/pkg/corerp/frontend/controller/bicepsettings/deletefilter.go
+++ b/pkg/corerp/frontend/controller/bicepsettings/deletefilter.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bicepsettings
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/radius-project/radius/pkg/armrpc/frontend/controller"
+	"github.com/radius-project/radius/pkg/armrpc/rest"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+)
+
+// PreventDeleteIfReferenced is a delete filter that prevents deletion of a BicepSettings
+// resource if it is still referenced by any environment.
+func PreventDeleteIfReferenced(ctx context.Context, oldResource *datamodel.BicepSettings_v20250801preview, options *controller.Options) (rest.Response, error) {
+	if len(oldResource.Properties.ReferencedBy) > 0 {
+		return rest.NewConflictResponse(fmt.Sprintf(
+			"Cannot delete bicepSettings: still referenced by environments: %v",
+			oldResource.Properties.ReferencedBy,
+		)), nil
+	}
+	return nil, nil
+}

--- a/pkg/corerp/frontend/controller/environments/v20250801preview/createorupdateenvironment.go
+++ b/pkg/corerp/frontend/controller/environments/v20250801preview/createorupdateenvironment.go
@@ -18,14 +18,17 @@ package v20250801preview
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	ctrl "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
 	"github.com/radius-project/radius/pkg/armrpc/rest"
+	"github.com/radius-project/radius/pkg/components/database"
 	"github.com/radius-project/radius/pkg/corerp/datamodel"
 	"github.com/radius-project/radius/pkg/corerp/datamodel/converter"
+	"github.com/radius-project/radius/pkg/corerp/frontend/controller/environments/v20250801preview/settingsref"
 	"github.com/radius-project/radius/pkg/corerp/frontend/controller/util"
 	"github.com/radius-project/radius/pkg/ucp/resources"
 	corev1 "k8s.io/api/core/v1"
@@ -103,6 +106,11 @@ func (e *CreateOrUpdateEnvironmentv20250801preview) Run(ctx context.Context, w h
 		return resp, err
 	}
 
+	// Validate and update settings references (TerraformSettings and BicepSettings)
+	if resp, err := e.validateAndUpdateSettingsReferences(ctx, serviceCtx.ResourceID.String(), newResource, old); resp != nil || err != nil {
+		return resp, err
+	}
+
 	newResource.SetProvisioningState(v1.ProvisioningStateSucceeded)
 	newEtag, err := e.SaveResource(ctx, serviceCtx.ResourceID.String(), newResource, etag)
 	if err != nil {
@@ -130,7 +138,11 @@ func (e *CreateOrUpdateEnvironmentv20250801preview) validateRecipePacks(ctx cont
 		// Get the recipe pack resource
 		obj, err := e.DatabaseClient().Get(ctx, id.String())
 		if err != nil {
-			return rest.NewBadRequestResponse(fmt.Sprintf("Failed to retrieve recipe pack %s: %v", recipePackID, err)), nil
+			if errors.Is(err, &database.ErrNotFound{}) {
+				return rest.NewBadRequestResponse(fmt.Sprintf("Recipe pack not found: %s", recipePackID)), nil
+			}
+			// Return internal error for other database errors (e.g., connection issues)
+			return nil, fmt.Errorf("failed to retrieve recipe pack %s: %w", recipePackID, err)
 		}
 
 		recipePack := &datamodel.RecipePack{}
@@ -148,4 +160,108 @@ func (e *CreateOrUpdateEnvironmentv20250801preview) validateRecipePacks(ctx cont
 	}
 
 	return nil, nil
+}
+
+// validateAndUpdateSettingsReferences validates that settings resources exist and updates their ReferencedBy lists.
+func (e *CreateOrUpdateEnvironmentv20250801preview) validateAndUpdateSettingsReferences(
+	ctx context.Context,
+	envID string,
+	newResource *datamodel.Environment_v20250801preview,
+	old *datamodel.Environment_v20250801preview,
+) (rest.Response, error) {
+	// Validate terraformSettings exists if specified
+	if newResource.Properties.TerraformSettings != "" {
+		if resp, err := e.validateSettingsExists(ctx, newResource.Properties.TerraformSettings, "terraformSettings"); resp != nil || err != nil {
+			return resp, err
+		}
+	}
+
+	// Validate bicepSettings exists if specified
+	if newResource.Properties.BicepSettings != "" {
+		if resp, err := e.validateSettingsExists(ctx, newResource.Properties.BicepSettings, "bicepSettings"); resp != nil || err != nil {
+			return resp, err
+		}
+	}
+
+	// Update ReferencedBy on old settings (remove) and new settings (add)
+	if err := e.updateSettingsReferences(ctx, envID, old, newResource); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// validateSettingsExists checks that a settings resource exists in the database.
+// It differentiates between "not found" errors and other database errors.
+func (e *CreateOrUpdateEnvironmentv20250801preview) validateSettingsExists(
+	ctx context.Context,
+	settingsID string,
+	settingsType string,
+) (rest.Response, error) {
+	id, err := resources.ParseResource(settingsID)
+	if err != nil {
+		return rest.NewBadRequestResponse(fmt.Sprintf("Invalid %s resource ID: %s", settingsType, settingsID)), nil
+	}
+
+	_, err = e.DatabaseClient().Get(ctx, id.String())
+	if err != nil {
+		if errors.Is(err, &database.ErrNotFound{}) {
+			return rest.NewBadRequestResponse(fmt.Sprintf("%s resource not found: %s", settingsType, settingsID)), nil
+		}
+		// Return internal error for other database errors (e.g., connection issues)
+		return nil, fmt.Errorf("failed to retrieve %s resource %s: %w", settingsType, settingsID, err)
+	}
+
+	return nil, nil
+}
+
+// updateSettingsReferences updates the ReferencedBy lists on settings resources when references change.
+// It uses the shared settingsref package which handles optimistic concurrency with retry logic.
+func (e *CreateOrUpdateEnvironmentv20250801preview) updateSettingsReferences(
+	ctx context.Context,
+	envID string,
+	old *datamodel.Environment_v20250801preview,
+	newResource *datamodel.Environment_v20250801preview,
+) error {
+	// Handle TerraformSettings reference changes
+	oldTF := ""
+	if old != nil {
+		oldTF = old.Properties.TerraformSettings
+	}
+	newTF := newResource.Properties.TerraformSettings
+
+	if oldTF != newTF {
+		if oldTF != "" {
+			if err := settingsref.RemoveTerraformSettingsReference(ctx, e.DatabaseClient(), oldTF, envID); err != nil {
+				return err
+			}
+		}
+		if newTF != "" {
+			if err := settingsref.AddTerraformSettingsReference(ctx, e.DatabaseClient(), newTF, envID); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Handle BicepSettings reference changes
+	oldBicep := ""
+	if old != nil {
+		oldBicep = old.Properties.BicepSettings
+	}
+	newBicep := newResource.Properties.BicepSettings
+
+	if oldBicep != newBicep {
+		if oldBicep != "" {
+			if err := settingsref.RemoveBicepSettingsReference(ctx, e.DatabaseClient(), oldBicep, envID); err != nil {
+				return err
+			}
+		}
+		if newBicep != "" {
+			if err := settingsref.AddBicepSettingsReference(ctx, e.DatabaseClient(), newBicep, envID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/corerp/frontend/controller/environments/v20250801preview/createorupdateenvironment_test.go
+++ b/pkg/corerp/frontend/controller/environments/v20250801preview/createorupdateenvironment_test.go
@@ -472,7 +472,7 @@ func TestCreateOrUpdateEnvironment_RecipePackValidation(t *testing.T) {
 					Return(nil, &database.ErrNotFound{ID: "nonexistent"})
 			},
 			expectedStatusCode: 400,
-			expectedError:      "Failed to retrieve recipe pack",
+			expectedError:      "Recipe pack not found",
 		},
 	}
 

--- a/pkg/corerp/frontend/controller/environments/v20250801preview/deletefilter.go
+++ b/pkg/corerp/frontend/controller/environments/v20250801preview/deletefilter.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v20250801preview
+
+import (
+	"context"
+
+	"github.com/radius-project/radius/pkg/armrpc/frontend/controller"
+	"github.com/radius-project/radius/pkg/armrpc/rest"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+	"github.com/radius-project/radius/pkg/corerp/frontend/controller/environments/v20250801preview/settingsref"
+	"github.com/radius-project/radius/pkg/ucp/ucplog"
+)
+
+// CleanupSettingsReferences is a delete filter that removes the environment's reference
+// from any referenced TerraformSettings and BicepSettings resources when the environment is deleted.
+func CleanupSettingsReferences(ctx context.Context, oldResource *datamodel.Environment_v20250801preview, options *controller.Options) (rest.Response, error) {
+	logger := ucplog.FromContextOrDiscard(ctx)
+	envID := oldResource.ID
+
+	// Remove reference from TerraformSettings if specified
+	if oldResource.Properties.TerraformSettings != "" {
+		if err := settingsref.RemoveTerraformSettingsReference(ctx, options.DatabaseClient, oldResource.Properties.TerraformSettings, envID); err != nil {
+			// Log error but don't fail deletion.
+			// The settings resource might have already been deleted or there could be a transient error.
+			// The ReferencedBy list is eventually consistent and can be cleaned up in a future reconciliation if needed.
+			logger.Error(err, "Failed to remove environment reference from terraformSettings during environment deletion",
+				"environmentID", envID,
+				"terraformSettingsID", oldResource.Properties.TerraformSettings)
+		}
+	}
+
+	// Remove reference from BicepSettings if specified
+	if oldResource.Properties.BicepSettings != "" {
+		if err := settingsref.RemoveBicepSettingsReference(ctx, options.DatabaseClient, oldResource.Properties.BicepSettings, envID); err != nil {
+			// Log error but don't fail deletion.
+			// The settings resource might have already been deleted or there could be a transient error.
+			// The ReferencedBy list is eventually consistent and can be cleaned up in a future reconciliation if needed.
+			logger.Error(err, "Failed to remove environment reference from bicepSettings during environment deletion",
+				"environmentID", envID,
+				"bicepSettingsID", oldResource.Properties.BicepSettings)
+		}
+	}
+
+	return nil, nil
+}

--- a/pkg/corerp/frontend/controller/environments/v20250801preview/settingsref/settingsref.go
+++ b/pkg/corerp/frontend/controller/environments/v20250801preview/settingsref/settingsref.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2026 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package settingsref provides shared helper functions for managing references
+// between environments and settings resources (TerraformSettings and BicepSettings).
+package settingsref
+
+import (
+	"context"
+	"errors"
+	"slices"
+
+	"github.com/radius-project/radius/pkg/components/database"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+	"github.com/radius-project/radius/pkg/ucp/resources"
+)
+
+const (
+	// maxRetries is the maximum number of retries for handling ErrConcurrency.
+	maxRetries = 3
+)
+
+// RemoveTerraformSettingsReference removes an environment ID from the ReferencedBy list of a TerraformSettings resource.
+// This function handles optimistic concurrency by retrying on ErrConcurrency up to maxRetries times.
+// If the settings resource doesn't exist (ErrNotFound), it returns nil as there's nothing to remove.
+func RemoveTerraformSettingsReference(ctx context.Context, dbClient database.Client, settingsID, envID string) error {
+	id, err := resources.ParseResource(settingsID)
+	if err != nil {
+		return err
+	}
+
+	for range maxRetries {
+		obj, err := dbClient.Get(ctx, id.String())
+		if err != nil {
+			// If settings doesn't exist, nothing to remove
+			if errors.Is(err, &database.ErrNotFound{}) {
+				return nil
+			}
+			return err
+		}
+
+		settings := &datamodel.TerraformSettings_v20250801preview{}
+		if err := obj.As(settings); err != nil {
+			return err
+		}
+
+		// Remove envID from ReferencedBy
+		newRefs := slices.DeleteFunc(settings.Properties.ReferencedBy, func(ref string) bool {
+			return ref == envID
+		})
+		settings.Properties.ReferencedBy = newRefs
+
+		obj.Data = settings
+		err = dbClient.Save(ctx, obj, database.WithETag(obj.ETag))
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, &database.ErrConcurrency{}) {
+			// Retry on concurrency conflict
+			continue
+		}
+		return err
+	}
+
+	return &database.ErrConcurrency{}
+}
+
+// RemoveBicepSettingsReference removes an environment ID from the ReferencedBy list of a BicepSettings resource.
+// This function handles optimistic concurrency by retrying on ErrConcurrency up to maxRetries times.
+// If the settings resource doesn't exist (ErrNotFound), it returns nil as there's nothing to remove.
+func RemoveBicepSettingsReference(ctx context.Context, dbClient database.Client, settingsID, envID string) error {
+	id, err := resources.ParseResource(settingsID)
+	if err != nil {
+		return err
+	}
+
+	for range maxRetries {
+		obj, err := dbClient.Get(ctx, id.String())
+		if err != nil {
+			// If settings doesn't exist, nothing to remove
+			if errors.Is(err, &database.ErrNotFound{}) {
+				return nil
+			}
+			return err
+		}
+
+		settings := &datamodel.BicepSettings_v20250801preview{}
+		if err := obj.As(settings); err != nil {
+			return err
+		}
+
+		// Remove envID from ReferencedBy
+		newRefs := slices.DeleteFunc(settings.Properties.ReferencedBy, func(ref string) bool {
+			return ref == envID
+		})
+		settings.Properties.ReferencedBy = newRefs
+
+		obj.Data = settings
+		err = dbClient.Save(ctx, obj, database.WithETag(obj.ETag))
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, &database.ErrConcurrency{}) {
+			// Retry on concurrency conflict
+			continue
+		}
+		return err
+	}
+
+	return &database.ErrConcurrency{}
+}
+
+// AddTerraformSettingsReference adds an environment ID to the ReferencedBy list of a TerraformSettings resource.
+// This function handles optimistic concurrency by retrying on ErrConcurrency up to maxRetries times.
+func AddTerraformSettingsReference(ctx context.Context, dbClient database.Client, settingsID, envID string) error {
+	id, err := resources.ParseResource(settingsID)
+	if err != nil {
+		return err
+	}
+
+	for range maxRetries {
+		obj, err := dbClient.Get(ctx, id.String())
+		if err != nil {
+			return err
+		}
+
+		settings := &datamodel.TerraformSettings_v20250801preview{}
+		if err := obj.As(settings); err != nil {
+			return err
+		}
+
+		// Add envID if not already present
+		if slices.Contains(settings.Properties.ReferencedBy, envID) {
+			return nil // Already referenced
+		}
+
+		settings.Properties.ReferencedBy = append(settings.Properties.ReferencedBy, envID)
+
+		obj.Data = settings
+		err = dbClient.Save(ctx, obj, database.WithETag(obj.ETag))
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, &database.ErrConcurrency{}) {
+			// Retry on concurrency conflict
+			continue
+		}
+		return err
+	}
+
+	return &database.ErrConcurrency{}
+}
+
+// AddBicepSettingsReference adds an environment ID to the ReferencedBy list of a BicepSettings resource.
+// This function handles optimistic concurrency by retrying on ErrConcurrency up to maxRetries times.
+func AddBicepSettingsReference(ctx context.Context, dbClient database.Client, settingsID, envID string) error {
+	id, err := resources.ParseResource(settingsID)
+	if err != nil {
+		return err
+	}
+
+	for range maxRetries {
+		obj, err := dbClient.Get(ctx, id.String())
+		if err != nil {
+			return err
+		}
+
+		settings := &datamodel.BicepSettings_v20250801preview{}
+		if err := obj.As(settings); err != nil {
+			return err
+		}
+
+		// Add envID if not already present
+		if slices.Contains(settings.Properties.ReferencedBy, envID) {
+			return nil // Already referenced
+		}
+
+		settings.Properties.ReferencedBy = append(settings.Properties.ReferencedBy, envID)
+
+		obj.Data = settings
+		err = dbClient.Save(ctx, obj, database.WithETag(obj.ETag))
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, &database.ErrConcurrency{}) {
+			// Retry on concurrency conflict
+			continue
+		}
+		return err
+	}
+
+	return &database.ErrConcurrency{}
+}

--- a/pkg/corerp/frontend/controller/environments/v20250801preview/settingsref/settingsref_test.go
+++ b/pkg/corerp/frontend/controller/environments/v20250801preview/settingsref/settingsref_test.go
@@ -1,0 +1,418 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package settingsref
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/radius-project/radius/pkg/components/database"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+const (
+	testTerraformSettingsID = "/subscriptions/sub1/resourceGroups/rg1/providers/Radius.Core/terraformSettings/tf-settings1"
+	testBicepSettingsID     = "/subscriptions/sub1/resourceGroups/rg1/providers/Radius.Core/bicepSettings/bicep-settings1"
+	testEnvID1              = "/subscriptions/sub1/resourceGroups/rg1/providers/Radius.Core/environments/env1"
+	testEnvID2              = "/subscriptions/sub1/resourceGroups/rg1/providers/Radius.Core/environments/env2"
+)
+
+func TestAddTerraformSettingsReference(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success - add reference to empty list", func(t *testing.T) {
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		dbClient := database.NewMockClient(mctrl)
+
+		settings := &datamodel.TerraformSettings_v20250801preview{
+			Properties: datamodel.TerraformSettingsProperties_v20250801preview{
+				ReferencedBy: []string{},
+			},
+		}
+
+		dbClient.EXPECT().
+			Get(gomock.Any(), testTerraformSettingsID).
+			Return(&database.Object{
+				Metadata: database.Metadata{ID: testTerraformSettingsID, ETag: "etag1"},
+				Data:     settings,
+			}, nil)
+
+		dbClient.EXPECT().
+			Save(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, obj *database.Object, opts ...database.SaveOptions) error {
+				savedSettings := obj.Data.(*datamodel.TerraformSettings_v20250801preview)
+				require.Contains(t, savedSettings.Properties.ReferencedBy, testEnvID1)
+				return nil
+			})
+
+		err := AddTerraformSettingsReference(ctx, dbClient, testTerraformSettingsID, testEnvID1)
+		require.NoError(t, err)
+	})
+
+	t.Run("success - idempotent - reference already exists", func(t *testing.T) {
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		dbClient := database.NewMockClient(mctrl)
+
+		settings := &datamodel.TerraformSettings_v20250801preview{
+			Properties: datamodel.TerraformSettingsProperties_v20250801preview{
+				ReferencedBy: []string{testEnvID1},
+			},
+		}
+
+		dbClient.EXPECT().
+			Get(gomock.Any(), testTerraformSettingsID).
+			Return(&database.Object{
+				Metadata: database.Metadata{ID: testTerraformSettingsID, ETag: "etag1"},
+				Data:     settings,
+			}, nil)
+
+		// Save should NOT be called since reference already exists
+		err := AddTerraformSettingsReference(ctx, dbClient, testTerraformSettingsID, testEnvID1)
+		require.NoError(t, err)
+	})
+
+	t.Run("success - retry on concurrency error", func(t *testing.T) {
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		dbClient := database.NewMockClient(mctrl)
+
+		attemptCount := 0
+		dbClient.EXPECT().
+			Get(gomock.Any(), testTerraformSettingsID).
+			DoAndReturn(func(ctx context.Context, id string, opts ...database.GetOptions) (*database.Object, error) {
+				// Return a fresh copy each time to simulate real database behavior
+				return &database.Object{
+					Metadata: database.Metadata{ID: testTerraformSettingsID, ETag: "etag1"},
+					Data: &datamodel.TerraformSettings_v20250801preview{
+						Properties: datamodel.TerraformSettingsProperties_v20250801preview{
+							ReferencedBy: []string{},
+						},
+					},
+				}, nil
+			}).Times(2)
+
+		dbClient.EXPECT().
+			Save(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, obj *database.Object, opts ...database.SaveOptions) error {
+				attemptCount++
+				if attemptCount == 1 {
+					return &database.ErrConcurrency{}
+				}
+				return nil
+			}).Times(2)
+
+		err := AddTerraformSettingsReference(ctx, dbClient, testTerraformSettingsID, testEnvID1)
+		require.NoError(t, err)
+		require.Equal(t, 2, attemptCount)
+	})
+
+	t.Run("failure - max retries exceeded on concurrency", func(t *testing.T) {
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		dbClient := database.NewMockClient(mctrl)
+
+		dbClient.EXPECT().
+			Get(gomock.Any(), testTerraformSettingsID).
+			DoAndReturn(func(ctx context.Context, id string, opts ...database.GetOptions) (*database.Object, error) {
+				// Return a fresh copy each time to simulate real database behavior
+				return &database.Object{
+					Metadata: database.Metadata{ID: testTerraformSettingsID, ETag: "etag1"},
+					Data: &datamodel.TerraformSettings_v20250801preview{
+						Properties: datamodel.TerraformSettingsProperties_v20250801preview{
+							ReferencedBy: []string{},
+						},
+					},
+				}, nil
+			}).Times(3)
+
+		dbClient.EXPECT().
+			Save(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&database.ErrConcurrency{}).Times(3)
+
+		err := AddTerraformSettingsReference(ctx, dbClient, testTerraformSettingsID, testEnvID1)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, &database.ErrConcurrency{}))
+	})
+
+	t.Run("failure - settings not found", func(t *testing.T) {
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		dbClient := database.NewMockClient(mctrl)
+
+		dbClient.EXPECT().
+			Get(gomock.Any(), testTerraformSettingsID).
+			Return(nil, &database.ErrNotFound{ID: testTerraformSettingsID})
+
+		err := AddTerraformSettingsReference(ctx, dbClient, testTerraformSettingsID, testEnvID1)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, &database.ErrNotFound{}))
+	})
+
+	t.Run("failure - non-retryable error on save", func(t *testing.T) {
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		dbClient := database.NewMockClient(mctrl)
+
+		settings := &datamodel.TerraformSettings_v20250801preview{
+			Properties: datamodel.TerraformSettingsProperties_v20250801preview{
+				ReferencedBy: []string{},
+			},
+		}
+
+		dbClient.EXPECT().
+			Get(gomock.Any(), testTerraformSettingsID).
+			Return(&database.Object{
+				Metadata: database.Metadata{ID: testTerraformSettingsID, ETag: "etag1"},
+				Data:     settings,
+			}, nil)
+
+		expectedErr := errors.New("database connection error")
+		dbClient.EXPECT().
+			Save(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(expectedErr)
+
+		err := AddTerraformSettingsReference(ctx, dbClient, testTerraformSettingsID, testEnvID1)
+		require.Error(t, err)
+		require.Equal(t, expectedErr, err)
+	})
+
+	t.Run("failure - invalid settings ID", func(t *testing.T) {
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		dbClient := database.NewMockClient(mctrl)
+
+		err := AddTerraformSettingsReference(ctx, dbClient, "invalid-id", testEnvID1)
+		require.Error(t, err)
+	})
+}
+
+func TestRemoveTerraformSettingsReference(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success - remove existing reference", func(t *testing.T) {
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		dbClient := database.NewMockClient(mctrl)
+
+		settings := &datamodel.TerraformSettings_v20250801preview{
+			Properties: datamodel.TerraformSettingsProperties_v20250801preview{
+				ReferencedBy: []string{testEnvID1, testEnvID2},
+			},
+		}
+
+		dbClient.EXPECT().
+			Get(gomock.Any(), testTerraformSettingsID).
+			Return(&database.Object{
+				Metadata: database.Metadata{ID: testTerraformSettingsID, ETag: "etag1"},
+				Data:     settings,
+			}, nil)
+
+		dbClient.EXPECT().
+			Save(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, obj *database.Object, opts ...database.SaveOptions) error {
+				savedSettings := obj.Data.(*datamodel.TerraformSettings_v20250801preview)
+				require.NotContains(t, savedSettings.Properties.ReferencedBy, testEnvID1)
+				require.Contains(t, savedSettings.Properties.ReferencedBy, testEnvID2)
+				return nil
+			})
+
+		err := RemoveTerraformSettingsReference(ctx, dbClient, testTerraformSettingsID, testEnvID1)
+		require.NoError(t, err)
+	})
+
+	t.Run("success - settings not found returns nil", func(t *testing.T) {
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		dbClient := database.NewMockClient(mctrl)
+
+		dbClient.EXPECT().
+			Get(gomock.Any(), testTerraformSettingsID).
+			Return(nil, &database.ErrNotFound{ID: testTerraformSettingsID})
+
+		err := RemoveTerraformSettingsReference(ctx, dbClient, testTerraformSettingsID, testEnvID1)
+		require.NoError(t, err)
+	})
+
+	t.Run("success - idempotent - reference not in list", func(t *testing.T) {
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		dbClient := database.NewMockClient(mctrl)
+
+		settings := &datamodel.TerraformSettings_v20250801preview{
+			Properties: datamodel.TerraformSettingsProperties_v20250801preview{
+				ReferencedBy: []string{testEnvID2}, // testEnvID1 not in list
+			},
+		}
+
+		dbClient.EXPECT().
+			Get(gomock.Any(), testTerraformSettingsID).
+			Return(&database.Object{
+				Metadata: database.Metadata{ID: testTerraformSettingsID, ETag: "etag1"},
+				Data:     settings,
+			}, nil)
+
+		dbClient.EXPECT().
+			Save(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil)
+
+		err := RemoveTerraformSettingsReference(ctx, dbClient, testTerraformSettingsID, testEnvID1)
+		require.NoError(t, err)
+	})
+
+	t.Run("success - retry on concurrency error", func(t *testing.T) {
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		dbClient := database.NewMockClient(mctrl)
+
+		settings := &datamodel.TerraformSettings_v20250801preview{
+			Properties: datamodel.TerraformSettingsProperties_v20250801preview{
+				ReferencedBy: []string{testEnvID1},
+			},
+		}
+
+		attemptCount := 0
+		dbClient.EXPECT().
+			Get(gomock.Any(), testTerraformSettingsID).
+			Return(&database.Object{
+				Metadata: database.Metadata{ID: testTerraformSettingsID, ETag: "etag1"},
+				Data:     settings,
+			}, nil).Times(2)
+
+		dbClient.EXPECT().
+			Save(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, obj *database.Object, opts ...database.SaveOptions) error {
+				attemptCount++
+				if attemptCount == 1 {
+					return &database.ErrConcurrency{}
+				}
+				return nil
+			}).Times(2)
+
+		err := RemoveTerraformSettingsReference(ctx, dbClient, testTerraformSettingsID, testEnvID1)
+		require.NoError(t, err)
+		require.Equal(t, 2, attemptCount)
+	})
+}
+
+func TestAddBicepSettingsReference(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success - add reference to empty list", func(t *testing.T) {
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		dbClient := database.NewMockClient(mctrl)
+
+		settings := &datamodel.BicepSettings_v20250801preview{
+			Properties: datamodel.BicepSettingsProperties_v20250801preview{
+				ReferencedBy: []string{},
+			},
+		}
+
+		dbClient.EXPECT().
+			Get(gomock.Any(), testBicepSettingsID).
+			Return(&database.Object{
+				Metadata: database.Metadata{ID: testBicepSettingsID, ETag: "etag1"},
+				Data:     settings,
+			}, nil)
+
+		dbClient.EXPECT().
+			Save(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, obj *database.Object, opts ...database.SaveOptions) error {
+				savedSettings := obj.Data.(*datamodel.BicepSettings_v20250801preview)
+				require.Contains(t, savedSettings.Properties.ReferencedBy, testEnvID1)
+				return nil
+			})
+
+		err := AddBicepSettingsReference(ctx, dbClient, testBicepSettingsID, testEnvID1)
+		require.NoError(t, err)
+	})
+
+	t.Run("success - idempotent - reference already exists", func(t *testing.T) {
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		dbClient := database.NewMockClient(mctrl)
+
+		settings := &datamodel.BicepSettings_v20250801preview{
+			Properties: datamodel.BicepSettingsProperties_v20250801preview{
+				ReferencedBy: []string{testEnvID1},
+			},
+		}
+
+		dbClient.EXPECT().
+			Get(gomock.Any(), testBicepSettingsID).
+			Return(&database.Object{
+				Metadata: database.Metadata{ID: testBicepSettingsID, ETag: "etag1"},
+				Data:     settings,
+			}, nil)
+
+		err := AddBicepSettingsReference(ctx, dbClient, testBicepSettingsID, testEnvID1)
+		require.NoError(t, err)
+	})
+}
+
+func TestRemoveBicepSettingsReference(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success - remove existing reference", func(t *testing.T) {
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		dbClient := database.NewMockClient(mctrl)
+
+		settings := &datamodel.BicepSettings_v20250801preview{
+			Properties: datamodel.BicepSettingsProperties_v20250801preview{
+				ReferencedBy: []string{testEnvID1, testEnvID2},
+			},
+		}
+
+		dbClient.EXPECT().
+			Get(gomock.Any(), testBicepSettingsID).
+			Return(&database.Object{
+				Metadata: database.Metadata{ID: testBicepSettingsID, ETag: "etag1"},
+				Data:     settings,
+			}, nil)
+
+		dbClient.EXPECT().
+			Save(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, obj *database.Object, opts ...database.SaveOptions) error {
+				savedSettings := obj.Data.(*datamodel.BicepSettings_v20250801preview)
+				require.NotContains(t, savedSettings.Properties.ReferencedBy, testEnvID1)
+				require.Contains(t, savedSettings.Properties.ReferencedBy, testEnvID2)
+				return nil
+			})
+
+		err := RemoveBicepSettingsReference(ctx, dbClient, testBicepSettingsID, testEnvID1)
+		require.NoError(t, err)
+	})
+
+	t.Run("success - settings not found returns nil", func(t *testing.T) {
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		dbClient := database.NewMockClient(mctrl)
+
+		dbClient.EXPECT().
+			Get(gomock.Any(), testBicepSettingsID).
+			Return(nil, &database.ErrNotFound{ID: testBicepSettingsID})
+
+		err := RemoveBicepSettingsReference(ctx, dbClient, testBicepSettingsID, testEnvID1)
+		require.NoError(t, err)
+	})
+}

--- a/pkg/corerp/frontend/controller/terraformsettings/deletefilter.go
+++ b/pkg/corerp/frontend/controller/terraformsettings/deletefilter.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package terraformsettings
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/radius-project/radius/pkg/armrpc/frontend/controller"
+	"github.com/radius-project/radius/pkg/armrpc/rest"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+)
+
+// PreventDeleteIfReferenced is a delete filter that prevents deletion of a TerraformSettings
+// resource if it is still referenced by any environment.
+func PreventDeleteIfReferenced(ctx context.Context, oldResource *datamodel.TerraformSettings_v20250801preview, options *controller.Options) (rest.Response, error) {
+	if len(oldResource.Properties.ReferencedBy) > 0 {
+		return rest.NewConflictResponse(fmt.Sprintf(
+			"Cannot delete terraformSettings: still referenced by environments: %v",
+			oldResource.Properties.ReferencedBy,
+		)), nil
+	}
+	return nil, nil
+}

--- a/pkg/corerp/setup/setup.go
+++ b/pkg/corerp/setup/setup.go
@@ -279,6 +279,11 @@ func SetupRadiusCoreNamespace(recipeControllerConfig *controllerconfig.RecipeCon
 		Patch: builder.Operation[datamodel.Environment_v20250801preview]{
 			APIController: env_v20250801_ctrl.NewCreateOrUpdateEnvironmentv20250801preview,
 		},
+		Delete: builder.Operation[datamodel.Environment_v20250801preview]{
+			DeleteFilters: []apictrl.DeleteFilter[datamodel.Environment_v20250801preview]{
+				env_v20250801_ctrl.CleanupSettingsReferences,
+			},
+		},
 	})
 
 	_ = ns.AddResource("applications", &builder.ResourceOption[*datamodel.Application_v20250801preview, datamodel.Application_v20250801preview]{
@@ -307,6 +312,11 @@ func SetupRadiusCoreNamespace(recipeControllerConfig *controllerconfig.RecipeCon
 		Patch: builder.Operation[datamodel.TerraformSettings_v20250801preview]{
 			APIController: tf_ctrl.NewCreateOrUpdateTerraformSettings,
 		},
+		Delete: builder.Operation[datamodel.TerraformSettings_v20250801preview]{
+			DeleteFilters: []apictrl.DeleteFilter[datamodel.TerraformSettings_v20250801preview]{
+				tf_ctrl.PreventDeleteIfReferenced,
+			},
+		},
 	})
 
 	_ = ns.AddResource("bicepSettings", &builder.ResourceOption[*datamodel.BicepSettings_v20250801preview, datamodel.BicepSettings_v20250801preview]{
@@ -318,6 +328,11 @@ func SetupRadiusCoreNamespace(recipeControllerConfig *controllerconfig.RecipeCon
 		},
 		Patch: builder.Operation[datamodel.BicepSettings_v20250801preview]{
 			APIController: bicep_ctrl.NewCreateOrUpdateBicepSettings,
+		},
+		Delete: builder.Operation[datamodel.BicepSettings_v20250801preview]{
+			DeleteFilters: []apictrl.DeleteFilter[datamodel.BicepSettings_v20250801preview]{
+				bicep_ctrl.PreventDeleteIfReferenced,
+			},
 		},
 	})
 

--- a/pkg/recipes/configloader/environment_test.go
+++ b/pkg/recipes/configloader/environment_test.go
@@ -545,7 +545,7 @@ func TestGetConfigurationV20250801(t *testing.T) {
 
 	for _, tc := range configTests {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := getConfigurationV20250801(tc.envResource)
+			result, err := getConfigurationV20250801(context.Background(), tc.envResource, nil)
 			if tc.errString != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.errString)

--- a/pkg/recipes/configloader/settings.go
+++ b/pkg/recipes/configloader/settings.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configloader
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	aztoken "github.com/radius-project/radius/pkg/azure/tokencredentials"
+	"github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
+	"github.com/radius-project/radius/pkg/ucp/resources"
+)
+
+// FetchTerraformSettings fetches a TerraformSettings resource using the provided settingsID and ClientOptions,
+// and returns the TerraformSettingsResource or an error.
+func FetchTerraformSettings(ctx context.Context, settingsID string, ucpOptions *arm.ClientOptions) (*v20250801preview.TerraformSettingsResource, error) {
+	id, err := resources.ParseResource(settingsID)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := v20250801preview.NewTerraformSettingsClient(id.RootScope(), &aztoken.AnonymousCredential{}, ucpOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.Get(ctx, id.Name(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.TerraformSettingsResource, nil
+}
+
+// FetchBicepSettings fetches a BicepSettings resource using the provided settingsID and ClientOptions,
+// and returns the BicepSettingsResource or an error.
+func FetchBicepSettings(ctx context.Context, settingsID string, ucpOptions *arm.ClientOptions) (*v20250801preview.BicepSettingsResource, error) {
+	id, err := resources.ParseResource(settingsID)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := v20250801preview.NewBicepSettingsClient(id.RootScope(), &aztoken.AnonymousCredential{}, ucpOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.Get(ctx, id.Name(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.BicepSettingsResource, nil
+}

--- a/pkg/recipes/driver/bicep/bicep.go
+++ b/pkg/recipes/driver/bicep/bicep.go
@@ -19,6 +19,7 @@ package bicep
 import (
 	"context"
 	"fmt"
+	"net/url"
 	reflect "reflect"
 	"strconv"
 	"time"
@@ -94,16 +95,47 @@ func (d *bicepDriver) Execute(ctx context.Context, opts driver.ExecuteOptions) (
 		return nil, err
 	}
 
-	registryClient := d.RegistryClient
-	// Get ORAS authentication client if secrets are found for the registry.
-	if !reflect.DeepEqual(secrets, recipes.SecretData{}) {
-		authClient, err := getRegistryAuthClient(ctx, secrets, opts.Definition.TemplatePath)
-		if err != nil {
-			return nil, err
-		}
-
-		registryClient = authClient
+	registryClient, err := d.resolveRegistryClient(ctx, opts.BaseOptions, secrets)
+	if err != nil {
+		return nil, err
 	}
+
+	// var newRegistryClient authclient.AuthClient
+	// // Get ORAS authentication client if secrets are found for the registry.
+	// if !reflect.DeepEqual(secrets, recipes.SecretData{}) {
+	// 	// TODO: Remove legacy secret-based registry auth once we completely transition to Radius.Core resources.
+	// 	newRegistryClient, err = authclient.GetNewRegistryAuthClient(secrets)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	// }
+
+	// if opts.Configuration.BicepSettings.Authentication != nil && opts.Configuration.BicepSettings.Authentication.Registries != nil {
+	// 	parsedURL, err := url.Parse("https://" + opts.Definition.TemplatePath)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	// 	if authType, ok := opts.Configuration.BicepSettings.Authentication.Registries[parsedURL.Host]; ok {
+	// 		if authType.Basic != nil {
+	// 			newRegistryClient = authclient.NewBasicAuthentication(authType.Basic.Username, opts.Secrets[authType.Basic.Password.SecretID].Data[authType.Basic.Password.Key])
+	// 		} else if authType.AzureWorkloadIdentity != nil {
+	// 			newRegistryClient = authclient.NewAzureWorkloadIdentity(authType.AzureWorkloadIdentity.ClientID, authType.AzureWorkloadIdentity.TenantID)
+
+	// 		} else if authType.AwsIrsa != nil {
+	// 			newRegistryClient = authclient.NewAwsIRSA(authType.AwsIrsa.RoleArn)
+	// 		}
+
+	// 	}
+	// }
+
+	// if newRegistryClient != nil {
+	// 	authClient, err := getRegistryAuthClient(ctx, newRegistryClient, opts.Definition.TemplatePath)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+
+	// 	registryClient = authClient
+	// }
 
 	err = util.ReadFromRegistry(ctx, opts.Definition, &recipeData, registryClient)
 	if err != nil {
@@ -281,16 +313,26 @@ func (d *bicepDriver) GetRecipeMetadata(ctx context.Context, opts driver.BaseOpt
 		return nil, err
 	}
 
-	registryClient := d.RegistryClient
-	// Get ORAS authentication client if secrets are found for the registry.
-	if !reflect.DeepEqual(secrets, recipes.SecretData{}) {
-		authClient, err := getRegistryAuthClient(ctx, secrets, opts.Definition.TemplatePath)
-		if err != nil {
-			return nil, err
-		}
-
-		registryClient = authClient
+	registryClient, err := d.resolveRegistryClient(ctx, opts, secrets)
+	if err != nil {
+		return nil, err
 	}
+
+	// registryClient := d.RegistryClient
+	// // Get ORAS authentication client if secrets are found for the registry.
+	// if !reflect.DeepEqual(secrets, recipes.SecretData{}) {
+	// 	newRegistryClient, err := authclient.GetNewRegistryAuthClient(secrets)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+
+	// 	authClient, err := getRegistryAuthClient(ctx, newRegistryClient, opts.Definition.TemplatePath)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+
+	// 	registryClient = authClient
+	// }
 
 	err = util.ReadFromRegistry(ctx, opts.Definition, &recipeData, registryClient)
 	if err != nil {
@@ -504,11 +546,48 @@ func addSecretStoreKeys(secretStoreIDResourceKeys map[string][]string, secretSto
 	secretStoreIDResourceKeys[secretStoreID] = append([]string(nil), filteredKeys...)
 }
 
-func getRegistryAuthClient(ctx context.Context, secrets recipes.SecretData, templatePath string) (remote.Client, error) {
-	newRegistryClient, err := authclient.GetNewRegistryAuthClient(secrets)
-	if err != nil {
-		return nil, err
+func getRegistryAuthClient(ctx context.Context, newRegistryClient authclient.AuthClient, templatePath string) (remote.Client, error) {
+	return newRegistryClient.GetAuthClient(ctx, templatePath)
+}
+
+func (d *bicepDriver) resolveRegistryClient(ctx context.Context, opts driver.BaseOptions, secrets recipes.SecretData) (remote.Client, error) {
+	// Prefer legacy secret-based auth when provided (to be removed after migration).
+	if !reflect.DeepEqual(secrets, recipes.SecretData{}) {
+		newRegistryClient, err := authclient.GetNewRegistryAuthClient(secrets)
+		if err != nil {
+			return nil, err
+		}
+		return getRegistryAuthClient(ctx, newRegistryClient, opts.Definition.TemplatePath)
 	}
 
-	return newRegistryClient.GetAuthClient(ctx, templatePath)
+	var newRegistryClient authclient.AuthClient
+	auth := opts.Configuration.BicepSettings.Authentication
+	if auth != nil && auth.Registries != nil {
+		parsedURL, err := url.Parse("https://" + opts.Definition.TemplatePath)
+		if err != nil {
+			return nil, err
+		}
+		if authType, ok := auth.Registries[parsedURL.Host]; ok {
+			switch {
+			case authType.Basic != nil:
+				newRegistryClient = authclient.NewBasicAuthentication(
+					authType.Basic.Username,
+					opts.Secrets[authType.Basic.Password.SecretID].Data[authType.Basic.Password.Key],
+				)
+			case authType.AzureWorkloadIdentity != nil:
+				newRegistryClient = authclient.NewAzureWorkloadIdentity(
+					authType.AzureWorkloadIdentity.ClientID,
+					authType.AzureWorkloadIdentity.TenantID,
+				)
+			case authType.AwsIrsa != nil:
+				newRegistryClient = authclient.NewAwsIRSA(authType.AwsIrsa.RoleArn)
+			}
+		}
+	}
+
+	if newRegistryClient == nil {
+		return d.RegistryClient, nil
+	}
+
+	return getRegistryAuthClient(ctx, newRegistryClient, opts.Definition.TemplatePath)
 }

--- a/pkg/recipes/driver/terraform/terraform.go
+++ b/pkg/recipes/driver/terraform/terraform.go
@@ -323,17 +323,23 @@ func (d *terraformDriver) FindSecretIDs(ctx context.Context, envConfig recipes.C
 
 	// Get the secret IDs and associated keys in provider configuration and environment variables
 	providerSecretIDs := terraform.GetProviderEnvSecretIDs(envConfig)
+	settingsSecretIDs := terraform.GetTerraformSettingsSecretIDs(envConfig)
 
 	// Merge secretStoreIDResourceKeys with providerSecretIDs
-	for secretStoreID, keys := range providerSecretIDs {
-		if _, ok := secretStoreIDResourceKeys[secretStoreID]; !ok {
-			secretStoreIDResourceKeys[secretStoreID] = keys
-		} else {
-			secretStoreIDResourceKeys[secretStoreID] = append(secretStoreIDResourceKeys[secretStoreID], keys...)
-		}
-	}
+	mergeSecretKeys(secretStoreIDResourceKeys, providerSecretIDs)
+	mergeSecretKeys(secretStoreIDResourceKeys, settingsSecretIDs)
 
 	return secretStoreIDResourceKeys, nil
+}
+
+func mergeSecretKeys(dest map[string][]string, src map[string][]string) {
+	for secretStoreID, keys := range src {
+		if _, ok := dest[secretStoreID]; !ok {
+			dest[secretStoreID] = append([]string(nil), keys...)
+		} else {
+			dest[secretStoreID] = append(dest[secretStoreID], keys...)
+		}
+	}
 }
 
 // getDeployedOutputResources is used to the get the resource IDs by parsing the terraform state for resource information and using it to create UCP qualified IDs.

--- a/pkg/recipes/driver/terraform/terraform_test.go
+++ b/pkg/recipes/driver/terraform/terraform_test.go
@@ -839,6 +839,15 @@ func Test_FindSecretIDs(t *testing.T) {
 			},
 		},
 		{
+			name:          "Secrets in terraform settings",
+			envConfig:     createTerraformConfigWithTerraformSettingsSecrets(),
+			definition:    definition,
+			expectedError: false,
+			expectedSecretIDs: map[string][]string{
+				"secret-store-settings": {"settings-token"},
+			},
+		},
+		{
 			name:          "GetPrivateGitRepoSecretStoreID returns error",
 			definition:    recipes.EnvironmentDefinition{TemplatePath: "git::https://dev.azu  re.com/project/module"},
 			envConfig:     createTerraformConfigWithAuthProviderEnvSecrets(),
@@ -1013,6 +1022,23 @@ func createTerraformConfigWithEnvSecrets() recipes.Configuration {
 				"secret1": {
 					Source: "secret-store-id1",
 					Key:    "secret-key-env2",
+				},
+			},
+		},
+	}
+}
+
+func createTerraformConfigWithTerraformSettingsSecrets() recipes.Configuration {
+	return recipes.Configuration{
+		TerraformSettings: &datamodel.TerraformSettingsProperties_v20250801preview{
+			TerraformRC: &datamodel.TerraformCliConfiguration{
+				Credentials: map[string]*datamodel.TerraformCredentialConfiguration{
+					"registry.terraform.io": {
+						Token: &datamodel.SecretRef{
+							SecretID: "secret-store-settings",
+							Key:      "settings-token",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/recipes/terraform/config/config.go
+++ b/pkg/recipes/terraform/config/config.go
@@ -278,6 +278,26 @@ func (cfg *TerraformConfig) AddTerraformBackend(resourceRecipe *recipes.Resource
 	return backendConfig, nil
 }
 
+// AddCustomBackend adds a custom backend configuration from TerraformSettings.
+// This allows users to configure their own backend (e.g., S3, AzureRM, GCS) instead of the default Kubernetes backend.
+// Save() must be called to save the generated backend config.
+func (cfg *TerraformConfig) AddCustomBackend(backendType string, backendConfig map[string]string) (map[string]any, error) {
+	if backendType == "" {
+		return nil, errors.New("backend type cannot be empty")
+	}
+
+	customBackendConfig := map[string]any{
+		backendType: backendConfig,
+	}
+
+	if cfg.Terraform == nil {
+		cfg.Terraform = &TerraformDefinition{}
+	}
+	cfg.Terraform.Backend = customBackendConfig
+
+	return customBackendConfig, nil
+}
+
 // Add outputs to the config file referencing module outputs to populate expected Radius resource outputs.
 // Outputs of modules are accessible through this format: module.<MODULE NAME>.<OUTPUT NAME>
 // https://developer.hashicorp.com/terraform/language/modules/syntax#accessing-module-output-values

--- a/pkg/recipes/terraform/execute.go
+++ b/pkg/recipes/terraform/execute.go
@@ -30,6 +30,8 @@ import (
 	"github.com/radius-project/radius/pkg/components/kubernetesclient/kubernetesclientprovider"
 	"github.com/radius-project/radius/pkg/components/metrics"
 	"github.com/radius-project/radius/pkg/components/secret/secretprovider"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+	"github.com/radius-project/radius/pkg/recipes"
 	"github.com/radius-project/radius/pkg/recipes/recipecontext"
 	"github.com/radius-project/radius/pkg/recipes/terraform/config"
 	"github.com/radius-project/radius/pkg/recipes/terraform/config/backends"
@@ -74,14 +76,14 @@ func (e *executor) Deploy(ctx context.Context, options Options) (*tfjson.State, 
 	}
 
 	// Create Terraform config in the working directory
-	kubernetesBackendSuffix, err := e.generateConfig(ctx, tf, options)
+	configResult, err := e.generateConfig(ctx, tf, options)
 	if err != nil {
 		return nil, err
 	}
 
 	if options.EnvConfig != nil {
 		// Set environment variables for the Terraform process.
-		err = e.setEnvironmentVariables(tf, options)
+		err = e.setEnvironmentVariables(tf, options, configResult.terraformRCPath)
 		if err != nil {
 			return nil, err
 		}
@@ -94,18 +96,20 @@ func (e *executor) Deploy(ctx context.Context, options Options) (*tfjson.State, 
 		return nil, err
 	}
 
-	// Validate that the terraform state file backend source exists.
-	// Currently only Kubernetes secret backend is supported, which is created by Terraform as a part of Terraform apply.
-	kubernetesClient, err := e.kubernetesClients.ClientGoClient()
-	if err != nil {
-		return nil, fmt.Errorf("error getting kubernetes client: %w", err)
-	}
+	if configResult.usesKubernetesBackend {
+		// Validate that the terraform state file backend source exists.
+		// Currently only Kubernetes secret backend is supported, which is created by Terraform as a part of Terraform apply.
+		kubernetesClient, err := e.kubernetesClients.ClientGoClient()
+		if err != nil {
+			return nil, fmt.Errorf("error getting kubernetes client: %w", err)
+		}
 
-	backendExists, err := backends.NewKubernetesBackend(kubernetesClient).ValidateBackendExists(ctx, backends.KubernetesBackendNamePrefix+kubernetesBackendSuffix)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving kubernetes secret for terraform state: %w", err)
-	} else if !backendExists {
-		return nil, errors.New("expected kubernetes secret for terraform state is not found")
+		backendExists, err := backends.NewKubernetesBackend(kubernetesClient).ValidateBackendExists(ctx, backends.KubernetesBackendNamePrefix+configResult.kubernetesBackendSuffix)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving kubernetes secret for terraform state: %w", err)
+		} else if !backendExists {
+			return nil, errors.New("expected kubernetes secret for terraform state is not found")
+		}
 	}
 
 	return state, nil
@@ -127,28 +131,37 @@ func (e *executor) Delete(ctx context.Context, options Options) error {
 	}
 
 	// Create Terraform config in the working directory
-	kubernetesBackendSuffix, err := e.generateConfig(ctx, tf, options)
+	configResult, err := e.generateConfig(ctx, tf, options)
 	if err != nil {
 		return err
 	}
 
-	// Before running terraform init and destroy, ensure that the Terraform state file storage source exists.
-	// If the state file source has been deleted or wasn't created due to a failure during apply then
-	// terraform initialization will fail due to missing backend source.
-	kubernetesClient, err := e.kubernetesClients.ClientGoClient()
-	if err != nil {
-		return fmt.Errorf("error getting kubernetes client: %w", err)
+	if options.EnvConfig != nil {
+		// Set environment variables for the Terraform process.
+		if err := e.setEnvironmentVariables(tf, options, configResult.terraformRCPath); err != nil {
+			return err
+		}
 	}
 
-	backendExists, err := backends.NewKubernetesBackend(kubernetesClient).ValidateBackendExists(ctx, backends.KubernetesBackendNamePrefix+kubernetesBackendSuffix)
-	if err != nil {
-		// Continue with the delete flow for all errors other than backend not found.
-		// If it is an intermittent error then the delete flow will fail and should be retried from the client.
-		logger.Info(fmt.Sprintf("Error retrieving Terraform state file backend: %s", err.Error()))
-	} else if !backendExists {
-		// Skip deletion if the backend does not exist. Delete can't be performed without Terraform state file.
-		logger.Info("Skipping deletion of recipe resources: Terraform state file backend does not exist.")
-		return nil
+	if configResult.usesKubernetesBackend {
+		// Before running terraform init and destroy, ensure that the Terraform state file storage source exists.
+		// If the state file source has been deleted or wasn't created due to a failure during apply then
+		// terraform initialization will fail due to missing backend source.
+		kubernetesClient, err := e.kubernetesClients.ClientGoClient()
+		if err != nil {
+			return fmt.Errorf("error getting kubernetes client: %w", err)
+		}
+
+		backendExists, err := backends.NewKubernetesBackend(kubernetesClient).ValidateBackendExists(ctx, backends.KubernetesBackendNamePrefix+configResult.kubernetesBackendSuffix)
+		if err != nil {
+			// Continue with the delete flow for all errors other than backend not found.
+			// If it is an intermittent error then the delete flow will fail and should be retried from the client.
+			logger.Info(fmt.Sprintf("Error retrieving Terraform state file backend: %s", err.Error()))
+		} else if !backendExists {
+			// Skip deletion if the backend does not exist. Delete can't be performed without Terraform state file.
+			logger.Info("Skipping deletion of recipe resources: Terraform state file backend does not exist.")
+			return nil
+		}
 	}
 
 	// Run TF Destroy in the working directory to delete the resources deployed by the recipe
@@ -158,12 +171,18 @@ func (e *executor) Delete(ctx context.Context, options Options) error {
 		return err
 	}
 
-	// Delete the kubernetes secret created for terraform state file.
-	err = kubernetesClient.CoreV1().
-		Secrets(backends.RadiusNamespace).
-		Delete(ctx, backends.KubernetesBackendNamePrefix+kubernetesBackendSuffix, metav1.DeleteOptions{})
-	if err != nil {
-		return fmt.Errorf("error deleting kubernetes secret for terraform state: %w", err)
+	if configResult.usesKubernetesBackend {
+		// Delete the kubernetes secret created for terraform state file.
+		kubernetesClient, err := e.kubernetesClients.ClientGoClient()
+		if err != nil {
+			return fmt.Errorf("error getting kubernetes client: %w", err)
+		}
+		err = kubernetesClient.CoreV1().
+			Secrets(backends.RadiusNamespace).
+			Delete(ctx, backends.KubernetesBackendNamePrefix+configResult.kubernetesBackendSuffix, metav1.DeleteOptions{})
+		if err != nil {
+			return fmt.Errorf("error deleting kubernetes secret for terraform state: %w", err)
+		}
 	}
 
 	return nil
@@ -194,7 +213,7 @@ func (e *executor) GetRecipeMetadata(ctx context.Context, options Options) (map[
 
 // setEnvironmentVariables sets environment variables for the Terraform process by reading values from the recipe configuration.
 // Terraform process will use environment variables as input for the recipe deployment.
-func (e executor) setEnvironmentVariables(tf *tfexec.Terraform, options Options) error {
+func (e executor) setEnvironmentVariables(tf *tfexec.Terraform, options Options, terraformRCPath string) error {
 	if options.EnvConfig == nil {
 		return nil
 	}
@@ -227,6 +246,33 @@ func (e executor) setEnvironmentVariables(tf *tfexec.Terraform, options Options)
 		}
 	}
 
+	// Apply TerraformSettings.Env if configured
+	if options.EnvConfig.TerraformSettings != nil && len(options.EnvConfig.TerraformSettings.Env) > 0 {
+		envVarUpdate = true
+		for key, value := range options.EnvConfig.TerraformSettings.Env {
+			envVars[key] = value
+		}
+	}
+
+	// Apply TerraformSettings.Logging (TF_LOG, TF_LOG_PATH) if configured
+	if options.EnvConfig.TerraformSettings != nil && options.EnvConfig.TerraformSettings.Logging != nil {
+		logging := options.EnvConfig.TerraformSettings.Logging
+		if logging.Level != "" {
+			envVarUpdate = true
+			envVars["TF_LOG"] = string(logging.Level)
+		}
+		if logging.Path != "" {
+			envVarUpdate = true
+			envVars["TF_LOG_PATH"] = logging.Path
+		}
+	}
+
+	// Apply TerraformSettings.TerraformRC (TF_CLI_CONFIG_FILE) if configured
+	if terraformRCPath != "" {
+		envVarUpdate = true
+		envVars["TF_CLI_CONFIG_FILE"] = terraformRCPath
+	}
+
 	// Set the environment variables for the Terraform process
 	if envVarUpdate {
 		if err := tf.SetEnv(envVars); err != nil {
@@ -251,45 +297,76 @@ func splitEnvVar(envVars []string) map[string]string {
 }
 
 // generateConfig generates Terraform configuration with required inputs for the module, providers and backend to be initialized and applied.
-func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, options Options) (string, error) {
+type generateConfigResult struct {
+	kubernetesBackendSuffix string
+	usesKubernetesBackend   bool
+	terraformRCPath         string
+}
+
+func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, options Options) (generateConfigResult, error) {
 	logger := ucplog.FromContextOrDiscard(ctx)
 	workingDir := tf.WorkingDir()
 
 	tfConfig, err := getTerraformConfig(ctx, workingDir, options)
 	if err != nil {
-		return "", err
+		return generateConfigResult{}, err
 	}
 
 	loadedModule, err := downloadAndInspect(ctx, tf, options)
 	if err != nil {
-		return "", err
+		return generateConfigResult{}, err
 	}
 
 	// Generate Terraform providers configuration for required providers and add it to the Terraform configuration.
 	logger.Info(fmt.Sprintf("Adding provider config for required providers %+v", loadedModule.RequiredProviders))
 	if err := tfConfig.AddProviders(ctx, loadedModule.RequiredProviders, providers.GetUCPConfiguredTerraformProviders(e.ucpConn, e.secretProvider),
 		options.EnvConfig, options.Secrets); err != nil {
-		return "", err
+		return generateConfigResult{}, err
 	}
 
-	kubernetesClient, err := e.kubernetesClients.ClientGoClient()
-	if err != nil {
-		return "", fmt.Errorf("error getting kubernetes client: %w", err)
-	}
+	// Configure backend: use custom backend from TerraformSettings if specified, otherwise use Kubernetes backend
+	var backendConfig map[string]any
+	result := generateConfigResult{}
 
-	backendConfig, err := tfConfig.AddTerraformBackend(options.ResourceRecipe, backends.NewKubernetesBackend(kubernetesClient))
-	if err != nil {
-		return "", err
-	}
-
-	// Retrieving the secret_suffix property from backend config to use it to verify secret creation during terraform init.
-	// This is only used for the backend of type kubernetes and should be moved inside an if block when we add more backends.
-	var secretSuffix string
-	if backendDetails, ok := backendConfig[backends.BackendKubernetes]; ok {
-		backendMap := backendDetails.(map[string]any)
-		if secret, ok := backendMap["secret_suffix"]; ok {
-			secretSuffix = secret.(string)
+	if options.EnvConfig != nil && options.EnvConfig.TerraformSettings != nil && options.EnvConfig.TerraformSettings.Backend != nil {
+		// Use custom backend from TerraformSettings
+		customBackend := options.EnvConfig.TerraformSettings.Backend
+		logger.Info(fmt.Sprintf("Using custom backend type: %s", customBackend.Type))
+		backendConfig, err = tfConfig.AddCustomBackend(customBackend.Type, customBackend.Config)
+		if err != nil {
+			return generateConfigResult{}, fmt.Errorf("error adding custom backend: %w", err)
 		}
+	} else {
+		// Use default Kubernetes backend
+		kubernetesClient, err := e.kubernetesClients.ClientGoClient()
+		if err != nil {
+			return generateConfigResult{}, fmt.Errorf("error getting kubernetes client: %w", err)
+		}
+
+		backendConfig, err = tfConfig.AddTerraformBackend(options.ResourceRecipe, backends.NewKubernetesBackend(kubernetesClient))
+		if err != nil {
+			return generateConfigResult{}, err
+		}
+		result.usesKubernetesBackend = true
+
+		// Retrieving the secret_suffix property from backend config to use it to verify secret creation during terraform init.
+		// This is only used for the backend of type kubernetes.
+		if backendDetails, ok := backendConfig[backends.BackendKubernetes]; ok {
+			backendMap := backendDetails.(map[string]any)
+			if secret, ok := backendMap["secret_suffix"]; ok {
+				result.kubernetesBackendSuffix = secret.(string)
+			}
+		}
+	}
+
+	// Write .terraformrc if TerraformSettings.TerraformRC is configured
+	if options.EnvConfig != nil && options.EnvConfig.TerraformSettings != nil && options.EnvConfig.TerraformSettings.TerraformRC != nil {
+		terraformrcPath, err := e.writeTerraformRC(ctx, workingDir, options.EnvConfig.TerraformSettings.TerraformRC, options.Secrets)
+		if err != nil {
+			return generateConfigResult{}, fmt.Errorf("error writing .terraformrc: %w", err)
+		}
+		logger.Info(fmt.Sprintf("Written .terraformrc to: %s", terraformrcPath))
+		result.terraformRCPath = terraformrcPath
 	}
 
 	// Add recipe context parameter to the generated Terraform config's module parameters.
@@ -300,7 +377,7 @@ func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, opt
 		// Create the recipe context object to be passed to the recipe deployment
 		recipectx, err := recipecontext.New(options.ResourceRecipe, options.EnvConfig)
 		if err != nil {
-			return "", err
+			return generateConfigResult{}, err
 		}
 
 		//update the recipe context with connected resources properties
@@ -309,12 +386,12 @@ func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, opt
 		}
 
 		if err = tfConfig.AddRecipeContext(ctx, options.EnvRecipe.Name, recipectx); err != nil {
-			return "", err
+			return generateConfigResult{}, err
 		}
 	}
 	if loadedModule.ResultOutputExists {
 		if err = tfConfig.AddOutputs(options.EnvRecipe.Name); err != nil {
-			return "", err
+			return generateConfigResult{}, err
 		}
 	}
 
@@ -322,10 +399,10 @@ func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, opt
 
 	// Ensure that we need to save the configuration after adding providers and recipecontext.
 	if err := tfConfig.Save(ctx, workingDir); err != nil {
-		return "", err
+		return generateConfigResult{}, err
 	}
 
-	return secretSuffix, nil
+	return result, nil
 }
 
 // getTerraformConfig initializes the Terraform json config with provided module source and saves it
@@ -361,6 +438,156 @@ func getStateLockTimeout(timeout string) string {
 		return DefaultStateLockTimeout
 	}
 	return timeout
+}
+
+// writeTerraformRC writes a .terraformrc file in the working directory with provider installation and credentials configuration.
+// Returns the path to the written file.
+func (e *executor) writeTerraformRC(ctx context.Context, workingDir string, tfrc *datamodel.TerraformCliConfiguration, secrets map[string]recipes.SecretData) (string, error) {
+	// Build the terraformrc content
+	var content strings.Builder
+
+	// Add provider_installation block if configured
+	if tfrc.ProviderInstallation != nil {
+		content.WriteString("provider_installation {\n")
+
+		// Add network_mirror block
+		if tfrc.ProviderInstallation.NetworkMirror != nil {
+			nm := tfrc.ProviderInstallation.NetworkMirror
+			content.WriteString("  network_mirror {\n")
+			content.WriteString(fmt.Sprintf("    url = \"%s\"\n", nm.URL))
+
+			if len(nm.Include) > 0 {
+				content.WriteString("    include = [")
+				for i, inc := range nm.Include {
+					if i > 0 {
+						content.WriteString(", ")
+					}
+					content.WriteString(fmt.Sprintf("\"%s\"", inc))
+				}
+				content.WriteString("]\n")
+			}
+
+			if len(nm.Exclude) > 0 {
+				content.WriteString("    exclude = [")
+				for i, exc := range nm.Exclude {
+					if i > 0 {
+						content.WriteString(", ")
+					}
+					content.WriteString(fmt.Sprintf("\"%s\"", exc))
+				}
+				content.WriteString("]\n")
+			}
+
+			content.WriteString("  }\n")
+		}
+
+		// Add direct block
+		if tfrc.ProviderInstallation.Direct != nil {
+			d := tfrc.ProviderInstallation.Direct
+			content.WriteString("  direct {\n")
+
+			if len(d.Include) > 0 {
+				content.WriteString("    include = [")
+				for i, inc := range d.Include {
+					if i > 0 {
+						content.WriteString(", ")
+					}
+					content.WriteString(fmt.Sprintf("\"%s\"", inc))
+				}
+				content.WriteString("]\n")
+			}
+
+			if len(d.Exclude) > 0 {
+				content.WriteString("    exclude = [")
+				for i, exc := range d.Exclude {
+					if i > 0 {
+						content.WriteString(", ")
+					}
+					content.WriteString(fmt.Sprintf("\"%s\"", exc))
+				}
+				content.WriteString("]\n")
+			}
+
+			content.WriteString("  }\n")
+		}
+
+		content.WriteString("}\n\n")
+	}
+
+	// Add credentials blocks if configured
+	if len(tfrc.Credentials) > 0 {
+		for hostname, cred := range tfrc.Credentials {
+			if cred.Token != nil {
+				// Resolve the token from secrets.
+				// If resolution fails, we return an error because the user explicitly configured
+				// these credentials - they are required for registry/host authentication.
+				tokenValue, err := resolveSecretRef(cred.Token, secrets)
+				if err != nil {
+					return "", fmt.Errorf("failed to resolve credential token for hostname %q: %w", hostname, err)
+				}
+
+				// Escape hostname and token values to prevent HCL injection and ensure valid syntax.
+				// This handles special characters like quotes, backslashes, and newlines.
+				content.WriteString(fmt.Sprintf("credentials \"%s\" {\n", escapeHCLString(hostname)))
+				content.WriteString(fmt.Sprintf("  token = \"%s\"\n", escapeHCLString(tokenValue)))
+				content.WriteString("}\n\n")
+			}
+		}
+	}
+
+	// Write the file
+	terraformrcPath := fmt.Sprintf("%s/.terraformrc", workingDir)
+	if err := os.WriteFile(terraformrcPath, []byte(content.String()), 0600); err != nil {
+		return "", fmt.Errorf("error writing .terraformrc: %w", err)
+	}
+
+	return terraformrcPath, nil
+}
+
+// resolveSecretRef resolves a secret reference to its actual value from the secrets map.
+func resolveSecretRef(ref *datamodel.SecretRef, secrets map[string]recipes.SecretData) (string, error) {
+	if ref == nil {
+		return "", errors.New("secret reference is nil")
+	}
+
+	secretData, ok := secrets[ref.SecretID]
+	if !ok {
+		return "", fmt.Errorf("secret not found: %s", ref.SecretID)
+	}
+
+	value, ok := secretData.Data[ref.Key]
+	if !ok {
+		return "", fmt.Errorf("key '%s' not found in secret '%s'", ref.Key, ref.SecretID)
+	}
+
+	return value, nil
+}
+
+// escapeHCLString escapes special characters in a string for safe inclusion in an HCL quoted string.
+// This prevents injection attacks and ensures the .terraformrc file is valid HCL.
+// Escaped characters: backslash, double quote, newline, carriage return, tab.
+func escapeHCLString(s string) string {
+	var result strings.Builder
+	result.Grow(len(s))
+
+	for _, r := range s {
+		switch r {
+		case '\\':
+			result.WriteString("\\\\")
+		case '"':
+			result.WriteString("\\\"")
+		case '\n':
+			result.WriteString("\\n")
+		case '\r':
+			result.WriteString("\\r")
+		case '\t':
+			result.WriteString("\\t")
+		default:
+			result.WriteRune(r)
+		}
+	}
+
+	return result.String()
 }
 
 // initAndApply runs Terraform init and apply in the provided working directory.

--- a/pkg/recipes/terraform/execute.go
+++ b/pkg/recipes/terraform/execute.go
@@ -332,7 +332,7 @@ func (e *executor) generateConfig(ctx context.Context, tf *tfexec.Terraform, opt
 		// Use custom backend from TerraformSettings
 		customBackend := options.EnvConfig.TerraformSettings.Backend
 		logger.Info(fmt.Sprintf("Using custom backend type: %s", customBackend.Type))
-		backendConfig, err = tfConfig.AddCustomBackend(customBackend.Type, customBackend.Config)
+		_, err = tfConfig.AddCustomBackend(customBackend.Type, customBackend.Config)
 		if err != nil {
 			return generateConfigResult{}, fmt.Errorf("error adding custom backend: %w", err)
 		}

--- a/pkg/recipes/terraform/execute_test.go
+++ b/pkg/recipes/terraform/execute_test.go
@@ -256,7 +256,7 @@ func TestSetEnvironmentVariables(t *testing.T) {
 			require.NoError(t, err)
 
 			e := executor{}
-			err = e.setEnvironmentVariables(tf, tc.opts)
+			err = e.setEnvironmentVariables(tf, tc.opts, "")
 
 			if tc.wantErr {
 				require.Error(t, err)

--- a/pkg/recipes/types.go
+++ b/pkg/recipes/types.go
@@ -46,6 +46,11 @@ type Configuration struct {
 	Simulated bool
 
 	RecipeConfig datamodel.RecipeConfigProperties
+
+	// TerraformSettings contains settings from Radius.Core/terraformSettings resource.
+	TerraformSettings *datamodel.TerraformSettingsProperties_v20250801preview
+	// BicepSettings contains settings from Radius.Core/bicepSettings resource.
+	BicepSettings *datamodel.BicepSettingsProperties_v20250801preview
 }
 
 // RuntimeConfiguration represents Runtime configuration for the environment.

--- a/pkg/rp/util/registry_test.go
+++ b/pkg/rp/util/registry_test.go
@@ -48,6 +48,39 @@ func Test_GetRegistrySecrets(t *testing.T) {
 	}{
 		{
 			definition: recipes.Configuration{
+				BicepSettings: &datamodel.BicepSettingsProperties_v20250801preview{
+					Authentication: &datamodel.BicepAuthenticationConfiguration{
+						Registries: map[string]*datamodel.BicepRegistryAuthentication{
+							"test.azurecr.io": {
+								Basic: &datamodel.BicepBasicAuthentication{
+									Password: &datamodel.SecretRef{SecretID: "settingsSecret", Key: "password"},
+								},
+							},
+						},
+					},
+				},
+				RecipeConfig: datamodel.RecipeConfigProperties{},
+			},
+			templatePath: "test.azurecr.io/test-private-registry:latest",
+			secrets: map[string]recipes.SecretData{
+				"settingsSecret": {
+					Type: "basicAuthentication",
+					Data: map[string]string{
+						"username": "test-username",
+						"password": "test-password",
+					},
+				},
+			},
+			exp: recipes.SecretData{
+				Type: "basicAuthentication",
+				Data: map[string]string{
+					"username": "test-username",
+					"password": "test-password",
+				},
+			},
+		},
+		{
+			definition: recipes.Configuration{
 				RecipeConfig: datamodel.RecipeConfigProperties{
 					Bicep: datamodel.BicepConfigProperties{
 						Authentication: map[string]datamodel.RegistrySecretConfig{

--- a/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/openapi.json
+++ b/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/openapi.json
@@ -1563,6 +1563,14 @@
         "authentication": {
           "$ref": "#/definitions/BicepAuthenticationConfiguration",
           "description": "Authentication settings for private registries."
+        },
+        "referencedBy": {
+          "type": "array",
+          "description": "List of environment resource IDs that reference this settings resource.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
         }
       }
     },
@@ -2387,6 +2395,14 @@
         "logging": {
           "$ref": "#/definitions/TerraformLoggingConfiguration",
           "description": "Logging configuration applied to Terraform executions."
+        },
+        "referencedBy": {
+          "type": "array",
+          "description": "List of environment resource IDs that reference this settings resource.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
         }
       }
     },

--- a/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/openapi.json
+++ b/swagger/specification/radius/resource-manager/Radius.Core/preview/2025-08-01-preview/openapi.json
@@ -377,7 +377,7 @@
         }
       }
     },
-    "/{rootScope}/providers/Radius.Core/bicepSettings/{bicepSettingsName}": {
+    "/{rootScope}/providers/Radius.Core/bicepSettings/{bicepSettingName}": {
       "get": {
         "operationId": "BicepSettings_Get",
         "tags": [
@@ -392,7 +392,7 @@
             "$ref": "#/parameters/RootScopeParameter"
           },
           {
-            "name": "bicepSettingsName",
+            "name": "bicepSettingName",
             "in": "path",
             "description": "Bicep settings resource name.",
             "required": true,
@@ -430,7 +430,7 @@
             "$ref": "#/parameters/RootScopeParameter"
           },
           {
-            "name": "bicepSettingsName",
+            "name": "bicepSettingName",
             "in": "path",
             "description": "Bicep settings resource name.",
             "required": true,
@@ -483,7 +483,7 @@
             "$ref": "#/parameters/RootScopeParameter"
           },
           {
-            "name": "bicepSettingsName",
+            "name": "bicepSettingName",
             "in": "path",
             "description": "Bicep settings resource name.",
             "required": true,
@@ -530,7 +530,7 @@
             "$ref": "#/parameters/RootScopeParameter"
           },
           {
-            "name": "bicepSettingsName",
+            "name": "bicepSettingName",
             "in": "path",
             "description": "Bicep settings resource name.",
             "required": true,
@@ -1044,7 +1044,7 @@
         }
       }
     },
-    "/{rootScope}/providers/Radius.Core/terraformSettings/{terraformSettingsName}": {
+    "/{rootScope}/providers/Radius.Core/terraformSettings/{terraformSettingName}": {
       "get": {
         "operationId": "TerraformSettings_Get",
         "tags": [
@@ -1059,7 +1059,7 @@
             "$ref": "#/parameters/RootScopeParameter"
           },
           {
-            "name": "terraformSettingsName",
+            "name": "terraformSettingName",
             "in": "path",
             "description": "Terraform settings resource name.",
             "required": true,
@@ -1097,7 +1097,7 @@
             "$ref": "#/parameters/RootScopeParameter"
           },
           {
-            "name": "terraformSettingsName",
+            "name": "terraformSettingName",
             "in": "path",
             "description": "Terraform settings resource name.",
             "required": true,
@@ -1150,7 +1150,7 @@
             "$ref": "#/parameters/RootScopeParameter"
           },
           {
-            "name": "terraformSettingsName",
+            "name": "terraformSettingName",
             "in": "path",
             "description": "Terraform settings resource name.",
             "required": true,
@@ -1197,7 +1197,7 @@
             "$ref": "#/parameters/RootScopeParameter"
           },
           {
-            "name": "terraformSettingsName",
+            "name": "terraformSettingName",
             "in": "path",
             "description": "Terraform settings resource name.",
             "required": true,

--- a/typespec/Radius.Core/bicepSettings.tsp
+++ b/typespec/Radius.Core/bicepSettings.tsp
@@ -39,7 +39,7 @@ namespace Radius.Core;
 model BicepSettingsResource
   is TrackedResourceRequired<BicepSettingsProperties, "bicepSettings"> {
   @doc("Bicep settings resource name.")
-  @key("bicepSettingsName")
+  @key("bicepSettingName")
   @path
   @segment("bicepSettings")
   name: ResourceNameString;

--- a/typespec/Radius.Core/bicepSettings.tsp
+++ b/typespec/Radius.Core/bicepSettings.tsp
@@ -53,6 +53,10 @@ model BicepSettingsProperties {
 
   @doc("Authentication settings for private registries.")
   authentication?: BicepAuthenticationConfiguration;
+
+  @doc("List of environment resource IDs that reference this settings resource.")
+  @visibility(Lifecycle.Read)
+  referencedBy?: string[];
 }
 
 @doc("Authentication configuration for Bicep registries.")

--- a/typespec/Radius.Core/terraformSettings.tsp
+++ b/typespec/Radius.Core/terraformSettings.tsp
@@ -62,6 +62,10 @@ model TerraformSettingsProperties {
 
   @doc("Logging configuration applied to Terraform executions.")
   logging?: TerraformLoggingConfiguration;
+
+  @doc("List of environment resource IDs that reference this settings resource.")
+  @visibility(Lifecycle.Read)
+  referencedBy?: string[];
 }
 
 @doc("Terraform CLI configuration matching the terraformrc file.")

--- a/typespec/Radius.Core/terraformSettings.tsp
+++ b/typespec/Radius.Core/terraformSettings.tsp
@@ -39,7 +39,7 @@ namespace Radius.Core;
 model TerraformSettingsResource
   is TrackedResourceRequired<TerraformSettingsProperties, "terraformSettings"> {
   @doc("Terraform settings resource name.")
-  @key("terraformSettingsName")
+  @key("terraformSettingName")
   @path
   @segment("terraformSettings")
   name: ResourceNameString;


### PR DESCRIPTION
# Description

- Connects TerraformSettings and BicepSettings resources to the Environment resource
- Adds validation during environment create/update to verify referenced settings exist
- Implements delete filters to prevent deletion of settings that are in use by environments
- Updates recipe config loaders and drivers to use settings from linked resources

**Test plan**

- Verify environment creation fails if referencing non-existent settings
- Verify settings cannot be deleted while referenced by an environment
- Verify recipes correctly load configuration from linked settings resources

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->