### PR TITLE
feat(install): add existing warning

### DIFF
--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -316,6 +316,10 @@ function Show-ExistingRadiusWarning {
 
         $candidate = Join-Path $dir $CliFileName
         if (Test-Path $candidate -PathType Leaf) {
+            # On non-Windows, skip non-executable files (matches bash installer's -x check)
+            if (-not ($IsWindows -or $env:OS -eq "Windows_NT")) {
+                if (-not (& test -x $candidate)) { continue }
+            }
             $resolvedDir = (Resolve-Path -Path $dir).Path
             if ($resolvedDir -ne $resolvedInstall) {
                 $stalePaths += $candidate
@@ -485,6 +489,7 @@ if (Test-Path $cliFilePath -PathType Leaf) {
     catch {
         Write-Output "Previous installation detected (version unknown)"
     }
+    Write-Output ""
     Write-Output "Reinstalling Radius CLI - $cliFilePath..."
 }
 else {

--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -295,6 +295,59 @@ function Install-RadRelease {
     }
 }
 
+function Show-ExistingRadiusWarning {
+    param (
+        [string]$TargetDir,
+        [string]$CliFileName
+    )
+
+    $resolvedInstall = (Resolve-Path -Path $TargetDir -ErrorAction SilentlyContinue).Path
+    if (-not $resolvedInstall) {
+        $resolvedInstall = $TargetDir
+    }
+
+    $separator = if ($IsWindows -or $env:OS -eq "Windows_NT") { ';' } else { ':' }
+    $stalePaths = @()
+
+    foreach ($dir in ($env:PATH -split [regex]::Escape($separator))) {
+        if (-not $dir -or -not (Test-Path $dir -PathType Container)) {
+            continue
+        }
+
+        $candidate = Join-Path $dir $CliFileName
+        if (Test-Path $candidate -PathType Leaf) {
+            $resolvedDir = (Resolve-Path -Path $dir).Path
+            if ($resolvedDir -ne $resolvedInstall) {
+                $stalePaths += $candidate
+            }
+        }
+    }
+
+    if ($stalePaths.Count -eq 0) {
+        return
+    }
+
+    Write-Output "============================================================================"
+    Write-Output "WARNING: Existing Radius CLI installation(s) found in different location(s):"
+    foreach ($p in $stalePaths) {
+        Write-Output "  $p"
+    }
+    Write-Output ""
+    Write-Output "The new installation will be placed in:"
+    Write-Output "  $(Join-Path $TargetDir $CliFileName)"
+    Write-Output ""
+    Write-Output "Remove the old binary(ies) before continuing to avoid using the wrong version:"
+    foreach ($p in $stalePaths) {
+        if ($IsWindows -or $env:OS -eq "Windows_NT") {
+            Write-Output "  Remove-Item $p"
+        }
+        else {
+            Write-Output "  rm $p"
+        }
+    }
+    Write-Output "============================================================================"
+}
+
 function Add-ToPath {
     param (
         [string]$TargetDir,
@@ -437,6 +490,9 @@ if (Test-Path $cliFilePath -PathType Leaf) {
 else {
     Write-Output "Installing Radius CLI..."
 }
+
+# Warn if rad exists elsewhere in PATH
+Show-ExistingRadiusWarning -TargetDir $resolvedInstallDir -CliFileName $cliFileName
 
 # Ensure TLS 1.2 on Windows PowerShell (version < 6)
 if ($PSVersionTable.PSVersion.Major -lt 6) {

--- a/deploy/install.ps1
+++ b/deploy/install.ps1
@@ -339,10 +339,10 @@ function Show-ExistingRadiusWarning {
     Write-Output "Remove the old binary(ies) before continuing to avoid using the wrong version:"
     foreach ($p in $stalePaths) {
         if ($IsWindows -or $env:OS -eq "Windows_NT") {
-            Write-Output "  Remove-Item $p"
+            Write-Output "  Remove-Item -LiteralPath `"$p`""
         }
         else {
-            Write-Output "  rm $p"
+            Write-Output "  rm `"$p`""
         }
     }
     Write-Output "============================================================================"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -200,6 +200,46 @@ checkExistingRadius() {
     fi
 }
 
+# Warn if existing rad binaries are found in PATH at different locations.
+warnExistingRadiusElsewhere() {
+    # Resolve the target install directory to an absolute path
+    local resolved_install
+    resolved_install=$(mkdir -p "${INSTALL_DIR}" 2> /dev/null && cd "${INSTALL_DIR}" && pwd -P)
+
+    # Walk every PATH directory looking for rad binaries elsewhere
+    local stale_paths=()
+    local IFS=':'
+    for dir in ${PATH}; do
+        local candidate="${dir}/${RADIUS_CLI_FILENAME}"
+        if [[ -x "${candidate}" ]]; then
+            local resolved_dir
+            resolved_dir=$(cd "${dir}" 2> /dev/null && pwd -P) || continue
+            if [[ "${resolved_dir}" != "${resolved_install}" ]]; then
+                stale_paths+=("${candidate}")
+            fi
+        fi
+    done
+
+    if (( ${#stale_paths[@]} == 0 )); then
+        return
+    fi
+
+    echo "============================================================================"
+    echo "WARNING: Existing Radius CLI installation(s) found in different location(s):"
+    for p in "${stale_paths[@]}"; do
+        echo "  ${p}"
+    done
+    echo ""
+    echo "The new installation will be placed in:"
+    echo "  ${INSTALL_DIR}/${RADIUS_CLI_FILENAME}"
+    echo ""
+    echo "Remove the old binary(ies) before continuing to avoid using the wrong version:"
+    for p in "${stale_paths[@]}"; do
+        echo "  rm ${p}"
+    done
+    echo "============================================================================"
+}
+
 getLatestRelease() {
     local radReleaseUrl="https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/releases"
     local latest_release=""
@@ -415,6 +455,7 @@ fi
 
 verifySupported
 checkExistingRadius
+warnExistingRadiusElsewhere
 
 echo "Installing ${ret_val} Radius CLI..."
 echo "Install directory: ${INSTALL_DIR}"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -202,9 +202,15 @@ checkExistingRadius() {
 
 # Warn if existing rad binaries are found in PATH at different locations.
 warnExistingRadiusElsewhere() {
-    # Resolve the target install directory to an absolute path
+    # Resolve the target install directory to an absolute path without creating it
     local resolved_install
-    resolved_install=$(mkdir -p "${INSTALL_DIR}" 2> /dev/null && cd "${INSTALL_DIR}" && pwd -P)
+    if [[ -d "${INSTALL_DIR}" ]]; then
+        if ! resolved_install=$(cd "${INSTALL_DIR}" && pwd -P); then
+            resolved_install="${INSTALL_DIR}"
+        fi
+    else
+        resolved_install="${INSTALL_DIR}"
+    fi
 
     # Walk every PATH directory looking for rad binaries elsewhere
     local stale_paths=()
@@ -242,7 +248,7 @@ warnExistingRadiusElsewhere() {
     echo ""
     echo "Remove the old binary(ies) before continuing to avoid using the wrong version:"
     for p in "${stale_paths[@]}"; do
-        echo "  rm ${p}"
+        echo "  rm -- \"${p}\""
     done
     echo "============================================================================"
 }

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -193,7 +193,7 @@ checkExistingRadius() {
     if [[ -f "${cli_file}" ]]; then
         local version
         version=$("${cli_file}" version --cli 2> /dev/null || echo "unknown")
-        printf '\nRadius CLI is detected. Current version: %s\n' "${version}"
+        printf '\nRadius CLI is detected. Current version: %s\n\n' "${version}"
         printf 'Reinstalling Radius CLI - %s...\n\n' "${cli_file}"
     else
         printf 'Installing Radius CLI...\n\n'

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -210,10 +210,17 @@ warnExistingRadiusElsewhere() {
     local stale_paths=()
     local IFS=':'
     for dir in ${PATH}; do
-        local candidate="${dir}/${RADIUS_CLI_FILENAME}"
+        local path_dir="${dir}"
+        if [[ "${path_dir}" == "~" ]]; then
+            path_dir="${HOME}"
+        elif [[ "${path_dir}" == "~/"* ]]; then
+            path_dir="${HOME}/${path_dir:2}"
+        fi
+
+        local candidate="${path_dir}/${RADIUS_CLI_FILENAME}"
         if [[ -x "${candidate}" ]]; then
             local resolved_dir
-            resolved_dir=$(cd "${dir}" 2> /dev/null && pwd -P) || continue
+            resolved_dir=$(cd "${path_dir}" 2> /dev/null && pwd -P) || continue
             if [[ "${resolved_dir}" != "${resolved_install}" ]]; then
                 stale_paths+=("${candidate}")
             fi

--- a/deploy/test-pwsh-install.ps1
+++ b/deploy/test-pwsh-install.ps1
@@ -6,9 +6,9 @@ param(
 ## Fetch PATH variable values
 $regKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $false)
 $originalPath = $regKey.GetValue( `
-    'PATH', `
-    '', `
-    [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames `
+        'PATH', `
+        '', `
+        [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames `
 )
 $originalPathType = $regKey.GetValueKind('PATH')
 
@@ -23,16 +23,16 @@ if ($LASTEXITCODE) {
 }
 
 $currentPath = $regKey.GetValue( `
-    'PATH', `
-    '', `
-    [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames `
+        'PATH', `
+        '', `
+        [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames `
 )
 
 ## Verify that the rad installation directory was successfully added to PATH
 $expectedPathEntry = $InstallFolder
 if (!$currentPath.Contains($expectedPathEntry)) {
-  Write-Error "Could not find path entry. Expected substring: $expectedPathEntry, Actual: $path"
-  exit 1
+    Write-Error "Could not find path entry. Expected substring: $expectedPathEntry, Actual: $path"
+    exit 1
 }
 
 ## Verify that the installation didn't change the REG_KEY Kind
@@ -62,4 +62,53 @@ if ($LASTEXITCODE) {
 if ($LASTEXITCODE) {
     Write-Error "Could not execute 'rad version'"
     exit 1
+}
+
+## ---------------------------------------------------------------
+## Test: stale rad elsewhere in PATH emits a warning banner
+## ---------------------------------------------------------------
+
+# Create a temporary directory with a dummy rad binary to simulate a stale install
+$staleDir = Join-Path $env:TEMP "rad-stale-test-$(Get-Random)"
+New-Item -Path $staleDir -ItemType Directory -Force | Out-Null
+
+$staleCliName = if ($env:OS -eq "Windows_NT" -or $IsWindows) { "rad.exe" } else { "rad" }
+$staleBinary = Join-Path $staleDir $staleCliName
+
+# Create a minimal dummy executable
+if ($env:OS -eq "Windows_NT" -or $IsWindows) {
+    # Copy the real binary so it's a valid executable
+    Copy-Item -Path (Join-Path $InstallFolder $staleCliName) -Destination $staleBinary -Force
+}
+else {
+    Set-Content -Path $staleBinary -Value '#!/bin/sh' -NoNewline
+    & chmod +x $staleBinary
+}
+
+try {
+    # Prepend the stale directory to PATH so the installer detects it
+    $savedPath = $env:PATH
+    $separator = if ($env:OS -eq "Windows_NT" -or $IsWindows) { ';' } else { ':' }
+    $env:PATH = "$staleDir$separator$env:PATH"
+
+    # Run the installer again and capture output
+    $output = & $PSScriptRoot/install.ps1 `
+        -RadiusRoot $InstallFolder 2>&1 | Out-String
+
+    # Assert the warning banner was emitted
+    if ($output -notmatch "WARNING: Existing Radius CLI installation\(s\) found in different location\(s\)") {
+        Write-Error "Expected stale-install warning banner, but it was not found in output:`n$output"
+        exit 1
+    }
+
+    if ($output -notmatch [regex]::Escape($staleBinary)) {
+        Write-Error "Expected stale path '$staleBinary' in warning output, but it was not found:`n$output"
+        exit 1
+    }
+
+    Write-Output "PASS: stale rad warning banner was correctly emitted"
+}
+finally {
+    $env:PATH = $savedPath
+    Remove-Item -Recurse -Force $staleDir -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
# Description

Adds highly visible installer warnings when `rad` is already present on PATH from a different location. The shell installer now scans all PATH entries instead of stopping at the first match, and the PowerShell installer adopts the same behavior so both entry points warn about stale binaries before reinstalling.

<img width="795" height="467" alt="image" src="https://github.com/user-attachments/assets/d69c151a-cb9b-4498-be88-1c8eb35e8bc8" />

<img width="895" height="512" alt="image" src="https://github.com/user-attachments/assets/2d586d58-4314-4a94-a253-a020ac8918ba" />


## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #11518

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->