### PR TITLE
build(go): bump to 1.26.0

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -25,8 +25,8 @@ pnpm config set store-dir /tmp/.pnpm-store
 
 # Install the binary form of golangci-lint, as recommended
 # https://golangci-lint.run/welcome/install/#local-installation
-echo "Installing golangci-lint v2.8.0..."
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.8.0
+echo "Installing golangci-lint v2.9.0..."
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.9.0
 
 # Other go tools
 echo "Installing controller-gen..."

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.8.0
+          version: v2.9.0
           args: --timeout=10m
           skip-cache: true
           install-mode: binary

--- a/docs/contributing/contributing-code/contributing-code-debugging/radius-os-processes-debugging.md
+++ b/docs/contributing/contributing-code/contributing-code-debugging/radius-os-processes-debugging.md
@@ -102,8 +102,8 @@ echo 'export PATH="$HOME/go/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
 
 ```bash
 # Install Go 1.25+
-wget https://go.dev/dl/go1.25.7.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.25.7.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.26.0.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.0.linux-amd64.tar.gz
 echo 'export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
 
 # Other tools

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/radius-project/radius
 
-go 1.25.7
+go 1.26.0
 
 // Replace digest lib to master to gather access to BLAKE3.
 // xref: https://github.com/opencontainers/go-digest/pull/66

--- a/test/magpiego/go.mod
+++ b/test/magpiego/go.mod
@@ -1,7 +1,6 @@
 module github.com/radius-project/radius/test/magpiego
 
-go 1.25.7
-
+go 1.26.0
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1

--- a/test/testrp/go.mod
+++ b/test/testrp/go.mod
@@ -1,3 +1,3 @@
 module testrp
 
-go 1.25.7
+go 1.26.0


### PR DESCRIPTION
# Description

This PR updates the repository Go toolchain version to Go 1.26.0 and updates related documentation and test module `go.mod` files.

- Updates `go.mod` (root) to `go 1.26.0`
- Updates test module `go.mod` files to `go 1.26.0`
- Updates the Go install snippet in the debugging contributor docs
- Updates the `bicep-types` submodule reference

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: N/A

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the design-notes repository, if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the samples repository is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the documentation repository is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the recipes repository is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->
