### PR TITLE
Gosec version rollback to fix invalid SARIF output

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Perform GoSec Analysis
         if: matrix.language == 'custom-gosec'
-        uses: securego/gosec@bb17e422fc34bf4c0a2e5cab9d07dc45a68c040c # v2.24.7
+        uses: securego/gosec@271492bcd930ef72dfb9d00e5bb9544b3b407fb5 # v2.24.0
         with:
           args: -no-fail -fmt sarif -out gosec-results.sarif ./...
         continue-on-error: true


### PR DESCRIPTION
# Description

Rolls back the `securego/gosec` GitHub Action from v2.24.7 to v2.24.0 in the CodeQL workflow. The newer version produces invalid SARIF files due to a combination of two upstream issues:

- https://github.com/securego/gosec/issues/1568
- https://github.com/securego/gosec/issues/1581

## Type of change

- This pull request fixes a bug in Radius workflows but does not have an approved issue

Fixes: N/A

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->