### PR TITLE
Add DepGroupUpdate to c9k auto-issue-classes

### DIFF
--- a/.github/workflows/c9k-failure-report.yml
+++ b/.github/workflows/c9k-failure-report.yml
@@ -29,7 +29,7 @@ jobs:
           auto-issue-dry-run: "true"
           auto-issue-min-confidence: "90"
           auto-issue-min-members: "2"
-          auto-issue-classes: "CodeChange,BrokenTestRun,DepMajorBump"
+          auto-issue-classes: "CodeChange,BrokenTestRun,DepMajorBump,DepGroupUpdate"
           auto-close-flaky: "true"
           assign-copilot: "false"
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds `DepGroupUpdate` to `auto-issue-classes` in [.github/workflows/c9k-failure-report.yml](.github/workflows/c9k-failure-report.yml) so c9k will also auto-file issues for grouped dependency updates (e.g. dependabot grouped PRs), in addition to single major-version bumps.

## Why

Grouped dependency updates are a common source of CI breakage in this repo, and v2.0.0 of c9k classifies them as their own root-cause class (`DepGroupUpdate`). Filing them gives us a per-cause issue instead of burying them in the rolling digest.

## Compatibility

`FlakyTestRun` is intentionally still excluded from this list, flaky groups are handled via `auto-close-flaky: true` and never get assigned to Copilot.

Per the v2.0.0 [`action.yml`](https://github.com/sylvainsf/causinator9000/blob/v2.0.0/action.yml), the default value is `CodeChange,BrokenTestRun,DepMajorBump,DepGroupUpdate`, so this brings the workflow in line with that default while keeping it explicit.