### PR TITLE
update rad env create and rad env update to make sure the env always has a recipe for core types

### DIFF
--- a/pkg/cli/cmd/env/create/preview/create.go
+++ b/pkg/cli/cmd/env/create/preview/create.go
@@ -30,6 +30,7 @@ import (
 	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
 	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/radius-project/radius/pkg/cli/recipepack"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
 	"github.com/radius-project/radius/pkg/to"
@@ -129,9 +130,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 }
 
 // Run runs the `rad env create` command.
-
-// Run creates an environment in the specified resource group using the provided environment name and
-// returns an error if unsuccessful.
+//
+// Run implements create-or-update semantics. If the environment does not exist, it creates
+// a new one with all singleton recipe packs for core resource types. If the environment
+// already exists, it checks the existing recipe packs and fills in any missing singletons
+// for core resource types, detecting conflicts along the way.
 func (r *Runner) Run(ctx context.Context) error {
 	if r.RadiusCoreClientFactory == nil {
 		clientFactory, err := cmd.InitializeRadiusCoreClientFactory(ctx, r.Workspace, r.Workspace.Scope)
@@ -141,19 +144,40 @@ func (r *Runner) Run(ctx context.Context) error {
 		r.RadiusCoreClientFactory = clientFactory
 	}
 
-	r.Output.LogInfo("Creating Radius Core Environment...")
+	return r.runCreate(ctx)
 
-	resource := &corerpv20250801.EnvironmentResource{
-		Location:   to.Ptr(v1.LocationGlobal),
-		Properties: &corerpv20250801.EnvironmentProperties{},
-	}
+}
 
-	_, err := r.RadiusCoreClientFactory.NewEnvironmentsClient().CreateOrUpdate(ctx, r.EnvironmentName, *resource, &corerpv20250801.EnvironmentsClientCreateOrUpdateOptions{})
+// runCreate creates a new environment with all singleton recipe packs for core resource types.
+func (r *Runner) runCreate(ctx context.Context) error {
+	r.Output.LogInfo("Creating Radius Core Environment %q...", r.EnvironmentName)
 
+	// Create all singleton recipe packs for core resource types
+	recipePackClient := r.RadiusCoreClientFactory.NewRecipePacksClient()
+	recipePackIDs, err := recipepack.CreateSingletonRecipePacks(ctx, recipePackClient, r.ResourceGroupName)
 	if err != nil {
 		return err
 	}
-	r.Output.LogInfo("Successfully created environment %q in resource group %q", r.EnvironmentName, r.ResourceGroupName)
 
+	// Link all recipe packs to the environment
+	recipePackPtrs := make([]*string, len(recipePackIDs))
+	for i, id := range recipePackIDs {
+		recipePackPtrs[i] = to.Ptr(id)
+	}
+
+	resource := &corerpv20250801.EnvironmentResource{
+		Location: to.Ptr(v1.LocationGlobal),
+		Properties: &corerpv20250801.EnvironmentProperties{
+			RecipePacks: recipePackPtrs,
+		},
+	}
+
+	envClient := r.RadiusCoreClientFactory.NewEnvironmentsClient()
+	_, err = envClient.CreateOrUpdate(ctx, r.EnvironmentName, *resource, nil)
+	if err != nil {
+		return err
+	}
+
+	r.Output.LogInfo("Successfully created environment %q in resource group %q with default Kubernetes recipe packs.", r.EnvironmentName, r.ResourceGroupName)
 	return nil
 }

--- a/pkg/cli/cmd/env/create/preview/create_test.go
+++ b/pkg/cli/cmd/env/create/preview/create_test.go
@@ -144,18 +144,23 @@ func Test_Validate(t *testing.T) {
 }
 
 func Test_Run(t *testing.T) {
-	t.Run("Success: environment created", func(t *testing.T) {
-		workspace := &workspaces.Workspace{
-			Name:  "test-workspace",
-			Scope: "/planes/radius/local/resourceGroups/test-resource-group",
-			Connection: map[string]any{
-				"kind":    "kubernetes",
-				"context": "kind-kind",
-			},
-		}
+	workspace := &workspaces.Workspace{
+		Name:  "test-workspace",
+		Scope: "/planes/radius/local/resourceGroups/test-resource-group",
+		Connection: map[string]any{
+			"kind":    "kubernetes",
+			"context": "kind-kind",
+		},
+	}
 
-		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(workspace.Scope, test_client_factory.WithEnvironmentServerNoError, nil)
+	t.Run("New environment: all singletons created", func(t *testing.T) {
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(
+			workspace.Scope,
+			test_client_factory.WithEnvironmentServer404OnGet,
+			test_client_factory.WithRecipePackServerCoreTypes,
+		)
 		require.NoError(t, err)
+
 		outputSink := &output.MockOutput{}
 		runner := &Runner{
 			RadiusCoreClientFactory: factory,
@@ -165,22 +170,17 @@ func Test_Run(t *testing.T) {
 			ResourceGroupName:       "test-resource-group",
 		}
 
-		expectedOutput := []any{
-			output.LogOutput{
-				Format: "Creating Radius Core Environment...",
-			},
-			output.LogOutput{
-				Format: "Successfully created environment %q in resource group %q",
-				Params: []interface{}{
-					"testenv",
-					"test-resource-group",
-				},
-			},
-		}
-
 		err = runner.Run(context.Background())
 		require.NoError(t, err)
-		require.Equal(t, expectedOutput, outputSink.Writes)
+
+		require.Contains(t, outputSink.Writes, output.LogOutput{
+			Format: "Creating Radius Core Environment %q...",
+			Params: []interface{}{"testenv"},
+		})
+		require.Contains(t, outputSink.Writes, output.LogOutput{
+			Format: "Successfully created environment %q in resource group %q with default Kubernetes recipe packs.",
+			Params: []interface{}{"testenv", "test-resource-group"},
+		})
 	})
 }
 

--- a/pkg/cli/cmd/env/update/preview/update_test.go
+++ b/pkg/cli/cmd/env/update/preview/update_test.go
@@ -114,8 +114,10 @@ func Test_Run(t *testing.T) {
 				output.FormattedOutput{
 					Format: "table",
 					Obj: environmentForDisplay{
-						Name:        "test-env",
-						RecipePacks: 3,
+						Name: "test-env",
+						// 1 existing pack from the environment, 2 user-specified
+						// packs, plus 4 singleton packs for core resource types.
+						RecipePacks: 7,
 						Providers:   3,
 					},
 					Options: environmentFormat(),
@@ -133,7 +135,7 @@ func Test_Run(t *testing.T) {
 			factory, err := test_client_factory.NewRadiusCoreTestClientFactory(
 				workspace.Scope,
 				tc.serverFactory,
-				nil,
+				test_client_factory.WithRecipePackServerUniqueTypes,
 			)
 			require.NoError(t, err)
 

--- a/pkg/cli/cmd/install/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/install/kubernetes/kubernetes.go
@@ -232,7 +232,6 @@ func deployRecipePack(ctx context.Context, kubeContext string, out output.Interf
 
 	clientOptions := sdk.NewClientOptions(connection)
 
-	// Create the default resource group.
 	rgClient, err := ucpv20231001.NewResourceGroupsClient(&aztoken.AnonymousCredential{}, clientOptions)
 	if err != nil {
 		return fmt.Errorf("failed to create resource group client: %w", err)
@@ -245,12 +244,11 @@ func deployRecipePack(ctx context.Context, kubeContext string, out output.Interf
 		return fmt.Errorf("failed to create resource group %q: %w", defaultResourceGroupName, err)
 	}
 
-	// Create the default recipe pack using the shared package.
 	_, err = recipepack.CreateDefaultRecipePack(ctx, connection, defaultResourceGroupName)
 	if err != nil {
 		return fmt.Errorf("failed to deploy recipe pack: %w", err)
 	}
 
-	out.LogInfo("Successfully deployed default recipe pack.")
+	out.LogInfo("Successfully deployed local-dev recipe pack.")
 	return nil
 }

--- a/pkg/cli/cmd/install/kubernetes/kubernetes.go
+++ b/pkg/cli/cmd/install/kubernetes/kubernetes.go
@@ -18,11 +18,18 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 
+	aztoken "github.com/radius-project/radius/pkg/azure/tokencredentials"
 	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
 	"github.com/radius-project/radius/pkg/cli/framework"
 	"github.com/radius-project/radius/pkg/cli/helm"
 	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/radius-project/radius/pkg/cli/workspaces"
+	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
+	"github.com/radius-project/radius/pkg/sdk"
+	"github.com/radius-project/radius/pkg/to"
+	ucpv20231001 "github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
 	"github.com/radius-project/radius/pkg/version"
 	"github.com/spf13/cobra"
 )
@@ -196,5 +203,103 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
+	// Deploy the default recipe pack after successful installation.
+	if err := deployRecipePack(ctx, r.KubeContext, r.Output); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+const defaultResourceGroupName = "default"
+
+// deployRecipePack connects to the newly installed Radius and deploys the default recipe pack.
+func deployRecipePack(ctx context.Context, kubeContext string, out output.Interface) error {
+	out.LogInfo("Deploying default recipe pack...")
+
+	ws := &workspaces.Workspace{
+		Connection: map[string]any{
+			"kind":    workspaces.KindKubernetes,
+			"context": kubeContext,
+		},
+		Scope: fmt.Sprintf("/planes/radius/local/resourceGroups/%s", defaultResourceGroupName),
+	}
+
+	connection, err := ws.Connect(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to connect to Radius: %w", err)
+	}
+
+	clientOptions := sdk.NewClientOptions(connection)
+
+	// Create the default resource group.
+	rgClient, err := ucpv20231001.NewResourceGroupsClient(&aztoken.AnonymousCredential{}, clientOptions)
+	if err != nil {
+		return fmt.Errorf("failed to create resource group client: %w", err)
+	}
+
+	_, err = rgClient.CreateOrUpdate(ctx, "local", defaultResourceGroupName, ucpv20231001.ResourceGroupResource{
+		Location: to.Ptr("global"),
+	}, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create resource group %q: %w", defaultResourceGroupName, err)
+	}
+
+	// Create the recipe pack.
+	rpClient, err := corerpv20250801.NewRecipePacksClient(
+		fmt.Sprintf("planes/radius/local/resourceGroups/%s", defaultResourceGroupName),
+		&aztoken.AnonymousCredential{},
+		clientOptions,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create recipe pack client: %w", err)
+	}
+
+	_, err = rpClient.CreateOrUpdate(ctx, "kuberecipepack", newDefaultRecipePackResource(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to deploy recipe pack: %w", err)
+	}
+
+	out.LogInfo("Successfully deployed default recipe pack.")
+	return nil
+}
+
+// newDefaultRecipePackResource builds the default RecipePackResource containing
+// Bicep recipes for the built-in Radius resource types.
+func newDefaultRecipePackResource() corerpv20250801.RecipePackResource {
+	bicepKind := corerpv20250801.RecipeKindBicep
+	plainHTTP := true
+
+	return corerpv20250801.RecipePackResource{
+		Location: to.Ptr("global"),
+		Properties: &corerpv20250801.RecipePackProperties{
+			Recipes: map[string]*corerpv20250801.RecipeDefinition{
+				"Radius.Compute/containers": {
+					RecipeKind:     &bicepKind,
+					RecipeLocation: to.Ptr("localhost:5000/radius-recipes/compute/containers/kubernetes/bicep/kubernetes-containers:latest"),
+					PlainHTTP:      &plainHTTP,
+				},
+				"Radius.Compute/persistentVolumes": {
+					RecipeKind:     &bicepKind,
+					RecipeLocation: to.Ptr("localhost:5000/radius-recipes/compute/persistentvolumes/kubernetes/bicep/kubernetes-volumes:latest"),
+					PlainHTTP:      &plainHTTP,
+				},
+				"Radius.Data/mySqlDatabases": {
+					RecipeKind:     &bicepKind,
+					RecipeLocation: to.Ptr("localhost:5000/radius-recipes/data/mysqldatabases/kubernetes/bicep/kubernetes-mysql:latest"),
+					PlainHTTP:      &plainHTTP,
+				},
+				"Radius.Data/postgreSqlDatabases": {
+					RecipeKind:     &bicepKind,
+					RecipeLocation: to.Ptr("localhost:5000/radius-recipes/data/postgresqldatabases/kubernetes/bicep/kubernetes-postgresql:latest"),
+					PlainHTTP:      &plainHTTP,
+				},
+				"Radius.Security/secrets": {
+					RecipeKind:     &bicepKind,
+					RecipeLocation: to.Ptr("localhost:5000/radius-recipes/security/secrets/kubernetes/bicep/kubernetes-secrets:latest"),
+					PlainHTTP:      &plainHTTP,
+				},
+			},
+		},
+	}
 }

--- a/pkg/cli/cmd/radinit/environment.go
+++ b/pkg/cli/cmd/radinit/environment.go
@@ -27,6 +27,7 @@ import (
 	"github.com/radius-project/radius/pkg/cli/prompt"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	corerp "github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
+	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
 	"github.com/radius-project/radius/pkg/to"
 	ucp "github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
 )
@@ -53,41 +54,44 @@ func (r *Runner) CreateEnvironment(ctx context.Context) error {
 		return clierrors.MessageWithCause(err, "Failed to create a resource group.")
 	}
 
-	providerList := []any{}
-	if r.Options.CloudProviders.Azure != nil {
-		providerList = append(providerList, r.Options.CloudProviders.Azure)
-	}
-	if r.Options.CloudProviders.AWS != nil {
-		providerList = append(providerList, r.Options.CloudProviders.AWS)
-	}
+	// Build providers for the new Radius.Core/environments resource type
+	providers := &corerpv20250801.Providers{}
 
-	providers, err := cmd.CreateEnvProviders(providerList)
-	if err != nil {
-		return err
-	}
-
-	var recipes map[string]map[string]corerp.RecipePropertiesClassification
-	if r.Options.Recipes.DevRecipes {
-		// Note: To use custom registry for recipes, users need to manually configure
-		// their environment after initialization or use custom recipe definitions
-		recipes, err = r.DevRecipeClient.GetDevRecipes(ctx)
-		if err != nil {
-			return err
+	if r.Options.Environment.Namespace != "" {
+		providers.Kubernetes = &corerpv20250801.ProvidersKubernetes{
+			Namespace: to.Ptr(r.Options.Environment.Namespace),
 		}
 	}
 
-	envProperties := corerp.EnvironmentProperties{
-		Compute: &corerp.KubernetesCompute{
-			Namespace: to.Ptr(r.Options.Environment.Namespace),
-		},
-		Providers: &providers,
-		Recipes:   recipes,
+	if r.Options.CloudProviders.Azure != nil {
+		providers.Azure = &corerpv20250801.ProvidersAzure{
+			SubscriptionID:    to.Ptr(r.Options.CloudProviders.Azure.SubscriptionID),
+			ResourceGroupName: to.Ptr(r.Options.CloudProviders.Azure.ResourceGroup),
+		}
 	}
 
-	err = client.CreateOrUpdateEnvironment(ctx, r.Options.Environment.Name, &corerp.EnvironmentResource{
+	if r.Options.CloudProviders.AWS != nil {
+		providers.Aws = &corerpv20250801.ProvidersAws{
+			AccountID: to.Ptr(r.Options.CloudProviders.AWS.AccountID),
+			Region:    to.Ptr(r.Options.CloudProviders.AWS.Region),
+		}
+	}
+
+	envProperties := corerpv20250801.EnvironmentProperties{
+		Providers: providers,
+	}
+
+	// Initialize the Radius.Core client factory
+	clientFactory, err := cmd.InitializeRadiusCoreClientFactory(ctx, r.Workspace, r.Workspace.Scope)
+	if err != nil {
+		return clierrors.MessageWithCause(err, "Failed to initialize Radius Core client.")
+	}
+
+	// Create the Radius.Core/environments resource
+	_, err = clientFactory.NewEnvironmentsClient().CreateOrUpdate(ctx, r.Options.Environment.Name, corerpv20250801.EnvironmentResource{
 		Location:   to.Ptr(v1.LocationGlobal),
 		Properties: &envProperties,
-	})
+	}, &corerpv20250801.EnvironmentsClientCreateOrUpdateOptions{})
 	if err != nil {
 		return clierrors.MessageWithCause(err, "Failed to create environment.")
 	}

--- a/pkg/cli/cmd/radinit/environment.go
+++ b/pkg/cli/cmd/radinit/environment.go
@@ -93,7 +93,7 @@ func (r *Runner) CreateEnvironment(ctx context.Context) error {
 
 	// Create singleton recipe packs (one per resource type) and link them to the environment
 	// We make singleton recipe packs so that its easier for users to override recipes for specific resource types if they want to.
-	recipePackIDs, err := recipepack.CreateSingletonRecipePacksWithClient(ctx, r.RadiusCoreClientFactory.NewRecipePacksClient(), r.Options.Environment.Name)
+	recipePackIDs, err := recipepack.CreateSingletonRecipePacks(ctx, r.RadiusCoreClientFactory.NewRecipePacksClient(), r.Options.Environment.Name)
 	if err != nil {
 		return clierrors.MessageWithCause(err, "Failed to create recipe packs.")
 	}

--- a/pkg/cli/cmd/radinit/environment.go
+++ b/pkg/cli/cmd/radinit/environment.go
@@ -92,6 +92,7 @@ func (r *Runner) CreateEnvironment(ctx context.Context) error {
 	}
 
 	// Create singleton recipe packs (one per resource type) and link them to the environment
+	// We make singleton recipe packs so that its easier for users to override recipes for specific resource types if they want to.
 	recipePackIDs, err := recipepack.CreateSingletonRecipePacksWithClient(ctx, r.RadiusCoreClientFactory.NewRecipePacksClient(), r.Options.Environment.Name)
 	if err != nil {
 		return clierrors.MessageWithCause(err, "Failed to create recipe packs.")

--- a/pkg/cli/cmd/radinit/init.go
+++ b/pkg/cli/cmd/radinit/init.go
@@ -38,6 +38,7 @@ import (
 	"github.com/radius-project/radius/pkg/cli/setup"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	corerp "github.com/radius-project/radius/pkg/corerp/api/v20231001preview"
+	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
 	"github.com/radius-project/radius/pkg/to"
 	ucp "github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
 	"github.com/spf13/cobra"
@@ -135,6 +136,10 @@ type Runner struct {
 
 	// DevRecipeClient is the interface for the dev recipe client.
 	DevRecipeClient DevRecipeClient
+
+	// RadiusCoreClientFactory is the client factory for Radius.Core resources.
+	// If nil, it will be initialized during Run.
+	RadiusCoreClientFactory *corerpv20250801.ClientFactory
 
 	// Format is the output format.
 	Format string

--- a/pkg/cli/cmd/radinit/init_test.go
+++ b/pkg/cli/cmd/radinit/init_test.go
@@ -1002,7 +1002,7 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 			outputSink := &output.MockOutput{}
 
 			helmInterface := helm.NewMockInterface(ctrl)
-			
+
 			// Verify that Set and SetFile values are passed to Helm
 			expectedClusterOptions := helm.CLIClusterOptions{
 				Radius: helm.ChartOptions{
@@ -1010,7 +1010,7 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 					SetFileArgs: tc.setFile,
 				},
 			}
-			
+
 			helmInterface.EXPECT().
 				InstallRadius(context.Background(), gomock.Any(), "kind-kind").
 				DoAndReturn(func(ctx context.Context, clusterOptions helm.ClusterOptions, kubeContext string) error {
@@ -1051,13 +1051,13 @@ func Test_Run_InstallAndCreateEnvironment(t *testing.T) {
 					ApplicationsManagementClient: appManagementClient,
 					CredentialManagementClient:   credentialManagementClient,
 				},
-				ConfigFileInterface:         configFileInterface,
-				ConfigHolder:                &framework.ConfigHolder{ConfigFilePath: "filePath"},
-				HelmInterface:               helmInterface,
-				Output:                      outputSink,
-				Prompter:                    prompter,
-				RadiusCoreClientFactory:     radiusCoreClientFactory,
-				Options:                     &options,
+				ConfigFileInterface:     configFileInterface,
+				ConfigHolder:            &framework.ConfigHolder{ConfigFilePath: "filePath"},
+				HelmInterface:           helmInterface,
+				Output:                  outputSink,
+				Prompter:                prompter,
+				RadiusCoreClientFactory: radiusCoreClientFactory,
+				Options:                 &options,
 				Workspace: &workspaces.Workspace{
 					Name:  "default",
 					Scope: "/planes/radius/local/resourceGroups/default",

--- a/pkg/cli/cmd/radinit/options.go
+++ b/pkg/cli/cmd/radinit/options.go
@@ -122,7 +122,7 @@ func (r *Runner) enterInitOptions(ctx context.Context) (*initOptions, *workspace
 		workspace.Name = ws.Name
 	}
 
-	workspace.Environment = fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Applications.Core/environments/%s", options.Environment.Name, options.Environment.Name)
+	workspace.Environment = fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Radius.Core/environments/%s", options.Environment.Name, options.Environment.Name)
 	workspace.Scope = fmt.Sprintf("/planes/radius/local/resourceGroups/%s", options.Environment.Name)
 	return &options, workspace, nil
 }

--- a/pkg/cli/cmd/radinit/options_test.go
+++ b/pkg/cli/cmd/radinit/options_test.go
@@ -53,7 +53,7 @@ func Test_enterInitOptions(t *testing.T) {
 				"context": "kind-kind",
 				"kind":    workspaces.KindKubernetes,
 			},
-			Environment: "/planes/radius/local/resourceGroups/default/providers/Applications.Core/environments/default",
+			Environment: "/planes/radius/local/resourceGroups/default/providers/Radius.Core/environments/default",
 			Scope:       "/planes/radius/local/resourceGroups/default",
 		}
 		require.Equal(t, expectedWorkspace, *workspace)
@@ -101,7 +101,7 @@ func Test_enterInitOptions(t *testing.T) {
 				"context": "kind-kind",
 				"kind":    workspaces.KindKubernetes,
 			},
-			Environment: "/planes/radius/local/resourceGroups/test-env/providers/Applications.Core/environments/test-env",
+			Environment: "/planes/radius/local/resourceGroups/test-env/providers/Radius.Core/environments/test-env",
 			Scope:       "/planes/radius/local/resourceGroups/test-env",
 		}
 		require.Equal(t, expectedWorkspace, *workspace)
@@ -137,7 +137,7 @@ workspaces:
         kind: kubernetes
         context: cool-beans
       scope: /a/b/c
-      environment: /a/b/c/providers/Applications.Core/environments/ice-cold
+      environment: /a/b/c/providers/Radius.Core/environments/ice-cold
 `
 		v, err := makeConfig(yaml)
 		runner := Runner{Prompter: prompter, KubernetesInterface: k8s, HelmInterface: helm, Full: true, ConfigHolder: &framework.ConfigHolder{Config: v}}
@@ -160,7 +160,7 @@ workspaces:
 				"context": "kind-kind",
 				"kind":    workspaces.KindKubernetes,
 			},
-			Environment: "/planes/radius/local/resourceGroups/test-env/providers/Applications.Core/environments/test-env",
+			Environment: "/planes/radius/local/resourceGroups/test-env/providers/Radius.Core/environments/test-env",
 			Scope:       "/planes/radius/local/resourceGroups/test-env",
 		}
 		require.Equal(t, expectedWorkspace, *workspace)
@@ -196,13 +196,13 @@ workspaces:
         kind: kubernetes
         context: cool-beans
       scope: /a/b/c
-      environment: /a/b/c/providers/Applications.Core/environments/ice-cold
+      environment: /a/b/c/providers/Radius.Core/environments/ice-cold
     default:
       connection:
         kind: kubernetes
         context: hot-beans
       scope: /d/e/f
-      environment: /a/b/c/providers/Applications.Core/environments/hot-coffee
+      environment: /a/b/c/providers/Radius.Core/environments/hot-coffee
 `
 		v, err := makeConfig(yaml)
 		runner := Runner{Prompter: prompter, KubernetesInterface: k8s, HelmInterface: helm, Full: true, ConfigHolder: &framework.ConfigHolder{Config: v}}
@@ -225,7 +225,7 @@ workspaces:
 				"context": "kind-kind",
 				"kind":    workspaces.KindKubernetes,
 			},
-			Environment: "/planes/radius/local/resourceGroups/test-env/providers/Applications.Core/environments/test-env",
+			Environment: "/planes/radius/local/resourceGroups/test-env/providers/Radius.Core/environments/test-env",
 			Scope:       "/planes/radius/local/resourceGroups/test-env",
 		}
 		require.Equal(t, expectedWorkspace, *workspace)

--- a/pkg/cli/recipepack/recipepack.go
+++ b/pkg/cli/recipepack/recipepack.go
@@ -19,7 +19,6 @@ package recipepack
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
 	"github.com/radius-project/radius/pkg/to"
@@ -47,27 +46,22 @@ func GetSingletonRecipePackDefinitions() []SingletonRecipePackDefinition {
 		{
 			Name:           "containers",
 			ResourceType:   "Radius.Compute/containers",
-			RecipeLocation: "localhost:5000/radius-recipes/compute/containers/kubernetes/bicep/kubernetes-containers:latest",
+			RecipeLocation: "ghcr.io/radius-project/kube-recipes/containers:latest",
 		},
 		{
 			Name:           "persistentvolumes",
 			ResourceType:   "Radius.Compute/persistentVolumes",
-			RecipeLocation: "localhost:5000/radius-recipes/compute/persistentvolumes/kubernetes/bicep/kubernetes-volumes:latest",
+			RecipeLocation: "ghcr.io/radius-project/kube-recipes/persistentvolumes:latest",
 		},
 		{
-			Name:           "mysqldatabases",
-			ResourceType:   "Radius.Data/mySqlDatabases",
-			RecipeLocation: "localhost:5000/radius-recipes/data/mysqldatabases/kubernetes/bicep/kubernetes-mysql:latest",
-		},
-		{
-			Name:           "postgresqldatabases",
-			ResourceType:   "Radius.Data/postgreSqlDatabases",
-			RecipeLocation: "localhost:5000/radius-recipes/data/postgresqldatabases/kubernetes/bicep/kubernetes-postgresql:latest",
+			Name:           "routes",
+			ResourceType:   "Radius.Compute/routes",
+			RecipeLocation: "ghcr.io/radius-project/kube-recipes/routes:latest",
 		},
 		{
 			Name:           "secrets",
 			ResourceType:   "Radius.Security/secrets",
-			RecipeLocation: "localhost:5000/radius-recipes/security/secrets/kubernetes/bicep/kubernetes-secrets:latest",
+			RecipeLocation: "ghcr.io/radius-project/kube-recipes/secrets:latest",
 		},
 	}
 }
@@ -75,7 +69,6 @@ func GetSingletonRecipePackDefinitions() []SingletonRecipePackDefinition {
 // NewSingletonRecipePackResource creates a RecipePackResource containing a single recipe for the given resource type.
 func NewSingletonRecipePackResource(resourceType, recipeLocation string) corerpv20250801.RecipePackResource {
 	bicepKind := corerpv20250801.RecipeKindBicep
-	plainHTTP := true
 
 	return corerpv20250801.RecipePackResource{
 		Location: to.Ptr("global"),
@@ -84,7 +77,6 @@ func NewSingletonRecipePackResource(resourceType, recipeLocation string) corerpv
 				resourceType: {
 					RecipeKind:     &bicepKind,
 					RecipeLocation: to.Ptr(recipeLocation),
-					PlainHTTP:      &plainHTTP,
 				},
 			},
 		},
@@ -111,69 +103,3 @@ func CreateSingletonRecipePacksWithClient(ctx context.Context, client *corerpv20
 
 	return recipePackIDs, nil
 }
-
-// GetRecipePackNameForResourceType returns the recipe pack name for a given resource type.
-// Returns empty string if the resource type is not found.
-func GetRecipePackNameForResourceType(resourceType string) string {
-	for _, def := range GetSingletonRecipePackDefinitions() {
-		if strings.EqualFold(def.ResourceType, resourceType) {
-			return def.Name
-		}
-	}
-	return ""
-}
-
-// CreateDefaultRecipePackWithClient creates the default Kubernetes recipe pack using a RecipePacksClient.
-// It returns the full resource ID of the created recipe pack.
-func CreateDefaultRecipePackWithClient(ctx context.Context, client *corerpv20250801.RecipePacksClient, resourceGroupName string) (string, error) {
-	resource := NewDefaultRecipePackResource()
-	_, err := client.CreateOrUpdate(ctx, DefaultRecipePackName, resource, nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to create recipe pack: %w", err)
-	}
-
-	// Return the full resource ID of the created recipe pack
-	recipePackID := fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Radius.Core/recipePacks/%s", resourceGroupName, DefaultRecipePackName)
-	return recipePackID, nil
-}
-
-// NewDefaultRecipePackResource builds the default RecipePackResource containing
-// Bicep recipes for the built-in Radius resource types.
-func NewDefaultRecipePackResource() corerpv20250801.RecipePackResource {
-	bicepKind := corerpv20250801.RecipeKindBicep
-	plainHTTP := true
-
-	return corerpv20250801.RecipePackResource{
-		Location: to.Ptr("global"),
-		Properties: &corerpv20250801.RecipePackProperties{
-			Recipes: map[string]*corerpv20250801.RecipeDefinition{
-				"Radius.Compute/containers": {
-					RecipeKind:     &bicepKind,
-					RecipeLocation: to.Ptr("localhost:5000/radius-recipes/compute/containers/kubernetes/bicep/kubernetes-containers:latest"),
-					PlainHTTP:      &plainHTTP,
-				},
-				"Radius.Compute/persistentVolumes": {
-					RecipeKind:     &bicepKind,
-					RecipeLocation: to.Ptr("localhost:5000/radius-recipes/compute/persistentvolumes/kubernetes/bicep/kubernetes-volumes:latest"),
-					PlainHTTP:      &plainHTTP,
-				},
-				"Radius.Data/mySqlDatabases": {
-					RecipeKind:     &bicepKind,
-					RecipeLocation: to.Ptr("localhost:5000/radius-recipes/data/mysqldatabases/kubernetes/bicep/kubernetes-mysql:latest"),
-					PlainHTTP:      &plainHTTP,
-				},
-				"Radius.Data/postgreSqlDatabases": {
-					RecipeKind:     &bicepKind,
-					RecipeLocation: to.Ptr("localhost:5000/radius-recipes/data/postgresqldatabases/kubernetes/bicep/kubernetes-postgresql:latest"),
-					PlainHTTP:      &plainHTTP,
-				},
-				"Radius.Security/secrets": {
-					RecipeKind:     &bicepKind,
-					RecipeLocation: to.Ptr("localhost:5000/radius-recipes/security/secrets/kubernetes/bicep/kubernetes-secrets:latest"),
-					PlainHTTP:      &plainHTTP,
-				},
-			},
-		},
-	}
-}
-

--- a/pkg/cli/recipepack/recipepack.go
+++ b/pkg/cli/recipepack/recipepack.go
@@ -31,6 +31,20 @@ const (
 	DefaultRecipePackName = "local-dev"
 )
 
+// CreateDefaultRecipePackWithClient creates the default Kubernetes recipe pack using a RecipePacksClient.
+// It returns the full resource ID of the created recipe pack.
+func CreateDefaultRecipePackWithClient(ctx context.Context, client *corerpv20250801.RecipePacksClient, resourceGroupName string) (string, error) {
+	resource := NewDefaultRecipePackResource()
+	_, err := client.CreateOrUpdate(ctx, DefaultRecipePackName, resource, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create recipe pack: %w", err)
+	}
+
+	// Return the full resource ID of the created recipe pack
+	recipePackID := fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Radius.Core/recipePacks/%s", resourceGroupName, DefaultRecipePackName)
+	return recipePackID, nil
+}
+
 // NewDefaultRecipePackResource builds the default RecipePackResource containing
 // Bicep recipes for the built-in Radius resource types.
 func NewDefaultRecipePackResource() corerpv20250801.RecipePackResource {

--- a/pkg/cli/recipepack/recipepack.go
+++ b/pkg/cli/recipepack/recipepack.go
@@ -19,6 +19,7 @@ package recipepack
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	aztoken "github.com/radius-project/radius/pkg/azure/tokencredentials"
 	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
@@ -30,6 +31,99 @@ const (
 	// DefaultRecipePackName is the name of the default Kubernetes recipe pack.
 	DefaultRecipePackName = "local-dev"
 )
+
+// SingletonRecipePackDefinition defines a singleton recipe pack for a single resource type.
+type SingletonRecipePackDefinition struct {
+	// Name is the name of the recipe pack (derived from resource type).
+	Name string
+	// ResourceType is the full resource type (e.g., "Radius.Compute/containers").
+	ResourceType string
+	// RecipeLocation is the OCI registry location for the recipe.
+	RecipeLocation string
+}
+
+// GetSingletonRecipePackDefinitions returns the list of singleton recipe pack definitions.
+// Each definition represents a single recipe pack containing one recipe for one resource type.
+func GetSingletonRecipePackDefinitions() []SingletonRecipePackDefinition {
+	return []SingletonRecipePackDefinition{
+		{
+			Name:           "containers",
+			ResourceType:   "Radius.Compute/containers",
+			RecipeLocation: "localhost:5000/radius-recipes/compute/containers/kubernetes/bicep/kubernetes-containers:latest",
+		},
+		{
+			Name:           "persistentvolumes",
+			ResourceType:   "Radius.Compute/persistentVolumes",
+			RecipeLocation: "localhost:5000/radius-recipes/compute/persistentvolumes/kubernetes/bicep/kubernetes-volumes:latest",
+		},
+		{
+			Name:           "mysqldatabases",
+			ResourceType:   "Radius.Data/mySqlDatabases",
+			RecipeLocation: "localhost:5000/radius-recipes/data/mysqldatabases/kubernetes/bicep/kubernetes-mysql:latest",
+		},
+		{
+			Name:           "postgresqldatabases",
+			ResourceType:   "Radius.Data/postgreSqlDatabases",
+			RecipeLocation: "localhost:5000/radius-recipes/data/postgresqldatabases/kubernetes/bicep/kubernetes-postgresql:latest",
+		},
+		{
+			Name:           "secrets",
+			ResourceType:   "Radius.Security/secrets",
+			RecipeLocation: "localhost:5000/radius-recipes/security/secrets/kubernetes/bicep/kubernetes-secrets:latest",
+		},
+	}
+}
+
+// NewSingletonRecipePackResource creates a RecipePackResource containing a single recipe for the given resource type.
+func NewSingletonRecipePackResource(resourceType, recipeLocation string) corerpv20250801.RecipePackResource {
+	bicepKind := corerpv20250801.RecipeKindBicep
+	plainHTTP := true
+
+	return corerpv20250801.RecipePackResource{
+		Location: to.Ptr("global"),
+		Properties: &corerpv20250801.RecipePackProperties{
+			Recipes: map[string]*corerpv20250801.RecipeDefinition{
+				resourceType: {
+					RecipeKind:     &bicepKind,
+					RecipeLocation: to.Ptr(recipeLocation),
+					PlainHTTP:      &plainHTTP,
+				},
+			},
+		},
+	}
+}
+
+// CreateSingletonRecipePacksWithClient creates singleton recipe packs (one per resource type) using a RecipePacksClient.
+// It returns the list of full resource IDs of the created recipe packs.
+func CreateSingletonRecipePacksWithClient(ctx context.Context, client *corerpv20250801.RecipePacksClient, resourceGroupName string) ([]string, error) {
+	definitions := GetSingletonRecipePackDefinitions()
+	recipePackIDs := make([]string, 0, len(definitions))
+
+	for _, def := range definitions {
+		resource := NewSingletonRecipePackResource(def.ResourceType, def.RecipeLocation)
+		_, err := client.CreateOrUpdate(ctx, def.Name, resource, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create recipe pack %q for resource type %q: %w", def.Name, def.ResourceType, err)
+		}
+
+		// Return the full resource ID of the created recipe pack
+		recipePackID := fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Radius.Core/recipePacks/%s", resourceGroupName, def.Name)
+		recipePackIDs = append(recipePackIDs, recipePackID)
+	}
+
+	return recipePackIDs, nil
+}
+
+// GetRecipePackNameForResourceType returns the recipe pack name for a given resource type.
+// Returns empty string if the resource type is not found.
+func GetRecipePackNameForResourceType(resourceType string) string {
+	for _, def := range GetSingletonRecipePackDefinitions() {
+		if strings.EqualFold(def.ResourceType, resourceType) {
+			return def.Name
+		}
+	}
+	return ""
+}
 
 // CreateDefaultRecipePackWithClient creates the default Kubernetes recipe pack using a RecipePacksClient.
 // It returns the full resource ID of the created recipe pack.

--- a/pkg/cli/recipepack/recipepack.go
+++ b/pkg/cli/recipepack/recipepack.go
@@ -21,9 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	aztoken "github.com/radius-project/radius/pkg/azure/tokencredentials"
 	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
-	"github.com/radius-project/radius/pkg/sdk"
 	"github.com/radius-project/radius/pkg/to"
 )
 
@@ -179,32 +177,3 @@ func NewDefaultRecipePackResource() corerpv20250801.RecipePackResource {
 	}
 }
 
-// CreateRecipePack creates a recipe pack in the specified resource group.
-// It returns the full resource ID of the created recipe pack.
-func CreateRecipePack(ctx context.Context, connection sdk.Connection, resourceGroupName string, recipePackName string, resource corerpv20250801.RecipePackResource) (string, error) {
-	clientOptions := sdk.NewClientOptions(connection)
-
-	rpClient, err := corerpv20250801.NewRecipePacksClient(
-		fmt.Sprintf("planes/radius/local/resourceGroups/%s", resourceGroupName),
-		&aztoken.AnonymousCredential{},
-		clientOptions,
-	)
-	if err != nil {
-		return "", fmt.Errorf("failed to create recipe pack client: %w", err)
-	}
-
-	_, err = rpClient.CreateOrUpdate(ctx, recipePackName, resource, nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to create recipe pack: %w", err)
-	}
-
-	// Return the full resource ID of the created recipe pack
-	recipePackID := fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Radius.Core/recipePacks/%s", resourceGroupName, recipePackName)
-	return recipePackID, nil
-}
-
-// CreateDefaultRecipePack creates the default Kubernetes recipe pack in the specified resource group.
-// It returns the full resource ID of the created recipe pack.
-func CreateDefaultRecipePack(ctx context.Context, connection sdk.Connection, resourceGroupName string) (string, error) {
-	return CreateRecipePack(ctx, connection, resourceGroupName, DefaultRecipePackName, NewDefaultRecipePackResource())
-}

--- a/pkg/cli/recipepack/recipepack.go
+++ b/pkg/cli/recipepack/recipepack.go
@@ -83,9 +83,9 @@ func NewSingletonRecipePackResource(resourceType, recipeLocation string) corerpv
 	}
 }
 
-// CreateSingletonRecipePacksWithClient creates singleton recipe packs (one per resource type) using a RecipePacksClient.
+// CreateSingletonRecipePacks creates singleton recipe packs (one per resource type) using a RecipePacksClient.
 // It returns the list of full resource IDs of the created recipe packs.
-func CreateSingletonRecipePacksWithClient(ctx context.Context, client *corerpv20250801.RecipePacksClient, resourceGroupName string) ([]string, error) {
+func CreateSingletonRecipePacks(ctx context.Context, client *corerpv20250801.RecipePacksClient, resourceGroupName string) ([]string, error) {
 	definitions := GetSingletonRecipePackDefinitions()
 	recipePackIDs := make([]string, 0, len(definitions))
 

--- a/pkg/cli/recipepack/recipepack.go
+++ b/pkg/cli/recipepack/recipepack.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	// DefaultRecipePackName is the name of the default Kubernetes recipe pack.
-	DefaultRecipePackName = "kuberecipepack"
+	DefaultRecipePackName = "local-dev"
 )
 
 // NewDefaultRecipePackResource builds the default RecipePackResource containing

--- a/pkg/cli/recipepack/recipepack.go
+++ b/pkg/cli/recipepack/recipepack.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package recipepack
+
+import (
+	"context"
+	"fmt"
+
+	aztoken "github.com/radius-project/radius/pkg/azure/tokencredentials"
+	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
+	"github.com/radius-project/radius/pkg/sdk"
+	"github.com/radius-project/radius/pkg/to"
+)
+
+const (
+	// DefaultRecipePackName is the name of the default Kubernetes recipe pack.
+	DefaultRecipePackName = "kuberecipepack"
+)
+
+// NewDefaultRecipePackResource builds the default RecipePackResource containing
+// Bicep recipes for the built-in Radius resource types.
+func NewDefaultRecipePackResource() corerpv20250801.RecipePackResource {
+	bicepKind := corerpv20250801.RecipeKindBicep
+	plainHTTP := true
+
+	return corerpv20250801.RecipePackResource{
+		Location: to.Ptr("global"),
+		Properties: &corerpv20250801.RecipePackProperties{
+			Recipes: map[string]*corerpv20250801.RecipeDefinition{
+				"Radius.Compute/containers": {
+					RecipeKind:     &bicepKind,
+					RecipeLocation: to.Ptr("localhost:5000/radius-recipes/compute/containers/kubernetes/bicep/kubernetes-containers:latest"),
+					PlainHTTP:      &plainHTTP,
+				},
+				"Radius.Compute/persistentVolumes": {
+					RecipeKind:     &bicepKind,
+					RecipeLocation: to.Ptr("localhost:5000/radius-recipes/compute/persistentvolumes/kubernetes/bicep/kubernetes-volumes:latest"),
+					PlainHTTP:      &plainHTTP,
+				},
+				"Radius.Data/mySqlDatabases": {
+					RecipeKind:     &bicepKind,
+					RecipeLocation: to.Ptr("localhost:5000/radius-recipes/data/mysqldatabases/kubernetes/bicep/kubernetes-mysql:latest"),
+					PlainHTTP:      &plainHTTP,
+				},
+				"Radius.Data/postgreSqlDatabases": {
+					RecipeKind:     &bicepKind,
+					RecipeLocation: to.Ptr("localhost:5000/radius-recipes/data/postgresqldatabases/kubernetes/bicep/kubernetes-postgresql:latest"),
+					PlainHTTP:      &plainHTTP,
+				},
+				"Radius.Security/secrets": {
+					RecipeKind:     &bicepKind,
+					RecipeLocation: to.Ptr("localhost:5000/radius-recipes/security/secrets/kubernetes/bicep/kubernetes-secrets:latest"),
+					PlainHTTP:      &plainHTTP,
+				},
+			},
+		},
+	}
+}
+
+// CreateRecipePack creates a recipe pack in the specified resource group.
+// It returns the full resource ID of the created recipe pack.
+func CreateRecipePack(ctx context.Context, connection sdk.Connection, resourceGroupName string, recipePackName string, resource corerpv20250801.RecipePackResource) (string, error) {
+	clientOptions := sdk.NewClientOptions(connection)
+
+	rpClient, err := corerpv20250801.NewRecipePacksClient(
+		fmt.Sprintf("planes/radius/local/resourceGroups/%s", resourceGroupName),
+		&aztoken.AnonymousCredential{},
+		clientOptions,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to create recipe pack client: %w", err)
+	}
+
+	_, err = rpClient.CreateOrUpdate(ctx, recipePackName, resource, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create recipe pack: %w", err)
+	}
+
+	// Return the full resource ID of the created recipe pack
+	recipePackID := fmt.Sprintf("/planes/radius/local/resourceGroups/%s/providers/Radius.Core/recipePacks/%s", resourceGroupName, recipePackName)
+	return recipePackID, nil
+}
+
+// CreateDefaultRecipePack creates the default Kubernetes recipe pack in the specified resource group.
+// It returns the full resource ID of the created recipe pack.
+func CreateDefaultRecipePack(ctx context.Context, connection sdk.Connection, resourceGroupName string) (string, error) {
+	return CreateRecipePack(ctx, connection, resourceGroupName, DefaultRecipePackName, NewDefaultRecipePackResource())
+}

--- a/pkg/cli/recipepack/recipepack_test.go
+++ b/pkg/cli/recipepack/recipepack_test.go
@@ -87,7 +87,7 @@ func Test_CreateSingletonRecipePacksWithClient(t *testing.T) {
 
 		recipePackClient := factory.NewRecipePacksClient()
 
-		recipePackIDs, err := CreateSingletonRecipePacksWithClient(context.Background(), recipePackClient, resourceGroupName)
+		recipePackIDs, err := CreateSingletonRecipePacks(context.Background(), recipePackClient, resourceGroupName)
 		require.NoError(t, err)
 
 		// Verify the correct number of recipe packs were created

--- a/pkg/cli/recipepack/recipepack_test.go
+++ b/pkg/cli/recipepack/recipepack_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package recipepack
+
+import (
+	"context"
+	"testing"
+
+	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
+	"github.com/radius-project/radius/pkg/cli/test_client_factory"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_NewDefaultRecipePackResource(t *testing.T) {
+	resource := NewDefaultRecipePackResource()
+
+	// Verify location
+	require.NotNil(t, resource.Location)
+	require.Equal(t, "global", *resource.Location)
+
+	// Verify properties exist
+	require.NotNil(t, resource.Properties)
+	require.NotNil(t, resource.Properties.Recipes)
+
+	// Verify expected recipes exist
+	expectedRecipeTypes := []string{
+		"Radius.Compute/containers",
+		"Radius.Compute/persistentVolumes",
+		"Radius.Data/mySqlDatabases",
+		"Radius.Data/postgreSqlDatabases",
+		"Radius.Security/secrets",
+	}
+
+	for _, recipeType := range expectedRecipeTypes {
+		recipe, exists := resource.Properties.Recipes[recipeType]
+		require.True(t, exists, "Expected recipe type %s to exist", recipeType)
+		require.NotNil(t, recipe, "Recipe for %s should not be nil", recipeType)
+		require.NotNil(t, recipe.RecipeKind, "RecipeKind for %s should not be nil", recipeType)
+		require.Equal(t, corerpv20250801.RecipeKindBicep, *recipe.RecipeKind, "RecipeKind for %s should be Bicep", recipeType)
+		require.NotNil(t, recipe.RecipeLocation, "RecipeLocation for %s should not be nil", recipeType)
+		require.NotNil(t, recipe.PlainHTTP, "PlainHTTP for %s should not be nil", recipeType)
+		require.True(t, *recipe.PlainHTTP, "PlainHTTP for %s should be true", recipeType)
+	}
+
+	// Verify the correct number of recipes
+	require.Len(t, resource.Properties.Recipes, len(expectedRecipeTypes))
+}
+
+func Test_CreateDefaultRecipePackWithClient(t *testing.T) {
+	t.Run("Success: creates recipe pack", func(t *testing.T) {
+		rootScope := "/planes/radius/local/resourceGroups/test-rg"
+		resourceGroupName := "test-rg"
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(rootScope, nil, nil)
+		require.NoError(t, err)
+
+		recipePackClient := factory.NewRecipePacksClient()
+
+		recipePackID, err := CreateDefaultRecipePackWithClient(context.Background(), recipePackClient, resourceGroupName)
+		require.NoError(t, err)
+
+		expectedID := "/planes/radius/local/resourceGroups/test-rg/providers/Radius.Core/recipePacks/local-dev"
+		require.Equal(t, expectedID, recipePackID)
+	})
+}
+
+func Test_DefaultRecipePackName(t *testing.T) {
+	require.Equal(t, "local-dev", DefaultRecipePackName)
+}

--- a/pkg/cli/recipepack/recipepack_test.go
+++ b/pkg/cli/recipepack/recipepack_test.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"testing"
 
-	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
 	"github.com/radius-project/radius/pkg/cli/test_client_factory"
+	corerpv20250801 "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
 	"github.com/stretchr/testify/require"
 )
 
@@ -80,4 +80,97 @@ func Test_CreateDefaultRecipePackWithClient(t *testing.T) {
 
 func Test_DefaultRecipePackName(t *testing.T) {
 	require.Equal(t, "local-dev", DefaultRecipePackName)
+}
+
+func Test_GetSingletonRecipePackDefinitions(t *testing.T) {
+	definitions := GetSingletonRecipePackDefinitions()
+
+	// Verify we have the expected number of definitions
+	require.Len(t, definitions, 5)
+
+	// Verify expected resource types and names
+	expectedDefinitions := map[string]string{
+		"containers":         "Radius.Compute/containers",
+		"persistentvolumes":  "Radius.Compute/persistentVolumes",
+		"mysqldatabases":     "Radius.Data/mySqlDatabases",
+		"postgresqldatabases": "Radius.Data/postgreSqlDatabases",
+		"secrets":            "Radius.Security/secrets",
+	}
+
+	for _, def := range definitions {
+		expectedResourceType, exists := expectedDefinitions[def.Name]
+		require.True(t, exists, "Unexpected definition name: %s", def.Name)
+		require.Equal(t, expectedResourceType, def.ResourceType, "Resource type mismatch for %s", def.Name)
+		require.NotEmpty(t, def.RecipeLocation, "RecipeLocation should not be empty for %s", def.Name)
+	}
+}
+
+func Test_NewSingletonRecipePackResource(t *testing.T) {
+	resourceType := "Radius.Compute/containers"
+	recipeLocation := "localhost:5000/test-recipe:latest"
+
+	resource := NewSingletonRecipePackResource(resourceType, recipeLocation)
+
+	// Verify location
+	require.NotNil(t, resource.Location)
+	require.Equal(t, "global", *resource.Location)
+
+	// Verify properties exist
+	require.NotNil(t, resource.Properties)
+	require.NotNil(t, resource.Properties.Recipes)
+
+	// Verify the resource contains exactly one recipe
+	require.Len(t, resource.Properties.Recipes, 1)
+
+	// Verify the recipe
+	recipe, exists := resource.Properties.Recipes[resourceType]
+	require.True(t, exists, "Expected recipe for resource type %s to exist", resourceType)
+	require.NotNil(t, recipe.RecipeKind)
+	require.Equal(t, corerpv20250801.RecipeKindBicep, *recipe.RecipeKind)
+	require.NotNil(t, recipe.RecipeLocation)
+	require.Equal(t, recipeLocation, *recipe.RecipeLocation)
+	require.NotNil(t, recipe.PlainHTTP)
+	require.True(t, *recipe.PlainHTTP)
+}
+
+func Test_CreateSingletonRecipePacksWithClient(t *testing.T) {
+	t.Run("Success: creates all singleton recipe packs", func(t *testing.T) {
+		rootScope := "/planes/radius/local/resourceGroups/test-rg"
+		resourceGroupName := "test-rg"
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(rootScope, nil, nil)
+		require.NoError(t, err)
+
+		recipePackClient := factory.NewRecipePacksClient()
+
+		recipePackIDs, err := CreateSingletonRecipePacksWithClient(context.Background(), recipePackClient, resourceGroupName)
+		require.NoError(t, err)
+
+		// Verify the correct number of recipe packs were created
+		definitions := GetSingletonRecipePackDefinitions()
+		require.Len(t, recipePackIDs, len(definitions))
+
+		// Verify the IDs are in the expected format
+		for i, def := range definitions {
+			expectedID := "/planes/radius/local/resourceGroups/test-rg/providers/Radius.Core/recipePacks/" + def.Name
+			require.Equal(t, expectedID, recipePackIDs[i])
+		}
+	})
+}
+
+func Test_GetRecipePackNameForResourceType(t *testing.T) {
+	t.Run("finds existing resource type", func(t *testing.T) {
+		name := GetRecipePackNameForResourceType("Radius.Compute/containers")
+		require.Equal(t, "containers", name)
+	})
+
+	t.Run("finds resource type case-insensitive", func(t *testing.T) {
+		name := GetRecipePackNameForResourceType("radius.compute/CONTAINERS")
+		require.Equal(t, "containers", name)
+	})
+
+	t.Run("returns empty for unknown resource type", func(t *testing.T) {
+		name := GetRecipePackNameForResourceType("Unknown/resourceType")
+		require.Empty(t, name)
+	})
 }

--- a/pkg/cli/test_client_factory/radius_core.go
+++ b/pkg/cli/test_client_factory/radius_core.go
@@ -18,6 +18,7 @@ package test_client_factory
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	armpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
@@ -165,6 +166,228 @@ func WithEnvironmentServerNoError() corerpfake.EnvironmentsServer {
 			options *v20250801preview.EnvironmentsClientDeleteOptions,
 		) (resp azfake.Responder[v20250801preview.EnvironmentsClientDeleteResponse], errResp azfake.ErrorResponder) {
 			resp.SetResponse(http.StatusNoContent, v20250801preview.EnvironmentsClientDeleteResponse{}, nil)
+			return
+		},
+	}
+}
+
+// WithEnvironmentServer404OnGet returns an EnvironmentsServer that returns 404 on Get
+// and success on CreateOrUpdate, simulating a new environment creation scenario.
+func WithEnvironmentServer404OnGet() corerpfake.EnvironmentsServer {
+	return corerpfake.EnvironmentsServer{
+		Get: func(
+			ctx context.Context,
+			environmentName string,
+			options *v20250801preview.EnvironmentsClientGetOptions,
+		) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
+			errResp.SetError(fmt.Errorf("environment not found"))
+			errResp.SetResponseError(404, "Not Found")
+			return
+		},
+		CreateOrUpdate: func(
+			ctx context.Context,
+			environmentName string,
+			resource v20250801preview.EnvironmentResource,
+			options *v20250801preview.EnvironmentsClientCreateOrUpdateOptions,
+		) (resp azfake.Responder[v20250801preview.EnvironmentsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+			result := v20250801preview.EnvironmentsClientCreateOrUpdateResponse{
+				EnvironmentResource: resource,
+			}
+			resp.SetResponse(http.StatusOK, result, nil)
+			return
+		},
+	}
+}
+
+// WithEnvironmentServerNoRecipePacks returns an EnvironmentsServer that returns an existing
+// environment with no recipe packs on Get, and success on CreateOrUpdate.
+func WithEnvironmentServerNoRecipePacks() corerpfake.EnvironmentsServer {
+	return corerpfake.EnvironmentsServer{
+		Get: func(
+			ctx context.Context,
+			environmentName string,
+			options *v20250801preview.EnvironmentsClientGetOptions,
+		) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
+			result := v20250801preview.EnvironmentsClientGetResponse{
+				EnvironmentResource: v20250801preview.EnvironmentResource{
+					Name:     to.Ptr(environmentName),
+					Location: to.Ptr("global"),
+					Properties: &v20250801preview.EnvironmentProperties{
+						RecipePacks: []*string{},
+					},
+				},
+			}
+			resp.SetResponse(http.StatusOK, result, nil)
+			return
+		},
+		CreateOrUpdate: func(
+			ctx context.Context,
+			environmentName string,
+			resource v20250801preview.EnvironmentResource,
+			options *v20250801preview.EnvironmentsClientCreateOrUpdateOptions,
+		) (resp azfake.Responder[v20250801preview.EnvironmentsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+			result := v20250801preview.EnvironmentsClientCreateOrUpdateResponse{
+				EnvironmentResource: resource,
+			}
+			resp.SetResponse(http.StatusOK, result, nil)
+			return
+		},
+	}
+}
+
+// WithEnvironmentServerCustomRecipePacks returns a factory function that creates an EnvironmentsServer
+// with the given recipe pack IDs on Get, and success on CreateOrUpdate.
+func WithEnvironmentServerCustomRecipePacks(recipePacks []*string) func() corerpfake.EnvironmentsServer {
+	return func() corerpfake.EnvironmentsServer {
+		return corerpfake.EnvironmentsServer{
+			Get: func(
+				ctx context.Context,
+				environmentName string,
+				options *v20250801preview.EnvironmentsClientGetOptions,
+			) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
+				result := v20250801preview.EnvironmentsClientGetResponse{
+					EnvironmentResource: v20250801preview.EnvironmentResource{
+						Name:     to.Ptr(environmentName),
+						Location: to.Ptr("global"),
+						Properties: &v20250801preview.EnvironmentProperties{
+							RecipePacks: recipePacks,
+						},
+					},
+				}
+				resp.SetResponse(http.StatusOK, result, nil)
+				return
+			},
+			CreateOrUpdate: func(
+				ctx context.Context,
+				environmentName string,
+				resource v20250801preview.EnvironmentResource,
+				options *v20250801preview.EnvironmentsClientCreateOrUpdateOptions,
+			) (resp azfake.Responder[v20250801preview.EnvironmentsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+				result := v20250801preview.EnvironmentsClientCreateOrUpdateResponse{
+					EnvironmentResource: resource,
+				}
+				resp.SetResponse(http.StatusOK, result, nil)
+				return
+			},
+		}
+	}
+}
+
+// WithRecipePackServerCoreTypes returns a RecipePacksServer that maps singleton pack names
+// to their actual core resource types. Non-singleton names get a unique test type.
+func WithRecipePackServerCoreTypes() corerpfake.RecipePacksServer {
+	// Build lookup from singleton definitions. These mirror the core
+	// singleton recipe packs used by the CLI, but are duplicated here to
+	// avoid importing the recipepack package and creating an import cycle in
+	// tests.
+	singletonTypes := map[string]string{
+		"containers":        "Radius.Compute/containers",
+		"persistentvolumes": "Radius.Compute/persistentVolumes",
+		"routes":            "Radius.Compute/routes",
+		"secrets":           "Radius.Security/secrets",
+	}
+
+	return corerpfake.RecipePacksServer{
+		Get: func(ctx context.Context, recipePackName string, options *v20250801preview.RecipePacksClientGetOptions) (resp azfake.Responder[v20250801preview.RecipePacksClientGetResponse], errResp azfake.ErrorResponder) {
+			resourceType, ok := singletonTypes[recipePackName]
+			if !ok {
+				resourceType = "Test.Resource/" + recipePackName
+			}
+			bicepKind := v20250801preview.RecipeKindBicep
+			result := v20250801preview.RecipePacksClientGetResponse{
+				RecipePackResource: v20250801preview.RecipePackResource{
+					Name: to.Ptr(recipePackName),
+					Properties: &v20250801preview.RecipePackProperties{
+						Recipes: map[string]*v20250801preview.RecipeDefinition{
+							resourceType: {
+								RecipeLocation: to.Ptr("ghcr.io/test/" + recipePackName + ":latest"),
+								RecipeKind:     &bicepKind,
+							},
+						},
+					},
+				},
+			}
+			resp.SetResponse(http.StatusOK, result, nil)
+			return
+		},
+		CreateOrUpdate: func(ctx context.Context, recipePackName string, resource v20250801preview.RecipePackResource, options *v20250801preview.RecipePacksClientCreateOrUpdateOptions) (resp azfake.Responder[v20250801preview.RecipePacksClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+			result := v20250801preview.RecipePacksClientCreateOrUpdateResponse{
+				RecipePackResource: v20250801preview.RecipePackResource{
+					Name:       to.Ptr(recipePackName),
+					Properties: resource.Properties,
+				},
+			}
+			resp.SetResponse(http.StatusOK, result, nil)
+			return
+		},
+	}
+}
+
+// WithRecipePackServerUniqueTypes returns a RecipePacksServer where each pack name
+// maps to a unique resource type based on the pack name.
+func WithRecipePackServerUniqueTypes() corerpfake.RecipePacksServer {
+	return corerpfake.RecipePacksServer{
+		Get: func(ctx context.Context, recipePackName string, options *v20250801preview.RecipePacksClientGetOptions) (resp azfake.Responder[v20250801preview.RecipePacksClientGetResponse], errResp azfake.ErrorResponder) {
+			bicepKind := v20250801preview.RecipeKindBicep
+			result := v20250801preview.RecipePacksClientGetResponse{
+				RecipePackResource: v20250801preview.RecipePackResource{
+					Name: to.Ptr(recipePackName),
+					Properties: &v20250801preview.RecipePackProperties{
+						Recipes: map[string]*v20250801preview.RecipeDefinition{
+							"Test.Resource/" + recipePackName: {
+								RecipeLocation: to.Ptr("ghcr.io/test/" + recipePackName + ":latest"),
+								RecipeKind:     &bicepKind,
+							},
+						},
+					},
+				},
+			}
+			resp.SetResponse(http.StatusOK, result, nil)
+			return
+		},
+		CreateOrUpdate: func(ctx context.Context, recipePackName string, resource v20250801preview.RecipePackResource, options *v20250801preview.RecipePacksClientCreateOrUpdateOptions) (resp azfake.Responder[v20250801preview.RecipePacksClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+			result := v20250801preview.RecipePacksClientCreateOrUpdateResponse{
+				RecipePackResource: v20250801preview.RecipePackResource{
+					Name:       to.Ptr(recipePackName),
+					Properties: resource.Properties,
+				},
+			}
+			resp.SetResponse(http.StatusOK, result, nil)
+			return
+		},
+	}
+}
+
+// WithRecipePackServerConflictingTypes returns a RecipePacksServer where every pack
+// returns the same resource type, simulating a conflict scenario.
+func WithRecipePackServerConflictingTypes() corerpfake.RecipePacksServer {
+	return corerpfake.RecipePacksServer{
+		Get: func(ctx context.Context, recipePackName string, options *v20250801preview.RecipePacksClientGetOptions) (resp azfake.Responder[v20250801preview.RecipePacksClientGetResponse], errResp azfake.ErrorResponder) {
+			bicepKind := v20250801preview.RecipeKindBicep
+			result := v20250801preview.RecipePacksClientGetResponse{
+				RecipePackResource: v20250801preview.RecipePackResource{
+					Name: to.Ptr(recipePackName),
+					Properties: &v20250801preview.RecipePackProperties{
+						Recipes: map[string]*v20250801preview.RecipeDefinition{
+							"Radius.Compute/containers": {
+								RecipeLocation: to.Ptr("ghcr.io/test/" + recipePackName + ":latest"),
+								RecipeKind:     &bicepKind,
+							},
+						},
+					},
+				},
+			}
+			resp.SetResponse(http.StatusOK, result, nil)
+			return
+		},
+		CreateOrUpdate: func(ctx context.Context, recipePackName string, resource v20250801preview.RecipePackResource, options *v20250801preview.RecipePacksClientCreateOrUpdateOptions) (resp azfake.Responder[v20250801preview.RecipePacksClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+			result := v20250801preview.RecipePacksClientCreateOrUpdateResponse{
+				RecipePackResource: v20250801preview.RecipePackResource{
+					Name:       to.Ptr(recipePackName),
+					Properties: resource.Properties,
+				},
+			}
+			resp.SetResponse(http.StatusOK, result, nil)
 			return
 		},
 	}

--- a/pkg/cli/test_client_factory/radius_core.go
+++ b/pkg/cli/test_client_factory/radius_core.go
@@ -82,6 +82,16 @@ func WithRecipePackServerNoError() corerpfake.RecipePacksServer {
 			resp.SetResponse(http.StatusOK, result, nil)
 			return
 		},
+		CreateOrUpdate: func(ctx context.Context, recipePackName string, resource v20250801preview.RecipePackResource, options *v20250801preview.RecipePacksClientCreateOrUpdateOptions) (resp azfake.Responder[v20250801preview.RecipePacksClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+			result := v20250801preview.RecipePacksClientCreateOrUpdateResponse{
+				RecipePackResource: v20250801preview.RecipePackResource{
+					Name:       to.Ptr(recipePackName),
+					Properties: resource.Properties,
+				},
+			}
+			resp.SetResponse(http.StatusOK, result, nil)
+			return
+		},
 	}
 }
 


### PR DESCRIPTION
# Description

Case 1:  When Environment is created without any Recipes registered for the respective core resource types (e.g. Radius.Core/containers, Radius.Core/routes, Radius.Security/Secrets, Radius.Core/persistentVolumes) Radius will make sure to add singleton recipepacks for each of the core types.

Case 2: Environment is updated using rad env update and user registers their own Recipes for some/all the respective core resource types (e.g. Radius.Core/containers, Radius.Core/routes, Radius.Security/Secrets, Radius.Core/persistentVolumes)
rad env update looks at all recipe pack contents and handle conflicts, and also add singltons for what ever core type is missing. 

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [ ] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [ ] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [ ] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [ ] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [ ] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [ ] Not applicable <!-- TaskRadio recipes-pr -->