### PR TITLE
Flaky test fixes for race conditions and timing issues

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -62,13 +62,20 @@ jobs:
           go install gotest.tools/gotestsum@v${{ env.GOTESTSUMVERSION }}
           make test
 
+      - name: Run make test-validate-cli (CLI integration tests)
+        env:
+          GOTESTSUM_OPTS: --junitfile ./dist/unit_test/cli_results.xml
+          GOTEST_OPTS: -race -coverprofile ./dist/unit_test/cli_coverage.out
+        run: |
+          make test-validate-cli
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           # This secret is unavailable for fork PRs; Codecov falls back to tokenless upload.
           token: ${{ secrets.CODECOV_TOKEN }}
           codecov_yml_path: ./.codecov.yml
-          files: ./dist/unit_test/ut_coverage.out
+          files: ./dist/unit_test/ut_coverage.out,./dist/unit_test/cli_coverage.out
           fail_ci_if_error: false
           verbose: true
 

--- a/build/test.mk
+++ b/build/test.mk
@@ -73,7 +73,7 @@ test-get-envtools:
 
 .PHONY: test-validate-cli
 test-validate-cli: ## Run cli integration tests
-	CGO_ENABLED=1 $(GOTEST_TOOL) -coverpkg= ./pkg/cli/cmd/... ./cmd/rad/... -timeout ${TEST_TIMEOUT} -v -parallel 5 $(GOTEST_OPTS)
+	CGO_ENABLED=1 $(GOTEST_TOOL) ./pkg/cli/cmd/... ./cmd/rad/... -timeout ${TEST_TIMEOUT} $(GOTEST_OPTS)
 
 .PHONY: test-functional-all
 test-functional-all: test-functional-ucp test-functional-kubernetes test-functional-corerp test-functional-cli test-functional-msgrp test-functional-daprrp test-functional-datastoresrp test-functional-samples test-functional-dynamicrp-noncloud ## Runs all functional tests

--- a/build/test.mk
+++ b/build/test.mk
@@ -56,7 +56,7 @@ endif
 
 .PHONY: test
 test: test-get-envtools test-helm ## Runs unit tests, excluding kubernetes controller tests
-	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" CGO_ENABLED=1 $(GOTEST_TOOL) -v ./pkg/... $(GOTEST_OPTS)
+	KUBEBUILDER_ASSETS="$(shell $(ENV_SETUP) use -p path ${K8S_VERSION} --arch amd64)" CGO_ENABLED=1 $(GOTEST_TOOL) ./pkg/... $(GOTEST_OPTS)
 
 .PHONY: test-compile
 test-compile: test-get-envtools ## Compiles all tests without running them

--- a/pkg/controller/reconciler/flux_controller_test.go
+++ b/pkg/controller/reconciler/flux_controller_test.go
@@ -431,7 +431,7 @@ func makeGitRepository(namespacedName types.NamespacedName, url string) sourcev1
 
 func waitForGitRepositoryToExistWithGeneration(ctx context.Context, k8sClient k8sclient.Client, key k8sclient.ObjectKey, obj k8sclient.Object, generation int64) error {
 	timeout := 10 * time.Second
-	interval := 1 * time.Second
+	interval := 200 * time.Millisecond
 	deadlineCtx, deadlineCancel := context.WithTimeout(ctx, timeout)
 	defer deadlineCancel()
 
@@ -462,7 +462,7 @@ func waitForGitRepositoryToExistWithGeneration(ctx context.Context, k8sClient k8
 
 func waitForDeploymentTemplateToExistWithGeneration(ctx context.Context, k8sClient k8sclient.Client, key types.NamespacedName, obj k8sclient.Object, generation int64) error {
 	timeout := 10 * time.Second
-	interval := 1 * time.Second
+	interval := 200 * time.Millisecond
 	deadlineCtx, deadlineCancel := context.WithTimeout(ctx, timeout)
 	defer deadlineCancel()
 

--- a/pkg/controller/reconciler/recipe_reconciler_test.go
+++ b/pkg/controller/reconciler/recipe_reconciler_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package reconciler
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/clients_new/generated"
@@ -73,8 +75,10 @@ func SetupRecipeTest(t *testing.T) (*mockRadiusClient, client.Client) {
 	require.NoError(t, err)
 
 	go func() {
-		err := mgr.Start(ctx)
-		require.NoError(t, err)
+		// Cannot use require/assert here - accessing testing.T from a non-test goroutine causes a data race.
+		if err := mgr.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			panic(fmt.Sprintf("manager exited with error: %v", err))
+		}
 	}()
 
 	return radius, mgr.GetClient()

--- a/pkg/controller/reconciler/shared_test.go
+++ b/pkg/controller/reconciler/shared_test.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	recipeTestWaitDuration            = time.Second * 10
-	recipeTestWaitInterval            = time.Second * 1
+	recipeTestWaitInterval            = time.Millisecond * 200
 	recipeTestControllerDelayInterval = time.Millisecond * 100
 )
 

--- a/pkg/ucp/integrationtests/radius/proxy_test.go
+++ b/pkg/ucp/integrationtests/radius/proxy_test.go
@@ -275,7 +275,7 @@ func Test_RadiusPlane_ResourceAsync(t *testing.T) {
 		err := json.Unmarshal(response.Body.Bytes(), resource)
 		require.NoError(t, err)
 		require.Equal(t, message, *resource.Properties.Message)
-		//Updating or Accepted are valid states, so test for not being Terminal.
+		// Updating or Accepted are valid states, so test for not being Terminal.
 		require.False(t, v1.ProvisioningState(*resource.Properties.ProvisioningState).IsTerminal())
 	})
 

--- a/pkg/ucp/integrationtests/radius/proxy_test.go
+++ b/pkg/ucp/integrationtests/radius/proxy_test.go
@@ -275,7 +275,8 @@ func Test_RadiusPlane_ResourceAsync(t *testing.T) {
 		err := json.Unmarshal(response.Body.Bytes(), resource)
 		require.NoError(t, err)
 		require.Equal(t, message, *resource.Properties.Message)
-		require.Equal(t, string(v1.ProvisioningStateAccepted), *resource.Properties.ProvisioningState)
+		//Updating or Accepted are valid states, so test for not being Terminal.
+		require.False(t, v1.ProvisioningState(*resource.Properties.ProvisioningState).IsTerminal())
 	})
 
 	t.Run("Complete PUT", func(t *testing.T) {

--- a/pkg/upgrade/preflight/config_check_test.go
+++ b/pkg/upgrade/preflight/config_check_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/radius-project/radius/pkg/cli/filesystem"
@@ -160,7 +161,7 @@ func TestCustomConfigValidationCheck_ChartValidation(t *testing.T) {
 			name: "valid set-file with chart",
 			setupFiles: func(t *testing.T, _ filesystem.FileSystem) []string {
 				tmpDir := t.TempDir()
-				tmpFile := tmpDir + "/config.yaml"
+				tmpFile := filepath.Join(tmpDir, "config.yaml")
 				err := os.WriteFile(tmpFile, []byte("custom-config-content"), 0644)
 				require.NoError(t, err)
 				return []string{fmt.Sprintf("global.rootCA.cert=%s", tmpFile)}

--- a/pkg/upgrade/preflight/config_check_test.go
+++ b/pkg/upgrade/preflight/config_check_test.go
@@ -202,7 +202,7 @@ func TestCustomConfigValidationCheck_ChartValidation(t *testing.T) {
 			// Setup files if needed (writes real temp files to disk)
 			setFileParams := tt.setFileParams
 			if tt.setupFiles != nil {
-				setFileParams = tt.setupFiles(t, nil)
+				setFileParams = tt.setupFiles(t, osFS)
 			}
 
 			// Use the real chart path and OS filesystem for chart loading


### PR DESCRIPTION
# Description

Fix flaky tests caused by data races on `testing.T`, overly coarse poll intervals, a race-sensitive provisioning state assertion, and in-memory filesystem misuse in chart validation tests.

## Changes

- **Controller reconciler tests**: Replace `require.NoError` in non-test goroutines with `panic` to avoid data races on `testing.T` when the controller manager exits with an error. Affected files: `deployment_reconciler_test.go`, `deploymentresource_reconciler_test.go`, `deploymenttemplate_reconciler_test.go`, `recipe_reconciler_test.go`, `recipe_webhook_test.go`.
- **Poll interval reduction**: Decrease wait intervals from 1s to 200ms across controller reconciler, flux controller, and shared test constants to reduce overall test timing from ~ 1m30s to ~25s.
- **Proxy async test**: Replace exact `Accepted` provisioning state check with a non-terminal state assertion, since `Updating` is also a valid intermediate state.
- **Config check chart validation test**: Use the OS filesystem and real temp files instead of an in-memory filesystem, fixing test failures when the chart exists on disk but not in memory.
- Add a dedicated `make test-validate-cli` workflow step to run CLI integration tests with race detection and its own coverage output.
- Upload both unit and CLI coverage files to Codecov so the new test run is included in coverage reporting.
- Removing `-v` from the default unit test invocation to improve CI reliability and reduce noisy/non-actionable output.

Notes on the reason for removing `-v`

- Our CI already uses gotestsum in package-summary mode, so per-test verbose lines are not part of the primary signal we consume.
- In parallel test runs with direct stdout writes, verbose mode increases output volume and interleaving, which can cause occasional FAIL ... (unknown) reporting despite package-level success.
- I reproduced this behavior in stress runs: `go test -json -race -v` showed missing per-test pass events for some tests, while non-verbose runs were stable.
- JUnit reporting is unaffected: --junitfile output is still generated and consumed by the Process Unit Test Results step.
Impact:
- Keeps package-level gotestsum output and CI pass/fail behavior intact.
- Preserves XML test artifacts (results.xml) and downstream PR annotations.
- Reduces log noise and flake risk in the default CI path.
- Detailed per-test logs remain available for targeted debugging by rerunning specific tests/packages with -v when needed.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and does not change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->