### PR TITLE
Add LoadDefaultManifests and update initializer for embedded manifest registration

### DIFF
--- a/pkg/cli/manifest/defaults.go
+++ b/pkg/cli/manifest/defaults.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"strings"
+
+	yaml "github.com/goccy/go-yaml"
+)
+
+// DefaultsConfig represents the structure of the defaults.yaml configuration file
+// that lists which resource type manifests should be registered by default.
+type DefaultsConfig struct {
+	// DefaultRegistration is a list of resource type names to register.
+	// Each entry uses the format Radius.<Namespace>/<typeName> (e.g., Radius.Compute/containers).
+	DefaultRegistration []string `yaml:"defaultRegistration"`
+}
+
+// LoadDefaultManifests reads defaults.yaml from the provided fs.FS and returns the
+// parsed, validated, and merged resource providers for default registration.
+//
+// The function performs the following steps:
+//  1. Reads defaults.yaml from the embedded filesystem to get the list of resource
+//     type names (e.g., Radius.Compute/containers).
+//  2. Resolves each name to a manifest file path using the naming convention:
+//     strip the "Radius." prefix, then <Namespace>/<typeName>/<typeName>.yaml.
+//  3. Reads and parses each manifest using the existing ReadBytes function.
+//  4. Validates that the manifest's namespace matches the expected namespace
+//     derived from the resource type name.
+//  5. Validates that the manifest contains the expected resource type in its
+//     types map.
+//  6. Validates schemas using the existing validateManifestSchemas function.
+//  7. Merges manifests sharing a namespace into a single ResourceProvider
+//     (e.g., three Radius.Compute manifests become one provider with all types).
+//
+// Returns nil, nil if defaults.yaml has no entries. Returns an error if any step
+// fails (missing files, parse errors, validation failures, namespace mismatches).
+func LoadDefaultManifests(ctx context.Context, fsys fs.FS) ([]ResourceProvider, error) {
+	// Read the defaults configuration that lists which resource types to register.
+	data, err := fs.ReadFile(fsys, "defaults.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read defaults.yaml: %w", err)
+	}
+
+	// Parse defaults.yaml with strict mode to catch typos in field names.
+	config := DefaultsConfig{}
+	decoder := yaml.NewDecoder(bytes.NewReader(data), yaml.Strict())
+	if err := decoder.Decode(&config); err != nil {
+		return nil, fmt.Errorf("failed to parse defaults.yaml: %w", err)
+	}
+
+	if len(config.DefaultRegistration) == 0 {
+		return nil, nil
+	}
+
+	// Parse and validate each manifest, merging providers that share a namespace.
+	// For example, Radius.Compute/containers and Radius.Compute/routes both belong
+	// to the Radius.Compute namespace and are merged into a single ResourceProvider.
+	merged := map[string]*ResourceProvider{}
+	for _, name := range config.DefaultRegistration {
+		// Resolve the resource type name to a file path.
+		path, err := resolveResourceTypePath(name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve resource type %s: %w", name, err)
+		}
+
+		// Read and parse the manifest file.
+		manifestData, err := fs.ReadFile(fsys, path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read manifest for %s (resolved to %s): %w", name, path, err)
+		}
+
+		provider, err := ReadBytes(manifestData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse manifest %s: %w", path, err)
+		}
+
+		// Validate the manifest namespace matches the expected namespace from the
+		// resource type name (e.g., Radius.Compute/containers expects
+		// namespace Radius.Compute).
+		parts := strings.SplitN(name, "/", 2)
+		expectedNamespace := parts[0]
+		expectedTypeName := parts[1]
+
+		if provider.Namespace != expectedNamespace {
+			return nil, fmt.Errorf("manifest %s declares namespace %q but expected %q from defaults.yaml entry %s", path, provider.Namespace, expectedNamespace, name)
+		}
+
+		// Validate the manifest contains the expected resource type.
+		if _, ok := provider.Types[expectedTypeName]; !ok {
+			return nil, fmt.Errorf("manifest %s does not define resource type %q listed in defaults.yaml entry %s", path, expectedTypeName, name)
+		}
+
+		// Validate the manifest schemas against OpenAPI format.
+		if err := validateManifestSchemas(ctx, provider); err != nil {
+			return nil, fmt.Errorf("failed to validate manifest %s: %w", path, err)
+		}
+
+		// Merge into existing provider for this namespace, or create a new one.
+		if existing, ok := merged[provider.Namespace]; ok {
+			for typeName, resourceType := range provider.Types {
+				existing.Types[typeName] = resourceType
+			}
+		} else {
+			merged[provider.Namespace] = provider
+		}
+	}
+
+	result := make([]ResourceProvider, 0, len(merged))
+	for _, provider := range merged {
+		result = append(result, *provider)
+	}
+
+	return result, nil
+}
+
+// resolveResourceTypePath converts a resource type name to a file path.
+// Format: Radius.<Namespace>/<typeName> -> <Namespace>/<typeName>/<typeName>.yaml
+// Example: Radius.Compute/containers -> Compute/containers/containers.yaml
+func resolveResourceTypePath(name string) (string, error) {
+	parts := strings.SplitN(name, "/", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid resource type name %q: expected format Radius.<Namespace>/<typeName>", name)
+	}
+
+	namespace := parts[0]
+	typeName := parts[1]
+
+	if !strings.HasPrefix(namespace, "Radius.") {
+		return "", fmt.Errorf("invalid namespace %q: must start with 'Radius.'", namespace)
+	}
+
+	// Strip "Radius." prefix
+	namespaceSuffix := strings.TrimPrefix(namespace, "Radius.")
+
+	return fmt.Sprintf("%s/%s/%s.yaml", namespaceSuffix, typeName, typeName), nil
+}

--- a/pkg/cli/manifest/defaults_test.go
+++ b/pkg/cli/manifest/defaults_test.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifest
+
+import (
+	"context"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadDefaultManifests(t *testing.T) {
+	t.Parallel()
+
+	validManifest1 := `
+namespace: Radius.Compute
+types:
+  containers:
+    apiVersions:
+      "2025-08-01-preview":
+        schema: {}`
+
+	validManifest2 := `
+namespace: Radius.Compute
+types:
+  routes:
+    apiVersions:
+      "2025-08-01-preview":
+        schema: {}`
+
+	validManifest3 := `
+namespace: Radius.Security
+types:
+  secrets:
+    apiVersions:
+      "2025-08-01-preview":
+        schema: {}`
+
+	t.Run("merges manifests sharing a namespace", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - Radius.Compute/containers
+  - Radius.Compute/routes
+  - Radius.Security/secrets
+`),
+			},
+			"Compute/containers/containers.yaml": &fstest.MapFile{Data: []byte(validManifest1)},
+			"Compute/routes/routes.yaml":         &fstest.MapFile{Data: []byte(validManifest2)},
+			"Security/secrets/secrets.yaml":       &fstest.MapFile{Data: []byte(validManifest3)},
+		}
+
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
+		require.NoError(t, err)
+		require.Len(t, providers, 2)
+
+		var computeProvider *ResourceProvider
+		var securityProvider *ResourceProvider
+		for i := range providers {
+			switch providers[i].Namespace {
+			case "Radius.Compute":
+				computeProvider = &providers[i]
+			case "Radius.Security":
+				securityProvider = &providers[i]
+			}
+		}
+
+		require.NotNil(t, computeProvider)
+		assert.Len(t, computeProvider.Types, 2)
+		assert.Contains(t, computeProvider.Types, "containers")
+		assert.Contains(t, computeProvider.Types, "routes")
+
+		require.NotNil(t, securityProvider)
+		assert.Len(t, securityProvider.Types, 1)
+		assert.Contains(t, securityProvider.Types, "secrets")
+	})
+
+	t.Run("returns error when defaults.yaml is missing", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{}
+
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read defaults.yaml")
+		assert.Nil(t, providers)
+	})
+
+	t.Run("returns nil when defaults.yaml has no entries", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte("defaultRegistration:\n"),
+			},
+		}
+
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
+		require.NoError(t, err)
+		assert.Nil(t, providers)
+	})
+
+	t.Run("returns error when manifest file is missing from FS", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - Radius.Compute/nonexistent
+`),
+			},
+		}
+
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read manifest for Radius.Compute/nonexistent")
+		assert.Nil(t, providers)
+	})
+
+	t.Run("returns error for invalid manifest YAML", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - Radius.Bad/thing
+`),
+			},
+			"Bad/thing/thing.yaml": &fstest.MapFile{Data: []byte("invalid: yaml: [")},
+		}
+
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse manifest")
+		assert.Nil(t, providers)
+	})
+
+	t.Run("returns error for invalid resource type name format", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - InvalidFormat
+`),
+			},
+		}
+
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid resource type name")
+		assert.Nil(t, providers)
+	})
+
+	t.Run("returns error for non-Radius namespace", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - Other.Compute/containers
+`),
+			},
+		}
+
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must start with 'Radius.'")
+		assert.Nil(t, providers)
+	})
+
+	t.Run("returns error when manifest namespace does not match expected", func(t *testing.T) {
+		t.Parallel()
+
+		mismatchedManifest := `
+namespace: Radius.Other
+types:
+  containers:
+    apiVersions:
+      "2025-08-01-preview":
+        schema: {}`
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - Radius.Compute/containers
+`),
+			},
+			"Compute/containers/containers.yaml": &fstest.MapFile{Data: []byte(mismatchedManifest)},
+		}
+
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "declares namespace")
+		assert.Contains(t, err.Error(), "expected")
+		assert.Nil(t, providers)
+	})
+
+	t.Run("returns error when manifest does not define expected type", func(t *testing.T) {
+		t.Parallel()
+
+		// Manifest declares Radius.Compute namespace but only has 'routes', not 'containers'
+		wrongTypeManifest := `
+namespace: Radius.Compute
+types:
+  routes:
+    apiVersions:
+      "2025-08-01-preview":
+        schema: {}`
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - Radius.Compute/containers
+`),
+			},
+			"Compute/containers/containers.yaml": &fstest.MapFile{Data: []byte(wrongTypeManifest)},
+		}
+
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not define resource type")
+		assert.Contains(t, err.Error(), "containers")
+		assert.Nil(t, providers)
+	})
+
+	t.Run("returns single provider without merging", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - Radius.Security/secrets
+`),
+			},
+			"Security/secrets/secrets.yaml": &fstest.MapFile{Data: []byte(validManifest3)},
+		}
+
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
+		require.NoError(t, err)
+		require.Len(t, providers, 1)
+		assert.Equal(t, "Radius.Security", providers[0].Namespace)
+		assert.Contains(t, providers[0].Types, "secrets")
+	})
+}
+
+func TestResolveResourceTypePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "standard resource type",
+			input:    "Radius.Compute/containers",
+			expected: "Compute/containers/containers.yaml",
+		},
+		{
+			name:     "nested namespace",
+			input:    "Radius.Security/secrets",
+			expected: "Security/secrets/secrets.yaml",
+		},
+		{
+			name:     "data namespace",
+			input:    "Radius.Data/mySqlDatabases",
+			expected: "Data/mySqlDatabases/mySqlDatabases.yaml",
+		},
+		{
+			name:        "missing slash",
+			input:       "Radius.Compute",
+			expectError: true,
+		},
+		{
+			name:        "non-Radius namespace",
+			input:       "Other.Compute/containers",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := resolveResourceTypePath(tt.input)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/ucp/initializer/service.go
+++ b/pkg/ucp/initializer/service.go
@@ -19,6 +19,7 @@ package initializer
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -32,16 +33,25 @@ import (
 )
 
 // Service implements the hosting.Service interface for registering manifests.
+// It supports two sources of manifests:
+//   - Embedded manifests from an fs.FS (typically from resource-types-contrib)
+//   - Directory-based manifests from the filesystem (configured via ManifestDirectory)
+//
+// Embedded manifests are processed first. Directory-based manifests are processed
+// second and can override embedded ones via last-write-wins semantics.
 type Service struct {
-	options *ucp.Options
+	options    *ucp.Options
+	embeddedFS fs.FS
 }
 
 var _ hosting.Service = (*Service)(nil)
 
 // NewService creates a server to register manifests.
-func NewService(options *ucp.Options) *Service {
+// The embeddedFS parameter is optional; pass nil to skip embedded manifest registration.
+func NewService(options *ucp.Options, embeddedFS fs.FS) *Service {
 	return &Service{
-		options: options,
+		options:    options,
+		embeddedFS: embeddedFS,
 	}
 }
 
@@ -54,6 +64,46 @@ func (w *Service) Run(ctx context.Context) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
 	manifestDir := w.options.Config.Initialization.ManifestDirectory
+
+	// If there's nothing to do, return early without initializing the database client.
+	if w.embeddedFS == nil && manifestDir == "" {
+		logger.Info("No embedded manifests or manifest directory specified, initialization is complete")
+		return nil
+	}
+
+	// Initialize the database client only when there is work to do.
+	dbClient, err := w.options.DatabaseProvider.GetClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get database client: %w", err)
+	}
+
+	// Step 1: Process embedded manifests from the embedded filesystem.
+	// These are the default resource types from resource-types-contrib that are
+	// compiled into the Radius binary via go:embed.
+	if w.embeddedFS != nil {
+		providers, err := manifest.LoadDefaultManifests(ctx, w.embeddedFS)
+		if err != nil {
+			return fmt.Errorf("failed to process embedded manifests: %w", err)
+		}
+
+		for _, provider := range providers {
+			logger.Info("Registering resource provider from embedded manifests", "namespace", provider.Namespace)
+			if err := registerResourceProviderDirect(ctx, dbClient, "local", provider); err != nil {
+				return fmt.Errorf("failed to register embedded resource provider %s: %w", provider.Namespace, err)
+			}
+		}
+
+		if len(providers) > 0 {
+			logger.Info("Successfully registered default resource type manifests")
+		}
+	}
+
+	// Step 2: Process directory-based manifests from the filesystem.
+	// These are manifests that require explicit location addresses (e.g., radius_core.yaml,
+	// microsoft_resources.yaml) or are provided as overrides.
+	// Directory-based manifests are processed after embedded ones, so they can override
+	// embedded providers via last-write-wins (registerResourceProviderDirect uses Save
+	// which is a create-or-update operation).
 	if manifestDir == "" {
 		logger.Info("No manifest directory specified, initialization is complete")
 		return nil
@@ -63,11 +113,6 @@ func (w *Service) Run(ctx context.Context) error {
 		return fmt.Errorf("manifest directory does not exist: %w", err)
 	} else if err != nil {
 		return fmt.Errorf("error checking manifest directory: %w", err)
-	}
-
-	dbClient, err := w.options.DatabaseProvider.GetClient(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
 	files, err := os.ReadDir(manifestDir)

--- a/pkg/ucp/initializer/service_test.go
+++ b/pkg/ucp/initializer/service_test.go
@@ -18,9 +18,11 @@ package initializer
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/cli/manifest"
@@ -170,14 +172,14 @@ func Test_Run(t *testing.T) {
 
 	t.Run("no manifest directory skips initialization", func(t *testing.T) {
 		t.Parallel()
-		svc := newTestService("")
+		svc := newTestService("", nil)
 		err := svc.Run(context.Background())
 		require.NoError(t, err)
 	})
 
 	t.Run("missing manifest directory returns error", func(t *testing.T) {
 		t.Parallel()
-		svc := newTestService("/nonexistent/path")
+		svc := newTestService("/nonexistent/path", nil)
 		err := svc.Run(context.Background())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "manifest directory does not exist")
@@ -201,7 +203,7 @@ types:
 		err := os.WriteFile(filepath.Join(tempDir, "test.yaml"), []byte(manifestContent), 0600)
 		require.NoError(t, err)
 
-		svc := newTestService(tempDir)
+		svc := newTestService(tempDir, nil)
 		dbClient, err := svc.options.DatabaseProvider.GetClient(context.Background())
 		require.NoError(t, err)
 
@@ -212,6 +214,146 @@ types:
 		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Test.Provider")
 		require.NoError(t, err)
 		require.NotNil(t, obj)
+	})
+
+	t.Run("registers embedded manifests", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - test.yaml
+`),
+			},
+			"test.yaml": &fstest.MapFile{
+				Data: []byte(`
+namespace: Embedded.Provider
+types:
+  myType:
+    apiVersions:
+      "2025-01-01":
+        schema: {}
+`),
+			},
+		}
+
+		svc := newTestService("", fsys)
+		dbClient, err := svc.options.DatabaseProvider.GetClient(context.Background())
+		require.NoError(t, err)
+
+		err = svc.Run(context.Background())
+		require.NoError(t, err)
+
+		// Verify the embedded resource provider was registered
+		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Embedded.Provider")
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+	})
+
+	t.Run("registers both embedded and directory manifests", func(t *testing.T) {
+		t.Parallel()
+
+		// Embedded manifest
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - embedded.yaml
+`),
+			},
+			"embedded.yaml": &fstest.MapFile{
+				Data: []byte(`
+namespace: Embedded.Provider
+types:
+  embeddedType:
+    apiVersions:
+      "2025-01-01":
+        schema: {}
+`),
+			},
+		}
+
+		// Directory manifest
+		tempDir := t.TempDir()
+		manifestContent := `
+namespace: Directory.Provider
+location:
+  global: "http://localhost:9090"
+types:
+  dirType:
+    apiVersions:
+      "2025-01-01":
+        schema: {}
+`
+		err := os.WriteFile(filepath.Join(tempDir, "dir.yaml"), []byte(manifestContent), 0600)
+		require.NoError(t, err)
+
+		svc := newTestService(tempDir, fsys)
+		dbClient, err := svc.options.DatabaseProvider.GetClient(context.Background())
+		require.NoError(t, err)
+
+		err = svc.Run(context.Background())
+		require.NoError(t, err)
+
+		// Both should be registered
+		_, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Embedded.Provider")
+		require.NoError(t, err)
+
+		_, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Directory.Provider")
+		require.NoError(t, err)
+	})
+
+	t.Run("directory manifests override embedded manifests", func(t *testing.T) {
+		t.Parallel()
+
+		// Embedded manifest for Same.Provider with typeA
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - same.yaml
+`),
+			},
+			"same.yaml": &fstest.MapFile{
+				Data: []byte(`
+namespace: Same.Provider
+types:
+  typeA:
+    apiVersions:
+      "2025-01-01":
+        schema: {}
+`),
+			},
+		}
+
+		// Directory manifest for Same.Provider with typeB (overrides)
+		tempDir := t.TempDir()
+		manifestContent := `
+namespace: Same.Provider
+location:
+  global: "http://localhost:9090"
+types:
+  typeB:
+    apiVersions:
+      "2025-01-01":
+        schema: {}
+`
+		err := os.WriteFile(filepath.Join(tempDir, "same.yaml"), []byte(manifestContent), 0600)
+		require.NoError(t, err)
+
+		svc := newTestService(tempDir, fsys)
+		dbClient, err := svc.options.DatabaseProvider.GetClient(context.Background())
+		require.NoError(t, err)
+
+		err = svc.Run(context.Background())
+		require.NoError(t, err)
+
+		// The directory manifest overwrites the embedded one (last-write-wins)
+		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Same.Provider")
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+
+		// typeB from directory should exist
+		_, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Same.Provider/resourceTypes/typeB")
+		require.NoError(t, err)
 	})
 }
 
@@ -241,17 +383,15 @@ func Test_saveResource(t *testing.T) {
 }
 
 // newTestService creates a Service with in-memory database for testing.
-func newTestService(manifestDir string) *Service {
-	return &Service{
-		options: &ucp.Options{
-			Config: &ucp.Config{
-				Initialization: ucp.InitializationConfig{
-					ManifestDirectory: manifestDir,
-				},
+func newTestService(manifestDir string, embeddedFS fs.FS) *Service {
+	return NewService(&ucp.Options{
+		Config: &ucp.Config{
+			Initialization: ucp.InitializationConfig{
+				ManifestDirectory: manifestDir,
 			},
-			DatabaseProvider: databaseprovider.FromMemory(),
 		},
-	}
+		DatabaseProvider: databaseprovider.FromMemory(),
+	}, embeddedFS)
 }
 
 func createTestResourceProvider() manifest.ResourceProvider {

--- a/pkg/ucp/server/server.go
+++ b/pkg/ucp/server/server.go
@@ -46,7 +46,7 @@ func NewServer(options *ucp.Options) (*hosting.Host, error) {
 		services = append(services, &traceservice.Service{Options: &options.Config.Tracing})
 	}
 
-	services = append(services, initializer.NewService(options))
+	services = append(services, initializer.NewService(options, nil))
 
 	return &hosting.Host{
 		Services: services,


### PR DESCRIPTION
## Summary

Add `LoadDefaultManifests` to the manifest package and update the UCP initializer to support embedded resource type manifests via `fs.FS`.

Implements the design https://github.com/radius-project/radius/pull/11610.

## Changes

### `pkg/cli/manifest/registerfs.go` (new)

- `LoadDefaultManifests(ctx, fs.FS)` — Reads `defaults.yaml` from an embedded filesystem, resolves each resource type name to a manifest file path, parses and validates each manifest, and merges manifests sharing a namespace into a single `ResourceProvider`
- `DefaultsConfig` type for `defaults.yaml` structure
- `resolveResourceTypePath` — Converts `Radius.<Namespace>/<typeName>` to `<Namespace>/<typeName>/<typeName>.yaml`
- Strict YAML decoding to catch typos in `defaults.yaml`
- Namespace and type name validation against each parsed manifest

### `pkg/ucp/initializer/service.go` (updated)

- `Service` struct gains `embeddedFS fs.FS` field
- `NewService` accepts an additional `fs.FS` parameter (pass `nil` to skip)
- `Run()` processes embedded manifests first via `LoadDefaultManifests`, then directory-based manifests
- Directory-based manifests can override embedded ones (last-write-wins via `Save`)

### `pkg/ucp/server/server.go` (updated)

- Updated `NewService` call to pass `nil` — no behavior change until `resource-types-contrib` is wired in a follow-up PR after https://github.com/radius-project/resource-types-contrib/pull/152 is merged.

## Startup flow

```
Run()
  |-- if embeddedFS != nil:
  |     |-- manifest.LoadDefaultManifests(ctx, embeddedFS) -> []ResourceProvider
  |     +-- for each provider: registerResourceProviderDirect()
  |
  +-- if manifestDir != "":
        |-- os.ReadDir(manifestDir)
        +-- for each file: ValidateManifest() -> registerResourceProviderDirect()
```

## Test plan

### `LoadDefaultManifests` unit tests
- Namespace merging (multiple manifests, same namespace)
- Missing `defaults.yaml`
- Empty `defaults.yaml`
- Missing manifest file
- Invalid manifest YAML
- Invalid resource type name format
- Non-Radius namespace
- Namespace mismatch between manifest and defaults.yaml entry
- Missing expected type in manifest
- `resolveResourceTypePath` table-driven tests

### Initializer integration tests
- Registers embedded manifests from `fs.FS`
- Registers both embedded and directory manifests
- Directory manifests override embedded ones (last-write-wins)
- Existing tests unchanged (pass `nil` for backward compatibility)

## Follow-up PRs

- Wire `resource-types-contrib` dependency: pass `DefaultManifests` in `server.go`, remove migrated manifest files
- CI diff report workflow for `resource-types-contrib` dependency bumps