### PR TITLE
Pin Deployment Engine image to 0.56 for v0.57.1 patch release

### DIFF
--- a/deploy/Chart/tests/helpers_test.yaml
+++ b/deploy/Chart/tests/helpers_test.yaml
@@ -398,6 +398,9 @@ tests:
       rp.image: applications-rp
       dynamicrp.image: dynamic-rp
       de.image: deployment-engine
+      # Clear the values.yaml pin so this test exercises the
+      # global.imageTag fallthrough for the DE image.
+      de.tag: ""
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image

--- a/deploy/Chart/values.yaml
+++ b/deploy/Chart/values.yaml
@@ -83,8 +83,8 @@ controller:
 
 de:
   image: deployment-engine
-  # Default tag uses Chart AppVersion.
-  # tag: latest
+  # Pin Deployment Engine to the v0.56.0 image for the v0.57.1 patch release.
+  tag: 0.56
   resources:
     requests:
       # request memory is the average memory usage + 10% buffer.


### PR DESCRIPTION
## Summary

Pins the Deployment Engine image used by the Radius Helm chart to the `0.56` tag for the upcoming `v0.57.1` patch release.

## Why

Deployment Engine `0.57.0` (the version `Chart.AppVersion` would otherwise resolve to via `radius.versiontag` for a `v0.57.1` chart) has a serious bug. Rolling DE back to the last known-good `0.56` image avoids shipping the regression in the `v0.57.1` patch.

Other components (controller, ucp, applications-rp, dynamic-rp, dashboard, bicep) continue to track `Chart.AppVersion` and will be published at `0.57` as expected.

## Change

`deploy/Chart/values.yaml`:

```yaml
de:
  image: deployment-engine
  # Pin Deployment Engine to the v0.56.0 image for the v0.57.1 patch release.
  tag: 0.56
```

The image tag `0.56` is the major.minor floating tag published to `ghcr.io/radius-project/deployment-engine` (consistent with how `radius.versiontag` derives tags for tagged releases).

## Override behavior preserved

The Helm tag-resolution chain in `templates/_helpers.tpl` is `component.tag → global.imageTag → Chart.AppVersion`. Setting `de.tag` here only changes the default; users can still override at install time:

- `--set de.tag=...`
- `--set global.imageTag=...` (overridden by the component tag — by design)

## Release process

Per [docs/contributing/contributing-releases/README.md](../blob/main/docs/contributing/contributing-releases/README.md) "Patching":

1. Merge bug-fix PR to `main` (this PR).
2. Follow-up PR to `main` bumping `versions.yaml` to `v0.57.1` and adding `docs/release-notes/v0.57.1.md`.
3. Cherry-pick both commits to `release/0.57`; `release.yaml` then tags and `build.yaml` packages the chart with `appVersion=0.57.1`.

## Follow-up

This pin should be removed once Deployment Engine `0.57.x` is fixed, so the chart resumes tracking `Chart.AppVersion` for DE on the `0.58` channel and beyond. Tracking issue to be filed.

## Testing

- `helm lint deploy/Chart` clean.
- `helm template` against this branch renders the DE deployment with `image: ghcr.io/radius-project/deployment-engine:0.56`.