### PR TITLE
Optimize UCP startup by replacing HTTP-based manifest registration with direct database writes

### DIFF
--- a/pkg/ucp/initializer/service.go
+++ b/pkg/ucp/initializer/service.go
@@ -19,17 +19,15 @@ package initializer
 import (
 	"context"
 	"fmt"
-	"net"
-	"net/url"
 	"os"
-	"time"
+	"path/filepath"
 
-	aztoken "github.com/radius-project/radius/pkg/azure/tokencredentials"
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/cli/manifest"
+	"github.com/radius-project/radius/pkg/components/database"
 	"github.com/radius-project/radius/pkg/components/hosting"
-	"github.com/radius-project/radius/pkg/sdk"
 	"github.com/radius-project/radius/pkg/ucp"
-	"github.com/radius-project/radius/pkg/ucp/api/v20231001preview"
+	"github.com/radius-project/radius/pkg/ucp/datamodel"
 	"github.com/radius-project/radius/pkg/ucp/ucplog"
 )
 
@@ -52,30 +50,6 @@ func (s *Service) Name() string {
 	return "initializer"
 }
 
-func waitForServer(ctx context.Context, host, port string, retryInterval time.Duration, connectionTimeout time.Duration, timeout time.Duration) error {
-	address := net.JoinHostPort(host, port)
-	deadline := time.Now().Add(timeout)
-
-	for {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("connection attempts canceled or timed out: %w", ctx.Err())
-		default:
-			conn, err := net.DialTimeout("tcp", address, connectionTimeout)
-			if err == nil {
-				conn.Close()
-				return nil
-			}
-
-			if time.Now().After(deadline) {
-				return fmt.Errorf("failed to connect to %s after %v: %w", address, timeout, err)
-			}
-
-			time.Sleep(retryInterval)
-		}
-	}
-}
-
 func (w *Service) Run(ctx context.Context) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
@@ -91,44 +65,206 @@ func (w *Service) Run(ctx context.Context) error {
 		return fmt.Errorf("error checking manifest directory: %w", err)
 	}
 
-	if w.options.UCP == nil || w.options.UCP.Endpoint() == "" {
-		return fmt.Errorf("connection to UCP is not set")
-	}
-
-	// Parse the endpoint URL and extract host and port
-	parsedURL, err := url.Parse(w.options.UCP.Endpoint())
+	dbClient, err := w.options.DatabaseProvider.GetClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to parse endpoint URL: %w", err)
+		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	hostName, port, err := net.SplitHostPort(parsedURL.Host)
+	files, err := os.ReadDir(manifestDir)
 	if err != nil {
-		return fmt.Errorf("failed to split host and port: %w", err)
+		return fmt.Errorf("failed to read manifest directory: %w", err)
 	}
 
-	// Attempt to connect to the server
-	err = waitForServer(ctx, hostName, port, 500*time.Millisecond, 500*time.Millisecond, 5*time.Second)
-	if err != nil {
-		return fmt.Errorf("failed to connect to server : %w", err)
-	}
+	for _, fileInfo := range files {
+		if fileInfo.IsDir() {
+			continue
+		}
 
-	// Server is up, proceed to register manifests
-	clientOptions := sdk.NewClientOptions(w.options.UCP)
+		filePath := filepath.Join(manifestDir, fileInfo.Name())
+		logger.Info("Registering manifest", "file", filePath)
 
-	clientFactory, err := v20231001preview.NewClientFactory(&aztoken.AnonymousCredential{}, clientOptions)
-	if err != nil {
-		return fmt.Errorf("error creating client factory: %w", err)
-	}
+		resourceProvider, err := manifest.ValidateManifest(ctx, filePath)
+		if err != nil {
+			return fmt.Errorf("failed to validate manifest %s: %w", filePath, err)
+		}
 
-	loggerFunc := func(format string, args ...any) {
-		logger.Info(fmt.Sprintf(format, args...))
-	}
-
-	if err := manifest.RegisterDirectory(ctx, clientFactory, "local", manifestDir, loggerFunc); err != nil {
-		return fmt.Errorf("error registering manifests : %w", err)
+		if err := registerResourceProviderDirect(ctx, dbClient, "local", *resourceProvider); err != nil {
+			return fmt.Errorf("failed to register manifest %s: %w", filePath, err)
+		}
 	}
 
 	logger.Info("Successfully registered manifests", "directory", manifestDir)
+	return nil
+}
+
+// registerResourceProviderDirect writes resource provider metadata directly to the database,
+// bypassing the HTTP API and async operation queue. This is used during server initialization
+// where the resources are known to not exist yet.
+func registerResourceProviderDirect(ctx context.Context, dbClient database.Client, planeName string, rp manifest.ResourceProvider) error {
+	rootScope := "/planes/radius/" + planeName
+
+	// Determine location name and address
+	locationName := v1.LocationGlobal
+	var address string
+	for name, addr := range rp.Location {
+		locationName = name
+		address = addr
+		break
+	}
+
+	rpID := rootScope + "/providers/System.Resources/resourceProviders/" + rp.Namespace
+
+	// 1. Save ResourceProvider
+	rpModel := &datamodel.ResourceProvider{
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:       rpID,
+				Name:     rp.Namespace,
+				Type:     datamodel.ResourceProviderResourceType,
+				Location: locationName,
+			},
+			InternalMetadata: v1.InternalMetadata{
+				AsyncProvisioningState: v1.ProvisioningStateSucceeded,
+			},
+		},
+	}
+
+	if err := saveResource(ctx, dbClient, rpID, rpModel); err != nil {
+		return fmt.Errorf("failed to save resource provider %s: %w", rp.Namespace, err)
+	}
+
+	// Build summary while iterating
+	summaryResourceTypes := map[string]datamodel.ResourceProviderSummaryPropertiesResourceType{}
+
+	// 2. Save ResourceTypes and APIVersions
+	for typeName, resourceType := range rp.Types {
+		typeID := rpID + "/resourceTypes/" + typeName
+
+		typeModel := &datamodel.ResourceType{
+			BaseResource: v1.BaseResource{
+				TrackedResource: v1.TrackedResource{
+					ID:   typeID,
+					Name: typeName,
+					Type: datamodel.ResourceTypeResourceType,
+				},
+				InternalMetadata: v1.InternalMetadata{
+					AsyncProvisioningState: v1.ProvisioningStateSucceeded,
+				},
+			},
+			Properties: datamodel.ResourceTypeProperties{
+				Capabilities:      resourceType.Capabilities,
+				DefaultAPIVersion: resourceType.DefaultAPIVersion,
+				Description:       resourceType.Description,
+			},
+		}
+
+		if err := saveResource(ctx, dbClient, typeID, typeModel); err != nil {
+			return fmt.Errorf("failed to save resource type %s/%s: %w", rp.Namespace, typeName, err)
+		}
+
+		summaryAPIVersions := map[string]datamodel.ResourceProviderSummaryPropertiesAPIVersion{}
+
+		for apiVersionName, apiVersion := range resourceType.APIVersions {
+			avID := typeID + "/apiVersions/" + apiVersionName
+
+			schema, _ := apiVersion.Schema.(map[string]any)
+			avModel := &datamodel.APIVersion{
+				BaseResource: v1.BaseResource{
+					TrackedResource: v1.TrackedResource{
+						ID:   avID,
+						Name: apiVersionName,
+						Type: datamodel.APIVersionResourceType,
+					},
+					InternalMetadata: v1.InternalMetadata{
+						AsyncProvisioningState: v1.ProvisioningStateSucceeded,
+					},
+				},
+				Properties: datamodel.APIVersionProperties{
+					Schema: schema,
+				},
+			}
+
+			if err := saveResource(ctx, dbClient, avID, avModel); err != nil {
+				return fmt.Errorf("failed to save API version %s/%s@%s: %w", rp.Namespace, typeName, apiVersionName, err)
+			}
+
+			summaryAPIVersions[apiVersionName] = datamodel.ResourceProviderSummaryPropertiesAPIVersion{
+				Schema: schema,
+			}
+		}
+
+		summaryResourceTypes[typeName] = datamodel.ResourceProviderSummaryPropertiesResourceType{
+			DefaultAPIVersion: resourceType.DefaultAPIVersion,
+			Capabilities:      resourceType.Capabilities,
+			Description:       resourceType.Description,
+			APIVersions:       summaryAPIVersions,
+		}
+	}
+
+	// 3. Save Location
+	locationID := rpID + "/locations/" + locationName
+	locationResourceTypes := map[string]datamodel.LocationResourceTypeConfiguration{}
+	for typeName, resourceType := range rp.Types {
+		apiVersions := map[string]datamodel.LocationAPIVersionConfiguration{}
+		for apiVersionName := range resourceType.APIVersions {
+			apiVersions[apiVersionName] = datamodel.LocationAPIVersionConfiguration{}
+		}
+		locationResourceTypes[typeName] = datamodel.LocationResourceTypeConfiguration{
+			APIVersions: apiVersions,
+		}
+	}
+
+	locationModel := &datamodel.Location{
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:   locationID,
+				Name: locationName,
+				Type: datamodel.LocationResourceType,
+			},
+			InternalMetadata: v1.InternalMetadata{
+				AsyncProvisioningState: v1.ProvisioningStateSucceeded,
+			},
+		},
+		Properties: datamodel.LocationProperties{
+			ResourceTypes: locationResourceTypes,
+		},
+	}
+	if address != "" {
+		locationModel.Properties.Address = &address
+	}
+
+	if err := saveResource(ctx, dbClient, locationID, locationModel); err != nil {
+		return fmt.Errorf("failed to save location %s/%s: %w", rp.Namespace, locationName, err)
+	}
+
+	// 4. Save ResourceProviderSummary
+	summaryID := rootScope + "/providers/System.Resources/resourceProviderSummaries/" + rp.Namespace
+	summaryModel := &datamodel.ResourceProviderSummary{
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:   summaryID,
+				Name: rp.Namespace,
+				Type: datamodel.ResourceProviderSummaryResourceType,
+			},
+		},
+		Properties: datamodel.ResourceProviderSummaryProperties{
+			Locations: map[string]datamodel.ResourceProviderSummaryPropertiesLocation{
+				locationName: {},
+			},
+			ResourceTypes: summaryResourceTypes,
+		},
+	}
+
+	if err := saveResource(ctx, dbClient, summaryID, summaryModel); err != nil {
+		return fmt.Errorf("failed to save resource provider summary %s: %w", rp.Namespace, err)
+	}
 
 	return nil
+}
+
+func saveResource(ctx context.Context, dbClient database.Client, id string, data any) error {
+	return dbClient.Save(ctx, &database.Object{
+		Metadata: database.Metadata{ID: id},
+		Data:     data,
+	})
 }

--- a/pkg/ucp/initializer/service_test.go
+++ b/pkg/ucp/initializer/service_test.go
@@ -1,0 +1,295 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initializer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	"github.com/radius-project/radius/pkg/cli/manifest"
+	"github.com/radius-project/radius/pkg/components/database/databaseprovider"
+	"github.com/radius-project/radius/pkg/components/database/inmemory"
+	"github.com/radius-project/radius/pkg/ucp"
+	"github.com/radius-project/radius/pkg/ucp/datamodel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_registerResourceProviderDirect(t *testing.T) {
+	t.Parallel()
+
+	t.Run("registers all resources for a simple manifest", func(t *testing.T) {
+		t.Parallel()
+		dbClient := inmemory.NewClient()
+
+		rp := createTestResourceProvider()
+		err := registerResourceProviderDirect(context.Background(), dbClient, "local", rp)
+		require.NoError(t, err)
+
+		// Verify resource provider was saved
+		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources")
+		require.NoError(t, err)
+
+		rpModel := &datamodel.ResourceProvider{}
+		require.NoError(t, obj.As(rpModel))
+		assert.Equal(t, "MyCompany.Resources", rpModel.Name)
+		assert.Equal(t, datamodel.ResourceProviderResourceType, rpModel.Type)
+		assert.Equal(t, v1.ProvisioningStateSucceeded, rpModel.InternalMetadata.AsyncProvisioningState)
+		assert.Equal(t, "global", rpModel.Location)
+
+		// Verify resource type was saved
+		obj, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources/resourceTypes/widgets")
+		require.NoError(t, err)
+
+		rtModel := &datamodel.ResourceType{}
+		require.NoError(t, obj.As(rtModel))
+		assert.Equal(t, "widgets", rtModel.Name)
+		assert.Equal(t, datamodel.ResourceTypeResourceType, rtModel.Type)
+		assert.Equal(t, v1.ProvisioningStateSucceeded, rtModel.InternalMetadata.AsyncProvisioningState)
+
+		// Verify API version was saved
+		obj, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources/resourceTypes/widgets/apiVersions/2023-10-01-preview")
+		require.NoError(t, err)
+
+		avModel := &datamodel.APIVersion{}
+		require.NoError(t, obj.As(avModel))
+		assert.Equal(t, "2023-10-01-preview", avModel.Name)
+		assert.Equal(t, datamodel.APIVersionResourceType, avModel.Type)
+
+		// Verify location was saved
+		obj, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources/locations/global")
+		require.NoError(t, err)
+
+		locModel := &datamodel.Location{}
+		require.NoError(t, obj.As(locModel))
+		assert.Equal(t, "global", locModel.Name)
+		assert.Equal(t, "http://localhost:8080", *locModel.Properties.Address)
+		assert.Contains(t, locModel.Properties.ResourceTypes, "widgets")
+		assert.Contains(t, locModel.Properties.ResourceTypes["widgets"].APIVersions, "2023-10-01-preview")
+
+		// Verify summary was saved
+		obj, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviderSummaries/MyCompany.Resources")
+		require.NoError(t, err)
+
+		summaryModel := &datamodel.ResourceProviderSummary{}
+		require.NoError(t, obj.As(summaryModel))
+		assert.Contains(t, summaryModel.Properties.Locations, "global")
+		assert.Contains(t, summaryModel.Properties.ResourceTypes, "widgets")
+		assert.Contains(t, summaryModel.Properties.ResourceTypes["widgets"].APIVersions, "2023-10-01-preview")
+	})
+
+	t.Run("registers provider with multiple types and versions", func(t *testing.T) {
+		t.Parallel()
+		dbClient := inmemory.NewClient()
+
+		rp := createTestResourceProviderMultiType()
+		err := registerResourceProviderDirect(context.Background(), dbClient, "local", rp)
+		require.NoError(t, err)
+
+		// Verify both resource types exist
+		for _, typeName := range []string{"typeA", "typeB"} {
+			_, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Multi.Provider/resourceTypes/"+typeName)
+			require.NoError(t, err, "expected resource type %s to exist", typeName)
+		}
+
+		// Verify typeA has two API versions
+		for _, version := range []string{"2023-01-01", "2024-01-01"} {
+			_, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Multi.Provider/resourceTypes/typeA/apiVersions/"+version)
+			require.NoError(t, err, "expected API version %s to exist for typeA", version)
+		}
+
+		// Verify summary has both types
+		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviderSummaries/Multi.Provider")
+		require.NoError(t, err)
+
+		summaryModel := &datamodel.ResourceProviderSummary{}
+		require.NoError(t, obj.As(summaryModel))
+		assert.Len(t, summaryModel.Properties.ResourceTypes, 2)
+		assert.Len(t, summaryModel.Properties.ResourceTypes["typeA"].APIVersions, 2)
+		assert.Len(t, summaryModel.Properties.ResourceTypes["typeB"].APIVersions, 1)
+	})
+
+	t.Run("registers provider with no location defaults to global", func(t *testing.T) {
+		t.Parallel()
+		dbClient := inmemory.NewClient()
+
+		rp := createTestResourceProvider()
+		rp.Location = nil
+		err := registerResourceProviderDirect(context.Background(), dbClient, "local", rp)
+		require.NoError(t, err)
+
+		// Location should default to "global"
+		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources/locations/global")
+		require.NoError(t, err)
+
+		locModel := &datamodel.Location{}
+		require.NoError(t, obj.As(locModel))
+		assert.Equal(t, "global", locModel.Name)
+		assert.Nil(t, locModel.Properties.Address) // No address when location is nil
+	})
+
+	t.Run("is idempotent", func(t *testing.T) {
+		t.Parallel()
+		dbClient := inmemory.NewClient()
+
+		rp := createTestResourceProvider()
+
+		// Register twice
+		err := registerResourceProviderDirect(context.Background(), dbClient, "local", rp)
+		require.NoError(t, err)
+
+		err = registerResourceProviderDirect(context.Background(), dbClient, "local", rp)
+		require.NoError(t, err)
+
+		// Should still be readable
+		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/MyCompany.Resources")
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+	})
+}
+
+func Test_Run(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no manifest directory skips initialization", func(t *testing.T) {
+		t.Parallel()
+		svc := newTestService("")
+		err := svc.Run(context.Background())
+		require.NoError(t, err)
+	})
+
+	t.Run("missing manifest directory returns error", func(t *testing.T) {
+		t.Parallel()
+		svc := newTestService("/nonexistent/path")
+		err := svc.Run(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "manifest directory does not exist")
+	})
+
+	t.Run("registers manifests from directory", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a temp directory with a test manifest
+		tempDir := t.TempDir()
+		manifestContent := `
+namespace: Test.Provider
+location:
+  global: "http://localhost:9090"
+types:
+  myType:
+    apiVersions:
+      "2025-01-01":
+        schema: {}
+`
+		err := os.WriteFile(filepath.Join(tempDir, "test.yaml"), []byte(manifestContent), 0600)
+		require.NoError(t, err)
+
+		svc := newTestService(tempDir)
+		dbClient, err := svc.options.DatabaseProvider.GetClient(context.Background())
+		require.NoError(t, err)
+
+		err = svc.Run(context.Background())
+		require.NoError(t, err)
+
+		// Verify the resource provider was registered
+		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Test.Provider")
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+	})
+}
+
+func Test_saveResource(t *testing.T) {
+	t.Parallel()
+
+	dbClient := inmemory.NewClient()
+	data := &datamodel.ResourceProvider{
+		BaseResource: v1.BaseResource{
+			TrackedResource: v1.TrackedResource{
+				ID:   "/planes/radius/local/providers/System.Resources/resourceProviders/Test",
+				Name: "Test",
+				Type: datamodel.ResourceProviderResourceType,
+			},
+		},
+	}
+
+	err := saveResource(context.Background(), dbClient, data.ID, data)
+	require.NoError(t, err)
+
+	obj, err := dbClient.Get(context.Background(), data.ID)
+	require.NoError(t, err)
+
+	result := &datamodel.ResourceProvider{}
+	require.NoError(t, obj.As(result))
+	assert.Equal(t, "Test", result.Name)
+}
+
+// newTestService creates a Service with in-memory database for testing.
+func newTestService(manifestDir string) *Service {
+	return &Service{
+		options: &ucp.Options{
+			Config: &ucp.Config{
+				Initialization: ucp.InitializationConfig{
+					ManifestDirectory: manifestDir,
+				},
+			},
+			DatabaseProvider: databaseprovider.FromMemory(),
+		},
+	}
+}
+
+func createTestResourceProvider() manifest.ResourceProvider {
+	return manifest.ResourceProvider{
+		Namespace: "MyCompany.Resources",
+		Location: map[string]string{
+			"global": "http://localhost:8080",
+		},
+		Types: map[string]*manifest.ResourceType{
+			"widgets": {
+				APIVersions: map[string]*manifest.ResourceTypeAPIVersion{
+					"2023-10-01-preview": {
+						Schema: map[string]any{},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createTestResourceProviderMultiType() manifest.ResourceProvider {
+	return manifest.ResourceProvider{
+		Namespace: "Multi.Provider",
+		Location: map[string]string{
+			"global": "http://localhost:8080",
+		},
+		Types: map[string]*manifest.ResourceType{
+			"typeA": {
+				APIVersions: map[string]*manifest.ResourceTypeAPIVersion{
+					"2023-01-01": {Schema: map[string]any{}},
+					"2024-01-01": {Schema: map[string]any{}},
+				},
+			},
+			"typeB": {
+				APIVersions: map[string]*manifest.ResourceTypeAPIVersion{
+					"2024-01-01": {Schema: map[string]any{}},
+				},
+			},
+		},
+	}
+}

--- a/pkg/ucp/integrationtests/resourceproviders/testdata/resourceprovider_manifest_list_responsebody.json
+++ b/pkg/ucp/integrationtests/resourceproviders/testdata/resourceprovider_manifest_list_responsebody.json
@@ -1,14 +1,14 @@
 {
   "value": [
     {
-      "id": "/planes/radius/local/providers/System.Resources/resourceproviders/TestProvider.TestCompany",
+      "id": "/planes/radius/local/providers/System.Resources/resourceProviders/TestProvider.TestCompany",
       "location": "global",
       "name": "TestProvider.TestCompany",
       "properties": {
         "provisioningState": "Succeeded"
       },
       "tags": {},
-      "type": "System.Resources/resourceproviders"
+      "type": "System.Resources/resourceProviders"
     }
   ]
 }

--- a/pkg/ucp/integrationtests/resourceproviders/testdata/resourceprovider_manifest_responsebody.json
+++ b/pkg/ucp/integrationtests/resourceproviders/testdata/resourceprovider_manifest_responsebody.json
@@ -1,10 +1,10 @@
 {
-  "id": "/planes/radius/local/providers/System.Resources/resourceproviders/TestProvider.TestCompany",
+  "id": "/planes/radius/local/providers/System.Resources/resourceProviders/TestProvider.TestCompany",
   "location": "global",
   "name": "TestProvider.TestCompany",
   "properties": {
     "provisioningState": "Succeeded"
   },
   "tags": {},
-  "type": "System.Resources/resourceproviders"
+  "type": "System.Resources/resourceProviders"
 }

--- a/pkg/ucp/integrationtests/resourceproviders/testdata/resourcetype_manifest_list_responsebody.json
+++ b/pkg/ucp/integrationtests/resourceproviders/testdata/resourcetype_manifest_list_responsebody.json
@@ -1,13 +1,13 @@
 {
   "value": [
     {
-      "id": "/planes/radius/local/providers/System.Resources/resourceproviders/TestProvider.TestCompany/resourcetypes/testResourcesAbc",
+      "id": "/planes/radius/local/providers/System.Resources/resourceProviders/TestProvider.TestCompany/resourceTypes/testResourcesAbc",
       "name": "testResourcesAbc",
       "properties": {
         "provisioningState": "Succeeded",
         "capabilities": []
       },
-      "type": "System.Resources/resourceproviders/resourcetypes"
+      "type": "System.Resources/resourceProviders/resourceTypes"
     }
   ]
 }

--- a/pkg/ucp/integrationtests/resourceproviders/testdata/resourcetype_manifest_responsebody.json
+++ b/pkg/ucp/integrationtests/resourceproviders/testdata/resourcetype_manifest_responsebody.json
@@ -1,9 +1,9 @@
 {
-  "id": "/planes/radius/local/providers/System.Resources/resourceproviders/TestProvider.TestCompany/resourcetypes/testResourcesAbc",
+  "id": "/planes/radius/local/providers/System.Resources/resourceProviders/TestProvider.TestCompany/resourceTypes/testResourcesAbc",
   "name": "testResourcesAbc",
   "properties": {
     "provisioningState": "Succeeded",
     "capabilities": []
   },
-  "type": "System.Resources/resourceproviders/resourcetypes"
+  "type": "System.Resources/resourceProviders/resourceTypes"
 }


### PR DESCRIPTION
# Description

The UCP initializer service previously registered built-in resource provider manifests by making HTTP API calls to itself during startup. Each manifest file triggered multiple async operations (resource provider, resource types, API versions, location, summary), each requiring a PUT request, an async queue dispatch, a worker pickup, a 1-second polling interval, and a GET status check. With ~95 async operations across 8 manifest files processed sequentially, this took **65 seconds**.

This PR replaces the HTTP-based registration path in the initializer with direct database writes. The initializer now reads manifest files, constructs the data model objects, and saves them directly to the database using the `database.Client`. This eliminates:

- TCP wait for the API server to be ready
- HTTP round-trips to localhost
- Async operation queue dispatch and worker processing
- 1-second polling intervals per operation
- 409 conflict retry logic

**Result: UCP initialization completes in ~230ms (down from ~65s), a ~280x speedup.**

The CLI (`rad` command) continues to use the HTTP-based registration path via `manifest.RegisterDirectory`, which is the correct approach for external clients.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->