### PR TITLE
Enable assign-copilot in c9k auto-issue

### DIFF
--- a/.github/workflows/c9k-failure-report.yml
+++ b/.github/workflows/c9k-failure-report.yml
@@ -31,5 +31,5 @@ jobs:
           auto-issue-min-members: "2"
           auto-issue-classes: "CodeChange,BrokenTestRun,DepMajorBump,DepGroupUpdate"
           auto-close-flaky: "true"
-          assign-copilot: "false"
+          assign-copilot: "true"
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Sets `assign-copilot: "true"` in [.github/workflows/c9k-failure-report.yml](.github/workflows/c9k-failure-report.yml).

## Why

Follow-up to #11750. We enabled `auto-issue` (non-dry-run) in that PR but left `assign-copilot` at `"false"`. Now that we're filing issues for real, also let c9k assign Copilot to the commit/broken-test root-cause issues so they get picked up automatically.

## Safety

Per the v2.1.0 [`action.yml`](https://github.com/sylvainsf/causinator9000/blob/v2.1.0/action.yml), Copilot is **never** assigned to flaky-test groups regardless of this flag, those continue to be commented + closed via `auto-close-flaky: true`.

No other inputs change.