### PR TITLE
Fix duplicated YAML keys in c9k-failure-report.yml

### DIFF
--- a/.github/workflows/c9k-failure-report.yml
+++ b/.github/workflows/c9k-failure-report.yml
@@ -33,31 +33,3 @@ jobs:
           auto-close-flaky: "true"
           assign-copilot: "false"
           github-token: ${{ secrets.GITHUB_TOKEN }}
-name: C9K CI Failure Report
-
-on:
-  schedule:
-    - cron: '0 */6 * * *'
-  workflow_dispatch:
-
-permissions:
-  contents: read
-  issues: write
-  actions: read
-
-jobs:
-  report:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: sylvainsf/causinator9000@v1.9.0
-        with:
-          repo: ${{ github.repository }}
-          hours: '48'
-          auto-issue: 'true'
-          auto-issue-dry-run: 'true'
-          auto-issue-min-confidence: '90'
-          auto-issue-min-members: '2'
-          auto-issue-classes: 'CodeChange,BrokenTestRun,DepMajorBump'
-          auto-close-flaky: 'true'
-          assign-copilot: 'false'
-          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Fixes `.github/workflows/c9k-failure-report.yml`, which currently fails to parse:

```
Invalid workflow file: .github/workflows/c9k-failure-report.yml#L1
(Line: 36, Col: 1): 'name' is already defined
(Line: 38, Col: 1): 'on' is already defined
(Line: 43, Col: 1): 'permissions' is already defined
(Line: 48, Col: 1): 'jobs' is already defined
```

## Why

The merged file accidentally contained two stacked workflow definitions concatenated together, producing duplicate top-level keys (`name`, `on`, `permissions`, `jobs`) and a non-SHA-pinned `uses:` line in the second copy.

## How

Replaced the file with a single, valid workflow definition:

- One `name`, `on`, `permissions: {}`, and `jobs:` block
- SHA-pinned to `sylvainsf/causinator9000@5be8cf7dfbb78394eb7f6f2c97e2a9a5ab95deef # v1.9.0`
- Same inputs as originally intended (dry-run, 48h window, etc.)

No behavioral changes from the originally intended workflow, just removes the duplicated, invalid second copy.