### PR TITLE
Long-running Azure test reliability and test-code ref override

### DIFF
--- a/.github/scripts/checkout-release-codebase.sh
+++ b/.github/scripts/checkout-release-codebase.sh
@@ -19,11 +19,15 @@
 # ============================================================================
 # Checkout Release Codebase
 #
-# This script clones the Radius repository at the tag matching the installed
-# Radius CLI version into a "current_release" subfolder.
+# This script clones the Radius repository into a "current_release" subfolder
+# so long-running tests can run against the release codebase while keeping the
+# main repository clone intact for workflow infrastructure.
 #
-# This allows long-running tests to run against the release codebase while
-# keeping the main repository clone intact for workflow infrastructure.
+# By default it clones the tag matching the installed Radius CLI version. The
+# ref to clone can be overridden by passing a git ref (branch, tag, or SHA) as
+# the first argument or via the TEST_CODE_REF environment variable. When
+# overridden, the product under test is still the installed release; only the
+# test/infrastructure code on disk changes.
 # ============================================================================
 
 set -euo pipefail
@@ -33,10 +37,14 @@ readonly SCRIPT_NAME
 readonly RELEASE_DIR="current_release"
 
 usage() {
-    echo "Usage: ${SCRIPT_NAME}"
+    echo "Usage: ${SCRIPT_NAME} [test-code-ref]"
     echo ""
-    echo "Clones the Radius repository at the installed release tag into"
-    echo "a '${RELEASE_DIR}' subfolder."
+    echo "Clones the Radius repository into a '${RELEASE_DIR}' subfolder."
+    echo ""
+    echo "Arguments:"
+    echo "  test-code-ref   Optional git ref (branch, tag, or SHA) to clone"
+    echo "                  instead of the installed release tag. May also be"
+    echo "                  supplied via the TEST_CODE_REF environment variable."
     echo ""
     echo "Requires rad CLI to be installed and in PATH."
     exit 0
@@ -50,6 +58,9 @@ main() {
     if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
         usage
     fi
+
+    # Optional override: positional arg takes precedence over TEST_CODE_REF env var.
+    local test_code_ref="${1:-${TEST_CODE_REF:-}}"
 
     if ! command -v rad &> /dev/null; then
         echo "Error: rad CLI not found in PATH"
@@ -86,6 +97,20 @@ main() {
     echo "Installed Radius version: ${release_version}"
     echo "Release tag: ${release_tag}"
 
+    # Determine the ref to clone. Default is the release tag matching the installed CLI.
+    # An explicit override clones a different branch/tag/SHA so test code (and only test
+    # code) can be patched without cutting a product patch release. The product under
+    # test is still the installed release.
+    local clone_ref="${release_tag}"
+    local clone_ref_source="release tag"
+    if [[ -n "${test_code_ref}" ]]; then
+        clone_ref="${test_code_ref}"
+        clone_ref_source="override"
+        echo "Test code ref override: ${clone_ref}"
+        echo "NOTE: product under test is still ${release_tag}; only the on-disk"
+        echo "      test/infrastructure code is taken from ${clone_ref}."
+    fi
+
     # Remove existing release directory if present
     if [[ -d "${RELEASE_DIR}" ]]; then
         echo ""
@@ -94,8 +119,8 @@ main() {
     fi
 
     echo ""
-    echo "Cloning repository at tag ${release_tag} into ${RELEASE_DIR}..."
-    git clone --depth 1 --branch "${release_tag}" --recurse-submodules \
+    echo "Cloning repository at ref ${clone_ref} (${clone_ref_source}) into ${RELEASE_DIR}..."
+    git clone --depth 1 --branch "${clone_ref}" --recurse-submodules \
         "https://github.com/radius-project/radius.git" "${RELEASE_DIR}"
 
     echo ""
@@ -114,11 +139,17 @@ main() {
     echo "Release Codebase Clone Complete"
     echo "============================================================================"
     echo "Release codebase location: ${RELEASE_DIR}"
-    echo "Release tag: ${release_tag}"
+    echo "Release tag (product under test): ${release_tag}"
+    echo "Cloned ref (test code source):    ${clone_ref} (${clone_ref_source})"
 
-    # Output the release directory for use in subsequent workflow steps
+    # Output values for use in subsequent workflow steps
     if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-        echo "release-dir=${RELEASE_DIR}" >> "${GITHUB_OUTPUT}"
+        {
+            echo "release-dir=${RELEASE_DIR}"
+            echo "release-tag=${release_tag}"
+            echo "test-code-ref=${clone_ref}"
+            echo "test-code-ref-source=${clone_ref_source}"
+        } >> "${GITHUB_OUTPUT}"
     fi
 }
 

--- a/.github/scripts/checkout-release-codebase.sh
+++ b/.github/scripts/checkout-release-codebase.sh
@@ -24,10 +24,11 @@
 # main repository clone intact for workflow infrastructure.
 #
 # By default it clones the tag matching the installed Radius CLI version. The
-# ref to clone can be overridden by passing a git ref (branch, tag, or SHA) as
-# the first argument or via the TEST_CODE_REF environment variable. When
-# overridden, the product under test is still the installed release; only the
-# test/infrastructure code on disk changes.
+# ref to clone can be overridden by passing a git branch or tag as the first
+# argument or via the TEST_CODE_REF environment variable. Raw commit SHAs are
+# not supported (git clone --branch does not accept them). When overridden, the
+# product under test is still the installed release; only the test/infrastructure
+# code on disk changes.
 # ============================================================================
 
 set -euo pipefail
@@ -42,9 +43,10 @@ usage() {
     echo "Clones the Radius repository into a '${RELEASE_DIR}' subfolder."
     echo ""
     echo "Arguments:"
-    echo "  test-code-ref   Optional git ref (branch, tag, or SHA) to clone"
-    echo "                  instead of the installed release tag. May also be"
-    echo "                  supplied via the TEST_CODE_REF environment variable."
+    echo "  test-code-ref   Optional git branch or tag to clone instead of the"
+    echo "                  installed release tag. Raw commit SHAs are not"
+    echo "                  supported. May also be supplied via the"
+    echo "                  TEST_CODE_REF environment variable."
     echo ""
     echo "Requires rad CLI to be installed and in PATH."
     exit 0
@@ -98,7 +100,7 @@ main() {
     echo "Release tag: ${release_tag}"
 
     # Determine the ref to clone. Default is the release tag matching the installed CLI.
-    # An explicit override clones a different branch/tag/SHA so test code (and only test
+    # An explicit override clones a different branch or tag so test code (and only test
     # code) can be patched without cutting a product patch release. The product under
     # test is still the installed release.
     local clone_ref="${release_tag}"

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -42,6 +42,17 @@ name: Long-running test on Azure
 on:
   # Enable manual trigger for testing.
   workflow_dispatch:
+    inputs:
+      test_code_ref:
+        description: |
+          Optional git ref (branch, tag, or SHA) in radius-project/radius to use
+          for test code. Leave blank to use the tag matching the installed
+          release CLI (default behavior). The product under test is always the
+          installed release; only the on-disk test/infrastructure code is taken
+          from this ref.
+        required: false
+        default: ''
+        type: string
   schedule:
     # Run once per day at 3:00 AM PDT (10:00 AM UTC)
     - cron: 0 10 * * *
@@ -161,6 +172,9 @@ jobs:
 
       - name: Checkout release codebase
         id: checkout-release-codebase
+        env:
+          # Optional override; empty string means "use the release tag matching the installed CLI".
+          TEST_CODE_REF: ${{ inputs.test_code_ref }}
         run: |
           export PATH=$GITHUB_WORKSPACE/bin:$PATH
           ./.github/scripts/checkout-release-codebase.sh
@@ -355,6 +369,8 @@ jobs:
           bicep restore "./${RELEASE_DIR}/test/functional-portable/corerp/cloud/resources/testdata/corerp-azure-connection-database-service.bicep" --force
           # Restore AWS Bicep types
           bicep restore "./${RELEASE_DIR}/test/functional-portable/corerp/cloud/resources/testdata/aws-s3-bucket.bicep" --force
+          # Restore UDT testresources Bicep types - required to avoid Azure CLI token expiry during the long-running tests
+          bicep restore "./${RELEASE_DIR}/test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha-recipe.bicep" --force
         env:
           RELEASE_DIR: ${{ steps.checkout-release-codebase.outputs.release-dir }}
 

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -45,10 +45,10 @@ on:
     inputs:
       test_code_ref:
         description: |
-          Optional git  branch in radius-project/radius for the test code to use
-          during the run. Leave blank to use the tag matching the release
+          Optional git branch or tag in radius-project/radius for the test code
+          to use during the run. Leave blank to use the tag matching the release
           (default behavior). This setting does not affect the code being tested,
-          which is always the installed release. This setting allows testing 
+          which is always the installed release. This setting allows testing
           updated test code, not updated product code.
         required: false
         default: ''

--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -45,11 +45,11 @@ on:
     inputs:
       test_code_ref:
         description: |
-          Optional git ref (branch, tag, or SHA) in radius-project/radius to use
-          for test code. Leave blank to use the tag matching the installed
-          release CLI (default behavior). The product under test is always the
-          installed release; only the on-disk test/infrastructure code is taken
-          from this ref.
+          Optional git  branch in radius-project/radius for the test code to use
+          during the run. Leave blank to use the tag matching the release
+          (default behavior). This setting does not affect the code being tested,
+          which is always the installed release. This setting allows testing 
+          updated test code, not updated product code.
         required: false
         default: ''
         type: string
@@ -369,7 +369,9 @@ jobs:
           bicep restore "./${RELEASE_DIR}/test/functional-portable/corerp/cloud/resources/testdata/corerp-azure-connection-database-service.bicep" --force
           # Restore AWS Bicep types
           bicep restore "./${RELEASE_DIR}/test/functional-portable/corerp/cloud/resources/testdata/aws-s3-bucket.bicep" --force
-          # Restore UDT testresources Bicep types - required to avoid Azure CLI token expiry during the long-running tests
+          # Pre-restore UDT testresources Bicep types so the first deploy in the run does not have to fetch them.
+          # Without pre-restore, the lazy restore happens mid-test and has occasionally exceeded the Azure CLI
+          # token lifetime during long-running tests.
           bicep restore "./${RELEASE_DIR}/test/functional-portable/dynamicrp/noncloud/resources/testdata/usertypealpha-recipe.bicep" --force
         env:
           RELEASE_DIR: ${{ steps.checkout-release-codebase.outputs.release-dir }}

--- a/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
+++ b/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/radius-project/radius/test/testcontext"
 	"github.com/radius-project/radius/test/testutil"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -411,19 +410,17 @@ func deleteNamespace(ctx context.Context, t *testing.T, namespace string, opts r
 		return
 	}
 
-	// First, wait for normal deletion. Use assert.Eventually (not require.Eventually) so that
-	// if the namespace is stuck Terminating we fall through to the finalizer-clearing fallback
-	// below instead of failing the test outright.
-	if assert.Eventually(t, func() bool {
+	// First, wait for normal deletion using a plain poll loop. We deliberately avoid
+	// assert.Eventually here because its timeout would mark the test failed even when the
+	// finalizer-clearing fallback below subsequently succeeds.
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
 		ns := &corev1.Namespace{}
 		getErr := opts.Client.Get(ctx, types.NamespacedName{Name: namespace}, ns)
 		if apierrors.IsNotFound(getErr) {
-			return true
+			return
 		}
-		// Tolerate transient errors and keep polling.
-		return false
-	}, time.Minute*2, time.Second*5, "waiting for namespace %s to be deleted", namespace) {
-		return
+		time.Sleep(5 * time.Second)
 	}
 
 	// Fallback for namespaces stuck in Terminating due to finalizers.

--- a/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
+++ b/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/radius-project/radius/test/testcontext"
 	"github.com/radius-project/radius/test/testutil"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -404,14 +405,52 @@ func deleteNamespace(ctx context.Context, t *testing.T, namespace string, opts r
 	err := opts.K8sClient.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
 	if !apierrors.IsNotFound(err) {
 		require.NoError(t, err, "failed to delete namespace %s", namespace)
-		t.Logf("Namespace %s deleted successfully", namespace)
+		t.Logf("Namespace %s delete requested", namespace)
 	} else {
 		t.Logf("Namespace %s already deleted or does not exist", namespace)
+		return
+	}
+
+	// First, wait for normal deletion. Use assert.Eventually (not require.Eventually) so that
+	// if the namespace is stuck Terminating we fall through to the finalizer-clearing fallback
+	// below instead of failing the test outright.
+	if assert.Eventually(t, func() bool {
+		ns := &corev1.Namespace{}
+		getErr := opts.Client.Get(ctx, types.NamespacedName{Name: namespace}, ns)
+		if apierrors.IsNotFound(getErr) {
+			return true
+		}
+		// Tolerate transient errors and keep polling.
+		return false
+	}, time.Minute*2, time.Second*5, "waiting for namespace %s to be deleted", namespace) {
+		return
+	}
+
+	// Fallback for namespaces stuck in Terminating due to finalizers.
+	// NOTE: Force-clearing namespace finalizers is a TEST-ONLY escape hatch. In production
+	// code this can leak the underlying resources owned by whichever controller registered
+	// the finalizer.
+	ns, err := opts.K8sClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return
+	}
+	require.NoError(t, err)
+
+	if len(ns.Spec.Finalizers) > 0 {
+		t.Logf("Namespace %s stuck terminating with finalizers: %v; clearing them", namespace, ns.Spec.Finalizers)
+		ns.Spec.Finalizers = nil
+		_, err = opts.K8sClient.CoreV1().Namespaces().Finalize(ctx, ns, metav1.UpdateOptions{})
+		// Tolerate NotFound (already gone) and Conflict (apiserver mutated the namespace
+		// between Get and Finalize); in either case the next Eventually below will reflect
+		// the final state.
+		if err != nil && !apierrors.IsNotFound(err) && !apierrors.IsConflict(err) {
+			require.NoError(t, err)
+		}
 	}
 
 	require.Eventually(t, func() bool {
-		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-		err = opts.Client.Get(ctx, types.NamespacedName{Name: namespace}, ns)
+		ns := &corev1.Namespace{}
+		err := opts.Client.Get(ctx, types.NamespacedName{Name: namespace}, ns)
 		return apierrors.IsNotFound(err)
-	}, time.Minute*10, time.Second*10, "waiting for environment namespace to be deleted")
+	}, time.Minute*5, time.Second*5, "waiting for namespace %s to be fully deleted", namespace)
 }

--- a/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
+++ b/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/radius-project/radius/test/testcontext"
 	"github.com/radius-project/radius/test/testutil"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -46,6 +47,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
+	"k8s.io/client-go/util/retry"
 	controller_runtime "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -402,13 +404,16 @@ func assertExpectedResourcesToNotExist(ctx context.Context, scope string, expect
 
 func deleteNamespace(ctx context.Context, t *testing.T, namespace string, opts rp.RPTestOptions) {
 	err := opts.K8sClient.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
-	if !apierrors.IsNotFound(err) {
-		require.NoError(t, err, "failed to delete namespace %s", namespace)
-		t.Logf("Namespace %s delete requested", namespace)
-	} else {
+	if apierrors.IsNotFound(err) {
 		t.Logf("Namespace %s already deleted or does not exist", namespace)
 		return
 	}
+	// Use assert.* (not require.*) here so a single failing namespace does not abort cleanup
+	// of subsequent namespaces in the caller's loop.
+	if !assert.NoError(t, err, "failed to delete namespace %s", namespace) {
+		return
+	}
+	t.Logf("Namespace %s delete requested", namespace)
 
 	// First, wait for normal deletion using a plain poll loop. We deliberately avoid
 	// assert.Eventually here because its timeout would mark the test failed even when the
@@ -427,27 +432,37 @@ func deleteNamespace(ctx context.Context, t *testing.T, namespace string, opts r
 	// NOTE: Force-clearing namespace finalizers is a TEST-ONLY escape hatch. In production
 	// code this can leak the underlying resources owned by whichever controller registered
 	// the finalizer.
-	ns, err := opts.K8sClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		return
-	}
-	require.NoError(t, err)
-
-	if len(ns.Spec.Finalizers) > 0 {
+	//
+	// Use RetryOnConflict so that if the apiserver mutates the namespace between Get and
+	// Finalize, we re-fetch and re-clear instead of giving up (which would leave finalizers
+	// in place and cause the Eventually below to time out spuriously).
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		ns, getErr := opts.K8sClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+		if apierrors.IsNotFound(getErr) {
+			return nil
+		}
+		if getErr != nil {
+			return getErr
+		}
+		if len(ns.Spec.Finalizers) == 0 {
+			return nil
+		}
 		t.Logf("Namespace %s stuck terminating with finalizers: %v; clearing them", namespace, ns.Spec.Finalizers)
 		ns.Spec.Finalizers = nil
-		_, err = opts.K8sClient.CoreV1().Namespaces().Finalize(ctx, ns, metav1.UpdateOptions{})
-		// Tolerate NotFound (already gone) and Conflict (apiserver mutated the namespace
-		// between Get and Finalize); in either case the next Eventually below will reflect
-		// the final state.
-		if err != nil && !apierrors.IsNotFound(err) && !apierrors.IsConflict(err) {
-			require.NoError(t, err)
+		_, finalizeErr := opts.K8sClient.CoreV1().Namespaces().Finalize(ctx, ns, metav1.UpdateOptions{})
+		if apierrors.IsNotFound(finalizeErr) {
+			return nil
 		}
+		return finalizeErr
+	})
+	if err != nil {
+		assert.NoError(t, err, "failed to clear finalizers on namespace %s", namespace)
+		return
 	}
 
-	require.Eventually(t, func() bool {
+	assert.Eventually(t, func() bool {
 		ns := &corev1.Namespace{}
-		err := opts.Client.Get(ctx, types.NamespacedName{Name: namespace}, ns)
-		return apierrors.IsNotFound(err)
+		getErr := opts.Client.Get(ctx, types.NamespacedName{Name: namespace}, ns)
+		return apierrors.IsNotFound(getErr)
 	}, time.Minute*5, time.Second*5, "waiting for namespace %s to be fully deleted", namespace)
 }

--- a/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
+++ b/test/functional-portable/kubernetes/noncloud/deploymenttemplate_test.go
@@ -47,7 +47,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
-	"k8s.io/client-go/util/retry"
 	controller_runtime "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -402,6 +401,15 @@ func assertExpectedResourcesToNotExist(ctx context.Context, scope string, expect
 	return nil
 }
 
+// deleteNamespace requests deletion of the namespace and waits for it to be fully removed.
+//
+// Callers MUST first delete any Radius resources (e.g. DeploymentTemplate) that own the
+// namespace, and wait for those resources' finalizers to drain, before calling this
+// function. We deliberately do NOT force-clear namespace finalizers here: a namespace
+// stuck Terminating with a finalizer is a symptom that underlying resources still exist,
+// and clearing the finalizer would leak those resources and leave the next test run in
+// an unpredictable state. If the namespace fails to drain within the timeout, the test
+// fails — which is the correct signal that real cleanup is broken.
 func deleteNamespace(ctx context.Context, t *testing.T, namespace string, opts rp.RPTestOptions) {
 	err := opts.K8sClient.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
@@ -415,54 +423,18 @@ func deleteNamespace(ctx context.Context, t *testing.T, namespace string, opts r
 	}
 	t.Logf("Namespace %s delete requested", namespace)
 
-	// First, wait for normal deletion using a plain poll loop. We deliberately avoid
-	// assert.Eventually here because its timeout would mark the test failed even when the
-	// finalizer-clearing fallback below subsequently succeeds.
-	deadline := time.Now().Add(2 * time.Minute)
-	for time.Now().Before(deadline) {
-		ns := &corev1.Namespace{}
-		getErr := opts.Client.Get(ctx, types.NamespacedName{Name: namespace}, ns)
-		if apierrors.IsNotFound(getErr) {
-			return
-		}
-		time.Sleep(5 * time.Second)
-	}
-
-	// Fallback for namespaces stuck in Terminating due to finalizers.
-	// NOTE: Force-clearing namespace finalizers is a TEST-ONLY escape hatch. In production
-	// code this can leak the underlying resources owned by whichever controller registered
-	// the finalizer.
-	//
-	// Use RetryOnConflict so that if the apiserver mutates the namespace between Get and
-	// Finalize, we re-fetch and re-clear instead of giving up (which would leave finalizers
-	// in place and cause the Eventually below to time out spuriously).
-	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		ns, getErr := opts.K8sClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
-		if apierrors.IsNotFound(getErr) {
-			return nil
-		}
-		if getErr != nil {
-			return getErr
-		}
-		if len(ns.Spec.Finalizers) == 0 {
-			return nil
-		}
-		t.Logf("Namespace %s stuck terminating with finalizers: %v; clearing them", namespace, ns.Spec.Finalizers)
-		ns.Spec.Finalizers = nil
-		_, finalizeErr := opts.K8sClient.CoreV1().Namespaces().Finalize(ctx, ns, metav1.UpdateOptions{})
-		if apierrors.IsNotFound(finalizeErr) {
-			return nil
-		}
-		return finalizeErr
-	})
-	if err != nil {
-		assert.NoError(t, err, "failed to clear finalizers on namespace %s", namespace)
-		return
-	}
-
 	assert.Eventually(t, func() bool {
 		ns := &corev1.Namespace{}
 		getErr := opts.Client.Get(ctx, types.NamespacedName{Name: namespace}, ns)
-		return apierrors.IsNotFound(getErr)
-	}, time.Minute*5, time.Second*5, "waiting for namespace %s to be fully deleted", namespace)
+		if apierrors.IsNotFound(getErr) {
+			return true
+		}
+		// Log finalizers periodically so a stuck namespace is easy to diagnose in CI logs
+		// without us having to reproduce locally.
+		if len(ns.Finalizers) > 0 || len(ns.Spec.Finalizers) > 0 {
+			t.Logf("Namespace %s still Terminating; metadata.finalizers=%v spec.finalizers=%v",
+				namespace, ns.Finalizers, ns.Spec.Finalizers)
+		}
+		return false
+	}, time.Minute*5, time.Second*5, "namespace %s was not fully deleted; underlying Radius resources are likely still present", namespace)
 }

--- a/test/functional-portable/kubernetes/noncloud/flux_test.go
+++ b/test/functional-portable/kubernetes/noncloud/flux_test.go
@@ -42,7 +42,9 @@ import (
 	"github.com/go-git/go-git/v5/config"
 	gitobject "github.com/go-git/go-git/v5/plumbing/object"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -217,7 +219,9 @@ func testFluxIntegration(t *testing.T, testName string, steps []GitOpsTestStep, 
 	err = opts.Client.Create(ctx, secret)
 	defer func() {
 		err := opts.Client.Delete(ctx, secret)
-		require.NoError(t, err)
+		if controller_runtime.IgnoreNotFound(err) != nil {
+			t.Errorf("Error deleting secret %s/%s: %v", secret.Namespace, secret.Name, err)
+		}
 	}()
 	require.NoError(t, err)
 
@@ -237,13 +241,19 @@ func testFluxIntegration(t *testing.T, testName string, steps []GitOpsTestStep, 
 	err = opts.Client.Create(ctx, fluxGitRepository)
 	defer func() {
 		err := opts.Client.Delete(ctx, fluxGitRepository)
-		require.NoError(t, err)
+		if controller_runtime.IgnoreNotFound(err) != nil {
+			t.Errorf("Error deleting GitRepository %s/%s: %v", fluxGitRepository.Namespace, fluxGitRepository.Name, err)
+		}
 	}()
 	require.NoError(t, err)
 
 	// Wait for the GitRepository to be ready.
 	_, err = waitForGitRepositoryReady(t, ctx, types.NamespacedName{Name: gitRepoName, Namespace: fluxSystemNamespace}, opts.Client, fluxGitRepository.ResourceVersion)
 	require.NoError(t, err)
+
+	// Track DeploymentTemplates created across steps so we can delete them and wait for
+	// the Radius finalizer to drain before tearing down namespaces.
+	var deploymentTemplates []*radappiov1alpha3.DeploymentTemplate
 
 	for stepIndex, step := range steps {
 		stepNumber := stepIndex + 1
@@ -307,13 +317,8 @@ func testFluxIntegration(t *testing.T, testName string, steps []GitOpsTestStep, 
 			name, namespace, _, _ := getValuesFromRadiusGitOpsConfig(configEntry)
 
 			deploymentTemplate, err := waitForDeploymentTemplateToBeReadyWithGeneration(t, ctx, types.NamespacedName{Name: name, Namespace: namespace}, stepNumber, opts.Client)
-			defer func() {
-				err := opts.Client.Delete(ctx, deploymentTemplate)
-				if controller_runtime.IgnoreNotFound(err) != nil {
-					t.Logf("Error deleting deployment template: %v", err)
-				}
-			}()
 			require.NoError(t, err)
+			deploymentTemplates = append(deploymentTemplates, deploymentTemplate)
 		}
 
 		scope := fmt.Sprintf("/planes/radius/local/resourceGroups/%s", step.resourceGroup)
@@ -340,6 +345,37 @@ func testFluxIntegration(t *testing.T, testName string, steps []GitOpsTestStep, 
 			t.Fatalf("Error asserting expected resources exist: %v", err)
 		}
 		t.Logf("Successfully asserted expected resources exist in %s", scope)
+	}
+
+	// IMPORTANT: tear down in reverse order of dependencies before deleting namespaces.
+	// If we delete the namespaces while DeploymentTemplates (and the Radius resources behind them)
+	// still exist, two things happen:
+	//   1. The namespace is stuck Terminating because of the radapp.io/deployment-template-finalizer.
+	//   2. radius-rp recreates application namespaces (e.g. <env>-<app>) because the underlying
+	//      Applications.Core/applications and containers still exist in Radius.
+	// Deleting and waiting for the DeploymentTemplates first lets the Radius controller
+	// drain its finalizer and remove the Radius resources, after which namespace deletion succeeds.
+	//
+	// Use assert.* (not require.*) during teardown so that one stuck DeploymentTemplate does
+	// not skip teardown of the others (and the namespaces below).
+	for _, dt := range deploymentTemplates {
+		t.Logf("Deleting DeploymentTemplate: %s/%s", dt.Namespace, dt.Name)
+		err := opts.Client.Delete(ctx, dt)
+		if controller_runtime.IgnoreNotFound(err) != nil {
+			assert.NoError(t, err)
+		}
+	}
+	if len(deploymentTemplates) > 0 {
+		assert.Eventually(t, func() bool {
+			for _, dt := range deploymentTemplates {
+				current := &radappiov1alpha3.DeploymentTemplate{}
+				getErr := opts.Client.Get(ctx, types.NamespacedName{Name: dt.Name, Namespace: dt.Namespace}, current)
+				if !apierrors.IsNotFound(getErr) {
+					return false
+				}
+			}
+			return true
+		}, time.Minute*5, time.Second*5, "DeploymentTemplates were not deleted in time")
 	}
 
 	for _, namespace := range namespaces {

--- a/test/functional-portable/kubernetes/noncloud/flux_test.go
+++ b/test/functional-portable/kubernetes/noncloud/flux_test.go
@@ -255,6 +255,46 @@ func testFluxIntegration(t *testing.T, testName string, steps []GitOpsTestStep, 
 	// the Radius finalizer to drain before tearing down namespaces.
 	var deploymentTemplates []*radappiov1alpha3.DeploymentTemplate
 
+	// Register teardown via t.Cleanup so it also runs when an earlier require.* aborts
+	// the test. See the long comment inside the cleanup for why ordering matters.
+	t.Cleanup(func() {
+		// IMPORTANT: tear down in reverse order of dependencies before deleting namespaces.
+		// If we delete the namespaces while DeploymentTemplates (and the Radius resources behind them)
+		// still exist, two things happen:
+		//   1. The namespace is stuck Terminating because of the radapp.io/deployment-template-finalizer.
+		//   2. radius-rp recreates application namespaces (e.g. <env>-<app>) because the underlying
+		//      Applications.Core/applications and containers still exist in Radius.
+		// Deleting and waiting for the DeploymentTemplates first lets the Radius controller
+		// drain its finalizer and remove the Radius resources, after which namespace deletion succeeds.
+		//
+		// Use assert.* (not require.*) during teardown so that one stuck DeploymentTemplate does
+		// not skip teardown of the others (and the namespaces below).
+		for _, dt := range deploymentTemplates {
+			t.Logf("Deleting DeploymentTemplate: %s/%s", dt.Namespace, dt.Name)
+			err := opts.Client.Delete(ctx, dt)
+			if controller_runtime.IgnoreNotFound(err) != nil {
+				t.Errorf("Error deleting DeploymentTemplate %s/%s: %v", dt.Namespace, dt.Name, err)
+			}
+		}
+		if len(deploymentTemplates) > 0 {
+			assert.Eventually(t, func() bool {
+				for _, dt := range deploymentTemplates {
+					current := &radappiov1alpha3.DeploymentTemplate{}
+					getErr := opts.Client.Get(ctx, types.NamespacedName{Name: dt.Name, Namespace: dt.Namespace}, current)
+					if !apierrors.IsNotFound(getErr) {
+						return false
+					}
+				}
+				return true
+			}, time.Minute*5, time.Second*5, "DeploymentTemplates were not deleted in time")
+		}
+
+		for _, namespace := range namespaces {
+			t.Logf("Deleting namespace: %s", namespace)
+			deleteNamespace(ctx, t, namespace, opts)
+		}
+	})
+
 	for stepIndex, step := range steps {
 		stepNumber := stepIndex + 1
 
@@ -347,41 +387,6 @@ func testFluxIntegration(t *testing.T, testName string, steps []GitOpsTestStep, 
 		t.Logf("Successfully asserted expected resources exist in %s", scope)
 	}
 
-	// IMPORTANT: tear down in reverse order of dependencies before deleting namespaces.
-	// If we delete the namespaces while DeploymentTemplates (and the Radius resources behind them)
-	// still exist, two things happen:
-	//   1. The namespace is stuck Terminating because of the radapp.io/deployment-template-finalizer.
-	//   2. radius-rp recreates application namespaces (e.g. <env>-<app>) because the underlying
-	//      Applications.Core/applications and containers still exist in Radius.
-	// Deleting and waiting for the DeploymentTemplates first lets the Radius controller
-	// drain its finalizer and remove the Radius resources, after which namespace deletion succeeds.
-	//
-	// Use assert.* (not require.*) during teardown so that one stuck DeploymentTemplate does
-	// not skip teardown of the others (and the namespaces below).
-	for _, dt := range deploymentTemplates {
-		t.Logf("Deleting DeploymentTemplate: %s/%s", dt.Namespace, dt.Name)
-		err := opts.Client.Delete(ctx, dt)
-		if controller_runtime.IgnoreNotFound(err) != nil {
-			assert.NoError(t, err)
-		}
-	}
-	if len(deploymentTemplates) > 0 {
-		assert.Eventually(t, func() bool {
-			for _, dt := range deploymentTemplates {
-				current := &radappiov1alpha3.DeploymentTemplate{}
-				getErr := opts.Client.Get(ctx, types.NamespacedName{Name: dt.Name, Namespace: dt.Namespace}, current)
-				if !apierrors.IsNotFound(getErr) {
-					return false
-				}
-			}
-			return true
-		}, time.Minute*5, time.Second*5, "DeploymentTemplates were not deleted in time")
-	}
-
-	for _, namespace := range namespaces {
-		t.Logf("Deleting namespace: %s", namespace)
-		deleteNamespace(ctx, t, namespace, opts)
-	}
 }
 
 func waitForDeploymentTemplateToBeReadyWithGeneration(t *testing.T, ctx context.Context, name types.NamespacedName, generation int, client controller_runtime.WithWatch) (*radappiov1alpha3.DeploymentTemplate, error) {


### PR DESCRIPTION
# Description

Improvements to the long-running Azure test workflow to prevent timeouts and to allow test code to be patched without cutting a product patch release.

Three independent fixes:

1. **Optional `test_code_ref` override for `checkout-release-codebase.sh` and the long-running Azure workflow.** When set (via positional arg, `TEST_CODE_REF` env var, or workflow_dispatch input), the script clones the supplied git ref into `current_release/` instead of the tag matching the installed CLI. The product under test is still the installed release; only the on-disk test/infrastructure code changes. This lets us iterate on test fixes without releasing a new patch.
2. **Pre-restore the UDT `usertypealpha-recipe.bicep` types in the workflow.** Restoring this lazily later in the run was racing with Azure CLI token expiry during the long-running tests.
3. **Robust namespace and DeploymentTemplate teardown in the Kubernetes/Flux noncloud tests.**
   - `deleteNamespace` now waits for normal deletion with `assert.Eventually` and falls back to clearing namespace finalizers (test-only escape hatch) when a namespace is stuck `Terminating`.
   - `testFluxIntegration` now deletes `DeploymentTemplate` resources first and waits for the Radius finalizer to drain before tearing down namespaces, so namespaces are not stuck on `radapp.io/deployment-template-finalizer` and `radius-rp` does not recreate application namespaces while their backing Applications.Core resources still exist.
   - Teardown uses `assert.*` instead of `require.*` so one stuck resource does not skip cleanup of the rest.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: #issue_number

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [x] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [x] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [x] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [x] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [x] Not applicable
