### PR TITLE
Add resource-types-contrib diff report workflow for PR visibility

### DIFF
--- a/.github/scripts/diff-resource-types.sh
+++ b/.github/scripts/diff-resource-types.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# ------------------------------------------------------------
+# Copyright 2023 The Radius Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+# diff-resource-types.sh generates a markdown diff report comparing default-
+# registered resource type manifests between two versions of the
+# resource-types-contrib Go module.
+#
+# Required environment variables:
+#   OLD_VERSION - The old module version (empty if new dependency)
+#   NEW_VERSION - The new module version
+#
+# Output:
+#   /tmp/diff-report.md - Markdown report suitable for a PR comment
+
+set -euo pipefail
+
+readonly MODULE="github.com/radius-project/resource-types-contrib"
+readonly REPORT_FILE="/tmp/diff-report.md"
+
+# Cleanup temp files on exit.
+cleanup() {
+    rm -f /tmp/diff-report-truncated.md
+}
+trap cleanup EXIT
+
+# Download both versions and get their local paths.
+OLD_DIR=""
+if [[ -n "${OLD_VERSION:-}" ]]; then
+    OLD_DIR=$(go mod download -json "${MODULE}@${OLD_VERSION}" | jq -r '.Dir')
+fi
+NEW_DIR=$(go mod download -json "${MODULE}@${NEW_VERSION}" | jq -r '.Dir')
+
+# Read the list of default resource types from defaults.yaml in both versions.
+# We diff only files listed in defaults.yaml (the authoritative list of what
+# gets embedded into the Radius binary), not the entire module.
+OLD_FILES=""
+NEW_FILES=""
+if [[ -n "${OLD_DIR}" ]] && [[ -f "${OLD_DIR}/defaults.yaml" ]]; then
+    OLD_FILES=$(yq '.defaultRegistration[]' "${OLD_DIR}/defaults.yaml" 2>/dev/null || echo "")
+fi
+if [[ -f "${NEW_DIR}/defaults.yaml" ]]; then
+    NEW_FILES=$(yq '.defaultRegistration[]' "${NEW_DIR}/defaults.yaml" 2>/dev/null || echo "")
+fi
+
+ALL_FILES=$(echo -e "${OLD_FILES}\n${NEW_FILES}" | sort -u | grep -v '^$' || true)
+
+if [[ -z "${ALL_FILES}" ]]; then
+    echo "No default manifests found in defaults.yaml"
+    exit 0
+fi
+
+# Build the diff report.
+DIFF_OUTPUT=""
+
+# Check if defaults.yaml itself changed.
+if [[ -n "${OLD_DIR}" ]] && [[ -f "${OLD_DIR}/defaults.yaml" ]] && [[ -f "${NEW_DIR}/defaults.yaml" ]]; then
+    DEFAULTS_DIFF=$(diff -u "${OLD_DIR}/defaults.yaml" "${NEW_DIR}/defaults.yaml" || true)
+    if [[ -n "${DEFAULTS_DIFF}" ]]; then
+        DIFF_OUTPUT+="### Changed: \`defaults.yaml\`"$'\n'
+        DIFF_OUTPUT+='```diff'$'\n'
+        DIFF_OUTPUT+="${DEFAULTS_DIFF}"$'\n'
+        DIFF_OUTPUT+='```'$'\n\n'
+    fi
+elif [[ -z "${OLD_DIR}" || ! -f "${OLD_DIR}/defaults.yaml" ]] && [[ -f "${NEW_DIR}/defaults.yaml" ]]; then
+    DIFF_OUTPUT+="### Added: \`defaults.yaml\`"$'\n'
+    DIFF_OUTPUT+='```yaml'$'\n'
+    DIFF_OUTPUT+=$(cat "${NEW_DIR}/defaults.yaml")$'\n'
+    DIFF_OUTPUT+='```'$'\n\n'
+fi
+
+# Diff each default-registered manifest file.
+while IFS= read -r entry; do
+    [[ -z "${entry}" ]] && continue
+
+    # Resolve resource type name to file path.
+    # Format: Radius.<Namespace>/<typeName> -> <Namespace>/<typeName>/<typeName>.yaml
+    NAMESPACE_SUFFIX=$(echo "${entry}" | cut -d'/' -f1 | sed 's/^Radius\.//')
+    TYPE_NAME=$(echo "${entry}" | cut -d'/' -f2)
+    file="${NAMESPACE_SUFFIX}/${TYPE_NAME}/${TYPE_NAME}.yaml"
+
+    OLD_FILE=""
+    if [[ -n "${OLD_DIR}" ]]; then
+        OLD_FILE="${OLD_DIR}/${file}"
+    fi
+    NEW_FILE="${NEW_DIR}/${file}"
+
+    if [[ -z "${OLD_FILE}" ]] || [[ ! -f "${OLD_FILE}" ]]; then
+        if [[ -f "${NEW_FILE}" ]]; then
+            DIFF_OUTPUT+="### Added: \`${file}\`"$'\n'
+            DIFF_OUTPUT+='```yaml'$'\n'
+            DIFF_OUTPUT+=$(head -c 10000 "${NEW_FILE}")$'\n'
+            DIFF_OUTPUT+='```'$'\n\n'
+        fi
+    elif [[ -f "${OLD_FILE}" ]] && [[ ! -f "${NEW_FILE}" ]]; then
+        DIFF_OUTPUT+="### Removed: \`${file}\`"$'\n\n'
+    elif [[ -f "${OLD_FILE}" ]] && [[ -f "${NEW_FILE}" ]]; then
+        FILE_DIFF=$(diff -u "${OLD_FILE}" "${NEW_FILE}" || true)
+        if [[ -n "${FILE_DIFF}" ]]; then
+            DIFF_OUTPUT+="### Changed: \`${file}\`"$'\n'
+            DIFF_OUTPUT+='```diff'$'\n'
+            DIFF_OUTPUT+=$(echo "${FILE_DIFF}" | head -200)$'\n'
+            DIFF_OUTPUT+='```'$'\n\n'
+        fi
+    fi
+done <<< "${ALL_FILES}"
+
+if [[ -z "${DIFF_OUTPUT}" ]]; then
+    DIFF_OUTPUT="No changes to default-registered manifest files."
+fi
+
+# Write the full report.
+{
+    echo "## Resource Types Diff Report"
+    echo ""
+    echo "Changes in default-registered manifests between \`${OLD_VERSION:-*(new dependency)*}\` and \`${NEW_VERSION}\`:"
+    echo ""
+    echo "${DIFF_OUTPUT}"
+    echo "---"
+    echo "<sub>This report shows only files listed in <code>defaults.yaml</code>. Generated automatically by the resource-types-diff workflow.</sub>"
+} > "${REPORT_FILE}"
+
+# Truncate if too large for PR comment (GitHub limit is 65536 chars).
+# Close any open code fence before appending the truncation footer.
+if [[ $(wc -c < "${REPORT_FILE}") -gt 60000 ]]; then
+    head -c 59000 "${REPORT_FILE}" > /tmp/diff-report-truncated.md
+    echo "" >> /tmp/diff-report-truncated.md
+    echo '```' >> /tmp/diff-report-truncated.md
+    echo "" >> /tmp/diff-report-truncated.md
+    echo "---" >> /tmp/diff-report-truncated.md
+    echo "*Report truncated. See [resource-types-contrib](https://github.com/radius-project/resource-types-contrib) for the full diff.*" >> /tmp/diff-report-truncated.md
+    mv /tmp/diff-report-truncated.md "${REPORT_FILE}"
+fi
+
+echo "Diff report written to ${REPORT_FILE}"

--- a/.github/workflows/resource-types-diff.yml
+++ b/.github/workflows/resource-types-diff.yml
@@ -1,0 +1,103 @@
+# ------------------------------------------------------------
+# Copyright 2023 The Radius Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+# This workflow posts a diff report on PRs that bump the resource-types-contrib
+# dependency, showing exactly which default-registered manifest files changed.
+# This gives reviewers visibility into YAML content changes that are otherwise
+# hidden behind an opaque go.mod version bump.
+#
+# Note: This workflow uses pull_request trigger, so the report is only posted
+# for in-repo PRs. Fork PRs will silently skip the comment step due to
+# read-only GITHUB_TOKEN.
+
+name: Resource Types Diff Report
+
+on:
+  pull_request:
+    paths:
+      - 'go.mod'
+  # Uncomment to test this workflow from a fork:
+  # workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  diff-report:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install yq
+        run: |
+          YQ_VERSION=v4.44.3
+          YQ_BINARY=yq_linux_amd64
+          YQ_URL="https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY}"
+          CHECKSUMS_URL="https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/checksums"
+
+          wget -qO "/tmp/${YQ_BINARY}" "${YQ_URL}"
+          wget -qO /tmp/yq_checksums "${CHECKSUMS_URL}"
+          grep " ${YQ_BINARY}\$" /tmp/yq_checksums | (cd /tmp && sha256sum -c -)
+          sudo install -m 0755 "/tmp/${YQ_BINARY}" /usr/local/bin/yq
+
+      - name: Detect resource-types-contrib version change
+        id: detect
+        run: |
+          # Get the old and new versions using go list -m for precise matching.
+          OLD_VERSION=$(git show ${{ github.event.pull_request.base.sha }}:go.mod | go mod edit -json /dev/stdin 2>/dev/null | jq -r '.Require[]? | select(.Path == "github.com/radius-project/resource-types-contrib") | .Version' || true)
+          NEW_VERSION=$(go list -m -json github.com/radius-project/resource-types-contrib 2>/dev/null | jq -r '.Version' || true)
+
+          if [[ -z "${OLD_VERSION}" ]] && [[ -z "${NEW_VERSION}" ]]; then
+            echo "resource-types-contrib dependency not found in go.mod"
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if [[ "${OLD_VERSION}" == "${NEW_VERSION}" ]]; then
+            echo "resource-types-contrib version unchanged (${OLD_VERSION})"
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo "Old version: ${OLD_VERSION}"
+          echo "New version: ${NEW_VERSION}"
+          echo "old=${OLD_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "new=${NEW_VERSION}" >> "${GITHUB_OUTPUT}"
+
+      - name: Generate diff report
+        if: steps.detect.outputs.skip != 'true'
+        env:
+          OLD_VERSION: ${{ steps.detect.outputs.old }}
+          NEW_VERSION: ${{ steps.detect.outputs.new }}
+        run: |
+          .github/scripts/diff-resource-types.sh
+
+      - name: Post PR comment
+        if: steps.detect.outputs.skip != 'true'
+        continue-on-error: true
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: resource-types-diff
+          path: /tmp/diff-report.md


### PR DESCRIPTION
## Summary

Add a CI workflow that posts a diff report comment on PRs when the `resource-types-contrib` dependency version changes in `go.mod`.

This implements the security recommendation from https://github.com/radius-project/radius/pull/11610

## Problem

When we bump the `resource-types-contrib` dependency, the PR diff in `radius` shows only a `go.mod`/`go.sum` version change. The actual YAML content changes are not visible. A reviewer must manually compare the two commit hashes in `resource-types-contrib` to see what changed.

## Solution

A GitHub Actions workflow that:
1. Triggers on `go.mod` changes in PRs
2. Detects if the `resource-types-contrib` version changed
3. Downloads both old and new module versions via `go mod download`
4. Reads `defaults.yaml` from both versions using `yq` to determine which manifest files to diff (only files listed for default registration are compared, not the entire module)
5. Resolves each `Radius.<Namespace>/<typeName>` entry to its manifest file path
6. Diffs `defaults.yaml` itself and each listed manifest
7. Posts a sticky PR comment with the focused diff report
8. Truncates large reports to stay under GitHub's comment size limit

## Files

- `.github/workflows/resource-types-diff.yml` — Workflow definition
- `.github/scripts/diff-resource-types.sh` — Diff generation script (extracted per repo convention)

## Example output

> ## Resource Types Diff Report
>
> Changes in default-registered manifests between `v0.0.0-20260408-abc123` and `v0.0.0-20260501-def456`:
>
> ### Changed: `defaults.yaml`
> ```diff
> +  - Radius.Networking/loadBalancers
> ```
>
> ### Added: `Networking/loadBalancers/loadBalancers.yaml`
> ```yaml
> namespace: Radius.Networking
> ...
> ```
>
> ---
> <sub>This report shows only files listed in <code>defaults.yaml</code>.</sub>

## Notes

- All actions pinned to full commit SHAs
- `ubuntu-24.04` runner
- `persist-credentials: false`, job-level permissions (`contents: read`, `pull-requests: write`)
- `continue-on-error` on comment step for fork PRs
- Script can be run locally: `OLD_VERSION=... NEW_VERSION=... .github/scripts/diff-resource-types.sh`