### PR TITLE
test(upc-aws): add response status validation and diags

### DIFF
--- a/test/functional-portable/ucp/cloud/aws_test.go
+++ b/test/functional-portable/ucp/cloud/aws_test.go
@@ -167,9 +167,12 @@ func setupTestAWSResource(t *testing.T, ctx context.Context, resourceName string
 	waitForSuccess(t, ctx, awsClient, response.ProgressEvent.RequestToken)
 
 	t.Cleanup(func() {
+		// Use a fresh context because t.Context() is cancelled before cleanup runs.
+		cleanupCtx := context.Background()
+
 		// Check if resource exists before issuing a delete because the AWS SDK async delete operation
 		// seems to fail if the resource does not exist
-		_, err := awsClient.GetResource(ctx, &cloudcontrol.GetResourceInput{
+		_, err := awsClient.GetResource(cleanupCtx, &cloudcontrol.GetResourceInput{
 			Identifier: &resourceName,
 			TypeName:   &awsLogGroupResourceType,
 		}, cloudControlOpts...)
@@ -177,14 +180,14 @@ func setupTestAWSResource(t *testing.T, ctx context.Context, resourceName string
 			return
 		}
 		// Just in case delete fails
-		deleteOutput, err := awsClient.DeleteResource(ctx, &cloudcontrol.DeleteResourceInput{
+		deleteOutput, err := awsClient.DeleteResource(cleanupCtx, &cloudcontrol.DeleteResourceInput{
 			Identifier: &resourceName,
 			TypeName:   &awsLogGroupResourceType,
 		}, cloudControlOpts...)
 		require.NoError(t, err)
 
 		// Ignoring status of delete since AWS command fails if the resource does not already exist
-		waitForSuccess(t, ctx, awsClient, deleteOutput.ProgressEvent.RequestToken)
+		waitForSuccess(t, cleanupCtx, awsClient, deleteOutput.ProgressEvent.RequestToken)
 	})
 	// End of test setup
 }

--- a/test/functional-portable/ucp/cloud/aws_test.go
+++ b/test/functional-portable/ucp/cloud/aws_test.go
@@ -73,6 +73,7 @@ func Test_AWS_DeleteResource(t *testing.T) {
 		deleteResponse, err := roundTripper.RoundTrip(deleteRequest)
 		require.NoError(t, err)
 		requireResponseStatus(t, deleteResponse, http.StatusAccepted)
+		defer deleteResponse.Body.Close()
 
 		// Get the operation status url from the Azure-Asyncoperation header
 		deleteResponseCompletionUrl := deleteResponse.Header["Azure-Asyncoperation"][0]
@@ -86,9 +87,9 @@ func Test_AWS_DeleteResource(t *testing.T) {
 			require.Equal(t, http.StatusOK, getResponse.StatusCode)
 
 			// Read the request status from the body
-			defer getResponse.Body.Close()
 			payload, err := io.ReadAll(getResponse.Body)
 			require.NoError(t, err)
+			require.NoError(t, getResponse.Body.Close())
 			body := map[string]any{}
 			err = json.Unmarshal(payload, &body)
 			require.NoError(t, err)

--- a/test/functional-portable/ucp/cloud/aws_test.go
+++ b/test/functional-portable/ucp/cloud/aws_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -45,10 +46,10 @@ var (
 )
 
 func Test_AWS_DeleteResource(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	myTest := test.NewUCPTest(t, "Test_AWS_DeleteResource", func(t *testing.T, url string, roundTripper http.RoundTripper) {
-		logGroupName := generateLogGroupName()
+		logGroupName := generateLogGroupName(t)
 		setupTestAWSResource(t, ctx, logGroupName)
 		resourceID, err := validation.GetResourceIdentifier(ctx, logGroupResourceType, logGroupName)
 		require.NoError(t, err)
@@ -71,7 +72,7 @@ func Test_AWS_DeleteResource(t *testing.T) {
 		require.NoError(t, err)
 		deleteResponse, err := roundTripper.RoundTrip(deleteRequest)
 		require.NoError(t, err)
-		require.Equal(t, http.StatusAccepted, deleteResponse.StatusCode)
+		requireResponseStatus(t, deleteResponse, http.StatusAccepted)
 
 		// Get the operation status url from the Azure-Asyncoperation header
 		deleteResponseCompletionUrl := deleteResponse.Header["Azure-Asyncoperation"][0]
@@ -106,10 +107,10 @@ func Test_AWS_DeleteResource(t *testing.T) {
 }
 
 func Test_AWS_ListResources(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	myTest := test.NewUCPTest(t, "Test_AWS_ListResources", func(t *testing.T, url string, roundTripper http.RoundTripper) {
-		var logGroupName = generateLogGroupName()
+		var logGroupName = generateLogGroupName(t)
 		setupTestAWSResource(t, ctx, logGroupName)
 		resourceID, err := validation.GetResourceIdentifier(ctx, logGroupResourceType, logGroupName)
 		require.NoError(t, err)
@@ -126,7 +127,7 @@ func Test_AWS_ListResources(t *testing.T) {
 		listResponse, err := roundTripper.RoundTrip(listRequest)
 		require.NoError(t, err)
 
-		require.Equal(t, http.StatusOK, listResponse.StatusCode)
+		requireResponseStatus(t, listResponse, http.StatusOK)
 
 		defer listResponse.Body.Close()
 		payload, err := io.ReadAll(listResponse.Body)
@@ -197,6 +198,41 @@ func waitForSuccess(t *testing.T, ctx context.Context, awsClient aws.AWSCloudCon
 	require.NoError(t, err)
 }
 
-func generateLogGroupName() string {
+func generateLogGroupName(t *testing.T) string {
+	t.Helper()
 	return "ucpfunctionaltest-" + uuid.NewString()
+}
+
+func requireResponseStatus(t *testing.T, response *http.Response, expectedStatus int) {
+	t.Helper()
+	require.NotNil(t, response)
+
+	if response.StatusCode == expectedStatus {
+		return
+	}
+
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+
+	response.Body = io.NopCloser(bytes.NewReader(body))
+
+	headerKeys := make([]string, 0, len(response.Header))
+	for key := range response.Header {
+		headerKeys = append(headerKeys, key)
+	}
+	sort.Strings(headerKeys)
+
+	headers := make([]string, 0, len(headerKeys))
+	for _, key := range headerKeys {
+		headers = append(headers, fmt.Sprintf("%s=%s", key, strings.Join(response.Header.Values(key), ",")))
+	}
+
+	require.Failf(t, "unexpected response status",
+		"expected status %d, got %d\nheaders: %s\nbody: %s",
+		expectedStatus,
+		response.StatusCode,
+		strings.Join(headers, "; "),
+		string(body),
+	)
 }


### PR DESCRIPTION
# Description

This change will help diagnose #10556

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->