### PR TITLE
fix(dashboard): set NODE_ENV=development to restore guest auth after Backstage upgrade

### DIFF
--- a/deploy/Chart/templates/dashboard/deployment.yaml
+++ b/deploy/Chart/templates/dashboard/deployment.yaml
@@ -30,6 +30,9 @@ spec:
       - name: dashboard
         image: "{{ include "radius.image" (dict "image" .Values.dashboard.image "tag" (.Values.dashboard.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"
         imagePullPolicy: Always
+        env:
+        - name: NODE_ENV
+          value: {{ .Values.dashboard.nodeEnv | default "development" | quote }}
         ports:
         - name: http
           containerPort: {{ .Values.dashboard.containerPort }}

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -146,6 +146,10 @@ dashboard:
   image: dashboard
   # Default tag uses Chart AppVersion.
   # tag: latest
+  # nodeEnv controls the NODE_ENV environment variable for the Backstage
+  # dashboard. Defaults to "development" so the guest auth provider is
+  # enabled. Set to "production" only when a real auth provider is configured.
+  nodeEnv: development
   resources:
     requests:
       memory: "60Mi"


### PR DESCRIPTION
# Description

The dashboard is completely inoperative on Radius 0.56.0, returning `401 Unauthorized` with `"Missing credentials"` on all pages ([screenshots in issue](https://github.com/radius-project/radius/issues/11519)).

**Root cause**: The dashboard repo's PR [radius-project/dashboard#206](https://github.com/radius-project/dashboard/pull/206) ("migrate to node 24 and upgrade deps") bumped `@backstage/plugin-auth-backend` from `^0.25.7` to `^0.27.2`. Starting in Backstage auth-backend 0.26.x, the **guest auth provider is silently disabled when `NODE_ENV=production`**. The dashboard Dockerfile has always set `NODE_ENV=production` (standard Node.js practice), so this behavior change broke guest auth without any visible error.

**Fix**: Set `NODE_ENV=development` on the dashboard container via the Helm chart deployment template. This re-enables the Backstage guest auth provider. The value is configurable through `dashboard.nodeEnv` in `values.yaml` and defaults to**Fix**: Set `NODE_ENV=development` on the a**Fix**per tool**Fix**: Set `NODE_ENV=development` on the dashboard container via the Helm chart deployment template. This re-enables the Backstage guest auth provider. The value is configurable through `dashboard.nodeEnv` k required).

Fixes: #11519

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius- A PR fosamples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the change- A PR for the [documentation repository](https://gacing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->
