### PR TITLE
increase timeout for ns deletion

### DIFF
--- a/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
+++ b/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
@@ -125,7 +125,7 @@ func Test_DeploymentTemplate_Env(t *testing.T) {
 			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
 			err = opts.Client.Get(ctx, types.NamespacedName{Name: namespace}, ns)
 			return apierrors.IsNotFound(err)
-		}, time.Minute*3, time.Second*10, "waiting for environment namespace to be deleted")
+		}, time.Minute*10, time.Second*10, "waiting for environment namespace to be deleted")
 	})
 }
 
@@ -413,5 +413,5 @@ func deleteNamespace(ctx context.Context, t *testing.T, namespace string, opts r
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
 		err = opts.Client.Get(ctx, types.NamespacedName{Name: namespace}, ns)
 		return apierrors.IsNotFound(err)
-	}, time.Minute*3, time.Second*10, "waiting for environment namespace to be deleted")
+	}, time.Minute*10, time.Second*10, "waiting for environment namespace to be deleted")
 }


### PR DESCRIPTION
# Description

Potential fix to help with below issue in new aks for LRT. 

error in lrt  deploymenttemplate_test.go:412:
        	Error Trace:	/home/runner/work/radius/radius/current_release/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go:412
        	            				/home/runner/work/radius/radius/current_release/test/functional-portable/kubernetes/noncloud/flux_test.go:347
        	            				/home/runner/work/radius/radius/current_release/test/functional-portable/kubernetes/noncloud/flux_test.go:135
        	Error:      	Condition never satisfied
        	Test:       	Test_Flux_Complex
        	Messages:   	waiting for environment namespace to be deleted

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->


## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->