### PR TITLE
ci(lrt): update Bicep artifact restoration process

### DIFF
--- a/.github/workflows/long-running-azure.yaml
+++ b/.github/workflows/long-running-azure.yaml
@@ -234,11 +234,11 @@ jobs:
           rad version
 
       - name: Publish UDT types
-        run: |  
-          export PATH=$GITHUB_WORKSPACE/bin:$PATH  
-          which rad || { echo "cannot find rad"; exit 1; }  
-          rad bicep publish-extension -f "./${RELEASE_DIR}/test/functional-portable/dynamicrp/noncloud/resources/testdata/testresourcetypes.yaml" --target "br:${TEST_BICEP_TYPES_REGISTRY}/testresources:latest" --force  
-        env:  
+        run: |
+          export PATH=$GITHUB_WORKSPACE/bin:$PATH
+          which rad || { echo "cannot find rad"; exit 1; }
+          rad bicep publish-extension -f "./${RELEASE_DIR}/test/functional-portable/dynamicrp/noncloud/resources/testdata/testresourcetypes.yaml" --target "br:${TEST_BICEP_TYPES_REGISTRY}/testresources:latest" --force
+        env:
           RELEASE_DIR: ${{ steps.checkout-release-codebase.outputs.release-dir }}
 
       - name: Point dynamicrp testresources extension to test ACR
@@ -347,23 +347,31 @@ jobs:
         run: |
           echo "FUNCTEST_OIDC_ISSUER=$(az aks show -n ${{ env.AKS_CLUSTER_NAME }} -g ${{ env.AKS_RESOURCE_GROUP }} --query "oidcIssuerProfile.issuerUrl" -otsv)" >> $GITHUB_OUTPUT
 
-      - name: Restore Bicep artifacts before running functional tests
-        # The exact files chosen to run the command can be changed, but we need 1 that uses the Radius extension, 1 that uses the AWS extension and 1 that uses UDT testresources
-        # so we can restore all Bicep artifacts before the tests start.
-        run: |
-          # Restore Radius Bicep types
-          bicep restore "./${RELEASE_DIR}/test/functional-portable/corerp/cloud/resources/testdata/corerp-azure-connection-database-service.bicep" --force
-          # Restore AWS Bicep types
-          bicep restore "./${RELEASE_DIR}/test/functional-portable/corerp/cloud/resources/testdata/aws-s3-bucket.bicep" --force
-        env:
-          RELEASE_DIR: ${{ steps.checkout-release-codebase.outputs.release-dir }}
-
       - name: Re-login to Azure before functional tests
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.AZURE_SP_TESTS_APPID }}
           tenant-id: ${{ secrets.AZURE_SP_TESTS_TENANTID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTIONID_TESTS }}
+
+      - name: Restore Bicep artifacts before running functional tests
+        # Pre-warm the local Bicep artifact cache so the long-running test step
+        # never has to authenticate to a private ACR after the WIF
+        # client-assertion expires. The exact files chosen to run the command
+        # can be changed, but we need 1 that uses the Radius extension, 1 that
+        # uses the AWS extension and 1 that uses UDT testresources so we can
+        # restore all Bicep artifacts before the tests start. This step must
+        # run after "Re-login to Azure" so the private TEST_BICEP_TYPES_REGISTRY
+        # restore has fresh credentials.
+        run: |
+          # Restore Radius Bicep types (public ACR)
+          bicep restore "./${RELEASE_DIR}/test/functional-portable/corerp/cloud/resources/testdata/corerp-azure-connection-database-service.bicep" --force
+          # Restore AWS Bicep types (public ACR)
+          bicep restore "./${RELEASE_DIR}/test/functional-portable/corerp/cloud/resources/testdata/aws-s3-bucket.bicep" --force
+          # Restore UDT testresources Bicep types (private TEST_BICEP_TYPES_REGISTRY)
+          bicep restore "./${RELEASE_DIR}/test/functional-portable/dynamicrp/noncloud/resources/testdata/externalresource.bicep" --force
+        env:
+          RELEASE_DIR: ${{ steps.checkout-release-codebase.outputs.release-dir }}
 
       - name: Run functional tests
         env:


### PR DESCRIPTION
# Description


This pull request updates the workflow for restoring Bicep artifacts before running functional tests in the `.github/workflows/long-running-azure.yaml` file. The main change is to ensure that all necessary Bicep artifacts, including those from a private registry, are restored after re-authenticating with Azure to avoid authentication issues during long-running tests.

Workflow improvements for Bicep artifact restoration:

* Moved the "Restore Bicep artifacts before running functional tests" step to occur after the "Re-login to Azure" step, ensuring that private registry credentials are fresh before restoring artifacts.
* Updated the artifact restoration step to explicitly restore three types of Bicep artifacts: one using the Radius extension (public ACR), one using the AWS extension (public ACR), and one using UDT testresources (private registry), improving cache pre-warming and reliability for the functional tests.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius (issue link optional).

Fixes: https://github.com/radius-project/radius/issues/11976

## Contributor checklist
Please verify that the PR meets the following requirements, where applicable:

- An overview of proposed schema changes is included in a linked GitHub issue.
    - [ ] Yes
    - [ ] Not applicable
- A design document is added or updated under `eng/design-notes/` in this repository, if new APIs are being introduced.
    - [ ] Yes
    - [ ] Not applicable
- The design document has been reviewed and approved by Radius maintainers/approvers.
    - [ ] Yes
    - [ ] Not applicable
- A PR for [resource-types-contrib](https://github.com/radius-project/resource-types-contrib/) is created, if resource types or recipes are affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable
- A PR for [dashboard](https://github.com/radius-project/dashboard/) is created, if the Radius Dashboard is affected by the changes in this PR.
    - [ ] Yes
    - [ ] Not applicable
- A PR for the [documentation repository](https://github.com/radius-project/docs) is created, if the changes in this PR affect the documentation or any user facing updates are made.
    - [ ] Yes
    - [ ] Not applicable
