### PR TITLE
fix(lrt): improve resource deletion logic

### DIFF
--- a/.github/scripts/cleanup-long-running-cluster.sh
+++ b/.github/scripts/cleanup-long-running-cluster.sh
@@ -16,11 +16,11 @@
 # limitations under the License.
 # ------------------------------------------------------------
 
-set -e
+set -euo pipefail
 
 SKIP_RESOURCE_FILE="${1:-}"
 echo "cleaning up long-running cluster on Azure"
-echo "Using skip-resource-list from: $SKIP_RESOURCE_FILE"
+echo "Using skip-resource-list from: ${SKIP_RESOURCE_FILE}"
 
 # Delete all test resources in queuemessages.
 if kubectl get crd queuemessages.ucp.dev >/dev/null 2>&1; then
@@ -28,23 +28,55 @@ if kubectl get crd queuemessages.ucp.dev >/dev/null 2>&1; then
     kubectl delete queuemessages.ucp.dev -n radius-system --all --wait=false
 fi
 
-# Testing deletion of deployment.apps.
-
-# Delete all test resources in resources without proxy resource.
+# Delete test resources in resources.ucp.dev while preserving resource provider
+# infrastructure. Resource providers, resource types, API versions, and locations
+# are essential for Radius to function (e.g., Applications.Core/environments).
+# Deleting them causes "resource type not found" errors that break subsequent runs.
 if kubectl get crd resources.ucp.dev >/dev/null 2>&1; then
-    echo "delete all resources in resources.ucp.dev"
+    echo "delete test resources in resources.ucp.dev"
+
+    # Build a list of resource provider infrastructure entries that must always be
+    # preserved, regardless of whether the skip-delete-resources-list.txt exists.
+    # These entries are identified by their ucp.dev/resource-type label.
+    RP_INFRA_FILE="$(mktemp)"
+    kubectl get resources.ucp.dev -n radius-system --no-headers \
+        -o custom-columns=":metadata.name" \
+        -l "ucp.dev/resource-type in (system.resources_resourceproviders,system.resources_resourceproviders_resourcetypes,system.resources_resourceproviders_resourcetypes_apiversions,system.resources_resourceproviders_locations)" \
+        > "${RP_INFRA_FILE}" 2>/dev/null || true
+    rp_count=$(wc -l < "${RP_INFRA_FILE}" | tr -d ' ')
+    echo "found ${rp_count} resource provider infrastructure entries to preserve"
+
     resources=$(kubectl get resources.ucp.dev -n radius-system --no-headers -o custom-columns=":metadata.name")
-    for r in $resources; do
-        # Skip resources if they're either scope.* or listed in skip resource file
-        if [[ $r == scope.local.* || $r == scope.aws.* || -z "$r" ]]; then
-            echo "skip deletion: $r"
-        elif [ -n "$SKIP_RESOURCE_FILE" ] && [ -f "$SKIP_RESOURCE_FILE" ] && grep -q "$r" "$SKIP_RESOURCE_FILE"; then
-            echo "Skip deletion: $r (found in skip-resource-list $SKIP_RESOURCE_FILE)"    
-        else
-            echo "deleting resource: $r"
-            kubectl delete resources.ucp.dev "$r" -n radius-system --ignore-not-found=true --wait=false
+    for r in ${resources}; do
+        if [[ -z "${r}" ]]; then
+            continue
         fi
+
+        # Skip all scope entries (planes, resource groups, etc.)
+        if [[ ${r} == scope.* ]]; then
+            echo "skip deletion: ${r} (scope entry)"
+            continue
+        fi
+
+        # Skip resource provider infrastructure entries (resource types, API versions, locations).
+        # This is the primary safeguard that protects resource types even when the
+        # skip-delete-resources-list.txt is missing due to a cache miss.
+        if grep -qFx "${r}" "${RP_INFRA_FILE}" 2>/dev/null; then
+            echo "skip deletion: ${r} (resource provider infrastructure)"
+            continue
+        fi
+
+        # Skip resources listed in skip resource file
+        if [[ -n "${SKIP_RESOURCE_FILE}" ]] && [[ -f "${SKIP_RESOURCE_FILE}" ]] && grep -qF "${r}" "${SKIP_RESOURCE_FILE}"; then
+            echo "skip deletion: ${r} (found in skip-resource-list ${SKIP_RESOURCE_FILE})"
+            continue
+        fi
+
+        echo "deleting resource: ${r}"
+        kubectl delete resources.ucp.dev "${r}" -n radius-system --ignore-not-found=true --wait=false
     done
+
+    rm -f "${RP_INFRA_FILE}"
 fi
 
 # Delete all test namespaces.
@@ -70,15 +102,15 @@ namespace_whitelist=(
     "secrets-store-csi-driver"
 )
 namespaces=$(kubectl get namespaces --no-headers -o custom-columns=":metadata.name")
-for ns in $namespaces; do
-    if [ -z "$ns" ]; then
+for ns in ${namespaces}; do
+    if [[ -z "${ns}" ]]; then
         break
     fi
     # shellcheck disable=SC2076
     if [[ " ${namespace_whitelist[*]} " =~ " ${ns} " ]]; then
-        echo "skip deletion: $ns"
+        echo "skip deletion: ${ns}"
     else
-        echo "deleting namespaces: $ns"
-        kubectl delete namespace "$ns" --ignore-not-found=true --wait=false
+        echo "deleting namespaces: ${ns}"
+        kubectl delete namespace "${ns}" --ignore-not-found=true --wait=false
     fi
 done

--- a/.github/scripts/cleanup-long-running-cluster.sh
+++ b/.github/scripts/cleanup-long-running-cluster.sh
@@ -39,10 +39,14 @@ if kubectl get crd resources.ucp.dev >/dev/null 2>&1; then
     # preserved, regardless of whether the skip-delete-resources-list.txt exists.
     # These entries are identified by their ucp.dev/resource-type label.
     RP_INFRA_FILE="$(mktemp)"
-    kubectl get resources.ucp.dev -n radius-system --no-headers \
+    if ! kubectl get resources.ucp.dev -n radius-system --no-headers \
         -o custom-columns=":metadata.name" \
         -l "ucp.dev/resource-type in (system.resources_resourceproviders,system.resources_resourceproviders_resourcetypes,system.resources_resourceproviders_resourcetypes_apiversions,system.resources_resourceproviders_locations)" \
-        > "${RP_INFRA_FILE}" 2>/dev/null || true
+        > "${RP_INFRA_FILE}"; then
+        echo "failed to build resource provider preserve list; aborting resources.ucp.dev cleanup" >&2
+        rm -f "${RP_INFRA_FILE}"
+        exit 1
+    fi
     rp_count=$(wc -l < "${RP_INFRA_FILE}" | tr -d ' ')
     echo "found ${rp_count} resource provider infrastructure entries to preserve"
 
@@ -67,7 +71,7 @@ if kubectl get crd resources.ucp.dev >/dev/null 2>&1; then
         fi
 
         # Skip resources listed in skip resource file
-        if [[ -n "${SKIP_RESOURCE_FILE}" ]] && [[ -f "${SKIP_RESOURCE_FILE}" ]] && grep -qF "${r}" "${SKIP_RESOURCE_FILE}"; then
+        if [[ -n "${SKIP_RESOURCE_FILE}" ]] && [[ -f "${SKIP_RESOURCE_FILE}" ]] && grep -qFx "${r}" "${SKIP_RESOURCE_FILE}"; then
             echo "skip deletion: ${r} (found in skip-resource-list ${SKIP_RESOURCE_FILE})"
             continue
         fi

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -213,6 +213,7 @@ jobs:
           key: skip-delete-resources-list-${{ steps.gen-id.outputs.UNIQUE_ID || github.run_id }}
           restore-keys: |
             skip-delete-resources-list-
+
       - name: Clean up cluster
         if: always()
         timeout-minutes: 60
@@ -234,11 +235,11 @@ jobs:
           rad version
 
       - name: Publish UDT types
-        run: |  
-          export PATH=$GITHUB_WORKSPACE/bin:$PATH  
-          which rad || { echo "cannot find rad"; exit 1; }  
-          rad bicep publish-extension -f "./${RELEASE_DIR}/test/functional-portable/dynamicrp/noncloud/resources/testdata/testresourcetypes.yaml" --target "br:${TEST_BICEP_TYPES_REGISTRY}/testresources:latest" --force  
-        env:  
+        run: |
+          export PATH=$GITHUB_WORKSPACE/bin:$PATH
+          which rad || { echo "cannot find rad"; exit 1; }
+          rad bicep publish-extension -f "./${RELEASE_DIR}/test/functional-portable/dynamicrp/noncloud/resources/testdata/testresourcetypes.yaml" --target "br:${TEST_BICEP_TYPES_REGISTRY}/testresources:latest" --force
+        env:
           RELEASE_DIR: ${{ steps.checkout-release-codebase.outputs.release-dir }}
 
       - name: Point dynamicrp testresources extension to test ACR


### PR DESCRIPTION
# Description

Fixes the long-running test (LRT) cleanup script deleting resource provider infrastructure (resource types, API versions, locations) from `resources.ucp.dev`, which causes `resource type not found` errors in subsequent runs. This was triggered by GitHub Actions cache misses on `skip-delete-resources-list.txt` (see issue comments on #8843).

The cleanup script now uses Kubernetes label selectors (`ucp.dev/resource-type`) to unconditionally preserve resource provider infrastructure entries, regardless of whether the skip-file is available.

**Key changes:**
- Query `resources.ucp.dev` entries with resource provider labels before the deletion loop and skip them unconditionally
- Broaden scope-skip from `scope.local.*`/`scope.aws.*` to `scope.*` to protect all scope entries
- Harden shell with `set -euo pipefail` and use `grep -qFx` for exact matching
- Simplify the pre-test cleanup step in the workflow to always pass the skip file path (the script handles missing files gracefully)

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #8845

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [x] Not applicable <!-- TaskRadio docs-pr -->