### PR TITLE
Register getGraph custom action for Radius.Core/applications

### DIFF
--- a/pkg/corerp/frontend/controller/applications/getgraph_v20250801preview.go
+++ b/pkg/corerp/frontend/controller/applications/getgraph_v20250801preview.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applications
+
+import (
+	"context"
+	"net/http"
+
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	ctrl "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
+	"github.com/radius-project/radius/pkg/armrpc/rest"
+	"github.com/radius-project/radius/pkg/cli/clients"
+	"github.com/radius-project/radius/pkg/corerp/datamodel"
+	"github.com/radius-project/radius/pkg/corerp/datamodel/converter"
+	"github.com/radius-project/radius/pkg/sdk"
+	"github.com/radius-project/radius/pkg/ucp/resources"
+)
+
+var _ ctrl.Controller = (*GetGraphV20250801Preview)(nil)
+
+// GetGraphV20250801Preview is the controller implementation to get application graph for Radius.Core/applications.
+type GetGraphV20250801Preview struct {
+	ctrl.Operation[*datamodel.Application_v20250801preview, datamodel.Application_v20250801preview]
+	connection sdk.Connection
+}
+
+// NewGetGraphV20250801Preview creates a new instance of the GetGraphV20250801Preview controller.
+func NewGetGraphV20250801Preview(opts ctrl.Options, connection sdk.Connection) (ctrl.Controller, error) {
+	return &GetGraphV20250801Preview{
+		ctrl.NewOperation(opts,
+			ctrl.ResourceOptions[datamodel.Application_v20250801preview]{
+				RequestConverter:  converter.Application20250801DataModelFromVersioned,
+				ResponseConverter: converter.Application20250801DataModelToVersioned,
+			},
+		),
+		connection,
+	}, nil
+}
+
+// Run retrieves the application graph for a Radius.Core/applications resource.
+func (c *GetGraphV20250801Preview) Run(ctx context.Context, w http.ResponseWriter, req *http.Request) (rest.Response, error) {
+	sCtx := v1.ARMRequestContextFromContext(ctx)
+
+	// Request route for getGraph has name of the operation as suffix which should be removed to get the resource id.
+	// route id format: /planes/radius/local/resourcegroups/default/providers/Radius.Core/applications/<appName>/getGraph
+	applicationID := sCtx.ResourceID.Truncate()
+	applicationResource, _, err := c.GetResource(ctx, applicationID)
+	if err != nil {
+		return nil, err
+	}
+	if applicationResource == nil {
+		return rest.NewNotFoundResponse(sCtx.ResourceID), nil
+	}
+
+	// An application **MUST** have an environment id
+	environmentID, err := resources.Parse(applicationResource.Properties.Environment)
+	if err != nil {
+		return nil, err
+	}
+
+	clientOptions := sdk.NewClientOptions(c.connection)
+
+	ucpApplicationsManagementClient := &clients.UCPApplicationsManagementClient{
+		RootScope:     radiusPlane + planeName,
+		ClientOptions: clientOptions,
+	}
+
+	resourceTypes, err := ucpApplicationsManagementClient.ListAllResourceTypesNames(ctx, "local")
+	if err != nil {
+		return nil, err
+	}
+
+	applicationResources, err := listAllResourcesByApplication(ctx, applicationID, resourceTypes, clientOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	environmentResources, err := listAllResourcesByEnvironment(ctx, environmentID, resourceTypes, clientOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	graph := computeGraph(applicationResources, environmentResources)
+	return rest.NewOKResponse(graph), nil
+}

--- a/pkg/corerp/frontend/controller/applications/getgraph_v20250801preview_test.go
+++ b/pkg/corerp/frontend/controller/applications/getgraph_v20250801preview_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applications
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
+	ctrl "github.com/radius-project/radius/pkg/armrpc/frontend/controller"
+	"github.com/radius-project/radius/pkg/armrpc/rpctest"
+	"github.com/radius-project/radius/pkg/components/database"
+	"github.com/radius-project/radius/pkg/sdk"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetGraphV20250801PreviewRun(t *testing.T) {
+	mctrl := gomock.NewController(t)
+	defer mctrl.Finish()
+
+	databaseClient := database.NewMockClient(mctrl)
+	req, err := rpctest.NewHTTPRequestWithContent(
+		context.Background(),
+		v1.OperationPost.HTTPMethod(),
+		"http://localhost:8080/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/radius-test-rg/providers/Radius.Core/Applications/myapp/getGraph?api-version=2025-08-01-preview", nil)
+
+	require.NoError(t, err)
+
+	t.Run("resource not found", func(t *testing.T) {
+		databaseClient.
+			EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(nil, &database.ErrNotFound{})
+		ctx := rpctest.NewARMRequestContext(req)
+		opts := ctrl.Options{
+			DatabaseClient: databaseClient,
+		}
+
+		conn, err := sdk.NewDirectConnection("http://localhost:9000/apis/api.ucp.dev/v1alpha3")
+		require.NoError(t, err)
+
+		ctl, err := NewGetGraphV20250801Preview(opts, conn)
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		resp, err := ctl.Run(ctx, w, req)
+		require.NoError(t, err)
+		err = resp.Apply(ctx, w, req)
+		require.NoError(t, err)
+		require.Equal(t, 404, w.Result().StatusCode)
+	})
+}

--- a/pkg/corerp/setup/setup.go
+++ b/pkg/corerp/setup/setup.go
@@ -293,6 +293,13 @@ func SetupRadiusCoreNamespace(recipeControllerConfig *controllerconfig.RecipeCon
 				rp_frontend.PrepareRadiusResource[*datamodel.Application_v20250801preview],
 			},
 		},
+		Custom: map[string]builder.Operation[datamodel.Application_v20250801preview]{
+			"getGraph": {
+				APIController: func(opt apictrl.Options) (apictrl.Controller, error) {
+					return app_ctrl.NewGetGraphV20250801Preview(opt, *recipeControllerConfig.UCPConnection)
+				},
+			},
+		},
 	})
 
 	return ns

--- a/pkg/corerp/setup/setup_test.go
+++ b/pkg/corerp/setup/setup_test.go
@@ -235,6 +235,10 @@ var radiusCoreHandlerTests = []rpctest.HandlerTestSpec{
 		OperationType: v1.OperationType{Type: "Radius.Core/applications", Method: v1.OperationPatch},
 		Path:          "/resourcegroups/testrg/providers/radius.core/applications/app0",
 		Method:        http.MethodPatch,
+	}, {
+		OperationType: v1.OperationType{Type: "Radius.Core/applications", Method: "ACTIONGETGRAPH"},
+		Path:          "/resourcegroups/testrg/providers/radius.core/applications/app0/getgraph",
+		Method:        http.MethodPost,
 	},
 }
 


### PR DESCRIPTION
## Description

Fixes #11794

The `Radius.Core/applications` resource type was missing the `getGraph` custom action registration in `SetupRadiusCoreNamespace`, causing `POST .../providers/Radius.Core/applications/{app}/getGraph` to return 404 in UCP. This blocked Dashboard from rendering the app graph for `Radius.Core/applications`.

## Changes

1. **New controller** (`getgraph_v20250801preview.go`): `GetGraphV20250801Preview` controller typed on `Application_v20250801preview` data model, with identical graph computation logic to the existing `GetGraph` controller for `Applications.Core/applications`.

2. **Registration** (`setup.go`): Added `Custom["getGraph"]` action to the `Radius.Core/applications` resource in `SetupRadiusCoreNamespace`.

3. **Tests**: Added router test entry for the new route in `setup_test.go` and unit test for the new controller in `getgraph_v20250801preview_test.go`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)