### PR TITLE
build(go): bump version to 1.26.1

### DIFF
--- a/docs/contributing/contributing-code/contributing-code-debugging/radius-os-processes-debugging.md
+++ b/docs/contributing/contributing-code/contributing-code-debugging/radius-os-processes-debugging.md
@@ -102,8 +102,8 @@ echo 'export PATH="$HOME/go/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc
 
 ```bash
 # Install Go 1.25+
-wget https://go.dev/dl/go1.26.0.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.26.0.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.26.1.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.1.linux-amd64.tar.gz
 echo 'export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
 
 # Other tools

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/radius-project/radius
 
-go 1.26.0
+go 1.26.1
 
 // Replace digest lib to master to gather access to BLAKE3.
 // xref: https://github.com/opencontainers/go-digest/pull/66

--- a/test/magpiego/go.mod
+++ b/test/magpiego/go.mod
@@ -1,6 +1,6 @@
 module github.com/radius-project/radius/test/magpiego
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0

--- a/test/testrp/go.mod
+++ b/test/testrp/go.mod
@@ -1,3 +1,3 @@
 module testrp
 
-go 1.26.0
+go 1.26.1


### PR DESCRIPTION
# Description

Updates the Go toolchain version in the root module from 1.26.0 to 1.26.1.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: N/A

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->