### PR TITLE
Reduce stale PR duration

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -1,4 +1,5 @@
-# This workflow warns and then closes PRs that have had no activity for 90 days.
+# This workflow marks PRs (including drafts) as stale after 4 weeks of inactivity,
+# then closes them 1 day later.
 #
 # For more information, see:
 # https://github.com/actions/stale
@@ -24,9 +25,10 @@ jobs:
         with:
           repo-token: ${{ github.token }}
           stale-pr-message: |
-            This pull request has been automatically marked as stale because it has been inactive for 90 days. Remove stale label or comment or this PR will be closed in 7 days.
+            This pull request has been automatically marked as stale because it has been inactive for 4 weeks. To keep it open, either remove the `stale` label or add a new comment to this pull request. If there is no further activity, it will be closed in 1 day.
           stale-pr-label: stale
-          days-before-pr-stale: 90 # 3 months
-          days-before-pr-close: 7
+          days-before-pr-stale: 28 # 4 weeks
+          days-before-pr-close: 1 # 1 day after being marked as stale
           days-before-issue-stale: -1
           days-before-issue-close: -1
+          exempt-draft-pr: false


### PR DESCRIPTION
# Description

Stale PRs were staying open for up to 97 days (90 days to mark stale + 7 days to close). Reduces this to 29 days total to keep the PR queue clean and actionable.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [ ] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [ ] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [ ] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [ ] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [ ] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [ ] Not applicable <!-- TaskRadio recipes-pr -->