### PR TITLE
fix(dashboard): set NODE_ENV=development to restore guest auth (backport to release/0.56)

### DIFF
--- a/deploy/Chart/templates/dashboard/deployment.yaml
+++ b/deploy/Chart/templates/dashboard/deployment.yaml
@@ -30,6 +30,9 @@ spec:
       - name: dashboard
         image: "{{ include "radius.image" (dict "image" .Values.dashboard.image "tag" (.Values.dashboard.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"
         imagePullPolicy: Always
+        env:
+        - name: NODE_ENV
+          value: {{ .Values.dashboard.nodeEnv | default "development" | quote }}
         ports:
         - name: http
           containerPort: {{ .Values.dashboard.containerPort }}

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -146,6 +146,10 @@ dashboard:
   image: dashboard
   # Default tag uses Chart AppVersion.
   # tag: latest
+  # nodeEnv controls the NODE_ENV environment variable for the Backstage
+  # dashboard. Defaults to "development" so the guest auth provider is
+  # enabled. Set to "production" only when a real auth provider is configured.
+  nodeEnv: development
   resources:
     requests:
       memory: "60Mi"


### PR DESCRIPTION
# Description

Cherry-pick of #11520 to `release/0.56` for inclusion in v0.56.1 patch release.

The dashboard is completely inoperative on Radius 0.56.0, returning `401 Unauthorized` with `"Missing credentials"` on all pages (#11519).

**Root cause**: Dashboard repo PR [radius-project/dashboard#206](https://github.com/radius-project/dashboard/pull/206) bumped `@backstage/plugin-auth-backend` from `^0.25.7` to `^0.27.2`. Starting in 0.26.x, the guest auth provider is silently disabled when `NODE_ENV=production`. The Dockerfile sets `NODE_ENV=production`, breaking guest auth.

**Fix**: Set `NODE_ENV=development` on the dashboard container via the Helm chart. The value is configurable through `dashboard.nodeEnv` in `values.yaml`.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #11519

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mThis checklist uses "TaskRadio" comments to make certain options mThis checklireaThis checklist uses "TaskRadio" comments to make certain options mThis checklist uses "TaskRadio" comments to make certain options mThis n a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/sample- A PR for the [samplesin- A PR for the [samples repository](https://github.com/radius-project/sampadio sampl- A PR for the [samples repository](https://github.com/radius-project/sample- A PR for the [samplesin- A PR for the [samples repository](https://github.com/radius-project/sampadio sampl- A PR for the [samples repository](https://github.com/radius-project/sample- A PR for the [samplesin- A PR for the [samplca- A PR for the [samples repo->
- A PR fo- A PR fo- A PR fo- A PR fo- A PR fo- A PR fo/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->
