### PR TITLE
Add c9k-failure-report workflow (dry-run)

### DIFF
--- a/.github/workflows/c9k-failure-report.yml
+++ b/.github/workflows/c9k-failure-report.yml
@@ -1,0 +1,63 @@
+# yaml-language-server: $schema=https://www.schemastore.org/github-workflow.json
+---
+name: c9k-failure-report
+
+on:
+  schedule:
+    - cron: "0 */6 * * *" # Every 6 hours
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  ci-failure-report:
+    # Only run on the main repository, not forks
+    if: github.repository == 'radius-project/radius'
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Generate CI failure report
+        uses: sylvainsf/causinator9000@5be8cf7dfbb78394eb7f6f2c97e2a9a5ab95deef # v1.9.0
+        with:
+          repo: ${{ github.repository }}
+          hours: "48"
+          auto-issue: "true"
+          auto-issue-dry-run: "true"
+          auto-issue-min-confidence: "90"
+          auto-issue-min-members: "2"
+          auto-issue-classes: "CodeChange,BrokenTestRun,DepMajorBump"
+          auto-close-flaky: "true"
+          assign-copilot: "false"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+name: C9K CI Failure Report
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sylvainsf/causinator9000@v1.9.0
+        with:
+          repo: ${{ github.repository }}
+          hours: '48'
+          auto-issue: 'true'
+          auto-issue-dry-run: 'true'
+          auto-issue-min-confidence: '90'
+          auto-issue-min-members: '2'
+          auto-issue-classes: 'CodeChange,BrokenTestRun,DepMajorBump'
+          auto-close-flaky: 'true'
+          assign-copilot: 'false'
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds a new GitHub Actions workflow at `.github/workflows/c9k-failure-report.yml` that runs [sylvainsf/causinator9000](https://github.com/sylvainsf/causinator9000) (C9K) to triage CI failures and propose issues for recurring problems.

## Why

Complements the existing `c9k-nightly` workflow with a higher-cadence (every 6 hours) report focused on the new auto-issue feature. We want C9K to start filing/closing issues for high-confidence failure clusters, but first we need to validate the volume and quality of what it would file.

## How

- Schedule: every 6 hours, plus `workflow_dispatch`
- Pinned to `sylvainsf/causinator9000@5be8cf7dfbb78394eb7f6f2c97e2a9a5ab95deef` (`v1.9.0`) per repo SHA-pinning policy
- Job-scoped permissions: `contents: read`, `issues: write`, `actions: read`
- Fork guard: `if: github.repository == 'radius-project/radius'`
- Inputs:
  - `hours: 48`
  - `auto-issue: true` with `auto-issue-dry-run: true` (no issues actually filed yet)
  - `auto-issue-min-confidence: 90`, `auto-issue-min-members: 2`
  - `auto-issue-classes: CodeChange,BrokenTestRun,DepMajorBump`
  - `auto-close-flaky: true`
  - `assign-copilot: false`

## Rollout plan

1. Merge this PR.
2. Manually dispatch the workflow from the Actions tab.
3. Inspect the planned-actions table in the job summary to assess issue volume.
4. Once volume looks right, open a follow-up PR to flip `auto-issue-dry-run` to `false` and `assign-copilot` to `true`.

## Reference

- Action docs: https://github.com/sylvainsf/causinator9000/blob/main/docs/action.md