### PR TITLE
Default Kubernetes image pull policy for Radius chart

### DIFF
--- a/deploy/Chart/templates/controller/deployment.yaml
+++ b/deploy/Chart/templates/controller/deployment.yaml
@@ -59,7 +59,6 @@ spec:
       containers:
       - name: controller
         image: "{{ include "radius.image" (dict "image" .Values.controller.image "tag" (.Values.controller.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"
-        imagePullPolicy: {{ .Values.controller.imagePullPolicy | default "Always" | quote }}
         args:
         - '--config-file'
         - '/etc/config/controller-config.yaml'

--- a/deploy/Chart/templates/dashboard/deployment.yaml
+++ b/deploy/Chart/templates/dashboard/deployment.yaml
@@ -29,7 +29,6 @@ spec:
       containers:
       - name: dashboard
         image: "{{ include "radius.image" (dict "image" .Values.dashboard.image "tag" (.Values.dashboard.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"
-        imagePullPolicy: Always
         env:
         - name: NODE_ENV
           value: {{ .Values.dashboard.nodeEnv | default "development" | quote }}

--- a/deploy/Chart/templates/database/statefulset.yaml
+++ b/deploy/Chart/templates/database/statefulset.yaml
@@ -31,7 +31,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         image: "{{ include "radius.image" (dict "image" .Values.database.image "tag" (.Values.database.tag | default .Values.global.imageTag | default "latest") "global" .Values.global) }}"
-        imagePullPolicy: IfNotPresent
         resources:
           requests:
             memory: "{{ .Values.database.resources.requests.memory }}"

--- a/deploy/Chart/templates/pre-upgrade/job.yaml
+++ b/deploy/Chart/templates/pre-upgrade/job.yaml
@@ -32,7 +32,6 @@ spec:
       containers:
       - name: pre-upgrade
         image: "{{ include "radius.image" (dict "image" .Values.preupgrade.image "tag" (.Values.preupgrade.tag | default .Values.global.imageTag | default $appversion) "global" .Values.global) }}"
-        imagePullPolicy: 'Always'
         env:
         - name: TARGET_VERSION
           value: "{{ .Values.preupgrade.targetVersion | default .Chart.AppVersion }}"

--- a/deploy/Chart/tests/helpers_test.yaml
+++ b/deploy/Chart/tests/helpers_test.yaml
@@ -10,6 +10,7 @@ templates:
   - de/deployment.yaml
   - dashboard/deployment.yaml
   - database/statefulset.yaml
+  - pre-upgrade/job.yaml
 tests:
   - it: should use default ghcr.io registry when global.imageRegistry is not set
     set:
@@ -323,6 +324,30 @@ tests:
           path: spec.template.spec.containers[0].image
           value: internal.registry.io/mirror/postgres:14-alpine
         template: database/statefulset.yaml
+
+  - it: should not set imagePullPolicy on chart-managed containers
+    templates:
+      - controller/deployment.yaml
+      - dashboard/deployment.yaml
+      - database/statefulset.yaml
+      - pre-upgrade/job.yaml
+    set:
+      dashboard.enabled: true
+      database.enabled: true
+      preupgrade.enabled: true
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].imagePullPolicy
+        template: controller/deployment.yaml
+      - isNull:
+          path: spec.template.spec.containers[0].imagePullPolicy
+        template: dashboard/deployment.yaml
+      - isNull:
+          path: spec.template.spec.containers[0].imagePullPolicy
+        template: database/statefulset.yaml
+      - isNull:
+          path: spec.template.spec.containers[0].imagePullPolicy
+        template: pre-upgrade/job.yaml
 
   - it: should handle mixed scenario - some with full paths, some without
     set:


### PR DESCRIPTION
# Description

The Radius Helm chart explicitly set `imagePullPolicy` on several chart-managed containers. This caused `Always` pulls for controller, dashboard, and pre-upgrade and an explicit `IfNotPresent` for database instead of letting Kubernetes choose the default from the rendered image tag.

This removes the explicit policy from controller, dashboard, database, and pre-upgrade templates and adds Helm unit coverage that those containers omit `imagePullPolicy`. A render check confirms no `imagePullPolicy` fields are emitted when dashboard, database, and pre-upgrade are enabled.

## Type of change

- This pull request fixes a bug in Radius and has an approved issue (issue link required).

Fixes: #10769

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
