### PR TITLE
Add Kubernetes namespace support for preview environments

### DIFF
--- a/pkg/cli/cmd/env/create/preview/create.go
+++ b/pkg/cli/cmd/env/create/preview/create.go
@@ -58,6 +58,7 @@ Applications deployed to an environment will inherit the container runtime, conf
 	commonflags.AddEnvironmentNameFlag(cmd)
 	commonflags.AddWorkspaceFlag(cmd)
 	commonflags.AddResourceGroupFlag(cmd)
+	commonflags.AddKubernetesNamespaceFlag(cmd)
 
 	return cmd, runner
 }
@@ -69,6 +70,7 @@ type Runner struct {
 	Workspace               *workspaces.Workspace
 	EnvironmentName         string
 	ResourceGroupName       string
+	Namespace               string
 	RadiusCoreClientFactory *corerpv20250801.ClientFactory
 	ConfigFileInterface     framework.ConfigFileInterface
 	ConnectionFactory       connections.Factory
@@ -102,6 +104,13 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 	r.Workspace.Scope, err = cli.RequireScope(cmd, *r.Workspace)
 	if err != nil {
 		return err
+	}
+
+	r.Namespace, err = cmd.Flags().GetString(commonflags.KubernetesNamespaceFlag)
+	if err != nil {
+		return err
+	} else if r.Namespace == "" {
+		r.Namespace = r.EnvironmentName
 	}
 
 	client, err := r.ConnectionFactory.CreateApplicationsManagementClient(cmd.Context(), *r.Workspace)
@@ -144,8 +153,14 @@ func (r *Runner) Run(ctx context.Context) error {
 	r.Output.LogInfo("Creating Radius Core Environment...")
 
 	resource := &corerpv20250801.EnvironmentResource{
-		Location:   to.Ptr(v1.LocationGlobal),
-		Properties: &corerpv20250801.EnvironmentProperties{},
+		Location: to.Ptr(v1.LocationGlobal),
+		Properties: &corerpv20250801.EnvironmentProperties{
+			Providers: &corerpv20250801.Providers{
+				Kubernetes: &corerpv20250801.ProvidersKubernetes{
+					Namespace: to.Ptr(r.Namespace),
+				},
+			},
+		},
 	}
 
 	_, err := r.RadiusCoreClientFactory.NewEnvironmentsClient().CreateOrUpdate(ctx, r.EnvironmentName, *resource, &corerpv20250801.EnvironmentsClientCreateOrUpdateOptions{})

--- a/pkg/cli/cmd/env/create/preview/create_test.go
+++ b/pkg/cli/cmd/env/create/preview/create_test.go
@@ -55,6 +55,22 @@ func Test_Validate(t *testing.T) {
 				r := runner.(*Runner)
 				require.Equal(t, "testingenv", r.EnvironmentName)
 				require.Equal(t, "test-resource-group", r.ResourceGroupName)
+				require.Equal(t, "testingenv", r.Namespace)
+			},
+		},
+		{
+			Name:          "Create command with explicit namespace",
+			Input:         []string{"testingenv", "--kubernetes-namespace", "my-namespace"},
+			ExpectedValid: true,
+			ConfigHolder: framework.ConfigHolder{
+				Config: configWithWorkspace,
+			},
+			ConfigureMocks: func(mocks radcli.ValidateMocks) {
+				expectResourceGroupSuccess(mocks.ApplicationManagementClient, "test-resource-group")
+			},
+			ValidateCallback: func(t *testing.T, runner framework.Runner) {
+				r := runner.(*Runner)
+				require.Equal(t, "my-namespace", r.Namespace)
 			},
 		},
 		{
@@ -163,6 +179,7 @@ func Test_Run(t *testing.T) {
 			Workspace:               workspace,
 			EnvironmentName:         "testenv",
 			ResourceGroupName:       "test-resource-group",
+			Namespace:               "testenv",
 		}
 
 		expectedOutput := []any{


### PR DESCRIPTION
Fixes #11672

When creating preview environments, we weren't passing a Kubernetes namespace to the API, which caused deployments to fail. Added a `--kubernetes-namespace` flag that defaults to the environment name if not specified.

The runner now reads the namespace flag, defaults it if needed, and passes it to the environment properties. Tests cover both default and explicit namespace behavior.

## Change type
Bug fix

## Checklist
- [ ] Schema changes - N/A
- [ ] Design docs - N/A
- [ ] Samples/docs/recipes repo PRs - N/A