### PR TITLE
Fix for deleting a recipe pack leaves the environment in a corrupt state

### DIFF
--- a/pkg/cli/cmd/env/update/preview/update.go
+++ b/pkg/cli/cmd/env/update/preview/update.go
@@ -18,6 +18,7 @@ package preview
 
 import (
 	"context"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -77,6 +78,9 @@ rad env update myenv --kubernetes-namespace mynamespace
 
 ## Remove Kubernetes cloud provider (preview)
 rad env update myenv --clear-kubernetes
+
+## Set recipe packs to environment (--preview)
+rad env update myenv --recipe-packs pack1,pack2
 `,
 		RunE: framework.RunCommand(runner),
 	}
@@ -206,12 +210,37 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	r.recipePacks, err = cmd.Flags().GetStringSlice("recipe-packs")
+	recipePacks, err := cmd.Flags().GetStringSlice("recipe-packs")
 	if err != nil {
 		return err
 	}
 
+	r.recipePacks = normalizeRecipePacks(recipePacks)
+
 	return nil
+}
+
+// normalizeRecipePacks splits comma-separated values, trims whitespace, and
+// removes empty entries and duplicates while preserving the first-seen order.
+// Deduplication avoids redundant referencedBy sync work and prevents server-side
+// recipe pack conflict validation from failing on repeated entries.
+func normalizeRecipePacks(recipepacks []string) []string {
+	seen := map[string]struct{}{}
+	result := []string{}
+	for _, value := range recipepacks {
+		for _, p := range strings.Split(value, ",") {
+			trimmed := strings.TrimSpace(p)
+			if trimmed == "" {
+				continue
+			}
+			if _, ok := seen[trimmed]; ok {
+				continue
+			}
+			seen[trimmed] = struct{}{}
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }
 
 // Run runs the `rad env update` preview command.
@@ -274,43 +303,53 @@ func (r *Runner) Run(ctx context.Context) error {
 		env.Properties.Providers.Kubernetes = r.providers.Kubernetes
 	}
 
-	// replace recipe packs if any are specified
+	newRecipePacks := []*string{}
+
+	// Update recipe packs if specified: replace the environment's recipe pack list,
+	// keeping referencedBy on each recipe pack in sync.
 	if len(r.recipePacks) > 0 {
 		if len(env.Properties.RecipePacks) > 0 {
 			r.Output.LogInfo("WARNING: The existing recipe pack list will be replaced with the specified packs.")
 		}
 
-		// Create a new list to replace the existing recipe packs
-		newRecipePacks := []*string{}
+		envID := *env.ID
 
+		// Resolve all new recipe packs to full IDs.
 		for _, recipePack := range r.recipePacks {
-			ID, err := resources.Parse(recipePack)
-			rClientFactory := r.RadiusCoreClientFactory
+			var rClientFactory *corerpv20250801.ClientFactory
+			recipePackID, err := resources.Parse(recipePack)
+			// If the provided recipe pack value is an ID, parse its scope.
 			if err == nil {
-				rClientFactory, err = cmd.InitializeRadiusCoreClientFactory(ctx, r.Workspace, ID.RootScope())
+				rClientFactory, err = cmd.InitializeRadiusCoreClientFactory(ctx, r.Workspace, recipePackID.RootScope())
 				if err != nil {
 					return err
 				}
-
 			} else {
+				rClientFactory = r.RadiusCoreClientFactory
 				scopeID, err := resources.ParseScope(r.Workspace.Scope)
 				if err != nil {
 					return err
 				}
 
-				ID = scopeID.Append(resources.TypeSegment{
+				recipePackID = scopeID.Append(resources.TypeSegment{
 					Type: "Radius.Core/recipePacks",
 					Name: recipePack,
 				})
 			}
 
 			cfclient := rClientFactory.NewRecipePacksClient()
-			_, err = cfclient.Get(ctx, ID.Name(), &corerpv20250801.RecipePacksClientGetOptions{})
+
+			_, err = cfclient.Get(ctx, recipePackID.Name(), &corerpv20250801.RecipePacksClientGetOptions{})
 			if err != nil {
 				return clierrors.Message("Recipe pack %q does not exist. Please provide a valid recipe pack to set on the environment.", recipePack)
 			}
 
-			newRecipePacks = append(newRecipePacks, to.Ptr(ID.String()))
+			newRecipePacks = append(newRecipePacks, to.Ptr(recipePackID.String()))
+		}
+
+		err := syncRecipePackReferences(ctx, envID, env.Properties.RecipePacks, newRecipePacks, r.Workspace, r.RadiusCoreClientFactory)
+		if err != nil {
+			return err
 		}
 
 		// Replace the entire recipe packs list
@@ -353,4 +392,198 @@ func (r *Runner) Run(ctx context.Context) error {
 	r.Output.LogInfo("Successfully updated environment %q.", r.EnvironmentName)
 
 	return nil
+}
+
+// syncRecipePackReferences updates the referencedBy field on recipe packs to reflect
+// a new environment-to-pack assignment. When an environment is updated with a new list of recipe packs,
+//
+//	this function removes the environment from the referencedBy list of recipe packs being removed,
+//
+// and adds the environment to the referencedBy list of newly added recipe packs.
+func syncRecipePackReferences(ctx context.Context, envID string, oldPackIDs []*string, newPackIDs []*string, workspace *workspaces.Workspace, defaultFactory *corerpv20250801.ClientFactory) error {
+	oldPackIDSet := makePackIDSet(oldPackIDs)
+	newPackIDSet := makePackIDSet(newPackIDs)
+	packIDsToAdd := packIDsOnlyInFirst(newPackIDs, oldPackIDSet)
+	packIDsToRemove := packIDsOnlyInFirst(oldPackIDs, newPackIDSet)
+	clientsByScope := map[string]*corerpv20250801.RecipePacksClient{}
+
+	// Remove this environment from referencedBy for packs being dropped.
+	for _, oldPackIDStr := range packIDsToRemove {
+		err := removeEnvReferenceFromRecipePack(ctx, envID, oldPackIDStr, workspace, defaultFactory, clientsByScope)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Add this environment to referencedBy for newly added packs.
+	for _, newPackIDStr := range packIDsToAdd {
+		err := addEnvReferenceToRecipePack(ctx, envID, newPackIDStr, workspace, defaultFactory, clientsByScope)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func makePackIDSet(packIDs []*string) map[string]struct{} {
+	result := map[string]struct{}{}
+	for _, packID := range packIDs {
+		if packID == nil {
+			continue
+		}
+
+		result[*packID] = struct{}{}
+	}
+
+	return result
+}
+
+func packIDsOnlyInFirst(first []*string, secondSet map[string]struct{}) []string {
+	result := []string{}
+	for _, packID := range first {
+		if packID == nil {
+			continue
+		}
+
+		if _, exists := secondSet[*packID]; exists {
+			continue
+		}
+
+		result = append(result, *packID)
+	}
+
+	return result
+}
+
+func getRecipePacksClientForScope(
+	ctx context.Context,
+	rootScope string,
+	workspace *workspaces.Workspace,
+	defaultFactory *corerpv20250801.ClientFactory,
+	clientsByScope map[string]*corerpv20250801.RecipePacksClient,
+) (*corerpv20250801.RecipePacksClient, error) {
+	if client, ok := clientsByScope[rootScope]; ok {
+		return client, nil
+	}
+
+	factory := defaultFactory
+	if rootScope != workspace.Scope {
+		var err error
+		factory, err = cmd.InitializeRadiusCoreClientFactory(ctx, workspace, rootScope)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	client := factory.NewRecipePacksClient()
+	clientsByScope[rootScope] = client
+
+	return client, nil
+}
+
+func removeEnvReferenceFromRecipePack(
+	ctx context.Context,
+	envID string,
+	packID string,
+	workspace *workspaces.Workspace,
+	defaultFactory *corerpv20250801.ClientFactory,
+	clientsByScope map[string]*corerpv20250801.RecipePacksClient,
+) error {
+	resourceID, err := resources.Parse(packID)
+	if err != nil {
+		return err
+	}
+
+	packClient, err := getRecipePacksClientForScope(ctx, resourceID.RootScope(), workspace, defaultFactory, clientsByScope)
+	if err != nil {
+		return err
+	}
+
+	packResp, err := packClient.Get(ctx, resourceID.Name(), &corerpv20250801.RecipePacksClientGetOptions{})
+	if clients.Is404Error(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	pack := packResp.RecipePackResource
+	pack.SystemData = nil
+	if pack.Properties == nil {
+		pack.Properties = &corerpv20250801.RecipePackProperties{}
+	}
+
+	pack.Properties.ReferencedBy = removeReference(pack.Properties.ReferencedBy, envID)
+
+	_, err = packClient.CreateOrUpdate(ctx, resourceID.Name(), pack, &corerpv20250801.RecipePacksClientCreateOrUpdateOptions{})
+	if err != nil {
+		return clierrors.MessageWithCause(err, "Failed to update recipe pack %q.", resourceID.Name())
+	}
+
+	return nil
+}
+
+func addEnvReferenceToRecipePack(
+	ctx context.Context,
+	envID string,
+	packID string,
+	workspace *workspaces.Workspace,
+	defaultFactory *corerpv20250801.ClientFactory,
+	clientsByScope map[string]*corerpv20250801.RecipePacksClient,
+) error {
+	resourceID, err := resources.Parse(packID)
+	if err != nil {
+		return err
+	}
+
+	packClient, err := getRecipePacksClientForScope(ctx, resourceID.RootScope(), workspace, defaultFactory, clientsByScope)
+	if err != nil {
+		return err
+	}
+
+	packResp, err := packClient.Get(ctx, resourceID.Name(), &corerpv20250801.RecipePacksClientGetOptions{})
+	if clients.Is404Error(err) {
+		return clierrors.Message("Recipe pack %q does not exist. Please provide a valid recipe pack to add to the environment.", resourceID.String())
+	}
+	if err != nil {
+		return err
+	}
+
+	pack := packResp.RecipePackResource
+	pack.SystemData = nil
+	if pack.Properties == nil {
+		pack.Properties = &corerpv20250801.RecipePackProperties{}
+	}
+
+	if !refExists(pack.Properties.ReferencedBy, envID) {
+		pack.Properties.ReferencedBy = append(pack.Properties.ReferencedBy, &envID)
+	}
+
+	_, err = packClient.CreateOrUpdate(ctx, resourceID.Name(), pack, &corerpv20250801.RecipePacksClientCreateOrUpdateOptions{})
+	if err != nil {
+		return clierrors.MessageWithCause(err, "Failed to update recipe pack %q.", resourceID.Name())
+	}
+
+	return nil
+}
+
+func removeReference(environmentRefs []*string, id string) []*string {
+	result := []*string{}
+	for _, ref := range environmentRefs {
+		if ref != nil && *ref != id {
+			result = append(result, ref)
+		}
+	}
+
+	return result
+}
+
+func refExists(environmentRefs []*string, id string) bool {
+	for _, r := range environmentRefs {
+		if r != nil && *r == id {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/cli/cmd/env/update/preview/update_test.go
+++ b/pkg/cli/cmd/env/update/preview/update_test.go
@@ -22,14 +22,17 @@ import (
 	"testing"
 
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
+	"github.com/radius-project/radius/pkg/cli/cmd/commonflags"
 	"github.com/radius-project/radius/pkg/cli/framework"
 	"github.com/radius-project/radius/pkg/cli/output"
 	"github.com/radius-project/radius/pkg/cli/test_client_factory"
 	"github.com/radius-project/radius/pkg/cli/workspaces"
 	"github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
 	"github.com/radius-project/radius/pkg/corerp/api/v20250801preview/fake"
+	corerpfake "github.com/radius-project/radius/pkg/corerp/api/v20250801preview/fake"
 	"github.com/radius-project/radius/pkg/to"
 	"github.com/radius-project/radius/test/radcli"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -93,22 +96,211 @@ func Test_Validate(t *testing.T) {
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
 }
 
-func Test_Run(t *testing.T) {
+func Test_ValidateRecipePackParsing(t *testing.T) {
+	configWithWorkspace := radcli.LoadConfigWithWorkspace(t)
 	workspace := &workspaces.Workspace{
 		Name:  "test-workspace",
 		Scope: "/planes/radius/local/resourceGroups/test-group",
 	}
 
 	testcases := []struct {
+		name          string
+		input         []string
+		expectedPacks []string
+	}{
+		{
+			name:          "single recipe pack",
+			input:         []string{"test-env", "--recipe-packs", "pack1"},
+			expectedPacks: []string{"pack1"},
+		},
+		{
+			name:          "comma-separated recipe packs",
+			input:         []string{"test-env", "--recipe-packs", "pack1,pack2"},
+			expectedPacks: []string{"pack1", "pack2"},
+		},
+		{
+			name:          "comma-separated with spaces",
+			input:         []string{"test-env", "--recipe-packs", "pack1, pack2 , pack3"},
+			expectedPacks: []string{"pack1", "pack2", "pack3"},
+		},
+		{
+			name:          "mixed simple names and full resource IDs",
+			input:         []string{"test-env", "--recipe-packs", "demorecipepack,/planes/radius/local/resourcegroups/kind-radius/providers/Radius.Core/recipePacks/kuberecipepack2"},
+			expectedPacks: []string{"demorecipepack", "/planes/radius/local/resourcegroups/kind-radius/providers/Radius.Core/recipePacks/kuberecipepack2"},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create command
+			cmd := &cobra.Command{}
+			// Validate uses cli.RequireWorkspace / RequireScope / RequireOutput,
+			// which expect these flags to be defined on the command.
+			commonflags.AddWorkspaceFlag(cmd)
+			commonflags.AddResourceGroupFlag(cmd)
+			commonflags.AddOutputFlag(cmd)
+			commonflags.AddEnvironmentNameFlag(cmd)
+			cmd.Flags().Bool(commonflags.ClearEnvAzureFlag, false, "")
+			cmd.Flags().Bool(commonflags.ClearEnvAWSFlag, false, "")
+			cmd.Flags().Bool(commonflags.ClearEnvKubernetesFlag, false, "")
+			cmd.Flags().StringSliceP("recipe-packs", "", []string{}, "Specify recipe packs to be added to the environment (--preview)")
+
+			// Parse flags
+			err := cmd.Flags().Parse(tc.input)
+			require.NoError(t, err)
+
+			// Create and validate runner
+			runner := &Runner{
+				ConfigHolder: &framework.ConfigHolder{
+					ConfigFilePath: "",
+					Config:         configWithWorkspace,
+				},
+				Output:    &output.MockOutput{},
+				Workspace: workspace,
+			}
+
+			err = runner.Validate(cmd, []string{"test-env"})
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectedPacks, runner.recipePacks, "recipe packs mismatch for test: %s", tc.name)
+		})
+	}
+}
+
+func Test_normalizeRecipePacks(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: []string{},
+		},
+		{
+			name:     "empty input",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "single value",
+			input:    []string{"pack1"},
+			expected: []string{"pack1"},
+		},
+		{
+			name:     "comma-separated values",
+			input:    []string{"pack1,pack2,pack3"},
+			expected: []string{"pack1", "pack2", "pack3"},
+		},
+		{
+			name:     "trims whitespace",
+			input:    []string{" pack1 , pack2 ,  pack3"},
+			expected: []string{"pack1", "pack2", "pack3"},
+		},
+		{
+			name:     "drops empty entries",
+			input:    []string{"pack1,,pack2", "", " , "},
+			expected: []string{"pack1", "pack2"},
+		},
+		{
+			name:     "deduplicates repeated flags",
+			input:    []string{"pack1", "pack1"},
+			expected: []string{"pack1"},
+		},
+		{
+			name:     "deduplicates within comma list",
+			input:    []string{"pack1,pack1,pack2"},
+			expected: []string{"pack1", "pack2"},
+		},
+		{
+			name:     "deduplicates across mixed sources preserving order",
+			input:    []string{"pack2", "pack1,pack2", " pack1 ", "pack3"},
+			expected: []string{"pack2", "pack1", "pack3"},
+		},
+		{
+			name:     "treats whitespace-only difference as duplicate",
+			input:    []string{"pack1", " pack1 "},
+			expected: []string{"pack1"},
+		},
+		{
+			name:     "preserves full resource ID and dedupes",
+			input:    []string{"/planes/radius/local/resourcegroups/g/providers/Radius.Core/recipePacks/p1,/planes/radius/local/resourcegroups/g/providers/Radius.Core/recipePacks/p1"},
+			expected: []string{"/planes/radius/local/resourcegroups/g/providers/Radius.Core/recipePacks/p1"},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, normalizeRecipePacks(tc.input))
+		})
+	}
+}
+
+func Test_Run(t *testing.T) {
+	workspace := &workspaces.Workspace{
+		Name:  "test-workspace",
+		Scope: "/planes/radius/local/resourceGroups/test-group",
+	}
+
+	// envServerWithID returns an environment that includes the full resource ID,
+	// which is required for the referencedBy sync in env update.
+	envServerWithID := func() corerpfake.EnvironmentsServer {
+		return corerpfake.EnvironmentsServer{
+			CreateOrUpdate: test_client_factory.WithEnvironmentServerNoError().CreateOrUpdate,
+			Get: func(
+				ctx context.Context,
+				environmentName string,
+				options *v20250801preview.EnvironmentsClientGetOptions,
+			) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
+				result := v20250801preview.EnvironmentsClientGetResponse{
+					EnvironmentResource: v20250801preview.EnvironmentResource{
+						ID:   to.Ptr(workspace.Scope + "/providers/Radius.Core/environments/" + environmentName),
+						Name: to.Ptr(environmentName),
+						Properties: &v20250801preview.EnvironmentProperties{
+							Providers: &v20250801preview.Providers{
+								Azure: &v20250801preview.ProvidersAzure{
+									SubscriptionID:    to.Ptr("test-subscription-id"),
+									ResourceGroupName: to.Ptr("test-resource-group"),
+								},
+								Aws: &v20250801preview.ProvidersAws{
+									AccountID: to.Ptr("test-account-id"),
+									Region:    to.Ptr("test-region"),
+								},
+								Kubernetes: &v20250801preview.ProvidersKubernetes{
+									Namespace: to.Ptr("test-namespace"),
+								},
+							},
+							RecipePacks: []*string{
+								to.Ptr(workspace.Scope + "/providers/Radius.Core/recipePacks/old-pack"),
+							},
+						},
+					},
+				}
+				resp.SetResponse(http.StatusOK, result, nil)
+				return
+			},
+		}
+	}
+
+	// recipePackServerWithCreateOrUpdate handles both Get (validation) and
+	// CreateOrUpdate (referencedBy sync) calls made during env update.
+	recipePackServerWithCreateOrUpdate := func() corerpfake.RecipePacksServer {
+		return corerpfake.RecipePacksServer{
+			Get:            test_client_factory.WithRecipePackServerNoError().Get,
+			CreateOrUpdate: recipePackCreateOrUpdateNoError(),
+		}
+	}
+
+	testcases := []struct {
 		name           string
 		envName        string
-		serverFactory  func() fake.EnvironmentsServer
 		expectedOutput []any
 	}{
 		{
-			name:          "update environment with azure provider and recipe packs",
-			envName:       "test-env",
-			serverFactory: test_client_factory.WithEnvironmentServerNoError,
+			name:    "update environment with azure provider and recipe packs",
+			envName: "test-env",
 			expectedOutput: []any{
 				output.LogOutput{
 					Format: "WARNING: The existing recipe pack list will be replaced with the specified packs.",
@@ -120,7 +312,7 @@ func Test_Run(t *testing.T) {
 					Format: "table",
 					Obj: environmentForDisplay{
 						Name:        "test-env",
-						RecipePacks: 2,
+						RecipePacks: 2, // rp1 and rp2 replace the old pack
 						Providers:   3,
 					},
 					Options: environmentFormat(),
@@ -137,8 +329,8 @@ func Test_Run(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			factory, err := test_client_factory.NewRadiusCoreTestClientFactory(
 				workspace.Scope,
-				tc.serverFactory,
-				nil,
+				envServerWithID,
+				recipePackServerWithCreateOrUpdate,
 			)
 			require.NoError(t, err)
 
@@ -152,15 +344,15 @@ func Test_Run(t *testing.T) {
 				recipePacks:             []string{"rp1", "rp2"},
 				providers: &v20250801preview.Providers{
 					Azure: &v20250801preview.ProvidersAzure{
-						SubscriptionID:    new("00000000-0000-0000-0000-000000000000"),
-						ResourceGroupName: new("testResourceGroup"),
+						SubscriptionID:    to.Ptr("00000000-0000-0000-0000-000000000000"),
+						ResourceGroupName: to.Ptr("testResourceGroup"),
 					},
 					Aws: &v20250801preview.ProvidersAws{
-						Region:    new("us-west-2"),
-						AccountID: new("testAWSAccount"),
+						Region:    to.Ptr("us-west-2"),
+						AccountID: to.Ptr("testAWSAccount"),
 					},
 					Kubernetes: &v20250801preview.ProvidersKubernetes{
-						Namespace: new("test-namespace"),
+						Namespace: to.Ptr("test-namespace"),
 					},
 				},
 			}
@@ -192,6 +384,7 @@ func Test_Run_RecipePacksReplaced(t *testing.T) {
 			) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
 				result := v20250801preview.EnvironmentsClientGetResponse{
 					EnvironmentResource: v20250801preview.EnvironmentResource{
+						ID:   to.Ptr(workspace.Scope + "/providers/Radius.Core/environments/" + environmentName),
 						Name: to.Ptr(environmentName),
 						Properties: &v20250801preview.EnvironmentProperties{
 							RecipePacks: []*string{to.Ptr(existingPackID)},
@@ -252,4 +445,173 @@ func Test_Run_RecipePacksReplaced(t *testing.T) {
 		}
 	}
 	require.True(t, foundWarning, "expected replacement warning in output")
+}
+
+func Test_syncRecipePackReferences(t *testing.T) {
+	scope := "/planes/radius/local/resourceGroups/test-group"
+	workspace := &workspaces.Workspace{
+		Name:  "test-workspace",
+		Scope: scope,
+	}
+	envID := scope + "/providers/Radius.Core/environments/test-env"
+
+	pack1FullID := scope + "/providers/Radius.Core/recipePacks/pack1"
+	pack2FullID := scope + "/providers/Radius.Core/recipePacks/pack2"
+	pack3FullID := scope + "/providers/Radius.Core/recipePacks/pack3"
+
+	t.Run("newly added packs get env added to referencedBy", func(t *testing.T) {
+		var capturedReferencedBy []*string
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(scope, nil, func() corerpfake.RecipePacksServer {
+			return corerpfake.RecipePacksServer{
+				Get: test_client_factory.WithRecipePackServerNoError().Get,
+				CreateOrUpdate: func(
+					ctx context.Context, name string,
+					resource v20250801preview.RecipePackResource,
+					_ *v20250801preview.RecipePacksClientCreateOrUpdateOptions,
+				) (resp azfake.Responder[v20250801preview.RecipePacksClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+					capturedReferencedBy = resource.Properties.ReferencedBy
+					resp.SetResponse(http.StatusOK, v20250801preview.RecipePacksClientCreateOrUpdateResponse{RecipePackResource: resource}, nil)
+					return
+				},
+			}
+		})
+		require.NoError(t, err)
+
+		newPackIDs := []*string{to.Ptr(pack1FullID)}
+
+		err = syncRecipePackReferences(context.Background(), envID, nil, newPackIDs, workspace, factory)
+		require.NoError(t, err)
+		require.Len(t, capturedReferencedBy, 1)
+		require.Equal(t, envID, *capturedReferencedBy[0])
+	})
+
+	t.Run("dropped packs get env removed from referencedBy", func(t *testing.T) {
+		var capturedReferencedBy []*string
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(scope, nil, func() corerpfake.RecipePacksServer {
+			return corerpfake.RecipePacksServer{
+				Get: func(
+					ctx context.Context, name string,
+					_ *v20250801preview.RecipePacksClientGetOptions,
+				) (resp azfake.Responder[v20250801preview.RecipePacksClientGetResponse], errResp azfake.ErrorResponder) {
+					// Pack has both this env and another env in referencedBy.
+					result := v20250801preview.RecipePacksClientGetResponse{
+						RecipePackResource: v20250801preview.RecipePackResource{
+							Name: to.Ptr(name),
+							Properties: &v20250801preview.RecipePackProperties{
+								Recipes:      map[string]*v20250801preview.RecipeDefinition{},
+								ReferencedBy: []*string{to.Ptr("some-other-env"), to.Ptr(envID)},
+							},
+						},
+					}
+					resp.SetResponse(http.StatusOK, result, nil)
+					return
+				},
+				CreateOrUpdate: func(
+					ctx context.Context, name string,
+					resource v20250801preview.RecipePackResource,
+					_ *v20250801preview.RecipePacksClientCreateOrUpdateOptions,
+				) (resp azfake.Responder[v20250801preview.RecipePacksClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+					capturedReferencedBy = resource.Properties.ReferencedBy
+					resp.SetResponse(http.StatusOK, v20250801preview.RecipePacksClientCreateOrUpdateResponse{RecipePackResource: resource}, nil)
+					return
+				},
+			}
+		})
+		require.NoError(t, err)
+
+		oldPackIDs := []*string{to.Ptr(pack1FullID)}
+
+		err = syncRecipePackReferences(context.Background(), envID, oldPackIDs, nil, workspace, factory)
+		require.NoError(t, err)
+		// This env is removed; the other env remains.
+		require.Len(t, capturedReferencedBy, 1)
+		require.Equal(t, "some-other-env", *capturedReferencedBy[0])
+	})
+
+	t.Run("unchanged packs are not updated", func(t *testing.T) {
+		createOrUpdateCalled := map[string]bool{}
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(scope, nil, func() corerpfake.RecipePacksServer {
+			return corerpfake.RecipePacksServer{
+				Get: func(
+					ctx context.Context, name string,
+					_ *v20250801preview.RecipePacksClientGetOptions,
+				) (resp azfake.Responder[v20250801preview.RecipePacksClientGetResponse], errResp azfake.ErrorResponder) {
+					result := v20250801preview.RecipePacksClientGetResponse{
+						RecipePackResource: v20250801preview.RecipePackResource{
+							Name: to.Ptr(name),
+							Properties: &v20250801preview.RecipePackProperties{
+								Recipes:      map[string]*v20250801preview.RecipeDefinition{},
+								ReferencedBy: []*string{to.Ptr(envID)},
+							},
+						},
+					}
+					resp.SetResponse(http.StatusOK, result, nil)
+					return
+				},
+				CreateOrUpdate: func(
+					ctx context.Context, name string,
+					resource v20250801preview.RecipePackResource,
+					_ *v20250801preview.RecipePacksClientCreateOrUpdateOptions,
+				) (resp azfake.Responder[v20250801preview.RecipePacksClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+					createOrUpdateCalled[name] = true
+					resp.SetResponse(http.StatusOK, v20250801preview.RecipePacksClientCreateOrUpdateResponse{RecipePackResource: resource}, nil)
+					return
+				},
+			}
+		})
+		require.NoError(t, err)
+
+		// old: [pack1, pack2], new: [pack1, pack3]
+		// pack1 unchanged — no update; pack2 dropped — updated; pack3 added — updated.
+		oldPackIDs := []*string{to.Ptr(pack1FullID), to.Ptr(pack2FullID)}
+		newPackIDs := []*string{to.Ptr(pack1FullID), to.Ptr(pack3FullID)}
+
+		err = syncRecipePackReferences(context.Background(), envID, oldPackIDs, newPackIDs, workspace, factory)
+		require.NoError(t, err)
+
+		require.False(t, createOrUpdateCalled["pack1"], "unchanged pack should not be updated")
+		require.True(t, createOrUpdateCalled["pack2"], "dropped pack should be updated")
+		require.True(t, createOrUpdateCalled["pack3"], "newly added pack should be updated")
+	})
+
+	t.Run("dropped pack already deleted is skipped without error", func(t *testing.T) {
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(scope, nil, func() corerpfake.RecipePacksServer {
+			return corerpfake.RecipePacksServer{
+				Get: func(
+					ctx context.Context, name string,
+					_ *v20250801preview.RecipePacksClientGetOptions,
+				) (resp azfake.Responder[v20250801preview.RecipePacksClientGetResponse], errResp azfake.ErrorResponder) {
+					errResp.SetResponseError(404, "Not Found")
+					return
+				},
+			}
+		})
+		require.NoError(t, err)
+
+		oldPackIDs := []*string{to.Ptr(pack1FullID)}
+
+		err = syncRecipePackReferences(context.Background(), envID, oldPackIDs, nil, workspace, factory)
+		require.NoError(t, err)
+	})
+}
+
+// recipePackCreateOrUpdateNoError returns a CreateOrUpdate handler that echoes the resource back.
+func recipePackCreateOrUpdateNoError() func(
+	ctx context.Context,
+	recipePackName string,
+	resource v20250801preview.RecipePackResource,
+	options *v20250801preview.RecipePacksClientCreateOrUpdateOptions,
+) (azfake.Responder[v20250801preview.RecipePacksClientCreateOrUpdateResponse], azfake.ErrorResponder) {
+	return func(
+		ctx context.Context,
+		recipePackName string,
+		resource v20250801preview.RecipePackResource,
+		options *v20250801preview.RecipePacksClientCreateOrUpdateOptions,
+	) (resp azfake.Responder[v20250801preview.RecipePacksClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+		resp.SetResponse(http.StatusOK, v20250801preview.RecipePacksClientCreateOrUpdateResponse{RecipePackResource: resource}, nil)
+		return
+	}
 }

--- a/pkg/cli/cmd/recipepack/delete/delete.go
+++ b/pkg/cli/cmd/recipepack/delete/delete.go
@@ -19,6 +19,7 @@ package delete
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -154,36 +155,57 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	envs := recipePack.Properties.ReferencedBy
 
+	if recipePack.ID == nil {
+		return fmt.Errorf("recipe pack %q is missing a resource ID", r.RecipePackName)
+	}
+	deletedPackID := *recipePack.ID
+
+	// Cache ClientFactory per root scope so we initialize at most once per scope
+	// even when the referenced environments span multiple root scopes.
+	factoriesByScope := map[string]*corerpv20250801.ClientFactory{}
+	if r.RadiusCoreClientFactory != nil {
+		factoriesByScope[r.Workspace.Scope] = r.RadiusCoreClientFactory
+	}
+
 	for _, env := range envs {
 		ID, err := resources.Parse(*env)
 		if err != nil {
 			return err
 		}
 
-		cd, err := utils.InitializeRadiusCoreClientFactory(ctx, r.Workspace, ID.RootScope())
-		if err != nil {
-			return err
+		envClientFactory, ok := factoriesByScope[ID.RootScope()]
+		if !ok {
+			envClientFactory, err = utils.InitializeRadiusCoreClientFactory(ctx, r.Workspace, ID.RootScope())
+			if err != nil {
+				return err
+			}
+			factoriesByScope[ID.RootScope()] = envClientFactory
 		}
 
-		envClient := cd.NewEnvironmentsClient()
+		envClient := envClientFactory.NewEnvironmentsClient()
 
-		resp, err := envClient.Get(ctx, *env, &corerpv20250801.EnvironmentsClientGetOptions{})
+		resp, err := envClient.Get(ctx, ID.Name(), &corerpv20250801.EnvironmentsClientGetOptions{})
 		if clients.Is404Error(err) {
 			continue
 		} else if err != nil {
-			return err
+			return clierrors.MessageWithCause(err, "An error occurred while retrieving environment %q referencing this recipe pack.", ID.String())
 		}
 
 		res := resp.EnvironmentResource
 		res.SystemData = nil
-		for i, rp := range res.Properties.RecipePacks {
-			if *rp == *recipePack.ID {
-				res.Properties.RecipePacks = append(res.Properties.RecipePacks[:i], res.Properties.RecipePacks[i+1:]...)
-				break
+
+		// Build a new list of recipe packs, excluding the one being deleted.
+		// Match by full resource ID (case-insensitive) so we never remove a
+		// same-named pack that lives in a different scope/resource group.
+		newRecipePacks := []*string{}
+		for _, rp := range res.Properties.RecipePacks {
+			if rp == nil || !strings.EqualFold(*rp, deletedPackID) {
+				newRecipePacks = append(newRecipePacks, rp)
 			}
 		}
+		res.Properties.RecipePacks = newRecipePacks
 
-		_, err = envClient.CreateOrUpdate(ctx, *env, res, &corerpv20250801.EnvironmentsClientCreateOrUpdateOptions{})
+		_, err = envClient.CreateOrUpdate(ctx, ID.Name(), res, &corerpv20250801.EnvironmentsClientCreateOrUpdateOptions{})
 		if err != nil {
 			return clierrors.MessageWithCause(err, "Failed to update environment %s.", *env)
 		}
@@ -195,7 +217,7 @@ func (r *Runner) Run(ctx context.Context) error {
 			r.Output.LogInfo(msgRecipePackNotFound, r.RecipePackName)
 			return nil
 		}
-		return fmt.Errorf("failed to delete resource group %s: %w", r.RecipePackName, err)
+		return fmt.Errorf("failed to delete recipe pack %q: %w", r.RecipePackName, err)
 	}
 
 	if deleted {

--- a/pkg/cli/cmd/recipepack/delete/delete_test.go
+++ b/pkg/cli/cmd/recipepack/delete/delete_test.go
@@ -17,9 +17,26 @@ limitations under the License.
 package delete
 
 import (
+	"context"
+	"fmt"
+	"net/http"
 	"testing"
 
+	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/radius-project/radius/pkg/cli/clients"
+	"github.com/radius-project/radius/pkg/cli/connections"
 	"github.com/radius-project/radius/pkg/cli/framework"
+	"github.com/radius-project/radius/pkg/cli/output"
+	"github.com/radius-project/radius/pkg/cli/prompt"
+	"github.com/radius-project/radius/pkg/cli/test_client_factory"
+	"github.com/radius-project/radius/pkg/cli/workspaces"
+	v20250801preview "github.com/radius-project/radius/pkg/corerp/api/v20250801preview"
+	corerpfake "github.com/radius-project/radius/pkg/corerp/api/v20250801preview/fake"
+	"github.com/radius-project/radius/pkg/to"
 	"github.com/radius-project/radius/test/radcli"
 )
 
@@ -61,4 +78,541 @@ func Test_Validate(t *testing.T) {
 	}
 
 	radcli.SharedValidateValidation(t, NewCommand, testcases)
+}
+
+func Test_Run(t *testing.T) {
+	scope := "/planes/radius/local/resourceGroups/test-group"
+	packName := "test-pack"
+	packFullID := scope + "/providers/Radius.Core/recipePacks/" + packName
+	envName := "test-env"
+	envFullID := scope + "/providers/Radius.Core/environments/" + envName
+
+	workspace := &workspaces.Workspace{
+		Connection: map[string]any{
+			"kind":    "kubernetes",
+			"context": "kind-kind",
+		},
+		Name:  "kind-kind",
+		Scope: scope,
+	}
+
+	t.Run("delete removes pack from referenced env then deletes pack", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		var capturedEnv v20250801preview.EnvironmentResource
+
+		appMgmtClient := clients.NewMockApplicationsManagementClient(ctrl)
+		appMgmtClient.EXPECT().
+			GetRecipePack(gomock.Any(), packName).
+			Return(v20250801preview.RecipePackResource{
+				ID:   to.Ptr(packFullID),
+				Name: to.Ptr(packName),
+				Properties: &v20250801preview.RecipePackProperties{
+					Recipes:      map[string]*v20250801preview.RecipeDefinition{},
+					ReferencedBy: []*string{to.Ptr(envFullID)},
+				},
+			}, nil)
+		appMgmtClient.EXPECT().
+			DeleteRecipePack(gomock.Any(), packName).
+			Return(true, nil)
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(scope, func() corerpfake.EnvironmentsServer {
+			return corerpfake.EnvironmentsServer{
+				Get: func(
+					ctx context.Context, environmentName string,
+					_ *v20250801preview.EnvironmentsClientGetOptions,
+				) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
+					resp.SetResponse(http.StatusOK, v20250801preview.EnvironmentsClientGetResponse{
+						EnvironmentResource: v20250801preview.EnvironmentResource{
+							Name: to.Ptr(environmentName),
+							Properties: &v20250801preview.EnvironmentProperties{
+								RecipePacks: []*string{to.Ptr(packFullID)},
+							},
+						},
+					}, nil)
+					return
+				},
+				CreateOrUpdate: func(
+					ctx context.Context, environmentName string,
+					resource v20250801preview.EnvironmentResource,
+					_ *v20250801preview.EnvironmentsClientCreateOrUpdateOptions,
+				) (resp azfake.Responder[v20250801preview.EnvironmentsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+					capturedEnv = resource
+					resp.SetResponse(http.StatusOK, v20250801preview.EnvironmentsClientCreateOrUpdateResponse{EnvironmentResource: resource}, nil)
+					return
+				},
+			}
+		}, nil)
+		require.NoError(t, err)
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			ConnectionFactory:       &connections.MockFactory{ApplicationsManagementClient: appMgmtClient},
+			RadiusCoreClientFactory: factory,
+			Workspace:               workspace,
+			Output:                  outputSink,
+			RecipePackName:          packName,
+			Confirm:                 true,
+		}
+
+		err = runner.Run(context.Background())
+		require.NoError(t, err)
+
+		// Pack must be removed from the environment's RecipePacks list.
+		require.Empty(t, capturedEnv.Properties.RecipePacks)
+
+		require.Equal(t, []any{
+			output.LogOutput{Format: msgDeletingRecipePack, Params: []any{packName}},
+			output.LogOutput{Format: msgRecipePackDeleted, Params: []any{packName}},
+		}, outputSink.Writes)
+	})
+
+	t.Run("delete with no referenced envs deletes pack directly", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		appMgmtClient := clients.NewMockApplicationsManagementClient(ctrl)
+		appMgmtClient.EXPECT().
+			GetRecipePack(gomock.Any(), packName).
+			Return(v20250801preview.RecipePackResource{
+				ID:   to.Ptr(packFullID),
+				Name: to.Ptr(packName),
+				Properties: &v20250801preview.RecipePackProperties{
+					Recipes:      map[string]*v20250801preview.RecipeDefinition{},
+					ReferencedBy: nil,
+				},
+			}, nil)
+		appMgmtClient.EXPECT().
+			DeleteRecipePack(gomock.Any(), packName).
+			Return(true, nil)
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appMgmtClient},
+			Workspace:         workspace,
+			Output:            outputSink,
+			RecipePackName:    packName,
+			Confirm:           true,
+		}
+
+		err := runner.Run(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, []any{
+			output.LogOutput{Format: msgDeletingRecipePack, Params: []any{packName}},
+			output.LogOutput{Format: msgRecipePackDeleted, Params: []any{packName}},
+		}, outputSink.Writes)
+	})
+
+	t.Run("delete skips referenced env that is already deleted", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		appMgmtClient := clients.NewMockApplicationsManagementClient(ctrl)
+		appMgmtClient.EXPECT().
+			GetRecipePack(gomock.Any(), packName).
+			Return(v20250801preview.RecipePackResource{
+				ID:   to.Ptr(packFullID),
+				Name: to.Ptr(packName),
+				Properties: &v20250801preview.RecipePackProperties{
+					Recipes:      map[string]*v20250801preview.RecipeDefinition{},
+					ReferencedBy: []*string{to.Ptr(envFullID)},
+				},
+			}, nil)
+		appMgmtClient.EXPECT().
+			DeleteRecipePack(gomock.Any(), packName).
+			Return(true, nil)
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(scope, func() corerpfake.EnvironmentsServer {
+			return corerpfake.EnvironmentsServer{
+				Get: func(
+					ctx context.Context, environmentName string,
+					_ *v20250801preview.EnvironmentsClientGetOptions,
+				) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
+					errResp.SetResponseError(404, "Not Found")
+					return
+				},
+			}
+		}, nil)
+		require.NoError(t, err)
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			ConnectionFactory:       &connections.MockFactory{ApplicationsManagementClient: appMgmtClient},
+			RadiusCoreClientFactory: factory,
+			Workspace:               workspace,
+			Output:                  outputSink,
+			RecipePackName:          packName,
+			Confirm:                 true,
+		}
+
+		err = runner.Run(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, []any{
+			output.LogOutput{Format: msgDeletingRecipePack, Params: []any{packName}},
+			output.LogOutput{Format: msgRecipePackDeleted, Params: []any{packName}},
+		}, outputSink.Writes)
+	})
+
+	t.Run("user declines confirmation — pack not deleted", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		appMgmtClient := clients.NewMockApplicationsManagementClient(ctrl)
+		promptMock := prompt.NewMockInterface(ctrl)
+
+		promptMock.EXPECT().
+			GetListInput(gomock.Any(), gomock.Any()).
+			Return(prompt.ConfirmNo, nil)
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appMgmtClient},
+			InputPrompter:     promptMock,
+			Workspace:         workspace,
+			Output:            outputSink,
+			RecipePackName:    packName,
+			Confirm:           false,
+		}
+
+		err := runner.Run(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, []any{
+			output.LogOutput{Format: msgRecipePackNotDeleted, Params: []any{packName}},
+		}, outputSink.Writes)
+	})
+
+	t.Run("get recipe pack returns 404 — returns error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		appMgmtClient := clients.NewMockApplicationsManagementClient(ctrl)
+		appMgmtClient.EXPECT().
+			GetRecipePack(gomock.Any(), packName).
+			Return(v20250801preview.RecipePackResource{}, &azcore.ResponseError{StatusCode: http.StatusNotFound})
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appMgmtClient},
+			Workspace:         workspace,
+			Output:            outputSink,
+			RecipePackName:    packName,
+			Confirm:           true,
+		}
+
+		err := runner.Run(context.Background())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), packName)
+	})
+
+	t.Run("get recipe pack returns error — propagates error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		appMgmtClient := clients.NewMockApplicationsManagementClient(ctrl)
+		appMgmtClient.EXPECT().
+			GetRecipePack(gomock.Any(), packName).
+			Return(v20250801preview.RecipePackResource{}, fmt.Errorf("test error"))
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appMgmtClient},
+			Workspace:         workspace,
+			Output:            outputSink,
+			RecipePackName:    packName,
+			Confirm:           true,
+		}
+
+		err := runner.Run(context.Background())
+		require.EqualError(t, err, "test error")
+	})
+
+	t.Run("env get returns non-404 error — returns error with context", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		appMgmtClient := clients.NewMockApplicationsManagementClient(ctrl)
+		appMgmtClient.EXPECT().
+			GetRecipePack(gomock.Any(), packName).
+			Return(v20250801preview.RecipePackResource{
+				ID:   to.Ptr(packFullID),
+				Name: to.Ptr(packName),
+				Properties: &v20250801preview.RecipePackProperties{
+					Recipes:      map[string]*v20250801preview.RecipeDefinition{},
+					ReferencedBy: []*string{to.Ptr(envFullID)},
+				},
+			}, nil)
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(scope, func() corerpfake.EnvironmentsServer {
+			return corerpfake.EnvironmentsServer{
+				Get: func(
+					ctx context.Context, environmentName string,
+					_ *v20250801preview.EnvironmentsClientGetOptions,
+				) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
+					errResp.SetError(fmt.Errorf("internal server error"))
+					return
+				},
+			}
+		}, nil)
+		require.NoError(t, err)
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			ConnectionFactory:       &connections.MockFactory{ApplicationsManagementClient: appMgmtClient},
+			RadiusCoreClientFactory: factory,
+			Workspace:               workspace,
+			Output:                  outputSink,
+			RecipePackName:          packName,
+			Confirm:                 true,
+		}
+
+		err = runner.Run(context.Background())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "An error occurred while retrieving environment")
+	})
+
+	t.Run("env update returns error — returns error with context", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		appMgmtClient := clients.NewMockApplicationsManagementClient(ctrl)
+		appMgmtClient.EXPECT().
+			GetRecipePack(gomock.Any(), packName).
+			Return(v20250801preview.RecipePackResource{
+				ID:   to.Ptr(packFullID),
+				Name: to.Ptr(packName),
+				Properties: &v20250801preview.RecipePackProperties{
+					Recipes:      map[string]*v20250801preview.RecipeDefinition{},
+					ReferencedBy: []*string{to.Ptr(envFullID)},
+				},
+			}, nil)
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(scope, func() corerpfake.EnvironmentsServer {
+			return corerpfake.EnvironmentsServer{
+				Get: func(
+					ctx context.Context, environmentName string,
+					_ *v20250801preview.EnvironmentsClientGetOptions,
+				) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
+					resp.SetResponse(http.StatusOK, v20250801preview.EnvironmentsClientGetResponse{
+						EnvironmentResource: v20250801preview.EnvironmentResource{
+							Name: to.Ptr(environmentName),
+							Properties: &v20250801preview.EnvironmentProperties{
+								RecipePacks: []*string{to.Ptr(packFullID)},
+							},
+						},
+					}, nil)
+					return
+				},
+				CreateOrUpdate: func(
+					ctx context.Context, environmentName string,
+					resource v20250801preview.EnvironmentResource,
+					_ *v20250801preview.EnvironmentsClientCreateOrUpdateOptions,
+				) (resp azfake.Responder[v20250801preview.EnvironmentsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+					errResp.SetError(fmt.Errorf("update failed"))
+					return
+				},
+			}
+		}, nil)
+		require.NoError(t, err)
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			ConnectionFactory:       &connections.MockFactory{ApplicationsManagementClient: appMgmtClient},
+			RadiusCoreClientFactory: factory,
+			Workspace:               workspace,
+			Output:                  outputSink,
+			RecipePackName:          packName,
+			Confirm:                 true,
+		}
+
+		err = runner.Run(context.Background())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Failed to update environment")
+	})
+
+	t.Run("delete pack already deleted", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		appMgmtClient := clients.NewMockApplicationsManagementClient(ctrl)
+		appMgmtClient.EXPECT().
+			GetRecipePack(gomock.Any(), packName).
+			Return(v20250801preview.RecipePackResource{
+				ID:   to.Ptr(packFullID),
+				Name: to.Ptr(packName),
+				Properties: &v20250801preview.RecipePackProperties{
+					Recipes:      map[string]*v20250801preview.RecipeDefinition{},
+					ReferencedBy: nil,
+				},
+			}, nil)
+		appMgmtClient.EXPECT().
+			DeleteRecipePack(gomock.Any(), packName).
+			Return(false, nil)
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			ConnectionFactory: &connections.MockFactory{ApplicationsManagementClient: appMgmtClient},
+			Workspace:         workspace,
+			Output:            outputSink,
+			RecipePackName:    packName,
+			Confirm:           true,
+		}
+
+		err := runner.Run(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, []any{
+			output.LogOutput{Format: msgDeletingRecipePack, Params: []any{packName}},
+			output.LogOutput{Format: msgRecipePackNotFound, Params: []any{packName}},
+		}, outputSink.Writes)
+	})
+
+	t.Run("multiple referenced envs in workspace scope reuse injected factory", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		envName2 := "test-env-2"
+		envFullID2 := scope + "/providers/Radius.Core/environments/" + envName2
+
+		appMgmtClient := clients.NewMockApplicationsManagementClient(ctrl)
+		appMgmtClient.EXPECT().
+			GetRecipePack(gomock.Any(), packName).
+			Return(v20250801preview.RecipePackResource{
+				ID:   to.Ptr(packFullID),
+				Name: to.Ptr(packName),
+				Properties: &v20250801preview.RecipePackProperties{
+					Recipes:      map[string]*v20250801preview.RecipeDefinition{},
+					ReferencedBy: []*string{to.Ptr(envFullID), to.Ptr(envFullID2)},
+				},
+			}, nil)
+		appMgmtClient.EXPECT().
+			DeleteRecipePack(gomock.Any(), packName).
+			Return(true, nil)
+
+		updatedEnvs := map[string]v20250801preview.EnvironmentResource{}
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(scope, func() corerpfake.EnvironmentsServer {
+			return corerpfake.EnvironmentsServer{
+				Get: func(
+					ctx context.Context, environmentName string,
+					_ *v20250801preview.EnvironmentsClientGetOptions,
+				) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
+					resp.SetResponse(http.StatusOK, v20250801preview.EnvironmentsClientGetResponse{
+						EnvironmentResource: v20250801preview.EnvironmentResource{
+							Name: to.Ptr(environmentName),
+							Properties: &v20250801preview.EnvironmentProperties{
+								RecipePacks: []*string{to.Ptr(packFullID)},
+							},
+						},
+					}, nil)
+					return
+				},
+				CreateOrUpdate: func(
+					ctx context.Context, environmentName string,
+					resource v20250801preview.EnvironmentResource,
+					_ *v20250801preview.EnvironmentsClientCreateOrUpdateOptions,
+				) (resp azfake.Responder[v20250801preview.EnvironmentsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+					updatedEnvs[environmentName] = resource
+					resp.SetResponse(http.StatusOK, v20250801preview.EnvironmentsClientCreateOrUpdateResponse{EnvironmentResource: resource}, nil)
+					return
+				},
+			}
+		}, nil)
+		require.NoError(t, err)
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			ConnectionFactory:       &connections.MockFactory{ApplicationsManagementClient: appMgmtClient},
+			RadiusCoreClientFactory: factory,
+			Workspace:               workspace,
+			Output:                  outputSink,
+			RecipePackName:          packName,
+			Confirm:                 true,
+		}
+
+		err = runner.Run(context.Background())
+		require.NoError(t, err)
+
+		// Both referenced envs should have been updated using the injected factory,
+		// with the deleted pack removed from each env's RecipePacks list.
+		require.Len(t, updatedEnvs, 2)
+		require.Contains(t, updatedEnvs, envName)
+		require.Contains(t, updatedEnvs, envName2)
+		require.Empty(t, updatedEnvs[envName].Properties.RecipePacks)
+		require.Empty(t, updatedEnvs[envName2].Properties.RecipePacks)
+	})
+
+	t.Run("same-named pack in a different scope is preserved (matches by full ID, not suffix)", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// Another pack with the same name but in a different resource group must
+		// not be removed from the environment when we delete this pack.
+		otherScopePackID := "/planes/radius/local/resourceGroups/other-group/providers/Radius.Core/recipePacks/" + packName
+		// Same ID as packFullID but with mixed-case segments — must still match.
+		mixedCasePackID := "/planes/radius/local/resourceGroups/test-group/providers/RADIUS.CORE/recipePacks/" + packName
+
+		var capturedEnv v20250801preview.EnvironmentResource
+
+		appMgmtClient := clients.NewMockApplicationsManagementClient(ctrl)
+		appMgmtClient.EXPECT().
+			GetRecipePack(gomock.Any(), packName).
+			Return(v20250801preview.RecipePackResource{
+				ID:   to.Ptr(packFullID),
+				Name: to.Ptr(packName),
+				Properties: &v20250801preview.RecipePackProperties{
+					Recipes:      map[string]*v20250801preview.RecipeDefinition{},
+					ReferencedBy: []*string{to.Ptr(envFullID)},
+				},
+			}, nil)
+		appMgmtClient.EXPECT().
+			DeleteRecipePack(gomock.Any(), packName).
+			Return(true, nil)
+
+		factory, err := test_client_factory.NewRadiusCoreTestClientFactory(scope, func() corerpfake.EnvironmentsServer {
+			return corerpfake.EnvironmentsServer{
+				Get: func(
+					ctx context.Context, environmentName string,
+					_ *v20250801preview.EnvironmentsClientGetOptions,
+				) (resp azfake.Responder[v20250801preview.EnvironmentsClientGetResponse], errResp azfake.ErrorResponder) {
+					resp.SetResponse(http.StatusOK, v20250801preview.EnvironmentsClientGetResponse{
+						EnvironmentResource: v20250801preview.EnvironmentResource{
+							Name: to.Ptr(environmentName),
+							Properties: &v20250801preview.EnvironmentProperties{
+								RecipePacks: []*string{
+									to.Ptr(mixedCasePackID),  // should be removed (case-insensitive match)
+									to.Ptr(otherScopePackID), // must NOT be removed
+								},
+							},
+						},
+					}, nil)
+					return
+				},
+				CreateOrUpdate: func(
+					ctx context.Context, environmentName string,
+					resource v20250801preview.EnvironmentResource,
+					_ *v20250801preview.EnvironmentsClientCreateOrUpdateOptions,
+				) (resp azfake.Responder[v20250801preview.EnvironmentsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+					capturedEnv = resource
+					resp.SetResponse(http.StatusOK, v20250801preview.EnvironmentsClientCreateOrUpdateResponse{EnvironmentResource: resource}, nil)
+					return
+				},
+			}
+		}, nil)
+		require.NoError(t, err)
+
+		outputSink := &output.MockOutput{}
+		runner := &Runner{
+			ConnectionFactory:       &connections.MockFactory{ApplicationsManagementClient: appMgmtClient},
+			RadiusCoreClientFactory: factory,
+			Workspace:               workspace,
+			Output:                  outputSink,
+			RecipePackName:          packName,
+			Confirm:                 true,
+		}
+
+		err = runner.Run(context.Background())
+		require.NoError(t, err)
+
+		require.Len(t, capturedEnv.Properties.RecipePacks, 1)
+		require.Equal(t, otherScopePackID, *capturedEnv.Properties.RecipePacks[0])
+	})
 }


### PR DESCRIPTION
# Description

A recipe pack's referencedBy property is supposed to hold a list of environments that point to this recipepack. 
This was always nil, because we had missed updating the list whenever there was a rad env update. 

This PR ensures that a recipe pack's referencedBy is always up to date. 

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: [#11671 ](https://github.com/radius-project/radius/issues/11671)

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

<!--
This checklist uses "TaskRadio" comments to make certain options mutually exclusive.
See: https://github.com/mheap/require-checklist-action?tab=readme-ov-file#radio-groups
For details on how this works and why it's required.
-->

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes <!-- TaskRadio schema -->
    - [x] Not applicable <!-- TaskRadio schema -->
- A design document PR is created in the [design-notes repository](https://github.com/radius-project/design-notes/), if new APIs are being introduced.
    - [ ] Yes <!-- TaskRadio design-pr -->
    - [x] Not applicable <!-- TaskRadio design-pr -->
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes <!-- TaskRadio design-review -->
    - [x] Not applicable <!-- TaskRadio design-review -->
- A PR for the [samples repository](https://github.com/radius-project/samples) is created, if existing samples are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio samples-pr -->
    - [x] Not applicable <!-- TaskRadio samples-pr -->
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes <!-- TaskRadio docs-pr -->
    - [x] Not applicable <!-- TaskRadio docs-pr -->
- A PR for the [recipes repository](https://github.com/radius-project/recipes) is created, if existing recipes are affected by the changes in this PR.
    - [ ] Yes <!-- TaskRadio recipes-pr -->
    - [x] Not applicable <!-- TaskRadio recipes-pr -->