### PR TITLE
Add update-resource-types Makefile target and release checklist step

### DIFF
--- a/build/generate.mk
+++ b/build/generate.mk
@@ -169,3 +169,15 @@ GOBIN=$(PROJECT_DIR)/bin go get -u $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef
+
+##@ Resource Types
+
+.PHONY: update-resource-types
+update-resource-types: ## Update resource-types-contrib dependency to latest
+	@echo "$(ARROW) Updating resource-types-contrib dependency..."
+	# Use @main because resource-types-contrib does not have tagged releases.
+	# @latest would look for a tagged version and fail. Once tagged releases
+	# are established, switch to @latest.
+	go get github.com/radius-project/resource-types-contrib@main
+	go mod tidy
+	@echo "$(ARROW) Done. Review the changes and commit."

--- a/docs/contributing/contributing-releases/README.md
+++ b/docs/contributing/contributing-releases/README.md
@@ -138,6 +138,16 @@ git pull origin main
 git checkout -b <USERNAME>/release-X.Y.0-rcN
 ```
 
+> **Before updating versions.yaml**, ensure the `resource-types-contrib` dependency is up to date. Run:
+>
+> ```bash
+> make update-resource-types
+> ```
+>
+> This bumps the `resource-types-contrib` Go module dependency to the latest version, ensuring the latest resource type schemas are included in the release. Review the `go.mod`/`go.sum` changes and commit them on this branch alongside (or before) the `versions.yaml` update.
+>
+> **If schema validation fails at startup after bumping**: Either fix the manifest in `resource-types-contrib` and re-bump, or pin `go.mod` to the last known good version of `resource-types-contrib` by running `go get github.com/radius-project/resource-types-contrib@<known-good-version>`.
+
 Edit `versions.yaml` to add the new RC as a supported version. Move the oldest supported version to the `deprecated` list if needed ([example PR](https://github.com/radius-project/radius/pull/6077/files)).
 
 ```yaml


### PR DESCRIPTION
## Summary

Add `update-resource-types` Makefile target and update the release process documentation to include a step for bumping the `resource-types-contrib` dependency before each release.

This is the final PR implementing [automated default registration of resource types from resource-types-contrib](https://github.com/radius-project/radius/blob/main/eng/design-notes/extensibility/2026-04-automated-default-resource-type-registration.md).

## Changes

### `build/generate.mk`

- Add `update-resource-types` target under `##@ Resource Types` section
- Uses `go get ...@main` (not `@latest`) because `resource-types-contrib` does not have tagged releases yet
- Includes comment explaining the `@main` usage and when to switch to `@latest`

### `docs/contributing/contributing-releases/README.md`

- Add a note in Step 3 (after creating the release branch) to run `make update-resource-types`
- The dependency bump happens on the release PR branch, not on `main`
- Include guidance on handling schema validation failures:
  - Fix the manifest in `resource-types-contrib` and re-bump
  - Or pin `go.mod` to the last known good version

## Dependencies

This PR should be merged after:
- [#11890](https://github.com/radius-project/radius/pull/11890) — Add LoadDefaultManifests and update initializer
- [#11891](https://github.com/radius-project/radius/pull/11891) — Wire resource-types-contrib dependency