### PR TITLE
fix: allow workspace create with unverifiable Radius Core environments

### DIFF
--- a/pkg/cli/cmd/workspace/create/create.go
+++ b/pkg/cli/cmd/workspace/create/create.go
@@ -195,7 +195,11 @@ func (r *Runner) Validate(cmd *cobra.Command, args []string) error {
 
 		_, err = client.GetEnvironment(cmd.Context(), env)
 		if err != nil {
-			return clierrors.Message("The environment %q does not exist. Run `rad env create` try again.", r.Workspace.Environment)
+			// For Radius Core environments created with `rad env create --preview`,
+			// the validation client may not be able to query them. Log a warning
+			// instead of failing, matching the workaround of creating the workspace
+			// without --environment.
+			r.Output.LogInfo("Warning: environment %q could not be verified: %v. The workspace will be created but may not be valid if the environment does not exist.", r.Workspace.Environment, err)
 		}
 	}
 

--- a/pkg/cli/cmd/workspace/create/create_test.go
+++ b/pkg/cli/cmd/workspace/create/create_test.go
@@ -93,7 +93,7 @@ func Test_Validate(t *testing.T) {
 		{
 			Name:          "valid create command with correct options but non existing env",
 			Input:         []string{"kubernetes", "-w", "ws", "-g", "rg1", "-e", "env1"},
-			ExpectedValid: false,
+			ExpectedValid: true,
 			ConfigHolder: framework.ConfigHolder{
 				ConfigFilePath: "",
 				Config:         configWithWorkspace,
@@ -104,6 +104,7 @@ func Test_Validate(t *testing.T) {
 				mocks.Helm.EXPECT().CheckRadiusInstall(gomock.Any()).Return(helm.InstallState{RadiusInstalled: true}, nil).Times(1)
 
 				// Resource group exists but environment does not
+				// (workspace create now logs a warning instead of failing)
 				mocks.ApplicationManagementClient.EXPECT().GetResourceGroup(gomock.Any(), "local", "rg1").Return(ucp.ResourceGroupResource{}, nil).Times(1)
 				mocks.ApplicationManagementClient.EXPECT().GetEnvironment(gomock.Any(), "env1").Return(corerp.EnvironmentResource{}, errors.New("environment does not exist")).Times(1)
 			},


### PR DESCRIPTION
## Description

When creating a workspace with `--environment`, the `Validate` method queries the environment via `GetEnvironment` to confirm it exists. For **Radius Core environments** created with `rad env create --preview`, the validation client (`v20231001preview`) cannot always query these environments, causing a false "does not exist" error that blocks workspace creation.

This fix changes the environment validation from a fatal error to a **warning log**, matching the existing workaround where users create workspaces without `--environment` and pass the environment later via `rad deploy -e`.

### Changes
- `pkg/cli/cmd/workspace/create/create.go`: Changed `GetEnvironment` error from fatal `clierrors.Message` to `r.Output.LogInfo` warning
- `pkg/cli/cmd/workspace/create/create_test.go`: Updated test expectations — workspace create now succeeds even when environment can't be verified

### Fixes
Fixes #11670

### Checklist
- [x] Updated unit tests
- [x] Verified fix matches existing user workaround
- [x] Disclosed AI-assisted contribution

---

*This contribution was prepared with AI assistance.*
