### PR TITLE
Simplify approval gate with dual-environment pattern

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -91,23 +91,34 @@ env:
   RADIUS_QPS_AND_BURST: "800"
 
 jobs:
-  # Approval gate for external contributors. This job uses GitHub Environment protection
-  # to require manual approval before running tests on PRs from non-members.
-  # - Org members (OWNER, MEMBER, COLLABORATOR): Tests run immediately
-  # - Dependabot: Tests run immediately
-  # - External contributors: Requires approval via GitHub UI button
+  # External contributor approval gate using GitHub Environment protection rules.
+  #
+  # How it works:
+  #   - For pull_request_target: Uses a conditional environment to gate external PRs.
+  #     Trusted users (org OWNER/MEMBER/COLLABORATOR and dependabot) use the
+  #     'pr-trusted' environment (no protection rules, runs immediately).
+  #     External contributors use 'external-contributor-approval' (requires manual approval).
+  #   - For all other events (schedule, workflow_dispatch, repository_dispatch):
+  #     This job is skipped entirely (no approval needed).
+  #
+  # Requirements:
+  #   1. 'external-contributor-approval' environment: configured with required reviewers
+  #   2. 'pr-trusted' environment: configured with NO protection rules (auto-approves)
   approval-gate:
     name: Approval Gate
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    # Only run for external contributors on pull_request_target events.
-    # Trusted users (dependabot, org members) skip this job entirely.
-    # External contributors require approval via 'external-contributor-approval' environment.
-    if: |
-      github.event_name == 'pull_request_target' &&
-      github.actor != 'dependabot[bot]' &&
-      !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
-    environment: external-contributor-approval
+    if: github.event_name == 'pull_request_target'
+    # Trusted users get 'pr-trusted' (no protection rules, instant approval).
+    # External contributors get 'external-contributor-approval' (requires manual review).
+    environment: >-
+      ${{
+        (github.actor == 'dependabot[bot]' ||
+         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                  github.event.pull_request.author_association))
+        && 'pr-trusted'
+        || 'external-contributor-approval'
+      }}
     permissions: {}
     steps:
       - name: Approved
@@ -116,12 +127,7 @@ jobs:
   setup:
     name: Setup
     needs: [approval-gate]
-    # Run for all events. For PRs, approval-gate either succeeds (external contributors approved)
-    # or is skipped (trusted users like org members and dependabot).
-    if: |
-      always() &&
-      (github.event_name != 'pull_request_target' || needs.approval-gate.result == 'success' || needs.approval-gate.result == 'skipped') &&
-      (github.event_name != 'schedule' || github.repository == vars.RADIUS_REPOSITORY)
+    if: ${{ !cancelled() && needs.approval-gate.result != 'failure' && (github.event_name != 'schedule' || github.repository == vars.RADIUS_REPOSITORY) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
# Description

Simplifies the approval gate in `functional-test-cloud.yaml` by adopting a dual-environment pattern (inspired by [SAP/crossplane-provider-btp](https://github.com/SAP/crossplane-provider-btp/blob/main/.github/workflows/pr-e2e.yaml)).

## Problem

The previous approach conditionally **skipped** the `approval-gate` job for trusted users and only ran it for external contributors. This led to a complex `if` condition on the `setup` job that had to enumerate every possible `approval-gate` result (`success`, `skipped`). The original implementation (before PR #11189) also had a falsy-value bug: `(condition) && '' || 'environment'` always returned `'environment'` because empty string is falsy in GitHub Actions expressions.

## Solution

Instead of skip-based gating, the `approval-gate` job now **always runs** on `pull_request_target` events and selects one of two GitHub environments:

| User type | Environment | Protection rules |
|-----------|------------|-----------------|
| Org members (OWNER/MEMBER/COLLABORATOR), dependabot | `pr-trusted` | None (instant) |
| External contributors | `external-contributor-approval` | Required reviewers |

Both branches of the ternary expression are **truthy strings**, avoiding the falsy-value bug entirely.

The `setup` job condition is simplified from `always() && (event != ... || result == 'success' || result == 'skipped')` to `!cancelled() && result != 'failure'`.

## Prerequisites

⚠️ **Before merging**: Create a `pr-trusted` GitHub environment in [repository settings](https://github.com/radius-project/radius/settings/environments) with **NO protection rules**.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->