### PR TITLE
Add nightly CI failure report workflow using Causinator 9000

### DIFF
--- a/.github/workflows/c9k-nightly.yml
+++ b/.github/workflows/c9k-nightly.yml
@@ -12,17 +12,19 @@ on:
         required: false
         default: "24"
 
-permissions:
-  issues: write
+permissions: {}
 
 jobs:
   ci-failure-report:
     # Only run on the main repository, not forks
     if: github.repository == 'radius-project/radius'
+    timeout-minutes: 30
+    permissions:
+      issues: write
     runs-on: ubuntu-24.04
     steps:
       - name: Generate CI failure report
-        uses: sylvainsf/causinator9000@v1
+        uses: sylvainsf/causinator9000@037827d60041f6b1235aa7b021a62979d6c3439c # v1
         with:
           hours: ${{ github.event.inputs.hours || '24' }}
           min-confidence: "50"

--- a/.github/workflows/c9k-nightly.yml
+++ b/.github/workflows/c9k-nightly.yml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://www.schemastore.org/github-workflow.json
+---
+name: c9k-nightly
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # Every day at 6am UTC
+  workflow_dispatch:
+    inputs:
+      hours:
+        description: "Lookback window in hours"
+        required: false
+        default: "24"
+
+permissions:
+  issues: write
+
+jobs:
+  ci-failure-report:
+    # Only run on the main repository, not forks
+    if: github.repository == 'radius-project/radius'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Generate CI failure report
+        uses: sylvainsf/causinator9000@v1
+        with:
+          hours: ${{ github.event.inputs.hours || '24' }}
+          min-confidence: "50"
+          create-issue: "true"
+          issue-label: "c9k-nightly"


### PR DESCRIPTION
# Description

Adds a nightly workflow that generates a Bayesian CI failure report using the Causinator 9000 GitHub Action (`sylvainsf/causinator9000@v1`).

The workflow:
- Runs daily at 6am UTC via cron schedule
- Supports manual triggering via `workflow_dispatch` with an optional `hours` input (default 24)
- Generates a CI failure report written to the GitHub Actions job summary
- Creates or updates a GitHub Issue labeled `c9k-nightly` with the report
- Only runs on the main repository (not forks)

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->