### PR TITLE
flux delete fix

### DIFF
--- a/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
+++ b/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
@@ -119,6 +119,9 @@ func Test_DeploymentTemplate_Env(t *testing.T) {
 	t.Run("Delete namespace", func(t *testing.T) {
 		t.Log("Deleting namespace")
 
+		// Log namespace state and all resources before deletion for diagnostics.
+		logNamespaceState(ctx, t, namespace, opts)
+
 		err = opts.K8sClient.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
 		require.NoError(t, err)
 
@@ -421,6 +424,9 @@ func deleteNamespace(ctx context.Context, t *testing.T, namespace string, opts r
 		return len(deployments.Items) == 0
 	}, time.Minute*3, time.Second*5, "waiting for deployments in namespace %s to be deleted before namespace deletion", namespace)
 
+	// Log namespace state and all resources before deletion for diagnostics.
+	logNamespaceState(ctx, t, namespace, opts)
+
 	err := opts.K8sClient.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
 	if !apierrors.IsNotFound(err) {
 		require.NoError(t, err, "failed to delete namespace %s", namespace)
@@ -434,4 +440,90 @@ func deleteNamespace(ctx context.Context, t *testing.T, namespace string, opts r
 		err = opts.Client.Get(ctx, types.NamespacedName{Name: namespace}, ns)
 		return apierrors.IsNotFound(err)
 	}, time.Minute*10, time.Second*10, "waiting for environment namespace to be deleted")
+}
+
+// logNamespaceState logs the namespace status, all pods, deployments, and other resources
+// present in the namespace. Used for diagnostics before namespace deletion.
+func logNamespaceState(ctx context.Context, t *testing.T, namespace string, opts rp.RPTestOptions) {
+	t.Logf("=== Namespace state before deletion: %s ===", namespace)
+
+	// Namespace status and finalizers
+	ns, err := opts.K8sClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		t.Logf("  Namespace %s does not exist", namespace)
+		return
+	}
+	if err != nil {
+		t.Logf("  Error getting namespace %s: %v", namespace, err)
+	} else {
+		t.Logf("  Namespace phase: %s, finalizers: %v", ns.Status.Phase, ns.Finalizers)
+		for _, cond := range ns.Status.Conditions {
+			t.Logf("  Namespace condition: type=%s status=%s reason=%s message=%s", cond.Type, cond.Status, cond.Reason, cond.Message)
+		}
+	}
+
+	// Pods
+	pods, err := opts.K8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Logf("  Error listing pods: %v", err)
+	} else {
+		t.Logf("  Pods (%d):", len(pods.Items))
+		for _, pod := range pods.Items {
+			t.Logf("    pod/%s phase=%s finalizers=%v", pod.Name, pod.Status.Phase, pod.Finalizers)
+			for _, cond := range pod.Status.Conditions {
+				t.Logf("      condition: type=%s status=%s reason=%s", cond.Type, cond.Status, cond.Reason)
+			}
+		}
+	}
+
+	// Deployments
+	deployments, err := opts.K8sClient.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Logf("  Error listing deployments: %v", err)
+	} else {
+		t.Logf("  Deployments (%d):", len(deployments.Items))
+		for _, d := range deployments.Items {
+			t.Logf("    deployment/%s replicas=%d ready=%d finalizers=%v deletionTimestamp=%v",
+				d.Name, d.Status.Replicas, d.Status.ReadyReplicas, d.Finalizers, d.DeletionTimestamp)
+			for _, cond := range d.Status.Conditions {
+				t.Logf("      condition: type=%s status=%s reason=%s message=%s", cond.Type, cond.Status, cond.Reason, cond.Message)
+			}
+		}
+	}
+
+	// ReplicaSets
+	replicaSets, err := opts.K8sClient.AppsV1().ReplicaSets(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Logf("  Error listing replicasets: %v", err)
+	} else {
+		t.Logf("  ReplicaSets (%d):", len(replicaSets.Items))
+		for _, rs := range replicaSets.Items {
+			t.Logf("    replicaset/%s replicas=%d ready=%d finalizers=%v deletionTimestamp=%v",
+				rs.Name, rs.Status.Replicas, rs.Status.ReadyReplicas, rs.Finalizers, rs.DeletionTimestamp)
+		}
+	}
+
+	// Services
+	services, err := opts.K8sClient.CoreV1().Services(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Logf("  Error listing services: %v", err)
+	} else {
+		t.Logf("  Services (%d):", len(services.Items))
+		for _, svc := range services.Items {
+			t.Logf("    service/%s finalizers=%v deletionTimestamp=%v", svc.Name, svc.Finalizers, svc.DeletionTimestamp)
+		}
+	}
+
+	// Secrets
+	secrets, err := opts.K8sClient.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Logf("  Error listing secrets: %v", err)
+	} else {
+		t.Logf("  Secrets (%d):", len(secrets.Items))
+		for _, s := range secrets.Items {
+			t.Logf("    secret/%s finalizers=%v deletionTimestamp=%v", s.Name, s.Finalizers, s.DeletionTimestamp)
+		}
+	}
+
+	t.Logf("=== End namespace state: %s ===", namespace)
 }

--- a/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
+++ b/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/radius-project/radius/test/testutil"
 
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -401,6 +402,25 @@ func assertExpectedResourcesToNotExist(ctx context.Context, scope string, expect
 }
 
 func deleteNamespace(ctx context.Context, t *testing.T, namespace string, opts rp.RPTestOptions) {
+	// Wait for all Deployments in the namespace to be gone before issuing the namespace delete.
+	// This avoids the namespace getting stuck in Terminating while pods from Radius-managed
+	// Deployments are still shutting down (Radius marks the operation complete before pods terminate).
+	require.Eventually(t, func() bool {
+		deployments := &appsv1.DeploymentList{}
+		err := opts.Client.List(ctx, deployments, controller_runtime.InNamespace(namespace))
+		if apierrors.IsNotFound(err) {
+			return true
+		}
+		if err != nil {
+			t.Logf("Error listing deployments in namespace %s: %v", namespace, err)
+			return false
+		}
+		if len(deployments.Items) > 0 {
+			t.Logf("Waiting for %d deployment(s) in namespace %s to be deleted", len(deployments.Items), namespace)
+		}
+		return len(deployments.Items) == 0
+	}, time.Minute*3, time.Second*5, "waiting for deployments in namespace %s to be deleted before namespace deletion", namespace)
+
 	err := opts.K8sClient.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
 	if !apierrors.IsNotFound(err) {
 		require.NoError(t, err, "failed to delete namespace %s", namespace)


### PR DESCRIPTION
# Description

Before deleting the namespace, waits up to 3 minutes for all Deployments to be gone (polling every 5s). By the time Radius has cleaned up its resources, the Deployments should already  be deleted — this step just waits for the pods to finish terminating.    

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [ ] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [ ] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [ ] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [ ] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [ ] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [ ] Not applicable <!-- TaskRadio recipes-pr -->