### PR TITLE
fix: x-plat installer scripts improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,32 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.{go,mod}]
+indent_style = tab
+
+[*.md]
+indent_size = unset
+
+[*.py]
+indent_size = 4
+
+[*.ps1]
+indent_size = 4
+
+[*.{cmd,bat}]
+end_of_line = crlf
+
+# Shell scripts
+[{*.sh,*.bash,.bashrc,.mk-sbuild.rc,.quiltrc,.startxwinrc,user-dirs.dirs}]
+indent_size = 4
+binary_next_line = true         # shfmt: -bn
+switch_case_indent = true       # shfmt: -ci
+space_redirects = true          # shfmt: -sr
+keep_padding = true             # shfmt: -kp

--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -335,7 +335,8 @@ function Add-ToPathWindows {
         Remove-Item -Recurse -Force "C:\radius"
     }
 
-    if (-not ($userPath -like "*$TargetDir*")) {
+    $pathEntries = $userPath -split ';' | Where-Object { $_ -ne '' }
+    if (-not ($pathEntries -contains $TargetDir)) {
         Write-Output "Adding $TargetDir to User Path..."
         $newPath = if ($userPath) { "$userPath;$TargetDir" } else { $TargetDir }
         Set-ItemProperty HKCU:\Environment "PATH" "$newPath" -Type ExpandString

--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -81,13 +81,12 @@ Environment Variables:
   INCLUDE_RC               Set to "true" to include release candidates
 
 Install Directory Detection:
-  Windows: LOCALAPPDATA\radius
-  macOS/Linux: HOME/.local/bin
-
+  Windows: `$env:LOCALAPPDATA\radius
+  macOS/Linux: `$HOME/.local/bin
 Examples:
   ./install.ps1
   ./install.ps1 -Version 0.40.0
-  ./install.ps1 -InstallDir "HOME/bin"
+  ./install.ps1 -InstallDir "`$HOME/bin"
   ./install.ps1 -Version edge
 "@
     Write-Output $helpText

--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -4,7 +4,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#    
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
@@ -14,204 +14,476 @@
 # limitations under the License.
 # ------------------------------------------------------------
 
+# ============================================================================
+# Radius CLI Installer (PowerShell - Cross-Platform)
+#
+# Usage:
+#   # Windows (PowerShell)
+#   iwr -useb https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.ps1 | iex
+#   ./install.ps1 -Version 0.40.0
+#   ./install.ps1 -InstallDir "$HOME/.local/bin"
+#   ./install.ps1 -IncludeRC
+#
+#   # macOS/Linux (pwsh)
+#   pwsh -c "& { iwr -useb https://...install.ps1 | iex }"
+#
+# Parameters:
+#   -Version       Version to install (e.g., 0.40.0, v0.40.0, edge)
+#   -InstallDir    Installation directory (default: auto-detected)
+#   -IncludeRC     Include release candidates when determining latest
+#   -Help          Show this help message
+#
+# Environment Variables:
+#   INSTALL_DIR    Override installation directory
+#   INCLUDE_RC     Set to "true" to include release candidates
+# ============================================================================
+
+[CmdletBinding()]
 param (
+    [Alias("v")]
     [string]$Version,
-    [string]$RadiusRoot = "$env:LOCALAPPDATA\radius"
+
+    [Alias("d", "RadiusRoot")]
+    [string]$InstallDir,
+
+    [Alias("rc")]
+    [switch]$IncludeRC,
+
+    [Alias("h")]
+    [switch]$Help
 )
 
-Write-Output ""
-$ErrorActionPreference = 'stop'
+$ErrorActionPreference = 'Stop'
 
 # Constants
-$RadiusCliFileName = "rad.exe"
-$RadiusCliFilePath = "${RadiusRoot}\${RadiusCliFileName}"
-$OS = "windows"
-$Arch = "amd64"
 $GitHubOrg = "radius-project"
 $GitHubRepo = "radius"
-$GitHubReleaseJsonUrl = "https://api.github.com/repos/${GitHubOrg}/${GitHubRepo}/releases"
+$GitHubReleaseJsonUrl = "https://api.github.com/repos/$GitHubOrg/$GitHubRepo/releases"
 
-function GetVersionInfo {
-    param (
-        [string]$Version,
-        $Releases
-    )
-    # Filter windows binary and download archive
-    if (!$Version) {
-        $release = $Releases | Where-Object { $_.tag_name -notlike "*rc*" } | Select-Object -First 1
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+function Show-Usage {
+    $helpText = @"
+Radius CLI Installer (PowerShell)
+
+Usage: install.ps1 [OPTIONS]
+
+Options:
+  -Version <VERSION>       Version to install (e.g., 0.40.0, edge)
+  -InstallDir <DIR>        Installation directory (default: auto-detected)
+  -IncludeRC               Include release candidates in latest version
+  -Help                    Show this help message
+
+Environment Variables:
+  INSTALL_DIR              Override installation directory
+  INCLUDE_RC               Set to "true" to include release candidates
+
+Install Directory Detection:
+  Windows: LOCALAPPDATA\radius
+  macOS/Linux: HOME/.local/bin
+
+Examples:
+  ./install.ps1
+  ./install.ps1 -Version 0.40.0
+  ./install.ps1 -InstallDir "HOME/bin"
+  ./install.ps1 -Version edge
+"@
+    Write-Output $helpText
+    exit 0
+}
+
+function Get-SystemInfo {
+    $detectedOS = if ($IsWindows -or $env:OS -eq "Windows_NT") {
+        "windows"
+    }
+    elseif ($IsMacOS) {
+        "darwin"
     }
     else {
-        $release = $Releases | Where-Object { $_.tag_name -eq "v$Version" } | Select-Object -First 1
+        "linux"
+    }
+
+    $rawArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLower()
+    $detectedArch = switch ($rawArch) {
+        "x64" { "amd64" }
+        "arm64" { "arm64" }
+        "arm" { "arm" }
+        default { $rawArch }
+    }
+
+    return @{ OS = $detectedOS; Arch = $detectedArch }
+}
+
+function Get-DefaultInstallDir {
+    param ([string]$DetectedOS)
+
+    if ($env:INSTALL_DIR) {
+        return $env:INSTALL_DIR
+    }
+
+    if ($DetectedOS -eq "windows") {
+        return Join-Path $env:LOCALAPPDATA "radius"
+    }
+
+    return Join-Path $HOME ".local" "bin"
+}
+
+function Get-CliFileName {
+    param ([string]$DetectedOS)
+    if ($DetectedOS -eq "windows") { return "rad.exe" }
+    return "rad"
+}
+
+function Get-GithubHeaders {
+    $headers = @{}
+    if ($env:GITHUB_USER -and $env:GITHUB_TOKEN) {
+        $pair = "$($env:GITHUB_USER):$($env:GITHUB_TOKEN)"
+        $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
+        $base64 = [System.Convert]::ToBase64String($bytes)
+        $headers["Authorization"] = "Basic $base64"
+    }
+    return $headers
+}
+
+function Get-LatestRelease {
+    param (
+        [bool]$ShouldIncludeRC,
+        [hashtable]$Headers
+    )
+
+    $releases = Invoke-RestMethod -Headers $Headers -Uri $GitHubReleaseJsonUrl -Method Get
+    if ($releases.Count -eq 0) {
+        throw "No releases found at github.com/$GitHubOrg/$GitHubRepo"
+    }
+
+    if ($ShouldIncludeRC) {
+        $release = $releases | Select-Object -First 1
+    }
+    else {
+        $release = $releases | Where-Object { $_.tag_name -notlike "*rc*" } | Select-Object -First 1
+    }
+
+    if (-not $release) {
+        throw "Could not determine latest release"
     }
 
     return $release
 }
 
-function GetWindowsAsset {
+function Get-ReleaseAsset {
     param (
-        $Release
+        $Release,
+        [string]$ArtifactName
     )
-    $windowsAsset = $Release | Select-Object -ExpandProperty assets | Where-Object { $_.name -Like "*${OS}_${Arch}.exe" }
-    if (!$windowsAsset) {
-        throw "Cannot find the Windows rad CLI binary"
+
+    $asset = $Release | Select-Object -ExpandProperty assets | Where-Object { $_.name -eq $ArtifactName }
+    if (-not $asset) {
+        throw "Cannot find asset '$ArtifactName' in release $($Release.tag_name)"
     }
-    [hashtable]$return = @{}
-    $return.url = $windowsAsset.url
-    $return.name = $windowsAsset.name
-    return $return
-}
 
-# Set Github request authentication for basic authentication.
-if ($Env:GITHUB_USER) {
-    $basicAuth = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($Env:GITHUB_USER + ":" + $Env:GITHUB_TOKEN));
-    $githubHeader = @{"Authorization" = "Basic $basicAuth" }
-}
-else {
-    $githubHeader = @{}
-}
-
-if ((Get-ExecutionPolicy) -gt 'RemoteSigned' -or (Get-ExecutionPolicy) -eq 'ByPass') {
-    Write-Output "PowerShell requires an execution policy of 'RemoteSigned'."
-    Write-Output "To make this change please run:"
-    Write-Output "'Set-ExecutionPolicy RemoteSigned -scope CurrentUser'"
-    break
-}
-
-# Change security protocol to support TLS 1.2 / 1.1 / 1.0 - old powershell uses TLS 1.0 as a default protocol
-[Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
-
-# Remove old rad CLI at legacy location, C:\radius
-if (Test-Path "C:\radius\rad.exe" -PathType Leaf) {
-    Remove-Item -Recurse -Force "C:\radius"
-}
-
-# Check if Radius CLI is installed.
-if (Test-Path $RadiusCliFilePath -PathType Leaf) {
-    Write-Output "Previous rad CLI detected: $RadiusCliFilePath"
-    try {
-        $CurrentVersion = &$RadiusCliFilePath version --cli --output json | ConvertFrom-JSON | Select-Object -ExpandProperty version
-        Write-Output "Previous version: $CurrentVersion`r`n"
-    }
-    catch {
-        Write-Output "Previous installation corrupted`r`n"
-    }
-    Write-Output "Reinstalling rad CLI..."
-}
-else {
-    Write-Output "Installing rad CLI..."
-}
-
-# Create Radius Directory
-if (-Not (Test-Path $RadiusRoot -PathType Container)) {
-    Write-Output "Creating $RadiusRoot directory..."
-    New-Item -ErrorAction Ignore -Path $RadiusRoot -ItemType "directory" | Out-Null
-    if (!(Test-Path $RadiusRoot -PathType Container)) {
-        throw "Cannot create $RadiusRoot"
+    return @{
+        Url  = $asset.url
+        Name = $asset.name
     }
 }
 
-if ($Version -eq "edge") {
-    # Check if oras CLI is installed
-    $orasExists = Get-Command oras -ErrorAction SilentlyContinue
-    if (-Not $orasExists) {
+function Install-RadEdge {
+    param (
+        [string]$TargetDir,
+        [string]$DetectedOS,
+        [string]$DetectedArch,
+        [string]$CliFileName
+    )
+
+    $orasCmd = Get-Command oras -ErrorAction SilentlyContinue
+    if (-not $orasCmd) {
         Write-Output "Error: oras CLI is not installed or not found in PATH."
-        Write-Output "Please visit https://edge.docs.radapp.io/installation for edge build installation instructions."
-        Exit 1
+        Write-Output "Please visit https://edge.docs.radapp.io/installation for edge CLI installation instructions."
+        exit 1
     }
 
-    $downloadURL = "ghcr.io/${GitHubOrg}/rad/${OS}-${Arch}:latest"
-    Write-Output "Downloading edge CLI from ${downloadURL}..."
-    oras pull $downloadURL -o $RadiusRoot
+    $downloadURL = "ghcr.io/$GitHubOrg/rad/$DetectedOS-$($DetectedArch):latest"
+    Write-Output "Downloading edge CLI from $downloadURL..."
 
-    # Check if the oras pull command was successful
+    & oras pull $downloadURL -o $TargetDir
     if ($LASTEXITCODE -ne 0) {
         Write-Output "Failed to download edge rad CLI."
         Write-Output "If this was an authentication issue, please run 'docker logout ghcr.io' to clear any expired credentials."
-        Write-Output "Visit https://edge.docs.radapp.io/installation for edge build installation instructions."
-        Exit 1
+        Write-Output "Visit https://edge.docs.radapp.io/installation for edge CLI installation instructions."
+        exit 1
+    }
+
+    $downloadedFile = Join-Path $TargetDir "rad"
+    $cliFilePath = Join-Path $TargetDir $CliFileName
+    if (($downloadedFile -ne $cliFilePath) -and (Test-Path $downloadedFile -PathType Leaf)) {
+        Move-Item -Path $downloadedFile -Destination $cliFilePath -Force
+    }
+
+    # Set executable permission on non-Windows
+    if ($DetectedOS -ne "windows") {
+        & chmod +x $cliFilePath
     }
 }
-else {
-    # Get the list of releases from GitHub
-    $releases = Invoke-RestMethod -Headers $githubHeader -Uri $GitHubReleaseJsonUrl -Method Get
+
+function Install-RadRelease {
+    param (
+        [string]$ReleaseTag,
+        [string]$TargetDir,
+        [string]$DetectedOS,
+        [string]$DetectedArch,
+        [string]$CliFileName,
+        [hashtable]$Headers
+    )
+
+    $releases = Invoke-RestMethod -Headers $Headers -Uri $GitHubReleaseJsonUrl -Method Get
     if ($releases.Count -eq 0) {
-        throw "No releases from github.com/${GitHubOrg}/${GitHubRepo}"
+        throw "No releases found at github.com/$GitHubOrg/$GitHubRepo"
     }
 
-    $release = GetVersionInfo -Version $Version -Releases $releases
-    if (!$release) {
-        throw "Cannot find the specified rad CLI binary version"
+    $release = $releases | Where-Object { $_.tag_name -eq $ReleaseTag } | Select-Object -First 1
+    if (-not $release) {
+        throw "Cannot find release $ReleaseTag"
     }
-    $asset = GetWindowsAsset -Release $release
-    $assetName = $asset.name
-    $exeFileUrl = $asset.url
-    $exeFilePath = $RadiusRoot + "\" + $assetName
 
-    # Download rad CLI
+    $artifactSuffix = if ($DetectedOS -eq "windows") { ".exe" } else { "" }
+    $artifactName = "rad_$($DetectedOS)_$($DetectedArch)$artifactSuffix"
+
+    $asset = Get-ReleaseAsset -Release $release -ArtifactName $artifactName
+    $tmpFile = Join-Path ([System.IO.Path]::GetTempPath()) $asset.Name
+
     try {
-        Write-Output "Downloading $exeFileUrl..."
-        $githubHeader.Accept = "application/octet-stream"
+        Write-Output "Downloading $($asset.Url)..."
+        $downloadHeaders = @{}
+        foreach ($key in $Headers.Keys) {
+            $downloadHeaders[$key] = $Headers[$key]
+        }
+        $downloadHeaders["Accept"] = "application/octet-stream"
         $oldProgressPreference = $ProgressPreference
-        $ProgressPreference = "SilentlyContinue" # Do not show progress bar
-        Invoke-WebRequest -Headers $githubHeader -Uri $exeFileUrl -OutFile $exeFilePath
+        $ProgressPreference = "SilentlyContinue"
+        Invoke-WebRequest -Headers $downloadHeaders -Uri $asset.Url -OutFile $tmpFile
     }
-    catch [Net.WebException] {
-        throw "ERROR: The specified release version: $Version does not exist."
+    catch {
+        throw "Failed to download rad CLI: $_"
     }
     finally {
-        $ProgressPreference = $oldProgressPreference;
+        $ProgressPreference = $oldProgressPreference
     }
 
-    if (!(Test-Path $exeFilePath -PathType Leaf)) {
-      throw "Failed to download rad CLI binary - $exeFilePath"
+    if (-not (Test-Path $tmpFile -PathType Leaf)) {
+        throw "Failed to download rad CLI binary"
     }
-    
-    # Remove old rad CLI if exists
-    if (Test-Path $RadiusCliFilePath -PathType Leaf) {
-        Remove-Item -Recurse -Force $RadiusCliFilePath
+
+    $cliFilePath = Join-Path $TargetDir $CliFileName
+    if (Test-Path $cliFilePath -PathType Leaf) {
+        Remove-Item -Force $cliFilePath
     }
-    
-    # Rename the downloaded rad CLI binary
-    Rename-Item -Path $exeFilePath -NewName $RadiusCliFileName -Force
+    Move-Item -Path $tmpFile -Destination $cliFilePath -Force
+
+    # Set executable permission on non-Windows
+    if ($DetectedOS -ne "windows") {
+        & chmod +x $cliFilePath
+    }
 }
 
-if (!(Test-Path $RadiusCliFilePath -PathType Leaf)) {
-  throw "Failed to download rad CLI binary - $exeFilePath"
+function Add-ToPath {
+    param (
+        [string]$TargetDir,
+        [string]$DetectedOS
+    )
+
+    if ($DetectedOS -eq "windows") {
+        Add-ToPathWindows -TargetDir $TargetDir
+    }
+    else {
+        Add-ToPathUnix -TargetDir $TargetDir
+    }
 }
 
-# Print the version string of the installed CLI
-Write-Output "rad CLI version: $(&$RadiusCliFilePath version --cli --output json | ConvertFrom-JSON | Select-Object -ExpandProperty version)"
+function Add-ToPathWindows {
+    param ([string]$TargetDir)
 
-# Add RadiusRoot directory to User Path environment variable
-$UserPathEnvironmentVar = (Get-Item -Path HKCU:\Environment).GetValue(
-    'PATH', # the registry-value name
-    $null, # the default value to return if no such value exists.
-    'DoNotExpandEnvironmentNames' # the option that suppresses expansion
-)
+    $userPath = (Get-Item -Path HKCU:\Environment).GetValue(
+        'PATH',
+        $null,
+        'DoNotExpandEnvironmentNames'
+    )
 
-# Remove legacy c:\radius from User Path if it exists
-if ($UserPathEnvironmentVar -like '*c:\radius*') {
-    $UserPathEnvironmentVar = $UserPathEnvironmentVar -replace 'c:\\radius;', ''
-    Set-ItemProperty HKCU:\Environment "PATH" "$UserPathEnvironmentVar" -Type ExpandString
+    if (-not $userPath) {
+        $userPath = ""
+    }
+
+    # Remove legacy c:\radius from User Path if it exists
+    if ($userPath -like '*c:\radius*') {
+        $userPath = $userPath -replace 'c:\\radius;?', ''
+        $userPath = $userPath.TrimEnd(';')
+        Set-ItemProperty HKCU:\Environment "PATH" "$userPath" -Type ExpandString
+    }
+
+    # Remove old rad CLI at legacy location
+    if (Test-Path "C:\radius\rad.exe" -PathType Leaf) {
+        Remove-Item -Recurse -Force "C:\radius"
+    }
+
+    if (-not ($userPath -like "*$TargetDir*")) {
+        Write-Output "Adding $TargetDir to User Path..."
+        $newPath = if ($userPath) { "$userPath;$TargetDir" } else { $TargetDir }
+        Set-ItemProperty HKCU:\Environment "PATH" "$newPath" -Type ExpandString
+        $env:PATH += ";$TargetDir"
+    }
 }
 
-if (-Not ($UserPathEnvironmentVar -like '*radius*')) {
-    Write-Output "Adding $RadiusRoot to User Path..."
-    # [Environment]::SetEnvironmentVariable sets the value kind as REG_SZ, use the function below to set a value of kind REG_EXPAND_SZ
-    Set-ItemProperty HKCU:\Environment "PATH" "$UserPathEnvironmentVar;$RadiusRoot" -Type ExpandString
-    # Also add the path to the current session
-    $env:PATH += ";$RadiusRoot"
+function Add-ToPathUnix {
+    param ([string]$TargetDir)
+
+    $pathDirs = $env:PATH -split ':'
+    if ($pathDirs -contains $TargetDir) {
+        return
+    }
+
+    Write-Output ""
+    Write-Output "============================================================================"
+    Write-Output "NOTE: $TargetDir is not in your PATH."
+    Write-Output ""
+    Write-Output "Add it by running one of the following:"
+    Write-Output ""
+
+    $shellName = if ($env:SHELL) { Split-Path $env:SHELL -Leaf } else { "bash" }
+    switch ($shellName) {
+        "zsh" {
+            Write-Output "  echo 'export PATH=""$TargetDir"":$PATH' >> ~/.zshrc"
+            Write-Output "  source ~/.zshrc"
+        }
+        "fish" {
+            Write-Output "  fish_add_path $TargetDir"
+        }
+        default {
+            Write-Output "  echo 'export PATH=""$TargetDir"":$PATH' >> ~/.bashrc"
+            Write-Output "  source ~/.bashrc"
+        }
+    }
+    Write-Output "============================================================================"
 }
 
-Write-Output "rad CLI has been successfully installed"
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
 
-Write-Output "`r`nInstalling Bicep..."
-$cmd = (Start-Process -NoNewWindow -FilePath $RadiusCliFilePath -ArgumentList "bicep download" -PassThru -Wait)
-if ($cmd.ExitCode -ne 0) {
-    Write-Warning "`r`nFailed to install bicep"
+if ($Help) {
+    Show-Usage
+}
+
+# Respect INCLUDE_RC environment variable
+$shouldIncludeRC = $IncludeRC.IsPresent
+if ($env:INCLUDE_RC -eq "true") {
+    $shouldIncludeRC = $true
+}
+
+# Detect system
+$sysInfo = Get-SystemInfo
+$detectedOS = $sysInfo.OS
+$detectedArch = $sysInfo.Arch
+$cliFileName = Get-CliFileName -DetectedOS $detectedOS
+
+Write-Output ""
+Write-Output "Your system is $($detectedOS)_$($detectedArch)"
+
+# Determine install directory
+if ($InstallDir) {
+    $resolvedInstallDir = $InstallDir
 }
 else {
-    Write-Output "Bicep has been successfully installed"
+    $resolvedInstallDir = Get-DefaultInstallDir -DetectedOS $detectedOS
 }
 
-Write-Output "`r`nTo get started with Radius, please visit https://docs.radapp.io/getting-started/"
+# Support RADIUS_INSTALL_DIR as backward-compatible alias
+if ($env:RADIUS_INSTALL_DIR -and -not $InstallDir -and -not $env:INSTALL_DIR) {
+    $resolvedInstallDir = $env:RADIUS_INSTALL_DIR
+}
+
+# Ensure install directory exists
+if (-not (Test-Path $resolvedInstallDir -PathType Container)) {
+    Write-Output "Creating $resolvedInstallDir directory..."
+    New-Item -Path $resolvedInstallDir -ItemType Directory -Force | Out-Null
+    if (-not (Test-Path $resolvedInstallDir -PathType Container)) {
+        throw "Cannot create $resolvedInstallDir"
+    }
+}
+
+$cliFilePath = Join-Path $resolvedInstallDir $cliFileName
+
+# Check for existing installation
+if (Test-Path $cliFilePath -PathType Leaf) {
+    Write-Output ""
+    try {
+        $currentVer = & $cliFilePath version --cli 2>$null
+        Write-Output "Radius CLI is detected. Current version: $currentVer"
+    }
+    catch {
+        Write-Output "Previous installation detected (version unknown)"
+    }
+    Write-Output "Reinstalling Radius CLI - $cliFilePath..."
+}
+else {
+    Write-Output "Installing Radius CLI..."
+}
+
+# Ensure TLS 1.2 on Windows PowerShell (version < 6)
+if ($PSVersionTable.PSVersion.Major -lt 6) {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+}
+
+$githubHeaders = Get-GithubHeaders
+
+# Determine version to install
+if (-not $Version) {
+    Write-Output "Getting the latest Radius CLI..."
+    if ($shouldIncludeRC) {
+        Write-Output "Including release candidates in version selection..."
+    }
+    $release = Get-LatestRelease -ShouldIncludeRC $shouldIncludeRC -Headers $githubHeaders
+    $releaseTag = $release.tag_name
+}
+elseif ($Version -eq "edge") {
+    $releaseTag = "edge"
+}
+else {
+    # Strip leading "v" if present, then normalize to v-prefixed format
+    $releaseTag = "v$($Version.TrimStart('v'))"
+}
+
+Write-Output ""
+Write-Output "Installing $releaseTag Radius CLI..."
+Write-Output "Install directory: $resolvedInstallDir"
+
+# Download and install
+if ($releaseTag -eq "edge") {
+    Install-RadEdge -TargetDir $resolvedInstallDir -DetectedOS $detectedOS -DetectedArch $detectedArch -CliFileName $cliFileName
+}
+else {
+    Install-RadRelease -ReleaseTag $releaseTag -TargetDir $resolvedInstallDir -DetectedOS $detectedOS -DetectedArch $detectedArch -CliFileName $cliFileName -Headers $githubHeaders
+}
+
+if (-not (Test-Path $cliFilePath -PathType Leaf)) {
+    throw "Failed to install rad CLI binary"
+}
+
+Write-Output "$cliFileName installed into $resolvedInstallDir successfully"
+
+# Install bicep
+Write-Output ""
+Write-Output "Installing bicep..."
+& $cliFilePath bicep download
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "Failed to install bicep"
+}
+else {
+    Write-Output "bicep installed successfully"
+}
+
+# Update PATH
+Add-ToPath -TargetDir $resolvedInstallDir -DetectedOS $detectedOS
+
+Write-Output ""
+Write-Output "To get started with Radius, please visit https://docs.radapp.io/getting-started/"

--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -105,9 +105,18 @@ function Get-SystemInfo {
         "linux"
     }
 
-    $rawArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLower()
+    # Use PROCESSOR_ARCHITECTURE on Windows (always available, including PS 5.1).
+    # Fall back to RuntimeInformation for non-Windows platforms (pwsh on Linux/macOS).
+    if ($detectedOS -eq "windows") {
+        $rawArch = ($env:PROCESSOR_ARCHITECTURE).ToLower()
+    }
+    else {
+        $rawArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLower()
+    }
+
     $detectedArch = switch ($rawArch) {
         "x64" { "amd64" }
+        "amd64" { "amd64" }
         "arm64" { "arm64" }
         "arm" { "arm" }
         default { $rawArch }
@@ -375,7 +384,7 @@ if ($Help) {
 }
 
 # Respect INCLUDE_RC environment variable
-$shouldIncludeRC = $IncludeRC.IsPresent
+$shouldIncludeRC = [bool]$IncludeRC
 if ($env:INCLUDE_RC -eq "true") {
     $shouldIncludeRC = $true
 }

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -148,20 +148,18 @@ needsSudo() {
 }
 
 runAsRoot() {
-    local CMD="$*"
-
     if needsSudo "${INSTALL_DIR}"; then
         if command -v sudo &> /dev/null; then
-            CMD="sudo ${CMD}"
+            sudo "$@"
         else
             echo "Error: installation to ${INSTALL_DIR} requires root privileges."
             echo "Either run as root, install sudo, or use --install-dir to choose a user-writable location."
             echo "  Example: $0 --install-dir \"\${HOME}/.local/bin\""
             exit 1
         fi
+    else
+        "$@"
     fi
-
-    ${CMD}
 }
 
 verifySupported() {

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -20,11 +20,12 @@
 # Radius CLI Installer
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh | /bin/bash
-#   curl -fsSL ... | /bin/bash -s -- --version 0.40.0
-#   curl -fsSL ... | /bin/bash -s -- --install-dir ~/.local/bin
-#   curl -fsSL ... | /bin/bash -s -- --version 0.40.0 --install-dir /opt/bin
-#   curl -fsSL ... | /bin/bash -s -- --include-rc
+#   wget -qO- https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh | /bin/bash
+#   wget -qO- ... | /bin/bash -s -- --version 0.40.0
+#   wget -qO- ... | /bin/bash -s -- --install-dir ~/.local/bin
+#   wget -qO- ... | /bin/bash -s -- --version 0.40.0 --install-dir /opt/bin
+#   wget -qO- ... | /bin/bash -s -- --include-rc
+#   wget -qO- ... | sudo /bin/bash -s -- --install-dir /usr/local/bin
 #
 # Environment variables (override flags):
 #   INSTALL_DIR         - Installation directory (default: auto-detected)

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -324,7 +324,7 @@ installCompleted() {
     echo ""
 
     # Check if the install dir is in PATH
-    if ! echo "${PATH}" | tr ':' '\n' | grep -qx "${INSTALL_DIR}"; then
+    if ! echo "${PATH}" | tr ':' '\n' | grep -Fqx "${INSTALL_DIR}"; then
         echo "============================================================================"
         echo "NOTE: ${INSTALL_DIR} is not in your \$PATH."
         echo ""

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -6,7 +6,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#    
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
@@ -16,42 +16,151 @@
 # limitations under the License.
 # ------------------------------------------------------------
 
-# Radius CLI location
-: ${RADIUS_INSTALL_DIR:="/usr/local/bin"}
+# ============================================================================
+# Radius CLI Installer
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh | /bin/bash
+#   curl -fsSL ... | /bin/bash -s -- --version 0.40.0
+#   curl -fsSL ... | /bin/bash -s -- --install-dir ~/.local/bin
+#   curl -fsSL ... | /bin/bash -s -- --version 0.40.0 --install-dir /opt/bin
+#   curl -fsSL ... | /bin/bash -s -- --include-rc
+#
+# Environment variables (override flags):
+#   INSTALL_DIR         - Installation directory (default: auto-detected)
+#   INCLUDE_RC          - Include release candidates ("true"/"false")
+# ============================================================================
 
-# sudo is required to copy binary to RADIUS_INSTALL_DIR for linux
-: ${USE_SUDO:="false"}
+set -euo pipefail
 
 # Include release candidates when determining latest version
-# Can be set via environment variable or --include-rc flag
-: ${INCLUDE_RC:="false"}
+: "${INCLUDE_RC:="false"}"
 
 # Http request CLI
-RADIUS_HTTP_REQUEST_CLI=curl
+RADIUS_HTTP_REQUEST_CLI="curl"
 
 # GitHub Organization and repo name to download release
-GITHUB_ORG=radius-project
-GITHUB_REPO=radius
+readonly GITHUB_ORG="radius-project"
+readonly GITHUB_REPO="radius"
 
 # Radius CLI filename
-RADIUS_CLI_FILENAME=rad
+readonly RADIUS_CLI_FILENAME="rad"
 
-RADIUS_CLI_FILE="${RADIUS_INSTALL_DIR}/${RADIUS_CLI_FILENAME}"
+# Temp directory for downloads (set in downloadFile, cleaned up on exit)
+RADIUS_TMP_ROOT=""
+
+# OS and ARCH are set in getSystemInfo
+OS=""
+ARCH=""
+
+usage() {
+    cat << EOF
+Radius CLI Installer
+
+Usage: install.sh [OPTIONS] [VERSION]
+
+Options:
+  -d, --install-dir <DIR>  Installation directory (default: auto-detected)
+  -v, --version <VERSION>  Version to install (e.g., 0.40.0, edge)
+  -rc, --include-rc        Include release candidates in latest version
+  -h, --help               Show this help message
+
+Environment Variables:
+  INSTALL_DIR              Override installation directory
+  INCLUDE_RC               Set to "true" to include release candidates
+
+Install Directory Detection:
+  - If run as root or with sudo available: /usr/local/bin
+  - Otherwise: \$HOME/.local/bin
+
+Examples:
+  # Install latest stable version
+  ./install.sh
+
+  # Install a specific version
+  ./install.sh --version 0.40.0
+
+  # Install to a custom directory (no root required)
+  ./install.sh --install-dir ~/.local/bin
+
+  # Install the edge (development) version
+  ./install.sh --version edge
+
+EOF
+    exit 0
+}
 
 getSystemInfo() {
     ARCH=$(uname -m)
-    case $ARCH in
-        armv7*) ARCH="arm";;
-        aarch64) ARCH="arm64";;
-        x86_64) ARCH="amd64";;
+    case "${ARCH}" in
+        armv7*) ARCH="arm" ;;
+        aarch64) ARCH="arm64" ;;
+        x86_64) ARCH="amd64" ;;
+        *) ;; # Other architectures are validated in verifySupported
     esac
 
-    OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
+    OS=$(uname | tr '[:upper:]' '[:lower:]')
+}
 
-    # Most linux distro needs root permission to copy the file to /usr/local/bin
-    if [[ "$OS" == "linux" || "$OS" == "darwin" ]] && [ "$RADIUS_INSTALL_DIR" == "/usr/local/bin" ]; then
-        USE_SUDO="true"
+# Determine the default install directory based on permissions.
+# Follows the pattern used by fnm/uv: use /usr/local/bin when root,
+# otherwise fall back to $HOME/.local/bin (always writable).
+getDefaultInstallDir() {
+    if [[ -n "${INSTALL_DIR:-}" ]]; then
+        # User explicitly set via environment variable or flag
+        echo "${INSTALL_DIR}"
+        return
     fi
+
+    if [[ ${EUID:-$(id -u)} -eq 0 ]]; then
+        echo "/usr/local/bin"
+        return
+    fi
+
+    # Non-root: use a user-writable location
+    echo "${HOME}/.local/bin"
+}
+
+# Determine whether sudo is needed and available for the chosen install dir.
+needsSudo() {
+    local install_dir="$1"
+
+    # Root never needs sudo
+    if [[ ${EUID:-$(id -u)} -eq 0 ]]; then
+        return 1
+    fi
+
+    # If the directory exists and is writable, no sudo needed
+    if [[ -d "${install_dir}" && -w "${install_dir}" ]]; then
+        return 1
+    fi
+
+    # If the parent directory is writable (dir doesn't exist yet), no sudo
+    local parent_dir
+    parent_dir=$(dirname "${install_dir}")
+    if [[ -d "${parent_dir}" && -w "${parent_dir}" ]]; then
+        return 1
+    fi
+
+    # Need elevated privileges
+    return 0
+}
+
+runAsRoot() {
+    local CMD="$*"
+
+    if needsSudo "${INSTALL_DIR}"; then
+        if command -v sudo &> /dev/null; then
+            CMD="sudo ${CMD}"
+        else
+            echo "Error: installation to ${INSTALL_DIR} requires root privileges."
+            echo "Either run as root, install sudo, or use --install-dir to choose a user-writable location."
+            echo "  Example: $0 --install-dir \"\${HOME}/.local/bin\""
+            exit 1
+        fi
+    fi
+
+    ${CMD}
 }
 
 verifySupported() {
@@ -59,7 +168,7 @@ verifySupported() {
     local current_osarch="${OS}-${ARCH}"
 
     for osarch in "${supported[@]}"; do
-        if [ "$osarch" == "$current_osarch" ]; then
+        if [[ "${osarch}" == "${current_osarch}" ]]; then
             echo "Your system is ${OS}_${ARCH}"
             return
         fi
@@ -69,20 +178,10 @@ verifySupported() {
     exit 1
 }
 
-runAsRoot() {
-    local CMD="$*"
-
-    if [ $EUID -ne 0 -a $USE_SUDO = "true" ]; then
-        CMD="sudo $CMD"
-    fi
-
-    $CMD
-}
-
 checkHttpRequestCLI() {
-    if type "curl" &> /dev/null; then
+    if command -v curl &> /dev/null; then
         RADIUS_HTTP_REQUEST_CLI=curl
-    elif type "wget" &> /dev/null; then
+    elif command -v wget &> /dev/null; then
         RADIUS_HTTP_REQUEST_CLI=wget
     else
         echo "Either curl or wget is required"
@@ -91,12 +190,14 @@ checkHttpRequestCLI() {
 }
 
 checkExistingRadius() {
-    if [ -f "$RADIUS_CLI_FILE" ]; then
-        version=$($RADIUS_CLI_FILE version --cli)
-        echo -e "\nRadius CLI is detected. Current version: ${version}"
-        echo -e "Reinstalling Radius CLI - ${RADIUS_CLI_FILE}...\n"
+    local cli_file="${INSTALL_DIR}/${RADIUS_CLI_FILENAME}"
+    if [[ -f "${cli_file}" ]]; then
+        local version
+        version=$("${cli_file}" version --cli 2> /dev/null || echo "unknown")
+        printf '\nRadius CLI is detected. Current version: %s\n' "${version}"
+        printf 'Reinstalling Radius CLI - %s...\n\n' "${cli_file}"
     else
-        echo -e "Installing Radius CLI...\n"
+        printf 'Installing Radius CLI...\n\n'
     fi
 }
 
@@ -104,133 +205,158 @@ getLatestRelease() {
     local radReleaseUrl="https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/releases"
     local latest_release=""
 
-    if [ "$INCLUDE_RC" == "true" ]; then
-        # Include release candidates when determining latest version
-        if [ "$RADIUS_HTTP_REQUEST_CLI" == "curl" ]; then
-            latest_release=$(curl -s $radReleaseUrl | grep \"tag_name\" | awk 'NR==1{print $2}' |  sed -n 's/\"\(.*\)\",/\1/p')
+    if [[ "${INCLUDE_RC}" == "true" ]]; then
+        if [[ "${RADIUS_HTTP_REQUEST_CLI}" == "curl" ]]; then
+            latest_release=$(curl -s "${radReleaseUrl}" | grep \"tag_name\" | awk 'NR==1{print $2}' | sed -n 's/\"\(.*\)\",/\1/p')
         else
-            latest_release=$(wget -q --header="Accept: application/json" -O - $radReleaseUrl | grep \"tag_name\" | awk 'NR==1{print $2}' |  sed -n 's/\"\(.*\)\",/\1/p')
+            latest_release=$(wget -q --header="Accept: application/json" -O - "${radReleaseUrl}" | grep \"tag_name\" | awk 'NR==1{print $2}' | sed -n 's/\"\(.*\)\",/\1/p')
         fi
     else
-        # Exclude release candidates (default behavior)
-        if [ "$RADIUS_HTTP_REQUEST_CLI" == "curl" ]; then
-            latest_release=$(curl -s $radReleaseUrl | grep \"tag_name\" | grep -v rc | awk 'NR==1{print $2}' |  sed -n 's/\"\(.*\)\",/\1/p')
+        if [[ "${RADIUS_HTTP_REQUEST_CLI}" == "curl" ]]; then
+            latest_release=$(curl -s "${radReleaseUrl}" | grep \"tag_name\" | grep -v rc | awk 'NR==1{print $2}' | sed -n 's/\"\(.*\)\",/\1/p')
         else
-            latest_release=$(wget -q --header="Accept: application/json" -O - $radReleaseUrl | grep \"tag_name\" | grep -v rc | awk 'NR==1{print $2}' |  sed -n 's/\"\(.*\)\",/\1/p')
+            latest_release=$(wget -q --header="Accept: application/json" -O - "${radReleaseUrl}" | grep \"tag_name\" | grep -v rc | awk 'NR==1{print $2}' | sed -n 's/\"\(.*\)\",/\1/p')
         fi
     fi
 
-    ret_val=$latest_release
+    if [[ -z "${latest_release}" ]]; then
+        echo "Error: could not determine latest release"
+        exit 1
+    fi
+
+    ret_val="${latest_release}"
 }
 
 downloadFile() {
-    RELEASE_TAG=$1
+    local release_tag="$1"
 
-    RADIUS_CLI_ARTIFACT="${RADIUS_CLI_FILENAME}_${OS}_${ARCH}"
+    local radius_cli_artifact="${RADIUS_CLI_FILENAME}_${OS}_${ARCH}"
 
-    # Create the temp directory
-    RADIUS_TMP_ROOT=$(mktemp -dt radius-install-XXXXXX)
-    ARTIFACT_TMP_FILE="$RADIUS_TMP_ROOT/$RADIUS_CLI_ARTIFACT"
+    RADIUS_TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/radius-install-XXXXXX")
+    local artifact_tmp_file="${RADIUS_TMP_ROOT}/${radius_cli_artifact}"
 
-    if [ "$RELEASE_TAG" == "edge" ]; then
+    if [[ "${release_tag}" == "edge" ]]; then
         if ! command -v oras &> /dev/null; then
             echo "Error: oras CLI is not installed or not found in PATH."
             echo "Please visit https://edge.docs.radapp.io/installation for edge CLI installation instructions."
             exit 1
         fi
 
-        DOWNLOAD_URL="ghcr.io/radius-project/rad/${OS}-${ARCH}:latest"
-        echo "Downloading edge CLI from ${DOWNLOAD_URL}..."
-        oras pull $DOWNLOAD_URL -o $RADIUS_TMP_ROOT
-
-        # Check if the oras pull command was successfull
-        if [ $? -ne 0 ]; then
+        local download_url="ghcr.io/radius-project/rad/${OS}-${ARCH}:latest"
+        echo "Downloading edge CLI from ${download_url}..."
+        if ! oras pull "${download_url}" -o "${RADIUS_TMP_ROOT}"; then
             echo "Failed to download edge CLI."
             echo "If this was an authentication issue, please run 'docker logout ghcr.io' to clear any expired credentials."
             echo "Visit https://edge.docs.radapp.io/installation for edge CLI installation instructions."
             exit 1
         fi
 
-        mv $RADIUS_TMP_ROOT/rad $ARTIFACT_TMP_FILE
+        mv "${RADIUS_TMP_ROOT}/rad" "${artifact_tmp_file}"
     else
-        DOWNLOAD_BASE="https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download"
-        DOWNLOAD_URL="${DOWNLOAD_BASE}/${RELEASE_TAG}/${RADIUS_CLI_ARTIFACT}"
+        local download_base="https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download"
+        local download_url="${download_base}/${release_tag}/${radius_cli_artifact}"
 
-        echo "Downloading ${DOWNLOAD_URL}..."
-        if [ "$RADIUS_HTTP_REQUEST_CLI" == "curl" ]; then
-            curl -SsL "$DOWNLOAD_URL" -o "$ARTIFACT_TMP_FILE"
+        echo "Downloading ${download_url}..."
+        if [[ "${RADIUS_HTTP_REQUEST_CLI}" == "curl" ]]; then
+            curl -SsL "${download_url}" -o "${artifact_tmp_file}"
         else
-            wget -q -O "$ARTIFACT_TMP_FILE" "$DOWNLOAD_URL"
+            wget -q -O "${artifact_tmp_file}" "${download_url}"
         fi
     fi
 
-    if [ ! -f "$ARTIFACT_TMP_FILE" ]; then
-        echo "failed to download ${DOWNLOAD_URL}..."
+    if [[ ! -f "${artifact_tmp_file}" ]]; then
+        echo "Failed to download ${download_url:-the artifact}..."
         exit 1
     fi
 }
 
 installFile() {
-    RADIUS_CLI_ARTIFACT="${RADIUS_CLI_FILENAME}_${OS}_${ARCH}"
-    local tmp_root_radius_cli="$RADIUS_TMP_ROOT/$RADIUS_CLI_ARTIFACT"
+    local radius_cli_artifact="${RADIUS_CLI_FILENAME}_${OS}_${ARCH}"
+    local tmp_root_radius_cli="${RADIUS_TMP_ROOT}/${radius_cli_artifact}"
+    local cli_file="${INSTALL_DIR}/${RADIUS_CLI_FILENAME}"
 
-    if [ ! -f "$tmp_root_radius_cli" ]; then
+    if [[ ! -f "${tmp_root_radius_cli}" ]]; then
         echo "Failed to unpack Radius CLI executable."
         exit 1
     fi
 
-    if [ -f "$RADIUS_CLI_FILE" ]; then
-        runAsRoot rm "$RADIUS_CLI_FILE"
+    if [[ -f "${cli_file}" ]]; then
+        runAsRoot rm "${cli_file}"
     fi
-    chmod a+x $tmp_root_radius_cli
-    mkdir -p $RADIUS_INSTALL_DIR
-    runAsRoot cp "$tmp_root_radius_cli" "$RADIUS_INSTALL_DIR"
-    runAsRoot mv "${RADIUS_INSTALL_DIR}/${RADIUS_CLI_ARTIFACT}" "${RADIUS_INSTALL_DIR}/${RADIUS_CLI_FILENAME}"
 
-    if [ -f "$RADIUS_CLI_FILE" ]; then
-        echo "$RADIUS_CLI_FILENAME installed into $RADIUS_INSTALL_DIR successfully"
+    chmod a+x "${tmp_root_radius_cli}"
+    runAsRoot mkdir -p "${INSTALL_DIR}"
+    runAsRoot cp "${tmp_root_radius_cli}" "${cli_file}"
+
+    if [[ -f "${cli_file}" ]]; then
+        echo "${RADIUS_CLI_FILENAME} installed into ${INSTALL_DIR} successfully"
 
         echo "Installing bicep (\"rad bicep download\")..."
-        $RADIUS_CLI_FILE bicep download
-        result=$?
-        if [ $result -eq 0 ]; then
+        if "${cli_file}" bicep download; then
             echo "bicep installed successfully"
         else
-           echo "Failed to install bicep"
-           exit 1
+            echo "Failed to install bicep"
+            exit 1
         fi
-
-        # TODO: $RADIUS_CLI_FILE --version
-    else 
-        echo "Failed to install $RADIUS_CLI_FILENAME"
+    else
+        echo "Failed to install ${RADIUS_CLI_FILENAME}"
         exit 1
     fi
 }
 
-fail_trap() {
-    result=$?
-    if [ "$result" != "0" ]; then
+failTrap() {
+    local result=$?
+    if [[ "${result}" != "0" ]]; then
         echo "Failed to install Radius CLI"
         echo "For support, go to https://github.com/radius-project/radius"
     fi
     cleanup
-    exit $result
+    exit "${result}"
 }
 
 cleanup() {
     if [[ -d "${RADIUS_TMP_ROOT:-}" ]]; then
-        rm -rf "$RADIUS_TMP_ROOT"
+        rm -rf "${RADIUS_TMP_ROOT}"
     fi
 }
 
+# Print post-install guidance, including PATH hints when needed.
 installCompleted() {
-    echo -e "\nTo get started with Radius, please visit https://docs.radapp.io/getting-started/"
+    echo ""
+
+    # Check if the install dir is in PATH
+    if ! echo "${PATH}" | tr ':' '\n' | grep -qx "${INSTALL_DIR}"; then
+        echo "============================================================================"
+        echo "NOTE: ${INSTALL_DIR} is not in your \$PATH."
+        echo ""
+        echo "Add it by running one of the following:"
+        echo ""
+
+        local current_shell
+        current_shell="$(basename "${SHELL:-bash}")"
+        case "${current_shell}" in
+            zsh)
+                echo "  echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.zshrc"
+                echo "  source ~/.zshrc"
+                ;;
+            fish)
+                echo "  fish_add_path ${INSTALL_DIR}"
+                ;;
+            *)
+                echo "  echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.bashrc"
+                echo "  source ~/.bashrc"
+                ;;
+        esac
+        echo "============================================================================"
+    fi
+
+    echo "To get started with Radius, please visit https://docs.radapp.io/getting-started/"
 }
 
 # -----------------------------------------------------------------------------
 # main
 # -----------------------------------------------------------------------------
-trap "fail_trap" EXIT
+trap "failTrap" EXIT
 
 getSystemInfo
 checkHttpRequestCLI
@@ -239,35 +365,62 @@ checkHttpRequestCLI
 VERSION_ARG=""
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --include-rc)
+        -v | --version)
+            VERSION_ARG="$2"
+            shift 2
+            ;;
+        -d | --install-dir)
+            INSTALL_DIR="$2"
+            shift 2
+            ;;
+        -rc | --include-rc)
             INCLUDE_RC="true"
             shift
             ;;
+        -h | --help)
+            usage
+            ;;
+        -*)
+            echo "Unknown option: $1"
+            echo "Run '$0 --help' for usage."
+            exit 1
+            ;;
         *)
+            # Support legacy positional version argument for backward compatibility
             VERSION_ARG="$1"
             shift
             ;;
     esac
 done
 
-if [ -z "$VERSION_ARG" ]; then
+# Support RADIUS_INSTALL_DIR as a backward-compatible alias for INSTALL_DIR
+if [[ -n "${RADIUS_INSTALL_DIR:-}" && -z "${INSTALL_DIR:-}" ]]; then
+    INSTALL_DIR="${RADIUS_INSTALL_DIR}"
+fi
+
+# Set install directory (after arg parsing so --install-dir takes effect)
+INSTALL_DIR=$(getDefaultInstallDir)
+
+if [[ -z "${VERSION_ARG}" ]]; then
     echo "Getting the latest Radius CLI..."
-    if [ "$INCLUDE_RC" == "true" ]; then
+    if [[ "${INCLUDE_RC}" == "true" ]]; then
         echo "Including release candidates in version selection..."
     fi
     getLatestRelease
-elif [ "$VERSION_ARG" == "edge" ]; then
+elif [[ "${VERSION_ARG}" == "edge" ]]; then
     ret_val="edge"
 else
-    ret_val=v$VERSION_ARG
+    # Strip leading "v" if present, then normalize to v-prefixed format
+    ret_val="v${VERSION_ARG#v}"
 fi
 
-verifySupported $ret_val
+verifySupported
 checkExistingRadius
 
-echo "Installing $ret_val Radius CLI..."
+echo "Installing ${ret_val} Radius CLI..."
+echo "Install directory: ${INSTALL_DIR}"
 
-downloadFile $ret_val
+downloadFile "${ret_val}"
 installFile
 cleanup
 


### PR DESCRIPTION
# Description

Modernize and align the Radius CLI installer scripts (`install.sh` and `install.ps1`) for improved cross-platform support, robustness, and feature parity.

### `install.sh` (Bash)
- Add `--version`/`-v`, `--install-dir`/`-d`, `--include-rc`/`-rc`, `--help`/`-h` flags
- Smart install directory detection: root → `/usr/local/bin`, non-root → `C:\Users\daporo/.local/bin`
- Dynamic `needsSudo()` check instead of hardcoded root detection
- Version v-prefix normalization (accepts both `0.40.0` and `v0.40.0`)
- Support `INSTALL_DIR` env var (`RADIUS_INSTALL_DIR` kept as backward-compat alias)
- Shell-specific PATH hints for bash/zsh/fish
- Fix portability issues: `echo -e` → `printf`, portable `mktemp`
- Maintain backward compatibility with positional args (used by devcontainer feature)

### `install.ps1` (PowerShell)
- Cross-platform support: works on Windows PowerShell 5.1 and pwsh 7.x (Windows/macOS/Linux)
- Dynamic OS/arch detection via `RuntimeInformation.OSArchitecture`
- Add `-IncludeRC`/`-rc`, `-InstallDir`/`-d`, `-Help`/`-h` parameters
- `-RadiusRoot` preserved as alias for `-InstallDir` (backward compat with `test-pwsh-install.ps1`)
- Platform-aware binary naming (`rad.exe` on Windows, `rad` elsewhere)
- `chmod +x` on non-Windows platforms
- TLS fix: only TLS 1.2 (removed deprecated 1.0/1.1), guarded behind PS version < 6
- Remove incorrect `Get-ExecutionPolicy` check that blocked `ByPass`
- Replace `Start-Process -NoNewWindow` (Windows-only) with direct `& rad bicep download`
- Unix PATH hints (bash/zsh/fish) on non-Windows; Windows registry PATH on Windows
- Support `INSTALL_DIR`, `RADIUS_INSTALL_DIR`, `INCLUDE_RC` env vars

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes #11461

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [x] Not applicable <!-- TaskRadio recipes-pr -->