### PR TITLE
Fix approval-gate skipping for org members in functional-test-cloud

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -98,15 +98,14 @@ jobs:
     name: Approval Gate
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    # Only applies to pull_request_target events
-    if: github.event_name == 'pull_request_target'
-    # Use environment with required reviewers for external contributors.
-    # Trusted users (dependabot, org members) get empty environment (no approval needed).
-    # External contributors get 'external-contributor-approval' environment (requires approval).
-    environment: ${{
-      (github.actor == 'dependabot[bot]' ||
-       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))
-      && '' || 'external-contributor-approval' }}
+    # Only run for external contributors on pull_request_target events.
+    # Trusted users (dependabot, org members) skip this job entirely.
+    # External contributors require approval via 'external-contributor-approval' environment.
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.actor != 'dependabot[bot]' &&
+      !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+    environment: external-contributor-approval
     permissions: {}
     steps:
       - name: Approved
@@ -115,10 +114,11 @@ jobs:
   setup:
     name: Setup
     needs: [approval-gate]
-    # Run for all events. For PRs, approval-gate ensures external contributors are approved.
+    # Run for all events. For PRs, approval-gate either succeeds (external contributors approved)
+    # or is skipped (trusted users like org members and dependabot).
     if: |
       always() &&
-      (github.event_name != 'pull_request_target' || needs.approval-gate.result == 'success') &&
+      (github.event_name != 'pull_request_target' || needs.approval-gate.result == 'success' || needs.approval-gate.result == 'skipped') &&
       (github.event_name != 'schedule' || github.repository == 'radius-project/radius')
     runs-on: ubuntu-24.04
     timeout-minutes: 5


### PR DESCRIPTION
# Description

Fix the approval-gate job in functional-test-cloud.yaml that was incorrectly gating PRs from org members (like PR #11177 from DariuszPorowski).

**Root cause:** The expression `environment: ${{ <condition> && '' || 'external-contributor-approval' }}` evaluates to an empty string `''` for trusted users. However, GitHub Actions treats an empty string as a valid environment reference (creating an empty-named environment), NOT as "skip using an environment."

**Fix:** Changed the approach to skip the `approval-gate` job entirely for trusted users via `if` condition, rather than using a conditional environment. Updated the `setup` job to also allow `needs.approval-gate.result == 'skipped'` so downstream jobs proceed correctly.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and does not change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->
