### PR TITLE
allow upgrade to pass when upgrading between rcs

### DIFF
--- a/pkg/upgrade/preflight/version_check.go
+++ b/pkg/upgrade/preflight/version_check.go
@@ -133,6 +133,13 @@ func (v *VersionCompatibilityCheck) isValidUpgradeVersion(currentVersion, target
 		return false, fmt.Sprintf("Skipping multiple major versions not supported. Expected next major version: %d.0.0", current.Major()+1), nil
 	}
 
+	// Allow upgrades within the same minor version (patch bumps, prerelease upgrades)
+	// e.g., 0.55.0-rc4 -> 0.55.0-rc5, 0.55.0-rc5 -> 0.55.0, 0.55.0 -> 0.55.1
+	// Same-version case (e.g., 0.55.0 -> 0.55.0) is already rejected by the Equal check above.
+	if target.Major() == current.Major() && target.Minor() == current.Minor() {
+		return true, "", nil
+	}
+
 	// Allow increment of minor version by exactly 1
 	if target.Major() == current.Major() && target.Minor() == current.Minor()+1 {
 		return true, "", nil

--- a/pkg/upgrade/preflight/version_check_test.go
+++ b/pkg/upgrade/preflight/version_check_test.go
@@ -163,25 +163,6 @@ func TestValidateVersionJump(t *testing.T) {
 			expectValid:    false,
 			expectMessage:  "Target version is the same as current version",
 		},
-		{
-			name:           "edge version bypass",
-			currentVersion: "0.42.42-dev",
-			targetVersion:  "v0.55.0",
-			expectValid:    true,
-		},
-		{
-			name:           "major version increment",
-			currentVersion: "v0.55.0",
-			targetVersion:  "v1.0.0",
-			expectValid:    true,
-		},
-		{
-			name:           "skip major versions rejected",
-			currentVersion: "v0.55.0",
-			targetVersion:  "v2.0.0",
-			expectValid:    false,
-			expectMessage:  "Skipping multiple major versions not supported",
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/upgrade/preflight/version_check_test.go
+++ b/pkg/upgrade/preflight/version_check_test.go
@@ -67,6 +67,27 @@ func TestVersionCompatibilityCheck_Run(t *testing.T) {
 			expectSuccess:  false,
 			expectMessage:  "Only incremental version upgrades are supported. Expected next version: 0.41.0",
 		},
+		{
+			name:           "valid prerelease upgrade same version",
+			currentVersion: "0.55.0-rc4",
+			targetVersion:  "0.55.0-rc5",
+			expectSuccess:  true,
+			expectMessage:  "Upgrade from 0.55.0-rc4 to 0.55.0-rc5 is valid",
+		},
+		{
+			name:           "valid prerelease to release upgrade",
+			currentVersion: "v0.55.0-rc5",
+			targetVersion:  "v0.55.0",
+			expectSuccess:  true,
+			expectMessage:  "Upgrade from v0.55.0-rc5 to v0.55.0 is valid",
+		},
+		{
+			name:           "valid patch version upgrade",
+			currentVersion: "v0.55.0",
+			targetVersion:  "v0.55.1",
+			expectSuccess:  true,
+			expectMessage:  "Upgrade from v0.55.0 to v0.55.1 is valid",
+		},
 	}
 
 	for _, tt := range tests {
@@ -116,6 +137,50 @@ func TestValidateVersionJump(t *testing.T) {
 			targetVersion:  "v0.43.0",
 			expectValid:    false,
 			expectMessage:  "Downgrading is not supported",
+		},
+		{
+			name:           "safe prerelease upgrade",
+			currentVersion: "0.55.0-rc4",
+			targetVersion:  "0.55.0-rc5",
+			expectValid:    true,
+		},
+		{
+			name:           "safe prerelease to release",
+			currentVersion: "0.55.0-rc5",
+			targetVersion:  "0.55.0",
+			expectValid:    true,
+		},
+		{
+			name:           "safe patch bump",
+			currentVersion: "v0.55.0",
+			targetVersion:  "v0.55.1",
+			expectValid:    true,
+		},
+		{
+			name:           "same version rejected",
+			currentVersion: "v0.55.0",
+			targetVersion:  "v0.55.0",
+			expectValid:    false,
+			expectMessage:  "Target version is the same as current version",
+		},
+		{
+			name:           "edge version bypass",
+			currentVersion: "0.42.42-dev",
+			targetVersion:  "v0.55.0",
+			expectValid:    true,
+		},
+		{
+			name:           "major version increment",
+			currentVersion: "v0.55.0",
+			targetVersion:  "v1.0.0",
+			expectValid:    true,
+		},
+		{
+			name:           "skip major versions rejected",
+			currentVersion: "v0.55.0",
+			targetVersion:  "v2.0.0",
+			expectValid:    false,
+			expectMessage:  "Skipping multiple major versions not supported",
 		},
 	}
 


### PR DESCRIPTION
# Description

Fixes error similar to below, where we are upgrading Radius from one rc version to next. 

https://github.com/radius-project/radius/actions/runs/22571565116/job/65380431400

Version mismatch detected. Attempting upgrade from 0.55.0-rc4 to 0.55.0-rc5...
Current Radius version: 0.55.0-rc4
Target Radius version: 0.55.0-rc5
Running pre-flight checks...
  Running Kubernetes Connectivity...
    ✓ Connected (version: v1.34.2) with sufficient permissions
  Running Helm Connectivity...
    ✓ Helm successfully connected to cluster and found Radius release (version: 0.55.0-rc4), Contour installed (version: 1.32.0)
  Running Radius Installation...
    ✓ Radius is installed (version: 0.55.0-rc4), Contour is installed (version: 1.32.0)
  Running Version Compatibility...
Error: ERROR] Only incremental version upgrades are supported. Expected next version: 0.56.0
Error: preflight checks failed: pre-flight check 'Version Compatibility' failed: Only incremental version upgrades are supported. Expected next version: 0.56.0


## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->