### PR TITLE
Add app-graph skill

### DIFF
--- a/.github/skills/app-graph/SKILL.md
+++ b/.github/skills/app-graph/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: app-graph
+description: >
+  Generate an interactive application graph visualization from a Radius
+  app.bicep file. Use when asked to visualize a Radius application,
+  generate an app graph, build an app graph, render the graph for an app,
+  show the application graph, or create an interactive graph. Produces
+  a self-contained HTML viewer (Cytoscape + dagre) that mirrors the
+  radius-project/github-extension graph renderer, opens it in the default
+  browser, and emits an inline mermaid preview in chat.
+---
+
+# Radius Application Graph
+
+Use this skill to render an interactive application graph from a Radius
+`app.bicep` file. The skill compiles the Bicep, invokes `rad graph build`,
+and produces a single self-contained `app-graph.html` whose renderer is
+ported verbatim from `radius-project/github-extension`
+(`src/content/graph-renderer.ts` + `src/content/graph-navigation.ts`).
+
+## Output Format
+
+Your entire visible response must follow this exact sequence. No extra
+headings, no analysis preamble.
+
+1. Say: I will generate an application graph for `<app-name>`.
+2. Show exactly these lines as a single blockquote:
+   > Compile app.bicep with the bicep CLI.
+   > Build the static graph artifact with `rad graph build`.
+   > Render the interactive HTML viewer.
+   > Generate an inline mermaid preview.
+3. Say: Here is an inline preview of the graph:
+4. Output a single ```mermaid fenced code block matching the rules in
+   [mermaid.md](references/mermaid.md).
+5. Say: A full interactive viewer has been written to `./app-graph.html`.
+6. Say: Opening it in your default browser now.
+7. Open the file (see Internal Workflow step 6).
+8. Say: Click any node in the viewer to see source-code and
+   app-definition links.
+
+That is the COMPLETE chat response.
+
+## Internal Workflow (do NOT show these steps to the user)
+
+1. Locate the Bicep file. Default search order: `./app.bicep`,
+   `./.radius/app.bicep`. If neither exists, ask the user for the path.
+2. Verify the `rad` CLI is available and supports `rad graph build`.
+   Run `rad graph build --help`. If the subcommand is missing, instruct
+   the user to install or build `rad` from
+   `radius-project/radius` (`features/radius-graph` branch until the
+   change merges to `main`). Do NOT auto-build.
+3. Verify the `bicep` CLI is on PATH. Try `bicep --version`, then
+   `az bicep version` as fallback. If neither works, instruct the user
+   to install Bicep and abort.
+4. Run `rad graph build --bicep <file> --output ./.radius/static/app.json`.
+   The CLI compiles Bicep, parses resources/connections, computes
+   diff hashes, and writes the `StaticGraphArtifact` JSON.
+   Read [artifact-path.md](references/artifact-path.md) for details.
+5. Read the JSON, then render the HTML viewer:
+   a. Read [`template/app-graph.html.tmpl`](template/app-graph.html.tmpl).
+   b. Replace the literal token `__GRAPH_DATA__` with the file
+      contents of `app.json` (substitute as a JSON literal — do NOT
+      wrap in quotes).
+   c. Write the result to `./app-graph.html`.
+6. Open the HTML file in the user's default browser:
+   - Windows: `Start-Process .\app-graph.html`
+   - macOS: `open ./app-graph.html`
+   - Linux: `xdg-open ./app-graph.html`
+7. Emit the mermaid preview per [mermaid.md](references/mermaid.md). One
+   node per resource, edges from each resource's `Outbound` connections
+   only when the target resource is also present, node text =
+   `<name><br/><shortType>`, no diff coloring (single-graph mode).
+
+## Renderer Conventions
+
+Read [rendering.md](references/rendering.md) for the exact Cytoscape +
+dagre options, the Primer color tables, and the edge construction rule.
+The template file already encodes these — do NOT modify the template's
+renderer code.
+
+## Schema
+
+Read [schema.md](references/schema.md) for the `StaticGraphArtifact` and
+`ApplicationGraphResource` shape consumed by the HTML viewer.
+
+## Validation Checklist
+
+Before saying "Opening it in your default browser now", verify ALL:
+
+- [ ] `./app-graph.html` exists and is non-empty.
+- [ ] The JSON substituted into the template is valid (parses).
+- [ ] Every resource in `application.resources` has `id`, `name`, `type`.
+- [ ] The mermaid block only references resource IDs that also appear
+      as mermaid node declarations (no dangling edges).
+- [ ] The opener command used matches the host OS.
+
+## Guardrails
+
+- Do NOT alter the renderer logic in `template/app-graph.html.tmpl`.
+  It is a verbatim port of `graph-renderer.ts` + `graph-navigation.ts`.
+- Do NOT inline a screenshot in chat in place of the mermaid block — the
+  user wants a structural preview, not a rasterized one.
+- Do NOT push to or create any orphan branch from this skill. The
+  `--orphan-branch` flag is reserved for the CI workflow.
+- Do NOT prompt the user before opening the HTML — the Output Format
+  already announces the open step.
+- If `rad graph build` fails, surface the stderr verbatim and stop.
+  Do NOT attempt to construct the JSON manually.
+- The HTML viewer is single-graph only. Diff coloring is preserved in
+  the ported code but unused; do NOT add UI to load a second artifact.

--- a/.github/skills/app-graph/SKILL.md
+++ b/.github/skills/app-graph/SKILL.md
@@ -75,8 +75,9 @@ That is the COMPLETE chat response.
 
 Read [rendering.md](references/rendering.md) for the exact Cytoscape +
 dagre options, the Primer color tables, and the edge construction rule.
-The template file already encodes these — do NOT modify the template's
-renderer code.
+Read [visual-style.md](references/visual-style.md) for the resource-type
+icon + color palette used to theme nodes and the legend in single-graph
+mode.
 
 ## Schema
 
@@ -96,8 +97,12 @@ Before saying "Opening it in your default browser now", verify ALL:
 
 ## Guardrails
 
-- Do NOT alter the renderer logic in `template/app-graph.html.tmpl`.
-  It is a verbatim port of `graph-renderer.ts` + `graph-navigation.ts`.
+- The renderer in `template/app-graph.html.tmpl` is a port of
+  `graph-renderer.ts` + `graph-navigation.ts`. The layout, popup
+  behavior, edge rule, and Primer color tables MUST stay verbatim. The
+  resource-type icon/color palette ([visual-style.md](references/visual-style.md))
+  is an additive extension — extend it for new resource types instead
+  of rewriting the renderer.
 - Do NOT inline a screenshot in chat in place of the mermaid block — the
   user wants a structural preview, not a rasterized one.
 - Do NOT push to or create any orphan branch from this skill. The
@@ -108,3 +113,6 @@ Before saying "Opening it in your default browser now", verify ALL:
   Do NOT attempt to construct the JSON manually.
 - The HTML viewer is single-graph only. Diff coloring is preserved in
   the ported code but unused; do NOT add UI to load a second artifact.
+  In single-graph mode every node uses the per-resource-type fill +
+  border + icon from `TYPE_STYLES`; the diff palette is reserved for
+  when a future diff mode lands.

--- a/.github/skills/app-graph/references/artifact-path.md
+++ b/.github/skills/app-graph/references/artifact-path.md
@@ -1,0 +1,53 @@
+# Building the Graph Artifact Locally
+
+The `rad graph build` subcommand has two output modes:
+
+1. **Local file** (this skill's mode). Default output path is
+   `.radius/static/app.json`. Override with `--output <path>`.
+2. **Orphan branch** (CI mode, NOT used by this skill). Commits the JSON
+   to `{source-branch}/app.json` on a configurable orphan branch.
+
+## Invocation
+
+```bash
+rad graph build --bicep ./app.bicep --output ./.radius/static/app.json
+```
+
+`--bicep` defaults to `app.bicep` and `--output` defaults to
+`.radius/static/app.json`, so the bare command also works when the
+file is named `app.bicep` in the current directory:
+
+```bash
+rad graph build
+```
+
+## Prerequisites
+
+- `bicep` CLI on PATH (or `az bicep` as fallback). `rad graph build`
+  shells out to `bicep build --outfile <tmp>` to compile to ARM JSON
+  before parsing.
+- `rad` CLI from `radius-project/radius` at a ref that contains the
+  `graph build` subcommand. Until the feature merges to `main`, build
+  from `features/radius-graph`:
+
+  ```bash
+  git clone -b features/radius-graph https://github.com/radius-project/radius
+  cd radius
+  go build -o rad ./cmd/rad
+  ```
+
+## Output shape
+
+The output is a `StaticGraphArtifact` (see [schema.md](schema.md)).
+
+## Errors
+
+If `rad graph build` exits non-zero, surface stderr verbatim and stop.
+Common failures:
+
+- `bicep build failed` — Bicep CLI not installed or `app.bicep` has
+  compile errors.
+- `compiling Bicep file` — the Bicep file path is wrong or unreadable.
+- `building static graph` — the compiled ARM JSON is missing required
+  Radius resource metadata; usually means the input Bicep is not a
+  Radius application.

--- a/.github/skills/app-graph/references/mermaid.md
+++ b/.github/skills/app-graph/references/mermaid.md
@@ -1,0 +1,35 @@
+# Inline Mermaid Preview
+
+The skill emits a mermaid `flowchart` block in chat alongside the full
+HTML viewer. It is a structural preview only — no diff coloring, no
+popup, no zoom. The full Cytoscape viewer is the source of truth.
+
+## Rules
+
+1. Use `flowchart TD` (top-down).
+2. One node per resource in `application.resources`.
+3. Node id = a sanitized form of `resource.name` (replace any char
+   matching `/[^A-Za-z0-9_]/` with `_`). If two resources collide,
+   append `_2`, `_3`, ...
+4. Node label = `<name><br/><shortType>` where
+   `shortType = resource.type.split('/').pop()`.
+5. Use rectangle shape: `id["label"]`.
+6. Edge rule (mirrors the HTML renderer): for every resource, iterate
+   `connections` and emit `source --> target` for each connection where
+   `direction === 'Outbound'` AND the target `id` is present in
+   `application.resources`. Use the same sanitized ids.
+7. Do NOT add a legend, do NOT add classDefs, do NOT add diff styling.
+
+## Example
+
+For an application with two resources `frontend` (a container) connected
+to `db` (a postgres database), emit:
+
+```mermaid
+flowchart TD
+  frontend["frontend<br/>containers"]
+  db["db<br/>postgreSqlDatabases"]
+  frontend --> db
+```
+
+That's the entire mermaid block.

--- a/.github/skills/app-graph/references/rendering.md
+++ b/.github/skills/app-graph/references/rendering.md
@@ -103,8 +103,11 @@ Background fills:
 | modified  | `#fff8c5` |
 | unchanged | `#f6f8fa` |
 
-In single-graph mode (this skill's default), every node uses the
-`unchanged` row.
+In single-graph mode (this skill's default), every node has diff status
+`unchanged`. The diff fill/border are then replaced by per-resource-type
+colors and the label is prefixed with a type icon — see
+[visual-style.md](visual-style.md). In a future diff mode the diff
+status fill/border wins so the diff signal stays dominant.
 
 ## Node label
 

--- a/.github/skills/app-graph/references/rendering.md
+++ b/.github/skills/app-graph/references/rendering.md
@@ -1,0 +1,142 @@
+# Rendering Conventions
+
+These conventions are a verbatim port of
+`radius-project/github-extension` `src/content/graph-renderer.ts`. The
+template file already encodes them — this file is for reference only.
+
+## Library versions
+
+The template loads from CDN:
+
+- `cytoscape` v3 (`https://unpkg.com/cytoscape@3/dist/cytoscape.min.js`)
+- `cytoscape-dagre` (`https://unpkg.com/cytoscape-dagre@2/cytoscape-dagre.js`)
+- `dagre` (peer dep of cytoscape-dagre, also from unpkg)
+
+## Layout
+
+```js
+{
+  name: 'dagre',
+  rankDir: 'TB',
+  nodeSep: 60,
+  rankSep: 80,
+  edgeSep: 20,
+  padding: 48,
+  animate: false,
+}
+```
+
+## Cytoscape core options
+
+```js
+{
+  userZoomingEnabled: true,
+  userPanningEnabled: true,
+  boxSelectionEnabled: false,
+  autoungrabify: true,
+  minZoom: 0.3,
+  maxZoom: 3,
+}
+```
+
+After init, call `cy.resize(); cy.fit(cy.elements(), 48); cy.center();`
+inside two nested `requestAnimationFrame` calls so the graph re-fits
+once the container has its final size.
+
+## Node style
+
+```js
+{
+  selector: 'node',
+  style: {
+    label: 'data(label)',
+    'text-valign': 'center',
+    'text-halign': 'center',
+    'font-size': '12px',
+    'font-family': '-apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif',
+    color: '#1f2328',
+    'background-color': 'data(bgColor)',
+    'border-color': 'data(borderColor)',
+    'border-width': 'data(borderWidth)',
+    shape: 'roundrectangle',
+    width: 140,
+    height: 55,
+    'text-wrap': 'wrap',
+    'text-max-width': '120px',
+  },
+}
+```
+
+## Edge style
+
+```js
+{
+  selector: 'edge',
+  style: {
+    width: 2,
+    'line-color': '#8c959f',
+    'target-arrow-color': '#8c959f',
+    'target-arrow-shape': 'triangle',
+    'curve-style': 'bezier',
+    'arrow-scale': 0.8,
+  },
+}
+```
+
+## Diff color tables (Primer)
+
+Border colors and widths:
+
+| Status    | Border    | Width |
+| --------- | --------- | ----- |
+| added     | `#1a7f37` | 3     |
+| removed   | `#cf222e` | 3     |
+| modified  | `#9a6700` | 3     |
+| unchanged | `#57606a` | 2     |
+
+Background fills:
+
+| Status    | Fill      |
+| --------- | --------- |
+| added     | `#dafbe1` |
+| removed   | `#ffebe9` |
+| modified  | `#fff8c5` |
+| unchanged | `#f6f8fa` |
+
+In single-graph mode (this skill's default), every node uses the
+`unchanged` row.
+
+## Node label
+
+`label = `${resource.name}\n${shortType}`` where
+`shortType = resource.type.split('/').pop() ?? resource.type`.
+
+## Edge rule
+
+Iterate every resource. For each `Outbound` connection, add an edge from
+the owning resource to the connection's `id` **only if** the target `id`
+appears in `application.resources`. Skip otherwise. Edge id is
+`${source}-->${target}`.
+
+## Popup behavior
+
+On node tap: read the node's rendered position, anchor a floating div
+at `position + (10, 10)`, show:
+
+1. Title = `resource.name`
+2. Subtitle = `resource.type`
+3. `📄 Source code` link to `resource.codeReference` (only if present
+   and parseable). For the standalone HTML viewer, the link target is a
+   `file://` URL or plain path — no GitHub context is available.
+4. `📐 App definition` link to `sourceFile#L<appDefinitionLine>`.
+5. `×` close button.
+
+Close on outside click, ESC, or close-button click.
+
+Critically: the popup div must call `stopPropagation` on `mousedown`,
+`mouseup`, `touchstart`, `touchend`, `pointerdown`, `pointerup` so
+Cytoscape's container-walking handler does not intercept link clicks.
+
+## Tap-on-background closes popup
+
+`cy.on('tap', e => { if (e.target === cy) closeGraphPopup(); })`.

--- a/.github/skills/app-graph/references/schema.md
+++ b/.github/skills/app-graph/references/schema.md
@@ -1,0 +1,48 @@
+# StaticGraphArtifact Schema
+
+The HTML viewer consumes a `StaticGraphArtifact` JSON object as produced
+by `rad graph build`. The shape mirrors `src/shared/graph-types.ts` in
+`radius-project/github-extension`.
+
+```ts
+interface StaticGraphArtifact {
+  version: string;                  // e.g. "1.0.0"
+  generatedAt: string;              // ISO 8601 timestamp
+  sourceFile: string;               // path to source Bicep file
+  application: {
+    resources: ApplicationGraphResource[];
+  };
+}
+
+interface ApplicationGraphResource {
+  id: string;                       // full resource ID
+  name: string;                     // display name
+  type: string;                     // e.g. "Applications.Core/containers"
+  provisioningState: string;        // e.g. "Succeeded"
+  connections: ApplicationGraphConnection[];
+  outputResources: ApplicationGraphOutputResource[];
+  codeReference?: string;           // "src/path/file.ts#L10"
+  appDefinitionLine?: number;       // 1-based line in app.bicep
+  diffHash?: string;                // hash of review-relevant fields
+}
+
+interface ApplicationGraphConnection {
+  id: string;                       // target resource ID
+  direction: 'Inbound' | 'Outbound';
+}
+
+interface ApplicationGraphOutputResource {
+  id: string;
+  name: string;
+  type: string;                     // e.g. "apps/Deployment"
+}
+```
+
+## Notes for the renderer
+
+- Nodes are derived from `application.resources`.
+- Edges are derived from each resource's `connections` where
+  `direction === 'Outbound'`, and only when the connection's target `id`
+  also exists in `application.resources`.
+- `codeReference` is `path#L<n>` — split on `#L` to get path and line.
+- `appDefinitionLine` is 1-based.

--- a/.github/skills/app-graph/references/visual-style.md
+++ b/.github/skills/app-graph/references/visual-style.md
@@ -1,0 +1,64 @@
+# Visual Style — Resource Types
+
+The renderer themes each node by its Radius resource type with a Primer-aligned
+color pair plus a Unicode icon. In single-graph mode the type palette replaces
+the muted "unchanged" gray fill so each resource type is visually distinct; in
+diff mode the diff colors win so the diff signal stays dominant.
+
+The mapping lives in `TYPE_STYLES` and `styleForType()` near the top of
+[`../template/app-graph.html.tmpl`](../template/app-graph.html.tmpl). Update
+both this table and the template together when adding a new resource type.
+
+## Type table
+
+| Resource type                       | Icon | Fill      | Border    | Legend label         |
+| ----------------------------------- | ---- | --------- | --------- | -------------------- |
+| `Applications.Core/applications`    | 📦   | `#ddf4ff` | `#0969da` | Application          |
+| `Radius.Compute/containers`         | 🐳   | `#dbeefb` | `#1f6feb` | Container            |
+| `Radius.Compute/containerImages`    | 🖼️   | `#fbefff` | `#8250df` | Container image      |
+| `Radius.Compute/gateways`           | 🌐   | `#e6f4ff` | `#218bff` | Gateway              |
+| `Radius.Data/mySqlDatabases`        | 🐬   | `#fff1e5` | `#bc4c00` | MySQL database       |
+| `Radius.Data/postgreSqlDatabases`   | 🐘   | `#eaf4ff` | `#0550ae` | PostgreSQL database  |
+| `Radius.Data/mongoDatabases`        | 🍃   | `#dafbe1` | `#1a7f37` | Mongo database       |
+| `Radius.Data/redisCaches`           | 🧱   | `#ffebe9` | `#cf222e` | Redis cache          |
+| `Radius.Security/secrets`           | 🔐   | `#fff8c5` | `#9a6700` | Secret               |
+
+## Provider-prefix fallbacks
+
+When a resource type is not in the table above, `styleForType()` falls back to
+a category style based on the provider prefix:
+
+| Provider prefix       | Icon | Fill      | Border    | Legend label       |
+| --------------------- | ---- | --------- | --------- | ------------------ |
+| `Radius.Compute/*`    | ⚙️    | `#dbeefb` | `#1f6feb` | Compute resource   |
+| `Radius.Data/*`       | 🗄️   | `#fff1e5` | `#bc4c00` | Data resource      |
+| `Radius.Security/*`   | 🔐   | `#fff8c5` | `#9a6700` | Security resource  |
+| `aws.*`               | ☁️   | `#fff5cc` | `#d29922` | AWS resource       |
+| _everything else_     | 📄   | `#f6f8fa` | `#57606a` | Resource           |
+
+## Label format
+
+```
+<icon>  <resource.name>
+<shortType>
+```
+
+The icon is prepended to the first label line. `shortType` is
+`resource.type.split('/').pop()`, unchanged from the verbatim ported renderer.
+
+## Popup format
+
+The detail popup uses the same icon prefix on its title:
+
+```
+<icon>  <resource.name>
+<resource.type>
+```
+
+## Legend
+
+The legend at the top of the viewer is built dynamically from the resource
+types actually present in the rendered graph (deduplicated, sorted). It shows
+a colored swatch containing the icon, followed by the human-readable label
+from the tables above. A swatch's `title` attribute carries the full resource
+type for hover discoverability.

--- a/.github/skills/app-graph/template/app-graph.html.tmpl
+++ b/.github/skills/app-graph/template/app-graph.html.tmpl
@@ -51,7 +51,7 @@
     inset: 0;
   }
 
-  /* Diff legend */
+  /* Legend (resource types in single-graph mode, diff status in diff mode) */
   .radius-graph-legend {
     display: inline-flex;
     gap: 12px;
@@ -66,11 +66,15 @@
     color: var(--fg-muted);
   }
   .radius-graph-legend-swatch {
-    display: inline-block;
-    width: 12px;
-    height: 12px;
-    border-radius: 3px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    border-radius: 4px;
     border: 2px solid;
+    font-size: 11px;
+    line-height: 1;
   }
   .radius-graph-legend-swatch--added    { background: #dafbe1; border-color: #1a7f37; }
   .radius-graph-legend-swatch--modified { background: #fff8c5; border-color: #9a6700; }
@@ -179,6 +183,33 @@ const GRAPH_ARTIFACT = __GRAPH_DATA__;
     unchanged: '#f6f8fa',
   };
 
+  // ----- Resource-type styles (icon + Primer color pair) -----
+  // Keyed by full Radius type. In single-graph (unchanged) mode the
+  // per-type fill/border replace the diff "unchanged" gray defaults; in
+  // diff mode the diff colors win so status remains the dominant signal.
+  const TYPE_STYLES = {
+    'Applications.Core/applications':       { icon: '📦', bg: '#ddf4ff', border: '#0969da', label: 'Application' },
+    'Radius.Compute/containers':            { icon: '🐳', bg: '#dbeefb', border: '#1f6feb', label: 'Container' },
+    'Radius.Compute/containerImages':       { icon: '🖼️', bg: '#fbefff', border: '#8250df', label: 'Container image' },
+    'Radius.Compute/gateways':              { icon: '🌐', bg: '#e6f4ff', border: '#218bff', label: 'Gateway' },
+    'Radius.Data/mySqlDatabases':           { icon: '🐬', bg: '#fff1e5', border: '#bc4c00', label: 'MySQL database' },
+    'Radius.Data/postgreSqlDatabases':      { icon: '🐘', bg: '#eaf4ff', border: '#0550ae', label: 'PostgreSQL database' },
+    'Radius.Data/mongoDatabases':           { icon: '🍃', bg: '#dafbe1', border: '#1a7f37', label: 'Mongo database' },
+    'Radius.Data/redisCaches':              { icon: '🧱', bg: '#ffebe9', border: '#cf222e', label: 'Redis cache' },
+    'Radius.Security/secrets':              { icon: '🔐', bg: '#fff8c5', border: '#9a6700', label: 'Secret' },
+  };
+  const DEFAULT_TYPE_STYLE = { icon: '📄', bg: '#f6f8fa', border: '#57606a', label: 'Resource' };
+
+  function styleForType(type) {
+    if (type && TYPE_STYLES[type]) return TYPE_STYLES[type];
+    // Group fallbacks by provider prefix so unknown subtypes still look right.
+    if (type && type.startsWith('Radius.Compute/'))  return { icon: '⚙️', bg: '#dbeefb', border: '#1f6feb', label: 'Compute resource' };
+    if (type && type.startsWith('Radius.Data/'))     return { icon: '🗄️', bg: '#fff1e5', border: '#bc4c00', label: 'Data resource' };
+    if (type && type.startsWith('Radius.Security/')) return { icon: '🔐', bg: '#fff8c5', border: '#9a6700', label: 'Security resource' };
+    if (type && type.startsWith('aws.'))             return { icon: '☁️', bg: '#fff5cc', border: '#d29922', label: 'AWS resource' };
+    return DEFAULT_TYPE_STYLE;
+  }
+
   const resources = (GRAPH_ARTIFACT && GRAPH_ARTIFACT.application && GRAPH_ARTIFACT.application.resources) || [];
   const sourceFile = (GRAPH_ARTIFACT && GRAPH_ARTIFACT.sourceFile) || '';
   const generatedAt = (GRAPH_ARTIFACT && GRAPH_ARTIFACT.generatedAt) || '';
@@ -188,19 +219,34 @@ const GRAPH_ARTIFACT = __GRAPH_DATA__;
     (sourceFile ? ` — ${sourceFile}` : '') +
     (generatedAt ? ` — ${generatedAt}` : '');
 
-  // ----- Build legend (verbatim from createDiffLegend) -----
+  // ----- Build legend (one swatch per resource type present) -----
   const legend = document.getElementById('legend');
-  for (const item of [
-    { label: 'Added',     className: 'radius-graph-legend-swatch--added' },
-    { label: 'Modified',  className: 'radius-graph-legend-swatch--modified' },
-    { label: 'Removed',   className: 'radius-graph-legend-swatch--removed' },
-    { label: 'Unchanged', className: 'radius-graph-legend-swatch--unchanged' },
-  ]) {
-    const el = document.createElement('span');
-    el.className = 'radius-graph-legend-item';
-    el.innerHTML = `<span class="radius-graph-legend-swatch ${item.className}"></span>${item.label}`;
-    legend.appendChild(el);
+  function renderTypeLegend(types) {
+    legend.replaceChildren();
+    const seen = new Set();
+    const ordered = types.filter(t => {
+      if (seen.has(t)) return false;
+      seen.add(t);
+      return true;
+    }).sort();
+    for (const type of ordered) {
+      const s = styleForType(type);
+      const el = document.createElement('span');
+      el.className = 'radius-graph-legend-item';
+      el.title = type;
+      const swatch = document.createElement('span');
+      swatch.className = 'radius-graph-legend-swatch';
+      swatch.style.background = s.bg;
+      swatch.style.borderColor = s.border;
+      swatch.textContent = s.icon;
+      const text = document.createElement('span');
+      text.textContent = s.label;
+      el.appendChild(swatch);
+      el.appendChild(text);
+      legend.appendChild(el);
+    }
   }
+  renderTypeLegend(resources.map(r => r.type));
 
   // ----- Build elements (verbatim from buildCytoscapeElements) -----
   function buildElements(resources) {
@@ -208,17 +254,25 @@ const GRAPH_ARTIFACT = __GRAPH_DATA__;
     for (const r of resources) {
       const status = 'unchanged'; // single-graph mode
       const shortType = r.type && r.type.split('/').pop() || r.type;
-      const label = `${r.name}\n${shortType}`;
+      const typeStyle = styleForType(r.type);
+      // Icon prefix on the first line; short type stays on the second line.
+      const label = `${typeStyle.icon}  ${r.name}\n${shortType}`;
+      // In single-graph mode the per-type fill/border replace the muted
+      // "unchanged" gray defaults so each resource type is visually distinct.
+      // In diff mode (status !== 'unchanged') the diff colors win.
+      const bg     = status === 'unchanged' ? typeStyle.bg     : DIFF_BG_COLORS[status];
+      const border = status === 'unchanged' ? typeStyle.border : DIFF_COLORS[status];
       elements.push({
         group: 'nodes',
         data: {
           id: r.id,
           resourceId: r.id,
           label,
-          borderColor: DIFF_COLORS[status],
+          borderColor: border,
           borderWidth: DIFF_BORDER_WIDTH[status],
-          bgColor: DIFF_BG_COLORS[status],
+          bgColor: bg,
           diffStatus: status,
+          resourceType: r.type,
         },
       });
     }
@@ -269,10 +323,10 @@ const GRAPH_ARTIFACT = __GRAPH_DATA__;
           'border-color': 'data(borderColor)',
           'border-width': 'data(borderWidth)',
           shape: 'roundrectangle',
-          width: 140,
-          height: 55,
+          width: 160,
+          height: 60,
           'text-wrap': 'wrap',
-          'text-max-width': '120px',
+          'text-max-width': '140px',
         },
       },
       {
@@ -351,9 +405,10 @@ const GRAPH_ARTIFACT = __GRAPH_DATA__;
     popup.style.left = `${position.x}px`;
     popup.style.top = `${position.y}px`;
 
+    const typeStyle = styleForType(resource.type);
     const title = document.createElement('div');
     title.className = 'radius-graph-popup-title';
-    title.textContent = resource.name;
+    title.textContent = `${typeStyle.icon}  ${resource.name}`;
     popup.appendChild(title);
 
     const typeEl = document.createElement('div');

--- a/.github/skills/app-graph/template/app-graph.html.tmpl
+++ b/.github/skills/app-graph/template/app-graph.html.tmpl
@@ -1,0 +1,437 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Radius application graph</title>
+<style>
+  :root {
+    color-scheme: light;
+    --fg: #1f2328;
+    --fg-muted: #57606a;
+    --bg-canvas: #ffffff;
+    --bg-subtle: #f6f8fa;
+    --border: #d0d7de;
+    --link: #0969da;
+    --shadow: 0 8px 24px rgba(140, 149, 159, 0.2);
+  }
+  html, body { height: 100%; margin: 0; }
+  body {
+    font: 13px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+    color: var(--fg);
+    background: var(--bg-canvas);
+    display: flex;
+    flex-direction: column;
+  }
+  header {
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-subtle);
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+  header h1 {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+  }
+  header .meta {
+    color: var(--fg-muted);
+    font-size: 12px;
+  }
+  main {
+    position: relative;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+  #graph {
+    position: absolute;
+    inset: 0;
+  }
+
+  /* Diff legend */
+  .radius-graph-legend {
+    display: inline-flex;
+    gap: 12px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .radius-graph-legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--fg-muted);
+  }
+  .radius-graph-legend-swatch {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 3px;
+    border: 2px solid;
+  }
+  .radius-graph-legend-swatch--added    { background: #dafbe1; border-color: #1a7f37; }
+  .radius-graph-legend-swatch--modified { background: #fff8c5; border-color: #9a6700; }
+  .radius-graph-legend-swatch--removed  { background: #ffebe9; border-color: #cf222e; }
+  .radius-graph-legend-swatch--unchanged{ background: #f6f8fa; border-color: #57606a; }
+
+  /* Popup */
+  .radius-graph-popup {
+    position: absolute;
+    z-index: 10;
+    min-width: 220px;
+    max-width: 320px;
+    padding: 12px 14px 12px 14px;
+    background: #ffffff;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    box-shadow: var(--shadow);
+    color: var(--fg);
+  }
+  .radius-graph-popup-title {
+    font-weight: 600;
+    font-size: 14px;
+    word-break: break-word;
+    padding-right: 24px;
+  }
+  .radius-graph-popup-type {
+    margin-top: 2px;
+    color: var(--fg-muted);
+    font-size: 12px;
+    word-break: break-word;
+  }
+  .radius-graph-popup-links {
+    margin-top: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .radius-graph-popup-link {
+    color: var(--link);
+    text-decoration: none;
+    font-size: 13px;
+  }
+  .radius-graph-popup-link:hover { text-decoration: underline; }
+  .radius-graph-popup-close {
+    position: absolute;
+    top: 6px;
+    right: 8px;
+    background: transparent;
+    border: 0;
+    color: var(--fg-muted);
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 2px 6px;
+    border-radius: 4px;
+  }
+  .radius-graph-popup-close:hover { background: var(--bg-subtle); color: var(--fg); }
+</style>
+</head>
+<body>
+<header>
+  <h1>Radius application graph</h1>
+  <span class="meta" id="meta"></span>
+  <span style="flex:1"></span>
+  <span class="radius-graph-legend" id="legend"></span>
+</header>
+<main>
+  <div id="graph"></div>
+</main>
+
+<script src="https://unpkg.com/cytoscape@3/dist/cytoscape.min.js"></script>
+<script src="https://unpkg.com/dagre@0.8.5/dist/dagre.min.js"></script>
+<script src="https://unpkg.com/cytoscape-dagre@2/cytoscape-dagre.js"></script>
+
+<script>
+// === Embedded artifact (substituted by the skill) =========================
+const GRAPH_ARTIFACT = __GRAPH_DATA__;
+// =========================================================================
+
+(function () {
+  if (typeof cytoscape !== 'function') {
+    document.getElementById('graph').textContent = 'Failed to load Cytoscape.';
+    return;
+  }
+  if (window.cytoscapeDagre) {
+    cytoscape.use(window.cytoscapeDagre);
+  }
+
+  // ----- Primer palette (verbatim from graph-renderer.ts) -----
+  const DIFF_COLORS = {
+    added: '#1a7f37',
+    removed: '#cf222e',
+    modified: '#9a6700',
+    unchanged: '#57606a',
+  };
+  const DIFF_BORDER_WIDTH = {
+    added: 3,
+    removed: 3,
+    modified: 3,
+    unchanged: 2,
+  };
+  const DIFF_BG_COLORS = {
+    added: '#dafbe1',
+    removed: '#ffebe9',
+    modified: '#fff8c5',
+    unchanged: '#f6f8fa',
+  };
+
+  const resources = (GRAPH_ARTIFACT && GRAPH_ARTIFACT.application && GRAPH_ARTIFACT.application.resources) || [];
+  const sourceFile = (GRAPH_ARTIFACT && GRAPH_ARTIFACT.sourceFile) || '';
+  const generatedAt = (GRAPH_ARTIFACT && GRAPH_ARTIFACT.generatedAt) || '';
+
+  document.getElementById('meta').textContent =
+    `${resources.length} resource${resources.length === 1 ? '' : 's'}` +
+    (sourceFile ? ` — ${sourceFile}` : '') +
+    (generatedAt ? ` — ${generatedAt}` : '');
+
+  // ----- Build legend (verbatim from createDiffLegend) -----
+  const legend = document.getElementById('legend');
+  for (const item of [
+    { label: 'Added',     className: 'radius-graph-legend-swatch--added' },
+    { label: 'Modified',  className: 'radius-graph-legend-swatch--modified' },
+    { label: 'Removed',   className: 'radius-graph-legend-swatch--removed' },
+    { label: 'Unchanged', className: 'radius-graph-legend-swatch--unchanged' },
+  ]) {
+    const el = document.createElement('span');
+    el.className = 'radius-graph-legend-item';
+    el.innerHTML = `<span class="radius-graph-legend-swatch ${item.className}"></span>${item.label}`;
+    legend.appendChild(el);
+  }
+
+  // ----- Build elements (verbatim from buildCytoscapeElements) -----
+  function buildElements(resources) {
+    const elements = [];
+    for (const r of resources) {
+      const status = 'unchanged'; // single-graph mode
+      const shortType = r.type && r.type.split('/').pop() || r.type;
+      const label = `${r.name}\n${shortType}`;
+      elements.push({
+        group: 'nodes',
+        data: {
+          id: r.id,
+          resourceId: r.id,
+          label,
+          borderColor: DIFF_COLORS[status],
+          borderWidth: DIFF_BORDER_WIDTH[status],
+          bgColor: DIFF_BG_COLORS[status],
+          diffStatus: status,
+        },
+      });
+    }
+    for (const r of resources) {
+      for (const conn of (r.connections || [])) {
+        if (conn.direction === 'Outbound') {
+          const targetExists = resources.some(x => x.id === conn.id);
+          if (targetExists) {
+            elements.push({
+              group: 'edges',
+              data: {
+                id: `${r.id}-->${conn.id}`,
+                source: r.id,
+                target: conn.id,
+              },
+            });
+          }
+        }
+      }
+    }
+    return elements;
+  }
+
+  // ----- Cytoscape init (verbatim from renderGraph) -----
+  const cy = cytoscape({
+    container: document.getElementById('graph'),
+    elements: buildElements(resources),
+    layout: {
+      name: 'dagre',
+      rankDir: 'TB',
+      nodeSep: 60,
+      rankSep: 80,
+      edgeSep: 20,
+      padding: 48,
+      animate: false,
+    },
+    style: [
+      {
+        selector: 'node',
+        style: {
+          label: 'data(label)',
+          'text-valign': 'center',
+          'text-halign': 'center',
+          'font-size': '12px',
+          'font-family': '-apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif',
+          color: '#1f2328',
+          'background-color': 'data(bgColor)',
+          'border-color': 'data(borderColor)',
+          'border-width': 'data(borderWidth)',
+          shape: 'roundrectangle',
+          width: 140,
+          height: 55,
+          'text-wrap': 'wrap',
+          'text-max-width': '120px',
+        },
+      },
+      {
+        selector: 'edge',
+        style: {
+          width: 2,
+          'line-color': '#8c959f',
+          'target-arrow-color': '#8c959f',
+          'target-arrow-shape': 'triangle',
+          'curve-style': 'bezier',
+          'arrow-scale': 0.8,
+        },
+      },
+      {
+        selector: 'node:active',
+        style: { 'overlay-opacity': 0.1 },
+      },
+    ],
+    userZoomingEnabled: true,
+    userPanningEnabled: true,
+    boxSelectionEnabled: false,
+    autoungrabify: true,
+    minZoom: 0.3,
+    maxZoom: 3,
+  });
+
+  function fitGraph() {
+    cy.resize();
+    cy.fit(cy.elements(), 48);
+    cy.center();
+  }
+  requestAnimationFrame(() => {
+    fitGraph();
+    requestAnimationFrame(fitGraph);
+  });
+  window.addEventListener('resize', fitGraph);
+
+  // ----- Popup (verbatim from graph-navigation.ts, standalone variant) -----
+  const container = document.getElementById('graph');
+  let activeOutsideClickHandler = null;
+  let activeKeydownHandler = null;
+
+  function closeGraphPopup() {
+    const existing = container.querySelector('#radius-graph-popup');
+    if (existing) existing.remove();
+    if (activeOutsideClickHandler) {
+      document.removeEventListener('click', activeOutsideClickHandler);
+      activeOutsideClickHandler = null;
+    }
+    if (activeKeydownHandler) {
+      document.removeEventListener('keydown', activeKeydownHandler);
+      activeKeydownHandler = null;
+    }
+  }
+
+  function parseCodeReference(ref) {
+    if (!ref) return null;
+    const hash = ref.indexOf('#L');
+    if (hash === -1) return { path: ref, line: undefined };
+    const line = Number(ref.slice(hash + 2));
+    return { path: ref.slice(0, hash), line: Number.isFinite(line) ? line : undefined };
+  }
+
+  function fileHref(path, line) {
+    if (!path) return null;
+    const lineSuffix = line ? `#L${line}` : '';
+    return `${path}${lineSuffix}`;
+  }
+
+  function showGraphPopup(resource, position) {
+    closeGraphPopup();
+
+    const popup = document.createElement('div');
+    popup.className = 'radius-graph-popup';
+    popup.id = 'radius-graph-popup';
+    popup.style.left = `${position.x}px`;
+    popup.style.top = `${position.y}px`;
+
+    const title = document.createElement('div');
+    title.className = 'radius-graph-popup-title';
+    title.textContent = resource.name;
+    popup.appendChild(title);
+
+    const typeEl = document.createElement('div');
+    typeEl.className = 'radius-graph-popup-type';
+    typeEl.textContent = resource.type;
+    popup.appendChild(typeEl);
+
+    const links = document.createElement('div');
+    links.className = 'radius-graph-popup-links';
+
+    const cr = parseCodeReference(resource.codeReference);
+    if (cr && cr.path) {
+      const sourceHref = fileHref(cr.path, cr.line);
+      const a = document.createElement('a');
+      a.className = 'radius-graph-popup-link';
+      a.href = sourceHref;
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      a.textContent = '📄 Source code';
+      links.appendChild(a);
+    }
+
+    if (sourceFile) {
+      const a = document.createElement('a');
+      a.className = 'radius-graph-popup-link';
+      a.href = fileHref(sourceFile, resource.appDefinitionLine);
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      a.textContent = '📐 App definition';
+      links.appendChild(a);
+    }
+
+    popup.appendChild(links);
+
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'radius-graph-popup-close';
+    closeBtn.textContent = '×';
+    closeBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      closeGraphPopup();
+    });
+    popup.appendChild(closeBtn);
+
+    // Stop mouse events from bubbling to Cytoscape's container handler.
+    for (const evt of ['mousedown', 'mouseup', 'touchstart', 'touchend', 'pointerdown', 'pointerup']) {
+      popup.addEventListener(evt, (e) => e.stopPropagation());
+    }
+
+    container.appendChild(popup);
+
+    const closeOnOutsideClick = (e) => {
+      if (!popup.contains(e.target)) closeGraphPopup();
+    };
+    activeOutsideClickHandler = closeOnOutsideClick;
+    setTimeout(() => {
+      if (activeOutsideClickHandler === closeOnOutsideClick) {
+        document.addEventListener('click', closeOnOutsideClick);
+      }
+    }, 0);
+
+    const onKey = (e) => { if (e.key === 'Escape') closeGraphPopup(); };
+    activeKeydownHandler = onKey;
+    document.addEventListener('keydown', onKey);
+  }
+
+  cy.on('tap', 'node', (event) => {
+    const node = event.target;
+    const resourceId = node.data('resourceId');
+    const resource = resources.find(r => r.id === resourceId);
+    if (!resource) return;
+    const pos = node.renderedPosition();
+    showGraphPopup(resource, { x: pos.x + 10, y: pos.y + 10 });
+  });
+
+  cy.on('tap', (event) => {
+    if (event.target === cy) closeGraphPopup();
+  });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adds .github/skills/app-graph/ which renders a Radius application graph from app.bicep. Mirrors the renderer in radius-project/github-extension (Cytoscape v3 + cytoscape-dagre, Primer palette, popup with source links) and produces a self-contained HTML file plus an inline mermaid preview. Depends on 'rad graph build' (features/radius-graph branch).

# Description

_Please explain the changes you've made._

## Type of change

<!--
Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.
If you are making a bug fix or functionality change to Radius and do not have an associated issue link, please create one now. 
-->
- This pull request fixes a bug in Radius and has an approved issue (issue link required).
- This pull request adds or changes features of Radius and has an approved issue (issue link required).
- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).
- This pull request is a design document and only includes files in the eng/design-notes directory.

<!-- Please update the following to link the associated issue. This is required for some kinds of changes (see above). -->
Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [ ] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [ ] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [ ] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [ ] Not applicable
