### PR TITLE
Automate default resource type registration from resource-types-contrib

### DIFF
--- a/.github/workflows/verify-resource-types.yaml
+++ b/.github/workflows/verify-resource-types.yaml
@@ -52,8 +52,7 @@ on:
       - 'Makefile'
       - 'build/resource-types.mk'
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: verify-resource-types-${{ github.event.pull_request.number || github.sha }}
@@ -63,6 +62,8 @@ jobs:
   verify-resource-types:
     name: Verify resource type copies are in sync
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/verify-resource-types.yaml
+++ b/.github/workflows/verify-resource-types.yaml
@@ -1,0 +1,98 @@
+# ------------------------------------------------------------
+# Copyright 2023 The Radius Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+# This workflow verifies that the resource type manifest files committed in
+# deploy/manifest/built-in-providers/ match the versions in the
+# resource-types-contrib module pinned in go.mod.
+#
+# It runs "make sync-resource-types", which re-copies the manifest files from
+# the Go module cache, and then checks for any diff.
+#
+# - If there is no diff, the committed copies are in sync and the check passes.
+# - If there is a diff, the committed copies have drifted from the pinned
+#   version and the check fails. The developer must run
+#   "make sync-resource-types" locally and commit the updated files.
+#
+# This catches:
+#   - A go.mod bump without re-running "make sync-resource-types"
+#   - Manual edits to copied manifest files that drift from upstream
+#   - New entries in defaults.yaml without re-syncing
+#
+# Similar in spirit to the "go mod tidy" check, ensuring generated/copied
+# artifacts are consistent with their source.
+
+name: Verify resource type manifests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - release/*
+    paths:
+      # Trigger when the default list, the copied manifests, the dependency
+      # version (go.mod/go.sum), or the sync logic (Makefile, resource-types.mk)
+      # changes.
+      - 'go.mod'
+      - 'go.sum'
+      - 'deploy/manifest/defaults.yaml'
+      - 'deploy/manifest/built-in-providers/**'
+      - 'Makefile'
+      - 'build/resource-types.mk'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-resource-types-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  verify-resource-types:
+    name: Verify resource type copies are in sync
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install yq
+        run: |
+          mkdir -p "${RUNNER_TEMP}/bin"
+          GOBIN="${RUNNER_TEMP}/bin" go install github.com/mikefarah/yq/v4@v4.44.3
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      # Re-run the copy step (without bumping the version) to regenerate the
+      # manifest files from the module version pinned in go.mod.
+      - name: Sync resource types from pinned version
+        run: make sync-resource-types
+
+      # If the regenerated files differ from what's committed, the PR has drift.
+      - name: Check for drift
+        run: |
+          if ! git diff --exit-code deploy/manifest/built-in-providers/; then
+            echo ""
+            echo "ERROR: Resource type manifest copies are out of sync with the pinned"
+            echo "resource-types-contrib version in deploy/manifest/defaults.yaml."
+            echo ""
+            echo "Run 'make sync-resource-types' and commit the updated files."
+            exit 1
+          fi
+          echo "Resource type manifest copies are in sync."

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@
 ARROW := \033[34;1m=>\033[0m
 
 # order matters for these
-include build/help.mk build/version.mk build/build.mk build/util.mk build/generate.mk build/test.mk build/docker.mk build/artifacts.mk build/recipes.mk build/install.mk build/db.mk build/prettier.mk build/spellcheck.mk build/debug.mk build/workflow.mk
+include build/help.mk build/version.mk build/build.mk build/util.mk build/generate.mk build/test.mk build/docker.mk build/artifacts.mk build/recipes.mk build/install.mk build/db.mk build/prettier.mk build/spellcheck.mk build/debug.mk build/workflow.mk build/resource-types.mk

--- a/build/resource-types.mk
+++ b/build/resource-types.mk
@@ -1,0 +1,142 @@
+# ------------------------------------------------------------
+# Copyright 2023 The Radius Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+# resource-types.mk provides targets for synchronizing default resource type
+# manifests from the resource-types-contrib repository.
+#
+# resource-types-contrib is added to go.mod as a Go module dependency. It
+# contains no executable Go code. We depend on it purely to leverage Go's
+# module system for versioned downloads of YAML manifest files.
+#
+# A blank import in pkg/resourcetypescontrib/import.go keeps go mod tidy from
+# removing the dependency.
+#
+# How it works:
+#   1. defaults.yaml lists which resource types to ship as defaults, using
+#      <namespace>/<typeName> names (e.g. Radius.Compute/containers).
+#   2. Each entry is resolved to a file path in the Go module cache:
+#        Radius.Compute/containers → Compute/containers/containers.yaml
+#      (strip "Radius." prefix, then <namespace>/<typeName>/<typeName>.yaml)
+#   3. The resolved file is copied into both dev/ and self-hosted/ directories
+#      under deploy/manifest/built-in-providers/.
+#   4. At startup, UCP's RegisterDirectory loads these files. Manifests without
+#      a "location" field are routed via DefaultDownstreamEndpoint (dynamic-rp).
+#
+# Targets:
+#   update-resource-types  - Bump go.mod to the latest resource-types-contrib
+#                            version and copy the manifest files.
+#   sync-resource-types    - Copy manifest files from the version already pinned
+#                            in go.mod (no version bump). Used by CI to verify
+#                            that committed copies match the pinned version.
+
+# Path to the file listing default resource types.
+DEFAULTS_YAML := deploy/manifest/defaults.yaml
+
+# Directories where manifest copies are placed. Both directories contain the
+# same set of files; dev/ is used for local development (endpoints point to
+# localhost) and self-hosted/ is used for Kubernetes deployments.
+# Note: The copied manifests themselves have no "location" field. The location
+# is only present in the manually maintained files (radius_core.yaml, etc.).
+MANIFEST_DEST_DIRS := deploy/manifest/built-in-providers/dev deploy/manifest/built-in-providers/self-hosted
+
+# The Go module path for resource-types-contrib.
+RESOURCE_TYPES_MODULE := github.com/radius-project/resource-types-contrib
+
+# Files in the manifest destination directories that are manually maintained
+# and should NOT be managed (created or deleted) by the sync target. These are
+# resource providers that require explicit location addresses and are not
+# sourced from resource-types-contrib.
+MANUAL_CORE_MANIFESTS := applications_core.yaml applications_dapr.yaml applications_datastores.yaml applications_messaging.yaml microsoft_resources.yaml radius_core.yaml
+
+##@ Resource Types
+
+.PHONY: update-resource-types
+update-resource-types: ## Bump resource-types-contrib to latest and sync manifest files
+	@echo "Updating $(RESOURCE_TYPES_MODULE) to latest version..."
+	# Update only the resource-types-contrib dependency in go.mod to the latest
+	# version. Using @latest (without -u) avoids upgrading transitive dependencies.
+	go get $(RESOURCE_TYPES_MODULE)@latest
+	go mod tidy
+	# Copy the manifest files from the newly pinned version.
+	$(MAKE) sync-resource-types
+
+.PHONY: sync-resource-types
+sync-resource-types: ## Copy manifest files listed in defaults.yaml from the pinned resource-types-contrib version
+	@# Verify required tools are available before making any changes.
+	@command -v yq >/dev/null 2>&1 || { echo "ERROR: yq is required but not found. Install via: go install github.com/mikefarah/yq/v4@latest"; exit 1; }
+	@command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required but not found. Install via: brew install jq (macOS) or apt-get install jq (Linux)"; exit 1; }
+	@echo "Syncing default resource types from resource-types-contrib..."
+	# Resolve the module's local cache directory from the version pinned in go.mod.
+	# "go mod download -json" outputs JSON with a "Dir" field pointing to the
+	# cached module source on disk.
+	@MODULE_DIR=$$(go mod download -json $(RESOURCE_TYPES_MODULE) | jq -r '.Dir') && \
+	if [ -z "$$MODULE_DIR" ] || [ "$$MODULE_DIR" = "null" ]; then \
+		echo "ERROR: Could not resolve module directory for $(RESOURCE_TYPES_MODULE)."; \
+		echo "       Is the dependency present in go.mod?"; \
+		exit 1; \
+	fi && \
+	echo "  Module directory: $$MODULE_DIR" && \
+	# Iterate over each entry in defaults.yaml and copy the corresponding YAML
+	# file from the module cache into the manifest destination directories.
+	for entry in $$(yq '.defaultRegistration[]' $(DEFAULTS_YAML)); do \
+		# Convert the resource type name to a relative path inside the module.
+		# Example: Radius.Compute/containers → Compute/containers
+		rel_path=$$(echo "$$entry" | sed 's/^Radius\.//') && \
+		# Extract the type name (second path component).
+		# Example: Compute/containers → containers
+		type_name=$$(echo "$$rel_path" | cut -d'/' -f2) && \
+		# Build the full source path: <module_dir>/<namespace>/<type>/<type>.yaml
+		src_path="$$MODULE_DIR/$$rel_path/$$type_name.yaml" && \
+		if [ ! -f "$$src_path" ]; then \
+			echo "ERROR: File not found: $$src_path (from entry '$$entry')"; \
+			echo "       Verify the entry in $(DEFAULTS_YAML) and the resource-types-contrib version."; \
+			exit 1; \
+		fi && \
+		# Copy into each destination directory (dev/ and self-hosted/).
+		for dest_dir in $(MANIFEST_DEST_DIRS); do \
+			cp "$$src_path" "$$dest_dir/$$type_name.yaml"; \
+		done && \
+		echo "  Copied $$entry"; \
+	done
+	# Remove stale managed files: any YAML in the destination directories that
+	# is NOT in MANUAL_CORE_MANIFESTS and NOT in the current defaults.yaml list. This
+	# prevents previously-copied manifests from remaining registered after their
+	# entry is removed from defaults.yaml.
+	@EXPECTED_FILES="" && \
+	for entry in $$(yq '.defaultRegistration[]' $(DEFAULTS_YAML)); do \
+		rel_path=$$(echo "$$entry" | sed 's/^Radius\.//') && \
+		type_name=$$(echo "$$rel_path" | cut -d'/' -f2) && \
+		EXPECTED_FILES="$$EXPECTED_FILES $$type_name.yaml"; \
+	done && \
+	for dest_dir in $(MANIFEST_DEST_DIRS); do \
+		for file in "$$dest_dir"/*.yaml; do \
+			basename=$$(basename "$$file") && \
+			is_manual=false && \
+			for mc in $(MANUAL_CORE_MANIFESTS); do \
+				if [ "$$basename" = "$$mc" ]; then is_manual=true; break; fi; \
+			done && \
+			if [ "$$is_manual" = "true" ]; then continue; fi && \
+			is_expected=false && \
+			for ef in $$EXPECTED_FILES; do \
+				if [ "$$basename" = "$$ef" ]; then is_expected=true; break; fi; \
+			done && \
+			if [ "$$is_expected" = "false" ]; then \
+				echo "  Removing stale manifest: $$file"; \
+				rm "$$file"; \
+			fi; \
+		done; \
+	done
+	@echo "Done. Review and commit the updated files."

--- a/build/resource-types.mk
+++ b/build/resource-types.mk
@@ -79,9 +79,12 @@ sync-resource-types: ## Copy manifest files listed in defaults.yaml from the pin
 	@command -v yq >/dev/null 2>&1 || { echo "ERROR: yq is required but not found. Install via: go install github.com/mikefarah/yq/v4@latest"; exit 1; }
 	@command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required but not found. Install via: brew install jq (macOS) or apt-get install jq (Linux)"; exit 1; }
 	@echo "Syncing default resource types from resource-types-contrib..."
-	# Resolve the module's local cache directory from the version pinned in go.mod.
-	# "go mod download -json" outputs JSON with a "Dir" field pointing to the
-	# cached module source on disk.
+	@# Resolve the module's local cache directory from the version pinned in
+	@# go.mod. "go mod download -json" outputs JSON with a "Dir" field pointing
+	@# to the cached module source on disk. Then iterate over each entry in
+	@# defaults.yaml, convert the resource type name to a module-relative path
+	@# (e.g. Radius.Compute/containers -> Compute/containers/containers.yaml),
+	@# and copy the file into each destination directory (dev/ and self-hosted/).
 	@MODULE_DIR=$$(go mod download -json $(RESOURCE_TYPES_MODULE) | jq -r '.Dir') && \
 	if [ -z "$$MODULE_DIR" ] || [ "$$MODULE_DIR" = "null" ]; then \
 		echo "ERROR: Could not resolve module directory for $(RESOURCE_TYPES_MODULE)."; \
@@ -89,32 +92,24 @@ sync-resource-types: ## Copy manifest files listed in defaults.yaml from the pin
 		exit 1; \
 	fi && \
 	echo "  Module directory: $$MODULE_DIR" && \
-	# Iterate over each entry in defaults.yaml and copy the corresponding YAML
-	# file from the module cache into the manifest destination directories.
 	for entry in $$(yq '.defaultRegistration[]' $(DEFAULTS_YAML)); do \
-		# Convert the resource type name to a relative path inside the module.
-		# Example: Radius.Compute/containers → Compute/containers
 		rel_path=$$(echo "$$entry" | sed 's/^Radius\.//') && \
-		# Extract the type name (second path component).
-		# Example: Compute/containers → containers
 		type_name=$$(echo "$$rel_path" | cut -d'/' -f2) && \
-		# Build the full source path: <module_dir>/<namespace>/<type>/<type>.yaml
 		src_path="$$MODULE_DIR/$$rel_path/$$type_name.yaml" && \
 		if [ ! -f "$$src_path" ]; then \
 			echo "ERROR: File not found: $$src_path (from entry '$$entry')"; \
 			echo "       Verify the entry in $(DEFAULTS_YAML) and the resource-types-contrib version."; \
 			exit 1; \
 		fi && \
-		# Copy into each destination directory (dev/ and self-hosted/).
 		for dest_dir in $(MANIFEST_DEST_DIRS); do \
 			cp "$$src_path" "$$dest_dir/$$type_name.yaml"; \
 		done && \
 		echo "  Copied $$entry"; \
 	done
-	# Remove stale managed files: any YAML in the destination directories that
-	# is NOT in MANUAL_CORE_MANIFESTS and NOT in the current defaults.yaml list. This
-	# prevents previously-copied manifests from remaining registered after their
-	# entry is removed from defaults.yaml.
+	@# Remove stale managed files: any YAML in the destination directories that
+	@# is NOT in MANUAL_CORE_MANIFESTS and NOT in the current defaults.yaml list.
+	@# This prevents previously-copied manifests from remaining registered after
+	@# their entry is removed from defaults.yaml.
 	@EXPECTED_FILES="" && \
 	for entry in $$(yq '.defaultRegistration[]' $(DEFAULTS_YAML)); do \
 		rel_path=$$(echo "$$entry" | sed 's/^Radius\.//') && \

--- a/deploy/manifest/built-in-providers/dev/containers.yaml
+++ b/deploy/manifest/built-in-providers/dev/containers.yaml
@@ -1,11 +1,10 @@
 namespace: Radius.Compute
-location:
-  global: "http://dynamic-rp.radius-system:8082"
 types:
   containers:
     description: |
       The Radius.Compute/containers Resource Type is the primary resource type for running one or more containers. It is always part of a Radius Application. To deploy a Container add a resource to the application definition Bicep file.
 
+      ```
       extension radius
       param environment string 
 
@@ -23,11 +22,13 @@ types:
           }
         }
       }
+      ```
 
       By default, Containers deploys to Kubernetes. In this case, a Kubernetes Deployment named myContainer is deployed which includes a Pod named myContainer. Your Radius environment may deploy to other container platforms such as Azure Container Instances. 
 
       To accept network connections, expose a port on the container.
 
+      ```
       resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
         name: 'myContainer'
         properties: {
@@ -45,11 +46,13 @@ types:
           }
         }
       }
+      ```
       
       When a port is included, a Kubernetes Service named demo with the type ClusterIP is created.
       
       To create a emphemeral emptyDir shared between two containers add a Containers.properties.volumes.
 
+      ```
       resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
         name: 'myContainer'
         properties: {
@@ -82,6 +85,7 @@ types:
           }
         }
       }
+      ```
 
       To mount a persistent volume or secret see the PersistentVolumes and Secrets Resource Types.
 
@@ -433,404 +437,3 @@ types:
                 type: any
                 description: (Required) Platform-specific properties.
           required: [environment, application, containers]
-  routes:
-    description: |
-      The Radius.Compute/routes Resource Type defines network routes for responding to external clients. Note that a Routes resource is not required for service-to-service communication. To use Routes, define a Container and ensure a `containerPort` is specified.
-
-      extension radius
-      param environment string
-
-      resource myApplication 'Radius.Core/applications@2025-08-01-preview' = { ... }
-      
-      resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
-        name: 'myContainer'
-        properties: {
-          environment: environment
-          application: myApplication.id
-          containers: {
-            frontend: {
-              image: 'frontend:1.25'
-              ports: {
-                web: {
-                  containerPort: 8080
-                }
-              }
-            }
-            accounts: {
-              image: 'accounts:1.25'
-              ports: {
-                web: {
-                  containerPort: 8080
-                }
-              }
-            }
-          }
-        }
-      }
-
-      Then define a Routes resource.
-
-      resource ingressRule 'Radius.Compute/routes@2025-08-01-preview' = {
-        name: 'ingressRule'
-        properties: {
-          application: myApplication.id
-          environment: environment
-          kind: 'HTTP'
-          rules: [
-            {
-              matches: [
-                {
-                  httpPath: '/'
-                }
-              ]
-              destinationContainer: {
-                resourceId: myContainer.id
-                containerName: 'frontend'
-                containerPortName: 'web'
-              }
-            }
-          ]
-        }
-      }
-
-      The hostname is determined by the Recipe. 
-
-      Multiple rules can be included in Routes.
-
-      resource ingressRule 'Radius.Compute/routes@2025-08-01-preview' = {
-        name: 'ingressRule'
-        properties: {
-          application: myApplication.id
-          environment: environment
-          kind: 'HTTP'
-          rules: [
-            {
-              matches: [
-                {
-                  httpPath: '/'
-                }
-              ]
-              destinationContainer: {
-                resourceId: myContainer.id
-                containerName: 'frontend'
-                containerPortName: 'web'
-              }
-            }
-            {
-              matches: [
-                {
-                  httpPath: '/accounts'
-                }
-              ]
-              destinationContainer: {
-                resourceId: myContainer.id
-                containerName: 'accounts'
-                containerPortName: 'web'
-              }
-            }
-          ]
-        }
-      }
-
-    apiVersions:
-      '2025-08-01-preview':
-        schema: 
-          type: object
-          properties:
-            environment:
-              type: string
-              description: (Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`.
-            application:
-              type: string
-              description: (Required) The Radius Application ID. `myApplication.id` for example.
-            kind:
-              type: string 
-              enum: [HTTP, TCP, TLS, UDP]
-              description: (Optional) The type of rule. If not specified, `HTTPRoute` is assumed. `HTTPRoute` provides L7 ingress with support for matching based on the hostname and HTTP header. `TCPRoute` provides L4 ingress with no support for matching (all traffic is forwarded to the Container). `TLSRoute` provides L4 ingress with the ability to match based on Server Name Indication (SNI) which is equivalent to hostname in TLS. `UDPRoute` is similar to TCPRoutes but uses UDP.
-            hostnames:
-              type: array
-              description: (Optional) Use only when kind is HTTP or TLS. When HTTP, match against the HTTP Host header. When using TLS, match against the SNI attribute of TLS ClientHello message. Hostname may be preceded by a * wildcard.
-              items:
-                type: string
-            rules:
-              type: array
-              description: (Required) Rules define semantics for matching a network connection request based on conditions and forwarding the request to a Container.
-              items:
-                type: object
-                properties:
-                  matches:
-                    type: array
-                    description: (Required) Matches define conditions used for matching a request. 
-                    items:
-                      type: object
-                      properties:
-                        httpHeaders:
-                          type: array
-                          description: (Optional) HTTP headers to match. Specify only when kind is HTTP. Multiple match values are ANDed together. A request must match all the specified headers to match.
-                          items:
-                            type: object
-                            properties:
-                              name:
-                                type: string
-                                description: (Required) The name of the HTTP Header to be matched. Must be exact.
-                              value:
-                                type: string
-                                description: (Required) Value of HTTP Header to be matched.
-                            required: [name, value]
-                        httpMethod:
-                          type: string
-                          description: (Optional) The HTTP method to match. Specify only when kind is HTTP. 
-                          enum: [GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH]
-                        httpPath:
-                          type: string
-                          description: (Optional) The HTTP request path to match. Trailing space is ignored. Requests for `/abc`, `/abc/`, and ``/abc/def/` will all match `/abc`.
-                        httpQueryParams:
-                          type: array
-                          description: (Optional) HTTP query parameters to match. Specify only when kind is HTTP.
-                          items:
-                            type: object
-                            properties:
-                              name:
-                                type: string
-                                description: (Required) Name of the HTTP query parameter to be matched. Specify only when kind is HTTP.
-                              value:
-                                type: string
-                                description: (Required) Value of the HTTP query parameter to be matched.
-                            required: [name, value]
-                  destinationContainer:
-                    type: object
-                    properties:
-                      resourceId:
-                        type: string
-                        description: (Required) The Radius Container resource ID.
-                      containerName:
-                        type: string
-                        description: (Required) The specific container to target within the Container resource.
-                      containerPortName:
-                        type: string
-                        description: (Required) The port name to target from the container.
-                    required: [resourceId, containerName, containerPortName]
-                required: [matches, destinationContainer]
-            listener:
-              type: object
-              description: (Read Only) The Gateway Listener the route is assigned to.
-              readOnly: true
-              properties:
-                hostname:
-                  type: string
-                port:
-                  type: integer
-                protocol:
-                  type: string
-                  enum: [HTTP, HTTPS, TLS, TCP, UDP]
-          required: [environment, application, rules]
-  persistentVolumes:
-    description: |
-      The Radius.Compute/persistentVolumes Resource Type represents a persistent storage volume. A PersistentVolume can be referenced in the volumes property of a Container. 
-      To deploy, first add a PersistentVolume resource to the application definition Bicep file.
-      
-      extension radius
-      param environment string 
-
-      resource myApplication 'Radius.Core/applications@2025-08-01-preview' = { ... }
-
-      resource myPersistentVolume 'Radius.Compute/persistentVolumes@2025-08-01-preview' = {
-        name: 'myPersistentVolume'
-        properties: {
-          environment: environment
-          application: myApplication.id
-          sizeInGib: 1
-        }
-      }
-
-      Then reference the PersistentVolume by ID in the volumes property of the Container. Finally, set the mountPath in the container referencing the volumeName.
-
-      resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
-        name: 'myContainer'
-        properties: {
-          environment: environment
-          application: myApplication.id
-          containers: {
-            demo: {
-              image: 'ghcr.io/radius-project/samples/demo:latest'
-              volumeMounts: [
-                {
-                volumeName: 'data'
-                mountPath: '/app/data'
-                } 
-              ] 
-            }
-          }
-          volumes: {
-            data: {
-              persistentVolume: {
-                resourceId: myPersistentVolume.id
-              }
-            }
-          }
-        }
-      }
-      
-      PersistentVolumes may be shared across multiple Containers. To mount an existing PersistentVolume in read-only mode, reference the PersistentVolume by name using the `existing` Bicep keyword. For example:
-      
-      resource existingPersistentVolume 'Radius.Compute/persistentVolumes@2025-08-01-preview' existing = {
-        name: 'existingPersistentVolume'
-      }
-      
-      Then add the existing PersistentVolume to the volumes property of a Container with accessMode set to `ReadOnlyMany`.
-      
-      resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
-        name: 'myContainer'
-        properties: {
-          environment: environment
-          application: myApplication.id
-          containers: {
-            demo: {
-              image: 'ghcr.io/radius-project/samples/demo:latest'
-              volumeMounts: [
-                {
-                  volumeName: 'readOnlyData'
-                  mountPath: '/app/data' 
-                }
-              ]
-            }
-          }
-          volumes: {
-            readOnlyData: {
-              persistentVolume: {
-                resourceId: existingPersistentVolume.id
-                accessMode: 'ReadOnlyMany'
-              }
-            }
-          }
-        }
-      }
-      
-      A PersistentVolume may be shared between multiple Containers in read/write mode if the PersistentVolume was created with `accessMode: ReadWriteMany` and the volume is set to ReadWriteMany as well. Note that not all infrastructures support this mode.
-
-    apiVersions:
-      '2025-08-01-preview':
-        schema: 
-          type: object
-          properties:
-            environment:
-              type: string
-              description: (Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`.
-            application:
-              type: string
-              description: (Optional) The Radius Application ID. `myApplication.id` for example.
-            sizeInGib:
-              type: integer
-              description: (Required) The size of the volume in gibibytes. `1` represents 1024 MiB.
-            allowedAccessModes:
-              type: string
-              enum: [ReadWriteOnce, ReadOnlyMany, ReadWriteMany]
-              description: (Optional) The access modes which are permitted to be requested by a Container. Assumed to be all modes if not specified.
-          required: [environment, sizeInGib]
-  containerImages:
-    description: |
-      The Radius.Compute/containerImages Resource Type builds a container image from source and pushes it to a container registry. It is always part of a Radius Application.
-
-      This resource type is designed for local development workflows where the source code is available on the Kubernetes node filesystem (e.g., via kind `extraMounts` or k3d `-v` flags). It uses BuildKit to build and push the image.
-
-      To build and push a container image, add a containerImages resource to your application definition Bicep file:
-
-        extension radius
-        extension containerImages
-
-        param environment string
-
-        resource myApp 'Radius.Core/applications@2025-08-01-preview' = {
-          name: 'myApp'
-          properties: {
-            environment: environment
-          }
-        }
-
-        resource myImage 'Radius.Compute/containerImages@2025-08-01-preview' = {
-          name: 'myImage'
-          properties: {
-            environment: environment
-            application: myApp.id
-            image: 'ghcr.io/myorg/myapp:latest'
-            build: {
-              context: '/app/src/myapp'
-            }
-          }
-        }
-
-      Registry credentials are configured by the platform engineer when registering the recipe. Developers do not need to manage credentials.
-
-      To reference the built image in a Container resource:
-
-        resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
-          name: 'myContainer'
-          properties: {
-            environment: environment
-            application: myApp.id
-            containers: {
-              app: {
-                image: myImage.properties.image
-                ports: {
-                  web: {
-                    containerPort: 3000
-                  }
-                }
-              }
-            }
-          }
-        }
-
-      Prerequisites:
-
-      1. The Kubernetes cluster must have the source directory available on the node. For kind, use `extraMounts`. For k3d, use `-v` flags.
-
-      2. Registry credentials must be configured as recipe parameters when registering the recipe:
-
-        rad recipe register default --resource-type Radius.Compute/containerImages --template-kind terraform --template-path git::https://github.com/radius-project/resource-types-contrib.git//Compute/containerImages/recipes/kubernetes/terraform --parameters ghcr_username=USERNAME --parameters ghcr_token=PAT
-
-    apiVersions:
-      '2025-08-01-preview':
-        schema:
-          type: object
-          properties:
-            environment:
-              type: string
-              description: (Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`.
-            application:
-              type: string
-              description: (Required) The Radius Application ID. `myApplication.id` for example.
-            image:
-              type: string
-              description: (Required) The full container image reference including registry, repository, and tag. `ghcr.io/myorg/myapp:latest` for example. Must be lowercase.
-            build:
-              type: object
-              description: (Required) Build configuration for the container image.
-              properties:
-                context:
-                  type: string
-                  description: (Required) The path to the build context directory on the Kubernetes node. This must be a path available on the node, for example via kind extraMounts or k3d volume flags. `/app/src/myapp` for example.
-                dockerfile:
-                  type: string
-                  description: (Optional) The path to the Dockerfile relative to the build context. If not specified, `Dockerfile` is assumed.
-              required:
-                - context
-            registry:
-              type: object
-              description: (Optional) Registry authentication overrides. If not specified, the recipe uses credentials configured by the platform engineer as recipe parameters.
-              properties:
-                server:
-                  type: string
-                  description: (Optional) The registry server address. If not specified, `ghcr.io` is assumed.
-                username:
-                  type: string
-                  description: (Optional) The registry username.
-                token:
-                  type: string
-                  description: (Optional) The registry token or PAT.
-                  x-radius-sensitive: true
-          required:
-            - environment
-            - application
-            - image
-            - build

--- a/deploy/manifest/built-in-providers/dev/mySqlDatabases.yaml
+++ b/deploy/manifest/built-in-providers/dev/mySqlDatabases.yaml
@@ -1,6 +1,4 @@
 namespace: Radius.Data
-location:
-  global: "http://localhost:8082"
 types:
   mySqlDatabases:
     description: |

--- a/deploy/manifest/built-in-providers/dev/persistentVolumes.yaml
+++ b/deploy/manifest/built-in-providers/dev/persistentVolumes.yaml
@@ -1,0 +1,109 @@
+namespace: Radius.Compute
+types:
+  persistentVolumes:
+    description: |
+      The Radius.Compute/persistentVolumes Resource Type represents a persistent storage volume. A PersistentVolume can be referenced in the volumes property of a Container. 
+      To deploy, first add a PersistentVolume resource to the application definition Bicep file.
+      ```
+      extension radius
+      param environment string 
+
+      resource myApplication 'Radius.Core/applications@2025-08-01-preview' = { ... }
+
+      resource myPersistentVolume 'Radius.Compute/persistentVolumes@2025-08-01-preview' = {
+        name: 'myPersistentVolume'
+        properties: {
+          environment: environment
+          application: myApplication.id
+          sizeInGib: 1
+        }
+      }
+      ```
+
+      Then reference the PersistentVolume by ID in the volumes property of the Container. Finally, set the mountPath in the container referencing the volumeName.
+      ```
+      resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
+        name: 'myContainer'
+        properties: {
+          environment: environment
+          application: myApplication.id
+          containers: {
+            demo: {
+              image: 'ghcr.io/radius-project/samples/demo:latest'
+              volumeMounts: [
+                {
+                volumeName: 'data'
+                mountPath: '/app/data'
+                } 
+              ] 
+            }
+          }
+          volumes: {
+            data: {
+              persistentVolume: {
+                resourceId: myPersistentVolume.id
+              }
+            }
+          }
+        }
+      }
+      ```
+
+      PersistentVolumes may be shared across multiple Containers. To mount an existing PersistentVolume in read-only mode, reference the PersistentVolume by name using the `existing` Bicep keyword. For example:
+      ```
+      resource existingPersistentVolume 'Radius.Compute/persistentVolumes@2025-08-01-preview' existing = {
+        name: 'existingPersistentVolume'
+      }
+      ```
+
+      Then add the existing PersistentVolume to the volumes property of a Container with accessMode set to `ReadOnlyMany`.
+      ```
+      resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
+        name: 'myContainer'
+        properties: {
+          environment: environment
+          application: myApplication.id
+          containers: {
+            demo: {
+              image: 'ghcr.io/radius-project/samples/demo:latest'
+              volumeMounts: [
+                {
+                  volumeName: 'readOnlyData'
+                  mountPath: '/app/data' 
+                }
+              ]
+            }
+          }
+          volumes: {
+            readOnlyData: {
+              persistentVolume: {
+                resourceId: existingPersistentVolume.id
+                accessMode: 'ReadOnlyMany'
+              }
+            }
+          }
+        }
+      }
+      ```
+
+      A PersistentVolume may be shared between multiple Containers in read/write mode if the PersistentVolume was created with `accessMode: ReadWriteMany` and the volume is set to ReadWriteMany as well. Note that not all infrastructures support this mode.
+
+    apiVersions:
+      '2025-08-01-preview':
+        schema: 
+          type: object
+          properties:
+            environment:
+              type: string
+              description: (Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`.
+            application:
+              type: string
+              description: (Optional) The Radius Application ID. `myApplication.id` for example.
+            sizeInGib:
+              type: integer
+              description: (Required) The size of the volume in gibibytes. `1` represents 1024 MiB.
+            allowedAccessModes:
+              type: string
+              enum: [ReadWriteOnce, ReadOnlyMany, ReadWriteMany]
+              description: (Optional) The access modes which are permitted to be requested by a Container. Assumed to be all modes if not specified.
+          required: [environment, sizeInGib]

--- a/deploy/manifest/built-in-providers/dev/routes.yaml
+++ b/deploy/manifest/built-in-providers/dev/routes.yaml
@@ -1,0 +1,196 @@
+namespace: Radius.Compute
+types:
+  routes:
+    description: |
+      The Radius.Compute/routes Resource Type defines network routes for responding to external clients. Note that a Routes resource is not required for service-to-service communication. To use Routes, define a Container and ensure a `containerPort` is specified.
+      ```
+      extension radius
+      param environment string
+
+      resource myApplication 'Radius.Core/applications@2025-08-01-preview' = { ... }
+
+      resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
+        name: 'myContainer'
+        properties: {
+          environment: environment
+          application: myApplication.id
+          containers: {
+            frontend: {
+              image: 'frontend:1.25'
+              ports: {
+                web: {
+                  containerPort: 8080
+                }
+              }
+            }
+            accounts: {
+              image: 'accounts:1.25'
+              ports: {
+                web: {
+                  containerPort: 8080
+                }
+              }
+            }
+          }
+        }
+      }
+      ```
+
+      Then define a Routes resource.
+      ```
+      resource ingressRule 'Radius.Compute/routes@2025-08-01-preview' = {
+        name: 'ingressRule'
+        properties: {
+          application: myApplication.id
+          environment: environment
+          kind: 'HTTP'
+          rules: [
+            {
+              matches: [
+                {
+                  httpPath: '/'
+                }
+              ]
+              destinationContainer: {
+                resourceId: myContainer.id
+                containerName: 'frontend'
+                containerPort: myContainer.properties.containers.frontend.ports.web.containerPort
+              }
+            }
+          ]
+        }
+      }
+      ```
+
+      The hostname is determined by the Recipe. 
+
+      Multiple rules can be included in Routes.
+      ```
+      resource ingressRule 'Radius.Compute/routes@2025-08-01-preview' = {
+        name: 'ingressRule'
+        properties: {
+          application: myApplication.id
+          environment: environment
+          kind: 'HTTP'
+          rules: [
+            {
+              matches: [
+                {
+                  httpPath: '/'
+                }
+              ]
+              destinationContainer: {
+                resourceId: myContainer.id
+                containerName: 'frontend'
+                containerPort: myContainer.properties.containers.frontend.ports.web.containerPort
+              }
+            }
+            {
+              matches: [
+                {
+                  httpPath: '/accounts'
+                }
+              ]
+              destinationContainer: {
+                resourceId: myContainer.id
+                containerName: 'accounts'
+                containerPort: myContainer.properties.containers.accounts.ports.web.containerPort
+              }
+            }
+          ]
+        }
+      }
+      ```
+
+    apiVersions:
+      '2025-08-01-preview':
+        schema: 
+          type: object
+          properties:
+            environment:
+              type: string
+              description: (Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`.
+            application:
+              type: string
+              description: (Required) The Radius Application ID. `myApplication.id` for example.
+            kind:
+              type: string 
+              enum: [HTTP, TCP, TLS, UDP]
+              description: (Optional) The type of rule. If not specified, `HTTPRoute` is assumed. `HTTPRoute` provides L7 ingress with support for matching based on the hostname and HTTP header. `TCPRoute` provides L4 ingress with no support for matching (all traffic is forwarded to the Container). `TLSRoute` provides L4 ingress with the ability to match based on Server Name Indication (SNI) which is equivalent to hostname in TLS. `UDPRoute` is similar to TCPRoutes but uses UDP.
+            hostnames:
+              type: array
+              description: (Optional) Use only when kind is HTTP or TLS. When HTTP, match against the HTTP Host header. When using TLS, match against the SNI attribute of TLS ClientHello message. Hostname may be preceded by a * wildcard.
+              items:
+                type: string
+            rules:
+              type: array
+              description: (Required) Rules define semantics for matching a network connection request based on conditions and forwarding the request to a Container.
+              items:
+                type: object
+                properties:
+                  matches:
+                    type: array
+                    description: (Required) Matches define conditions used for matching a request. 
+                    items:
+                      type: object
+                      properties:
+                        httpHeaders:
+                          type: array
+                          description: (Optional) HTTP headers to match. Specify only when kind is HTTP. Multiple match values are ANDed together. A request must match all the specified headers to match.
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: (Required) The name of the HTTP Header to be matched. Must be exact.
+                              value:
+                                type: string
+                                description: (Required) Value of HTTP Header to be matched.
+                            required: [name, value]
+                        httpMethod:
+                          type: string
+                          description: (Optional) The HTTP method to match. Specify only when kind is HTTP. 
+                          enum: [GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH]
+                        httpPath:
+                          type: string
+                          description: (Optional) The HTTP request path to match. Trailing space is ignored. Requests for `/abc`, `/abc/`, and ``/abc/def/` will all match `/abc`.
+                        httpQueryParams:
+                          type: array
+                          description: (Optional) HTTP query parameters to match. Specify only when kind is HTTP.
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: (Required) Name of the HTTP query parameter to be matched. Specify only when kind is HTTP.
+                              value:
+                                type: string
+                                description: (Required) Value of the HTTP query parameter to be matched.
+                            required: [name, value]
+                  destinationContainer:
+                    type: object
+                    properties:
+                      resourceId:
+                        type: string
+                        description: (Required) The Radius Container resource ID.
+                      containerName:
+                        type: string
+                        description: (Required) The specific container to target within the Container resource.
+                      containerPort:
+                        type: integer
+                        description: (Required) The port to target from the container. 
+                    required: [resourceId, containerName, containerPort]
+                required: [matches, destinationContainer]
+            listener:
+              type: object
+              description: (Read Only) The Gateway Listener the route is assigned to.
+              readOnly: true
+              properties:
+                hostname:
+                  type: string
+                port:
+                  type: integer
+                protocol:
+                  type: string
+                  enum: [HTTP, HTTPS, TLS, TCP, UDP]
+          required: [environment, application, rules]

--- a/deploy/manifest/built-in-providers/dev/secrets.yaml
+++ b/deploy/manifest/built-in-providers/dev/secrets.yaml
@@ -1,79 +1,46 @@
 namespace: Radius.Security
-location:
-  global: "http://dynamic-rp.radius-system:8082"
 types:
   secrets:
     description: |
       The Radius.Security/secrets Resource Type stores sensitive data such as tokens, passwords, keys, and certificates. To create a new Secret, start by adding parameter to your application definition decorated with `@secure()`. Then add a `secrets` resource. Never include secret values in an application definition. 
+      ```
+        extension radius
+
+        @description('The Radius environment ID')
+        param environment string
 
         @secure()
-        param myTokenValue string
+        param password string
 
-        resource mySecret 'Radius.Security/secrets@2025-08-01-preview' = {
-          name: 'mySecret'
+        resource myApplication 'Radius.Core/applications@2025-08-01-preview' = { 
+          name: 'my-app'
+          properties: {
+            environment: environment
+          }
+        }
+
+        // Passing password as a parameter to `rad deploy`
+        // password=$(openssl rand -hex 16) 
+        // rad deploy app.bicep -p password=$password
+        resource dbCredentials 'Radius.Security/secrets@2025-08-01-preview' = {
+          name: 'db-creds'
           properties: {
             environment: environment
             application: myApplication.id
             data: {
-              myToken: {
-                value: myTokenValue
-                encoding: 'base64'   //optional
+              username: {
+                value: 'admin'
+              }
+              password: {
+                // From password parameter passed in via CLI. 
+                value: password
               }
             }
           }
         }
-
-      When `encoding` is not set, the value is assumed to be a string. For non-string secret data, set the `encoding` to `base64`.  
-
-      To use the new Secret with a Container, either, include the Secret in the `env` property or mount the Secret using the `volumes` property.
-
-      1. To use the Secret as an environment variable:
-
-        resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
-          name: 'myContainer'
-          properties: {
-            ...
-            container: {
-              ...
-              env: 
-                MY_SECRET_VALUE: {
-                  valueFrom: {
-                    secretRef: {
-                      source: mySecret.id
-                      key: 'myToken'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-
-      2. To mount the secret as a volume:
-
-        resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
-          name: 'myContainer'
-          properties: {
-            ...
-            container: {
-              ...
-              volumes: 
-                mySecretVolume: {
-                  kind: 'secret'
-                  mountPath: '/secrets'
-                  source: mySecret.id
-                }
-              }
-            }
-          }
-        }
-
-      Secrets may already existing in the Radius Resource Group. These can be referenced by name using the `existing` Bicep keyword. For example:
-
-        resource existingSecret 'Radius.Security/secrets@2025-08-01-preview' existing = {
-          name: 'existingSecret'
-        }
-
+        ```
+      When deploying the application, specify the secret value as a command-line parameter. It is recommended to use a password generator such as `openssl` or equivalent. For example, `rad deploy app.bicep -p password=$(openssl rand -hex 16)`.
+      For details on how to use the secret with another resource such as a container or database, see the documentation for those resource types.    
     apiVersions:
       "2025-08-01-preview":
         schema:
@@ -100,7 +67,6 @@ types:
             data:
               type: object
               description: '(Required) Map of secret data. For example: `data: { username: { value: user1 } password: { value: pass }}`'
-              x-radius-sensitive: true
               additionalProperties:
                 type: object
                 properties:
@@ -110,6 +76,7 @@ types:
                     description: (Optional) Content encoding of the value. If not specified, `string` is assumed.
                   value:
                     type: string
+                    x-radius-sensitive: true
                     description: (Required) The string value of the secret unless encoding is set to 'base64'.
                 required: [value]
           required:

--- a/deploy/manifest/built-in-providers/self-hosted/containers.yaml
+++ b/deploy/manifest/built-in-providers/self-hosted/containers.yaml
@@ -1,11 +1,10 @@
 namespace: Radius.Compute
-location:
-  global: "http://localhost:8082"
 types:
   containers:
     description: |
       The Radius.Compute/containers Resource Type is the primary resource type for running one or more containers. It is always part of a Radius Application. To deploy a Container add a resource to the application definition Bicep file.
 
+      ```
       extension radius
       param environment string 
 
@@ -23,11 +22,13 @@ types:
           }
         }
       }
+      ```
 
       By default, Containers deploys to Kubernetes. In this case, a Kubernetes Deployment named myContainer is deployed which includes a Pod named myContainer. Your Radius environment may deploy to other container platforms such as Azure Container Instances. 
 
       To accept network connections, expose a port on the container.
 
+      ```
       resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
         name: 'myContainer'
         properties: {
@@ -45,11 +46,13 @@ types:
           }
         }
       }
+      ```
       
       When a port is included, a Kubernetes Service named demo with the type ClusterIP is created.
       
       To create a emphemeral emptyDir shared between two containers add a Containers.properties.volumes.
 
+      ```
       resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
         name: 'myContainer'
         properties: {
@@ -82,6 +85,7 @@ types:
           }
         }
       }
+      ```
 
       To mount a persistent volume or secret see the PersistentVolumes and Secrets Resource Types.
 
@@ -433,404 +437,3 @@ types:
                 type: any
                 description: (Required) Platform-specific properties.
           required: [environment, application, containers]
-  routes:
-    description: |
-      The Radius.Compute/routes Resource Type defines network routes for responding to external clients. Note that a Routes resource is not required for service-to-service communication. To use Routes, define a Container and ensure a `containerPort` is specified.
-
-      extension radius
-      param environment string
-
-      resource myApplication 'Radius.Core/applications@2025-08-01-preview' = { ... }
-      
-      resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
-        name: 'myContainer'
-        properties: {
-          environment: environment
-          application: myApplication.id
-          containers: {
-            frontend: {
-              image: 'frontend:1.25'
-              ports: {
-                web: {
-                  containerPort: 8080
-                }
-              }
-            }
-            accounts: {
-              image: 'accounts:1.25'
-              ports: {
-                web: {
-                  containerPort: 8080
-                }
-              }
-            }
-          }
-        }
-      }
-
-      Then define a Routes resource.
-
-      resource ingressRule 'Radius.Compute/routes@2025-08-01-preview' = {
-        name: 'ingressRule'
-        properties: {
-          application: myApplication.id
-          environment: environment
-          kind: 'HTTP'
-          rules: [
-            {
-              matches: [
-                {
-                  httpPath: '/'
-                }
-              ]
-              destinationContainer: {
-                resourceId: myContainer.id
-                containerName: 'frontend'
-                containerPortName: 'web'
-              }
-            }
-          ]
-        }
-      }
-
-      The hostname is determined by the Recipe. 
-
-      Multiple rules can be included in Routes.
-
-      resource ingressRule 'Radius.Compute/routes@2025-08-01-preview' = {
-        name: 'ingressRule'
-        properties: {
-          application: myApplication.id
-          environment: environment
-          kind: 'HTTP'
-          rules: [
-            {
-              matches: [
-                {
-                  httpPath: '/'
-                }
-              ]
-              destinationContainer: {
-                resourceId: myContainer.id
-                containerName: 'frontend'
-                containerPortName: 'web'
-              }
-            }
-            {
-              matches: [
-                {
-                  httpPath: '/accounts'
-                }
-              ]
-              destinationContainer: {
-                resourceId: myContainer.id
-                containerName: 'accounts'
-                containerPortName: 'web'
-              }
-            }
-          ]
-        }
-      }
-
-    apiVersions:
-      '2025-08-01-preview':
-        schema: 
-          type: object
-          properties:
-            environment:
-              type: string
-              description: (Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`.
-            application:
-              type: string
-              description: (Required) The Radius Application ID. `myApplication.id` for example.
-            kind:
-              type: string 
-              enum: [HTTP, TCP, TLS, UDP]
-              description: (Optional) The type of rule. If not specified, `HTTPRoute` is assumed. `HTTPRoute` provides L7 ingress with support for matching based on the hostname and HTTP header. `TCPRoute` provides L4 ingress with no support for matching (all traffic is forwarded to the Container). `TLSRoute` provides L4 ingress with the ability to match based on Server Name Indication (SNI) which is equivalent to hostname in TLS. `UDPRoute` is similar to TCPRoutes but uses UDP.
-            hostnames:
-              type: array
-              description: (Optional) Use only when kind is HTTP or TLS. When HTTP, match against the HTTP Host header. When using TLS, match against the SNI attribute of TLS ClientHello message. Hostname may be preceded by a * wildcard.
-              items:
-                type: string
-            rules:
-              type: array
-              description: (Required) Rules define semantics for matching a network connection request based on conditions and forwarding the request to a Container.
-              items:
-                type: object
-                properties:
-                  matches:
-                    type: array
-                    description: (Required) Matches define conditions used for matching a request. 
-                    items:
-                      type: object
-                      properties:
-                        httpHeaders:
-                          type: array
-                          description: (Optional) HTTP headers to match. Specify only when kind is HTTP. Multiple match values are ANDed together. A request must match all the specified headers to match.
-                          items:
-                            type: object
-                            properties:
-                              name:
-                                type: string
-                                description: (Required) The name of the HTTP Header to be matched. Must be exact.
-                              value:
-                                type: string
-                                description: (Required) Value of HTTP Header to be matched.
-                            required: [name, value]
-                        httpMethod:
-                          type: string
-                          description: (Optional) The HTTP method to match. Specify only when kind is HTTP. 
-                          enum: [GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH]
-                        httpPath:
-                          type: string
-                          description: (Optional) The HTTP request path to match. Trailing space is ignored. Requests for `/abc`, `/abc/`, and ``/abc/def/` will all match `/abc`.
-                        httpQueryParams:
-                          type: array
-                          description: (Optional) HTTP query parameters to match. Specify only when kind is HTTP.
-                          items:
-                            type: object
-                            properties:
-                              name:
-                                type: string
-                                description: (Required) Name of the HTTP query parameter to be matched. Specify only when kind is HTTP.
-                              value:
-                                type: string
-                                description: (Required) Value of the HTTP query parameter to be matched.
-                            required: [name, value]
-                  destinationContainer:
-                    type: object
-                    properties:
-                      resourceId:
-                        type: string
-                        description: (Required) The Radius Container resource ID.
-                      containerName:
-                        type: string
-                        description: (Required) The specific container to target within the Container resource.
-                      containerPortName:
-                        type: string
-                        description: (Required) The port name to target from the container.
-                    required: [resourceId, containerName, containerPortName]
-                required: [matches, destinationContainer]
-            listener:
-              type: object
-              description: (Read Only) The Gateway Listener the route is assigned to.
-              readOnly: true
-              properties:
-                hostname:
-                  type: string
-                port:
-                  type: integer
-                protocol:
-                  type: string
-                  enum: [HTTP, HTTPS, TLS, TCP, UDP]
-          required: [environment, application, rules]
-  persistentVolumes:
-    description: |
-      The Radius.Compute/persistentVolumes Resource Type represents a persistent storage volume. A PersistentVolume can be referenced in the volumes property of a Container. 
-      To deploy, first add a PersistentVolume resource to the application definition Bicep file.
-      
-      extension radius
-      param environment string 
-
-      resource myApplication 'Radius.Core/applications@2025-08-01-preview' = { ... }
-
-      resource myPersistentVolume 'Radius.Compute/persistentVolumes@2025-08-01-preview' = {
-        name: 'myPersistentVolume'
-        properties: {
-          environment: environment
-          application: myApplication.id
-          sizeInGib: 1
-        }
-      }
-
-      Then reference the PersistentVolume by ID in the volumes property of the Container. Finally, set the mountPath in the container referencing the volumeName.
-
-      resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
-        name: 'myContainer'
-        properties: {
-          environment: environment
-          application: myApplication.id
-          containers: {
-            demo: {
-              image: 'ghcr.io/radius-project/samples/demo:latest'
-              volumeMounts: [
-                {
-                volumeName: 'data'
-                mountPath: '/app/data'
-                } 
-              ] 
-            }
-          }
-          volumes: {
-            data: {
-              persistentVolume: {
-                resourceId: myPersistentVolume.id
-              }
-            }
-          }
-        }
-      }
-      
-      PersistentVolumes may be shared across multiple Containers. To mount an existing PersistentVolume in read-only mode, reference the PersistentVolume by name using the `existing` Bicep keyword. For example:
-      
-      resource existingPersistentVolume 'Radius.Compute/persistentVolumes@2025-08-01-preview' existing = {
-        name: 'existingPersistentVolume'
-      }
-      
-      Then add the existing PersistentVolume to the volumes property of a Container with accessMode set to `ReadOnlyMany`.
-      
-      resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
-        name: 'myContainer'
-        properties: {
-          environment: environment
-          application: myApplication.id
-          containers: {
-            demo: {
-              image: 'ghcr.io/radius-project/samples/demo:latest'
-              volumeMounts: [
-                {
-                  volumeName: 'readOnlyData'
-                  mountPath: '/app/data' 
-                }
-              ]
-            }
-          }
-          volumes: {
-            readOnlyData: {
-              persistentVolume: {
-                resourceId: existingPersistentVolume.id
-                accessMode: 'ReadOnlyMany'
-              }
-            }
-          }
-        }
-      }
-      
-      A PersistentVolume may be shared between multiple Containers in read/write mode if the PersistentVolume was created with `accessMode: ReadWriteMany` and the volume is set to ReadWriteMany as well. Note that not all infrastructures support this mode.
-
-    apiVersions:
-      '2025-08-01-preview':
-        schema: 
-          type: object
-          properties:
-            environment:
-              type: string
-              description: (Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`.
-            application:
-              type: string
-              description: (Optional) The Radius Application ID. `myApplication.id` for example.
-            sizeInGib:
-              type: integer
-              description: (Required) The size of the volume in gibibytes. `1` represents 1024 MiB.
-            allowedAccessModes:
-              type: string
-              enum: [ReadWriteOnce, ReadOnlyMany, ReadWriteMany]
-              description: (Optional) The access modes which are permitted to be requested by a Container. Assumed to be all modes if not specified.
-          required: [environment, sizeInGib]
-  containerImages:
-    description: |
-      The Radius.Compute/containerImages Resource Type builds a container image from source and pushes it to a container registry. It is always part of a Radius Application.
-
-      This resource type is designed for local development workflows where the source code is available on the Kubernetes node filesystem (e.g., via kind `extraMounts` or k3d `-v` flags). It uses BuildKit to build and push the image.
-
-      To build and push a container image, add a containerImages resource to your application definition Bicep file:
-
-        extension radius
-        extension containerImages
-
-        param environment string
-
-        resource myApp 'Radius.Core/applications@2025-08-01-preview' = {
-          name: 'myApp'
-          properties: {
-            environment: environment
-          }
-        }
-
-        resource myImage 'Radius.Compute/containerImages@2025-08-01-preview' = {
-          name: 'myImage'
-          properties: {
-            environment: environment
-            application: myApp.id
-            image: 'ghcr.io/myorg/myapp:latest'
-            build: {
-              context: '/app/src/myapp'
-            }
-          }
-        }
-
-      Registry credentials are configured by the platform engineer when registering the recipe. Developers do not need to manage credentials.
-
-      To reference the built image in a Container resource:
-
-        resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
-          name: 'myContainer'
-          properties: {
-            environment: environment
-            application: myApp.id
-            containers: {
-              app: {
-                image: myImage.properties.image
-                ports: {
-                  web: {
-                    containerPort: 3000
-                  }
-                }
-              }
-            }
-          }
-        }
-
-      Prerequisites:
-
-      1. The Kubernetes cluster must have the source directory available on the node. For kind, use `extraMounts`. For k3d, use `-v` flags.
-
-      2. Registry credentials must be configured as recipe parameters when registering the recipe:
-
-        rad recipe register default --resource-type Radius.Compute/containerImages --template-kind terraform --template-path git::https://github.com/radius-project/resource-types-contrib.git//Compute/containerImages/recipes/kubernetes/terraform --parameters ghcr_username=USERNAME --parameters ghcr_token=PAT
-
-    apiVersions:
-      '2025-08-01-preview':
-        schema:
-          type: object
-          properties:
-            environment:
-              type: string
-              description: (Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`.
-            application:
-              type: string
-              description: (Required) The Radius Application ID. `myApplication.id` for example.
-            image:
-              type: string
-              description: (Required) The full container image reference including registry, repository, and tag. `ghcr.io/myorg/myapp:latest` for example. Must be lowercase.
-            build:
-              type: object
-              description: (Required) Build configuration for the container image.
-              properties:
-                context:
-                  type: string
-                  description: (Required) The path to the build context directory on the Kubernetes node. This must be a path available on the node, for example via kind extraMounts or k3d volume flags. `/app/src/myapp` for example.
-                dockerfile:
-                  type: string
-                  description: (Optional) The path to the Dockerfile relative to the build context. If not specified, `Dockerfile` is assumed.
-              required:
-                - context
-            registry:
-              type: object
-              description: (Optional) Registry authentication overrides. If not specified, the recipe uses credentials configured by the platform engineer as recipe parameters.
-              properties:
-                server:
-                  type: string
-                  description: (Optional) The registry server address. If not specified, `ghcr.io` is assumed.
-                username:
-                  type: string
-                  description: (Optional) The registry username.
-                token:
-                  type: string
-                  description: (Optional) The registry token or PAT.
-                  x-radius-sensitive: true
-          required:
-            - environment
-            - application
-            - image
-            - build

--- a/deploy/manifest/built-in-providers/self-hosted/mySqlDatabases.yaml
+++ b/deploy/manifest/built-in-providers/self-hosted/mySqlDatabases.yaml
@@ -1,6 +1,4 @@
 namespace: Radius.Data
-location:
-  global: "http://dynamic-rp.radius-system:8082"
 types:
   mySqlDatabases:
     description: |
@@ -96,6 +94,4 @@ types:
               type: integer
               description: "(Read-only) The port number used to connect to the database."
               readOnly: true
-          required:
-            - environment
-            - secretName
+          required: [environment,secretName]

--- a/deploy/manifest/built-in-providers/self-hosted/persistentVolumes.yaml
+++ b/deploy/manifest/built-in-providers/self-hosted/persistentVolumes.yaml
@@ -1,0 +1,109 @@
+namespace: Radius.Compute
+types:
+  persistentVolumes:
+    description: |
+      The Radius.Compute/persistentVolumes Resource Type represents a persistent storage volume. A PersistentVolume can be referenced in the volumes property of a Container. 
+      To deploy, first add a PersistentVolume resource to the application definition Bicep file.
+      ```
+      extension radius
+      param environment string 
+
+      resource myApplication 'Radius.Core/applications@2025-08-01-preview' = { ... }
+
+      resource myPersistentVolume 'Radius.Compute/persistentVolumes@2025-08-01-preview' = {
+        name: 'myPersistentVolume'
+        properties: {
+          environment: environment
+          application: myApplication.id
+          sizeInGib: 1
+        }
+      }
+      ```
+
+      Then reference the PersistentVolume by ID in the volumes property of the Container. Finally, set the mountPath in the container referencing the volumeName.
+      ```
+      resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
+        name: 'myContainer'
+        properties: {
+          environment: environment
+          application: myApplication.id
+          containers: {
+            demo: {
+              image: 'ghcr.io/radius-project/samples/demo:latest'
+              volumeMounts: [
+                {
+                volumeName: 'data'
+                mountPath: '/app/data'
+                } 
+              ] 
+            }
+          }
+          volumes: {
+            data: {
+              persistentVolume: {
+                resourceId: myPersistentVolume.id
+              }
+            }
+          }
+        }
+      }
+      ```
+
+      PersistentVolumes may be shared across multiple Containers. To mount an existing PersistentVolume in read-only mode, reference the PersistentVolume by name using the `existing` Bicep keyword. For example:
+      ```
+      resource existingPersistentVolume 'Radius.Compute/persistentVolumes@2025-08-01-preview' existing = {
+        name: 'existingPersistentVolume'
+      }
+      ```
+
+      Then add the existing PersistentVolume to the volumes property of a Container with accessMode set to `ReadOnlyMany`.
+      ```
+      resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
+        name: 'myContainer'
+        properties: {
+          environment: environment
+          application: myApplication.id
+          containers: {
+            demo: {
+              image: 'ghcr.io/radius-project/samples/demo:latest'
+              volumeMounts: [
+                {
+                  volumeName: 'readOnlyData'
+                  mountPath: '/app/data' 
+                }
+              ]
+            }
+          }
+          volumes: {
+            readOnlyData: {
+              persistentVolume: {
+                resourceId: existingPersistentVolume.id
+                accessMode: 'ReadOnlyMany'
+              }
+            }
+          }
+        }
+      }
+      ```
+
+      A PersistentVolume may be shared between multiple Containers in read/write mode if the PersistentVolume was created with `accessMode: ReadWriteMany` and the volume is set to ReadWriteMany as well. Note that not all infrastructures support this mode.
+
+    apiVersions:
+      '2025-08-01-preview':
+        schema: 
+          type: object
+          properties:
+            environment:
+              type: string
+              description: (Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`.
+            application:
+              type: string
+              description: (Optional) The Radius Application ID. `myApplication.id` for example.
+            sizeInGib:
+              type: integer
+              description: (Required) The size of the volume in gibibytes. `1` represents 1024 MiB.
+            allowedAccessModes:
+              type: string
+              enum: [ReadWriteOnce, ReadOnlyMany, ReadWriteMany]
+              description: (Optional) The access modes which are permitted to be requested by a Container. Assumed to be all modes if not specified.
+          required: [environment, sizeInGib]

--- a/deploy/manifest/built-in-providers/self-hosted/routes.yaml
+++ b/deploy/manifest/built-in-providers/self-hosted/routes.yaml
@@ -1,0 +1,196 @@
+namespace: Radius.Compute
+types:
+  routes:
+    description: |
+      The Radius.Compute/routes Resource Type defines network routes for responding to external clients. Note that a Routes resource is not required for service-to-service communication. To use Routes, define a Container and ensure a `containerPort` is specified.
+      ```
+      extension radius
+      param environment string
+
+      resource myApplication 'Radius.Core/applications@2025-08-01-preview' = { ... }
+
+      resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
+        name: 'myContainer'
+        properties: {
+          environment: environment
+          application: myApplication.id
+          containers: {
+            frontend: {
+              image: 'frontend:1.25'
+              ports: {
+                web: {
+                  containerPort: 8080
+                }
+              }
+            }
+            accounts: {
+              image: 'accounts:1.25'
+              ports: {
+                web: {
+                  containerPort: 8080
+                }
+              }
+            }
+          }
+        }
+      }
+      ```
+
+      Then define a Routes resource.
+      ```
+      resource ingressRule 'Radius.Compute/routes@2025-08-01-preview' = {
+        name: 'ingressRule'
+        properties: {
+          application: myApplication.id
+          environment: environment
+          kind: 'HTTP'
+          rules: [
+            {
+              matches: [
+                {
+                  httpPath: '/'
+                }
+              ]
+              destinationContainer: {
+                resourceId: myContainer.id
+                containerName: 'frontend'
+                containerPort: myContainer.properties.containers.frontend.ports.web.containerPort
+              }
+            }
+          ]
+        }
+      }
+      ```
+
+      The hostname is determined by the Recipe. 
+
+      Multiple rules can be included in Routes.
+      ```
+      resource ingressRule 'Radius.Compute/routes@2025-08-01-preview' = {
+        name: 'ingressRule'
+        properties: {
+          application: myApplication.id
+          environment: environment
+          kind: 'HTTP'
+          rules: [
+            {
+              matches: [
+                {
+                  httpPath: '/'
+                }
+              ]
+              destinationContainer: {
+                resourceId: myContainer.id
+                containerName: 'frontend'
+                containerPort: myContainer.properties.containers.frontend.ports.web.containerPort
+              }
+            }
+            {
+              matches: [
+                {
+                  httpPath: '/accounts'
+                }
+              ]
+              destinationContainer: {
+                resourceId: myContainer.id
+                containerName: 'accounts'
+                containerPort: myContainer.properties.containers.accounts.ports.web.containerPort
+              }
+            }
+          ]
+        }
+      }
+      ```
+
+    apiVersions:
+      '2025-08-01-preview':
+        schema: 
+          type: object
+          properties:
+            environment:
+              type: string
+              description: (Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`.
+            application:
+              type: string
+              description: (Required) The Radius Application ID. `myApplication.id` for example.
+            kind:
+              type: string 
+              enum: [HTTP, TCP, TLS, UDP]
+              description: (Optional) The type of rule. If not specified, `HTTPRoute` is assumed. `HTTPRoute` provides L7 ingress with support for matching based on the hostname and HTTP header. `TCPRoute` provides L4 ingress with no support for matching (all traffic is forwarded to the Container). `TLSRoute` provides L4 ingress with the ability to match based on Server Name Indication (SNI) which is equivalent to hostname in TLS. `UDPRoute` is similar to TCPRoutes but uses UDP.
+            hostnames:
+              type: array
+              description: (Optional) Use only when kind is HTTP or TLS. When HTTP, match against the HTTP Host header. When using TLS, match against the SNI attribute of TLS ClientHello message. Hostname may be preceded by a * wildcard.
+              items:
+                type: string
+            rules:
+              type: array
+              description: (Required) Rules define semantics for matching a network connection request based on conditions and forwarding the request to a Container.
+              items:
+                type: object
+                properties:
+                  matches:
+                    type: array
+                    description: (Required) Matches define conditions used for matching a request. 
+                    items:
+                      type: object
+                      properties:
+                        httpHeaders:
+                          type: array
+                          description: (Optional) HTTP headers to match. Specify only when kind is HTTP. Multiple match values are ANDed together. A request must match all the specified headers to match.
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: (Required) The name of the HTTP Header to be matched. Must be exact.
+                              value:
+                                type: string
+                                description: (Required) Value of HTTP Header to be matched.
+                            required: [name, value]
+                        httpMethod:
+                          type: string
+                          description: (Optional) The HTTP method to match. Specify only when kind is HTTP. 
+                          enum: [GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH]
+                        httpPath:
+                          type: string
+                          description: (Optional) The HTTP request path to match. Trailing space is ignored. Requests for `/abc`, `/abc/`, and ``/abc/def/` will all match `/abc`.
+                        httpQueryParams:
+                          type: array
+                          description: (Optional) HTTP query parameters to match. Specify only when kind is HTTP.
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: (Required) Name of the HTTP query parameter to be matched. Specify only when kind is HTTP.
+                              value:
+                                type: string
+                                description: (Required) Value of the HTTP query parameter to be matched.
+                            required: [name, value]
+                  destinationContainer:
+                    type: object
+                    properties:
+                      resourceId:
+                        type: string
+                        description: (Required) The Radius Container resource ID.
+                      containerName:
+                        type: string
+                        description: (Required) The specific container to target within the Container resource.
+                      containerPort:
+                        type: integer
+                        description: (Required) The port to target from the container. 
+                    required: [resourceId, containerName, containerPort]
+                required: [matches, destinationContainer]
+            listener:
+              type: object
+              description: (Read Only) The Gateway Listener the route is assigned to.
+              readOnly: true
+              properties:
+                hostname:
+                  type: string
+                port:
+                  type: integer
+                protocol:
+                  type: string
+                  enum: [HTTP, HTTPS, TLS, TCP, UDP]
+          required: [environment, application, rules]

--- a/deploy/manifest/built-in-providers/self-hosted/secrets.yaml
+++ b/deploy/manifest/built-in-providers/self-hosted/secrets.yaml
@@ -1,79 +1,46 @@
 namespace: Radius.Security
-location:
-  global: "http://localhost:8082"
 types:
   secrets:
     description: |
       The Radius.Security/secrets Resource Type stores sensitive data such as tokens, passwords, keys, and certificates. To create a new Secret, start by adding parameter to your application definition decorated with `@secure()`. Then add a `secrets` resource. Never include secret values in an application definition. 
+      ```
+        extension radius
+
+        @description('The Radius environment ID')
+        param environment string
 
         @secure()
-        param myTokenValue string
+        param password string
 
-        resource mySecret 'Radius.Security/secrets@2025-08-01-preview' = {
-          name: 'mySecret'
+        resource myApplication 'Radius.Core/applications@2025-08-01-preview' = { 
+          name: 'my-app'
+          properties: {
+            environment: environment
+          }
+        }
+
+        // Passing password as a parameter to `rad deploy`
+        // password=$(openssl rand -hex 16) 
+        // rad deploy app.bicep -p password=$password
+        resource dbCredentials 'Radius.Security/secrets@2025-08-01-preview' = {
+          name: 'db-creds'
           properties: {
             environment: environment
             application: myApplication.id
             data: {
-              myToken: {
-                value: myTokenValue
-                encoding: 'base64'   //optional
+              username: {
+                value: 'admin'
+              }
+              password: {
+                // From password parameter passed in via CLI. 
+                value: password
               }
             }
           }
         }
-
-      When `encoding` is not set, the value is assumed to be a string. For non-string secret data, set the `encoding` to `base64`.  
-
-      To use the new Secret with a Container, either, include the Secret in the `env` property or mount the Secret using the `volumes` property.
-
-      1. To use the Secret as an environment variable:
-
-        resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
-          name: 'myContainer'
-          properties: {
-            ...
-            container: {
-              ...
-              env: 
-                MY_SECRET_VALUE: {
-                  valueFrom: {
-                    secretRef: {
-                      source: mySecret.id
-                      key: 'myToken'
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-
-      2. To mount the secret as a volume:
-
-        resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
-          name: 'myContainer'
-          properties: {
-            ...
-            container: {
-              ...
-              volumes: 
-                mySecretVolume: {
-                  kind: 'secret'
-                  mountPath: '/secrets'
-                  source: mySecret.id
-                }
-              }
-            }
-          }
-        }
-
-      Secrets may already existing in the Radius Resource Group. These can be referenced by name using the `existing` Bicep keyword. For example:
-
-        resource existingSecret 'Radius.Security/secrets@2025-08-01-preview' existing = {
-          name: 'existingSecret'
-        }
-
+        ```
+      When deploying the application, specify the secret value as a command-line parameter. It is recommended to use a password generator such as `openssl` or equivalent. For example, `rad deploy app.bicep -p password=$(openssl rand -hex 16)`.
+      For details on how to use the secret with another resource such as a container or database, see the documentation for those resource types.    
     apiVersions:
       "2025-08-01-preview":
         schema:
@@ -100,7 +67,6 @@ types:
             data:
               type: object
               description: '(Required) Map of secret data. For example: `data: { username: { value: user1 } password: { value: pass }}`'
-              x-radius-sensitive: true
               additionalProperties:
                 type: object
                 properties:
@@ -110,6 +76,7 @@ types:
                     description: (Optional) Content encoding of the value. If not specified, `string` is assumed.
                   value:
                     type: string
+                    x-radius-sensitive: true
                     description: (Required) The string value of the secret unless encoding is set to 'base64'.
                 required: [value]
           required:

--- a/deploy/manifest/defaults.yaml
+++ b/deploy/manifest/defaults.yaml
@@ -1,0 +1,20 @@
+# defaults.yaml lists the resource types from resource-types-contrib that ship
+# as defaults in Radius. Each entry uses the <namespace>/<typeName> format
+# and is resolved to a file path in the resource-types-contrib module
+# using the convention: strip the "Radius." prefix, then
+# <namespace>/<typeName>/<typeName>.yaml.
+#
+# The version of resource-types-contrib is pinned in go.mod. To update:
+#   make update-resource-types
+#
+# To add a new default resource type:
+#   1. Merge the manifest in resource-types-contrib.
+#   2. Add the entry below.
+#   3. Run: make update-resource-types
+#   4. Commit the updated files (defaults.yaml, go.mod, go.sum, and copied YAMLs).
+defaultRegistration:
+  - Radius.Compute/containers
+  - Radius.Compute/persistentVolumes
+  - Radius.Compute/routes
+  - Radius.Data/mySqlDatabases
+  - Radius.Security/secrets

--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/projectcontour/contour v1.33.4
 	github.com/prometheus/client_golang v1.23.2
+	github.com/radius-project/resource-types-contrib v0.0.0-20260515162318-067b29d71eb8
 	github.com/sethvargo/go-retry v0.3.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -612,6 +612,8 @@ github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEo
 github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
 github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
+github.com/radius-project/resource-types-contrib v0.0.0-20260515162318-067b29d71eb8 h1:6Yb23+vXPwd+Dn5oGGb4uClCqe5V2CUzmbdbwZ03/9I=
+github.com/radius-project/resource-types-contrib v0.0.0-20260515162318-067b29d71eb8/go.mod h1:Bl5/B3MAJSCQMR0PNEFhkNdKy+nFsNoyC65O1iowhMU=
 github.com/redis/go-redis/extra/rediscmd/v9 v9.0.5 h1:EaDatTxkdHG+U3Bk4EUr+DZ7fOGwTfezUiUJMaIcaho=
 github.com/redis/go-redis/extra/rediscmd/v9 v9.0.5/go.mod h1:fyalQWdtzDBECAQFBJuQe5bzQ02jGd5Qcbgb97Flm7U=
 github.com/redis/go-redis/extra/redisotel/v9 v9.0.5 h1:EfpWLLCyXw8PSM2/XNJLjI3Pb27yVE+gIAfeqp8LUCc=

--- a/pkg/resourcetypescontrib/import.go
+++ b/pkg/resourcetypescontrib/import.go
@@ -1,0 +1,30 @@
+// Copyright 2023 The Radius Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package resourcetypescontrib exists solely to keep the
+// github.com/radius-project/resource-types-contrib dependency in go.mod.
+//
+// resource-types-contrib is a Go module containing YAML manifest files (no
+// executable Go code). The blank import below prevents "go mod tidy" from
+// removing the dependency. The actual manifest files are copied from the
+// module cache into deploy/manifest/built-in-providers/ by
+// "make sync-resource-types".
+package resourcetypescontrib
+
+import (
+	// Blank import to retain the resource-types-contrib module dependency in
+	// go.mod. Without this import, "go mod tidy" would remove the dependency
+	// because no Go code directly references the module.
+	_ "github.com/radius-project/resource-types-contrib"
+)

--- a/pkg/ucp/integrationtests/resourceproviders/resourceproviders_test.go
+++ b/pkg/ucp/integrationtests/resourceproviders/resourceproviders_test.go
@@ -177,6 +177,7 @@ func Test_ResourceProvider_RegisterManifests_NoLocation(t *testing.T) {
 	noLocationNamespace := "Radius.Compute"
 	noLocationResourceProviderURL := "/planes/radius/local/providers/System.Resources/resourceproviders/" + noLocationNamespace + radiusAPIVersion
 	noLocationResourceTypeURL := "/planes/radius/local/providers/System.Resources/resourceproviders/" + noLocationNamespace + "/resourcetypes/containers" + radiusAPIVersion
+	noLocationLocationURL := "/planes/radius/local/providers/System.Resources/resourceproviders/" + noLocationNamespace + "/locations/global" + radiusAPIVersion
 
 	require.EventuallyWithTf(t, func(collect *assert.CollectT) {
 		// Verify the resource provider was registered.
@@ -186,6 +187,21 @@ func Test_ResourceProvider_RegisterManifests_NoLocation(t *testing.T) {
 		// Verify the resource type was registered.
 		response = server.MakeRequest(http.MethodGet, noLocationResourceTypeURL, nil)
 		assert.Equal(collect, 200, response.Raw.StatusCode, "resource type Radius.Compute/containers should be registered")
+
+		// Verify the location was created with no address, so UCP uses
+		// DefaultDownstreamEndpoint for routing.
+		response = server.MakeRequest(http.MethodGet, noLocationLocationURL, nil)
+		if !assert.Equal(collect, 200, response.Raw.StatusCode, "location global should be registered") {
+			return
+		}
+
+		var locationBody map[string]any
+		if !assert.NoError(collect, json.Unmarshal(response.Body.Bytes(), &locationBody)) {
+			return
+		}
+
+		props, _ := locationBody["properties"].(map[string]any)
+		assert.Nil(collect, props["address"], "location address should be absent for no-location manifests")
 	}, registerManifestWaitDuration, registerManifestWaitInterval, "no-location manifest registration did not complete in time")
 }
 

--- a/pkg/ucp/integrationtests/resourceproviders/resourceproviders_test.go
+++ b/pkg/ucp/integrationtests/resourceproviders/resourceproviders_test.go
@@ -161,6 +161,34 @@ func Test_ResourceProvider_RegisterManifests(t *testing.T) {
 	deleteManifestResourceProvider(server)
 }
 
+// Test_ResourceProvider_RegisterManifests_NoLocation verifies that manifests
+// without a "location" field are registered successfully at startup. This is
+// the code path used by resource type manifests copied from
+// resource-types-contrib, which omit location so that UCP routes requests via
+// DefaultDownstreamEndpoint (dynamic-rp).
+func Test_ResourceProvider_RegisterManifests_NoLocation(t *testing.T) {
+	server := testhost.Start(t, testhost.TestHostOptionFunc(func(options *ucp.Options) {
+		options.Config.Initialization.ManifestDirectory = "testdata/manifests-no-location"
+	}))
+	defer server.Close()
+
+	createRadiusPlane(server)
+
+	noLocationNamespace := "Radius.Compute"
+	noLocationResourceProviderURL := "/planes/radius/local/providers/System.Resources/resourceproviders/" + noLocationNamespace + radiusAPIVersion
+	noLocationResourceTypeURL := "/planes/radius/local/providers/System.Resources/resourceproviders/" + noLocationNamespace + "/resourcetypes/containers" + radiusAPIVersion
+
+	require.EventuallyWithTf(t, func(collect *assert.CollectT) {
+		// Verify the resource provider was registered.
+		response := server.MakeRequest(http.MethodGet, noLocationResourceProviderURL, nil)
+		assert.Equal(collect, 200, response.Raw.StatusCode, "resource provider Radius.Compute should be registered")
+
+		// Verify the resource type was registered.
+		response = server.MakeRequest(http.MethodGet, noLocationResourceTypeURL, nil)
+		assert.Equal(collect, 200, response.Raw.StatusCode, "resource type Radius.Compute/containers should be registered")
+	}, registerManifestWaitDuration, registerManifestWaitInterval, "no-location manifest registration did not complete in time")
+}
+
 // removeSystemData removes the systemData property from the response body recursively.
 // This matches the behavior of TestResponse.removeSystemData in the testhost package.
 func removeSystemData(body map[string]any) {

--- a/pkg/ucp/integrationtests/resourceproviders/testdata/manifests-no-location/containers.yaml
+++ b/pkg/ucp/integrationtests/resourceproviders/testdata/manifests-no-location/containers.yaml
@@ -1,0 +1,13 @@
+namespace: Radius.Compute
+types:
+  containers:
+    apiVersions:
+      "2025-08-01-preview":
+        schema:
+          type: object
+          properties:
+            environment:
+              type: string
+            application:
+              type: string
+          required: [environment, application]


### PR DESCRIPTION
## Overview

Implement automated sync of default resource type manifests from `resource-types-contrib` into the `radius` repo, as described in the design: https://github.com/radius-project/radius/pull/11610/changes.

This eliminates manual cross-repo file editing and schema drift by making `resource-types-contrib` the single source of truth for resource type manifests that ship as defaults in Radius.

## How it works

There are two pieces: a **manual Makefile target** that copies manifests, and a **CI check** that verifies the copies are up to date.

### 1. Manual sync (developer runs locally)

When a developer wants to update the default resource types - either to pick up schema changes from `resource-types-contrib` or to add/remove a default type - they run:

```bash
make update-resource-types   # bumps go.mod to latest resource-types-contrib, then copies manifests
```

`make sync-resource-types` (copy only, no version bump) is useful when:
- A new entry was added to `defaults.yaml` without changing the `resource-types-contrib` version
- A previously-copied manifest was accidentally hand-edited and needs to be restored
- CI reports drift and the developer needs to regenerate the copies

```bash
make sync-resource-types     # copies manifests from the version already pinned in go.mod
```

This reads `deploy/manifest/defaults.yaml` to determine which resource types to copy, resolves each entry to a file in the `resource-types-contrib` Go module cache, and copies it into `deploy/manifest/built-in-providers/{dev,self-hosted}/`. It also removes any stale previously-copied files that are no longer in `defaults.yaml`. The developer then commits the resulting changes.

**There is no automated workflow that does the copying** - it is always a deliberate local action followed by a PR.

### 2. CI drift detection (runs automatically on PRs)

The `verify-resource-types.yaml` workflow runs on every PR that touches `go.mod`, `go.sum`, `defaults.yaml`, the copied manifests, or the sync logic. It:

1. Re-runs `make sync-resource-types` in CI (copy only, no version bump).
2. Checks `git diff` on the `built-in-providers/` directories.
   - **No diff** → the committed copies match the pinned version → check **passes**.
   - **Diff found** → the committed copies have drifted → check **fails** with a message telling the developer to run `make sync-resource-types` and commit.

This catches cases where someone bumps `go.mod` but forgets to re-sync, manually edits a copied file, or adds an entry to `defaults.yaml` without re-running the copy.

## Key design points

- **Version pinning via `go.mod`**: `resource-types-contrib` is added as a Go module dependency. A blank import in `pkg/resourcetypescontrib/import.go` keeps `go mod tidy` from removing it. The version pinned in `go.mod` is the single source of truth for which version of manifests are used.
- **No runtime changes**: The existing `RegisterDirectory` startup path is reused as-is. Copied manifests have no `location` field, so UCP routes via `DefaultDownstreamEndpoint` (dynamic-rp).
- **Per-type file layout**: Previously, `built-in-providers/` contained one YAML file per namespace (e.g., `radius_compute.yaml` with `containers`, `routes`, and `persistentVolumes` all in one file). Now each resource type has its own file (e.g., `containers.yaml`, `routes.yaml`). This matches the per-type file layout in `resource-types-contrib`, makes it straightforward to map `defaults.yaml` entries to files, and keeps diffs scoped to the individual type that changed.

## Changes

### New files
- **`deploy/manifest/defaults.yaml`** - Lists which resource types from `resource-types-contrib` ship as defaults.
- **`build/resource-types.mk`** - Makefile targets:
  - `make update-resource-types` - Bumps `go.mod` to the latest `resource-types-contrib` version and syncs manifest files.
  - `make sync-resource-types` - Copies manifest files from the version pinned in `go.mod` (no version bump). Used by CI for drift detection.
- **`.github/workflows/verify-resource-types.yaml`** - CI drift detection: runs `make sync-resource-types` and fails if committed copies diverge from the pinned version.
- **`pkg/resourcetypescontrib/import.go`** - Blank import to retain the `resource-types-contrib` dependency in `go.mod`.
- **Per-type manifest files** in both `dev/` and `self-hosted/`: `containers.yaml`, `persistentVolumes.yaml`, `routes.yaml`, `mySqlDatabases.yaml`, `secrets.yaml`

### Removed files
- `radius_compute.yaml` (dev + self-hosted) - Replaced by per-type files: `containers.yaml`, `persistentVolumes.yaml`, `routes.yaml`
- `radius_data.yaml` (dev + self-hosted) - Replaced by per-type file: `mySqlDatabases.yaml`
- `radius_security.yaml` (dev + self-hosted) - Replaced by per-type file: `secrets.yaml`

### Modified files
- **`Makefile`** - Includes `build/resource-types.mk`
- **`go.mod`** - Adds `resource-types-contrib` dependency (pinned to `v0.0.0-20260515162318-067b29d71eb8`)

## Dependencies

- Depends on https://github.com/radius-project/resource-types-contrib/pull/158 (adds `go.mod` and `doc.go` to `resource-types-contrib`) - **merged**

## Test plan

- `make sync-resource-types` copies exactly the files listed in `defaults.yaml`
- Running twice produces no diff (idempotent)
- Adding a missing path to `defaults.yaml` causes the script to fail clearly
- Existing `Test_ResourceProvider_RegisterManifests` continues to pass
- CI drift detection catches manual edits or missed syncs
