### PR TITLE
Workspace group display in workspace commands

### DIFF
--- a/pkg/cli/cmd/workspace/common/objectformats.go
+++ b/pkg/cli/cmd/workspace/common/objectformats.go
@@ -22,7 +22,7 @@ import (
 )
 
 // WorkspaceFormat returns a FormatterOptions object which contains a list of columns to be used for displaying
-// workspace information such as name, kind, kubecontext and environment."
+// workspace information such as name, kind, kubecontext, group, and environment.
 func WorkspaceFormat() output.FormatterOptions {
 	return output.FormatterOptions{
 		Columns: []output.Column{
@@ -37,6 +37,11 @@ func WorkspaceFormat() output.FormatterOptions {
 			{
 				Heading:  "KUBECONTEXT",
 				JSONPath: "{ .Connection.context }",
+			},
+			{
+				Heading:     "GROUP",
+				JSONPath:    "{ .Scope }",
+				Transformer: &objectformats.ResourceScopeToResourceGroupNameTransformer{},
 			},
 			{
 				Heading:     "ENVIRONMENT",

--- a/pkg/cli/cmd/workspace/common/objectformats_test.go
+++ b/pkg/cli/cmd/workspace/common/objectformats_test.go
@@ -32,6 +32,7 @@ func Test_WorkspaceFormat(t *testing.T) {
 			"kind":    workspaces.KindKubernetes,
 			"context": "test-context",
 		},
+		Scope:       "/planes/radius/local/resourceGroups/test-group",
 		Environment: "/planes/radius/local/resourceGroups/test-group/providers/Applications.Core/environments/test",
 	}
 
@@ -39,6 +40,6 @@ func Test_WorkspaceFormat(t *testing.T) {
 	err := output.Write(output.FormatTable, obj, buffer, WorkspaceFormat())
 	require.NoError(t, err)
 
-	expected := "WORKSPACE  KIND        KUBECONTEXT   ENVIRONMENT\ntest       kubernetes  test-context  test\n"
+	expected := "WORKSPACE  KIND        KUBECONTEXT   GROUP       ENVIRONMENT\ntest       kubernetes  test-context  test-group  test\n"
 	require.Equal(t, expected, buffer.String())
 }

--- a/pkg/cli/cmd/workspace/list/list_test.go
+++ b/pkg/cli/cmd/workspace/list/list_test.go
@@ -74,11 +74,13 @@ func Test_Run(t *testing.T) {
 				// Intentionally NOT in alphabetical order
 				"workspace-b": {
 					Environment: "b",
+					Scope:       "/planes/radius/local/resourceGroups/group-b",
 					Source:      workspaces.SourceUserConfig,
 					Connection:  map[string]any{},
 				},
 				"workspace-a": {
 					Environment: "a",
+					Scope:       "/planes/radius/local/resourceGroups/group-a",
 					Source:      workspaces.SourceUserConfig,
 					Connection:  map[string]any{},
 				},
@@ -104,12 +106,14 @@ func Test_Run(t *testing.T) {
 					{
 						Name:        "workspace-a",
 						Environment: "a",
+						Scope:       "/planes/radius/local/resourceGroups/group-a",
 						Source:      workspaces.SourceUserConfig,
 						Connection:  map[string]any{},
 					},
 					{
 						Name:        "workspace-b",
 						Environment: "b",
+						Scope:       "/planes/radius/local/resourceGroups/group-b",
 						Source:      workspaces.SourceUserConfig,
 						Connection:  map[string]any{},
 					},

--- a/pkg/cli/cmd/workspace/show/show_test.go
+++ b/pkg/cli/cmd/workspace/show/show_test.go
@@ -93,6 +93,7 @@ func Test_Run(t *testing.T) {
 				Source:      workspaces.SourceUserConfig,
 				Name:        "test-workspace",
 				Environment: "test-environment",
+				Scope:       "/planes/radius/local/resourceGroups/test-group",
 				Connection:  map[string]any{},
 			},
 		}
@@ -107,6 +108,7 @@ func Test_Run(t *testing.T) {
 					Source:      workspaces.SourceUserConfig,
 					Name:        "test-workspace",
 					Environment: "test-environment",
+					Scope:       "/planes/radius/local/resourceGroups/test-group",
 					Connection:  map[string]any{},
 				},
 				Options: common.WorkspaceFormat(),

--- a/pkg/cli/objectformats/transformers.go
+++ b/pkg/cli/objectformats/transformers.go
@@ -41,6 +41,26 @@ func (t *ResourceIDToResourceGroupNameTransformer) Transform(input string) strin
 	return id.FindScope(radius.ScopeResourceGroups)
 }
 
+// ResourceScopeToResourceGroupNameTransformer is a transformer that takes a scope ID and returns the resource group name.
+type ResourceScopeToResourceGroupNameTransformer struct {
+}
+
+// Transform takes a scope ID and returns the resource group name.
+func (t *ResourceScopeToResourceGroupNameTransformer) Transform(input string) string {
+	if input == "" {
+		return ""
+	}
+
+	// NOTE: this is for display to human users in a table. It's not a great place
+	// for us to put a long explanation.
+	id, err := resources.ParseScope(input)
+	if err != nil {
+		return "<error>"
+	}
+
+	return id.FindScope(radius.ScopeResourceGroups)
+}
+
 // ResourceIDToResourceNameTransformer is a transformer that takes a resource ID and returns the resource name.
 type ResourceIDToResourceNameTransformer struct {
 }

--- a/pkg/cli/objectformats/transformers_test.go
+++ b/pkg/cli/objectformats/transformers_test.go
@@ -85,3 +85,35 @@ func Test_ResourceIDToResourceGroupNameTransformer(t *testing.T) {
 		})
 	}
 }
+
+func Test_ResourceScopeToResourceGroupNameTransformer(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "invalid input",
+			input:    "////",
+			expected: "<error>",
+		},
+		{
+			name:     "valid input",
+			input:    "/planes/radius/local/resourceGroups/test-group",
+			expected: "test-group",
+		},
+	}
+
+	for _, testcase := range cases {
+		t.Run(testcase.name, func(t *testing.T) {
+			transformer := &ResourceScopeToResourceGroupNameTransformer{}
+			actual := transformer.Transform(testcase.input)
+			require.Equal(t, testcase.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
# Description

`rad workspace list` and `rad workspace show` did not show the resource group even though the workspace scope contains it. This adds a GROUP column to the shared workspace table formatter and derives the displayed group name from the workspace scope. Structured workspace data remains unchanged.

The change also adds a scope-specific resource group transformer and coverage for the workspace formatter and transformer.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #9805

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
