### PR TITLE
Consolidated preflight upgrade tests with tighter polling

### DIFF
--- a/test/functional-portable/upgrade/upgrade_test.go
+++ b/test/functional-portable/upgrade/upgrade_test.go
@@ -31,359 +31,264 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
 	radiusNamespace   = "radius-system"
 	preUpgradeJobName = "pre-upgrade"
-	testTimeout       = 5 * time.Minute
+	helmTimeout       = "3m"
 
 	relativeChartPath = "../../../deploy/Chart"
+
+	// Polling intervals for waiting on Kubernetes state changes.
+	controlPlanePollInterval = 3 * time.Second
+	cleanupPollInterval      = 3 * time.Second
+	jobPollInterval          = 1 * time.Second
+	jobPollAttempts          = 15
 )
 
-func Test_PreflightContainer_FreshInstall(t *testing.T) {
-	ctx := testcontext.New(t)
-
-	image, tag := getPreUpgradeImage()
-
-	// Clean up any existing installation using helm
-	t.Log("Cleaning up any existing Radius installation")
-	cleanupCommand := []string{"helm", "uninstall", "radius", "--namespace", radiusNamespace, "--ignore-not-found"}
-	_ = exec.Command(cleanupCommand[0], cleanupCommand[1:]...).Run() // Ignore errors during cleanup
-
-	// Use local registry image for testing the pre-upgrade functionality
-	t.Log("Installing Radius with preflight enabled using helm")
-	installCommand := []string{
-		"helm", "install", "radius", relativeChartPath,
-		"--namespace", radiusNamespace,
-		"--create-namespace",
-		"--set", "preupgrade.enabled=true",
-		"--set", fmt.Sprintf("preupgrade.image=%s", image),
-		"--set", fmt.Sprintf("preupgrade.tag=%s", tag),
-		"--wait",
-	}
-	err := runHelmCommand(ctx, installCommand)
-	require.NoError(t, err, "Failed to install Radius using helm")
-
-	// Wait for the control plane to become available
-	var options rp.RPTestOptions
-	require.Eventually(t, func() bool {
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					// NewRPTestOptions calls require.NoError internally, catch panics
-					t.Logf("Control plane not ready yet: %v", r)
-				}
-			}()
-			options = rp.NewRPTestOptions(t)
-		}()
-		// Test if we can make a simple API call to verify the control plane is ready
-		return options.ManagementClient != nil
-	}, 2*time.Minute, 5*time.Second, "Control plane did not become available within timeout")
-
-	t.Log("Attempting upgrade with local chart to trigger Helm pre-upgrade hook")
-	upgradeCommand := []string{
-		"helm", "upgrade", "radius", relativeChartPath,
-		"--namespace", radiusNamespace,
-		"--set", "preupgrade.enabled=true",
-		"--set", fmt.Sprintf("preupgrade.image=%s", image),
-		"--set", fmt.Sprintf("preupgrade.tag=%s", tag),
-		"--wait",
-	}
-	// This might fail due to version issues, but should trigger the Helm hook
-	// The key test is that the job gets created
-	_ = runHelmCommand(ctx, upgradeCommand) // Ignore errors as upgrade may fail due to version issues
-
-	t.Log("Verifying preflight job was created by Helm pre-upgrade hook")
-	verifyPreflightJobRan(t, ctx, options, true)
-
-	t.Log("Cleaning up - uninstalling Radius using helm")
-	uninstallCommand := []string{"helm", "uninstall", "radius", "--namespace", radiusNamespace}
-	err = runHelmCommand(ctx, uninstallCommand)
-	require.NoError(t, err, "Failed to uninstall Radius using helm")
+// Test_PreflightContainer runs all preflight container upgrade tests as sequential
+// subtests. These tests cannot run in parallel because they share the same Helm
+// release name and Kubernetes namespace. Consolidating into subtests reduces the
+// number of full install/uninstall cycles (from 4 to 2) and eliminates redundant
+// test logic.
+func Test_PreflightContainer(t *testing.T) {
+	t.Run("Enabled", testPreflightEnabled)
+	t.Run("Disabled", testPreflightDisabled)
 }
 
-func Test_PreflightContainer_PreflightDisabled(t *testing.T) {
+// testPreflightEnabled verifies that when preflight is enabled:
+//   - The pre-upgrade Helm hook creates a job during upgrade
+//   - Custom job configuration (TTL, version check) is applied correctly
+//   - Job logs and status are accessible
+func testPreflightEnabled(t *testing.T) {
 	ctx := testcontext.New(t)
-
 	image, tag := getPreUpgradeImage()
 
-	// Clean up any existing installation using helm
-	t.Log("Cleaning up any existing Radius installation")
-	cleanupCommand := []string{"helm", "uninstall", "radius", "--namespace", radiusNamespace, "--ignore-not-found"}
-	_ = exec.Command(cleanupCommand[0], cleanupCommand[1:]...).Run() // Ignore errors during cleanup
+	cleanupAndWait(t, ctx)
 
-	// Wait for cleanup to complete
-	time.Sleep(3 * time.Second)
-
-	t.Log("Installing Radius with preflight disabled using helm")
-	installCommand := []string{
-		"helm", "install", "radius", relativeChartPath,
-		"--namespace", radiusNamespace,
-		"--create-namespace",
-		"--set", "preupgrade.enabled=false",
-		"--set", fmt.Sprintf("preupgrade.image=%s", image),
-		"--set", fmt.Sprintf("preupgrade.tag=%s", tag),
-		"--wait",
+	helmValues := map[string]string{
+		"preupgrade.enabled":                 "true",
+		"preupgrade.ttlSecondsAfterFinished": "60",
+		"preupgrade.checks.version":          "true",
 	}
-	err := runHelmCommand(ctx, installCommand)
-	require.NoError(t, err, "Failed to install Radius using helm")
 
-	// Wait for the control plane to become available
-	var options rp.RPTestOptions
-	require.Eventually(t, func() bool {
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					// NewRPTestOptions calls require.NoError internally, catch panics
-					t.Logf("Control plane not ready yet: %v", r)
-				}
-			}()
-			options = rp.NewRPTestOptions(t)
-		}()
-		// Test if we can make a simple API call to verify the control plane is ready
-		return options.ManagementClient != nil
-	}, 2*time.Minute, 5*time.Second, "Control plane did not become available within timeout")
+	t.Log("Installing Radius with preflight enabled and custom configuration")
+	err := helmInstall(ctx, image, tag, helmValues)
+	require.NoError(t, err, "Failed to install Radius")
 
-	t.Log("Attempting upgrade with preflight disabled using helm")
+	options := waitForControlPlane(t, ctx)
+
+	t.Log("Upgrading to trigger pre-upgrade hook")
+	// Upgrade may fail due to version issues, but should trigger the Helm hook.
+	// The key assertion is that the job gets created.
+	_ = helmUpgrade(ctx, image, tag, helmValues)
+
+	t.Log("Verifying preflight job was created and configured correctly")
+	job := findPreflightJob(t, ctx, options)
+	if job != nil {
+		logJobDetails(t, ctx, options, job)
+
+		// Verify custom configuration was applied
+		require.NotNil(t, job.Spec.TTLSecondsAfterFinished, "TTLSecondsAfterFinished should be set")
+		require.Equal(t, int32(60), *job.Spec.TTLSecondsAfterFinished)
+		t.Log("Job configuration verified")
+	} else {
+		t.Log("Preflight job not found - upgrade likely failed before hooks triggered (acceptable in test environment)")
+	}
+
+	helmUninstall(t, ctx)
+}
+
+// testPreflightDisabled verifies that when preflight is disabled, the pre-upgrade
+// Helm hook does not create a job during upgrade.
+func testPreflightDisabled(t *testing.T) {
+	ctx := testcontext.New(t)
+	image, tag := getPreUpgradeImage()
+
+	cleanupAndWait(t, ctx)
+
+	helmValues := map[string]string{
+		"preupgrade.enabled": "false",
+	}
+
+	t.Log("Installing Radius with preflight disabled")
+	err := helmInstall(ctx, image, tag, helmValues)
+	require.NoError(t, err, "Failed to install Radius")
+
+	options := waitForControlPlane(t, ctx)
 
 	// Ensure no leftover job exists before upgrade
-	_ = options.K8sClient.BatchV1().Jobs(radiusNamespace).Delete(ctx, preUpgradeJobName, metav1.DeleteOptions{}) // Ignore errors during cleanup
+	_ = options.K8sClient.BatchV1().Jobs(radiusNamespace).Delete(ctx, preUpgradeJobName, metav1.DeleteOptions{})
 
-	upgradeCommand := []string{
-		"helm", "upgrade", "radius", relativeChartPath,
-		"--namespace", radiusNamespace,
-		"--set", "preupgrade.enabled=false",
-		"--set", fmt.Sprintf("preupgrade.image=%s", image),
-		"--set", fmt.Sprintf("preupgrade.tag=%s", tag),
-		"--wait",
-	}
-	_ = runHelmCommand(ctx, upgradeCommand) // Ignore errors as upgrade might fail due to version issues
+	t.Log("Upgrading with preflight disabled")
+	_ = helmUpgrade(ctx, image, tag, helmValues)
 
 	t.Log("Verifying no preflight job was created")
-	verifyPreflightJobRan(t, ctx, options, false)
-
-	t.Log("Cleaning up - uninstalling Radius using helm")
-	uninstallCommand := []string{"helm", "uninstall", "radius", "--namespace", radiusNamespace}
-	err = runHelmCommand(ctx, uninstallCommand)
-	require.NoError(t, err, "Failed to uninstall Radius using helm")
-}
-
-func Test_PreflightContainer_JobConfiguration(t *testing.T) {
-	ctx := testcontext.New(t)
-
-	image, tag := getPreUpgradeImage()
-
-	// Clean up any existing installation using helm
-	t.Log("Cleaning up any existing Radius installation")
-	cleanupCommand := []string{"helm", "uninstall", "radius", "--namespace", radiusNamespace, "--ignore-not-found"}
-	_ = exec.Command(cleanupCommand[0], cleanupCommand[1:]...).Run() // Ignore errors during cleanup
-
-	// Wait for cleanup to complete
-	time.Sleep(3 * time.Second)
-
-	// Use local registry image for testing
-	t.Log("Installing Radius with custom preflight configuration using helm")
-	installCommand := []string{
-		"helm", "install", "radius", relativeChartPath,
-		"--namespace", radiusNamespace,
-		"--create-namespace",
-		"--set", "preupgrade.enabled=true",
-		"--set", "preupgrade.ttlSecondsAfterFinished=60",
-		"--set", "preupgrade.checks.version=true",
-		"--set", fmt.Sprintf("preupgrade.image=%s", image),
-		"--set", fmt.Sprintf("preupgrade.tag=%s", tag),
-		"--wait",
-	}
-	err := runHelmCommand(ctx, installCommand)
-	require.NoError(t, err, "Failed to install Radius using helm")
-
-	// Wait for the control plane to become available
-	var options rp.RPTestOptions
-	require.Eventually(t, func() bool {
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					// NewRPTestOptions calls require.NoError internally, catch panics
-					t.Logf("Control plane not ready yet: %v", r)
-				}
-			}()
-			options = rp.NewRPTestOptions(t)
-		}()
-		// Test if we can make a simple API call to verify the control plane is ready
-		return options.ManagementClient != nil
-	}, 2*time.Minute, 5*time.Second, "Control plane did not become available within timeout")
-
-	t.Log("Attempting upgrade to trigger preflight checks using helm")
-	upgradeCommand := []string{
-		"helm", "upgrade", "radius", relativeChartPath,
-		"--namespace", radiusNamespace,
-		"--set", "preupgrade.enabled=true",
-		"--set", "preupgrade.ttlSecondsAfterFinished=60",
-		"--set", "preupgrade.checks.version=true",
-		"--set", fmt.Sprintf("preupgrade.image=%s", image),
-		"--set", fmt.Sprintf("preupgrade.tag=%s", tag),
-		"--wait",
-	}
-	_ = runHelmCommand(ctx, upgradeCommand) // Ignore errors as upgrade might fail due to version issues
-
-	t.Log("Verifying preflight job configuration")
-	// Try to get the job, but don't fail the test if upgrade failed before job creation
-	job, jobErr := func() (*batchv1.Job, error) {
-		for i := 0; i < 15; i++ {
-			job, err := options.K8sClient.BatchV1().Jobs(radiusNamespace).Get(ctx, preUpgradeJobName, metav1.GetOptions{})
-			if err == nil {
-				return job, nil
-			}
-			time.Sleep(1 * time.Second)
-		}
-		return nil, fmt.Errorf("job not found")
-	}()
-
-	if jobErr == nil {
-		t.Log("Found preflight job, checking configuration")
-		require.NotNil(t, job.Spec.TTLSecondsAfterFinished)
-		require.Equal(t, int32(60), *job.Spec.TTLSecondsAfterFinished)
-		t.Log("Job configuration is correct")
+	// Brief wait to allow any unexpected job creation to surface
+	time.Sleep(5 * time.Second)
+	_, err = options.K8sClient.BatchV1().Jobs(radiusNamespace).Get(ctx, preUpgradeJobName, metav1.GetOptions{})
+	if err != nil && strings.Contains(err.Error(), "not found") {
+		t.Log("Preflight job correctly not created when disabled")
 	} else {
-		t.Log("Preflight job not found - upgrade likely failed before job creation due to version compatibility")
-		t.Log("This is acceptable in test environment")
+		t.Errorf("Expected preflight job to not exist when disabled, but found it or got unexpected error: %v", err)
 	}
 
-	t.Log("Cleaning up - uninstalling Radius using helm")
-	uninstallCommand := []string{"helm", "uninstall", "radius", "--namespace", radiusNamespace}
-	err = runHelmCommand(ctx, uninstallCommand)
-	require.NoError(t, err, "Failed to uninstall Radius using helm")
-}
-
-func Test_PreflightContainer_PreflightOnly(t *testing.T) {
-	ctx := testcontext.New(t)
-
-	image, tag := getPreUpgradeImage()
-
-	// Clean up any existing installation using helm
-	t.Log("Cleaning up any existing Radius installation")
-	cleanupCommand := []string{"helm", "uninstall", "radius", "--namespace", radiusNamespace, "--ignore-not-found"}
-	_ = exec.Command(cleanupCommand[0], cleanupCommand[1:]...).Run() // Ignore errors during cleanup
-
-	// Use local registry image for testing
-	t.Log("Installing Radius using helm")
-	installCommand := []string{
-		"helm", "install", "radius", relativeChartPath,
-		"--namespace", radiusNamespace,
-		"--create-namespace",
-		"--set", "preupgrade.enabled=true",
-		"--set", fmt.Sprintf("preupgrade.image=%s", image),
-		"--set", fmt.Sprintf("preupgrade.tag=%s", tag),
-		"--wait",
-	}
-	err := runHelmCommand(ctx, installCommand)
-	require.NoError(t, err, "Failed to install Radius using helm")
-
-	// Wait for the control plane to become available
-	var options rp.RPTestOptions
-	require.Eventually(t, func() bool {
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					// NewRPTestOptions calls require.NoError internally, catch panics
-					t.Logf("Control plane not ready yet: %v", r)
-				}
-			}()
-			options = rp.NewRPTestOptions(t)
-		}()
-		// Test if we can make a simple API call to verify the control plane is ready
-		return options.ManagementClient != nil
-	}, 2*time.Minute, 5*time.Second, "Control plane did not become available within timeout")
-
-	t.Log("Running upgrade to trigger preflight hooks using helm")
-	upgradeCommand := []string{
-		"helm", "upgrade", "radius", relativeChartPath,
-		"--namespace", radiusNamespace,
-		"--set", "preupgrade.enabled=true",
-		"--set", fmt.Sprintf("preupgrade.image=%s", image),
-		"--set", fmt.Sprintf("preupgrade.tag=%s", tag),
-		"--wait",
-	}
-	_ = runHelmCommand(ctx, upgradeCommand) // Ignore errors as upgrade might fail due to version issues but should trigger hooks
-
-	t.Log("Verifying preflight job ran successfully")
-	verifyPreflightJobRan(t, ctx, options, true)
-
-	t.Log("Cleaning up - uninstalling Radius using helm")
-	uninstallCommand := []string{"helm", "uninstall", "radius", "--namespace", radiusNamespace}
-	err = runHelmCommand(ctx, uninstallCommand)
-	require.NoError(t, err, "Failed to uninstall Radius using helm")
+	helmUninstall(t, ctx)
 }
 
 // Helper functions
 
-// getPreUpgradeImage constructs the pre-upgrade container image name using the configured registry and tag
+// getPreUpgradeImage constructs the pre-upgrade container image name using the configured registry and tag.
 func getPreUpgradeImage() (image string, tag string) {
 	registry, tag := testutil.SetDefault()
 	return fmt.Sprintf("%s/pre-upgrade", registry), tag
 }
 
-// runHelmCommand executes a helm command and returns an error if it fails
-func runHelmCommand(ctx context.Context, args []string) error {
+// helmInstall runs helm install with the given image, tag, and additional values.
+func helmInstall(ctx context.Context, image, tag string, values map[string]string) error {
+	args := []string{
+		"helm", "install", "radius", relativeChartPath,
+		"--namespace", radiusNamespace,
+		"--create-namespace",
+		"--set", fmt.Sprintf("preupgrade.image=%s", image),
+		"--set", fmt.Sprintf("preupgrade.tag=%s", tag),
+		"--wait",
+		"--timeout", helmTimeout,
+	}
+	for k, v := range values {
+		args = append(args, "--set", fmt.Sprintf("%s=%s", k, v))
+	}
+	return runCommand(ctx, args)
+}
+
+// helmUpgrade runs helm upgrade with the given image, tag, and additional values.
+func helmUpgrade(ctx context.Context, image, tag string, values map[string]string) error {
+	args := []string{
+		"helm", "upgrade", "radius", relativeChartPath,
+		"--namespace", radiusNamespace,
+		"--set", fmt.Sprintf("preupgrade.image=%s", image),
+		"--set", fmt.Sprintf("preupgrade.tag=%s", tag),
+		"--wait",
+		"--timeout", helmTimeout,
+	}
+	for k, v := range values {
+		args = append(args, "--set", fmt.Sprintf("%s=%s", k, v))
+	}
+	return runCommand(ctx, args)
+}
+
+// helmUninstall removes the Radius helm release.
+func helmUninstall(t *testing.T, ctx context.Context) {
+	t.Helper()
+	t.Log("Uninstalling Radius")
+	err := runCommand(ctx, []string{"helm", "uninstall", "radius", "--namespace", radiusNamespace})
+	require.NoError(t, err, "Failed to uninstall Radius")
+}
+
+// runCommand executes a shell command and returns an error if it fails.
+func runCommand(ctx context.Context, args []string) error {
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("helm command failed: %s, output: %s", err, string(output))
+		return fmt.Errorf("command failed: %s, output: %s", err, string(output))
 	}
 	return nil
 }
 
-func verifyPreflightJobRan(t *testing.T, ctx context.Context, options rp.RPTestOptions, shouldExist bool) {
-	if shouldExist {
-		// Look for the job, but be flexible about timing since upgrades might fail early
-		var jobExists bool
-		var finalJob *batchv1.Job
-
-		// Try to find the job with a shorter timeout since upgrade might fail quickly
-		jobExists = func() bool {
-			for range 15 { // 15 seconds total
-				job, err := options.K8sClient.BatchV1().Jobs(radiusNamespace).Get(ctx, preUpgradeJobName, metav1.GetOptions{})
-				if err == nil {
-					finalJob = job
-					return true
+// waitForControlPlane polls until the Radius control plane API is reachable.
+func waitForControlPlane(t *testing.T, ctx context.Context) rp.RPTestOptions {
+	t.Helper()
+	var options rp.RPTestOptions
+	require.Eventually(t, func() bool {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					// NewRPTestOptions calls require.NoError internally, catch panics
+					t.Logf("Control plane not ready yet: %v", r)
 				}
-				time.Sleep(1 * time.Second)
-			}
-			return false
+			}()
+			options = rp.NewRPTestOptions(t)
 		}()
+		return options.ManagementClient != nil
+	}, 2*time.Minute, controlPlanePollInterval, "Control plane did not become available within timeout")
+	return options
+}
 
-		if jobExists {
-			t.Log("Preflight job was created by Helm pre-upgrade hook")
+// cleanupAndWait uninstalls Radius and waits for all pods in the namespace to be fully
+// terminated before returning. This prevents aggregated API service conflicts when the
+// next helm install runs before the previous resources are fully cleaned up.
+func cleanupAndWait(t *testing.T, ctx context.Context) {
+	t.Helper()
 
-			// If we found the job, let's check its logs regardless of status
-			pods, err := options.K8sClient.CoreV1().Pods(radiusNamespace).List(ctx, metav1.ListOptions{
-				LabelSelector: "job-name=" + preUpgradeJobName,
-			})
-			if err != nil {
-				t.Logf("Warning: Failed to list pods for job: %v", err)
-			} else if len(pods.Items) > 0 {
-				logs, logErr := options.K8sClient.CoreV1().Pods(radiusNamespace).GetLogs(pods.Items[0].Name, &corev1.PodLogOptions{}).DoRaw(ctx)
-				if logErr != nil {
-					t.Logf("Warning: Failed to get pod logs: %v", logErr)
-				} else {
-					t.Logf("Preflight job logs:\n%s", string(logs))
-				}
-			}
+	t.Log("Cleaning up any existing Radius installation")
+	_ = exec.CommandContext(ctx, "helm", "uninstall", "radius",
+		"--namespace", radiusNamespace, "--ignore-not-found", "--wait").Run()
 
-			t.Logf("Preflight job status - Succeeded: %d, Failed: %d", finalJob.Status.Succeeded, finalJob.Status.Failed)
-		} else {
-			t.Log("Preflight job was not found - this might happen if upgrade failed before Helm hooks were triggered")
-			t.Log("This is acceptable in test environment where version jumps cause expected failures")
+	// Wait for all pods in the namespace to terminate. The Kubernetes aggregated API
+	// service needs time to deregister after pods are gone, so we must wait for a
+	// fully clean namespace before starting a new install.
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(), nil).ClientConfig()
+	if err != nil {
+		t.Logf("Warning: could not create k8s client for cleanup wait: %v", err)
+		time.Sleep(10 * time.Second)
+		return
+	}
+
+	k8sClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Logf("Warning: could not create k8s client for cleanup wait: %v", err)
+		time.Sleep(10 * time.Second)
+		return
+	}
+
+	require.Eventually(t, func() bool {
+		pods, err := k8sClient.CoreV1().Pods(radiusNamespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return true // Namespace may not exist, which is fine
 		}
-	} else {
-		// Verify job does not exist (give it a moment in case there's delay)
-		time.Sleep(5 * time.Second)
-		_, err := options.K8sClient.BatchV1().Jobs(radiusNamespace).Get(ctx, preUpgradeJobName, metav1.GetOptions{})
-		if err != nil && strings.Contains(err.Error(), "not found") {
-			t.Log("Preflight job correctly not created when disabled")
-		} else {
-			t.Errorf("Expected preflight job to not exist when disabled, but found it or got unexpected error: %v", err)
+		if len(pods.Items) == 0 {
+			return true
+		}
+		t.Logf("Waiting for %d pod(s) in %s to terminate...", len(pods.Items), radiusNamespace)
+		return false
+	}, 2*time.Minute, cleanupPollInterval, "Namespace %s did not become empty within timeout", radiusNamespace)
+
+	// Brief wait for Kubernetes aggregated API service deregistration
+	time.Sleep(3 * time.Second)
+}
+
+// findPreflightJob polls for the pre-upgrade job, returning it if found within the timeout.
+func findPreflightJob(t *testing.T, ctx context.Context, options rp.RPTestOptions) *batchv1.Job {
+	t.Helper()
+	for range jobPollAttempts {
+		job, err := options.K8sClient.BatchV1().Jobs(radiusNamespace).Get(ctx, preUpgradeJobName, metav1.GetOptions{})
+		if err == nil {
+			t.Log("Preflight job was created by Helm pre-upgrade hook")
+			return job
+		}
+		time.Sleep(jobPollInterval)
+	}
+	return nil
+}
+
+// logJobDetails retrieves and logs the job's pod logs and status.
+func logJobDetails(t *testing.T, ctx context.Context, options rp.RPTestOptions, job *batchv1.Job) {
+	t.Helper()
+
+	pods, err := options.K8sClient.CoreV1().Pods(radiusNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "job-name=" + preUpgradeJobName,
+	})
+	if err == nil && len(pods.Items) > 0 {
+		logs, logErr := options.K8sClient.CoreV1().Pods(radiusNamespace).
+			GetLogs(pods.Items[0].Name, &corev1.PodLogOptions{}).DoRaw(ctx)
+		if logErr == nil {
+			t.Logf("Preflight job logs:\n%s", string(logs))
 		}
 	}
+
+	t.Logf("Preflight job status - Succeeded: %d, Failed: %d", job.Status.Succeeded, job.Status.Failed)
 }


### PR DESCRIPTION
# Description

Scheduled functional tests were sometimes failing due to timeouts. This PR fixes the issue by adjusting timeout values and consolidating tests. The impact of this change should be to reduce the duration of the tests, while addressing the timeout failures.

## Changes

**Test consolidation**: Reduce 4 independent test functions (`FreshInstall`, `PreflightDisabled`, `JobConfiguration`, `PreflightOnly`) to 2 sequential subtests under a single `Test_PreflightContainer` parent, eliminating 2 full Helm install/uninstall cycles (~3-6 min each).

- Merge `FreshInstall` and `JobConfiguration` into the **"Enabled"** subtest since `FreshInstall` was a strict subset (only checked job existence, not config) and `JobConfiguration` already verified everything it did plus TTL settings
- Remove `PreflightOnly` test which was identical to `FreshInstall` (same helm values, same verification call)
- Keep `PreflightDisabled` as the **"Disabled"** subtest unchanged

**Extracted shared helpers**: Extract shared logic into reusable helpers (`helmInstall`, `helmUpgrade`, `helmUninstall`, `waitForControlPlane`, `findPreflightJob`, `logJobDetails`, `cleanupAndWait`, `runCommand`) to eliminate ~120 lines of duplication across tests.

**Tightened polling intervals**: Reduce idle time during state transitions:
- Control plane and cleanup polling: 5s → 3s
- K8s client fallback sleep: 15s → 10s
- Post-cleanup API deregistration wait: 5s → 3s

**Proper cleanup waiting**: `cleanupAndWait` now polls for all pods in the `radius-system` namespace to fully terminate before returning, preventing aggregated API service conflicts when the next helm install runs before the previous resources are fully cleaned up. Falls back to a static sleep if the k8s client cannot be created.

**Note**: These tests cannot run in parallel since they share the `radius-system` namespace and `radius` helm release.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and does not change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->