### PR TITLE
Add retry support to DeployExecutor for transient errors in ACI Test

### DIFF
--- a/test/functional-portable/corerp/cloud/resources/aci_test.go
+++ b/test/functional-portable/corerp/cloud/resources/aci_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
@@ -34,8 +35,6 @@ import (
 )
 
 func Test_ACI(t *testing.T) {
-	// Temporarily skipping due to transient Azure ManagedServiceIdentityNotFound issue.
-	t.Skip("https://github.com/radius-project/radius/issues/11708")
 	name := "aci-app"
 	containerResourceName := "frontend"
 	containerResourceName2 := "magpie"
@@ -44,7 +43,7 @@ func Test_ACI(t *testing.T) {
 
 	test := rp.NewRPTest(t, name, []rp.TestStep{
 		{
-			Executor:             step.NewDeployExecutor(template),
+			Executor:             step.NewDeployExecutor(template).WithRetry(1, 30*time.Second, isTransientAzureError),
 			SkipObjectValidation: true,
 			RPResources: &validation.RPResourceSet{
 				Resources: []validation.RPResource{
@@ -162,4 +161,25 @@ func verifyACIResourceLocations(ctx context.Context, t *testing.T, appName strin
 // e.g., "East US" -> "eastus", "West Europe" -> "westeurope"
 func normalizeLocation(location string) string {
 	return strings.ToLower(strings.ReplaceAll(location, " ", ""))
+}
+
+// isTransientAzureError returns true if the error is a known transient Azure error
+// that may succeed on retry.
+func isTransientAzureError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := err.Error()
+	transientErrors := []string{
+		"ManagedServiceIdentityNotFound",
+	}
+
+	for _, te := range transientErrors {
+		if strings.Contains(msg, te) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/test/step/deployexecutor.go
+++ b/test/step/deployexecutor.go
@@ -123,9 +123,11 @@ func (d *DeployExecutor) executeWithRetry(ctx context.Context, t *testing.T, dep
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		if attempt > 1 {
 			t.Logf("waiting %s before retry attempt %d/%d", d.RetryDelay, attempt, maxAttempts)
+			timer := time.NewTimer(d.RetryDelay)
 			select {
-			case <-time.After(d.RetryDelay):
+			case <-timer.C:
 			case <-ctx.Done():
+				timer.Stop()
 				lastErr = ctx.Err()
 			}
 			if ctx.Err() != nil {

--- a/test/step/deployexecutor.go
+++ b/test/step/deployexecutor.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -43,6 +44,17 @@ type DeployExecutor struct {
 	// Environment sets the `--environment` command-line parameter. This is needed in cases where
 	// the environment is not defined in bicep.
 	Environment string
+
+	// MaxRetries is the maximum number of retry attempts after the initial deployment fails.
+	// Zero means no retries (default behavior).
+	MaxRetries int
+
+	// RetryDelay is the duration to wait between retry attempts.
+	RetryDelay time.Duration
+
+	// ShouldRetry is a predicate that determines whether a failed deployment should be retried.
+	// If nil, no retries are attempted regardless of MaxRetries.
+	ShouldRetry func(error) bool
 }
 
 // NewDeployExecutor creates a new DeployExecutor instance with the given template and parameters.
@@ -66,6 +78,17 @@ func (d *DeployExecutor) WithEnvironment(environment string) *DeployExecutor {
 	return d
 }
 
+// WithRetry configures retry behavior for transient deployment failures.
+// maxRetries is the number of additional attempts after the first failure.
+// delay is the wait time between attempts. shouldRetry determines whether
+// a given error is eligible for retry.
+func (d *DeployExecutor) WithRetry(maxRetries int, delay time.Duration, shouldRetry func(error) bool) *DeployExecutor {
+	d.MaxRetries = maxRetries
+	d.RetryDelay = delay
+	d.ShouldRetry = shouldRetry
+	return d
+}
+
 // GetDescription returns the Description field of the DeployExecutor instance.
 func (d *DeployExecutor) GetDescription() string {
 	return d.Description
@@ -79,7 +102,48 @@ func (d *DeployExecutor) Execute(ctx context.Context, t *testing.T, options test
 	templateFilePath := filepath.Join(cwd, d.Template)
 	t.Logf("deploying %s from file %s", d.Description, d.Template)
 	cli := radcli.NewCLI(t, options.ConfigFilePath)
-	err = cli.Deploy(ctx, templateFilePath, d.Environment, d.Application, d.Parameters...)
+
+	deployFunc := func() error {
+		return cli.Deploy(ctx, templateFilePath, d.Environment, d.Application, d.Parameters...)
+	}
+
+	err = d.executeWithRetry(ctx, t, deployFunc)
 	require.NoErrorf(t, err, "failed to deploy %s", d.Description)
 	t.Logf("finished deploying %s from file %s", d.Description, d.Template)
+}
+
+// executeWithRetry runs the deploy function with optional retry logic.
+func (d *DeployExecutor) executeWithRetry(ctx context.Context, t *testing.T, deployFunc func() error) error {
+	maxAttempts := 1
+	if d.MaxRetries > 0 && d.ShouldRetry != nil {
+		maxAttempts = d.MaxRetries + 1
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if attempt > 1 {
+			t.Logf("waiting %s before retry attempt %d/%d", d.RetryDelay, attempt, maxAttempts)
+			select {
+			case <-time.After(d.RetryDelay):
+			case <-ctx.Done():
+				lastErr = ctx.Err()
+			}
+			if ctx.Err() != nil {
+				break
+			}
+		}
+
+		lastErr = deployFunc()
+		if lastErr == nil {
+			break
+		}
+
+		if attempt == maxAttempts || !d.ShouldRetry(lastErr) {
+			break
+		}
+
+		t.Logf("deployment attempt %d/%d failed with retryable error: %v", attempt, maxAttempts, lastErr)
+	}
+
+	return lastErr
 }

--- a/test/step/deployexecutor_test.go
+++ b/test/step/deployexecutor_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func Test_ExecuteWithRetry_SucceedsOnFirstAttempt(t *testing.T) {
+	t.Parallel()
 	var calls atomic.Int32
 	d := NewDeployExecutor("test.bicep").WithRetry(2, 10*time.Millisecond, func(error) bool { return true })
 
@@ -41,6 +42,7 @@ func Test_ExecuteWithRetry_SucceedsOnFirstAttempt(t *testing.T) {
 }
 
 func Test_ExecuteWithRetry_RetriesOnTransientThenSucceeds(t *testing.T) {
+	t.Parallel()
 	var calls atomic.Int32
 	transientErr := errors.New("ManagedServiceIdentityNotFound")
 	d := NewDeployExecutor("test.bicep").WithRetry(2, 10*time.Millisecond, func(err error) bool {
@@ -60,6 +62,7 @@ func Test_ExecuteWithRetry_RetriesOnTransientThenSucceeds(t *testing.T) {
 }
 
 func Test_ExecuteWithRetry_DoesNotRetryNonTransientError(t *testing.T) {
+	t.Parallel()
 	var calls atomic.Int32
 	d := NewDeployExecutor("test.bicep").WithRetry(2, 10*time.Millisecond, func(err error) bool {
 		return err.Error() == "transient"
@@ -76,6 +79,7 @@ func Test_ExecuteWithRetry_DoesNotRetryNonTransientError(t *testing.T) {
 }
 
 func Test_ExecuteWithRetry_ExhaustsAllRetries(t *testing.T) {
+	t.Parallel()
 	var calls atomic.Int32
 	d := NewDeployExecutor("test.bicep").WithRetry(2, 10*time.Millisecond, func(error) bool { return true })
 
@@ -90,6 +94,7 @@ func Test_ExecuteWithRetry_ExhaustsAllRetries(t *testing.T) {
 }
 
 func Test_ExecuteWithRetry_NoRetriesWithoutConfig(t *testing.T) {
+	t.Parallel()
 	var calls atomic.Int32
 	d := NewDeployExecutor("test.bicep") // no WithRetry
 
@@ -103,6 +108,7 @@ func Test_ExecuteWithRetry_NoRetriesWithoutConfig(t *testing.T) {
 }
 
 func Test_ExecuteWithRetry_ContextCancelledDuringDelay(t *testing.T) {
+	t.Parallel()
 	var calls atomic.Int32
 	ctx, cancel := context.WithCancel(context.Background())
 	d := NewDeployExecutor("test.bicep").WithRetry(2, 5*time.Second, func(error) bool { return true })
@@ -123,6 +129,7 @@ func Test_ExecuteWithRetry_ContextCancelledDuringDelay(t *testing.T) {
 }
 
 func Test_ExecuteWithRetry_NilShouldRetryDisablesRetries(t *testing.T) {
+	t.Parallel()
 	var calls atomic.Int32
 	d := NewDeployExecutor("test.bicep")
 	d.MaxRetries = 3

--- a/test/step/deployexecutor_test.go
+++ b/test/step/deployexecutor_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package step
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ExecuteWithRetry_SucceedsOnFirstAttempt(t *testing.T) {
+	var calls atomic.Int32
+	d := NewDeployExecutor("test.bicep").WithRetry(2, 10*time.Millisecond, func(error) bool { return true })
+
+	err := d.executeWithRetry(context.Background(), t, func() error {
+		calls.Add(1)
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func Test_ExecuteWithRetry_RetriesOnTransientThenSucceeds(t *testing.T) {
+	var calls atomic.Int32
+	transientErr := errors.New("ManagedServiceIdentityNotFound")
+	d := NewDeployExecutor("test.bicep").WithRetry(2, 10*time.Millisecond, func(err error) bool {
+		return err.Error() == "ManagedServiceIdentityNotFound"
+	})
+
+	err := d.executeWithRetry(context.Background(), t, func() error {
+		n := calls.Add(1)
+		if n == 1 {
+			return transientErr
+		}
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), calls.Load())
+}
+
+func Test_ExecuteWithRetry_DoesNotRetryNonTransientError(t *testing.T) {
+	var calls atomic.Int32
+	d := NewDeployExecutor("test.bicep").WithRetry(2, 10*time.Millisecond, func(err error) bool {
+		return err.Error() == "transient"
+	})
+
+	err := d.executeWithRetry(context.Background(), t, func() error {
+		calls.Add(1)
+		return errors.New("permanent failure")
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, "permanent failure", err.Error())
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func Test_ExecuteWithRetry_ExhaustsAllRetries(t *testing.T) {
+	var calls atomic.Int32
+	d := NewDeployExecutor("test.bicep").WithRetry(2, 10*time.Millisecond, func(error) bool { return true })
+
+	err := d.executeWithRetry(context.Background(), t, func() error {
+		calls.Add(1)
+		return errors.New("always fails")
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, "always fails", err.Error())
+	assert.Equal(t, int32(3), calls.Load()) // 1 initial + 2 retries
+}
+
+func Test_ExecuteWithRetry_NoRetriesWithoutConfig(t *testing.T) {
+	var calls atomic.Int32
+	d := NewDeployExecutor("test.bicep") // no WithRetry
+
+	err := d.executeWithRetry(context.Background(), t, func() error {
+		calls.Add(1)
+		return errors.New("fails")
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func Test_ExecuteWithRetry_ContextCancelledDuringDelay(t *testing.T) {
+	var calls atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	d := NewDeployExecutor("test.bicep").WithRetry(2, 5*time.Second, func(error) bool { return true })
+
+	// Cancel context immediately after first deploy attempt
+	err := d.executeWithRetry(ctx, t, func() error {
+		n := calls.Add(1)
+		if n == 1 {
+			cancel()
+			return errors.New("transient")
+		}
+		return nil
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, int32(1), calls.Load()) // should not have retried
+}
+
+func Test_ExecuteWithRetry_NilShouldRetryDisablesRetries(t *testing.T) {
+	var calls atomic.Int32
+	d := NewDeployExecutor("test.bicep")
+	d.MaxRetries = 3
+	d.ShouldRetry = nil // nil predicate
+
+	err := d.executeWithRetry(context.Background(), t, func() error {
+		calls.Add(1)
+		return errors.New("fails")
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, int32(1), calls.Load())
+}


### PR DESCRIPTION
Add opt-in retry logic to DeployExecutor which allows tests to specify which errors are retryable. This addresses transient Azure ManagedServiceIdentityNotFound failures in Test_ACI.

- WithRetry(maxRetries, delay, shouldRetry) method
- Context-aware delay between retries
- Only retries when the predicate returns true for the error
- Re-enable Test_ACI with retry on ManagedServiceIdentityNotFound
- Add unit tests for retry configuration and predicate logic

Fixes: https://github.com/radius-project/radius/issues/11708

# Description
This pull request introduces a retry mechanism for deployment steps in the test framework, making tests more resilient to transient Azure errors (such as `ManagedServiceIdentityNotFound`). The main changes include adding configurable retry logic to the `DeployExecutor`, updating the ACI test to use this retry logic, and providing comprehensive unit tests to cover the new behavior.

## Type of change
- This pull request fixes a bug in Radius and has an approved issue (#11708).

Fixes: #11708 

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->