### PR TITLE
Bump causinator9000 to v2.1.0 and enable c9k auto-issue

### DIFF
--- a/.github/workflows/c9k-failure-report.yml
+++ b/.github/workflows/c9k-failure-report.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Generate CI failure report
-        uses: sylvainsf/causinator9000@e3f8b80056e36cd55cf85c7c44c5e4bdaa876c04 # v2.0.0
+        uses: sylvainsf/causinator9000@ff3e97fcf74f2dd23dc56cf5ddd10f9e1c127eeb # v2.1.0
         with:
           repo: ${{ github.repository }}
           hours: "48"
           auto-issue: "true"
-          auto-issue-dry-run: "true"
+          auto-issue-dry-run: "false"
           auto-issue-min-confidence: "90"
           auto-issue-min-members: "2"
           auto-issue-classes: "CodeChange,BrokenTestRun,DepMajorBump,DepGroupUpdate"

--- a/.github/workflows/c9k-nightly.yml
+++ b/.github/workflows/c9k-nightly.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Generate CI failure report
-        uses: sylvainsf/causinator9000@e3f8b80056e36cd55cf85c7c44c5e4bdaa876c04 # v2.0.0
+        uses: sylvainsf/causinator9000@ff3e97fcf74f2dd23dc56cf5ddd10f9e1c127eeb # v2.1.0
         with:
           hours: ${{ github.event.inputs.hours || '24' }}
           min-confidence: "50"


### PR DESCRIPTION
## What

1. Bumps `sylvainsf/causinator9000` to `v2.1.0` in both c9k workflows.
2. Flips `auto-issue-dry-run` from `"true"` to `"false"` in [c9k-failure-report.yml](.github/workflows/c9k-failure-report.yml) so the workflow will actually file root-cause issues.

## Pin

- `e3f8b80` (v2.0.0) -> `ff3e97f` (v2.1.0) in both:
  - [.github/workflows/c9k-failure-report.yml](.github/workflows/c9k-failure-report.yml)
  - [.github/workflows/c9k-nightly.yml](.github/workflows/c9k-nightly.yml)

## Auto-issue rollout

- `auto-issue: true` (unchanged)
- `auto-issue-dry-run: false` (was `true`)
- `assign-copilot: false` (unchanged, still off for this rollout step)
- `auto-close-flaky: true` (unchanged, flaky groups are commented + closed, never assigned)
- Confidence/member thresholds and class allow-list unchanged.

## Verification plan (post-merge)

1. Manually dispatch the `c9k-failure-report` workflow from the Actions tab.
2. Review newly opened issues labelled `c9k-auto`.
3. If anything looks wrong (wrong issues filed, noisy titles, mis-classified causes), open a follow-up PR setting `auto-issue-dry-run` back to `"true"`.

## Reference

- Release: https://github.com/sylvainsf/causinator9000/releases/tag/v2.1.0