### PR TITLE
Add Bicep extensions for Radius.Compute and Radius.Security to bicepconfig.json

### DIFF
--- a/bicepconfig.json
+++ b/bicepconfig.json
@@ -1,9 +1,11 @@
 {
-	"experimentalFeaturesEnabled": {
-		"extensibility": true
-	},
-	"extensions": {
-		"radius": "br:biceptypes.azurecr.io/radius:latest",
-		"aws": "br:biceptypes.azurecr.io/aws:latest"
-	}
+  "experimentalFeaturesEnabled": {
+    "extensibility": true
+  },
+  "extensions": {
+    "radius": "br:biceptypes.azurecr.io/radius:latest",
+    "aws": "br:biceptypes.azurecr.io/aws:latest",
+    "radiusCompute": "br:biceptypes.azurecr.io/radiuscompute:latest",
+    "radiusSecurity": "br:biceptypes.azurecr.io/radiussecurity:latest"
+  }
 }

--- a/bicepconfig.json
+++ b/bicepconfig.json
@@ -5,6 +5,7 @@
   "extensions": {
     "radius": "br:biceptypes.azurecr.io/radius:latest",
     "radiusCompute": "br:biceptypes.azurecr.io/radiuscompute:latest",
+    "radiusData": "br:biceptypes.azurecr.io/radiusdata:latest",
     "radiusSecurity": "br:biceptypes.azurecr.io/radiussecurity:latest",
     "aws": "br:biceptypes.azurecr.io/aws:latest"
   }

--- a/bicepconfig.json
+++ b/bicepconfig.json
@@ -4,8 +4,8 @@
   },
   "extensions": {
     "radius": "br:biceptypes.azurecr.io/radius:latest",
-    "aws": "br:biceptypes.azurecr.io/aws:latest",
     "radiusCompute": "br:biceptypes.azurecr.io/radiuscompute:latest",
-    "radiusSecurity": "br:biceptypes.azurecr.io/radiussecurity:latest"
+    "radiusSecurity": "br:biceptypes.azurecr.io/radiussecurity:latest",
+    "aws": "br:biceptypes.azurecr.io/aws:latest"
   }
 }

--- a/build/install-bicep.sh
+++ b/build/install-bicep.sh
@@ -49,6 +49,7 @@ cat <<EOF > $OUTPUT_DIR/bicepconfig.json
   "extensions": {
     "radius": "br:biceptypes.azurecr.io/radius:${REL_CHANNEL}",
     "radiusCompute": "br:biceptypes.azurecr.io/radiuscompute:${REL_CHANNEL}",
+    "radiusData": "br:biceptypes.azurecr.io/radiusdata:${REL_CHANNEL}",
     "radiusSecurity": "br:biceptypes.azurecr.io/radiussecurity:${REL_CHANNEL}",
     "aws": "br:biceptypes.azurecr.io/aws:${REL_CHANNEL}"
   }

--- a/build/install-bicep.sh
+++ b/build/install-bicep.sh
@@ -48,6 +48,8 @@ cat <<EOF > $OUTPUT_DIR/bicepconfig.json
   },
   "extensions": {
     "radius": "br:biceptypes.azurecr.io/radius:${REL_CHANNEL}",
+    "radiusCompute": "br:biceptypes.azurecr.io/radiuscompute:${REL_CHANNEL}",
+    "radiusSecurity": "br:biceptypes.azurecr.io/radiussecurity:${REL_CHANNEL}",
     "aws": "br:biceptypes.azurecr.io/aws:${REL_CHANNEL}"
   }
 }

--- a/pkg/cli/setup/application.go
+++ b/pkg/cli/setup/application.go
@@ -57,6 +57,7 @@ resource demo 'Applications.Core/containers@2023-10-01-preview' = {
 	"extensions": {
 		"radius": "br:biceptypes.azurecr.io/radius:%s",
 		"radiusCompute": "br:biceptypes.azurecr.io/radiuscompute:%s",
+		"radiusData": "br:biceptypes.azurecr.io/radiusdata:%s",
 		"radiusSecurity": "br:biceptypes.azurecr.io/radiussecurity:%s",
 		"aws": "br:biceptypes.azurecr.io/aws:%s"
 	}
@@ -116,5 +117,5 @@ func getVersionedBicepConfig() string {
 		tag = "latest"
 	}
 
-	return fmt.Sprintf(bicepConfigTemplate, tag, tag, tag, tag)
+	return fmt.Sprintf(bicepConfigTemplate, tag, tag, tag, tag, tag)
 }

--- a/pkg/cli/setup/application.go
+++ b/pkg/cli/setup/application.go
@@ -56,6 +56,8 @@ resource demo 'Applications.Core/containers@2023-10-01-preview' = {
 	},
 	"extensions": {
 		"radius": "br:biceptypes.azurecr.io/radius:%s",
+		"radiusCompute": "br:biceptypes.azurecr.io/radiuscompute:%s",
+		"radiusSecurity": "br:biceptypes.azurecr.io/radiussecurity:%s",
 		"aws": "br:biceptypes.azurecr.io/aws:%s"
 	}
 }`
@@ -114,5 +116,5 @@ func getVersionedBicepConfig() string {
 		tag = "latest"
 	}
 
-	return fmt.Sprintf(bicepConfigTemplate, tag, tag)
+	return fmt.Sprintf(bicepConfigTemplate, tag, tag, tag, tag)
 }

--- a/pkg/cli/setup/application_test.go
+++ b/pkg/cli/setup/application_test.go
@@ -58,7 +58,7 @@ func Test_ScaffoldApplication_CreatesBothFiles(t *testing.T) {
 
 	b, err = os.ReadFile(filepath.Join(directory, "bicepconfig.json"))
 	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintf(bicepConfigTemplate, latest, latest), string(b))
+	require.Equal(t, fmt.Sprintf(bicepConfigTemplate, latest, latest, latest, latest, latest), string(b))
 }
 
 func Test_ScaffoldApplication_KeepsAppBicepButWritesRadYaml(t *testing.T) {


### PR DESCRIPTION
Published bicep extensions for `Radius.Compute` and `Radius.Security` to `biceptypes.azurecr.io`. This PR updates `bicepconfig.json` to reference the published extensions.

## What changed

- Published `Radius.Compute` types (containers, routes, persistentVolumes) to `br:biceptypes.azurecr.io/radiuscompute:latest`
- Published `Radius.Security` types (secrets) to `br:biceptypes.azurecr.io/radiussecurity:latest`
- Updated `bicepconfig.json` to include the new extensions

### Why two separate paths instead of one `radiusResources`?
`rad bicep publish-extension` only supports one namespace per manifest, there's no way to combine `Radius.Compute` and `Radius.Security` into a single extension with the current tooling. We could merge the generated JSON manually but that requires hand-rolling `$ref` index rewriting which is fragile and untestable.

The proper fix is adding `ConvertMultiple()` to the Go converter (`bicep-tools/pkg/converter`) so multiple manifests can share a single `TypeFactory`. Going with two separate paths works for now to unblock users. Will follow up on consolidating into a single `radiusResources` extension path.

## Type of change

<!--

Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.

If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 

-->

- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

<!--

Please update the following to link the associated issue. This is required for some kinds of changes (see above).

-->

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->