### PR TITLE
[Do not review] Test Cloud Functional Tests with new Azure tenant

### DIFF
--- a/test/functional-portable/corerp/cloud/mechanics/aws_mechanics_test.go
+++ b/test/functional-portable/corerp/cloud/mechanics/aws_mechanics_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func Test_AWSRedeployWithUpdatedResourceUpdatesResource(t *testing.T) {
+	t.Skip("TEMP: disabling AWS tests")
+
 	template := "testdata/aws-mechanics-redeploy-withupdatedresource.bicep"
 	name := "radiusfunctionaltest-" + uuid.New().String()
 	creationTimestamp := testutil.GetCreationTimestamp()

--- a/test/functional-portable/corerp/cloud/resources/aws_logs_loggroup_test.go
+++ b/test/functional-portable/corerp/cloud/resources/aws_logs_loggroup_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func Test_AWS_LogsLogGroup(t *testing.T) {
+	t.Skip("TEMP: disabling AWS tests")
+
 	template := "testdata/aws-logs-loggroup.bicep"
 	name := "radiusfunctionaltest-" + uuid.New().String()
 	creationTimestamp := testutil.GetCreationTimestamp()
@@ -63,6 +65,8 @@ func Test_AWS_LogsLogGroup(t *testing.T) {
 }
 
 func Test_AWS_LogsLogGroup_Existing(t *testing.T) {
+	t.Skip("TEMP: disabling AWS tests")
+
 	template := "testdata/aws-logs-loggroup.bicep"
 	templateExisting := "testdata/aws-logs-loggroup-existing.bicep"
 	name := "radiusfunctionaltest-" + uuid.New().String()

--- a/test/functional-portable/corerp/cloud/resources/aws_multi_identifier_resource_test.go
+++ b/test/functional-portable/corerp/cloud/resources/aws_multi_identifier_resource_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func Test_AWS_MultiIdentifier_Resource(t *testing.T) {
+	t.Skip("TEMP: disabling AWS tests")
+
 	template := "testdata/aws-multi-identifier.bicep"
 	filterName := "ms" + uuid.New().String()
 	logGroupName := "ms" + uuid.New().String()

--- a/test/functional-portable/corerp/cloud/resources/extender_test.go
+++ b/test/functional-portable/corerp/cloud/resources/extender_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func Test_Extender_RecipeAWS_LogGroup(t *testing.T) {
+	t.Skip("TEMP: disabling AWS tests")
+
 	awsAccountID := os.Getenv("AWS_ACCOUNT_ID")
 	awsRegion := os.Getenv("AWS_REGION")
 	// Error the test if the required environment variables are not set

--- a/test/functional-portable/ucp/cloud/aws_credential_test.go
+++ b/test/functional-portable/ucp/cloud/aws_credential_test.go
@@ -31,6 +31,8 @@ import (
 )
 
 func Test_AWS_Credential_Operations(t *testing.T) {
+	t.Skip("TEMP: disabling AWS tests")
+
 	myTest := test.NewUCPTest(t, "Test_AWS_Credential_Operations", func(t *testing.T, url string, roundTripper http.RoundTripper) {
 		resourceTypePath := "/planes/aws/awstest/providers/System.AWS/credentials"
 		resourceURL := fmt.Sprintf("%s%s/default?api-version=%s", url, resourceTypePath, ucp.Version)

--- a/test/functional-portable/ucp/cloud/aws_test.go
+++ b/test/functional-portable/ucp/cloud/aws_test.go
@@ -45,6 +45,8 @@ var (
 )
 
 func Test_AWS_DeleteResource(t *testing.T) {
+	t.Skip("TEMP: disabling AWS tests")
+
 	ctx := context.Background()
 
 	myTest := test.NewUCPTest(t, "Test_AWS_DeleteResource", func(t *testing.T, url string, roundTripper http.RoundTripper) {
@@ -106,6 +108,8 @@ func Test_AWS_DeleteResource(t *testing.T) {
 }
 
 func Test_AWS_ListResources(t *testing.T) {
+	t.Skip("TEMP: disabling AWS tests")
+
 	ctx := context.Background()
 
 	myTest := test.NewUCPTest(t, "Test_AWS_ListResources", func(t *testing.T, url string, roundTripper http.RoundTripper) {


### PR DESCRIPTION
# Description

_Please explain the changes you've made._

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [ ] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [ ] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [ ] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [ ] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [ ] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [ ] Not applicable <!-- TaskRadio recipes-pr -->