### PR TITLE
Show individual test results in functional test logs

### DIFF
--- a/.github/workflows/functional-test-cloud.yaml
+++ b/.github/workflows/functional-test-cloud.yaml
@@ -942,7 +942,7 @@ jobs:
           BICEP_RECIPE_REGISTRY: ${{ env.BICEP_RECIPE_REGISTRY }}
           BICEP_RECIPE_TAG_VERSION: ${{ env.BICEP_RECIPE_TAG_VERSION }}
           GH_TOKEN: ${{ steps.get_installation_token.outputs.token }}
-          GOTESTSUM_OPTS: --junitfile ./dist/functional_test/results.xml
+          GOTESTSUM_OPTS: --junitfile ./dist/functional_test/results.xml --format testname --format-hide-empty-pkg
 
       - name: Process Functional Test Results
         uses: ./.github/actions/process-test-results

--- a/.github/workflows/functional-test-noncloud.yaml
+++ b/.github/workflows/functional-test-noncloud.yaml
@@ -504,7 +504,7 @@ jobs:
           BICEP_RECIPE_REGISTRY: ${{ env.LOCAL_REGISTRY_NAME }}:${{ env.LOCAL_REGISTRY_PORT }}
           BICEP_RECIPE_TAG_VERSION: ${{ env.BICEP_RECIPE_TAG_VERSION }}
           GH_TOKEN: ${{ github.token }}
-          GOTESTSUM_OPTS: --junitfile ./dist/functional_test/results.xml
+          GOTESTSUM_OPTS: --junitfile ./dist/functional_test/results.xml --format testname --format-hide-empty-pkg
           RADIUS_TEST_FAST_CLEANUP: true
           GIT_HTTP_PASSWORD: ${{ env.GIT_HTTP_PASSWORD }}
 


### PR DESCRIPTION
## Purpose

Show pass/fail status and elapsed time for each individual functional test in CI logs, instead of one consolidated line per package. This will help us find and optimize tests with lengthy execution times.

## Changes

Adds `--format testname --format-hide-empty-pkg` to `GOTESTSUM_OPTS` in both functional test workflows:

- `.github/workflows/functional-test-cloud.yaml`
- `.github/workflows/functional-test-noncloud.yaml`

## Before

`gotestsum` defaulted to `pkgname` format, producing one line per package:

```text
✓  test/functional-portable/corerp/cloud/mechanics (56.015s)
✓  test/functional-portable/corerp/cloud/resources (19m42.189s)
```

Individual test names and timings were hidden.

## After

`testname` format prints a line per test as it completes (with PASS/FAIL/SKIP and elapsed time). `--format-hide-empty-pkg` suppresses noise from packages that contain no tests.

```text
::group::PASS test/functional-portable/samples/noncloud.Test_FirstApplicationSample/deploy_testdata/tutorial-environment.bicep (14.26s)
PASS test/functional-portable/samples/noncloud.Test_FirstApplicationSample/deploy_testdata/tutorial-environment.bicep (14.26s)
::group::PASS test/functional-portable/samples/noncloud.Test_FirstApplicationSample/deploy_../../../../samples/samples/demo/app.bicep (37.94s)
PASS test/functional-portable/samples/noncloud.Test_FirstApplicationSample/deploy_../../../../samples/samples/demo/app.bicep (37.94s)
::group::PASS test/functional-portable/samples/noncloud.Test_FirstApplicationSample (52.22s)
PASS test/functional-portable/samples/noncloud.Test_FirstApplicationSample (52.22s)
  PASS Package test/functional-portable/samples/noncloud (52.248s)
```

## References

- [gotestsum output formats](https://github.com/gotestyourself/gotestsum#output-format)
- `gotestsum --help` → `--format-hide-empty-pkg: do not print empty packages in compact formats`