### PR TITLE
Bump causinator9000 to v2.0.0

### DIFF
--- a/.github/workflows/c9k-failure-report.yml
+++ b/.github/workflows/c9k-failure-report.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Generate CI failure report
-        uses: sylvainsf/causinator9000@5be8cf7dfbb78394eb7f6f2c97e2a9a5ab95deef # v1.9.0
+        uses: sylvainsf/causinator9000@e3f8b80056e36cd55cf85c7c44c5e4bdaa876c04 # v2.0.0
         with:
           repo: ${{ github.repository }}
           hours: "48"

--- a/.github/workflows/c9k-nightly.yml
+++ b/.github/workflows/c9k-nightly.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Generate CI failure report
-        uses: sylvainsf/causinator9000@207ebfa74e52adc25d8319f85f72ca4447d7e15b # v1
+        uses: sylvainsf/causinator9000@e3f8b80056e36cd55cf85c7c44c5e4bdaa876c04 # v2.0.0
         with:
           hours: ${{ github.event.inputs.hours || '24' }}
           min-confidence: "50"


### PR DESCRIPTION
## What

Bumps `sylvainsf/causinator9000` to `v2.0.0` in both c9k workflows.

## Changes

- [.github/workflows/c9k-failure-report.yml](.github/workflows/c9k-failure-report.yml): `5be8cf7` (v1.9.0) -> `e3f8b80` (v2.0.0)
- [.github/workflows/c9k-nightly.yml](.github/workflows/c9k-nightly.yml): `207ebfa` (v1, was floating) -> `e3f8b80` (v2.0.0)

The nightly workflow was previously pinned to a v1 SHA without an exact minor version. Re-pin to the explicit v2.0.0 SHA for parity with the failure-report workflow.

## Compatibility

Verified against [`action.yml` at v2.0.0](https://github.com/sylvainsf/causinator9000/blob/v2.0.0/action.yml): all inputs used by both workflows (`hours`, `min-confidence`, `create-issue`, `issue-label`, `repo`, `auto-issue*`, `auto-close-flaky`, `assign-copilot`, `github-token`) still exist with the same names and semantics.

## Reference

- Release: https://github.com/sylvainsf/causinator9000/releases/tag/v2.0.0